### PR TITLE
docs: multica parity reference — entity models + master gap matrix

### DIFF
--- a/docs/explorations/multica-reference/README.md
+++ b/docs/explorations/multica-reference/README.md
@@ -1,0 +1,168 @@
+# Multica ↔ Hangar Parity Reference
+
+The ground-truth reference for how far Hangar (ainb's control plane) is from
+Multica's behavioral model, entity by entity. Drive the roadmap from this
+README; dive into the per-entity files for field-level detail, schema
+citations, and `file:line` references.
+
+## Purpose & how to use
+
+- **What this is:** a durable, verify-against-it map of what Multica does that
+  Hangar does not (and the handful of things Hangar already does *better*).
+  Each entity file was produced by a deep-dive over both codebases and carries
+  full field tables, migration references, and source citations.
+- **Source of the reference:** Multica — `github.com/multica-ai/multica`,
+  fair-source Apache-2.0. This is a **behavioral reference, not a verbatim
+  port**: read it for the *shape* of a feature (what fields exist, what the
+  dispatch predicate decides, how a trigger fans out), then re-implement in
+  Hangar's Rust/SQLite idiom. Do not copy source line-by-line.
+- **The north star:** Multica's organizing principle is **"agents are team
+  members, not tools."** Concretely that means a *polymorphic actor* model —
+  every "who did this" column is `actor_type ('member'|'agent') + actor_id`, so
+  agents own issues, post comments, receive inbox items, and get @mentioned
+  exactly like humans. Most of Hangar's biggest gaps trace back to it being
+  **agent-centric** (agents are the thing that does work) rather than
+  **actor-polymorphic** (agents and humans are symmetric collaborators). When
+  ranking work, "does this move Hangar toward actor symmetry?" is the tie-breaker.
+
+## Entity files
+
+| File | Entity | Rough parity | Headline gap |
+|---|---|---|---|
+| [issue.md](issue.md) | Issue | ~35% | No comment @mention dispatch; no subtasks |
+| [squad.md](squad.md) | Squad | ~40% | Leader gets no briefing — "leader" is nominal |
+| [workspace.md](workspace.md) | Workspace / membership | ~40% | Single singleton workspace; no human members |
+| [agent.md](agent.md) | Agent | ~55% | No 2-dim presence; no agent builder |
+| [autopilot.md](autopilot.md) | Autopilot | ~75% | No rule-versioning/attribution; no `api` trigger |
+| [task-flow.md](task-flow.md) | Task + dispatch flow | ~80% | No dispatch reason codes; no activity log |
+
+Parity % is a rough eyeball, not a measured metric — it exists to signal where
+the structural holes are (Issue/Squad/Workspace), versus where Hangar is already
+close (Task-flow, Autopilot, where it is *ahead* on some axes).
+
+## Master gap matrix
+
+One ranked table across all entities. Overlapping gaps (the polymorphic-actor
+gap surfaces in Workspace + Issue + Squad; comment-dispatch underpins Squad
+coordination too) are **stated once** at their foundational home and
+cross-referenced. Ranked by "changes what the product *is*" first, then
+user-visible impact, then effort. Effort: **S** ≈ days, **M** ≈ 1–2 weeks,
+**L** ≈ multi-week / touches many surfaces.
+
+| # | Entity | Gap | Multica has | Hangar has | Impact (what it unlocks) | Effort |
+|---|---|---|---|---|---|---|
+| **1** | Cross-cutting | **Polymorphic actors + human members** | `actor_type (member\|agent)` on assignee/creator/comment/inbox/activity; humans are first-class collaborators | Agent-centric; no human assignee/commenter/inbox concept; `user`+`member` tables exist but nothing mints a 2nd human | The whole "agents are team members" identity. Every collaboration surface (assign, comment, mention, inbox) becomes symmetric. Foundation the mention-dispatch and squad-human-members gaps sit on | L |
+| **2** | Issue / Squad | **Comment @mention auto-dispatch** | `[@x](mention://type/id)` parsed → routes to explicit-mention / reply-parent / thread-owner / assignee-fallback; per-target `queued\|coalesced\|deferred\|blocked` outcomes; preview; self-loop + private-agent gates; merge-into-pending dedup | Comments are inert text — zero side effects on write | Hand off work by *conversation*. This is the single biggest behavioral feature Hangar lacks — it is also the mechanism squad leader→member delegation and re-trigger loops are built on | L |
+| **3** | Issue | **Subtasks: parent/child + stage barriers + child-done cascade** | `parent_issue_id` self-FK; `stage` barrier groups; child terminal→parent wake comment; batched multi-stage aggregation | No parent/child of any kind; only an untyped `card_dependency` blocks-edge | Decompose an issue into tracked sub-issues with roll-up progress and automatic parent wake when a stage closes | L |
+| **4** | Workspace | **Multi-workspace (create / switch / delete)** | `CreateWorkspace` API + `/{slug}/…` nav, reserved-slug validation, per-instance creation lockdown flag | Exactly one bootstrapped singleton (`default`); no create path at any layer | More than one project/tenant at all. Everything below (invites, roles, per-workspace config) is moot with one workspace | L |
+| **5** | Squad | **Task-level `squad_id` + claim-time leader briefing hook** | `agent_task_queue.squad_id` (mig 127) so the daemon injects briefing at claim | Task rows carry no `squad_id`; issue has `squad_id` but the task doesn't — no claim-time hook to key briefing off | Structural prerequisite for a real squad leader (gap #7). Cheap column, but unlocks the whole leader-coordination model | S |
+| **6** | Agent | **Two-dimensional derived presence** | `Availability` (online/unstable/offline/archived, 5-min "unstable" grace) × `Workload` (working/queued/idle from live task counts) — pure derivation | `agent.archived` bool + `agent_runtime.status` binary online/offline; no grace window, no workload signal | Every list/card dot. Users can tell "runtime blipped" from "dead", and "queued/stuck" from "idle" — the signal Multica's whole list UI is built on | M |
+| **7** | Squad | **Leader briefing (Operating Protocol + Roster + Instructions)** | System-prompt injection at claim: coordinator role + 6 responsibilities, ready-to-paste mention roster with skill names, user-authored routing instructions | Nothing — a fanned-out leader runs like a solo agent, no idea it's a leader | Makes "squad leader" a real role instead of nominal. Depends on #5 (task `squad_id`) + #2 (mention dispatch for delegation) | L |
+| **8** | Agent | **Invocation permissions (private / public_to + allow-list)** | `permission_mode` + `agent_invocation_target` (workspace/member/team, OR-matched); admin does NOT bypass private | `visibility` (workspace/private) only; no allow-list, no `canInvokeAgent` gate | Share one agent with a *subset* of people; an auditable invoke gate. Depends on #1 for member targets to exist | M |
+| **9** | Agent | **Conversational Agent Builder** | Chat with a hidden `kind='system'` agent that proposes name/description/instructions/model/skills/permission as a structured draft the user confirms | Bare name-input field (TUI) or flag-driven CLI; no assisted authoring | Non-technical users create good agents without hand-writing instructions or guessing model ids. Needs `kind`/`system_key` first | L |
+| **10** | Issue | **Structured / faceted filtering** | status/priority/assignee/creator/label/property/date-range facets, facet-value-with-counts, 2-level grouping, cursor pagination | 4 fixed chips (All/Members/Agents/Mine) + free-text substring | Actually find issues at scale. No filter by status/priority/label/date exists today | L |
+| **11** | Issue | **Acceptance criteria + context refs** | `acceptance_criteria` JSONB structured list + `context_refs` JSONB | Single free-text `external_ref` string | Give an agent a structured definition-of-done and multiple linked context items instead of one URL | M |
+| **12** | Task | **Dispatch reason codes** | `dispatch.ReasonCode` enum (`invocation_not_allowed`/`target_unavailable`/`runtime_offline`/`attribution_blocked`/`already_active`/`self_trigger_suppressed`/…), wire-shared | Only `FailureReason` (post-hoc run failure); nothing for admission-time skips | "Why didn't this run?" observability for an issue that never produced a task at all | M |
+| **13** | Task | **Generic activity log / audit trail** | `activity_log(actor_type, actor_id, action, details)` fed by bus listeners → per-issue timeline | `run_history` (task-execution-scoped only) | A per-issue narrative of every assign/label/comment/status event, not just run outcomes | M |
+| **14** | Autopilot | **Rule versioning + human attribution** | `autopilot_rule_version` append-only per substantive publish; `originator` vs `accountable_user` split | None | Who is accountable for an unattended run — matters once autopilots are shared. Related to #1/#13 | M |
+| **15** | Autopilot | **`api` trigger kind + `skipped` run status** | 3rd trigger kind (bare programmatic fire); `skipped` a first-class run row | schedule + webhook only; policy-skip is a log event, not a queryable row | CI/other-tool fire without minting a webhook secret; reporting can tell "skipped" from "never happened" | S |
+| **16** | Squad | **Selective leader routing vs spray fan-out** | Leader reads issue, picks the *fit* member(s) by skill/role, delegates via @mention; others get no task | `assign_fanout` sprays to *every* agent member concurrently, no selection | Product decision, not a pure gap: mediated routing vs parallel-worker fan-out. Depends on #2 + #7. Decide before "fixing" | L |
+| **17** | Issue | **Custom properties + metadata scratch** | `issue_property` typed catalog (select/multi_select, archivable) + flat `metadata` KV bag for agent pipeline state | Neither | User-defined fields (Linear/Notion-style) + a place for agents to stash pipeline state (PR#, status) | M–L |
+| **18** | Workspace | **Membership lifecycle (invite → accept/expire)** | `workspace_invitation` (7-day expiry, one-pending-per-email, stale sweep), auto-stub user, role-at-invite | `MemberRepo` list/set-role/remove + last-owner guard, but nothing *creates* a 2nd member | Add a second human. Repo primitives already exist; needs invite table + accept flow. Depends on #4 | M |
+| 19 | Issue | **`blocked` + `cancelled` states** | 7-state lifecycle with DB CHECK | 5 states, no `blocked`/`cancelled`, no CHECK (free text) | Represent blocked/cancelled as first-class states | S |
+| 20 | Issue | **Typed dependency graph** | `issue_dependency` `blocks`/`blocked_by`/`related` | `card_dependency` single untyped blocks-edge (cycle-checked, auto-run) — core mechanic already parity | "related"/reverse edges + a browsable graph | S–M |
+| 21 | Issue | **Origin provenance** | `origin_type`/`origin_id` (autopilot/quick_create/lark/slack/agent_create) | None | Trace who/what caused an agent-created issue | S–M |
+| 22 | Issue | **Subscribers + reactions** | `issue_subscriber` (reason-tagged) + `issue_reaction` | Neither | Notification subscriptions + emoji reactions | M |
+| 23 | Agent | **Metadata columns** | `description` (255-cap), `avatar_url`, `kind`(user/system), `service_tier`, `UNIQUE(workspace,name)` | None of these | Blurb/avatar in lists; no silent duplicate names; Codex service-tier control. `kind`/`system_key` also unblocks #9 | S–M |
+| 24 | Agent | **Per-agent skill enable/disable** | `agent_skill.enabled` + `disabled_runtime_skills` | Attach/detach only, no toggle | Temporarily disable a skill for one agent without detaching | S |
+| 25 | Squad | **Per-member `role` + `instructions` + archive** | Free-text `role` (leader routes by fit), `squad.instructions`, `archived_at`/`archived_by` w/ transfer-on-archive | None of these columns | Route by stated specialty; per-squad routing guidance; safe squad retirement | S–M |
+| 26 | Agent / Squad | **Archive audit trail** | `archived_at` + `archived_by` (who/when) | `archived` boolean only (agent); no archive at all (squad) | Accountability for who retired an agent/squad and when | S |
+| 27 | Autopilot | **Subscriber / collaborator model** | `autopilot_subscriber` (auto-subscribe to spawned issues) + `autopilot_collaborator` write-grants | Single-owner only | Team-shared autopilots. Depends on #1. Fine to defer while solo | S–M |
+| 28 | Issue | **Surface existing priority/due/labels in create wizard** | `CreateIssueRequest` accepts priority/status/labels/dates directly | Schema has priority/due/labels since mig 0014 — **wizard never surfaces them** | Cheapest real win: three more wizard rows, columns already exist | S |
+| 29 | Squad | **#450: Boards `q:squad` hotkey unreachable** | (n/a) | Global router steals bare `q` as quit before Boards' `q → AssignSquad`; card fan-out unreachable by keyboard | Unblocks the *existing* fan-out feature. Add a Boards-no-overlay guard, same pattern as existing screen guards | S |
+| 30 | Agent | **`custom_env` redaction contract** | Never serialized; `has_custom_env`/key-count only; audited GET/PUT endpoint | Stored/returned plain JSON | Secrets hygiene if Hangar ever grows multi-user/remote | S |
+
+## Deliberately NOT chasing
+
+The task-flow deep-dive flagged several "gaps" that are **moot given Hangar's
+architecture** (single-process daemon colocated with SQLite, one TUI client, no
+browser/remote client). Listing them so nobody re-opens them:
+
+| Multica feature | Why it's not a gap for Hangar |
+|---|---|
+| `EmptyClaim` Redis short-circuit cache | SQLite claim is one local statement — no network round-trip to amortize |
+| `reconcileBroadcaster` one-slot replay | Daemon + DB are colocated; no daemon↔server WS reconnect to recover from |
+| `FinalizeTaskClaim` split-commit + requeue-on-payload-fail | Claim + dispatch are same-process; no network boundary between "claimed" and "daemon has payload" |
+| Two-hub fan-out (browser realtime.Hub + daemon wakeup) | No browser client to fan out to; the TUI plugin is the only subscriber and gets full payloads directly |
+| Authoritative-vs-estimated cost split (`cost_usd_ticks`) | `run_history` + `cost_rollup` VIEW is adequate at Hangar's scale; cosmetic |
+| Generic DB-backed lease/scope scheduler | Purpose-built single-daemon scheduler is fine; no multi-instance lease contention |
+
+And two axes where **Hangar is ahead of Multica**:
+
+- **`concurrency_policy` (skip/queue/replace)** — Hangar's is fully wired and
+  tested (`scheduler.rs` + `scheduler_concurrency_policies.rs`); Multica's is a
+  **dead schema column** read nowhere.
+- **Squad fan-out** — Hangar dispatches leader + every agent member concurrently
+  (each its own worktree); Multica only dispatches the leader. (Whether spray or
+  mediated routing is *wanted* is gap #16, a product call.)
+
+Parity axes already reached: autopilot `execution_mode`, autopilot webhook
+delivery-audit + event-filters, the per-(issue,agent) claim guard + concurrency
+cap, the dispatched/reclaim/timeout sweeper ladder.
+
+## Prioritized roadmap
+
+Grouped by tier. Within a tier, items are roughly dependency-ordered.
+
+### P0 — Foundational (structural; other work depends on these)
+
+| # | Item | Effort | Unblocks |
+|---|---|---|---|
+| 1 | Polymorphic actors + human members (member\|agent everywhere) | L | #2, #8, #18, #25-human, autopilot attribution |
+| 5 | Task-level `squad_id` + claim-time briefing hook | S | #7 (leader briefing) |
+| 3 | Subtasks: `parent_issue_id` + stage barriers + child-done cascade | L | roll-up progress, staged completion |
+| 4 | Multi-workspace (create/switch) | L | #18 invites, per-workspace config, slug validation |
+
+Cheapest P0 to land first: **#5** (one column + a claim hook) makes the squad
+leader briefing (#7) possible and is nearly free.
+
+### P1 — High-impact (the features that make agents feel like team members)
+
+| # | Item | Effort |
+|---|---|---|
+| 2 | Comment @mention auto-dispatch (route + outcomes + preview + gates) | L |
+| 7 | Squad leader briefing (protocol + roster + instructions) | L |
+| 6 | Two-dimensional derived agent presence (availability × workload) | M |
+| 8 | Invocation permissions (private/public_to + allow-list) | M |
+| 9 | Conversational Agent Builder | L |
+| 10 | Structured / faceted issue filtering | L |
+| 11 | Acceptance criteria + context refs | M |
+| 12 | Dispatch reason codes | M |
+| 13 | Generic activity log / audit trail | M |
+| 14 | Autopilot rule versioning + human attribution | M |
+| 16 | Squad selective routing (product decision first) | L |
+
+### P2 — Polish / cheap wins (several are UI-only; schema already has the column)
+
+| # | Item | Effort | Note |
+|---|---|---|---|
+| 28 | Surface priority/due/labels in issue create wizard | S | **schema already has these (mig 0014)** — UI-only |
+| 29 | Fix #450 Boards `q:squad` hotkey | S | unblocks existing fan-out feature |
+| 19 | `blocked` + `cancelled` issue states | S | |
+| 23 | Agent metadata columns (description/avatar/kind/service_tier/unique-name) | S–M | `kind`/`system_key` also unblocks #9 |
+| 24 | Per-agent skill enable/disable toggle | S | |
+| 26 | Archive audit trail (agent + squad `archived_at`/`archived_by`) | S | |
+| 25 | Squad per-member `role` + `instructions` + archive | S–M | `instructions` feeds #7 briefing |
+| 20 | Typed issue dependency graph (`blocked_by`/`related`) | S–M | core auto-run mechanic already parity |
+| 21 | Issue origin provenance (`origin_type`/`origin_id`) | S–M | |
+| 15 | Autopilot `api` trigger + `skipped` status | S | |
+| 30 | `custom_env` redaction contract | S | |
+| 17 | Custom properties + metadata scratch | M–L | larger; promote to P1 if agent-pipeline-state is needed |
+| 22 | Issue subscribers + reactions | M | |
+| 27 | Autopilot subscriber/collaborator | S–M | depends on #1; defer while solo |
+| 18 | Membership invite lifecycle | M | depends on #4; defer while single-workspace |
+
+**Cheap-wins where the schema already has it and only the UI is missing:**
+issue **priority / due_date / labels** (columns since mig 0014, wizard omits
+them — #28), and the `card_dependency` auto-run mechanic (#20 core already
+built, only the typed-edge variants + graph browse are missing).

--- a/docs/explorations/multica-reference/agent.md
+++ b/docs/explorations/multica-reference/agent.md
@@ -1,0 +1,134 @@
+# Agent entity: Multica vs Hangar
+
+## Multica Agent
+
+### Schema (full field list, `agent` table)
+
+Assembled from `server/migrations/001_init.up.sql:36-46` plus every subsequent `agent_*` migration.
+
+| Field | Type | Meaning | Migration |
+|---|---|---|---|
+| `id` | UUID PK | — | 001 |
+| `workspace_id` | UUID FK → workspace, cascade | tenant | 001 |
+| `name` | TEXT | display name | 001 |
+| `avatar_url` | TEXT nullable | avatar image | 001 |
+| `runtime_mode` | TEXT CHECK `local|cloud` | legacy pre-runtime-table field, still present | 001 |
+| `runtime_config` | JSONB default `{}` | provider-specific config blob (e.g. openclaw gateway `{gateway:{token}}`) | 001 |
+| `visibility` | TEXT CHECK `workspace|private`, default `private` (030) | legacy/derived; superseded as auth source by `permission_mode` (130) but kept in sync for old clients | 001, 030 |
+| `status` | TEXT CHECK `idle|working|blocked|error|offline`, default `offline` | legacy column; front-end no longer reads it for presence — see derive-presence below | 001 |
+| `max_concurrent_tasks` | INT, default 1→6 (023) | dispatch cap | 001, 023 |
+| `owner_id` | UUID FK → user, nullable | — | 001 |
+| `runtime_id` | UUID NOT NULL FK → `agent_runtime`, RESTRICT | every agent binds to exactly one runtime row (004 backfilled this from the old `runtime_mode`/`runtime_config`) | 004 |
+| `description` | TEXT NOT NULL default `''`, CHECK `char_length<=255` (060) | — | 002, 060 |
+| `skills` | TEXT NOT NULL default `''` | legacy free-text skills field (superseded by `agent_skill` join) | 002 |
+| `tools` | JSONB default `[]` | legacy tool list | 002 |
+| `triggers` | JSONB default `[]` | legacy trigger config | 002 |
+| `instructions` | TEXT NOT NULL default `''` | system prompt | 021 |
+| `archived_at` | TIMESTAMPTZ nullable | soft-archive marker; NOT NULL = archived | 031 |
+| `archived_by` | UUID FK → user, nullable | audit: who archived it | 031 |
+| `custom_env` | JSONB default `{}` | user env vars injected at subprocess launch (router/Bedrock/Vertex creds); **never serialized** in API responses — only `has_custom_env`/`custom_env_key_count`; read/write via dedicated audited `GET/PUT /api/agents/{id}/env` | 040 |
+| `custom_args` | JSONB default `[]` | extra CLI args appended at launch | 041 |
+| `mcp_config` | JSONB nullable | agent's own MCP server config; redacted (`mcp_config_redacted`) for non-owners | 046 |
+| (constraint) | UNIQUE(workspace_id, name) | 409 instead of silent dup/500 | 046 |
+| `model` | TEXT nullable | explicit per-agent model override (first-class column so UI can render a dropdown; some providers like Codex app-server reject `-m` in custom_args) | 050 |
+| `thinking_level` | TEXT nullable | runtime-native reasoning/effort token (Claude: `low|medium|high|xhigh|max`; Codex: `none|minimal|low|medium|high|xhigh`); NULL = provider default, deliberately NOT normalized cross-runtime | 095 |
+| `kind` | TEXT CHECK `user|system`, default `user` | distinguishes ordinary agents from hidden system agents (e.g. the agent-builder carrier) | 163 |
+| `system_key` | TEXT nullable | identity key for system agents; unique per `(workspace_id, owner_id, runtime_id, system_key)` where not null (172) | 163, 172 |
+| `disabled_runtime_skills` | JSONB default `[]` | per-agent tool/skill disable list at the RUNTIME level (distinct from workspace `agent_skill` attach/detach) | 206 |
+| `service_tier` | TEXT nullable | per-agent Codex service-tier override (runtime-native catalog id, e.g. `"priority"` shown as "Fast"); NULL = inherit local Codex config | 212 |
+| `permission_mode` | TEXT CHECK `private|public_to`, default `private` | AUTHORITATIVE invocation-permission source (MUL-3963), replacing `visibility`; `private` = owner-only, admin does NOT bypass (fixes a Composio mailbox-leak privacy hole) | 130 |
+| `composio_toolkit_allowlist` | TEXT[] | Composio toolkit slugs this agent may mount as MCP for any run that passes the invocation gate, using the OWNER's Composio connection; redacted for non-owners | (Composio-era, commented in 130) |
+
+Companion table `agent_invocation_target` (130): `id`, `agent_id` (no FK — app-layer cleanup), `target_type` CHECK `workspace|member|team`, `target_id` (polymorphic), `created_by`, `created_at`; UNIQUE(agent_id, target_type, target_id). Targets stack — `canInvokeAgent` OR-matches across all rows for a `public_to` agent.
+
+Separate `agent_runtime` table (004): `id`, `workspace_id`, `daemon_id`, `name`, `runtime_mode` (`local|cloud`), `provider`, `status` CHECK `online|offline`, `device_info`, `metadata` JSONB, `last_seen_at`. One physical daemon+provider = one runtime row; an agent binds to exactly one.
+
+`agent_skill` join gained `enabled BOOLEAN NOT NULL DEFAULT TRUE` (161) — per-agent, per-skill on/off toggle independent of the skill's global existence.
+
+### States / status model
+
+Legacy `agent.status` column (idle/working/blocked/error/offline) still exists but the front-end does **not** read it for presence. Presence is entirely re-derived client-side (`packages/core/agents/derive-presence.ts:1-155`) from two orthogonal, independently-computed dimensions:
+
+1. **`AgentAvailability`** (`types.ts:23-33`) = `online | unstable | offline | archived` — pure function of runtime reachability (`deriveRuntimeHealth`), folding `about_to_gc` into `offline`. `unstable` is a transient ~5-minute amber grace window after the runtime goes unreachable, decaying to `offline` if no fresh heartbeat lands (hence a 30s poll on consuming hooks). `archived` (agent.archived_at set) wins over everything — checked BEFORE runtime health so a leftover "online" runtime row can never make a retired agent look live.
+2. **`Workload`** (`derive-presence.ts:38-46`) = `working | queued | idle` — pure function of *live* task counts only (`running>0 → working`; else `queued>0 → queued`; else `idle`). Deliberately excludes terminal states (completed/failed/cancelled) — history lives on the detail page / Inbox, never bleeds into the list-level dot.
+
+`buildPresenceMap` batches this over a whole workspace in one O(N) pass (group tasks by agent_id, one runtimesById lookup) for list/card views.
+
+### Create-flow inputs (`CreateAgentRequest`, `agent.go:927-965`)
+
+`name`, `description`, `instructions`, `avatar_url`, `runtime_id` (required), `runtime_config`, `custom_env` (map), `custom_args`, `mcp_config`, `visibility` (legacy), `permission_mode` + `invocation_targets` (authoritative when present), `max_concurrent_tasks`, `model`, `thinking_level`, `service_tier`, `composio_toolkit_allowlist`, `template` (which quick-create template slug seeded it, for the `agent_created` analytics event), `skill_ids` (attached in the same transaction as the row, so create is never partially-configured).
+
+### Agent Builder / quick-create (`agent_builder.go:1-120`)
+
+A conversational, LLM-driven creation flow: `CreateAgentBuilderSession` spins up a hidden **system agent** (`kind='system'`, `system_key='agent_builder:<flowID>'`, name `.multica-agent-builder-<flowID>`) on an existing runtime, running a fixed system prompt (`agentBuilderInstructions`) that interviews the user and must end every turn with a strict `<agent_draft>{"name","description","instructions","model","skill_ids","permission_scope","member_ids"}</agent_draft>` JSON block. The builder agent itself never appears in normal lists / assignee pickers. Rules baked into the prompt: model must be empty or an exact id from the caller-supplied available-models list (never invent), skill_ids must be from the caller-supplied available-skills list, permission_scope defaults to `private`, never leaks secrets into the draft, and the LLM never claims the agent was actually created — the user must confirm in the UI. This is the actual "agent builder" UX: chat → structured draft → user reviews/edits → confirms → real `CreateAgent` call.
+
+### Per-provider config (`server/pkg/agent/*.go`)
+
+One Go file per provider (`claude.go`, `codex.go`, `cursor.go`, `copilot.go`, `grok.go`, `kimi.go`, `qwen.go`, `openclaw.go`, `deveco.go`, `hermes.go`, `qoder.go`, `pi.go`, `kiro.go`, `traecli.go`, `codebuddy.go`, `antigravity.go`, `opencode.go`...) — roughly 15 first-party provider integrations, each 400-3000 lines covering: invocation shape (argv/stdin/app-server RPC), model catalog + validation, thinking/reasoning-effort mapping (`thinking.go`, `thinking_test.go` — 785/1131 lines, a dedicated cross-provider effort-level module), MCP config translation (`mcp_config.go`, `browser_mcp_config.go`, `opencode_mcp.go`), version detection (`version.go`), stream-JSON result parsing (`stream_json_result.go`), and process lifecycle (`proc_other.go`/`proc_windows.go`). This is a full per-CLI adapter layer, not a single generic "provider" enum.
+
+### Permissions / effective access (`packages/core/agents/effective-access.ts`)
+
+Front-end derives a 3-state `AccessScope` (`workspace | specific-people | owner-only`) from the authoritative `permission_mode` + `invocation_targets`, because the legacy 2-state `visibility` is lossy (a `public_to` agent scoped to specific people collapses to `visibility:"private"`, indistinguishable from truly owner-only). Mirrors the server's `canInvokeAgent` gate.
+
+---
+
+## Hangar Agent (ainb)
+
+### Schema / struct fields (`crates/ainb-hangar-store/src/repo/agent.rs:39-82`, migrations 0002/0006/0015/0041/0042)
+
+| Field | Type | Meaning | Migration |
+|---|---|---|---|
+| `id` | TEXT PK (ULID) | — | 0002 |
+| `workspace_id` | TEXT FK → workspace | — | 0002 |
+| `name` | TEXT NOT NULL | — | 0002 |
+| `runtime_id` | TEXT NOT NULL FK → agent_runtime | required, same "always bound" invariant as multica | 0002 |
+| `instructions` | TEXT nullable | system prompt | 0002 |
+| `visibility` | TEXT CHECK `workspace|private` | only auth model that exists — no `permission_mode`/allow-list equivalent | 0002 |
+| `owner_id` | TEXT FK → user | — | 0002 |
+| `max_concurrent_tasks` | INTEGER NOT NULL default 1 | dispatch cap; column exists but is **not exposed on the `Agent` struct** (dispatch reads it via raw SQL separately) | 0006 |
+| `archived` | INTEGER (bool) CHECK 0/1, default 0 | boolean only — no timestamp, no "archived_by" audit trail | 0015 |
+| `model` | TEXT nullable | provider model override | 0015 |
+| `cli_args` | TEXT (JSON array) default `[]` | extra CLI args | 0015 |
+| `mcp_config` | TEXT (JSON object) default `{}` | raw MCP config; no ownership/redaction model | 0015 |
+| `thinking` | TEXT nullable | reasoning/effort level | 0015 |
+| `agent_env` | TEXT (JSON object) default `{}` | per-agent env vars; stored/returned in plain — no `has_custom_env`/key-count redaction contract | 0015 |
+| `provider` | TEXT nullable | which CLI backend (`claude`/`codex`/`copilot`); NULL = fall back to runtime's advertised provider | 0041 |
+| `token_budget` | INTEGER nullable | optional rtk/headroom cap; stored + surfaced only — no dispatch-time enforcement yet | 0042 |
+
+`agent_runtime` (0002): `id`, `workspace_id`, `daemon_id`, `provider`, `runtime_mode` (`local|cloud`), `last_seen_at`, `status` default `'offline'` — no explicit CHECK constraint value list shown, effectively binary online/offline, no grace-window/`unstable` state.
+
+`agent_skill` join (0002): `agent_id`, `skill_id` composite PK — **no `enabled` column** (no per-agent skill on/off toggle; attach/detach is the only lever). No `disabled_runtime_skills` equivalent.
+
+No `description`, `avatar_url`, `kind`/`system_key`, `service_tier`, `permission_mode`/invocation-target table, `composio_toolkit_allowlist`, or name-uniqueness constraint exist on the hangar `agent` table.
+
+### What create actually collects today
+
+- **CLI** (`crates/ainb-core/src/cli/hangar/mod.rs:416-430`, `AgentCreateArgs`): `--name` (required), `--provider` (optional, default claude), `--instructions` (optional), `--workspace` (optional). That's it — no model, no thinking level, no mcp_config, no env, no max_concurrent, no skills at create time (all of those exist only via the separate `hangar agent edit` command, which does cover model/instructions/args/mcp/thinking/env/token-budget with explicit `--clear-*` flags for the four nullable fields).
+- **TUI Agents screen** (`crates/ainb-plugin-hangar/src/screen/agents.rs:59-292`): even narrower — `n` opens a single inline "New agent name:" text buffer (`create_input: Option<String>`); Enter with a non-blank name submits, Esc cancels. No provider picker, no instructions, no model/thinking — the screen literally only collects a name; everything else must be set afterward via CLI `agent edit`.
+- No agent-builder / conversational quick-create flow exists anywhere in ainb.
+
+---
+
+## GAPS
+
+| Multica has | Hangar has | Gap | Effort |
+|---|---|---|---|
+| Two-dimensional derived presence: `AgentAvailability` (online/unstable/offline/archived, with a 5-min "unstable" grace window before decaying to offline) × `Workload` (working/queued/idle from LIVE task counts only, terminal states excluded) | `agent.archived` boolean + `agent_runtime.status` binary online/offline; no grace window, no separate workload signal, no pure derivation module | Users can't tell "runtime just blipped" from "truly dead", and there's no "queued but stuck" signal at all | M — port `derive-presence.ts`'s two pure functions + a task-count query; biggest single UX gap since it drives every list/card dot |
+| `permission_mode` (private/public_to) + `agent_invocation_target` allow-list (workspace/member/team, OR-matched); admin does NOT bypass private | `visibility` column only (workspace/private), no allow-list, no explicit invoke-gate function | Can't share one agent with a subset of people; no `canInvokeAgent`-equivalent gate exists to audit | M — new join table + gate function; can start as a straight port of the 130 migration shape |
+| Conversational **Agent Builder**: chat with a hidden system agent that proposes name/description/instructions/model/skills/permission as a structured draft the user reviews before real creation | Only a bare name-input field (TUI) or flag-driven CLI create; no assisted authoring at all | New/non-technical users must hand-write instructions and guess model ids with zero help | L — needs `kind='system'`/`system_key` support first, then the draft-loop prompt + parser |
+| Full per-provider adapter layer (~15 providers, each with model catalog validation, thinking/effort mapping, MCP config translation, stream-JSON parsing, version detection) | 3 providers (`claude`/`codex`/`copilot`) recorded as a bare string with no per-provider model/thinking validation surfaced | Free-text `model`/`thinking` fields can silently hold invalid values per provider; no catalog to drive a UI dropdown | L — long tail, but even a validation-only pass for the 3 existing providers is worthwhile |
+| `description` (255-char capped), `avatar_url`, `kind`(user/system), `service_tier` (Codex), `composio_toolkit_allowlist` w/ owner-based redaction, UNIQUE(workspace,name) | None of these columns exist | Agents have no blurb/avatar in lists; duplicate names silently allowed; no service-tier control for Codex agents | S–M — mostly additive columns + one unique index; cheapest wins here |
+| `agent_skill.enabled` per-agent toggle + `disabled_runtime_skills` (per-agent tool/skill disable at runtime level, distinct from workspace attach) | `agent_skill` join with no enable flag; no disabled-runtime-skills equivalent | Can't temporarily disable a skill for one agent without detaching it; no fine-grained tool gating | S — one boolean column + one JSON column, same pattern as 0015 |
+| `archived_at` + `archived_by` (who/when audit) | `archived` boolean only | No audit trail for who archived an agent or when | S — swap boolean for nullable timestamp + owner FK (mirrors 031 exactly) |
+| `custom_env` never serialized in API responses (has_custom_env/key_count only), read/write gated behind a dedicated audited endpoint, `canViewAgentSecrets` gate | `agent_env` stored and presumably returned as plain JSON with no redaction contract | Lower stakes for a local single-user TUI, but still a good hygiene gap if hangar ever grows multi-user/remote access | S — mostly a serialization-layer change since hangar is local-first |
+
+### Top gaps, ranked by user-visible impact
+
+1. **Presence/status derivation** — biggest UX gap; hangar's binary online/offline + boolean archived can't express "flaky" or "stuck/queued", which multica's whole list UI is built around.
+2. **Invocation permission (private/public_to + allow-list)** — hangar has no way to share an agent with specific people; only global workspace vs fully private.
+3. **Agent Builder conversational create** — multica's create flow is guided; hangar's is a bare name field, with model/instructions/provider only settable after the fact via CLI edit.
+4. **Per-provider adapter depth** — multica validates/maps model+thinking per provider; hangar stores free-text with no validation, so bad values fail silently at dispatch instead of at create/edit time.
+5. **Missing metadata columns** (`description`, `avatar_url`, `kind`/`system_key`, `service_tier`) — cheap, additive, but currently absent entirely.
+6. **Per-agent skill enable/disable + disabled_runtime_skills** — hangar can only attach/detach, not temporarily toggle.
+7. **Archive audit trail** (`archived_at`/`archived_by` vs plain boolean) — small but real accountability gap.
+8. **Name uniqueness constraint** — multica prevents duplicate agent names per workspace at the DB level; hangar does not (unclear if enforced at all).

--- a/docs/explorations/multica-reference/autopilot.md
+++ b/docs/explorations/multica-reference/autopilot.md
@@ -1,0 +1,86 @@
+# Autopilot / Workflow-automation: Multica vs Hangar
+
+## 1. Multica Autopilot
+
+Schema (`server/migrations/042_autopilot.up.sql`, extended by 11 later migrations).
+
+**`autopilot`** (042_autopilot.up.sql:3-25; 058 dropped `priority`/`project_id`, 097 re-added `project_id`, 096 added `assignee_type`):
+- `workspace_id`, `project_id` (nullable), `title`, `description`
+- `assignee_id` + `assignee_type` (`agent`|`squad`, migration 096 — squad autopilots dispatch to `squad.leader_id`, app-layer resolved, no FK)
+- `status`: `active`|`paused`|`archived`
+- `execution_mode`: `create_issue`|`run_only` (042_autopilot.up.sql:14-15)
+- `issue_title_template` (validated via `service.ValidateIssueTitleTemplate`)
+- `concurrency_policy`: `skip`|`queue`|`replace` (042_autopilot.up.sql:16-17) — **dead column**: `grep -rn "ConcurrencyPolicy" server/**/*.go` returns zero hits outside the raw migration SQL; not even in the sqlc-generated `Autopilot` struct. Schema declared it, application code never reads it.
+- `created_by_type`/`created_by_id`, `last_run_at`
+
+**`autopilot_trigger`** — three kinds (042_autopilot.up.sql:29-40):
+- `kind`: `schedule`|`webhook`|`api`
+- schedule: `cron_expression` + `timezone` (default UTC) + cached `next_run_at` (display-only)
+- webhook: `webhook_token` (unique per 091_autopilot_webhook_triggers.up.sql, partial-unique on `kind='webhook'`), `event_filters` JSONB added in 110 (`[{"event":"workflow_run","actions":["completed"]}]`, NULL = accept all)
+- 189_autopilot_trigger_publisher.up.sql: `published_by_type`/`published_by_id` — per-trigger "responsible publisher" for human-attribution audit, re-stamped on any substantive edit to that trigger's cron/filter/enabled state
+
+**`autopilot_run`** — lifecycle (042_autopilot.up.sql:47-65):
+- `status`: `pending → issue_created|running → completed|failed` (+`skipped` added 079_autopilot_run_skipped_status.up.sql)
+- `source`: `schedule`|`manual`|`webhook`|`api`
+- links `issue_id`, `task_id` (`agent_task_queue.id`), `trigger_id`
+- `trigger_payload`/`result` JSONB, `failure_reason`
+- 124_autopilot_run_planned_at: `planned_at` + partial-unique `(trigger_id, planned_at)` — the idempotency guard so a stale-lease-steal retry cannot double-create a run for the same cron occurrence
+- 096: `squad_id` attribution hook (not yet consumed)
+
+**`autopilot_rule_version`** (186/187) — append-only, one row per *substantive* publish (create/enable/resume/target/instructions change; cosmetic edits like rename don't count), records `published_by_id` + `config_summary` JSONB. Dispatch reads the newest row per `(workspace_id, autopilot_id)` (index in 187) as the run's accountable human — decoupled from `originator_user_id` (which stays NULL for unattended fires). Human-attribution project MUL-4302.
+
+**`autopilot_subscriber`** (120) / **`autopilot_collaborator`** (128) — auto-subscribe workspace members to spawned issues; explicit write-grants beyond creator/owner/admin. Both no-FK, app-layer integrity, mirror `issue_subscriber`.
+
+### Scheduling engine (the real trigger-firing mechanism)
+
+`server/internal/scheduler/jobs_autopilot.go` + `spec.go` — a generic DB-backed lease/lock scheduler (`sys_cron_executions` unique key on `(job_name, scope_kind, scope_id, plan_time)`), autopilot plugs into it as one job:
+
+- Each **enabled schedule trigger is its own scope** (`scope_kind="autopilot_trigger"`, `scope_id=trigger.id`) — `jobs_autopilot.go:169-218`.
+- `PlansForScope` hook (`jobs_autopilot.go:235-317`) computes cron occurrences in `(lastPlan, dbNow]` via `service.NextOccurrencesUTC`, collapses missed fires to the **latest only** (`CatchUpLatestOnly`), rejects anything > 5 min late (`maxAutopilotScheduleLateness`, line 38).
+- Anchor for "since when do we enumerate" is 3-tiered: prior `sys_cron_executions` row → `trigger.last_fired_at` → `trigger.created_at`, capped by a 24h replay window — this ordering exists specifically to avoid replaying an occurrence already fired by a legacy pre-migration goroutine (comment cites the actual incident, `spec.go` equivalent doc at jobs_autopilot.go:261-301).
+- Handler (`jobs_autopilot.go:328-412`) re-loads trigger+autopilot fresh (so a mid-tick disable/pause takes effect immediately), calls `AutopilotService.DispatchAutopilotForPlan`, then advances the **display-only** `next_run_at` floored at `max(now, planTime)` so a lagging clock can't recompute the same slot (MUL-3749 regression guard).
+- Retry: `AllowStaleReentry=true`, `MaxAttempts=3`, backoff `[1m,5m,15m]`; a crashed claim promotes to FAILED via stale-lease sweep and a sibling can steal it — idempotent via the `(trigger_id, planned_at)` unique index.
+- Generic `JobSpec` (`spec.go`) is reused across other scheduled jobs (hourly rollups etc.) — Autopilot is just the arbitrary-cron-per-scope instance of it, via `PlansForScope` overriding the uniform-cadence default.
+
+### Dispatch core (`server/internal/service/autopilot.go`)
+
+- `DispatchAutopilotForPlan` (scheduled path, :356-414): idempotency lookup by `(trigger_id, planned_at)` first; a complete run short-circuits, a partial run (e.g. `issue_created` with NULL `issue_id`) is recovered/failed and re-dispatched fresh — `isAutopilotRunComplete` (:438-449) explicitly treats `pending`/valueless in-flight states as **not** safe to reuse (cites a prior incident, #4443).
+- `shouldSkipDispatch` (:1186-1259) — admission gate, run **every** dispatch regardless of source: no assignee → skip; agent/squad resolution failure (archived squad / hard-deleted agent) → skip with typed reason; `AgentReadiness` check (offline runtime tolerated only for `create_issue` mode, since the issue can sit queued); an **invocation/access gate** (`autopilotAdmitInvoke`) — manual "run now" is judged against the clicking human's own access to the assignee agent, automation falls back to the autopilot's creator. **This is where `concurrency_policy` should live and doesn't** — there is no concurrency/in-flight check anywhere in this function or its callers.
+- `dispatchAutopilotRun` (:498-549) switches on `execution_mode`: `create_issue` creates an issue (assignee inherited, squad-leader-resolved) then the existing issue-listener chain enqueues the task; `run_only` enqueues a task directly, no issue. Unknown mode fails closed.
+- Manual trigger (`TriggerAutopilot`, handler:1995-2036) resolves the human actor and attributes the run `direct_human` (vs. `rule_owner` for unattended fires) — the attribution model forks on how dispatch was invoked, not just who created the rule.
+- Webhook ingress (`autopilot_webhook.go: HandleAutopilotWebhook`, :345+): 2-tier rate limiting (absolute IP ceiling + bad-credential-IP limiter), token lookup distinguishes no-row (404, generic) from DB error (500, so providers retry), workspace-consistency cross-check before persisting the delivery row, event-filter matching (`webhookEventAllowedByTriggerScope`) against the trigger's declared `event_filters`.
+
+### What creating an autopilot collects (`CreateAutopilot`, handler:598-727)
+`title` (required), `assignee_id` (required) + `assignee_type` (agent|squad, validated against workspace), `execution_mode` (required, `create_issue`|`run_only`), `issue_title_template` (optional, template-validated), `description`, `project_id` (optional), `subscribers` (list of member ids, validated before insert so a bad payload can't half-create the row). Creation itself is a transaction that **also** writes rule-version v1 (creator = accountable human) — every autopilot has an accountable human from birth (MUL-4302 §3.4).
+
+## 2. Hangar (ainb) Autopilot — current state
+
+This is considerably further along than a first grep suggests — the pure/IO-free layer (`ainb-hangar-core/src/autopilot/{mod,service,cron}.rs`) is the *older, simpler* v1 sketch (cron+agent+instructions+`max_concurrent_runs` only, no execution_mode/concurrency_policy). The **live** implementation is in `ainb-hangar-store/src/repo/autopilot.rs` + `ainb-hangar-daemon/src/scheduler.rs`, which has since grown real parity on several axes:
+
+- **`Autopilot` row** (`repo/autopilot.rs:133-160`): `workspace_id`, `agent_id`, `name` (unique per workspace), `instructions`, `cron_expr`, `max_concurrent_runs`, `execution_mode`, `concurrency_policy`, `next_tick_at`, `enabled`, `created_at`.
+- **`ExecutionMode`** (`repo/autopilot.rs:50-59`): `RunOnly` (default) | `CreateIssue` — direct match to multica's execution_mode, same two variants, same semantics (issue-first vs task-only).
+- **`ConcurrencyPolicy`** (`repo/autopilot.rs:91-104`): `Skip` (default) | `Queue` | `Replace` — **same three-value enum as multica's schema**, but unlike multica this one is fully wired: `scheduler.rs:381-430` (`fire_or_skip`) checks in-flight count against `max_concurrent_runs` and branches on the policy live — `skip` drops the tick + emits `tick_skipped`; `queue` fires anyway (relies on the shared claim/dispatch queue to serialize); `replace` cancels the open run(s) + their task, then fires fresh. Proven under contention by `tests/scheduler_concurrency_policies.rs` (real sqlite + advanceable clock, asserts actual row counts/status, not just the emitted event). **Hangar's concurrency_policy is a real, tested behavior; multica's is a dead column.**
+- **Trigger kinds**: schedule (cron, via `AutopilotScheduler` loop, `scheduler.rs`) + **webhook** (`ainb-hangar-daemon/src/webhook_ingress.rs`) — a hand-rolled localhost-only (`127.0.0.1`, never `0.0.0.0`) HTTP/1.1 listener at `POST /hangar/webhook/<autopilot_id>`, HMAC-SHA256 signature verification (`X-Hangar-Signature`) against a per-autopilot secret (0600 file store, DB holds only the digest), event-filter matching (`event_passes_filter`), and a full delivery audit log (`autopilot_webhook_delivery` table via `AutopilotWebhookRepo`, inspectable via `ainb hangar autopilot deliveries <id>`). **No `api` trigger kind** (multica's third kind, a bare programmatic-fire path) — not present in hangar.
+- **Run lifecycle**: `running → completed|failed|cancelled` (`repo/autopilot_run.rs`) — no `pending`/`issue_created`/`skipped` intermediate states; the replace-policy path directly writes `cancelled` on supersede.
+- **No rule versioning** — no equivalent of `autopilot_rule_version` / human-attribution audit trail. No `originator`/`accountable_user` split; runs aren't attributed to a publishing human vs. the triggering source.
+- **No subscriber/collaborator tables** — no auto-subscribe-members-to-spawned-issues, no explicit collaborator write-grants beyond implicit ownership.
+- **No squad/team assignee** — `agent_id` only, single agent, no squad-leader resolution path.
+- **Create flow** (`ainb-core/src/cli/hangar/mod.rs:288+`, `AutopilotCreateArgs`): CLI-only (`hangar autopilot create`) — name, agent, cron, instructions, `max_concurrent_runs`, execution-mode arg, concurrency-policy arg, workspace slug. No TUI creation wizard yet in `screen/autopilots.rs` (that screen is list/inspect-oriented — cron, state, last-run — not a create form); no title-template, no project scoping, no subscriber list.
+- Separate from the D13 "auto-standup" watcher (`ainb-hangar-daemon/src/standup.rs`) — that's a fixed always-on idle-session nudge, not a user-defined autopilot rule (documented previously in memory as off-by-default).
+
+## 3. GAPS
+
+| Multica has | Hangar has | Gap | Effort |
+|---|---|---|---|
+| `api` trigger kind (bare programmatic fire, alongside schedule/webhook) | schedule + webhook only | Add a 3rd trigger kind: authenticated local RPC/CLI verb that fires a run without going through cron or the webhook HMAC path (useful for CI/other-tool integration without minting a webhook secret) | S |
+| Rule versioning + human attribution (`autopilot_rule_version`, `originator` vs `accountable_user`) | none | No audit trail of "who is accountable for this unattended run" — matters once autopilots are multi-user/shared | M |
+| `autopilot_subscriber` / `autopilot_collaborator` (auto-subscribe + write-grants) | none | Single-owner model only; fine for solo `ainb` but blocks any future team-shared workspace autopilots | S–M |
+| Squad/team assignee (leader-resolves dispatch) | single agent only | No equivalent concept of squads in ainb yet — likely out of scope until ainb has a team/squad primitive | L (blocked on a missing primitive) |
+| Run lifecycle: `pending→issue_created|running→completed|failed|skipped` (5-6 states, `skipped` distinct from `failed`) | `running→completed|failed|cancelled` (4 states) | Hangar conflates "policy-skipped tick" into a log event (`tick_skipped`), not a queryable run row — history/reporting can't distinguish "we skipped this" from "it never happened" without re-parsing logs | S |
+| `execution_mode` (`create_issue`/`run_only`) | same two variants, fully wired | **Parity** — no gap | — |
+| `concurrency_policy` (`skip`/`queue`/`replace`) | same, but hangar's is tested/live, multica's is a dead schema column | **Hangar ahead here** | — |
+| TUI/UI create form with title-template, project scoping, subscriber picker | CLI-only create, no template/project/subscriber fields | No TUI creation wizard for autopilots at all; today it's `hangar autopilot create` CLI only | M |
+| Webhook delivery audit + event filters | same shape, already built (HMAC, filters, delivery log, CLI verb) | **Parity** — no gap | — |
+| Scheduler: generic DB-backed lease/scope engine reused across multiple job types, stale-lease steal + idempotent replan | Purpose-built `AutopilotScheduler` loop, single job type, cron-per-autopilot with `max_concurrent_runs` limit check at fire time | Hangar's scheduler is simpler/narrower (fine at current scale — SQLite single-daemon, no multi-instance lease contention to solve) — not a gap worth closing unless ainb goes multi-daemon | — (defer) |
+
+**Top gaps ranked**: (1) no `api` trigger kind, (2) no rule-versioning/human-attribution audit trail, (3) `skipped` not a first-class run status (only a log event), (4) no subscriber/collaborator model, (5) no TUI create wizard (CLI-only today).

--- a/docs/explorations/multica-reference/issue.md
+++ b/docs/explorations/multica-reference/issue.md
@@ -1,0 +1,217 @@
+# Issue entity: Multica vs Hangar
+
+## Multica Issue
+
+### Schema (`server/migrations/001_init.up.sql:52-94` + later migrations)
+
+Base `issue` table (`001_init.up.sql:52-72`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | |
+| `workspace_id` | UUID FK | cascade delete |
+| `title` | TEXT NOT NULL | |
+| `description` | TEXT | nullable |
+| `status` | TEXT CHECK | `backlog\|todo\|in_progress\|in_review\|done\|blocked\|cancelled` (7 states) |
+| `priority` | TEXT CHECK | `urgent\|high\|medium\|low\|none` |
+| `assignee_type` | TEXT CHECK | `member\|agent` at init; **`squad` added later** (no dedicated migration found, but `assignee_type` string is validated `'member', 'agent', or 'squad'` in handler, `issue.go:3055`) |
+| `assignee_id` | UUID | nullable, polymorphic |
+| `creator_type` | TEXT CHECK | `member\|agent` |
+| `creator_id` | UUID NOT NULL | |
+| `parent_issue_id` | UUID FK → issue(id) ON DELETE SET NULL | **SUBTASKS** |
+| `acceptance_criteria` | JSONB NOT NULL DEFAULT '[]' | structured criteria list |
+| `context_refs` | JSONB NOT NULL DEFAULT '[]' | linked context references |
+| `position` | FLOAT NOT NULL DEFAULT 0 | manual ordering, see Move below |
+| `due_date` | TIMESTAMPTZ → later `DATE` (migration 112) | |
+| `created_at`/`updated_at` | TIMESTAMPTZ | |
+
+Sibling tables from the same init migration:
+- `issue_label` (workspace-scoped `name`+`color`) and `issue_to_label` (composite PK many-to-many join) — `001_init.up.sql:75-86`.
+- `issue_dependency` (`001_init.up.sql:89-94`): `(issue_id, depends_on_issue_id, type)` where `type ∈ {blocks, blocked_by, related}` — a **typed dependency graph**, not just a single-direction blocker edge.
+- `comment` table with `type ∈ {comment, status_change, progress_update, system}` (`001_init.up.sql:97-107`) — feeds the mention-trigger pipeline below.
+
+Fields added by later migrations (all additive, non-destructive):
+- `number` + workspace `issue_prefix`/`issue_counter` → human-readable `PREFIX-N` ids, unique per workspace (`020_issue_number.up.sql`).
+- `origin_type`/`origin_id` (added in `042_autopilot`, extended `060`/`111`/`131`/`149`) — provenance: `autopilot`, `quick_create`, `lark_chat`, `slack_chat`, `agent_create`. Used to attribute agent-created issues back to a human originator (`149_issue_origin_agent_create.up.sql`).
+- `start_date` (`091_issue_start_date.up.sql`) pairs with `due_date` for Gantt; both converted `TIMESTAMPTZ → DATE` in `112_issue_dates_to_date.up.sql` (calendar-day semantics, timezone-bug fix).
+- `metadata` JSONB (`105_issue_metadata.up.sql`) — free-form small KV bag (≤50 keys, primitives only, 8KB cap, GIN `jsonb_path_ops` index) for agent pipeline state (PR number, pipeline_status, waiting_on…). Single-key atomic writes only (`issue_metadata.go:1-30`) — `UpdateIssue` never touches it, to avoid races with concurrent agent writes.
+- `first_executed_at` (`050_issue_first_executed_at.up.sql`) — stamped once, atomically, first time the issue's task reaches `done`; analytics funnel source of truth.
+- `stage` INTEGER, nullable, `>=1` (`123_issue_stage.up.sql`) — orders sub-issues sharing a `parent_issue_id` into **barrier groups**; drives the child-done cascade (below).
+- `properties` JSONB (`191_issue_properties.up.sql`) + `issue_property` catalog table — custom typed per-workspace properties (text/number/select/multi_select/date/checkbox/url), keyed by definition UUID so renames don't require value migrations. Capped at 20 active defs/workspace, 16KB value bag.
+- `issue_subscriber` (`015_issue_subscriber.up.sql`) — notification subscription per `(issue, user)` with `reason ∈ {creator, assignee, commenter, mentioned, manual}`.
+- `issue_reaction` (`027_issue_reactions.up.sql`) — emoji reactions, unique per `(issue, actor, emoji)`.
+- `issue_pull_request` — link table (not in 001_init, found via later migrations `109`/`127`) carrying `close_intent` (explicit "Closes #N" keyword) and `reference_only` (bare mention, no closing keyword) flags, so the PR↔issue auto-advance gate can distinguish a working PR from a passing reference.
+
+### Status lifecycle
+7 states: `backlog, todo, in_progress, in_review, done, blocked, cancelled`. `done`/`cancelled` are terminal (`isTerminalChildStatus`, `issue_child_done.go`). `backlog` is an explicit "parking lot" — assigning/creating into backlog never auto-starts a run (`issue_trigger.go` service, `WillEnqueueRun`).
+
+### Assignee polymorphism
+`assignee_type ∈ {member, agent, squad}` + `assignee_id` UUID, no FK (cross-table polymorphism). Validated in `validateAssigneePair` (`issue.go:2996-3063`, error message literally enumerates `"assignee_type must be 'member', 'agent', or 'squad'"`). A **squad** assignee resolves to its `leader_id` agent for actually running (`service/issue_trigger.go:130-146`) — squad assignment fans a run to the squad leader, not a member-per-task at the issue level (task-level squad fanout is a separate service, `SquadAssignService`, referenced only from hangar's analogue below).
+
+### Subtasks (parent/child)
+`parent_issue_id` (self-FK, `ON DELETE SET NULL`) is a first-class column since `001_init`. `ListChildIssues` / `ListChildrenByParents` / `ChildIssueProgress` (`issue.go:1902-2065`) serve the child list + roll-up progress. `stage` (migration 123) groups children into ordered barrier stages under one parent — an unstaged set is one implicit stage.
+
+**Child-done → parent cascade** (`issue_child_done.go`, 695 lines): when a child transitions non-terminal → terminal (done OR cancelled):
+1. Guard: parent exists, parent not already done/cancelled, parent not `backlog` (a backlog parent is deliberately parked — waking it would let the agent auto-promote siblings, a previously-reported bug MUL-3497/#4320), parent assignee not a human member (no task to trigger, no point notifying a human via bot comment).
+2. **Stage barrier**: fires only when the *stage closes* — every sibling in the lowest unfinished stage is now terminal (`stageBarrierClosed`). This collapses "wake on every child" into "wake once when the stage's last child finishes."
+3. Posts a system comment on the parent (bypassing the normal `on_comment` trigger path so it can't accidentally re-mention unrelated members) embedding a `mention://{agent,squad}/<id>` link targeting the parent's own assignee, which explicitly fires that assignee's own agent-run trigger (`dispatchParentAssigneeTrigger`).
+4. Batch variant (`notifyParentsOfBatchChildDone`) aggregates across a whole batch update so multiple stages closing in one request produce one comment per parent from final state, not one per intermediate stage (order-independence fix, MUL-4155).
+
+### Dependencies
+`issue_dependency` table: `(issue_id, depends_on_issue_id, type)`, `type ∈ {blocks, blocked_by, related}` — a real directed, typed dependency graph (`001_init.up.sql:88-94`). (Full CRUD/gating handler not read in this pass; table exists since day one.)
+
+### Labels
+`issue_label` (workspace-scoped name+color) + `issue_to_label` many-to-many join (`001_init.up.sql:74-86`). Faceted filtering supports `label_ids` array (see Filtering below).
+
+### Custom properties vs metadata (two distinct JSONB surfaces)
+- `metadata` (105): agent-internal KV scratch, flat primitives, no catalog, not user-facing structure — for pipeline bookkeeping.
+- `properties` (191) + `issue_property` catalog: user-defined typed custom fields (like Linear/Notion properties), with select/multi_select option catalogs, position-ordered, archivable (never hard-deleted).
+
+### Comment `@mention` auto-dispatch trigger (the "comment_trigger" model)
+Lives in `server/internal/handler/comment.go` (not `issue_trigger.go`, which only covers **assign/status** writes — a deliberately separate predicate; see `issue_trigger.go:66-72`).
+
+Mention markup: `[@Label](mention://{member|agent|squad|issue|all}/<uuid|all>)`, parsed both server-side (Go, `util.ParseMentions`) and client-side (`packages/core/issues/comment-trigger-outcomes.ts:8-9` regex — kept in sync).
+
+Flow (`comment.go:1897-1998`, `computeCommentAgentTriggers`):
+1. Parse mentions in the comment body.
+2. If any explicit `@agent`/`@squad` mention exists → route ONLY to those targets (`resolveMentionedAgentCommentTriggers`), skipping the fallback logic entirely.
+3. Else if a `@member` mention exists → member-mention path (notification only, no agent trigger).
+4. Else → **assignee-fallback routing**: reply-to-parent-author, thread-root-owner routing, or the issue's own assignee (`routeReplyToParentAuthor`, `routeThreadRootOwners`).
+5. Each resolved trigger is enqueued (`enqueueCommentAgentTriggers`) with per-target outcomes: `queued | coalesced | deferred | blocked` (`CommentTriggerOutcome`, MUL-4525 §2) — the wire response includes this array so the client can show "N not triggered" toasts.
+6. A **squad** mention routes to the squad's leader (`commentTriggerSourceMentionSquadLeader`); an **agent** mention routes directly (`commentTriggerSourceMentionAgent`).
+7. Private-agent visibility gate (`CanAccessAgent`/`canInvokeAgent`) applies identically to preview and real enqueue so preview never leaks a private agent's readiness to someone who can't see it.
+8. Self-loop guard: an agent's own comment on its own running issue does not re-trigger itself (`IsSelfLoop`).
+9. Merge-into-pending: a new mention against an agent that already holds a pending/active task for the issue coalesces into that task rather than double-enqueuing (`mergeCommentIntoPendingTask`).
+10. `PreviewCommentTriggers` / `PreviewIssueTrigger` (dry-run, `comment.go:1130` / `issue_trigger.go` handler) let the UI show "will start N runs" before the user hits send — single source of truth shared with the real write path (MUL-3375).
+
+This is the single biggest structural feature hangar lacks entirely: **comments never dispatch agent work in hangar.**
+
+### Issue creation — all inputs
+`CreateIssueRequest` (`issue.go:2372-2399`): `title` (required), `description`, `status`, `priority`, `assignee_type`+`assignee_id`, `parent_issue_id`, `acceptance_criteria`, `context_refs`, `due_date`/`start_date`, `label_ids`, `origin_type`+`origin_id` (provenance, optional pair). No repo/branch fields at all — multica's "issue" is decoupled from any git workspace concept (that lives in its separate task/run layer), unlike hangar where repo/branch selection is baked into issue creation.
+
+Also: `QuickCreateIssue` (`issue.go:2066-2282`) — a daemon-driven fast-path creation (stamps `origin_type=quick_create`) used by autopilot / chat-origin flows (Lark/Slack), with a runtime-online + CLI-version gate before allowing it.
+
+### Filtering / faceted list view
+Two query surfaces:
+1. **Legacy flat list** `ListIssues` (`issue.go:778-1275`) — query params: `assignee_types` (CSV), `assignee` actor filter, workspace scope, status, etc.
+2. **Modern table query** (`issue_table_query.go` + `issue_table_facets.go`, 993 combined lines) — a structured POST body (`issueTableQuerySpec`):
+   - `Filters`: `Statuses[]`, `Priorities[]`, `Assignees[]` (+`IncludeNoAssignee`), `Creators[]`, `ProjectIDs[]` (+`IncludeNoProject`), `LabelIDs[]`, `Properties map[propertyID][]values` (custom-property faceted filter), `Date{Field,Start,End}` range filter, `WorkingOnly`/`WorkingIssueIDs`, `IncludeSubIssues`.
+   - `Scope`: `kind` (e.g. workspace/project/assignee-group), `AssigneeTypes[]`, `ProjectID`, `Actor` (an involves-filter), `Relation`.
+   - `Sort{Field,Direction}`, free-text `Search`.
+   - `Group`: group-by kind (status/assignee/property/etc.), with `Secondary`/`SecondaryValues` for a 2-level grouping, cursor-paginated (`Page{Limit,Cursor}`), optional parent-hierarchy expansion (`Hierarchy{Enabled}`, `ParentID`).
+   - `Facets` endpoint (`ListIssueTableFacets`) returns, per requested facet (e.g. "distinct assignees present in this filtered set" with counts), the value+count pairs used to render filter-picker option lists that only show options actually present in-scope.
+   - Full-text search (`SearchIssues`, `issue.go:625-764`) with snippet extraction, numeric issue-number matching, term highlighting.
+
+### Move / reorder
+`MoveIssue` (`issue_move.go`) takes relative neighbor anchors (`before_id`/`after_id`, optional `project_id`) rather than a client-authored `position` float; server derives the new float position (midpoint, or ±1 at a list end) and re-dispatches through the same `UpdateIssue` write path so realtime/triggers/validation stay on one path. Stale/exhausted-float anchors fail closed with 409 rather than silently renumbering.
+
+---
+
+## Hangar Issue
+
+### Schema (`crates/ainb-hangar-store/migrations/0003_issue_comment.sql` + later)
+
+Base `issue` table (`0003_issue_comment.sql:19-29`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | TEXT PK (ULID) | |
+| `workspace_id` | TEXT FK | |
+| `title` | TEXT NOT NULL | |
+| `description` | TEXT | nullable |
+| `state` | TEXT DEFAULT 'open' | no CHECK constraint (free text); remapped `open→todo`, `closed→done` in migration `0023` |
+| `assignee_type`/`assignee_id` | TEXT CHECK `member\|agent` | polymorphic, **no `squad` value in the CHECK** at the schema level |
+| `creator_type`/`creator_id` | TEXT NOT NULL CHECK `member\|agent` | |
+| `created_at` | INTEGER (epoch ms) | |
+
+Sibling: `comment` table (`author_type/author_id` polymorphic, `body`, `created_at`) — plain comment, no `type` discriminant (no status_change/progress_update/system distinction).
+
+Fields added later, all `ALTER TABLE ADD COLUMN`:
+- `priority` INTEGER `0..3` (`0014`) — HIGHER = MORE URGENT (inverse of multica's `urgent|high|medium|low|none` text enum), mirrors `agent_task_queue.priority`.
+- `due_date` INTEGER epoch ms (`0014`).
+- `labels` TEXT JSON-array column (`0014`) — denormalized read-cache; promoted to a real `label` + `issue_label` join table in `0016` (source of truth is the join, `issue.labels` JSON kept in sync as a cache, never re-derived by JOIN on the hot list path).
+- `external_ref` TEXT (`0043`) — free-form upstream GitHub/Jira reference (URL or `owner/repo#123`), shown on the board card and appended to the dispatched brief as `Linked issue: <ref>`. Roughly analogous to multica's `context_refs`/`issue_pull_request` but far more minimal (single string, no structured link table, no close-intent tracking).
+- `auto_run` INTEGER boolean, default 0 (`0036`) — per-issue opt-in: auto-launch once its last dependency (`card_dependency`) completes.
+- `squad_id` TEXT nullable (`0035`) — squad assignment lives as a SEPARATE column from `assignee_type/assignee_id`, not a third polymorphic value; when set, a run fans out leader+members each into their own worktree. **This is structurally different from multica**, where `squad` is just a third `assignee_type` enum value resolved to the leader for a single run.
+- `ord` INTEGER on `board_card` (not `issue` itself) (`0034`) — per-column manual ordering, default 0, only meaningful within one board column (not a single global float position like multica's `issue.position`).
+
+`card_dependency` table (`0036_card_dependency.sql`): `(workspace_id, dependent_issue_id, blocker_issue_id, created_at)`, composite PK `(dependent_issue_id, blocker_issue_id)` — a single **untyped, blocks-only** edge (no `blocked_by`/`related` variants, no reverse "this relates to" semantic). Enforced service-side: DFS cycle check on insert, self-edge rejected, dependent refuses to RUN while an unfinished blocker exists, auto-dispatches dependents only if `auto_run=1`.
+
+### Rust repo type (`crates/ainb-hangar-store/src/repo/issue.rs:58-84`)
+```rust
+pub struct Issue {
+    pub id: String,
+    pub workspace_id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub state: String,
+    pub assignee: Option<ActorRef>,
+    pub creator: ActorRef,
+    pub created_at: i64,
+    pub priority: i64,
+    pub due_date: Option<i64>,
+    pub labels: Vec<String>,
+    pub external_ref: Option<String>,
+}
+```
+Notably **`squad_id` and `auto_run` are NOT fields on this typed struct** at all (verified via grep — zero hits in `issue.rs`) — those columns exist in the schema but are read/written through other ad-hoc SQL paths (board/squad-assign/dependency services), not the canonical `IssueRepo`/`Issue` type. There is no `parent_issue_id`, no `acceptance_criteria`, no `context_refs`, no `metadata`, no `properties`, no `position` float, no `stage`, no `origin_type`, no `start_date` on this struct or in the schema at all.
+
+### Status lifecycle (`crates/ainb-plugin-hangar/src/screen/issue_list.rs:51-61`, `IssueLifecycle`)
+5 canonical states: `backlog, todo, in_progress, in_review, done`. **No `blocked`, no `cancelled`.** Legacy `open`/`closed` map forward once (migration `0023`) but the column has no CHECK constraint — any string is accepted, unknown values fail-visible into the `Todo` column.
+
+### Create wizard (`issue_list.rs:307-499`, `WizardRow`)
+7 rows, all present at once (not staged): **Title → Brief → Link → Repo → Source → Target → Agent**.
+- `Title` (required, non-blank)
+- `Brief` (optional multi-line) → becomes `issue.description` and the dispatched `claude -p` prompt
+- `Link` (optional) → `issue.external_ref`
+- `Repo` (required, `@` fuzzy picker or ←/→ cycle)
+- `Source` branch (prefilled `main`)
+- `Target` branch (prefilled `main`, where a future PR would land)
+- `Agent` (←/→ cycle `AgentChip::ALL`, or the named-agent roster via `WizardAgent` if any exist)
+
+**No priority, due date, labels, acceptance criteria, or custom properties in the create wizard** — despite the schema supporting priority/due_date/labels since migration 0014, the create UI never surfaces them (schema-ahead-of-UI gap). Only a title-only/repo-less/agent-less create is blocked (Enter jumps focus to the missing required row instead).
+
+### Filtering (`issue_list.rs:150-234`, `FilterChip`)
+4 fixed chips only: `All`, `Members`, `Agents`, `Mine` (Mine is a documented P5 placeholder currently behaving as `All`). Cycled with Tab/Shift+Tab. Plus a free-text `/` query filter (`IssueListState::query`) — substring search, not the structured multi-facet query multica has. **No status/priority/label/property/date-range filters, no faceted "show me only values present in this view" endpoint, no involves/creator filters, no server-side paginated table query with grouping.**
+
+### Assignee polymorphism
+`assignee_type ∈ {member, agent}` only at the schema CHECK level. Squad assignment is bolted on as an orthogonal `squad_id` column rather than a third assignee-type value — meaning "who is this issue assigned to" is answerable from two different columns depending on whether it's solo or squad, unlike multica's single `(assignee_type, assignee_id)` pair that already covers `squad`.
+
+### Subtasks / parent-child
+**Absent entirely.** No `parent_issue_id` column, no child-list query, no stage/barrier concept, no child-done → parent cascade or notification. An issue in hangar has no relationship to any other issue except through the untyped `card_dependency` blocks-edge.
+
+### Dependencies
+`card_dependency`: single directed "blocks" edge, DFS-cycled-checked, auto-run opt-in on completion. No `related`/`blocked_by` distinction, no dependency-type enum, no UI to browse the dependency graph beyond gating a run.
+
+### Acceptance criteria / context refs
+**Absent.** No JSONB structured-criteria column, no linked-context-references column. The closest analogue is the single free-text `external_ref` string (one upstream link, no structured list, no closing-keyword tracking).
+
+### Comment @mention auto-dispatch
+**Absent entirely.** Confirmed via grep across `ainb-plugin-hangar/src` and `ainb-hangar-store/src`: no mention parsing, no comment-triggered task enqueue, no per-target outcome tracking, no preview endpoint. Hangar's `comment` table is pure text storage with zero side effects on write.
+
+### Custom properties / metadata
+**Absent.** No `issue_property` catalog, no per-issue JSONB properties bag, no per-issue metadata KV scratch space for agent pipeline state.
+
+### Move / reorder
+Board-column-scoped `ord` integer (`board_card.ord`, migration 0034) — reordering is local to one column, contiguous `0..n` rewrite on reorder, no cross-column global float position, no anchor-based (`before_id`/`after_id`) API — reorder mechanics not directly inspected this pass but the storage model is structurally simpler (integer bucket-local index vs. multica's workspace-global float with anchor-derived midpoint math and 409-on-stale-anchor).
+
+---
+
+## GAPS (multica has → hangar has → gap → effort)
+
+| # | Multica has | Hangar has | Gap | Effort |
+|---|---|---|---|---|
+| 1 | Comment `@mention` auto-dispatch: parses `[@x](mention://type/id)`, routes to explicit mention / reply-parent / thread-owner / assignee-fallback, per-target `queued/coalesced/deferred/blocked` outcomes, preview endpoint, self-loop + private-agent gates, merge-into-pending dedup | Nothing — comments are inert text | **Largest structural gap.** No way to hand off work via conversation; every dispatch must go through explicit assign/status-change | **L** |
+| 2 | `parent_issue_id` subtasks + `stage` barrier groups + child-done→parent cascade comment+wake, staged multi-child completion aggregation | No parent/child relationship of any kind | Cannot decompose an issue into tracked sub-issues at all; no roll-up progress | **L** |
+| 3 | `issue_dependency`: typed graph (`blocks`/`blocked_by`/`related`), any-direction | `card_dependency`: single untyped "blocks" edge, cycle-checked, `auto_run` opt-in | Narrower semantics (no "related", no reverse blocked_by as distinct type) but the *core* auto-run-on-blocker-done mechanic already exists — this is the closest-to-parity gap | **S–M** |
+| 4 | `acceptance_criteria` JSONB structured list + `context_refs` JSONB | Neither; only a single free-text `external_ref` string | No structured acceptance criteria or multi-item context linking | **M** |
+| 5 | Structured table-query filtering: status/priority/assignee/creator/project/label/property/date-range facets, faceted-value-with-counts endpoint, 2-level grouping, cursor pagination, involves/scope filters | 4 fixed chips (All/Members/Agents/Mine) + free-text substring search | No real filtering beyond assignee-kind + text query; no way to filter by status/priority/label/date/property, no facet counts | **L** |
+| 6 | Custom `issue_property` catalog (typed, select/multi_select options, archivable) + separate `metadata` KV scratch | Neither | No user-defined custom fields, no agent-pipeline-state scratch space on the issue | **M–L** |
+| 7 | `assignee_type` single enum incl. `squad`, resolved via `WillEnqueueRun` shared predicate for create/assign/status-promote triggers, self-loop + private-agent gated, preview endpoint | `squad_id` bolted on as a separate column from `assignee_type/id`; no shared "will this start a run" predicate exposed for preview | Squad-assignment model less unified; no dry-run "what will happen" preview for issue writes | **M** |
+| 8 | `origin_type`/`origin_id` provenance (autopilot/quick_create/lark_chat/slack_chat/agent_create) for attribution chains | None found | Cannot trace who/what ultimately caused an agent-created issue | **S–M** |
+| 9 | 7-state lifecycle incl. `blocked`, `cancelled`, DB-level CHECK constraint | 5-state lifecycle, no `blocked`/`cancelled`, no CHECK (free text) | Cannot represent "blocked" or "cancelled" as first-class terminal/blocking states | **S** |
+| 10 | Workspace-global float `position` + anchor-based (`before_id`/`after_id`) move endpoint, 409 on stale/exhausted anchors | Column-local integer `ord`, simpler reorder | Lower fidelity reordering across columns/views but functionally adequate for board-only use | **S** |
+| 11 | Create wizard equivalent (`CreateIssueRequest`) accepts priority/status/labels/acceptance_criteria/parent/dates directly | Create wizard (7 rows) omits priority/due/labels/acceptance-criteria entirely even though schema supports priority/due/labels since 0014 | UI hasn't caught up to schema — quick win since columns already exist | **S** |
+| 12 | `issue_subscriber` (notification subscriptions, reason-tagged) + `issue_reaction` (emoji reactions) | Neither | No subscription model, no reactions | **M** |
+
+**Top-ranked (do first):** #1 (comment-mention dispatch) and #2 (subtasks/parent-child) are the two gaps that change what the product *is*, not just what it displays — everything downstream (stage barriers, cascade notifications, mention-based handoff) builds on them. #11 is the cheapest real win (schema already has priority/due/labels; wizard just needs three more rows).

--- a/docs/explorations/multica-reference/squad.md
+++ b/docs/explorations/multica-reference/squad.md
@@ -1,0 +1,137 @@
+# Squad entity: Multica vs Hangar
+
+## 1. Multica Squad
+
+### Schema (server/migrations/084_squad.up.sql:2-33, +085/086/087/088)
+
+```
+squad
+  id, workspace_id, name, description, leader_id (→agent, RESTRICT),
+  creator_id, created_at, updated_at
+  UNIQUE(workspace_id, name)            -- 087 later DROPS this uniqueness
+  + avatar_url (086), instructions TEXT DEFAULT '' (088), archived_at/archived_by (085)
+
+squad_member
+  id, squad_id (→squad CASCADE), member_type CHECK IN ('agent','member'),
+  member_id, role TEXT DEFAULT '', created_at
+  UNIQUE(squad_id, member_type, member_id)
+
+issue.assignee_type CHECK IN ('member','agent','squad')   -- squad is a first-class assignee
+autopilot.assignee_type CHECK IN ('agent','squad')          -- 096, autopilot can target a squad too
+agent_task_queue.squad_id                                    -- 127, no FK (hot table), lets the
+                                                              -- daemon inject the right briefing at claim time
+```
+
+Leader must be an agent (FK RESTRICT to `agent`, never `member`). Members can be `agent` or `member` (human). A squad with only the leader is valid.
+
+### Leader/member model, roles (server/internal/handler/squad.go)
+
+- `CreateSquad` (squad.go:225-318): any workspace member can create a squad → becomes `creator_id`. Leader must be an agent in-workspace, and a non-admin creator can only wire an agent they can themselves `@`-trigger (`memberCanWireAgent`, squad.go:134-140) — stops smuggling an inaccessible agent into a squad. Leader auto-added as member with `role="leader"` (squad.go:297-303).
+- Management is **creator-scoped**: owner/admin manage every squad; a regular member manages only squads they created (`canManageSquad`, squad.go:118-123). Visibility is workspace-wide regardless (`ListSquads` unfiltered).
+- `AddSquadMember` / `RemoveSquadMember` / `UpdateSquadMemberRole` (squad.go:690-881): role is a free-text label ("owns the migrations") the leader reads when delegating. Leader cannot be removed (must change leader first, squad.go:810-813).
+- `ListSquadMemberStatus` (squad.go:579-688): derives a per-member `working/idle/unstable/offline/archived` status from runtime + active-task rows — squad members get live presence in the UI.
+- Docs confirm (`apps/docs/content/docs/squads.mdx:12`): "members can be agents **or human members**" — humans are first-class squad members, they just can't be leader and don't get dispatched-to by the fan-out mechanism (they're delegation *targets* via @mention only, handled by the normal comment/mention pipeline, not a special squad-fanout).
+
+### Assignment + briefing/kickoff fan-out
+
+Key design: **a squad-assigned issue enqueues ONE task — for the LEADER only** (`enqueueSquadLeaderTask`, squad.go:1027-1087). There is no member fan-out at assignment time in multica — that's the crucial difference from hangar (see §3). The leader is the sole dispatch target; it then *delegates by posting a comment that @mentions members*, which independently triggers each mentioned member through the ordinary mention-trigger pipeline.
+
+On claim, `buildSquadLeaderBriefing` (squad_briefing.go:164-177) appends 3 sections to the leader's system instructions:
+
+1. **Squad Operating Protocol** (squad_briefing.go:23-144, hard-coded, not user-editable): explains the leader's coordinator role, 6 numbered responsibilities —
+   1. Read the issue, pick the best member by matching to their listed **skills**/role.
+   2. Delegate by @mention — exact `[@Name](mention://agent|member/<uuid>)` markdown, terse (don't restate issue body).
+   3. Record evaluation via `multica squad activity <issue-id> <action|no_action|failed> --reason "..."` — mandatory every turn.
+   4. Stop after dispatching — no implementation work.
+   5. Re-evaluate on each re-trigger (member reply, mention, etc).
+   6. **Own parent issue status** — but ONLY if this squad actually owns the issue (`ownsIssueStatus` flag, squad_briefing.go:73-105): move to `in_progress` on first turn, `in_review` when overall goal met, never `done` (left to human/PR-merge). If the leader was pulled in via an `@squad` mention on someone else's issue, responsibility 6 flips to "do NOT change status."
+   Hard rules section (squad_briefing.go:107-134) reiterates: mention markdown is mandatory (no plain "@name"), don't @mention non-members, one delegation comment per turn, don't double-fire (assignment-trigger vs mention-trigger collision warning).
+2. **Squad Roster** (`buildSquadRoster`, squad_briefing.go:181-227) — leader self-row + one row per non-archived member, each with literal ready-to-paste mention markdown and (for agents) their **skill names** (`agentSkillsRosterSegment`, squad_briefing.go:299-307) so the leader can match capability→task. Archived agents are silently skipped.
+3. **Squad Instructions** (squad_briefing.go:170-175) — the user-authored `squad.instructions` field (routing rules, escalation policy), omitted entirely if blank.
+
+### Coordination / result-aggregation back to leader
+
+There is no explicit "aggregation" step — coordination is entirely comment-driven:
+- Leader posts delegation comment(s); each mentioned member gets its own task via the ordinary mention-trigger machinery (shared with direct agent mentions).
+- Leader is **re-triggered** on: a non-member comment, a squad member's progress update with no @mention (re-evaluate), an issue cross-reference-only comment. Leader is **not** re-triggered on: its own comment (`shouldSuppressSquadLeaderSelfTrigger`, squad.go:985-1002), or when anyone else's comment explicitly @mentions someone else (that mention *is* the routing signal — no double-trigger).
+- `squad_no_action.go` — `HasSquadLeaderNoActionEvaluationForTask` dedups so a `no_action` evaluation isn't recorded twice for the same task.
+- `RecordSquadLeaderEvaluation` (squad.go:888-981) — CLI-driven activity-log entry (`squad_leader_evaluated`), gated so **only the squad leader agent** can record it for an issue actually assigned to that squad (security check squad.go:923-930), tied to the exact task via `X-Task-ID` header.
+
+### Create-inputs for a squad
+
+- `CreateSquad`: `name` (required), `description` (optional), `leader_id` (required, must resolve to an in-workspace agent), `avatar_url` (optional).
+- `UpdateSquad`: any of `name`, `description`, `instructions`, `leader_id` (re-validates + auto-adds new leader as member), `avatar_url`.
+- Member add: `member_type` (`agent`|`member`), `member_id`, `role` (free text).
+- Squads are also assignable to **autopilots** (096 migration) — Path A "squad-as-leader": autopilot dispatch resolves squad→leader.leader_id, same semantics as manual assign.
+- Archive (`DeleteSquad`, squad.go:423-481): transfers assigned issues AND autopilots to the leader agent (so nothing goes silent), then soft-deletes (`archived_at`/`archived_by`); rejects new assignments to an archived squad.
+
+---
+
+## 2. Hangar Squad (ainb)
+
+### Schema (crates/ainb-hangar-store/migrations/0017_squad.sql, 0035_card_squad_assignment.sql)
+
+```
+squad
+  id, workspace_id (→workspace), name,
+  leader_type CHECK IN ('member','agent'), leader_id, created_at
+  UNIQUE(workspace_id, name)
+
+squad_member
+  squad_id (→squad), member_type CHECK IN ('member','agent'), member_id
+  PRIMARY KEY (squad_id, member_type, member_id)      -- no role column, no created_at
+
+issue.squad_id  TEXT   -- nullable, no FK, orthogonal axis to issue.agent_kind / repo_ref (0035)
+```
+
+No `description`, no `instructions`, no `avatar_url`, no `archived_at`, no per-member `role` column, no `creator_id` — a much thinner shape than multica's fully-evolved (7-migration) squad. `leader_id` has no FK (SQLite `PRAGMA foreign_keys` off in this crate by convention).
+
+### Service layer (`SquadAssignService`, crates/ainb-hangar-store/src/service/squad_assign.rs)
+
+Two operations:
+- `assign_to_leader` (lines 156-203): resolves squad→leader agent→leader's runtime, enqueues ONE task keyed to `(leader_agent_id, leader_runtime_id)`. This mirrors multica's leader-only assignment exactly.
+- `assign_fanout` (lines 240-347): **hangar goes further than multica here** — it fans a card/issue out to the LEADER **and** every distinct `agent` member (human members skipped, no runtime to route to) in a single all-or-nothing transaction, each member getting its own task on the same issue, each provisioning its own worktree (`repo_ref`/`agent_kind` stamped per task, tcp T4/F7). Cross-workspace member refs are rejected (`agent_runtime_in_ws`, lines 379-391); dangling member refs abort the whole fan-out atomically (tested at lines 738-788); leader-listed-as-member is deduped (lines 690-736).
+
+This is architecturally the *opposite* shape from multica: hangar dispatches leader+members concurrently up front; multica dispatches leader-only and lets the leader's own @mention comment trigger members one at a time. Hangar's fan-out has no analogue to multica's "leader decides who, and only who's needed" routing — every agent member gets a task regardless of fit.
+
+### What's missing: briefing / kickoff / roster / instructions
+
+Grep across `ainb-hangar-store` and `ainb-hangar-daemon` for `briefing|roster|instructions` (scoped to squad code) returns **nothing** outside the doc-comment in `squad_assign.rs`. There is no equivalent of multica's `buildSquadLeaderBriefing`:
+- No system-prompt injection telling the leader "you are a squad LEADER, delegate by @mention, don't do the work yourself."
+- No Squad Roster block with ready-to-paste mention markdown or skill names.
+- No per-squad `instructions` field to even hold user-authored routing guidance (schema doesn't have the column).
+- Nothing analogous to `squad_no_action.go` / `RecordSquadLeaderEvaluation` — no evaluation/audit trail of what the leader decided each turn.
+
+The `agent_task_queue.squad_id` column multica added specifically so the daemon could inject briefing content at claim time (migration 127 comment) has **no hangar equivalent** — hangar's task rows carry no `squad_id`, so even if briefing were added, there's no claim-time hook to key it off today (a task only knows its own `agent_id`/`issue_id`).
+
+Net effect: a hangar squad leader that claims a fanned-out task receives **no instruction that it's a leader**, no roster, nothing telling it to coordinate rather than just do its own slice of work directly. Since hangar's fan-out already dispatches to every agent member concurrently (unlike multica's leader-mediated one-at-a-time), the "leader" role in hangar today is nominal — it gets a task like everyone else, with no special system prompt distinguishing it.
+
+### TUI surface (`crates/ainb-plugin-hangar/src/screen/squads.rs`)
+
+Pure reducer + width-aware render, hotkey `S` for the Squads screen:
+- `n` create an agent inline (helps clear the "no agent available" gate), `c` create a squad (name-only, leader chosen by the glue from cached agents — no leader picker UI, no description/instructions/avatar inputs), `a` add a member (glue auto-picks "next cached agent not already on the squad" — no member picker, no role input), `d` remove selected member row, `x` assign current issue to squad (fires `squad_fanout`).
+- No archive/delete action exposed in this screen at all (schema has no `archived_at` to archive into anyway).
+- Renders leader + members with live presence dots; member rows tagged `agent`/`human`.
+
+### Known bug: issue #450 — Boards' `q:squad` hotkey unreachable
+
+Confirmed via `gh issue view 450` (OPEN): Boards screen advertises `q:squad` in its footer to open the assign-squad picker on a focused card (`BoardsEvent::AssignSquad`), but the **global key router** (`ainb-plugin-hangar/src/plugin.rs::on_key` → `routing_event`) matches bare `'q'` unconditionally as quit for *every* screen, before `boards.rs`'s screen-local `'q' → AssignSquad` mapping is ever reached. Root cause: no "Boards screen, no overlay open" guard exists alongside the other screen-specific capturing-input guards (Squads create-input, Boards overlay input) that already protect their own keys from the router. Reproduced via tmux: pressing `q` on a focused, unrun card closes the whole Hangar panel back to Sessions; the card persists with `squad_id = NULL`. Impact: **card-level squad fan-out is unreachable via keyboard** — the only working path is the CLI `ainb hangar squad assign <squad_id>`, which is leader-only (no fan-out), not equivalent to the card's documented fan-out semantics.
+
+---
+
+## 3. GAPS
+
+| # | Multica has | Hangar has | Gap | Effort |
+|---|---|---|---|---|
+| 1 | Leader system-prompt briefing (Operating Protocol + Roster + Instructions) injected at claim time, keyed via `agent_task_queue.squad_id` | Nothing — no briefing text, no injection hook, task rows carry no `squad_id` | **Biggest gap.** A hangar squad leader has no idea it's a leader or who's on the roster; it just runs like a solo agent. Needs: `squad_id` column on hangar's task table (mirroring migration 127), a `SquadBriefing` builder, and a claim-time injection point in the daemon (`ainb-hangar-daemon`) | L |
+| 2 | Per-member free-text `role` column, surfaced in the roster so the leader matches task→member by fit | `squad_member` has no `role` column at all | Leader (once briefing exists) can't route by stated specialty; TUI `a` add-member also has no role input | M (schema + repo + TUI input) |
+| 3 | User-authored `squad.instructions` field (routing rules, escalation policy) | No `instructions` column | Even with briefing, no per-squad custom guidance channel | S (schema + briefing template once #1 lands) |
+| 4 | Leader-mediated, **selective** dispatch — leader reads issue, picks the *right* member(s) by skill/role, delegates via one @mention comment; members not needed get no task | `assign_fanout` dispatches to **every** agent member unconditionally, concurrently, no selection logic | Hangar's fan-out is "spray to all," not "route to the fit one." Architecturally this may be an intentional different pattern (parallel worker fan-out vs mediated routing) rather than a straight gap — worth a product decision before "fixing" | L (if selective routing is wanted, needs briefing + comment-driven re-trigger machinery, effectively porting multica's whole coordination model) |
+| 5 | Human (`member`) squad members are legitimate delegation targets (via @mention, same as agents) | Human members are stored (`member_type='member'`) but structurally **excluded** from fan-out (no runtime → skipped) and there's no comment/mention system to delegate to them another way | Human squad members are currently inert in hangar — schema allows adding them but nothing routes work to them | M/L (depends on whether hangar has any comment/mention pipeline to hook into — needs investigation) |
+| 6 | Evaluation/audit trail per turn (`squad_leader_evaluated` activity, `no_action` outcome, dedup) | None | No visibility into whether/why a leader acted; no dedup mechanism for repeat evaluations | M |
+| 7 | Result-aggregation is comment-driven: leader re-triggered on member replies, re-evaluates, decides next step or marks `in_review` | No re-trigger/coordination loop — hangar's fan-out is fire-and-forget, no mechanism for the leader to see member results and react | Once dispatched, hangar has no loop closing the leader back in when members finish — needs a trigger/wake mechanism (comment system or task-completion webhook) | L |
+| 8 | Squad is soft-deletable (`archived_at`/`archived_by`), issues/autopilots auto-transferred to leader on archive, rejects assignment to archived squad | No archive concept in schema or TUI at all | Deleting/retiring a squad has no safe path; stale squads accumulate, no transfer-on-delete safety net | S/M |
+| 9 | Squad assignable to **autopilot** (`autopilot.assignee_type='squad'`) | No autopilot-squad linkage found | Squads can't be targeted by hangar's automation/autopilot equivalent (if one exists) | Unclear — needs autopilot-equivalent audit first |
+| 10 | Card-level squad-fan-out reachable via keyboard (assign-squad picker) | **Broken**: `q:squad` hotkey stolen by global router (issue #450, OPEN) — fan-out only reachable via CLI (leader-only, not fan-out-equivalent) | Immediate, scoped, well-understood regression — fix before any of the above | **S** (add a Boards-no-overlay guard in `plugin.rs::on_key`, same pattern as existing screen guards) |
+
+**Priority read:** #10 is a quick, isolated fix and should land first (it blocks the *existing* fan-out feature from being reachable at all). #1 (briefing) is the structural gap that most changes what a hangar squad leader actually *is* — everything else (role column, instructions, evaluation trail) is downstream of having a briefing mechanism to put them in. #4/#5 are product-shape questions (selective routing vs spray-fanout; human members) worth a decision before investing further engineering.

--- a/docs/explorations/multica-reference/task-flow.md
+++ b/docs/explorations/multica-reference/task-flow.md
@@ -1,0 +1,179 @@
+# Task + Task-Flow: Multica vs Hangar
+
+## 1. Multica Task + Flow
+
+### Schema (`agent_task_queue`)
+
+`server/migrations/001_init.up.sql:123-136` — base table:
+```
+id, agent_id, issue_id, status, priority, dispatched_at, started_at,
+completed_at, result, error, created_at
+status IN ('queued','dispatched','running','completed','failed','cancelled')
+```
+Grown by later migrations (all additive `ALTER TABLE agent_task_queue`):
+- `020_task_session.up.sql` — `session_id`, `work_dir` (resume a Claude Code session via `--resume`).
+- `022_task_lifecycle_guards.up.sql` — partial unique index `idx_one_pending_task_per_issue` on `(issue_id) WHERE status IN ('queued','dispatched')` — **global** per-issue at this point (superseded later by per-(issue,agent) semantics referenced in `ClaimAgentTask`, see hangar comment citing `pkg/db/queries/agent.sql`).
+- `026_task_messages.up.sql` — new table `task_message(task_id, seq, type, tool, content, input, output)` — the transcript/message-stream store, indexed `(task_id, seq)`.
+- `028_task_trigger_comment.up.sql` — `trigger_comment_id` FK to `comment` — threads a task back to the comment that fired it.
+- `032_task_usage.up.sql` — new table `task_usage(task_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at)`, `UNIQUE(task_id, provider, model)` — per-model usage row (a task can span multiple provider calls, e.g. tool loop).
+- `072-078` — `updated_at` column + rollup infra.
+- `101-103` — hourly rollup table `task_usage_hourly` + trigger-driven dirty-queue (`task_usage_hourly_dirty`) replacing daily rollups.
+- `207-211` — `client_usage_daily` (desktop/web client heartbeat telemetry, not task-scoped).
+- `213_task_usage_authoritative_cost.up.sql` — adds `cost_usd_ticks BIGINT` (1e-10 USD ticks) to `task_usage`, NULL when the provider reported no cost (falls back to client-side rate-table estimate); the hourly rollup carries a parallel `uncosted_*_tokens` split so a bucket can mix authoritative and estimated rows without under- or over-reporting (see inline migration comment, extensively documented — this is the most-engineered piece of the reference schema).
+
+Also relevant tables: `daemon_connection` (agent_id, daemon_id, status, last_heartbeat_at, runtime_info) and `activity_log` (workspace_id, issue_id, actor_type, actor_id, action, details JSONB) — both from `001_init.up.sql:138-163`.
+
+### States & transitions
+`queued → dispatched → running → completed|failed|cancelled`, plus a documented `waiting_local_directory` sub-state (daemon parked on a busy local_directory path) and a `deferred` pre-queued state (assignee-fallback escalation, `EnqueueDeferredAssigneeFallback`, promoted by `PromoteDueDeferredTasksForRuntime`).
+
+### Claim protocol (`server/internal/service/task.go`)
+
+- **`ClaimTask(agentID)`** (`task.go:2009`) — single-agent claim, one DB transaction:
+  1. `GetAgentForClaimUpdate` (row lock)
+  2. `CountRunningTasks` vs `agent.MaxConcurrentTasks` — capacity gate
+  3. `ClaimAgentTask` (the actual `queued→dispatched` UPDATE, atomic CAS, `pgx.ErrNoRows` = no candidate)
+  4. outside the tx: `ReconcileAgentStatus`, `broadcastTaskDispatch`
+  Every step is timed and logged via `maybeLogClaimSlow` (claim latency budget observability).
+
+- **`ClaimTaskForRuntime(runtimeID)`** (`task.go:2100`) — the per-runtime entry point a daemon actually calls:
+  1. `PromoteDueDeferredTasksForRuntime` — promote due `deferred` rows first
+  2. `ReclaimStaleDispatchedTaskForRuntime` — reclaim a stuck `dispatched` row **before** the empty-cache check (a lost claim response moves the task out of `queued`, so the empty-cache can't represent it)
+  3. **`EmptyClaim` cache** (Redis-backed) — if a recent check found the runtime's queue empty, short-circuit without touching Postgres. Race-safe via a **version sample before the SELECT**: `preSelectVersion := EmptyClaim.CurrentVersion(...)` taken before `ListQueuedClaimCandidatesByRuntime`, so a concurrent enqueue's `Bump` in between is visible to the *next* `IsEmpty` check even though this call's `MarkEmpty` races it.
+  4. `ListQueuedClaimCandidatesByRuntime` → loop distinct `agent_id`s, delegate each to `ClaimTask` until one lands on this runtime.
+
+- **`ClaimTasksForRuntimes(runtimeIDs, maxTasks)`** (`task.go:2296`) — MUL-4257 batch counterpart: one promote-UPDATE + one reclaim-UPDATE + one candidate-SELECT across the *whole set* of a daemon's runtimes, then per-distinct-agent `ClaimTask` calls (preserves per-agent concurrency cap + per-issue guard) until `maxTasks`. Lets one daemon poll for N runtimes with O(1) DB round-trips instead of O(N).
+
+- **`FinalizeTaskClaim`** (`task.go:2217`) — a *second* atomic step after claim: persists the task-scoped auth token + (for comment-triggered tasks) the exact `delivered_comment_ids` snapshot, in one transaction. Must be called only after the full HTTP response payload is built; a failure here calls **`RequeueTaskAfterClaimFailure`** (CAS on `dispatched_at` so a late handler can't roll back a *newer* reclaim) which puts the row back to `queued` and re-broadcasts + re-notifies — i.e. claim and "hand the payload to the daemon" are split into two commit points so a crash between them can't strand a claimed-but-undelivered task.
+
+### Dispatch reason codes (`server/internal/dispatch/reason.go`)
+A dedicated leaf package (MUL-4525) — the *admission* decision (not failure classification):
+```
+queued | coalesced | deferred                         (success path)
+invocation_not_allowed | target_unavailable | runtime_offline
+| attribution_blocked | already_active | self_trigger_suppressed
+internal_error
+```
+Deliberately generic where enumeration-safety matters (`invocation_not_allowed` doesn't distinguish "private" from "doesn't exist"). Shared by the service layer (decides) and handler layer (serializes to wire) so they can't drift — one canonical vocabulary for "why did/didn't this trigger dispatch."
+
+### Full create → assign → dispatch → run → review → done chain
+```
+comment/@mention/assignment
+        │
+        ▼
+enqueueIssueTask / enqueueMentionTask family (task.go:973-1291)
+  → resolves attribution (who is responsible), builds MCP overlay,
+    stamps trigger_comment_id / coalesced_comment_ids / review SHA
+        │  captureTaskQueued (analytics) + broadcastTaskEvent(EventTaskQueued)
+        │  notifyTaskAvailable → EmptyClaim.Bump + Wakeup.NotifyTaskAvailable(runtime, task)
+        ▼
+ClaimTaskForRuntime / ClaimTasksForRuntimes  (daemon polls, or wakeup-driven)
+        │  captureTaskDispatched, ReconcileAgentStatus, broadcastTaskDispatch (EventTaskDispatch)
+        ▼
+FinalizeTaskClaim (token + delivered_comment_ids persisted atomically with the response)
+        │
+        ▼
+daemon spawns provider CLI → StartTask (EventTaskRunning) → streams task_message rows (EventTaskMessage/Progress)
+        │
+        ▼
+CompleteTask / FailTask / CancelTask  (task.go:2603 / 2929 / 1737)
+  - idempotent: a status-CAS `UPDATE ... WHERE status='running'` that returns
+    no rows is NOT an error — re-fetch and treat as already-finalized (race-safe
+    against a duplicate daemon callback)
+  - CompleteTask: writes chat outcome row in the SAME tx as the status flip,
+    synthesizes a fallback issue comment if the agent posted nothing,
+    reconciles agent status, broadcasts EventTaskCompleted
+  - FailTask: classifies failure reason → retry ladder (retryEligible,
+    retryAttemptCeiling, retryDelayForAttempt) → may auto-enqueue a retry child
+  - CancelTask: distinguishes not-started (synchronous draft restore) vs
+    started-with-transcript (synchronous stop) vs started-empty-transcript
+    (DEFERRED judgment — FinalizeDeferredCancelledChat resolves later once the
+    daemon flushes or the sweeper grace period expires)
+        │
+        ▼
+CaptureTaskUsage (task_usage row per provider/model) → hourly rollup → dashboard
+activity_log entries (via bus listeners) → issue timeline / audit trail
+```
+
+### Wire protocol / two-hub event fan-out
+- **In-process pub/sub**: `events.Bus` (`server/internal/events/bus.go`) — synchronous `Subscribe(type, handler)` / `SubscribeAll(handler)` / `Publish(Event{Type, WorkspaceID, ActorType, ActorID, Payload})`, panic-isolated per-handler. Every side-effect (Slack/Lark outbound, autopilot triggers, activity-log writes, notifications, subscriber fanout) is a bus subscriber wired in `server/cmd/server/*_listeners.go` — task.go itself never imports those concerns, it only publishes.
+- **Hub 1 — browser realtime** (`server/internal/realtime`, wired in `server/cmd/server/listeners.go:152`): `bus.SubscribeAll` → JSON-marshal → `realtime.Hub` fans out over the workspace-scoped WebSocket to web/desktop clients; a parallel per-user personal-event branch (`SendToUser`) handles `inbox:*`/mentions.
+- **Hub 2 — daemon WS** (`server/internal/daemon/wsrpc.go`, `daemon.go`): NOT bus-driven. The claim path calls `TaskWakeupNotifier.NotifyTaskAvailable(runtimeID, taskID)` (`task.go:3961`) directly — a push down the daemon's own WS control connection (`EventDaemonTaskAvailable`) so a daemon claims immediately instead of waiting its next poll tick. This is deliberately a *separate* channel from the browser Hub: task events for daemons are wakeup pokes, not full event payloads (the daemon still calls HTTP/WS-RPC claim to get the actual row).
+- `EventDaemonRPCRequest`/`EventDaemonRPCResponse` — generic daemon→server correlated RPC over the same WS control connection (MUL-4257), the transport for WS-first claim with HTTP fallback.
+
+### Reconciliation on daemon reconnect (`server/internal/daemon/reconcile.go`)
+`reconcileBroadcaster` — close-and-replace channel broadcaster with **one-slot replay**: coarse daemon-side tickers (task-cancellation poll @5s, workspace sync @30s) would otherwise miss a server-side change that happened during a WS disconnect until their next tick. On WS reconnect, `broadcast()` wakes every current subscriber and arms a replay flag for late subscribers, debounced within `minBroadcastInterval` (1s) so a flapping connection can't stampede `GetTaskStatus`/`ListWorkspaces`. A companion `workspaceChangeSignal` (buffered chan, size 1) coalesces workspace-set-changed notifications the same way.
+
+### Usage/cost tracking
+`CaptureTaskUsage(task, provider, model, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, costUSDTicks)` (`task.go:673`) writes one `task_usage` row per (task, provider, model). `213_task_usage_authoritative_cost` layers a provider-reported-cost column (`cost_usd_ticks`, nullable) on top of the pre-existing static-rate-table estimate, with the hourly rollup carrying a parallel `uncosted_*` split so mixed buckets (some rows authoritative, some estimated) never silently under/over-report — this is the single most heavily-engineered piece of the reference schema (see migration comment, `~90 lines` of rationale).
+
+### Activity log / audit trail
+`activity_log(workspace_id, issue_id, actor_type, actor_id, action, details JSONB, created_at)` (`001_init.up.sql:150-159`, handler in `server/internal/handler/activity.go`, 291 lines) — populated by bus listeners (`server/cmd/server/activity_listeners.go:23,51,244,249` — subscribes to `EventIssueCreated/Updated/TaskCompleted/TaskFailed`) — a free-text `action` + structured `details` JSONB audit trail scoped to an issue, rendered as the issue's activity timeline in the UI. Task lifecycle events (completed/failed) ARE captured here, giving a per-issue narrative independent of the raw `agent_task_queue` row.
+
+---
+
+## 2. Hangar (ainb) Task + Flow
+
+### Schema (`crates/ainb-hangar-store`, SQLite)
+`agent_task_queue` (repo type in `crates/ainb-hangar-store/src/repo/task.rs:69-148`): `id (ULID), workspace_id, runtime_id, agent_id, issue_id?, status, result?, session_id?, work_dir?, attempt, max_attempts, parent_task_id?, failure_reason?, priority (0..3, higher=more urgent), created_at, dispatched_at?, started_at?, finished_at?, autopilot_run_id?, mode (headless|interactive), session_name? (tmux), repo_ref? (checkout path | "scratch"), agent_kind (claude|codex|copilot), branch? (ainb/<slug>, stamped only if commits landed), generation (run/fan-out grouping), source_branch?`.
+
+Two dedicated cost/history tables (parity migrations, both cite `task.go`/reference line numbers in their doc comments):
+- `0022_task_usage.sql` — `task_usage(task_id PK, workspace_id, agent_id, input_tokens, output_tokens, cost_usd, created_at)` — one row per task, **`INSERT OR REPLACE`** on re-run (so a retried task's usage is overwritten, not accumulated).
+- `0029_run_history.sql` — `run_history(run_id PK, task_id?, workspace_id, session_id?, provider, profile?, started_at?, finished_at NOT NULL, outcome (success|failed), input_tokens, output_tokens, cost_usd, diff_add, diff_del)` + a live `cost_rollup` VIEW (workspace, provider, UTC-day bucket, summed tokens/cost/run-count) — this is the one that actually preserves history across retries (distinct `run_id` per attempt, unlike `task_usage`'s overwrite-on-retry).
+
+### Claim protocol (single claim loop, no cache layer)
+`ClaimTaskService::claim_for_runtime` (`crates/ainb-hangar-store/src/service/claim.rs:96-178`) — **one SQL statement**, no separate transaction/cache dance:
+```sql
+UPDATE agent_task_queue SET status='dispatched', dispatched_at=?1
+WHERE id = (
+  SELECT q.id FROM agent_task_queue q JOIN agent a ON a.id=q.agent_id
+  WHERE q.status='queued' AND q.runtime_id=?2
+    AND (SELECT COUNT(*) FROM agent_task_queue r
+         WHERE r.agent_id=q.agent_id AND r.status IN ('dispatched','running')) < a.max_concurrent_tasks
+    AND NOT EXISTS (SELECT 1 FROM agent_task_queue s
+         WHERE s.issue_id=q.issue_id AND s.agent_id=q.agent_id AND s.id<>q.id
+           AND s.status IN ('queued','dispatched','running'))
+  ORDER BY q.priority DESC, q.created_at, q.id LIMIT 1
+) RETURNING *
+```
+SQLite's single-writer serialization makes this atomic by construction — no explicit transaction wrapper needed, no analog to multica's Redis `EmptyClaim` short-circuit cache (SQLite reads are cheap/local; there's no network round-trip to amortize). Comment block explicitly documents the concurrency-cap race this closes (counting `dispatched`, not just `running`, e38.27) and cites the reference's `task.go:761` / `ClaimAgentTask` as the model for the per-(issue,agent) `NOT EXISTS` guard and the per-agent concurrency cap.
+
+### Dispatch loop, single-process (`crates/ainb-hangar-daemon/src/run_loop.rs`, 3735 lines)
+- On daemon start: `reclaim_orphaned_on_startup(pool, runtime_id)` (`run_loop.rs:465`) — one-time crash-recovery reclaim of anything left `dispatched`/`running` from a prior process; a reclaim fault is non-fatal because the time-based sweepers still backstop it.
+- `execute_claimed` (`run_loop.rs:840`) — the whole spawn/stream/finalize pipeline for one claimed task, in-process, no second daemon/server split: `resolve_dispatch` → `prepare_spawn_inputs` → spawn provider CLI (headless `claude -p` style, or `run_interactive` into a real tmux session for `mode=interactive`) → stream transcript → `finalize_success` / `finalize_failure` / `finalize_setup_failure` / `finalize_cancelled`.
+- `FailureReason` enum (`crates/ainb-hangar-store/src/service/fail.rs:39-127`, values: `AgentError, Timeout, SpawnError, ProvisionError, ...`, `as_db_str()`) — this is **failure classification**, not an admission/dispatch reason code. There is no equivalent of multica's `dispatch.ReasonCode` (`invocation_not_allowed`/`target_unavailable`/`runtime_offline`/`attribution_blocked`/`already_active`/`self_trigger_suppressed`) anywhere in hangar — a task either gets claimed or it doesn't; nothing records *why* an issue's task wasn't dispatched (no assignee, agent offline, already active, etc.) as a stable machine-readable code.
+- `maybe_spawn_retry` (`run_loop.rs:1913`) re-reads the failed row and decides on a retry child, paralleling multica's `MaybeRetryFailedTask`.
+
+### Sweepers (`crates/ainb-hangar-daemon/src/sweeper.rs`, 422 lines) — direct parity with the reference, cites reference line numbers in doc comments
+```
+dispatched_at        +90s              +5min
+     │                 │                  │
+─────┼─────────────────┼──────────────────┼────────▶ age
+     │ recovery window │ reclaim → queued │ fail → Timeout
+     │ (in-flight, skip)│ (lost response)  │ (runtime crashed)
+```
+`QUEUED_TTL` = 2h, running TTL = 2.5h (cites `runtime_sweeper.go:52,40`), dispatched reclaim window = 90s (cites `task.go:85`). Every sweep statement constrains source `status` in its WHERE clause so terminal rows are never re-touched (idempotent).
+
+### JSON-RPC surface / wire protocol (`crates/ainb-hangar-proto`)
+Single channel: the daemon exposes a JSON-RPC 2.0 method surface (`crates/ainb-hangar-proto/src/methods.rs`) — `hangar/task_transition`, `hangar/task_retry`, `hangar/issue_run`, `hangar/tasks_list`, `hangar/usage_rollup`, etc. — over a **single UDS socket** (not two WS hubs). Events push as JSON-RPC *notifications* (no `id`) on method `hangar/event`, payload an internally-tagged `HangarEvent` enum (`crates/ainb-hangar-proto/src/events.rs`): `TaskQueued, TaskStarted, TaskProgress, TaskMessage, TaskFinished, CommentAdded, AgentPresence, SkillUpdated, ...`. There is one subscription channel per plugin connection carrying every event type — no split between "browser realtime" and "daemon wakeup" because there is no browser client and no separate wakeup-vs-payload split: the TUI plugin *is* the only subscriber, and it gets full event payloads directly (no poke-then-fetch two-step).
+
+### Reconciliation on daemon restart
+Limited to the one-shot `reclaim_orphaned_on_startup` call above — no reconcile-broadcaster / one-slot-replay mechanism, because there is no daemon↔server WS reconnect scenario to handle (hangar's daemon and its SQLite store are colocated; a plugin reconnecting to the daemon just re-subscribes and re-fetches via `hangar/tasks_list`, it doesn't need a "what changed while I was gone" broadcast since the daemon itself never lost the DB).
+
+### Activity/audit log
+No `activity_log` equivalent. `run_history` (0029) captures per-run outcome/cost/session but is task-execution-scoped only — no generic `(actor_type, actor_id, action, details)` audit trail for issue/comment/label/assignment events the way multica's `activity_log` does. The Hangar issue timeline (if any) would have to be reconstructed from `comment` rows + task terminal states; there's no single append-only audit stream.
+
+---
+
+## 3. GAPS
+
+| Multica has | Hangar has | Gap | Effort |
+|---|---|---|---|
+| `dispatch.ReasonCode` enum (`queued/coalesced/deferred/invocation_not_allowed/target_unavailable/runtime_offline/attribution_blocked/already_active/self_trigger_suppressed/internal_error`) — a stable, wire-shared vocabulary for *why* a task did/didn't dispatch | Only `FailureReason` (post-hoc run failure classification: `agent_error/timeout/spawn_error/provision_error`) — nothing for admission-time skips (no assignee, agent offline, already active) | No dispatch-explain surface: a user cannot see "why didn't this run" for an issue that never got a task at all, only why a task that WAS created later failed | **M** — needs a new leaf enum + a call site at every non-dispatch decision point (`hangar/issue_run`, autopilot fire, squad assign) |
+| `activity_log` table + bus-listener writers (issue/comment/task events) + handler — generic per-issue audit timeline | `run_history` (task-execution-scoped only) | No general audit trail for issue/label/assignment/comment lifecycle — only run outcomes are durable | **M** — new table + write call sites; could piggyback on existing `HangarEvent` notification points |
+| `task_usage` (per model/provider row, cumulative across retries via `UNIQUE(task_id,provider,model)`) + `task_usage_hourly` rollup + `client_usage_daily` + authoritative-cost split (`cost_usd_ticks`, provider-reported vs rate-table-estimated) | `task_usage` (overwritten on retry, `INSERT OR REPLACE`) + `run_history` (append-only, has the retry history) + `cost_rollup` VIEW (daily, workspace+provider) | Functionally close — hangar's `run_history`+VIEW covers what multica needed two migrations (hourly rollup, dirty-queue) to get; hangar has NO authoritative-vs-estimated cost split (all `cost_usd` is provider `total_cost_usd`, no per-request tick-level accounting) | **S** — cosmetic gap only, current design is arguably simpler/adequate at hangar's scale |
+| Two-hub fan-out: `events.Bus` → **browser realtime.Hub** (web/desktop WS) + **separate daemon-wakeup push** (`TaskWakeupNotifier` over daemon's own WS, decoupled from the bus) | Single JSON-RPC notification channel (`hangar/event`) over one UDS socket, TUI plugin is the only subscriber | Structural, not a gap: hangar has no browser client to fan out to. If a future hangar web/remote client is added, today's single-channel design would need the same wakeup-vs-full-payload split multica has (to avoid pushing full transcripts down a control channel meant for pokes) | **L** (only if a second client class is ever added — not needed today) |
+| `EmptyClaim` Redis cache (version-stamped, race-closed against concurrent enqueue) short-circuits empty-queue polls without hitting Postgres | None — every claim call is one local SQLite statement | Non-gap: SQLite has no network round-trip to amortize; the cache exists in multica specifically because Postgres-over-network claim polling at scale needed it | **N/A** |
+| `reconcileBroadcaster` — one-slot-replay wakeup for daemon-side tickers on WS reconnect (so a missed change isn't invisible until the next 5s/30s tick) | One-shot `reclaim_orphaned_on_startup`, no reconnect-broadcast mechanism | Non-gap at hangar's current architecture (daemon+DB colocated, no daemon↔server WS to drop); would become relevant if hangar ever splits daemon from a remote store | **N/A** today |
+| `FinalizeTaskClaim` — split commit: claim (queued→dispatched) then a SECOND atomic step to persist the delivery token/comment-ids, with `RequeueTaskAfterClaimFailure` (dispatched_at-CAS) to roll back a claim whose payload build failed before the HTTP response was written | Single claim statement; `execute_claimed` runs the whole pipeline in-process after claim, with `finalize_setup_failure` requeuing on a provision error | Hangar's claim+dispatch is same-process so there's no network-boundary failure window between "claimed" and "daemon has the payload" the way multica's claim-then-HTTP-response split has — this asymmetry may not need closing | **N/A** — different architecture removes the failure window multica's split exists to cover |
+
+**Top-ranked, worth scoping**: (1) dispatch reason codes — genuine observability gap, medium effort; (2) generic activity/audit log — genuine gap, medium effort. The rest are either already-adequate (usage/cost) or architecturally moot given hangar's single-process, single-client design (no second hub, no cache layer, no reconnect-broadcast needed).

--- a/docs/explorations/multica-reference/workspace.md
+++ b/docs/explorations/multica-reference/workspace.md
@@ -1,0 +1,129 @@
+# Workspace / Membership / Tenancy: Multica vs Hangar
+
+## 1. Multica Workspace
+
+**Schema** (`server/migrations/001_init.up.sql:15-33`):
+
+```sql
+CREATE TABLE workspace (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    slug TEXT UNIQUE NOT NULL,
+    description TEXT,
+    settings JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE member (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(workspace_id, user_id)
+);
+```
+
+Columns bolted on by later migrations (still same `workspace` row, all nullable/defaulted, non-breaking):
+- `context` TEXT — `006_workspace_context.up.sql:1`. The **workspace-level agent system prompt**: every agent in the workspace reads it (docs/product-overview.md:120,138).
+- `repos` JSONB DEFAULT '[]' — `014_workspace_repos.up.sql:1`. Git-repo allow-list an agent task may check out (docs:138, "仓库白名单").
+- `avatar_url` TEXT — `111_workspace_avatar.up.sql:1`.
+- `attribution_fail_closed` BOOLEAN NOT NULL DEFAULT FALSE — `188_workspace_attribution_fail_closed.up.sql`. Compliance knob: when true, an agent run that can't resolve to a precise accountable human is refused at enqueue instead of degrading to "owner_fallback".
+- `issue_prefix` (referenced throughout handler code, e.g. `workspace.go:139` `IssuePrefix string`) — per-workspace issue numbering prefix (e.g. `ACME-42`), auto-derived from the name (`generateIssuePrefix`, `workspace.go:24-34`) or caller-supplied at create.
+
+`settings` JSONB is a free-form escape hatch (no fixed shape found in this pass beyond the typed columns above absorbing the concrete knobs — `settings` itself appears unused for anything with a fixed contract in the handler; typed columns (`context`, `repos`, `issue_prefix`, `attribution_fail_closed`, `avatar_url`) are where real config actually lives).
+
+**Membership model** (`workspace.go:83-95`, `168-256`):
+- Roles: `owner` / `admin` / `member`, closed set, enforced in Postgres CHECK **and** re-validated in Go (`normalizeMemberRole`, `workspace.go:311-321`).
+- **Last-owner invariant**: `UpdateMember`/`DeleteMember`/`LeaveWorkspace` all call `countOwners(members) <= 1` before demoting/removing/self-removing an owner and reject with 400 "workspace must have at least one owner" (`workspace.go:398-406, 456-464, 496-504`).
+- Only an existing `owner` can promote/demote to/from `owner` (`workspace.go:397-401` for members, `385-388` for create).
+- `ListMembers` / `ListMembersWithUser` (`workspace.go:262-322`) — the latter joins `user` for name/email/avatar, the display shape the Members settings pane renders.
+- Membership is workspace-scoped throughout: every mutation resolves the requester via `h.workspaceMember`/`requireWorkspaceMember` first (403/404 on a foreign workspace), and a `MembershipCache` is invalidated on every role/removal change (`workspace.go:441,...`).
+
+**Invites** — `CreateMember` in `workspace.go` (name kept for the route, but per `invitation.go:52-56` it "replaces the old instant-add CreateMember flow") is superseded by `CreateInvitation` (`invitation.go`):
+- `POST /api/workspaces/{id}/members` now creates a `workspace_invitation` row, not an instant member.
+- Schema (`041_workspace_invitation.up.sql`): `workspace_id`, `inviter_id`, `invitee_email`, `invitee_user_id` (nullable — filled once the invitee has an account), `role` (admin|member — **cannot invite as owner**, `invitation.go` rejects it explicitly), `status` (pending/accepted/declined/expired), `expires_at` default now()+7 days.
+- One live pending invite per `(workspace_id, invitee_email)` — partial unique index `idx_invitation_unique_pending ... WHERE status='pending'`. Stale pending invites are expired first (`ExpireStalePendingInvitations`) before a re-invite, working around #2055.
+- Old `CreateMember`/`CreateInvitation` still auto-create a stub `user` row by email if none exists (`workspace.go:326-333`, "Auto-create user with email so they can be invited before signing up").
+- Zero-workspace invite acceptance: an invited user who has no workspace of their own skips onboarding entirely and lands directly in the invited workspace (docs:641-648).
+
+**Agent-as-member modeling** — NOT literally a `member` row. Multica's "agents are team members" design is the **polymorphic actor pattern**: any "who did this" column is a pair `actor_type ('member'|'agent')` + `actor_id`, not a shared identity table (docs:121, "几乎所有'谁做了什么'的字段都是 actor_type + actor_id"). Concretely, from `001_init.up.sql`:
+- `issue.assignee_type CHECK (assignee_type IN ('member','agent'))` (line 61) — an issue can be assigned to a human member OR an agent, same column shape.
+- `issue.creator_type CHECK (creator_type IN ('member','agent'))` (line 63) — an agent can create issues.
+- `comment.author_type CHECK (author_type IN ('member','agent'))` (line 100) — agent comments render the same as human comments.
+- `inbox_item.recipient_type CHECK (recipient_type IN ('member','agent'))` (line 113) — **agents get an inbox too**.
+- `activity_log.actor_type CHECK (actor_type IN ('member','agent','system'))` (line 160).
+- Squad "lead" is likewise polymorphic member-or-agent (docs:224).
+So an `agent` is its own top-level table (`agent`, lines 36-49: `workspace_id`, `name`, `runtime_mode`, `visibility`, `status`, `owner_id`, …) — agents are NOT rows in `member` — but every collaboration surface (assignment, authorship, comments, inbox, activity, @-mentions in the Tiptap editor per docs:190) is typed to accept `member` OR `agent` interchangeably. That symmetric plumbing is the actual "agents are team members, not tools" claim.
+
+**Create-workspace inputs** (`CreateWorkspaceRequest`, `workspace.go:150-156`): `name`, `slug` (validated `^[a-z0-9]+(-[a-z0-9]+)*$`, checked against a shared reserved-slugs list embedded from `reserved_slugs.json` so it can never collide with a top-level frontend route), optional `description`, `context`, `issue_prefix` (else auto-derived from `name`). `CreateWorkspace` (`workspace.go:158-227`):
+1. Gated by `DISABLE_WORKSPACE_CREATION` operator flag (self-host lockdown, 403 for everyone including existing owners).
+2. One transaction: insert `workspace` row, then insert a `member` row for the creator with `role='owner'`.
+3. Deliberately does NOT mark the user onboarded (`onboarded_at` is owned by a separate `CompleteOnboarding` step / by `AcceptInvitation`) — "has a workspace" and "finished setup" are decoupled.
+4. Emits `WorkspaceCreated` analytics event + notifies the daemon of workspace-list change.
+
+Frontend (`packages/core/workspace/mutations.ts`): `useCreateWorkspace` seeds the workspace-list query cache synchronously in `onSuccess` (so navigating to `/{slug}/issues` never flashes a loading state), `useDeleteWorkspace`/`useLeaveWorkspace` invalidate the list on settle. Multi-workspace switching is "pure navigation" — `/{workspaceSlug}/...` URL shape, `X-Workspace-Slug` header on every API call (docs:143).
+
+## 2. Hangar Workspace (ainb)
+
+**Schema** (`crates/ainb-hangar-store/migrations/0001_init_workspace_user_member.sql:10-28`):
+
+```sql
+CREATE TABLE workspace (
+    id         TEXT PRIMARY KEY,
+    slug       TEXT NOT NULL UNIQUE,
+    name       TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE user (
+    id         TEXT PRIMARY KEY,
+    email      TEXT NOT NULL UNIQUE,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE member (
+    workspace_id TEXT NOT NULL REFERENCES workspace(id),
+    user_id      TEXT NOT NULL REFERENCES user(id),
+    role         TEXT NOT NULL CHECK (role IN ('owner','admin','member')),
+    PRIMARY KEY (workspace_id, user_id)
+);
+```
+
+Migration 0001's own header comment is explicit about intent: "multi-tenancy is a day-1 primitive… `user` + `member` model the single-user-at-v1 reality without a refactor cost when multi-user lands" (`0001_init_workspace_user_member.sql:1-8`) — i.e. the tables mirror multica's shape on purpose, but nothing downstream exercises multi-user or multi-workspace yet.
+
+Extra columns added by migration 0020 (`0020_workspace_config.sql`), explicitly modeled as the hangar analog of multica's `context`/`repos`/`issue_prefix`:
+- `context_prompt` TEXT nullable — same role as multica's `workspace.context`: injected as a `CLAUDE.md` into every task's execenv.
+- `repo_whitelist` TEXT nullable (JSON array string) — same role as multica's `workspace.repos`; **persisted and validated but the checkout-flow gate that consumes it does not exist yet** (migration comment: "A repo-checkout flow does not exist yet").
+- `issue_prefix` TEXT nullable — prepended to a new issue's title.
+No `settings` JSONB, no `description`, no `avatar_url`, no `attribution_fail_closed` equivalent.
+
+**Bootstrap / creation** (`crates/ainb-hangar-store/src/bootstrap.rs`): there is **no `CreateWorkspace` request path at all**. `ensure_default_workspace` (lines 148-186) lazily inserts exactly one workspace (slug `"default"`, name `"Default Workspace"`) + one owner user (email `"stevie@local"`, `bootstrap.rs:36`) + one `member` row with `role='owner'`, the first time any entry point touches the DB, and is a pure find-or-create idempotent singleton (tested for idempotency and for concurrent-writer convergence, lines 265-311 in bootstrap.rs's test module). Every other CLI verb defaults `--workspace` to this bootstrapped slug (`crates/ainb-core/src/cli/hangar/mod.rs:117-129` doc comment, and `--workspace: Option<String>` on essentially every subcommand's args struct).
+
+**CLI surface** (`crates/ainb-core/src/cli/hangar/mod.rs`):
+- `hangar workspace <verb>` (lines 117-135) has **only two verbs**: `config` (set `context_prompt`/`repo_whitelist`/`issue_prefix`, with `--clear-*` flags to unset) and `show`. **No `create`, `list`, `switch`, or `delete` verb exists.**
+- `hangar member <verb>` (lines 532-540) has **only** `list`, `set-role`, `remove`. **No `add`/`invite` verb** — there is no code path that creates a new `user` row or a new `member` row outside the one-time bootstrap seed.
+- `MemberRepo` (`crates/ainb-hangar-store/src/repo/member.rs`) is real and well-tested: `list` (join to `user` for email/role, workspace-scoped), `set_role`, `remove`, both guarding a **last-owner invariant** identical in spirit to multica's (`owner_count_in_tx <= 1` check inside the mutation transaction, `member.rs:126-167, 184-205`) and both workspace-scoped by the `(workspace_id, user_id)` composite PK (a foreign-tenant pair resolves to `NotFound`, never a cross-tenant edit — mirrors multica's `requireWorkspaceMember` pattern).
+- No invitation table, no invitation flow, no email-based join, no `workspace_invitation`-equivalent anywhere in `ainb-hangar-store` or `ainb-plugin-hangar`.
+
+**Is there any multi-workspace UI/CLI, or human members at all?**
+- The schema is multi-tenant-capable (workspace-scoped FKs everywhere, `MemberRepo` fully workspace-scoped) — this is a deliberate "no refactor cost later" bet per the migration 0001 comment.
+- In practice: **single default workspace only**. No create-workspace surface exists (CLI, RPC, or TUI) — `ensure_default_workspace` is the only writer of the `workspace` table, and it is idempotent-singleton by construction (`ORDER BY created_at LIMIT 1` is how every "the workspace" lookup resolves — `find_default_workspace`, `bootstrap.rs:148`).
+- Humans ARE modeled (`user` + `member` tables, real roles, real last-owner guard) but there is **no way to add a second human**: no invite flow, no `member add`, no signup/auth surface that mints a new `user` row. The one seeded owner (`stevie@local`) is effectively hardcoded as "the" user.
+- No polymorphic actor pattern: grep across `ainb-hangar-store/src/repo` and `ainb-plugin-hangar/src` for `member`/`role` hits `squad.rs`, `card_parity.rs`, `task.rs`, etc., but issue/comment/inbox assignment types are NOT modeled as `member`-or-`agent` — agents are simply the thing that does the work; there is no human-assignee or human-commenter concept in the current TUI/CLI surface to be symmetric with.
+
+## 3. GAPS
+
+| # | Multica has | Hangar has | Gap | Effort |
+|---|---|---|---|---|
+| 1 | Multi-workspace: `CreateWorkspace` API + frontend nav (`/{slug}/...`), reserved-slug validation, per-instance `DISABLE_WORKSPACE_CREATION` gate | Exactly one bootstrapped singleton workspace, no create path at any layer | **No multi-workspace capability at all** — structurally the single biggest gap; everything else (invites, roles) is moot with one workspace | L |
+| 2 | Full membership lifecycle: invite by email → pending → accept/decline/expire, auto-stub user, role assign at invite time | `MemberRepo` list/set_role/remove only; last-owner guard present and solid | **No way to add a second human member** — the repo can manage members once they exist, but nothing creates one | M (repo primitives already exist; needs invite table + accept flow + some notification/email channel) |
+| 3 | `workspace_invitation` table, 7-day expiry, one-pending-per-email partial unique index, stale-expiry sweep | None | **No invitation concept whatsoever** | M |
+| 4 | Real multi-human orgs: `user` created via auth/signup, arbitrary email domains | Single hardcoded owner (`stevie@local`), no signup surface | **No real user/auth model** — hangar's "user" is a bootstrap fixture, not an account system | L (depends on whether ainb ever needs real multi-user auth, vs. staying single-operator by design) |
+| 5 | Polymorphic actor (`actor_type` member\|agent) across issue/comment/inbox/activity — agents and humans are symmetric collaborators | Agents only; no human-assignee/commenter/inbox-recipient concept | **No "agents are team members" symmetry** — hangar's model is agent-centric, not actor-polymorphic | L (touches issue/comment/inbox schemas + every UI surface that renders them) |
+| 6 | `workspace.context` (agent system prompt), `.repos` (checkout whitelist), `.issue_prefix`, `.avatar_url`, `.attribution_fail_closed`, `.description`, `.settings` JSONB | `context_prompt`, `repo_whitelist` (persisted, gate not wired), `issue_prefix` — direct analogs of the first three | **Config surface is ~50% ported**; missing `description`, `avatar_url`, compliance/attribution knob, and the whitelist gate is a stub | S–M (config columns are cheap; wiring the repo-checkout gate to `repo_whitelist` is the real remaining work, already flagged in the migration 0020 comment) |
+| 7 | Reserved-slug list shared Go↔TypeScript via generated JSON, CI-enforced drift check | No slug validation surface (moot with one workspace, `slug` is just `"default"`) | N/A until gap #1 is addressed | S (once workspace-create exists) |
+| 8 | Role-change/removal cache invalidation (`MembershipCache.Invalidate`) + realtime `member:added/updated/removed` websocket events | No realtime/event layer found for membership changes | **No live membership event stream** — minor, since single-workspace + no invites means membership rarely changes today | S |
+
+**Ranked by impact**: #1 (no multi-workspace) > #2/#3 (no invite/second-human path) > #5 (no agent-as-member symmetry) > #4 (no real auth) > #6 (config parity gaps, mostly already tracked) > #7/#8 (follow naturally once #1 lands).


### PR DESCRIPTION
## Multica ↔ Hangar parity reference

A durable, verify-against-it map of where Hangar (ainb's control plane) sits
relative to Multica's behavioral model, entity by entity. Multica
(`github.com/multica-ai/multica`, fair-source Apache-2.0) is used as a
**behavioral reference, not a verbatim port**. Its north star — **"agents are
team members, not tools"** — is a *polymorphic actor* model (`actor_type
member|agent` everywhere), and most of Hangar's biggest gaps trace back to it
being agent-centric rather than actor-polymorphic.

Lives in `docs/explorations/multica-reference/`: a synthesis `README.md` plus
six per-entity deep-dives (agent, workspace, issue, task-flow, autopilot,
squad) with full field tables, migration/`file:line` citations, and per-entity
gap tables.

### Master gap matrix (top of the ranked 30)

Ranked by "changes what the product *is*" first, then user impact, then effort.

| # | Entity | Gap | Effort |
|---|---|---|---|
| 1 | Cross-cutting | Polymorphic actors + human members | L |
| 2 | Issue/Squad | Comment @mention auto-dispatch | L |
| 3 | Issue | Subtasks: parent/child + stage barriers + cascade | L |
| 4 | Workspace | Multi-workspace (create/switch) | L |
| 5 | Squad | Task-level `squad_id` + claim-time briefing hook | S |
| 6 | Agent | Two-dimensional derived presence | M |
| 7 | Squad | Leader briefing (protocol + roster + instructions) | L |
| 8 | Agent | Invocation permissions (private/public_to + allow-list) | M |
| 9 | Agent | Conversational Agent Builder | L |
| 10 | Issue | Structured / faceted filtering | L |

(20 more in `README.md`, down to cheap UI-only wins.)

### Roadmap tiers

- **P0 Foundational:** polymorphic actors (#1), task `squad_id`+briefing hook
  (#5, cheapest), subtasks (#3), multi-workspace (#4).
- **P1 High-impact:** comment @mention dispatch, squad leader briefing, 2-dim
  presence, invocation permissions, agent builder, faceted filtering,
  acceptance criteria, dispatch reason codes, activity log, autopilot rule
  versioning, squad selective-routing (product call).
- **P2 Polish / cheap wins:** surface existing priority/due/labels in the issue
  wizard (schema already has them — UI-only), fix #450 Boards `q:squad` hotkey,
  blocked/cancelled states, agent metadata columns, skill toggle, archive audit,
  squad role/instructions, typed dependency edges, autopilot `api` trigger, etc.

### Deliberately NOT chasing

Architecturally-moot axes given Hangar's single-process daemon + colocated
SQLite + single TUI client: EmptyClaim cache, reconcile-broadcaster,
FinalizeTaskClaim split-commit, two-hub fan-out, authoritative-cost split,
generic lease scheduler. Also notes two axes where **Hangar is ahead**:
`concurrency_policy` (live/tested vs Multica's dead column) and squad fan-out.

Reference only — do not merge on my behalf.
