### PR TITLE
feat(hangar): task-level squad_id column + claim-time briefing hook (multica-gap #5)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -837,6 +837,23 @@ async fn prepare_spawn_inputs(
 // Bundling them into a context struct is a larger refactor than this credential
 // change warrants; the sibling run functions here carry the same shape.
 #[allow(clippy::too_many_arguments)]
+/// The claim-time squad-leader briefing injection seam (migration 0045 / GAPS #1).
+///
+/// When a claimed task carries a `squad_id`, the daemon will inject the leader
+/// briefing (Operating Protocol + Roster + Instructions) into the run's system
+/// instructions here. gap #5 lands the HOOK POINT + the dispatch-log evidence;
+/// the briefing BODY is gap #1 — this returns `None` (no text yet) but logs that
+/// the injection point fired, keyed off the `squad_id`, so the seam is observable.
+fn squad_briefing_hook(task: &Task) -> Option<String> {
+    let squad_id = task.squad_id.as_deref()?;
+    tracing::info!(
+        task_id = %task.id,
+        squad_id = %squad_id,
+        "squad briefing hook: leader-briefing injection point (body: gap #1)"
+    );
+    None // gap #1 fills this with buildSquadLeaderBriefing()
+}
+
 async fn execute_claimed(
     pool: &SqlitePool,
     runner: &Runner,
@@ -881,6 +898,14 @@ async fn execute_claimed(
         Err(e) => {
             tracing::warn!(error = %e, task_id = %task.id, "context prompt read failed");
         }
+    }
+
+    // Claim-time squad briefing injection point (migration 0045). Fires BEFORE
+    // provider dispatch so the hook is exercised even when the run later fails to
+    // spawn (a nonexistent provider path still exercises it).
+    if let Some(briefing) = squad_briefing_hook(&task) {
+        // gap #1: merge `briefing` into the run's system instructions / CLAUDE.md here.
+        let _ = briefing;
     }
 
     // e38.16: resolve which provider exec path this task routes to (agent →
@@ -1585,7 +1610,10 @@ fn failure_detail(
             || "no exit code (killed)".to_string(),
             |c| format!("exit {c}"),
         );
-        return format!("{}: provider {provider} {exit} with no output", reason.as_db_str());
+        return format!(
+            "{}: provider {provider} {exit} with no output",
+            reason.as_db_str()
+        );
     }
     let mut detail = format!("run failed ({}):", reason.as_db_str());
     if !stdout.is_empty() {
@@ -3134,6 +3162,175 @@ mod tests {
             Some("spawn_timeout"),
             "the umbrella must attribute the wedge as spawn_timeout (got {:?})",
             row.failure_reason
+        );
+    }
+
+    /// migration 0045 / gap #5: driving the REAL `execute_claimed` seam for a task
+    /// stamped with a `squad_id` must emit the claim-time squad-briefing hook line —
+    /// carrying BOTH the `task_id` and the `squad_id` — BEFORE the provider spawn.
+    /// The provider paths are nonexistent so the run fails, yet the hook must have
+    /// already fired (the observable seam gap #1 keys its briefing injection off).
+    /// Deleting the `squad_briefing_hook(&task)` call from `execute_claimed` turns
+    /// this RED: no hook event is captured though the row still terminalises.
+    #[tokio::test]
+    async fn execute_claimed_fires_the_squad_briefing_hook_before_spawn() {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
+        use ainb_hangar_store::service::claim::ClaimTaskService;
+        use std::sync::{Arc, Mutex};
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::{Context, SubscriberExt};
+        use tracing_subscriber::registry::LookupSpan;
+
+        #[derive(Default, Clone)]
+        struct Ev {
+            message: String,
+            fields: Vec<(String, String)>,
+        }
+        type Log = Arc<Mutex<Vec<Ev>>>;
+        struct Collect<'a>(&'a mut Ev);
+        impl Visit for Collect<'_> {
+            fn record_str(&mut self, field: &Field, value: &str) {
+                if field.name() == "message" {
+                    self.0.message = value.to_string();
+                } else {
+                    self.0.fields.push((field.name().to_string(), value.to_string()));
+                }
+            }
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                let rendered = format!("{value:?}");
+                if field.name() == "message" {
+                    self.0.message = rendered;
+                } else {
+                    self.0.fields.push((field.name().to_string(), rendered));
+                }
+            }
+        }
+        struct CollectLayer {
+            log: Log,
+        }
+        impl<S> Layer<S> for CollectLayer
+        where
+            S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+        {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                let mut captured = Ev::default();
+                event.record(&mut Collect(&mut captured));
+                self.log.lock().expect("event log lock").push(captured);
+            }
+        }
+
+        // Serialise with every other `$AINB_HANGAR_HOME`-mutating test.
+        let _env = ainb_hangar_store::test_support::lock_env();
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("hangar-home");
+        let prior_home = std::env::var_os(ainb_hangar_core::paths::HANGAR_HOME_ENV);
+        std::env::set_var(ainb_hangar_core::paths::HANGAR_HOME_ENV, &home);
+
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        let rt = bootstrap::default_runtime_id();
+        bootstrap::ensure_runtime(pool, &rt, 1).await.unwrap();
+        let agent = bootstrap::create_agent(pool, &ws, "leader", "claude", None).await.unwrap();
+
+        let task_id =
+            ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        TaskRepo::insert(
+            pool,
+            &NewTask {
+                id: task_id.clone(),
+                workspace_id: ws.clone(),
+                runtime_id: rt.clone(),
+                agent_id: agent.id.clone(),
+                issue_id: None,
+                work_dir: None,
+                priority: 0,
+                created_at: 1,
+                autopilot_run_id: None,
+                generation: 0,
+            },
+        )
+        .await
+        .unwrap();
+        // Stamp the dispatching squad, exactly as a squad dispatch would, so the
+        // claimed task carries it into `execute_claimed`.
+        TaskRepo::set_squad_id(pool, &task_id, "squad-alpha").await.unwrap();
+
+        let clock = SystemClock;
+        let claimed = ClaimTaskService::claim_for_runtime(pool, &rt, &clock)
+            .await
+            .unwrap()
+            .expect("the queued task must claim");
+
+        // Nonexistent provider paths: the run fails to spawn, but the squad hook
+        // must have fired first (it is placed BEFORE provider dispatch).
+        let runner = Runner::new(RunnerConfig {
+            claude_path: "/nonexistent/hangar-test-claude".into(),
+            codex_path: "/nonexistent/hangar-test-codex".into(),
+            copilot_path: "/nonexistent/hangar-test-copilot".into(),
+            max_runtime: Duration::from_secs(1),
+            tail_lines: 1,
+            sandbox: false,
+        });
+        let stats = HealthStats::default();
+        let events = crate::events::EventBroker::new().sink();
+        let interactive = InteractiveSessions::default();
+
+        let log: Log = Arc::default();
+        let subscriber = tracing_subscriber::registry().with(CollectLayer { log: log.clone() });
+        let outcome = {
+            // Current-thread runtime: the guard holds the subscriber across every
+            // `.await` in `execute_claimed`, so the inline hook event is captured.
+            let _guard = tracing::subscriber::set_default(subscriber);
+            execute_claimed(
+                pool,
+                &runner,
+                &claimed,
+                &clock,
+                &stats,
+                &events,
+                &interactive,
+                Arc::new(ainb_hangar_secrets::InMemoryBackend::new()),
+            )
+            .await
+        };
+
+        // Restore env BEFORE asserting so a failed assertion never leaks it.
+        match prior_home {
+            Some(v) => std::env::set_var(ainb_hangar_core::paths::HANGAR_HOME_ENV, v),
+            None => std::env::remove_var(ainb_hangar_core::paths::HANGAR_HOME_ENV),
+        }
+        outcome.expect("execute_claimed handles the spawn failure internally (never Err)");
+
+        let events: Vec<Ev> = log.lock().expect("event log").clone();
+        let hook: Vec<&Ev> =
+            events.iter().filter(|e| e.message.contains("squad briefing hook")).collect();
+        assert_eq!(
+            hook.len(),
+            1,
+            "exactly one claim-time squad-briefing hook line must fire"
+        );
+        let field =
+            |e: &Ev, k: &str| e.fields.iter().find(|(name, _)| name == k).map(|(_, v)| v.clone());
+        assert_eq!(
+            field(hook[0], "squad_id").as_deref(),
+            Some("squad-alpha"),
+            "the hook line must carry the dispatching squad_id"
+        );
+        assert_eq!(
+            field(hook[0], "task_id").as_deref(),
+            Some(task_id.as_str()),
+            "the hook line must carry the claimed task_id"
+        );
+
+        // The run still terminalised (nonexistent provider) — proving the hook
+        // fired on the path to a FAILED run, before the spawn, not only on success.
+        let row = TaskRepo::get_by_id(pool, &task_id).await.unwrap().unwrap();
+        assert_eq!(
+            row.status, "failed",
+            "the nonexistent provider must terminalise the run"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/execenv_layout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/execenv_layout.rs
@@ -58,6 +58,7 @@ fn task_fixture(id: &str, issue_id: Option<&str>) -> Task {
         repo_ref: None,
         agent_kind: "claude".to_string(),
         branch: None,
+        squad_id: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/worktree_integration.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/worktree_integration.rs
@@ -68,6 +68,7 @@ fn task_fixture(id: &str, issue_id: Option<&str>) -> Task {
         repo_ref: None,
         agent_kind: "claude".to_string(),
         branch: None,
+        squad_id: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0045_task_squad_id.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0045_task_squad_id.sql
@@ -1,0 +1,19 @@
+-- Hangar v1 schema, migration 0045: stamp the dispatching SQUAD onto the task row.
+--
+-- Mirrors multica migration 127 (`agent_task_queue.squad_id`): a squad-dispatched
+-- task (the leader brief + every fanned-out member, or a CLI leader-only assign)
+-- records WHICH squad dispatched it, so the daemon can key a claim-time leader
+-- briefing injection off the row without re-deriving the squad from the issue.
+--
+-- Distinct from `issue.squad_id` (migration 0035, the durable CARD assignment axis):
+-- that says "this card is owned by a squad"; THIS says "this specific task row was
+-- produced by a squad dispatch". A single-agent (non-squad) task reads back NULL.
+--
+-- No FK (hot queue table; `PRAGMA foreign_keys` is off in this crate — see 0002/0035);
+-- referential integrity of the squad ref is a service-layer concern, exactly as
+-- `issue.squad_id` and the task actor/repo refs are. ALTER ... ADD COLUMN with no
+-- default is an O(1) catalog change in SQLite (no table rewrite), safe on populated
+-- DBs (mirrors 0031/0032/0033/0035). Every pre-existing task reads back squad_id = NULL.
+
+ALTER TABLE agent_task_queue
+    ADD COLUMN squad_id TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -154,6 +154,12 @@ pub struct Task {
     /// [`super::card_parity::CardParityRepo::set_task_source_branch_in_tx`],
     /// read back here so dispatch provisions from the claimed row.
     pub source_branch: Option<String>,
+    /// The squad that dispatched this task (migration 0045), or `None` for a
+    /// single-agent task. Stamped post-insert by
+    /// [`SquadAssignService`](crate::service::squad_assign::SquadAssignService);
+    /// read back so the daemon claim path can key a leader-briefing injection off
+    /// it. An infra-retry child copies it verbatim.
+    pub squad_id: Option<String>,
 }
 
 /// Stateless typed wrapper over the `agent_task_queue` table.
@@ -254,6 +260,48 @@ impl TaskRepo {
             .bind(branch)
             .bind(id)
             .execute(pool)
+            .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Stamp the dispatching `squad_id` onto a task row (migration 0045), the
+    /// non-transactional sibling of [`set_squad_id_in_tx`](Self::set_squad_id_in_tx).
+    /// Used by the CLI leader-only assign path, which inserts the leader task in its
+    /// own transaction and then stamps the squad ref on the committed row. Returns
+    /// `true` iff exactly one row was updated.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn set_squad_id(
+        pool: &SqlitePool,
+        id: &str,
+        squad_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query("UPDATE agent_task_queue SET squad_id = ? WHERE id = ?")
+            .bind(squad_id)
+            .bind(id)
+            .execute(pool)
+            .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Stamp the dispatching squad onto a task row WITHIN a fan-out transaction
+    /// (migration 0045), so the stamp commits atomically with the fanned-out task
+    /// inserts. Returns `true` iff exactly one row was updated.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn set_squad_id_in_tx(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        id: &str,
+        squad_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query("UPDATE agent_task_queue SET squad_id = ? WHERE id = ?")
+            .bind(squad_id)
+            .bind(id)
+            .execute(&mut **tx)
             .await?;
         Ok(res.rows_affected() == 1)
     }
@@ -542,7 +590,7 @@ impl TaskRepo {
 const COLUMNS: &str = "id, workspace_id, runtime_id, agent_id, issue_id, status, result, \
      session_id, work_dir, attempt, max_attempts, parent_task_id, failure_reason, \
      priority, created_at, dispatched_at, started_at, finished_at, autopilot_run_id, \
-     mode, session_name, repo_ref, agent_kind, branch, generation, source_branch";
+     mode, session_name, repo_ref, agent_kind, branch, generation, source_branch, squad_id";
 
 /// Map one raw `agent_task_queue` row into a [`Task`].
 fn task_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Task, sqlx::Error> {
@@ -573,6 +621,7 @@ fn task_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Task, sqlx::Error> {
         branch: row.try_get("branch")?,
         generation: row.try_get("generation")?,
         source_branch: row.try_get("source_branch")?,
+        squad_id: row.try_get("squad_id")?,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/service/claim.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/claim.rs
@@ -66,6 +66,9 @@ pub struct ClaimedTask {
     pub prior_work_dir: Option<String>,
     /// When the claim happened (`HangarClock::now_ms`), epoch milliseconds.
     pub dispatched_at: i64,
+    /// The dispatching squad (migration 0045), or `None` for a single-agent task.
+    /// The daemon keys its claim-time leader-briefing hook off this.
+    pub squad_id: Option<String>,
 }
 
 /// Stateless claim service over the `agent_task_queue` table.
@@ -158,7 +161,7 @@ WHERE id = ( \
     ORDER BY q.priority DESC, q.created_at, q.id \
     LIMIT 1 \
 ) \
-RETURNING id, workspace_id, agent_id, runtime_id, issue_id, session_id, work_dir, dispatched_at";
+RETURNING id, workspace_id, agent_id, runtime_id, issue_id, session_id, work_dir, dispatched_at, squad_id";
 
 /// Decode a [`ClaimedTask`] from the `RETURNING` row of [`CLAIM_SQL`].
 ///
@@ -174,5 +177,6 @@ fn claimed_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<ClaimedTask, sqlx::
         prior_session_id: row.try_get("session_id")?,
         prior_work_dir: row.try_get("work_dir")?,
         dispatched_at: row.try_get("dispatched_at")?,
+        squad_id: row.try_get("squad_id")?,
     })
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/retry.rs
@@ -6,8 +6,9 @@
 //! attempts remaining spawns a fresh `queued` child row whose `parent_task_id`
 //! chains back to the failed task and whose `attempt` is `parent.attempt + 1`.
 //! Everything else (workspace / runtime / agent / issue / work_dir / priority /
-//! max_attempts / **repo_ref / agent_kind**) is inherited verbatim so the retry
-//! re-provisions the SAME repo's worktree under the SAME provider (tcp 19n); all
+//! max_attempts / **repo_ref / agent_kind / squad_id**) is inherited verbatim so
+//! the retry re-provisions the SAME repo's worktree under the SAME provider (tcp
+//! 19n) and stays keyed to the SAME dispatching squad (migration 0045); all
 //! per-run timestamps, outputs, and the recorded `branch` reset.
 //!
 //! # Retry/resume taxonomy (reference migration 055 + `GetLastTaskSession`)
@@ -125,15 +126,21 @@ pub enum RetryDecision {
 /// retry is a NEW ATTEMPT of the SAME logical run, so it belongs to the parent's
 /// run generation — the card-state folds must fold the retry child together with
 /// its parent's siblings, not treat it as a fresh generation.
+/// `squad_id` is copied from the parent (migration 0045): a retried squad task is
+/// still that squad's task, so the child must carry the same squad ref — dropping
+/// it on retry would silently disarm the daemon's claim-time briefing hook for the
+/// child (the same class of bug as the `repo_ref` / `generation` drops guarded
+/// above).
 /// Binds, in order: `id`, `workspace_id`, `runtime_id`, `agent_id`, `issue_id`,
 /// `work_dir`, `priority`, `attempt`, `max_attempts`, `parent_task_id`,
-/// `session_id`, `repo_ref`, `agent_kind`, `generation`, `created_at`.
+/// `session_id`, `repo_ref`, `agent_kind`, `generation`, `source_branch`,
+/// `squad_id`, `created_at`.
 const SPAWN_CHILD_SQL: &str = "\
 INSERT INTO agent_task_queue \
  (id, workspace_id, runtime_id, agent_id, issue_id, status, work_dir, priority, \
   attempt, max_attempts, parent_task_id, session_id, repo_ref, agent_kind, generation, \
-  source_branch, created_at) \
- VALUES (?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+  source_branch, squad_id, created_at) \
+ VALUES (?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 /// Stateless retry service over `agent_task_queue`.
 pub struct RetryService;
@@ -274,9 +281,9 @@ impl RetryService {
     /// (`attempt = parent.attempt + 1`, `max_attempts`, `parent_task_id`,
     /// `session_id`) in one statement so the child is correct-or-absent rather than
     /// transiently carrying the schema defaults. `repo_ref` / `agent_kind` /
-    /// `priority` / `generation` / `source_branch` are inherited; the per-run
-    /// columns (`result` / `failure_reason` / `started_at` / `finished_at` /
-    /// `dispatched_at` / `branch`) reset by being omitted (NULL). `session_id` is
+    /// `priority` / `generation` / `source_branch` / `squad_id` are inherited; the
+    /// per-run columns (`result` / `failure_reason` / `started_at` / `finished_at`
+    /// / `dispatched_at` / `branch`) reset by being omitted (NULL). `session_id` is
     /// bound by the caller per the retry/resume taxonomy.
     async fn spawn_child(
         pool: &SqlitePool,
@@ -302,6 +309,7 @@ impl RetryService {
             .bind(&parent.agent_kind)
             .bind(parent.generation)
             .bind(&parent.source_branch)
+            .bind(&parent.squad_id)
             .bind(clock.now_ms())
             .execute(pool)
             .await?;

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -194,6 +194,11 @@ impl SquadAssignService {
             },
         )
         .await?;
+        // Stamp the dispatching squad onto the just-committed leader row (migration
+        // 0045), so the daemon claim path can key a leader-briefing injection off it.
+        // The insert used its own transaction; a follow-up UPDATE on the committed
+        // row is fine (the row is not yet claimable-and-gone this same tick).
+        TaskRepo::set_squad_id(pool, &task_id, squad_id).await?;
 
         Ok(SquadAssignment {
             task_id,
@@ -309,6 +314,11 @@ impl SquadAssignService {
         )
         .await?;
         Self::stamp_dispatch_fields(&mut tx, &leader_task_id, request).await?;
+        // Stamp the dispatching squad onto the leader brief (migration 0045). A
+        // SEPARATE call from `stamp_dispatch_fields` (not folded in) so squad_id is
+        // stamped even for the no-repo squads-screen fan-out, where
+        // `stamp_dispatch_fields` early-returns on a NULL `repo_ref`.
+        TaskRepo::set_squad_id_in_tx(&mut tx, &leader_task_id, squad_id).await?;
         for (agent_id, runtime_id) in member_targets {
             let task_id = idgen.new_ulid();
             TaskRepo::insert_in_tx(
@@ -328,6 +338,7 @@ impl SquadAssignService {
             )
             .await?;
             Self::stamp_dispatch_fields(&mut tx, &task_id, request).await?;
+            TaskRepo::set_squad_id_in_tx(&mut tx, &task_id, squad_id).await?;
             members.push(SquadMemberDispatch {
                 task_id,
                 agent_id,
@@ -525,6 +536,15 @@ mod tests {
             "the runtime was DERIVED from the squad's leader, not supplied"
         );
 
+        // The dispatching squad is stamped on the leader task row (migration 0045),
+        // so the daemon claim path can key a leader-briefing injection off it.
+        let row = TaskRepo::get_by_id(pool, &assignment.task_id).await.unwrap().unwrap();
+        assert_eq!(
+            row.squad_id.as_deref(),
+            Some("s1"),
+            "the leader-only assign stamps squad_id on the task row"
+        );
+
         // The LEADER's runtime claims the squad task — routing took effect.
         let claimed = ClaimTaskService::claim_for_runtime(pool, "rt-lead", &FixedClock(10_000))
             .await
@@ -534,6 +554,13 @@ mod tests {
         assert_eq!(
             claimed.agent_id, "a-lead",
             "dispatched to the LEADER agent, not anyone else"
+        );
+        // The claim projection carries the squad ref through to the daemon's
+        // briefing hook (migration 0045).
+        assert_eq!(
+            claimed.squad_id.as_deref(),
+            Some("s1"),
+            "the claimed projection carries squad_id for the briefing hook"
         );
 
         // The OTHER runtime claims nothing — the task is the leader's alone.
@@ -634,6 +661,21 @@ mod tests {
         assert_eq!(lead.issue_id.as_deref(), Some("issue-1"));
         assert_eq!(m1.issue_id.as_deref(), Some("issue-1"));
         assert_eq!(m2.issue_id.as_deref(), Some("issue-1"));
+
+        // Every fanned-out task (leader + both members) carries the dispatching
+        // squad (migration 0045), so the daemon keys a briefing hook off each.
+        for id in [
+            &fanout.leader.task_id,
+            &fanout.members[0].task_id,
+            &fanout.members[1].task_id,
+        ] {
+            let row = TaskRepo::get_by_id(pool, id).await.unwrap().unwrap();
+            assert_eq!(
+                row.squad_id.as_deref(),
+                Some("s1"),
+                "fanned task {id} must carry squad_id"
+            );
+        }
     }
 
     /// FAN-OUT stamps the card's repo + agent-kind onto EVERY fanned task (leader

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
@@ -406,6 +406,20 @@ async fn assert_added_columns_read_defaults(pool: &SqlitePool) {
             .expect("task 0033 branch column");
     assert_eq!(task_branch, None, "0033 task.branch defaults NULL");
 
+    // 0045 task.squad_id defaults NULL on a pre-existing row (a single-agent task
+    // carries no dispatching squad), so legacy tasks arm no claim-time briefing hook.
+    assert_eq!(
+        sqlx::query_scalar::<_, Option<String>>(
+            "SELECT squad_id FROM agent_task_queue WHERE id = ?"
+        )
+        .bind("task-1")
+        .fetch_one(pool)
+        .await
+        .expect("task 0045 squad_id column"),
+        None,
+        "0045 task.squad_id defaults NULL"
+    );
+
     // 0032 workspace.default_agent defaults NULL on prior rows.
     assert_eq!(
         sqlx::query_scalar::<_, Option<String>>("SELECT default_agent FROM workspace WHERE id = ?")
@@ -593,7 +607,7 @@ async fn full_chain_upgrade_preserves_every_seeded_entity_and_is_idempotent() {
         .fetch_one(&pool)
         .await
         .expect("read head migration version");
-    assert_eq!(head_version, 43, "head is migration 0043");
+    assert_eq!(head_version, 45, "head is migration 0045");
 
     // (b) Every seeded row survived: the population is row-for-row identical.
     let after = population_snapshot(&pool).await;

--- a/ainb-tui/crates/ainb-hangar-store/tests/retry_chain.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/retry_chain.rs
@@ -265,6 +265,58 @@ async fn child_inherits_repo_ref_and_agent_kind_but_not_branch() {
 }
 
 #[tokio::test]
+async fn child_inherits_parent_squad_id() {
+    // migration 0045: a retried squad task is still that squad's task. The child
+    // INSERT must copy the parent's `squad_id` verbatim — dropping it would silently
+    // disarm the daemon's claim-time leader-briefing hook for the child (the same
+    // class of bug as the `repo_ref` drop guarded above).
+    let (_dir, store) = open_seeded().await;
+    let parent_seed = seed_failed_task(
+        &store,
+        "t-squad",
+        None,
+        None,
+        1,
+        3,
+        FailureReason::RuntimeOffline,
+    )
+    .await;
+    // Stamp the dispatching squad on the parent, exactly as a squad dispatch would.
+    sqlx::query("UPDATE agent_task_queue SET squad_id = ? WHERE id = ?")
+        .bind("squad-alpha")
+        .bind(&parent_seed.id)
+        .execute(store.pool())
+        .await
+        .expect("stamp squad_id on parent");
+    let parent = TaskRepo::get_by_id(store.pool(), &parent_seed.id)
+        .await
+        .unwrap()
+        .expect("parent re-reads");
+    assert_eq!(parent.squad_id.as_deref(), Some("squad-alpha"));
+
+    let clock = FixedClock(NOW_MS);
+    let decision = RetryService::maybe_retry_failed(store.pool(), &parent, "child-squad", &clock)
+        .await
+        .expect("retry ok");
+    assert_eq!(
+        decision,
+        RetryDecision::Spawned {
+            new_task_id: "child-squad".to_string()
+        }
+    );
+
+    let child = TaskRepo::get_by_id(store.pool(), "child-squad")
+        .await
+        .unwrap()
+        .expect("child row exists");
+    assert_eq!(
+        child.squad_id.as_deref(),
+        Some("squad-alpha"),
+        "child inherits the parent's squad_id (the briefing hook stays armed)"
+    );
+}
+
+#[tokio::test]
 async fn child_inherits_parent_priority() {
     // A retried urgent task must stay urgent: the child row inherits the
     // parent's `priority` (0..3 = P3..P0, higher = more urgent) so it keeps


### PR DESCRIPTION
## multica-parity gap #5 — task-level `squad_id` column + claim-time briefing hook point

Lands the **structural half** of squad-reference GAPS #1 (mirroring multica migration `127`): the `agent_task_queue.squad_id` column, dispatch-time stamping on both squad paths, retry inheritance, and an empty claim-time briefing-injection seam the daemon keys off. The `SquadBriefing` body (Operating Protocol + Roster + Instructions) is the L remainder of GAPS #1 and is **out of scope** here — the hook returns `None` for now.

### Changes (6 single-concern commits)
1. `feat(hangar-store)`: migration `0045` adds nullable `agent_task_queue.squad_id` (no FK, no default — O(1) catalog change; pre-existing rows read NULL). Distinct from `issue.squad_id` (0035, the durable card axis).
2. `feat(hangar-store)`: read `squad_id` back on `Task` (+ `COLUMNS`, `task_from_row`) and add `set_squad_id` / `set_squad_id_in_tx` stamp helpers. `NewTask`/`insert` untouched — stamped post-insert like `repo_ref`/`agent_kind`.
3. `feat(hangar-store)`: stamp `squad_id` on both dispatch paths — `assign_fanout` (leader + every member, inside the fan-out tx) and CLI `assign_to_leader`. Separate from `stamp_dispatch_fields` so it lands even for the no-repo squads-screen fan-out.
4. `feat(hangar-store)`: carry `squad_id` on the claim projection (`ClaimedTask`, `RETURNING`, `claimed_from_row`).
5. `fix(hangar-store)`: inherit `squad_id` on retry — a retried squad task is still that squad's task; dropping it would silently disarm the child's briefing hook.
6. `feat(hangar-daemon)`: `squad_briefing_hook(&task)` in `execute_claimed`, fired after the context-prompt block and **before** provider dispatch, emitting a structured dispatch-log line keyed off `squad_id` (so it fires even when the run later fails to spawn).

### Tests (behavioral, fail-before/pass-after)
- `squad_assign` module: every enqueued task's `squad_id` round-trips (leader-only + fan-out), and `ClaimTaskService::claim_for_runtime` returns `ClaimedTask.squad_id`.
- `retry_chain`: a retry child inherits the parent's `squad_id`.
- `migration_upgrade_full_chain`: head is `0045`; a pre-existing task reads `squad_id = NULL`.
- `run_loop` (daemon): drives the **real** `execute_claimed` with a nonexistent provider and asserts the hook line carries **both** the `task_id` and `squad_id` before the run terminalises. Mutation-verified (neutering the call site turns it RED).

### tmux-verify acceptance (real CLI + real daemon, isolated `AINB_HANGAR_HOME`)
- **Half 1** — `hangar squad assign` → `sqlite3` shows the task row carries `squad_id`; a non-squad task reads `NULL` (negative control).
- **Half 2** — the daemon claims the task and logs `squad briefing hook: leader-briefing injection point (body: gap #1)` carrying the matching `task_id` + `squad_id` **before** the (nonexistent-provider) spawn; the task then terminalises `failed`/`spawn_error`.

### Notes
- `cargo test -p ainb-hangar-store -p ainb-hangar-daemon` green; `cargo build -p ainb` green; clippy introduces no new lints.
- `migration_upgrade_full_chain`'s head-version assertion was already stale on `main` (expected 43 while `0044` had landed); bumped to 45 as part of this migration.
- Pre-existing `rustfmt` nightly/stable drift in `tests/live_e2e.rs` (untouched) is left as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added squad attribution to tasks, including leader and fan-out assignments.
  * Preserved squad information when tasks are retried.
  * Added a squad briefing hook before task execution begins.
  * Improved failure details when a provider produces no output.

* **Tests**
  * Added coverage confirming squad attribution, retry inheritance, and briefing-hook execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->