### PR TITLE
feat(hangar): two-dimensional derived presence (availability × workload)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -24,7 +24,7 @@ use ainb_hangar_core::ids::{AgentId, AutopilotId, CommentId, IssueId, SkillId, W
 use ainb_hangar_core::task_status::TaskStatus;
 use ainb_hangar_proto::events::{
     ActorRow, AttentionRow, AutopilotRow, AutopilotRunRow, CommentRow, InboxEntryRow, IssueRow,
-    PresenceState, SkillFile, SkillRow, TaskCardRow,
+    PresenceState, SkillFile, SkillRow, TaskCardRow, Workload,
 };
 use ainb_hangar_proto::snapshots::{SkillDetail, SkillsSyncResult};
 use ainb_hangar_store::repo::agent::AgentRepo;
@@ -439,8 +439,13 @@ pub async fn agents_list(
 ) -> Result<Vec<ActorRow>, sqlx::Error> {
     let mut out = Vec::new();
 
+    // Fetch the whole workspace's live task counts ONCE (multica buildPresenceMap)
+    // so the per-agent workload dimension is an O(1) map lookup, not an N+1 query.
+    let workload_map = TaskRepo::live_workload_by_workspace(pool, workspace_id).await?;
+
     for agent in AgentRepo::list_by_workspace(pool, workspace_id).await? {
-        out.push(agent_actor_row(pool, &agent).await?);
+        let (running, queued) = workload_map.get(&agent.id).copied().unwrap_or((0, 0));
+        out.push(agent_actor_row_with_counts(pool, &agent, running, queued).await?);
     }
 
     for member in members_of(pool, workspace_id).await? {
@@ -449,6 +454,8 @@ pub async fn agents_list(
             display_name: member.email,
             subtitle: member.role,
             presence: PresenceState::Online,
+            // A human member carries no live task workload — always Idle.
+            workload: Workload::Idle,
             is_agent: false,
             recent_rank: None,
         });
@@ -759,20 +766,41 @@ fn presence_from_status(status: &str) -> PresenceState {
 }
 
 /// Map one store [`Agent`](ainb_hangar_store::repo::agent::Agent) onto its picker
-/// [`ActorRow`], deriving presence from the backing runtime's status.
+/// [`ActorRow`], deriving presence from the backing runtime's status and the
+/// workload dimension from the agent's OWN live task counts.
 ///
-/// Shared by [`agents_list`] and the e38.15 agent-CRUD wrappers
-/// ([`agent_update`] / [`agent_archive`]) so the row a mutation answers with is
-/// byte-identical to the same agent's `agents_list` row. A missing runtime maps
+/// Shared by the e38.15 agent-CRUD wrappers ([`agent_update`] / [`agent_archive`])
+/// so the row a mutation answers with is byte-identical to the same agent's
+/// `agents_list` row. Fetches the single-agent live counts itself (the batch
+/// [`agents_list`] path instead resolves them once and calls
+/// [`agent_actor_row_with_counts`] directly, avoiding an N+1 query).
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the runtime or task-count lookup fails.
+async fn agent_actor_row(
+    pool: &SqlitePool,
+    agent: &ainb_hangar_store::repo::agent::Agent,
+) -> Result<ActorRow, sqlx::Error> {
+    let (running, queued) = TaskRepo::live_workload_for_agent(pool, &agent.id).await?;
+    agent_actor_row_with_counts(pool, agent, running, queued).await
+}
+
+/// Build one agent's picker [`ActorRow`] from its store row plus already-resolved
+/// live task counts (`running`, `queued`), deriving presence from the runtime and
+/// workload via [`Workload::derive`]. The counts-taking seam lets [`agents_list`]
+/// batch the workload query once for the whole workspace. A missing runtime maps
 /// to `Offline` (the runtime FK is required, but a deleted-out-of-band runtime
 /// must not panic the snapshot).
 ///
 /// # Errors
 ///
 /// Returns a [`sqlx::Error`] if the runtime lookup fails.
-async fn agent_actor_row(
+async fn agent_actor_row_with_counts(
     pool: &SqlitePool,
     agent: &ainb_hangar_store::repo::agent::Agent,
+    running: i64,
+    queued: i64,
 ) -> Result<ActorRow, sqlx::Error> {
     let presence = match AgentRuntimeRepo::get(pool, &agent.runtime_id).await? {
         Some(rt) => presence_from_status(&rt.status),
@@ -783,6 +811,7 @@ async fn agent_actor_row(
         display_name: agent.name.clone(),
         subtitle: "agent".to_string(),
         presence,
+        workload: Workload::derive(running, queued),
         is_agent: true,
         recent_rank: None,
     })

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_workload.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_workload.rs
@@ -1,0 +1,143 @@
+//! Integration: the `hangar/agents_list` snapshot carries the two-dimensional
+//! presence (multica gap #6) — an agent's `ActorRow.workload` is derived from its
+//! LIVE task counts, orthogonal to its `presence` availability. As a task on the
+//! agent walks its lifecycle the workload flips `Idle → Queued → Working → Idle`
+//! while `presence` stays `Online` throughout (proving the dimensions are
+//! independent), and the single-row `agent_update` response carries the SAME
+//! workload as the batch `agents_list` row for that agent.
+
+use ainb_hangar_core::task_status::TaskStatus;
+use ainb_hangar_daemon::rpc::snapshots;
+use ainb_hangar_proto::events::{PresenceState, Workload};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::agent::AgentConfigUpdate;
+use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
+
+const WS: &str = "ws-a";
+const RT: &str = "rt-a";
+const AGENT: &str = "agent-a";
+
+/// Seed a workspace with an ONLINE runtime + one agent, so availability reads
+/// `online` and workload is the only dimension that moves.
+async fn seed(store: &Store) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(WS)
+        .bind(WS)
+        .bind(WS)
+        .execute(store.pool())
+        .await
+        .expect("ws");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u', 'u@x.test', 0)")
+        .execute(store.pool())
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode, status) \
+         VALUES (?, ?, 'd', 'claude', 'local', 'online')",
+    )
+    .bind(RT)
+    .bind(WS)
+    .execute(store.pool())
+    .await
+    .expect("runtime");
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES (?, ?, ?, ?, 'workspace', 'u')",
+    )
+    .bind(AGENT)
+    .bind(WS)
+    .bind(AGENT)
+    .bind(RT)
+    .execute(store.pool())
+    .await
+    .expect("agent");
+}
+
+fn new_task(id: &str) -> NewTask {
+    NewTask {
+        id: id.into(),
+        workspace_id: WS.into(),
+        runtime_id: RT.into(),
+        agent_id: AGENT.into(),
+        issue_id: None,
+        work_dir: None,
+        priority: 0,
+        created_at: 100,
+        autopilot_run_id: None,
+        generation: 0,
+    }
+}
+
+/// The agent row's workload in the current `agents_list` snapshot.
+async fn agent_row(store: &Store) -> ainb_hangar_proto::events::ActorRow {
+    snapshots::agents_list(store.pool(), WS)
+        .await
+        .expect("agents_list")
+        .into_iter()
+        .find(|a| a.actor_ref == format!("agent:{AGENT}"))
+        .expect("agent row present")
+}
+
+#[tokio::test]
+async fn agents_list_workload_tracks_lifecycle_and_agent_update_agrees() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    // Baseline: no tasks → Idle, availability online.
+    let row = agent_row(&store).await;
+    assert_eq!(row.presence, PresenceState::Online);
+    assert_eq!(row.workload, Workload::Idle, "no live tasks → idle");
+
+    // Enqueue → Queued (availability unchanged).
+    TaskRepo::insert(store.pool(), &new_task("t-1")).await.unwrap();
+    let row = agent_row(&store).await;
+    assert_eq!(
+        row.presence,
+        PresenceState::Online,
+        "availability unchanged"
+    );
+    assert_eq!(row.workload, Workload::Queued);
+
+    // Running → Working.
+    TaskRepo::transition_status(store.pool(), WS, "t-1", TaskStatus::Running, 200)
+        .await
+        .unwrap();
+    let row = agent_row(&store).await;
+    assert_eq!(row.presence, PresenceState::Online);
+    assert_eq!(row.workload, Workload::Working);
+
+    // The single-row agent_update response carries the SAME workload as the
+    // batch agents_list row (a no-op rename to the same name still re-reads it).
+    let updated = snapshots::agent_update(
+        store.pool(),
+        WS,
+        AGENT,
+        &AgentConfigUpdate {
+            name: Some(AGENT.to_string()),
+            instructions: None,
+            model: None,
+            cli_args: None,
+            mcp_config: None,
+            thinking: None,
+            agent_env: None,
+            token_budget: None,
+        },
+    )
+    .await
+    .expect("agent_update")
+    .expect("row present");
+    assert_eq!(
+        updated.workload,
+        Workload::Working,
+        "single-row CRUD workload matches the batch snapshot",
+    );
+
+    // Done → back to Idle (terminal excluded), availability still online.
+    TaskRepo::transition_status(store.pool(), WS, "t-1", TaskStatus::Done, 300)
+        .await
+        .unwrap();
+    let row = agent_row(&store).await;
+    assert_eq!(row.presence, PresenceState::Online);
+    assert_eq!(row.workload, Workload::Idle, "terminal task → idle");
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -238,6 +238,50 @@ pub enum PresenceState {
     Offline,
 }
 
+/// Workload dimension (multica `Workload`), orthogonal to availability.
+///
+/// Derived from LIVE task counts only — terminal tasks
+/// (`done`/`failed`/`cancelled`) are excluded, so history never bleeds into the
+/// list-level dot. An agent is a `(presence, workload)` pair: e.g.
+/// `online · working`, `unstable · queued`, `offline · idle`. `Unstable`
+/// (runtime degraded) must never be conflated with `Queued` (waiting work) — the
+/// two dimensions ([`PresenceState`] and this) are computed independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Workload {
+    /// At least one task is `running` (`⚙ working`, green).
+    Working,
+    /// No running task but >=1 `queued`/`dispatched` (`◔ queued`, amber).
+    Queued,
+    /// No live tasks (`· idle`, gray).
+    #[default]
+    Idle,
+}
+
+impl Workload {
+    /// Whether this is the default `Idle` (backs the wire `skip_serializing_if`,
+    /// so an idle workload is omitted from the JSON and the shape only grows for
+    /// a producer that supplies a non-idle value).
+    #[must_use]
+    pub const fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+
+    /// Derive the workload from an agent's LIVE task counts: `running > 0 →
+    /// Working`, else `queued > 0 → Queued`, else `Idle`. Kept here so the store,
+    /// daemon, and tests share one definition (multica `deriveWorkload`).
+    #[must_use]
+    pub const fn derive(running: i64, queued: i64) -> Self {
+        if running > 0 {
+            Self::Working
+        } else if queued > 0 {
+            Self::Queued
+        } else {
+            Self::Idle
+        }
+    }
+}
+
 /// A wire-side issue row.
 ///
 /// This is the daemon's read model carried to the plugin — distinct from the
@@ -384,6 +428,12 @@ pub struct ActorRow {
     pub subtitle: String,
     /// Current presence (drives the inline 3-state dot).
     pub presence: PresenceState,
+    /// Live workload dimension (multica `Workload`), orthogonal to `presence`.
+    /// Derived from the agent's live task counts; `Idle` for members and for a
+    /// pre-workload snapshot (`#[serde(default)]`). Omitted from the wire when
+    /// `Idle` so the shape only grows for a producer that supplies it.
+    #[serde(default, skip_serializing_if = "Workload::is_idle")]
+    pub workload: Workload,
     /// Whether this actor is an agent (`true`) or a human member (`false`).
     pub is_agent: bool,
     /// Recent-use rank: `Some(n)` pins the actor in the `RECENT` section (lower
@@ -605,4 +655,53 @@ pub struct CommentRow {
     pub body: String,
     /// Creation timestamp (epoch milliseconds).
     pub created_at: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Workload::derive` folds live counts per the multica precedence:
+    /// `running > 0 → Working` beats `queued > 0 → Queued` beats `Idle`.
+    #[test]
+    fn workload_derive_precedence() {
+        assert_eq!(Workload::derive(0, 0), Workload::Idle);
+        assert_eq!(Workload::derive(0, 3), Workload::Queued);
+        assert_eq!(Workload::derive(2, 0), Workload::Working);
+        // running wins even when both are non-zero.
+        assert_eq!(Workload::derive(1, 5), Workload::Working);
+    }
+
+    /// An `ActorRow` JSON without a `workload` key decodes to `Idle` (a
+    /// pre-workload snapshot), and an `Idle` workload is omitted from the wire.
+    #[test]
+    fn actor_row_workload_is_additive_wire() {
+        let json = r#"{"actor_ref":"agent:a1","display_name":"bot","subtitle":"agent","presence":"online","is_agent":true,"recent_rank":null}"#;
+        let row: ActorRow = serde_json::from_str(json).unwrap();
+        assert_eq!(row.workload, Workload::Idle);
+
+        // Idle is skip_serializing_if — the key never appears for an idle row.
+        let out = serde_json::to_string(&row).unwrap();
+        assert!(
+            !out.contains("workload"),
+            "idle workload must be omitted from the wire: {out}"
+        );
+    }
+
+    /// A non-idle workload round-trips through JSON as a `snake_case` token.
+    #[test]
+    fn actor_row_workload_round_trips() {
+        let row = ActorRow {
+            actor_ref: "agent:a1".into(),
+            display_name: "bot".into(),
+            subtitle: "agent".into(),
+            presence: PresenceState::Online,
+            workload: Workload::Working,
+            is_agent: true,
+            recent_rank: None,
+        };
+        let out = serde_json::to_string(&row).unwrap();
+        assert!(out.contains("\"workload\":\"working\""), "{out}");
+        assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), row);
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2059,7 +2059,7 @@ pub struct DaemonConfigListResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::events::PresenceState;
+    use crate::events::{PresenceState, Workload};
 
     /// The params + result envelopes round-trip through JSON.
     #[test]
@@ -2144,6 +2144,7 @@ mod tests {
                 display_name: "claude-agent".into(),
                 subtitle: "agent · claude".into(),
                 presence: PresenceState::Online,
+                workload: Workload::Working,
                 is_agent: true,
                 recent_rank: Some(0),
             }],

--- a/ainb-tui/crates/ainb-hangar-store/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-store/Cargo.toml
@@ -56,6 +56,9 @@ tracing-subscriber = { workspace = true }
 # tests do not inherit `#[cfg(test)]`, so the feature must be turned on
 # explicitly for the test build.
 ainb-hangar-store = { path = ".", features = ["test-support"] }
+# Test-only: the workload integration test folds live counts through the shared
+# `Workload::derive` so it pins the exact same derivation the daemon ships.
+ainb-hangar-proto = { path = "../ainb-hangar-proto" }
 
 # Local lint config rather than `workspace = true` because the
 # workspace-level lints declare lint groups (clippy::all, ::pedantic,

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -520,6 +520,78 @@ impl TaskRepo {
         rows.iter().map(task_from_row).collect()
     }
 
+    /// Live (non-terminal) task counts per agent for a whole workspace, in one
+    /// O(N) pass — the batch backing for `agents_list`'s workload dimension
+    /// (multica `buildPresenceMap`). Returns `agent_id -> (running, queued)`
+    /// where `queued` folds Hangar's `queued` + `dispatched` (claimed-but-not-yet-
+    /// running is still "waiting to work"). Terminal rows (`done`/`failed`/
+    /// `cancelled`) are excluded, so history never reaches the list-level dot.
+    /// An agent with zero live tasks is absent from the map (the caller defaults
+    /// it to `Idle`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn live_workload_by_workspace(
+        pool: &SqlitePool,
+        workspace_id: &str,
+    ) -> Result<std::collections::HashMap<String, (i64, i64)>, sqlx::Error> {
+        // SQLite booleans are 0/1, so `SUM(status = 'running')` counts the running
+        // rows (same idiom as `issue_aggregate_terminal_state`). The predicate
+        // pre-filters to live rows so the GROUP BY only spans agents with work.
+        let rows = sqlx::query(
+            "SELECT agent_id, \
+                    COALESCE(SUM(status = 'running'), 0) AS running, \
+                    COALESCE(SUM(status IN ('queued','dispatched')), 0) AS queued \
+               FROM agent_task_queue \
+              WHERE workspace_id = ? \
+                AND status IN ('queued','dispatched','running') \
+              GROUP BY agent_id",
+        )
+        .bind(workspace_id)
+        .fetch_all(pool)
+        .await?;
+        rows.iter()
+            .map(|row| {
+                Ok((
+                    row.try_get::<String, _>("agent_id")?,
+                    (
+                        row.try_get::<i64, _>("running")?,
+                        row.try_get::<i64, _>("queued")?,
+                    ),
+                ))
+            })
+            .collect()
+    }
+
+    /// Live (non-terminal) counts for ONE agent — the single-row backing for the
+    /// `agent_update` / `agent_archive` CRUD responses, so their row's workload
+    /// is byte-identical to the same agent's `agents_list` row. Returns
+    /// `(running, queued)`, or `(0, 0)` when the agent has no live task.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn live_workload_for_agent(
+        pool: &SqlitePool,
+        agent_id: &str,
+    ) -> Result<(i64, i64), sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT COALESCE(SUM(status = 'running'), 0) AS running, \
+                    COALESCE(SUM(status IN ('queued','dispatched')), 0) AS queued \
+               FROM agent_task_queue \
+              WHERE agent_id = ? \
+                AND status IN ('queued','dispatched','running')",
+        )
+        .bind(agent_id)
+        .fetch_one(pool)
+        .await?;
+        Ok((
+            row.try_get::<i64, _>("running")?,
+            row.try_get::<i64, _>("queued")?,
+        ))
+    }
+
     /// Move one task to `to_status`, **scoped to `workspace_id`**, stamping the
     /// lifecycle timestamps the new status implies. Backs the Kanban card-move
     /// (P8.4): `Shift+←/→` drags a card to a new column.

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_workload.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_workload.rs
@@ -1,0 +1,187 @@
+//! Integration tests for the workload dimension's store backing (multica gap #6):
+//! [`TaskRepo::live_workload_by_workspace`] (the batch map) and
+//! [`TaskRepo::live_workload_for_agent`] (the single-row CRUD backing). The
+//! property under test is that the counts fold LIVE task counts only — terminal
+//! statuses (`done`/`failed`/`cancelled`) never count — and that
+//! [`Workload::derive`] over them walks `Idle → Queued → Working → Idle` as a
+//! task moves through its real lifecycle via [`TaskRepo::transition_status`] (the
+//! same call the Kanban card-move uses).
+
+use ainb_hangar_core::task_status::TaskStatus;
+use ainb_hangar_proto::events::Workload;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
+
+const WS: &str = "ws-a";
+const RT: &str = "rt-a";
+const AGENT: &str = "agent-a";
+
+/// Seed the minimal FK chain (workspace / user / online runtime / agent) so task
+/// rows insert cleanly and the agent reads as `online` (availability), leaving
+/// workload the only dimension under test.
+async fn seed(store: &Store) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(WS)
+        .bind(WS)
+        .bind(WS)
+        .execute(store.pool())
+        .await
+        .expect("ws");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u', 'u@x.test', 0)")
+        .execute(store.pool())
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode, status) \
+         VALUES (?, ?, 'd', 'claude', 'local', 'online')",
+    )
+    .bind(RT)
+    .bind(WS)
+    .execute(store.pool())
+    .await
+    .expect("runtime");
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES (?, ?, ?, ?, 'workspace', 'u')",
+    )
+    .bind(AGENT)
+    .bind(WS)
+    .bind(AGENT)
+    .bind(RT)
+    .execute(store.pool())
+    .await
+    .expect("agent");
+}
+
+fn new_task(id: &str, created_at: i64) -> NewTask {
+    NewTask {
+        id: id.into(),
+        workspace_id: WS.into(),
+        runtime_id: RT.into(),
+        agent_id: AGENT.into(),
+        issue_id: None,
+        work_dir: None,
+        priority: 0,
+        created_at,
+        autopilot_run_id: None,
+        generation: 0,
+    }
+}
+
+/// The workload derived for `AGENT` from the batch map (defaulting a missing
+/// agent to `(0, 0)` = `Idle`, the daemon's contract).
+async fn agent_workload(store: &Store) -> Workload {
+    let map = TaskRepo::live_workload_by_workspace(store.pool(), WS)
+        .await
+        .expect("batch workload");
+    let (running, queued) = map.get(AGENT).copied().unwrap_or((0, 0));
+    Workload::derive(running, queued)
+}
+
+/// A task walking its real lifecycle drives the agent's workload
+/// `Idle → Queued → Working → Idle`, and the single-agent path agrees with the
+/// batch path at every step. Terminal `done` returns to `Idle` (history excluded).
+#[tokio::test]
+async fn workload_tracks_live_task_lifecycle() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    // (a) No tasks → absent from the batch map → Idle.
+    assert_eq!(agent_workload(&store).await, Workload::Idle);
+    assert_eq!(
+        TaskRepo::live_workload_for_agent(store.pool(), AGENT).await.unwrap(),
+        (0, 0),
+        "no live tasks"
+    );
+
+    // (b) One queued task (insert defaults to `queued`) → Queued.
+    TaskRepo::insert(store.pool(), &new_task("t-1", 100)).await.unwrap();
+    assert_eq!(agent_workload(&store).await, Workload::Queued);
+    assert_eq!(
+        TaskRepo::live_workload_for_agent(store.pool(), AGENT).await.unwrap(),
+        (0, 1),
+    );
+
+    // (c) Transition it to running → Working.
+    assert!(
+        TaskRepo::transition_status(store.pool(), WS, "t-1", TaskStatus::Running, 200)
+            .await
+            .unwrap()
+    );
+    assert_eq!(agent_workload(&store).await, Workload::Working);
+    assert_eq!(
+        TaskRepo::live_workload_for_agent(store.pool(), AGENT).await.unwrap(),
+        (1, 0),
+    );
+
+    // (d) Transition it to done → Idle (terminal rows never count).
+    assert!(
+        TaskRepo::transition_status(store.pool(), WS, "t-1", TaskStatus::Done, 300)
+            .await
+            .unwrap()
+    );
+    assert_eq!(agent_workload(&store).await, Workload::Idle);
+    assert_eq!(
+        TaskRepo::live_workload_for_agent(store.pool(), AGENT).await.unwrap(),
+        (0, 0),
+        "a terminal task is excluded from the live counts",
+    );
+}
+
+/// `dispatched` (claimed-but-not-yet-running) folds into the `queued` count, and
+/// a `running` task alongside a queued one still reads `Working` (running wins).
+#[tokio::test]
+async fn dispatched_counts_as_queued_and_running_wins() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    TaskRepo::insert(store.pool(), &new_task("t-run", 100)).await.unwrap();
+    TaskRepo::insert(store.pool(), &new_task("t-disp", 101)).await.unwrap();
+    // Move one to running, one to dispatched.
+    TaskRepo::transition_status(store.pool(), WS, "t-run", TaskStatus::Running, 200)
+        .await
+        .unwrap();
+    TaskRepo::transition_status(store.pool(), WS, "t-disp", TaskStatus::Dispatched, 200)
+        .await
+        .unwrap();
+
+    let (running, queued) = TaskRepo::live_workload_for_agent(store.pool(), AGENT).await.unwrap();
+    assert_eq!(
+        (running, queued),
+        (1, 1),
+        "dispatched folds into the queued count",
+    );
+    assert_eq!(
+        Workload::derive(running, queued),
+        Workload::Working,
+        "a running task outranks a queued one",
+    );
+}
+
+/// Terminal statuses (`failed`, `cancelled`) never contribute to the live counts.
+#[tokio::test]
+async fn terminal_statuses_never_count() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    for (id, status) in [
+        ("t-fail", TaskStatus::Failed),
+        ("t-cancel", TaskStatus::Cancelled),
+    ] {
+        TaskRepo::insert(store.pool(), &new_task(id, 100)).await.unwrap();
+        TaskRepo::transition_status(store.pool(), WS, id, status, 200).await.unwrap();
+    }
+
+    assert_eq!(
+        TaskRepo::live_workload_for_agent(store.pool(), AGENT).await.unwrap(),
+        (0, 0),
+        "failed + cancelled are terminal — excluded from the live dot",
+    );
+    assert!(
+        TaskRepo::live_workload_by_workspace(store.pool(), WS).await.unwrap().is_empty(),
+        "no agent has a live task",
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -6182,6 +6182,7 @@ mod tests {
             display_name: "alice".into(),
             subtitle: "dev".into(),
             presence: PresenceState::Online,
+            workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent: false,
             recent_rank: Some(0),
         }]);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agent_picker.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agent_picker.rs
@@ -403,6 +403,7 @@ mod render_tests {
             display_name: name.to_string(),
             subtitle: "sub".into(),
             presence: PresenceState::Online,
+            workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank,
         }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -24,7 +24,7 @@
 //!     a single press; never traps the user (a bare Esc leaves navigation intact,
 //!     the footer advertises the tab hotkeys + `q` to leave).
 
-use ainb_hangar_proto::events::{ActorRow, PresenceState};
+use ainb_hangar_proto::events::{ActorRow, PresenceState, Workload};
 use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
 
 use crate::widgets::presence_dot::presence_dot;
@@ -39,6 +39,9 @@ const SOFT_WHITE: Color = Color::rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::rgb(120, 120, 140);
 /// Destructive-confirm red — a delete prompt is never painted like a success.
 const ERROR_RED: Color = Color::rgb(235, 90, 90);
+/// Workload `queued` amber — waiting-to-work, distinct from the `unstable`
+/// availability dot (which is a runtime-degraded signal, never workload).
+const WORKLOAD_AMBER: Color = Color::rgb(230, 180, 60);
 
 /// One agent resolved for render: its canonical ref, display name, subtitle, and
 /// live presence (drives the inline 3-state dot).
@@ -50,8 +53,11 @@ pub struct AgentView {
     pub name: String,
     /// A short subtitle (the snapshot's `subtitle`, e.g. `agent`).
     pub subtitle: String,
-    /// Live presence (drives the inline dot).
+    /// Live presence — the availability dimension (drives the inline dot).
     pub presence: PresenceState,
+    /// Live workload — the orthogonal second dimension (multica `Workload`),
+    /// derived by the daemon from the agent's live task counts.
+    pub workload: Workload,
 }
 
 /// The render-state cache for the Agents screen.
@@ -100,6 +106,7 @@ impl AgentsState {
                 name: a.display_name.clone(),
                 subtitle: a.subtitle.clone(),
                 presence: a.presence,
+                workload: a.workload,
             })
             .collect();
         Self::new(agents)
@@ -498,7 +505,12 @@ fn render_action_hints(buf: &mut WireBuffer, row: u16, area_w: u16) {
     put_str(buf, area_w - hint_w, row, HINTS, GOLD, area_w);
 }
 
-/// Render one agent row: `▶ <name>  <dot> <presence>  · <subtitle>`.
+/// Render one agent row:
+/// `▶ <name>  <dot> <presence> · <wl-glyph> <workload>  · <subtitle>`.
+///
+/// The two dimensions are painted side by side (multica `presence × workload`):
+/// the availability dot+word, then ` · ` + the workload glyph+word colour-coded
+/// by its state, so an `online` agent visibly reads `working` vs `idle`.
 fn render_agent_row(
     buf: &mut WireBuffer,
     row: u16,
@@ -535,6 +547,12 @@ fn render_agent_row(
         MUTED_GRAY,
         area_w,
     );
+    // The orthogonal workload dimension, painted right after availability.
+    let (wl_glyph, wl_color) = workload_dot(agent.workload);
+    x = put_str(buf, x, row, " · ", MUTED_GRAY, area_w);
+    x = put_cell(buf, x, row, wl_glyph, wl_color, area_w);
+    x = put_str(buf, x, row, " ", MUTED_GRAY, area_w);
+    x = put_str(buf, x, row, workload_word(agent.workload), wl_color, area_w);
     if !agent.subtitle.is_empty() {
         x = put_str(buf, x, row, "  · ", MUTED_GRAY, area_w);
         put_str(buf, x, row, &agent.subtitle, MUTED_GRAY, area_w);
@@ -547,6 +565,25 @@ const fn presence_word(presence: PresenceState) -> &'static str {
         PresenceState::Online => "online",
         PresenceState::Unstable => "unstable",
         PresenceState::Offline => "offline",
+    }
+}
+
+/// The lowercase workload word rendered next to its glyph.
+const fn workload_word(workload: Workload) -> &'static str {
+    match workload {
+        Workload::Working => "working",
+        Workload::Queued => "queued",
+        Workload::Idle => "idle",
+    }
+}
+
+/// The workload glyph + colour: `⚙ working` (green), `◔ queued` (amber),
+/// `· idle` (gray) — mirroring the availability `presence_dot` idiom.
+const fn workload_dot(workload: Workload) -> (char, Color) {
+    match workload {
+        Workload::Working => ('⚙', SELECTION_GREEN),
+        Workload::Queued => ('◔', WORKLOAD_AMBER),
+        Workload::Idle => ('·', MUTED_GRAY),
     }
 }
 
@@ -592,6 +629,7 @@ mod tests {
                 "member".into()
             },
             presence: PresenceState::Online,
+            workload: Workload::Idle,
             is_agent,
             recent_rank: None,
         }
@@ -781,6 +819,65 @@ mod tests {
         let text = buffer_text(&buf, 80, 24);
         assert!(text.contains("Delete agent"), "confirm overlay must render");
         assert!(text.contains("backend-bot"), "confirm names the agent");
+    }
+
+    /// `from_actors` carries the workload dimension through from the snapshot.
+    #[test]
+    fn from_actors_carries_workload() {
+        let mut queued = actor("agent:a-1", "backend-bot", true);
+        queued.workload = Workload::Queued;
+        let state = AgentsState::from_actors(&[queued]);
+        assert_eq!(state.agents()[0].workload, Workload::Queued);
+    }
+
+    /// The render paints BOTH dimensions: the availability word AND the
+    /// orthogonal workload word are independently present on the same row.
+    #[test]
+    fn render_shows_both_presence_and_workload() {
+        let state = AgentsState::new(vec![
+            AgentView {
+                actor_ref: "agent:a-1".into(),
+                name: "worker".into(),
+                subtitle: "claude".into(),
+                presence: PresenceState::Online,
+                workload: Workload::Working,
+            },
+            AgentView {
+                actor_ref: "agent:a-2".into(),
+                name: "waiter".into(),
+                subtitle: "claude".into(),
+                presence: PresenceState::Online,
+                workload: Workload::Queued,
+            },
+        ]);
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        // Availability dimension still independently present.
+        assert!(text.contains("online"), "availability word must render");
+        // Orthogonal workload dimension present for both agents.
+        assert!(
+            text.contains("working"),
+            "a running agent renders `working`"
+        );
+        assert!(text.contains("queued"), "a queued agent renders `queued`");
+    }
+
+    /// An idle agent renders the `idle` workload word (the default dimension is
+    /// still surfaced, not blank).
+    #[test]
+    fn render_shows_idle_workload() {
+        let state = AgentsState::new(vec![AgentView {
+            actor_ref: "agent:a-1".into(),
+            name: "resting".into(),
+            subtitle: "claude".into(),
+            presence: PresenceState::Online,
+            workload: Workload::Idle,
+        }]);
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(text.contains("idle"), "an idle agent renders `idle`");
     }
 
     /// Reassemble the buffer text for render assertions.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
@@ -783,6 +783,7 @@ mod tests {
             display_name: name.into(),
             subtitle: String::new(),
             presence,
+            workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank: None,
         }
@@ -908,7 +909,11 @@ mod tests {
     fn create_agent_flow_raises_intent_and_esc_cancels_in_one_press() {
         let state = SquadsState::from_snapshot(&snapshot(), &actors());
         let opened = reduce_squads(&state, SquadsEvent::Key('n')).state;
-        assert_eq!(opened.agent_buffer(), Some(""), "n opens the agent-create input");
+        assert_eq!(
+            opened.agent_buffer(),
+            Some(""),
+            "n opens the agent-create input"
+        );
         assert!(!opened.is_creating(), "the squad-create input stays closed");
 
         // Type "bot".
@@ -919,12 +924,18 @@ mod tests {
 
         // Enter submits and closes the input.
         let out = reduce_squads(&typed, SquadsEvent::Key('\n'));
-        assert_eq!(out.intent, Some(SquadsIntent::CreateAgent { name: "bot".into() }));
+        assert_eq!(
+            out.intent,
+            Some(SquadsIntent::CreateAgent { name: "bot".into() })
+        );
         assert!(out.state.agent_buffer().is_none(), "input closes on submit");
 
         // A SINGLE Esc on the open input cancels with no intent.
         let cancel = reduce_squads(&typed, SquadsEvent::Esc);
-        assert!(cancel.state.agent_buffer().is_none(), "one Esc closes the agent input");
+        assert!(
+            cancel.state.agent_buffer().is_none(),
+            "one Esc closes the agent input"
+        );
         assert!(cancel.intent.is_none());
     }
 
@@ -935,7 +946,11 @@ mod tests {
         let opened = reduce_squads(&state, SquadsEvent::Key('n')).state;
         let out = reduce_squads(&opened, SquadsEvent::Key('\n'));
         assert!(out.intent.is_none());
-        assert_eq!(out.state.agent_buffer(), Some(""), "blank submit keeps the input open");
+        assert_eq!(
+            out.state.agent_buffer(),
+            Some(""),
+            "blank submit keeps the input open"
+        );
     }
 
     /// A blank create submit is a no-op — the input stays open, no intent.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/actor_row.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/actor_row.rs
@@ -153,6 +153,7 @@ mod tests {
             display_name: "name".into(),
             subtitle: "sub".into(),
             presence,
+            workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank: None,
         }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_reducer_test.rs
@@ -34,6 +34,7 @@ fn actor(
             "backend dev".into()
         },
         presence,
+        workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: recent,
     }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_routing_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_routing_test.rs
@@ -24,6 +24,7 @@ fn actor() -> ActorRow {
         display_name: "claude-agent".into(),
         subtitle: "agent · gpt5".into(),
         presence: PresenceState::Online,
+        workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent: true,
         recent_rank: Some(0),
     }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
@@ -22,6 +22,7 @@ fn actor(actor_ref: &str, name: &str, presence: PresenceState, is_agent: bool) -
         display_name: name.into(),
         subtitle: String::new(),
         presence,
+        workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: None,
     }
@@ -89,7 +90,10 @@ fn render_empty_shows_help() {
         full.contains("Press 'n' to create an agent, 'c' to create a squad"),
         "empty help line missing:\n{full}"
     );
-    assert!(full.contains("[n]ew-agent"), "new-agent hint missing:\n{full}");
+    assert!(
+        full.contains("[n]ew-agent"),
+        "new-agent hint missing:\n{full}"
+    );
     assert!(full.contains("[c]reate"), "create hint missing:\n{full}");
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -112,6 +112,7 @@ fn seeded_agents() -> serde_json::Value {
         display_name: name.into(),
         subtitle: String::new(),
         presence,
+        workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: None,
     };


### PR DESCRIPTION
## Multica parity — Gap #6: two-dimensional derived presence (availability × workload)

Adds a second, orthogonal presence dimension to the Agents surface. Before this, an agent showed only **availability** (`online / unstable / offline`, mapped from `agent_runtime.status`) — an `online` agent looked identical whether grinding three tasks or completely idle. This adds **workload** (`working / queued / idle`), derived purely from the agent's **live** task counts, rendered beside availability.

### Derivation (matches multica `deriveWorkload` / `buildPresenceMap`)
```
running_count > 0            → working
else queued_count > 0        → queued
else                         → idle
```
- `queued_count` folds Hangar's `queued` + `dispatched` (claimed-but-not-yet-running is still waiting to work).
- Terminal statuses (`done` / `failed` / `cancelled`) are **excluded** — history never bleeds into the list-level dot.
- The two dimensions are independent: `unstable` (runtime degraded) is never conflated with `queued` (waiting work).

### Changes (buildable crate-atoms)
1. **hangar-proto** — new `Workload` enum + `derive`/`is_idle`; `ActorRow.workload` as an **append-only** wire field (`serde(default, skip_serializing_if)`), so a pre-workload snapshot decodes to `Idle` and idle is omitted from the wire. Proto round-trip test.
2. **hangar-store** — `TaskRepo::live_workload_by_workspace` (O(N) batch map backing `agents_list`) + `live_workload_for_agent` (single-row backing for the CRUD responses), both folding live rows only via SQLite boolean-as-int SUM. Lifecycle integration test.
3. **hangar-daemon** — `agents_list` fetches the batch map once and derives each row's workload (no N+1); the single-agent `agent_actor_row` (used by `agent_update` / `agent_archive`) fetches its own counts so a CRUD response is byte-identical to the batch snapshot. Members are always `Idle`. Snapshot integration test asserts `Idle → Queued → Working → Idle` while `presence` stays `Online`, plus batch/single parity.
4. **hangar-plugin** — `AgentView.workload`; `render_agent_row` paints both dimensions (`⚙ working` green, `◔ queued` amber, `· idle` gray). Render tests assert both words are independently visible.

**No migration** (pure derivation over existing `agent_task_queue` rows). Wire growth is additive only.

### Tests
- proto: `Workload::derive` precedence + additive-wire round-trip.
- store `repo_agent_workload.rs`: task walks its real lifecycle via `transition_status`; `dispatched` folds into queued; terminal statuses never count.
- daemon `rpc_agent_workload.rs`: `agents_list.workload` flips `Idle → Queued → Working → Idle` with `presence` held `Online`; `agent_update` agrees with the batch row.
- plugin render: an `online` agent renders `working` / `queued` / `idle` with availability still independently present.

All touched-crate suites green. `cargo build -p ainb` clean. Branch is merged up to current `origin/main`, which resolved the earlier `tripwire_migrations_apply` failure (a stale-base artifact — main's tripwire is now `all_migrations_preserve_every_core_table`, verified green locally and on the macOS hangar-e2e job here).

**Green on this PR:** Test (macos + ubuntu), ainb-hooks (macos + ubuntu), **hangar-e2e (macos)**, CLI-reference-freshness, Cargo Machete, CodeRabbit.

**Two pre-existing reds, both present on `origin/main` and NOT caused by this gap:**

- **Rustfmt** flags `crates/ainb-hangar-daemon/tests/live_e2e.rs`, a file this branch never modifies (byte-identical to `origin/main`). It is the known stable-vs-nightly rustfmt drift (`stable` rewraps long argv literals `nightly` leaves inline); `origin/main`'s own latest run fails the identical check. Reformatting it is out of scope and would churn an unrelated file.
- **hangar-e2e (ubuntu)** — the ubuntu runner executes the full 59-tripwire suite under contention and flakes on a rotating pool of ~9–10 e2e tripwires (`tripwire_board_auto_move_e2e`, `tripwire_ccc_*`, `tripwire_tcp_card_*`, `tripwire_create_flow_round_trip`, `tripwire_daemon_health_sparkline`, `tripwire_p2_answer_flip_e2e`). **None are touched by this PR** (diff overlap = 0). The macOS hangar-e2e job runs the identical suite and passes. `origin/main`'s latest pre-PR run (30065698791) shows the same shape: ubuntu hangar-e2e `ran=59 failed=9` on the same tripwire pool, macOS green — and the exact failing set differs run-to-run, the signature of a concurrency flake, not a code regression. Rerun-isolated confirms attribution.