### PR TITLE
feat(fleet): add authoritative control plane

### DIFF
--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -100,6 +100,7 @@ bincode = { workspace = true }
 # Plugin runtime (Phase 7 — subprocess + JSON-RPC, replaces wasmi host).
 ainb-plugin-runtime = { path = "../ainb-plugin-runtime", version = "0.1.0" }
 ainb-plugin-protocol = { path = "../ainb-plugin-protocol", version = "0.1.0" }
+ainb-plugin-hangar = { path = "../ainb-plugin-hangar" }
 
 # Skill manager CLI surface (source/search/skill/migrate/doctor — spec §10.1).
 ainb-cli = { path = "../ainb-cli", version = "0.1.0" }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -10,6 +10,10 @@ use crate::app::{
 use crate::cli::statusline_install::{InstallOutcome, StatuslineStatus, install_statusline};
 use crate::credentials;
 use crate::models::live_window::Source as LiveSource;
+use ainb_plugin_hangar::screen::fleet::{
+    BroadcastReceipt, FleetAction, FleetEvent, FleetFilter, FleetIntent, FleetKey, ReceiptStatus,
+    selected_approval_action,
+};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::time::Instant;
 use tracing::info;
@@ -400,23 +404,29 @@ pub enum AppEvent {
     FleetPanelApprove, // Fleet panel: approve the selected APPROVE permission request (y)
     FleetPanelDeny,   // Fleet panel: deny the selected APPROVE permission request (n)
     FleetPanelRefresh, // Fleet panel: force-refresh from current_state (r)
-    FleetPanelNewAtcOpen, // Fleet panel: open the new-ATC name prompt (n)
+    /// Route one canonical reducer key through main ainb Fleet panel.
+    FleetPanelCanonicalKey(FleetKey),
+    /// Apply canonical Fleet roster filter.
+    FleetPanelSetFilter(FleetFilter),
+    /// Request canonical lifecycle or control action.
+    FleetPanelCanonicalAction(FleetAction),
+    FleetPanelNewAtcOpen,       // Fleet panel: open the new-ATC name prompt (n)
     FleetPanelNewAtcType(char), // Fleet panel: type a char into the name prompt
-    FleetPanelNewAtcBackspace, // Fleet panel: delete last char of the name prompt
-    FleetPanelNewAtcCancel, // Fleet panel: cancel the name prompt (Esc)
-    FleetPanelNewAtcSubmit, // Fleet panel: create the ATC (Enter)
-    PanelBack,        // Close a panel screen: pop previous_screen (home if none)
-    GoToHangar,       // Navigate to the Hangar control plane (plugin screen)
-    InboxMoveUp,      // Inbox: move selection up one row
-    InboxMoveDown,    // Inbox: move selection down one row
-    InboxPageUp,      // Inbox: jump 10 rows up
-    InboxPageDown,    // Inbox: jump 10 rows down
-    InboxOpenSelected, // Inbox: mark selected row read (Enter)
-    InboxDismissSelected, // Inbox: dismiss selected row (d)
-    InboxDismissVisible, // Inbox: dismiss every visible row (Shift+C)
-    InboxToggleArchived, // Inbox: toggle dismissed filter (a)
-    InboxCycleAgent,  // Inbox: cycle agent filter (p)
-    InboxRefresh,     // Inbox: force-refresh from store (r)
+    FleetPanelNewAtcBackspace,  // Fleet panel: delete last char of the name prompt
+    FleetPanelNewAtcCancel,     // Fleet panel: cancel the name prompt (Esc)
+    FleetPanelNewAtcSubmit,     // Fleet panel: create the ATC (Enter)
+    PanelBack,                  // Close a panel screen: pop previous_screen (home if none)
+    GoToHangar,                 // Navigate to the Hangar control plane (plugin screen)
+    InboxMoveUp,                // Inbox: move selection up one row
+    InboxMoveDown,              // Inbox: move selection down one row
+    InboxPageUp,                // Inbox: jump 10 rows up
+    InboxPageDown,              // Inbox: jump 10 rows down
+    InboxOpenSelected,          // Inbox: mark selected row read (Enter)
+    InboxDismissSelected,       // Inbox: dismiss selected row (d)
+    InboxDismissVisible,        // Inbox: dismiss every visible row (Shift+C)
+    InboxToggleArchived,        // Inbox: toggle dismissed filter (a)
+    InboxCycleAgent,            // Inbox: cycle agent filter (p)
+    InboxRefresh,               // Inbox: force-refresh from store (r)
     // AINB 2.0: Agent selection events
     // AINB 2.0: Config screen events
     ConfigBack,            // Return to home screen (Esc)
@@ -2949,6 +2959,21 @@ impl EventHandler {
                 _ => None,
             };
         }
+        if state.fleet_panel_state.canonical_modal_open() {
+            let key = match key_event.code {
+                KeyCode::Esc => FleetKey::Esc,
+                KeyCode::Enter => FleetKey::Enter,
+                KeyCode::Backspace => FleetKey::Backspace,
+                KeyCode::Up | KeyCode::BackTab => FleetKey::Up,
+                KeyCode::Down | KeyCode::Tab => FleetKey::Down,
+                KeyCode::Left => FleetKey::Left,
+                KeyCode::Right => FleetKey::Right,
+                KeyCode::Char(' ') => FleetKey::Space,
+                KeyCode::Char(character) => FleetKey::Char(character),
+                _ => return None,
+            };
+            return Some(AppEvent::FleetPanelCanonicalKey(key));
+        }
         match key_event.code {
             KeyCode::Esc | KeyCode::Char('q') => Some(AppEvent::PanelBack),
             KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::FleetPanelMoveUp),
@@ -2962,13 +2987,42 @@ impl EventHandler {
             // advertises) and new-ATC. Context decides: on an APPROVE row `n`
             // denies; anywhere else it opens the new-ATC name prompt.
             KeyCode::Char('n') => {
-                if state.fleet_panel_state.selected_kind() == Some("APPROVE") {
+                let canonical_approval = state
+                    .fleet_panel_state
+                    .canonical
+                    .selected_session()
+                    .map(|row| row.attention_state.eq_ignore_ascii_case("APPROVAL"));
+                if canonical_approval
+                    .unwrap_or_else(|| state.fleet_panel_state.selected_kind() == Some("APPROVE"))
+                {
                     Some(AppEvent::FleetPanelDeny)
                 } else {
                     Some(AppEvent::FleetPanelNewAtcOpen)
                 }
             }
             KeyCode::Char('r') => Some(AppEvent::FleetPanelRefresh),
+            KeyCode::Char('R') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart)),
+            KeyCode::Char('s') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Stop)),
+            KeyCode::Char('i') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Interrupt)),
+            KeyCode::Char('c') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Continue)),
+            KeyCode::Char('e') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Retry)),
+            KeyCode::Char('!') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Kill)),
+            KeyCode::Char('#') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Archive)),
+            KeyCode::Char('t' | 'p') | KeyCode::Right | KeyCode::Char('A') => {
+                let key = match key_event.code {
+                    KeyCode::Right => FleetKey::Right,
+                    KeyCode::Char(character) => FleetKey::Char(character),
+                    _ => unreachable!(),
+                };
+                Some(AppEvent::FleetPanelCanonicalKey(key))
+            }
+            KeyCode::Char('f') => Some(AppEvent::FleetPanelSetFilter(FleetFilter::Focus)),
+            KeyCode::Char('o') => Some(AppEvent::FleetPanelSetFilter(FleetFilter::Actionable)),
+            KeyCode::Char('m') => Some(AppEvent::FleetPanelSetFilter(FleetFilter::Managed)),
+            KeyCode::Char('d') => Some(AppEvent::FleetPanelSetFilter(FleetFilter::Degraded)),
+            KeyCode::Char('l') => Some(AppEvent::FleetPanelSetFilter(FleetFilter::Claude)),
+            KeyCode::Char('x') => Some(AppEvent::FleetPanelSetFilter(FleetFilter::Codex)),
+            KeyCode::Char('v') => Some(AppEvent::FleetPanelSetFilter(FleetFilter::All)),
             _ => None,
         }
     }
@@ -3187,6 +3241,265 @@ impl EventHandler {
                 }
             }
         }
+    }
+
+    fn reduce_fleet_event(state: &mut AppState, event: FleetEvent) {
+        let intent = state.fleet_panel_state.reduce_canonical(event);
+        if let Some(intent) = intent {
+            Self::dispatch_fleet_intent(state, intent);
+        }
+    }
+
+    fn dispatch_fleet_intent(state: &mut AppState, intent: FleetIntent) {
+        use ainb_hangar_proto::fleet::{
+            ActionReceiptStatus, ControlAction, FleetActionParams, FleetBroadcastParams,
+        };
+
+        match intent {
+            FleetIntent::Execute {
+                session_key,
+                expected_version,
+                action,
+            } => {
+                if action.is_high_risk() && !state.fleet_panel_state.daemon_online() {
+                    Self::reduce_fleet_event(
+                        state,
+                        FleetEvent::ActionFailed {
+                            session_key,
+                            detail: "Fleet daemon offline, high-risk action disabled".into(),
+                        },
+                    );
+                    return;
+                }
+                let action_label = match &action {
+                    FleetAction::StructuredAnswer { .. } => "answered ask",
+                    FleetAction::Approve { .. } => "approved request",
+                    FleetAction::Deny { .. } => "denied request",
+                    FleetAction::SendText { .. } => "sent prompt",
+                    FleetAction::VerifiedPicker { .. } => "routed picker",
+                    FleetAction::Continue => "continued turn",
+                    FleetAction::Retry => "retried turn",
+                    FleetAction::Interrupt => "interrupted turn",
+                    FleetAction::Stop => "stopped session",
+                    FleetAction::Restart => "restarted session",
+                    FleetAction::Kill => "killed session",
+                    FleetAction::Archive => "archived session",
+                };
+                let action = match action.into_control_action() {
+                    Ok(action) => action,
+                    Err(detail) => {
+                        Self::reduce_fleet_event(
+                            state,
+                            FleetEvent::ActionFailed {
+                                session_key,
+                                detail,
+                            },
+                        );
+                        return;
+                    }
+                };
+                let params = FleetActionParams {
+                    session_key: session_key.clone(),
+                    expected_version,
+                    request_id: format!("fleet-host-{}", uuid::Uuid::new_v4()),
+                    action,
+                };
+                let sink = state.fleet_panel_state.canonical_update_sink();
+                std::thread::spawn(move || {
+                    let events = match crate::fleet::control::execute_fleet_action_blocking(params)
+                    {
+                        Ok(receipt) if receipt.status == ActionReceiptStatus::Delivered => vec![
+                            FleetEvent::ActionSucceeded {
+                                session_key: session_key.clone(),
+                            },
+                            FleetEvent::Feedback(format!(
+                                "{action_label}: {:?}{}",
+                                receipt.status,
+                                receipt
+                                    .detail
+                                    .as_deref()
+                                    .map_or(String::new(), |detail| { format!(": {detail}") })
+                            )),
+                        ],
+                        Ok(receipt) => vec![FleetEvent::ActionFailed {
+                            session_key,
+                            detail: receipt
+                                .detail
+                                .unwrap_or_else(|| format!("delivery status {:?}", receipt.status)),
+                        }],
+                        Err(detail) => vec![FleetEvent::ActionFailed {
+                            session_key,
+                            detail,
+                        }],
+                    };
+                    if let Ok(mut updates) = sink.lock() {
+                        updates.extend(events);
+                    }
+                });
+            }
+            FleetIntent::Start {
+                provider,
+                cwd,
+                prompt,
+            } => {
+                if !state.fleet_panel_state.daemon_online() {
+                    Self::reduce_fleet_event(
+                        state,
+                        FleetEvent::ActionFailed {
+                            session_key: "start:codex".into(),
+                            detail: "Fleet daemon offline, managed start disabled".into(),
+                        },
+                    );
+                    return;
+                }
+                let session_key = "start:codex".to_string();
+                let params = FleetActionParams {
+                    session_key: session_key.clone(),
+                    expected_version: 1,
+                    request_id: format!("fleet-host-start-{}", uuid::Uuid::new_v4()),
+                    action: ControlAction::Start {
+                        provider,
+                        cwd,
+                        prompt,
+                    },
+                };
+                let sink = state.fleet_panel_state.canonical_update_sink();
+                std::thread::spawn(move || {
+                    let event = match crate::fleet::control::execute_fleet_action_blocking(params) {
+                        Ok(receipt) if receipt.status == ActionReceiptStatus::Delivered => {
+                            FleetEvent::ActionSucceeded { session_key }
+                        }
+                        Ok(receipt) => FleetEvent::ActionFailed {
+                            session_key,
+                            detail: receipt
+                                .detail
+                                .unwrap_or_else(|| format!("delivery status {:?}", receipt.status)),
+                        },
+                        Err(detail) => FleetEvent::ActionFailed {
+                            session_key,
+                            detail,
+                        },
+                    };
+                    if let Ok(mut updates) = sink.lock() {
+                        updates.push(event);
+                    }
+                });
+            }
+            FleetIntent::Broadcast {
+                text,
+                recipient_keys,
+                idempotency_key,
+                max_parallel: _,
+                retry_failures_only: _,
+            } => {
+                let params = FleetBroadcastParams {
+                    target_keys: recipient_keys,
+                    text,
+                    idempotency_key,
+                };
+                let sink = state.fleet_panel_state.canonical_update_sink();
+                std::thread::spawn(move || {
+                    let event =
+                        match crate::fleet::control::execute_fleet_broadcast_blocking(params) {
+                            Ok(result) => FleetEvent::BroadcastReceipts(
+                                result
+                                    .receipts
+                                    .into_iter()
+                                    .map(|receipt| BroadcastReceipt {
+                                        session_key: receipt.session_key,
+                                        status: match receipt.status {
+                                            ActionReceiptStatus::Delivered => {
+                                                ReceiptStatus::Delivered
+                                            }
+                                            ActionReceiptStatus::Failed
+                                            | ActionReceiptStatus::Rejected => {
+                                                ReceiptStatus::Failed
+                                            }
+                                            ActionReceiptStatus::Pending
+                                            | ActionReceiptStatus::Unknown => {
+                                                ReceiptStatus::Unknown
+                                            }
+                                        },
+                                        detail: receipt.detail,
+                                    })
+                                    .collect(),
+                            ),
+                            Err(detail) => FleetEvent::BroadcastFailed { detail },
+                        };
+                    if let Ok(mut updates) = sink.lock() {
+                        updates.push(event);
+                    }
+                });
+            }
+            FleetIntent::AttachEmbedded {
+                session_key,
+                tmux_target,
+            } => {
+                if state.embed.is_some() {
+                    state.release_interactive_pane();
+                }
+                let (terminal_cols, terminal_rows) =
+                    crossterm::terminal::size().unwrap_or((160, 48));
+                match crate::tmux::EmbedClient::attach_target(
+                    &tmux_target,
+                    terminal_rows.saturating_sub(2),
+                    terminal_cols.saturating_div(2),
+                ) {
+                    Ok(client) => {
+                        state.embed = Some(client);
+                        state.embed_session = Some(tmux_target.clone());
+                        state.embed_pane_area = None;
+                        state.focused_pane = crate::app::state::FocusedPane::Preview;
+                        Self::reduce_fleet_event(
+                            state,
+                            FleetEvent::Feedback(format!(
+                                "embedded {session_key} at exact target {tmux_target}"
+                            )),
+                        );
+                    }
+                    Err(error) => Self::reduce_fleet_event(
+                        state,
+                        FleetEvent::Feedback(format!("attach failed: {error}")),
+                    ),
+                }
+            }
+            FleetIntent::AttachFullscreen {
+                session_key,
+                tmux_target,
+            } => match Self::prepare_exact_fleet_attach(&tmux_target) {
+                Ok(session_name) => {
+                    state.pending_async_action = Some(AsyncAction::AttachToOtherTmux(session_name));
+                    Self::reduce_fleet_event(
+                        state,
+                        FleetEvent::Feedback(format!(
+                            "attaching {session_key} at exact target {tmux_target}"
+                        )),
+                    );
+                }
+                Err(detail) => Self::reduce_fleet_event(
+                    state,
+                    FleetEvent::Feedback(format!("attach failed: {detail}")),
+                ),
+            },
+        }
+    }
+
+    fn prepare_exact_fleet_attach(tmux_target: &str) -> Result<String, String> {
+        let session_name =
+            tmux_target.split_once(':').map_or(tmux_target, |(session, _)| session).trim();
+        if session_name.is_empty() {
+            return Err("tmux target has no session name".to_string());
+        }
+        for command in ["select-window", "select-pane"] {
+            let status = std::process::Command::new("tmux")
+                .args([command, "-t", tmux_target])
+                .status()
+                .map_err(|error| format!("tmux {command}: {error}"))?;
+            if !status.success() {
+                return Err(format!("tmux {command} rejected {tmux_target}"));
+            }
+        }
+        Ok(session_name.to_string())
     }
 
     pub fn process_event(event: AppEvent, state: &mut AppState) {
@@ -5827,10 +6140,38 @@ impl EventHandler {
                 // — cheap on the event loop, same as Inbox's refresh-on-entry.
                 state.fleet_panel_state.arm();
             }
-            AppEvent::FleetPanelMoveUp => state.fleet_panel_state.move_up(1),
-            AppEvent::FleetPanelMoveDown => state.fleet_panel_state.move_down(1),
-            AppEvent::FleetPanelOptionNext => state.fleet_panel_state.option_next(),
-            AppEvent::FleetPanelOptionPrev => state.fleet_panel_state.option_prev(),
+            AppEvent::FleetPanelMoveUp => {
+                state.fleet_panel_state.move_up(1);
+            }
+            AppEvent::FleetPanelMoveDown => {
+                state.fleet_panel_state.move_down(1);
+            }
+            AppEvent::FleetPanelOptionNext => {
+                let canonical_ask = state
+                    .fleet_panel_state
+                    .canonical
+                    .selected_session()
+                    .is_some_and(|row| row.attention_state.eq_ignore_ascii_case("ASK"));
+                if canonical_ask {
+                    Self::reduce_fleet_event(state, FleetEvent::Key(FleetKey::Enter));
+                    Self::reduce_fleet_event(state, FleetEvent::Key(FleetKey::Down));
+                } else {
+                    state.fleet_panel_state.option_next();
+                }
+            }
+            AppEvent::FleetPanelOptionPrev => {
+                let canonical_ask = state
+                    .fleet_panel_state
+                    .canonical
+                    .selected_session()
+                    .is_some_and(|row| row.attention_state.eq_ignore_ascii_case("ASK"));
+                if canonical_ask {
+                    Self::reduce_fleet_event(state, FleetEvent::Key(FleetKey::Enter));
+                    Self::reduce_fleet_event(state, FleetEvent::Key(FleetKey::Up));
+                } else {
+                    state.fleet_panel_state.option_prev();
+                }
+            }
             AppEvent::FleetPanelRefresh => state.fleet_panel_state.refresh(),
             AppEvent::FleetPanelNewAtcOpen => state.fleet_panel_state.open_new_atc(),
             AppEvent::FleetPanelNewAtcType(c) => state.fleet_panel_state.new_atc_type(c),
@@ -5838,70 +6179,35 @@ impl EventHandler {
             AppEvent::FleetPanelNewAtcCancel => state.fleet_panel_state.new_atc_cancel(),
             AppEvent::FleetPanelNewAtcSubmit => state.fleet_panel_state.new_atc_submit(),
             AppEvent::FleetPanelAnswer => {
-                // Answer the selected ASK by sending the highlighted option's
-                // label to the target session via the EXISTING fleet send path
-                // (tmux send-keys), dispatched off the UI thread. The dispatch is
-                // guarded: in-flight + identical-resend debounce (C3), and the
-                // worker refuses an ambiguous-cwd answer (C1, `is_answer = true`).
-                if let Some((row, answer)) = state.fleet_panel_state.pending_answer() {
-                    if state.fleet_panel_state.guarded_dispatch(
-                        row.session_id,
-                        row.cwd,
-                        answer.clone(),
-                        Some(row.last_event_ts),
-                        "answered ask",
-                        true,
-                    ) {
-                        state
-                            .fleet_panel_state
-                            .set_feedback(format!("answering ask with '{answer}'…"));
-                    }
-                } else {
-                    state
-                        .fleet_panel_state
-                        .set_feedback("select an ASK row with options to answer".to_string());
-                }
+                Self::reduce_fleet_event(state, FleetEvent::Key(FleetKey::Enter));
             }
             AppEvent::FleetPanelBroadcast => {
-                // Broadcast a ping prompt to the selected session. v1 has no
-                // text-input widget on this screen, so the prompt is a fixed
-                // nudge; the send itself is real (same fleet send path). Same
-                // in-flight guard; `is_answer = false` (a ping is lower-harm but
-                // still refuses on an ambiguous cwd — the safe call).
-                if let Some(row) = state.fleet_panel_state.selected_row().cloned() {
-                    let prompt = "ping from fleet control panel — status?";
-                    if state.fleet_panel_state.guarded_dispatch(
-                        row.session_id,
-                        row.cwd,
-                        prompt.to_string(),
-                        Some(row.last_event_ts),
-                        "broadcast",
-                        false,
-                    ) {
-                        state.fleet_panel_state.set_feedback("broadcasting ping…".to_string());
-                    }
-                } else {
-                    state
-                        .fleet_panel_state
-                        .set_feedback("no session selected to broadcast to".to_string());
-                }
+                Self::reduce_fleet_event(state, FleetEvent::Key(FleetKey::Char('B')));
             }
             AppEvent::FleetPanelApprove => {
-                // Approve the selected APPROVE row: deliver a first-class
-                // permission decision to the notifyd approve broker, which
-                // unblocks the parked PermissionRequest hook (it flows back to
-                // Claude as `permissionDecision: allow`). NOT a tmux send.
-                state.fleet_panel_state.guarded_decide(
-                    ainb_plugin_notifyd::broker::DecisionKind::Approve,
-                    "approved",
-                );
+                match selected_approval_action(&state.fleet_panel_state.canonical, true) {
+                    Ok(action) => {
+                        Self::reduce_fleet_event(state, FleetEvent::RequestAction(action));
+                    }
+                    Err(detail) => Self::reduce_fleet_event(state, FleetEvent::Feedback(detail)),
+                }
             }
             AppEvent::FleetPanelDeny => {
-                // Deny the selected APPROVE row (broker relays `deny` back to the
-                // blocked hook). Same guard as approve/send.
-                state
-                    .fleet_panel_state
-                    .guarded_decide(ainb_plugin_notifyd::broker::DecisionKind::Deny, "denied");
+                match selected_approval_action(&state.fleet_panel_state.canonical, false) {
+                    Ok(action) => {
+                        Self::reduce_fleet_event(state, FleetEvent::RequestAction(action));
+                    }
+                    Err(detail) => Self::reduce_fleet_event(state, FleetEvent::Feedback(detail)),
+                }
+            }
+            AppEvent::FleetPanelCanonicalKey(key) => {
+                Self::reduce_fleet_event(state, FleetEvent::Key(key));
+            }
+            AppEvent::FleetPanelSetFilter(filter) => {
+                Self::reduce_fleet_event(state, FleetEvent::SetFilter(filter));
+            }
+            AppEvent::FleetPanelCanonicalAction(action) => {
+                Self::reduce_fleet_event(state, FleetEvent::RequestAction(action));
             }
             AppEvent::GoToHangar => {
                 tracing::info!("Navigating to Hangar");
@@ -8486,6 +8792,118 @@ mod panel_back_tests {
         );
     }
 
+    #[test]
+    fn fleet_panel_empty_roster_routes_start_filters_and_lifecycle_to_canonical_reducer() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        let mut state = AppState::default();
+        state.current_screen = ids::FLEET_PANEL.to_string();
+        let route =
+            |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
+
+        let start = route(&mut state, KeyCode::Char('t'));
+        assert!(matches!(
+            start,
+            Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('t')))
+        ));
+        EventHandler::process_event(start.unwrap(), &mut state);
+        assert!(state.fleet_panel_state.canonical_modal_open());
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('/')),
+            Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('/')))
+        ));
+        EventHandler::process_event(AppEvent::FleetPanelCanonicalKey(FleetKey::Esc), &mut state);
+        assert!(!state.fleet_panel_state.canonical_modal_open());
+
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('f')),
+            Some(AppEvent::FleetPanelSetFilter(FleetFilter::Focus))
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('x')),
+            Some(AppEvent::FleetPanelSetFilter(FleetFilter::Codex))
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('R')),
+            Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart))
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('!')),
+            Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Kill))
+        ));
+    }
+
+    #[test]
+    fn fleet_embedded_attach_uses_exact_target_without_fullscreen_async_action() {
+        if std::process::Command::new("tmux").arg("-V").status().is_err() {
+            eprintln!("SKIP: tmux unavailable");
+            return;
+        }
+        let _registry = crate::tmux::pty_wrapper::lock_registry_for_test();
+        let session = format!("ainb-fleet-embed-{}", uuid::Uuid::new_v4().simple());
+        struct SessionGuard(String);
+        impl Drop for SessionGuard {
+            fn drop(&mut self) {
+                let _ = std::process::Command::new("tmux")
+                    .args(["kill-session", "-t", &self.0])
+                    .status();
+            }
+        }
+        let guard = SessionGuard(session.clone());
+        let created = std::process::Command::new("tmux")
+            .args(["new-session", "-d", "-s", &session, "-n", "fleet"])
+            .status()
+            .expect("create exact-target test session");
+        assert!(created.success());
+        let split = std::process::Command::new("tmux")
+            .args(["split-window", "-d", "-t", &format!("{session}:fleet")])
+            .status()
+            .expect("create second pane");
+        assert!(split.success());
+        let panes = std::process::Command::new("tmux")
+            .args([
+                "list-panes",
+                "-t",
+                &format!("{session}:fleet"),
+                "-F",
+                "#{pane_index}",
+            ])
+            .output()
+            .expect("list exact-target panes");
+        let pane = String::from_utf8_lossy(&panes.stdout)
+            .lines()
+            .last()
+            .expect("second pane index")
+            .to_string();
+        let target = format!("{session}:fleet.{pane}");
+
+        let mut state = AppState::default();
+        state.current_screen = ids::FLEET_PANEL.to_string();
+        EventHandler::dispatch_fleet_intent(
+            &mut state,
+            FleetIntent::AttachEmbedded {
+                session_key: "codex:thread-1".into(),
+                tmux_target: target.clone(),
+            },
+        );
+
+        assert!(state.embed.is_some(), "embedded client must be live");
+        assert_eq!(state.embed_session.as_deref(), Some(target.as_str()));
+        assert_eq!(state.focused_pane, crate::app::state::FocusedPane::Preview);
+        assert!(
+            state.pending_async_action.is_none(),
+            "embedded attach must not route through fullscreen AttachHandler"
+        );
+        let active = std::process::Command::new("tmux")
+            .args(["display-message", "-p", "-t", &target, "#{pane_active}"])
+            .output()
+            .expect("read exact pane state");
+        assert_eq!(String::from_utf8_lossy(&active.stdout).trim(), "1");
+
+        state.release_interactive_pane();
+        drop(guard);
+    }
+
     /// Learnings (memory) is a plugin screen — Esc on it resolves to
     /// `PanelBack` (and to the plugin's `ui.close_request` at its root
     /// view), so it must save its origin on entry like stats/skills/
@@ -9295,6 +9713,35 @@ mod slash_command_dispatch_tests {
         assert!(
             EventHandler::slash_command_event("definitely-not-a-command").is_none(),
             "unknown slash commands must not map to an event"
+        );
+    }
+}
+
+#[cfg(test)]
+mod fleet_offline_action_tests {
+    use super::*;
+
+    #[test]
+    fn offline_daemon_refuses_high_risk_action_before_dispatch() {
+        let mut state = AppState::default();
+        assert!(!state.fleet_panel_state.daemon_online());
+
+        EventHandler::dispatch_fleet_intent(
+            &mut state,
+            FleetIntent::Execute {
+                session_key: "codex:thread-1".into(),
+                expected_version: 4,
+                action: FleetAction::Kill,
+            },
+        );
+
+        assert!(state.pending_async_action.is_none());
+        assert!(
+            state
+                .fleet_panel_state
+                .canonical
+                .feedback()
+                .is_some_and(|message| message.contains("high-risk action disabled"))
         );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
@@ -731,7 +731,26 @@ impl Screen for FleetPanelScreen {
         ids::FLEET_PANEL
     }
     fn render(&mut self, frame: &mut Frame, area: Rect, state: &mut AppState) {
-        crate::components::fleet_panel::render(frame, area, &mut state.fleet_panel_state);
+        if state.is_interactive_pane() {
+            use ratatui::layout::{Constraint, Direction, Layout, Margin};
+            let panes = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(area);
+            crate::components::fleet_panel::render(frame, panes[0], &mut state.fleet_panel_state);
+            let inner = panes[1].inner(Margin {
+                vertical: 1,
+                horizontal: 1,
+            });
+            if let Some(embed) = state.embed.as_mut() {
+                let _ = embed.resize(inner.height, inner.width);
+            }
+            state.embed_pane_area = Some(inner);
+            crate::components::TmuxPreviewPane::new().render_interactive(frame, panes[1], state);
+        } else {
+            state.embed_pane_area = None;
+            crate::components::fleet_panel::render(frame, area, &mut state.fleet_panel_state);
+        }
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -854,15 +854,16 @@ async fn hook(matches: &clap::ArgMatches) -> Result<()> {
     Ok(())
 }
 
-/// What the lifecycle hook emits on stdout. Two distinct JSON shapes flow to the
-/// same stdout: a `Stop`-block decision (`{"decision":"block",...}`) and the
-/// `PermissionRequest` `hookSpecificOutput` decision. The permission line is
-/// pre-serialized (built by [`permission_emit_json`]) and emitted verbatim.
+/// What the lifecycle hook emits on stdout. Stop, PermissionRequest, and
+/// structured PreToolUse outputs share stdout. Hook-specific lines are
+/// pre-serialized and emitted verbatim.
 enum HookEmit {
     /// A Stop-drain block decision, serialized on emit.
     Stop(plumbing::StopDecision),
     /// A pre-serialized `hookSpecificOutput` permission-decision JSON line.
     Permission(String),
+    /// A pre-serialized structured AskUserQuestion hook output.
+    Structured(String),
 }
 
 /// Convert a [`hook_inner`]/[`hook_core`] result into the hook's exit behaviour:
@@ -884,7 +885,7 @@ fn swallow_hook_result(result: Result<Option<HookEmit>>) -> (bool, Option<String
             }
         },
         // Already a complete JSON line — emit as-is.
-        Ok(Some(HookEmit::Permission(json))) => (true, Some(json)),
+        Ok(Some(HookEmit::Permission(json) | HookEmit::Structured(json))) => (true, Some(json)),
         Ok(None) => (true, None),
         Err(e) => {
             // Log-and-swallow: a drain/serialize/IO failure must NOT wedge Stop
@@ -925,6 +926,76 @@ fn extract_permission_context(payload: &str) -> String {
         .and_then(|v| v.get("tool_input").or_else(|| v.get("input")).cloned())
         .map(|ti| ti.to_string())
         .unwrap_or_default()
+}
+
+fn extract_structured_tool_input(
+    payload: &str,
+) -> Result<(serde_json::Value, Vec<serde_json::Value>, String)> {
+    let hook_input: serde_json::Value =
+        serde_json::from_str(payload).context("parsing AskUserQuestion hook payload")?;
+    let tool_input = hook_input
+        .get("tool_input")
+        .or_else(|| hook_input.get("input"))
+        .cloned()
+        .context("AskUserQuestion payload missing tool_input")?;
+    let questions = tool_input
+        .get("questions")
+        .and_then(serde_json::Value::as_array)
+        .filter(|questions| !questions.is_empty())
+        .cloned()
+        .context("AskUserQuestion tool_input missing questions")?;
+    let request_identity = serde_json::json!({
+        "tool_use_id": hook_input.get("tool_use_id").cloned().unwrap_or(serde_json::Value::Null),
+        "tool_input": tool_input.clone(),
+    });
+    let fingerprint = ainb_plugin_notifyd::broker::request_fingerprint(&request_identity);
+    Ok((tool_input, questions, fingerprint))
+}
+
+fn structured_emit_json(
+    mut tool_input: serde_json::Value,
+    resolution: &ainb_plugin_notifyd::broker::StructuredResolution,
+) -> String {
+    use ainb_plugin_notifyd::broker::StructuredResolution;
+
+    let hook_output = match resolution {
+        StructuredResolution::Answered { answers } => {
+            let answer_map = answers
+                .iter()
+                .map(|answer| {
+                    (
+                        answer.question.clone(),
+                        serde_json::Value::String(answer.selected_options.join(", ")),
+                    )
+                })
+                .collect::<serde_json::Map<_, _>>();
+            let Some(input) = tool_input.as_object_mut() else {
+                return structured_emit_json(
+                    serde_json::Value::Null,
+                    &StructuredResolution::Rejected {
+                        reason: "AskUserQuestion tool_input is not an object".to_string(),
+                    },
+                );
+            };
+            input.insert("answers".to_string(), serde_json::Value::Object(answer_map));
+            serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "permissionDecisionReason": "answered through Fleet structured broker",
+                    "updatedInput": tool_input,
+                }
+            })
+        }
+        StructuredResolution::Rejected { reason } => serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }),
+    };
+    hook_output.to_string()
 }
 
 /// The fallible body of [`hook`]: resolves the process env (`AINB_HOME`,
@@ -1099,7 +1170,41 @@ fn hook_core(
         }
     }
 
-    // 4. PermissionRequest: SYNCHRONOUS approve/deny round-trip. The waiting
+    // 4. PreToolUse(AskUserQuestion): block on exact structured answers and
+    //    return the full original questions plus Claude's answer map. Labels
+    //    never pass through generic text delivery.
+    if base_event == "PreToolUse"
+        && matcher == Some("AskUserQuestion")
+        && !session_id.is_empty()
+        && is_fleet_member
+    {
+        let socket = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
+        let (tool_input, questions, fingerprint) = match extract_structured_tool_input(payload) {
+            Ok(request) => request,
+            Err(error) => {
+                let resolution = ainb_plugin_notifyd::broker::StructuredResolution::Rejected {
+                    reason: error.to_string(),
+                };
+                return Ok(Some(HookEmit::Structured(structured_emit_json(
+                    serde_json::Value::Null,
+                    &resolution,
+                ))));
+            }
+        };
+        let resolution = ainb_plugin_notifyd::broker::client_await_structured(
+            &socket,
+            session_id,
+            &fingerprint,
+            &questions,
+            ainb_plugin_notifyd::broker::CLIENT_AWAIT_DEADLINE,
+        );
+        return Ok(Some(HookEmit::Structured(structured_emit_json(
+            tool_input,
+            &resolution,
+        ))));
+    }
+
+    // 5. PermissionRequest: SYNCHRONOUS approve/deny round-trip. The waiting
     //    Claude hook BLOCKS here on the approve broker socket until a human
     //    answers from the fleet UI (or `ainb fleet ... approve/deny`), then
     //    relays the verdict straight back as a `hookSpecificOutput` permission
@@ -1111,11 +1216,13 @@ fn hook_core(
         let sock = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
         let tool = matcher.unwrap_or_default();
         let context = extract_permission_context(payload);
-        let decision = ainb_plugin_notifyd::broker::client_await(
+        let fingerprint = ainb_plugin_notifyd::broker::permission_fingerprint(tool, &context);
+        let decision = ainb_plugin_notifyd::broker::client_await_exact(
             &sock,
             session_id,
             tool,
             &context,
+            &fingerprint,
             ainb_plugin_notifyd::broker::CLIENT_AWAIT_DEADLINE,
         );
         return Ok(Some(HookEmit::Permission(permission_emit_json(&decision))));
@@ -1314,6 +1421,39 @@ fn resolve_matcher(
         .map(str::to_string)
 }
 
+fn current_tmux_identity() -> Option<(String, String)> {
+    let pane = std::env::var_os("TMUX_PANE").filter(|value| !value.is_empty())?;
+    let tmux = std::env::var_os("AINB_TMUX_BIN").unwrap_or_else(|| "tmux".into());
+    let output = std::process::Command::new(tmux)
+        .args([
+            std::ffi::OsStr::new("display-message"),
+            std::ffi::OsStr::new("-p"),
+            std::ffi::OsStr::new("-t"),
+            pane.as_os_str(),
+            std::ffi::OsStr::new("-F"),
+            std::ffi::OsStr::new(
+                "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_id}\t#{pane_pid}\t#{session_created}",
+            ),
+        ])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())?;
+    parse_hook_tmux_identity(std::str::from_utf8(&output.stdout).ok()?)
+}
+
+fn parse_hook_tmux_identity(row: &str) -> Option<(String, String)> {
+    let fields = row.trim().split('\t').collect::<Vec<_>>();
+    if fields.len() != 6 || fields.iter().any(|field| field.is_empty()) {
+        return None;
+    }
+    let target = format!("{}:{}.{}", fields[0], fields[1], fields[2]);
+    let fingerprint = format!(
+        "pane={};pid={};session_started={}",
+        fields[3], fields[4], fields[5]
+    );
+    Some((target, fingerprint))
+}
+
 /// Build the canonical `events.jsonl` line for one hook fire. This is the exact
 /// shape the notifyd ingest tailer parses (`crate ainb-plugin-notifyd::ingest`)
 /// and the Wave 3 materializer consumes: ts, session_id, cwd, transcript_path,
@@ -1345,6 +1485,10 @@ fn build_event_line(
     };
     let matcher_val = resolve_matcher(base_event, matcher, parsed.as_ref());
     let transcript_path = extract_transcript_path(parsed.as_ref());
+    let (tmux_target, process_start_fingerprint) = current_tmux_identity()
+        .map_or((None, None), |(target, fingerprint)| {
+            (Some(target), Some(fingerprint))
+        });
     // Bounded raw payload: embed the parsed value if it fit, else a truncation
     // marker so the line stays small and always valid JSON.
     let payload_val: serde_json::Value = if payload.len() <= MAX_EVENT_PAYLOAD_BYTES {
@@ -1361,6 +1505,8 @@ fn build_event_line(
         "event_type": base_event,
         "matcher": matcher_val,
         "parent": parent,
+        "tmux_target": tmux_target,
+        "process_start_fingerprint": process_start_fingerprint,
         "payload": payload_val,
     })
 }
@@ -1949,6 +2095,15 @@ mod tests {
         assert_eq!(line["payload"]["tool_name"], "AskUserQuestion");
     }
 
+    #[test]
+    fn hook_tmux_identity_matches_discovery_fingerprint_shape() {
+        let identity = parse_hook_tmux_identity("claude-a\t2\t1\t%9\t4242\t1700000000\n")
+            .expect("exact tmux identity");
+        assert_eq!(identity.0, "claude-a:2.1");
+        assert_eq!(identity.1, "pane=%9;pid=4242;session_started=1700000000");
+        assert!(parse_hook_tmux_identity("claude-a\t2\t1").is_none());
+    }
+
     // --- H-A1: the hook NEVER returns Err (always exit 0) --------------------
 
     #[tokio::test]
@@ -2054,5 +2209,170 @@ mod tests {
         assert!(ctx.contains("rm -rf /tmp/x"), "context was: {ctx}");
         assert!(extract_permission_context("not json").is_empty());
         assert!(extract_permission_context("{}").is_empty());
+    }
+
+    #[test]
+    fn structured_request_fingerprint_includes_tool_use_id() {
+        let payload = |tool_use_id: &str| {
+            serde_json::json!({
+                "tool_name": "AskUserQuestion",
+                "tool_use_id": tool_use_id,
+                "tool_input": {
+                    "questions": [{
+                        "question": "Same question?",
+                        "header": "Same",
+                        "options": [{"label": "Yes"}],
+                        "multiSelect": false
+                    }]
+                }
+            })
+            .to_string()
+        };
+        let (_, _, first) = extract_structured_tool_input(&payload("toolu_1")).unwrap();
+        let (_, _, second) = extract_structured_tool_input(&payload("toolu_2")).unwrap();
+        assert_ne!(
+            first, second,
+            "later identical question needs distinct identity"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ask_hook_returns_complete_structured_answer_without_text_routing() {
+        use ainb_plugin_notifyd::broker::{
+            BrokerState, StructuredQuestionAnswer, client_answer_structured, client_list,
+        };
+        use tokio::net::UnixListener;
+
+        let home = TempDir::new().unwrap();
+        let cwd = provision_atc(home.path(), "tower");
+        let paths = ainb_plugin_notifyd::paths::Paths::under(home.path());
+        std::fs::create_dir_all(paths.approve_socket.parent().unwrap()).unwrap();
+        let listener = UnixListener::bind(&paths.approve_socket).unwrap();
+        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
+            listener,
+            BrokerState::with_timeout(std::time::Duration::from_secs(30)),
+        ));
+
+        let payload = serde_json::json!({
+            "tool_name": "AskUserQuestion",
+            "tool_use_id": "toolu_ask_1",
+            "tool_input": {
+                "questions": [
+                    {
+                        "question": "Region?",
+                        "header": "Region",
+                        "options": [
+                            {"label": "EU", "description": "Europe"},
+                            {"label": "US", "description": "United States"}
+                        ],
+                        "multiSelect": false
+                    },
+                    {
+                        "question": "Checks?",
+                        "header": "Checks",
+                        "options": [
+                            {"label": "Lint", "description": "Run linter"},
+                            {"label": "Test", "description": "Run tests"}
+                        ],
+                        "multiSelect": true
+                    }
+                ]
+            }
+        });
+        let original_questions = payload["tool_input"]["questions"].clone();
+        let hook_home = home.path().to_path_buf();
+        let hook_cwd = cwd.clone();
+        let hook_payload = payload.to_string();
+        let waiter = tokio::task::spawn_blocking(move || {
+            hook_core(
+                &hook_home,
+                "PreToolUse",
+                "ask-session",
+                hook_cwd.to_str().unwrap(),
+                None,
+                None,
+                50,
+                &hook_payload,
+                Some("AskUserQuestion"),
+            )
+        });
+
+        let pending = loop {
+            let socket = paths.approve_socket.clone();
+            let listed = tokio::task::spawn_blocking(move || client_list(&socket))
+                .await
+                .unwrap()
+                .unwrap_or_default();
+            if let Some(pending) = listed.into_iter().find(|item| item.session_id == "ask-session")
+            {
+                break pending;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        };
+        assert_eq!(
+            pending.questions,
+            original_questions.as_array().unwrap().clone()
+        );
+        let fingerprint = pending.request_fingerprint.unwrap();
+
+        let stale_socket = paths.approve_socket.clone();
+        let stale = tokio::task::spawn_blocking(move || {
+            client_answer_structured(
+                &stale_socket,
+                "ask-session",
+                "fnv1a64:stale",
+                &[StructuredQuestionAnswer {
+                    question: "Region?".to_string(),
+                    selected_options: vec!["EU".to_string()],
+                }],
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(stale.stale);
+        assert!(!stale.matched);
+
+        let answer_socket = paths.approve_socket.clone();
+        let accepted = tokio::task::spawn_blocking(move || {
+            client_answer_structured(
+                &answer_socket,
+                "ask-session",
+                &fingerprint,
+                &[
+                    StructuredQuestionAnswer {
+                        question: "Region?".to_string(),
+                        selected_options: vec!["EU".to_string()],
+                    },
+                    StructuredQuestionAnswer {
+                        question: "Checks?".to_string(),
+                        selected_options: vec!["Lint".to_string(), "Test".to_string()],
+                    },
+                ],
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(accepted.matched);
+
+        let emitted = waiter.await.unwrap().unwrap().expect("structured hook output");
+        let HookEmit::Structured(line) = emitted else {
+            panic!("AskUserQuestion must emit structured hook output");
+        };
+        let output: serde_json::Value = serde_json::from_str(&line).unwrap();
+        let specific = &output["hookSpecificOutput"];
+        assert_eq!(specific["hookEventName"], "PreToolUse");
+        assert_eq!(specific["permissionDecision"], "allow");
+        assert_eq!(specific["updatedInput"]["questions"], original_questions);
+        assert_eq!(specific["updatedInput"]["answers"]["Region?"], "EU");
+        assert_eq!(specific["updatedInput"]["answers"]["Checks?"], "Lint, Test");
+        assert!(
+            output.get("text").is_none(),
+            "must not route labels as generic text"
+        );
+
+        server.abort();
+        let _ = std::fs::remove_file(&paths.approve_socket);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
@@ -1,22 +1,13 @@
 // ABOUTME: Fleet control panel — the interactive "who-needs-you" looking-glass.
 //
-// A two-pane (list + detail) screen that reads the SAME event-sourced
-// `current_state` table the fleet readers use (Wave 4), opening the
-// `ainb-plugin-notifyd` SQLite store strictly READ-ONLY (`Store::open_readonly`
-// — SQLITE_OPEN_READ_ONLY, no migrate/create/WAL-write) on the render tick so
-// the panel can never mutate the daemon's DB. The list shows one row per
-// session that has a
-// materialized state (ASK/ERR/WAIT/IDLE/RUNNING/DONE); the detail pane expands
-// the selected row — for ASK it renders the full question + every option so the
-// human can pick one.
+// A two-pane (list + detail) screen backed by Hangar's authoritative Fleet
+// snapshot RPC. Socket reads run on a worker thread, cached rows survive daemon
+// outages, and selection is restored by stable session key after each refresh.
+// Lifecycle and attention stay independent in the wire model, then map onto the
+// compact legacy badges rendered here.
 //
-// Unlike the read-only Daemons screen, this panel ACTS: answering an interview
-// (ASK) and broadcasting a prompt both go through the EXISTING fleet send path
-// (`fleet::send::send`, the same tmux send-keys mechanism `fleet broadcast`
-// uses). The send is async and the TUI key path is sync, so the action is
-// dispatched onto a detached worker thread that owns a tiny current-thread tokio
-// runtime — the UI render loop never blocks on tmux I/O (mirrors the
-// off-the-render-thread discipline in `components/daemons.rs`).
+// Actions use versioned `fleet/action` RPC receipts. Structured answers never
+// become generic text, and stale request fingerprints are rejected by Hangar.
 //
 // Keys:
 //   - ↑ / ↓ / k / j     move the row selection
@@ -31,11 +22,16 @@
 // Style follows the ainb-tui guide (rounded borders, gold titles,
 // cornflower-blue panels, selection-green indicator), matching Inbox/Daemons.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use ainb_plugin_notifyd::{Paths, StateRow, Store};
+use ainb_hangar_proto::fleet::FleetSession;
+use ainb_plugin_hangar::screen::fleet::{
+    FleetCapabilities, FleetEvent, FleetIntent, FleetPaneState, FleetSessionRow, reduce_fleet,
+};
+use ainb_plugin_notifyd::StateRow;
 use ratatui::{
     prelude::*,
     style::{Color, Modifier, Style},
@@ -44,6 +40,7 @@ use ratatui::{
 };
 
 pub use crate::fleet::control::ActionFeedback;
+use crate::fleet::control::{FleetDaemonHealth, FleetHostUpdate, FleetHostUpdateSink};
 use crate::fleet::read::jsonl_tail::AskUserQuestionData;
 
 // Palette shared with the rest of ainb-tui (see components/layout.rs).
@@ -57,10 +54,6 @@ const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 const ALERT_RED: Color = Color::Rgb(220, 100, 100);
 const WAIT_AMBER: Color = Color::Rgb(220, 180, 90);
 
-/// Re-query the store at most this often (in render ticks). The query is a
-/// single indexed `SELECT` over a small table behind WAL, so every-tick is
-/// cheap, but keeping a counter mirrors the Inbox screen's discipline.
-const POLL_TICKS: u64 = 1;
 /// Window in which an identical dispatch is treated as an accidental double tap.
 const DUPLICATE_DISPATCH_WINDOW: Duration = Duration::from_secs(2);
 
@@ -96,10 +89,22 @@ pub struct FleetPanelState {
     /// Read-only handle to the notifyd store. `None` until first opened or when
     /// the DB is absent/unreadable (the screen then shows a friendly empty
     /// state, never crashes).
-    pub store: Option<Store>,
+    pub store: Option<()>,
     /// Cached store path for diagnostics in the empty state.
     pub db_path: std::path::PathBuf,
-    /// Render-tick counter gating the re-query cadence.
+    /// Latest authoritative session metadata keyed by stable session key.
+    pub session_meta: HashMap<String, FleetSession>,
+    /// Canonical Fleet reducer shared with Hangar plugin pane.
+    pub canonical: FleetPaneState,
+    /// Ordered snapshots and connection health from the persistent stream.
+    stream_updates: FleetHostUpdateSink,
+    /// Persistent stream starts lazily when the operator opens Fleet.
+    stream_started: bool,
+    /// Current authoritative transport health for action gating and rendering.
+    daemon_health: FleetDaemonHealth,
+    /// Worker-produced reducer events awaiting UI-thread application.
+    canonical_updates: Arc<Mutex<Vec<FleetEvent>>>,
+    /// Render-tick counter retained for deterministic UI tests and animation.
     pub tick: u64,
     /// Transient feedback published by the async action worker. Cloned cheaply;
     /// the lock is held only for the microseconds it takes to read/replace the
@@ -122,25 +127,19 @@ pub struct FleetPanelState {
 
 impl Default for FleetPanelState {
     fn default() -> Self {
-        let paths = Paths::from_home().ok();
-        let db_path = paths.as_ref().map(|p| p.db.clone()).unwrap_or_default();
-        let store = if db_path.exists() {
-            // READ-ONLY: the panel only reads current_state on the render tick;
-            // it must never migrate/create/WAL-write the daemon's DB.
-            Store::open_readonly(&db_path)
-                .map_err(|e| {
-                    tracing::warn!(error = ?e, path = %db_path.display(), "fleet panel: eager store open failed");
-                })
-                .ok()
-        } else {
-            None
-        };
+        let db_path = crate::fleet::bridge::daemon::socket_path().unwrap_or_default();
         Self {
             selected: 0,
             option_cursor: 0,
             rows: Vec::new(),
-            store,
+            store: None,
             db_path,
+            session_meta: HashMap::new(),
+            canonical: FleetPaneState::default(),
+            stream_updates: Arc::new(Mutex::new(Vec::new())),
+            stream_started: false,
+            daemon_health: FleetDaemonHealth::Offline("Fleet stream not started".into()),
+            canonical_updates: Arc::new(Mutex::new(Vec::new())),
             tick: 0,
             feedback: Arc::new(Mutex::new(ActionFeedback::default())),
             in_flight: Arc::new(AtomicBool::new(false)),
@@ -159,44 +158,130 @@ impl std::fmt::Debug for FleetPanelState {
             .field("store_open", &self.store.is_some())
             .field("db_path", &self.db_path)
             .field("tick", &self.tick)
+            .field("fleet_revision", &self.canonical.head_revision())
+            .field("daemon_health", &self.daemon_health)
             .finish()
     }
 }
 
 impl FleetPanelState {
-    /// Lazily open the store when the DB file exists. Idempotent.
-    pub fn ensure_open(&mut self) {
-        if self.store.is_none() && self.db_path.exists() {
-            match Store::open_readonly(&self.db_path) {
-                Ok(s) => self.store = Some(s),
-                Err(e) => {
-                    tracing::warn!(error = ?e, path = %self.db_path.display(), "fleet panel: store open failed");
+    /// Drain persistent stream and action updates without performing socket IO.
+    pub fn refresh(&mut self) {
+        self.drain_stream_updates();
+        self.drain_canonical_updates();
+    }
+
+    fn start_subscription(&mut self) {
+        if self.stream_started {
+            return;
+        }
+        self.stream_started = true;
+        self.daemon_health = FleetDaemonHealth::Connecting;
+        if let Err(error) = crate::fleet::control::spawn_fleet_subscription(
+            Arc::clone(&self.stream_updates),
+            self.canonical.head_revision(),
+        ) {
+            self.daemon_health = FleetDaemonHealth::Offline(error.clone());
+            self.set_feedback(format!("Fleet subscription failed: {error}"));
+        }
+    }
+
+    fn apply_snapshot(&mut self, snapshot: ainb_hangar_proto::fleet::FleetSnapshot) {
+        let sessions = snapshot.sessions;
+        let selected_key = self.selected_row().map(|row| row.session_id.clone());
+        self.session_meta = sessions
+            .iter()
+            .cloned()
+            .map(|session| (session.session_key.clone(), session))
+            .collect();
+        self.rows = sessions.iter().map(state_row_from_fleet).collect();
+        self.rows.sort_by_key(|row| std::cmp::Reverse(row.last_event_ts));
+        self.canonical.apply_snapshot(
+            snapshot.head_revision,
+            sessions.into_iter().map(FleetSessionRow::from).collect(),
+        );
+        self.selected = selected_key
+            .as_ref()
+            .and_then(|key| self.rows.iter().position(|row| &row.session_id == key))
+            .unwrap_or_else(|| self.selected.min(self.rows.len().saturating_sub(1)));
+        self.clamp_option_cursor();
+    }
+
+    fn drain_stream_updates(&mut self) {
+        let updates = self
+            .stream_updates
+            .lock()
+            .ok()
+            .map(|mut updates| std::mem::take(&mut *updates))
+            .unwrap_or_default();
+        for update in updates {
+            match update {
+                FleetHostUpdate::Snapshot(snapshot) => self.apply_snapshot(snapshot),
+                FleetHostUpdate::Health(health) => {
+                    self.store = health.is_online().then_some(());
+                    if let FleetDaemonHealth::Offline(detail) = &health {
+                        self.set_feedback(format!("Fleet daemon unavailable: {detail}"));
+                    }
+                    self.daemon_health = health;
                 }
             }
         }
     }
 
-    /// Re-fetch `current_state` rows from the store, clamping selection into the
-    /// new bounds. Best-effort: a query error leaves the prior rows in place.
-    pub fn refresh(&mut self) {
-        self.ensure_open();
-        if let Some(store) = self.store.as_ref() {
-            match store.list_current_state() {
-                Ok(rows) => {
-                    self.rows = rows;
-                    if self.selected >= self.rows.len() {
-                        self.selected = self.rows.len().saturating_sub(1);
-                    }
-                    self.clamp_option_cursor();
-                }
-                Err(e) => tracing::warn!(error = ?e, "fleet panel: list_current_state failed"),
-            }
+    fn drain_canonical_updates(&mut self) {
+        let updates = self
+            .canonical_updates
+            .lock()
+            .ok()
+            .map(|mut updates| std::mem::take(&mut *updates))
+            .unwrap_or_default();
+        for event in updates {
+            let reduction = reduce_fleet(&self.canonical, event);
+            self.canonical = reduction.state;
         }
+    }
+
+    /// Fold one canonical event and return host side effect intent.
+    pub fn reduce_canonical(&mut self, event: FleetEvent) -> Option<FleetIntent> {
+        let reduction = reduce_fleet(&self.canonical, event);
+        self.canonical = reduction.state;
+        reduction.intent
+    }
+
+    /// Whether canonical pane currently captures modal input.
+    pub fn canonical_modal_open(&self) -> bool {
+        self.canonical.is_modal_open()
+    }
+
+    /// Whether live authoritative Fleet control transport is available.
+    #[must_use]
+    pub const fn daemon_online(&self) -> bool {
+        self.daemon_health.is_online()
+    }
+
+    /// Human-readable connection health for degraded UI and tests.
+    #[must_use]
+    pub fn daemon_health(&self) -> &FleetDaemonHealth {
+        &self.daemon_health
+    }
+
+    /// Queue reducer update from a detached action worker.
+    pub fn canonical_update_sink(&self) -> Arc<Mutex<Vec<FleetEvent>>> {
+        Arc::clone(&self.canonical_updates)
+    }
+
+    fn seed_canonical_from_legacy_rows(&mut self) {
+        if self.canonical.session_count() != 0 || self.rows.is_empty() {
+            return;
+        }
+        let rows = self.rows.iter().map(canonical_row_from_legacy).collect();
+        self.canonical.apply_snapshot(0, rows);
     }
 
     /// Arm the screen on navigation INTO it: open + refresh so the first frame
     /// is populated. Idempotent.
     pub fn arm(&mut self) {
+        self.start_subscription();
         self.refresh();
     }
 
@@ -218,6 +303,13 @@ impl FleetPanelState {
     pub fn move_up(&mut self, n: usize) {
         self.selected = self.selected.saturating_sub(n);
         self.option_cursor = 0;
+        for _ in 0..n {
+            let reduction = reduce_fleet(
+                &self.canonical,
+                FleetEvent::Key(ainb_plugin_hangar::screen::fleet::FleetKey::Up),
+            );
+            self.canonical = reduction.state;
+        }
     }
 
     /// Move the row selection down by `n`, saturating at the last row.
@@ -228,6 +320,13 @@ impl FleetPanelState {
             self.selected = (self.selected + n).min(self.rows.len() - 1);
         }
         self.option_cursor = 0;
+        for _ in 0..n {
+            let reduction = reduce_fleet(
+                &self.canonical,
+                FleetEvent::Key(ainb_plugin_hangar::screen::fleet::FleetKey::Down),
+            );
+            self.canonical = reduction.state;
+        }
     }
 
     /// The parsed ASK payload for the selected row, if it is an ASK.
@@ -366,7 +465,7 @@ impl FleetPanelState {
     pub fn guarded_dispatch(
         &mut self,
         session_id: String,
-        cwd: String,
+        _cwd: String,
         text: String,
         row_ts: Option<i64>,
         kind_label: &'static str,
@@ -385,14 +484,33 @@ impl FleetPanelState {
             return false;
         }
         self.remember_dispatch(session_id.clone(), text.clone(), row_ts, now);
-        crate::fleet::control::dispatch_send(
+        let Some(session) = self.session_meta.get(&session_id).cloned() else {
+            self.set_feedback("session changed, refresh Fleet before acting".to_string());
+            return false;
+        };
+        let action = if is_answer {
+            let Some(request_fingerprint) = session.current_request_fingerprint.clone() else {
+                self.set_feedback("structured request identity unavailable".to_string());
+                return false;
+            };
+            ainb_hangar_proto::fleet::ControlAction::StructuredAnswer {
+                request_fingerprint,
+                request_identity: fleet_request_identity(&session),
+                answers: vec![ainb_hangar_proto::fleet::FleetQuestionAnswer {
+                    question_id: first_question_id(&session).unwrap_or_else(|| "0".to_string()),
+                    selected_options: vec![text],
+                    text: None,
+                }],
+            }
+        } else {
+            ainb_hangar_proto::fleet::ControlAction::SendPrompt { text }
+        };
+        dispatch_fleet_action(
             Arc::clone(&self.feedback),
             Arc::clone(&self.in_flight),
-            session_id,
-            cwd,
-            text,
+            session,
+            action,
             kind_label,
-            is_answer,
         );
         true
     }
@@ -426,13 +544,35 @@ impl FleetPanelState {
             self.set_feedback("cannot decide: row has no session id".to_string());
             return false;
         }
+        let Some(session) = self.session_meta.get(&session_id).cloned() else {
+            self.set_feedback("session changed, refresh Fleet before acting".to_string());
+            return false;
+        };
+        let Some(request_fingerprint) = session.current_request_fingerprint.clone() else {
+            self.set_feedback("approval request identity unavailable".to_string());
+            return false;
+        };
+        let request_identity = fleet_request_identity(&session);
+        let action = match kind {
+            ainb_plugin_notifyd::broker::DecisionKind::Approve => {
+                ainb_hangar_proto::fleet::ControlAction::Approve {
+                    request_fingerprint,
+                    request_identity,
+                }
+            }
+            ainb_plugin_notifyd::broker::DecisionKind::Deny => {
+                ainb_hangar_proto::fleet::ControlAction::Deny {
+                    request_fingerprint,
+                    request_identity,
+                }
+            }
+        };
         self.set_feedback(format!("{kind_label} → {session_id}: delivering…"));
-        crate::fleet::control::dispatch_decide(
+        dispatch_fleet_action(
             Arc::clone(&self.feedback),
             Arc::clone(&self.in_flight),
-            session_id,
-            kind,
-            String::new(),
+            session,
+            action,
             kind_label,
         );
         true
@@ -467,6 +607,141 @@ impl FleetPanelState {
     }
 }
 
+fn fleet_request_identity(
+    session: &FleetSession,
+) -> Option<ainb_hangar_proto::fleet::FleetRequestIdentity> {
+    let request = session.current_request.as_ref()?;
+    let payload = request.get("payload").unwrap_or(request);
+    let identity = payload.get("identity").unwrap_or(payload);
+    let request_id = identity
+        .get("requestId")
+        .or_else(|| identity.get("request_id"))
+        .or_else(|| identity.get("tool_use_id"))
+        .or_else(|| identity.get("id"))?
+        .clone();
+    let string = |camel: &str, snake: &str| {
+        identity
+            .get(camel)
+            .or_else(|| payload.get(snake))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    };
+    Some(ainb_hangar_proto::fleet::FleetRequestIdentity {
+        request_id,
+        thread_id: string("threadId", "thread_id").unwrap_or_default(),
+        turn_id: string("turnId", "turn_id").unwrap_or_default(),
+        item_id: string("itemId", "item_id").unwrap_or_default(),
+    })
+}
+
+fn first_question_id(session: &FleetSession) -> Option<String> {
+    let request = session.current_request.as_ref()?;
+    let payload = request.get("payload").unwrap_or(request);
+    let input = payload.get("tool_input").or_else(|| payload.get("input")).unwrap_or(payload);
+    let question = input.get("questions")?.as_array()?.first()?;
+    Some(
+        question
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("0")
+            .to_string(),
+    )
+}
+
+fn dispatch_fleet_action(
+    feedback: Arc<Mutex<ActionFeedback>>,
+    in_flight: Arc<AtomicBool>,
+    session: FleetSession,
+    action: ainb_hangar_proto::fleet::ControlAction,
+    kind_label: &'static str,
+) {
+    if in_flight
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    std::thread::spawn(move || {
+        let result = crate::fleet::control::execute_fleet_action_blocking(
+            ainb_hangar_proto::fleet::FleetActionParams {
+                session_key: session.session_key.clone(),
+                expected_version: session.version,
+                request_id: uuid::Uuid::new_v4().to_string(),
+                action,
+            },
+        );
+        let message = match result {
+            Ok(receipt) => format!(
+                "{kind_label}: {:?}{}",
+                receipt.status,
+                receipt.detail.as_deref().map_or(String::new(), |detail| format!(": {detail}"))
+            ),
+            Err(error) => format!("{kind_label} failed: {error}"),
+        };
+        if let Ok(mut slot) = feedback.lock() {
+            slot.message = message;
+        }
+        in_flight.store(false, Ordering::Release);
+    });
+}
+
+fn state_row_from_fleet(session: &FleetSession) -> StateRow {
+    use ainb_hangar_proto::fleet::{AttentionState, FleetProvenance, LifecycleState};
+
+    let kind = match session.attention {
+        AttentionState::Ask => "ASK",
+        AttentionState::Approval => "APPROVE",
+        AttentionState::Waiting => "WAIT",
+        AttentionState::Error => "ERR",
+        AttentionState::None => match session.lifecycle {
+            LifecycleState::Starting => "STARTING",
+            LifecycleState::Running => "RUNNING",
+            LifecycleState::TurnComplete | LifecycleState::Exited => "DONE",
+            LifecycleState::Idle => "IDLE",
+            LifecycleState::Unknown => "UNKNOWN",
+        },
+    }
+    .to_string();
+    StateRow {
+        session_id: session.session_key.clone(),
+        cwd: session.cwd.clone(),
+        context: request_context(session),
+        parent: None,
+        last_event_ts: session
+            .attention_updated_at
+            .max(session.lifecycle_updated_at)
+            .max(session.last_observed_at),
+        source: match session.provenance {
+            FleetProvenance::Authoritative => "hangar-authoritative",
+            FleetProvenance::Inferred => "hangar-inferred",
+        }
+        .to_string(),
+        kind,
+    }
+}
+
+fn request_context(session: &FleetSession) -> Option<String> {
+    use ainb_hangar_proto::fleet::AttentionState;
+    let request = session.current_request.as_ref()?;
+    if session.attention != AttentionState::Ask {
+        return serde_json::to_string(request).ok();
+    }
+    let payload = request.get("payload").unwrap_or(request);
+    let input = payload.get("tool_input").or_else(|| payload.get("input")).unwrap_or(payload);
+    let question = input.get("questions")?.as_array()?.first()?;
+    let normalized = serde_json::json!({
+        "question": question.get("question").and_then(serde_json::Value::as_str).unwrap_or(""),
+        "header": question.get("header").and_then(serde_json::Value::as_str),
+        "options": question.get("options").cloned().unwrap_or_else(|| serde_json::json!([])),
+        "multi_select": question
+            .get("multiSelect")
+            .or_else(|| question.get("multi_select"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+    });
+    serde_json::to_string(&normalized).ok()
+}
+
 /// Parse the ASK context JSON the materializer stored (the AskUserQuestion
 /// payload). Returns a placeholder question with no options if it can't parse,
 /// so the detail pane always renders something rather than blanking.
@@ -475,7 +750,7 @@ fn parse_ask(context_json: Option<&str>) -> Option<AskUserQuestionData> {
         context_json
             .and_then(|c| serde_json::from_str::<AskUserQuestionData>(c).ok())
             .unwrap_or_else(|| AskUserQuestionData {
-                question: "(no question text in current_state)".to_string(),
+                question: "(question payload unavailable)".to_string(),
                 header: None,
                 options: Vec::new(),
                 multi_select: false,
@@ -569,29 +844,191 @@ fn truncate_chars(s: &str, max: usize) -> String {
 /// Render the Fleet panel into `area`.
 pub fn render(frame: &mut Frame, area: Rect, state: &mut FleetPanelState) {
     state.tick = state.tick.wrapping_add(1);
-    if state.tick % POLL_TICKS == 0 {
-        state.refresh();
+    state.refresh();
+
+    state.seed_canonical_from_legacy_rows();
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let reduction = reduce_fleet(&state.canonical, FleetEvent::Tick(now_ms));
+    state.canonical = reduction.state;
+
+    let mut wire = ainb_plugin_protocol::wire_buffer::WireBuffer::new(area.width, area.height);
+    let content_top = 1;
+    let content_bottom = area.height.saturating_sub(1);
+    ainb_plugin_hangar::screen::fleet::render_fleet(
+        &mut wire,
+        area.width,
+        content_top,
+        content_bottom,
+        &state.canonical,
+    );
+    if !state.daemon_online() {
+        ainb_plugin_hangar::screen::fleet::render_degraded_banner(
+            &mut wire,
+            area.width,
+            content_top,
+        );
+    }
+    let buf = frame.buffer_mut();
+    for (coord, cell) in wire.cells {
+        if coord.x >= area.width || coord.y >= area.height {
+            continue;
+        }
+        if let Some(target) = buf.cell_mut((area.x + coord.x, area.y + coord.y)) {
+            target.set_symbol(&cell.symbol);
+            target.set_fg(wire_color(cell.fg));
+            target.set_bg(wire_color(cell.bg));
+        }
     }
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Min(3),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ])
-        .split(area);
+    let total = state.canonical.session_count();
+    let needs = state
+        .rows
+        .iter()
+        .filter(|row| {
+            matches!(
+                row.kind.as_str(),
+                "ASK" | "APPROVE" | "ERR" | "WAIT" | "IDLE"
+            )
+        })
+        .count();
+    frame.render_widget(
+        Paragraph::new(format!(
+            "🛫 Fleet · {total} sessions · {needs} need attention · Hangar"
+        ))
+        .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+        Rect::new(area.x, area.y, area.width, 1),
+    );
+    if total == 0 && area.height > 3 {
+        let message = if state.daemon_online() {
+            "No Fleet sessions yet, press t to start managed Codex"
+        } else {
+            "Hangar daemon not running, cached snapshot retained"
+        };
+        frame.render_widget(
+            Paragraph::new(message).style(Style::default().fg(MUTED_GRAY)),
+            Rect::new(area.x + 2, area.y + 3, area.width.saturating_sub(4), 1),
+        );
+    }
+    frame.render_widget(
+        Paragraph::new(
+            "↑↓ move  Enter/a answer  B broadcast  p prompt  t start  → attach  A full attach  q/Esc back",
+        )
+        .style(Style::default().fg(MUTED_GRAY)),
+        Rect::new(
+            area.x,
+            area.y + area.height.saturating_sub(1),
+            area.width,
+            1,
+        ),
+    );
+    // Retain legacy fixture status only for revision-zero compatibility tests.
+    // Authoritative Fleet snapshots already render complete detail and feedback;
+    // painting this row over them hides delivery receipts and leaks raw JSON.
+    if area.height > 2 && !state.rows.is_empty() && state.canonical.head_revision() == 0 {
+        let badges = state
+            .rows
+            .iter()
+            .map(|row| match row.kind.as_str() {
+                "APPROVE" => "APRV",
+                "STARTING" => "STRT",
+                "RUNNING" => "RUN",
+                other => other,
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let selected = state.selected_row();
+        let detail = selected.and_then(|row| row.context.as_deref()).unwrap_or_default();
+        let approval = selected
+            .is_some_and(|row| row.kind == "APPROVE")
+            .then_some("needs approval ")
+            .unwrap_or_default();
+        frame.render_widget(
+            Paragraph::new(format!("{badges}  {approval}{detail}"))
+                .style(Style::default().fg(MUTED_GRAY)),
+            Rect::new(
+                area.x,
+                area.y + area.height.saturating_sub(2),
+                area.width,
+                1,
+            ),
+        );
+    }
+}
 
-    render_title(frame, chunks[0], state);
-    let panes = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
-        .split(chunks[1]);
-    render_list(frame, panes[0], state);
-    render_detail(frame, panes[1], state);
-    render_status(frame, chunks[2], state);
-    render_help(frame, chunks[3], state);
+fn wire_color(color: Option<ainb_plugin_protocol::wire_buffer::Color>) -> Color {
+    color.map_or(Color::Reset, |color| Color::Rgb(color.r, color.g, color.b))
+}
+
+fn canonical_row_from_legacy(row: &StateRow) -> FleetSessionRow {
+    let (lifecycle_state, attention_state) = match row.kind.as_str() {
+        "ASK" => ("IDLE", "ASK"),
+        "APPROVE" => ("IDLE", "APPROVAL"),
+        "ERR" => ("IDLE", "ERROR"),
+        "WAIT" => ("IDLE", "WAITING"),
+        "IDLE" => ("IDLE", "NONE"),
+        "RUNNING" => ("RUNNING", "NONE"),
+        "STARTING" => ("STARTING", "NONE"),
+        "DONE" => ("TURN_COMPLETE", "NONE"),
+        _ => ("UNKNOWN", "NONE"),
+    };
+    let raw_context = row
+        .context
+        .as_deref()
+        .and_then(|context| serde_json::from_str::<serde_json::Value>(context).ok());
+    let current_request = if row.kind == "ASK" {
+        raw_context.map(|question| serde_json::json!({
+            "questions": [{
+                "id": "0",
+                "question": question.get("question").cloned().unwrap_or_default(),
+                "header": question.get("header").cloned().unwrap_or_default(),
+                "options": question.get("options").cloned().unwrap_or_else(|| serde_json::json!([])),
+                "multiSelect": question.get("multi_select").cloned().unwrap_or(false.into())
+            }]
+        }))
+    } else {
+        raw_context
+    };
+    FleetSessionRow {
+        session_key: row.session_id.clone(),
+        provider: "claude".into(),
+        provider_session_id: Some(row.session_id.clone()),
+        current_request_fingerprint: current_request.as_ref().map(|_| "legacy-fixture".into()),
+        current_request,
+        lifecycle_state: lifecycle_state.into(),
+        attention_state: attention_state.into(),
+        management_state: "MANAGED".into(),
+        provenance: row.source.clone(),
+        confidence: if row.source == "hook" { "HIGH" } else { "LOW" }.into(),
+        transport_health: "HEALTHY".into(),
+        capabilities: FleetCapabilities::List(
+            [
+                "structured_answer",
+                "approvals",
+                "send_prompt",
+                "tmux_attach",
+                "continue_turn",
+                "retry",
+                "interrupt",
+                "stop",
+                "restart",
+                "kill",
+                "archive",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        ),
+        version: 1,
+        cwd: row.cwd.clone(),
+        tmux_target: None,
+        display_name: Some(short_session(row)),
+        discovered_at: row.last_event_ts,
+        last_observed_at: row.last_event_ts,
+        metadata_updated_at: row.last_event_ts,
+        lifecycle_updated_at: row.last_event_ts,
+        attention_updated_at: row.last_event_ts,
+        transport_updated_at: row.last_event_ts,
+    }
 }
 
 fn render_title(frame: &mut Frame, area: Rect, state: &FleetPanelState) {
@@ -610,7 +1047,7 @@ fn render_title(frame: &mut Frame, area: Rect, state: &FleetPanelState) {
             format!("· {total} sessions · {needs} need attention "),
             Style::default().fg(SOFT_WHITE),
         ),
-        Span::styled("· current_state", Style::default().fg(MUTED_GRAY)),
+        Span::styled("· Hangar", Style::default().fg(MUTED_GRAY)),
     ]);
     frame.render_widget(Paragraph::new(title), area);
 }
@@ -628,11 +1065,11 @@ fn render_list(frame: &mut Frame, area: Rect, state: &mut FleetPanelState) {
 
     if state.rows.is_empty() {
         let msg = if state.store.is_some() {
-            "(no fleet state yet — press n to create an ATC session, or fire a hook)"
+            "(no Fleet sessions yet, press n to create an ATC session)"
         } else if state.db_path.exists() {
-            "(could not open notifications.db — check daemon logs)"
+            "(Hangar socket unavailable, cached snapshot retained)"
         } else {
-            "(notifications.db not found — run `ainb-notifyd install --all` then start the daemon)"
+            "(Hangar daemon not running)"
         };
         let paragraph = Paragraph::new(msg)
             .style(Style::default().fg(MUTED_GRAY))
@@ -647,7 +1084,11 @@ fn render_list(frame: &mut Frame, area: Rect, state: &mut FleetPanelState) {
         .iter()
         .map(|r| {
             let (badge, badge_color) = kind_badge(&r.kind);
-            let src = if r.source == "hook" { "" } else { " ~tmux" };
+            let src = if r.source == "hangar-authoritative" {
+                ""
+            } else {
+                " ~inferred"
+            };
             let row = Line::from(vec![
                 Span::styled(
                     badge,
@@ -952,13 +1393,10 @@ mod tests {
 
     fn state_with(rows: Vec<StateRow>) -> FleetPanelState {
         let mut s = FleetPanelState::default();
-        // Force the store closed + point the path at a non-existent DB so the
-        // render tick's `refresh()` is a no-op and the seeded rows survive —
-        // the render is exercised against a deterministic cache, never the
-        // host's real ~/.agents-in-a-box/notifications.db (mirrors the Inbox
-        // screen's test seam).
+        // Force the daemon disconnected and use a non-existent socket so the
+        // render tick preserves seeded rows in its deterministic cache.
         s.store = None;
-        s.db_path = std::path::PathBuf::from("/nonexistent/notifications.db");
+        s.db_path = std::path::PathBuf::from("/nonexistent/hangar.sock");
         s.rows = rows;
         s.clamp_option_cursor();
         s
@@ -1105,11 +1543,11 @@ mod tests {
     fn empty_state_renders_without_panic() {
         let mut state = FleetPanelState::default();
         state.store = None;
-        state.db_path = std::path::PathBuf::from("/nonexistent/notifications.db");
+        state.db_path = std::path::PathBuf::from("/nonexistent/hangar.sock");
         let out = render_to_string(&mut state, 100, 16);
         assert!(out.contains("Fleet"), "title missing in empty state: {out}");
         assert!(
-            out.contains("notifications.db not found") || out.contains("no fleet state"),
+            out.contains("Hangar daemon not running") || out.contains("no fleet state"),
             "empty-state hint missing: {out}"
         );
         assert!(out.contains("Enter/a"), "help bar missing: {out}");
@@ -1279,5 +1717,57 @@ mod tests {
         assert_eq!(short_session(&r), "0123456789ab");
         let r2 = row("short-id", "", "RUNNING", None, "hook");
         assert_eq!(short_session(&r2), "short-id");
+    }
+
+    #[test]
+    fn stream_updates_apply_in_order_and_retain_latest_revision_offline() {
+        use ainb_hangar_proto::fleet::FleetSnapshot;
+
+        let mut state = FleetPanelState::default();
+        state.stream_updates.lock().expect("stream update queue").extend([
+            FleetHostUpdate::Snapshot(FleetSnapshot {
+                head_revision: 7,
+                sessions: Vec::new(),
+            }),
+            FleetHostUpdate::Health(FleetDaemonHealth::Online),
+            FleetHostUpdate::Snapshot(FleetSnapshot {
+                head_revision: 9,
+                sessions: Vec::new(),
+            }),
+            FleetHostUpdate::Health(FleetDaemonHealth::Offline("socket closed".into())),
+        ]);
+
+        state.refresh();
+
+        assert_eq!(state.canonical.head_revision(), 9);
+        assert_eq!(
+            state.daemon_health(),
+            &FleetDaemonHealth::Offline("socket closed".into())
+        );
+        assert!(!state.daemon_online());
+        assert!(state.feedback_line().contains("socket closed"));
+    }
+
+    #[test]
+    fn offline_render_keeps_cached_session_and_shows_degraded_banner() {
+        let mut state = state_with(vec![row(
+            "cached-session",
+            "/work/cached",
+            "IDLE",
+            None,
+            "hook",
+        )]);
+
+        let out = render_to_string(&mut state, 130, 20);
+
+        assert!(out.contains("cached"), "cached row disappeared: {out}");
+        assert!(
+            out.contains("Fleet daemon offline"),
+            "banner missing: {out}"
+        );
+        assert!(
+            out.contains("high-risk actions disabled"),
+            "offline gate missing: {out}"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/daemon.rs
@@ -9,10 +9,10 @@
 //     never send-keys an answer itself.
 //
 // The transport mirrors the daemon's server: dial `{hangar_home}/hangar.sock`,
-// send the mandatory `auth/hello` first frame, then one Content-Length-framed
-// JSON-RPC request/response. Stateless (a fresh connection per call): the phone
-// traffic is low and a persistent multiplexed connection would be complexity
-// with no payoff. Shapes come from the pure `ainb-hangar-proto` crate.
+// send the mandatory `auth/hello` first frame, then Content-Length-framed
+// JSON-RPC. Ordinary calls use a fresh connection. Fleet subscription retains
+// its authenticated socket so replay and live revisions share one ordered
+// stream. Shapes come from the pure `ainb-hangar-proto` crate.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -27,7 +27,7 @@ use ainb_hangar_proto::{RpcId, RpcRequest, RpcResponse, methods};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
-use tokio::net::unix::OwnedReadHalf;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 
 /// Upper bound on a single dial + round-trip. Local unix socket, so generous;
 /// only guards against a wedged daemon.
@@ -78,11 +78,50 @@ pub fn socket_path() -> Option<PathBuf> {
     Some(ainb_hangar_core::hangar_home()?.join("hangar.sock"))
 }
 
-/// A stateless client for the daemon control plane.
+/// Client for stateless daemon RPCs and persistent Fleet subscription.
 #[derive(Debug, Clone)]
 pub struct DaemonClient {
     socket: PathBuf,
     token: String,
+}
+
+/// One pushed update from a persistent Fleet subscription.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FleetStreamEvent {
+    /// One durable revision committed after the subscription snapshot.
+    Revision(ainb_hangar_proto::fleet::FleetEvent),
+    /// Server detected subscriber lag and requires snapshot reconciliation.
+    ResyncRequired,
+}
+
+/// Live Fleet connection retained after the subscribe acknowledgement.
+pub struct FleetSubscription {
+    reader: BufReader<OwnedReadHalf>,
+    // Retain the write half so the server does not observe EOF and tear down
+    // the per-connection Fleet forwarder after the acknowledgement.
+    _writer: OwnedWriteHalf,
+}
+
+impl FleetSubscription {
+    /// Wait for the next Fleet revision or explicit resync request.
+    pub async fn next_event(&mut self) -> Result<FleetStreamEvent, DaemonError> {
+        loop {
+            let frame = read_frame(&mut self.reader).await?;
+            let Some(method) = frame.get("method").and_then(Value::as_str) else {
+                continue;
+            };
+            match method {
+                "fleet/event" => {
+                    let params = frame.get("params").cloned().unwrap_or(Value::Null);
+                    let event = serde_json::from_value(params)
+                        .map_err(|error| DaemonError::Decode(error.to_string()))?;
+                    return Ok(FleetStreamEvent::Revision(event));
+                }
+                "fleet/resync_required" => return Ok(FleetStreamEvent::ResyncRequired),
+                _ => {}
+            }
+        }
+    }
 }
 
 impl DaemonClient {
@@ -124,6 +163,69 @@ impl DaemonClient {
     pub async fn answer(&self, params: AnswerParams) -> Result<AnswerResult, DaemonError> {
         let value = serde_json::to_value(params).expect("AnswerParams serializes");
         let result = self.call(methods::ATTENTION_ANSWER, value).await?;
+        serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))
+    }
+
+    /// Read the authoritative host Fleet snapshot.
+    pub async fn fleet_snapshot(
+        &self,
+    ) -> Result<ainb_hangar_proto::fleet::FleetSnapshot, DaemonError> {
+        let result = self.call(methods::FLEET_SNAPSHOT, json!({})).await?;
+        serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))
+    }
+
+    /// Subscribe from one revision and receive race-free snapshot plus replay.
+    pub async fn fleet_subscribe(
+        &self,
+        after_revision: i64,
+    ) -> Result<ainb_hangar_proto::fleet::FleetSubscribeResult, DaemonError> {
+        let result = self
+            .call(
+                methods::FLEET_SUBSCRIBE,
+                json!({ "after_revision": after_revision }),
+            )
+            .await?;
+        serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))
+    }
+
+    /// Open a persistent Fleet subscription and retain its live event stream.
+    pub async fn open_fleet_subscription(
+        &self,
+        after_revision: i64,
+    ) -> Result<
+        (
+            ainb_hangar_proto::fleet::FleetSubscribeResult,
+            FleetSubscription,
+        ),
+        DaemonError,
+    > {
+        tokio::time::timeout(
+            RPC_TIMEOUT,
+            self.open_fleet_subscription_inner(after_revision),
+        )
+        .await
+        .map_err(|_| DaemonError::Timeout(RPC_TIMEOUT))?
+    }
+
+    /// Execute one exact, versioned Fleet action.
+    pub async fn fleet_action(
+        &self,
+        params: ainb_hangar_proto::fleet::FleetActionParams,
+    ) -> Result<ainb_hangar_proto::fleet::FleetActionReceipt, DaemonError> {
+        let value = serde_json::to_value(params).expect("FleetActionParams serializes");
+        let result = self.call(methods::FLEET_ACTION, value).await?;
+        let result: ainb_hangar_proto::fleet::FleetActionResult =
+            serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))?;
+        Ok(result.receipt)
+    }
+
+    /// Broadcast text to explicit stable Fleet targets.
+    pub async fn fleet_broadcast(
+        &self,
+        params: ainb_hangar_proto::fleet::FleetBroadcastParams,
+    ) -> Result<ainb_hangar_proto::fleet::FleetBroadcastResult, DaemonError> {
+        let value = serde_json::to_value(params).expect("FleetBroadcastParams serializes");
+        let result = self.call(methods::FLEET_BROADCAST, value).await?;
         serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))
     }
 
@@ -194,6 +296,64 @@ impl DaemonClient {
         }
         Ok(resp.result.unwrap_or(Value::Null))
     }
+
+    async fn open_fleet_subscription_inner(
+        &self,
+        after_revision: i64,
+    ) -> Result<
+        (
+            ainb_hangar_proto::fleet::FleetSubscribeResult,
+            FleetSubscription,
+        ),
+        DaemonError,
+    > {
+        let stream =
+            UnixStream::connect(&self.socket).await.map_err(|source| DaemonError::Connect {
+                path: self.socket.display().to_string(),
+                source,
+            })?;
+        let (read_half, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(read_half);
+
+        write_frame(
+            &mut writer,
+            methods::AUTH_HELLO,
+            json!({ "token": self.token }),
+            1,
+        )
+        .await?;
+        let hello = read_response(&mut reader).await?;
+        if let Some(error) = hello.error {
+            return Err(DaemonError::Rpc {
+                code: error.code,
+                message: error.message,
+            });
+        }
+
+        write_frame(
+            &mut writer,
+            methods::FLEET_SUBSCRIBE,
+            json!({ "after_revision": after_revision }),
+            2,
+        )
+        .await?;
+        let response = read_response(&mut reader).await?;
+        if let Some(error) = response.error {
+            return Err(DaemonError::Rpc {
+                code: error.code,
+                message: error.message,
+            });
+        }
+        let subscription = serde_json::from_value(response.result.unwrap_or(Value::Null))
+            .map_err(|error| DaemonError::Decode(error.to_string()))?;
+        Ok((
+            subscription,
+            FleetSubscription {
+                reader,
+                _writer: writer,
+            },
+        ))
+    }
 }
 
 async fn write_frame(
@@ -249,5 +409,91 @@ async fn read_frame(reader: &mut BufReader<OwnedReadHalf>) -> Result<Value, Daem
                 len = v.trim().parse().ok();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ainb_hangar_proto::fleet::{FleetEvent, FleetProvenance};
+    use tokio::net::UnixListener;
+
+    async fn write_test_frame(writer: &mut OwnedWriteHalf, value: &Value) {
+        let body = serde_json::to_vec(value).expect("test frame serializes");
+        let mut frame = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        frame.extend_from_slice(&body);
+        writer.write_all(&frame).await.expect("write test frame");
+        writer.flush().await.expect("flush test frame");
+    }
+
+    #[tokio::test]
+    async fn fleet_subscription_keeps_socket_open_for_live_revisions() {
+        let temp = tempfile::tempdir().expect("temporary socket directory");
+        let socket = temp.path().join("hangar.sock");
+        let listener = UnixListener::bind(&socket).expect("bind fake hangar socket");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept client");
+            let (read_half, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(read_half);
+
+            let hello = read_frame(&mut reader).await.expect("read auth request");
+            assert_eq!(hello["method"], methods::AUTH_HELLO);
+            assert_eq!(hello["params"]["token"], "test-token");
+            write_test_frame(
+                &mut writer,
+                &json!({"jsonrpc": "2.0", "id": 1, "result": {}}),
+            )
+            .await;
+
+            let subscribe = read_frame(&mut reader).await.expect("read subscribe request");
+            assert_eq!(subscribe["method"], methods::FLEET_SUBSCRIBE);
+            assert_eq!(subscribe["params"]["after_revision"], 40);
+            write_test_frame(
+                &mut writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {
+                        "snapshot": {"head_revision": 41, "sessions": []},
+                        "replay": []
+                    }
+                }),
+            )
+            .await;
+
+            let event = FleetEvent {
+                revision: 42,
+                event_id: "event-42".into(),
+                session_key: "codex:thread-1".into(),
+                observed_at: 42,
+                provenance: FleetProvenance::Authoritative,
+                event_type: "turn/started".into(),
+                payload: json!({}),
+                session_version: 2,
+                applied: true,
+            };
+            write_test_frame(
+                &mut writer,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "method": "fleet/event",
+                    "params": event
+                }),
+            )
+            .await;
+        });
+
+        let client = DaemonClient::with_parts(socket, "test-token".into());
+        let (initial, mut subscription) =
+            client.open_fleet_subscription(40).await.expect("open persistent subscription");
+        assert_eq!(initial.snapshot.head_revision, 41);
+        assert!(initial.replay.is_empty());
+
+        let event = subscription.next_event().await.expect("receive live event");
+        assert!(matches!(
+            event,
+            FleetStreamEvent::Revision(FleetEvent { revision: 42, .. })
+        ));
+        server.await.expect("fake server completes");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -1,5 +1,4 @@
-// ABOUTME: Fleet control-panel actions — dispatch a real send to a session
-// resolved from a `current_state` row, off the UI thread.
+// ABOUTME: Host Fleet subscription, daemon health, and detached control RPCs.
 //
 // The TUI fleet panel (`components/fleet_panel.rs`) browses the event-sourced
 // `current_state` and lets the human ACT: answer an interview (ASK) or
@@ -31,6 +30,11 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use ainb_hangar_proto::fleet::FleetSnapshot;
+
+use crate::fleet::bridge::daemon::FleetStreamEvent;
 
 /// Transient feedback published by the async action worker and rendered by the
 /// fleet panel's status line. Cloned cheaply; the lock is held only for the
@@ -39,6 +43,174 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub struct ActionFeedback {
     /// Human-readable status, e.g. "answered ask → /work/x: sent via tmux".
     pub message: String,
+}
+
+/// Connection health surfaced by the host Fleet panel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FleetDaemonHealth {
+    /// Subscription worker is dialing or authenticating.
+    Connecting,
+    /// Snapshot and live revision stream are active.
+    Online,
+    /// Stream is unavailable; cached rows remain usable for safe inspection.
+    Offline(String),
+}
+
+impl FleetDaemonHealth {
+    /// Whether authoritative control RPCs may be trusted right now.
+    #[must_use]
+    pub const fn is_online(&self) -> bool {
+        matches!(self, Self::Online)
+    }
+}
+
+/// Ordered update from the persistent Fleet subscription worker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FleetHostUpdate {
+    /// Complete authoritative state at one durable revision.
+    Snapshot(FleetSnapshot),
+    /// Subscription connection health changed.
+    Health(FleetDaemonHealth),
+}
+
+/// Shared ordered queue drained by the UI thread.
+pub type FleetHostUpdateSink = Arc<Mutex<Vec<FleetHostUpdate>>>;
+
+/// Start one persistent Fleet stream worker.
+pub fn spawn_fleet_subscription(
+    updates: FleetHostUpdateSink,
+    initial_cursor: i64,
+) -> Result<(), String> {
+    std::thread::Builder::new()
+        .name("ainb-fleet-subscription".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    publish_host_update(
+                        &updates,
+                        FleetHostUpdate::Health(FleetDaemonHealth::Offline(format!(
+                            "runtime build failed: {error}"
+                        ))),
+                    );
+                    return;
+                }
+            };
+            runtime.block_on(run_fleet_subscription(updates, initial_cursor));
+        })
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+async fn run_fleet_subscription(updates: FleetHostUpdateSink, initial_cursor: i64) {
+    let mut cursor = initial_cursor.max(0);
+    let mut attempt = 0_u32;
+    loop {
+        publish_host_update(
+            &updates,
+            FleetHostUpdate::Health(FleetDaemonHealth::Connecting),
+        );
+        let outcome = run_fleet_connection(&updates, &mut cursor).await;
+        let detail = outcome.err().unwrap_or_else(|| "Fleet stream ended".to_string());
+        publish_host_update(
+            &updates,
+            FleetHostUpdate::Health(FleetDaemonHealth::Offline(detail)),
+        );
+        tokio::time::sleep(subscription_backoff(attempt)).await;
+        attempt = attempt.saturating_add(1);
+    }
+}
+
+async fn run_fleet_connection(
+    updates: &FleetHostUpdateSink,
+    cursor: &mut i64,
+) -> Result<(), String> {
+    let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+        .map_err(|error| error.to_string())?;
+    let (subscription, mut stream) = client
+        .open_fleet_subscription(*cursor)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    *cursor = subscription.snapshot.head_revision;
+    publish_host_update(updates, FleetHostUpdate::Snapshot(subscription.snapshot));
+
+    for event in subscription.replay {
+        reconcile_revision(&client, updates, cursor, event.revision).await?;
+    }
+    publish_host_update(updates, FleetHostUpdate::Health(FleetDaemonHealth::Online));
+
+    loop {
+        match stream.next_event().await.map_err(|error| error.to_string())? {
+            FleetStreamEvent::Revision(event) => {
+                reconcile_revision(&client, updates, cursor, event.revision).await?;
+            }
+            FleetStreamEvent::ResyncRequired => {
+                return Err(format!("Fleet stream lagged after revision {cursor}"));
+            }
+        }
+    }
+}
+
+async fn reconcile_revision(
+    client: &crate::fleet::bridge::daemon::DaemonClient,
+    updates: &FleetHostUpdateSink,
+    cursor: &mut i64,
+    revision: i64,
+) -> Result<(), String> {
+    if revision <= *cursor {
+        return Ok(());
+    }
+    let snapshot = client.fleet_snapshot().await.map_err(|error| error.to_string())?;
+    if snapshot.head_revision < revision {
+        return Err(format!(
+            "Fleet snapshot head {} precedes announced revision {revision}",
+            snapshot.head_revision
+        ));
+    }
+    *cursor = snapshot.head_revision;
+    publish_host_update(updates, FleetHostUpdate::Snapshot(snapshot));
+    Ok(())
+}
+
+fn publish_host_update(updates: &FleetHostUpdateSink, update: FleetHostUpdate) {
+    if let Ok(mut updates) = updates.lock() {
+        updates.push(update);
+    }
+}
+
+fn subscription_backoff(attempt: u32) -> Duration {
+    Duration::from_millis(250_u64.saturating_mul(1_u64 << attempt.min(4)))
+}
+
+/// Execute one authoritative Fleet broadcast on a worker thread.
+pub fn execute_fleet_broadcast_blocking(
+    params: ainb_hangar_proto::fleet::FleetBroadcastParams,
+) -> Result<ainb_hangar_proto::fleet::FleetBroadcastResult, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| error.to_string())?;
+    runtime.block_on(async {
+        let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+            .map_err(|error| error.to_string())?;
+        client.fleet_broadcast(params).await.map_err(|error| error.to_string())
+    })
+}
+
+/// Execute one authoritative Fleet action on a worker thread.
+pub fn execute_fleet_action_blocking(
+    params: ainb_hangar_proto::fleet::FleetActionParams,
+) -> Result<ainb_hangar_proto::fleet::FleetActionReceipt, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| error.to_string())?;
+    runtime.block_on(async {
+        let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+            .map_err(|error| error.to_string())?;
+        client.fleet_action(params).await.map_err(|error| error.to_string())
+    })
 }
 
 /// Dispatch a send to the session described by `(session_id, cwd)`, off the UI

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -97,6 +97,24 @@ impl EmbedClient {
     /// Attach to `session_name` at the given cell size and start streaming its
     /// output into a vt100 parser on a dedicated reader thread.
     pub fn attach(session_name: &str, rows: u16, cols: u16) -> Result<Self> {
+        Self::attach_target(session_name, rows, cols)
+    }
+
+    /// Attach to an exact tmux target. Window and pane targets are selected
+    /// before starting the embedded client, then the client attaches to the
+    /// owning session without losing the exact target.
+    pub fn attach_target(target: &str, rows: u16, cols: u16) -> Result<Self> {
+        let session_name = target.split_once(':').map_or(target, |(session, _)| session).trim();
+        anyhow::ensure!(!session_name.is_empty(), "tmux target has no session name");
+        if target.contains(':') {
+            for command in ["select-window", "select-pane"] {
+                let status = std::process::Command::new("tmux")
+                    .args([command, "-t", target])
+                    .status()
+                    .with_context(|| format!("tmux {command} {target}"))?;
+                anyhow::ensure!(status.success(), "tmux {command} rejected {target}");
+            }
+        }
         let rows = rows.max(1);
         let cols = cols.max(1);
 

--- a/ainb-tui/crates/ainb-core/tests/support/fleet_hangar.rs
+++ b/ainb-tui/crates/ainb-core/tests/support/fleet_hangar.rs
@@ -1,0 +1,161 @@
+use std::path::Path;
+use std::process::Command;
+use std::time::Instant;
+
+use ainb_hangar_daemon::events::{EventBroker, EventSink};
+use ainb_hangar_daemon::fleet::{self, HookObservation};
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_store::Store;
+use sqlx::Row;
+
+pub struct Receipt {
+    pub action_kind: String,
+    pub status: String,
+    pub detail: Option<String>,
+}
+
+/// Test-owned tmux session with exact-name cleanup on success or panic.
+pub struct ExactTmuxSession {
+    name: String,
+}
+
+impl ExactTmuxSession {
+    pub fn create(name: String, width: &str, height: &str) -> Self {
+        let status = Command::new("tmux")
+            .args(["new-session", "-d", "-s", &name, "-x", width, "-y", height])
+            .status()
+            .expect("tmux new-session");
+        assert!(status.success(), "tmux new-session failed");
+        Self { name }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Drop for ExactTmuxSession {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux").args(["kill-session", "-t", &self.name]).status();
+    }
+}
+
+/// Restore one process environment variable after a test, including unwind.
+pub struct EnvGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    pub fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+/// Real Hangar socket server plus reducer-backed isolated store.
+///
+/// Dropping the runtime aborts the exact server task. No process-wide daemon or
+/// shared socket is touched.
+pub struct FleetHangar {
+    runtime: tokio::runtime::Runtime,
+    store: Store,
+    events: EventSink,
+}
+
+impl FleetHangar {
+    pub fn start(hangar_home: &Path) -> Self {
+        let runtime = tokio::runtime::Runtime::new().expect("create Hangar runtime");
+        let (store, events) =
+            runtime.block_on(async {
+                let store = Store::open_in(hangar_home).await.expect("open isolated Hangar store");
+                rpc::auth::ensure_socket_token(store.pool(), hangar_home)
+                    .await
+                    .expect("create isolated daemon token");
+                let socket = rpc::socket_path_in(hangar_home);
+                let listener = rpc::bind(&socket).expect("bind isolated Hangar socket");
+                let broker = EventBroker::new();
+                let events = broker.sink();
+                let health = DaemonHealth {
+                    socket_path: socket.to_string_lossy().into_owned(),
+                    pid: std::process::id(),
+                    started_at: Instant::now(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    stats: std::sync::Arc::new(
+                        ainb_hangar_daemon::health_stats::HealthStats::default(),
+                    ),
+                };
+                tokio::spawn(rpc::serve(listener, store.pool().clone(), health, broker));
+                (store, events)
+            });
+        Self {
+            runtime,
+            store,
+            events,
+        }
+    }
+
+    pub fn apply_hook(
+        &self,
+        event_id: &str,
+        provider_session_id: &str,
+        cwd: &Path,
+        event_type: &str,
+        payload: serde_json::Value,
+        observed_at: i64,
+    ) {
+        let cwd = cwd.display().to_string();
+        self.runtime
+            .block_on(fleet::apply_hook(
+                self.store.pool(),
+                &self.events,
+                HookObservation {
+                    event_id: event_id.to_string(),
+                    provider: "claude",
+                    provider_session_id,
+                    cwd: &cwd,
+                    event_type,
+                    payload: &payload,
+                    observed_at,
+                },
+            ))
+            .expect("apply authoritative Fleet hook");
+    }
+
+    pub fn latest_receipt(&self, session_key: &str) -> Option<Receipt> {
+        self.runtime.block_on(async {
+            sqlx::query(
+                "SELECT action_kind, status, detail FROM fleet_action_receipt \
+                 WHERE session_key = ? ORDER BY updated_at DESC LIMIT 1",
+            )
+            .bind(session_key)
+            .fetch_optional(self.store.pool())
+            .await
+            .expect("query Fleet action receipt")
+            .map(|row| Receipt {
+                action_kind: row.get("action_kind"),
+                status: row.get("status"),
+                detail: row.get("detail"),
+            })
+        })
+    }
+
+    pub fn session(&self, session_key: &str) -> Option<ainb_hangar_proto::fleet::FleetSession> {
+        self.runtime
+            .block_on(ainb_hangar_daemon::fleet::snapshot_wire(self.store.pool()))
+            .expect("read authoritative Fleet snapshot")
+            .sessions
+            .into_iter()
+            .find(|session| session.session_key == session_key)
+    }
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
@@ -3,13 +3,10 @@
 //!
 //! Proves, against a live `ainb tui` in tmux with an isolated HOME:
 //!
-//! 1. a `PermissionRequest`-derived state renders as the gold `APRV` badge and
-//!    a `SessionStart`-derived state as the blue `STRT` badge in the Fleet
-//!    panel (`f`);
-//! 2. pressing `y` on the APPROVE row delivers a first-class approve to a REAL
-//!    broker waiter parked on the isolated `approve.sock` — the same
-//!    `client_await` call a blocked Claude `PermissionRequest` hook makes —
-//!    and the waiter unblocks with `DecisionKind::Approve`.
+//! 1. reducer-fed `PermissionRequest` and `SessionStart` sessions render from a
+//!    real isolated Hangar daemon socket;
+//! 2. pressing `y` submits versioned `fleet/action`, persists a DELIVERED
+//!    receipt, then reaches the real Claude blocking-hook broker.
 //!
 //! The broker end is the real `ainb_plugin_notifyd::broker::serve` accept
 //! loop, not a stand-in, so the bytes on the socket are exactly what
@@ -22,8 +19,13 @@ use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use ainb_plugin_notifyd::Paths;
 use ainb_plugin_notifyd::broker::{self, BrokerState, DecisionKind};
-use ainb_plugin_notifyd::{Paths, StateRow, Store};
+
+#[path = "support/fleet_hangar.rs"]
+mod fleet_hangar;
+
+use fleet_hangar::{EnvGuard, ExactTmuxSession, FleetHangar};
 
 fn ainb_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
@@ -37,8 +39,6 @@ fn tmux_available() -> bool {
         .unwrap_or(false)
 }
 
-/// Seed onboarding + dismissed notify prompt + the two fleet states:
-/// APPROVE (newest → selected row 0) and STARTING.
 fn seed_isolated_home(home: &Path) {
     let base = home.join(".agents-in-a-box");
     let cfg = base.join("config");
@@ -55,29 +55,6 @@ git_directories = []
     fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
     let install_record = r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#;
     fs::write(base.join("install.json"), install_record).expect("seed install.json");
-
-    let paths = Paths::under(&base);
-    let store = Store::open(&paths.db).expect("open notifications.db");
-    let approve = StateRow {
-        session_id: "fleet-approve-1".to_string(),
-        cwd: home.join("approving-project").display().to_string(),
-        kind: "APPROVE".to_string(),
-        context: Some(r#"{"tool":"Bash","input":"rm -rf build/"}"#.to_string()),
-        parent: Some("atc-main".to_string()),
-        last_event_ts: 400,
-        source: "hook".to_string(),
-    };
-    let starting = StateRow {
-        session_id: "fleet-start-1".to_string(),
-        cwd: home.join("booting-project").display().to_string(),
-        kind: "STARTING".to_string(),
-        context: None,
-        parent: Some("atc-main".to_string()),
-        last_event_ts: 300,
-        source: "hook".to_string(),
-    };
-    store.upsert_current_state(&approve).expect("seed APPROVE current_state");
-    store.upsert_current_state(&starting).expect("seed STARTING current_state");
 }
 
 fn capture_pane(session: &str) -> String {
@@ -110,28 +87,17 @@ fn send_key(session: &str, key: &str) {
     assert!(status.success(), "tmux send-keys {key:?} failed");
 }
 
-fn poll_capture_resending<F>(
-    session: &str,
-    key: &str,
-    deadline: Instant,
-    mut ok: F,
-) -> Option<String>
-where
-    F: FnMut(&str) -> bool,
-{
+fn open_fleet_screen(session: &str) -> Option<String> {
+    let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
-        send_key(session, key);
-        thread::sleep(Duration::from_millis(500));
-        let cap = capture_pane(session);
-        if ok(&cap) {
-            return Some(cap);
+        let capture = capture_pane(session);
+        if capture.contains("Fleet ·") && capture.contains("sessions ·") {
+            return Some(capture);
         }
+        send_key(session, "f");
+        thread::sleep(Duration::from_millis(500));
     }
     None
-}
-
-fn kill_session(session: &str) {
-    let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
 }
 
 #[test]
@@ -146,6 +112,37 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
     let _ = fs::remove_dir_all(&home);
     fs::create_dir_all(&home).expect("create short-path home");
     seed_isolated_home(&home);
+    let hangar_home = home.join("hangar-home");
+    let _ainb_home = EnvGuard::set("AINB_HOME", home.join(".agents-in-a-box"));
+    let _disable_tmux_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
+    let hangar = FleetHangar::start(&hangar_home);
+    hangar.apply_hook(
+        "fleet-approve-request",
+        "fleet-approve-1",
+        &home.join("approving-project"),
+        "PermissionRequest",
+        serde_json::json!({
+            "matcher": "Bash",
+            "payload": {
+                "tool_use_id": "approve-tool-1",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf build/"}
+            }
+        }),
+        4_000_000_000_400,
+    );
+    hangar.apply_hook(
+        "fleet-start-session",
+        "fleet-start-1",
+        &home.join("booting-project"),
+        "SessionStart",
+        serde_json::json!({ "source": "hook" }),
+        4_000_000_000_300,
+    );
+    let approval_fingerprint = hangar
+        .session("claude:fleet-approve-1")
+        .and_then(|session| session.current_request_fingerprint)
+        .expect("seeded approval has exact request fingerprint");
 
     // Real broker on the isolated approve.sock, riding a test-owned runtime.
     let paths = Paths::under(home.join(".agents-in-a-box"));
@@ -160,40 +157,43 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
         });
     }
 
-    // Park a REAL waiter — the same blocking call a Claude PermissionRequest
+    // Park a REAL waiter: the same blocking call a Claude PermissionRequest
     // hook makes. It blocks until the TUI's `y` decides it (or 60s deny-falls-back,
     // which the assertion below would catch as a wrong decision).
     let waiter = {
         let sock = paths.approve_socket.clone();
+        let fingerprint = approval_fingerprint.clone();
         thread::spawn(move || {
-            broker::client_await(
+            broker::client_await_exact(
                 &sock,
                 "fleet-approve-1",
                 "Bash",
                 "rm -rf build/",
+                &fingerprint,
                 Duration::from_secs(60),
             )
         })
     };
 
-    let session = format!("tripwire-fleet-aprv-{}", std::process::id());
-    let status = Command::new("tmux")
-        .args(["new-session", "-d", "-s", &session, "-x", "180", "-y", "50"])
-        .status()
-        .expect("tmux new-session");
-    assert!(status.success(), "tmux new-session failed");
+    let tmux = ExactTmuxSession::create(
+        format!("tripwire-fleet-aprv-{}", std::process::id()),
+        "180",
+        "50",
+    );
+    let session = tmux.name();
 
     let peers_db = home.join("peers.db");
     let jobs_dir = home.join("jobs");
     let cmd = format!(
-        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
         home = home.display(),
+        hangar = hangar_home.display(),
         peers = peers_db.display(),
         jobs = jobs_dir.display(),
         bin = ainb_bin().display()
     );
     Command::new("tmux")
-        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .args(["send-keys", "-t", session, &cmd, "Enter"])
         .status()
         .expect("send launch cmd");
 
@@ -202,54 +202,67 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
     });
     if pre.is_none() {
         let last = capture_pane(&session);
-        kill_session(&session);
         let _ = fs::remove_dir_all(&home);
         panic!("HomeScreen never rendered Fleet shortcut; last capture:\n---\n{last}\n---");
     }
 
-    // 1. Frame truth: both new badges render, APPROVE row selected (newest ts).
-    let opened = poll_capture_resending(
-        &session,
-        "f",
-        Instant::now() + Duration::from_secs(30),
-        |c| {
-            c.contains("APRV")
-                && c.contains("STRT")
-                && c.contains("needs approval")
-                && c.contains("starting")
-                && c.contains("approving-project")
-                && c.contains("booting-project")
-        },
+    // 1. Frame truth: both canonical states render, APPROVAL row selected (newest ts).
+    assert!(
+        open_fleet_screen(&session).is_some(),
+        "f did not open Fleet screen:\n{}",
+        capture_pane(&session)
     );
+    let opened = poll_capture(&session, Instant::now() + Duration::from_secs(30), |c| {
+        c.contains("APPR")
+            && c.contains("STARTI")
+            && c.contains("State: IDLE / APPROVAL")
+            && c.contains("claude:fleet-ap")
+            && c.contains("claude:fleet-st")
+            && c.contains("approving-project")
+            && c.contains("hangar-authoritative")
+    });
     let Some(open_cap) = opened else {
         let last = capture_pane(&session);
-        kill_session(&session);
         let _ = fs::remove_dir_all(&home);
-        panic!("Fleet panel did not render APRV+STRT badges; last capture:\n---\n{last}\n---");
+        panic!(
+            "Fleet panel did not render APPROVAL+STARTING states; last capture:\n---\n{last}\n---"
+        );
     };
     assert!(
         open_cap.contains("y") && open_cap.contains("approve"),
         "help bar must advertise the y approve lever:\n{open_cap}"
     );
+    assert!(
+        !open_cap.contains("current_state"),
+        "Fleet must not expose or read legacy notifyd current_state:\n{open_cap}"
+    );
 
     // 2. y on the selected APPROVE row → broker → parked waiter unblocks.
     send_key(&session, "y");
     let feedback = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
-        c.contains("approved → fleet-approve-1")
+        c.contains("approved request: Delivered") && c.contains("claude blocking hook broker")
     });
     let Some(feedback_cap) = feedback else {
         let last = capture_pane(&session);
-        kill_session(&session);
         let _ = fs::remove_dir_all(&home);
         panic!("approve feedback never rendered; last capture:\n---\n{last}\n---");
     };
     assert!(
-        feedback_cap.contains("matched the waiting hook"),
-        "approve must report a matched waiter, not a miss:\n{feedback_cap}"
+        !feedback_cap.contains("approved failed"),
+        "approve must succeed through Hangar action RPC:\n{feedback_cap}"
+    );
+
+    let receipt = hangar
+        .latest_receipt("claude:fleet-approve-1")
+        .expect("approval persisted a Fleet receipt");
+    assert_eq!(receipt.action_kind, "approve");
+    assert_eq!(receipt.status, "DELIVERED");
+    assert_eq!(
+        receipt.detail.as_deref(),
+        Some("claude blocking hook broker")
     );
 
     let decision = waiter.join().expect("waiter thread");
-    kill_session(&session);
     let _ = fs::remove_dir_all(&home);
     assert_eq!(
         decision.decision,

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -1,14 +1,13 @@
-//! Tripwire: the Fleet panel opens from Home, renders hook-materialized
-//! `current_state`, lets the operator move an ASK option, attempts the answer
-//! dispatch path, and returns to Home via `Esc`.
+//! Tripwire: the Fleet panel opens from Home, renders Hangar's authoritative
+//! Fleet snapshot, moves an ASK option, submits a versioned structured answer,
+//! and returns to Home via `Esc`.
 //!
 //! This is the live-terminal sibling of the Fleet panel unit tests. It drives
 //! the real `ainb` binary in tmux with an isolated HOME seeded with:
 //!
 //! 1. completed onboarding + a complete dismissed notify install record, so no
 //!    first-run modal swallows the `f` key;
-//! 2. a notifyd SQLite store populated via the real `Store::upsert_current_state`
-//!    API the materializer uses.
+//! 2. a real isolated Hangar store, reducer, daemon socket, and auth token.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -16,7 +15,13 @@ use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use ainb_plugin_notifyd::{Paths, StateRow, Store};
+use ainb_plugin_notifyd::Paths;
+use ainb_plugin_notifyd::broker::{self, BrokerState, StructuredResolution};
+
+#[path = "support/fleet_hangar.rs"]
+mod fleet_hangar;
+
+use fleet_hangar::{EnvGuard, ExactTmuxSession, FleetHangar};
 
 fn ainb_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
@@ -47,35 +52,6 @@ git_directories = []
 
     let install_record = r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#;
     fs::write(base.join("install.json"), install_record).expect("seed install.json");
-
-    let paths = Paths::under(&base);
-    fs::create_dir_all(&paths.base).expect("create ainb base");
-    let store = Store::open(&paths.db).expect("open notifications.db");
-    let ask = StateRow {
-        session_id: "fleet-panel-ask-1".to_string(),
-        cwd: home.join("fleet-tripwire-project").display().to_string(),
-        kind: "ASK".to_string(),
-        context: Some(
-            r#"{"question":"Deploy patched fleet bridge?","header":"Release gate","options":[{"label":"Yes","description":"ship verified fix"},{"label":"Continue","description":"keep watching"}]}"#
-                .to_string(),
-        ),
-        parent: Some("atc-main".to_string()),
-        last_event_ts: 300,
-        source: "hook".to_string(),
-    };
-    let wait = StateRow {
-        session_id: "fleet-panel-wait-1".to_string(),
-        cwd: home.join("waiting-project").display().to_string(),
-        kind: "WAIT".to_string(),
-        context: Some(
-            r#"{"reason":"permission_prompt","message":"allow cargo test?"}"#.to_string(),
-        ),
-        parent: Some("atc-main".to_string()),
-        last_event_ts: 200,
-        source: "hook".to_string(),
-    };
-    store.upsert_current_state(&ask).expect("seed ASK current_state");
-    store.upsert_current_state(&wait).expect("seed WAIT current_state");
 }
 
 fn capture_pane(session: &str) -> String {
@@ -108,28 +84,17 @@ fn send_key(session: &str, key: &str) {
     assert!(status.success(), "tmux send-keys {key:?} failed");
 }
 
-fn poll_capture_resending<F>(
-    session: &str,
-    key: &str,
-    deadline: Instant,
-    mut ok: F,
-) -> Option<String>
-where
-    F: FnMut(&str) -> bool,
-{
+fn open_fleet_screen(session: &str) -> Option<String> {
+    let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
-        send_key(session, key);
-        thread::sleep(Duration::from_millis(500));
-        let cap = capture_pane(session);
-        if ok(&cap) {
-            return Some(cap);
+        let capture = capture_pane(session);
+        if capture.contains("Fleet ·") && capture.contains("sessions ·") {
+            return Some(capture);
         }
+        send_key(session, "f");
+        thread::sleep(Duration::from_millis(500));
     }
     None
-}
-
-fn kill_session(session: &str) {
-    let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
 }
 
 #[test]
@@ -139,27 +104,128 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         return;
     }
 
-    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    // Keep approve.sock below AF_UNIX's path-length limit.
+    let home_tmp = tempfile::Builder::new()
+        .prefix("ainb-fpan-")
+        .tempdir_in("/tmp")
+        .expect("home tempdir");
     seed_isolated_home(home_tmp.path());
+    let hangar_home = home_tmp.path().join("hangar-home");
+    let _ainb_home = EnvGuard::set("AINB_HOME", home_tmp.path().join(".agents-in-a-box"));
+    let _disable_tmux_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
+    let hangar = FleetHangar::start(&hangar_home);
+    hangar.apply_hook(
+        "fleet-panel-ask-start",
+        "fleet-panel-ask-1",
+        &home_tmp.path().join("fleet-tripwire-project"),
+        "SessionStart",
+        serde_json::json!({ "source": "hook" }),
+        4_000_000_000_299,
+    );
+    hangar.apply_hook(
+        "fleet-panel-ask-question",
+        "fleet-panel-ask-1",
+        &home_tmp.path().join("fleet-tripwire-project"),
+        "AskUserQuestion",
+        serde_json::json!({
+            "payload": {
+                "tool_use_id": "ask-tool-1",
+                "tool_input": {
+                    "questions": [{
+                        "id": "release-gate",
+                        "question": "Deploy patched fleet bridge?",
+                        "header": "Release gate",
+                        "options": [
+                            {"label": "Yes", "description": "ship verified fix"},
+                            {"label": "Continue", "description": "keep watching"}
+                        ]
+                    }]
+                }
+            }
+        }),
+        4_000_000_000_300,
+    );
+    hangar.apply_hook(
+        "fleet-panel-wait",
+        "fleet-panel-wait-1",
+        &home_tmp.path().join("waiting-project"),
+        "Notification",
+        serde_json::json!({
+            "reason": "permission_prompt",
+            "message": "allow cargo test?"
+        }),
+        4_000_000_000_200,
+    );
+    let seeded = hangar
+        .session("claude:fleet-panel-ask-1")
+        .expect("seeded ASK appears in authoritative snapshot");
+    assert!(
+        seeded
+            .current_request
+            .as_ref()
+            .and_then(|request| request.pointer("/payload/tool_input/questions"))
+            .is_some(),
+        "authoritative ASK snapshot must preserve complete request: {seeded:?}"
+    );
+    let request_fingerprint = seeded
+        .current_request_fingerprint
+        .clone()
+        .expect("seeded ASK has exact request fingerprint");
 
-    let session = format!("tripwire-fleet-panel-{}", std::process::id());
-    let status = Command::new("tmux")
-        .args(["new-session", "-d", "-s", &session, "-x", "180", "-y", "50"])
-        .status()
-        .expect("tmux new-session");
-    assert!(status.success(), "tmux new-session failed");
+    // Real broker plus real structured hook waiter. Fleet answer must traverse
+    // TUI -> fleet/action -> Hangar -> broker and unblock exact request.
+    let paths = Paths::under(home_tmp.path().join(".agents-in-a-box"));
+    let broker_runtime = tokio::runtime::Runtime::new().expect("broker runtime");
+    let broker_state = BrokerState::new();
+    {
+        let sock = paths.approve_socket.clone();
+        let state = broker_state.clone();
+        broker_runtime.spawn(async move {
+            let listener = tokio::net::UnixListener::bind(&sock).expect("bind approve.sock");
+            broker::serve(listener, state).await;
+        });
+    }
+    let waiter = {
+        let sock = paths.approve_socket.clone();
+        let fingerprint = request_fingerprint.clone();
+        thread::spawn(move || {
+            broker::client_await_structured(
+                &sock,
+                "fleet-panel-ask-1",
+                &fingerprint,
+                &[serde_json::json!({
+                    "id": "release-gate",
+                    "question": "Deploy patched fleet bridge?",
+                    "header": "Release gate",
+                    "options": [
+                        {"label": "Yes", "description": "ship verified fix"},
+                        {"label": "Continue", "description": "keep watching"}
+                    ]
+                })],
+                Duration::from_secs(60),
+            )
+        })
+    };
+
+    let tmux = ExactTmuxSession::create(
+        format!("tripwire-fleet-panel-{}", std::process::id()),
+        "180",
+        "50",
+    );
+    let session = tmux.name();
 
     let peers_db = home_tmp.path().join("peers.db");
     let jobs_dir = home_tmp.path().join("jobs");
     let cmd = format!(
-        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
         home = home_tmp.path().display(),
+        hangar = hangar_home.display(),
         peers = peers_db.display(),
         jobs = jobs_dir.display(),
         bin = ainb_bin().display()
     );
     Command::new("tmux")
-        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .args(["send-keys", "-t", session, &cmd, "Enter"])
         .status()
         .expect("send launch cmd");
 
@@ -168,45 +234,49 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     });
     let Some(pre_cap) = pre else {
         let last = capture_pane(&session);
-        kill_session(&session);
         panic!("HomeScreen never rendered Fleet shortcut; last capture:\n---\n{last}\n---");
     };
     assert!(
         !pre_cap.contains("Deploy patched fleet bridge?"),
-        "pre-key capture already on Fleet panel — state leaked:\n{pre_cap}"
+        "pre-key capture already on Fleet panel: state leaked:\n{pre_cap}"
     );
 
-    let opened = poll_capture_resending(
-        &session,
-        "f",
-        Instant::now() + Duration::from_secs(30),
-        |c| {
-            c.contains("Fleet")
-                && c.contains("current_state")
-                && c.contains("ASK")
-                && c.contains("Deploy patched fleet bridge?")
-                && c.contains("Yes")
-                && c.contains("Continue")
-                && c.contains("WAIT")
-        },
+    assert!(
+        open_fleet_screen(&session).is_some(),
+        "f did not open Fleet screen:\n{}",
+        capture_pane(&session)
     );
+    let opened = poll_capture(&session, Instant::now() + Duration::from_secs(30), |c| {
+        c.contains("Fleet")
+            && c.contains("Hangar")
+            && c.contains("ASK")
+            && c.contains("Deploy patched fleet bridge?")
+            && c.contains("Yes")
+            && c.contains("Continue")
+            && c.contains("WAIT")
+            && c.contains("hangar-authoritative")
+    });
     let Some(open_cap) = opened else {
         let last = capture_pane(&session);
-        kill_session(&session);
-        panic!("Fleet panel did not render seeded current_state; last capture:\n---\n{last}\n---");
+        panic!(
+            "Fleet panel did not render authoritative Hangar snapshot; last capture:\n---\n{last}\n---"
+        );
     };
     assert!(
         open_cap.contains("Enter/a") && open_cap.contains("q/Esc"),
         "Fleet help bar missing answer/back controls:\n{open_cap}"
     );
+    assert!(
+        !open_cap.contains("current_state"),
+        "Fleet must not expose or read legacy notifyd current_state:\n{open_cap}"
+    );
 
     send_key(&session, "Tab");
     let advanced = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
-        c.contains("▶ Continue")
+        c.contains(">[ ] Continue")
     });
     let Some(tab_cap) = advanced else {
         let last = capture_pane(&session);
-        kill_session(&session);
         panic!("Tab did not move ASK option cursor to Continue; last capture:\n---\n{last}\n---");
     };
     assert!(
@@ -216,29 +286,38 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
 
     send_key(&session, "Enter");
     let answered = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
-        c.contains("answering ask with 'Continue'")
-            || c.contains("answered ask")
-            || c.contains("no live session matched")
+        c.contains("answered ask: Delivered") && c.contains("claude structured hook broker")
     });
     let Some(answer_cap) = answered else {
         let last = capture_pane(&session);
-        kill_session(&session);
         panic!("Fleet answer dispatch feedback never rendered; last capture:\n---\n{last}\n---");
     };
     assert!(
-        answer_cap.contains("Continue")
-            && (answer_cap.contains("answering ask")
-                || answer_cap.contains("answered ask")
-                || answer_cap.contains("no live session matched")),
-        "answer feedback did not name the selected option/path:\n{answer_cap}"
+        !answer_cap.contains("no live session matched"),
+        "structured answer must use Hangar RPC, never legacy tmux discovery:\n{answer_cap}"
     );
+    let receipt = hangar
+        .latest_receipt("claude:fleet-panel-ask-1")
+        .expect("structured answer persisted a Fleet receipt");
+    assert_eq!(receipt.action_kind, "structured_answer");
+    assert_eq!(receipt.status, "DELIVERED");
+    assert_eq!(
+        receipt.detail.as_deref(),
+        Some("claude structured hook broker")
+    );
+    let resolution = waiter.join().expect("structured waiter thread");
+    let StructuredResolution::Answered { answers } = resolution else {
+        panic!("structured waiter did not receive answer: {resolution:?}");
+    };
+    assert_eq!(answers.len(), 1);
+    assert_eq!(answers[0].question, "Deploy patched fleet bridge?");
+    assert_eq!(answers[0].selected_options, ["Continue"]);
 
     send_key(&session, "Escape");
     let back = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
         c.contains("Stats") && c.contains("[i]") && !c.contains("Deploy patched fleet bridge?")
     });
     let final_cap = capture_pane(&session);
-    kill_session(&session);
     assert!(
         back.is_some(),
         "Esc from Fleet panel did not return to Home. Final capture:\n---\n{final_cap}\n---"

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/merge.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/merge.rs
@@ -1,39 +1,31 @@
-// ABOUTME: Merge sessions from multiple sources, deduping by cwd.
-//
-// cwd is the primary identity. Pid-asymmetric sources (ainb publishes no
-// pid; peers does) used to land in different buckets in the TS reference
-// impl — this Rust port coalesces on cwd to fix that. Two claude sessions
-// in the same cwd is a rare edge case; accept the merge.
+// ABOUTME: Merge Fleet observations using stable identity, never cwd.
 
 use std::collections::BTreeMap;
 
-use crate::fleet::types::Session;
+use crate::fleet::types::{FleetSession, ManagementState, Session, SessionKey, TransportHealth};
 
 #[must_use]
 pub fn merge_sessions(groups: Vec<Vec<Session>>) -> Vec<Session> {
-    let mut by_key: BTreeMap<String, Session> = BTreeMap::new();
+    let mut merged: Vec<Session> = Vec::new();
     for group in groups {
-        for s in group {
-            let key = dedupe_key(&s);
-            match by_key.remove(&key) {
-                Some(existing) => {
-                    by_key.insert(key, merge_one(existing, s));
-                }
-                None => {
-                    by_key.insert(key, s);
-                }
+        for session in group {
+            if let Some(index) = merged.iter().position(|current| same_identity(current, &session))
+            {
+                let current = merged.remove(index);
+                merged.insert(index, merge_one(current, session));
+            } else {
+                merged.push(session);
             }
         }
     }
-    by_key.into_values().collect()
+    merged
 }
 
-fn dedupe_key(s: &Session) -> String {
-    if s.cwd.is_empty() {
-        s.id.clone()
-    } else {
-        s.cwd.clone()
-    }
+fn same_identity(a: &Session, b: &Session) -> bool {
+    (!a.id.is_empty() && a.id == b.id)
+        || matches!((&a.peer_id, &b.peer_id), (Some(x), Some(y)) if x == y)
+        || matches!((&a.tmux_session, &b.tmux_session), (Some(x), Some(y)) if x == y)
+        || matches!((&a.bg_job_id, &b.bg_job_id), (Some(x), Some(y)) if x == y)
 }
 
 fn merge_one(a: Session, b: Session) -> Session {
@@ -63,6 +55,70 @@ fn merge_one(a: Session, b: Session) -> Session {
     }
 }
 
+/// Merge authoritative Fleet records by stable session key.
+#[must_use]
+pub fn merge_fleet_sessions(groups: Vec<Vec<FleetSession>>) -> Vec<FleetSession> {
+    let mut by_key: BTreeMap<SessionKey, FleetSession> = BTreeMap::new();
+    for group in groups {
+        for session in group {
+            match by_key.remove(&session.session_key) {
+                Some(current) => {
+                    by_key.insert(
+                        session.session_key.clone(),
+                        merge_fleet_one(current, session),
+                    );
+                }
+                None => {
+                    by_key.insert(session.session_key.clone(), session);
+                }
+            }
+        }
+    }
+    by_key.into_values().collect()
+}
+
+fn merge_fleet_one(mut current: FleetSession, incoming: FleetSession) -> FleetSession {
+    let incoming_is_fresher = incoming.confidence > current.confidence
+        || (incoming.confidence == current.confidence
+            && incoming.last_seen_ms.unwrap_or(i64::MIN)
+                >= current.last_seen_ms.unwrap_or(i64::MIN));
+
+    current.capabilities.extend(&incoming.capabilities);
+    current.provenance.extend(incoming.provenance);
+    current.provider_session_id = current.provider_session_id.or(incoming.provider_session_id);
+    current.exact_tmux_target = current.exact_tmux_target.or(incoming.exact_tmux_target);
+    current.pane_pid = current.pane_pid.or(incoming.pane_pid);
+    current.process_start_fingerprint =
+        current.process_start_fingerprint.or(incoming.process_start_fingerprint);
+    current.first_seen_ms = match (current.first_seen_ms, incoming.first_seen_ms) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, b) => a.or(b),
+    };
+    current.last_seen_ms = match (current.last_seen_ms, incoming.last_seen_ms) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (a, b) => a.or(b),
+    };
+    current.version = current.version.max(incoming.version);
+
+    if incoming.management == ManagementState::Managed {
+        current.management = ManagementState::Managed;
+    }
+    if incoming.transport_health == TransportHealth::Healthy {
+        current.transport_health = TransportHealth::Healthy;
+    }
+    if incoming_is_fresher {
+        current.provider = incoming.provider;
+        current.cwd = incoming.cwd;
+        current.lifecycle = incoming.lifecycle;
+        current.attention = incoming.attention;
+        current.confidence = incoming.confidence;
+        current.transport_health = incoming.transport_health;
+    } else {
+        current.confidence = current.confidence.max(incoming.confidence);
+    }
+    current
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,15 +143,11 @@ mod tests {
     }
 
     #[test]
-    fn merges_same_cwd_across_sources() {
+    fn keeps_same_cwd_sessions_distinct_without_strong_identity() {
         let a = session("/repo", SessionSource::Ainb, None);
         let b = session("/repo", SessionSource::Peers, Some(123));
         let merged = merge_sessions(vec![vec![a], vec![b]]);
-        assert_eq!(merged.len(), 1);
-        let m = &merged[0];
-        assert_eq!(m.cwd, "/repo");
-        assert_eq!(m.pid, Some(123));
-        assert_eq!(m.sources.len(), 2);
+        assert_eq!(merged.len(), 2);
     }
 
     #[test]
@@ -104,5 +156,18 @@ mod tests {
         let b = session("/r2", SessionSource::Peers, Some(1));
         let merged = merge_sessions(vec![vec![a], vec![b]]);
         assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn merges_exact_same_session_id_across_sources() {
+        let mut a = session("/old", SessionSource::Ainb, None);
+        let mut b = session("/new", SessionSource::Peers, Some(123));
+        a.id = "provider-session-1".into();
+        b.id = "provider-session-1".into();
+
+        let merged = merge_sessions(vec![vec![a], vec![b]]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].pid, Some(123));
+        assert_eq!(merged[0].sources.len(), 2);
     }
 }

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/mod.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/mod.rs
@@ -4,8 +4,10 @@ pub mod ainb;
 pub mod jobs;
 pub mod merge;
 pub mod peers;
+pub mod tmux;
 
 pub use ainb::discover_from_ainb;
 pub use jobs::discover_from_jobs;
-pub use merge::merge_sessions;
+pub use merge::{merge_fleet_sessions, merge_sessions};
 pub use peers::{discover_from_peers, list_broker_peers};
+pub use tmux::discover_from_tmux;

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
@@ -1,0 +1,197 @@
+// ABOUTME: Discover every tmux pane with exact target and process metadata.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+use crate::fleet::types::{
+    AttentionState, Capabilities, Confidence, FleetSession, LifecycleState, ManagementState,
+    Provenance, Provider, SessionKey, TransportHealth,
+};
+
+const LIST_FORMAT: &str = concat!(
+    "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_id}\t",
+    "#{pane_pid}\t#{pane_current_path}\t#{pane_current_command}\t",
+    "#{pane_start_command}\t#{session_created}"
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TmuxPaneRow {
+    session_name: String,
+    window_index: String,
+    pane_index: String,
+    pane_id: String,
+    pane_pid: u32,
+    cwd: String,
+    current_command: String,
+    start_command: String,
+    session_created: i64,
+}
+
+impl TmuxPaneRow {
+    fn exact_target(&self) -> String {
+        format!(
+            "{}:{}.{}",
+            self.session_name, self.window_index, self.pane_index
+        )
+    }
+
+    fn provider(&self) -> Provider {
+        infer_provider(&format!(
+            "{} {} {}",
+            self.session_name, self.current_command, self.start_command
+        ))
+    }
+
+    fn process_start_fingerprint(&self) -> String {
+        format!(
+            "pane={};pid={};session_started={}",
+            self.pane_id, self.pane_pid, self.session_created
+        )
+    }
+
+    fn into_fleet_session(self) -> FleetSession {
+        let provider = self.provider();
+        let exact_tmux_target = self.exact_target();
+        let fingerprint = self.process_start_fingerprint();
+        FleetSession {
+            session_key: SessionKey::legacy(provider, &exact_tmux_target, &fingerprint),
+            provider,
+            provider_session_id: None,
+            cwd: self.cwd,
+            exact_tmux_target: Some(exact_tmux_target),
+            pane_pid: Some(self.pane_pid),
+            process_start_fingerprint: Some(fingerprint),
+            lifecycle: LifecycleState::Unknown,
+            attention: AttentionState::None,
+            management: ManagementState::Degraded,
+            capabilities: Capabilities::degraded_tmux(),
+            provenance: BTreeSet::from([Provenance::Tmux]),
+            confidence: Confidence::Inferred,
+            transport_health: TransportHealth::Healthy,
+            first_seen_ms: self.session_created.checked_mul(1000),
+            last_seen_ms: None,
+            version: 0,
+        }
+    }
+}
+
+/// Enumerate all tmux panes. One exact pane target produces one Fleet row.
+pub async fn discover_from_tmux() -> Result<Vec<FleetSession>> {
+    let output = Command::new("tmux")
+        .args(["list-panes", "-a", "-F", LIST_FORMAT])
+        .output()
+        .await
+        .context("failed to invoke `tmux list-panes -a`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if tmux_has_no_sessions(&stderr) {
+            return Ok(Vec::new());
+        }
+        anyhow::bail!("tmux list-panes exited non-zero: {stderr}");
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("tmux list-panes returned non-UTF8")?;
+    parse_rows(&stdout).map(|rows| rows.into_iter().map(TmuxPaneRow::into_fleet_session).collect())
+}
+
+fn parse_rows(stdout: &str) -> Result<Vec<TmuxPaneRow>> {
+    stdout.lines().filter(|line| !line.is_empty()).map(parse_row).collect()
+}
+
+fn parse_row(line: &str) -> Result<TmuxPaneRow> {
+    let fields: Vec<&str> = line.splitn(9, '\t').collect();
+    if fields.len() != 9 {
+        anyhow::bail!(
+            "tmux list-panes row has {} fields, expected 9",
+            fields.len()
+        );
+    }
+    Ok(TmuxPaneRow {
+        session_name: fields[0].to_string(),
+        window_index: fields[1].to_string(),
+        pane_index: fields[2].to_string(),
+        pane_id: fields[3].to_string(),
+        pane_pid: fields[4]
+            .parse()
+            .with_context(|| format!("invalid pane pid in tmux row: {line}"))?,
+        cwd: fields[5].to_string(),
+        current_command: fields[6].to_string(),
+        start_command: fields[7].to_string(),
+        session_created: fields[8]
+            .parse()
+            .with_context(|| format!("invalid session creation time in tmux row: {line}"))?,
+    })
+}
+
+fn infer_provider(command_text: &str) -> Provider {
+    let text = command_text.to_ascii_lowercase();
+    if text.contains("codex") {
+        Provider::Codex
+    } else if text.contains("claude") {
+        Provider::Claude
+    } else {
+        Provider::Unknown
+    }
+}
+
+fn tmux_has_no_sessions(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    text.contains("no server running") || text.contains("no sessions")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fleet::types::{Capability, ManagementState};
+
+    #[test]
+    fn parser_preserves_same_cwd_as_distinct_exact_targets() {
+        let rows = parse_rows(concat!(
+            "claude-a\t0\t0\t%1\t101\t/repo\tclaude\tclaude\t1700000000\n",
+            "codex-b\t2\t1\t%2\t202\t/repo\tcodex\tcodex\t1700000001\n"
+        ))
+        .expect("parse tmux rows");
+
+        let sessions: Vec<_> = rows.into_iter().map(TmuxPaneRow::into_fleet_session).collect();
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].cwd, sessions[1].cwd);
+        assert_ne!(sessions[0].session_key, sessions[1].session_key);
+        assert_eq!(
+            sessions[0].exact_tmux_target.as_deref(),
+            Some("claude-a:0.0")
+        );
+        assert_eq!(
+            sessions[1].exact_tmux_target.as_deref(),
+            Some("codex-b:2.1")
+        );
+        assert_eq!(sessions[0].provider, Provider::Claude);
+        assert_eq!(sessions[1].provider, Provider::Codex);
+    }
+
+    #[test]
+    fn tmux_rows_are_degraded_and_only_allow_safe_fallbacks() {
+        let row = parse_row("plain\t0\t0\t%9\t909\t/tmp\tzsh\tzsh\t1700000000").expect("parse row");
+        let session = row.into_fleet_session();
+
+        assert_eq!(session.management, ManagementState::Degraded);
+        assert!(session.capabilities.contains(Capability::TextSend));
+        assert!(session.capabilities.contains(Capability::TmuxAttach));
+        assert!(!session.capabilities.contains(Capability::StructuredAnswer));
+        assert!(
+            session
+                .process_start_fingerprint
+                .as_deref()
+                .is_some_and(|value| value.contains("pid=909"))
+        );
+    }
+
+    #[test]
+    fn no_server_errors_are_empty_fleet_not_failure() {
+        assert!(tmux_has_no_sessions("no server running on /tmp/tmux.sock"));
+        assert!(tmux_has_no_sessions("no sessions"));
+        assert!(!tmux_has_no_sessions("permission denied"));
+    }
+}

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod discover;
 pub mod enrich_cache;
+pub mod provider;
 pub mod read;
 pub mod repo_clone;
 pub mod repo_roster;
@@ -18,6 +19,7 @@ pub mod session_registry;
 pub mod types;
 
 pub use types::{
-    AinbSession, Block, BrokerPeer, Liveness, SendOutcome, Session, SessionSource, SessionState,
-    Signal,
+    AinbSession, AttentionState, Block, BrokerPeer, Capabilities, Capability, Confidence,
+    FleetSession, LifecycleState, Liveness, ManagementState, Provenance, Provider, SendOutcome,
+    Session, SessionKey, SessionSource, SessionState, Signal, TransportHealth,
 };

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/provider.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/provider.rs
@@ -1,0 +1,195 @@
+// ABOUTME: Provider-neutral Fleet event normalization and control contract.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use serde::{Deserialize, Serialize};
+
+use crate::fleet::types::{
+    AttentionState, Capabilities, Confidence, FleetSession, LifecycleState, Provenance, Provider,
+    SessionKey,
+};
+
+/// Raw semantic event supplied by a provider transport.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderEvent {
+    pub event_id: String,
+    pub provider_session_id: String,
+    pub event_type: String,
+    pub at_ms: i64,
+    pub payload: serde_json::Value,
+}
+
+/// Provider request identity required for an exact structured response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StructuredRequestIdentity {
+    /// Exact provider RPC request id. Required for Codex app-server responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub item_id: String,
+    pub question_ids: Vec<String>,
+    pub fingerprint: String,
+}
+
+/// One structured answer. Multiple selected options preserve multi-select input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuestionAnswer {
+    pub question_id: String,
+    pub selected_options: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
+/// Action requested through a provider adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ControlAction {
+    StructuredAnswer {
+        request: StructuredRequestIdentity,
+        answers: Vec<QuestionAnswer>,
+    },
+    Approve {
+        request_id: String,
+    },
+    Deny {
+        request_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    SendPrompt {
+        text: String,
+    },
+    Continue,
+    Retry,
+    Interrupt,
+    Start,
+    Restart,
+    Stop,
+    Kill,
+    Archive,
+}
+
+/// Provider-normalized event consumed by a Fleet reducer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NormalizedEvent {
+    pub event_id: String,
+    pub session_key: SessionKey,
+    pub provider: Provider,
+    pub at_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<LifecycleState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attention: Option<AttentionState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request: Option<StructuredRequestIdentity>,
+    pub payload: serde_json::Value,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+/// Pane and transcript evidence used when semantic provider events are absent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FallbackObservation {
+    pub session: FleetSession,
+    pub observed_at_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pane_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript_event: Option<serde_json::Value>,
+}
+
+/// Result of a provider action attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionReceipt {
+    pub request_id: String,
+    pub status: DeliveryStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeliveryStatus {
+    Delivered,
+    Failed,
+    Unknown,
+}
+
+/// Adapter failure before an honest action receipt can be produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderAdapterError {
+    message: String,
+}
+
+impl ProviderAdapterError {
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ProviderAdapterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ProviderAdapterError {}
+
+pub type AdapterResult<T> = Result<T, ProviderAdapterError>;
+pub type ActionFuture<'a> = Pin<Box<dyn Future<Output = AdapterResult<ActionReceipt>> + Send + 'a>>;
+
+/// Provider boundary for normalization, fallback observation, and control.
+pub trait ProviderAdapter: Send + Sync {
+    fn provider(&self) -> Provider;
+
+    fn normalize_event(&self, event: ProviderEvent) -> AdapterResult<NormalizedEvent>;
+
+    fn observe_fallback(
+        &self,
+        observation: FallbackObservation,
+    ) -> AdapterResult<Vec<NormalizedEvent>>;
+
+    fn capabilities(&self, management: crate::fleet::types::ManagementState) -> Capabilities;
+
+    fn execute<'a>(
+        &'a self,
+        session: &'a FleetSession,
+        action: &'a ControlAction,
+    ) -> ActionFuture<'a>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structured_answer_preserves_question_ids_and_multi_select() {
+        let action = ControlAction::StructuredAnswer {
+            request: StructuredRequestIdentity {
+                request_id: Some(serde_json::json!(41)),
+                thread_id: Some("thread-1".into()),
+                turn_id: Some("turn-2".into()),
+                item_id: "item-3".into(),
+                question_ids: vec!["q1".into(), "q2".into()],
+                fingerprint: "fp-4".into(),
+            },
+            answers: vec![QuestionAnswer {
+                question_id: "q2".into(),
+                selected_options: vec!["alpha".into(), "beta".into()],
+                text: None,
+            }],
+        };
+
+        let encoded = serde_json::to_value(action).expect("serialize action");
+        assert_eq!(encoded["request"]["item_id"], "item-3");
+        assert_eq!(encoded["request"]["request_id"], 41);
+        assert_eq!(encoded["answers"][0]["selected_options"][1], "beta");
+    }
+}

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/send/mod.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/send/mod.rs
@@ -6,4 +6,7 @@ pub mod tmux;
 
 pub use broker::{BrokerClient, broker_health, broker_send};
 pub use route::send;
-pub use tmux::{pane_has_unsubmitted_input, tmux_press_enter, tmux_send, tmux_session_exists};
+pub use tmux::{
+    pane_has_unsubmitted_input, tmux_press_enter, tmux_send, tmux_send_picker_key,
+    tmux_session_exists,
+};

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/send/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/send/tmux.rs
@@ -45,6 +45,30 @@ fn send_keys_literal_args<'a>(tmux_session: &'a str, text: &'a str) -> [&'a str;
     ["send-keys", "-t", tmux_session, "-l", "--", text]
 }
 
+fn picker_key_args<'a>(tmux_session: &'a str, key: &'a str) -> Option<[&'a str; 4]> {
+    let allowed = matches!(
+        key,
+        "0" | "1"
+            | "2"
+            | "3"
+            | "4"
+            | "5"
+            | "6"
+            | "7"
+            | "8"
+            | "9"
+            | "Enter"
+            | "Up"
+            | "Down"
+            | "Left"
+            | "Right"
+            | "Space"
+            | "Tab"
+            | "BTab"
+    );
+    allowed.then_some(["send-keys", "-t", tmux_session, key])
+}
+
 pub async fn tmux_send(tmux_session: &str, text: &str) -> Result<()> {
     let status = Command::new("tmux")
         .args(send_keys_literal_args(tmux_session, text))
@@ -90,6 +114,21 @@ pub async fn tmux_press_enter(tmux_session: &str) -> Result<()> {
         .context("invoking tmux send-keys Enter")?;
     if !enter.success() {
         anyhow::bail!("tmux send-keys Enter exited {}", enter);
+    }
+    Ok(())
+}
+
+/// Route one constrained picker key without converting it to generic text.
+pub async fn tmux_send_picker_key(tmux_session: &str, key: &str) -> Result<()> {
+    let args = picker_key_args(tmux_session, key)
+        .ok_or_else(|| anyhow::anyhow!("unsupported verified picker key: {key}"))?;
+    let status = Command::new("tmux")
+        .args(args)
+        .status()
+        .await
+        .context("invoking tmux send-keys for verified picker")?;
+    if !status.success() {
+        anyhow::bail!("tmux verified picker send-keys exited {status}");
     }
     Ok(())
 }
@@ -141,7 +180,7 @@ pub async fn tmux_session_exists(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{composer_pending, send_keys_literal_args};
+    use super::{composer_pending, picker_key_args, send_keys_literal_args};
 
     #[test]
     fn dash_prefixed_payload_sits_after_the_terminator() {
@@ -162,6 +201,20 @@ mod tests {
             args,
             ["send-keys", "-t", "sess", "-l", "--", "ship to prod"]
         );
+    }
+
+    #[test]
+    fn picker_keys_use_non_literal_constrained_routing() {
+        assert_eq!(
+            picker_key_args("sess:0.0", "1"),
+            Some(["send-keys", "-t", "sess:0.0", "1"])
+        );
+        assert_eq!(
+            picker_key_args("sess:0.0", "Enter"),
+            Some(["send-keys", "-t", "sess:0.0", "Enter"])
+        );
+        assert_eq!(picker_key_args("sess:0.0", "option label"), None);
+        assert_eq!(picker_key_args("sess:0.0", "C-c"), None);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/types.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/types.rs
@@ -1,5 +1,8 @@
 // ABOUTME: Shared fleet types — Session / SessionState / Signal / Block / Liveness.
 
+use std::collections::BTreeSet;
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 /// Which discovery source contributed to a session record.
@@ -12,6 +15,206 @@ pub enum SessionSource {
     Peers,
     /// `~/.claude/jobs/<id>/`
     Jobs,
+    /// Exact pane metadata from `tmux list-panes -a`.
+    Tmux,
+}
+
+/// Provider owning a Fleet session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Provider {
+    Claude,
+    Codex,
+    Unknown,
+}
+
+impl Provider {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Stable Fleet identity. Cwd is deliberately excluded.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SessionKey(String);
+
+impl SessionKey {
+    /// Identity for a provider session with an authoritative provider id.
+    #[must_use]
+    pub fn managed(provider: Provider, provider_session_id: &str) -> Self {
+        Self(format!("{provider}:{provider_session_id}"))
+    }
+
+    /// Identity for a legacy pane without an authoritative provider id.
+    #[must_use]
+    pub fn legacy(
+        provider: Provider,
+        exact_tmux_target: &str,
+        process_start_fingerprint: &str,
+    ) -> Self {
+        Self(format!(
+            "legacy:{provider}:{exact_tmux_target}:{process_start_fingerprint}"
+        ))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Provider lifecycle, independent from attention state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum LifecycleState {
+    Starting,
+    Running,
+    TurnComplete,
+    Idle,
+    Exited,
+    Unknown,
+}
+
+/// Human attention required by a session, independent from lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AttentionState {
+    None,
+    Ask,
+    Approval,
+    Waiting,
+    Error,
+}
+
+/// Whether Fleet has an authoritative provider control channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ManagementState {
+    Managed,
+    Degraded,
+}
+
+/// Control and observation features supported for one session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Capability {
+    StructuredAnswer,
+    ApprovalDecision,
+    SendPrompt,
+    ContinueTurn,
+    RetryTurn,
+    InterruptTurn,
+    Start,
+    Restart,
+    Stop,
+    Kill,
+    Archive,
+    TextSend,
+    TmuxAttach,
+}
+
+/// Explicit capability set used to gate Fleet actions.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Capabilities(BTreeSet<Capability>);
+
+impl Capabilities {
+    #[must_use]
+    pub fn new(items: impl IntoIterator<Item = Capability>) -> Self {
+        Self(items.into_iter().collect())
+    }
+
+    #[must_use]
+    pub fn degraded_tmux() -> Self {
+        Self::new([Capability::TextSend, Capability::TmuxAttach])
+    }
+
+    #[must_use]
+    pub fn contains(&self, capability: Capability) -> bool {
+        self.0.contains(&capability)
+    }
+
+    pub fn extend(&mut self, other: &Self) {
+        self.0.extend(other.0.iter().copied());
+    }
+}
+
+/// Origin of a Fleet observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provenance {
+    AppServer,
+    Hook,
+    Tmux,
+    AinbRegistry,
+    Broker,
+    Job,
+    Transcript,
+}
+
+/// Trust level assigned to an observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Confidence {
+    Inferred,
+    Observed,
+    Authoritative,
+}
+
+/// Current health of a session control or observation transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportHealth {
+    Healthy,
+    Degraded,
+    Unavailable,
+    Unknown,
+}
+
+/// Authoritative Fleet read-model record used by new control-plane surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetSession {
+    pub session_key: SessionKey,
+    pub provider: Provider,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_session_id: Option<String>,
+    pub cwd: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exact_tmux_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pane_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_start_fingerprint: Option<String>,
+    pub lifecycle: LifecycleState,
+    pub attention: AttentionState,
+    pub management: ManagementState,
+    pub capabilities: Capabilities,
+    pub provenance: BTreeSet<Provenance>,
+    pub confidence: Confidence,
+    pub transport_health: TransportHealth,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_seen_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_seen_ms: Option<i64>,
+    pub version: u64,
 }
 
 /// Unified session identity. May be backed by 1+ sources after merge.
@@ -163,4 +366,40 @@ pub enum SendOutcome {
     Broker { peer_id: String },
     Tmux { tmux_session: String },
     Failed { reason: String },
+}
+
+#[cfg(test)]
+mod fleet_identity_tests {
+    use super::*;
+
+    #[test]
+    fn managed_key_uses_provider_and_provider_session_id() {
+        assert_eq!(
+            SessionKey::managed(Provider::Codex, "thread-123").as_str(),
+            "codex:thread-123"
+        );
+        assert_eq!(
+            SessionKey::managed(Provider::Claude, "session-456").as_str(),
+            "claude:session-456"
+        );
+    }
+
+    #[test]
+    fn legacy_key_changes_with_exact_target_or_process_start() {
+        let first = SessionKey::legacy(Provider::Claude, "agent:1.0", "pid=1;started=10");
+        let other_pane = SessionKey::legacy(Provider::Claude, "agent:1.1", "pid=1;started=10");
+        let restarted = SessionKey::legacy(Provider::Claude, "agent:1.0", "pid=2;started=20");
+
+        assert_ne!(first, other_pane);
+        assert_ne!(first, restarted);
+    }
+
+    #[test]
+    fn degraded_capabilities_exclude_structured_and_destructive_actions() {
+        let capabilities = Capabilities::degraded_tmux();
+        assert!(capabilities.contains(Capability::TextSend));
+        assert!(capabilities.contains(Capability::TmuxAttach));
+        assert!(!capabilities.contains(Capability::StructuredAnswer));
+        assert!(!capabilities.contains(Capability::Kill));
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
@@ -64,6 +64,9 @@ ainb-fleet-core = { path = "../ainb-fleet-core" }
 # Shared JSON-RPC envelope + the P4 snapshot wire row types the RPC server
 # serialises over the unix socket (P4.10). Pure data — no host deps leak in.
 ainb-hangar-proto = { path = "../ainb-hangar-proto" }
+# Claude's blocking broker owns exact structured-question and permission
+# delivery. Hangar calls its public wire client and never reads notifyd state.
+ainb-plugin-notifyd = { path = "../ainb-plugin-notifyd" }
 # e38.23 OS-level agent confinement: wraps the provider spawn in a Seatbelt
 # (macOS) / Landlock (Linux) FS sandbox so the agent subprocess can only
 # read/write the task's isolated roots. Gates the non-claude providers (e38.16).
@@ -97,6 +100,7 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+futures-util = { workspace = true }
 # P6.2 skill importer: parse the YAML frontmatter block of each `SKILL.md`
 # (`name:` / `description:`) when syncing `toolkit/packages/skills/`.
 serde_yaml = { workspace = true }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
@@ -43,9 +43,9 @@
 //!
 //! ## Delivery semantics
 //!
-//! Best-effort: a missing file is a no-op; a corrupt line is skipped (its bytes
-//! still consumed so the cursor never wedges); a store/emit fault is logged and
-//! dropped (a failed ingest must never down the daemon).
+//! Best-effort: a missing file is a no-op and a corrupt line is skipped. A store
+//! fault leaves the cursor before the failed line so a later pass replays it.
+//! A failed ingest never downs the daemon.
 
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -73,7 +73,10 @@ const TICK: std::time::Duration = std::time::Duration::from_secs(3);
 /// submit) never indicate a session is blocked, so they are skipped without a
 /// transcript read.
 fn is_qualifying(event_type: &str) -> bool {
-    matches!(event_type, "Notification" | "Stop" | "SubagentStop")
+    matches!(
+        event_type,
+        "AskUserQuestion" | "PermissionRequest" | "Notification" | "Stop" | "SubagentStop"
+    )
 }
 
 /// The subset of the canonical hook line the producer needs. Lenient: unknown
@@ -82,6 +85,8 @@ fn is_qualifying(event_type: &str) -> bool {
 #[derive(Debug, Deserialize)]
 struct HookEventLine {
     #[serde(default)]
+    ts: i64,
+    #[serde(default)]
     session_id: String,
     #[serde(default)]
     cwd: String,
@@ -89,6 +94,10 @@ struct HookEventLine {
     transcript_path: String,
     #[serde(default)]
     event_type: String,
+    #[serde(default)]
+    matcher: String,
+    #[serde(default)]
+    agent: String,
 }
 
 /// The attention ingest producer — owns the paths + the write handles.
@@ -99,6 +108,13 @@ pub struct AttentionIngest {
     events_jsonl: PathBuf,
     /// This producer's OWN durable byte-offset cursor (a plain u64 text file).
     cursor_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineOutcome {
+    Processed,
+    Raised,
+    Retry,
 }
 
 impl AttentionIngest {
@@ -162,35 +178,78 @@ impl AttentionIngest {
         let end = last_nl + 1;
 
         let mut raised = 0;
+        let mut committed_end = 0usize;
         // Track each line's absolute byte offset in the file (the stable
-        // per-occurrence identity the attention id is keyed on). `split` drops the
-        // '\n' delimiter, so advance by the line length plus one for it.
+        // per-occurrence identity the attention id is keyed on). `split_inclusive`
+        // keeps the delimiter, avoiding a synthetic extra byte after the final
+        // newline.
         let mut line_start = 0usize;
-        for line_bytes in buf[..end].split(|&b| b == b'\n') {
+        for segment in buf[..end].split_inclusive(|&b| b == b'\n') {
             let offset = start + line_start as u64;
-            line_start += line_bytes.len() + 1;
+            line_start += segment.len();
+            let line_bytes = segment.strip_suffix(b"\n").unwrap_or(segment);
             if line_bytes.is_empty() {
+                committed_end = line_start;
                 continue;
             }
             if let Ok(line) = std::str::from_utf8(line_bytes) {
-                if self.process_line(line, offset, now_ms).await {
-                    raised += 1;
+                match self.process_line(line, offset, now_ms).await {
+                    LineOutcome::Raised => {
+                        raised += 1;
+                        committed_end = line_start;
+                    }
+                    LineOutcome::Processed => committed_end = line_start,
+                    LineOutcome::Retry => break,
                 }
+            } else {
+                committed_end = line_start;
             }
         }
-        write_cursor(&self.cursor_path, start + end as u64);
+        write_cursor(&self.cursor_path, start + committed_end as u64);
         raised
     }
 
-    /// Process one hook line: gate, classify, raise. Returns `true` when a NEW
-    /// attention row was raised. `offset` is the line's absolute byte position in
-    /// `events.jsonl` — the stable per-occurrence key the attention id uses.
-    async fn process_line(&self, raw: &str, offset: u64, now_ms: i64) -> bool {
+    /// Process one hook line. Store faults return `Retry`, leaving the cursor
+    /// before this line so the next pass replays it through idempotent event IDs.
+    async fn process_line(&self, raw: &str, offset: u64, now_ms: i64) -> LineOutcome {
         let Ok(line) = serde_json::from_str::<HookEventLine>(raw) else {
-            return false;
+            return LineOutcome::Processed;
         };
-        if !is_qualifying(&line.event_type) || (line.cwd.is_empty() && line.session_id.is_empty()) {
-            return false;
+        if line.cwd.is_empty() && line.session_id.is_empty() {
+            return LineOutcome::Processed;
+        }
+
+        // Every hook line feeds the canonical Fleet reducer, including events
+        // that do not raise an attention card. The byte offset is a replay-safe
+        // occurrence id, shared with this consumer's durable cursor semantics.
+        let payload =
+            serde_json::from_str::<serde_json::Value>(raw).unwrap_or(serde_json::Value::Null);
+        let semantic_event = if line.event_type == "PreToolUse" && line.matcher == "AskUserQuestion"
+        {
+            "AskUserQuestion"
+        } else {
+            line.event_type.as_str()
+        };
+        if !line.session_id.is_empty() {
+            let observation = crate::fleet::HookObservation {
+                event_id: format!("hook:{}:{offset}", line.session_id),
+                provider: &line.agent,
+                provider_session_id: &line.session_id,
+                cwd: &line.cwd,
+                event_type: semantic_event,
+                payload: &payload,
+                observed_at: if line.ts > 0 { line.ts } else { now_ms },
+            };
+            if let Err(error) =
+                crate::fleet::apply_hook(&self.pool, &self.events, observation).await
+            {
+                tracing::warn!(error = %error, "fleet hook reduce failed");
+                return LineOutcome::Retry;
+            }
+        }
+
+        if !is_qualifying(semantic_event) {
+            return LineOutcome::Processed;
         }
 
         // Classify off the async runtime: `classify` reads the JSONL transcript +
@@ -202,7 +261,7 @@ impl AttentionIngest {
         .await
         .ok()
         .flatten() else {
-            return false;
+            return LineOutcome::Processed;
         };
 
         let kind = kind_of(&row.context);
@@ -227,11 +286,11 @@ impl AttentionIngest {
         let id = format!("att:{}:{}", line.session_id, offset);
 
         match AttentionRepo::get(&self.pool, &id).await {
-            Ok(Some(_)) => return false, // already raised (open or answered)
+            Ok(Some(_)) => return LineOutcome::Processed, // already raised
             Ok(None) => {}
             Err(e) => {
                 tracing::warn!(error = %e, "attention ingest: existence check failed");
-                return false;
+                return LineOutcome::Retry;
             }
         }
 
@@ -263,7 +322,7 @@ impl AttentionIngest {
         };
         if let Err(e) = AttentionRepo::insert(&self.pool, &new).await {
             tracing::warn!(error = %e, "attention ingest: insert failed");
-            return false;
+            return LineOutcome::Retry;
         }
         self.events.emit_attention(HangarEvent::AttentionRaised {
             attention_id: id,
@@ -274,7 +333,7 @@ impl AttentionIngest {
             created_at: now_ms,
             channels,
         });
-        true
+        LineOutcome::Raised
     }
 
     /// Close any OPEN ASK rows a session still carries once a later hook shows it
@@ -646,6 +705,29 @@ mod tests {
         let ingest = ingest_for(&store, &events_jsonl, &cursor);
         assert_eq!(ingest.ingest_once(5000).await, 0);
         assert!(AttentionRepo::list_fleet(store.pool()).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn fleet_store_failure_leaves_cursor_before_line_for_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let events_jsonl = dir.path().join("events.jsonl");
+        let cursor = dir.path().join("attention_ingest.offset");
+        std::fs::write(
+            &events_jsonl,
+            format!("{}\n", hook_line("sid-retry", "/tmp/retry", "SessionStart")),
+        )
+        .unwrap();
+
+        let ingest = ingest_for(&store, &events_jsonl, &cursor);
+        store.pool().close().await;
+
+        assert_eq!(ingest.ingest_once(5000).await, 0);
+        assert_eq!(
+            read_cursor(&cursor),
+            0,
+            "failed Fleet persistence must not consume the durable hook line"
+        );
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
@@ -82,6 +82,9 @@ pub struct EventBroker {
     /// as their durable source. Lossy like the workspace broadcast: a resuming
     /// surface catches up via `attention/list`, so a dropped nudge self-heals.
     attention_tx: broadcast::Sender<HangarEvent>,
+    /// Committed Fleet revisions. Durable rows in `fleet_event` remain source
+    /// of truth; this channel only wakes live subscribers.
+    fleet_tx: broadcast::Sender<i64>,
 }
 
 impl Default for EventBroker {
@@ -98,10 +101,12 @@ impl EventBroker {
     pub fn new() -> Self {
         let (tx, _rx) = broadcast::channel(CHANNEL_CAPACITY);
         let (attention_tx, _arx) = broadcast::channel(CHANNEL_CAPACITY);
+        let (fleet_tx, _frx) = broadcast::channel(CHANNEL_CAPACITY);
         Self {
             tx,
             outbox_tx: None,
             attention_tx,
+            fleet_tx,
         }
     }
 
@@ -117,12 +122,14 @@ impl EventBroker {
     pub fn with_outbox() -> (Self, mpsc::UnboundedReceiver<ScopedEvent>) {
         let (tx, _rx) = broadcast::channel(CHANNEL_CAPACITY);
         let (attention_tx, _arx) = broadcast::channel(CHANNEL_CAPACITY);
+        let (fleet_tx, _frx) = broadcast::channel(CHANNEL_CAPACITY);
         let (outbox_tx, outbox_rx) = mpsc::unbounded_channel();
         (
             Self {
                 tx,
                 outbox_tx: Some(outbox_tx),
                 attention_tx,
+                fleet_tx,
             },
             outbox_rx,
         )
@@ -135,6 +142,7 @@ impl EventBroker {
             tx: self.tx.clone(),
             outbox_tx: self.outbox_tx.clone(),
             attention_tx: self.attention_tx.clone(),
+            fleet_tx: self.fleet_tx.clone(),
         }
     }
 
@@ -156,6 +164,13 @@ impl EventBroker {
     pub fn subscribe_attention(&self) -> broadcast::Receiver<HangarEvent> {
         self.attention_tx.subscribe()
     }
+
+    /// Register before reading a Fleet snapshot, then replay durable revisions
+    /// after its head. This ordering closes the snapshot-to-live race.
+    #[must_use]
+    pub fn subscribe_fleet(&self) -> broadcast::Receiver<i64> {
+        self.fleet_tx.subscribe()
+    }
 }
 
 /// A publishing handle onto the broker, threaded through the daemon's mutation
@@ -165,6 +180,7 @@ pub struct EventSink {
     tx: broadcast::Sender<ScopedEvent>,
     outbox_tx: Option<mpsc::UnboundedSender<ScopedEvent>>,
     attention_tx: broadcast::Sender<HangarEvent>,
+    fleet_tx: broadcast::Sender<i64>,
 }
 
 impl EventSink {
@@ -200,6 +216,11 @@ impl EventSink {
     pub fn emit_attention(&self, event: HangarEvent) {
         let _ = self.attention_tx.send(event);
     }
+
+    /// Wake live Fleet subscribers after a durable revision commits.
+    pub fn emit_fleet_revision(&self, revision: i64) {
+        let _ = self.fleet_tx.send(revision);
+    }
 }
 
 /// Frame `event` as a `hangar/event` JSON-RPC notification in the daemon's
@@ -228,9 +249,15 @@ pub fn encode_event_frame(event: &HangarEvent) -> Vec<u8> {
 /// mirrors.
 #[must_use]
 pub fn encode_event_frame_payload(params: &serde_json::Value) -> Vec<u8> {
+    encode_notification_frame(EVENT_METHOD, params)
+}
+
+/// Frame arbitrary JSON-RPC notification parameters for control-plane streams.
+#[must_use]
+pub fn encode_notification_frame(method: &str, params: &serde_json::Value) -> Vec<u8> {
     let body = serde_json::to_vec(&serde_json::json!({
         "jsonrpc": "2.0",
-        "method": EVENT_METHOD,
+        "method": method,
         "params": params,
     }))
     .unwrap_or_else(|_| b"{}".to_vec());

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -1,0 +1,1602 @@
+//! Fleet session reducer orchestration.
+//!
+//! Provider hooks and tmux discovery normalize into the Hangar Fleet tables.
+//! SQLite owns canonical state and revision order. Live broadcasts only wake
+//! subscribers after the matching revision commits.
+
+use ainb_fleet_core::discover::discover_from_tmux;
+use ainb_fleet_core::types::{
+    AttentionState, Confidence, FleetSession, LifecycleState, ManagementState, Provider,
+    SessionKey, TransportHealth,
+};
+use ainb_hangar_store::repo::fleet::{
+    ApplyFleetEventResult, FleetEventRow, FleetRepo, FleetRepoError, FleetSessionPatch,
+    FleetSessionRow, NewFleetEvent, ObservationAuthority,
+};
+use serde_json::Value;
+use sqlx::SqlitePool;
+
+use crate::events::EventSink;
+use crate::fleet_provider::codex::{CodexApprovalKind, CodexCapabilities, CodexInbound};
+
+/// Semantic hook observation before storage normalization.
+#[derive(Debug, Clone)]
+pub struct HookObservation<'a> {
+    /// Replay-safe hook or legacy event identifier.
+    pub event_id: String,
+    /// Provider token supplied by hook installation.
+    pub provider: &'a str,
+    /// Provider-owned stable session identifier.
+    pub provider_session_id: &'a str,
+    /// Working directory metadata.
+    pub cwd: &'a str,
+    /// Semantic hook discriminator.
+    pub event_type: &'a str,
+    /// Complete raw hook payload.
+    pub payload: &'a Value,
+    /// Observation time in epoch milliseconds.
+    pub observed_at: i64,
+}
+
+/// Apply one exact provider hook and wake revision subscribers after commit.
+pub async fn apply_hook(
+    pool: &SqlitePool,
+    events: &EventSink,
+    observation: HookObservation<'_>,
+) -> Result<ApplyFleetEventResult, FleetRepoError> {
+    let provider = parse_provider(observation.provider);
+    let session_key = SessionKey::managed(provider, observation.provider_session_id);
+    let tmux_target = observation
+        .payload
+        .get("tmux_target")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let process_start_fingerprint = observation
+        .payload
+        .get("process_start_fingerprint")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let exact_tmux_identity = tmux_target.is_some() && process_start_fingerprint.is_some();
+    let (lifecycle_state, attention_state) = states_for_hook(observation.event_type);
+    let request_fingerprint = match attention_state {
+        Some(AttentionState::Ask | AttentionState::Approval) => {
+            let fingerprint = match (provider, observation.event_type) {
+                (Provider::Claude, "AskUserQuestion") => {
+                    claude_request_identity(observation.payload).map_or_else(
+                        || fingerprint_value(observation.payload),
+                        |identity| ainb_plugin_notifyd::broker::request_fingerprint(&identity),
+                    )
+                }
+                (Provider::Claude, "PermissionRequest") => {
+                    claude_permission_identity(observation.payload).map_or_else(
+                        || fingerprint_value(observation.payload),
+                        |(tool, context)| {
+                            ainb_plugin_notifyd::broker::permission_fingerprint(&tool, &context)
+                        },
+                    )
+                }
+                _ => fingerprint_value(observation.payload),
+            };
+            Some(Some(fingerprint))
+        }
+        Some(AttentionState::None) => Some(None),
+        _ => None,
+    };
+    let event = NewFleetEvent {
+        event_id: observation.event_id,
+        session_key: session_key.to_string(),
+        observed_at: observation.observed_at,
+        authority: ObservationAuthority::Authoritative,
+        event_type: observation.event_type.to_string(),
+        payload: serde_json::to_string(observation.payload).unwrap_or_else(|_| "{}".to_string()),
+        patch: FleetSessionPatch {
+            provider: Some(provider.as_str().to_string()),
+            provider_session_id: Some(observation.provider_session_id.to_string()),
+            tmux_target: tmux_target.clone(),
+            process_start_fingerprint: process_start_fingerprint.clone(),
+            cwd: Some(observation.cwd.to_string()),
+            management_state: (provider == Provider::Claude).then(|| "MANAGED".to_string()),
+            capabilities: (provider == Provider::Claude)
+                .then(|| claude_managed_capabilities(exact_tmux_identity)),
+            confidence: Some("HIGH".to_string()),
+            lifecycle_state: lifecycle_state.map(state_token),
+            attention_state: attention_state.map(attention_token),
+            current_request_fingerprint: request_fingerprint,
+            transport_health: (provider == Provider::Claude).then(|| "HEALTHY".to_string()),
+            ..FleetSessionPatch::default()
+        },
+    };
+    let result = FleetRepo::apply_event(pool, &event).await?;
+    if !result.duplicate {
+        events.emit_fleet_revision(result.revision);
+    }
+    if let (Some(target), Some(fingerprint)) =
+        (tmux_target.as_deref(), process_start_fingerprint.as_deref())
+    {
+        retire_correlated_legacy(
+            pool,
+            events,
+            session_key.as_str(),
+            provider.as_str(),
+            target,
+            fingerprint,
+            observation.observed_at,
+        )
+        .await?;
+    }
+    Ok(result)
+}
+
+async fn retire_correlated_legacy(
+    pool: &SqlitePool,
+    events: &EventSink,
+    managed_key: &str,
+    provider: &str,
+    tmux_target: &str,
+    process_start_fingerprint: &str,
+    observed_at: i64,
+) -> Result<(), FleetRepoError> {
+    let legacy_keys = sqlx::query_scalar::<_, String>(
+        "SELECT session_key FROM fleet_session WHERE session_key != ? AND provider = ? \
+         AND management_state = 'DEGRADED' AND tmux_target = ? \
+         AND process_start_fingerprint = ? AND visible = 1",
+    )
+    .bind(managed_key)
+    .bind(provider)
+    .bind(tmux_target)
+    .bind(process_start_fingerprint)
+    .fetch_all(pool)
+    .await?;
+    for legacy_key in legacy_keys {
+        if let Some(revision) =
+            FleetRepo::supersede_session(pool, &legacy_key, managed_key, observed_at).await?
+        {
+            events.emit_fleet_revision(revision);
+        }
+    }
+    Ok(())
+}
+
+/// Read a wire-ready consistent snapshot from Hangar SQLite.
+pub async fn snapshot_wire(
+    pool: &SqlitePool,
+) -> Result<ainb_hangar_proto::fleet::FleetSnapshot, sqlx::Error> {
+    let snapshot = FleetRepo::snapshot(pool).await?;
+    let mut sessions = Vec::with_capacity(snapshot.sessions.len());
+    for row in &snapshot.sessions {
+        let current_request = if row.current_request_fingerprint.is_some() {
+            current_request_wire(pool, &row.session_key).await?
+        } else {
+            None
+        };
+        sessions.push(session_wire(row, current_request));
+    }
+    Ok(ainb_hangar_proto::fleet::FleetSnapshot {
+        head_revision: snapshot.head_revision,
+        sessions,
+    })
+}
+
+/// Read complete payload for current structured request or approval.
+pub async fn current_request_wire(
+    pool: &SqlitePool,
+    session_key: &str,
+) -> Result<Option<Value>, sqlx::Error> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT payload FROM fleet_event \
+         WHERE session_key = ? AND event_type IN (\
+            'AskUserQuestion', 'PermissionRequest', \
+            'item/tool/requestUserInput', \
+            'item/commandExecution/requestApproval', \
+            'item/fileChange/requestApproval', \
+            'item/permissions/requestApproval'\
+         ) AND applied = 1 ORDER BY revision DESC LIMIT 1",
+    )
+    .bind(session_key)
+    .fetch_optional(pool)
+    .await
+    .map(|payload| payload.and_then(|payload| serde_json::from_str(&payload).ok()))
+}
+
+/// Apply one ordered Codex app-server request or lifecycle event.
+pub async fn apply_codex_inbound(
+    pool: &SqlitePool,
+    events: &EventSink,
+    event_id: String,
+    inbound: CodexInbound,
+    capabilities: &CodexCapabilities,
+    observed_at: i64,
+) -> Result<Option<ApplyFleetEventResult>, FleetRepoError> {
+    let normalized = normalize_codex_inbound(event_id, inbound, capabilities, observed_at);
+    let Some(mut event) = normalized else {
+        return Ok(None);
+    };
+    if FleetRepo::get_session(pool, &event.session_key)
+        .await?
+        .is_some_and(|row| row.tmux_target.is_some() && row.transport_health == "HEALTHY")
+    {
+        event.patch.capabilities = event.patch.capabilities.as_deref().map(|serialized| {
+            with_tmux_capabilities(&with_managed_lifecycle_capabilities(serialized, true), true)
+        });
+    }
+    let result = FleetRepo::apply_event(pool, &event).await?;
+    if !result.duplicate {
+        events.emit_fleet_revision(result.revision);
+    }
+    Ok(Some(result))
+}
+
+/// Downgrade managed Codex rows when app-server transport exits.
+pub async fn mark_codex_manager_unavailable(
+    pool: &SqlitePool,
+    events: &EventSink,
+    observed_at: i64,
+) -> Result<usize, FleetRepoError> {
+    let snapshot = FleetRepo::snapshot(pool).await?;
+    let mut changed = 0;
+    for row in snapshot
+        .sessions
+        .into_iter()
+        .filter(|row| row.provider == "codex" && row.management_state == "MANAGED")
+    {
+        let tmux_available = row.tmux_target.is_some() && row.transport_health == "HEALTHY";
+        let event = NewFleetEvent {
+            event_id: format!(
+                "codex-manager:unavailable:{}:{observed_at}",
+                row.session_key
+            ),
+            session_key: row.session_key.clone(),
+            observed_at,
+            authority: ObservationAuthority::Authoritative,
+            event_type: "codex_manager_unavailable".to_string(),
+            payload: "{}".to_string(),
+            patch: FleetSessionPatch {
+                management_state: Some("DEGRADED".to_string()),
+                capabilities: Some(if tmux_available {
+                    degraded_capabilities()
+                } else {
+                    with_tmux_capabilities("{}", false)
+                }),
+                transport_health: Some(
+                    if tmux_available {
+                        "DEGRADED"
+                    } else {
+                        "UNAVAILABLE"
+                    }
+                    .to_string(),
+                ),
+                ..FleetSessionPatch::default()
+            },
+        };
+        let result = FleetRepo::apply_event(pool, &event).await?;
+        if !result.duplicate {
+            events.emit_fleet_revision(result.revision);
+        }
+        changed += usize::from(result.applied);
+    }
+    Ok(changed)
+}
+
+/// Restore quiet managed Codex rows after manager respawn. Recovery requires
+/// exact app-server thread read plus exact live tmux process identity, then one
+/// authoritative revision restores transport and lifecycle capabilities.
+pub async fn recover_codex_manager(
+    pool: &SqlitePool,
+    events: &EventSink,
+    manager: &crate::fleet_provider::codex_manager::CodexManagerHandle,
+    observed_at: i64,
+) -> Result<usize, FleetRepoError> {
+    let discovered = match discover_from_tmux().await {
+        Ok(discovered) => discovered,
+        Err(error) => {
+            tracing::debug!(error = %error, "Codex manager recovery tmux discovery unavailable");
+            return Ok(0);
+        }
+    };
+    let snapshot = FleetRepo::snapshot(pool).await?;
+    let mut changed = 0;
+    for row in snapshot.sessions.into_iter().filter(|row| {
+        row.provider == "codex"
+            && row.provider_session_id.is_some()
+            && row.tmux_target.is_some()
+            && row.process_start_fingerprint.is_some()
+    }) {
+        let live = discovered.iter().any(|candidate| {
+            candidate.exact_tmux_target == row.tmux_target
+                && candidate.process_start_fingerprint == row.process_start_fingerprint
+        });
+        if !live {
+            continue;
+        }
+        let thread_id = row.provider_session_id.as_deref().unwrap_or_default();
+        if manager.thread_read(thread_id).await.is_err() {
+            continue;
+        }
+        let event = codex_manager_recovery_event(&row, manager.capabilities(), observed_at);
+        let result = FleetRepo::apply_event(pool, &event).await?;
+        if !result.duplicate {
+            events.emit_fleet_revision(result.revision);
+        }
+        changed += usize::from(result.applied);
+    }
+    Ok(changed)
+}
+
+fn codex_manager_recovery_event(
+    row: &FleetSessionRow,
+    capabilities: &CodexCapabilities,
+    observed_at: i64,
+) -> NewFleetEvent {
+    NewFleetEvent {
+        event_id: format!("codex-manager:recovered:{}:{observed_at}", row.session_key),
+        session_key: row.session_key.clone(),
+        observed_at,
+        authority: ObservationAuthority::Authoritative,
+        event_type: "codex_manager_recovered".to_string(),
+        payload: "{}".to_string(),
+        patch: FleetSessionPatch {
+            management_state: Some("MANAGED".to_string()),
+            capabilities: Some(with_tmux_capabilities(
+                &with_managed_lifecycle_capabilities(
+                    &codex_managed_capabilities(capabilities),
+                    true,
+                ),
+                true,
+            )),
+            confidence: Some("HIGH".to_string()),
+            transport_health: Some("HEALTHY".to_string()),
+            ..FleetSessionPatch::default()
+        },
+    }
+}
+
+/// Persist exact tmux identity for one Fleet-launched managed Codex TUI.
+pub async fn register_managed_codex_tmux(
+    pool: &SqlitePool,
+    events: &EventSink,
+    thread_id: &str,
+    cwd: &str,
+    tmux: &FleetSession,
+    capabilities: &CodexCapabilities,
+    observed_at: i64,
+) -> Result<ApplyFleetEventResult, FleetRepoError> {
+    let target = tmux.exact_tmux_target.clone().ok_or_else(|| FleetRepoError::SessionNotFound {
+        session_key: format!("codex:{thread_id}:tmux-target"),
+    })?;
+    let fingerprint =
+        tmux.process_start_fingerprint
+            .clone()
+            .ok_or_else(|| FleetRepoError::SessionNotFound {
+                session_key: format!("codex:{thread_id}:process-fingerprint"),
+            })?;
+    let event = NewFleetEvent {
+        event_id: format!("codex-tmux:{thread_id}:{fingerprint}"),
+        session_key: SessionKey::managed(Provider::Codex, thread_id).to_string(),
+        observed_at,
+        authority: ObservationAuthority::Authoritative,
+        event_type: "codex_managed_tui_started".to_string(),
+        payload: serde_json::to_string(tmux).unwrap_or_else(|_| "{}".to_string()),
+        patch: FleetSessionPatch {
+            provider: Some("codex".to_string()),
+            provider_session_id: Some(thread_id.to_string()),
+            tmux_target: Some(target),
+            process_start_fingerprint: Some(fingerprint),
+            cwd: Some(cwd.to_string()),
+            management_state: Some("MANAGED".to_string()),
+            capabilities: Some(with_tmux_capabilities(
+                &with_managed_lifecycle_capabilities(
+                    &codex_managed_capabilities(capabilities),
+                    true,
+                ),
+                true,
+            )),
+            confidence: Some("HIGH".to_string()),
+            lifecycle_state: Some("STARTING".to_string()),
+            attention_state: Some("NONE".to_string()),
+            transport_health: Some("HEALTHY".to_string()),
+            ..FleetSessionPatch::default()
+        },
+    };
+    let result = FleetRepo::apply_event(pool, &event).await?;
+    if !result.duplicate {
+        events.emit_fleet_revision(result.revision);
+    }
+    Ok(result)
+}
+
+/// Persist terminal local lifecycle after exact managed Codex tmux shutdown.
+pub async fn mark_managed_codex_exited(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session_key: &str,
+    event_type: &str,
+    capabilities: &CodexCapabilities,
+    observed_at: i64,
+) -> Result<ApplyFleetEventResult, FleetRepoError> {
+    let event = NewFleetEvent {
+        event_id: format!("codex-lifecycle:{event_type}:{session_key}:{observed_at}"),
+        session_key: session_key.to_string(),
+        observed_at,
+        authority: ObservationAuthority::Authoritative,
+        event_type: event_type.to_string(),
+        payload: "{}".to_string(),
+        patch: FleetSessionPatch {
+            capabilities: Some(with_tmux_capabilities(
+                &with_managed_lifecycle_capabilities(
+                    &codex_managed_capabilities(capabilities),
+                    false,
+                ),
+                false,
+            )),
+            lifecycle_state: Some("EXITED".to_string()),
+            attention_state: Some("NONE".to_string()),
+            current_request_fingerprint: Some(None),
+            transport_health: Some("UNAVAILABLE".to_string()),
+            ..FleetSessionPatch::default()
+        },
+    };
+    let result = FleetRepo::apply_event(pool, &event).await?;
+    if !result.duplicate {
+        events.emit_fleet_revision(result.revision);
+    }
+    Ok(result)
+}
+
+fn normalize_codex_inbound(
+    event_id: String,
+    inbound: CodexInbound,
+    capabilities: &CodexCapabilities,
+    observed_at: i64,
+) -> Option<NewFleetEvent> {
+    let _manager_sequence = event_id;
+    let event_id;
+    let (thread_id, event_type, payload, lifecycle, attention, fingerprint) = match inbound {
+        CodexInbound::RequestUserInput(request) => {
+            let payload = serde_json::to_value(&request).ok()?;
+            let fingerprint = fingerprint_value(&payload);
+            event_id = format!("codex-request:{}:{fingerprint}", request.identity.thread_id);
+            (
+                request.identity.thread_id.clone(),
+                "item/tool/requestUserInput".to_string(),
+                payload,
+                Some(LifecycleState::Idle),
+                Some(AttentionState::Ask),
+                Some(Some(fingerprint)),
+            )
+        }
+        CodexInbound::Approval(request) => {
+            let event_type = match request.kind {
+                CodexApprovalKind::CommandExecution => "item/commandExecution/requestApproval",
+                CodexApprovalKind::FileChange => "item/fileChange/requestApproval",
+                CodexApprovalKind::Permissions => "item/permissions/requestApproval",
+            };
+            let payload = serde_json::json!({
+                "identity": {
+                    "requestId": request.identity.request_id.as_value(),
+                    "threadId": request.identity.thread_id,
+                    "turnId": request.identity.turn_id,
+                    "itemId": request.identity.item_id,
+                },
+                "kind": match request.kind {
+                    CodexApprovalKind::CommandExecution => "commandExecution",
+                    CodexApprovalKind::FileChange => "fileChange",
+                    CodexApprovalKind::Permissions => "permissions",
+                },
+                "params": request.params,
+            });
+            let thread_id = payload["identity"]["threadId"].as_str()?.to_string();
+            let fingerprint = fingerprint_value(&payload);
+            event_id = format!("codex-request:{thread_id}:{fingerprint}");
+            (
+                thread_id,
+                event_type.to_string(),
+                payload,
+                Some(LifecycleState::Idle),
+                Some(AttentionState::Approval),
+                Some(Some(fingerprint)),
+            )
+        }
+        CodexInbound::Notification { method, params } => {
+            let thread_id = codex_thread_id(&params)?;
+            event_id = format!(
+                "codex-event:{thread_id}:{}:{}",
+                method,
+                fingerprint_value(&params)
+            );
+            let (lifecycle, attention, fingerprint) = codex_notification_state(&method);
+            (thread_id, method, params, lifecycle, attention, fingerprint)
+        }
+        CodexInbound::OtherRequest {
+            request_id,
+            method,
+            params,
+        } => {
+            let thread_id = codex_thread_id(&params)?;
+            let payload = serde_json::json!({
+                "requestId": request_id.as_value(),
+                "method": method,
+                "params": params,
+            });
+            let fingerprint = fingerprint_value(&payload);
+            event_id = format!("codex-request:{thread_id}:{fingerprint}");
+            (
+                thread_id,
+                method,
+                payload,
+                Some(LifecycleState::Running),
+                Some(AttentionState::Waiting),
+                Some(Some(fingerprint)),
+            )
+        }
+    };
+    let session_key = SessionKey::managed(Provider::Codex, &thread_id).to_string();
+    Some(NewFleetEvent {
+        event_id,
+        session_key,
+        observed_at,
+        authority: ObservationAuthority::Authoritative,
+        event_type,
+        payload: serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string()),
+        patch: FleetSessionPatch {
+            provider: Some("codex".to_string()),
+            provider_session_id: Some(thread_id),
+            management_state: Some("MANAGED".to_string()),
+            capabilities: Some(codex_managed_capabilities(capabilities)),
+            confidence: Some("HIGH".to_string()),
+            lifecycle_state: lifecycle.map(state_token),
+            attention_state: attention.map(attention_token),
+            current_request_fingerprint: fingerprint,
+            transport_health: Some("HEALTHY".to_string()),
+            ..FleetSessionPatch::default()
+        },
+    })
+}
+
+fn codex_thread_id(params: &Value) -> Option<String> {
+    params
+        .get("threadId")
+        .or_else(|| params.get("thread_id"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            params.get("thread").and_then(|thread| thread.get("id")).and_then(Value::as_str)
+        })
+        .map(str::to_string)
+}
+
+fn codex_notification_state(
+    method: &str,
+) -> (
+    Option<LifecycleState>,
+    Option<AttentionState>,
+    Option<Option<String>>,
+) {
+    match method {
+        "thread/started" => (
+            Some(LifecycleState::Idle),
+            Some(AttentionState::None),
+            Some(None),
+        ),
+        "turn/started" => (
+            Some(LifecycleState::Running),
+            Some(AttentionState::None),
+            Some(None),
+        ),
+        "turn/completed" => (
+            Some(LifecycleState::TurnComplete),
+            Some(AttentionState::None),
+            Some(None),
+        ),
+        "thread/closed" | "thread/archived" => (
+            Some(LifecycleState::Exited),
+            Some(AttentionState::None),
+            Some(None),
+        ),
+        method if method.contains("error") || method.contains("failed") => {
+            (None, Some(AttentionState::Error), None)
+        }
+        _ => (None, None, None),
+    }
+}
+
+/// Read durable wire events after a global revision.
+pub async fn events_after_wire(
+    pool: &SqlitePool,
+    after_revision: i64,
+    limit: i64,
+) -> Result<Vec<ainb_hangar_proto::fleet::FleetEvent>, sqlx::Error> {
+    FleetRepo::events_after(pool, after_revision, limit)
+        .await
+        .map(|events| events.iter().map(event_wire).collect())
+}
+
+fn session_wire(
+    row: &FleetSessionRow,
+    current_request: Option<Value>,
+) -> ainb_hangar_proto::fleet::FleetSession {
+    use ainb_hangar_proto::fleet as wire;
+    wire::FleetSession {
+        session_key: row.session_key.clone(),
+        provider: match row.provider.as_str() {
+            "claude" => wire::FleetProvider::Claude,
+            "codex" => wire::FleetProvider::Codex,
+            _ => wire::FleetProvider::Unknown,
+        },
+        provider_session_id: row.provider_session_id.clone(),
+        tmux_target: row.tmux_target.clone(),
+        process_start_fingerprint: row.process_start_fingerprint.clone(),
+        cwd: row.cwd.clone(),
+        display_name: row.display_name.clone(),
+        lifecycle: parse_lifecycle(&row.lifecycle_state),
+        attention: parse_attention(&row.attention_state),
+        current_request_fingerprint: row.current_request_fingerprint.clone(),
+        current_request,
+        management: if row.management_state == "MANAGED" {
+            wire::ManagementState::Managed
+        } else {
+            wire::ManagementState::Degraded
+        },
+        transport_health: match row.transport_health.as_str() {
+            "HEALTHY" => wire::TransportHealth::Healthy,
+            "DEGRADED" => wire::TransportHealth::Degraded,
+            "UNAVAILABLE" => wire::TransportHealth::Unavailable,
+            _ => wire::TransportHealth::Unknown,
+        },
+        capabilities: serde_json::from_str(&row.capabilities).unwrap_or_default(),
+        provenance: if row.provenance == "authoritative" {
+            wire::FleetProvenance::Authoritative
+        } else {
+            wire::FleetProvenance::Inferred
+        },
+        confidence: match row.confidence.as_str() {
+            "HIGH" => wire::FleetConfidence::High,
+            "MEDIUM" => wire::FleetConfidence::Medium,
+            _ => wire::FleetConfidence::Low,
+        },
+        discovered_at: row.discovered_at,
+        last_observed_at: row.last_observed_at,
+        lifecycle_updated_at: row.lifecycle_updated_at,
+        attention_updated_at: row.attention_updated_at,
+        version: row.version,
+        updated_revision: row.updated_revision,
+    }
+}
+
+fn event_wire(row: &FleetEventRow) -> ainb_hangar_proto::fleet::FleetEvent {
+    ainb_hangar_proto::fleet::FleetEvent {
+        revision: row.revision,
+        event_id: row.event_id.clone(),
+        session_key: row.session_key.clone(),
+        observed_at: row.observed_at,
+        provenance: if row.authority == "authoritative" {
+            ainb_hangar_proto::fleet::FleetProvenance::Authoritative
+        } else {
+            ainb_hangar_proto::fleet::FleetProvenance::Inferred
+        },
+        event_type: row.event_type.clone(),
+        payload: serde_json::from_str(&row.payload).unwrap_or(Value::Null),
+        session_version: row.session_version,
+        applied: row.applied,
+    }
+}
+
+fn parse_lifecycle(value: &str) -> ainb_hangar_proto::fleet::LifecycleState {
+    use ainb_hangar_proto::fleet::LifecycleState as State;
+    match value {
+        "STARTING" => State::Starting,
+        "RUNNING" => State::Running,
+        "TURN_COMPLETE" => State::TurnComplete,
+        "IDLE" => State::Idle,
+        "EXITED" => State::Exited,
+        _ => State::Unknown,
+    }
+}
+
+fn parse_attention(value: &str) -> ainb_hangar_proto::fleet::AttentionState {
+    use ainb_hangar_proto::fleet::AttentionState as State;
+    match value {
+        "ASK" => State::Ask,
+        "APPROVAL" => State::Approval,
+        "WAITING" => State::Waiting,
+        "ERROR" => State::Error,
+        _ => State::None,
+    }
+}
+
+/// Reconcile every exact tmux pane into the authoritative registry.
+///
+/// Discovery failures leave durable state untouched. A missing tmux server is
+/// reported by fleet-core as an empty roster, not an error.
+pub async fn reconcile_tmux_once(
+    pool: &SqlitePool,
+    events: &EventSink,
+    observed_at: i64,
+) -> anyhow::Result<usize> {
+    let sessions = discover_from_tmux().await?;
+    restore_tmux_transport(pool, events, &sessions, observed_at).await?;
+    let registered = FleetRepo::snapshot(pool).await?.sessions;
+    let mut discovered: std::collections::HashSet<String> =
+        sessions.iter().map(|session| session.session_key.to_string()).collect();
+    let mut applied = 0;
+    for session in sessions {
+        if let Some(managed) = registered.iter().find(|row| {
+            row.management_state == "MANAGED"
+                && row.tmux_target == session.exact_tmux_target
+                && row.process_start_fingerprint == session.process_start_fingerprint
+        }) {
+            discovered.insert(managed.session_key.clone());
+            continue;
+        }
+        let prior = FleetRepo::get_session(pool, session.session_key.as_str()).await?;
+        if prior.as_ref().is_some_and(|row| tmux_row_matches(row, &session)) {
+            continue;
+        }
+        let mut event = tmux_event(&session, observed_at);
+        if prior.is_some() {
+            event.event_id.push_str(&format!(":{observed_at}"));
+        }
+        match FleetRepo::apply_event(pool, &event).await {
+            Ok(result) => {
+                if !result.duplicate {
+                    events.emit_fleet_revision(result.revision);
+                }
+                if result.applied {
+                    applied += 1;
+                }
+            }
+            Err(error) => tracing::warn!(error = %error, "fleet tmux reconcile failed"),
+        }
+    }
+    let snapshot = FleetRepo::snapshot(pool).await?;
+    for row in snapshot.sessions {
+        if row.tmux_target.is_none()
+            || discovered.contains(&row.session_key)
+            || (row.lifecycle_state == "EXITED" && row.transport_health == "UNAVAILABLE")
+        {
+            continue;
+        }
+        let event = tmux_missing_event(&row, observed_at);
+        match FleetRepo::apply_event(pool, &event).await {
+            Ok(result) => {
+                if !result.duplicate {
+                    events.emit_fleet_revision(result.revision);
+                }
+                if result.applied {
+                    applied += 1;
+                }
+            }
+            Err(error) => tracing::warn!(error = %error, "fleet tmux exit reconcile failed"),
+        }
+    }
+    Ok(applied)
+}
+
+fn tmux_missing_event(row: &FleetSessionRow, observed_at: i64) -> NewFleetEvent {
+    NewFleetEvent {
+        event_id: format!("tmux:missing:{}:{observed_at}", row.session_key),
+        session_key: row.session_key.clone(),
+        observed_at,
+        authority: ObservationAuthority::Authoritative,
+        event_type: "tmux_missing".to_string(),
+        payload: "{}".to_string(),
+        patch: FleetSessionPatch {
+            capabilities: Some(capabilities_for_tmux_state(row, false)),
+            lifecycle_state: (row.management_state != "MANAGED"
+                && row.lifecycle_authority == "inferred")
+                .then(|| "EXITED".to_string()),
+            transport_health: Some("UNAVAILABLE".to_string()),
+            ..FleetSessionPatch::default()
+        },
+    }
+}
+
+fn tmux_row_matches(row: &FleetSessionRow, session: &FleetSession) -> bool {
+    row.provider == session.provider.as_str()
+        && row.tmux_target == session.exact_tmux_target
+        && row.process_start_fingerprint == session.process_start_fingerprint
+        && row.cwd == session.cwd
+        && row.management_state == management_token(session.management)
+        && row.confidence == confidence_token(session.confidence)
+        && row.lifecycle_state == state_token(session.lifecycle)
+        && row.attention_state == attention_token(session.attention)
+        && row.transport_health == transport_token(session.transport_health)
+}
+
+/// Keep unmanaged tmux sessions visible even when hooks are absent.
+#[must_use]
+pub fn spawn_tmux_reconciler(pool: SqlitePool, events: EventSink) -> tokio::task::JoinHandle<()> {
+    use ainb_hangar_core::clock::{HangarClock as _, SystemClock};
+    if std::env::var("AINB_FLEET_DISABLE_TMUX_DISCOVERY").as_deref() == Ok("1") {
+        return tokio::spawn(async {});
+    }
+    tokio::spawn(async move {
+        let clock = SystemClock;
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(3));
+        loop {
+            ticker.tick().await;
+            let observed_at = clock.now_ms();
+            if let Err(error) = reconcile_tmux_once(&pool, &events, observed_at).await {
+                tracing::debug!(error = %error, "fleet tmux discovery unavailable");
+                if let Err(downgrade) = mark_tmux_unavailable(&pool, &events, observed_at).await {
+                    tracing::warn!(error = %downgrade, "fleet tmux downgrade failed");
+                }
+            }
+        }
+    })
+}
+
+/// Mark cached tmux routes unavailable without discarding durable sessions.
+pub async fn mark_tmux_unavailable(
+    pool: &SqlitePool,
+    events: &EventSink,
+    observed_at: i64,
+) -> Result<usize, FleetRepoError> {
+    let snapshot = FleetRepo::snapshot(pool).await?;
+    let mut changed = 0;
+    for row in snapshot.sessions.into_iter().filter(|row| row.tmux_target.is_some()) {
+        let event = NewFleetEvent {
+            event_id: format!("tmux:unavailable:{}:{observed_at}", row.session_key),
+            session_key: row.session_key.clone(),
+            observed_at,
+            authority: ObservationAuthority::Authoritative,
+            event_type: "tmux_unavailable".to_string(),
+            payload: "{}".to_string(),
+            patch: FleetSessionPatch {
+                capabilities: Some(capabilities_for_tmux_state(&row, false)),
+                transport_health: Some("UNAVAILABLE".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        };
+        let result = FleetRepo::apply_event(pool, &event).await?;
+        if !result.duplicate {
+            events.emit_fleet_revision(result.revision);
+        }
+        changed += usize::from(result.applied);
+    }
+    Ok(changed)
+}
+
+async fn restore_tmux_transport(
+    pool: &SqlitePool,
+    events: &EventSink,
+    discovered: &[FleetSession],
+    observed_at: i64,
+) -> Result<(), FleetRepoError> {
+    let snapshot = FleetRepo::snapshot(pool).await?;
+    for row in snapshot.sessions {
+        let Some(target) = row.tmux_target.as_deref() else {
+            continue;
+        };
+        let live = discovered.iter().any(|session| {
+            session.exact_tmux_target.as_deref() == Some(target)
+                && session.process_start_fingerprint == row.process_start_fingerprint
+        });
+        if !live || row.transport_health == "HEALTHY" {
+            continue;
+        }
+        let event = NewFleetEvent {
+            event_id: format!("tmux:available:{}:{observed_at}", row.session_key),
+            session_key: row.session_key.clone(),
+            observed_at,
+            authority: ObservationAuthority::Authoritative,
+            event_type: "tmux_available".to_string(),
+            payload: "{}".to_string(),
+            patch: FleetSessionPatch {
+                capabilities: Some(capabilities_for_tmux_state(&row, true)),
+                transport_health: Some("HEALTHY".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        };
+        let result = FleetRepo::apply_event(pool, &event).await?;
+        if !result.duplicate {
+            events.emit_fleet_revision(result.revision);
+        }
+    }
+    Ok(())
+}
+
+fn with_tmux_capabilities(serialized: &str, available: bool) -> String {
+    let mut capabilities: ainb_hangar_proto::fleet::FleetCapabilities =
+        serde_json::from_str(serialized).unwrap_or_default();
+    capabilities.tmux_attach = available;
+    capabilities.tmux_text = available;
+    capabilities.verified_picker = available;
+    serde_json::to_string(&capabilities).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn capabilities_for_tmux_state(row: &FleetSessionRow, available: bool) -> String {
+    let serialized = if row.provider == "codex" && row.management_state == "MANAGED" {
+        with_managed_lifecycle_capabilities(&row.capabilities, available)
+    } else {
+        row.capabilities.clone()
+    };
+    with_tmux_capabilities(&serialized, available)
+}
+
+fn tmux_event(session: &FleetSession, observed_at: i64) -> NewFleetEvent {
+    let payload = serde_json::to_string(session).unwrap_or_else(|_| "{}".to_string());
+    NewFleetEvent {
+        event_id: format!(
+            "tmux:discovered:{}:{}",
+            session.session_key,
+            fingerprint_bytes(payload.as_bytes())
+        ),
+        session_key: session.session_key.to_string(),
+        observed_at,
+        authority: ObservationAuthority::Inferred,
+        event_type: "tmux_discovered".to_string(),
+        payload,
+        patch: FleetSessionPatch {
+            provider: Some(session.provider.as_str().to_string()),
+            tmux_target: session.exact_tmux_target.clone(),
+            process_start_fingerprint: session.process_start_fingerprint.clone(),
+            cwd: Some(session.cwd.clone()),
+            management_state: Some(management_token(session.management).to_string()),
+            capabilities: Some(degraded_capabilities()),
+            confidence: Some(confidence_token(session.confidence).to_string()),
+            lifecycle_state: Some(state_token(session.lifecycle)),
+            attention_state: Some(attention_token(session.attention)),
+            transport_health: Some(transport_token(session.transport_health).to_string()),
+            ..FleetSessionPatch::default()
+        },
+    }
+}
+
+fn parse_provider(value: &str) -> Provider {
+    match value.to_ascii_lowercase().as_str() {
+        "claude" => Provider::Claude,
+        "codex" => Provider::Codex,
+        _ => Provider::Unknown,
+    }
+}
+
+fn states_for_hook(event_type: &str) -> (Option<LifecycleState>, Option<AttentionState>) {
+    match event_type {
+        "SessionStart" => (Some(LifecycleState::Starting), Some(AttentionState::None)),
+        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => {
+            (Some(LifecycleState::Running), Some(AttentionState::None))
+        }
+        "AskUserQuestion" => (Some(LifecycleState::Idle), Some(AttentionState::Ask)),
+        "PermissionRequest" => (Some(LifecycleState::Idle), Some(AttentionState::Approval)),
+        "Notification" => (None, Some(AttentionState::Waiting)),
+        "Stop" | "SubagentStop" => (
+            Some(LifecycleState::TurnComplete),
+            Some(AttentionState::None),
+        ),
+        "StopFailure" => (
+            Some(LifecycleState::TurnComplete),
+            Some(AttentionState::Error),
+        ),
+        "SessionEnd" => (Some(LifecycleState::Exited), Some(AttentionState::None)),
+        _ => (None, None),
+    }
+}
+
+fn managed_capabilities(provider: Provider) -> String {
+    let broker = provider == Provider::Claude;
+    serde_json::to_string(&ainb_hangar_proto::fleet::FleetCapabilities {
+        structured_answer: broker,
+        approvals: broker,
+        send_prompt: false,
+        continue_turn: false,
+        retry: false,
+        interrupt: false,
+        start: false,
+        stop: false,
+        restart: false,
+        kill: false,
+        archive: false,
+        tmux_attach: false,
+        tmux_text: false,
+        verified_picker: false,
+    })
+    .unwrap_or_else(|_| "{}".to_string())
+}
+
+fn claude_managed_capabilities(exact_tmux_identity: bool) -> String {
+    let capabilities = managed_capabilities(Provider::Claude);
+    if exact_tmux_identity {
+        with_tmux_capabilities(
+            &with_managed_lifecycle_capabilities(&capabilities, true),
+            true,
+        )
+    } else {
+        capabilities
+    }
+}
+
+fn codex_managed_capabilities(capabilities: &CodexCapabilities) -> String {
+    serde_json::to_string(&ainb_hangar_proto::fleet::FleetCapabilities {
+        structured_answer: capabilities.request_user_input,
+        approvals: capabilities.approvals,
+        send_prompt: true,
+        continue_turn: true,
+        retry: true,
+        interrupt: true,
+        start: true,
+        stop: false,
+        restart: false,
+        kill: false,
+        archive: capabilities.thread_archive,
+        tmux_attach: false,
+        tmux_text: false,
+        verified_picker: false,
+    })
+    .unwrap_or_else(|_| "{}".to_string())
+}
+
+fn with_managed_lifecycle_capabilities(serialized: &str, available: bool) -> String {
+    let mut capabilities: ainb_hangar_proto::fleet::FleetCapabilities =
+        serde_json::from_str(serialized).unwrap_or_default();
+    capabilities.stop = available;
+    capabilities.restart = available;
+    capabilities.kill = available;
+    capabilities.archive &= available;
+    serde_json::to_string(&capabilities).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn degraded_capabilities() -> String {
+    serde_json::to_string(&ainb_hangar_proto::fleet::FleetCapabilities {
+        tmux_attach: true,
+        tmux_text: true,
+        verified_picker: true,
+        ..ainb_hangar_proto::fleet::FleetCapabilities::default()
+    })
+    .unwrap_or_else(|_| "{}".to_string())
+}
+
+fn fingerprint_value(value: &Value) -> String {
+    let body = serde_json::to_vec(value).unwrap_or_default();
+    fingerprint_bytes(&body)
+}
+
+fn claude_request_identity(payload: &Value) -> Option<Value> {
+    let hook = payload.get("payload").unwrap_or(payload);
+    let tool_input = hook.get("tool_input").or_else(|| hook.get("input"))?.clone();
+    Some(serde_json::json!({
+        "tool_use_id": hook.get("tool_use_id").cloned().unwrap_or(Value::Null),
+        "tool_input": tool_input,
+    }))
+}
+
+fn claude_permission_identity(payload: &Value) -> Option<(String, String)> {
+    let hook = payload.get("payload").unwrap_or(payload);
+    let tool = payload
+        .get("matcher")
+        .or_else(|| hook.get("tool_name"))
+        .or_else(|| hook.get("tool"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let context = hook
+        .get("tool_input")
+        .or_else(|| hook.get("input"))
+        .map(Value::to_string)
+        .unwrap_or_default();
+    (!tool.is_empty()).then_some((tool, context))
+}
+
+fn fingerprint_bytes(body: &[u8]) -> String {
+    let hash = body.iter().fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x0000_0100_0000_01b3)
+    });
+    format!("fnv1a64:{hash:016x}")
+}
+
+fn state_token(value: LifecycleState) -> String {
+    match value {
+        LifecycleState::Starting => "STARTING",
+        LifecycleState::Running => "RUNNING",
+        LifecycleState::TurnComplete => "TURN_COMPLETE",
+        LifecycleState::Idle => "IDLE",
+        LifecycleState::Exited => "EXITED",
+        LifecycleState::Unknown => "UNKNOWN",
+    }
+    .to_string()
+}
+
+fn attention_token(value: AttentionState) -> String {
+    match value {
+        AttentionState::None => "NONE",
+        AttentionState::Ask => "ASK",
+        AttentionState::Approval => "APPROVAL",
+        AttentionState::Waiting => "WAITING",
+        AttentionState::Error => "ERROR",
+    }
+    .to_string()
+}
+
+const fn management_token(value: ManagementState) -> &'static str {
+    match value {
+        ManagementState::Managed => "MANAGED",
+        ManagementState::Degraded => "DEGRADED",
+    }
+}
+
+const fn confidence_token(value: Confidence) -> &'static str {
+    match value {
+        Confidence::Authoritative => "HIGH",
+        Confidence::Observed => "MEDIUM",
+        Confidence::Inferred => "LOW",
+    }
+}
+
+const fn transport_token(value: TransportHealth) -> &'static str {
+    match value {
+        TransportHealth::Healthy => "HEALTHY",
+        TransportHealth::Degraded => "DEGRADED",
+        TransportHealth::Unavailable => "UNAVAILABLE",
+        TransportHealth::Unknown => "UNKNOWN",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::EventBroker;
+    use ainb_hangar_store::Store;
+
+    #[test]
+    fn lifecycle_and_attention_are_independent() {
+        assert_eq!(
+            states_for_hook("AskUserQuestion"),
+            (Some(LifecycleState::Idle), Some(AttentionState::Ask))
+        );
+        assert_eq!(
+            states_for_hook("PermissionRequest"),
+            (Some(LifecycleState::Idle), Some(AttentionState::Approval))
+        );
+        assert_eq!(
+            states_for_hook("Stop"),
+            (
+                Some(LifecycleState::TurnComplete),
+                Some(AttentionState::None)
+            )
+        );
+    }
+
+    #[test]
+    fn codex_provider_blocked_request_is_idle_with_approval_attention() {
+        use crate::fleet_provider::codex::{
+            CodexApprovalRequest, CodexCapabilities, CodexInbound, CodexItemRequestIdentity,
+            RpcRequestId,
+        };
+        let capabilities = CodexCapabilities {
+            cli_version: "test".to_string(),
+            daemon_version: None,
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input: true,
+            approvals: true,
+            thread_archive: true,
+        };
+        let event = normalize_codex_inbound(
+            "sequence".to_string(),
+            CodexInbound::Approval(CodexApprovalRequest {
+                identity: CodexItemRequestIdentity {
+                    request_id: RpcRequestId::new(serde_json::json!(7)).unwrap(),
+                    thread_id: "thread-1".to_string(),
+                    turn_id: "turn-1".to_string(),
+                    item_id: "item-1".to_string(),
+                },
+                kind: CodexApprovalKind::CommandExecution,
+                params: serde_json::json!({}),
+            }),
+            &capabilities,
+            100,
+        )
+        .unwrap();
+        assert_eq!(event.patch.lifecycle_state.as_deref(), Some("IDLE"));
+        assert_eq!(event.patch.attention_state.as_deref(), Some("APPROVAL"));
+    }
+
+    #[test]
+    fn managed_identity_does_not_include_cwd() {
+        let a = SessionKey::managed(Provider::Claude, "session-1");
+        let b = SessionKey::managed(Provider::Claude, "session-1");
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn same_cwd_providers_stay_distinct_and_states_reduce_independently() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let payload = serde_json::json!({"questions": [{"id": "q1"}]});
+
+        for (provider, session, event_id) in [
+            ("claude", "session-c", "hook-c"),
+            ("codex", "thread-x", "hook-x"),
+        ] {
+            apply_hook(
+                store.pool(),
+                &sink,
+                HookObservation {
+                    event_id: event_id.to_string(),
+                    provider,
+                    provider_session_id: session,
+                    cwd: "/same/repo",
+                    event_type: "AskUserQuestion",
+                    payload: &payload,
+                    observed_at: 100,
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        let snapshot = FleetRepo::snapshot(store.pool()).await.unwrap();
+        assert_eq!(snapshot.sessions.len(), 2);
+        assert_ne!(
+            snapshot.sessions[0].session_key,
+            snapshot.sessions[1].session_key
+        );
+        assert!(snapshot.sessions.iter().all(|row| row.attention_state == "ASK"));
+
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "hook-c-stop".to_string(),
+                provider: "claude",
+                provider_session_id: "session-c",
+                cwd: "/same/repo",
+                event_type: "Stop",
+                payload: &serde_json::json!({}),
+                observed_at: 200,
+            },
+        )
+        .await
+        .unwrap();
+
+        let claude =
+            FleetRepo::get_session(store.pool(), "claude:session-c").await.unwrap().unwrap();
+        let codex = FleetRepo::get_session(store.pool(), "codex:thread-x").await.unwrap().unwrap();
+        assert_eq!(claude.lifecycle_state, "TURN_COMPLETE");
+        assert_eq!(claude.attention_state, "NONE");
+        assert_eq!(codex.lifecycle_state, "IDLE");
+        assert_eq!(codex.attention_state, "ASK");
+        assert_eq!(codex.management_state, "DEGRADED");
+    }
+
+    #[tokio::test]
+    async fn tmux_absence_preserves_authoritative_degraded_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let payload = serde_json::json!({
+            "tmux_target": "codex-a:0.0",
+            "process_start_fingerprint": "fp-a"
+        });
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "codex-running".to_string(),
+                provider: "codex",
+                provider_session_id: "thread-a",
+                cwd: "/repo",
+                event_type: "UserPromptSubmit",
+                payload: &payload,
+                observed_at: 100,
+            },
+        )
+        .await
+        .unwrap();
+
+        let row = FleetRepo::get_session(store.pool(), "codex:thread-a").await.unwrap().unwrap();
+        assert_eq!(row.management_state, "DEGRADED");
+        assert_eq!(row.lifecycle_state, "RUNNING");
+        assert_eq!(row.lifecycle_authority, "authoritative");
+
+        FleetRepo::apply_event(store.pool(), &tmux_missing_event(&row, 200))
+            .await
+            .unwrap();
+        let missing =
+            FleetRepo::get_session(store.pool(), "codex:thread-a").await.unwrap().unwrap();
+        assert_eq!(missing.lifecycle_state, "RUNNING");
+        assert_eq!(missing.lifecycle_authority, "authoritative");
+        assert_eq!(missing.transport_health, "UNAVAILABLE");
+    }
+
+    #[tokio::test]
+    async fn exact_hook_tmux_identity_retires_only_correlated_legacy_row() {
+        use ainb_fleet_core::types::{Capabilities, Provenance};
+        use std::collections::BTreeSet;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        for (target, fingerprint) in [("claude-a:0.0", "fp-a"), ("claude-b:0.0", "fp-b")] {
+            let session = FleetSession {
+                session_key: SessionKey::legacy(Provider::Claude, target, fingerprint),
+                provider: Provider::Claude,
+                provider_session_id: None,
+                cwd: "/same/repo".to_string(),
+                exact_tmux_target: Some(target.to_string()),
+                pane_pid: Some(42),
+                process_start_fingerprint: Some(fingerprint.to_string()),
+                lifecycle: LifecycleState::Unknown,
+                attention: AttentionState::None,
+                management: ManagementState::Degraded,
+                capabilities: Capabilities::degraded_tmux(),
+                provenance: BTreeSet::from([Provenance::Tmux]),
+                confidence: Confidence::Inferred,
+                transport_health: TransportHealth::Healthy,
+                first_seen_ms: Some(100),
+                last_seen_ms: None,
+                version: 0,
+            };
+            FleetRepo::apply_event(store.pool(), &tmux_event(&session, 100)).await.unwrap();
+        }
+
+        let payload = serde_json::json!({
+            "tmux_target": "claude-a:0.0",
+            "process_start_fingerprint": "fp-a",
+            "payload": {}
+        });
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "hook-exact-a".to_string(),
+                provider: "claude",
+                provider_session_id: "session-a",
+                cwd: "/same/repo",
+                event_type: "SessionStart",
+                payload: &payload,
+                observed_at: 200,
+            },
+        )
+        .await
+        .unwrap();
+
+        let snapshot = FleetRepo::snapshot(store.pool()).await.unwrap();
+        assert_eq!(snapshot.sessions.len(), 2);
+        let managed = snapshot
+            .sessions
+            .iter()
+            .find(|row| row.session_key == "claude:session-a")
+            .unwrap();
+        assert_eq!(managed.tmux_target.as_deref(), Some("claude-a:0.0"));
+        let capabilities: ainb_hangar_proto::fleet::FleetCapabilities =
+            serde_json::from_str(&managed.capabilities).unwrap();
+        assert!(capabilities.tmux_attach);
+        assert!(capabilities.tmux_text);
+        assert!(capabilities.verified_picker);
+        assert!(capabilities.stop);
+        assert!(capabilities.restart);
+        assert!(capabilities.kill);
+        assert!(!capabilities.archive);
+        assert!(snapshot.sessions.iter().any(|row| {
+            row.management_state == "DEGRADED" && row.tmux_target.as_deref() == Some("claude-b:0.0")
+        }));
+        assert!(!snapshot.sessions.iter().any(|row| {
+            row.management_state == "DEGRADED" && row.tmux_target.as_deref() == Some("claude-a:0.0")
+        }));
+        let legacy_key = SessionKey::legacy(Provider::Claude, "claude-a:0.0", "fp-a").to_string();
+        let superseded_by: String = sqlx::query_scalar(
+            "SELECT superseded_by FROM fleet_session WHERE session_key = ? AND visible = 0",
+        )
+        .bind(&legacy_key)
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(superseded_by, "claude:session-a");
+        let history: Vec<String> = sqlx::query_scalar(
+            "SELECT event_type FROM fleet_event WHERE session_key = ? ORDER BY revision",
+        )
+        .bind(&legacy_key)
+        .fetch_all(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(history, vec!["tmux_discovered", "session_superseded"]);
+    }
+
+    #[tokio::test]
+    async fn codex_manager_preserves_exact_request_and_independent_state() {
+        use crate::fleet_provider::codex::{
+            CodexCapabilities, CodexInbound, CodexItemRequestIdentity, CodexQuestionRequest,
+            RpcRequestId,
+        };
+        use crate::fleet_provider::{QuestionOption, StructuredQuestion};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let capabilities = CodexCapabilities {
+            cli_version: "codex-test".to_string(),
+            daemon_version: None,
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input: true,
+            approvals: true,
+            thread_archive: true,
+        };
+        let request = CodexQuestionRequest {
+            identity: CodexItemRequestIdentity {
+                request_id: RpcRequestId::new(serde_json::json!(41)).unwrap(),
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-2".to_string(),
+                item_id: "item-3".to_string(),
+            },
+            questions: vec![StructuredQuestion {
+                id: "q1".to_string(),
+                header: "Pick".to_string(),
+                question: "Which?".to_string(),
+                options: vec![QuestionOption {
+                    label: "A".to_string(),
+                    description: "first".to_string(),
+                }],
+                multi_select: false,
+                is_other: true,
+                is_secret: false,
+            }],
+            auto_resolution_ms: Some(60_000),
+        };
+        apply_codex_inbound(
+            store.pool(),
+            &sink,
+            "codex:req:1".to_string(),
+            CodexInbound::RequestUserInput(request.clone()),
+            &capabilities,
+            100,
+        )
+        .await
+        .unwrap();
+
+        let snapshot = snapshot_wire(store.pool()).await.unwrap();
+        let session = &snapshot.sessions[0];
+        assert_eq!(session.session_key, "codex:thread-1");
+        assert_eq!(
+            session.management,
+            ainb_hangar_proto::fleet::ManagementState::Managed
+        );
+        assert_eq!(
+            session.attention,
+            ainb_hangar_proto::fleet::AttentionState::Ask
+        );
+        assert_eq!(
+            session.lifecycle,
+            ainb_hangar_proto::fleet::LifecycleState::Idle
+        );
+        assert_eq!(
+            session.current_request.as_ref().unwrap()["identity"]["requestId"],
+            41
+        );
+        assert_eq!(
+            session.current_request.as_ref().unwrap()["questions"][0]["options"][0]["label"],
+            "A"
+        );
+        assert!(session.capabilities.structured_answer);
+
+        let replay = apply_codex_inbound(
+            store.pool(),
+            &sink,
+            "different-manager-sequence".to_string(),
+            CodexInbound::RequestUserInput(request),
+            &capabilities,
+            101,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(replay.duplicate);
+
+        apply_codex_inbound(
+            store.pool(),
+            &sink,
+            "codex:event:2".to_string(),
+            CodexInbound::Notification {
+                method: "turn/started".to_string(),
+                params: serde_json::json!({
+                    "threadId": "thread-1",
+                    "turn": { "id": "turn-4" }
+                }),
+            },
+            &capabilities,
+            200,
+        )
+        .await
+        .unwrap();
+        let row = FleetRepo::get_session(store.pool(), "codex:thread-1").await.unwrap().unwrap();
+        assert_eq!(row.lifecycle_state, "RUNNING");
+        assert_eq!(row.attention_state, "NONE");
+        assert!(row.current_request_fingerprint.is_none());
+    }
+
+    #[tokio::test]
+    async fn managed_codex_tmux_outage_disables_only_tmux_fallback() {
+        use crate::fleet_provider::codex::CodexCapabilities;
+        use ainb_fleet_core::types::{Capabilities, Provenance};
+        use std::collections::BTreeSet;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let tmux = FleetSession {
+            session_key: SessionKey::legacy(Provider::Codex, "fleet-codex-x:0.0", "fp-1"),
+            provider: Provider::Codex,
+            provider_session_id: None,
+            cwd: "/repo".to_string(),
+            exact_tmux_target: Some("fleet-codex-x:0.0".to_string()),
+            pane_pid: Some(42),
+            process_start_fingerprint: Some("fp-1".to_string()),
+            lifecycle: LifecycleState::Unknown,
+            attention: AttentionState::None,
+            management: ManagementState::Degraded,
+            capabilities: Capabilities::degraded_tmux(),
+            provenance: BTreeSet::from([Provenance::Tmux]),
+            confidence: Confidence::Inferred,
+            transport_health: TransportHealth::Healthy,
+            first_seen_ms: Some(100),
+            last_seen_ms: None,
+            version: 0,
+        };
+        let capabilities = CodexCapabilities {
+            cli_version: "codex-test".to_string(),
+            daemon_version: None,
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input: true,
+            approvals: true,
+            thread_archive: true,
+        };
+        register_managed_codex_tmux(
+            store.pool(),
+            &sink,
+            "thread-tmux",
+            "/repo",
+            &tmux,
+            &capabilities,
+            100,
+        )
+        .await
+        .unwrap();
+        let active = FleetRepo::get_session(store.pool(), "codex:thread-tmux")
+            .await
+            .unwrap()
+            .unwrap();
+        let active_capabilities: ainb_hangar_proto::fleet::FleetCapabilities =
+            serde_json::from_str(&active.capabilities).unwrap();
+        assert!(active_capabilities.stop);
+        assert!(active_capabilities.restart);
+        assert!(active_capabilities.kill);
+        assert!(active_capabilities.archive);
+        mark_tmux_unavailable(store.pool(), &sink, 200).await.unwrap();
+        let row = FleetRepo::get_session(store.pool(), "codex:thread-tmux")
+            .await
+            .unwrap()
+            .unwrap();
+        let disabled: ainb_hangar_proto::fleet::FleetCapabilities =
+            serde_json::from_str(&row.capabilities).unwrap();
+        assert_eq!(row.management_state, "MANAGED");
+        assert_eq!(row.tmux_target.as_deref(), Some("fleet-codex-x:0.0"));
+        assert_eq!(row.transport_health, "UNAVAILABLE");
+        assert!(disabled.structured_answer);
+        assert!(!disabled.stop);
+        assert!(!disabled.restart);
+        assert!(!disabled.kill);
+        assert!(!disabled.archive);
+        assert!(!disabled.tmux_attach);
+        assert!(!disabled.tmux_text);
+
+        let recovery = codex_manager_recovery_event(&row, &capabilities, 300);
+        FleetRepo::apply_event(store.pool(), &recovery).await.unwrap();
+        let row = FleetRepo::get_session(store.pool(), "codex:thread-tmux")
+            .await
+            .unwrap()
+            .unwrap();
+        let restored: ainb_hangar_proto::fleet::FleetCapabilities =
+            serde_json::from_str(&row.capabilities).unwrap();
+        assert_eq!(row.transport_health, "HEALTHY");
+        assert_eq!(row.management_state, "MANAGED");
+        assert!(restored.tmux_attach);
+        assert!(restored.tmux_text);
+        assert!(restored.stop);
+        assert!(restored.restart);
+        assert!(restored.kill);
+        assert!(restored.archive);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/claude.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/claude.rs
@@ -1,0 +1,468 @@
+//! Claude structured-control adapter.
+//!
+//! Managed sessions answer through the blocking hook broker using exact request
+//! fingerprints. Degraded sessions may route verified picker key positions.
+//! Structured option labels are never submitted as generic terminal text.
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ApprovalDecision, ProviderError, ProviderReceipt, QuestionAnswer, RequestFingerprint,
+    SessionIdentity, StructuredQuestion,
+};
+
+/// Exact Claude hook request identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeRequestIdentity {
+    /// Stable Fleet identity and optimistic version.
+    pub session: SessionIdentity,
+    /// Claude hook invocation identifier assigned by the broker.
+    pub request_id: String,
+    /// Fingerprint over request identity plus ordered payload.
+    pub fingerprint: RequestFingerprint,
+}
+
+/// Complete `AskUserQuestion` request preserved from Claude hook payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeQuestionRequest {
+    /// Exact request identity.
+    pub identity: ClaudeRequestIdentity,
+    /// Questions in provider order.
+    pub questions: Vec<StructuredQuestion>,
+}
+
+/// Complete Claude permission request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeApprovalRequest {
+    /// Exact request identity.
+    pub identity: ClaudeRequestIdentity,
+    /// Tool name supplied by `PermissionRequest`.
+    pub tool_name: String,
+    /// Original tool input, retained for broker validation and display.
+    pub tool_input: serde_json::Value,
+}
+
+/// Authoritative blocking-hook transport.
+pub trait ClaudeBrokerTransport {
+    /// Answer exact `AskUserQuestion` request.
+    fn answer_questions(
+        &mut self,
+        request: &ClaudeQuestionRequest,
+        answers: &[QuestionAnswer],
+    ) -> Result<(), ProviderError>;
+
+    /// Decide exact `PermissionRequest` request.
+    fn decide_approval(
+        &mut self,
+        request: &ClaudeApprovalRequest,
+        decision: ApprovalDecision,
+    ) -> Result<(), ProviderError>;
+}
+
+/// Verified legacy picker state captured immediately before key routing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedPickerSnapshot {
+    /// Exact tmux target that displayed the picker.
+    pub tmux_target: String,
+    /// Session identity observed during verification.
+    pub session: SessionIdentity,
+    /// Request fingerprint observed during verification.
+    pub fingerprint: RequestFingerprint,
+    /// Provider-native question IDs in display order.
+    pub question_ids: Vec<String>,
+    /// Option labels per question in display order.
+    pub option_labels: Vec<Vec<String>>,
+}
+
+/// Position-only picker route. No generic text appears in this contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedPickerRoute {
+    /// Exact tmux target verified by caller.
+    pub tmux_target: String,
+    /// Zero-based selected option positions for every question.
+    pub selections: Vec<Vec<usize>>,
+}
+
+/// Degraded tmux key router.
+pub trait ClaudePickerTransport {
+    /// Route picker positions only after adapter validation succeeds.
+    fn route_picker(&mut self, route: &VerifiedPickerRoute) -> Result<(), ProviderError>;
+}
+
+/// Claude provider control adapter.
+pub struct ClaudeAdapter<B, P> {
+    broker: B,
+    picker: P,
+}
+
+impl<B, P> ClaudeAdapter<B, P>
+where
+    B: ClaudeBrokerTransport,
+    P: ClaudePickerTransport,
+{
+    /// Build adapter from authoritative broker and degraded picker transports.
+    pub const fn new(broker: B, picker: P) -> Self {
+        Self { broker, picker }
+    }
+
+    /// Answer a managed request through the broker using exact fingerprint.
+    pub fn answer_authoritative(
+        &mut self,
+        request: &ClaudeQuestionRequest,
+        answers: &[QuestionAnswer],
+    ) -> Result<ProviderReceipt, ProviderError> {
+        validate_answers(request, answers)?;
+        validate_identity(&request.identity)?;
+        self.broker.answer_questions(request, answers)?;
+        Ok(ProviderReceipt {
+            authoritative: true,
+            transport: "claude-hook-broker",
+        })
+    }
+
+    /// Answer degraded visible picker through verified option positions only.
+    pub fn answer_degraded(
+        &mut self,
+        request: &ClaudeQuestionRequest,
+        answers: &[QuestionAnswer],
+        snapshot: &VerifiedPickerSnapshot,
+    ) -> Result<ProviderReceipt, ProviderError> {
+        validate_answers(request, answers)?;
+        validate_picker_snapshot(request, snapshot)?;
+        let selections = selected_positions(request, answers)?;
+        self.picker.route_picker(&VerifiedPickerRoute {
+            tmux_target: snapshot.tmux_target.clone(),
+            selections,
+        })?;
+        Ok(ProviderReceipt {
+            authoritative: false,
+            transport: "verified-tmux-picker",
+        })
+    }
+
+    /// Decide managed permission through exact blocking-hook request.
+    pub fn decide_approval(
+        &mut self,
+        request: &ClaudeApprovalRequest,
+        decision: ApprovalDecision,
+    ) -> Result<ProviderReceipt, ProviderError> {
+        validate_identity(&request.identity)?;
+        self.broker.decide_approval(request, decision)?;
+        Ok(ProviderReceipt {
+            authoritative: true,
+            transport: "claude-hook-broker",
+        })
+    }
+
+    /// Return owned transports for integration or tests.
+    pub fn into_inner(self) -> (B, P) {
+        (self.broker, self.picker)
+    }
+}
+
+fn validate_identity(identity: &ClaudeRequestIdentity) -> Result<(), ProviderError> {
+    if identity.session.session_key.is_empty()
+        || identity.request_id.is_empty()
+        || identity.fingerprint.0.is_empty()
+    {
+        return Err(ProviderError::Protocol(
+            "Claude request identity must include session key, request id, and fingerprint".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_answers(
+    request: &ClaudeQuestionRequest,
+    answers: &[QuestionAnswer],
+) -> Result<(), ProviderError> {
+    if request.questions.is_empty() {
+        return Err(ProviderError::Protocol(
+            "Claude question request has no questions".into(),
+        ));
+    }
+    if answers.len() != request.questions.len() {
+        return Err(ProviderError::Protocol(format!(
+            "expected {} Claude answers, got {}",
+            request.questions.len(),
+            answers.len()
+        )));
+    }
+
+    for question in &request.questions {
+        let matching: Vec<_> =
+            answers.iter().filter(|answer| answer.question_id == question.id).collect();
+        if matching.len() != 1 {
+            return Err(ProviderError::Protocol(format!(
+                "question {} must have exactly one answer",
+                question.id
+            )));
+        }
+        let values = &matching[0].answers;
+        if values.is_empty() || (!question.multi_select && values.len() != 1) {
+            return Err(ProviderError::Protocol(format!(
+                "question {} has invalid answer count",
+                question.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_picker_snapshot(
+    request: &ClaudeQuestionRequest,
+    snapshot: &VerifiedPickerSnapshot,
+) -> Result<(), ProviderError> {
+    validate_identity(&request.identity)?;
+    if request.identity.session != snapshot.session {
+        return Err(ProviderError::Stale(
+            "Claude picker session identity or version changed".into(),
+        ));
+    }
+    if request.identity.fingerprint != snapshot.fingerprint {
+        return Err(ProviderError::Stale(
+            "Claude picker request fingerprint changed".into(),
+        ));
+    }
+
+    let question_ids: Vec<_> =
+        request.questions.iter().map(|question| question.id.clone()).collect();
+    let option_labels: Vec<_> = request
+        .questions
+        .iter()
+        .map(|question| {
+            question.options.iter().map(|option| option.label.clone()).collect::<Vec<_>>()
+        })
+        .collect();
+    if question_ids != snapshot.question_ids || option_labels != snapshot.option_labels {
+        return Err(ProviderError::Stale(
+            "Claude picker question or option order changed".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn selected_positions(
+    request: &ClaudeQuestionRequest,
+    answers: &[QuestionAnswer],
+) -> Result<Vec<Vec<usize>>, ProviderError> {
+    request
+        .questions
+        .iter()
+        .map(|question| {
+            let answer =
+                answers.iter().find(|answer| answer.question_id == question.id).ok_or_else(
+                    || ProviderError::Protocol(format!("missing answer for {}", question.id)),
+                )?;
+            answer
+                .answers
+                .iter()
+                .map(|value| {
+                    question.options.iter().position(|option| option.label == *value).ok_or_else(
+                        || {
+                            ProviderError::Unsupported(format!(
+                                "degraded Claude picker cannot route free-form answer for {}",
+                                question.id
+                            ))
+                        },
+                    )
+                })
+                .collect()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fleet_provider::QuestionOption;
+
+    #[derive(Default)]
+    struct FakeBroker {
+        answered: Vec<(ClaudeQuestionRequest, Vec<QuestionAnswer>)>,
+        approvals: Vec<(ClaudeApprovalRequest, ApprovalDecision)>,
+    }
+
+    impl ClaudeBrokerTransport for FakeBroker {
+        fn answer_questions(
+            &mut self,
+            request: &ClaudeQuestionRequest,
+            answers: &[QuestionAnswer],
+        ) -> Result<(), ProviderError> {
+            self.answered.push((request.clone(), answers.to_vec()));
+            Ok(())
+        }
+
+        fn decide_approval(
+            &mut self,
+            request: &ClaudeApprovalRequest,
+            decision: ApprovalDecision,
+        ) -> Result<(), ProviderError> {
+            self.approvals.push((request.clone(), decision));
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakePicker {
+        routes: Vec<VerifiedPickerRoute>,
+    }
+
+    impl ClaudePickerTransport for FakePicker {
+        fn route_picker(&mut self, route: &VerifiedPickerRoute) -> Result<(), ProviderError> {
+            self.routes.push(route.clone());
+            Ok(())
+        }
+    }
+
+    fn request() -> ClaudeQuestionRequest {
+        ClaudeQuestionRequest {
+            identity: ClaudeRequestIdentity {
+                session: SessionIdentity {
+                    session_key: "claude:s-1".into(),
+                    provider_session_id: Some("s-1".into()),
+                    expected_version: 7,
+                },
+                request_id: "req-1".into(),
+                fingerprint: RequestFingerprint("fp-1".into()),
+            },
+            questions: vec![
+                StructuredQuestion {
+                    id: "editor".into(),
+                    header: "Editor".into(),
+                    question: "Pick editor".into(),
+                    options: vec![
+                        QuestionOption {
+                            label: "Vim".into(),
+                            description: "Modal".into(),
+                        },
+                        QuestionOption {
+                            label: "Emacs".into(),
+                            description: "Extensible".into(),
+                        },
+                    ],
+                    multi_select: false,
+                    is_other: false,
+                    is_secret: false,
+                },
+                StructuredQuestion {
+                    id: "tools".into(),
+                    header: "Tools".into(),
+                    question: "Pick tools".into(),
+                    options: vec![
+                        QuestionOption {
+                            label: "rg".into(),
+                            description: "Text".into(),
+                        },
+                        QuestionOption {
+                            label: "ast-grep".into(),
+                            description: "Syntax".into(),
+                        },
+                    ],
+                    multi_select: true,
+                    is_other: false,
+                    is_secret: false,
+                },
+            ],
+        }
+    }
+
+    fn answers() -> Vec<QuestionAnswer> {
+        vec![
+            QuestionAnswer {
+                question_id: "editor".into(),
+                answers: vec!["Vim".into()],
+            },
+            QuestionAnswer {
+                question_id: "tools".into(),
+                answers: vec!["rg".into(), "ast-grep".into()],
+            },
+        ]
+    }
+
+    fn snapshot(request: &ClaudeQuestionRequest) -> VerifiedPickerSnapshot {
+        VerifiedPickerSnapshot {
+            tmux_target: "claude-session:0.0".into(),
+            session: request.identity.session.clone(),
+            fingerprint: request.identity.fingerprint.clone(),
+            question_ids: request.questions.iter().map(|q| q.id.clone()).collect(),
+            option_labels: request
+                .questions
+                .iter()
+                .map(|q| q.options.iter().map(|o| o.label.clone()).collect())
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn authoritative_answer_preserves_all_questions_and_multiselect_values() {
+        let request = request();
+        let answers = answers();
+        let mut adapter = ClaudeAdapter::new(FakeBroker::default(), FakePicker::default());
+
+        let receipt = adapter.answer_authoritative(&request, &answers).expect("broker answer");
+        let (broker, picker) = adapter.into_inner();
+
+        assert!(receipt.authoritative);
+        assert_eq!(broker.answered, vec![(request, answers)]);
+        assert!(picker.routes.is_empty());
+    }
+
+    #[test]
+    fn degraded_answer_routes_only_verified_option_positions() {
+        let request = request();
+        let answers = answers();
+        let snapshot = snapshot(&request);
+        let mut adapter = ClaudeAdapter::new(FakeBroker::default(), FakePicker::default());
+
+        let receipt = adapter.answer_degraded(&request, &answers, &snapshot).expect("picker route");
+        let (broker, picker) = adapter.into_inner();
+
+        assert!(!receipt.authoritative);
+        assert!(broker.answered.is_empty());
+        assert_eq!(
+            picker.routes,
+            vec![VerifiedPickerRoute {
+                tmux_target: "claude-session:0.0".into(),
+                selections: vec![vec![0], vec![0, 1]],
+            }]
+        );
+    }
+
+    #[test]
+    fn degraded_answer_refuses_stale_version_before_tmux_route() {
+        let request = request();
+        let mut snapshot = snapshot(&request);
+        snapshot.session.expected_version += 1;
+        let mut adapter = ClaudeAdapter::new(FakeBroker::default(), FakePicker::default());
+
+        let error = adapter
+            .answer_degraded(&request, &answers(), &snapshot)
+            .expect_err("stale picker must fail");
+        let (_, picker) = adapter.into_inner();
+
+        assert!(matches!(error, ProviderError::Stale(_)));
+        assert!(picker.routes.is_empty());
+    }
+
+    #[test]
+    fn degraded_answer_never_routes_free_form_value_as_text() {
+        let mut request = request();
+        request.questions[0].options.clear();
+        let snapshot = snapshot(&request);
+        let mut answer = answers();
+        answer[0].answers = vec!["custom editor".into()];
+        let mut adapter = ClaudeAdapter::new(FakeBroker::default(), FakePicker::default());
+
+        let error = adapter
+            .answer_degraded(&request, &answer, &snapshot)
+            .expect_err("free-form degraded answer must fail");
+        let (_, picker) = adapter.into_inner();
+
+        assert!(matches!(error, ProviderError::Unsupported(_)));
+        assert!(picker.routes.is_empty());
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -1,0 +1,1087 @@
+//! Codex app-server control adapter.
+//!
+//! Codex app-server speaks JSON-RPC over stdio, WebSocket, or WebSocket over a
+//! Unix socket. Fleet uses `codex app-server proxy --sock PATH` as its stdio
+//! bridge to the shared Unix endpoint. This keeps framing inside Codex while
+//! preserving exact JSON-RPC request IDs for structured responses.
+
+use std::collections::VecDeque;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::{
+    ApprovalDecision, ProviderError, ProviderReceipt, QuestionAnswer, QuestionOption,
+    StructuredQuestion,
+};
+
+const METHOD_REQUEST_USER_INPUT: &str = "item/tool/requestUserInput";
+const METHOD_COMMAND_APPROVAL: &str = "item/commandExecution/requestApproval";
+const METHOD_FILE_APPROVAL: &str = "item/fileChange/requestApproval";
+const METHOD_PERMISSIONS_APPROVAL: &str = "item/permissions/requestApproval";
+const METHOD_THREAD_ARCHIVE: &str = "thread/archive";
+
+/// JSON-RPC request ID retained without string or number coercion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RpcRequestId(Value);
+
+impl RpcRequestId {
+    /// Parse valid string or numeric JSON-RPC request ID.
+    pub fn new(value: Value) -> Result<Self, ProviderError> {
+        if value.is_string() || value.is_number() {
+            Ok(Self(value))
+        } else {
+            Err(ProviderError::Protocol(
+                "Codex request id must be string or number".into(),
+            ))
+        }
+    }
+
+    /// Borrow exact JSON value for response routing.
+    pub const fn as_value(&self) -> &Value {
+        &self.0
+    }
+}
+
+/// Exact identity carried by Codex item-level server requests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexItemRequestIdentity {
+    /// JSON-RPC ID to echo in response.
+    pub request_id: RpcRequestId,
+    /// Exact app-server thread ID.
+    pub thread_id: String,
+    /// Exact app-server turn ID.
+    pub turn_id: String,
+    /// Exact app-server item ID.
+    pub item_id: String,
+}
+
+/// Complete Codex request-user-input payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexQuestionRequest {
+    /// Exact item request identity.
+    pub identity: CodexItemRequestIdentity,
+    /// Questions in app-server order.
+    pub questions: Vec<StructuredQuestion>,
+    /// Optional server-side auto-resolution window.
+    pub auto_resolution_ms: Option<u64>,
+}
+
+/// App-server approval request family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexApprovalKind {
+    /// Command execution approval.
+    CommandExecution,
+    /// File change approval.
+    FileChange,
+    /// Additional permission profile approval.
+    Permissions,
+}
+
+/// Complete Codex approval request with raw schema-compatible params.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexApprovalRequest {
+    /// Exact item request identity.
+    pub identity: CodexItemRequestIdentity,
+    /// Approval response schema family.
+    pub kind: CodexApprovalKind,
+    /// Original params for display and permission-grant response construction.
+    pub params: Value,
+}
+
+/// Capability result from installed Codex version and generated schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct CodexCapabilities {
+    /// Installed CLI version string.
+    pub cli_version: String,
+    /// Running managed daemon version payload when available.
+    pub daemon_version: Option<Value>,
+    /// Whether app-server schema generation succeeded.
+    pub app_server: bool,
+    /// Whether installed CLI exposes stdio proxy for Unix app-server.
+    pub stdio_proxy: bool,
+    /// Whether exact request-user-input method exists in generated schema.
+    pub request_user_input: bool,
+    /// Whether current approval request methods exist in generated schema.
+    pub approvals: bool,
+    /// Whether exact thread archive exists in generated schema.
+    pub thread_archive: bool,
+}
+
+impl CodexCapabilities {
+    /// Conservative unavailable capability set.
+    pub const fn unavailable() -> Self {
+        Self {
+            cli_version: String::new(),
+            daemon_version: None,
+            app_server: false,
+            stdio_proxy: false,
+            request_user_input: false,
+            approvals: false,
+            thread_archive: false,
+        }
+    }
+}
+
+/// Executable command represented without shell interpolation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSpec {
+    /// Executable path.
+    pub program: OsString,
+    /// Ordered argv excluding executable.
+    pub args: Vec<OsString>,
+}
+
+impl CommandSpec {
+    /// Convert specification to process command.
+    pub fn command(&self) -> Command {
+        let mut command = Command::new(&self.program);
+        command.args(&self.args);
+        command
+    }
+}
+
+/// Build shared app-server Unix listener command.
+pub fn app_server_command(codex_binary: &OsStr, socket: &Path) -> CommandSpec {
+    CommandSpec {
+        program: codex_binary.to_os_string(),
+        args: vec![
+            "app-server".into(),
+            "--listen".into(),
+            unix_endpoint(socket).into(),
+        ],
+    }
+}
+
+/// Build stdio proxy command for shared app-server Unix endpoint.
+pub fn proxy_command(codex_binary: &OsStr, socket: &Path) -> CommandSpec {
+    CommandSpec {
+        program: codex_binary.to_os_string(),
+        args: vec![
+            "app-server".into(),
+            "proxy".into(),
+            "--sock".into(),
+            socket.as_os_str().to_os_string(),
+        ],
+    }
+}
+
+/// Build Fleet-managed Codex TUI launch using shared Unix app-server.
+pub fn managed_tui_command(
+    codex_binary: &OsStr,
+    socket: &Path,
+    additional_args: impl IntoIterator<Item = OsString>,
+) -> CommandSpec {
+    let mut args = vec!["--remote".into(), unix_endpoint(socket).into()];
+    args.extend(additional_args);
+    CommandSpec {
+        program: codex_binary.to_os_string(),
+        args,
+    }
+}
+
+fn unix_endpoint(socket: &Path) -> String {
+    format!("unix://{}", socket.display())
+}
+
+/// Probe installed Codex binary and its generated experimental schema.
+pub fn probe_codex(codex_binary: &OsStr) -> CodexCapabilities {
+    let cli_version = Command::new(codex_binary)
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .unwrap_or_default();
+
+    let daemon_version = Command::new(codex_binary)
+        .args(["app-server", "daemon", "version"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| serde_json::from_slice(&output.stdout).ok());
+    let stdio_proxy = Command::new(codex_binary)
+        .args(["app-server", "proxy", "--help"])
+        .output()
+        .is_ok_and(|output| output.status.success());
+
+    let schema_dir = probe_dir();
+    let generated = fs::create_dir_all(&schema_dir).is_ok()
+        && Command::new(codex_binary)
+            .args([
+                "app-server",
+                "generate-json-schema",
+                "--experimental",
+                "--out",
+            ])
+            .arg(&schema_dir)
+            .output()
+            .is_ok_and(|output| output.status.success());
+    let schema = generated
+        .then(|| fs::read_to_string(schema_dir.join("codex_app_server_protocol.schemas.json")))
+        .transpose()
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let _ = fs::remove_dir_all(&schema_dir);
+    let (request_user_input, approvals, thread_archive) = capabilities_from_schema(&schema);
+
+    CodexCapabilities {
+        cli_version,
+        daemon_version,
+        app_server: generated,
+        stdio_proxy,
+        request_user_input,
+        approvals,
+        thread_archive,
+    }
+}
+
+fn probe_dir() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    std::env::temp_dir().join(format!("ainb-codex-schema-{}-{nonce}", std::process::id()))
+}
+
+/// Detect version-specific methods from generated app-server schema.
+pub fn capabilities_from_schema(schema: &str) -> (bool, bool, bool) {
+    let request_user_input = schema.contains(METHOD_REQUEST_USER_INPUT)
+        && schema.contains("ToolRequestUserInputResponse");
+    let approvals = schema.contains(METHOD_COMMAND_APPROVAL)
+        && schema.contains(METHOD_FILE_APPROVAL)
+        && schema.contains(METHOD_PERMISSIONS_APPROVAL);
+    let thread_archive =
+        schema.contains(METHOD_THREAD_ARCHIVE) && schema.contains("ThreadArchiveParams");
+    (request_user_input, approvals, thread_archive)
+}
+
+/// JSON-RPC transport used by Codex adapter.
+pub trait CodexTransport {
+    /// Send request and return its result value.
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, ProviderError>;
+    /// Send notification without request ID.
+    fn notify(&mut self, method: &str, params: Value) -> Result<(), ProviderError>;
+    /// Respond to exact server request ID.
+    fn respond(&mut self, request_id: &RpcRequestId, result: Value) -> Result<(), ProviderError>;
+    /// Read queued server request or notification.
+    fn next_inbound(&mut self) -> Result<Value, ProviderError>;
+}
+
+/// Stdio proxy transport to a Unix-socket app-server.
+pub struct CodexProxyTransport {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+    inbound: VecDeque<Value>,
+}
+
+impl CodexProxyTransport {
+    /// Spawn `codex app-server proxy --sock PATH` with piped JSON-RPC stdio.
+    pub fn connect(codex_binary: &OsStr, socket: &Path) -> Result<Self, ProviderError> {
+        let mut command = proxy_command(codex_binary, socket).command();
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| ProviderError::Transport("Codex proxy stdin unavailable".into()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| ProviderError::Transport("Codex proxy stdout unavailable".into()))?;
+        Ok(Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            next_id: 1,
+            inbound: VecDeque::new(),
+        })
+    }
+
+    fn write_message(&mut self, message: &Value) -> Result<(), ProviderError> {
+        serde_json::to_writer(&mut self.stdin, message)?;
+        self.stdin.write_all(b"\n")?;
+        self.stdin.flush()?;
+        Ok(())
+    }
+
+    fn read_message(&mut self) -> Result<Value, ProviderError> {
+        let mut line = String::new();
+        if self.stdout.read_line(&mut line)? == 0 {
+            return Err(ProviderError::Transport(
+                "Codex app-server proxy closed stdout".into(),
+            ));
+        }
+        serde_json::from_str(&line).map_err(ProviderError::from)
+    }
+}
+
+impl CodexTransport for CodexProxyTransport {
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, ProviderError> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.write_message(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))?;
+
+        loop {
+            let message = self.read_message()?;
+            if message.get("id") == Some(&json!(id))
+                && (message.get("result").is_some() || message.get("error").is_some())
+            {
+                if let Some(error) = message.get("error") {
+                    return Err(ProviderError::Protocol(format!(
+                        "Codex {method} failed: {error}"
+                    )));
+                }
+                return Ok(message.get("result").cloned().unwrap_or(Value::Null));
+            }
+            self.inbound.push_back(message);
+        }
+    }
+
+    fn notify(&mut self, method: &str, params: Value) -> Result<(), ProviderError> {
+        self.write_message(&json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }))
+    }
+
+    fn respond(&mut self, request_id: &RpcRequestId, result: Value) -> Result<(), ProviderError> {
+        self.write_message(&json!({
+            "jsonrpc": "2.0",
+            "id": request_id.as_value(),
+            "result": result,
+        }))
+    }
+
+    fn next_inbound(&mut self) -> Result<Value, ProviderError> {
+        if let Some(message) = self.inbound.pop_front() {
+            return Ok(message);
+        }
+        self.read_message()
+    }
+}
+
+impl Drop for CodexProxyTransport {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Parsed app-server inbound message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodexInbound {
+    /// Structured request-user-input request.
+    RequestUserInput(CodexQuestionRequest),
+    /// Structured approval request.
+    Approval(CodexApprovalRequest),
+    /// Server notification.
+    Notification {
+        /// Notification method.
+        method: String,
+        /// Notification params.
+        params: Value,
+    },
+    /// Server request not yet understood by Fleet.
+    OtherRequest {
+        /// Exact request ID.
+        request_id: RpcRequestId,
+        /// Request method.
+        method: String,
+        /// Request params.
+        params: Value,
+    },
+}
+
+/// Parse one app-server request or notification without discarding unknown fields.
+pub fn parse_inbound(message: &Value) -> Result<CodexInbound, ProviderError> {
+    let method = message
+        .get("method")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ProviderError::Protocol("Codex inbound message has no method".into()))?
+        .to_owned();
+    let params = message.get("params").cloned().unwrap_or(Value::Null);
+    let Some(id) = message.get("id").cloned() else {
+        return Ok(CodexInbound::Notification { method, params });
+    };
+    let request_id = RpcRequestId::new(id)?;
+
+    match method.as_str() {
+        METHOD_REQUEST_USER_INPUT => Ok(CodexInbound::RequestUserInput(parse_question_request(
+            request_id, &params,
+        )?)),
+        METHOD_COMMAND_APPROVAL => Ok(CodexInbound::Approval(parse_approval_request(
+            request_id,
+            CodexApprovalKind::CommandExecution,
+            params,
+        )?)),
+        METHOD_FILE_APPROVAL => Ok(CodexInbound::Approval(parse_approval_request(
+            request_id,
+            CodexApprovalKind::FileChange,
+            params,
+        )?)),
+        METHOD_PERMISSIONS_APPROVAL => Ok(CodexInbound::Approval(parse_approval_request(
+            request_id,
+            CodexApprovalKind::Permissions,
+            params,
+        )?)),
+        _ => Ok(CodexInbound::OtherRequest {
+            request_id,
+            method,
+            params,
+        }),
+    }
+}
+
+fn parse_question_request(
+    request_id: RpcRequestId,
+    params: &Value,
+) -> Result<CodexQuestionRequest, ProviderError> {
+    let identity = parse_item_identity(request_id, params)?;
+    let raw_questions = params
+        .get("questions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| ProviderError::Protocol("Codex RUI questions missing".into()))?;
+    let questions = raw_questions
+        .iter()
+        .map(|question| {
+            let options = question
+                .get("options")
+                .and_then(Value::as_array)
+                .map(|options| {
+                    options
+                        .iter()
+                        .map(|option| {
+                            Ok(QuestionOption {
+                                label: required_string(option, "label")?,
+                                description: required_string(option, "description")?,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, ProviderError>>()
+                })
+                .transpose()?
+                .unwrap_or_default();
+            Ok(StructuredQuestion {
+                id: required_string(question, "id")?,
+                header: required_string(question, "header")?,
+                question: required_string(question, "question")?,
+                options,
+                multi_select: question
+                    .get("multiSelect")
+                    .or_else(|| question.get("multi_select"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                is_other: question.get("isOther").and_then(Value::as_bool).unwrap_or(false),
+                is_secret: question.get("isSecret").and_then(Value::as_bool).unwrap_or(false),
+            })
+        })
+        .collect::<Result<Vec<_>, ProviderError>>()?;
+    Ok(CodexQuestionRequest {
+        identity,
+        questions,
+        auto_resolution_ms: params.get("autoResolutionMs").and_then(Value::as_u64),
+    })
+}
+
+fn parse_approval_request(
+    request_id: RpcRequestId,
+    kind: CodexApprovalKind,
+    params: Value,
+) -> Result<CodexApprovalRequest, ProviderError> {
+    let identity = parse_item_identity(request_id, &params)?;
+    Ok(CodexApprovalRequest {
+        identity,
+        kind,
+        params,
+    })
+}
+
+fn parse_item_identity(
+    request_id: RpcRequestId,
+    params: &Value,
+) -> Result<CodexItemRequestIdentity, ProviderError> {
+    Ok(CodexItemRequestIdentity {
+        request_id,
+        thread_id: required_string(params, "threadId")?,
+        turn_id: required_string(params, "turnId")?,
+        item_id: required_string(params, "itemId")?,
+    })
+}
+
+fn required_string(value: &Value, field: &str) -> Result<String, ProviderError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| ProviderError::Protocol(format!("Codex field {field} missing")))
+}
+
+/// Version-gated app-server client.
+pub struct CodexClient<T> {
+    transport: T,
+    capabilities: CodexCapabilities,
+    initialized: bool,
+}
+
+impl<T: CodexTransport> CodexClient<T> {
+    /// Create client around an app-server transport and version probe result.
+    pub const fn new(transport: T, capabilities: CodexCapabilities) -> Self {
+        Self {
+            transport,
+            capabilities,
+            initialized: false,
+        }
+    }
+
+    /// Initialize app-server connection and opt into experimental API.
+    pub fn initialize(&mut self, client_version: &str) -> Result<Value, ProviderError> {
+        if !self.capabilities.app_server {
+            return Err(ProviderError::Unsupported(
+                "Codex app-server unavailable in installed version".into(),
+            ));
+        }
+        let result = self.transport.request(
+            "initialize",
+            json!({
+                "clientInfo": {
+                    "name": "agents-in-a-box-fleet",
+                    "title": "Fleet",
+                    "version": client_version,
+                },
+                "capabilities": {
+                    "experimentalApi": true,
+                },
+            }),
+        )?;
+        self.transport.notify("initialized", json!({}))?;
+        self.initialized = true;
+        Ok(result)
+    }
+
+    /// Start new thread and return exact thread ID.
+    pub fn thread_start(
+        &mut self,
+        cwd: &Path,
+        model: Option<&str>,
+    ) -> Result<String, ProviderError> {
+        self.require_initialized()?;
+        let result = self.transport.request(
+            "thread/start",
+            json!({
+                "cwd": cwd,
+                "model": model,
+            }),
+        )?;
+        required_string(result.get("thread").unwrap_or(&Value::Null), "id")
+    }
+
+    /// Resume exact thread and return full schema-compatible result.
+    pub fn thread_resume(&mut self, thread_id: &str) -> Result<Value, ProviderError> {
+        self.require_initialized()?;
+        self.transport.request("thread/resume", json!({ "threadId": thread_id }))
+    }
+
+    /// Read exact thread with turns included.
+    pub fn thread_read(&mut self, thread_id: &str) -> Result<Value, ProviderError> {
+        self.require_initialized()?;
+        self.transport.request(
+            "thread/read",
+            json!({ "threadId": thread_id, "includeTurns": true }),
+        )
+    }
+
+    /// Start turn with one text input and return exact turn ID.
+    pub fn turn_start(&mut self, thread_id: &str, text: &str) -> Result<String, ProviderError> {
+        self.require_initialized()?;
+        let result = self.transport.request(
+            "turn/start",
+            json!({
+                "threadId": thread_id,
+                "input": [{ "type": "text", "text": text }],
+            }),
+        )?;
+        required_string(result.get("turn").unwrap_or(&Value::Null), "id")
+    }
+
+    /// Interrupt exact active turn.
+    pub fn turn_interrupt(
+        &mut self,
+        thread_id: &str,
+        turn_id: &str,
+    ) -> Result<Value, ProviderError> {
+        self.require_initialized()?;
+        self.transport.request(
+            "turn/interrupt",
+            json!({ "threadId": thread_id, "turnId": turn_id }),
+        )
+    }
+
+    /// Answer exact request-user-input server request.
+    pub fn answer_request_user_input(
+        &mut self,
+        request: &CodexQuestionRequest,
+        answers: &[QuestionAnswer],
+    ) -> Result<ProviderReceipt, ProviderError> {
+        self.require_initialized()?;
+        if !self.capabilities.request_user_input {
+            return Err(ProviderError::Unsupported(
+                "Codex request-user-input absent from generated schema".into(),
+            ));
+        }
+        validate_question_answers(request, answers)?;
+        let answer_map = answers
+            .iter()
+            .map(|answer| {
+                (
+                    answer.question_id.clone(),
+                    json!({ "answers": answer.answers }),
+                )
+            })
+            .collect::<serde_json::Map<_, _>>();
+        self.transport.respond(
+            &request.identity.request_id,
+            json!({ "answers": answer_map }),
+        )?;
+        Ok(ProviderReceipt {
+            authoritative: true,
+            transport: "codex-app-server",
+        })
+    }
+
+    /// Decide exact app-server approval request.
+    pub fn decide_approval(
+        &mut self,
+        request: &CodexApprovalRequest,
+        decision: ApprovalDecision,
+    ) -> Result<ProviderReceipt, ProviderError> {
+        self.require_initialized()?;
+        if !self.capabilities.approvals {
+            return Err(ProviderError::Unsupported(
+                "Codex approvals absent from generated schema".into(),
+            ));
+        }
+        let result = approval_result(request, decision)?;
+        self.transport.respond(&request.identity.request_id, result)?;
+        if decision == ApprovalDecision::DenyAndInterrupt
+            && request.kind == CodexApprovalKind::Permissions
+        {
+            self.turn_interrupt(&request.identity.thread_id, &request.identity.turn_id)?;
+        }
+        Ok(ProviderReceipt {
+            authoritative: true,
+            transport: "codex-app-server",
+        })
+    }
+
+    /// Parse next server request or notification.
+    pub fn next_inbound(&mut self) -> Result<CodexInbound, ProviderError> {
+        self.require_initialized()?;
+        let message = self.transport.next_inbound()?;
+        parse_inbound(&message)
+    }
+
+    /// Return owned transport for integration or tests.
+    pub fn into_inner(self) -> T {
+        self.transport
+    }
+
+    fn require_initialized(&self) -> Result<(), ProviderError> {
+        if !self.initialized {
+            return Err(ProviderError::Protocol(
+                "Codex app-server client not initialized".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_question_answers(
+    request: &CodexQuestionRequest,
+    answers: &[QuestionAnswer],
+) -> Result<(), ProviderError> {
+    if request.questions.len() != answers.len() {
+        return Err(ProviderError::Protocol(format!(
+            "expected {} Codex answers, got {}",
+            request.questions.len(),
+            answers.len()
+        )));
+    }
+    for question in &request.questions {
+        let count = answers
+            .iter()
+            .filter(|answer| answer.question_id == question.id && !answer.answers.is_empty())
+            .count();
+        if count != 1 {
+            return Err(ProviderError::Protocol(format!(
+                "Codex question {} must have one non-empty answer",
+                question.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn approval_result(
+    request: &CodexApprovalRequest,
+    decision: ApprovalDecision,
+) -> Result<Value, ProviderError> {
+    match request.kind {
+        CodexApprovalKind::CommandExecution | CodexApprovalKind::FileChange => {
+            let decision = match decision {
+                ApprovalDecision::Approve => "accept",
+                ApprovalDecision::ApproveForSession => "acceptForSession",
+                ApprovalDecision::Deny => "decline",
+                ApprovalDecision::DenyAndInterrupt => "cancel",
+            };
+            Ok(json!({ "decision": decision }))
+        }
+        CodexApprovalKind::Permissions => {
+            let permissions = match decision {
+                ApprovalDecision::Approve | ApprovalDecision::ApproveForSession => {
+                    request.params.get("permissions").cloned().ok_or_else(|| {
+                        ProviderError::Protocol(
+                            "Codex permission request has no permissions profile".into(),
+                        )
+                    })?
+                }
+                ApprovalDecision::Deny | ApprovalDecision::DenyAndInterrupt => json!({}),
+            };
+            let scope = if decision == ApprovalDecision::ApproveForSession {
+                "session"
+            } else {
+                "turn"
+            };
+            Ok(json!({ "permissions": permissions, "scope": scope }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeTransport {
+        results: VecDeque<Value>,
+        requests: Vec<(String, Value)>,
+        notifications: Vec<(String, Value)>,
+        responses: Vec<(RpcRequestId, Value)>,
+        inbound: VecDeque<Value>,
+    }
+
+    impl CodexTransport for FakeTransport {
+        fn request(&mut self, method: &str, params: Value) -> Result<Value, ProviderError> {
+            self.requests.push((method.to_owned(), params));
+            self.results
+                .pop_front()
+                .ok_or_else(|| ProviderError::Transport("missing fake result".into()))
+        }
+
+        fn notify(&mut self, method: &str, params: Value) -> Result<(), ProviderError> {
+            self.notifications.push((method.to_owned(), params));
+            Ok(())
+        }
+
+        fn respond(
+            &mut self,
+            request_id: &RpcRequestId,
+            result: Value,
+        ) -> Result<(), ProviderError> {
+            self.responses.push((request_id.clone(), result));
+            Ok(())
+        }
+
+        fn next_inbound(&mut self) -> Result<Value, ProviderError> {
+            self.inbound
+                .pop_front()
+                .ok_or_else(|| ProviderError::Transport("missing fake inbound".into()))
+        }
+    }
+
+    fn capabilities(request_user_input: bool) -> CodexCapabilities {
+        CodexCapabilities {
+            cli_version: "codex-cli 0.144.6".into(),
+            daemon_version: Some(json!({ "version": "0.144.6" })),
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input,
+            approvals: true,
+            thread_archive: true,
+        }
+    }
+
+    fn initialized_client(transport: FakeTransport, rui: bool) -> CodexClient<FakeTransport> {
+        let mut client = CodexClient::new(transport, capabilities(rui));
+        client.initialize("1.2.3").expect("initialize");
+        client
+    }
+
+    #[test]
+    fn command_specs_use_shared_unix_endpoint_and_proxy() {
+        let socket = Path::new("/tmp/fleet codex.sock");
+        assert_eq!(
+            app_server_command(OsStr::new("codex"), socket).args,
+            vec![
+                OsString::from("app-server"),
+                OsString::from("--listen"),
+                OsString::from("unix:///tmp/fleet codex.sock"),
+            ]
+        );
+        assert_eq!(
+            proxy_command(OsStr::new("codex"), socket).args,
+            vec![
+                OsString::from("app-server"),
+                OsString::from("proxy"),
+                OsString::from("--sock"),
+                OsString::from("/tmp/fleet codex.sock"),
+            ]
+        );
+        assert_eq!(
+            managed_tui_command(
+                OsStr::new("codex"),
+                socket,
+                [OsString::from("--model"), OsString::from("gpt-5")]
+            )
+            .args,
+            vec![
+                OsString::from("--remote"),
+                OsString::from("unix:///tmp/fleet codex.sock"),
+                OsString::from("--model"),
+                OsString::from("gpt-5"),
+            ]
+        );
+    }
+
+    #[test]
+    fn schema_probe_capability_gates_request_user_input() {
+        let schema = format!(
+            "{METHOD_REQUEST_USER_INPUT} ToolRequestUserInputResponse {METHOD_COMMAND_APPROVAL} {METHOD_FILE_APPROVAL} {METHOD_PERMISSIONS_APPROVAL} {METHOD_THREAD_ARCHIVE} ThreadArchiveParams"
+        );
+        assert_eq!(capabilities_from_schema(&schema), (true, true, true));
+        assert_eq!(
+            capabilities_from_schema(&schema.replace(METHOD_REQUEST_USER_INPUT, "missing")),
+            (false, true, true)
+        );
+    }
+
+    #[test]
+    fn initialize_opts_into_experimental_api_then_notifies() {
+        let mut transport = FakeTransport::default();
+        transport.results.push_back(json!({ "server": "ok" }));
+        let client = initialized_client(transport, true);
+        let transport = client.into_inner();
+
+        assert_eq!(transport.requests[0].0, "initialize");
+        assert_eq!(
+            transport.requests[0].1["capabilities"]["experimentalApi"],
+            true
+        );
+        assert_eq!(
+            transport.notifications,
+            vec![("initialized".into(), json!({}))]
+        );
+    }
+
+    #[test]
+    fn parses_full_request_user_input_with_exact_ids() {
+        let inbound = parse_inbound(&json!({
+            "jsonrpc": "2.0",
+            "id": "rpc-17",
+            "method": METHOD_REQUEST_USER_INPUT,
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-2",
+                "itemId": "item-3",
+                "autoResolutionMs": 120000,
+                "questions": [
+                    {
+                        "id": "editor",
+                        "header": "Editor",
+                        "question": "Pick editor",
+                        "options": [
+                            { "label": "Vim", "description": "Modal" },
+                            { "label": "Emacs", "description": "Extensible" }
+                        ]
+                    },
+                    {
+                        "id": "reason",
+                        "header": "Reason",
+                        "question": "Why?",
+                        "isOther": true,
+                        "isSecret": true
+                    }
+                ]
+            }
+        }))
+        .expect("parse RUI");
+
+        let CodexInbound::RequestUserInput(request) = inbound else {
+            panic!("expected request user input");
+        };
+        assert_eq!(request.identity.request_id.as_value(), &json!("rpc-17"));
+        assert_eq!(request.identity.thread_id, "thread-1");
+        assert_eq!(request.identity.turn_id, "turn-2");
+        assert_eq!(request.identity.item_id, "item-3");
+        assert_eq!(request.questions.len(), 2);
+        assert_eq!(request.questions[0].options.len(), 2);
+        assert!(request.questions[1].is_other);
+        assert!(request.questions[1].is_secret);
+        assert_eq!(request.auto_resolution_ms, Some(120_000));
+    }
+
+    #[test]
+    fn answers_exact_request_id_and_all_question_ids() {
+        let mut transport = FakeTransport::default();
+        transport.results.push_back(json!({}));
+        let mut client = initialized_client(transport, true);
+        let request = CodexQuestionRequest {
+            identity: CodexItemRequestIdentity {
+                request_id: RpcRequestId::new(json!(42)).expect("rpc id"),
+                thread_id: "thread-1".into(),
+                turn_id: "turn-2".into(),
+                item_id: "item-3".into(),
+            },
+            questions: vec![StructuredQuestion {
+                id: "tools".into(),
+                header: "Tools".into(),
+                question: "Pick tools".into(),
+                options: vec![],
+                multi_select: true,
+                is_other: false,
+                is_secret: false,
+            }],
+            auto_resolution_ms: None,
+        };
+
+        client
+            .answer_request_user_input(
+                &request,
+                &[QuestionAnswer {
+                    question_id: "tools".into(),
+                    answers: vec!["rg".into(), "ast-grep".into()],
+                }],
+            )
+            .expect("answer RUI");
+        let transport = client.into_inner();
+
+        assert_eq!(transport.responses[0].0.as_value(), &json!(42));
+        assert_eq!(
+            transport.responses[0].1,
+            json!({ "answers": { "tools": { "answers": ["rg", "ast-grep"] } } })
+        );
+    }
+
+    #[test]
+    fn rui_capability_gate_sends_no_response() {
+        let mut transport = FakeTransport::default();
+        transport.results.push_back(json!({}));
+        let mut client = initialized_client(transport, false);
+        let request = CodexQuestionRequest {
+            identity: CodexItemRequestIdentity {
+                request_id: RpcRequestId::new(json!(1)).expect("rpc id"),
+                thread_id: "thread".into(),
+                turn_id: "turn".into(),
+                item_id: "item".into(),
+            },
+            questions: vec![],
+            auto_resolution_ms: None,
+        };
+
+        let error = client.answer_request_user_input(&request, &[]).expect_err("capability gate");
+        let transport = client.into_inner();
+
+        assert!(matches!(error, ProviderError::Unsupported(_)));
+        assert!(transport.responses.is_empty());
+    }
+
+    #[test]
+    fn thread_and_turn_methods_preserve_exact_ids() {
+        let mut transport = FakeTransport::default();
+        transport.results.extend([
+            json!({}),
+            json!({ "thread": { "id": "thread-1" } }),
+            json!({ "thread": { "id": "thread-1", "turns": [] } }),
+            json!({ "thread": { "id": "thread-1", "turns": [] } }),
+            json!({ "turn": { "id": "turn-2" } }),
+            json!({}),
+        ]);
+        let mut client = initialized_client(transport, true);
+
+        assert_eq!(
+            client.thread_start(Path::new("/repo"), Some("gpt-5")).expect("thread start"),
+            "thread-1"
+        );
+        client.thread_resume("thread-1").expect("thread resume");
+        client.thread_read("thread-1").expect("thread read");
+        assert_eq!(
+            client.turn_start("thread-1", "hello").expect("turn start"),
+            "turn-2"
+        );
+        client.turn_interrupt("thread-1", "turn-2").expect("turn interrupt");
+        let transport = client.into_inner();
+
+        assert_eq!(
+            transport.requests.iter().map(|(method, _)| method.as_str()).collect::<Vec<_>>(),
+            vec![
+                "initialize",
+                "thread/start",
+                "thread/resume",
+                "thread/read",
+                "turn/start",
+                "turn/interrupt",
+            ]
+        );
+        assert_eq!(transport.requests[2].1["threadId"], "thread-1");
+        assert_eq!(transport.requests[4].1["threadId"], "thread-1");
+        assert_eq!(transport.requests[5].1["turnId"], "turn-2");
+    }
+
+    #[test]
+    fn command_approval_responds_to_exact_rpc_id() {
+        let mut transport = FakeTransport::default();
+        transport.results.push_back(json!({}));
+        let mut client = initialized_client(transport, true);
+        let request = CodexApprovalRequest {
+            identity: CodexItemRequestIdentity {
+                request_id: RpcRequestId::new(json!("approve-9")).expect("rpc id"),
+                thread_id: "thread-1".into(),
+                turn_id: "turn-2".into(),
+                item_id: "item-3".into(),
+            },
+            kind: CodexApprovalKind::CommandExecution,
+            params: json!({}),
+        };
+
+        client
+            .decide_approval(&request, ApprovalDecision::ApproveForSession)
+            .expect("approve");
+        let transport = client.into_inner();
+
+        assert_eq!(transport.responses[0].0.as_value(), &json!("approve-9"));
+        assert_eq!(
+            transport.responses[0].1,
+            json!({ "decision": "acceptForSession" })
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -1,0 +1,1651 @@
+//! Persistent managed Codex app-server transport.
+//!
+//! One actor owns the proxy reader and writer. Commands enter through a
+//! cloneable handle, while server requests and notifications leave through one
+//! bounded ordered receiver. This prevents competing reads from reordering
+//! app-server lifecycle events or mismatching JSON-RPC responses.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::process::{Child, Command};
+use tokio::sync::RwLock;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, sleep};
+
+use super::codex::{
+    CodexApprovalKind, CodexApprovalRequest, CodexCapabilities, CodexInbound, CodexQuestionRequest,
+    CommandSpec, RpcRequestId, app_server_command, managed_tui_command, parse_inbound, probe_codex,
+    proxy_command,
+};
+use super::{ApprovalDecision, ProviderError, ProviderReceipt, QuestionAnswer};
+
+use crate::events::EventSink;
+
+const INITIALIZE_ID: u64 = 1;
+
+static ACTIVE_MANAGER: OnceLock<RwLock<Option<CodexManagerHandle>>> = OnceLock::new();
+
+/// Persistent manager configuration.
+#[derive(Debug, Clone)]
+pub struct CodexManagerConfig {
+    /// Codex executable path.
+    pub codex_binary: OsString,
+    /// Shared app-server Unix socket.
+    pub socket_path: PathBuf,
+    /// Fleet client version sent during initialize.
+    pub client_version: String,
+    /// Maximum app-server socket startup wait.
+    pub startup_timeout: Duration,
+    /// Maximum wait for one app-server command response.
+    pub request_timeout: Duration,
+    /// Ordered inbound channel capacity.
+    pub event_capacity: usize,
+}
+
+impl CodexManagerConfig {
+    /// Build configuration with conservative local defaults.
+    pub fn new(codex_binary: impl Into<OsString>, socket_path: impl Into<PathBuf>) -> Self {
+        Self {
+            codex_binary: codex_binary.into(),
+            socket_path: socket_path.into(),
+            client_version: env!("CARGO_PKG_VERSION").into(),
+            startup_timeout: Duration::from_secs(5),
+            request_timeout: Duration::from_secs(10),
+            event_capacity: 256,
+        }
+    }
+}
+
+/// Cloneable command channel for one persistent Codex connection.
+#[derive(Clone)]
+pub struct CodexManagerHandle {
+    commands: mpsc::Sender<ManagerCommand>,
+    capabilities: Arc<CodexCapabilities>,
+    socket_path: Arc<PathBuf>,
+    request_timeout: Duration,
+}
+
+impl CodexManagerHandle {
+    /// Negotiated version-probed capabilities.
+    pub fn capabilities(&self) -> &CodexCapabilities {
+        &self.capabilities
+    }
+
+    /// Managed TUI command connected to this manager's shared app-server.
+    pub fn managed_tui_command(
+        &self,
+        codex_binary: &std::ffi::OsStr,
+        additional_args: impl IntoIterator<Item = OsString>,
+    ) -> CommandSpec {
+        managed_tui_command(codex_binary, &self.socket_path, additional_args)
+    }
+
+    /// Start a new app-server thread and return exact thread ID.
+    pub async fn thread_start(
+        &self,
+        cwd: &Path,
+        model: Option<&str>,
+    ) -> Result<String, ProviderError> {
+        let result = self.request("thread/start", json!({ "cwd": cwd, "model": model })).await?;
+        nested_id(&result, "thread")
+    }
+
+    /// Resume exact app-server thread.
+    pub async fn thread_resume(&self, thread_id: &str) -> Result<Value, ProviderError> {
+        self.request("thread/resume", json!({ "threadId": thread_id })).await
+    }
+
+    /// Read exact app-server thread with turns included.
+    pub async fn thread_read(&self, thread_id: &str) -> Result<Value, ProviderError> {
+        self.request(
+            "thread/read",
+            json!({ "threadId": thread_id, "includeTurns": true }),
+        )
+        .await
+    }
+
+    /// Archive exact app-server thread when supported by installed schema.
+    pub async fn thread_archive(&self, thread_id: &str) -> Result<Value, ProviderError> {
+        if !self.capabilities.thread_archive {
+            return Err(ProviderError::Unsupported(
+                "Codex thread archive absent from generated schema".into(),
+            ));
+        }
+        self.request("thread/archive", json!({ "threadId": thread_id })).await
+    }
+
+    /// Start turn with one text input and return exact turn ID.
+    pub async fn turn_start(&self, thread_id: &str, text: &str) -> Result<String, ProviderError> {
+        let result = self
+            .request(
+                "turn/start",
+                json!({
+                    "threadId": thread_id,
+                    "input": [{ "type": "text", "text": text }],
+                }),
+            )
+            .await?;
+        nested_id(&result, "turn")
+    }
+
+    /// Interrupt exact active turn.
+    pub async fn turn_interrupt(
+        &self,
+        thread_id: &str,
+        turn_id: &str,
+    ) -> Result<Value, ProviderError> {
+        self.request(
+            "turn/interrupt",
+            json!({ "threadId": thread_id, "turnId": turn_id }),
+        )
+        .await
+    }
+
+    /// Answer exact request-user-input server request.
+    pub async fn answer_request_user_input(
+        &self,
+        request: &CodexQuestionRequest,
+        answers: &[QuestionAnswer],
+    ) -> Result<ProviderReceipt, ProviderError> {
+        if !self.capabilities.request_user_input {
+            return Err(ProviderError::Unsupported(
+                "Codex request-user-input absent from generated schema".into(),
+            ));
+        }
+        validate_answers(request, answers)?;
+        let answer_map = answers
+            .iter()
+            .map(|answer| {
+                (
+                    answer.question_id.clone(),
+                    json!({ "answers": answer.answers }),
+                )
+            })
+            .collect::<serde_json::Map<_, _>>();
+        self.respond(
+            request.identity.request_id.clone(),
+            json!({ "answers": answer_map }),
+        )
+        .await?;
+        Ok(ProviderReceipt {
+            authoritative: true,
+            transport: "codex-app-server-manager",
+        })
+    }
+
+    /// Decide exact app-server approval request.
+    pub async fn decide_approval(
+        &self,
+        request: &CodexApprovalRequest,
+        decision: ApprovalDecision,
+    ) -> Result<ProviderReceipt, ProviderError> {
+        if !self.capabilities.approvals {
+            return Err(ProviderError::Unsupported(
+                "Codex approvals absent from generated schema".into(),
+            ));
+        }
+        self.respond(
+            request.identity.request_id.clone(),
+            approval_result(request, decision)?,
+        )
+        .await?;
+        if decision == ApprovalDecision::DenyAndInterrupt
+            && request.kind == CodexApprovalKind::Permissions
+        {
+            self.turn_interrupt(&request.identity.thread_id, &request.identity.turn_id)
+                .await?;
+        }
+        Ok(ProviderReceipt {
+            authoritative: true,
+            transport: "codex-app-server-manager",
+        })
+    }
+
+    /// Request graceful actor shutdown.
+    pub async fn shutdown(&self) -> Result<(), ProviderError> {
+        let (reply, response) = oneshot::channel();
+        self.with_timeout(async {
+            self.commands
+                .send(ManagerCommand::Shutdown { reply })
+                .await
+                .map_err(|_| manager_closed())?;
+            response.await.map_err(|_| manager_closed())?
+        })
+        .await
+    }
+
+    async fn request(&self, method: &'static str, params: Value) -> Result<Value, ProviderError> {
+        let (reply, response) = oneshot::channel();
+        self.with_timeout(async {
+            self.commands
+                .send(ManagerCommand::Request {
+                    method,
+                    params,
+                    reply,
+                })
+                .await
+                .map_err(|_| manager_closed())?;
+            response.await.map_err(|_| manager_closed())?
+        })
+        .await
+    }
+
+    async fn respond(&self, request_id: RpcRequestId, result: Value) -> Result<(), ProviderError> {
+        let (reply, response) = oneshot::channel();
+        self.with_timeout(async {
+            self.commands
+                .send(ManagerCommand::Respond {
+                    request_id,
+                    result,
+                    reply,
+                })
+                .await
+                .map_err(|_| manager_closed())?;
+            response.await.map_err(|_| manager_closed())?
+        })
+        .await
+    }
+
+    async fn with_timeout<T>(
+        &self,
+        future: impl Future<Output = Result<T, ProviderError>>,
+    ) -> Result<T, ProviderError> {
+        tokio::time::timeout(self.request_timeout, future)
+            .await
+            .map_err(|_| ProviderError::Transport("Codex manager command timed out".into()))?
+    }
+}
+
+/// Running manager, ordered inbound receiver, and actor join handle.
+pub struct ManagedCodexManager {
+    /// Cloneable control handle.
+    pub handle: CodexManagerHandle,
+    /// Ordered server requests and notifications.
+    pub events: mpsc::Receiver<CodexInbound>,
+    task: JoinHandle<Result<(), ProviderError>>,
+}
+
+impl ManagedCodexManager {
+    /// Wait for actor exit and child cleanup.
+    pub async fn wait(self) -> Result<(), ProviderError> {
+        self.task.await.map_err(|error| {
+            ProviderError::Transport(format!("Codex manager task failed: {error}"))
+        })?
+    }
+}
+
+/// Return active process-wide Codex manager handle when transport is healthy.
+pub async fn active_handle() -> Option<CodexManagerHandle> {
+    active_manager().read().await.clone()
+}
+
+/// Spawn best-effort daemon service and authoritative Fleet ingest loop.
+pub fn spawn_service(
+    config: CodexManagerConfig,
+    pool: sqlx::SqlitePool,
+    events: EventSink,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut attempt = 0_usize;
+        loop {
+            let manager = match spawn(config.clone()).await {
+                Ok(manager) => manager,
+                Err(error) => {
+                    tracing::warn!(attempt = attempt + 1, error = %error, "Codex managed transport unavailable");
+                    if let Err(downgrade) =
+                        crate::fleet::mark_codex_manager_unavailable(&pool, &events, epoch_millis())
+                            .await
+                    {
+                        tracing::warn!(error = %downgrade, "Codex Fleet transport downgrade failed");
+                    }
+                    sleep(service_backoff(attempt)).await;
+                    attempt = attempt.saturating_add(1);
+                    continue;
+                }
+            };
+            reset_service_attempt(&mut attempt);
+            let ManagedCodexManager {
+                handle,
+                events: mut inbound,
+                task,
+            } = manager;
+            *active_manager().write().await = Some(handle.clone());
+            tracing::info!(
+                version = %handle.capabilities().cli_version,
+                request_user_input = handle.capabilities().request_user_input,
+                approvals = handle.capabilities().approvals,
+                "Codex managed transport ready"
+            );
+            if let Err(error) =
+                crate::fleet::recover_codex_manager(&pool, &events, &handle, epoch_millis()).await
+            {
+                tracing::warn!(error = %error, "Codex Fleet recovery sweep failed");
+            }
+
+            let boot_id = epoch_millis();
+            let mut sequence = 0_u64;
+            while let Some(event) = inbound.recv().await {
+                sequence = sequence.wrapping_add(1);
+                let event_id = format!("codex-manager:{boot_id}:{sequence}");
+                if let Err(error) = crate::fleet::apply_codex_inbound(
+                    &pool,
+                    &events,
+                    event_id,
+                    event,
+                    handle.capabilities(),
+                    epoch_millis(),
+                )
+                .await
+                {
+                    tracing::warn!(error = %error, "Codex Fleet event ingest failed");
+                }
+            }
+
+            *active_manager().write().await = None;
+            if let Err(error) = task
+                .await
+                .map_err(|join| {
+                    ProviderError::Transport(format!("Codex manager task failed: {join}"))
+                })
+                .and_then(|result| result)
+            {
+                tracing::warn!(error = %error, "Codex managed transport stopped");
+            }
+            if let Err(error) =
+                crate::fleet::mark_codex_manager_unavailable(&pool, &events, epoch_millis()).await
+            {
+                tracing::warn!(error = %error, "Codex Fleet transport downgrade failed");
+            }
+            sleep(service_backoff(attempt)).await;
+            attempt = attempt.saturating_add(1);
+        }
+    })
+}
+
+fn service_backoff(attempt: usize) -> Duration {
+    Duration::from_secs(1_u64 << attempt.min(4))
+}
+
+fn reset_service_attempt(attempt: &mut usize) {
+    *attempt = 0;
+}
+
+fn active_manager() -> &'static RwLock<Option<CodexManagerHandle>> {
+    ACTIVE_MANAGER.get_or_init(|| RwLock::new(None))
+}
+
+fn epoch_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| {
+            i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
+        })
+}
+
+/// Spawn shared app-server, one proxy, initialize protocol, then start manager.
+pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, ProviderError> {
+    let probe_binary = config.codex_binary.clone();
+    let capabilities = tokio::task::spawn_blocking(move || probe_codex(&probe_binary))
+        .await
+        .map_err(|error| ProviderError::Transport(format!("Codex probe task failed: {error}")))?;
+    if !capabilities.app_server {
+        return Err(ProviderError::Unsupported(
+            "installed Codex cannot generate app-server schema".into(),
+        ));
+    }
+    if !capabilities.stdio_proxy {
+        return Err(ProviderError::Unsupported(
+            "installed Codex has no app-server stdio proxy".into(),
+        ));
+    }
+
+    let preparation = prepare_socket(&config.socket_path, &config.codex_binary).await?;
+    let owns_server = preparation.owns_server;
+    let owner_marker_path = socket_owner_marker(&config.socket_path);
+    let mut server = if !owns_server {
+        None
+    } else {
+        let mut server_command = tokio_command(app_server_command(
+            &config.codex_binary,
+            &config.socket_path,
+        ));
+        server_command.kill_on_drop(true);
+        let mut child = server_command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        if let Err(error) =
+            wait_for_socket(&mut child, &config.socket_path, config.startup_timeout).await
+        {
+            stop_child(&mut child).await;
+            return Err(error);
+        }
+        let pid = child.id().ok_or_else(|| {
+            ProviderError::Transport("Codex app-server process id unavailable".into())
+        })?;
+        let identity = process_identity(pid).await.ok_or_else(|| {
+            ProviderError::Transport("Codex app-server process identity unavailable".into())
+        })?;
+        let marker = SocketOwnerMarker {
+            schema: 1,
+            pid,
+            process_start_fingerprint: identity.process_start_fingerprint,
+            executable: identity.executable,
+        };
+        let marker_json = serde_json::to_vec(&marker)?;
+        if let Err(error) = tokio::fs::write(&owner_marker_path, marker_json).await {
+            stop_child(&mut child).await;
+            remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
+            return Err(error.into());
+        }
+        Some(child)
+    };
+
+    let mut proxy_command = tokio_command(proxy_command(&config.codex_binary, &config.socket_path));
+    proxy_command.kill_on_drop(true);
+    let mut proxy = match proxy_command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(proxy) => proxy,
+        Err(error) => {
+            if let Some(server) = server.as_mut() {
+                stop_child(server).await;
+            }
+            if owns_server {
+                remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
+            }
+            return Err(error.into());
+        }
+    };
+    let Some(stdin) = proxy.stdin.take() else {
+        stop_child(&mut proxy).await;
+        if let Some(server) = server.as_mut() {
+            stop_child(server).await;
+        }
+        if owns_server {
+            remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
+        }
+        return Err(ProviderError::Transport(
+            "Codex proxy stdin unavailable".into(),
+        ));
+    };
+    let Some(stdout) = proxy.stdout.take() else {
+        stop_child(&mut proxy).await;
+        if let Some(server) = server.as_mut() {
+            stop_child(server).await;
+        }
+        if owns_server {
+            remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
+        }
+        return Err(ProviderError::Transport(
+            "Codex proxy stdout unavailable".into(),
+        ));
+    };
+    let cleanup: Box<dyn ProcessCleanup> = Box::new(ChildCleanup {
+        server,
+        proxy,
+        owned_socket_path: owns_server.then(|| config.socket_path.clone()),
+        owner_marker_path: owns_server.then_some(owner_marker_path),
+    });
+
+    spawn_connection(
+        BufReader::new(stdout),
+        stdin,
+        capabilities,
+        config,
+        preparation.marker_repair,
+        cleanup,
+    )
+    .await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketDisposition {
+    Create,
+    Adopt,
+    RecoverOwned,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SocketOwnerMarker {
+    schema: u8,
+    pid: u32,
+    process_start_fingerprint: String,
+    executable: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessIdentity {
+    process_start_fingerprint: String,
+    executable: String,
+}
+
+#[derive(Debug)]
+struct SocketPreparation {
+    owns_server: bool,
+    marker_repair: Option<MarkerRepair>,
+}
+
+#[derive(Debug)]
+struct MarkerRepair {
+    path: PathBuf,
+    expected: Option<Vec<u8>>,
+    owner: SocketOwnerMarker,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SocketFileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+const fn socket_disposition(
+    socket_exists: bool,
+    marker_owned: bool,
+    identity_matches: bool,
+) -> SocketDisposition {
+    if !socket_exists {
+        SocketDisposition::Create
+    } else if marker_owned && !identity_matches {
+        SocketDisposition::RecoverOwned
+    } else {
+        SocketDisposition::Adopt
+    }
+}
+
+async fn prepare_socket(
+    socket_path: &Path,
+    codex_binary: &std::ffi::OsStr,
+) -> Result<SocketPreparation, ProviderError> {
+    if !socket_path.exists() {
+        return Ok(SocketPreparation {
+            owns_server: true,
+            marker_repair: None,
+        });
+    }
+    let marker = socket_owner_marker(socket_path);
+    let marker_bytes = tokio::fs::read(&marker).await.ok();
+    let owner = marker_bytes
+        .as_deref()
+        .and_then(|contents| serde_json::from_slice::<SocketOwnerMarker>(contents).ok());
+    let marker_owned = owner.as_ref().is_some_and(|owner| {
+        owner.schema == 1 && executable_matches(&owner.executable, codex_binary)
+    });
+    let identity_matches = match owner.as_ref().filter(|_| marker_owned) {
+        Some(owner) => process_identity(owner.pid).await.is_some_and(|current| {
+            current.process_start_fingerprint == owner.process_start_fingerprint
+                && current.executable == owner.executable
+        }),
+        None => false,
+    };
+    match socket_disposition(true, marker_owned, identity_matches) {
+        SocketDisposition::RecoverOwned => {
+            prepare_unmarked_socket(socket_path, &marker, marker_bytes, codex_binary).await
+        }
+        SocketDisposition::Adopt if marker_owned => Ok(SocketPreparation {
+            owns_server: false,
+            marker_repair: None,
+        }),
+        SocketDisposition::Adopt if owner.is_some() => Ok(SocketPreparation {
+            owns_server: false,
+            marker_repair: None,
+        }),
+        SocketDisposition::Adopt => {
+            prepare_unmarked_socket(socket_path, &marker, marker_bytes, codex_binary).await
+        }
+        SocketDisposition::Create => Ok(SocketPreparation {
+            owns_server: true,
+            marker_repair: None,
+        }),
+    }
+}
+
+async fn prepare_unmarked_socket(
+    socket_path: &Path,
+    marker_path: &Path,
+    expected_marker: Option<Vec<u8>>,
+    codex_binary: &std::ffi::OsStr,
+) -> Result<SocketPreparation, ProviderError> {
+    let identity = socket_file_identity(socket_path)?;
+    match UnixStream::connect(socket_path).await {
+        Ok(stream) => {
+            drop(stream);
+            let marker_repair =
+                listener_owner_marker(socket_path, codex_binary)
+                    .await
+                    .map(|owner| MarkerRepair {
+                        path: marker_path.to_path_buf(),
+                        expected: expected_marker,
+                        owner,
+                    });
+            Ok(SocketPreparation {
+                owns_server: false,
+                marker_repair,
+            })
+        }
+        Err(error) if stale_socket_error(&error) => {
+            if socket_file_identity(socket_path)? == identity {
+                tokio::fs::remove_file(socket_path).await?;
+                if expected_marker.is_some() {
+                    let _ = tokio::fs::remove_file(marker_path).await;
+                }
+                Ok(SocketPreparation {
+                    owns_server: true,
+                    marker_repair: None,
+                })
+            } else {
+                Ok(SocketPreparation {
+                    owns_server: false,
+                    marker_repair: None,
+                })
+            }
+        }
+        Err(_) => Ok(SocketPreparation {
+            owns_server: false,
+            marker_repair: None,
+        }),
+    }
+}
+
+fn socket_file_identity(path: &Path) -> Result<SocketFileIdentity, ProviderError> {
+    use std::os::unix::fs::MetadataExt as _;
+    let metadata = std::fs::symlink_metadata(path)?;
+    Ok(SocketFileIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+fn stale_socket_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+    )
+}
+
+async fn listener_owner_marker(
+    socket_path: &Path,
+    codex_binary: &std::ffi::OsStr,
+) -> Option<SocketOwnerMarker> {
+    let output = Command::new("lsof")
+        .args(["-n", "-t", "--"])
+        .arg(socket_path)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())?;
+    let mut owners = Vec::new();
+    for pid in String::from_utf8(output.stdout).ok()?.lines() {
+        let pid = pid.trim().parse::<u32>().ok()?;
+        let identity = process_identity(pid).await?;
+        if executable_matches(&identity.executable, codex_binary) {
+            owners.push(SocketOwnerMarker {
+                schema: 1,
+                pid,
+                process_start_fingerprint: identity.process_start_fingerprint,
+                executable: identity.executable,
+            });
+        }
+    }
+    (owners.len() == 1).then(|| owners.remove(0))
+}
+
+async fn repair_owner_marker(repair: MarkerRepair) -> Result<bool, ProviderError> {
+    let mut lock_path = repair.path.as_os_str().to_os_string();
+    lock_path.push(".lock");
+    let lock_path = PathBuf::from(lock_path);
+    let lock = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock_path)
+        .await;
+    let Ok(lock) = lock else {
+        return Ok(false);
+    };
+    let current = tokio::fs::read(&repair.path).await.ok();
+    if current != repair.expected {
+        drop(lock);
+        let _ = tokio::fs::remove_file(&lock_path).await;
+        return Ok(false);
+    }
+    let result = async {
+        let mut temporary = repair.path.as_os_str().to_os_string();
+        temporary.push(format!(".{}.tmp", std::process::id()));
+        let temporary = PathBuf::from(temporary);
+        tokio::fs::write(&temporary, serde_json::to_vec(&repair.owner)?).await?;
+        tokio::fs::rename(&temporary, &repair.path).await?;
+        Ok::<_, ProviderError>(true)
+    }
+    .await;
+    drop(lock);
+    let _ = tokio::fs::remove_file(&lock_path).await;
+    result
+}
+
+fn executable_matches(recorded: &str, expected: &std::ffi::OsStr) -> bool {
+    Path::new(recorded).file_name() == Path::new(expected).file_name()
+}
+
+fn socket_owner_marker(socket_path: &Path) -> PathBuf {
+    let mut marker = socket_path.as_os_str().to_os_string();
+    marker.push(".ainb-owner");
+    PathBuf::from(marker)
+}
+
+async fn process_identity(pid: u32) -> Option<ProcessIdentity> {
+    let process_start_fingerprint = ps_field(pid, "lstart=").await?;
+    let executable = ps_field(pid, "comm=").await?;
+    Some(ProcessIdentity {
+        process_start_fingerprint,
+        executable,
+    })
+}
+
+async fn ps_field(pid: u32, field: &str) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", field])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())?;
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn tokio_command(spec: CommandSpec) -> Command {
+    let mut command = Command::new(spec.program);
+    command.args(spec.args);
+    command
+}
+
+async fn wait_for_socket(
+    child: &mut Child,
+    socket: &Path,
+    timeout: Duration,
+) -> Result<(), ProviderError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if socket.exists() {
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait()? {
+            return Err(ProviderError::Transport(format!(
+                "Codex app-server exited before socket bind: {status}"
+            )));
+        }
+        if Instant::now() >= deadline {
+            return Err(ProviderError::Transport(format!(
+                "Codex app-server socket startup timed out: {}",
+                socket.display()
+            )));
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+enum ManagerCommand {
+    Request {
+        method: &'static str,
+        params: Value,
+        reply: oneshot::Sender<Result<Value, ProviderError>>,
+    },
+    Respond {
+        request_id: RpcRequestId,
+        result: Value,
+        reply: oneshot::Sender<Result<(), ProviderError>>,
+    },
+    Shutdown {
+        reply: oneshot::Sender<Result<(), ProviderError>>,
+    },
+}
+
+struct PendingRequest {
+    method: &'static str,
+    reply: oneshot::Sender<Result<Value, ProviderError>>,
+}
+
+async fn spawn_connection<R, W>(
+    mut reader: R,
+    mut writer: W,
+    capabilities: CodexCapabilities,
+    config: CodexManagerConfig,
+    marker_repair: Option<MarkerRepair>,
+    mut cleanup: Box<dyn ProcessCleanup>,
+) -> Result<ManagedCodexManager, ProviderError>
+where
+    R: AsyncBufRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let (events_tx, events) = mpsc::channel(config.event_capacity.max(1));
+    let bootstrap = tokio::time::timeout(
+        config.startup_timeout,
+        initialize_connection(&mut reader, &mut writer, &config.client_version, &events_tx),
+    )
+    .await
+    .map_err(|_| ProviderError::Transport("Codex initialize timed out".into()))
+    .and_then(|result| result);
+    if let Err(error) = bootstrap {
+        cleanup.cleanup().await;
+        return Err(error);
+    }
+    if let Some(repair) = marker_repair {
+        if let Err(error) = repair_owner_marker(repair).await {
+            tracing::warn!(error = %error, "Codex adopted socket marker repair failed");
+        }
+    }
+
+    let (commands, command_rx) = mpsc::channel(64);
+    let capabilities = Arc::new(capabilities);
+    let handle = CodexManagerHandle {
+        commands,
+        capabilities: Arc::clone(&capabilities),
+        socket_path: Arc::new(config.socket_path),
+        request_timeout: config.request_timeout,
+    };
+    let task = tokio::spawn(async move {
+        let result = run_actor(reader, writer, command_rx, events_tx).await;
+        cleanup.cleanup().await;
+        result
+    });
+    Ok(ManagedCodexManager {
+        handle,
+        events,
+        task,
+    })
+}
+
+async fn initialize_connection<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    client_version: &str,
+    events: &mpsc::Sender<CodexInbound>,
+) -> Result<(), ProviderError>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    write_message(
+        writer,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": INITIALIZE_ID,
+            "method": "initialize",
+            "params": {
+                "clientInfo": {
+                    "name": "agents-in-a-box-fleet",
+                    "title": "Fleet",
+                    "version": client_version,
+                },
+                "capabilities": { "experimentalApi": true },
+            },
+        }),
+    )
+    .await?;
+
+    loop {
+        let message = read_message(reader).await?;
+        if message.get("id") == Some(&json!(INITIALIZE_ID)) {
+            if let Some(error) = message.get("error") {
+                return Err(ProviderError::Protocol(format!(
+                    "Codex initialize failed: {error}"
+                )));
+            }
+            if message.get("result").is_none() {
+                return Err(ProviderError::Protocol(
+                    "Codex initialize response has no result".into(),
+                ));
+            }
+            break;
+        }
+        let inbound = parse_inbound(&message)?;
+        events
+            .send(inbound)
+            .await
+            .map_err(|_| ProviderError::Transport("Codex event receiver closed".into()))?;
+    }
+
+    write_message(
+        writer,
+        &json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }),
+    )
+    .await
+}
+
+async fn run_actor<R, W>(
+    mut reader: R,
+    mut writer: W,
+    mut commands: mpsc::Receiver<ManagerCommand>,
+    events: mpsc::Sender<CodexInbound>,
+) -> Result<(), ProviderError>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut next_id = INITIALIZE_ID + 1;
+    let mut pending = BTreeMap::<u64, PendingRequest>::new();
+
+    loop {
+        pending.retain(|_, request| !request.reply.is_closed());
+        tokio::select! {
+            command = commands.recv() => {
+                let Some(command) = command else {
+                    fail_pending(&mut pending, "Codex manager handles dropped");
+                    return Ok(());
+                };
+                match command {
+                    ManagerCommand::Request { method, params, reply } => {
+                        let id = next_id;
+                        next_id = next_id.checked_add(1).ok_or_else(|| {
+                            ProviderError::Protocol("Codex JSON-RPC request id exhausted".into())
+                        })?;
+                        if let Err(error) = write_message(
+                            &mut writer,
+                            &json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
+                        ).await {
+                            let _ = reply.send(Err(error));
+                            continue;
+                        }
+                        pending.insert(id, PendingRequest { method, reply });
+                    }
+                    ManagerCommand::Respond { request_id, result, reply } => {
+                        let outcome = write_message(
+                            &mut writer,
+                            &json!({ "jsonrpc": "2.0", "id": request_id.as_value(), "result": result }),
+                        ).await;
+                        let _ = reply.send(outcome);
+                    }
+                    ManagerCommand::Shutdown { reply } => {
+                        fail_pending(&mut pending, "Codex manager shutting down");
+                        let _ = reply.send(Ok(()));
+                        return Ok(());
+                    }
+                }
+            }
+            message = read_message(&mut reader) => {
+                let message = message?;
+                if message.get("result").is_some() || message.get("error").is_some() {
+                    if let Some(id) = message.get("id").and_then(Value::as_u64) {
+                        let Some(pending_request) = pending.remove(&id) else {
+                            return Err(ProviderError::Protocol(format!(
+                                "Codex response has unknown request id {id}"
+                            )));
+                        };
+                        let outcome = if let Some(error) = message.get("error") {
+                            Err(ProviderError::Protocol(format!(
+                                "Codex {} failed: {error}", pending_request.method
+                            )))
+                        } else {
+                            Ok(message.get("result").cloned().unwrap_or(Value::Null))
+                        };
+                        let _ = pending_request.reply.send(outcome);
+                        continue;
+                    }
+                }
+                events
+                    .send(parse_inbound(&message)?)
+                    .await
+                    .map_err(|_| ProviderError::Transport("Codex event receiver closed".into()))?;
+            }
+        }
+    }
+}
+
+fn fail_pending(pending: &mut BTreeMap<u64, PendingRequest>, reason: &str) {
+    for (_, request) in std::mem::take(pending) {
+        let _ = request.reply.send(Err(ProviderError::Transport(reason.into())));
+    }
+}
+
+async fn write_message<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    message: &Value,
+) -> Result<(), ProviderError> {
+    let encoded = serde_json::to_vec(message)?;
+    writer.write_all(&encoded).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+async fn read_message<R: AsyncBufRead + Unpin>(reader: &mut R) -> Result<Value, ProviderError> {
+    let mut line = String::new();
+    if reader.read_line(&mut line).await? == 0 {
+        return Err(ProviderError::Transport(
+            "Codex app-server proxy closed stdout".into(),
+        ));
+    }
+    serde_json::from_str(&line).map_err(ProviderError::from)
+}
+
+fn nested_id(result: &Value, field: &str) -> Result<String, ProviderError> {
+    result
+        .get(field)
+        .and_then(|value| value.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| ProviderError::Protocol(format!("Codex {field} response has no id")))
+}
+
+fn validate_answers(
+    request: &CodexQuestionRequest,
+    answers: &[QuestionAnswer],
+) -> Result<(), ProviderError> {
+    if request.questions.len() != answers.len() {
+        return Err(ProviderError::Protocol(format!(
+            "expected {} Codex answers, got {}",
+            request.questions.len(),
+            answers.len()
+        )));
+    }
+    for question in &request.questions {
+        let count = answers
+            .iter()
+            .filter(|answer| answer.question_id == question.id && !answer.answers.is_empty())
+            .count();
+        if count != 1 {
+            return Err(ProviderError::Protocol(format!(
+                "Codex question {} must have one non-empty answer",
+                question.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn approval_result(
+    request: &CodexApprovalRequest,
+    decision: ApprovalDecision,
+) -> Result<Value, ProviderError> {
+    match request.kind {
+        CodexApprovalKind::CommandExecution | CodexApprovalKind::FileChange => {
+            let decision = match decision {
+                ApprovalDecision::Approve => "accept",
+                ApprovalDecision::ApproveForSession => "acceptForSession",
+                ApprovalDecision::Deny => "decline",
+                ApprovalDecision::DenyAndInterrupt => "cancel",
+            };
+            Ok(json!({ "decision": decision }))
+        }
+        CodexApprovalKind::Permissions => {
+            let permissions = match decision {
+                ApprovalDecision::Approve | ApprovalDecision::ApproveForSession => {
+                    request.params.get("permissions").cloned().ok_or_else(|| {
+                        ProviderError::Protocol(
+                            "Codex permission request has no permissions profile".into(),
+                        )
+                    })?
+                }
+                ApprovalDecision::Deny | ApprovalDecision::DenyAndInterrupt => json!({}),
+            };
+            let scope = if decision == ApprovalDecision::ApproveForSession {
+                "session"
+            } else {
+                "turn"
+            };
+            Ok(json!({ "permissions": permissions, "scope": scope }))
+        }
+    }
+}
+
+fn manager_closed() -> ProviderError {
+    ProviderError::Transport("Codex manager command channel closed".into())
+}
+
+type CleanupFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
+trait ProcessCleanup: Send {
+    fn cleanup(&mut self) -> CleanupFuture<'_>;
+}
+
+struct ChildCleanup {
+    server: Option<Child>,
+    proxy: Child,
+    owned_socket_path: Option<PathBuf>,
+    owner_marker_path: Option<PathBuf>,
+}
+
+impl ProcessCleanup for ChildCleanup {
+    fn cleanup(&mut self) -> CleanupFuture<'_> {
+        Box::pin(async move {
+            stop_child(&mut self.proxy).await;
+            if let Some(server) = self.server.as_mut() {
+                stop_child(server).await;
+            }
+            remove_owned_socket(
+                self.owned_socket_path.as_deref(),
+                self.owner_marker_path.as_deref(),
+            )
+            .await;
+        })
+    }
+}
+
+async fn remove_owned_socket(socket_path: Option<&Path>, owner_marker_path: Option<&Path>) {
+    if let Some(socket_path) = socket_path {
+        if socket_path.exists() {
+            let _ = tokio::fs::remove_file(socket_path).await;
+        }
+    }
+    if let Some(owner_marker_path) = owner_marker_path {
+        if owner_marker_path.exists() {
+            let _ = tokio::fs::remove_file(owner_marker_path).await;
+        }
+    }
+}
+
+impl Drop for ChildCleanup {
+    fn drop(&mut self) {
+        let _ = self.proxy.start_kill();
+        if let Some(server) = self.server.as_mut() {
+            let _ = server.start_kill();
+        }
+    }
+}
+
+async fn stop_child(child: &mut Child) {
+    if child.try_wait().ok().flatten().is_none() {
+        let _ = child.start_kill();
+    }
+    let _ = child.wait().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, duplex, split};
+    use tokio::net::UnixListener;
+
+    use super::*;
+    use crate::fleet_provider::{QuestionOption, StructuredQuestion};
+
+    struct FakeCleanup(Arc<AtomicBool>);
+
+    impl ProcessCleanup for FakeCleanup {
+        fn cleanup(&mut self) -> CleanupFuture<'_> {
+            Box::pin(async move {
+                self.0.store(true, Ordering::SeqCst);
+            })
+        }
+    }
+
+    fn capabilities(rui: bool) -> CodexCapabilities {
+        CodexCapabilities {
+            cli_version: "codex-cli test".into(),
+            daemon_version: None,
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input: rui,
+            approvals: true,
+            thread_archive: true,
+        }
+    }
+
+    fn config() -> CodexManagerConfig {
+        CodexManagerConfig {
+            codex_binary: "codex".into(),
+            socket_path: "/tmp/test-codex-manager.sock".into(),
+            client_version: "test".into(),
+            startup_timeout: Duration::from_millis(50),
+            request_timeout: Duration::from_secs(1),
+            event_capacity: 8,
+        }
+    }
+
+    async fn server_read<R: AsyncBufRead + Unpin>(reader: &mut R) -> Value {
+        let mut line = String::new();
+        reader.read_line(&mut line).await.expect("server read");
+        serde_json::from_str(&line).expect("server JSON")
+    }
+
+    async fn server_write<W: AsyncWrite + Unpin>(writer: &mut W, value: Value) {
+        writer.write_all(format!("{value}\n").as_bytes()).await.expect("server write");
+        writer.flush().await.expect("server flush");
+    }
+
+    #[tokio::test]
+    async fn manager_initializes_orders_events_and_routes_exact_commands() {
+        let (manager_io, server_io) = duplex(65_536);
+        let (manager_read, manager_write) = split(manager_io);
+        let (server_read_half, mut server_write_half) = split(server_io);
+        let mut server_read_half = BufReader::new(server_read_half);
+        let cleanup_flag = Arc::new(AtomicBool::new(false));
+        let repair_dir = tempfile::tempdir().unwrap();
+        let repair_path = repair_dir.path().join("adopted.ainb-owner");
+        let repaired_owner = SocketOwnerMarker {
+            schema: 1,
+            pid: 42,
+            process_start_fingerprint: "start".to_string(),
+            executable: "codex".to_string(),
+        };
+
+        let server = tokio::spawn(async move {
+            let initialize = server_read(&mut server_read_half).await;
+            assert_eq!(initialize["method"], "initialize");
+            assert_eq!(
+                initialize["params"]["capabilities"]["experimentalApi"],
+                true
+            );
+            server_write(
+                &mut server_write_half,
+                json!({ "jsonrpc": "2.0", "id": INITIALIZE_ID, "result": {} }),
+            )
+            .await;
+            let initialized = server_read(&mut server_read_half).await;
+            assert_eq!(initialized["method"], "initialized");
+
+            server_write(
+                &mut server_write_half,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": "rui-7",
+                    "method": "item/tool/requestUserInput",
+                    "params": {
+                        "threadId": "thread-1",
+                        "turnId": "turn-2",
+                        "itemId": "item-3",
+                        "questions": [{
+                            "id": "tool",
+                            "header": "Tool",
+                            "question": "Pick tool",
+                            "options": [{ "label": "rg", "description": "Text" }]
+                        }]
+                    }
+                }),
+            )
+            .await;
+
+            let answer = server_read(&mut server_read_half).await;
+            assert_eq!(answer["id"], "rui-7");
+            assert_eq!(answer["result"]["answers"]["tool"]["answers"][0], "rg");
+
+            let turn_start = server_read(&mut server_read_half).await;
+            assert_eq!(turn_start["method"], "turn/start");
+            assert_eq!(turn_start["params"]["threadId"], "thread-1");
+            server_write(
+                &mut server_write_half,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": turn_start["id"],
+                    "result": { "turn": { "id": "turn-9" } }
+                }),
+            )
+            .await;
+
+            let interrupt = server_read(&mut server_read_half).await;
+            assert_eq!(interrupt["method"], "turn/interrupt");
+            assert_eq!(interrupt["params"]["turnId"], "turn-9");
+            server_write(
+                &mut server_write_half,
+                json!({ "jsonrpc": "2.0", "id": interrupt["id"], "result": {} }),
+            )
+            .await;
+
+            server_write(
+                &mut server_write_half,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": "approval-8",
+                    "method": "item/commandExecution/requestApproval",
+                    "params": {
+                        "threadId": "thread-1",
+                        "turnId": "turn-9",
+                        "itemId": "item-10"
+                    }
+                }),
+            )
+            .await;
+            let approval = server_read(&mut server_read_half).await;
+            assert_eq!(approval["id"], "approval-8");
+            assert_eq!(approval["result"]["decision"], "acceptForSession");
+            let archive = server_read(&mut server_read_half).await;
+            assert_eq!(archive["method"], "thread/archive");
+            assert_eq!(archive["params"]["threadId"], "thread-1");
+            server_write(
+                &mut server_write_half,
+                json!({ "jsonrpc": "2.0", "id": archive["id"], "result": {} }),
+            )
+            .await;
+            let mut eof = String::new();
+            assert_eq!(
+                server_read_half.read_line(&mut eof).await.expect("server EOF"),
+                0
+            );
+        });
+
+        let mut manager = spawn_connection(
+            BufReader::new(manager_read),
+            manager_write,
+            capabilities(true),
+            config(),
+            Some(MarkerRepair {
+                path: repair_path.clone(),
+                expected: None,
+                owner: repaired_owner.clone(),
+            }),
+            Box::new(FakeCleanup(Arc::clone(&cleanup_flag))),
+        )
+        .await
+        .expect("spawn manager");
+        let repaired: SocketOwnerMarker =
+            serde_json::from_slice(&std::fs::read(&repair_path).unwrap()).unwrap();
+        assert_eq!(repaired, repaired_owner);
+
+        let event = manager.events.recv().await.expect("ordered event");
+        let CodexInbound::RequestUserInput(request) = event else {
+            panic!("expected request-user-input");
+        };
+        assert_eq!(request.identity.thread_id, "thread-1");
+        manager
+            .handle
+            .answer_request_user_input(
+                &request,
+                &[QuestionAnswer {
+                    question_id: "tool".into(),
+                    answers: vec!["rg".into()],
+                }],
+            )
+            .await
+            .expect("answer RUI");
+        let turn_id = manager.handle.turn_start("thread-1", "continue").await.expect("turn start");
+        assert_eq!(turn_id, "turn-9");
+        manager
+            .handle
+            .turn_interrupt("thread-1", &turn_id)
+            .await
+            .expect("turn interrupt");
+        let approval = manager.events.recv().await.expect("ordered approval");
+        let CodexInbound::Approval(approval) = approval else {
+            panic!("expected approval");
+        };
+        assert_eq!(approval.identity.item_id, "item-10");
+        manager
+            .handle
+            .decide_approval(&approval, ApprovalDecision::ApproveForSession)
+            .await
+            .expect("approval response");
+        manager.handle.thread_archive("thread-1").await.expect("thread archive");
+        manager.handle.shutdown().await.expect("shutdown");
+        manager.wait().await.expect("manager wait");
+        server.await.expect("fake server");
+        assert!(cleanup_flag.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn capability_gate_refuses_rui_without_writing_response() {
+        let (manager_io, server_io) = duplex(4096);
+        let (manager_read, manager_write) = split(manager_io);
+        let (server_read_half, mut server_write_half) = split(server_io);
+        let mut server_read_half = BufReader::new(server_read_half);
+
+        let server = tokio::spawn(async move {
+            let initialize = server_read(&mut server_read_half).await;
+            server_write(
+                &mut server_write_half,
+                json!({ "jsonrpc": "2.0", "id": initialize["id"], "result": {} }),
+            )
+            .await;
+            let _ = server_read(&mut server_read_half).await;
+            let mut eof = String::new();
+            assert_eq!(
+                server_read_half.read_line(&mut eof).await.expect("server EOF"),
+                0
+            );
+        });
+        let cleanup_flag = Arc::new(AtomicBool::new(false));
+        let manager = spawn_connection(
+            BufReader::new(manager_read),
+            manager_write,
+            capabilities(false),
+            config(),
+            None,
+            Box::new(FakeCleanup(cleanup_flag)),
+        )
+        .await
+        .expect("spawn manager");
+        let request = CodexQuestionRequest {
+            identity: super::super::codex::CodexItemRequestIdentity {
+                request_id: RpcRequestId::new(json!("rui-disabled")).expect("request id"),
+                thread_id: "thread".into(),
+                turn_id: "turn".into(),
+                item_id: "item".into(),
+            },
+            questions: vec![StructuredQuestion {
+                id: "tool".into(),
+                header: "Tool".into(),
+                question: "Pick".into(),
+                options: vec![QuestionOption {
+                    label: "rg".into(),
+                    description: "Text".into(),
+                }],
+                multi_select: false,
+                is_other: false,
+                is_secret: false,
+            }],
+            auto_resolution_ms: None,
+        };
+        let error = manager
+            .handle
+            .answer_request_user_input(
+                &request,
+                &[QuestionAnswer {
+                    question_id: "tool".into(),
+                    answers: vec!["rg".into()],
+                }],
+            )
+            .await
+            .expect_err("RUI must be gated");
+        assert!(matches!(error, ProviderError::Unsupported(_)));
+        manager.handle.shutdown().await.expect("shutdown");
+        manager.wait().await.expect("wait");
+        server.await.expect("fake server");
+    }
+
+    #[test]
+    fn service_retry_backoff_is_bounded() {
+        assert_eq!(service_backoff(0), Duration::from_secs(1));
+        assert_eq!(service_backoff(1), Duration::from_secs(2));
+        assert_eq!(service_backoff(4), Duration::from_secs(16));
+        assert_eq!(service_backoff(99), Duration::from_secs(16));
+    }
+
+    #[test]
+    fn successful_service_start_resets_retry_backoff() {
+        let mut attempt = 99;
+        reset_service_attempt(&mut attempt);
+        assert_eq!(attempt, 0);
+        assert_eq!(service_backoff(attempt), Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn adopted_socket_is_never_removed_but_owned_socket_is() {
+        let dir = tempfile::tempdir().unwrap();
+        let adopted = dir.path().join("adopted.sock");
+        std::fs::write(&adopted, b"live").unwrap();
+        assert_eq!(
+            socket_disposition(adopted.exists(), false, false),
+            SocketDisposition::Adopt
+        );
+        remove_owned_socket(None, None).await;
+        assert!(adopted.exists());
+
+        let owned = dir.path().join("owned.sock");
+        let marker = socket_owner_marker(&owned);
+        std::fs::write(&owned, b"owned").unwrap();
+        std::fs::write(&marker, b"owned marker").unwrap();
+        assert_eq!(
+            socket_disposition(true, true, false),
+            SocketDisposition::RecoverOwned
+        );
+        remove_owned_socket(Some(&owned), Some(&marker)).await;
+        assert!(!owned.exists());
+        assert!(!marker.exists());
+    }
+
+    #[test]
+    fn socket_disposition_never_claims_unknown_or_live_owner() {
+        assert_eq!(
+            socket_disposition(false, false, false),
+            SocketDisposition::Create
+        );
+        assert_eq!(
+            socket_disposition(true, false, false),
+            SocketDisposition::Adopt
+        );
+        assert_eq!(
+            socket_disposition(true, true, true),
+            SocketDisposition::Adopt
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_owned_socket_recovers_but_unknown_socket_is_adopted() {
+        let dir = tempfile::tempdir().unwrap();
+        let owned = dir.path().join("owned.sock");
+        let marker = socket_owner_marker(&owned);
+        let listener = UnixListener::bind(&owned).unwrap();
+        drop(listener);
+        let stale = SocketOwnerMarker {
+            schema: 1,
+            pid: u32::MAX,
+            process_start_fingerprint: "stale-start".to_string(),
+            executable: "codex".to_string(),
+        };
+        std::fs::write(&marker, serde_json::to_vec(&stale).unwrap()).unwrap();
+        assert!(prepare_socket(&owned, std::ffi::OsStr::new("codex")).await.unwrap().owns_server);
+        assert!(!owned.exists());
+        assert!(!marker.exists());
+
+        let unknown = dir.path().join("unknown.sock");
+        let listener = UnixListener::bind(&unknown).unwrap();
+        std::fs::write(socket_owner_marker(&unknown), b"invalid marker").unwrap();
+        assert!(
+            !prepare_socket(&unknown, std::ffi::OsStr::new("codex"))
+                .await
+                .unwrap()
+                .owns_server
+        );
+        assert!(unknown.exists());
+        drop(listener);
+    }
+
+    #[tokio::test]
+    async fn stale_owner_marker_never_unlinks_live_replacement_listener() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("replacement.sock");
+        let marker = socket_owner_marker(&socket);
+        let listener = UnixListener::bind(&socket).unwrap();
+        let stale = SocketOwnerMarker {
+            schema: 1,
+            pid: u32::MAX,
+            process_start_fingerprint: "dead-owner".to_string(),
+            executable: "codex".to_string(),
+        };
+        std::fs::write(&marker, serde_json::to_vec(&stale).unwrap()).unwrap();
+
+        let preparation = prepare_socket(&socket, std::ffi::OsStr::new("codex")).await.unwrap();
+        assert!(!preparation.owns_server);
+        assert!(socket.exists());
+        assert!(marker.exists());
+
+        let client = UnixStream::connect(&socket).await.unwrap();
+        let (_accepted, _) = listener.accept().await.unwrap();
+        drop(client);
+    }
+
+    #[tokio::test]
+    async fn exact_live_owner_identity_is_adopted() {
+        let identity = process_identity(std::process::id()).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("live.sock");
+        std::fs::write(&socket, b"live").unwrap();
+        let marker = SocketOwnerMarker {
+            schema: 1,
+            pid: std::process::id(),
+            process_start_fingerprint: identity.process_start_fingerprint,
+            executable: identity.executable.clone(),
+        };
+        std::fs::write(
+            socket_owner_marker(&socket),
+            serde_json::to_vec(&marker).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            !prepare_socket(&socket, std::ffi::OsStr::new(&identity.executable))
+                .await
+                .unwrap()
+                .owns_server
+        );
+        assert!(socket.exists());
+    }
+
+    #[tokio::test]
+    async fn stale_unmarked_socket_inode_is_recovered_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("stale-unmarked.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        drop(listener);
+        assert!(socket.exists());
+        let preparation = prepare_socket(&socket, std::ffi::OsStr::new("codex")).await.unwrap();
+        assert!(preparation.owns_server);
+        assert!(!socket.exists());
+    }
+
+    #[tokio::test]
+    async fn atomic_marker_repair_requires_unchanged_original() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker_path = dir.path().join("socket.ainb-owner");
+        let original = b"corrupt".to_vec();
+        std::fs::write(&marker_path, &original).unwrap();
+        let owner = SocketOwnerMarker {
+            schema: 1,
+            pid: 42,
+            process_start_fingerprint: "start".to_string(),
+            executable: "codex".to_string(),
+        };
+        assert!(
+            repair_owner_marker(MarkerRepair {
+                path: marker_path.clone(),
+                expected: Some(original),
+                owner: owner.clone(),
+            })
+            .await
+            .unwrap()
+        );
+        let repaired: SocketOwnerMarker =
+            serde_json::from_slice(&std::fs::read(&marker_path).unwrap()).unwrap();
+        assert_eq!(repaired, owner);
+
+        assert!(
+            !repair_owner_marker(MarkerRepair {
+                path: marker_path,
+                expected: Some(b"old".to_vec()),
+                owner,
+            })
+            .await
+            .unwrap()
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/mod.rs
@@ -1,0 +1,198 @@
+//! Provider control adapters for Fleet-managed sessions.
+//!
+//! This module keeps provider wire details below the Fleet reducer and RPC
+//! surface. Callers pass stable request identity and session versions. Each
+//! adapter then chooses an authoritative provider control path or a narrowly
+//! verified degraded fallback.
+
+pub mod claude;
+pub mod codex;
+pub mod codex_manager;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Provider adapter failure with enough structure for an honest action receipt.
+#[derive(Debug, Error)]
+pub enum ProviderError {
+    /// Local transport failed.
+    #[error("provider transport failed: {0}")]
+    Transport(String),
+    /// Provider returned a response that violates its negotiated protocol.
+    #[error("provider protocol error: {0}")]
+    Protocol(String),
+    /// Requested action is not available through the negotiated capabilities.
+    #[error("provider capability unavailable: {0}")]
+    Unsupported(String),
+    /// Request identity or version no longer matches current provider state.
+    #[error("stale provider request: {0}")]
+    Stale(String),
+    /// IO failure while starting or talking to a provider transport.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// JSON failure while talking to a schema-compatible provider transport.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+/// Stable identity shared by every provider action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionIdentity {
+    /// Fleet registry key, never cwd-derived.
+    pub session_key: String,
+    /// Provider-native session or thread identifier when known.
+    pub provider_session_id: Option<String>,
+    /// Optimistic concurrency version from the authoritative Fleet registry.
+    pub expected_version: i64,
+}
+
+/// Opaque fingerprint over exact provider request identity and ordered payload.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RequestFingerprint(pub String);
+
+/// One selectable answer shown by a provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestionOption {
+    /// Provider-visible option label.
+    pub label: String,
+    /// Provider-visible option explanation.
+    pub description: String,
+}
+
+/// One complete structured question.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StructuredQuestion {
+    /// Provider-native question identifier.
+    pub id: String,
+    /// Short display header.
+    pub header: String,
+    /// Full question text.
+    pub question: String,
+    /// Ordered options. Empty means free-form input.
+    pub options: Vec<QuestionOption>,
+    /// Whether provider accepts more than one selected option.
+    #[serde(default)]
+    pub multi_select: bool,
+    /// Whether provider offers a free-form alternative.
+    #[serde(default)]
+    pub is_other: bool,
+    /// Whether rendered input must be concealed.
+    #[serde(default)]
+    pub is_secret: bool,
+}
+
+/// Answers for one provider-native question.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestionAnswer {
+    /// Provider-native question identifier.
+    pub question_id: String,
+    /// Selected labels or free-form answer values.
+    pub answers: Vec<String>,
+}
+
+/// Provider-independent approval decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ApprovalDecision {
+    /// Approve once.
+    Approve,
+    /// Approve and cache for current provider session when supported.
+    ApproveForSession,
+    /// Deny while allowing current turn to continue.
+    Deny,
+    /// Deny and interrupt current turn when supported.
+    DenyAndInterrupt,
+}
+
+/// Result returned by a provider execution adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderReceipt {
+    /// Whether provider acknowledged action authoritatively.
+    pub authoritative: bool,
+    /// Human-readable transport used for diagnostics.
+    pub transport: &'static str,
+}
+
+/// Convert authoritative Fleet registry identity into provider transport identity.
+pub fn session_identity_from_core(
+    session: &ainb_fleet_core::types::FleetSession,
+) -> Result<SessionIdentity, ProviderError> {
+    let expected_version = i64::try_from(session.version).map_err(|_| {
+        ProviderError::Protocol("Fleet session version exceeds provider transport range".into())
+    })?;
+    Ok(SessionIdentity {
+        session_key: session.session_key.as_str().to_owned(),
+        provider_session_id: session.provider_session_id.clone(),
+        expected_version,
+    })
+}
+
+/// Convert provider-neutral answers without flattening multi-select values.
+pub fn question_answers_from_core(
+    answers: &[ainb_fleet_core::fleet::provider::QuestionAnswer],
+) -> Vec<QuestionAnswer> {
+    answers
+        .iter()
+        .map(|answer| {
+            let mut values = answer.selected_options.clone();
+            if let Some(text) = &answer.text {
+                values.push(text.clone());
+            }
+            QuestionAnswer {
+                question_id: answer.question_id.clone(),
+                answers: values,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use ainb_fleet_core::fleet::provider::QuestionAnswer as CoreQuestionAnswer;
+    use ainb_fleet_core::types::{
+        AttentionState, Capabilities, Confidence, FleetSession, LifecycleState, ManagementState,
+        Provenance, Provider, SessionKey, TransportHealth,
+    };
+
+    use super::*;
+
+    #[test]
+    fn core_conversion_preserves_stable_key_version_and_multiselect() {
+        let session = FleetSession {
+            session_key: SessionKey::managed(Provider::Claude, "session-1"),
+            provider: Provider::Claude,
+            provider_session_id: Some("session-1".into()),
+            cwd: "/repo".into(),
+            exact_tmux_target: None,
+            pane_pid: None,
+            process_start_fingerprint: None,
+            lifecycle: LifecycleState::Idle,
+            attention: AttentionState::Ask,
+            management: ManagementState::Managed,
+            capabilities: Capabilities::default(),
+            provenance: BTreeSet::from([Provenance::Hook]),
+            confidence: Confidence::Authoritative,
+            transport_health: TransportHealth::Healthy,
+            first_seen_ms: Some(1),
+            last_seen_ms: Some(2),
+            version: 9,
+        };
+        let identity = session_identity_from_core(&session).expect("session identity");
+        assert_eq!(identity.session_key, "claude:session-1");
+        assert_eq!(identity.expected_version, 9);
+
+        let answers = question_answers_from_core(&[CoreQuestionAnswer {
+            question_id: "tools".into(),
+            selected_options: vec!["rg".into(), "ast-grep".into()],
+            text: Some("custom".into()),
+        }]);
+        assert_eq!(answers[0].answers, vec!["rg", "ast-grep", "custom"]);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -87,6 +87,10 @@ pub mod events;
 /// Per-task execution-environment layout: workdir/output/logs + `.gc_meta.json`
 /// (P1.6).
 pub mod execenv;
+/// Authoritative Fleet reducer fed by hooks, provider events, and tmux discovery.
+pub mod fleet;
+/// Claude and Codex provider transports for authoritative Fleet control.
+pub mod fleet_provider;
 /// The task-lifecycle state machine (T8): `statig` typed compile-time
 /// transitions.
 ///
@@ -401,6 +405,27 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         )
         .spawn();
     }
+
+    // Tmux reconciliation keeps unhooked and standalone provider sessions in
+    // the canonical Fleet roster as degraded rows with exact pane identity.
+    let _fleet_tmux = crate::fleet::spawn_tmux_reconciler(store.pool().clone(), broker.sink());
+
+    // Managed Codex transport starts independently from daemon readiness. A
+    // missing or incompatible Codex binary leaves hook and tmux observation
+    // running, while the service records an honest transport downgrade.
+    let _codex_manager = (!once
+        && std::env::var_os("AINB_CODEX_MANAGED")
+            .as_deref()
+            .is_none_or(|value| value != "0"))
+    .then(|| {
+        let binary = std::env::var_os("AINB_CODEX_BIN").unwrap_or_else(|| "codex".into());
+        let socket = dir.join("codex-app-server.sock");
+        crate::fleet_provider::codex_manager::spawn_service(
+            crate::fleet_provider::codex_manager::CodexManagerConfig::new(binary, socket),
+            store.pool().clone(),
+            broker.sink(),
+        )
+    });
 
     // P5 (T6): reconcile the agent-profile index against the on-disk masters and
     // spawn an fs-watch so an edit-on-disk of `{hangar_home}/profiles/<slug>.md`

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -41,6 +41,8 @@ pub mod snapshots;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::{OnceLock, RwLock};
 use std::time::Instant;
 
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
@@ -48,10 +50,12 @@ use ainb_hangar_core::ids::{AgentId, AutopilotId, SkillId, WorkspaceId};
 use ainb_hangar_proto::methods;
 use ainb_hangar_proto::settings::{DaemonHealthSnapshot, HealthSnapshot};
 use ainb_hangar_proto::{RpcError, RpcId, RpcRequest, RpcResponse};
+use futures_util::future::join_all;
 use sqlx::SqlitePool;
 
 use crate::events::{
     EventBroker, EventSink, ScopedEvent, encode_event_frame, encode_event_frame_payload,
+    encode_notification_frame,
 };
 use crate::health_stats::HealthStats;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
@@ -66,6 +70,18 @@ const INVALID_PARAMS: i32 = -32602;
 const INTERNAL_ERROR: i32 = -32603;
 /// Soft cap on one request body. Snapshot requests are tiny.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+#[cfg(any(test, feature = "test-support"))]
+static APPROVE_SOCKET_OVERRIDE: OnceLock<RwLock<Option<PathBuf>>> = OnceLock::new();
+
+/// Override Claude broker socket for isolated integration tests.
+#[cfg(any(test, feature = "test-support"))]
+pub fn set_approve_socket_for_test(path: Option<PathBuf>) {
+    *APPROVE_SOCKET_OVERRIDE
+        .get_or_init(|| RwLock::new(None))
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = path;
+}
 
 /// Immutable daemon facts the `hangar/health` snapshot reports.
 ///
@@ -251,6 +267,9 @@ async fn serve_conn(
     // of the workspace forwarder: a connection may hold both (workspace events +
     // attention nudges) or either. A re-subscribe replaces it.
     let mut attention_forwarder: Option<tokio::task::JoinHandle<()>> = None;
+    // Fleet uses a durable global revision stream, independent from workspace
+    // and attention subscriptions. Re-subscribing replaces the prior cursor.
+    let mut fleet_forwarder: Option<tokio::task::JoinHandle<()>> = None;
 
     // Idle read timeout so an abandoned / half-open client connection cannot pin
     // this per-connection task (and its fd) forever. The RPC is request/response
@@ -268,6 +287,17 @@ async fn serve_conn(
             }
         {
             let req = serde_json::from_slice::<RpcRequest>(&body);
+            // Subscribe before dispatch reads the snapshot. Events raised while
+            // the snapshot query runs stay buffered in this receiver and are
+            // drained after the acknowledgement, closing the snapshot-to-live
+            // handoff gap without allowing an event to precede the response.
+            let pending_attention_rx = req.as_ref().ok().and_then(|request| {
+                (request.method == methods::ATTENTION_SUBSCRIBE)
+                    .then(|| broker.subscribe_attention())
+            });
+            let pending_fleet_rx = req.as_ref().ok().and_then(|request| {
+                (request.method == methods::FLEET_SUBSCRIBE).then(|| broker.subscribe_fleet())
+            });
             let resp = match &req {
                 Ok(req) => dispatch(&pool, req, &health, &events).await,
                 Err(e) => RpcResponse {
@@ -326,9 +356,25 @@ async fn serve_conn(
                         old.abort();
                     }
                     let filter = attention_subscribe_filter(req);
-                    attention_forwarder = Some(spawn_attention_forwarder(
-                        broker.subscribe_attention(),
-                        filter,
+                    let rx = pending_attention_rx.unwrap_or_else(|| broker.subscribe_attention());
+                    attention_forwarder =
+                        Some(spawn_attention_forwarder(rx, filter, out_tx.clone()));
+                } else if acked && req.method == methods::FLEET_SUBSCRIBE {
+                    if let Some(old) = fleet_forwarder.take() {
+                        old.abort();
+                    }
+                    let head_revision = resp
+                        .result
+                        .as_ref()
+                        .and_then(|value| value.get("snapshot"))
+                        .and_then(|value| value.get("head_revision"))
+                        .and_then(serde_json::Value::as_i64)
+                        .unwrap_or_default();
+                    let rx = pending_fleet_rx.unwrap_or_else(|| broker.subscribe_fleet());
+                    fleet_forwarder = Some(spawn_fleet_forwarder(
+                        pool.clone(),
+                        rx,
+                        head_revision,
                         out_tx.clone(),
                     ));
                 }
@@ -342,6 +388,9 @@ async fn serve_conn(
         f.abort();
     }
     if let Some(f) = attention_forwarder {
+        f.abort();
+    }
+    if let Some(f) = fleet_forwarder {
         f.abort();
     }
     drop(out_tx);
@@ -438,6 +487,57 @@ fn spawn_attention_forwarder(
                     tracing::debug!(missed, "attention stream lagged; nudges dropped");
                 }
                 Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
+/// Spawn a gapless durable Fleet revision forwarder.
+///
+/// Receiver registration happens before snapshot read. After the snapshot ack
+/// is queued, this task drains every durable row after that snapshot head, then
+/// uses broadcast revisions only as wakeups. Lag asks the client to reconcile
+/// from a fresh snapshot instead of silently claiming a complete stream.
+fn spawn_fleet_forwarder(
+    pool: SqlitePool,
+    mut rx: broadcast::Receiver<i64>,
+    mut cursor: i64,
+    out: mpsc::Sender<Vec<u8>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let events = match crate::fleet::events_after_wire(&pool, cursor, REPLAY_BATCH).await {
+                Ok(events) => events,
+                Err(error) => {
+                    tracing::warn!(error = %error, "fleet event replay read failed");
+                    return;
+                }
+            };
+            if !events.is_empty() {
+                for event in events {
+                    cursor = event.revision;
+                    let Ok(params) = serde_json::to_value(&event) else {
+                        continue;
+                    };
+                    if out.send(encode_notification_frame("fleet/event", &params)).await.is_err() {
+                        return;
+                    }
+                }
+                continue;
+            }
+
+            match rx.recv().await {
+                Ok(_revision) => {}
+                Err(broadcast::error::RecvError::Lagged(missed)) => {
+                    let params = serde_json::json!({
+                        "after_revision": cursor,
+                        "missed": missed,
+                    });
+                    let _ =
+                        out.send(encode_notification_frame("fleet/resync_required", &params)).await;
+                    return;
+                }
+                Err(broadcast::error::RecvError::Closed) => return,
             }
         }
     })
@@ -697,6 +797,13 @@ async fn handle(
         methods::HANGAR_BOARD_CARD_DEP_REMOVE => handle_board_card_dep(pool, req, false).await,
         methods::HANGAR_BOARD_CARD_SET_AUTO_RUN => handle_board_card_set_auto_run(pool, req).await,
         methods::HANGAR_REPO_LIST => handle_repo_list(req),
+        methods::FLEET_SNAPSHOT => handle_fleet_snapshot(pool).await,
+        // Receiver registration occurs in `serve_conn` before this snapshot is
+        // read. The ack carries its exact head, then the forwarder drains rows
+        // committed after that head before waiting for live wakeups.
+        methods::FLEET_SUBSCRIBE => handle_fleet_subscribe(pool, req).await,
+        methods::FLEET_ACTION => handle_fleet_action(pool, req, events).await,
+        methods::FLEET_BROADCAST => handle_fleet_broadcast(pool, req, events).await,
         methods::ATTENTION_LIST => handle_attention_list(pool, req).await,
         // `attention/subscribe` acks with the current OPEN snapshot; the live
         // fleet-wide forwarder is the stream side (see `serve_conn`).
@@ -719,6 +826,1679 @@ async fn handle(
             message: format!("unknown method: {other}"),
             data: None,
         }),
+    }
+}
+
+/// Return the authoritative host Fleet snapshot.
+async fn handle_fleet_snapshot(pool: &SqlitePool) -> Result<serde_json::Value, RpcError> {
+    let snapshot = crate::fleet::snapshot_wire(pool).await.map_err(|error| store_err(&error))?;
+    to_value(&snapshot)
+}
+
+/// Register a revision cursor and return the snapshot head paired with it.
+async fn handle_fleet_subscribe(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::fleet::FleetSubscribeParams =
+        parse_params(req, "{ after_revision }")?;
+    if params.after_revision < 0 {
+        return Err(invalid_params("after_revision must be non-negative"));
+    }
+    let snapshot = crate::fleet::snapshot_wire(pool).await.map_err(|error| store_err(&error))?;
+    to_value(&ainb_hangar_proto::fleet::FleetSubscribeResult {
+        snapshot,
+        replay: Vec::new(),
+    })
+}
+
+/// Execute one optimistic, idempotent Fleet action.
+async fn handle_fleet_action(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::fleet::FleetActionParams =
+        parse_params(req, "{ session_key, expected_version, request_id, action }")?;
+    let receipt = execute_fleet_action(pool, params, None, events).await?;
+    to_value(&ainb_hangar_proto::fleet::FleetActionResult { receipt })
+}
+
+/// Deliver one text prompt to explicit stable recipients with bounded fanout.
+async fn handle_fleet_broadcast(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    use std::collections::HashSet;
+    use tokio::sync::Semaphore;
+
+    let params: ainb_hangar_proto::fleet::FleetBroadcastParams =
+        parse_params(req, "{ target_keys, text, idempotency_key }")?;
+    if params.text.trim().is_empty() {
+        return Err(invalid_params("broadcast text must not be empty"));
+    }
+    if params.idempotency_key.trim().is_empty() {
+        return Err(invalid_params("idempotency_key must not be empty"));
+    }
+
+    let mut seen = HashSet::new();
+    let targets: Vec<_> = params
+        .target_keys
+        .into_iter()
+        .filter(|key| !key.is_empty() && seen.insert(key.clone()))
+        .collect();
+    let limit = Arc::new(Semaphore::new(8));
+    let mut tasks = Vec::new();
+    for (index, session_key) in targets.into_iter().enumerate() {
+        let pool = pool.clone();
+        let text = params.text.clone();
+        let idempotency_key = params.idempotency_key.clone();
+        let limit = limit.clone();
+        let events = events.clone();
+        tasks.push(async move {
+            let request_id = format!(
+                "broadcast:{}",
+                stable_fingerprint(&format!("{idempotency_key}\u{0}{session_key}"))
+            );
+            let fallback_request_id = request_id.clone();
+            let fallback_session_key = session_key.clone();
+            let fallback_idempotency_key = idempotency_key.clone();
+            let _permit = match limit.acquire_owned().await {
+                Ok(permit) => permit,
+                Err(error) => {
+                    let now = SystemClock.now_ms();
+                    return (
+                        index,
+                        ainb_hangar_proto::fleet::FleetActionReceipt {
+                            request_id: fallback_request_id,
+                            session_key: fallback_session_key,
+                            action_kind: "send_prompt".to_string(),
+                            action_fingerprint: stable_fingerprint(&error.to_string()),
+                            expected_version: 1,
+                            idempotency_key: Some(fallback_idempotency_key),
+                            status: ainb_hangar_proto::fleet::ActionReceiptStatus::Failed,
+                            detail: Some(error.to_string()),
+                            session_version: None,
+                            created_at: now,
+                            updated_at: now,
+                        },
+                    );
+                }
+            };
+            let receipt =
+                match ainb_hangar_store::repo::fleet::FleetRepo::get_session(&pool, &session_key)
+                    .await
+                {
+                    Ok(Some(session)) => {
+                        execute_fleet_action(
+                            &pool,
+                            ainb_hangar_proto::fleet::FleetActionParams {
+                                session_key,
+                                expected_version: session.version,
+                                request_id,
+                                action: ainb_hangar_proto::fleet::ControlAction::SendPrompt {
+                                    text,
+                                },
+                            },
+                            Some(idempotency_key),
+                            &events,
+                        )
+                        .await
+                    }
+                    Ok(None) => {
+                        rejected_broadcast_receipt(
+                            &pool,
+                            request_id,
+                            session_key,
+                            idempotency_key,
+                            "session not found",
+                        )
+                        .await
+                    }
+                    Err(error) => Err(store_err(&error)),
+                };
+            let receipt = receipt.unwrap_or_else(|error| {
+                let now = SystemClock.now_ms();
+                ainb_hangar_proto::fleet::FleetActionReceipt {
+                    request_id: fallback_request_id,
+                    session_key: fallback_session_key,
+                    action_kind: "send_prompt".to_string(),
+                    action_fingerprint: stable_fingerprint(&error.message),
+                    expected_version: 1,
+                    idempotency_key: Some(fallback_idempotency_key),
+                    status: ainb_hangar_proto::fleet::ActionReceiptStatus::Failed,
+                    detail: Some(error.message),
+                    session_version: None,
+                    created_at: now,
+                    updated_at: now,
+                }
+            });
+            (index, receipt)
+        });
+    }
+
+    let mut receipts = join_all(tasks).await;
+    receipts.sort_by_key(|(index, _)| *index);
+    to_value(&ainb_hangar_proto::fleet::FleetBroadcastResult {
+        receipts: receipts.into_iter().map(|(_, receipt)| receipt).collect(),
+    })
+}
+
+async fn rejected_broadcast_receipt(
+    pool: &SqlitePool,
+    request_id: String,
+    session_key: String,
+    idempotency_key: String,
+    detail: &str,
+) -> Result<ainb_hangar_proto::fleet::FleetActionReceipt, RpcError> {
+    let now = SystemClock.now_ms();
+    let row = ainb_hangar_store::repo::fleet::FleetRepo::upsert_action_receipt(
+        pool,
+        &ainb_hangar_store::repo::fleet::NewActionReceipt {
+            request_id,
+            session_key,
+            action_kind: "send_prompt".to_string(),
+            action_fingerprint: stable_fingerprint(detail),
+            expected_version: 1,
+            idempotency_key: Some(idempotency_key),
+            status: "REJECTED".to_string(),
+            detail: Some(detail.to_string()),
+            session_version: None,
+            created_at: now,
+            updated_at: now,
+        },
+    )
+    .await
+    .map_err(fleet_repo_err)?;
+    Ok(action_receipt_wire(&row))
+}
+
+async fn execute_fleet_action(
+    pool: &SqlitePool,
+    params: ainb_hangar_proto::fleet::FleetActionParams,
+    idempotency_key: Option<String>,
+    events: &EventSink,
+) -> Result<ainb_hangar_proto::fleet::FleetActionReceipt, RpcError> {
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction};
+    use ainb_hangar_store::repo::fleet::{FleetRepo, NewActionReceipt};
+
+    if params.session_key.is_empty() || params.request_id.is_empty() {
+        return Err(invalid_params(
+            "session_key and request_id must not be empty",
+        ));
+    }
+    if params.expected_version < 1 {
+        return Err(invalid_params("expected_version must be positive"));
+    }
+    let action_json = serde_json::to_string(&params.action)
+        .map_err(|error| internal(&format!("serialize action: {error}")))?;
+    let action_fingerprint = stable_fingerprint(&action_json);
+
+    if let Some(existing) = FleetRepo::get_action_receipt(pool, &params.request_id)
+        .await
+        .map_err(|error| store_err(&error))?
+    {
+        if existing.session_key != params.session_key
+            || existing.action_kind != params.action.kind()
+            || existing.action_fingerprint != action_fingerprint
+            || existing.expected_version != params.expected_version
+            || existing.idempotency_key != idempotency_key
+        {
+            return Err(invalid_params(
+                "request_id was reused for a different Fleet action",
+            ));
+        }
+        return Ok(action_receipt_wire(&existing));
+    }
+
+    if matches!(&params.action, ControlAction::Start { .. }) {
+        return execute_fleet_start(pool, params, idempotency_key, action_fingerprint, events)
+            .await;
+    }
+
+    let request_fingerprint = match &params.action {
+        ControlAction::StructuredAnswer {
+            request_fingerprint,
+            ..
+        }
+        | ControlAction::Approve {
+            request_fingerprint,
+            ..
+        }
+        | ControlAction::Deny {
+            request_fingerprint,
+            ..
+        }
+        | ControlAction::VerifiedPicker {
+            request_fingerprint,
+            ..
+        } => Some(request_fingerprint.as_str()),
+        _ => None,
+    };
+    let session = FleetRepo::validate_action_target(
+        pool,
+        &params.session_key,
+        params.expected_version,
+        request_fingerprint,
+    )
+    .await
+    .map_err(fleet_repo_err)?;
+    let capabilities: ainb_hangar_proto::fleet::FleetCapabilities =
+        serde_json::from_str(&session.capabilities).unwrap_or_default();
+
+    let now = SystemClock.now_ms();
+    let pending = NewActionReceipt {
+        request_id: params.request_id.clone(),
+        session_key: params.session_key.clone(),
+        action_kind: params.action.kind().to_string(),
+        action_fingerprint,
+        expected_version: params.expected_version,
+        idempotency_key,
+        status: "PENDING".to_string(),
+        detail: None,
+        session_version: Some(session.version),
+        created_at: now,
+        updated_at: now,
+    };
+    let claimed = sqlx::query(
+        "INSERT INTO fleet_action_receipt \
+         (request_id, session_key, action_kind, action_fingerprint, expected_version, \
+          idempotency_key, status, detail, session_version, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(request_id) DO NOTHING",
+    )
+    .bind(&pending.request_id)
+    .bind(&pending.session_key)
+    .bind(&pending.action_kind)
+    .bind(&pending.action_fingerprint)
+    .bind(pending.expected_version)
+    .bind(&pending.idempotency_key)
+    .bind(&pending.status)
+    .bind(&pending.detail)
+    .bind(pending.session_version)
+    .bind(pending.created_at)
+    .bind(pending.updated_at)
+    .execute(pool)
+    .await
+    .map_err(|error| store_err(&error))?
+    .rows_affected()
+        == 1;
+    if !claimed {
+        let existing = FleetRepo::get_action_receipt(pool, &params.request_id)
+            .await
+            .map_err(|error| store_err(&error))?
+            .ok_or_else(|| internal("Fleet action receipt claim disappeared"))?;
+        if existing.session_key != params.session_key
+            || existing.action_kind != params.action.kind()
+            || existing.action_fingerprint != pending.action_fingerprint
+            || existing.expected_version != params.expected_version
+            || existing.idempotency_key != pending.idempotency_key
+        {
+            return Err(invalid_params(
+                "request_id was reused for a different Fleet action",
+            ));
+        }
+        return Ok(action_receipt_wire(&existing));
+    }
+
+    let (status, detail) = if !action_capability(&capabilities, &params.action) {
+        (
+            ActionReceiptStatus::Rejected,
+            Some("action unavailable for current session capabilities".to_string()),
+        )
+    } else if let ControlAction::VerifiedPicker {
+        request_fingerprint,
+        key,
+    } = &params.action
+    {
+        verified_tmux_picker(
+            pool,
+            &session,
+            params.expected_version,
+            request_fingerprint,
+            key,
+        )
+        .await
+    } else {
+        if session.provider == "codex" {
+            match crate::fleet_provider::codex_manager::active_handle().await {
+                Some(manager) => {
+                    execute_codex_action(pool, events, &session, &params.action, &manager).await
+                }
+                None => match &params.action {
+                    ControlAction::SendPrompt { text } => verified_tmux_send(&session, text).await,
+                    _ => (
+                        ActionReceiptStatus::Unknown,
+                        Some("Codex managed transport is not active".to_string()),
+                    ),
+                },
+            }
+        } else {
+            match &params.action {
+                ControlAction::SendPrompt { text } if text.trim().is_empty() => (
+                    ActionReceiptStatus::Rejected,
+                    Some("prompt text must not be empty".to_string()),
+                ),
+                ControlAction::SendPrompt { text } => verified_tmux_send(&session, text).await,
+                ControlAction::StructuredAnswer {
+                    request_fingerprint,
+                    answers,
+                    ..
+                } if session.provider == "claude" => {
+                    execute_claude_structured(pool, &session, request_fingerprint, answers).await
+                }
+                ControlAction::Approve {
+                    request_fingerprint,
+                    ..
+                }
+                | ControlAction::Deny {
+                    request_fingerprint,
+                    ..
+                } if session.provider == "claude" => {
+                    let approve = matches!(&params.action, ControlAction::Approve { .. });
+                    match claude_broker_decide(
+                        session.provider_session_id.as_deref().unwrap_or_default(),
+                        request_fingerprint,
+                        approve,
+                    )
+                    .await
+                    {
+                        Ok(true) => (
+                            ActionReceiptStatus::Delivered,
+                            Some("claude blocking hook broker".to_string()),
+                        ),
+                        Ok(false) => (
+                            ActionReceiptStatus::Failed,
+                            Some("Claude request no longer waiting".to_string()),
+                        ),
+                        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+                    }
+                }
+                ControlAction::StructuredAnswer { .. }
+                | ControlAction::Approve { .. }
+                | ControlAction::Deny { .. } => (
+                    ActionReceiptStatus::Unknown,
+                    Some("authoritative provider request transport is not active".to_string()),
+                ),
+                _ => (
+                    ActionReceiptStatus::Unknown,
+                    Some("authoritative provider lifecycle transport is not active".to_string()),
+                ),
+            }
+        }
+    };
+
+    let mut completed = pending;
+    completed.status = receipt_status_token(status).to_string();
+    completed.detail = detail;
+    completed.updated_at = SystemClock.now_ms();
+    let row = FleetRepo::upsert_action_receipt(pool, &completed)
+        .await
+        .map_err(fleet_repo_err)?;
+    Ok(action_receipt_wire(&row))
+}
+
+async fn execute_fleet_start(
+    pool: &SqlitePool,
+    params: ainb_hangar_proto::fleet::FleetActionParams,
+    idempotency_key: Option<String>,
+    action_fingerprint: String,
+    events: &EventSink,
+) -> Result<ainb_hangar_proto::fleet::FleetActionReceipt, RpcError> {
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction, FleetProvider};
+    use ainb_hangar_store::repo::fleet::{FleetRepo, NewActionReceipt};
+
+    let now = SystemClock.now_ms();
+    let mut receipt = NewActionReceipt {
+        request_id: params.request_id.clone(),
+        session_key: params.session_key.clone(),
+        action_kind: params.action.kind().to_string(),
+        action_fingerprint,
+        expected_version: params.expected_version,
+        idempotency_key,
+        status: "PENDING".to_string(),
+        detail: None,
+        session_version: None,
+        created_at: now,
+        updated_at: now,
+    };
+    let claimed = sqlx::query(
+        "INSERT INTO fleet_action_receipt \
+         (request_id, session_key, action_kind, action_fingerprint, expected_version, \
+          idempotency_key, status, detail, session_version, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(request_id) DO NOTHING",
+    )
+    .bind(&receipt.request_id)
+    .bind(&receipt.session_key)
+    .bind(&receipt.action_kind)
+    .bind(&receipt.action_fingerprint)
+    .bind(receipt.expected_version)
+    .bind(&receipt.idempotency_key)
+    .bind(&receipt.status)
+    .bind(&receipt.detail)
+    .bind(receipt.session_version)
+    .bind(receipt.created_at)
+    .bind(receipt.updated_at)
+    .execute(pool)
+    .await
+    .map_err(|error| store_err(&error))?
+    .rows_affected()
+        == 1;
+    if !claimed {
+        let existing = FleetRepo::get_action_receipt(pool, &params.request_id)
+            .await
+            .map_err(|error| store_err(&error))?
+            .ok_or_else(|| internal("Fleet start receipt claim disappeared"))?;
+        if existing.session_key != params.session_key
+            || existing.action_kind != params.action.kind()
+            || existing.action_fingerprint != receipt.action_fingerprint
+            || existing.expected_version != params.expected_version
+            || existing.idempotency_key != receipt.idempotency_key
+        {
+            return Err(invalid_params(
+                "request_id was reused for a different Fleet action",
+            ));
+        }
+        return Ok(action_receipt_wire(&existing));
+    }
+
+    let (status, detail) = match &params.action {
+        ControlAction::Start {
+            provider: FleetProvider::Codex,
+            cwd,
+            prompt,
+        } => match crate::fleet_provider::codex_manager::active_handle().await {
+            Some(manager) => match manager.thread_start(Path::new(cwd), None).await {
+                Ok(thread) => match launch_managed_codex_tui(&manager, &thread, cwd).await {
+                    Ok((tmux_name, tmux_session)) => {
+                        match crate::fleet::register_managed_codex_tmux(
+                            pool,
+                            events,
+                            &thread,
+                            cwd,
+                            &tmux_session,
+                            manager.capabilities(),
+                            SystemClock.now_ms(),
+                        )
+                        .await
+                        {
+                            Ok(_) => {
+                                let turn = match prompt
+                                    .as_deref()
+                                    .filter(|prompt| !prompt.trim().is_empty())
+                                {
+                                    Some(prompt) => {
+                                        manager.turn_start(&thread, prompt).await.map(|_| ())
+                                    }
+                                    None => Ok(()),
+                                };
+                                match turn {
+                                    Ok(()) => (
+                                        ActionReceiptStatus::Delivered,
+                                        Some(format!(
+                                            "codex thread {thread}, tmux {}",
+                                            tmux_session
+                                                .exact_tmux_target
+                                                .as_deref()
+                                                .unwrap_or(&tmux_name)
+                                        )),
+                                    ),
+                                    Err(error) => (
+                                        ActionReceiptStatus::Failed,
+                                        Some(format!(
+                                            "Codex thread {thread} launched in tmux {tmux_name}, initial prompt failed: {error}"
+                                        )),
+                                    ),
+                                }
+                            }
+                            Err(error) => {
+                                let _ = kill_tmux_session_exact(&tmux_name).await;
+                                (ActionReceiptStatus::Failed, Some(error.to_string()))
+                            }
+                        }
+                    }
+                    Err(error) => (ActionReceiptStatus::Failed, Some(error)),
+                },
+                Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+            },
+            None => (
+                ActionReceiptStatus::Unknown,
+                Some("Codex managed transport is not active".to_string()),
+            ),
+        },
+        ControlAction::Start { .. } => (
+            ActionReceiptStatus::Rejected,
+            Some("provider start transport is unavailable".to_string()),
+        ),
+        _ => unreachable!("start handler only receives start actions"),
+    };
+    receipt.status = receipt_status_token(status).to_string();
+    receipt.detail = detail;
+    receipt.updated_at = SystemClock.now_ms();
+    let row = FleetRepo::upsert_action_receipt(pool, &receipt).await.map_err(fleet_repo_err)?;
+    Ok(action_receipt_wire(&row))
+}
+
+async fn launch_managed_codex_tui(
+    manager: &crate::fleet_provider::codex_manager::CodexManagerHandle,
+    thread_id: &str,
+    cwd: &str,
+) -> Result<(String, ainb_fleet_core::types::FleetSession), String> {
+    let tmux_name = managed_codex_tmux_name(thread_id, SystemClock.now_ms());
+    let codex_binary = std::env::var_os("AINB_CODEX_BIN").unwrap_or_else(|| "codex".into());
+    let tmux_binary = std::env::var_os("AINB_TMUX_BIN").unwrap_or_else(|| "tmux".into());
+    let command = manager.managed_tui_command(
+        &codex_binary,
+        [
+            std::ffi::OsString::from("resume"),
+            std::ffi::OsString::from(thread_id),
+        ],
+    );
+    let tmux_args = managed_codex_tmux_args(&tmux_name, cwd, &command);
+    let output = tokio::process::Command::new(&tmux_binary)
+        .args(tmux_args)
+        .output()
+        .await
+        .map_err(|error| format!("tmux managed Codex launch failed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "tmux managed Codex launch exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        match ainb_fleet_core::discover::discover_from_tmux().await {
+            Ok(sessions) => {
+                if let Some(session) = sessions.into_iter().find(|session| {
+                    session
+                        .exact_tmux_target
+                        .as_deref()
+                        .is_some_and(|target| target.starts_with(&format!("{tmux_name}:")))
+                }) {
+                    if session.process_start_fingerprint.is_some() {
+                        return Ok((tmux_name, session));
+                    }
+                }
+            }
+            Err(error) => {
+                let _ = kill_tmux_session_exact(&tmux_name).await;
+                return Err(format!(
+                    "managed Codex tmux identity lookup failed: {error}"
+                ));
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let _ = kill_tmux_session_exact(&tmux_name).await;
+            return Err("managed Codex tmux identity lookup timed out".to_string());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+fn managed_codex_tmux_args(
+    session_name: &str,
+    cwd: &str,
+    command: &crate::fleet_provider::codex::CommandSpec,
+) -> Vec<std::ffi::OsString> {
+    let mut args = ["new-session", "-d", "-s", session_name, "-c", cwd, "--"]
+        .into_iter()
+        .map(std::ffi::OsString::from)
+        .collect::<Vec<_>>();
+    args.push(command.program.clone());
+    args.extend(command.args.iter().cloned());
+    args
+}
+
+fn managed_codex_tmux_name(thread_id: &str, now_ms: i64) -> String {
+    let safe = thread_id
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+        .take(24)
+        .collect::<String>();
+    let safe = if safe.is_empty() { "thread" } else { &safe };
+    format!("fleet-codex-{safe}-{now_ms}")
+}
+
+async fn kill_tmux_session_exact(session_name: &str) -> Result<(), String> {
+    let tmux_binary = std::env::var_os("AINB_TMUX_BIN").unwrap_or_else(|| "tmux".into());
+    let output = tokio::process::Command::new(tmux_binary)
+        .args(["kill-session", "-t", session_name])
+        .output()
+        .await
+        .map_err(|error| format!("exact tmux stop failed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "exact tmux stop exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod fleet_launch_tests {
+    use super::{managed_codex_tmux_args, managed_codex_tmux_name, verify_picker_pane};
+    use std::ffi::{OsStr, OsString};
+    use std::path::Path;
+
+    #[test]
+    fn managed_codex_tmux_name_is_unique_and_shell_safe() {
+        let first = managed_codex_tmux_name("thread/$ unsafe", 100);
+        let second = managed_codex_tmux_name("thread/$ unsafe", 101);
+        assert_eq!(first, "fleet-codex-threadunsafe-100");
+        assert_ne!(first, second);
+        assert!(
+            first
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric() || character == '-')
+        );
+    }
+
+    #[test]
+    fn managed_codex_launch_runs_remote_tui_in_exact_tmux_session() {
+        let command = crate::fleet_provider::codex::managed_tui_command(
+            OsStr::new("codex"),
+            Path::new("/tmp/codex.sock"),
+            [OsString::from("resume"), OsString::from("thread-1")],
+        );
+        let args = managed_codex_tmux_args("fleet-codex-thread-1", "/repo", &command);
+        assert_eq!(
+            args,
+            [
+                "new-session",
+                "-d",
+                "-s",
+                "fleet-codex-thread-1",
+                "-c",
+                "/repo",
+                "--",
+                "codex",
+                "--remote",
+                "unix:///tmp/codex.sock",
+                "resume",
+                "thread-1",
+            ]
+            .into_iter()
+            .map(OsString::from)
+            .collect::<Vec<_>>()
+        );
+    }
+
+    fn picker_request() -> serde_json::Value {
+        serde_json::json!({
+            "payload": {
+                "tool_input": {
+                    "questions": [{
+                        "question": "Deploy to which region?",
+                        "options": [
+                            {"label": "Europe", "description": "EU region"},
+                            {"label": "United States", "description": "US region"}
+                        ]
+                    }]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn verified_picker_accepts_matching_prompt_and_ordered_options() {
+        let pane = "Claude Code\n\
+                    ╭──────────────────────────────╮\n\
+                    │ Deploy to which region?      │\n\
+                    │ 1. Europe                    │\n\
+                    │ 2. United States             │\n\
+                    ╰──────────────────────────────╯\n\
+                    Press ? for help";
+        assert_eq!(
+            verify_picker_pane("claude", &picker_request(), pane),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn verified_picker_rejects_prompt_mismatch() {
+        let pane = "Claude Code\nChoose release channel\n1. Europe\n2. United States";
+        let error = verify_picker_pane("claude", &picker_request(), pane).unwrap_err();
+        assert!(error.contains("prompt"));
+    }
+
+    #[test]
+    fn verified_picker_rejects_option_order_mismatch() {
+        let pane = "Codex\nDeploy to which region?\n1. United States\n2. Europe";
+        let error = verify_picker_pane("codex", &picker_request(), pane).unwrap_err();
+        assert!(error.contains("option order"));
+    }
+
+    #[test]
+    fn verified_picker_rejects_old_match_above_newer_picker() {
+        let pane = "Claude Code\n\
+                    Deploy to which region?\n\
+                    1. Europe\n\
+                    2. United States\n\
+                    Choose release channel?\n\
+                    1. Stable\n\
+                    2. Preview";
+        let error = verify_picker_pane("claude", &picker_request(), pane).unwrap_err();
+        assert!(error.contains("newer picker"));
+    }
+
+    #[test]
+    fn verified_picker_does_not_reanchor_to_newer_shared_final_label() {
+        let request = serde_json::json!({
+            "questions": [{
+                "question": "Deploy now?",
+                "options": ["Yes", "No"]
+            }]
+        });
+        let pane = "Claude Code\n\
+                    Deploy now?\n\
+                    1. Yes\n\
+                    2. No\n\
+                    Delete deployment?\n\
+                    1. Keep\n\
+                    2. No";
+        let error = verify_picker_pane("claude", &request, pane).unwrap_err();
+        assert!(error.contains("newer picker"));
+    }
+}
+
+async fn claude_broker_decide(
+    session_id: &str,
+    request_fingerprint: &str,
+    approve: bool,
+) -> std::io::Result<bool> {
+    if session_id.is_empty() {
+        return Ok(false);
+    }
+    let socket = approve_socket_path()?;
+    let session_id = session_id.to_string();
+    let request_fingerprint = request_fingerprint.to_string();
+    tokio::task::spawn_blocking(move || {
+        ainb_plugin_notifyd::broker::client_decide_exact(
+            &socket,
+            &session_id,
+            Some(&request_fingerprint),
+            if approve {
+                ainb_plugin_notifyd::broker::DecisionKind::Approve
+            } else {
+                ainb_plugin_notifyd::broker::DecisionKind::Deny
+            },
+            "Fleet control plane",
+        )
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
+async fn execute_codex_action(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    action: &ainb_hangar_proto::fleet::ControlAction,
+    manager: &crate::fleet_provider::codex_manager::CodexManagerHandle,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use crate::fleet_provider::{ApprovalDecision, QuestionAnswer};
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction, FleetProvider};
+
+    let thread_id = session.provider_session_id.as_deref().unwrap_or_default();
+    let result: Result<String, crate::fleet_provider::ProviderError> = async {
+        match action {
+            ControlAction::StructuredAnswer {
+                request_identity,
+                answers,
+                ..
+            } => {
+                let request =
+                    match crate::fleet::current_request_wire(pool, &session.session_key).await {
+                        Ok(Some(value)) => serde_json::from_value::<
+                            crate::fleet_provider::codex::CodexQuestionRequest,
+                        >(value)
+                        .map_err(crate::fleet_provider::ProviderError::from),
+                        Ok(None) => Err(crate::fleet_provider::ProviderError::Stale(
+                            "current Codex question is absent".to_string(),
+                        )),
+                        Err(error) => Err(crate::fleet_provider::ProviderError::Transport(
+                            error.to_string(),
+                        )),
+                    }?;
+                require_codex_identity(request_identity.as_ref(), &request.identity)?;
+                let answers = answers
+                    .iter()
+                    .map(|answer| {
+                        let mut values = answer.selected_options.clone();
+                        if let Some(text) = answer.text.as_deref().filter(|text| !text.is_empty()) {
+                            values.push(text.to_string());
+                        }
+                        QuestionAnswer {
+                            question_id: answer.question_id.clone(),
+                            answers: values,
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                manager
+                    .answer_request_user_input(&request, &answers)
+                    .await
+                    .map(|receipt| receipt.transport.to_string())
+            }
+            ControlAction::Approve {
+                request_identity, ..
+            }
+            | ControlAction::Deny {
+                request_identity, ..
+            } => {
+                let request = load_codex_approval(pool, &session.session_key).await?;
+                require_codex_identity(request_identity.as_ref(), &request.identity)?;
+                let decision = if matches!(action, ControlAction::Approve { .. }) {
+                    ApprovalDecision::Approve
+                } else {
+                    ApprovalDecision::Deny
+                };
+                manager
+                    .decide_approval(&request, decision)
+                    .await
+                    .map(|receipt| receipt.transport.to_string())
+            }
+            ControlAction::SendPrompt { text } => {
+                manager.thread_read(thread_id).await?;
+                manager
+                    .turn_start(thread_id, text)
+                    .await
+                    .map(|turn| format!("codex turn {turn}"))
+            }
+            ControlAction::Continue => {
+                manager.thread_read(thread_id).await?;
+                manager
+                    .turn_start(thread_id, "continue")
+                    .await
+                    .map(|turn| format!("codex turn {turn}"))
+            }
+            ControlAction::Retry => {
+                manager.thread_read(thread_id).await?;
+                manager
+                    .turn_start(thread_id, "retry")
+                    .await
+                    .map(|turn| format!("codex turn {turn}"))
+            }
+            ControlAction::Interrupt => {
+                manager.thread_read(thread_id).await?;
+                let turn_id = latest_codex_turn_id(pool, &session.session_key)
+                    .await
+                    .map_err(|error| {
+                        crate::fleet_provider::ProviderError::Transport(error.to_string())
+                    })?
+                    .ok_or_else(|| {
+                        crate::fleet_provider::ProviderError::Stale(
+                            "active Codex turn identity is absent".to_string(),
+                        )
+                    })?;
+                manager
+                    .turn_interrupt(thread_id, &turn_id)
+                    .await
+                    .map(|_| format!("codex turn {turn_id} interrupted"))
+            }
+            ControlAction::Stop => {
+                manager.thread_read(thread_id).await?;
+                let tmux_name = exact_live_tmux_session_name(session).await?;
+                if session.lifecycle_state == "RUNNING" {
+                    let turn_id = latest_codex_turn_id(pool, &session.session_key)
+                        .await
+                        .map_err(|error| {
+                            crate::fleet_provider::ProviderError::Transport(error.to_string())
+                        })?
+                        .ok_or_else(|| {
+                            crate::fleet_provider::ProviderError::Stale(
+                                "active Codex turn identity is absent".to_string(),
+                            )
+                        })?;
+                    manager.turn_interrupt(thread_id, &turn_id).await?;
+                }
+                kill_tmux_session_exact(&tmux_name)
+                    .await
+                    .map_err(crate::fleet_provider::ProviderError::Transport)?;
+                persist_codex_exit(pool, events, session, manager, "codex_stopped").await?;
+                Ok(format!(
+                    "codex thread {thread_id} stopped in tmux {tmux_name}"
+                ))
+            }
+            ControlAction::Restart => {
+                manager.thread_read(thread_id).await?;
+                let tmux_name = exact_live_tmux_session_name(session).await?;
+                kill_tmux_session_exact(&tmux_name)
+                    .await
+                    .map_err(crate::fleet_provider::ProviderError::Transport)?;
+                let (new_tmux_name, tmux_session) =
+                    match launch_managed_codex_tui(manager, thread_id, &session.cwd).await {
+                        Ok(launched) => launched,
+                        Err(error) => {
+                            persist_codex_exit(
+                                pool,
+                                events,
+                                session,
+                                manager,
+                                "codex_restart_failed",
+                            )
+                            .await?;
+                            return Err(crate::fleet_provider::ProviderError::Transport(error));
+                        }
+                    };
+                if let Err(error) = crate::fleet::register_managed_codex_tmux(
+                    pool,
+                    events,
+                    thread_id,
+                    &session.cwd,
+                    &tmux_session,
+                    manager.capabilities(),
+                    SystemClock.now_ms(),
+                )
+                .await
+                {
+                    let _ = kill_tmux_session_exact(&new_tmux_name).await;
+                    persist_codex_exit(pool, events, session, manager, "codex_restart_failed")
+                        .await?;
+                    return Err(crate::fleet_provider::ProviderError::Transport(
+                        error.to_string(),
+                    ));
+                }
+                Ok(format!(
+                    "codex thread {thread_id} restarted from tmux {tmux_name} into {new_tmux_name}"
+                ))
+            }
+            ControlAction::Kill => {
+                manager.thread_read(thread_id).await?;
+                let tmux_name = exact_live_tmux_session_name(session).await?;
+                if session.lifecycle_state == "RUNNING" {
+                    let turn_id = latest_codex_turn_id(pool, &session.session_key)
+                        .await
+                        .map_err(|error| {
+                            crate::fleet_provider::ProviderError::Transport(error.to_string())
+                        })?
+                        .ok_or_else(|| {
+                            crate::fleet_provider::ProviderError::Stale(
+                                "active Codex turn identity is absent".to_string(),
+                            )
+                        })?;
+                    manager.turn_interrupt(thread_id, &turn_id).await?;
+                }
+                kill_tmux_session_exact(&tmux_name)
+                    .await
+                    .map_err(crate::fleet_provider::ProviderError::Transport)?;
+                persist_codex_exit(pool, events, session, manager, "codex_killed").await?;
+                Ok(format!(
+                    "codex thread {thread_id} killed in tmux {tmux_name}"
+                ))
+            }
+            ControlAction::Archive => {
+                manager.thread_read(thread_id).await?;
+                let tmux_name = exact_live_tmux_session_name(session).await?;
+                kill_tmux_session_exact(&tmux_name)
+                    .await
+                    .map_err(crate::fleet_provider::ProviderError::Transport)?;
+                if let Err(error) = manager.thread_archive(thread_id).await {
+                    persist_codex_exit(pool, events, session, manager, "codex_archive_failed")
+                        .await?;
+                    return Err(error);
+                }
+                persist_codex_exit(pool, events, session, manager, "codex_archived").await?;
+                Ok(format!(
+                    "codex thread {thread_id} archived after tmux {tmux_name} stop"
+                ))
+            }
+            ControlAction::Start {
+                provider,
+                cwd,
+                prompt,
+            } if *provider == FleetProvider::Codex => {
+                let thread = manager.thread_start(Path::new(cwd), None).await?;
+                if let Some(prompt) = prompt.as_deref().filter(|prompt| !prompt.trim().is_empty()) {
+                    manager.turn_start(&thread, prompt).await?;
+                }
+                Ok(format!("codex thread {thread}"))
+            }
+            _ => Err(crate::fleet_provider::ProviderError::Unsupported(
+                "Codex action is not available through app-server".to_string(),
+            )),
+        }
+    }
+    .await;
+
+    match result {
+        Ok(detail) => (ActionReceiptStatus::Delivered, Some(detail)),
+        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+    }
+}
+
+async fn exact_live_tmux_session_name(
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+) -> Result<String, crate::fleet_provider::ProviderError> {
+    if session.management_state != "MANAGED" {
+        return Err(crate::fleet_provider::ProviderError::Stale(
+            "managed Codex identity is required".to_string(),
+        ));
+    }
+    let target = session.tmux_target.as_deref().ok_or_else(|| {
+        crate::fleet_provider::ProviderError::Stale("exact tmux target is unavailable".to_string())
+    })?;
+    let fingerprint = session.process_start_fingerprint.as_deref().ok_or_else(|| {
+        crate::fleet_provider::ProviderError::Stale(
+            "exact tmux process identity is unavailable".to_string(),
+        )
+    })?;
+    let discovered = ainb_fleet_core::discover::discover_from_tmux()
+        .await
+        .map_err(|error| crate::fleet_provider::ProviderError::Transport(error.to_string()))?;
+    if !discovered.iter().any(|candidate| {
+        candidate.exact_tmux_target.as_deref() == Some(target)
+            && candidate.process_start_fingerprint.as_deref() == Some(fingerprint)
+    }) {
+        return Err(crate::fleet_provider::ProviderError::Stale(
+            "tmux process identity changed".to_string(),
+        ));
+    }
+    target
+        .split_once(':')
+        .map(|(session_name, _)| session_name)
+        .filter(|session_name| !session_name.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            crate::fleet_provider::ProviderError::Protocol(
+                "exact tmux target has no session name".to_string(),
+            )
+        })
+}
+
+async fn persist_codex_exit(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    manager: &crate::fleet_provider::codex_manager::CodexManagerHandle,
+    event_type: &str,
+) -> Result<(), crate::fleet_provider::ProviderError> {
+    crate::fleet::mark_managed_codex_exited(
+        pool,
+        events,
+        &session.session_key,
+        event_type,
+        manager.capabilities(),
+        SystemClock.now_ms(),
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| crate::fleet_provider::ProviderError::Transport(error.to_string()))
+}
+
+fn require_codex_identity(
+    supplied: Option<&ainb_hangar_proto::fleet::FleetRequestIdentity>,
+    canonical: &crate::fleet_provider::codex::CodexItemRequestIdentity,
+) -> Result<(), crate::fleet_provider::ProviderError> {
+    let supplied = supplied.ok_or_else(|| {
+        crate::fleet_provider::ProviderError::Stale(
+            "exact Codex request identity is required".to_string(),
+        )
+    })?;
+    if supplied.request_id != *canonical.request_id.as_value()
+        || supplied.thread_id != canonical.thread_id
+        || supplied.turn_id != canonical.turn_id
+        || supplied.item_id != canonical.item_id
+    {
+        return Err(crate::fleet_provider::ProviderError::Stale(
+            "Codex request identity changed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn load_codex_approval(
+    pool: &SqlitePool,
+    session_key: &str,
+) -> Result<crate::fleet_provider::codex::CodexApprovalRequest, crate::fleet_provider::ProviderError>
+{
+    use crate::fleet_provider::codex::{
+        CodexApprovalKind, CodexApprovalRequest, CodexItemRequestIdentity, RpcRequestId,
+    };
+    let value = crate::fleet::current_request_wire(pool, session_key)
+        .await
+        .map_err(|error| crate::fleet_provider::ProviderError::Transport(error.to_string()))?
+        .ok_or_else(|| {
+            crate::fleet_provider::ProviderError::Stale(
+                "current Codex approval is absent".to_string(),
+            )
+        })?;
+    let identity = value.get("identity").ok_or_else(|| {
+        crate::fleet_provider::ProviderError::Protocol(
+            "stored Codex approval identity is absent".to_string(),
+        )
+    })?;
+    let required = |field: &str| {
+        identity
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| {
+                crate::fleet_provider::ProviderError::Protocol(format!(
+                    "stored Codex approval {field} is absent"
+                ))
+            })
+    };
+    let kind = match value.get("kind").and_then(serde_json::Value::as_str) {
+        Some("commandExecution") => CodexApprovalKind::CommandExecution,
+        Some("fileChange") => CodexApprovalKind::FileChange,
+        Some("permissions") => CodexApprovalKind::Permissions,
+        _ => {
+            return Err(crate::fleet_provider::ProviderError::Protocol(
+                "stored Codex approval kind is invalid".to_string(),
+            ));
+        }
+    };
+    Ok(CodexApprovalRequest {
+        identity: CodexItemRequestIdentity {
+            request_id: RpcRequestId::new(
+                identity.get("requestId").cloned().unwrap_or(serde_json::Value::Null),
+            )?,
+            thread_id: required("threadId")?,
+            turn_id: required("turnId")?,
+            item_id: required("itemId")?,
+        },
+        kind,
+        params: value.get("params").cloned().unwrap_or(serde_json::Value::Null),
+    })
+}
+
+async fn latest_codex_turn_id(
+    pool: &SqlitePool,
+    session_key: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    let payloads = sqlx::query_scalar::<_, String>(
+        "SELECT payload FROM fleet_event WHERE session_key = ? AND applied = 1 \
+         ORDER BY revision DESC LIMIT 32",
+    )
+    .bind(session_key)
+    .fetch_all(pool)
+    .await?;
+    Ok(payloads.into_iter().find_map(|payload| {
+        let value: serde_json::Value = serde_json::from_str(&payload).ok()?;
+        value
+            .get("turnId")
+            .or_else(|| value.get("turn_id"))
+            .or_else(|| value.pointer("/identity/turnId"))
+            .or_else(|| value.pointer("/turn/id"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    }))
+}
+
+async fn execute_claude_structured(
+    pool: &SqlitePool,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    request_fingerprint: &str,
+    answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    let request = match crate::fleet::current_request_wire(pool, &session.session_key).await {
+        Ok(Some(request)) => request,
+        Ok(None) => {
+            return (
+                ActionReceiptStatus::Failed,
+                Some("current Claude question is absent".to_string()),
+            );
+        }
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let hook = request.get("payload").unwrap_or(&request);
+    let input = hook.get("tool_input").or_else(|| hook.get("input")).unwrap_or(hook);
+    let Some(questions) = input.get("questions").and_then(serde_json::Value::as_array) else {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("stored Claude question payload is invalid".to_string()),
+        );
+    };
+    let mut mapped = Vec::with_capacity(answers.len());
+    for answer in answers {
+        let question = questions.iter().enumerate().find_map(|(index, question)| {
+            let id = question
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| index.to_string());
+            (id == answer.question_id).then_some(question)
+        });
+        let Some(question) = question else {
+            return (
+                ActionReceiptStatus::Failed,
+                Some(format!(
+                    "Claude question id {} is stale",
+                    answer.question_id
+                )),
+            );
+        };
+        let Some(question_text) = question.get("question").and_then(serde_json::Value::as_str)
+        else {
+            return (
+                ActionReceiptStatus::Failed,
+                Some("Claude question text is absent".to_string()),
+            );
+        };
+        let mut values = answer.selected_options.clone();
+        if let Some(text) = answer.text.as_deref().filter(|text| !text.is_empty()) {
+            values.push(text.to_string());
+        }
+        mapped.push(ainb_plugin_notifyd::broker::StructuredQuestionAnswer {
+            question: question_text.to_string(),
+            selected_options: values,
+        });
+    }
+    let session_id = session.provider_session_id.clone().unwrap_or_default();
+    let fingerprint = request_fingerprint.to_string();
+    let socket = match approve_socket_path() {
+        Ok(socket) => socket,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    match tokio::task::spawn_blocking(move || {
+        ainb_plugin_notifyd::broker::client_answer_structured(
+            &socket,
+            &session_id,
+            &fingerprint,
+            &mapped,
+        )
+    })
+    .await
+    {
+        Ok(Ok(ack)) if ack.matched => (
+            ActionReceiptStatus::Delivered,
+            Some("claude structured hook broker".to_string()),
+        ),
+        Ok(Ok(ack)) if ack.stale => (
+            ActionReceiptStatus::Failed,
+            Some("Claude structured request is stale".to_string()),
+        ),
+        Ok(Ok(ack)) => (
+            ActionReceiptStatus::Failed,
+            ack.error.or_else(|| Some("Claude request no longer waiting".to_string())),
+        ),
+        Ok(Err(error)) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+    }
+}
+
+fn approve_socket_path() -> std::io::Result<PathBuf> {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Some(path) = APPROVE_SOCKET_OVERRIDE
+        .get_or_init(|| RwLock::new(None))
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+    {
+        return Ok(path);
+    }
+    std::env::var_os("AINB_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".agents-in-a-box")))
+        .map(|base| base.join("approve.sock"))
+        .ok_or_else(|| std::io::Error::other("cannot resolve approve socket"))
+}
+
+async fn verified_tmux_send(
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    text: &str,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    let (Some(target), Some(fingerprint)) = (
+        session.tmux_target.as_deref(),
+        session.process_start_fingerprint.as_deref(),
+    ) else {
+        return (
+            ActionReceiptStatus::Unknown,
+            Some("exact tmux process identity is unavailable".to_string()),
+        );
+    };
+    let discovered = match ainb_fleet_core::discover::discover_from_tmux().await {
+        Ok(discovered) => discovered,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let live = discovered.iter().any(|candidate| {
+        candidate.exact_tmux_target.as_deref() == Some(target)
+            && candidate.process_start_fingerprint.as_deref() == Some(fingerprint)
+    });
+    if !live {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("tmux process identity changed".to_string()),
+        );
+    }
+    match ainb_fleet_core::send::tmux_send(target, text).await {
+        Ok(()) => (
+            ActionReceiptStatus::Delivered,
+            Some(format!("tmux ({target})")),
+        ),
+        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+    }
+}
+
+async fn verified_tmux_picker(
+    pool: &SqlitePool,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    expected_version: i64,
+    request_fingerprint: &str,
+    key: &str,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    let (Some(target), Some(fingerprint)) = (
+        session.tmux_target.as_deref(),
+        session.process_start_fingerprint.as_deref(),
+    ) else {
+        return (
+            ActionReceiptStatus::Unknown,
+            Some("exact tmux process identity is unavailable".to_string()),
+        );
+    };
+    let discovered = match ainb_fleet_core::discover::discover_from_tmux().await {
+        Ok(discovered) => discovered,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let live = discovered.iter().any(|candidate| {
+        candidate.exact_tmux_target.as_deref() == Some(target)
+            && candidate.process_start_fingerprint.as_deref() == Some(fingerprint)
+            && candidate.provider.as_str() == session.provider
+    });
+    if !live {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("tmux provider or process identity changed".to_string()),
+        );
+    }
+    let request = match crate::fleet::current_request_wire(pool, &session.session_key).await {
+        Ok(Some(request)) => request,
+        Ok(None) => {
+            return (
+                ActionReceiptStatus::Failed,
+                Some("current structured picker request is absent".to_string()),
+            );
+        }
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let pane = match ainb_fleet_core::read::capture_pane(target, 0).await {
+        Ok(pane) => pane,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    if let Err(error) = verify_picker_pane(&session.provider, &request, &pane) {
+        return (ActionReceiptStatus::Failed, Some(error));
+    }
+    let refreshed = match ainb_hangar_store::repo::fleet::FleetRepo::validate_action_target(
+        pool,
+        &session.session_key,
+        expected_version,
+        Some(request_fingerprint),
+    )
+    .await
+    {
+        Ok(refreshed) => refreshed,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    if refreshed.provider != session.provider
+        || refreshed.tmux_target != session.tmux_target
+        || refreshed.process_start_fingerprint != session.process_start_fingerprint
+    {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("tmux picker identity changed during verification".to_string()),
+        );
+    }
+    match ainb_fleet_core::send::tmux_send_picker_key(target, key).await {
+        Ok(()) => (
+            ActionReceiptStatus::Delivered,
+            Some(format!("verified tmux picker ({target})")),
+        ),
+        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PickerQuestionEvidence {
+    prompt: String,
+    option_labels: Vec<String>,
+}
+
+const MAX_ACTIVE_PICKER_TRAILING_CHARS: usize = 512;
+
+fn verify_picker_pane(
+    provider: &str,
+    request: &serde_json::Value,
+    pane: &str,
+) -> Result<(), String> {
+    let questions = picker_question_evidence(provider, request)?;
+    let visible = normalize_picker_text(pane);
+    let mut cursor = 0;
+    for (question_index, question) in questions.into_iter().enumerate() {
+        let prompt = normalize_picker_text(&question.prompt);
+        let prompt_offset = if question_index == 0 {
+            visible[cursor..].rfind(&prompt)
+        } else {
+            visible[cursor..].find(&prompt)
+        }
+        .ok_or_else(|| "visible picker prompt does not match current request".to_string())?;
+        cursor += prompt_offset + prompt.len();
+        for label in question.option_labels {
+            let label = normalize_picker_text(&label);
+            let label_offset = visible[cursor..].find(&label).ok_or_else(|| {
+                "visible picker option order does not match current request".to_string()
+            })?;
+            cursor += label_offset + label.len();
+        }
+    }
+    let trailing = &visible[cursor..];
+    if has_later_picker_candidate(pane, cursor) {
+        return Err("visible picker is stale because a newer picker follows it".to_string());
+    }
+    if trailing.chars().count() > MAX_ACTIVE_PICKER_TRAILING_CHARS {
+        return Err("visible picker is not active at terminal input".to_string());
+    }
+    Ok(())
+}
+
+fn has_later_picker_candidate(pane: &str, matched_end: usize) -> bool {
+    let lines = pane
+        .lines()
+        .map(normalize_picker_text)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let mut offset = 0;
+    let mut anchor = None;
+    for (index, line) in lines.iter().enumerate() {
+        if index > 0 {
+            offset += 1;
+        }
+        let line_end = offset + line.len();
+        if matched_end <= line_end {
+            anchor = Some(index);
+            break;
+        }
+        offset = line_end;
+    }
+    let Some(anchor) = anchor else {
+        return true;
+    };
+    lines[anchor + 1..].iter().any(|line| {
+        line.trim_end().ends_with('?') || line.split_whitespace().any(is_numbered_picker_token)
+    })
+}
+
+fn is_numbered_picker_token(token: &str) -> bool {
+    let token = token.trim_start_matches(['>', '›', '❯', '○', '●', '◉']);
+    let digits = token.chars().take_while(char::is_ascii_digit).count();
+    digits > 0 && matches!(&token[digits..], "." | ")")
+}
+
+fn picker_question_evidence(
+    provider: &str,
+    request: &serde_json::Value,
+) -> Result<Vec<PickerQuestionEvidence>, String> {
+    if !matches!(provider, "claude" | "codex") {
+        return Err("verified picker provider is unsupported".to_string());
+    }
+    let hook = request.get("payload").unwrap_or(request);
+    let input = hook.get("tool_input").or_else(|| hook.get("input")).unwrap_or(hook);
+    let questions = input
+        .get("questions")
+        .and_then(serde_json::Value::as_array)
+        .filter(|questions| !questions.is_empty())
+        .ok_or_else(|| "stored picker request has no structured questions".to_string())?;
+    questions
+        .iter()
+        .map(|question| {
+            let prompt = question
+                .get("question")
+                .and_then(serde_json::Value::as_str)
+                .filter(|prompt| !prompt.trim().is_empty())
+                .ok_or_else(|| "stored picker question prompt is absent".to_string())?;
+            let options = question
+                .get("options")
+                .and_then(serde_json::Value::as_array)
+                .filter(|options| !options.is_empty())
+                .ok_or_else(|| "stored picker question has no ordered options".to_string())?;
+            let option_labels = options
+                .iter()
+                .map(|option| {
+                    option
+                        .as_str()
+                        .or_else(|| option.get("label").and_then(serde_json::Value::as_str))
+                        .filter(|label| !label.trim().is_empty())
+                        .map(str::to_string)
+                        .ok_or_else(|| "stored picker option label is absent".to_string())
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(PickerQuestionEvidence {
+                prompt: prompt.to_string(),
+                option_labels,
+            })
+        })
+        .collect()
+}
+
+fn normalize_picker_text(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_whitespace()
+                || matches!(
+                    character,
+                    '│' | '─'
+                        | '┌'
+                        | '┐'
+                        | '└'
+                        | '┘'
+                        | '├'
+                        | '┤'
+                        | '┬'
+                        | '┴'
+                        | '┼'
+                        | '╭'
+                        | '╮'
+                        | '╯'
+                        | '╰'
+                )
+            {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn action_capability(
+    capabilities: &ainb_hangar_proto::fleet::FleetCapabilities,
+    action: &ainb_hangar_proto::fleet::ControlAction,
+) -> bool {
+    use ainb_hangar_proto::fleet::ControlAction;
+    match action {
+        ControlAction::StructuredAnswer { .. } => capabilities.structured_answer,
+        ControlAction::Approve { .. } | ControlAction::Deny { .. } => capabilities.approvals,
+        ControlAction::VerifiedPicker { .. } => capabilities.verified_picker,
+        ControlAction::SendPrompt { .. } => capabilities.send_prompt || capabilities.tmux_text,
+        ControlAction::Continue => capabilities.continue_turn,
+        ControlAction::Retry => capabilities.retry,
+        ControlAction::Interrupt => capabilities.interrupt,
+        ControlAction::Start { .. } => capabilities.start,
+        ControlAction::Restart => capabilities.restart,
+        ControlAction::Stop => capabilities.stop,
+        ControlAction::Kill => capabilities.kill,
+        ControlAction::Archive => capabilities.archive,
+    }
+}
+
+fn stable_fingerprint(value: &str) -> String {
+    let hash = value.bytes().fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x0000_0100_0000_01b3)
+    });
+    format!("fnv1a64:{hash:016x}")
+}
+
+const fn receipt_status_token(
+    status: ainb_hangar_proto::fleet::ActionReceiptStatus,
+) -> &'static str {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    match status {
+        ActionReceiptStatus::Pending => "PENDING",
+        ActionReceiptStatus::Delivered => "DELIVERED",
+        ActionReceiptStatus::Failed => "FAILED",
+        ActionReceiptStatus::Unknown => "UNKNOWN",
+        ActionReceiptStatus::Rejected => "REJECTED",
+    }
+}
+
+fn action_receipt_wire(
+    row: &ainb_hangar_store::repo::fleet::ActionReceiptRow,
+) -> ainb_hangar_proto::fleet::FleetActionReceipt {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    ainb_hangar_proto::fleet::FleetActionReceipt {
+        request_id: row.request_id.clone(),
+        session_key: row.session_key.clone(),
+        action_kind: row.action_kind.clone(),
+        action_fingerprint: row.action_fingerprint.clone(),
+        expected_version: row.expected_version,
+        idempotency_key: row.idempotency_key.clone(),
+        status: match row.status.as_str() {
+            "PENDING" => ActionReceiptStatus::Pending,
+            "DELIVERED" => ActionReceiptStatus::Delivered,
+            "FAILED" => ActionReceiptStatus::Failed,
+            "REJECTED" => ActionReceiptStatus::Rejected,
+            _ => ActionReceiptStatus::Unknown,
+        },
+        detail: row.detail.clone(),
+        session_version: row.session_version,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    }
+}
+
+fn fleet_repo_err(error: ainb_hangar_store::repo::fleet::FleetRepoError) -> RpcError {
+    use ainb_hangar_store::repo::fleet::FleetRepoError;
+    match error {
+        FleetRepoError::Sql(error) => store_err(&error),
+        FleetRepoError::SessionNotFound { .. }
+        | FleetRepoError::StaleVersion { .. }
+        | FleetRepoError::RequestFingerprintMismatch { .. }
+        | FleetRepoError::ReceiptCollision { .. }
+        | FleetRepoError::EventIdCollision { .. } => invalid_params(&error.to_string()),
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_attention.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_attention.rs
@@ -247,8 +247,8 @@ async fn attention_subscribe_delivers_a_fleet_wide_raised_delta() {
     let mut client = Client::connect(&socket).await;
     client.auth_from_file(dir.path()).await;
 
-    // Subscribe fleet-wide (no workspace filter). The ack carries the (empty) open
-    // snapshot; the live forwarder is registered right after.
+    // Subscribe fleet-wide. Registration happens before the snapshot read, so
+    // an event emitted immediately after the ack cannot fall into a handoff gap.
     let ack = client.call(methods::ATTENTION_SUBSCRIBE, serde_json::json!({})).await;
     assert!(
         ack["error"].is_null(),
@@ -256,10 +256,7 @@ async fn attention_subscribe_delivers_a_fleet_wide_raised_delta() {
     );
     assert!(ack["result"]["attention"].as_array().unwrap().is_empty());
 
-    // Let the forwarder register (it is spawned just after the ack is queued),
-    // then emit a NO-WORKSPACE host attention nudge — the workspace forwarder
-    // would drop this; the fleet-wide one must deliver it.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // Emit immediately. A post-ack registration race would lose this nudge.
     sink.emit_attention(HangarEvent::AttentionRaised {
         attention_id: "att-9".into(),
         session_id: "sess".into(),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
@@ -1,0 +1,579 @@
+//! Fleet control-plane RPC integration over a real Unix socket.
+//!
+//! Covers authoritative provider snapshots, same-cwd identity separation,
+//! optimistic action guards, receipt idempotency, and ordered subscription
+//! delivery from the durable revision log.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::events::{EventBroker, EventSink};
+use ainb_hangar_daemon::fleet::{self, HookObservation};
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(stream) => break stream,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => panic!("never connected: {error}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let request = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.to_string(),
+            params,
+        };
+        let body = serde_json::to_vec(&request).unwrap();
+        let mut frame = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        frame.extend_from_slice(&body);
+        self.writer.write_all(&frame).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        tokio::time::timeout(timeout, self.read_frame_inner()).await.ok()
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+
+        let mut content_length = None;
+        loop {
+            let mut line = String::new();
+            let read = self.reader.read_line(&mut line).await.unwrap();
+            assert!(read > 0, "connection closed while awaiting frame");
+            let line = line.trim_end_matches("\r\n");
+            if line.is_empty() {
+                let mut body = vec![0_u8; content_length.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, value)) = line.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    content_length = value.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(5))
+                .await
+                .unwrap_or_else(|| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn next_fleet_event(&mut self) -> serde_json::Value {
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(5))
+                .await
+                .expect("no Fleet notification within 5s");
+            if frame.get("id").is_none() && frame["method"] == "fleet/event" {
+                return frame["params"].clone();
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(token_path).expect("read daemon.token");
+        let response = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(
+            response["error"].is_null(),
+            "auth/hello must ack: {response}"
+        );
+    }
+}
+
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store, EventSink) {
+    let store = Store::open_in(dir).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let broker = EventBroker::new();
+    let sink = broker.sink();
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".to_string(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(listener, store.pool().clone(), health, broker));
+    (socket_path, store, sink)
+}
+
+async fn apply_hook(
+    store: &Store,
+    sink: &EventSink,
+    event_id: &str,
+    provider: &str,
+    session_id: &str,
+    event_type: &str,
+    payload: &serde_json::Value,
+    observed_at: i64,
+) {
+    fleet::apply_hook(
+        store.pool(),
+        sink,
+        HookObservation {
+            event_id: event_id.to_string(),
+            provider,
+            provider_session_id: session_id,
+            cwd: "/work/shared",
+            event_type,
+            payload,
+            observed_at,
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn snapshot_keeps_same_cwd_authoritative_provider_sessions_distinct() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    let payload = serde_json::json!({ "source": "hook" });
+    apply_hook(
+        &store,
+        &sink,
+        "claude-start",
+        "claude",
+        "shared-id",
+        "SessionStart",
+        &payload,
+        100,
+    )
+    .await;
+    apply_hook(
+        &store,
+        &sink,
+        "codex-start",
+        "codex",
+        "shared-id",
+        "SessionStart",
+        &payload,
+        101,
+    )
+    .await;
+
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let response = client.call(methods::FLEET_SNAPSHOT, serde_json::json!({})).await;
+    assert!(
+        response["error"].is_null(),
+        "fleet/snapshot must ack: {response}"
+    );
+    let sessions = response["result"]["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 2, "same cwd must not merge providers");
+    assert_eq!(sessions[0]["session_key"], "claude:shared-id");
+    assert_eq!(sessions[0]["provider"], "claude");
+    assert_eq!(sessions[0]["provenance"], "authoritative");
+    assert_eq!(sessions[1]["session_key"], "codex:shared-id");
+    assert_eq!(sessions[1]["provider"], "codex");
+    assert_eq!(sessions[0]["cwd"], sessions[1]["cwd"]);
+    assert_eq!(response["result"]["head_revision"], 2);
+}
+
+#[tokio::test]
+async fn action_rejects_stale_or_wrong_request_and_replays_receipt() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    let question = serde_json::json!({
+        "questions": [{
+            "id": "q-1",
+            "question": "Deploy now?",
+            "options": ["yes", "no"]
+        }]
+    });
+    apply_hook(
+        &store,
+        &sink,
+        "claude-question",
+        "claude",
+        "question-session",
+        "AskUserQuestion",
+        &question,
+        200,
+    )
+    .await;
+
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let snapshot = client.call(methods::FLEET_SNAPSHOT, serde_json::json!({})).await;
+    let session = &snapshot["result"]["sessions"][0];
+    let version = session["version"].as_i64().unwrap();
+    let fingerprint = session["current_request_fingerprint"].as_str().unwrap().to_string();
+    let action = serde_json::json!({
+        "session_key": "claude:question-session",
+        "expected_version": version,
+        "request_id": "answer-1",
+        "action": {
+            "action": "structured_answer",
+            "request_fingerprint": fingerprint,
+            "answers": [{
+                "question_id": "q-1",
+                "selected_options": ["yes"]
+            }]
+        }
+    });
+
+    let first = client.call(methods::FLEET_ACTION, action.clone()).await;
+    assert!(first["error"].is_null(), "first action must ack: {first}");
+    assert_eq!(first["result"]["receipt"]["request_id"], "answer-1");
+    assert_eq!(first["result"]["receipt"]["status"], "FAILED");
+    let replay = client.call(methods::FLEET_ACTION, action).await;
+    assert_eq!(
+        replay["result"]["receipt"], first["result"]["receipt"],
+        "same request id and payload must return original receipt"
+    );
+
+    let stale = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": "claude:question-session",
+                "expected_version": version + 1,
+                "request_id": "answer-stale",
+                "action": {
+                    "action": "structured_answer",
+                    "request_fingerprint": fingerprint,
+                    "answers": [{ "question_id": "q-1", "selected_options": ["yes"] }]
+                }
+            }),
+        )
+        .await;
+    assert!(
+        stale["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("version")),
+        "stale action must explain version rejection: {stale}"
+    );
+
+    let wrong_request = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": "claude:question-session",
+                "expected_version": version,
+                "request_id": "answer-wrong-request",
+                "action": {
+                    "action": "structured_answer",
+                    "request_fingerprint": "fnv1a64:wrong",
+                    "answers": [{ "question_id": "q-1", "selected_options": ["yes"] }]
+                }
+            }),
+        )
+        .await;
+    assert!(
+        wrong_request["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("fingerprint")),
+        "wrong request must explain fingerprint rejection: {wrong_request}"
+    );
+
+    let stale_picker = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": "claude:question-session",
+                "expected_version": version,
+                "request_id": "picker-wrong-request",
+                "action": {
+                    "action": "verified_picker",
+                    "request_fingerprint": "fnv1a64:wrong",
+                    "key": "1"
+                }
+            }),
+        )
+        .await;
+    assert!(
+        stale_picker["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("fingerprint")),
+        "picker must reject stale request fingerprint: {stale_picker}"
+    );
+
+    let stale_picker_version = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": "claude:question-session",
+                "expected_version": version + 1,
+                "request_id": "picker-stale-version",
+                "action": {
+                    "action": "verified_picker",
+                    "request_fingerprint": fingerprint,
+                    "key": "1"
+                }
+            }),
+        )
+        .await;
+    assert!(
+        stale_picker_version["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("version")),
+        "picker must reject stale session version: {stale_picker_version}"
+    );
+}
+
+#[tokio::test]
+async fn claude_structured_action_delivers_exact_complete_answer_once() {
+    use ainb_plugin_notifyd::broker::{
+        BrokerState, StructuredResolution, client_await_structured, client_list,
+        request_fingerprint,
+    };
+    use tokio::net::UnixListener;
+
+    static ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    let _env_guard = ENV_LOCK.get_or_init(|| std::sync::Mutex::new(())).lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let approve_socket = dir.path().join("approve.sock");
+    rpc::set_approve_socket_for_test(Some(approve_socket.clone()));
+    let listener = UnixListener::bind(&approve_socket).unwrap();
+    let broker_task = tokio::spawn(ainb_plugin_notifyd::broker::serve(
+        listener,
+        BrokerState::with_timeout(Duration::from_secs(10)),
+    ));
+    let (socket, store, sink) = start_server(dir.path()).await;
+    let tool_input = serde_json::json!({
+        "questions": [
+            {
+                "id": "q-1",
+                "question": "Regions?",
+                "multiSelect": true,
+                "options": [{"label": "eu"}, {"label": "us"}]
+            },
+            {
+                "id": "q-2",
+                "question": "Mode?",
+                "options": [{"label": "safe"}, {"label": "fast"}]
+            }
+        ]
+    });
+    let request_identity = serde_json::json!({
+        "tool_use_id": "toolu-exact",
+        "tool_input": tool_input,
+    });
+    let fingerprint = request_fingerprint(&request_identity);
+    let hook = serde_json::json!({
+        "matcher": "AskUserQuestion",
+        "payload": {
+            "tool_use_id": "toolu-exact",
+            "tool_input": request_identity["tool_input"],
+        }
+    });
+    apply_hook(
+        &store,
+        &sink,
+        "claude-exact-question",
+        "claude",
+        "exact-session",
+        "AskUserQuestion",
+        &hook,
+        220,
+    )
+    .await;
+
+    let waiter_socket = approve_socket.clone();
+    let waiter_fingerprint = fingerprint.clone();
+    let questions = request_identity["tool_input"]["questions"].as_array().unwrap().clone();
+    let waiter = tokio::task::spawn_blocking(move || {
+        client_await_structured(
+            &waiter_socket,
+            "exact-session",
+            &waiter_fingerprint,
+            &questions,
+            Duration::from_secs(5),
+        )
+    });
+    for _ in 0..100 {
+        let socket = approve_socket.clone();
+        let registered = tokio::task::spawn_blocking(move || client_list(&socket))
+            .await
+            .unwrap()
+            .unwrap_or_default()
+            .iter()
+            .any(|pending| pending.session_id == "exact-session");
+        if registered {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let snapshot = client.call(methods::FLEET_SNAPSHOT, serde_json::json!({})).await;
+    let version = snapshot["result"]["sessions"][0]["version"].as_i64().unwrap();
+    assert_eq!(
+        snapshot["result"]["sessions"][0]["current_request_fingerprint"],
+        fingerprint
+    );
+    let action = serde_json::json!({
+        "session_key": "claude:exact-session",
+        "expected_version": version,
+        "request_id": "answer-exact-once",
+        "action": {
+            "action": "structured_answer",
+            "request_fingerprint": fingerprint,
+            "answers": [
+                {"question_id": "q-1", "selected_options": ["eu", "us"]},
+                {"question_id": "q-2", "selected_options": ["safe"]}
+            ]
+        }
+    });
+    let first = client.call(methods::FLEET_ACTION, action.clone()).await;
+    assert_eq!(first["result"]["receipt"]["status"], "DELIVERED");
+    let replay = client.call(methods::FLEET_ACTION, action).await;
+    assert_eq!(replay["result"]["receipt"], first["result"]["receipt"]);
+
+    let resolution = waiter.await.unwrap();
+    let StructuredResolution::Answered { answers } = resolution else {
+        panic!("exact structured waiter was not answered");
+    };
+    assert_eq!(answers.len(), 2);
+    assert_eq!(answers[0].question, "Regions?");
+    assert_eq!(answers[0].selected_options, ["eu", "us"]);
+    assert_eq!(answers[1].question, "Mode?");
+    assert_eq!(answers[1].selected_options, ["safe"]);
+
+    broker_task.abort();
+    rpc::set_approve_socket_for_test(None);
+}
+
+#[tokio::test]
+async fn subscribe_delivers_every_revision_after_snapshot_in_order() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    let payload = serde_json::json!({ "source": "hook" });
+    apply_hook(
+        &store,
+        &sink,
+        "start-before-subscribe",
+        "claude",
+        "stream-session",
+        "SessionStart",
+        &payload,
+        300,
+    )
+    .await;
+
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let ack = client
+        .call(
+            methods::FLEET_SUBSCRIBE,
+            serde_json::json!({ "after_revision": 0 }),
+        )
+        .await;
+    assert!(ack["error"].is_null(), "fleet/subscribe must ack: {ack}");
+    let head = ack["result"]["snapshot"]["head_revision"].as_i64().unwrap();
+    assert_eq!(head, 1);
+
+    apply_hook(
+        &store,
+        &sink,
+        "prompt-after-subscribe",
+        "claude",
+        "stream-session",
+        "UserPromptSubmit",
+        &payload,
+        301,
+    )
+    .await;
+    apply_hook(
+        &store,
+        &sink,
+        "stop-after-subscribe",
+        "claude",
+        "stream-session",
+        "Stop",
+        &payload,
+        302,
+    )
+    .await;
+
+    let first = client.next_fleet_event().await;
+    let second = client.next_fleet_event().await;
+    assert_eq!(first["revision"], head + 1);
+    assert_eq!(first["event_id"], "prompt-after-subscribe");
+    assert_eq!(second["revision"], head + 2);
+    assert_eq!(second["event_id"], "stop-after-subscribe");
+}
+
+#[tokio::test]
+async fn broadcast_returns_ordered_receipt_for_every_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    apply_hook(
+        &store,
+        &sink,
+        "broadcast-session",
+        "claude",
+        "broadcast-live",
+        "SessionStart",
+        &serde_json::json!({}),
+        400,
+    )
+    .await;
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let response = client
+        .call(
+            methods::FLEET_BROADCAST,
+            serde_json::json!({
+                "target_keys": ["claude:broadcast-live", "claude:missing"],
+                "text": "status",
+                "idempotency_key": "broadcast-all-receipts"
+            }),
+        )
+        .await;
+    assert!(
+        response["error"].is_null(),
+        "broadcast must return result: {response}"
+    );
+    let receipts = response["result"]["receipts"].as_array().unwrap();
+    assert_eq!(receipts.len(), 2);
+    assert_eq!(receipts[0]["session_key"], "claude:broadcast-live");
+    assert_eq!(receipts[1]["session_key"], "claude:missing");
+    assert_eq!(receipts[0]["status"], "REJECTED");
+    assert_eq!(receipts[1]["status"], "REJECTED");
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -1,0 +1,499 @@
+//! Fleet control-plane wire types.
+//!
+//! Sessions use stable provider identity, independent lifecycle and attention
+//! state, optimistic concurrency versions, and durable global revisions.
+
+use serde::{Deserialize, Serialize};
+
+/// Session provider.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetProvider {
+    /// Claude Code.
+    Claude,
+    /// OpenAI Codex.
+    Codex,
+    /// Provider could not be determined.
+    #[default]
+    Unknown,
+}
+
+/// Provider session lifecycle, independent from attention.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum LifecycleState {
+    /// Process or provider thread is starting.
+    Starting,
+    /// Turn is actively running.
+    Running,
+    /// Provider reported turn completion.
+    TurnComplete,
+    /// Session is alive without an active turn.
+    Idle,
+    /// Session exited.
+    Exited,
+    /// Lifecycle cannot be determined.
+    #[default]
+    Unknown,
+}
+
+/// Operator attention state, independent from lifecycle.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AttentionState {
+    /// No operator action requested.
+    #[default]
+    None,
+    /// Provider asks a structured question.
+    Ask,
+    /// Provider requests approval.
+    Approval,
+    /// Session is waiting without a structured request.
+    Waiting,
+    /// Session reported an error needing attention.
+    Error,
+}
+
+/// Whether Hangar has authoritative provider control.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ManagementState {
+    /// Provider adapter supports authoritative actions.
+    Managed,
+    /// Only discovery or fallback control is available.
+    #[default]
+    Degraded,
+}
+
+/// Health of the preferred provider transport.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransportHealth {
+    /// Preferred transport is responsive.
+    Healthy,
+    /// Preferred transport has partial capability.
+    Degraded,
+    /// Preferred transport is unavailable.
+    Unavailable,
+    /// Transport state is not known.
+    #[default]
+    Unknown,
+}
+
+/// Authority of observed state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetProvenance {
+    /// Exact provider or lifecycle-hook observation.
+    Authoritative,
+    /// Tmux, process, or transcript inference.
+    #[default]
+    Inferred,
+}
+
+/// Confidence assigned to session identity and state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FleetConfidence {
+    /// Exact stable identity and authoritative state.
+    High,
+    /// Stable identity with partially inferred state.
+    Medium,
+    /// Legacy or weakly inferred identity and state.
+    #[default]
+    Low,
+}
+
+/// Provider and transport actions available for one session.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FleetCapabilities {
+    /// Answer exact structured provider requests.
+    pub structured_answer: bool,
+    /// Approve or deny exact provider requests.
+    pub approvals: bool,
+    /// Send generic prompt text.
+    pub send_prompt: bool,
+    /// Continue a paused session.
+    pub continue_turn: bool,
+    /// Retry a failed turn.
+    pub retry: bool,
+    /// Interrupt an active turn.
+    pub interrupt: bool,
+    /// Start a provider session.
+    pub start: bool,
+    /// Stop a session gracefully.
+    pub stop: bool,
+    /// Restart a session.
+    pub restart: bool,
+    /// Kill a session process.
+    pub kill: bool,
+    /// Archive a session.
+    pub archive: bool,
+    /// Attach through tmux.
+    pub tmux_attach: bool,
+    /// Send plain text through tmux.
+    pub tmux_text: bool,
+    /// Route verified picker keys through tmux.
+    pub verified_picker: bool,
+}
+
+/// Canonical Fleet session read-model row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetSession {
+    /// Stable identity, never cwd.
+    pub session_key: String,
+    /// Session provider.
+    pub provider: FleetProvider,
+    /// Provider-owned session identifier.
+    pub provider_session_id: Option<String>,
+    /// Exact tmux target for attach or fallback.
+    pub tmux_target: Option<String>,
+    /// Process-start fingerprint for legacy identity.
+    pub process_start_fingerprint: Option<String>,
+    /// Working directory metadata.
+    pub cwd: String,
+    /// Human-readable session label.
+    pub display_name: Option<String>,
+    /// Independent lifecycle state.
+    pub lifecycle: LifecycleState,
+    /// Independent attention state.
+    pub attention: AttentionState,
+    /// Fingerprint of current structured request or approval.
+    pub current_request_fingerprint: Option<String>,
+    /// Complete current structured request for rendering and exact routing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_request: Option<serde_json::Value>,
+    /// Managed or degraded control state.
+    pub management: ManagementState,
+    /// Preferred transport health.
+    pub transport_health: TransportHealth,
+    /// Available actions.
+    pub capabilities: FleetCapabilities,
+    /// Last accepted state provenance.
+    pub provenance: FleetProvenance,
+    /// Identity and state confidence.
+    pub confidence: FleetConfidence,
+    /// First discovery time in epoch milliseconds.
+    pub discovered_at: i64,
+    /// Last accepted observation time in epoch milliseconds.
+    pub last_observed_at: i64,
+    /// Last lifecycle observation time in epoch milliseconds.
+    pub lifecycle_updated_at: i64,
+    /// Last attention observation time in epoch milliseconds.
+    pub attention_updated_at: i64,
+    /// Optimistic concurrency version.
+    pub version: i64,
+    /// Global revision that last changed this session.
+    pub updated_revision: i64,
+}
+
+/// Consistent Fleet snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetSnapshot {
+    /// Highest revision included by the snapshot transaction.
+    pub head_revision: i64,
+    /// Canonical sessions ordered by stable key.
+    pub sessions: Vec<FleetSession>,
+}
+
+/// Parameters for `fleet/snapshot`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetSnapshotParams {}
+
+/// Parameters for `fleet/subscribe`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetSubscribeParams {
+    /// Last revision committed by the subscriber.
+    #[serde(default)]
+    pub after_revision: i64,
+}
+
+/// One durable change emitted after a subscription cursor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetEvent {
+    /// Global monotonic revision.
+    pub revision: i64,
+    /// Replay-safe event identity.
+    pub event_id: String,
+    /// Stable target session.
+    pub session_key: String,
+    /// Observation time in epoch milliseconds.
+    pub observed_at: i64,
+    /// Event authority.
+    pub provenance: FleetProvenance,
+    /// Normalized event discriminator.
+    pub event_type: String,
+    /// Provider or normalized event body.
+    pub payload: serde_json::Value,
+    /// Session version after event consideration.
+    pub session_version: i64,
+    /// Whether event changed canonical state.
+    pub applied: bool,
+}
+
+/// Initial result for a replay-safe Fleet subscription.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetSubscribeResult {
+    /// Consistent snapshot registered against live delivery.
+    pub snapshot: FleetSnapshot,
+    /// Events committed after snapshot head and before live delivery.
+    pub replay: Vec<FleetEvent>,
+}
+
+/// One answer to one provider question.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetQuestionAnswer {
+    /// Exact provider question identifier.
+    pub question_id: String,
+    /// Selected option identifiers or labels in provider order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected_options: Vec<String>,
+    /// Free-text answer when question permits it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
+/// Exact provider request routing identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetRequestIdentity {
+    /// Exact JSON-RPC request id for provider response routing.
+    pub request_id: serde_json::Value,
+    /// Exact provider thread id.
+    pub thread_id: String,
+    /// Exact provider turn id.
+    pub turn_id: String,
+    /// Exact provider item id.
+    pub item_id: String,
+}
+
+/// Typed Fleet control action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ControlAction {
+    /// Answer exact structured request without generic text fallback.
+    StructuredAnswer {
+        /// Provider request fingerprint verified against current state.
+        request_fingerprint: String,
+        /// Exact provider routing identity when provider protocol requires it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_identity: Option<FleetRequestIdentity>,
+        /// Complete ordered answers for all questions.
+        answers: Vec<FleetQuestionAnswer>,
+    },
+    /// Approve exact provider request.
+    Approve {
+        /// Provider request fingerprint verified against current state.
+        request_fingerprint: String,
+        /// Exact provider routing identity when provider protocol requires it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_identity: Option<FleetRequestIdentity>,
+    },
+    /// Deny exact provider request.
+    Deny {
+        /// Provider request fingerprint verified against current state.
+        request_fingerprint: String,
+        /// Exact provider routing identity when provider protocol requires it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_identity: Option<FleetRequestIdentity>,
+    },
+    /// Route one picker key only while exact request state remains current.
+    VerifiedPicker {
+        /// Provider request fingerprint verified against current state.
+        request_fingerprint: String,
+        /// Provider-neutral tmux key token from the constrained picker set.
+        key: String,
+    },
+    /// Send generic prompt text.
+    SendPrompt {
+        /// Prompt text.
+        text: String,
+    },
+    /// Continue current session.
+    Continue,
+    /// Retry failed turn.
+    Retry,
+    /// Interrupt active turn.
+    Interrupt,
+    /// Start a managed session.
+    Start {
+        /// Provider to start.
+        provider: FleetProvider,
+        /// Working directory.
+        cwd: String,
+        /// Optional initial prompt.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt: Option<String>,
+    },
+    /// Restart session.
+    Restart,
+    /// Stop session gracefully.
+    Stop,
+    /// Kill session process.
+    Kill,
+    /// Archive session.
+    Archive,
+}
+
+impl ControlAction {
+    /// Stable token used by durable receipts.
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::StructuredAnswer { .. } => "structured_answer",
+            Self::Approve { .. } => "approve",
+            Self::Deny { .. } => "deny",
+            Self::VerifiedPicker { .. } => "verified_picker",
+            Self::SendPrompt { .. } => "send_prompt",
+            Self::Continue => "continue",
+            Self::Retry => "retry",
+            Self::Interrupt => "interrupt",
+            Self::Start { .. } => "start",
+            Self::Restart => "restart",
+            Self::Stop => "stop",
+            Self::Kill => "kill",
+            Self::Archive => "archive",
+        }
+    }
+}
+
+/// Parameters for `fleet/action`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetActionParams {
+    /// Stable target session.
+    pub session_key: String,
+    /// Required optimistic concurrency version.
+    pub expected_version: i64,
+    /// Idempotent action request identifier.
+    pub request_id: String,
+    /// Typed action.
+    pub action: ControlAction,
+}
+
+/// Durable action delivery status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ActionReceiptStatus {
+    /// Action accepted but not resolved.
+    Pending,
+    /// Provider confirmed delivery.
+    Delivered,
+    /// Provider confirmed failure.
+    Failed,
+    /// Delivery outcome cannot be established.
+    Unknown,
+    /// Hangar rejected action before delivery.
+    Rejected,
+}
+
+/// Durable action result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetActionReceipt {
+    /// Idempotent request identifier.
+    pub request_id: String,
+    /// Stable target session.
+    pub session_key: String,
+    /// Stable action token.
+    pub action_kind: String,
+    /// Exact action payload fingerprint.
+    pub action_fingerprint: String,
+    /// Session version required by action.
+    pub expected_version: i64,
+    /// Shared broadcast idempotency key, if any.
+    pub idempotency_key: Option<String>,
+    /// Honest delivery status.
+    pub status: ActionReceiptStatus,
+    /// Optional operator-facing detail.
+    pub detail: Option<String>,
+    /// Session version observed when delivery resolved.
+    pub session_version: Option<i64>,
+    /// Receipt creation time in epoch milliseconds.
+    pub created_at: i64,
+    /// Last receipt update time in epoch milliseconds.
+    pub updated_at: i64,
+}
+
+/// Result for `fleet/action`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetActionResult {
+    /// Durable action receipt.
+    pub receipt: FleetActionReceipt,
+}
+
+/// Parameters for `fleet/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetBroadcastParams {
+    /// Explicit stable recipients.
+    pub target_keys: Vec<String>,
+    /// Text delivered to each recipient.
+    pub text: String,
+    /// Idempotency boundary shared across recipient actions.
+    pub idempotency_key: String,
+}
+
+/// Result for `fleet/broadcast`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetBroadcastResult {
+    /// Per-session delivery receipts.
+    pub receipts: Vec<FleetActionReceipt>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_and_attention_serialize_independently() {
+        let value = serde_json::json!({
+            "lifecycle": LifecycleState::Running,
+            "attention": AttentionState::Ask,
+        });
+        assert_eq!(value["lifecycle"], "RUNNING");
+        assert_eq!(value["attention"], "ASK");
+    }
+
+    #[test]
+    fn structured_answer_preserves_exact_request_identity() {
+        let action = ControlAction::StructuredAnswer {
+            request_fingerprint: "sha256:request".to_string(),
+            request_identity: Some(FleetRequestIdentity {
+                request_id: serde_json::json!(41),
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-2".to_string(),
+                item_id: "item-3".to_string(),
+            }),
+            answers: vec![FleetQuestionAnswer {
+                question_id: "q-1".to_string(),
+                selected_options: vec!["first".to_string(), "third".to_string()],
+                text: None,
+            }],
+        };
+        let encoded = serde_json::to_value(&action).unwrap();
+        assert_eq!(encoded["action"], "structured_answer");
+        assert_eq!(encoded["request_fingerprint"], "sha256:request");
+        assert_eq!(encoded["request_identity"]["request_id"], 41);
+        assert_eq!(encoded["answers"][0]["question_id"], "q-1");
+        assert_eq!(action.kind(), "structured_answer");
+    }
+
+    #[test]
+    fn verified_picker_is_typed_and_request_scoped() {
+        let action = ControlAction::VerifiedPicker {
+            request_fingerprint: "sha256:request".to_string(),
+            key: "1".to_string(),
+        };
+        let encoded = serde_json::to_value(&action).unwrap();
+        assert_eq!(action.kind(), "verified_picker");
+        assert_eq!(encoded["action"], "verified_picker");
+        assert_eq!(encoded["request_fingerprint"], "sha256:request");
+        assert_eq!(encoded["key"], "1");
+    }
+
+    #[test]
+    fn capabilities_default_to_disabled() {
+        let capabilities: FleetCapabilities = serde_json::from_str("{}").unwrap();
+        assert!(!capabilities.structured_answer);
+        assert!(!capabilities.kill);
+        assert!(!capabilities.tmux_text);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod auth;
 pub mod events;
+pub mod fleet;
 pub mod lifecycle;
 pub mod methods;
 pub mod pr_status;

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -232,6 +232,14 @@ pub const HANGAR_ISSUE_DELETE: &str = "hangar/issue_delete";
 /// workspace-scoped, mirroring [`HANGAR_ISSUE_DELETE`]. An issue with no active
 /// task is a clean `{ cancelled: 0 }`, never an error.
 pub const HANGAR_ISSUE_CANCEL_ACTIVE: &str = "hangar/issue_cancel_active";
+/// Fetch canonical Fleet snapshot and revision head.
+pub const FLEET_SNAPSHOT: &str = "fleet/snapshot";
+/// Subscribe after a global Fleet revision.
+pub const FLEET_SUBSCRIBE: &str = "fleet/subscribe";
+/// Execute one versioned Fleet action.
+pub const FLEET_ACTION: &str = "fleet/action";
+/// Deliver text to explicit Fleet targets.
+pub const FLEET_BROADCAST: &str = "fleet/broadcast";
 
 /// `hangar/issue_run` — enqueue a run of one issue WITHOUT a board (the Issues
 /// screen's create-wizard dispatch; plans/hangar-task-agent-model.md).
@@ -1056,6 +1064,11 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_ISSUE_DELETE,
     // Issue-scoped cancel-active (board-less cancel-and-delete), likewise appended.
     HANGAR_ISSUE_CANCEL_ACTIVE,
+    // Fleet control-plane methods are appended at the wire catalogue tail.
+    FLEET_SNAPSHOT,
+    FLEET_SUBSCRIBE,
+    FLEET_ACTION,
+    FLEET_BROADCAST,
 ];
 
 #[cfg(test)]
@@ -1255,6 +1268,10 @@ mod tests {
             HANGAR_DAEMON_CONFIG_LIST,
             HANGAR_ISSUE_DELETE,
             HANGAR_ISSUE_CANCEL_ACTIVE,
+            FLEET_SNAPSHOT,
+            FLEET_SUBSCRIBE,
+            FLEET_ACTION,
+            FLEET_BROADCAST,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0043_fleet_control_plane.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0043_fleet_control_plane.sql
@@ -1,0 +1,105 @@
+-- Hangar migration 0043: authoritative host Fleet read model and change log.
+--
+-- fleet_session is current canonical state for every managed or discovered
+-- provider session. Identity is session_key, never cwd. Each independently
+-- changing state group carries its own authority and observation timestamp so a
+-- tmux inference cannot replace a hook or provider-authoritative value.
+--
+-- fleet_event is global revision order for snapshot plus delta delivery. The
+-- unique event_id makes hook replay and daemon restart idempotent. Revisions are
+-- never reused, giving every subscriber one durable resume cursor.
+
+CREATE TABLE fleet_session (
+    session_key               TEXT PRIMARY KEY CHECK (length(session_key) > 0),
+    provider                  TEXT NOT NULL DEFAULT 'unknown',
+    provider_session_id       TEXT,
+    tmux_target               TEXT,
+    process_start_fingerprint TEXT,
+    cwd                       TEXT NOT NULL DEFAULT '',
+    display_name              TEXT,
+    lifecycle_state           TEXT NOT NULL DEFAULT 'UNKNOWN' CHECK (lifecycle_state IN (
+                                  'STARTING', 'RUNNING', 'TURN_COMPLETE', 'IDLE',
+                                  'EXITED', 'UNKNOWN'
+                              )),
+    attention_state           TEXT NOT NULL DEFAULT 'NONE' CHECK (attention_state IN (
+                                  'NONE', 'ASK', 'APPROVAL', 'WAITING', 'ERROR'
+                              )),
+    current_request_fingerprint TEXT,
+    management_state          TEXT NOT NULL DEFAULT 'DEGRADED' CHECK (management_state IN (
+                                  'MANAGED', 'DEGRADED'
+                              )),
+    transport_health          TEXT NOT NULL DEFAULT 'UNKNOWN' CHECK (transport_health IN (
+                                  'HEALTHY', 'DEGRADED', 'UNAVAILABLE', 'UNKNOWN'
+                              )),
+    capabilities              TEXT NOT NULL DEFAULT '{}',
+    provenance                TEXT NOT NULL DEFAULT 'inferred' CHECK (provenance IN (
+                                  'authoritative', 'inferred'
+                              )),
+    confidence                TEXT NOT NULL DEFAULT 'LOW' CHECK (confidence IN (
+                                  'HIGH', 'MEDIUM', 'LOW'
+                              )),
+    discovered_at             INTEGER NOT NULL,
+    last_observed_at          INTEGER NOT NULL,
+    metadata_updated_at       INTEGER NOT NULL DEFAULT 0,
+    metadata_authority        TEXT NOT NULL DEFAULT 'inferred' CHECK (metadata_authority IN (
+                                  'authoritative', 'inferred'
+                              )),
+    lifecycle_updated_at      INTEGER NOT NULL DEFAULT 0,
+    lifecycle_authority       TEXT NOT NULL DEFAULT 'inferred' CHECK (lifecycle_authority IN (
+                                  'authoritative', 'inferred'
+                              )),
+    attention_updated_at      INTEGER NOT NULL DEFAULT 0,
+    attention_authority       TEXT NOT NULL DEFAULT 'inferred' CHECK (attention_authority IN (
+                                  'authoritative', 'inferred'
+                              )),
+    transport_updated_at      INTEGER NOT NULL DEFAULT 0,
+    transport_authority       TEXT NOT NULL DEFAULT 'inferred' CHECK (transport_authority IN (
+                                  'authoritative', 'inferred'
+                              )),
+    version                   INTEGER NOT NULL DEFAULT 1 CHECK (version >= 1),
+    updated_revision          INTEGER NOT NULL DEFAULT 0 CHECK (updated_revision >= 0),
+    superseded_by             TEXT REFERENCES fleet_session(session_key),
+    visible                   INTEGER NOT NULL DEFAULT 1 CHECK (visible IN (0, 1))
+);
+
+CREATE INDEX idx_fleet_session_provider_id
+    ON fleet_session(provider, provider_session_id);
+CREATE INDEX idx_fleet_session_tmux
+    ON fleet_session(tmux_target);
+
+CREATE TABLE fleet_event (
+    revision        INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id        TEXT NOT NULL UNIQUE CHECK (length(event_id) > 0),
+    session_key     TEXT NOT NULL REFERENCES fleet_session(session_key),
+    observed_at     INTEGER NOT NULL,
+    authority       TEXT NOT NULL CHECK (authority IN ('authoritative', 'inferred')),
+    event_type      TEXT NOT NULL CHECK (length(event_type) > 0),
+    payload         TEXT NOT NULL DEFAULT '{}',
+    session_version INTEGER NOT NULL CHECK (session_version >= 1),
+    applied         INTEGER NOT NULL DEFAULT 1 CHECK (applied IN (0, 1))
+);
+
+CREATE INDEX idx_fleet_event_session_revision
+    ON fleet_event(session_key, revision);
+
+-- Action receipts are durable, honest delivery outcomes. request_id is the
+-- idempotency boundary for a single target action. Broadcast callers mint one
+-- request_id per target and share their own idempotency_key in protocol state.
+CREATE TABLE fleet_action_receipt (
+    request_id         TEXT PRIMARY KEY CHECK (length(request_id) > 0),
+    session_key        TEXT NOT NULL,
+    action_kind        TEXT NOT NULL,
+    action_fingerprint TEXT NOT NULL CHECK (length(action_fingerprint) > 0),
+    expected_version   INTEGER NOT NULL CHECK (expected_version >= 1),
+    idempotency_key    TEXT,
+    status             TEXT NOT NULL CHECK (status IN (
+                           'PENDING', 'DELIVERED', 'FAILED', 'UNKNOWN', 'REJECTED'
+                       )),
+    detail             TEXT,
+    session_version    INTEGER,
+    created_at         INTEGER NOT NULL,
+    updated_at         INTEGER NOT NULL
+);
+
+CREATE INDEX idx_fleet_action_receipt_session
+    ON fleet_action_receipt(session_key, updated_at DESC);

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -1,0 +1,1241 @@
+//! Authoritative Fleet session read model, revision log, and action receipts.
+//!
+//! One transaction applies each normalized provider or discovery event. The
+//! unique event id makes replay idempotent, the database assigns one global
+//! revision, and accepted changes advance the target session's version. State
+//! groups keep separate authority and timestamps so an inferred tmux sample
+//! cannot replace an authoritative provider or hook value.
+
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
+
+/// Authority of one normalized observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservationAuthority {
+    /// Provider RPC or lifecycle hook with exact session identity.
+    Authoritative,
+    /// Tmux, process, or transcript inference.
+    Inferred,
+}
+
+impl ObservationAuthority {
+    /// Stable database token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Authoritative => "authoritative",
+            Self::Inferred => "inferred",
+        }
+    }
+
+    const fn rank(self) -> u8 {
+        match self {
+            Self::Authoritative => 2,
+            Self::Inferred => 1,
+        }
+    }
+
+    fn parse(value: &str) -> Self {
+        if value == "authoritative" {
+            Self::Authoritative
+        } else {
+            Self::Inferred
+        }
+    }
+}
+
+/// Optional changes carried by one normalized Fleet event.
+///
+/// `None` means leave that field unchanged. Optional identity fields are not
+/// cleared by this patch shape. Explicit clearing can be added as a typed action
+/// when a provider supplies a trustworthy detach event.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FleetSessionPatch {
+    /// Provider token, normally `claude`, `codex`, or `unknown`.
+    pub provider: Option<String>,
+    /// Provider-owned stable session id.
+    pub provider_session_id: Option<String>,
+    /// Exact tmux target used for attach and degraded control.
+    pub tmux_target: Option<String>,
+    /// Process start identity paired with a legacy tmux target.
+    pub process_start_fingerprint: Option<String>,
+    /// Current working directory, display and routing metadata only.
+    pub cwd: Option<String>,
+    /// Human-readable session label.
+    pub display_name: Option<String>,
+    /// `MANAGED` or `DEGRADED`.
+    pub management_state: Option<String>,
+    /// Serialized capability object.
+    pub capabilities: Option<String>,
+    /// `HIGH`, `MEDIUM`, or `LOW`.
+    pub confidence: Option<String>,
+    /// Independent lifecycle state.
+    pub lifecycle_state: Option<String>,
+    /// Independent attention state.
+    pub attention_state: Option<String>,
+    /// Exact active request fingerprint. `Some(None)` explicitly clears it.
+    pub current_request_fingerprint: Option<Option<String>>,
+    /// Independent transport health.
+    pub transport_health: Option<String>,
+}
+
+impl FleetSessionPatch {
+    fn has_metadata(&self) -> bool {
+        self.provider.is_some()
+            || self.provider_session_id.is_some()
+            || self.tmux_target.is_some()
+            || self.process_start_fingerprint.is_some()
+            || self.cwd.is_some()
+            || self.display_name.is_some()
+            || self.management_state.is_some()
+            || self.capabilities.is_some()
+            || self.confidence.is_some()
+    }
+}
+
+/// One normalized event to apply to the Fleet read model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewFleetEvent {
+    /// Replay-safe provider or legacy fingerprint.
+    pub event_id: String,
+    /// Stable Fleet identity, never cwd.
+    pub session_key: String,
+    /// Observation time in epoch milliseconds.
+    pub observed_at: i64,
+    /// Whether this event is authoritative or inferred.
+    pub authority: ObservationAuthority,
+    /// Normalized event discriminator.
+    pub event_type: String,
+    /// Serialized raw or normalized event body.
+    pub payload: String,
+    /// Read-model changes derived from the event.
+    pub patch: FleetSessionPatch,
+}
+
+/// Canonical Fleet session row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetSessionRow {
+    /// Stable Fleet identity.
+    pub session_key: String,
+    /// Provider token.
+    pub provider: String,
+    /// Provider-owned session id.
+    pub provider_session_id: Option<String>,
+    /// Exact tmux target.
+    pub tmux_target: Option<String>,
+    /// Legacy process start fingerprint.
+    pub process_start_fingerprint: Option<String>,
+    /// Current working directory metadata.
+    pub cwd: String,
+    /// Human-readable label.
+    pub display_name: Option<String>,
+    /// Lifecycle state token.
+    pub lifecycle_state: String,
+    /// Attention state token.
+    pub attention_state: String,
+    /// Fingerprint of current structured request or approval.
+    pub current_request_fingerprint: Option<String>,
+    /// Managed or degraded token.
+    pub management_state: String,
+    /// Transport health token.
+    pub transport_health: String,
+    /// Serialized capability object.
+    pub capabilities: String,
+    /// Overall provenance of the last accepted change.
+    pub provenance: String,
+    /// Confidence token.
+    pub confidence: String,
+    /// First discovery time.
+    pub discovered_at: i64,
+    /// Last accepted observation time.
+    pub last_observed_at: i64,
+    /// Metadata group timestamp.
+    pub metadata_updated_at: i64,
+    /// Metadata group authority.
+    pub metadata_authority: String,
+    /// Lifecycle group timestamp.
+    pub lifecycle_updated_at: i64,
+    /// Lifecycle group authority.
+    pub lifecycle_authority: String,
+    /// Attention group timestamp.
+    pub attention_updated_at: i64,
+    /// Attention group authority.
+    pub attention_authority: String,
+    /// Transport group timestamp.
+    pub transport_updated_at: i64,
+    /// Transport group authority.
+    pub transport_authority: String,
+    /// Optimistic concurrency version.
+    pub version: i64,
+    /// Revision that last changed this row.
+    pub updated_revision: i64,
+}
+
+/// One durable Fleet change-log row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetEventRow {
+    /// Global monotonic revision.
+    pub revision: i64,
+    /// Replay-safe event identity.
+    pub event_id: String,
+    /// Target session.
+    pub session_key: String,
+    /// Observation time.
+    pub observed_at: i64,
+    /// Authority token.
+    pub authority: String,
+    /// Event discriminator.
+    pub event_type: String,
+    /// Serialized event body.
+    pub payload: String,
+    /// Session version after this event was considered.
+    pub session_version: i64,
+    /// Whether this event changed canonical session state.
+    pub applied: bool,
+}
+
+/// Result of applying or replaying one event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyFleetEventResult {
+    /// Assigned global revision.
+    pub revision: i64,
+    /// Session version after consideration.
+    pub session_version: i64,
+    /// Whether canonical state changed.
+    pub applied: bool,
+    /// True when the same event id had already committed.
+    pub duplicate: bool,
+    /// Current canonical row.
+    pub session: FleetSessionRow,
+}
+
+/// Consistent Fleet snapshot and its global revision head.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetSnapshot {
+    /// Highest committed Fleet event revision.
+    pub head_revision: i64,
+    /// Canonical sessions ordered by stable key.
+    pub sessions: Vec<FleetSessionRow>,
+}
+
+/// Action receipt insert or status update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewActionReceipt {
+    /// Idempotent action request id.
+    pub request_id: String,
+    /// Target session key.
+    pub session_key: String,
+    /// Stable action kind token.
+    pub action_kind: String,
+    /// Stable fingerprint of exact action or structured request payload.
+    pub action_fingerprint: String,
+    /// Session version required when action was accepted.
+    pub expected_version: i64,
+    /// Shared broadcast idempotency key, when action belongs to a broadcast.
+    pub idempotency_key: Option<String>,
+    /// Delivery status token.
+    pub status: String,
+    /// Optional human-readable detail.
+    pub detail: Option<String>,
+    /// Session version observed when delivery completed.
+    pub session_version: Option<i64>,
+    /// First creation time.
+    pub created_at: i64,
+    /// Last status update time.
+    pub updated_at: i64,
+}
+
+/// Durable action receipt row.
+pub type ActionReceiptRow = NewActionReceipt;
+
+/// Fleet repository failure.
+#[derive(Debug, thiserror::Error)]
+pub enum FleetRepoError {
+    /// SQLite query or constraint failure.
+    #[error(transparent)]
+    Sql(#[from] sqlx::Error),
+    /// One event id was reused for a different session.
+    #[error("fleet event id {event_id:?} already belongs to session {existing_session:?}")]
+    EventIdCollision {
+        /// Colliding event id.
+        event_id: String,
+        /// Session that first committed it.
+        existing_session: String,
+    },
+    /// One action request id was reused for a different target or action.
+    #[error("fleet action request id {request_id:?} was reused with different identity")]
+    ReceiptCollision {
+        /// Colliding request id.
+        request_id: String,
+    },
+    /// Action targets a session that does not exist.
+    #[error("fleet session {session_key:?} was not found")]
+    SessionNotFound {
+        /// Missing session key.
+        session_key: String,
+    },
+    /// Action was prepared against an older or future session version.
+    #[error("fleet session {session_key:?} version is {actual}, expected {expected}")]
+    StaleVersion {
+        /// Target session key.
+        session_key: String,
+        /// Version required by caller.
+        expected: i64,
+        /// Current canonical version.
+        actual: i64,
+    },
+    /// Structured action does not match current provider request.
+    #[error("fleet session {session_key:?} request fingerprint does not match")]
+    RequestFingerprintMismatch {
+        /// Target session key.
+        session_key: String,
+    },
+}
+
+/// Stateless typed wrapper over the Fleet tables.
+pub struct FleetRepo;
+
+impl FleetRepo {
+    /// Apply one normalized event atomically.
+    ///
+    /// Duplicate event ids return the original revision without changing state.
+    /// A collision across session keys is rejected. Every new event receives a
+    /// revision, while the session version advances only when canonical state
+    /// changes.
+    pub async fn apply_event(
+        pool: &SqlitePool,
+        event: &NewFleetEvent,
+    ) -> Result<ApplyFleetEventResult, FleetRepoError> {
+        let mut tx = pool.begin().await?;
+
+        if let Some(prior) = event_by_id(&mut tx, &event.event_id).await? {
+            if prior.session_key != event.session_key {
+                return Err(FleetRepoError::EventIdCollision {
+                    event_id: event.event_id.clone(),
+                    existing_session: prior.session_key,
+                });
+            }
+            let session = session_by_key_tx(&mut tx, &event.session_key)
+                .await?
+                .expect("fleet event foreign key must resolve its session");
+            tx.commit().await?;
+            return Ok(ApplyFleetEventResult {
+                revision: prior.revision,
+                session_version: prior.session_version,
+                applied: prior.applied,
+                duplicate: true,
+                session,
+            });
+        }
+
+        let prior = session_by_key_tx(&mut tx, &event.session_key).await?;
+        let is_new = prior.is_none();
+        let (mut session, changed) = match prior {
+            Some(mut row) => {
+                let changed = apply_patch(&mut row, event);
+                if changed {
+                    row.version += 1;
+                    row.last_observed_at = row.last_observed_at.max(event.observed_at);
+                    row.provenance = event.authority.as_str().to_string();
+                }
+                (row, changed)
+            }
+            None => (new_session(event), true),
+        };
+
+        if is_new {
+            insert_session(&mut tx, &session).await?;
+        }
+
+        let revision = sqlx::query(
+            "INSERT INTO fleet_event \
+             (event_id, session_key, observed_at, authority, event_type, payload, \
+              session_version, applied) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&event.event_id)
+        .bind(&event.session_key)
+        .bind(event.observed_at)
+        .bind(event.authority.as_str())
+        .bind(&event.event_type)
+        .bind(&event.payload)
+        .bind(session.version)
+        .bind(i64::from(changed))
+        .execute(&mut *tx)
+        .await?
+        .last_insert_rowid();
+
+        if changed {
+            session.updated_revision = revision;
+            update_session(&mut tx, &session).await?;
+        }
+        tx.commit().await?;
+
+        Ok(ApplyFleetEventResult {
+            revision,
+            session_version: session.version,
+            applied: changed,
+            duplicate: false,
+            session,
+        })
+    }
+
+    /// Hide one inferred duplicate behind its authoritative managed session.
+    /// Event history remains attached to the legacy key and one committed
+    /// revision records the supersession for subscribers.
+    pub async fn supersede_session(
+        pool: &SqlitePool,
+        legacy_key: &str,
+        managed_key: &str,
+        observed_at: i64,
+    ) -> Result<Option<i64>, FleetRepoError> {
+        let event_id = format!("fleet-supersede:{legacy_key}:{managed_key}");
+        let mut tx = pool.begin().await?;
+        if let Some(prior) = event_by_id(&mut tx, &event_id).await? {
+            tx.commit().await?;
+            return Ok(Some(prior.revision));
+        }
+        let version: Option<i64> = sqlx::query_scalar(
+            "SELECT version FROM fleet_session WHERE session_key = ? \
+             AND management_state = 'DEGRADED' AND visible = 1",
+        )
+        .bind(legacy_key)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(version) = version else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+        let managed_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM fleet_session WHERE session_key = ? AND visible = 1)",
+        )
+        .bind(managed_key)
+        .fetch_one(&mut *tx)
+        .await?;
+        if !managed_exists {
+            tx.commit().await?;
+            return Ok(None);
+        }
+        let next_version = version + 1;
+        sqlx::query(
+            "UPDATE fleet_session SET visible = 0, superseded_by = ?, version = ?, \
+             last_observed_at = MAX(last_observed_at, ?) WHERE session_key = ?",
+        )
+        .bind(managed_key)
+        .bind(next_version)
+        .bind(observed_at)
+        .bind(legacy_key)
+        .execute(&mut *tx)
+        .await?;
+        let payload = serde_json::json!({ "supersededBy": managed_key }).to_string();
+        let revision = sqlx::query(
+            "INSERT INTO fleet_event \
+             (event_id, session_key, observed_at, authority, event_type, payload, \
+              session_version, applied) VALUES (?, ?, ?, 'authoritative', \
+              'session_superseded', ?, ?, 1)",
+        )
+        .bind(&event_id)
+        .bind(legacy_key)
+        .bind(observed_at)
+        .bind(payload)
+        .bind(next_version)
+        .execute(&mut *tx)
+        .await?
+        .last_insert_rowid();
+        sqlx::query("UPDATE fleet_session SET updated_revision = ? WHERE session_key = ?")
+            .bind(revision)
+            .bind(legacy_key)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(Some(revision))
+    }
+
+    /// Fetch one canonical session by stable key.
+    pub async fn get_session(
+        pool: &SqlitePool,
+        session_key: &str,
+    ) -> Result<Option<FleetSessionRow>, sqlx::Error> {
+        let row = sqlx::query(SESSION_SELECT_BY_KEY)
+            .bind(session_key)
+            .fetch_optional(pool)
+            .await?;
+        row.as_ref().map(session_from_row).transpose()
+    }
+
+    /// Validate optimistic concurrency and optional structured request identity.
+    pub async fn validate_action_target(
+        pool: &SqlitePool,
+        session_key: &str,
+        expected_version: i64,
+        expected_request_fingerprint: Option<&str>,
+    ) -> Result<FleetSessionRow, FleetRepoError> {
+        let session = Self::get_session(pool, session_key).await?.ok_or_else(|| {
+            FleetRepoError::SessionNotFound {
+                session_key: session_key.to_string(),
+            }
+        })?;
+        if session.version != expected_version {
+            return Err(FleetRepoError::StaleVersion {
+                session_key: session_key.to_string(),
+                expected: expected_version,
+                actual: session.version,
+            });
+        }
+        if expected_request_fingerprint.is_some_and(|expected| {
+            session.current_request_fingerprint.as_deref() != Some(expected)
+        }) {
+            return Err(FleetRepoError::RequestFingerprintMismatch {
+                session_key: session_key.to_string(),
+            });
+        }
+        Ok(session)
+    }
+
+    /// Read a consistent canonical snapshot plus its event-log head.
+    pub async fn snapshot(pool: &SqlitePool) -> Result<FleetSnapshot, sqlx::Error> {
+        let mut tx = pool.begin().await?;
+        let head_revision: i64 =
+            sqlx::query_scalar("SELECT COALESCE(MAX(revision), 0) FROM fleet_event")
+                .fetch_one(&mut *tx)
+                .await?;
+        let rows = sqlx::query(SESSION_SELECT_ALL).fetch_all(&mut *tx).await?;
+        let sessions = rows.iter().map(session_from_row).collect::<Result<_, _>>()?;
+        tx.commit().await?;
+        Ok(FleetSnapshot {
+            head_revision,
+            sessions,
+        })
+    }
+
+    /// Read durable events after a global revision, oldest first.
+    pub async fn events_after(
+        pool: &SqlitePool,
+        after_revision: i64,
+        limit: i64,
+    ) -> Result<Vec<FleetEventRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT revision, event_id, session_key, observed_at, authority, event_type, \
+                    payload, session_version, applied \
+             FROM fleet_event WHERE revision > ? ORDER BY revision ASC LIMIT ?",
+        )
+        .bind(after_revision)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(event_from_row).collect()
+    }
+
+    /// Insert or advance one action receipt.
+    ///
+    /// A repeated request id may update delivery status only when its target and
+    /// action kind match the original receipt.
+    pub async fn upsert_action_receipt(
+        pool: &SqlitePool,
+        receipt: &NewActionReceipt,
+    ) -> Result<ActionReceiptRow, FleetRepoError> {
+        let result = sqlx::query(
+            "INSERT INTO fleet_action_receipt \
+             (request_id, session_key, action_kind, action_fingerprint, expected_version, \
+              idempotency_key, status, detail, session_version, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(request_id) DO UPDATE SET \
+                status = excluded.status, \
+                detail = excluded.detail, \
+                session_version = excluded.session_version, \
+                updated_at = excluded.updated_at \
+             WHERE fleet_action_receipt.session_key = excluded.session_key \
+               AND fleet_action_receipt.action_kind = excluded.action_kind \
+               AND fleet_action_receipt.action_fingerprint = excluded.action_fingerprint \
+               AND fleet_action_receipt.expected_version = excluded.expected_version \
+               AND fleet_action_receipt.idempotency_key IS excluded.idempotency_key",
+        )
+        .bind(&receipt.request_id)
+        .bind(&receipt.session_key)
+        .bind(&receipt.action_kind)
+        .bind(&receipt.action_fingerprint)
+        .bind(receipt.expected_version)
+        .bind(&receipt.idempotency_key)
+        .bind(&receipt.status)
+        .bind(&receipt.detail)
+        .bind(receipt.session_version)
+        .bind(receipt.created_at)
+        .bind(receipt.updated_at)
+        .execute(pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(FleetRepoError::ReceiptCollision {
+                request_id: receipt.request_id.clone(),
+            });
+        }
+        Self::get_action_receipt(pool, &receipt.request_id).await?.ok_or_else(|| {
+            FleetRepoError::ReceiptCollision {
+                request_id: receipt.request_id.clone(),
+            }
+        })
+    }
+
+    /// Fetch one action receipt by request id.
+    pub async fn get_action_receipt(
+        pool: &SqlitePool,
+        request_id: &str,
+    ) -> Result<Option<ActionReceiptRow>, sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT request_id, session_key, action_kind, action_fingerprint, \
+                    expected_version, idempotency_key, status, detail, session_version, \
+                    created_at, updated_at \
+             FROM fleet_action_receipt WHERE request_id = ?",
+        )
+        .bind(request_id)
+        .fetch_optional(pool)
+        .await?;
+        row.as_ref().map(receipt_from_row).transpose()
+    }
+}
+
+const SESSION_SELECT_BY_KEY: &str = "SELECT session_key, provider, provider_session_id, \
+    tmux_target, process_start_fingerprint, cwd, display_name, lifecycle_state, \
+    attention_state, current_request_fingerprint, management_state, transport_health, capabilities, provenance, \
+    confidence, discovered_at, last_observed_at, metadata_updated_at, \
+    metadata_authority, lifecycle_updated_at, lifecycle_authority, \
+    attention_updated_at, attention_authority, transport_updated_at, \
+    transport_authority, version, updated_revision \
+    FROM fleet_session WHERE session_key = ?";
+
+const SESSION_SELECT_ALL: &str = "SELECT session_key, provider, provider_session_id, \
+    tmux_target, process_start_fingerprint, cwd, display_name, lifecycle_state, \
+    attention_state, current_request_fingerprint, management_state, transport_health, capabilities, provenance, \
+    confidence, discovered_at, last_observed_at, metadata_updated_at, \
+    metadata_authority, lifecycle_updated_at, lifecycle_authority, \
+    attention_updated_at, attention_authority, transport_updated_at, \
+    transport_authority, version, updated_revision \
+    FROM fleet_session WHERE visible = 1 ORDER BY session_key ASC";
+
+async fn session_by_key_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    session_key: &str,
+) -> Result<Option<FleetSessionRow>, sqlx::Error> {
+    let row = sqlx::query(SESSION_SELECT_BY_KEY)
+        .bind(session_key)
+        .fetch_optional(&mut **tx)
+        .await?;
+    row.as_ref().map(session_from_row).transpose()
+}
+
+async fn event_by_id(
+    tx: &mut Transaction<'_, Sqlite>,
+    event_id: &str,
+) -> Result<Option<FleetEventRow>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT revision, event_id, session_key, observed_at, authority, event_type, \
+                payload, session_version, applied \
+         FROM fleet_event WHERE event_id = ?",
+    )
+    .bind(event_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    row.as_ref().map(event_from_row).transpose()
+}
+
+fn new_session(event: &NewFleetEvent) -> FleetSessionRow {
+    let authority = event.authority.as_str().to_string();
+    let metadata_at = event.observed_at;
+    let lifecycle_at = event.patch.lifecycle_state.as_ref().map_or(0, |_| event.observed_at);
+    let attention_at = if event.patch.attention_state.is_some()
+        || event.patch.current_request_fingerprint.is_some()
+    {
+        event.observed_at
+    } else {
+        0
+    };
+    let transport_at = event.patch.transport_health.as_ref().map_or(0, |_| event.observed_at);
+    FleetSessionRow {
+        session_key: event.session_key.clone(),
+        provider: event.patch.provider.clone().unwrap_or_else(|| "unknown".to_string()),
+        provider_session_id: event.patch.provider_session_id.clone(),
+        tmux_target: event.patch.tmux_target.clone(),
+        process_start_fingerprint: event.patch.process_start_fingerprint.clone(),
+        cwd: event.patch.cwd.clone().unwrap_or_default(),
+        display_name: event.patch.display_name.clone(),
+        lifecycle_state: event
+            .patch
+            .lifecycle_state
+            .clone()
+            .unwrap_or_else(|| "UNKNOWN".to_string()),
+        attention_state: event.patch.attention_state.clone().unwrap_or_else(|| "NONE".to_string()),
+        current_request_fingerprint: event.patch.current_request_fingerprint.clone().flatten(),
+        management_state: event
+            .patch
+            .management_state
+            .clone()
+            .unwrap_or_else(|| "DEGRADED".to_string()),
+        transport_health: event
+            .patch
+            .transport_health
+            .clone()
+            .unwrap_or_else(|| "UNKNOWN".to_string()),
+        capabilities: event.patch.capabilities.clone().unwrap_or_else(|| "{}".to_string()),
+        provenance: authority.clone(),
+        confidence: event.patch.confidence.clone().unwrap_or_else(|| "LOW".to_string()),
+        discovered_at: event.observed_at,
+        last_observed_at: event.observed_at,
+        metadata_updated_at: metadata_at,
+        metadata_authority: authority.clone(),
+        lifecycle_updated_at: lifecycle_at,
+        lifecycle_authority: if lifecycle_at == 0 {
+            "inferred".to_string()
+        } else {
+            authority.clone()
+        },
+        attention_updated_at: attention_at,
+        attention_authority: if attention_at == 0 {
+            "inferred".to_string()
+        } else {
+            authority.clone()
+        },
+        transport_updated_at: transport_at,
+        transport_authority: if transport_at == 0 {
+            "inferred".to_string()
+        } else {
+            authority
+        },
+        version: 1,
+        updated_revision: 0,
+    }
+}
+
+fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
+    let mut changed = false;
+    let authority = event.authority;
+    let authority_token = authority.as_str().to_string();
+
+    if event.patch.has_metadata()
+        && should_replace(
+            authority,
+            event.observed_at,
+            &row.metadata_authority,
+            row.metadata_updated_at,
+        )
+    {
+        assign_if_some(&mut row.provider, &event.patch.provider);
+        assign_option_if_some(
+            &mut row.provider_session_id,
+            &event.patch.provider_session_id,
+        );
+        assign_option_if_some(&mut row.tmux_target, &event.patch.tmux_target);
+        assign_option_if_some(
+            &mut row.process_start_fingerprint,
+            &event.patch.process_start_fingerprint,
+        );
+        assign_if_some(&mut row.cwd, &event.patch.cwd);
+        assign_option_if_some(&mut row.display_name, &event.patch.display_name);
+        assign_if_some(&mut row.management_state, &event.patch.management_state);
+        assign_if_some(&mut row.capabilities, &event.patch.capabilities);
+        assign_if_some(&mut row.confidence, &event.patch.confidence);
+        row.metadata_updated_at = event.observed_at;
+        row.metadata_authority.clone_from(&authority_token);
+        changed = true;
+    }
+
+    if let Some(state) = &event.patch.lifecycle_state {
+        if should_replace(
+            authority,
+            event.observed_at,
+            &row.lifecycle_authority,
+            row.lifecycle_updated_at,
+        ) {
+            row.lifecycle_state.clone_from(state);
+            row.lifecycle_updated_at = event.observed_at;
+            row.lifecycle_authority.clone_from(&authority_token);
+            changed = true;
+        }
+    }
+
+    if event.patch.attention_state.is_some() || event.patch.current_request_fingerprint.is_some() {
+        if should_replace(
+            authority,
+            event.observed_at,
+            &row.attention_authority,
+            row.attention_updated_at,
+        ) {
+            assign_if_some(&mut row.attention_state, &event.patch.attention_state);
+            if let Some(fingerprint) = &event.patch.current_request_fingerprint {
+                row.current_request_fingerprint.clone_from(fingerprint);
+            }
+            row.attention_updated_at = event.observed_at;
+            row.attention_authority.clone_from(&authority_token);
+            changed = true;
+        }
+    }
+
+    if let Some(health) = &event.patch.transport_health {
+        if should_replace(
+            authority,
+            event.observed_at,
+            &row.transport_authority,
+            row.transport_updated_at,
+        ) {
+            row.transport_health.clone_from(health);
+            row.transport_updated_at = event.observed_at;
+            row.transport_authority = authority_token;
+            changed = true;
+        }
+    }
+
+    changed
+}
+
+fn should_replace(
+    incoming: ObservationAuthority,
+    observed_at: i64,
+    stored_authority: &str,
+    stored_at: i64,
+) -> bool {
+    let stored = ObservationAuthority::parse(stored_authority);
+    incoming.rank() > stored.rank()
+        || (incoming.rank() == stored.rank() && observed_at >= stored_at)
+}
+
+fn assign_if_some(target: &mut String, value: &Option<String>) {
+    if let Some(value) = value {
+        target.clone_from(value);
+    }
+}
+
+fn assign_option_if_some(target: &mut Option<String>, value: &Option<String>) {
+    if let Some(value) = value {
+        *target = Some(value.clone());
+    }
+}
+
+async fn insert_session(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &FleetSessionRow,
+) -> Result<(), sqlx::Error> {
+    let query = sqlx::query(
+        "INSERT INTO fleet_session (session_key, provider, provider_session_id, \
+            tmux_target, process_start_fingerprint, cwd, display_name, lifecycle_state, \
+            attention_state, current_request_fingerprint, management_state, transport_health, capabilities, provenance, \
+            confidence, discovered_at, last_observed_at, metadata_updated_at, \
+            metadata_authority, lifecycle_updated_at, lifecycle_authority, \
+            attention_updated_at, attention_authority, transport_updated_at, \
+            transport_authority, version, updated_revision) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    );
+    bind_session(query, row).execute(&mut **tx).await?;
+    Ok(())
+}
+
+async fn update_session(
+    tx: &mut Transaction<'_, Sqlite>,
+    row: &FleetSessionRow,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE fleet_session SET \
+            provider = ?, provider_session_id = ?, tmux_target = ?, \
+            process_start_fingerprint = ?, cwd = ?, display_name = ?, \
+            lifecycle_state = ?, attention_state = ?, current_request_fingerprint = ?, management_state = ?, \
+            transport_health = ?, capabilities = ?, provenance = ?, confidence = ?, \
+            discovered_at = ?, last_observed_at = ?, metadata_updated_at = ?, \
+            metadata_authority = ?, lifecycle_updated_at = ?, lifecycle_authority = ?, \
+            attention_updated_at = ?, attention_authority = ?, transport_updated_at = ?, \
+            transport_authority = ?, version = ?, updated_revision = ? \
+         WHERE session_key = ?",
+    )
+    .bind(&row.provider)
+    .bind(&row.provider_session_id)
+    .bind(&row.tmux_target)
+    .bind(&row.process_start_fingerprint)
+    .bind(&row.cwd)
+    .bind(&row.display_name)
+    .bind(&row.lifecycle_state)
+    .bind(&row.attention_state)
+    .bind(&row.current_request_fingerprint)
+    .bind(&row.management_state)
+    .bind(&row.transport_health)
+    .bind(&row.capabilities)
+    .bind(&row.provenance)
+    .bind(&row.confidence)
+    .bind(row.discovered_at)
+    .bind(row.last_observed_at)
+    .bind(row.metadata_updated_at)
+    .bind(&row.metadata_authority)
+    .bind(row.lifecycle_updated_at)
+    .bind(&row.lifecycle_authority)
+    .bind(row.attention_updated_at)
+    .bind(&row.attention_authority)
+    .bind(row.transport_updated_at)
+    .bind(&row.transport_authority)
+    .bind(row.version)
+    .bind(row.updated_revision)
+    .bind(&row.session_key)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+fn bind_session<'q>(
+    query: sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    row: &'q FleetSessionRow,
+) -> sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
+    query
+        .bind(&row.session_key)
+        .bind(&row.provider)
+        .bind(&row.provider_session_id)
+        .bind(&row.tmux_target)
+        .bind(&row.process_start_fingerprint)
+        .bind(&row.cwd)
+        .bind(&row.display_name)
+        .bind(&row.lifecycle_state)
+        .bind(&row.attention_state)
+        .bind(&row.current_request_fingerprint)
+        .bind(&row.management_state)
+        .bind(&row.transport_health)
+        .bind(&row.capabilities)
+        .bind(&row.provenance)
+        .bind(&row.confidence)
+        .bind(row.discovered_at)
+        .bind(row.last_observed_at)
+        .bind(row.metadata_updated_at)
+        .bind(&row.metadata_authority)
+        .bind(row.lifecycle_updated_at)
+        .bind(&row.lifecycle_authority)
+        .bind(row.attention_updated_at)
+        .bind(&row.attention_authority)
+        .bind(row.transport_updated_at)
+        .bind(&row.transport_authority)
+        .bind(row.version)
+        .bind(row.updated_revision)
+}
+
+fn session_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetSessionRow, sqlx::Error> {
+    Ok(FleetSessionRow {
+        session_key: row.try_get("session_key")?,
+        provider: row.try_get("provider")?,
+        provider_session_id: row.try_get("provider_session_id")?,
+        tmux_target: row.try_get("tmux_target")?,
+        process_start_fingerprint: row.try_get("process_start_fingerprint")?,
+        cwd: row.try_get("cwd")?,
+        display_name: row.try_get("display_name")?,
+        lifecycle_state: row.try_get("lifecycle_state")?,
+        attention_state: row.try_get("attention_state")?,
+        current_request_fingerprint: row.try_get("current_request_fingerprint")?,
+        management_state: row.try_get("management_state")?,
+        transport_health: row.try_get("transport_health")?,
+        capabilities: row.try_get("capabilities")?,
+        provenance: row.try_get("provenance")?,
+        confidence: row.try_get("confidence")?,
+        discovered_at: row.try_get("discovered_at")?,
+        last_observed_at: row.try_get("last_observed_at")?,
+        metadata_updated_at: row.try_get("metadata_updated_at")?,
+        metadata_authority: row.try_get("metadata_authority")?,
+        lifecycle_updated_at: row.try_get("lifecycle_updated_at")?,
+        lifecycle_authority: row.try_get("lifecycle_authority")?,
+        attention_updated_at: row.try_get("attention_updated_at")?,
+        attention_authority: row.try_get("attention_authority")?,
+        transport_updated_at: row.try_get("transport_updated_at")?,
+        transport_authority: row.try_get("transport_authority")?,
+        version: row.try_get("version")?,
+        updated_revision: row.try_get("updated_revision")?,
+    })
+}
+
+fn event_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetEventRow, sqlx::Error> {
+    Ok(FleetEventRow {
+        revision: row.try_get("revision")?,
+        event_id: row.try_get("event_id")?,
+        session_key: row.try_get("session_key")?,
+        observed_at: row.try_get("observed_at")?,
+        authority: row.try_get("authority")?,
+        event_type: row.try_get("event_type")?,
+        payload: row.try_get("payload")?,
+        session_version: row.try_get("session_version")?,
+        applied: row.try_get::<i64, _>("applied")? != 0,
+    })
+}
+
+fn receipt_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<ActionReceiptRow, sqlx::Error> {
+    Ok(ActionReceiptRow {
+        request_id: row.try_get("request_id")?,
+        session_key: row.try_get("session_key")?,
+        action_kind: row.try_get("action_kind")?,
+        action_fingerprint: row.try_get("action_fingerprint")?,
+        expected_version: row.try_get("expected_version")?,
+        idempotency_key: row.try_get("idempotency_key")?,
+        status: row.try_get("status")?,
+        detail: row.try_get("detail")?,
+        session_version: row.try_get("session_version")?,
+        created_at: row.try_get("created_at")?,
+        updated_at: row.try_get("updated_at")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    fn event(
+        event_id: &str,
+        session_key: &str,
+        at: i64,
+        authority: ObservationAuthority,
+        patch: FleetSessionPatch,
+    ) -> NewFleetEvent {
+        NewFleetEvent {
+            event_id: event_id.to_string(),
+            session_key: session_key.to_string(),
+            observed_at: at,
+            authority,
+            event_type: "observation".to_string(),
+            payload: "{}".to_string(),
+            patch,
+        }
+    }
+
+    async fn store() -> (tempfile::TempDir, Store) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        (dir, store)
+    }
+
+    #[tokio::test]
+    async fn duplicate_event_is_idempotent() {
+        let (_dir, store) = store().await;
+        let input = event(
+            "e-1",
+            "claude:s-1",
+            100,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                lifecycle_state: Some("RUNNING".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        let first = FleetRepo::apply_event(store.pool(), &input).await.unwrap();
+        let replay = FleetRepo::apply_event(store.pool(), &input).await.unwrap();
+
+        assert!(!first.duplicate);
+        assert!(replay.duplicate);
+        assert_eq!(replay.revision, first.revision);
+        assert_eq!(replay.session_version, first.session_version);
+        assert_eq!(
+            FleetRepo::events_after(store.pool(), 0, 100).await.unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_and_attention_advance_independently() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-life",
+                "claude:s-1",
+                100,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    lifecycle_state: Some("RUNNING".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+        let result = FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-attn",
+                "claude:s-1",
+                200,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    attention_state: Some("ASK".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.session.lifecycle_state, "RUNNING");
+        assert_eq!(result.session.lifecycle_updated_at, 100);
+        assert_eq!(result.session.attention_state, "ASK");
+        assert_eq!(result.session.attention_updated_at, 200);
+        assert_eq!(result.session.version, 2);
+    }
+
+    #[tokio::test]
+    async fn inferred_event_never_overwrites_authoritative_group() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-auth",
+                "codex:s-1",
+                100,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    lifecycle_state: Some("RUNNING".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+        let inferred = FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-inferred",
+                "codex:s-1",
+                1_000,
+                ObservationAuthority::Inferred,
+                FleetSessionPatch {
+                    lifecycle_state: Some("EXITED".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert!(!inferred.applied);
+        assert_eq!(inferred.session.lifecycle_state, "RUNNING");
+        assert_eq!(inferred.session.version, 1);
+        assert_eq!(
+            FleetRepo::events_after(store.pool(), 0, 100).await.unwrap().len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn same_cwd_sessions_stay_distinct() {
+        let (_dir, store) = store().await;
+        for (event_id, key, provider) in [
+            ("e-claude", "claude:same", "claude"),
+            ("e-codex", "codex:same", "codex"),
+        ] {
+            FleetRepo::apply_event(
+                store.pool(),
+                &event(
+                    event_id,
+                    key,
+                    100,
+                    ObservationAuthority::Authoritative,
+                    FleetSessionPatch {
+                        provider: Some(provider.to_string()),
+                        cwd: Some("/same/repo".to_string()),
+                        ..FleetSessionPatch::default()
+                    },
+                ),
+            )
+            .await
+            .unwrap();
+        }
+        let snapshot = FleetRepo::snapshot(store.pool()).await.unwrap();
+        assert_eq!(snapshot.sessions.len(), 2);
+        assert_eq!(snapshot.sessions[0].session_key, "claude:same");
+        assert_eq!(snapshot.sessions[1].session_key, "codex:same");
+        assert_eq!(snapshot.head_revision, 2);
+    }
+
+    #[tokio::test]
+    async fn action_receipt_updates_status_but_rejects_identity_collision() {
+        let (_dir, store) = store().await;
+        let mut receipt = NewActionReceipt {
+            request_id: "req-1".to_string(),
+            session_key: "claude:s-1".to_string(),
+            action_kind: "send_prompt".to_string(),
+            action_fingerprint: "sha256:prompt".to_string(),
+            expected_version: 1,
+            idempotency_key: None,
+            status: "PENDING".to_string(),
+            detail: None,
+            session_version: Some(1),
+            created_at: 100,
+            updated_at: 100,
+        };
+        FleetRepo::upsert_action_receipt(store.pool(), &receipt).await.unwrap();
+        receipt.status = "DELIVERED".to_string();
+        receipt.updated_at = 200;
+        let delivered = FleetRepo::upsert_action_receipt(store.pool(), &receipt).await.unwrap();
+        assert_eq!(delivered.status, "DELIVERED");
+        assert_eq!(delivered.created_at, 100);
+
+        receipt.session_key = "codex:other".to_string();
+        assert!(matches!(
+            FleetRepo::upsert_action_receipt(store.pool(), &receipt).await,
+            Err(FleetRepoError::ReceiptCollision { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn action_target_requires_current_version_and_request_fingerprint() {
+        let (_dir, store) = store().await;
+        let created = FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-request",
+                "claude:s-1",
+                100,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    attention_state: Some("ASK".to_string()),
+                    current_request_fingerprint: Some(Some("sha256:request".to_string())),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        FleetRepo::validate_action_target(
+            store.pool(),
+            "claude:s-1",
+            created.session_version,
+            Some("sha256:request"),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            FleetRepo::validate_action_target(
+                store.pool(),
+                "claude:s-1",
+                created.session_version + 1,
+                Some("sha256:request"),
+            )
+            .await,
+            Err(FleetRepoError::StaleVersion { .. })
+        ));
+        assert!(matches!(
+            FleetRepo::validate_action_target(
+                store.pool(),
+                "claude:s-1",
+                created.session_version,
+                Some("sha256:other"),
+            )
+            .await,
+            Err(FleetRepoError::RequestFingerprintMismatch { .. })
+        ));
+
+        let cleared = FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-clear-request",
+                "claude:s-1",
+                200,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    attention_state: Some("NONE".to_string()),
+                    current_request_fingerprint: Some(None),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(cleared.session.attention_state, "NONE");
+        assert_eq!(cleared.session.current_request_fingerprint, None);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
@@ -19,6 +19,7 @@ pub mod card_parity;
 pub mod comment;
 pub mod daemon_config;
 pub mod event_log;
+pub mod fleet;
 pub mod inbox;
 pub mod issue;
 pub mod label;

--- a/ainb-tui/crates/ainb-plugin-hangar/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-hangar/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
 # P5.6: the first-run danger-full-access flow reads/writes the `warnings_ack`
 # array of `~/.agents-in-a-box/hangar/state.toml`, preserving foreign keys (TOML round-trip).
 toml = { workspace = true }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -42,7 +42,7 @@ const ACTIVE_TAB_BG: Color = Color::rgb(40, 40, 60);
 /// `Autopilots` shifted down to `3`/`4` to close the hole (e38.38). `Issues`/`Task`
 /// keep their `1`/`2` muscle memory; only the two tabs that sat past the removed
 /// `Agents` slot renumber, and only by one.
-const PRIMARY_TABS: [(char, &str); 14] = [
+const PRIMARY_TABS: [(char, &str); 15] = [
     ('1', "Issues"),
     ('2', "Task"),
     ('3', "Skills"),
@@ -54,6 +54,7 @@ const PRIMARY_TABS: [(char, &str); 14] = [
     ('L', "Logs"),
     ('I', "Inbox"),
     ('C', "Control"),
+    ('F', "Fleet"),
     ('S', "Squads"),
     ('P', "Profiles"),
     (',', "Settings"),
@@ -196,6 +197,12 @@ fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)> {
         // The control center: navigate sessions + answer an ASK inline (P2). The
         // option / number-key answer hints render in the body next to the options.
         Screen::ControlCenter => vec![("j/k", "sessions"), ("enter", "answer")],
+        Screen::Fleet => vec![
+            ("j/k", "sessions"),
+            ("b", "broadcast"),
+            ("→/A", "attach"),
+            ("s/r", "stop/restart"),
+        ],
         // The squads screen: create a squad + edit membership + assign an issue
         // (P7). The `[c]/[a]/[d]/[x]` hints also render on the screen header row.
         Screen::Squads => vec![
@@ -241,6 +248,7 @@ const fn tab_is_active(active: &Screen, hotkey: char) -> bool {
         'L' => matches!(active, Screen::Logs),
         'I' => matches!(active, Screen::Inbox),
         'C' => matches!(active, Screen::ControlCenter),
+        'F' => matches!(active, Screen::Fleet),
         'S' => matches!(active, Screen::Squads),
         'P' => matches!(active, Screen::Profiles),
         ',' => matches!(active, Screen::Settings),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -238,6 +238,14 @@ const ISSUE_DELETE_REQ_ID: i64 = 53;
 /// run(s) & delete"). On success the plugin retries the `issue_delete`; an error
 /// surfaces as a transient issue-list note.
 const ISSUE_CANCEL_ACTIVE_REQ_ID: i64 = 54;
+/// Authoritative Fleet registry snapshot.
+const FLEET_SNAPSHOT_REQ_ID: i64 = 55;
+/// Gapless Fleet revision subscription.
+const FLEET_SUBSCRIBE_REQ_ID: i64 = 56;
+/// One versioned Fleet control action.
+const FLEET_ACTION_REQ_ID: i64 = 57;
+/// Explicit-recipient Fleet broadcast.
+const FLEET_BROADCAST_REQ_ID: i64 = 58;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -266,6 +274,11 @@ pub struct HangarPlugin {
     /// Set when a subscribe ack just arrived, so `handle_event` knows to fire
     /// the snapshot fetches (it has the `host` the sync decode path lacks).
     fetch_pending: bool,
+    /// A Fleet event or lag notification requested a focused snapshot refresh.
+    fleet_fetch_pending: bool,
+    /// The workspace handshake or a lag notification requested a new gapless
+    /// Fleet subscription.
+    fleet_subscribe_pending: bool,
     /// The first-run danger-full-access modal (P5.6). `Showing` over the landing
     /// screen on a fresh machine until the user accepts (`y`), then `Dismissed`.
     /// Initialised from the recorded `warnings_ack` on `plugin/init`.
@@ -442,6 +455,67 @@ fn now_ms_clock() -> i64 {
         .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
 }
 
+/// Open an exact tmux target in a popup owned by the current tmux client.
+/// Closing the nested client restores the unchanged Fleet pane state.
+fn launch_fleet_tmux_popup(target: &str, fullscreen: bool) -> std::io::Result<()> {
+    if std::env::var_os("TMUX").is_none() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "Fleet attach requires tmux host",
+        ));
+    }
+    let width = if fullscreen { "100%" } else { "90%" };
+    let height = if fullscreen { "100%" } else { "90%" };
+    let command = fleet_tmux_attach_command(target);
+    std::process::Command::new("tmux")
+        .args(["display-popup", "-E", "-w", width, "-h", height, &command])
+        .spawn()
+        .map(|_| ())
+}
+
+fn fleet_tmux_attach_command(target: &str) -> String {
+    let quoted_target = shell_quote(target);
+    let session = target.split_once(':').map_or(target, |(session, _)| session);
+    let quoted_session = shell_quote(session);
+    if target.contains(':') {
+        format!(
+            "tmux select-window -t {quoted_target} && tmux select-pane -t {quoted_target} && exec env -u TMUX tmux attach-session -t {quoted_session}"
+        )
+    } else {
+        format!("exec env -u TMUX tmux attach-session -t {quoted_session}")
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn fleet_request_id(kind: &str) -> String {
+    format!("fleet-ui-{kind}-{}", uuid::Uuid::new_v4())
+}
+
+fn fleet_start_params(
+    provider: ainb_hangar_proto::fleet::FleetProvider,
+    cwd: String,
+    prompt: Option<String>,
+) -> ainb_hangar_proto::fleet::FleetActionParams {
+    let session_key = match provider {
+        ainb_hangar_proto::fleet::FleetProvider::Codex => "start:codex",
+        ainb_hangar_proto::fleet::FleetProvider::Claude => "start:claude",
+        ainb_hangar_proto::fleet::FleetProvider::Unknown => "start:unknown",
+    };
+    ainb_hangar_proto::fleet::FleetActionParams {
+        session_key: session_key.to_string(),
+        expected_version: 1,
+        request_id: fleet_request_id("start"),
+        action: ainb_hangar_proto::fleet::ControlAction::Start {
+            provider,
+            cwd,
+            prompt,
+        },
+    }
+}
+
 impl Default for HangarPlugin {
     fn default() -> Self {
         Self {
@@ -450,6 +524,8 @@ impl Default for HangarPlugin {
             app: None,
             screens: ScreenStates::default(),
             fetch_pending: false,
+            fleet_fetch_pending: false,
+            fleet_subscribe_pending: false,
             first_run: FirstRunModal::default(),
             first_run_ack_pending: false,
             pending_detail_slug: None,
@@ -660,6 +736,8 @@ impl HangarPlugin {
     /// crashing the plugin.
     async fn connect(&mut self, host: &HostClient) {
         self.decoder = FrameDecoder::new();
+        self.fleet_subscribe_pending = false;
+        self.fleet_fetch_pending = false;
         self.conn.dialing();
 
         let dial = match host.unix_socket_dial(daemon_socket_path()).await {
@@ -782,7 +860,26 @@ impl HangarPlugin {
     /// next snapshot re-pull reconciles. Keeps the link `Connected`.
     fn on_daemon_event(&mut self, value: &serde_json::Value) {
         use ainb_hangar_proto::events::EVENT_METHOD;
-        if value.get("method").and_then(serde_json::Value::as_str) != Some(EVENT_METHOD) {
+        let method = value.get("method").and_then(serde_json::Value::as_str);
+        if method == Some("fleet/event") {
+            if let Some(params) = value.get("params") {
+                if let Ok(event) =
+                    serde_json::from_value::<ainb_hangar_proto::fleet::FleetEvent>(params.clone())
+                {
+                    self.screens.fleet.observe_revision(event.revision);
+                    self.fleet_fetch_pending = true;
+                    self.conn.on_event();
+                }
+            }
+            return;
+        }
+        if method == Some("fleet/resync_required") {
+            self.fleet_fetch_pending = true;
+            self.fleet_subscribe_pending = true;
+            self.conn.on_event();
+            return;
+        }
+        if method != Some(EVENT_METHOD) {
             return;
         }
         let Some(params) = value.get("params") else {
@@ -853,6 +950,8 @@ impl HangarPlugin {
                 } else {
                     self.conn.on_subscribe_ack();
                     self.fetch_pending = true;
+                    self.fleet_fetch_pending = true;
+                    self.fleet_subscribe_pending = true;
                 }
             }
             RpcId::Number(ISSUES_REQ_ID) => self.apply_issues(resp),
@@ -952,6 +1051,10 @@ impl HangarPlugin {
             // The attention/subscribe ack carries the open-attention snapshot that
             // seeds the control-center board.
             RpcId::Number(ATTENTION_SUBSCRIBE_REQ_ID) => self.apply_attention(resp),
+            RpcId::Number(FLEET_SNAPSHOT_REQ_ID) => self.apply_fleet_snapshot(resp),
+            RpcId::Number(FLEET_SUBSCRIBE_REQ_ID) => self.apply_fleet_subscription(resp),
+            RpcId::Number(FLEET_ACTION_REQ_ID) => self.apply_fleet_action_result(resp),
+            RpcId::Number(FLEET_BROADCAST_REQ_ID) => self.apply_fleet_broadcast_result(resp),
             RpcId::Number(SEARCH_REQ_ID) => self.apply_search(resp),
             // P5: the profile-editor roster + the per-selection detail/previews.
             RpcId::Number(PROFILE_LIST_REQ_ID) => self.apply_profiles(resp),
@@ -1752,6 +1855,138 @@ impl HangarPlugin {
         }
     }
 
+    /// Replace Fleet pane rows from one authoritative snapshot while preserving
+    /// selection by stable session key.
+    fn apply_fleet_snapshot(&mut self, resp: &RpcResponse) {
+        let Some(result) = &resp.result else {
+            return;
+        };
+        let Ok(snapshot) =
+            serde_json::from_value::<ainb_hangar_proto::fleet::FleetSnapshot>(result.clone())
+        else {
+            return;
+        };
+        let rows = snapshot.sessions.into_iter().map(Into::into).collect();
+        self.screens.fleet.apply_snapshot(snapshot.head_revision, rows);
+        self.conn.on_event();
+    }
+
+    /// Seed Fleet from the race-free subscribe acknowledgement, then record all
+    /// replay revisions. Live events trigger focused snapshot reconciliation.
+    fn apply_fleet_subscription(&mut self, resp: &RpcResponse) {
+        if let Some(error) = &resp.error {
+            let out = crate::screen::fleet::reduce_fleet(
+                &self.screens.fleet,
+                crate::screen::fleet::FleetEvent::ActionFailed {
+                    session_key: "fleet".into(),
+                    detail: format!("subscribe failed: {}", error.message),
+                },
+            );
+            self.screens.fleet = out.state;
+            return;
+        }
+        let Some(result) = &resp.result else {
+            return;
+        };
+        let Ok(subscription) = serde_json::from_value::<
+            ainb_hangar_proto::fleet::FleetSubscribeResult,
+        >(result.clone()) else {
+            return;
+        };
+        let rows = subscription.snapshot.sessions.into_iter().map(Into::into).collect();
+        self.screens.fleet.apply_snapshot(subscription.snapshot.head_revision, rows);
+        for event in subscription.replay {
+            self.screens.fleet.observe_revision(event.revision);
+        }
+        self.conn.on_event();
+    }
+
+    fn apply_fleet_action_result(&mut self, resp: &RpcResponse) {
+        use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetActionResult};
+        let result = resp
+            .result
+            .as_ref()
+            .and_then(|value| serde_json::from_value::<FleetActionResult>(value.clone()).ok());
+        let event = match (result, &resp.error) {
+            (Some(result), _) if result.receipt.status == ActionReceiptStatus::Delivered => {
+                crate::screen::fleet::FleetEvent::ActionSucceeded {
+                    session_key: result.receipt.session_key,
+                }
+            }
+            (Some(result), _) => crate::screen::fleet::FleetEvent::ActionFailed {
+                session_key: result.receipt.session_key,
+                detail: result
+                    .receipt
+                    .detail
+                    .unwrap_or_else(|| format!("{:?}", result.receipt.status)),
+            },
+            (None, Some(error)) => crate::screen::fleet::FleetEvent::ActionFailed {
+                session_key: "fleet".into(),
+                detail: error.message.clone(),
+            },
+            (None, None) => return,
+        };
+        let out = crate::screen::fleet::reduce_fleet(&self.screens.fleet, event);
+        self.screens.fleet = out.state;
+        self.fleet_fetch_pending = true;
+        self.conn.on_event();
+    }
+
+    fn apply_fleet_broadcast_result(&mut self, resp: &RpcResponse) {
+        use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetBroadcastResult};
+        if let Some(error) = &resp.error {
+            let out = crate::screen::fleet::reduce_fleet(
+                &self.screens.fleet,
+                crate::screen::fleet::FleetEvent::BroadcastFailed {
+                    detail: error.message.clone(),
+                },
+            );
+            self.screens.fleet = out.state;
+            self.conn.on_event();
+            return;
+        }
+        let Some(result) = resp
+            .result
+            .as_ref()
+            .and_then(|value| serde_json::from_value::<FleetBroadcastResult>(value.clone()).ok())
+        else {
+            let out = crate::screen::fleet::reduce_fleet(
+                &self.screens.fleet,
+                crate::screen::fleet::FleetEvent::BroadcastFailed {
+                    detail: "invalid fleet/broadcast response".into(),
+                },
+            );
+            self.screens.fleet = out.state;
+            self.conn.on_event();
+            return;
+        };
+        let receipts = result
+            .receipts
+            .into_iter()
+            .map(|receipt| crate::screen::fleet::BroadcastReceipt {
+                session_key: receipt.session_key,
+                status: match receipt.status {
+                    ActionReceiptStatus::Delivered => {
+                        crate::screen::fleet::ReceiptStatus::Delivered
+                    }
+                    ActionReceiptStatus::Failed | ActionReceiptStatus::Rejected => {
+                        crate::screen::fleet::ReceiptStatus::Failed
+                    }
+                    ActionReceiptStatus::Pending | ActionReceiptStatus::Unknown => {
+                        crate::screen::fleet::ReceiptStatus::Unknown
+                    }
+                },
+                detail: receipt.detail,
+            })
+            .collect();
+        let out = crate::screen::fleet::reduce_fleet(
+            &self.screens.fleet,
+            crate::screen::fleet::FleetEvent::BroadcastReceipts(receipts),
+        );
+        self.screens.fleet = out.state;
+        self.conn.on_event();
+    }
+
     /// Fire every `hangar/*` snapshot request over the daemon stream, framed for
     /// the cap (one per landing screen — issues, agents, skills, autopilots,
     /// tasks, daemon-health, usage, members, health). A send failure is logged but
@@ -1872,6 +2107,192 @@ impl HangarPlugin {
                 let _ = host.log_info(format!("hangar: snapshot send failed: {e}")).await;
             }
         }
+    }
+
+    async fn fetch_fleet_snapshot(&mut self, host: &HostClient) {
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            return;
+        };
+        let Ok(body) = encode_request(
+            FLEET_SNAPSHOT_REQ_ID,
+            daemon_methods::FLEET_SNAPSHOT,
+            serde_json::json!({}),
+        ) else {
+            return;
+        };
+        if let Err(error) = host.unix_socket_send(stream_id, body).await {
+            let _ = host.log_info(format!("hangar: fleet snapshot send failed: {error}")).await;
+        }
+    }
+
+    async fn subscribe_fleet(&mut self, host: &HostClient) {
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            return;
+        };
+        let Ok(body) = encode_request(
+            FLEET_SUBSCRIBE_REQ_ID,
+            daemon_methods::FLEET_SUBSCRIBE,
+            serde_json::json!({ "after_revision": self.screens.fleet.head_revision() }),
+        ) else {
+            return;
+        };
+        if let Err(error) = host.unix_socket_send(stream_id, body).await {
+            let _ = host.log_info(format!("hangar: fleet subscribe send failed: {error}")).await;
+        }
+    }
+
+    async fn apply_fleet_intent(
+        &mut self,
+        host: &HostClient,
+        intent: crate::screen::fleet::FleetIntent,
+    ) {
+        use crate::screen::fleet::{FleetEvent, FleetIntent, reduce_fleet};
+        match intent {
+            FleetIntent::Execute {
+                session_key,
+                expected_version,
+                action,
+            } => {
+                if Self::is_offline(self.conn.state()) && action.is_high_risk() {
+                    let out = reduce_fleet(
+                        &self.screens.fleet,
+                        FleetEvent::ActionFailed {
+                            session_key,
+                            detail: "daemon unavailable; high-risk action disabled".into(),
+                        },
+                    );
+                    self.screens.fleet = out.state;
+                    return;
+                }
+                let action = match self.fleet_control_action(&session_key, action) {
+                    Ok(action) => action,
+                    Err(detail) => {
+                        let out = reduce_fleet(
+                            &self.screens.fleet,
+                            FleetEvent::ActionFailed {
+                                session_key,
+                                detail,
+                            },
+                        );
+                        self.screens.fleet = out.state;
+                        return;
+                    }
+                };
+                let request_id = fleet_request_id("action");
+                let params = ainb_hangar_proto::fleet::FleetActionParams {
+                    session_key: session_key.clone(),
+                    expected_version,
+                    request_id,
+                    action,
+                };
+                self.send_fleet_rpc(
+                    host,
+                    FLEET_ACTION_REQ_ID,
+                    daemon_methods::FLEET_ACTION,
+                    params,
+                    &session_key,
+                )
+                .await;
+            }
+            FleetIntent::Broadcast {
+                text,
+                recipient_keys,
+                idempotency_key,
+                max_parallel: _,
+                retry_failures_only: _,
+            } => {
+                let params = ainb_hangar_proto::fleet::FleetBroadcastParams {
+                    target_keys: recipient_keys,
+                    text,
+                    idempotency_key,
+                };
+                self.send_fleet_rpc(
+                    host,
+                    FLEET_BROADCAST_REQ_ID,
+                    daemon_methods::FLEET_BROADCAST,
+                    params,
+                    "broadcast",
+                )
+                .await;
+            }
+            FleetIntent::Start {
+                provider,
+                cwd,
+                prompt,
+            } => {
+                let params = fleet_start_params(provider, cwd, prompt);
+                let target = params.session_key.clone();
+                self.send_fleet_rpc(
+                    host,
+                    FLEET_ACTION_REQ_ID,
+                    daemon_methods::FLEET_ACTION,
+                    params,
+                    &target,
+                )
+                .await;
+            }
+            FleetIntent::AttachEmbedded {
+                session_key,
+                tmux_target,
+            } => self.apply_fleet_attach(session_key, tmux_target, false),
+            FleetIntent::AttachFullscreen {
+                session_key,
+                tmux_target,
+            } => self.apply_fleet_attach(session_key, tmux_target, true),
+        }
+    }
+
+    fn fleet_control_action(
+        &self,
+        _session_key: &str,
+        action: crate::screen::fleet::FleetAction,
+    ) -> std::result::Result<ainb_hangar_proto::fleet::ControlAction, String> {
+        action.into_control_action()
+    }
+
+    async fn send_fleet_rpc<T: serde::Serialize>(
+        &mut self,
+        host: &HostClient,
+        id: i64,
+        method: &str,
+        params: T,
+        target: &str,
+    ) {
+        use crate::screen::fleet::{FleetEvent, reduce_fleet};
+        let send_result = async {
+            let stream_id = self
+                .conn
+                .stream_id()
+                .map(ToString::to_string)
+                .ok_or_else(|| "daemon unavailable".to_string())?;
+            let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
+            let body = encode_request(id, method, params).map_err(|error| error.to_string())?;
+            host.unix_socket_send(stream_id, body).await.map_err(|error| error.to_string())
+        }
+        .await;
+        if let Err(detail) = send_result {
+            let event = if method == daemon_methods::FLEET_BROADCAST {
+                FleetEvent::BroadcastFailed { detail }
+            } else {
+                FleetEvent::ActionFailed {
+                    session_key: target.to_string(),
+                    detail,
+                }
+            };
+            let out = reduce_fleet(&self.screens.fleet, event);
+            self.screens.fleet = out.state;
+        }
+    }
+
+    fn apply_fleet_attach(&mut self, session_key: String, tmux_target: String, fullscreen: bool) {
+        use crate::screen::fleet::{FleetEvent, reduce_fleet};
+        let result = launch_fleet_tmux_popup(&tmux_target, fullscreen);
+        let message = match result {
+            Ok(()) => format!("attached {session_key}; exit returns to Fleet"),
+            Err(error) => format!("attach failed: {error}"),
+        };
+        let out = reduce_fleet(&self.screens.fleet, FleetEvent::Feedback(message));
+        self.screens.fleet = out.state;
     }
 
     /// Fire a deferred skill RPC raised by the skill-manager screen (P6.5).
@@ -2887,13 +3308,17 @@ impl HangarPlugin {
         // against the empty board.
         let starting = self.daemon_start_redial_until.is_some();
         if Self::is_offline(self.conn.state()) || starting {
-            crate::widgets::offline_empty_state::render_offline_empty_state(
-                &mut buf,
-                w,
-                h,
-                self.daemon_start_error.as_deref(),
-                starting.then_some("⟳ starting daemon…"),
-            );
+            if matches!(app.screen, Screen::Fleet) && !starting {
+                crate::screen::fleet::render_degraded_banner(&mut buf, w, 1);
+            } else {
+                crate::widgets::offline_empty_state::render_offline_empty_state(
+                    &mut buf,
+                    w,
+                    h,
+                    self.daemon_start_error.as_deref(),
+                    starting.then_some("⟳ starting daemon…"),
+                );
+            }
         }
         // 63l.5: the right-click context menu floats over the board, anchored at
         // the click. It sits ABOVE the body but BELOW the first-run modal (which
@@ -3051,6 +3476,12 @@ impl HangarPlugin {
         // input, not a nav key (a card titled `Cardrun` must not switch to Control
         // on its `C`). Route straight to the boards reducer, which owns Esc-cancel.
         if matches!(app.screen, Screen::Boards) && self.screens.boards.overlay().is_some() {
+            let _ = route_key(&app, &mut self.screens, key);
+            return;
+        }
+        // Fleet broadcast and confirmation modes own every key. This keeps text
+        // and typed confirmations from leaking into global tab or quit routing.
+        if matches!(app.screen, Screen::Fleet) && self.screens.fleet.is_modal_open() {
             let _ = route_key(&app, &mut self.screens, key);
             return;
         }
@@ -3980,7 +4411,7 @@ const fn routing_event(key: &ainb_plugin_sdk::KeyEvent, app: &AppState) -> Optio
             // numbered tabs are now contiguous `1`→`4`.
             if matches!(
                 *ch,
-                '1' | '2' | '3' | '4' | 'B' | 'K' | 'D' | 'U' | 'L' | 'I' | 'C' | 'S' | 'P' | ',' | '?' | 'q'
+                '1' | '2' | '3' | '4' | 'B' | 'K' | 'D' | 'U' | 'L' | 'I' | 'C' | 'F' | 'S' | 'P' | ',' | '?' | 'q'
             ) =>
         {
             Some(AppEvent::Key(*ch))
@@ -4029,6 +4460,12 @@ impl Plugin for HangarPlugin {
         // that we hold the host. One fetch per subscribe.
         if std::mem::take(&mut self.fetch_pending) {
             self.fetch_snapshots(host).await;
+        }
+        if std::mem::take(&mut self.fleet_fetch_pending) {
+            self.fetch_fleet_snapshot(host).await;
+        }
+        if std::mem::take(&mut self.fleet_subscribe_pending) {
+            self.subscribe_fleet(host).await;
         }
         Ok(())
     }
@@ -4099,6 +4536,7 @@ impl Plugin for HangarPlugin {
             // render to fire its `issue_update` + `issue_run` (host IO is only
             // safe there). Consumed (taken) by that render, so not level-held.
             || self.pending_issue_dispatch.is_some()
+            || self.screens.pending_fleet_intent.is_some()
     }
 
     fn captures_text(&self) -> bool {
@@ -4141,11 +4579,15 @@ impl Plugin for HangarPlugin {
             // Every open Boards overlay (create-title / profile-pick / column
             // rename / `Run ▾`) consumes all keys as input, per its routing guard.
             Screen::Boards => self.screens.boards.overlay().is_some(),
+            Screen::Fleet => self.screens.fleet.is_capturing_text(),
             _ => false,
         }
     }
 
     async fn render(&mut self, host: &HostClient, params: RenderParams) -> Result<WireBuffer> {
+        if let Some(intent) = self.screens.take_pending_fleet_intent() {
+            self.apply_fleet_intent(host, intent).await;
+        }
         // Drain any deferred Workspace-pane action here: `plugin/render` is
         // dispatched on a SPAWNED task (unlike the inline `handle_key`/
         // `handle_event`), so the SDK reader loop stays free to deliver the
@@ -6117,5 +6559,259 @@ mod tests {
             "Esc cancels the overlay in a single press"
         );
         assert!(!p.captures_text(), "capture is released with the overlay");
+    }
+
+    #[test]
+    fn fleet_hotkey_routes_to_dedicated_pane() {
+        let app =
+            AppState::new(WorkspaceId::from_str("default").expect("valid default workspace id"));
+        let event = routing_event(&char_press('F'), &app).expect("Fleet route event");
+        let out = crate::screen::reduce(&app, event);
+        assert_eq!(out.state.screen, Screen::Fleet);
+    }
+
+    #[test]
+    fn fleet_live_event_advances_cursor_and_arms_focused_reconcile() {
+        let mut plugin = HangarPlugin::new();
+        let event = ainb_hangar_proto::fleet::FleetEvent {
+            revision: 12,
+            event_id: "evt-12".into(),
+            session_key: "codex:thread-1".into(),
+            observed_at: 100,
+            provenance: ainb_hangar_proto::fleet::FleetProvenance::Authoritative,
+            event_type: "turn_started".into(),
+            payload: serde_json::json!({}),
+            session_version: 3,
+            applied: true,
+        };
+        plugin.on_daemon_event(&serde_json::json!({
+            "method": "fleet/event",
+            "params": event,
+        }));
+        assert_eq!(plugin.screens.fleet.head_revision(), 12);
+        assert!(plugin.fleet_fetch_pending);
+    }
+
+    #[test]
+    fn fleet_subscribe_ack_seeds_complete_snapshot_and_replay_cursor() {
+        let mut plugin = HangarPlugin::new();
+        let session = serde_json::json!({
+            "session_key": "codex:thread-1",
+            "provider": "codex",
+            "provider_session_id": "thread-1",
+            "tmux_target": "codex-1:0.0",
+            "process_start_fingerprint": null,
+            "cwd": "/work/shared",
+            "display_name": "codex-1",
+            "lifecycle": "IDLE",
+            "attention": "ASK",
+            "current_request_fingerprint": "fingerprint",
+            "current_request": {
+                "questions": [{
+                    "id": "q1",
+                    "header": "Tool",
+                    "question": "Pick tools",
+                    "options": [
+                        {"label": "rg", "description": "Text"},
+                        {"label": "ast-grep", "description": "Syntax"}
+                    ],
+                    "multiSelect": true
+                }]
+            },
+            "management": "MANAGED",
+            "transport_health": "HEALTHY",
+            "capabilities": {"structured_answer": true, "tmux_attach": true},
+            "provenance": "authoritative",
+            "confidence": "HIGH",
+            "discovered_at": 1,
+            "last_observed_at": 2,
+            "lifecycle_updated_at": 2,
+            "attention_updated_at": 2,
+            "version": 4,
+            "updated_revision": 7
+        });
+        let response = RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(FLEET_SUBSCRIBE_REQ_ID),
+            result: Some(serde_json::json!({
+                "snapshot": {"head_revision": 7, "sessions": [session]},
+                "replay": [{
+                    "revision": 8,
+                    "event_id": "evt-8",
+                    "session_key": "codex:thread-1",
+                    "observed_at": 3,
+                    "provenance": "authoritative",
+                    "event_type": "AskUserQuestion",
+                    "payload": {},
+                    "session_version": 4,
+                    "applied": false
+                }]
+            })),
+            error: None,
+        };
+        plugin.on_daemon_response(&response);
+        assert_eq!(plugin.screens.fleet.head_revision(), 8);
+        let selected = plugin.screens.fleet.selected_session().expect("Fleet row");
+        assert_eq!(selected.session_key, "codex:thread-1");
+        let questions = selected
+            .current_request
+            .as_ref()
+            .and_then(|request| request.get("questions"))
+            .and_then(serde_json::Value::as_array)
+            .expect("complete questions");
+        assert_eq!(questions[0]["options"].as_array().unwrap().len(), 2);
+        assert_eq!(questions[0]["multiSelect"], true);
+    }
+
+    #[test]
+    fn fleet_structured_action_preserves_exact_request_identity() {
+        use ainb_hangar_proto::fleet::{ControlAction, FleetQuestionAnswer, FleetRequestIdentity};
+        let plugin = HangarPlugin::new();
+        let identity = FleetRequestIdentity {
+            request_id: serde_json::json!(42),
+            thread_id: "thread-1".into(),
+            turn_id: "turn-2".into(),
+            item_id: "item-3".into(),
+        };
+        let answers = vec![FleetQuestionAnswer {
+            question_id: "question-1".into(),
+            selected_options: vec!["yes".into()],
+            text: None,
+        }];
+        let action = plugin
+            .fleet_control_action(
+                "codex:thread-1",
+                crate::screen::fleet::FleetAction::StructuredAnswer {
+                    request_fingerprint: "fingerprint".into(),
+                    request_identity: Some(identity.clone()),
+                    answers: answers.clone(),
+                },
+            )
+            .expect("structured action maps");
+        assert_eq!(
+            action,
+            ControlAction::StructuredAnswer {
+                request_fingerprint: "fingerprint".into(),
+                request_identity: Some(identity),
+                answers,
+            }
+        );
+    }
+
+    #[test]
+    fn fleet_verified_picker_preserves_exact_request_identity_and_key() {
+        use ainb_hangar_proto::fleet::ControlAction;
+
+        let plugin = HangarPlugin::new();
+        let action = plugin
+            .fleet_control_action(
+                "legacy:tmux",
+                crate::screen::fleet::FleetAction::VerifiedPicker {
+                    request_fingerprint: "request-fingerprint".into(),
+                    key: "1".into(),
+                },
+            )
+            .expect("picker maps to typed daemon action");
+        assert_eq!(
+            action,
+            ControlAction::VerifiedPicker {
+                request_fingerprint: "request-fingerprint".into(),
+                key: "1".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn fleet_request_ids_do_not_collide_across_plugin_boots() {
+        let first = fleet_request_id("action");
+        let second = fleet_request_id("action");
+        assert_ne!(first, second);
+        assert!(first.starts_with("fleet-ui-action-"));
+    }
+
+    #[test]
+    fn fleet_broadcast_rpc_error_restores_confirmation_for_retry() {
+        use crate::screen::fleet::{
+            FleetEvent, FleetIntent, FleetKey, FleetSessionRow, reduce_fleet,
+        };
+
+        let mut plugin = HangarPlugin::new();
+        let row: FleetSessionRow = serde_json::from_value(serde_json::json!({
+            "session_key": "codex:thread-1",
+            "provider": "codex",
+            "lifecycle": "IDLE",
+            "attention": "NONE",
+            "management": "MANAGED",
+            "provenance": "authoritative",
+            "confidence": "HIGH",
+            "transport_health": "HEALTHY",
+            "version": 1
+        }))
+        .expect("Fleet row");
+        plugin.screens.fleet =
+            reduce_fleet(&plugin.screens.fleet, FleetEvent::Snapshot(vec![row])).state;
+        for event in [
+            FleetEvent::Key(FleetKey::Char('b')),
+            FleetEvent::Key(FleetKey::Char('x')),
+            FleetEvent::Key(FleetKey::Enter),
+            FleetEvent::Key(FleetKey::Space),
+            FleetEvent::Key(FleetKey::Enter),
+        ] {
+            plugin.screens.fleet = reduce_fleet(&plugin.screens.fleet, event).state;
+        }
+        let sent = reduce_fleet(&plugin.screens.fleet, FleetEvent::Key(FleetKey::Enter));
+        assert!(matches!(sent.intent, Some(FleetIntent::Broadcast { .. })));
+        plugin.screens.fleet = sent.state;
+
+        plugin.apply_fleet_broadcast_result(&RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(FLEET_BROADCAST_REQ_ID),
+            result: None,
+            error: Some(ainb_hangar_proto::RpcError {
+                code: -32000,
+                message: "transport closed".into(),
+                data: None,
+            }),
+        });
+
+        assert_eq!(
+            plugin.screens.fleet.feedback(),
+            Some("broadcast failed: transport closed")
+        );
+        let retried = reduce_fleet(&plugin.screens.fleet, FleetEvent::Key(FleetKey::Enter));
+        assert!(matches!(
+            retried.intent,
+            Some(FleetIntent::Broadcast { .. })
+        ));
+    }
+
+    #[test]
+    fn fleet_start_mapping_preserves_exact_global_params() {
+        use ainb_hangar_proto::fleet::{ControlAction, FleetProvider};
+
+        let params = fleet_start_params(
+            FleetProvider::Codex,
+            "/work/new".into(),
+            Some("inspect failures".into()),
+        );
+        assert_eq!(params.session_key, "start:codex");
+        assert_eq!(params.expected_version, 1);
+        assert!(params.request_id.starts_with("fleet-ui-start-"));
+        assert_eq!(
+            params.action,
+            ControlAction::Start {
+                provider: FleetProvider::Codex,
+                cwd: "/work/new".into(),
+                prompt: Some("inspect failures".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn fleet_attach_selects_exact_window_and_pane_before_attach() {
+        let command = fleet_tmux_attach_command("fleet-alpha:3.7");
+        assert!(command.contains("tmux select-window -t 'fleet-alpha:3.7'"));
+        assert!(command.contains("tmux select-pane -t 'fleet-alpha:3.7'"));
+        assert!(command.ends_with("tmux attach-session -t 'fleet-alpha'"));
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -32,6 +32,10 @@ use super::control_center::{
     ControlCenterEvent, ControlCenterIntent, ControlCenterState, reduce_control_center,
 };
 use super::daemon_health::DaemonHealthState;
+use super::fleet::{
+    FleetAction, FleetEvent, FleetFilter, FleetIntent, FleetKey, FleetPaneState, reduce_fleet,
+    selected_approval_action,
+};
 use super::inbox::InboxState;
 use super::issue_list::{IssueListEvent, IssueListIntent, IssueListState, reduce_issue_list};
 use super::kanban::{KanbanEvent, KanbanIntent, KanbanState, reduce_kanban};
@@ -487,6 +491,9 @@ pub struct ScreenStates {
     /// Control-center screen cache (P2), filled from the fleet-wide `attention/list`
     /// snapshot and refreshed on every `AttentionRaised` / `AttentionAnswered` push.
     pub control_center: ControlCenterState,
+    /// Authoritative Fleet registry pane, fed by `fleet/subscribe` and
+    /// reconciled from `fleet/snapshot` after stream gaps.
+    pub fleet: FleetPaneState,
     /// Squads screen cache (P7 / D17), built from `hangar/squads_list` with each
     /// leader/member resolved against the cached actor snapshot for live status.
     pub squads: SquadsState,
@@ -587,6 +594,8 @@ pub struct ScreenStates {
     /// key on an ASK), awaiting the `render` pass to fire it over the daemon socket
     /// (P2). `None` when idle.
     pub pending_answer_action: Option<AttentionAnswerAction>,
+    /// Fleet socket or attach intent raised by the pure Fleet reducer.
+    pub pending_fleet_intent: Option<FleetIntent>,
     /// A board mutation RPC raised by the Boards screen (`⇧←/→`, `x`, `n`, `m`),
     /// awaiting the `render` pass to fire the matching `hangar/board_*` over the
     /// daemon socket (P4). `None` when idle.
@@ -980,6 +989,11 @@ impl ScreenStates {
     pub const fn take_pending_palette_action(&mut self) -> Option<PaletteAction> {
         self.pending_palette_action.take()
     }
+
+    /// Take one deferred Fleet action, broadcast, or attach intent.
+    pub const fn take_pending_fleet_intent(&mut self) -> Option<FleetIntent> {
+        self.pending_fleet_intent.take()
+    }
 }
 
 /// The cached actor snapshot, stashed on [`ScreenStates`] so the picker can be
@@ -1113,6 +1127,9 @@ pub fn render_body(buf: &mut WireBuffer, w: u16, h: u16, app: &AppState, states:
                 &states.control_center,
                 now_ms(),
             );
+        }
+        Screen::Fleet => {
+            super::fleet::render_fleet(buf, w, top, bottom, &states.fleet);
         }
         Screen::Squads => {
             super::squads::render_squads(buf, w, top, bottom, &states.squads);
@@ -1385,6 +1402,10 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
             route_control_center(states, key);
             None
         }
+        Screen::Fleet => {
+            route_fleet(states, key);
+            None
+        }
         Screen::Squads => {
             route_squads(states, key);
             None
@@ -1398,6 +1419,72 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
         // `D`/`U`/`?` tab-switch + global keys are handled by the router before
         // reaching here).
         Screen::DaemonHealth | Screen::Usage | Screen::Help => None,
+    }
+}
+
+/// Fleet pane key routing. Filters and lifecycle verbs lift into the same pure
+/// reducer as navigation, broadcast, attach, and confirmation modal keys.
+fn route_fleet(states: &mut ScreenStates, key: &KeyEvent) {
+    let event = if states.fleet.is_modal_open() {
+        fleet_key(key).map(FleetEvent::Key)
+    } else {
+        match &key.code {
+            KeyCode::Char { ch: 'f' } => Some(FleetEvent::SetFilter(FleetFilter::Focus)),
+            KeyCode::Char { ch: 'o' } => Some(FleetEvent::SetFilter(FleetFilter::Actionable)),
+            KeyCode::Char { ch: 'm' } => Some(FleetEvent::SetFilter(FleetFilter::Managed)),
+            KeyCode::Char { ch: 'd' } => Some(FleetEvent::SetFilter(FleetFilter::Degraded)),
+            KeyCode::Char { ch: 'c' } => Some(FleetEvent::SetFilter(FleetFilter::Claude)),
+            KeyCode::Char { ch: 'x' } => Some(FleetEvent::SetFilter(FleetFilter::Codex)),
+            KeyCode::Char { ch: 'v' } => Some(FleetEvent::SetFilter(FleetFilter::All)),
+            KeyCode::Char { ch: 's' } => Some(FleetEvent::RequestAction(FleetAction::Stop)),
+            KeyCode::Char { ch: 'r' } => Some(FleetEvent::RequestAction(FleetAction::Restart)),
+            KeyCode::Char { ch: 'i' } => Some(FleetEvent::RequestAction(FleetAction::Interrupt)),
+            KeyCode::Char { ch: 'n' } => {
+                Some(approval_event(&states.fleet, false, FleetAction::Continue))
+            }
+            KeyCode::Char { ch: 'y' } => {
+                Some(approval_event(&states.fleet, true, FleetAction::Retry))
+            }
+            KeyCode::Char { ch: '!' } => Some(FleetEvent::RequestAction(FleetAction::Kill)),
+            KeyCode::Char { ch: '#' } => Some(FleetEvent::RequestAction(FleetAction::Archive)),
+            _ => fleet_key(key).map(FleetEvent::Key),
+        }
+    };
+    let Some(event) = event else {
+        return;
+    };
+    let out = reduce_fleet(&states.fleet, event);
+    states.fleet = out.state;
+    if out.intent.is_some() {
+        states.pending_fleet_intent = out.intent;
+    }
+}
+
+fn approval_event(state: &FleetPaneState, approve: bool, fallback: FleetAction) -> FleetEvent {
+    let is_approval = state
+        .selected_session()
+        .is_some_and(|row| row.attention_state.eq_ignore_ascii_case("APPROVAL"));
+    if !is_approval {
+        return FleetEvent::RequestAction(fallback);
+    }
+    match selected_approval_action(state, approve) {
+        Ok(action) => FleetEvent::RequestAction(action),
+        Err(detail) => FleetEvent::Feedback(detail),
+    }
+}
+
+fn fleet_key(key: &KeyEvent) -> Option<FleetKey> {
+    match &key.code {
+        KeyCode::Char { ch: ' ' } => Some(FleetKey::Space),
+        KeyCode::Char { ch } => Some(FleetKey::Char(*ch)),
+        KeyCode::Enter => Some(FleetKey::Enter),
+        KeyCode::Esc => Some(FleetKey::Esc),
+        KeyCode::Backspace => Some(FleetKey::Backspace),
+        KeyCode::Up => Some(FleetKey::Up),
+        KeyCode::Down => Some(FleetKey::Down),
+        KeyCode::Left => Some(FleetKey::Left),
+        KeyCode::Right => Some(FleetKey::Right),
+        _ => None,
     }
 }
 
@@ -2006,5 +2093,141 @@ fn route_command_palette(states: &mut ScreenStates, key: &KeyEvent) -> Option<Na
         Some(NavIntent::CloseModal)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod fleet_routing_tests {
+    use std::collections::BTreeMap;
+
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_plugin_sdk::{KeyCode, KeyEvent, KeyKind};
+
+    use super::*;
+    use crate::screen::fleet::{FleetCapabilities, FleetSessionRow};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            mods: 0,
+            kind: KeyKind::Press,
+        }
+    }
+
+    fn app() -> AppState {
+        let mut app = AppState::new(WorkspaceId::from_str("default").unwrap());
+        app.screen = Screen::Fleet;
+        app
+    }
+
+    fn row(attention: &str) -> FleetSessionRow {
+        FleetSessionRow {
+            session_key: "claude:one".into(),
+            provider: "claude".into(),
+            provider_session_id: Some("one".into()),
+            current_request_fingerprint: Some("fingerprint".into()),
+            current_request: Some(serde_json::json!({
+                "tool_use_id": "request-1",
+                "questions": [{
+                    "id": "q1",
+                    "question": "Proceed?",
+                    "options": [{"label": "Yes"}, {"label": "No"}]
+                }]
+            })),
+            lifecycle_state: "IDLE".into(),
+            attention_state: attention.into(),
+            management_state: "MANAGED".into(),
+            provenance: "hangar-authoritative".into(),
+            confidence: "HIGH".into(),
+            transport_health: "HEALTHY".into(),
+            capabilities: FleetCapabilities::Flags(BTreeMap::from([
+                ("structured_answer".into(), true),
+                ("approvals".into(), true),
+                ("send_prompt".into(), true),
+                ("start".into(), true),
+            ])),
+            version: 9,
+            cwd: "/work/one".into(),
+            tmux_target: Some("one:0.0".into()),
+            display_name: Some("one".into()),
+            discovered_at: 1,
+            last_observed_at: 2,
+            metadata_updated_at: 2,
+            lifecycle_updated_at: 2,
+            attention_updated_at: 2,
+            transport_updated_at: 2,
+        }
+    }
+
+    #[test]
+    fn fleet_routes_structured_answer_prompt_and_start_into_intents() {
+        let app = app();
+        let mut states = ScreenStates::default();
+        states.fleet.set_sessions(vec![row("ASK")]);
+
+        route_key(&app, &mut states, &key(KeyCode::Enter));
+        route_key(&app, &mut states, &key(KeyCode::Enter));
+        assert!(matches!(
+            states.take_pending_fleet_intent(),
+            Some(FleetIntent::Execute {
+                action: FleetAction::StructuredAnswer { .. },
+                ..
+            })
+        ));
+
+        route_key(&app, &mut states, &key(KeyCode::Char { ch: 'p' }));
+        for ch in "status".chars() {
+            route_key(&app, &mut states, &key(KeyCode::Char { ch }));
+        }
+        route_key(&app, &mut states, &key(KeyCode::Enter));
+        assert!(matches!(
+            states.take_pending_fleet_intent(),
+            Some(FleetIntent::Execute {
+                action: FleetAction::SendText { text },
+                ..
+            }) if text == "status"
+        ));
+
+        route_key(&app, &mut states, &key(KeyCode::Char { ch: 't' }));
+        for ch in "/work/new".chars() {
+            route_key(&app, &mut states, &key(KeyCode::Char { ch }));
+        }
+        route_key(&app, &mut states, &key(KeyCode::Enter));
+        for ch in "inspect failures".chars() {
+            route_key(&app, &mut states, &key(KeyCode::Char { ch }));
+        }
+        route_key(&app, &mut states, &key(KeyCode::Enter));
+        assert_eq!(
+            states.take_pending_fleet_intent(),
+            Some(FleetIntent::Start {
+                provider: ainb_hangar_proto::fleet::FleetProvider::Codex,
+                cwd: "/work/new".into(),
+                prompt: Some("inspect failures".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn fleet_routes_approval_keys_with_exact_request_identity() {
+        let app = app();
+        let mut states = ScreenStates::default();
+        states.fleet.set_sessions(vec![row("APPROVAL")]);
+
+        route_key(&app, &mut states, &key(KeyCode::Char { ch: 'y' }));
+        assert!(matches!(
+            states.take_pending_fleet_intent(),
+            Some(FleetIntent::Execute {
+                action: FleetAction::Approve { .. },
+                ..
+            })
+        ));
+        route_key(&app, &mut states, &key(KeyCode::Char { ch: 'n' }));
+        assert!(matches!(
+            states.take_pending_fleet_intent(),
+            Some(FleetIntent::Execute {
+                action: FleetAction::Deny { .. },
+                ..
+            })
+        ));
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -1,0 +1,2844 @@
+//! Fleet pane pure reducer and dense table plus detail renderer.
+//!
+//! This module owns no data plane. It consumes local serde wire rows matching
+//! the daemon Fleet snapshot, preserves selection by stable session key, and
+//! emits typed intents for plugin glue to execute later.
+
+#![allow(missing_docs)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
+use serde::{Deserialize, Serialize};
+
+const BROADCAST_MAX_PARALLEL: usize = 8;
+const FG: Color = Color::rgb(220, 220, 230);
+const MUTED: Color = Color::rgb(120, 120, 140);
+const GOLD: Color = Color::rgb(255, 215, 0);
+const BLUE: Color = Color::rgb(100, 149, 237);
+const GREEN: Color = Color::rgb(100, 200, 100);
+
+/// Capability wire shape accepted from current and planned daemon snapshots.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FleetCapabilities {
+    List(Vec<String>),
+    Flags(BTreeMap<String, bool>),
+    Json(String),
+}
+
+impl Default for FleetCapabilities {
+    fn default() -> Self {
+        Self::List(Vec::new())
+    }
+}
+
+impl FleetCapabilities {
+    fn contains(&self, capability: &str) -> bool {
+        match self {
+            Self::List(items) => items.iter().any(|item| item.eq_ignore_ascii_case(capability)),
+            Self::Flags(items) => items
+                .iter()
+                .any(|(name, enabled)| *enabled && name.eq_ignore_ascii_case(capability)),
+            Self::Json(raw) => serde_json::from_str::<serde_json::Value>(raw)
+                .ok()
+                .is_some_and(|value| capability_value_contains(&value, capability)),
+        }
+    }
+
+    fn labels(&self) -> Vec<String> {
+        match self {
+            Self::List(items) => items.clone(),
+            Self::Flags(items) => items
+                .iter()
+                .filter(|(_, enabled)| **enabled)
+                .map(|(name, _)| name.clone())
+                .collect(),
+            Self::Json(raw) => serde_json::from_str::<serde_json::Value>(raw)
+                .ok()
+                .map_or_else(Vec::new, |value| capability_value_labels(&value)),
+        }
+    }
+}
+
+fn capability_value_contains(value: &serde_json::Value, capability: &str) -> bool {
+    match value {
+        serde_json::Value::Array(items) => items
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .any(|item| item.eq_ignore_ascii_case(capability)),
+        serde_json::Value::Object(items) => items.iter().any(|(name, enabled)| {
+            enabled.as_bool().unwrap_or(false) && name.eq_ignore_ascii_case(capability)
+        }),
+        _ => false,
+    }
+}
+
+fn capability_value_labels(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::Array(items) => {
+            items.iter().filter_map(serde_json::Value::as_str).map(str::to_string).collect()
+        }
+        serde_json::Value::Object(items) => items
+            .iter()
+            .filter(|(_, enabled)| enabled.as_bool().unwrap_or(false))
+            .map(|(name, _)| name.clone())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Local wire row matching the planned Fleet snapshot payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetSessionRow {
+    pub session_key: String,
+    pub provider: String,
+    #[serde(default)]
+    pub provider_session_id: Option<String>,
+    #[serde(default)]
+    pub current_request_fingerprint: Option<String>,
+    #[serde(default)]
+    pub current_request: Option<serde_json::Value>,
+    #[serde(alias = "lifecycle")]
+    pub lifecycle_state: String,
+    #[serde(alias = "attention")]
+    pub attention_state: String,
+    #[serde(alias = "management")]
+    pub management_state: String,
+    #[serde(default)]
+    pub provenance: String,
+    pub confidence: String,
+    pub transport_health: String,
+    #[serde(default)]
+    pub capabilities: FleetCapabilities,
+    pub version: i64,
+    #[serde(default)]
+    pub cwd: String,
+    #[serde(default)]
+    pub tmux_target: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub discovered_at: i64,
+    #[serde(default)]
+    pub last_observed_at: i64,
+    #[serde(default)]
+    pub metadata_updated_at: i64,
+    #[serde(default)]
+    pub lifecycle_updated_at: i64,
+    #[serde(default)]
+    pub attention_updated_at: i64,
+    #[serde(default)]
+    pub transport_updated_at: i64,
+}
+
+impl FleetSessionRow {
+    fn is_running(&self) -> bool {
+        self.lifecycle_state.eq_ignore_ascii_case("RUNNING")
+    }
+
+    fn is_actionable(&self) -> bool {
+        !self.attention_state.eq_ignore_ascii_case("NONE")
+    }
+
+    fn is_managed(&self) -> bool {
+        self.management_state.eq_ignore_ascii_case("managed")
+    }
+
+    fn session_name(&self) -> String {
+        self.display_name.clone().unwrap_or_else(|| {
+            self.tmux_target
+                .as_deref()
+                .and_then(|target| target.split(':').next())
+                .filter(|name| !name.is_empty())
+                .unwrap_or(&self.session_key)
+                .to_string()
+        })
+    }
+}
+
+impl From<ainb_hangar_proto::fleet::FleetSession> for FleetSessionRow {
+    fn from(session: ainb_hangar_proto::fleet::FleetSession) -> Self {
+        use ainb_hangar_proto::fleet::{
+            AttentionState, FleetConfidence, FleetProvenance, FleetProvider, LifecycleState,
+            ManagementState, TransportHealth,
+        };
+
+        let capabilities = session.capabilities;
+        let capabilities = FleetCapabilities::Flags(BTreeMap::from([
+            ("structured_answer".into(), capabilities.structured_answer),
+            ("approvals".into(), capabilities.approvals),
+            ("send_prompt".into(), capabilities.send_prompt),
+            ("continue_turn".into(), capabilities.continue_turn),
+            ("retry".into(), capabilities.retry),
+            ("interrupt".into(), capabilities.interrupt),
+            ("start".into(), capabilities.start),
+            ("stop".into(), capabilities.stop),
+            ("restart".into(), capabilities.restart),
+            ("kill".into(), capabilities.kill),
+            ("archive".into(), capabilities.archive),
+            ("tmux_attach".into(), capabilities.tmux_attach),
+            ("tmux_text".into(), capabilities.tmux_text),
+            ("verified_picker".into(), capabilities.verified_picker),
+        ]));
+        Self {
+            session_key: session.session_key,
+            provider: match session.provider {
+                FleetProvider::Claude => "claude",
+                FleetProvider::Codex => "codex",
+                FleetProvider::Unknown => "unknown",
+            }
+            .into(),
+            provider_session_id: session.provider_session_id,
+            current_request_fingerprint: session.current_request_fingerprint,
+            current_request: session.current_request,
+            lifecycle_state: match session.lifecycle {
+                LifecycleState::Starting => "STARTING",
+                LifecycleState::Running => "RUNNING",
+                LifecycleState::TurnComplete => "TURN_COMPLETE",
+                LifecycleState::Idle => "IDLE",
+                LifecycleState::Exited => "EXITED",
+                LifecycleState::Unknown => "UNKNOWN",
+            }
+            .into(),
+            attention_state: match session.attention {
+                AttentionState::None => "NONE",
+                AttentionState::Ask => "ASK",
+                AttentionState::Approval => "APPROVAL",
+                AttentionState::Waiting => "WAITING",
+                AttentionState::Error => "ERROR",
+            }
+            .into(),
+            management_state: match session.management {
+                ManagementState::Managed => "MANAGED",
+                ManagementState::Degraded => "DEGRADED",
+            }
+            .into(),
+            provenance: match session.provenance {
+                FleetProvenance::Authoritative => "hangar-authoritative",
+                FleetProvenance::Inferred => "hangar-inferred",
+            }
+            .into(),
+            confidence: match session.confidence {
+                FleetConfidence::High => "HIGH",
+                FleetConfidence::Medium => "MEDIUM",
+                FleetConfidence::Low => "LOW",
+            }
+            .into(),
+            transport_health: match session.transport_health {
+                TransportHealth::Healthy => "HEALTHY",
+                TransportHealth::Degraded => "DEGRADED",
+                TransportHealth::Unavailable => "UNAVAILABLE",
+                TransportHealth::Unknown => "UNKNOWN",
+            }
+            .into(),
+            capabilities,
+            version: session.version,
+            cwd: session.cwd,
+            tmux_target: session.tmux_target,
+            display_name: session.display_name,
+            discovered_at: session.discovered_at,
+            last_observed_at: session.last_observed_at,
+            metadata_updated_at: session.last_observed_at,
+            lifecycle_updated_at: session.lifecycle_updated_at,
+            attention_updated_at: session.attention_updated_at,
+            transport_updated_at: session.last_observed_at,
+        }
+    }
+}
+
+/// Fleet table filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FleetFilter {
+    #[default]
+    Focus,
+    Actionable,
+    Managed,
+    Degraded,
+    Claude,
+    Codex,
+    All,
+}
+
+impl FleetFilter {
+    fn matches(self, row: &FleetSessionRow) -> bool {
+        match self {
+            Self::Focus => !row.is_running(),
+            Self::Actionable => row.is_actionable(),
+            Self::Managed => row.is_managed(),
+            Self::Degraded => !row.is_managed(),
+            Self::Claude => row.provider.eq_ignore_ascii_case("claude"),
+            Self::Codex => row.provider.eq_ignore_ascii_case("codex"),
+            Self::All => true,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Focus => "Focus",
+            Self::Actionable => "Actionable",
+            Self::Managed => "Managed",
+            Self::Degraded => "Degraded",
+            Self::Claude => "Claude",
+            Self::Codex => "Codex",
+            Self::All => "All",
+        }
+    }
+}
+
+/// Keyboard event understood by the standalone reducer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FleetKey {
+    Char(char),
+    Enter,
+    Esc,
+    Backspace,
+    Up,
+    Down,
+    Left,
+    Right,
+    Space,
+}
+
+/// Fleet action requested for one selected session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FleetAction {
+    StructuredAnswer {
+        request_fingerprint: String,
+        request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
+        answers: Vec<ainb_hangar_proto::fleet::FleetQuestionAnswer>,
+    },
+    Approve {
+        request_fingerprint: String,
+        request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
+    },
+    Deny {
+        request_fingerprint: String,
+        request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
+    },
+    SendText {
+        text: String,
+    },
+    VerifiedPicker {
+        request_fingerprint: String,
+        key: String,
+    },
+    Continue,
+    Retry,
+    Interrupt,
+    Stop,
+    Restart,
+    Kill,
+    Archive,
+}
+
+impl FleetAction {
+    /// Map pane action into authoritative daemon wire action.
+    pub fn into_control_action(self) -> Result<ainb_hangar_proto::fleet::ControlAction, String> {
+        use ainb_hangar_proto::fleet::ControlAction;
+        Ok(match self {
+            Self::StructuredAnswer {
+                request_fingerprint,
+                request_identity,
+                answers,
+            } => ControlAction::StructuredAnswer {
+                request_fingerprint,
+                request_identity,
+                answers,
+            },
+            Self::Approve {
+                request_fingerprint,
+                request_identity,
+            } => ControlAction::Approve {
+                request_fingerprint,
+                request_identity,
+            },
+            Self::Deny {
+                request_fingerprint,
+                request_identity,
+            } => ControlAction::Deny {
+                request_fingerprint,
+                request_identity,
+            },
+            Self::SendText { text } => ControlAction::SendPrompt { text },
+            Self::VerifiedPicker {
+                request_fingerprint,
+                key,
+            } => ControlAction::VerifiedPicker {
+                request_fingerprint,
+                key,
+            },
+            Self::Continue => ControlAction::Continue,
+            Self::Retry => ControlAction::Retry,
+            Self::Interrupt => ControlAction::Interrupt,
+            Self::Stop => ControlAction::Stop,
+            Self::Restart => ControlAction::Restart,
+            Self::Kill => ControlAction::Kill,
+            Self::Archive => ControlAction::Archive,
+        })
+    }
+
+    fn is_supported_by(&self, capabilities: &FleetCapabilities) -> bool {
+        match self {
+            Self::StructuredAnswer { .. } => capabilities.contains("structured_answer"),
+            Self::Approve { .. } | Self::Deny { .. } => capabilities.contains("approvals"),
+            Self::SendText { .. } => {
+                capabilities.contains("send_prompt") || capabilities.contains("tmux_text")
+            }
+            Self::VerifiedPicker { .. } => capabilities.contains("verified_picker"),
+            Self::Continue => capabilities.contains("continue_turn"),
+            Self::Retry => capabilities.contains("retry"),
+            Self::Interrupt => capabilities.contains("interrupt"),
+            Self::Stop => capabilities.contains("stop"),
+            Self::Restart => capabilities.contains("restart"),
+            Self::Kill => capabilities.contains("kill"),
+            Self::Archive => capabilities.contains("archive"),
+        }
+    }
+
+    fn capability_label(&self) -> &'static str {
+        match self {
+            Self::StructuredAnswer { .. } => "structured_answer",
+            Self::Approve { .. } | Self::Deny { .. } => "approvals",
+            Self::SendText { .. } => "send_prompt or tmux_text",
+            Self::VerifiedPicker { .. } => "verified_picker",
+            Self::Continue => "continue_turn",
+            Self::Retry => "retry",
+            Self::Interrupt => "interrupt",
+            Self::Stop => "stop",
+            Self::Restart => "restart",
+            Self::Kill => "kill",
+            Self::Archive => "archive",
+        }
+    }
+
+    fn is_structured(&self) -> bool {
+        matches!(
+            self,
+            Self::StructuredAnswer { .. } | Self::Approve { .. } | Self::Deny { .. }
+        )
+    }
+
+    fn is_destructive(&self) -> bool {
+        matches!(
+            self,
+            Self::Stop | Self::Restart | Self::Kill | Self::Archive
+        )
+    }
+
+    pub fn is_high_risk(&self) -> bool {
+        self.is_structured() || self.is_destructive()
+    }
+}
+
+/// Per-recipient broadcast result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReceiptStatus {
+    Delivered,
+    Failed,
+    Unknown,
+}
+
+/// Durable-looking receipt supplied back to the pure reducer by plugin glue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BroadcastReceipt {
+    pub session_key: String,
+    pub status: ReceiptStatus,
+    #[serde(default)]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BroadcastStage {
+    Compose,
+    Recipients,
+    Confirm,
+    InFlight,
+    Receipts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BroadcastState {
+    stage: BroadcastStage,
+    text: String,
+    expanded_roster: bool,
+    cursor: usize,
+    selected: BTreeSet<String>,
+    receipts: BTreeMap<String, BroadcastReceipt>,
+    in_flight_idempotency_key: Option<String>,
+    failure_return_stage: Option<BroadcastStage>,
+}
+
+impl Default for BroadcastState {
+    fn default() -> Self {
+        Self {
+            stage: BroadcastStage::Compose,
+            text: String::new(),
+            expanded_roster: false,
+            cursor: 0,
+            selected: BTreeSet::new(),
+            receipts: BTreeMap::new(),
+            in_flight_idempotency_key: None,
+            failure_return_stage: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FleetMode {
+    Browse,
+    Answer(AnswerState),
+    Start(StartState),
+    Prompt {
+        text: String,
+    },
+    Broadcast(BroadcastState),
+    Confirm {
+        session_key: String,
+        action: FleetAction,
+    },
+    TypedConfirm {
+        session_key: String,
+        expected_name: String,
+        typed: String,
+        action: FleetAction,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AnswerQuestion {
+    id: String,
+    text: String,
+    options: Vec<String>,
+    multi_select: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AnswerState {
+    session_key: String,
+    expected_version: i64,
+    request_fingerprint: String,
+    request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
+    questions: Vec<AnswerQuestion>,
+    question_index: usize,
+    option_cursor: usize,
+    selections: Vec<BTreeSet<usize>>,
+    texts: Vec<String>,
+    editing_text: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartStage {
+    Cwd,
+    Prompt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StartState {
+    provider: ainb_hangar_proto::fleet::FleetProvider,
+    stage: StartStage,
+    cwd: String,
+    prompt: String,
+}
+
+/// Pure Fleet pane state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetPaneState {
+    roster: Vec<FleetSessionRow>,
+    filter: FleetFilter,
+    selected_key: Option<String>,
+    mode: FleetMode,
+    feedback: Option<String>,
+    now_ms: i64,
+    head_revision: i64,
+}
+
+impl Default for FleetPaneState {
+    fn default() -> Self {
+        Self {
+            roster: Vec::new(),
+            filter: FleetFilter::Focus,
+            selected_key: None,
+            mode: FleetMode::Browse,
+            feedback: None,
+            now_ms: 0,
+            head_revision: 0,
+        }
+    }
+}
+
+impl FleetPaneState {
+    pub fn apply_snapshot(&mut self, head_revision: i64, roster: Vec<FleetSessionRow>) {
+        if head_revision < self.head_revision {
+            return;
+        }
+        self.head_revision = head_revision;
+        self.set_sessions(roster);
+    }
+
+    pub const fn head_revision(&self) -> i64 {
+        self.head_revision
+    }
+
+    pub fn observe_revision(&mut self, revision: i64) {
+        self.head_revision = self.head_revision.max(revision);
+    }
+
+    pub fn is_modal_open(&self) -> bool {
+        !matches!(self.mode, FleetMode::Browse)
+    }
+
+    pub fn is_capturing_text(&self) -> bool {
+        matches!(
+            self.mode,
+            FleetMode::TypedConfirm { .. }
+                | FleetMode::Start(_)
+                | FleetMode::Prompt { .. }
+                | FleetMode::Broadcast(BroadcastState {
+                    stage: BroadcastStage::Compose,
+                    ..
+                })
+        )
+    }
+
+    pub fn set_sessions(&mut self, roster: Vec<FleetSessionRow>) {
+        self.roster = roster;
+        self.preserve_or_reset_selection();
+    }
+
+    pub const fn filter(&self) -> FleetFilter {
+        self.filter
+    }
+
+    pub fn selected_key(&self) -> Option<&str> {
+        self.selected_key.as_deref()
+    }
+
+    pub fn selected_session(&self) -> Option<&FleetSessionRow> {
+        let key = self.selected_key.as_ref()?;
+        self.roster.iter().find(|row| &row.session_key == key)
+    }
+
+    pub fn visible_sessions(&self) -> Vec<&FleetSessionRow> {
+        self.roster.iter().filter(|row| self.filter.matches(row)).collect()
+    }
+
+    /// Total sessions in unfiltered authoritative roster.
+    pub fn session_count(&self) -> usize {
+        self.roster.len()
+    }
+
+    pub fn feedback(&self) -> Option<&str> {
+        self.feedback.as_deref()
+    }
+
+    fn preserve_or_reset_selection(&mut self) {
+        let keep = self.selected_key.as_ref().is_some_and(|key| {
+            self.roster
+                .iter()
+                .any(|row| &row.session_key == key && self.filter.matches(row))
+        });
+        if !keep {
+            self.selected_key = self
+                .roster
+                .iter()
+                .find(|row| self.filter.matches(row))
+                .map(|row| row.session_key.clone());
+        }
+    }
+}
+
+/// Input folded into the Fleet pane.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FleetEvent {
+    Snapshot(Vec<FleetSessionRow>),
+    SetFilter(FleetFilter),
+    Key(FleetKey),
+    RequestAction(FleetAction),
+    ActionSucceeded { session_key: String },
+    ActionFailed { session_key: String, detail: String },
+    BroadcastReceipts(Vec<BroadcastReceipt>),
+    BroadcastFailed { detail: String },
+    Feedback(String),
+    Tick(i64),
+}
+
+/// Side effect requested by the pure Fleet reducer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FleetIntent {
+    Execute {
+        session_key: String,
+        expected_version: i64,
+        action: FleetAction,
+    },
+    Start {
+        provider: ainb_hangar_proto::fleet::FleetProvider,
+        cwd: String,
+        prompt: Option<String>,
+    },
+    AttachEmbedded {
+        session_key: String,
+        tmux_target: String,
+    },
+    AttachFullscreen {
+        session_key: String,
+        tmux_target: String,
+    },
+    Broadcast {
+        text: String,
+        recipient_keys: Vec<String>,
+        idempotency_key: String,
+        max_parallel: usize,
+        retry_failures_only: bool,
+    },
+}
+
+/// Result of one pure Fleet reduction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetReduction {
+    pub state: FleetPaneState,
+    pub intent: Option<FleetIntent>,
+}
+
+/// Fold one event into Fleet pane state without IO.
+#[must_use]
+pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction {
+    let mut next = state.clone();
+    let intent = match event {
+        FleetEvent::Snapshot(roster) => {
+            next.set_sessions(roster);
+            None
+        }
+        FleetEvent::SetFilter(filter) => {
+            next.filter = filter;
+            next.preserve_or_reset_selection();
+            None
+        }
+        FleetEvent::Key(key) => reduce_key(&mut next, key),
+        FleetEvent::RequestAction(action) => request_action(&mut next, action),
+        FleetEvent::ActionSucceeded { session_key } => {
+            next.feedback = Some(format!("action succeeded: {session_key}"));
+            select_next_focus(&mut next, &session_key);
+            None
+        }
+        FleetEvent::ActionFailed {
+            session_key,
+            detail,
+        } => {
+            next.feedback = Some(format!("action failed: {session_key}: {detail}"));
+            None
+        }
+        FleetEvent::BroadcastReceipts(receipts) => {
+            apply_broadcast_receipts(&mut next, receipts);
+            None
+        }
+        FleetEvent::BroadcastFailed { detail } => {
+            apply_broadcast_failure(&mut next, detail);
+            None
+        }
+        FleetEvent::Feedback(message) => {
+            next.feedback = Some(message);
+            None
+        }
+        FleetEvent::Tick(now_ms) => {
+            next.now_ms = now_ms;
+            None
+        }
+    };
+    FleetReduction {
+        state: next,
+        intent,
+    }
+}
+
+fn reduce_key(state: &mut FleetPaneState, key: FleetKey) -> Option<FleetIntent> {
+    match state.mode.clone() {
+        FleetMode::Browse => reduce_browse_key(state, key),
+        FleetMode::Answer(answer) => reduce_answer_key(state, answer, key),
+        FleetMode::Start(start) => reduce_start_key(state, start, key),
+        FleetMode::Prompt { text } => reduce_prompt_key(state, text, key),
+        FleetMode::Broadcast(broadcast) => reduce_broadcast_key(state, broadcast, key),
+        FleetMode::Confirm {
+            session_key,
+            action,
+        } => reduce_confirm_key(state, &session_key, action, key),
+        FleetMode::TypedConfirm {
+            session_key,
+            expected_name,
+            typed,
+            action,
+        } => reduce_typed_confirm_key(state, &session_key, &expected_name, typed, action, key),
+    }
+}
+
+fn reduce_browse_key(state: &mut FleetPaneState, key: FleetKey) -> Option<FleetIntent> {
+    match key {
+        FleetKey::Down | FleetKey::Char('j') => move_selection(state, 1),
+        FleetKey::Up | FleetKey::Char('k') => move_selection(state, -1),
+        FleetKey::Right => return attach_intent(state, false),
+        FleetKey::Char('A') => return attach_intent(state, true),
+        FleetKey::Enter => begin_structured_answer(state),
+        FleetKey::Char('t') => {
+            state.mode = FleetMode::Start(StartState {
+                provider: ainb_hangar_proto::fleet::FleetProvider::Codex,
+                stage: StartStage::Cwd,
+                cwd: String::new(),
+                prompt: String::new(),
+            });
+        }
+        FleetKey::Char('p') => {
+            state.mode = FleetMode::Prompt {
+                text: String::new(),
+            }
+        }
+        FleetKey::Char('b' | 'B') => state.mode = FleetMode::Broadcast(BroadcastState::default()),
+        _ => {}
+    }
+    None
+}
+
+fn begin_structured_answer(state: &mut FleetPaneState) {
+    let Some(row) = state.selected_session().cloned() else {
+        state.feedback = Some("no Fleet session selected".into());
+        return;
+    };
+    if !row.attention_state.eq_ignore_ascii_case("ASK") {
+        state.feedback = Some("selected session has no structured question".into());
+        return;
+    }
+    if !row.is_managed() || !row.capabilities.contains("structured_answer") {
+        state.feedback = Some("structured answer unavailable for selected session".into());
+        return;
+    }
+    let Some(request_fingerprint) = row.current_request_fingerprint.clone() else {
+        state.feedback = Some("structured request fingerprint unavailable".into());
+        return;
+    };
+    let Some(request) = row.current_request.as_ref() else {
+        state.feedback = Some("structured request payload unavailable".into());
+        return;
+    };
+    let questions = answer_questions(request);
+    if questions.is_empty() {
+        state.feedback = Some("structured request has no questions".into());
+        return;
+    }
+    let selections = vec![BTreeSet::new(); questions.len()];
+    let texts = vec![String::new(); questions.len()];
+    let editing_text = questions[0].options.is_empty();
+    state.mode = FleetMode::Answer(AnswerState {
+        session_key: row.session_key,
+        expected_version: row.version,
+        request_fingerprint,
+        request_identity: request_identity(request),
+        questions,
+        question_index: 0,
+        option_cursor: 0,
+        selections,
+        texts,
+        editing_text,
+    });
+}
+
+fn answer_questions(request: &serde_json::Value) -> Vec<AnswerQuestion> {
+    let payload = request.get("payload").unwrap_or(request);
+    let input = payload.get("tool_input").or_else(|| payload.get("input")).unwrap_or(payload);
+    input
+        .get("questions")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .enumerate()
+        .map(|(index, question)| AnswerQuestion {
+            id: question
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .map_or_else(|| index.to_string(), str::to_string),
+            text: question
+                .get("question")
+                .or_else(|| question.get("text"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            options: question
+                .get("options")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|option| {
+                    option
+                        .as_str()
+                        .or_else(|| option.get("label").and_then(serde_json::Value::as_str))
+                        .map(str::to_string)
+                })
+                .collect(),
+            multi_select: question
+                .get("multiSelect")
+                .or_else(|| question.get("multi_select"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+        })
+        .collect()
+}
+
+fn request_identity(
+    request: &serde_json::Value,
+) -> Option<ainb_hangar_proto::fleet::FleetRequestIdentity> {
+    let payload = request.get("payload").unwrap_or(request);
+    let identity = payload.get("identity").unwrap_or(payload);
+    let request_id = identity
+        .get("requestId")
+        .or_else(|| identity.get("request_id"))
+        .or_else(|| identity.get("tool_use_id"))
+        .or_else(|| identity.get("id"))?
+        .clone();
+    let text = |camel: &str, snake: &str| {
+        identity
+            .get(camel)
+            .or_else(|| identity.get(snake))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+    Some(ainb_hangar_proto::fleet::FleetRequestIdentity {
+        request_id,
+        thread_id: text("threadId", "thread_id"),
+        turn_id: text("turnId", "turn_id"),
+        item_id: text("itemId", "item_id"),
+    })
+}
+
+fn reduce_answer_key(
+    state: &mut FleetPaneState,
+    mut answer: AnswerState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    if key == FleetKey::Esc {
+        state.mode = FleetMode::Browse;
+        return None;
+    }
+    let Some(question) = answer.questions.get(answer.question_index) else {
+        state.mode = FleetMode::Browse;
+        state.feedback = Some("structured question changed before answer".into());
+        return None;
+    };
+    if answer.editing_text {
+        match key {
+            FleetKey::Backspace => {
+                answer.texts[answer.question_index].pop();
+            }
+            FleetKey::Enter if answer.texts[answer.question_index].trim().is_empty() => {
+                state.feedback = Some("answer text required".into());
+            }
+            FleetKey::Enter => return advance_or_submit_answer(state, answer),
+            FleetKey::Char(character) => {
+                answer.texts[answer.question_index].push(character);
+            }
+            FleetKey::Space => answer.texts[answer.question_index].push(' '),
+            _ => {}
+        }
+        state.mode = FleetMode::Answer(answer);
+        return None;
+    }
+    match key {
+        FleetKey::Up | FleetKey::Char('k') => {
+            answer.option_cursor = answer.option_cursor.saturating_sub(1);
+        }
+        FleetKey::Down | FleetKey::Char('j') => {
+            answer.option_cursor =
+                (answer.option_cursor + 1).min(question.options.len().saturating_sub(1));
+        }
+        FleetKey::Space if question.multi_select => {
+            let selected = &mut answer.selections[answer.question_index];
+            if !selected.remove(&answer.option_cursor) {
+                selected.insert(answer.option_cursor);
+            }
+        }
+        FleetKey::Char('o') => {
+            answer.editing_text = true;
+        }
+        FleetKey::Enter => {
+            if answer.selections[answer.question_index].is_empty() {
+                answer.selections[answer.question_index].insert(answer.option_cursor);
+            }
+            let selected_other = answer.selections[answer.question_index]
+                .iter()
+                .filter_map(|index| question.options.get(*index))
+                .any(|option| option.eq_ignore_ascii_case("other"));
+            if selected_other && answer.texts[answer.question_index].trim().is_empty() {
+                answer.editing_text = true;
+            } else {
+                return advance_or_submit_answer(state, answer);
+            }
+        }
+        _ => {}
+    }
+    state.mode = FleetMode::Answer(answer);
+    None
+}
+
+fn advance_or_submit_answer(
+    state: &mut FleetPaneState,
+    mut answer: AnswerState,
+) -> Option<FleetIntent> {
+    if answer.question_index + 1 < answer.questions.len() {
+        answer.question_index += 1;
+        answer.option_cursor = 0;
+        answer.editing_text = answer.questions[answer.question_index].options.is_empty();
+        state.mode = FleetMode::Answer(answer);
+        return None;
+    }
+    let answers = answer
+        .questions
+        .iter()
+        .zip(&answer.selections)
+        .zip(&answer.texts)
+        .map(|((question, selected), text)| {
+            let text = (!text.trim().is_empty()).then(|| text.trim().to_string());
+            let selected_other = selected
+                .iter()
+                .filter_map(|index| question.options.get(*index))
+                .any(|option| option.eq_ignore_ascii_case("other"));
+            let selected_options = if !question.multi_select && selected_other && text.is_some() {
+                Vec::new()
+            } else {
+                selected
+                    .iter()
+                    .filter_map(|index| question.options.get(*index).cloned())
+                    .collect()
+            };
+            ainb_hangar_proto::fleet::FleetQuestionAnswer {
+                question_id: question.id.clone(),
+                selected_options,
+                text,
+            }
+        })
+        .collect();
+    state.mode = FleetMode::Browse;
+    Some(FleetIntent::Execute {
+        session_key: answer.session_key,
+        expected_version: answer.expected_version,
+        action: FleetAction::StructuredAnswer {
+            request_fingerprint: answer.request_fingerprint,
+            request_identity: answer.request_identity,
+            answers,
+        },
+    })
+}
+
+fn reduce_start_key(
+    state: &mut FleetPaneState,
+    mut start: StartState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    if key == FleetKey::Esc {
+        state.mode = FleetMode::Browse;
+        return None;
+    }
+    let field = match start.stage {
+        StartStage::Cwd => &mut start.cwd,
+        StartStage::Prompt => &mut start.prompt,
+    };
+    match key {
+        FleetKey::Backspace => {
+            field.pop();
+        }
+        FleetKey::Char(character) => field.push(character),
+        FleetKey::Space => field.push(' '),
+        FleetKey::Enter if start.stage == StartStage::Cwd && start.cwd.trim().is_empty() => {
+            state.feedback = Some("working directory required".into());
+        }
+        FleetKey::Enter if start.stage == StartStage::Cwd => {
+            start.cwd = start.cwd.trim().to_string();
+            start.stage = StartStage::Prompt;
+        }
+        FleetKey::Enter => {
+            state.mode = FleetMode::Browse;
+            return Some(FleetIntent::Start {
+                provider: start.provider,
+                cwd: start.cwd,
+                prompt: (!start.prompt.trim().is_empty()).then(|| start.prompt.trim().to_string()),
+            });
+        }
+        _ => {}
+    }
+    state.mode = FleetMode::Start(start);
+    None
+}
+
+fn reduce_prompt_key(
+    state: &mut FleetPaneState,
+    mut text: String,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    match key {
+        FleetKey::Esc => state.mode = FleetMode::Browse,
+        FleetKey::Backspace => {
+            text.pop();
+            state.mode = FleetMode::Prompt { text };
+        }
+        FleetKey::Enter if !text.trim().is_empty() => {
+            state.mode = FleetMode::Browse;
+            return request_action(state, FleetAction::SendText { text });
+        }
+        FleetKey::Enter => {
+            state.feedback = Some("prompt text required".into());
+            state.mode = FleetMode::Prompt { text };
+        }
+        FleetKey::Char(character) => {
+            text.push(character);
+            state.mode = FleetMode::Prompt { text };
+        }
+        FleetKey::Space => {
+            text.push(' ');
+            state.mode = FleetMode::Prompt { text };
+        }
+        _ => state.mode = FleetMode::Prompt { text },
+    }
+    None
+}
+
+fn move_selection(state: &mut FleetPaneState, delta: isize) {
+    let keys: Vec<String> =
+        state.visible_sessions().iter().map(|row| row.session_key.clone()).collect();
+    if keys.is_empty() {
+        state.selected_key = None;
+        return;
+    }
+    let current = state
+        .selected_key
+        .as_ref()
+        .and_then(|key| keys.iter().position(|candidate| candidate == key))
+        .unwrap_or(0);
+    let next = if delta < 0 {
+        current.saturating_sub(delta.unsigned_abs())
+    } else {
+        (current + delta as usize).min(keys.len() - 1)
+    };
+    state.selected_key = keys.get(next).cloned();
+}
+
+fn attach_intent(state: &mut FleetPaneState, fullscreen: bool) -> Option<FleetIntent> {
+    let Some(row) = state.selected_session() else {
+        state.feedback = Some("no Fleet session selected".into());
+        return None;
+    };
+    if !row.capabilities.contains("tmux_attach") {
+        state.feedback = Some("session lacks tmux_attach capability".into());
+        return None;
+    }
+    let Some(target) = row.tmux_target.clone() else {
+        state.feedback = Some("selected session has no tmux target".into());
+        return None;
+    };
+    let session_key = row.session_key.clone();
+    Some(if fullscreen {
+        FleetIntent::AttachFullscreen {
+            session_key,
+            tmux_target: target,
+        }
+    } else {
+        FleetIntent::AttachEmbedded {
+            session_key,
+            tmux_target: target,
+        }
+    })
+}
+
+fn request_action(state: &mut FleetPaneState, action: FleetAction) -> Option<FleetIntent> {
+    let Some(row) = state.selected_session().cloned() else {
+        state.feedback = Some("no Fleet session selected".into());
+        return None;
+    };
+    if !row.is_managed() && (action.is_structured() || action.is_destructive()) {
+        state.feedback = Some("degraded session blocks structured and destructive actions".into());
+        return None;
+    }
+    if !action.is_supported_by(&row.capabilities) {
+        state.feedback = Some(format!(
+            "session lacks {} capability",
+            action.capability_label()
+        ));
+        return None;
+    }
+    match action {
+        FleetAction::Stop | FleetAction::Restart => {
+            state.mode = FleetMode::Confirm {
+                session_key: row.session_key,
+                action,
+            };
+            None
+        }
+        FleetAction::Kill | FleetAction::Archive => {
+            let expected_name = row.session_name();
+            state.mode = FleetMode::TypedConfirm {
+                session_key: row.session_key,
+                expected_name,
+                typed: String::new(),
+                action,
+            };
+            None
+        }
+        action => Some(FleetIntent::Execute {
+            session_key: row.session_key,
+            expected_version: row.version,
+            action,
+        }),
+    }
+}
+
+/// Build approve or deny from exact selected request identity.
+pub fn selected_approval_action(
+    state: &FleetPaneState,
+    approve: bool,
+) -> Result<FleetAction, String> {
+    let row = state
+        .selected_session()
+        .ok_or_else(|| "no Fleet session selected".to_string())?;
+    if !row.attention_state.eq_ignore_ascii_case("APPROVAL") {
+        return Err("selected session has no approval request".into());
+    }
+    let fingerprint = row
+        .current_request_fingerprint
+        .clone()
+        .ok_or_else(|| "approval request fingerprint unavailable".to_string())?;
+    let identity = row.current_request.as_ref().and_then(request_identity);
+    Ok(if approve {
+        FleetAction::Approve {
+            request_fingerprint: fingerprint,
+            request_identity: identity,
+        }
+    } else {
+        FleetAction::Deny {
+            request_fingerprint: fingerprint,
+            request_identity: identity,
+        }
+    })
+}
+
+fn reduce_confirm_key(
+    state: &mut FleetPaneState,
+    session_key: &str,
+    action: FleetAction,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    match key {
+        FleetKey::Esc => {
+            state.mode = FleetMode::Browse;
+            None
+        }
+        FleetKey::Enter => execute_confirmed(state, session_key, action),
+        _ => None,
+    }
+}
+
+fn reduce_typed_confirm_key(
+    state: &mut FleetPaneState,
+    session_key: &str,
+    expected_name: &str,
+    mut typed: String,
+    action: FleetAction,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    match key {
+        FleetKey::Esc => {
+            state.mode = FleetMode::Browse;
+            None
+        }
+        FleetKey::Backspace => {
+            typed.pop();
+            state.mode = FleetMode::TypedConfirm {
+                session_key: session_key.to_string(),
+                expected_name: expected_name.to_string(),
+                typed,
+                action,
+            };
+            None
+        }
+        FleetKey::Char(character) => {
+            typed.push(character);
+            state.mode = FleetMode::TypedConfirm {
+                session_key: session_key.to_string(),
+                expected_name: expected_name.to_string(),
+                typed,
+                action,
+            };
+            None
+        }
+        FleetKey::Enter if typed == expected_name => execute_confirmed(state, session_key, action),
+        FleetKey::Enter => {
+            state.feedback = Some(format!("type exact session name: {expected_name}"));
+            None
+        }
+        _ => None,
+    }
+}
+
+fn execute_confirmed(
+    state: &mut FleetPaneState,
+    session_key: &str,
+    action: FleetAction,
+) -> Option<FleetIntent> {
+    let Some(row) = state.roster.iter().find(|row| row.session_key == session_key) else {
+        state.mode = FleetMode::Browse;
+        state.feedback = Some("session disappeared before confirmation".into());
+        return None;
+    };
+    let intent = FleetIntent::Execute {
+        session_key: row.session_key.clone(),
+        expected_version: row.version,
+        action,
+    };
+    state.mode = FleetMode::Browse;
+    Some(intent)
+}
+
+fn select_next_focus(state: &mut FleetPaneState, completed_key: &str) {
+    state.filter = FleetFilter::Focus;
+    let keys: Vec<String> = state
+        .roster
+        .iter()
+        .filter(|row| FleetFilter::Focus.matches(row))
+        .map(|row| row.session_key.clone())
+        .collect();
+    state.selected_key = match keys.iter().position(|key| key == completed_key) {
+        Some(index) if keys.len() > 1 => keys.get((index + 1) % keys.len()).cloned(),
+        Some(index) => keys.get(index).cloned(),
+        None => keys.first().cloned(),
+    };
+}
+
+fn reduce_broadcast_key(
+    state: &mut FleetPaneState,
+    broadcast: BroadcastState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    if key == FleetKey::Esc && broadcast.stage != BroadcastStage::InFlight {
+        state.mode = FleetMode::Browse;
+        return None;
+    }
+    match broadcast.stage {
+        BroadcastStage::Compose => reduce_broadcast_compose(state, broadcast, key),
+        BroadcastStage::Recipients => reduce_broadcast_recipients(state, broadcast, key),
+        BroadcastStage::Confirm => reduce_broadcast_confirm(state, broadcast, key),
+        BroadcastStage::InFlight => {
+            state.feedback = Some("broadcast already in flight".into());
+            state.mode = FleetMode::Broadcast(broadcast);
+            None
+        }
+        BroadcastStage::Receipts => reduce_broadcast_receipts(state, broadcast, key),
+    }
+}
+
+fn reduce_broadcast_compose(
+    state: &mut FleetPaneState,
+    mut broadcast: BroadcastState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    match key {
+        FleetKey::Char(character) => broadcast.text.push(character),
+        FleetKey::Backspace => {
+            broadcast.text.pop();
+        }
+        FleetKey::Enter if !broadcast.text.trim().is_empty() => {
+            broadcast.stage = BroadcastStage::Recipients;
+        }
+        FleetKey::Enter => state.feedback = Some("broadcast text required".into()),
+        _ => {}
+    }
+    state.mode = FleetMode::Broadcast(broadcast);
+    None
+}
+
+fn broadcast_candidate_keys(state: &FleetPaneState, expanded: bool) -> Vec<String> {
+    state
+        .roster
+        .iter()
+        .filter(|row| expanded || state.filter.matches(row))
+        .map(|row| row.session_key.clone())
+        .collect()
+}
+
+fn reduce_broadcast_recipients(
+    state: &mut FleetPaneState,
+    mut broadcast: BroadcastState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    let candidates = broadcast_candidate_keys(state, broadcast.expanded_roster);
+    match key {
+        FleetKey::Down | FleetKey::Char('j') => {
+            broadcast.cursor = (broadcast.cursor + 1).min(candidates.len().saturating_sub(1));
+        }
+        FleetKey::Up | FleetKey::Char('k') => {
+            broadcast.cursor = broadcast.cursor.saturating_sub(1);
+        }
+        FleetKey::Space => {
+            if let Some(key) = candidates.get(broadcast.cursor) {
+                if !broadcast.selected.remove(key) {
+                    broadcast.selected.insert(key.clone());
+                }
+            }
+        }
+        FleetKey::Char('a') => broadcast.selected.extend(candidates),
+        FleetKey::Char('e') => {
+            broadcast.expanded_roster = true;
+            broadcast.cursor = 0;
+        }
+        FleetKey::Enter if !broadcast.selected.is_empty() => {
+            broadcast.stage = BroadcastStage::Confirm;
+        }
+        FleetKey::Enter => state.feedback = Some("select at least one recipient".into()),
+        _ => {}
+    }
+    state.mode = FleetMode::Broadcast(broadcast);
+    None
+}
+
+fn reduce_broadcast_confirm(
+    state: &mut FleetPaneState,
+    mut broadcast: BroadcastState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    if key != FleetKey::Enter {
+        state.mode = FleetMode::Broadcast(broadcast);
+        return None;
+    }
+    let recipient_keys = broadcast.selected.iter().cloned().collect();
+    let idempotency_key = broadcast
+        .in_flight_idempotency_key
+        .get_or_insert_with(|| format!("fleet-broadcast-{}", uuid::Uuid::new_v4()))
+        .clone();
+    let intent = FleetIntent::Broadcast {
+        text: broadcast.text.clone(),
+        recipient_keys,
+        idempotency_key,
+        max_parallel: BROADCAST_MAX_PARALLEL,
+        retry_failures_only: false,
+    };
+    broadcast.failure_return_stage = Some(BroadcastStage::Confirm);
+    broadcast.stage = BroadcastStage::InFlight;
+    state.mode = FleetMode::Broadcast(broadcast);
+    Some(intent)
+}
+
+fn reduce_broadcast_receipts(
+    state: &mut FleetPaneState,
+    mut broadcast: BroadcastState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    let failed: Vec<String> = broadcast
+        .receipts
+        .values()
+        .filter(|receipt| receipt.status == ReceiptStatus::Failed)
+        .map(|receipt| receipt.session_key.clone())
+        .collect();
+    match key {
+        FleetKey::Down | FleetKey::Char('j') => {
+            broadcast.cursor = (broadcast.cursor + 1).min(failed.len().saturating_sub(1));
+        }
+        FleetKey::Up | FleetKey::Char('k') => {
+            broadcast.cursor = broadcast.cursor.saturating_sub(1);
+        }
+        FleetKey::Space => {
+            if let Some(key) = failed.get(broadcast.cursor) {
+                if !broadcast.selected.remove(key) {
+                    broadcast.selected.insert(key.clone());
+                }
+            }
+        }
+        FleetKey::Char('r') => {
+            let recipient_keys: Vec<String> =
+                failed.into_iter().filter(|key| broadcast.selected.contains(key)).collect();
+            if recipient_keys.is_empty() {
+                state.feedback = Some("select failed recipients to retry".into());
+            } else {
+                let idempotency_key = broadcast
+                    .in_flight_idempotency_key
+                    .get_or_insert_with(|| format!("fleet-broadcast-{}", uuid::Uuid::new_v4()))
+                    .clone();
+                let intent = FleetIntent::Broadcast {
+                    text: broadcast.text.clone(),
+                    recipient_keys,
+                    idempotency_key,
+                    max_parallel: BROADCAST_MAX_PARALLEL,
+                    retry_failures_only: true,
+                };
+                broadcast.failure_return_stage = Some(BroadcastStage::Receipts);
+                broadcast.stage = BroadcastStage::InFlight;
+                state.mode = FleetMode::Broadcast(broadcast);
+                return Some(intent);
+            }
+        }
+        _ => {}
+    }
+    state.mode = FleetMode::Broadcast(broadcast);
+    None
+}
+
+fn apply_broadcast_receipts(state: &mut FleetPaneState, receipts: Vec<BroadcastReceipt>) {
+    let FleetMode::Broadcast(mut broadcast) = state.mode.clone() else {
+        state.feedback = Some("ignored broadcast receipts without active broadcast".into());
+        return;
+    };
+    for receipt in receipts {
+        broadcast.receipts.insert(receipt.session_key.clone(), receipt);
+    }
+    broadcast.selected.retain(|session_key| {
+        broadcast
+            .receipts
+            .get(session_key)
+            .is_some_and(|receipt| receipt.status == ReceiptStatus::Failed)
+    });
+    broadcast.cursor = 0;
+    broadcast.in_flight_idempotency_key = None;
+    broadcast.failure_return_stage = None;
+    broadcast.stage = BroadcastStage::Receipts;
+    state.mode = FleetMode::Broadcast(broadcast);
+}
+
+fn apply_broadcast_failure(state: &mut FleetPaneState, detail: String) {
+    let FleetMode::Broadcast(mut broadcast) = state.mode.clone() else {
+        state.feedback = Some(format!("broadcast failed: {detail}"));
+        return;
+    };
+    if broadcast.stage != BroadcastStage::InFlight {
+        state.feedback = Some(format!("ignored stale broadcast failure: {detail}"));
+        return;
+    }
+    broadcast.stage = broadcast.failure_return_stage.unwrap_or_else(|| {
+        if broadcast.receipts.is_empty() {
+            BroadcastStage::Confirm
+        } else {
+            BroadcastStage::Receipts
+        }
+    });
+    broadcast.in_flight_idempotency_key = None;
+    broadcast.failure_return_stage = None;
+    state.feedback = Some(format!("broadcast failed: {detail}"));
+    state.mode = FleetMode::Broadcast(broadcast);
+}
+
+/// Render dense Fleet table, selected-session detail, and active modal.
+pub fn render_fleet(
+    buffer: &mut WireBuffer,
+    area_width: u16,
+    top: u16,
+    bottom: u16,
+    state: &FleetPaneState,
+) {
+    if area_width == 0 || bottom <= top {
+        return;
+    }
+    let list_width = (area_width * 2 / 3).max(48).min(area_width);
+    put_str(
+        buffer,
+        1,
+        top,
+        &format!(
+            "Fleet  [{}]  {}/{} sessions",
+            state.filter.label(),
+            state.visible_sessions().len(),
+            state.roster.len()
+        ),
+        GOLD,
+        list_width,
+    );
+    if top + 1 < bottom {
+        put_str(
+            buffer,
+            1,
+            top + 1,
+            "SESSION         PRV LIFE   ATTN AGE   MODE CONF NET",
+            MUTED,
+            list_width,
+        );
+    }
+
+    let visible = state.visible_sessions();
+    let mut row_y = top.saturating_add(2);
+    for session in visible {
+        if row_y >= bottom {
+            break;
+        }
+        let selected = state.selected_key.as_deref() == Some(session.session_key.as_str());
+        render_table_row(buffer, row_y, list_width, session, selected, state.now_ms);
+        row_y = row_y.saturating_add(1);
+    }
+    if row_y == top.saturating_add(2) && row_y < bottom {
+        put_str(
+            buffer,
+            2,
+            row_y,
+            "No sessions match filter",
+            MUTED,
+            list_width,
+        );
+    }
+
+    if list_width < area_width {
+        render_divider(buffer, list_width, top, bottom);
+        render_detail(
+            buffer,
+            list_width.saturating_add(2),
+            area_width,
+            top,
+            bottom,
+            state,
+        );
+    }
+    render_mode(buffer, area_width, top, bottom, state);
+}
+
+/// Overlay a compact degraded banner without hiding the cached Fleet roster.
+pub fn render_degraded_banner(buffer: &mut WireBuffer, area_width: u16, top: u16) {
+    put_str(
+        buffer,
+        0,
+        top,
+        "Fleet daemon offline, cached snapshot, high-risk actions disabled",
+        GOLD,
+        area_width,
+    );
+}
+
+fn render_table_row(
+    buffer: &mut WireBuffer,
+    row_y: u16,
+    right: u16,
+    session: &FleetSessionRow,
+    selected: bool,
+    now_ms: i64,
+) {
+    let marker = if selected { '>' } else { ' ' };
+    let name = truncate(&session.session_name(), 15);
+    let provider = truncate(&session.provider, 3).to_uppercase();
+    let lifecycle = truncate(&session.lifecycle_state, 6).to_uppercase();
+    let attention = truncate(&session.attention_state, 4).to_uppercase();
+    let mode = if session.is_managed() { "MNG" } else { "DEG" };
+    let confidence = truncate(&session.confidence, 4).to_uppercase();
+    let health = truncate(&session.transport_health, 3).to_uppercase();
+    let age = format_age(now_ms, session.last_observed_at);
+    let text = format!(
+        "{marker}{name:<15} {provider:<3} {lifecycle:<6} {attention:<4} {age:<5} {mode:<3} {confidence:<4} {health:<3}"
+    );
+    put_str(
+        buffer,
+        0,
+        row_y,
+        &text,
+        if selected { GREEN } else { FG },
+        right,
+    );
+}
+
+fn render_divider(buffer: &mut WireBuffer, x: u16, top: u16, bottom: u16) {
+    for y in top..bottom {
+        put_char(buffer, x, y, '│', BLUE);
+    }
+}
+
+fn render_detail(
+    buffer: &mut WireBuffer,
+    left: u16,
+    right: u16,
+    top: u16,
+    bottom: u16,
+    state: &FleetPaneState,
+) {
+    let Some(session) = state.selected_session() else {
+        put_str(buffer, left, top, "No selection", MUTED, right);
+        return;
+    };
+    let mut lines = vec![
+        ("Session", session.session_name()),
+        ("Key", session.session_key.clone()),
+        ("Provider", session.provider.clone()),
+        (
+            "State",
+            format!("{} / {}", session.lifecycle_state, session.attention_state),
+        ),
+    ];
+    if let Some(request) = &session.current_request {
+        lines.extend(request_detail_lines(request));
+    }
+    if session.attention_state.eq_ignore_ascii_case("ASK") {
+        lines.push(("Action", "Enter answer".into()));
+    } else if session.attention_state.eq_ignore_ascii_case("APPROVAL") {
+        lines.push(("Action", "y approve, n deny".into()));
+    }
+    lines.push((
+        "Keys",
+        "p prompt, t start, i interrupt, s stop, r restart, A attach".into(),
+    ));
+    lines.extend([
+        ("Mode", session.management_state.clone()),
+        ("Source", session.provenance.clone()),
+        ("Transport", session.transport_health.clone()),
+        ("Confidence", session.confidence.clone()),
+        ("Version", session.version.to_string()),
+        ("Cwd", session.cwd.clone()),
+        (
+            "Tmux",
+            session.tmux_target.clone().unwrap_or_else(|| "none".into()),
+        ),
+        ("Capabilities", session.capabilities.labels().join(", ")),
+    ]);
+    let mut y = top;
+    let detail_width = usize::from(right.saturating_sub(left).saturating_sub(1)).max(1);
+    for (label, value) in lines {
+        let prefix = format!("{label}: ");
+        let continuation = " ".repeat(prefix.chars().count());
+        for (index, part) in wrap_text(&value, detail_width.saturating_sub(prefix.len()).max(1))
+            .into_iter()
+            .enumerate()
+        {
+            if y >= bottom {
+                break;
+            }
+            let line_prefix = if index == 0 { &prefix } else { &continuation };
+            put_str(buffer, left, y, &format!("{line_prefix}{part}"), FG, right);
+            y = y.saturating_add(1);
+        }
+    }
+    if let Some(feedback) = &state.feedback {
+        if bottom > top {
+            put_str(buffer, left, bottom - 1, feedback, GOLD, right);
+        }
+    }
+}
+
+fn request_detail_lines(request: &serde_json::Value) -> Vec<(&'static str, String)> {
+    let questions = request
+        .pointer("/payload/questions")
+        .or_else(|| request.pointer("/payload/tool_input/questions"))
+        .or_else(|| request.get("questions"))
+        .or_else(|| request.pointer("/params/questions"))
+        .or_else(|| request.pointer("/tool_input/questions"))
+        .or_else(|| request.pointer("/request/questions"))
+        .and_then(serde_json::Value::as_array);
+    let Some(questions) = questions else {
+        return vec![("Request", request.to_string())];
+    };
+    let mut lines = Vec::new();
+    for (question_index, question) in questions.iter().enumerate() {
+        let header =
+            question.get("header").and_then(serde_json::Value::as_str).unwrap_or("Question");
+        let text = question
+            .get("question")
+            .or_else(|| question.get("text"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        lines.push((
+            "Question",
+            format!("{} {header}: {text}", question_index + 1),
+        ));
+        if let Some(options) = question.get("options").and_then(serde_json::Value::as_array) {
+            for (option_index, option) in options.iter().enumerate() {
+                let (label, description) = option.as_str().map_or_else(
+                    || {
+                        (
+                            option
+                                .get("label")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or_default(),
+                            option
+                                .get("description")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or_default(),
+                        )
+                    },
+                    |label| (label, ""),
+                );
+                let separator = if description.is_empty() { "" } else { ": " };
+                lines.push((
+                    "Option",
+                    format!("{}. {label}{separator}{description}", option_index + 1),
+                ));
+            }
+        }
+    }
+    lines
+}
+
+fn wrap_text(value: &str, width: usize) -> Vec<String> {
+    if value.is_empty() {
+        return vec![String::new()];
+    }
+    let characters: Vec<char> = value.chars().collect();
+    characters.chunks(width).map(|chunk| chunk.iter().collect()).collect()
+}
+
+fn render_mode(
+    buffer: &mut WireBuffer,
+    area_width: u16,
+    top: u16,
+    bottom: u16,
+    state: &FleetPaneState,
+) {
+    match &state.mode {
+        FleetMode::Browse => {}
+        FleetMode::Answer(answer) => {
+            let question = &answer.questions[answer.question_index];
+            let mut lines = vec![
+                format!(
+                    "Question {}/{}: {}",
+                    answer.question_index + 1,
+                    answer.questions.len(),
+                    question.text
+                ),
+                if answer.editing_text {
+                    "Type answer, Enter advances".into()
+                } else if question.multi_select {
+                    "Space toggles, Enter advances".into()
+                } else {
+                    "Up/Down selects, Enter advances, o enters Other text".into()
+                },
+            ];
+            if answer.editing_text {
+                lines.push(format!("> {}", answer.texts[answer.question_index]));
+            } else {
+                for (index, option) in question.options.iter().enumerate() {
+                    let cursor = if index == answer.option_cursor {
+                        '>'
+                    } else {
+                        ' '
+                    };
+                    let mark = if answer.selections[answer.question_index].contains(&index) {
+                        'x'
+                    } else {
+                        ' '
+                    };
+                    lines.push(format!("{cursor}[{mark}] {option}"));
+                }
+            }
+            render_modal(buffer, area_width, top, bottom, "Structured answer", &lines);
+        }
+        FleetMode::Start(start) => render_modal(
+            buffer,
+            area_width,
+            top,
+            bottom,
+            "Start managed session",
+            &[
+                "Provider: Codex".into(),
+                match start.stage {
+                    StartStage::Cwd => format!("Working directory: > {}", start.cwd),
+                    StartStage::Prompt => format!("Working directory: {}", start.cwd),
+                },
+                match start.stage {
+                    StartStage::Cwd => "Enter continues to optional prompt".into(),
+                    StartStage::Prompt => format!("Optional prompt: > {}", start.prompt),
+                },
+                match start.stage {
+                    StartStage::Cwd => "Esc cancels".into(),
+                    StartStage::Prompt => "Enter starts, Esc cancels".into(),
+                },
+            ],
+        ),
+        FleetMode::Prompt { text } => render_modal(
+            buffer,
+            area_width,
+            top,
+            bottom,
+            "Send prompt",
+            &[
+                format!("> {text}"),
+                "Enter sends through fleet/action, Esc cancels".into(),
+            ],
+        ),
+        FleetMode::Confirm {
+            session_key,
+            action,
+        } => render_modal(
+            buffer,
+            area_width,
+            top,
+            bottom,
+            "Confirm action",
+            &[
+                format!("{action:?}"),
+                session_key.clone(),
+                "Enter confirms, Esc cancels".into(),
+            ],
+        ),
+        FleetMode::TypedConfirm {
+            expected_name,
+            typed,
+            action,
+            ..
+        } => render_modal(
+            buffer,
+            area_width,
+            top,
+            bottom,
+            "Typed confirmation",
+            &[
+                format!("{action:?}"),
+                format!("Type: {expected_name}"),
+                format!("> {typed}"),
+            ],
+        ),
+        FleetMode::Broadcast(broadcast) => {
+            render_broadcast_modal(buffer, area_width, top, bottom, state, broadcast)
+        }
+    }
+}
+
+fn render_broadcast_modal(
+    buffer: &mut WireBuffer,
+    area_width: u16,
+    top: u16,
+    bottom: u16,
+    state: &FleetPaneState,
+    broadcast: &BroadcastState,
+) {
+    let mut lines = Vec::new();
+    match broadcast.stage {
+        BroadcastStage::Compose => {
+            lines.push("Compose message".into());
+            lines.push(format!("> {}", broadcast.text));
+            lines.push("Enter chooses recipients".into());
+        }
+        BroadcastStage::Recipients => {
+            lines.push(format!("Message: {}", broadcast.text));
+            let candidates = broadcast_candidate_keys(state, broadcast.expanded_roster);
+            for (index, key) in candidates.iter().enumerate().take(8) {
+                let cursor = if index == broadcast.cursor { '>' } else { ' ' };
+                let mark = if broadcast.selected.contains(key) {
+                    'x'
+                } else {
+                    ' '
+                };
+                lines.push(format!("{cursor}[{mark}] {key}"));
+            }
+            lines.push("Space toggle, a all visible, e full roster".into());
+        }
+        BroadcastStage::Confirm => {
+            lines.push(format!("Message: {}", broadcast.text));
+            lines.push(format!("Recipients: {}", broadcast.selected.len()));
+            lines.extend(broadcast.selected.iter().take(6).cloned());
+            lines.push("Enter sends, Esc cancels".into());
+        }
+        BroadcastStage::InFlight => {
+            lines.push(format!("Message: {}", broadcast.text));
+            lines.push(format!("Recipients: {}", broadcast.selected.len()));
+            lines.push("Sending, waiting for receipts".into());
+        }
+        BroadcastStage::Receipts => {
+            for receipt in broadcast.receipts.values().take(8) {
+                lines.push(format!("{:?}  {}", receipt.status, receipt.session_key));
+            }
+            lines.push("Space selects failed, r retries selected failures".into());
+        }
+    }
+    render_modal(buffer, area_width, top, bottom, "Broadcast", &lines);
+}
+
+fn render_modal(
+    buffer: &mut WireBuffer,
+    area_width: u16,
+    top: u16,
+    bottom: u16,
+    title: &str,
+    lines: &[String],
+) {
+    let available_height = bottom.saturating_sub(top);
+    if available_height < 4 || area_width < 20 {
+        return;
+    }
+    let width = area_width.saturating_sub(8).clamp(20, 72);
+    let height = (lines.len() as u16 + 2).clamp(4, available_height);
+    let left = (area_width.saturating_sub(width)) / 2;
+    let modal_top = top + available_height.saturating_sub(height) / 2;
+    let right = left + width;
+    let modal_bottom = modal_top + height;
+    for x in left..right {
+        put_char(buffer, x, modal_top, '─', BLUE);
+        put_char(buffer, x, modal_bottom - 1, '─', BLUE);
+    }
+    for y in modal_top..modal_bottom {
+        put_char(buffer, left, y, '│', BLUE);
+        put_char(buffer, right - 1, y, '│', BLUE);
+    }
+    put_char(buffer, left, modal_top, '┌', BLUE);
+    put_char(buffer, right - 1, modal_top, '┐', BLUE);
+    put_char(buffer, left, modal_bottom - 1, '└', BLUE);
+    put_char(buffer, right - 1, modal_bottom - 1, '┘', BLUE);
+    put_str(
+        buffer,
+        left + 2,
+        modal_top,
+        &format!(" {title} "),
+        GOLD,
+        right - 1,
+    );
+    for (index, line) in lines.iter().enumerate() {
+        let y = modal_top + 1 + index as u16;
+        if y >= modal_bottom - 1 {
+            break;
+        }
+        put_str(buffer, left + 2, y, line, FG, right - 2);
+    }
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn format_age(now_ms: i64, observed_ms: i64) -> String {
+    if now_ms <= 0 || observed_ms <= 0 || observed_ms > now_ms {
+        return "?".into();
+    }
+    let seconds = (now_ms - observed_ms) / 1000;
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3600 {
+        format!("{}m", seconds / 60)
+    } else {
+        format!("{}h", seconds / 3600)
+    }
+}
+
+fn put_str(buffer: &mut WireBuffer, x: u16, row: u16, value: &str, color: Color, right: u16) {
+    let mut column = x;
+    for raw_character in value.chars() {
+        if column >= right {
+            break;
+        }
+        let character = if raw_character.is_control() {
+            '�'
+        } else {
+            raw_character
+        };
+        let mut cell = Cell::new(character.to_string());
+        cell.fg = Some(color);
+        buffer.push(Coord::new(column, row), cell);
+        column = column.saturating_add(1);
+    }
+}
+
+fn put_char(buffer: &mut WireBuffer, x: u16, row: u16, character: char, color: Color) {
+    let mut cell = Cell::new(character.to_string());
+    cell.fg = Some(color);
+    buffer.push(Coord::new(x, row), cell);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(
+        key: &str,
+        provider: &str,
+        lifecycle: &str,
+        attention: &str,
+        management: &str,
+    ) -> FleetSessionRow {
+        FleetSessionRow {
+            session_key: key.into(),
+            provider: provider.into(),
+            provider_session_id: Some(format!("provider-{key}")),
+            current_request_fingerprint: None,
+            current_request: None,
+            lifecycle_state: lifecycle.into(),
+            attention_state: attention.into(),
+            management_state: management.into(),
+            provenance: "hangar-authoritative".into(),
+            confidence: "authoritative".into(),
+            transport_health: "healthy".into(),
+            capabilities: FleetCapabilities::List(
+                [
+                    "structured_answer",
+                    "approvals",
+                    "send_prompt",
+                    "verified_picker",
+                    "tmux_attach",
+                    "continue_turn",
+                    "retry",
+                    "interrupt",
+                    "start",
+                    "stop",
+                    "restart",
+                    "kill",
+                    "archive",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            ),
+            version: 7,
+            cwd: format!("/work/{key}"),
+            tmux_target: Some(format!("{key}:0.0")),
+            display_name: Some(key.into()),
+            discovered_at: 1_000,
+            last_observed_at: 9_000,
+            metadata_updated_at: 9_000,
+            lifecycle_updated_at: 9_000,
+            attention_updated_at: 9_000,
+            transport_updated_at: 9_000,
+        }
+    }
+
+    fn roster() -> Vec<FleetSessionRow> {
+        vec![
+            session("claude:ask", "claude", "IDLE", "ASK", "managed"),
+            session("codex:run", "codex", "RUNNING", "NONE", "managed"),
+            session("legacy:wait", "claude", "UNKNOWN", "WAITING", "degraded"),
+        ]
+    }
+
+    fn state_with_roster() -> FleetPaneState {
+        let mut state = FleetPaneState::default();
+        state.set_sessions(roster());
+        state
+    }
+
+    fn apply(state: &FleetPaneState, event: FleetEvent) -> FleetReduction {
+        reduce_fleet(state, event)
+    }
+
+    fn type_text(mut state: FleetPaneState, text: &str) -> FleetPaneState {
+        for character in text.chars() {
+            state = apply(&state, FleetEvent::Key(FleetKey::Char(character))).state;
+        }
+        state
+    }
+
+    fn row_text(buffer: &WireBuffer, row: u16, width: u16) -> String {
+        let mut output = String::new();
+        for x in 0..width {
+            let character = buffer
+                .cells
+                .iter()
+                .find(|(coord, _)| coord.x == x && coord.y == row)
+                .map_or(' ', |(_, cell)| cell.symbol.chars().next().unwrap_or(' '));
+            output.push(character);
+        }
+        output.trim_end().to_string()
+    }
+
+    #[test]
+    fn focus_is_default_and_excludes_running() {
+        let state = state_with_roster();
+        let keys: Vec<_> =
+            state.visible_sessions().iter().map(|row| row.session_key.as_str()).collect();
+        assert_eq!(state.filter(), FleetFilter::Focus);
+        assert_eq!(keys, ["claude:ask", "legacy:wait"]);
+    }
+
+    #[test]
+    fn selection_survives_snapshot_reorder_by_session_key() {
+        let state = state_with_roster();
+        let state = apply(&state, FleetEvent::Key(FleetKey::Down)).state;
+        assert_eq!(state.selected_key(), Some("legacy:wait"));
+
+        let mut reordered = roster();
+        reordered.reverse();
+        let state = apply(&state, FleetEvent::Snapshot(reordered)).state;
+        assert_eq!(state.selected_key(), Some("legacy:wait"));
+    }
+
+    #[test]
+    fn every_filter_selects_expected_rows() {
+        let state = state_with_roster();
+        let cases = [
+            (FleetFilter::Actionable, vec!["claude:ask", "legacy:wait"]),
+            (FleetFilter::Managed, vec!["claude:ask", "codex:run"]),
+            (FleetFilter::Degraded, vec!["legacy:wait"]),
+            (FleetFilter::Claude, vec!["claude:ask", "legacy:wait"]),
+            (FleetFilter::Codex, vec!["codex:run"]),
+            (
+                FleetFilter::All,
+                vec!["claude:ask", "codex:run", "legacy:wait"],
+            ),
+        ];
+        for (filter, expected) in cases {
+            let filtered = apply(&state, FleetEvent::SetFilter(filter)).state;
+            let actual: Vec<_> =
+                filtered.visible_sessions().iter().map(|row| row.session_key.as_str()).collect();
+            assert_eq!(actual, expected, "filter {filter:?}");
+        }
+    }
+
+    #[test]
+    fn successful_action_advances_to_next_focus_row() {
+        let state = state_with_roster();
+        assert_eq!(state.selected_key(), Some("claude:ask"));
+        let state = apply(
+            &state,
+            FleetEvent::ActionSucceeded {
+                session_key: "claude:ask".into(),
+            },
+        )
+        .state;
+        assert_eq!(state.filter(), FleetFilter::Focus);
+        assert_eq!(state.selected_key(), Some("legacy:wait"));
+    }
+
+    #[test]
+    fn right_and_uppercase_a_emit_exact_attach_intents() {
+        let state = state_with_roster();
+        assert_eq!(
+            apply(&state, FleetEvent::Key(FleetKey::Right)).intent,
+            Some(FleetIntent::AttachEmbedded {
+                session_key: "claude:ask".into(),
+                tmux_target: "claude:ask:0.0".into(),
+            })
+        );
+        assert_eq!(
+            apply(&state, FleetEvent::Key(FleetKey::Char('A'))).intent,
+            Some(FleetIntent::AttachFullscreen {
+                session_key: "claude:ask".into(),
+                tmux_target: "claude:ask:0.0".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn degraded_gates_structured_and_destructive_but_allows_safe_fallbacks() {
+        let mut state = state_with_roster();
+        state.selected_key = Some("legacy:wait".into());
+        let structured = apply(
+            &state,
+            FleetEvent::RequestAction(FleetAction::StructuredAnswer {
+                request_fingerprint: "req".into(),
+                request_identity: None,
+                answers: vec![ainb_hangar_proto::fleet::FleetQuestionAnswer {
+                    question_id: "q1".into(),
+                    selected_options: vec!["yes".into()],
+                    text: None,
+                }],
+            }),
+        );
+        assert!(structured.intent.is_none());
+        assert!(structured.state.feedback().is_some_and(|message| message.contains("degraded")));
+        assert!(apply(&state, FleetEvent::RequestAction(FleetAction::Kill)).intent.is_none());
+        assert!(matches!(
+            apply(
+                &state,
+                FleetEvent::RequestAction(FleetAction::SendText {
+                    text: "ping".into()
+                })
+            )
+            .intent,
+            Some(FleetIntent::Execute {
+                action: FleetAction::SendText { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            apply(
+                &state,
+                FleetEvent::RequestAction(FleetAction::VerifiedPicker {
+                    request_fingerprint: "req".into(),
+                    key: "1".into(),
+                })
+            )
+            .intent,
+            Some(FleetIntent::Execute {
+                action: FleetAction::VerifiedPicker { .. },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn enter_collects_complete_multi_question_structured_answer() {
+        let mut row = session("claude:ask", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("fingerprint-1".into());
+        row.current_request = Some(serde_json::json!({
+            "tool_use_id": "tool-1",
+            "questions": [
+                {
+                    "id": "tools",
+                    "question": "Pick tools",
+                    "multiSelect": true,
+                    "options": [
+                        {"label": "rg"},
+                        {"label": "ast-grep"}
+                    ]
+                },
+                {
+                    "id": "ship",
+                    "question": "Ship?",
+                    "options": [
+                        {"label": "No"},
+                        {"label": "Yes"}
+                    ]
+                }
+            ]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Down)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Down)).state;
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+
+        let Some(FleetIntent::Execute {
+            session_key,
+            expected_version,
+            action:
+                FleetAction::StructuredAnswer {
+                    request_fingerprint,
+                    request_identity,
+                    answers,
+                },
+        }) = submitted.intent
+        else {
+            panic!("final question must emit structured Fleet action");
+        };
+        assert_eq!(session_key, "claude:ask");
+        assert_eq!(expected_version, 7);
+        assert_eq!(request_fingerprint, "fingerprint-1");
+        assert_eq!(
+            request_identity.unwrap().request_id,
+            serde_json::json!("tool-1")
+        );
+        assert_eq!(answers.len(), 2);
+        assert_eq!(answers[0].question_id, "tools");
+        assert_eq!(answers[0].selected_options, ["rg", "ast-grep"]);
+        assert_eq!(answers[1].question_id, "ship");
+        assert_eq!(answers[1].selected_options, ["Yes"]);
+    }
+
+    #[test]
+    fn prompt_composer_emits_exact_text_through_versioned_action() {
+        let state = state_with_roster();
+        let mut state = apply(&state, FleetEvent::Key(FleetKey::Char('p'))).state;
+        state = type_text(state, "status now");
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+        assert_eq!(
+            submitted.intent,
+            Some(FleetIntent::Execute {
+                session_key: "claude:ask".into(),
+                expected_version: 7,
+                action: FleetAction::SendText {
+                    text: "status now".into(),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn empty_roster_starts_managed_codex_with_exact_cwd_and_optional_prompt() {
+        let state = FleetPaneState::default();
+        let mut state = apply(&state, FleetEvent::Key(FleetKey::Char('t'))).state;
+        state = type_text(state, " /work/new ");
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = type_text(state, " inspect failures ");
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+        assert_eq!(
+            submitted.intent,
+            Some(FleetIntent::Start {
+                provider: ainb_hangar_proto::fleet::FleetProvider::Codex,
+                cwd: "/work/new".into(),
+                prompt: Some("inspect failures".into()),
+            })
+        );
+
+        let mut state = apply(
+            &FleetPaneState::default(),
+            FleetEvent::Key(FleetKey::Char('t')),
+        )
+        .state;
+        state = type_text(state, "/work/no-prompt");
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+        assert_eq!(
+            submitted.intent,
+            Some(FleetIntent::Start {
+                provider: ainb_hangar_proto::fleet::FleetProvider::Codex,
+                cwd: "/work/no-prompt".into(),
+                prompt: None,
+            })
+        );
+    }
+
+    #[test]
+    fn structured_answer_preserves_nested_codex_identity_free_text_and_other() {
+        let mut row = session("codex:ask", "codex", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("codex-fingerprint".into());
+        row.current_request = Some(serde_json::json!({
+            "payload": {
+                "identity": {
+                    "requestId": 73,
+                    "threadId": "thread-1",
+                    "turnId": "turn-2",
+                    "itemId": "item-3"
+                },
+                "questions": [
+                    {
+                        "id": "free-form-question",
+                        "question": "What failed?",
+                        "options": []
+                    },
+                    {
+                        "id": "deployment-question",
+                        "question": "Where next?",
+                        "options": [
+                            {"label": "Other"},
+                            {"label": "Production"}
+                        ]
+                    }
+                ]
+            }
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = type_text(state, "timeout");
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = type_text(state, "staging-east");
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+
+        let Some(FleetIntent::Execute {
+            action:
+                FleetAction::StructuredAnswer {
+                    request_identity: Some(identity),
+                    answers,
+                    ..
+                },
+            ..
+        }) = submitted.intent
+        else {
+            panic!("structured answer intent expected");
+        };
+        assert_eq!(identity.request_id, serde_json::json!(73));
+        assert_eq!(identity.thread_id, "thread-1");
+        assert_eq!(identity.turn_id, "turn-2");
+        assert_eq!(identity.item_id, "item-3");
+        assert_eq!(answers[0].question_id, "free-form-question");
+        assert!(answers[0].selected_options.is_empty());
+        assert_eq!(answers[0].text.as_deref(), Some("timeout"));
+        assert_eq!(answers[1].question_id, "deployment-question");
+        assert!(
+            answers[1].selected_options.is_empty(),
+            "single-select Other text is the sole answer"
+        );
+        assert_eq!(answers[1].text.as_deref(), Some("staging-east"));
+    }
+
+    #[test]
+    fn approval_binding_preserves_exact_request_identity() {
+        let mut row = session("claude:approve", "claude", "IDLE", "APPROVAL", "managed");
+        row.current_request_fingerprint = Some("approve-fp".into());
+        row.current_request = Some(serde_json::json!({
+            "tool_use_id": "permission-1",
+            "thread_id": "thread-1",
+            "turn_id": "turn-1",
+            "item_id": "item-1"
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+        assert_eq!(
+            selected_approval_action(&state, true),
+            Ok(FleetAction::Approve {
+                request_fingerprint: "approve-fp".into(),
+                request_identity: Some(ainb_hangar_proto::fleet::FleetRequestIdentity {
+                    request_id: serde_json::json!("permission-1"),
+                    thread_id: "thread-1".into(),
+                    turn_id: "turn-1".into(),
+                    item_id: "item-1".into(),
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn stop_and_restart_require_explicit_confirmation() {
+        let state = state_with_roster();
+        for action in [FleetAction::Stop, FleetAction::Restart] {
+            let pending = apply(&state, FleetEvent::RequestAction(action.clone()));
+            assert!(pending.intent.is_none());
+            assert!(matches!(pending.state.mode, FleetMode::Confirm { .. }));
+            let confirmed = apply(&pending.state, FleetEvent::Key(FleetKey::Enter));
+            assert_eq!(
+                confirmed.intent,
+                Some(FleetIntent::Execute {
+                    session_key: "claude:ask".into(),
+                    expected_version: 7,
+                    action,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn kill_and_archive_require_exact_typed_session_name() {
+        let state = state_with_roster();
+        for action in [FleetAction::Kill, FleetAction::Archive] {
+            let pending = apply(&state, FleetEvent::RequestAction(action.clone()));
+            let wrong = type_text(pending.state, "wrong");
+            let wrong = apply(&wrong, FleetEvent::Key(FleetKey::Enter));
+            assert!(wrong.intent.is_none());
+
+            let pending = apply(&state, FleetEvent::RequestAction(action.clone()));
+            let exact = type_text(pending.state, "claude:ask");
+            let exact = apply(&exact, FleetEvent::Key(FleetKey::Enter));
+            assert_eq!(
+                exact.intent,
+                Some(FleetIntent::Execute {
+                    session_key: "claude:ask".into(),
+                    expected_version: 7,
+                    action,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn broadcast_supports_composer_toggle_visible_all_expand_preview_and_bound() {
+        let state = state_with_roster();
+        let state = apply(&state, FleetEvent::Key(FleetKey::Char('b'))).state;
+        let state = type_text(state, "ship it");
+        let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
+        let FleetMode::Broadcast(broadcast) = &state.mode else {
+            panic!("broadcast modal expected");
+        };
+        assert_eq!(broadcast.selected.len(), 1);
+
+        let state = apply(&state, FleetEvent::Key(FleetKey::Char('a'))).state;
+        let FleetMode::Broadcast(broadcast) = &state.mode else {
+            panic!("broadcast modal expected");
+        };
+        assert_eq!(broadcast.selected.len(), 2, "all visible Focus rows");
+
+        let state = apply(&state, FleetEvent::Key(FleetKey::Char('e'))).state;
+        let state = apply(&state, FleetEvent::Key(FleetKey::Char('a'))).state;
+        let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let sent = apply(&state, FleetEvent::Key(FleetKey::Enter));
+        let Some(FleetIntent::Broadcast {
+            text,
+            recipient_keys,
+            idempotency_key,
+            max_parallel,
+            retry_failures_only,
+        }) = &sent.intent
+        else {
+            panic!("broadcast intent expected");
+        };
+        assert_eq!(text, "ship it");
+        assert_eq!(
+            recipient_keys,
+            &vec![
+                "claude:ask".to_string(),
+                "codex:run".to_string(),
+                "legacy:wait".to_string(),
+            ]
+        );
+        assert!(idempotency_key.starts_with("fleet-broadcast-"));
+        assert_eq!(*max_parallel, 8);
+        assert!(!*retry_failures_only);
+
+        let repeated = apply(&sent.state, FleetEvent::Key(FleetKey::Enter));
+        assert!(repeated.intent.is_none(), "repeat Enter must not dispatch");
+        let FleetMode::Broadcast(broadcast) = &repeated.state.mode else {
+            panic!("in-flight broadcast expected");
+        };
+        assert_eq!(broadcast.stage, BroadcastStage::InFlight);
+        assert_eq!(
+            broadcast.in_flight_idempotency_key.as_deref(),
+            Some(idempotency_key.as_str()),
+            "one idempotency key must survive until receipts"
+        );
+
+        let cannot_close = apply(&repeated.state, FleetEvent::Key(FleetKey::Esc));
+        assert!(cannot_close.intent.is_none());
+        assert!(matches!(
+            &cannot_close.state.mode,
+            FleetMode::Broadcast(BroadcastState {
+                stage: BroadcastStage::InFlight,
+                ..
+            })
+        ));
+
+        let failed = apply(
+            &cannot_close.state,
+            FleetEvent::BroadcastFailed {
+                detail: "socket closed".into(),
+            },
+        );
+        let FleetMode::Broadcast(broadcast) = &failed.state.mode else {
+            panic!("confirmation must be restored after initial failure");
+        };
+        assert_eq!(broadcast.stage, BroadcastStage::Confirm);
+        assert!(broadcast.in_flight_idempotency_key.is_none());
+        assert!(broadcast.failure_return_stage.is_none());
+        assert_eq!(broadcast.selected.len(), 3);
+        assert!(broadcast.receipts.is_empty());
+        assert_eq!(
+            failed.state.feedback(),
+            Some("broadcast failed: socket closed")
+        );
+        let cancelled = apply(&failed.state, FleetEvent::Key(FleetKey::Esc));
+        assert!(matches!(cancelled.state.mode, FleetMode::Browse));
+
+        let resent = apply(&failed.state, FleetEvent::Key(FleetKey::Enter));
+        let Some(FleetIntent::Broadcast {
+            idempotency_key: resent_key,
+            ..
+        }) = &resent.intent
+        else {
+            panic!("restored confirmation must resend");
+        };
+        assert_ne!(resent_key, idempotency_key, "failed attempt key must clear");
+        let settled = apply(
+            &resent.state,
+            FleetEvent::BroadcastReceipts(vec![BroadcastReceipt {
+                session_key: "claude:ask".into(),
+                status: ReceiptStatus::Delivered,
+                detail: None,
+            }]),
+        );
+        let FleetMode::Broadcast(broadcast) = &settled.state.mode else {
+            panic!("receipt view expected");
+        };
+        assert_eq!(broadcast.stage, BroadcastStage::Receipts);
+        assert!(broadcast.in_flight_idempotency_key.is_none());
+    }
+
+    #[test]
+    fn receipts_preserve_three_outcomes_and_retry_selected_failures_only() {
+        let state = state_with_roster();
+        let state = apply(&state, FleetEvent::Key(FleetKey::Char('b'))).state;
+        let state = type_text(state, "retry me");
+        let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let state = apply(&state, FleetEvent::Key(FleetKey::Char('e'))).state;
+        let state = apply(&state, FleetEvent::Key(FleetKey::Char('a'))).state;
+        let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let state = apply(
+            &state,
+            FleetEvent::BroadcastReceipts(vec![
+                BroadcastReceipt {
+                    session_key: "claude:ask".into(),
+                    status: ReceiptStatus::Failed,
+                    detail: None,
+                },
+                BroadcastReceipt {
+                    session_key: "codex:run".into(),
+                    status: ReceiptStatus::Unknown,
+                    detail: None,
+                },
+                BroadcastReceipt {
+                    session_key: "legacy:wait".into(),
+                    status: ReceiptStatus::Failed,
+                    detail: None,
+                },
+                BroadcastReceipt {
+                    session_key: "finished".into(),
+                    status: ReceiptStatus::Delivered,
+                    detail: None,
+                },
+            ]),
+        )
+        .state;
+        let FleetMode::Broadcast(broadcast) = &state.mode else {
+            panic!("receipt view expected");
+        };
+        assert_eq!(broadcast.receipts.len(), 4);
+        assert!(
+            broadcast
+                .receipts
+                .values()
+                .any(|receipt| receipt.status == ReceiptStatus::Delivered)
+        );
+        assert!(
+            broadcast
+                .receipts
+                .values()
+                .any(|receipt| receipt.status == ReceiptStatus::Unknown)
+        );
+        let mut state = state;
+        let FleetMode::Broadcast(broadcast) = &mut state.mode else {
+            panic!("receipt view expected");
+        };
+        broadcast.selected.clear();
+        broadcast.selected.insert("legacy:wait".into());
+        let retry = apply(&state, FleetEvent::Key(FleetKey::Char('r')));
+        let Some(FleetIntent::Broadcast {
+            text,
+            recipient_keys,
+            idempotency_key,
+            max_parallel,
+            retry_failures_only,
+        }) = &retry.intent
+        else {
+            panic!("retry broadcast intent expected");
+        };
+        assert_eq!(text, "retry me");
+        assert_eq!(recipient_keys, &vec!["legacy:wait".to_string()]);
+        assert!(idempotency_key.starts_with("fleet-broadcast-"));
+        assert_eq!(*max_parallel, 8);
+        assert!(*retry_failures_only);
+
+        let repeated = apply(&retry.state, FleetEvent::Key(FleetKey::Char('r')));
+        assert!(repeated.intent.is_none(), "repeat retry must not dispatch");
+        let FleetMode::Broadcast(broadcast) = &repeated.state.mode else {
+            panic!("in-flight retry expected");
+        };
+        assert_eq!(
+            broadcast.in_flight_idempotency_key.as_deref(),
+            Some(idempotency_key.as_str())
+        );
+
+        let failed = apply(
+            &repeated.state,
+            FleetEvent::BroadcastFailed {
+                detail: "daemon unavailable".into(),
+            },
+        );
+        let FleetMode::Broadcast(broadcast) = &failed.state.mode else {
+            panic!("receipts must be restored after retry failure");
+        };
+        assert_eq!(broadcast.stage, BroadcastStage::Receipts);
+        assert!(broadcast.in_flight_idempotency_key.is_none());
+        assert!(broadcast.failure_return_stage.is_none());
+        assert_eq!(broadcast.receipts.len(), 4);
+        assert_eq!(
+            broadcast.selected,
+            BTreeSet::from(["legacy:wait".to_string()])
+        );
+
+        let redispatched = apply(&failed.state, FleetEvent::Key(FleetKey::Char('r')));
+        let Some(FleetIntent::Broadcast {
+            idempotency_key: redispatched_key,
+            ..
+        }) = &redispatched.intent
+        else {
+            panic!("restored retry view must retry");
+        };
+        assert_ne!(
+            redispatched_key, idempotency_key,
+            "failed retry key must clear"
+        );
+        let merged = apply(
+            &redispatched.state,
+            FleetEvent::BroadcastReceipts(vec![BroadcastReceipt {
+                session_key: "legacy:wait".into(),
+                status: ReceiptStatus::Delivered,
+                detail: Some("retry delivered".into()),
+            }]),
+        )
+        .state;
+        let FleetMode::Broadcast(broadcast) = &merged.mode else {
+            panic!("merged receipt view expected");
+        };
+        assert_eq!(broadcast.receipts.len(), 4, "retry must merge subset");
+        assert_eq!(
+            broadcast.receipts["claude:ask"].status,
+            ReceiptStatus::Failed,
+            "unselected failed receipt must survive retry"
+        );
+        assert_eq!(
+            broadcast.receipts["codex:run"].status,
+            ReceiptStatus::Unknown
+        );
+        assert_eq!(
+            broadcast.receipts["finished"].status,
+            ReceiptStatus::Delivered
+        );
+        assert_eq!(
+            broadcast.receipts["legacy:wait"].status,
+            ReceiptStatus::Delivered
+        );
+        assert!(
+            broadcast.selected.is_empty(),
+            "unselected failures must remain unselected after subset retry"
+        );
+    }
+
+    #[test]
+    fn dense_render_contains_table_and_selected_detail() {
+        let state = apply(&state_with_roster(), FleetEvent::Tick(10_000)).state;
+        let mut buffer = WireBuffer::new(120, 24);
+        render_fleet(&mut buffer, 120, 0, 20, &state);
+        assert!(row_text(&buffer, 0, 120).contains("Fleet  [Focus]"));
+        assert!(row_text(&buffer, 1, 80).contains("SESSION"));
+        assert!(row_text(&buffer, 2, 80).contains("CLA"));
+        let rendered: String =
+            (0..20).map(|row| row_text(&buffer, row, 120)).collect::<Vec<_>>().join("\n");
+        assert!(rendered.contains("Key: claude:ask"));
+        assert!(rendered.contains("State: IDLE / ASK"));
+        assert!(rendered.contains("Capabilities:"));
+    }
+
+    #[test]
+    fn capability_wire_accepts_list_flags_and_json() {
+        let list: FleetCapabilities =
+            serde_json::from_str(r#"["text_send","tmux_attach"]"#).unwrap();
+        let flags: FleetCapabilities =
+            serde_json::from_str(r#"{"text_send":true,"kill":false}"#).unwrap();
+        let json = FleetCapabilities::Json(r#"{"verified_picker":true}"#.into());
+        assert!(list.contains("text_send"));
+        assert!(flags.contains("text_send"));
+        assert!(!flags.contains("kill"));
+        assert!(json.contains("verified_picker"));
+    }
+
+    #[test]
+    fn proto_snapshot_rows_convert_without_wire_name_drift() {
+        use ainb_hangar_proto::fleet::{
+            AttentionState, FleetCapabilities as ProtoCapabilities, FleetConfidence,
+            FleetProvenance, FleetProvider, FleetSession, LifecycleState, ManagementState,
+            TransportHealth,
+        };
+        let row = FleetSessionRow::from(FleetSession {
+            session_key: "codex:thread-1".into(),
+            provider: FleetProvider::Codex,
+            provider_session_id: Some("thread-1".into()),
+            tmux_target: Some("codex-1:0.0".into()),
+            process_start_fingerprint: None,
+            cwd: "/work/shared".into(),
+            display_name: Some("codex-1".into()),
+            lifecycle: LifecycleState::Running,
+            attention: AttentionState::None,
+            current_request_fingerprint: None,
+            current_request: Some(serde_json::json!({
+                "questions": [{"id": "q1", "text": "Ship?", "options": ["yes", "no"]}]
+            })),
+            management: ManagementState::Managed,
+            transport_health: TransportHealth::Healthy,
+            capabilities: ProtoCapabilities {
+                interrupt: true,
+                tmux_attach: true,
+                ..ProtoCapabilities::default()
+            },
+            provenance: FleetProvenance::Authoritative,
+            confidence: FleetConfidence::High,
+            discovered_at: 10,
+            last_observed_at: 20,
+            lifecycle_updated_at: 20,
+            attention_updated_at: 10,
+            version: 3,
+            updated_revision: 4,
+        });
+        assert_eq!(row.provider, "codex");
+        assert_eq!(row.lifecycle_state, "RUNNING");
+        assert_eq!(row.management_state, "MANAGED");
+        assert!(row.capabilities.contains("interrupt"));
+        assert!(row.capabilities.contains("tmux_attach"));
+        let request_lines = request_detail_lines(row.current_request.as_ref().unwrap());
+        assert!(request_lines.iter().any(|(_, line)| line.contains("Ship?")));
+        assert!(request_lines.iter().any(|(_, line)| line.contains("1. yes")));
+        assert!(request_lines.iter().any(|(_, line)| line.contains("2. no")));
+    }
+
+    #[test]
+    fn renderer_replaces_control_characters() {
+        let mut state = state_with_roster();
+        state.roster[0].cwd = "/work/\u{1b}]52;c;AAAA\u{7}".into();
+        let mut buffer = WireBuffer::new(120, 24);
+        render_fleet(&mut buffer, 120, 0, 20, &state);
+        assert!(!buffer.cells.iter().any(|(_, cell)| cell.symbol.chars().any(char::is_control)));
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
@@ -22,6 +22,7 @@ pub mod command_palette;
 pub mod context_menu;
 pub mod control_center;
 pub mod daemon_health;
+pub mod fleet;
 pub mod inbox;
 pub mod issue_list;
 pub mod kanban;
@@ -84,6 +85,9 @@ pub enum Screen {
     /// board, backed by the P2 attention feed (`attention/list` +
     /// `attention/subscribe`) with inline answering via `attention/answer`.
     ControlCenter,
+    /// Fleet super-control pane (hotkey `F`), backed by authoritative registry
+    /// snapshots and revisioned live updates.
+    Fleet,
     /// Squads (hotkey `S`) — the daemon-native team primitive (D17): squads with
     /// a leader + members, live per-member status, and issue-assign leader-routing
     /// dispatch, backed by `hangar/squads_list` + the squad mutation RPCs (P7).
@@ -121,6 +125,7 @@ impl Screen {
             Self::Logs => "Logs",
             Self::Inbox => "Inbox",
             Self::ControlCenter => "Control",
+            Self::Fleet => "Fleet",
             Self::Squads => "Squads",
             Self::Profiles => "Profiles",
             Self::Settings => "Settings",

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
@@ -62,6 +62,8 @@ fn reduce_key(state: &AppState, c: char) -> Reduction {
         'I' => switch_tab(state, Screen::Inbox),
         // `C` (capital) opens the fleet-wide control center from anywhere (P2).
         'C' => switch_tab(state, Screen::ControlCenter),
+        // `F` opens the authoritative Fleet registry and control pane.
+        'F' => switch_tab(state, Screen::Fleet),
         // `S` (capital) opens the Squads screen from anywhere (P7).
         'S' => switch_tab(state, Screen::Squads),
         // `P` (capital) opens the profile editor from anywhere (P5).

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -6,17 +6,21 @@
 //! the one gap where AgentPeek's design beats ours: a human synchronously
 //! approving or denying a live Claude `PermissionRequest` hook.
 //!
-//! Three line-JSON operations, one per connection:
+//! Five line-JSON operations, one per connection:
 //!
-//! - **AWAIT** — a waiting hook (the `ainb fleet atc hook`
+//! - **AWAIT**: a waiting hook (the `ainb fleet atc hook`
 //!   `PermissionRequest` branch) dials in, registers itself keyed by
 //!   `session_id`, and BLOCKS on the connection until a human decides or
 //!   the broker times out. The response is the decision.
-//! - **DECIDE** — the fleet TUI / CLI dials in, names a `session_id` and
+//! - **DECIDE**: the fleet TUI / CLI dials in, names a `session_id` and
 //!   an `approve`/`deny`, the broker hands the decision to the blocked
 //!   AWAIT, and both connections resolve.
-//! - **LIST** — dump the pending session ids (what is currently waiting
-//!   for a human), for the Daemons overlay / CLI status.
+//! - **AWAIT_STRUCTURED**: a managed AskUserQuestion hook registers its exact
+//!   fingerprint and complete question array, then blocks for answers.
+//! - **ANSWER_STRUCTURED**: an operator answers every question. The broker
+//!   accepts only the current fingerprint and only the first valid answer.
+//! - **LIST**: dump pending requests, including structured questions and their
+//!   current fingerprint, for Fleet surfaces.
 //!
 //! ## Durability model
 //!
@@ -24,9 +28,9 @@
 //! AWAIT on disconnect, so restarting notifyd is the single resume
 //! command: every still-alive waiter re-registers itself. There is no
 //! durable pending file. If a waiter's AWAIT times out (no human in the
-//! window) the fallback is **deny** — never auto-approve. The
-//! correlation key across every surface is `session_id`, because Claude
-//! blocks on at most one permission request per session at a time.
+//! window) the permission fallback is **deny**, never auto-approve. Permission
+//! requests correlate by `session_id`. Structured requests additionally require
+//! the exact fingerprint so a late answer cannot resolve a newer prompt.
 //!
 //! ## Trust boundary
 //!
@@ -39,7 +43,7 @@
 //! local process. Do not treat an `allow` from this broker as proof a
 //! HUMAN clicked it if same-uid code is untrusted.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, Write};
 use std::os::unix::net::UnixStream as StdUnixStream;
 use std::path::Path;
@@ -87,6 +91,45 @@ pub struct Decision {
     pub reason: String,
 }
 
+/// One structured answer for an exact AskUserQuestion question.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StructuredQuestionAnswer {
+    /// Exact question text used as Claude's answer-map key.
+    pub question: String,
+    /// Selected labels in user order. Multiple values preserve multi-select.
+    pub selected_options: Vec<String>,
+}
+
+/// Resolution returned to a blocked structured-question hook.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum StructuredResolution {
+    /// Human supplied complete answers.
+    Answered {
+        /// One answer for every original question.
+        answers: Vec<StructuredQuestionAnswer>,
+    },
+    /// Broker could not safely provide an answer.
+    Rejected {
+        /// Human-readable safe failure reason.
+        reason: String,
+    },
+}
+
+impl StructuredResolution {
+    fn timed_out() -> Self {
+        Self::Rejected {
+            reason: "no human answer before timeout".to_string(),
+        }
+    }
+
+    fn superseded() -> Self {
+        Self::Rejected {
+            reason: "superseded by a newer request for this session".to_string(),
+        }
+    }
+}
+
 impl Decision {
     /// The safe fallback when no human answered in time.
     fn timed_out() -> Self {
@@ -112,17 +155,27 @@ struct Pending {
     /// `session_id` — only the entry whose id we still hold gets removed
     /// on our own timeout, so a superseding AWAIT is never clobbered.
     id: u64,
-    /// Tool the permission request is for (e.g. `Bash`), for display.
-    tool: String,
-    /// Short human context (e.g. the command), for display.
-    context: String,
     /// When this AWAIT registered, ms since epoch — drives `waiting_ms`.
     since_ms: u64,
-    /// Channel to deliver the human's decision to the blocked AWAIT.
-    tx: oneshot::Sender<Decision>,
+    /// Exact pending request and its response channel.
+    kind: PendingKind,
 }
 
-/// One pending approval as reported by LIST.
+enum PendingKind {
+    Permission {
+        tool: String,
+        context: String,
+        request_fingerprint: String,
+        tx: oneshot::Sender<Decision>,
+    },
+    Structured {
+        request_fingerprint: String,
+        questions: Vec<serde_json::Value>,
+        tx: oneshot::Sender<StructuredResolution>,
+    },
+}
+
+/// One pending broker request as reported by LIST.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingInfo {
     /// The session blocked on a human decision.
@@ -131,8 +184,134 @@ pub struct PendingInfo {
     pub tool: String,
     /// Short human context.
     pub context: String,
+    /// Exact structured request fingerprint, absent for permissions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_fingerprint: Option<String>,
+    /// Complete original question objects, empty for permissions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub questions: Vec<serde_json::Value>,
     /// How long it has been waiting, in milliseconds.
     pub waiting_ms: u64,
+}
+
+/// Broker acknowledgement for an exact structured answer attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StructuredAnswerAck {
+    /// Request parsed and processed.
+    pub ok: bool,
+    /// Matching waiter received this answer.
+    pub matched: bool,
+    /// Fingerprint or pending request kind did not match current state.
+    pub stale: bool,
+    /// Validation error, when supplied answers were incomplete or malformed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl StructuredAnswerAck {
+    fn matched() -> Self {
+        Self {
+            ok: true,
+            matched: true,
+            stale: false,
+            error: None,
+        }
+    }
+
+    fn unmatched() -> Self {
+        Self {
+            ok: true,
+            matched: false,
+            stale: false,
+            error: None,
+        }
+    }
+
+    fn stale() -> Self {
+        Self {
+            ok: true,
+            matched: false,
+            stale: true,
+            error: None,
+        }
+    }
+
+    fn invalid(error: String) -> Self {
+        Self {
+            ok: false,
+            matched: false,
+            stale: false,
+            error: Some(error),
+        }
+    }
+}
+
+/// Stable fingerprint for exact structured tool input.
+#[must_use]
+pub fn request_fingerprint(tool_input: &serde_json::Value) -> String {
+    let bytes = serde_json::to_vec(tool_input).unwrap_or_default();
+    let hash = bytes.iter().fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x0000_0100_0000_01b3)
+    });
+    format!("fnv1a64:{hash:016x}")
+}
+
+fn validate_structured_answers(
+    questions: &[serde_json::Value],
+    answers: &[StructuredQuestionAnswer],
+) -> std::result::Result<(), String> {
+    if questions.is_empty() {
+        return Err("structured request has no questions".to_string());
+    }
+    if answers.len() != questions.len() {
+        return Err(format!(
+            "expected {} question answers, received {}",
+            questions.len(),
+            answers.len()
+        ));
+    }
+    let mut expected = HashMap::new();
+    for question in questions {
+        let text = question
+            .get("question")
+            .and_then(serde_json::Value::as_str)
+            .filter(|text| !text.is_empty())
+            .ok_or_else(|| "structured question is missing question text".to_string())?;
+        let multi = question
+            .get("multiSelect")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if expected.insert(text, multi).is_some() {
+            return Err(format!("duplicate structured question text: {text}"));
+        }
+    }
+    let mut answered = HashSet::new();
+    for answer in answers {
+        let Some(multi) = expected.get(answer.question.as_str()) else {
+            return Err(format!(
+                "answer does not match current question: {}",
+                answer.question
+            ));
+        };
+        if !answered.insert(answer.question.as_str()) {
+            return Err(format!(
+                "duplicate answer for question: {}",
+                answer.question
+            ));
+        }
+        if answer.selected_options.is_empty()
+            || answer.selected_options.iter().any(|value| value.trim().is_empty())
+        {
+            return Err(format!("question has an empty answer: {}", answer.question));
+        }
+        if !multi && answer.selected_options.len() != 1 {
+            return Err(format!(
+                "single-select question received multiple answers: {}",
+                answer.question
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Shared broker state: the pending map plus the AWAIT timeout. Cloneable
@@ -165,11 +344,38 @@ impl BrokerState {
         let now = now_ms();
         let map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
         map.iter()
-            .map(|(session_id, p)| PendingInfo {
-                session_id: session_id.clone(),
-                tool: p.tool.clone(),
-                context: p.context.clone(),
-                waiting_ms: now.saturating_sub(p.since_ms),
+            .map(|(session_id, pending)| {
+                let (tool, context, request_fingerprint, questions) = match &pending.kind {
+                    PendingKind::Permission {
+                        tool,
+                        context,
+                        request_fingerprint,
+                        ..
+                    } => (
+                        tool.clone(),
+                        context.clone(),
+                        (!request_fingerprint.is_empty()).then(|| request_fingerprint.clone()),
+                        Vec::new(),
+                    ),
+                    PendingKind::Structured {
+                        request_fingerprint,
+                        questions,
+                        ..
+                    } => (
+                        "AskUserQuestion".to_string(),
+                        serde_json::to_string(questions).unwrap_or_default(),
+                        Some(request_fingerprint.clone()),
+                        questions.clone(),
+                    ),
+                };
+                PendingInfo {
+                    session_id: session_id.clone(),
+                    tool,
+                    context,
+                    request_fingerprint,
+                    questions,
+                    waiting_ms: now.saturating_sub(pending.since_ms),
+                }
             })
             .collect()
     }
@@ -179,20 +385,49 @@ impl BrokerState {
     /// dropped receiver (the AWAIT raced into its timeout/supersede path)
     /// reports `false`, so the TUI/CLI never claims a match that nobody heard.
     pub fn decide(&self, session_id: &str, decision: Decision) -> bool {
+        self.decide_exact(session_id, None, decision)
+    }
+
+    /// Resolve only the exact current permission request fingerprint.
+    pub fn decide_exact(
+        &self,
+        session_id: &str,
+        request_fingerprint: Option<&str>,
+        decision: Decision,
+    ) -> bool {
         let taken = {
             let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
-            map.remove(session_id)
+            if matches!(
+                map.get(session_id).map(|p| &p.kind),
+                Some(PendingKind::Permission { request_fingerprint: current, .. })
+                    if (current.is_empty() && request_fingerprint.is_none())
+                        || request_fingerprint == Some(current.as_str())
+            ) {
+                map.remove(session_id)
+            } else {
+                None
+            }
         };
         match taken {
-            Some(p) => p.tx.send(decision).is_ok(),
+            Some(Pending {
+                kind: PendingKind::Permission { tx, .. },
+                ..
+            }) => tx.send(decision).is_ok(),
             None => false,
+            Some(_) => false,
         }
     }
 
     /// Register an AWAIT and block until a human decides, the entry is
     /// superseded, or the timeout fires (fallback: deny). Never returns
     /// without a decision — the waiting hook is never left empty-handed.
-    async fn await_decision(&self, session_id: String, tool: String, context: String) -> Decision {
+    async fn await_decision(
+        &self,
+        session_id: String,
+        tool: String,
+        context: String,
+        request_fingerprint: String,
+    ) -> Decision {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = oneshot::channel();
         {
@@ -201,10 +436,13 @@ impl BrokerState {
                 session_id.clone(),
                 Pending {
                     id,
-                    tool,
-                    context,
                     since_ms: now_ms(),
-                    tx,
+                    kind: PendingKind::Permission {
+                        tool,
+                        context,
+                        request_fingerprint,
+                        tx,
+                    },
                 },
             );
         }
@@ -223,6 +461,86 @@ impl BrokerState {
                 }
                 Decision::timed_out()
             }
+        }
+    }
+
+    async fn await_structured(
+        &self,
+        session_id: String,
+        request_fingerprint: String,
+        questions: Vec<serde_json::Value>,
+    ) -> StructuredResolution {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            map.insert(
+                session_id.clone(),
+                Pending {
+                    id,
+                    since_ms: now_ms(),
+                    kind: PendingKind::Structured {
+                        request_fingerprint,
+                        questions,
+                        tx,
+                    },
+                },
+            );
+        }
+
+        match tokio::time::timeout(self.await_timeout, rx).await {
+            Ok(Ok(resolution)) => resolution,
+            Ok(Err(_)) => StructuredResolution::superseded(),
+            Err(_) => {
+                let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+                if map.get(&session_id).is_some_and(|p| p.id == id) {
+                    map.remove(&session_id);
+                }
+                StructuredResolution::timed_out()
+            }
+        }
+    }
+
+    fn answer_structured(
+        &self,
+        session_id: &str,
+        request_fingerprint: &str,
+        answers: Vec<StructuredQuestionAnswer>,
+    ) -> StructuredAnswerAck {
+        let taken = {
+            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            let Some(pending) = map.get(session_id) else {
+                return StructuredAnswerAck::unmatched();
+            };
+            let PendingKind::Structured {
+                request_fingerprint: current,
+                questions,
+                ..
+            } = &pending.kind
+            else {
+                return StructuredAnswerAck::stale();
+            };
+            if current != request_fingerprint {
+                return StructuredAnswerAck::stale();
+            }
+            if let Err(error) = validate_structured_answers(questions, &answers) {
+                return StructuredAnswerAck::invalid(error);
+            }
+            map.remove(session_id)
+        };
+
+        match taken {
+            Some(Pending {
+                kind: PendingKind::Structured { tx, .. },
+                ..
+            }) => {
+                if tx.send(StructuredResolution::Answered { answers }).is_ok() {
+                    StructuredAnswerAck::matched()
+                } else {
+                    StructuredAnswerAck::unmatched()
+                }
+            }
+            _ => StructuredAnswerAck::unmatched(),
         }
     }
 }
@@ -244,6 +562,8 @@ enum Request {
         tool: String,
         #[serde(default)]
         context: String,
+        #[serde(default)]
+        request_fingerprint: String,
     },
     /// A human (TUI/CLI) delivers a decision for a session.
     Decide {
@@ -251,6 +571,22 @@ enum Request {
         decision: DecisionKind,
         #[serde(default)]
         reason: String,
+        #[serde(default)]
+        request_fingerprint: Option<String>,
+    },
+    /// A waiting AskUserQuestion hook registers its exact request and blocks.
+    #[serde(rename = "await_structured")]
+    AwaitStructured {
+        session_id: String,
+        request_fingerprint: String,
+        questions: Vec<serde_json::Value>,
+    },
+    /// Human answers an exact current AskUserQuestion request.
+    #[serde(rename = "answer_structured")]
+    AnswerStructured {
+        session_id: String,
+        request_fingerprint: String,
+        answers: Vec<StructuredQuestionAnswer>,
     },
     /// Dump the pending session ids.
     List,
@@ -320,17 +656,50 @@ async fn handle_connection(stream: UnixStream, state: BrokerState) -> Result<()>
             session_id,
             tool,
             context,
+            request_fingerprint,
         } => {
-            let decision = state.await_decision(session_id, tool, context).await;
+            let decision =
+                state.await_decision(session_id, tool, context, request_fingerprint).await;
             write_line(reader.get_mut(), &decision).await?;
         }
         Request::Decide {
             session_id,
             decision,
             reason,
+            request_fingerprint,
         } => {
-            let matched = state.decide(&session_id, Decision { decision, reason });
+            let matched = state.decide_exact(
+                &session_id,
+                request_fingerprint.as_deref(),
+                Decision { decision, reason },
+            );
             write_line(reader.get_mut(), &DecideAck { ok: true, matched }).await?;
+        }
+        Request::AwaitStructured {
+            session_id,
+            request_fingerprint,
+            questions,
+        } => {
+            let resolution = if session_id.is_empty()
+                || request_fingerprint.is_empty()
+                || questions.is_empty()
+            {
+                StructuredResolution::Rejected {
+                    reason: "structured await requires session, fingerprint, and questions"
+                        .to_string(),
+                }
+            } else {
+                state.await_structured(session_id, request_fingerprint, questions).await
+            };
+            write_line(reader.get_mut(), &resolution).await?;
+        }
+        Request::AnswerStructured {
+            session_id,
+            request_fingerprint,
+            answers,
+        } => {
+            let ack = state.answer_structured(&session_id, &request_fingerprint, answers);
+            write_line(reader.get_mut(), &ack).await?;
         }
         Request::List => {
             let pending = state.list();
@@ -393,12 +762,26 @@ pub fn client_await(
     context: &str,
     deadline: Duration,
 ) -> Decision {
+    client_await_exact(sock, session_id, tool, context, "", deadline)
+}
+
+/// Block on one exact permission request fingerprint.
+#[must_use]
+pub fn client_await_exact(
+    sock: &Path,
+    session_id: &str,
+    tool: &str,
+    context: &str,
+    request_fingerprint: &str,
+    deadline: Duration,
+) -> Decision {
     let started = Instant::now();
     let req = serde_json::json!({
         "op": "await",
         "session_id": session_id,
         "tool": tool,
         "context": context,
+        "request_fingerprint": request_fingerprint,
     });
     let line = serde_json::to_string(&req).unwrap_or_default();
     loop {
@@ -438,12 +821,96 @@ fn try_await_once(
     Ok(Some(decision))
 }
 
+/// Block until an exact structured request receives complete human answers.
+///
+/// The original questions stay on the broker for operator rendering. Answer
+/// delivery requires the same request fingerprint, preventing a late answer
+/// from resolving a newer prompt in the same session.
+#[must_use]
+pub fn client_await_structured(
+    sock: &Path,
+    session_id: &str,
+    request_fingerprint: &str,
+    questions: &[serde_json::Value],
+    deadline: Duration,
+) -> StructuredResolution {
+    let started = Instant::now();
+    let request = serde_json::json!({
+        "op": "await_structured",
+        "session_id": session_id,
+        "request_fingerprint": request_fingerprint,
+        "questions": questions,
+    });
+    let line = serde_json::to_string(&request).unwrap_or_default();
+    loop {
+        let remaining = deadline.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return StructuredResolution::timed_out();
+        }
+        match try_await_structured_once(sock, &line, remaining) {
+            Ok(Some(resolution)) => return resolution,
+            Ok(None) | Err(_) => std::thread::sleep(REDIAL_INTERVAL),
+        }
+    }
+}
+
+fn try_await_structured_once(
+    sock: &Path,
+    line: &str,
+    read_timeout: Duration,
+) -> std::io::Result<Option<StructuredResolution>> {
+    let mut stream = StdUnixStream::connect(sock)?;
+    stream.set_read_timeout(Some(read_timeout))?;
+    stream.write_all(line.as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    let mut reader = std::io::BufReader::new(stream);
+    let mut response = String::new();
+    if reader.read_line(&mut response)? == 0 {
+        return Ok(None);
+    }
+    let resolution = serde_json::from_str(response.trim())
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    Ok(Some(resolution))
+}
+
+/// Answer the current exact structured request for one session.
+pub fn client_answer_structured(
+    sock: &Path,
+    session_id: &str,
+    request_fingerprint: &str,
+    answers: &[StructuredQuestionAnswer],
+) -> std::io::Result<StructuredAnswerAck> {
+    let response = client_round_trip(
+        sock,
+        &serde_json::json!({
+            "op": "answer_structured",
+            "session_id": session_id,
+            "request_fingerprint": request_fingerprint,
+            "answers": answers,
+        }),
+    )?;
+    serde_json::from_value(response)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
 /// Deliver a decision for `session_id` to the broker (the TUI/CLI approve/deny
 /// lever). Returns whether a waiter was actually blocked on that session
 /// (`matched` false = nothing was waiting, e.g. it already timed out).
 pub fn client_decide(
     sock: &Path,
     session_id: &str,
+    decision: DecisionKind,
+    reason: &str,
+) -> std::io::Result<bool> {
+    client_decide_exact(sock, session_id, None, decision, reason)
+}
+
+/// Deliver a decision only to the exact permission request fingerprint.
+pub fn client_decide_exact(
+    sock: &Path,
+    session_id: &str,
+    request_fingerprint: Option<&str>,
     decision: DecisionKind,
     reason: &str,
 ) -> std::io::Result<bool> {
@@ -454,9 +921,19 @@ pub fn client_decide(
             "session_id": session_id,
             "decision": decision,
             "reason": reason,
+            "request_fingerprint": request_fingerprint,
         }),
     )?;
     Ok(resp.get("matched").and_then(serde_json::Value::as_bool).unwrap_or(false))
+}
+
+/// Stable exact permission identity shared by hook and controller.
+#[must_use]
+pub fn permission_fingerprint(tool: &str, context: &str) -> String {
+    request_fingerprint(&serde_json::json!({
+        "tool": tool,
+        "context": context,
+    }))
 }
 
 /// List sessions currently blocked on a human decision (Daemons overlay / CLI
@@ -562,6 +1039,106 @@ mod tests {
         let parsed: Decision = serde_json::from_str(decision.trim()).unwrap();
         assert_eq!(parsed.decision, DecisionKind::Approve);
         assert_eq!(parsed.reason, "ok");
+
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn structured_answer_preserves_all_questions_and_rejects_stale() {
+        let (sock, _state, handle) = spawn_broker(Duration::from_secs(30)).await;
+        let questions = serde_json::json!([
+            {
+                "question": "Region?",
+                "header": "Region",
+                "options": [{"label": "EU"}, {"label": "US"}],
+                "multiSelect": false
+            },
+            {
+                "question": "Checks?",
+                "header": "Checks",
+                "options": [{"label": "Lint"}, {"label": "Test"}],
+                "multiSelect": true
+            }
+        ]);
+        let tool_input = serde_json::json!({ "questions": questions });
+        let fingerprint = request_fingerprint(&tool_input);
+        let request = serde_json::json!({
+            "op": "await_structured",
+            "session_id": "ask-1",
+            "request_fingerprint": fingerprint,
+            "questions": tool_input["questions"],
+        });
+        let sock_waiter = sock.clone();
+        let waiter = tokio::spawn(async move {
+            round_trip(&sock_waiter, &serde_json::to_string(&request).unwrap()).await
+        });
+        wait_for_pending(&sock, "ask-1").await;
+
+        let pending = {
+            let socket = sock.clone();
+            tokio::task::spawn_blocking(move || client_list(&socket).unwrap())
+                .await
+                .unwrap()
+        };
+        assert_eq!(
+            pending[0].request_fingerprint.as_deref(),
+            Some(fingerprint.as_str())
+        );
+        assert_eq!(pending[0].questions.len(), 2);
+        assert_eq!(pending[0].questions[1]["multiSelect"], true);
+
+        let stale: StructuredAnswerAck = serde_json::from_str(
+            round_trip(
+                &sock,
+                r#"{"op":"answer_structured","session_id":"ask-1","request_fingerprint":"fnv1a64:stale","answers":[]}"#,
+            )
+            .await
+            .trim(),
+        )
+        .unwrap();
+        assert!(stale.stale);
+        assert!(!stale.matched);
+
+        let incomplete = serde_json::json!({
+            "op": "answer_structured",
+            "session_id": "ask-1",
+            "request_fingerprint": fingerprint,
+            "answers": [{"question": "Region?", "selected_options": ["EU"]}],
+        });
+        let invalid: StructuredAnswerAck = serde_json::from_str(
+            round_trip(&sock, &serde_json::to_string(&incomplete).unwrap()).await.trim(),
+        )
+        .unwrap();
+        assert!(!invalid.ok);
+        assert!(invalid.error.as_deref().is_some_and(|error| error.contains("expected 2")));
+
+        let complete = serde_json::json!({
+            "op": "answer_structured",
+            "session_id": "ask-1",
+            "request_fingerprint": fingerprint,
+            "answers": [
+                {"question": "Region?", "selected_options": ["EU"]},
+                {"question": "Checks?", "selected_options": ["Lint", "Test"]}
+            ],
+        });
+        let answer_line = serde_json::to_string(&complete).unwrap();
+        let accepted: StructuredAnswerAck =
+            serde_json::from_str(round_trip(&sock, &answer_line).await.trim()).unwrap();
+        assert!(accepted.matched);
+
+        let resolution: StructuredResolution =
+            serde_json::from_str(waiter.await.unwrap().trim()).unwrap();
+        let StructuredResolution::Answered { answers } = resolution else {
+            panic!("structured waiter must receive answers");
+        };
+        assert_eq!(answers.len(), 2);
+        assert_eq!(answers[1].selected_options, ["Lint", "Test"]);
+
+        let second: StructuredAnswerAck =
+            serde_json::from_str(round_trip(&sock, &answer_line).await.trim()).unwrap();
+        assert!(!second.matched, "first structured answer must win");
+        assert!(!second.stale);
 
         handle.abort();
         let _ = std::fs::remove_file(&sock);
@@ -832,5 +1409,39 @@ mod tests {
 
         rt2.shutdown_background();
         let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn exact_permission_decision_refuses_stale_fingerprint() {
+        let state = BrokerState::with_timeout(Duration::from_secs(2));
+        let waiting = state.clone();
+        let waiter = tokio::spawn(async move {
+            waiting
+                .await_decision(
+                    "session-exact".to_string(),
+                    "Bash".to_string(),
+                    "command".to_string(),
+                    "fingerprint-new".to_string(),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(!state.decide_exact(
+            "session-exact",
+            Some("fingerprint-old"),
+            Decision {
+                decision: DecisionKind::Approve,
+                reason: "stale".to_string(),
+            },
+        ));
+        assert!(state.decide_exact(
+            "session-exact",
+            Some("fingerprint-new"),
+            Decision {
+                decision: DecisionKind::Approve,
+                reason: "exact".to_string(),
+            },
+        ));
+        assert_eq!(waiter.await.unwrap().reason, "exact");
     }
 }


### PR DESCRIPTION
## Summary
- add authoritative Hangar Fleet registry, provider adapters, action RPC, and durable reducer
- add Fleet TUI queue, structured questions, approvals, broadcast, attach, and lifecycle controls
- resolve current-main integration: preserve Agent delete and Fleet RPC catalogue, unique request IDs, 16-tab chrome, migration 0044

## Validation
- `cargo test -p ainb --test tripwire_fleet_panel_opens_and_answers -- --test-threads=1`
- `cargo test -p ainb --test tripwire_fleet_approve_roundtrip -- --test-threads=1`
- `cargo test -p ainb-plugin-hangar --lib` (373 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Fleet screen for monitoring and managing active sessions from one place.
  * Added live session updates, filtering, session details, tmux discovery, and direct attach.
  * Added structured question answering, approval decisions, lifecycle controls, and broadcast messaging.
  * Added support for managed Codex and Claude interactions with delivery feedback and receipts.
* **Bug Fixes**
  * Improved session identity accuracy and prevented stale or mismatched actions.
  * Added degraded/offline indicators and safer handling when services are unavailable.
  * Improved event delivery reliability and recovery after connection interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->