### PR TITLE
feat(hangar): polymorphic actors + human members (multica-gap #1)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -530,6 +530,8 @@ pub struct AgentArchiveArgs {
 /// owner is rejected.
 #[derive(Subcommand, Debug)]
 pub enum MemberCommand {
+    /// Add a human member (find-or-create the user by email, then join).
+    Add(MemberAddArgs),
     /// List the workspace's members (email + role).
     List(MemberListArgs),
     /// Change a member's role (`owner` / `admin` / `member`).
@@ -537,6 +539,21 @@ pub enum MemberCommand {
     SetRole(MemberSetRoleArgs),
     /// Remove a member from the workspace (the user row survives).
     Remove(MemberRemoveArgs),
+}
+
+/// Arguments for `hangar member add`.
+#[derive(Args, Debug)]
+pub struct MemberAddArgs {
+    /// The member's email (find-or-create the user by this address).
+    #[arg(long)]
+    pub email: String,
+    /// The role to grant: `owner`, `admin`, or `member` (default `member`).
+    #[arg(long, value_enum, default_value_t = MemberRoleArg::Member)]
+    pub role: MemberRoleArg,
+    /// Workspace slug to add the member to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// Arguments for `hangar member list`.
@@ -1952,10 +1969,30 @@ fn clear_or_set<T>(clear: bool, value: Option<T>) -> Option<Option<T>> {
 async fn dispatch_member(cmd: MemberCommand, format: OutputFormat) -> Result<()> {
     let store = Store::open_default().await.context("open hangar database")?;
     match cmd {
+        MemberCommand::Add(args) => run_member_add(&store, args).await,
         MemberCommand::List(args) => run_member_list(&store, args, format).await,
         MemberCommand::SetRole(args) => run_member_set_role(&store, args).await,
         MemberCommand::Remove(args) => run_member_remove(&store, args).await,
     }
+}
+
+/// `hangar member add`: find-or-create the user by email, then join the member
+/// to the workspace. Mirrors [`run_member_set_role`] (talks to the store
+/// directly, not the daemon). Prints the minted/reused user id, email, and role.
+async fn run_member_add(store: &Store, args: MemberAddArgs) -> Result<()> {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::member::MemberRepo;
+
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
+    let member = MemberRepo::add(store.pool(), &ws, &args.email, args.role.to_repo())
+        .await
+        .map_err(member_cli_err)?;
+    println!(
+        "added member {} ({}) as {}",
+        member.user_id, member.email, member.role
+    );
+    Ok(())
 }
 
 /// `hangar member list`: list the workspace's members (email + role).
@@ -2033,6 +2070,10 @@ fn member_cli_err(e: ainb_hangar_store::repo::member::MemberRepoError) -> anyhow
         MemberRepoError::LastOwner => {
             anyhow::anyhow!("a workspace must always keep at least one owner")
         }
+        MemberRepoError::AlreadyMember => {
+            anyhow::anyhow!("that user is already a member of this workspace")
+        }
+        MemberRepoError::EmptyEmail => anyhow::anyhow!("email must not be empty"),
         other => anyhow::Error::new(other).context("member mutation failed"),
     }
 }
@@ -2784,13 +2825,15 @@ async fn run_issue_update(store: &Store, args: IssueUpdateArgs) -> Result<()> {
     let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
 
     // Map the present flags onto the partial edit. The two nullable fields use
-    // the clear-flag to distinguish "clear to none" from "leave unchanged".
+    // the clear-flag to distinguish "clear to none" from "leave unchanged". The
+    // assign token is polymorphic: `member:<id>`/`agent:<id>`, or a bare id
+    // (back-compat: a bare id is an agent).
     let assignee = if args.unassign {
         Some(None)
     } else {
         args.assign
             .as_deref()
-            .map(|id| ActorRef::new(ActorKind::Agent, id).context("assignee agent id was empty"))
+            .map(parse_assignee)
             .transpose()?
             .map(Some)
     };
@@ -2830,14 +2873,33 @@ async fn run_issue_update(store: &Store, args: IssueUpdateArgs) -> Result<()> {
     // in-product path back to work short of filing a brand-new issue. The task
     // reads the issue card's persisted repo/branch/agent, and the one-active-run
     // guard means a re-assign while a run is in flight never double-dispatches.
-    if let Some(agent_id) = args.assign.as_deref() {
-        if let Some(task_id) =
-            enqueue_assigned_task(store.pool(), &workspace_id, &args.id, agent_id).await?
-        {
-            println!("queued task {task_id}");
+    // Only an AGENT assignee dispatches a run — a member assignee just commits
+    // (agents-are-team-members symmetry: same column, but a human does no work).
+    if let Some(raw) = args.assign.as_deref() {
+        let assignee = parse_assignee(raw)?;
+        if assignee.kind() == ActorKind::Agent {
+            if let Some(task_id) =
+                enqueue_assigned_task(store.pool(), &workspace_id, &args.id, assignee.id()).await?
+            {
+                println!("queued task {task_id}");
+            }
         }
     }
     Ok(())
+}
+
+/// Parse a CLI `--assign` token into a polymorphic [`ActorRef`].
+///
+/// A token containing `:` is parsed as the canonical `member:<id>`/`agent:<id>`
+/// form. A bare token (no `:`) stays an **agent** for back-compat, so every
+/// existing script and tripwire that passes a raw agent id is byte-unchanged.
+fn parse_assignee(raw: &str) -> Result<ActorRef> {
+    if raw.contains(':') {
+        raw.parse::<ActorRef>()
+            .with_context(|| format!("invalid assignee `{raw}` (expected member:<id> or agent:<id>)"))
+    } else {
+        ActorRef::new(ActorKind::Agent, raw).context("assignee agent id was empty")
+    }
 }
 
 /// Enqueue one `queued` task for `agent_id` on `issue_id`, mirroring the daemon's
@@ -2958,12 +3020,19 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
     let creator = ActorRef::new(ActorKind::Member, DEFAULT_CREATOR_ID)
         .expect("default creator id is non-empty");
 
-    // Resolve the assignee (if any): the agent must exist in the workspace; its
-    // runtime is the queue the task lands on. Resolved BEFORE the issue insert so
-    // a bad agent id fails before any write.
-    let assignment = match args.assign.as_deref() {
-        Some(agent_id) => Some(resolve_agent_runtime(pool, &workspace_id, agent_id).await?),
-        None => None,
+    // Resolve the assignee (if any). The token is polymorphic: an AGENT
+    // (`agent:<id>` or a bare id) must exist in the workspace and its runtime is
+    // the queue the task lands on — resolved BEFORE the issue insert so a bad
+    // agent id fails before any write. A MEMBER (`member:<id>`) is stored as-is
+    // and enqueues NO task (agents-are-team-members symmetry: a human does no
+    // work).
+    let parsed_assignee = args.assign.as_deref().map(parse_assignee).transpose()?;
+    let (assignment, member_assignee) = match parsed_assignee {
+        Some(actor) if actor.kind() == ActorKind::Agent => {
+            (Some(resolve_agent_runtime(pool, &workspace_id, actor.id()).await?), None)
+        }
+        Some(actor) => (None, Some(actor)),
+        None => (None, None),
     };
     let now = ainb_hangar_core::clock::HangarClock::now_ms(&clock);
 
@@ -2985,7 +3054,8 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         state: args.state,
         assignee: assignment
             .as_ref()
-            .map(|a| ActorRef::new(ActorKind::Agent, &a.agent_id).expect("agent id non-empty")),
+            .map(|a| ActorRef::new(ActorKind::Agent, &a.agent_id).expect("agent id non-empty"))
+            .or_else(|| member_assignee.clone()),
         creator,
         created_at: now,
         priority: args.priority,

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -2831,11 +2831,7 @@ async fn run_issue_update(store: &Store, args: IssueUpdateArgs) -> Result<()> {
     let assignee = if args.unassign {
         Some(None)
     } else {
-        args.assign
-            .as_deref()
-            .map(parse_assignee)
-            .transpose()?
-            .map(Some)
+        args.assign.as_deref().map(parse_assignee).transpose()?.map(Some)
     };
     let due_date = if args.clear_due {
         Some(None)
@@ -2895,8 +2891,9 @@ async fn run_issue_update(store: &Store, args: IssueUpdateArgs) -> Result<()> {
 /// existing script and tripwire that passes a raw agent id is byte-unchanged.
 fn parse_assignee(raw: &str) -> Result<ActorRef> {
     if raw.contains(':') {
-        raw.parse::<ActorRef>()
-            .with_context(|| format!("invalid assignee `{raw}` (expected member:<id> or agent:<id>)"))
+        raw.parse::<ActorRef>().with_context(|| {
+            format!("invalid assignee `{raw}` (expected member:<id> or agent:<id>)")
+        })
     } else {
         ActorRef::new(ActorKind::Agent, raw).context("assignee agent id was empty")
     }
@@ -3028,9 +3025,10 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
     // work).
     let parsed_assignee = args.assign.as_deref().map(parse_assignee).transpose()?;
     let (assignment, member_assignee) = match parsed_assignee {
-        Some(actor) if actor.kind() == ActorKind::Agent => {
-            (Some(resolve_agent_runtime(pool, &workspace_id, actor.id()).await?), None)
-        }
+        Some(actor) if actor.kind() == ActorKind::Agent => (
+            Some(resolve_agent_runtime(pool, &workspace_id, actor.id()).await?),
+            None,
+        ),
         Some(actor) => (None, Some(actor)),
         None => (None, None),
     };
@@ -4270,10 +4268,7 @@ fn issue_line(i: &Issue) -> String {
     };
     // The assignee's canonical `member:<id>`/`agent:<id>` form surfaces the actor
     // KIND (a human member vs an agent), shown only when the issue is assigned.
-    let assignee = i
-        .assignee
-        .as_ref()
-        .map_or_else(String::new, |a| format!("  assignee={a}"));
+    let assignee = i.assignee.as_ref().map_or_else(String::new, |a| format!("  assignee={a}"));
     format!(
         "{}  [{}]  priority={}  {}{assignee}{due}{labels}",
         i.id, i.state, i.priority, i.title

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -4268,8 +4268,14 @@ fn issue_line(i: &Issue) -> String {
     } else {
         format!("  labels={}", i.labels.join(","))
     };
+    // The assignee's canonical `member:<id>`/`agent:<id>` form surfaces the actor
+    // KIND (a human member vs an agent), shown only when the issue is assigned.
+    let assignee = i
+        .assignee
+        .as_ref()
+        .map_or_else(String::new, |a| format!("  assignee={a}"));
     format!(
-        "{}  [{}]  priority={}  {}{due}{labels}",
+        "{}  [{}]  priority={}  {}{assignee}{due}{labels}",
         i.id, i.state, i.priority, i.title
     )
 }
@@ -4279,13 +4285,22 @@ fn issue_line(i: &Issue) -> String {
 fn issue_to_json(i: &Issue) -> String {
     let desc = i.description.as_deref().map_or_else(|| "null".to_string(), json_string);
     let due = i.due_date.map_or_else(|| "null".to_string(), |d| d.to_string());
+    // Assignee + creator render as their canonical `member:<id>`/`agent:<id>`
+    // string (the polymorphic actor kind), `null` when the issue is unassigned.
+    let assignee = i
+        .assignee
+        .as_ref()
+        .map_or_else(|| "null".to_string(), |a| json_string(&a.to_string()));
+    let creator = json_string(&i.creator.to_string());
     format!(
-        "{{\"id\":{},\"workspace_id\":{},\"title\":{},\"description\":{},\"state\":{},\"created_at\":{},\"priority\":{},\"due_date\":{},\"labels\":{}}}",
+        "{{\"id\":{},\"workspace_id\":{},\"title\":{},\"description\":{},\"state\":{},\"assignee\":{},\"creator\":{},\"created_at\":{},\"priority\":{},\"due_date\":{},\"labels\":{}}}",
         json_string(&i.id),
         json_string(&i.workspace_id),
         json_string(&i.title),
         desc,
         json_string(&i.state),
+        assignee,
+        creator,
         i.created_at,
         i.priority,
         due,
@@ -4951,16 +4966,18 @@ fn md_cell(s: &str) -> String {
 }
 
 const fn issue_csv_header() -> &'static str {
-    "id,state,title,description,created_at,priority,due_date,labels"
+    "id,state,title,description,assignee,created_at,priority,due_date,labels"
 }
 fn issue_csv_row(i: &Issue) -> String {
     let due = i.due_date.map_or_else(String::new, |d| d.to_string());
+    let assignee = i.assignee.as_ref().map(ToString::to_string).unwrap_or_default();
     format!(
-        "{},{},{},{},{},{},{},{}",
+        "{},{},{},{},{},{},{},{},{}",
         csv_field(&i.id),
         csv_field(&i.state),
         csv_field(&i.title),
         csv_field(i.description.as_deref().unwrap_or("")),
+        csv_field(&assignee),
         i.created_at,
         i.priority,
         csv_field(&due),
@@ -4968,17 +4985,19 @@ fn issue_csv_row(i: &Issue) -> String {
     )
 }
 const fn issue_md_header() -> &'static str {
-    "| id | state | title | description | priority | due_date | labels |\n\
-     | --- | --- | --- | --- | --- | --- | --- |\n"
+    "| id | state | title | description | assignee | priority | due_date | labels |\n\
+     | --- | --- | --- | --- | --- | --- | --- | --- |\n"
 }
 fn issue_md_row(i: &Issue) -> String {
     let due = i.due_date.map_or_else(String::new, |d| d.to_string());
+    let assignee = i.assignee.as_ref().map(ToString::to_string).unwrap_or_default();
     format!(
-        "| {} | {} | {} | {} | {} | {} | {} |",
+        "| {} | {} | {} | {} | {} | {} | {} | {} |",
         md_cell(&i.id),
         md_cell(&i.state),
         md_cell(&i.title),
         md_cell(i.description.as_deref().unwrap_or("")),
+        md_cell(&assignee),
         i.priority,
         md_cell(&due),
         md_cell(&i.labels.join(" ")),

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -5472,6 +5472,142 @@ mod tests {
         );
     }
 
+    /// `parse_assignee` is polymorphic: a `member:`/`agent:` token keeps its
+    /// kind, a bare id stays an agent (back-compat). Mutation-provable: flip the
+    /// bare-id branch to Member and the last two assertions go red.
+    #[test]
+    fn parse_assignee_is_polymorphic_bare_id_is_agent() {
+        let m = parse_assignee("member:u-1").expect("member ref");
+        assert_eq!(m.kind(), ActorKind::Member);
+        assert_eq!(m.id(), "u-1");
+        let a = parse_assignee("agent:a-1").expect("agent ref");
+        assert_eq!(a.kind(), ActorKind::Agent);
+        assert_eq!(a.id(), "a-1");
+        // Back-compat: a bare id is an agent, unchanged from before.
+        let bare = parse_assignee("a-1").expect("bare id");
+        assert_eq!(bare.kind(), ActorKind::Agent);
+        assert_eq!(bare.id(), "a-1");
+    }
+
+    /// `issue create --assign member:<id>` persists `(member, id)` on the issue
+    /// AND enqueues NO agent task — a human assignee does no work.
+    ///
+    /// Mutation-provable: if the create path silently coerced the member into an
+    /// agent, the assignee kind would read `agent` (first assert) and a task row
+    /// would appear (last assert). Both would go red.
+    #[tokio::test]
+    async fn issue_create_assign_member_persists_and_enqueues_no_task() {
+        use ainb_hangar_core::ids::WorkspaceId;
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::member::{MemberRepo, MemberRole};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+        let ws_id = bootstrap::ensure_default_workspace(store.pool())
+            .await
+            .expect("bootstrap workspace");
+        let ws = WorkspaceId::from_str(ws_id.clone()).unwrap();
+        let member = MemberRepo::add(store.pool(), &ws, "dana@example.com", MemberRole::Member)
+            .await
+            .expect("add member");
+
+        let HangarCommand::Issue(IssueCommand::Create(args)) = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "issue",
+            "create",
+            "--title",
+            "human task",
+            "--assign",
+            &format!("member:{}", member.user_id),
+        ]) else {
+            panic!("expected issue create");
+        };
+        run_issue_create(&store, args).await.expect("create issue");
+
+        let issue = IssueRepo::list_by_workspace_state(store.pool(), &ws_id, DEFAULT_ISSUE_STATE)
+            .await
+            .expect("list issues")
+            .into_iter()
+            .find(|i| i.title == "human task")
+            .expect("created issue present");
+        let assignee = issue.assignee.as_ref().expect("member issue is assigned");
+        assert_eq!(assignee.kind(), ActorKind::Member, "stored as a MEMBER");
+        assert_eq!(assignee.id(), member.user_id, "the member's user id");
+
+        let tasks: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue")
+            .fetch_one(store.pool())
+            .await
+            .expect("count tasks");
+        assert_eq!(tasks, 0, "a member assignee enqueues NO agent task");
+
+        // And the read surface shows the polymorphic kind.
+        assert!(
+            issue_to_json(&issue).contains(&format!("\"assignee\":\"member:{}\"", member.user_id)),
+            "json surfaces the member actor-ref"
+        );
+        assert!(
+            issue_line(&issue).contains(&format!("assignee=member:{}", member.user_id)),
+            "text line surfaces the member actor-ref"
+        );
+    }
+
+    /// `issue create --assign agent:<id>` persists `(agent, id)` AND enqueues one
+    /// task — the symmetric agent path still dispatches a run.
+    ///
+    /// Mutation-provable pair to the member test above: this asserts the task IS
+    /// enqueued for an agent, so a change that skipped agent enqueue goes red.
+    #[tokio::test]
+    async fn issue_create_assign_agent_persists_and_enqueues_task() {
+        use ainb_hangar_store::bootstrap;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+        let ws = bootstrap::ensure_default_workspace(store.pool())
+            .await
+            .expect("bootstrap workspace");
+        bootstrap::ensure_runtime(store.pool(), &bootstrap::default_runtime_id(), 1)
+            .await
+            .expect("ensure runtime");
+        let agent = bootstrap::create_agent(store.pool(), &ws, "robot", "claude", None)
+            .await
+            .expect("create agent");
+
+        let HangarCommand::Issue(IssueCommand::Create(args)) = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "issue",
+            "create",
+            "--title",
+            "robot task",
+            "--repo",
+            "scratch",
+            "--assign",
+            &format!("agent:{}", agent.id),
+        ]) else {
+            panic!("expected issue create");
+        };
+        run_issue_create(&store, args).await.expect("create issue");
+
+        let issue = IssueRepo::list_by_workspace_state(store.pool(), &ws, DEFAULT_ISSUE_STATE)
+            .await
+            .expect("list issues")
+            .into_iter()
+            .find(|i| i.title == "robot task")
+            .expect("created issue present");
+        let assignee = issue.assignee.as_ref().expect("agent issue is assigned");
+        assert_eq!(assignee.kind(), ActorKind::Agent, "stored as an AGENT");
+        assert_eq!(assignee.id(), agent.id);
+
+        let tasks: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE agent_id = ?")
+                .bind(&agent.id)
+                .fetch_one(store.pool())
+                .await
+                .expect("count tasks");
+        assert_eq!(tasks, 1, "an agent assignee enqueues exactly one run");
+    }
+
     #[test]
     fn parses_issue_list_default_state_open() {
         let cmd = parse_hangar(&["ainb", "hangar", "issue", "list"]);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3965,6 +3965,10 @@ fn member_repo_err(e: &ainb_hangar_store::repo::member::MemberRepoError) -> RpcE
             invalid_params("a workspace must always keep at least one owner")
         }
         MemberRepoError::InvalidRole => invalid_params("role must be one of owner/admin/member"),
+        MemberRepoError::EmptyEmail => invalid_params("email must not be empty"),
+        MemberRepoError::AlreadyMember => {
+            invalid_params("that user is already a member of this workspace")
+        }
         MemberRepoError::Db(db) => store_err(db),
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
@@ -31,7 +31,9 @@
 //! are semantic rules no constraint can express, so they are enforced here in
 //! application code.
 
+use ainb_hangar_core::clock::{HangarClock, SystemClock};
 use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use sqlx::SqlitePool;
 
 /// The three roles a member can hold within a workspace (`member.role`).
@@ -90,6 +92,88 @@ pub struct Member {
 pub struct MemberRepo;
 
 impl MemberRepo {
+    /// Add a human member: find-or-create the `user` by email, then insert the
+    /// `(workspace_id, user_id, role)` membership. Workspace-scoped.
+    ///
+    /// Mirrors multica's membership flow (`workspace.go` `CreateMember`,
+    /// auto-stubbing a `user` by email when none exists). In one transaction it
+    /// looks up `user.id` for `email`; if absent it mints a ULID user id (the
+    /// store's [`IdGen`] convention) and inserts the `user` row, then inserts the
+    /// membership. An existing user (a member of another workspace, say) is
+    /// reused, so the same email in a sibling tenant is a *separate* membership
+    /// over one shared user row.
+    ///
+    /// Idempotent-safe: re-adding an existing `(workspace, user)` pair trips the
+    /// member composite-PK uniqueness and is reported as
+    /// [`MemberRepoError::AlreadyMember`] (nothing written), never a duplicate.
+    ///
+    /// Returns the created membership as a [`Member`] (the same shape
+    /// [`list`](MemberRepo::list) returns).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemberRepoError::EmptyEmail`] when `email` is blank,
+    /// [`MemberRepoError::AlreadyMember`] when the pair already exists, or
+    /// [`MemberRepoError::Db`] on a store failure.
+    pub async fn add(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        email: &str,
+        role: MemberRole,
+    ) -> Result<Member, MemberRepoError> {
+        let email = email.trim();
+        if email.is_empty() {
+            return Err(MemberRepoError::EmptyEmail);
+        }
+
+        let mut tx = pool.begin().await?;
+        // Find-or-create the user by email (`user.email` is NOT NULL UNIQUE).
+        let existing: Option<String> =
+            sqlx::query_scalar("SELECT id FROM user WHERE email = ?")
+                .bind(email)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let user_id = match existing {
+            Some(id) => id,
+            None => {
+                let id = SystemIdGen.new_ulid();
+                let now = HangarClock::now_ms(&SystemClock);
+                sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
+                    .bind(&id)
+                    .bind(email)
+                    .bind(now)
+                    .execute(&mut *tx)
+                    .await?;
+                id
+            }
+        };
+
+        // Insert the membership. A conflict on the composite PK means this user is
+        // already a member of this workspace → AlreadyMember (not a raw Db error).
+        let inserted =
+            sqlx::query("INSERT INTO member (workspace_id, user_id, role) VALUES (?, ?, ?)")
+                .bind(workspace.as_str())
+                .bind(&user_id)
+                .bind(role.as_str())
+                .execute(&mut *tx)
+                .await;
+        if let Err(e) = inserted {
+            let already_member = e
+                .as_database_error()
+                .is_some_and(sqlx::error::DatabaseError::is_unique_violation);
+            if already_member {
+                return Err(MemberRepoError::AlreadyMember);
+            }
+            return Err(MemberRepoError::Db(e));
+        }
+        tx.commit().await?;
+        Ok(Member {
+            user_id,
+            email: email.to_string(),
+            role: role.as_str().to_string(),
+        })
+    }
+
     /// List every member of `workspace`, joined with their user record, ordered
     /// by email (the stable Members-pane render order).
     ///
@@ -251,6 +335,14 @@ pub enum MemberRepoError {
     /// set. Surfaced by the caller after [`MemberRole::parse`] returns `None`.
     #[error("invalid role: must be one of owner/admin/member")]
     InvalidRole,
+    /// [`add`](MemberRepo::add) was called with a blank email. Rejected before
+    /// any write (a member's email is its human label; it must be non-empty).
+    #[error("email must not be empty")]
+    EmptyEmail,
+    /// [`add`](MemberRepo::add) targeted a `(workspace, user)` pair that already
+    /// exists — the user is already a member of this workspace. Nothing written.
+    #[error("that user is already a member of this workspace")]
+    AlreadyMember,
     /// An underlying `sqlx` failure (uniqueness conflict, IO, …).
     #[error(transparent)]
     Db(#[from] sqlx::Error),
@@ -424,6 +516,124 @@ mod tests {
         assert!(matches!(err, MemberRepoError::LastOwner), "got {err:?}");
         let members = MemberRepo::list(pool, &ws("ws-a")).await.unwrap();
         assert_eq!(members.len(), 2, "rejected removal left both members");
+    }
+
+    /// `add` mints a fresh user (by email) AND the membership when neither
+    /// exists — the workspace's first *added* member.
+    #[tokio::test]
+    async fn add_mints_user_and_membership() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+
+        let m = MemberRepo::add(pool, &ws("ws-a"), "dana@example.com", MemberRole::Member)
+            .await
+            .unwrap();
+        assert_eq!(m.email, "dana@example.com");
+        assert_eq!(m.role, "member");
+        assert!(!m.user_id.is_empty(), "a user id was minted");
+
+        // The user row exists and the membership is listed.
+        let members = MemberRepo::list(pool, &ws("ws-a")).await.unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].email, "dana@example.com");
+        assert_eq!(members[0].user_id, m.user_id);
+    }
+
+    /// Re-adding the SAME `(workspace, user)` pair is rejected as `AlreadyMember`
+    /// — idempotent-safe, never a duplicate row.
+    #[tokio::test]
+    async fn add_existing_pair_is_already_member() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+
+        MemberRepo::add(pool, &ws("ws-a"), "dana@example.com", MemberRole::Member)
+            .await
+            .unwrap();
+        let err = MemberRepo::add(pool, &ws("ws-a"), "dana@example.com", MemberRole::Admin)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemberRepoError::AlreadyMember), "got {err:?}");
+
+        // Still exactly one membership, and the original role is untouched.
+        let members = MemberRepo::list(pool, &ws("ws-a")).await.unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].role, "member", "re-add did not overwrite the role");
+    }
+
+    /// `add` reuses an EXISTING user (found by email) rather than minting a
+    /// second user row — the same person joining a second workspace.
+    #[tokio::test]
+    async fn add_reuses_existing_user_by_email() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_ws(pool, "ws-b").await;
+        // Dana already exists as a member of ws-a.
+        let first = MemberRepo::add(pool, &ws("ws-a"), "dana@example.com", MemberRole::Member)
+            .await
+            .unwrap();
+
+        let second = MemberRepo::add(pool, &ws("ws-b"), "dana@example.com", MemberRole::Admin)
+            .await
+            .unwrap();
+        assert_eq!(
+            second.user_id, first.user_id,
+            "the same email reuses the one user row"
+        );
+        // Exactly one `user` row for that email.
+        let user_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM user WHERE email = 'dana@example.com'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(user_count, 1, "no duplicate user minted");
+    }
+
+    /// `add` is workspace-scoped: the same email added to two sibling tenants is
+    /// two separate memberships (one shared user), each with its own role.
+    #[tokio::test]
+    async fn add_is_workspace_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_ws(pool, "ws-b").await;
+
+        MemberRepo::add(pool, &ws("ws-a"), "dana@example.com", MemberRole::Member)
+            .await
+            .unwrap();
+        MemberRepo::add(pool, &ws("ws-b"), "dana@example.com", MemberRole::Admin)
+            .await
+            .unwrap();
+
+        let a = MemberRepo::list(pool, &ws("ws-a")).await.unwrap();
+        let b = MemberRepo::list(pool, &ws("ws-b")).await.unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        assert_eq!(a[0].role, "member", "ws-a keeps its own role");
+        assert_eq!(b[0].role, "admin", "ws-b keeps its own role");
+        assert_eq!(a[0].user_id, b[0].user_id, "one shared user across tenants");
+    }
+
+    /// A blank email is rejected before any write.
+    #[tokio::test]
+    async fn add_rejects_empty_email() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+
+        let err = MemberRepo::add(pool, &ws("ws-a"), "   ", MemberRole::Member)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MemberRepoError::EmptyEmail), "got {err:?}");
+        let members = MemberRepo::list(pool, &ws("ws-a")).await.unwrap();
+        assert!(members.is_empty(), "nothing written on a blank email");
     }
 
     /// `MemberRole::parse` round-trips the closed set and rejects junk.

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
@@ -32,8 +32,8 @@
 //! application code.
 
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
-use ainb_hangar_core::ids::WorkspaceId;
 use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
+use ainb_hangar_core::ids::WorkspaceId;
 use sqlx::SqlitePool;
 
 /// The three roles a member can hold within a workspace (`member.role`).
@@ -128,24 +128,22 @@ impl MemberRepo {
 
         let mut tx = pool.begin().await?;
         // Find-or-create the user by email (`user.email` is NOT NULL UNIQUE).
-        let existing: Option<String> =
-            sqlx::query_scalar("SELECT id FROM user WHERE email = ?")
+        let existing: Option<String> = sqlx::query_scalar("SELECT id FROM user WHERE email = ?")
+            .bind(email)
+            .fetch_optional(&mut *tx)
+            .await?;
+        let user_id = if let Some(id) = existing {
+            id
+        } else {
+            let id = SystemIdGen.new_ulid();
+            let now = HangarClock::now_ms(&SystemClock);
+            sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
+                .bind(&id)
                 .bind(email)
-                .fetch_optional(&mut *tx)
+                .bind(now)
+                .execute(&mut *tx)
                 .await?;
-        let user_id = match existing {
-            Some(id) => id,
-            None => {
-                let id = SystemIdGen.new_ulid();
-                let now = HangarClock::now_ms(&SystemClock);
-                sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
-                    .bind(&id)
-                    .bind(email)
-                    .bind(now)
-                    .execute(&mut *tx)
-                    .await?;
-                id
-            }
+            id
         };
 
         // Insert the membership. A conflict on the composite PK means this user is
@@ -561,7 +559,10 @@ mod tests {
         // Still exactly one membership, and the original role is untouched.
         let members = MemberRepo::list(pool, &ws("ws-a")).await.unwrap();
         assert_eq!(members.len(), 1);
-        assert_eq!(members[0].role, "member", "re-add did not overwrite the role");
+        assert_eq!(
+            members[0].role, "member",
+            "re-add did not overwrite the role"
+        );
     }
 
     /// `add` reuses an EXISTING user (found by email) rather than minting a
@@ -628,9 +629,7 @@ mod tests {
         let pool = store.pool();
         seed_ws(pool, "ws-a").await;
 
-        let err = MemberRepo::add(pool, &ws("ws-a"), "   ", MemberRole::Member)
-            .await
-            .unwrap_err();
+        let err = MemberRepo::add(pool, &ws("ws-a"), "   ", MemberRole::Member).await.unwrap_err();
         assert!(matches!(err, MemberRepoError::EmptyEmail), "got {err:?}");
         let members = MemberRepo::list(pool, &ws("ws-a")).await.unwrap();
         assert!(members.is_empty(), "nothing written on a blank email");

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -179,6 +179,25 @@ mod tests {
         assert!(row_text(&buf, 1, 40).contains("unassigned"));
     }
 
+    /// The Assignee row surfaces the polymorphic actor KIND: a member assignee
+    /// paints its `member:` prefix, distinct from the `agent:` an agent shows
+    /// (agents-are-team-members symmetry, made visible in the TUI). Mutation-
+    /// provable: strip the kind prefix from the snapshot ref and this goes red.
+    #[test]
+    fn assignee_row_distinguishes_member_from_agent_kind() {
+        let mut member_buf = WireBuffer::new(48, 8);
+        render_sidebar(&mut member_buf, 0, 0, 8, 48, &issue(None, Some("member:dana")));
+        let member_row = row_text(&member_buf, 1, 48);
+        assert!(member_row.contains("member:dana"), "member kind shown: {member_row}");
+        assert!(!member_row.contains("agent:"), "not painted as an agent");
+
+        let mut agent_buf = WireBuffer::new(48, 8);
+        render_sidebar(&mut agent_buf, 0, 0, 8, 48, &issue(None, Some("agent:claude")));
+        let agent_row = row_text(&agent_buf, 1, 48);
+        assert!(agent_row.contains("agent:claude"), "agent kind shown: {agent_row}");
+        assert!(!agent_row.contains("member:"), "not painted as a member");
+    }
+
     /// Progressive disclosure: a `None` description omits the Notes row entirely.
     #[test]
     fn absent_description_omits_notes_row() {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -186,15 +186,35 @@ mod tests {
     #[test]
     fn assignee_row_distinguishes_member_from_agent_kind() {
         let mut member_buf = WireBuffer::new(48, 8);
-        render_sidebar(&mut member_buf, 0, 0, 8, 48, &issue(None, Some("member:dana")));
+        render_sidebar(
+            &mut member_buf,
+            0,
+            0,
+            8,
+            48,
+            &issue(None, Some("member:dana")),
+        );
         let member_row = row_text(&member_buf, 1, 48);
-        assert!(member_row.contains("member:dana"), "member kind shown: {member_row}");
+        assert!(
+            member_row.contains("member:dana"),
+            "member kind shown: {member_row}"
+        );
         assert!(!member_row.contains("agent:"), "not painted as an agent");
 
         let mut agent_buf = WireBuffer::new(48, 8);
-        render_sidebar(&mut agent_buf, 0, 0, 8, 48, &issue(None, Some("agent:claude")));
+        render_sidebar(
+            &mut agent_buf,
+            0,
+            0,
+            8,
+            48,
+            &issue(None, Some("agent:claude")),
+        );
         let agent_row = row_text(&agent_buf, 1, 48);
-        assert!(agent_row.contains("agent:claude"), "agent kind shown: {agent_row}");
+        assert!(
+            agent_row.contains("agent:claude"),
+            "agent kind shown: {agent_row}"
+        );
         assert!(!agent_row.contains("member:"), "not painted as a member");
     }
 


### PR DESCRIPTION
## multica-gap #1 — Polymorphic actors + human members

Maps to workspace-reference GAPS row #5 (agents-are-team-members symmetry).
Closes the three holes that blocked the acceptance: no way to CREATE a human
member, the CLI couldn't assign an issue to a member, and the actor type wasn't
surfaced on issue read surfaces. The DB (0003) + TUI-assign plumbing already
existed on main and is unchanged.

### Acceptance (tmux-provable) — verified
A human member can be created and assigned an issue alongside an agent; the
actor type shows in the TUI; the DB stores `(actor_type, actor_id)`
polymorphically. Verified end-to-end against an isolated `AINB_HANGAR_HOME`:

```
$ ainb hangar member add --email dana@example.com --role member
added member 01KY8AF7FM2ZA609CD1D36W3P6 (dana@example.com) as member
$ ainb hangar issue create --title "human task" --assign "member:$UID"
$ ainb hangar issue create --title "robot task" --assign "agent:$AID"
$ ainb hangar issue list --format json | jq '.[].assignee'
"member:01KY8AF7FM2ZA609CD1D36W3P6"
"agent:01KY8AF7GWY18PJA27J6QGCV6Z"
# DB: issue.assignee_type = member|agent respectively
# member assignee enqueued 0 agent tasks; agent assignee enqueued 1
```

### Changes
- **Store** (`MemberRepo::add`): find-or-create the `user` by email (multica's
  auto-stub-user-by-email flow), then insert the `(workspace, user, role)`
  membership in one transaction. Reuses an existing user across workspaces
  (same email in a sibling tenant is a separate membership over one shared user).
  New `EmptyEmail` / `AlreadyMember` errors; re-add of an existing pair trips the
  composite PK and is reported as `AlreadyMember` (nothing written).
- **CLI** `hangar member add --email --role [--workspace]`: mirrors
  `member set-role` (direct store), prints `added member <id> (<email>) as <role>`.
- **CLI** `parse_assignee`: `--assign` now accepts `member:<id>`/`agent:<id>`
  polymorphically; a **bare id stays an agent** (back-compat — every existing
  script/tripwire byte-unchanged). `issue create` and `issue update --assign`
  store a member assignee but enqueue **no** agent task; only an agent assignee
  dispatches a run (symmetric column, asymmetric side-effect).
- **CLI read surfaces**: `issue_line`, `issue_to_json` (+`creator`), and the
  csv/md rows now print the assignee's canonical `member:<id>`/`agent:<id>` form,
  so the actor KIND is visible on every read surface.
- **TUI**: verify-only. The daemon snapshot already emits the assignee as
  `member:<id>`/`agent:<id>` and the detail sidebar's `Assignee` row renders it,
  so the actor kind is already visible; added a render test asserting a member
  ref paints `member:` distinct from an agent's `agent:`. No plugin code change
  (smallest correct diff).

### Migration
None. Schema is already polymorphic (0003) — no `ALTER`/`CREATE`.

### Tests
- Store: `add_mints_user_and_membership`, `add_existing_pair_is_already_member`,
  `add_reuses_existing_user_by_email`, `add_is_workspace_scoped`,
  `add_rejects_empty_email`.
- CLI integration (mutation-provable pair): `issue create --assign member:<id>`
  persists `(member,id)` and enqueues **no** task; `--assign agent:<id>` persists
  `(agent,id)` **and** enqueues one run. Plus `parse_assignee` back-compat.
- Plugin: sidebar renders member vs agent kind distinctly.

### Scope note (honest)
Per the spec, a full tmux tripwire for Part B was descoped in favour of the
plugin sidebar render test + CLI integration tests (non-flaky, mutation-provable
proof of the same TUI-visible-kind claim). Out of scope (follow-ups): inbox
recipient polymorphism, the full invite/expire lifecycle (gaps #2/#3), and a
daemon `member_add` RPC / TUI settings action.

### CI / test notes
Touched crates green for my changes. Three **pre-existing** failures on `main`
(files byte-identical to `origin/main`, unrelated to this PR): the
`render_full_health_pane_snapshot` version-drift (`1.15.0` vs workspace
`1.16.1`), `paste_lands_in_onboarding_otel_field`, and
`worktree_on_ainb_slug_branch` (passes in isolation — a git-worktree
concurrency flake). Per repo convention CI gates on `cargo fmt --check`, not
clippy; the changed lines are fmt- and clippy-clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `hangar member add` to add workspace members by email and assign a role.
  - Issue assignees now support both agents and members.
  - Issue details now display assignees in text, JSON, and CSV formats.

- **Bug Fixes**
  - Improved validation and error messages for blank emails and duplicate memberships.
  - Follow-up tasks are created only for issues assigned to agents, not members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->