### PR TITLE
fix(hangar): restore full macOS hangar-e2e gate (migration count + CSV header drift)

### DIFF
--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -360,10 +360,18 @@ fn issue_list_all_four_formats_are_distinct() {
         json.trim_start().starts_with('['),
         "json not an array:\n{json}"
     );
-    assert!(
-        csv.contains("id,state,title,description,created_at"),
-        "csv header missing:\n{csv}"
-    );
+    // Assert the CSV header carries its core columns individually rather than
+    // as one contiguous run — parity work inserts columns (e.g. `assignee`
+    // between `description` and `created_at`), and a hardcoded substring drifts
+    // every time. A comma-delimited header line with these fields is enough to
+    // prove the CSV format is distinct and structured.
+    let csv_header = csv.lines().next().expect("csv should have a header line");
+    for col in ["id", "state", "title", "description", "created_at"] {
+        assert!(
+            csv_header.split(',').any(|c| c == col),
+            "csv header missing column `{col}`:\n{csv}"
+        );
+    }
     assert!(
         csv.contains("\"Wire, up payments\""),
         "csv must quote the comma-bearing title:\n{csv}"

--- a/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
@@ -888,7 +888,13 @@ async fn migration_0019_adds_autopilot_execution_mode_and_concurrency_policy_col
 }
 
 #[tokio::test]
-async fn all_migrations_create_exactly_thirty_six_tables() {
+async fn all_migrations_preserve_every_core_table() {
+    // Guards against a migration DROPPING or renaming a core table. This used
+    // to assert an exact table count, which broke on every PR that added a
+    // migration (the multica-parity work adds new tables continuously): the
+    // exact count was never the point, catching a lost table is. So this
+    // checks that every table in `expected` still exists by name (a floor,
+    // not a ceiling): new tables are fine, a missing one fails loudly.
     let dir = tempfile::tempdir().expect("tempdir");
     let pool = fresh_pool(dir.path()).await;
 
@@ -949,7 +955,14 @@ async fn all_migrations_create_exactly_thirty_six_tables() {
         "user",
         "workspace",
     ];
-    assert_eq!(names.len(), 37, "expected 37 v1 tables, got {names:?}");
+    // Floor, not a frozen ceiling: new migrations are free to add tables, but
+    // the table count must never drop below the known core set.
+    assert!(
+        names.len() >= expected.len(),
+        "expected at least {} core tables, got {} ({names:?})",
+        expected.len(),
+        names.len()
+    );
     for table in expected {
         assert!(
             names.iter().any(|n| n == table),


### PR DESCRIPTION
## Summary

Restores the **full macOS `hangar-e2e` gate**, which the multica-parity work had accumulated fixture drift on. Two independent fixture-drift fixes, each a stale assertion frozen against an old schema/shape that parity work legitimately grew:

**1. Migration table-count (`tripwire_migrations_apply`)**
- `all_migrations_create_exactly_thirty_six_tables` hardcoded an exact table count (37). Parity work continuously adds migrations that create new tables, so this was permanently red on main whenever a table got added.
- The test's real purpose is catching a migration that DROPS or renames a core table, not freezing the total count. Renamed to `all_migrations_preserve_every_core_table` and replaced `assert_eq!(names.len(), 37, ...)` with a floor check (`names.len() >= expected.len()`), keeping the per-table membership assertions that catch a dropped/renamed table.

**2. Issue-list CSV header (`hangar_cli_integration::issue_list_all_four_formats_are_distinct`)**
- Parity work added an `assignee` column to the issue-list CSV/markdown output (`Issue.assignee`), inserted between `description` and `created_at`. The test asserted the hardcoded **contiguous** substring `id,state,title,description,created_at`, which no longer matched (header is now `id,state,title,description,assignee,created_at,priority,due_date,labels`).
- Replaced the contiguous-substring check with a per-column presence check against the parsed header line, so future column inserts don't drift this gate. This was fixture drift, **not** a real bug — the CSV output is correct.

## Verification (local, this branch)

Ran exactly what the macOS `hangar-e2e` job runs:

- [x] **macOS tripwire gate** (`HANGAR_TRIPWIRE_SMOKE=1 HANGAR_TRIPWIRE_BUDGET_SCALE=3 run_all_tripwires.sh`) — `ran=6 failed=0 skipped=0` (green).
- [x] **Acceptance suite** (`run_acceptance_tests.sh`) — `ran=97 failed=0 skipped=0` (green). Includes `hangar_cli_integration` (30/30) which carried the CSV drift.
- [x] `cargo test -p ainb --test hangar_cli_integration` — 30 passed / 0 failed.
- [x] `cargo test -p ainb-hangar-store --test tripwire_migrations_apply` — green.
- [x] `cargo fmt` (no unrelated drift), `cargo build -p ainb` clean.

**Note on the full (Linux-leg) tripwire suite:** running `run_all_tripwires.sh` *without* SMOKE locally surfaced ~2–8 heavy `ccc_*` / `tcp_*` tmux tripwire timeouts that vary run-to-run (2 in one run, 8 in another). 6 of 8 pass in isolation; the 2 `ccc_*` ones are the known load-sensitive daemon/Codex-transport flakes. These are **pruned from the macOS leg by design** (`HANGAR_TRIPWIRE_SMOKE`) — the macOS runner is too small to run the full heavy serial suite, and the Linux leg is the authoritative full matrix. No fix needed for the macOS gate; no real regression found.
