### PR TITLE
feat(hangar): squad leader briefing injected at claim (multica parity gap #7)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -233,6 +233,14 @@ pub mod seed;
 /// [`ainb_hangar_store::repo::skill::SkillRepo::upsert_by_name`] — idempotent
 /// and all-or-nothing.
 pub mod skills_sync;
+/// Claim-time squad-leader briefing builder (multica `squad_briefing.go` parity,
+/// gap #7).
+///
+/// [`squad_briefing::build_squad_leader_briefing`] composes the Operating
+/// Protocol + Squad Roster appended to a leader agent's run `CLAUDE.md` at claim
+/// time, so a squad-leader task runs with the coordinator role + the roster of
+/// members it can delegate to. Member tasks and non-squad tasks get no briefing.
+pub mod squad_briefing;
 /// Auto-standup watcher (D13; spec P9 §4.8).
 ///
 /// [`standup::StandupWatcher`] is a daemon-global periodic scan that WRITES

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -837,21 +837,25 @@ async fn prepare_spawn_inputs(
 // Bundling them into a context struct is a larger refactor than this credential
 // change warrants; the sibling run functions here carry the same shape.
 #[allow(clippy::too_many_arguments)]
-/// The claim-time squad-leader briefing injection seam (migration 0045 / GAPS #1).
+/// The claim-time squad-leader briefing (migration 0045 / gap #7).
 ///
-/// When a claimed task carries a `squad_id`, the daemon will inject the leader
-/// briefing (Operating Protocol + Roster + Instructions) into the run's system
-/// instructions here. gap #5 lands the HOOK POINT + the dispatch-log evidence;
-/// the briefing BODY is gap #1 — this returns `None` (no text yet) but logs that
-/// the injection point fired, keyed off the `squad_id`, so the seam is observable.
-fn squad_briefing_hook(task: &Task) -> Option<String> {
+/// When a claimed task carries a `squad_id`, log the injection point (keyed off
+/// the `squad_id` + `task_id`, so the seam stays observable) and build the
+/// leader briefing. Returns `Some(briefing)` ONLY when the claiming agent is the
+/// squad's leader agent (member tasks / non-squad tasks → `None`); the caller
+/// appends it to the run's `CLAUDE.md`. A dangling `squad_id`, a human-leader
+/// squad, or a workspace-id parse fault all resolve to `None` silently — the
+/// task still dispatches.
+async fn squad_leader_briefing(pool: &SqlitePool, task: &Task) -> Option<String> {
     let squad_id = task.squad_id.as_deref()?;
     tracing::info!(
         task_id = %task.id,
         squad_id = %squad_id,
-        "squad briefing hook: leader-briefing injection point (body: gap #1)"
+        "squad briefing hook: leader-briefing injection point"
     );
-    None // gap #1 fills this with buildSquadLeaderBriefing()
+    let workspace = ainb_hangar_core::ids::WorkspaceId::from_str(task.workspace_id.clone()).ok()?;
+    crate::squad_briefing::build_squad_leader_briefing(pool, &workspace, squad_id, &task.agent_id)
+        .await
 }
 
 async fn execute_claimed(
@@ -884,28 +888,34 @@ async fn execute_claimed(
         Err(e) => return finalize_setup_failure(pool, &task, &e, clock, stats, events).await,
     };
 
-    // e38.21: inject the workspace's context prompt into the task's execenv as a
-    // `CLAUDE.md` so the agent run actually sees the per-workspace context (the
-    // provider reads `CLAUDE.md` from its CWD). An unconfigured workspace writes
-    // no file (the v1 behaviour); a config-read or write fault is non-fatal — a
-    // task must still dispatch even if its context cannot be materialised.
-    match workspace_context_prompt(pool, &task.workspace_id).await {
-        Ok(prompt) => {
-            if let Err(e) = write_context_prompt(&env, prompt.as_deref()) {
-                tracing::warn!(error = %e, task_id = %task.id, "context prompt injection failed");
-            }
-        }
+    // e38.21 + gap #7: materialise ONE `CLAUDE.md` in the task's execenv carrying
+    // the workspace context prompt AND (for a squad-LEADER task) the claim-time
+    // squad-leader briefing. The provider reads `CLAUDE.md` from its CWD, so this
+    // is the single seam that makes both provable on disk / in transcript.
+    //
+    // Both parts are best-effort: an unconfigured workspace writes no context
+    // (v1 behaviour), a non-squad or member task gets no briefing, and a
+    // config-read / write fault is non-fatal — a task must still dispatch even if
+    // its context cannot be materialised. Fires BEFORE provider dispatch so the
+    // briefing is injected even when the run later fails to spawn.
+    let ws_prompt = match workspace_context_prompt(pool, &task.workspace_id).await {
+        Ok(p) => p,
         Err(e) => {
             tracing::warn!(error = %e, task_id = %task.id, "context prompt read failed");
+            None
         }
-    }
-
-    // Claim-time squad briefing injection point (migration 0045). Fires BEFORE
-    // provider dispatch so the hook is exercised even when the run later fails to
-    // spawn (a nonexistent provider path still exercises it).
-    if let Some(briefing) = squad_briefing_hook(&task) {
-        // gap #1: merge `briefing` into the run's system instructions / CLAUDE.md here.
-        let _ = briefing;
+    };
+    let briefing = squad_leader_briefing(pool, &task).await;
+    // Append-only / no-replace: the workspace context stays authoritative and the
+    // briefing stacks after it (multica daemon.go append semantics).
+    let combined = match (ws_prompt, briefing) {
+        (Some(p), Some(b)) => Some(format!("{p}\n\n{b}")),
+        (Some(p), None) => Some(p),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+    if let Err(e) = write_context_prompt(&env, combined.as_deref()) {
+        tracing::warn!(error = %e, task_id = %task.id, "context prompt injection failed");
     }
 
     // e38.16: resolve which provider exec path this task routes to (agent →
@@ -3165,16 +3175,21 @@ mod tests {
         );
     }
 
-    /// migration 0045 / gap #5: driving the REAL `execute_claimed` seam for a task
-    /// stamped with a `squad_id` must emit the claim-time squad-briefing hook line —
-    /// carrying BOTH the `task_id` and the `squad_id` — BEFORE the provider spawn.
-    /// The provider paths are nonexistent so the run fails, yet the hook must have
-    /// already fired (the observable seam gap #1 keys its briefing injection off).
-    /// Deleting the `squad_briefing_hook(&task)` call from `execute_claimed` turns
-    /// this RED: no hook event is captured though the row still terminalises.
+    /// migration 0045 / gap #7: driving the REAL `execute_claimed` seam for a
+    /// LEADER task stamped with a `squad_id` must (a) emit the claim-time
+    /// squad-briefing hook line — carrying BOTH `task_id` and `squad_id` — BEFORE
+    /// the provider spawn, AND (b) materialise the leader briefing into the run's
+    /// `CLAUDE.md` (Operating Protocol + Roster with the member's name). The
+    /// provider paths are nonexistent so the run fails, yet both happen first (the
+    /// injection is pre-spawn). A MEMBER task carrying the same `squad_id` gets NO
+    /// roster (only the workspace context, which is unset here → no file). Deleting
+    /// the hook/inject wiring from `execute_claimed` turns this RED.
     #[tokio::test]
-    async fn execute_claimed_fires_the_squad_briefing_hook_before_spawn() {
+    async fn execute_claimed_injects_the_squad_leader_briefing_before_spawn() {
+        use ainb_hangar_core::actor::{ActorKind, ActorRef};
+        use ainb_hangar_core::ids::WorkspaceId;
         use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::squad::SquadRepo;
         use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
         use ainb_hangar_store::service::claim::ClaimTaskService;
         use std::sync::{Arc, Mutex};
@@ -3233,7 +3248,29 @@ mod tests {
         let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
         let rt = bootstrap::default_runtime_id();
         bootstrap::ensure_runtime(pool, &rt, 1).await.unwrap();
-        let agent = bootstrap::create_agent(pool, &ws, "leader", "claude", None).await.unwrap();
+        // A squad "alpha" led by `captain`, with `scout` as a member — so the
+        // leader-task claim resolves a real roster to inject.
+        let captain = bootstrap::create_agent(pool, &ws, "captain", "claude", None).await.unwrap();
+        let scout = bootstrap::create_agent(pool, &ws, "scout", "claude", None).await.unwrap();
+        let ws_id = WorkspaceId::from_str(ws.clone()).unwrap();
+        SquadRepo::create(
+            pool,
+            &ws_id,
+            "squad-alpha",
+            "alpha",
+            &ActorRef::new(ActorKind::Agent, captain.id.clone()).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
+        SquadRepo::add_member(
+            pool,
+            &ws_id,
+            "squad-alpha",
+            &ActorRef::new(ActorKind::Agent, scout.id.clone()).unwrap(),
+        )
+        .await
+        .unwrap();
 
         let task_id =
             ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
@@ -3243,7 +3280,7 @@ mod tests {
                 id: task_id.clone(),
                 workspace_id: ws.clone(),
                 runtime_id: rt.clone(),
-                agent_id: agent.id.clone(),
+                agent_id: captain.id.clone(),
                 issue_id: None,
                 work_dir: None,
                 priority: 0,
@@ -3297,12 +3334,94 @@ mod tests {
             .await
         };
 
+        // A MEMBER task (agent `scout`, same squad) claimed + dispatched next: the
+        // builder returns `None` for a non-leader claimer, so with no workspace
+        // context configured NO `CLAUDE.md` is written. Runs inside the env window
+        // (before the restore below), outside the log-capture guard so the
+        // leader-only hook-once assertion holds.
+        let member_task_id =
+            ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        TaskRepo::insert(
+            pool,
+            &NewTask {
+                id: member_task_id.clone(),
+                workspace_id: ws.clone(),
+                runtime_id: rt.clone(),
+                agent_id: scout.id.clone(),
+                issue_id: None,
+                work_dir: None,
+                priority: 0,
+                created_at: 2,
+                autopilot_run_id: None,
+                generation: 0,
+            },
+        )
+        .await
+        .unwrap();
+        TaskRepo::set_squad_id(pool, &member_task_id, "squad-alpha").await.unwrap();
+        let member_claimed = ClaimTaskService::claim_for_runtime(pool, &rt, &clock)
+            .await
+            .unwrap()
+            .expect("the member task must claim");
+        execute_claimed(
+            pool,
+            &runner,
+            &member_claimed,
+            &clock,
+            &stats,
+            &events,
+            &interactive,
+            Arc::new(ainb_hangar_secrets::InMemoryBackend::new()),
+        )
+        .await
+        .expect("member execute_claimed handles the spawn failure internally");
+
+        // Resolve the on-disk materialised prompts while env is still set.
+        let ws_slug = workspace_slug(pool, &ws).await.unwrap();
+        let leader_md = crate::execenv::task_root(&home, &ws_slug, &task_id)
+            .join("workdir")
+            .join(crate::execenv::CONTEXT_PROMPT_FILE);
+        let member_md = crate::execenv::task_root(&home, &ws_slug, &member_task_id)
+            .join("workdir")
+            .join(crate::execenv::CONTEXT_PROMPT_FILE);
+
         // Restore env BEFORE asserting so a failed assertion never leaks it.
         match prior_home {
             Some(v) => std::env::set_var(ainb_hangar_core::paths::HANGAR_HOME_ENV, v),
             None => std::env::remove_var(ainb_hangar_core::paths::HANGAR_HOME_ENV),
         }
         outcome.expect("execute_claimed handles the spawn failure internally (never Err)");
+
+        // The LEADER task's materialised `CLAUDE.md` carries the full briefing.
+        let leader_prompt = std::fs::read_to_string(&leader_md)
+            .expect("the leader task's CLAUDE.md must be materialised pre-spawn");
+        assert!(
+            leader_prompt.contains("## Squad Operating Protocol"),
+            "leader briefing missing the operating protocol:\n{leader_prompt}"
+        );
+        assert!(
+            leader_prompt.contains("## Squad Roster"),
+            "leader briefing missing the roster:\n{leader_prompt}"
+        );
+        assert!(
+            leader_prompt.contains("Leader (you)"),
+            "leader briefing missing the leader self-row:\n{leader_prompt}"
+        );
+        assert!(
+            leader_prompt.contains("captain"),
+            "leader briefing missing the leader name:\n{leader_prompt}"
+        );
+        assert!(
+            leader_prompt.contains("scout"),
+            "leader briefing missing the member name in the roster:\n{leader_prompt}"
+        );
+
+        // The MEMBER task gets no roster (no file at all, since no workspace ctx).
+        assert!(
+            !member_md.exists()
+                || !std::fs::read_to_string(&member_md).unwrap().contains("## Squad Roster"),
+            "a member task must NOT receive the leader briefing"
+        );
 
         let events: Vec<Ev> = log.lock().expect("event log").clone();
         let hook: Vec<&Ev> =

--- a/ainb-tui/crates/ainb-hangar-daemon/src/squad_briefing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/squad_briefing.rs
@@ -1,0 +1,346 @@
+//! Claim-time squad-leader briefing (multica `squad_briefing.go` parity, gap #7).
+//!
+//! When the daemon claims a task carrying a `squad_id` AND the claiming agent is
+//! that squad's LEADER, it appends this briefing to the run's materialised
+//! `CLAUDE.md` so the leader agent runs with squad context (the coordinator role
+//! + the roster of members it can delegate to). Member tasks and non-squad tasks
+//! get no briefing.
+//!
+//! # Faithful where it matters, honest where hangar differs
+//!
+//! Ported from multica's `buildSquadLeaderBriefing`, with two deliberate
+//! divergences the current hangar schema forces:
+//!
+//! - **No @mention dispatch.** Multica's roster carries literal
+//!   `[@Name](mention://<type>/<uuid>)` strings that round-trip through its
+//!   mention-parse pipeline. Hangar has no such trigger, so the protocol
+//!   describes coordination without promising a mention link it cannot honour,
+//!   and roster rows carry `name — <agent|human> — <id>` (no mention markdown).
+//! - **No skills / role / `squad.instructions`.** Those columns are downstream
+//!   gaps (not landed), so roster rows omit skills/role and the
+//!   `## Squad Instructions` section is omitted entirely — exactly as multica
+//!   omits it when `squad.instructions` is blank.
+
+use ainb_hangar_core::actor::ActorKind;
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_store::repo::agent::AgentRepo;
+use ainb_hangar_store::repo::squad::{Squad, SquadRepo};
+use sqlx::SqlitePool;
+
+/// The hard-coded, not-user-editable operating protocol prepended to every
+/// squad-leader briefing.
+///
+/// Adapted from multica's `squadOperatingProtocolHeader` + `…HardRules`: hangar
+/// has no @mention trigger and no `multica squad activity` CLI, so the dispatch
+/// mechanism is described as coordination over the roster rather than a mention
+/// link, and the two `ownsIssueStatus` responsibility-6 variants are dropped
+/// (hangar has no comment/status-ask pipeline to hang them on).
+const SQUAD_OPERATING_PROTOCOL: &str = "\
+## Squad Operating Protocol
+
+**You have been activated as a squad LEADER for this task.** Your job is to \
+**coordinate** the squad, not to silently do all the work yourself. Even if the \
+task reads like a direct request to \"do X\", prefer to delegate X to the squad \
+member best suited to it — doing everything yourself defeats the purpose of the \
+squad.
+
+Your responsibilities, in order:
+
+1. **Read the issue** (title, description, latest comments, acceptance criteria) \
+and decide which squad member is best suited to do the work. Match the task to \
+the members listed in the Squad Roster below.
+2. **Delegate and sequence the work** across the members in the Squad Roster. \
+Split the work so each member owns the part that fits them.
+3. **Coordinate, don't re-do.** Track what each member is doing and how the \
+pieces fit together; only do the work yourself when no member is suitable.
+4. **Stop after coordinating.** Once you have decided the plan and handed work \
+to the members, end your turn — you will be re-triggered when a member reports \
+back or the issue moves forward.
+5. **Re-evaluate on each trigger.** When you wake again, read the new activity \
+and decide the next step: delegate the next piece, escalate to the reporter, or \
+close the loop.
+
+Hard rules:
+- Only involve members that appear in the Squad Roster below — nobody else is \
+part of this squad.
+- Do NOT restate the issue body or prior discussion when you delegate — every \
+member already has the full issue context.
+- Do NOT do the implementation work yourself unless the squad has no suitable \
+member for it.
+";
+
+/// Build the leader briefing for `squad_id` IF `claiming_agent_id` is the
+/// squad's leader AGENT; otherwise `None`.
+///
+/// Sections: the Operating Protocol constant, then the Squad Roster (a leader
+/// self-row plus one row per non-archived member). `## Squad Instructions` is
+/// omitted (no `squad.instructions` column yet — parity with multica's
+/// blank-omit).
+///
+/// Returns `None` on:
+/// - squad not found for `(workspace, squad_id)` — the dangling-`squad_id` guard
+///   (mirrors multica's defensive re-check: a squad row gone → skip silently);
+/// - the squad's leader is a human `member` (no agent to brief a runtime with);
+/// - `claiming_agent_id` is not the leader (a member task — multica's
+///   `daemon.go` leader-task discriminant, and the defensive
+///   `squad.LeaderID == resp.Agent.ID` re-check).
+///
+/// The briefing never crosses the JSON-RPC boundary — the caller appends it to
+/// the run CWD's `CLAUDE.md`.
+pub async fn build_squad_leader_briefing(
+    pool: &SqlitePool,
+    workspace: &WorkspaceId,
+    squad_id: &str,
+    claiming_agent_id: &str,
+) -> Option<String> {
+    let squad = SquadRepo::get(pool, workspace, squad_id).await.ok().flatten()?;
+    // Leader-task discriminant + defensive re-check (multica daemon.go:1755):
+    // only an AGENT leader that equals the claimer gets briefed.
+    if squad.leader.kind() != ActorKind::Agent || squad.leader.id() != claiming_agent_id {
+        return None;
+    }
+    let mut out = String::from(SQUAD_OPERATING_PROTOCOL);
+    out.push('\n');
+    out.push_str(&render_roster(pool, &squad).await);
+    Some(out)
+}
+
+/// Render the `## Squad Roster` section: the leader self-row followed by one row
+/// per non-archived, resolvable member.
+///
+/// - The leader self-row uses [`AgentRepo::get`] for the name, falling back to
+///   `"Leader"` on a lookup miss (multica `buildSquadRoster` parity).
+/// - The leader is skipped if it also appears in the member list (no
+///   self-delegation row).
+/// - An `agent` member that cannot be loaded, or that is archived, is skipped
+///   silently (multica `renderMemberRow` parity).
+/// - A human `member` is listed (inert in fan-out, but the leader should see it)
+///   with its email as the label, falling back to the id.
+/// - When no member rows survive: `"Members: (none — you are the only member of
+///   this squad)"`.
+async fn render_roster(pool: &SqlitePool, squad: &Squad) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::from("## Squad Roster\n\n");
+
+    let leader_id = squad.leader.id();
+    let leader_name = AgentRepo::get(pool, leader_id)
+        .await
+        .ok()
+        .flatten()
+        .map_or_else(|| "Leader".to_string(), |a| a.name);
+    out.push_str("Leader (you):\n");
+    let _ = writeln!(out, "- {leader_name} — agent — {leader_id}");
+
+    let mut rows: Vec<String> = Vec::with_capacity(squad.members.len());
+    for m in &squad.members {
+        match m.kind() {
+            ActorKind::Agent => {
+                // Skip the leader-as-member dupe (already shown above).
+                if m.id() == leader_id {
+                    continue;
+                }
+                match AgentRepo::get(pool, m.id()).await {
+                    Ok(Some(agent)) if !agent.archived => {
+                        rows.push(format!("- {} — agent — {}\n", agent.name, m.id()));
+                    }
+                    // Unresolvable or archived agent → skip silently.
+                    _ => {}
+                }
+            }
+            ActorKind::Member => {
+                let label = human_label(pool, m.id()).await;
+                rows.push(format!("- {label} — human — {}\n", m.id()));
+            }
+        }
+    }
+
+    if rows.is_empty() {
+        out.push_str("\nMembers: (none — you are the only member of this squad)\n");
+        return out;
+    }
+    out.push_str("\nMembers:\n");
+    for r in &rows {
+        out.push_str(r);
+    }
+    out
+}
+
+/// Resolve a human member's display label (its `user.email`), falling back to the
+/// raw id when the user row cannot be read — humans have no agent record, so this
+/// is a direct scalar read rather than a repo model.
+async fn human_label(pool: &SqlitePool, user_id: &str) -> String {
+    sqlx::query_scalar::<_, String>("SELECT email FROM user WHERE id = ?")
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| user_id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ainb_hangar_core::actor::ActorRef;
+    use ainb_hangar_store::{Store, bootstrap};
+
+    fn ws(id: &str) -> WorkspaceId {
+        WorkspaceId::from_str(id.to_string()).unwrap()
+    }
+
+    /// A leader claiming its own squad task gets a briefing with the protocol,
+    /// the roster, its self-row and every non-archived member — and NOT the
+    /// archived agent. A member claimer, an unknown squad, and a human-leader
+    /// squad all return `None`.
+    #[tokio::test]
+    async fn builds_leader_briefing_with_roster_skipping_archived() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws_id = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        let w = ws(&ws_id);
+
+        // Leader L + agent members A, B, an archived agent C, and a human H.
+        let leader =
+            bootstrap::create_agent(pool, &ws_id, "captain", "claude", None).await.unwrap();
+        let a = bootstrap::create_agent(pool, &ws_id, "scout", "claude", None).await.unwrap();
+        let b = bootstrap::create_agent(pool, &ws_id, "medic", "claude", None).await.unwrap();
+        let c = bootstrap::create_agent(pool, &ws_id, "ghost", "claude", None).await.unwrap();
+        AgentRepo::set_archived(pool, &ws_id, &c.id, true).await.unwrap();
+
+        SquadRepo::create(
+            pool,
+            &w,
+            "sq-1",
+            "alpha",
+            &ActorRef::new(ActorKind::Agent, leader.id.clone()).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
+        for m in [&a.id, &b.id, &c.id] {
+            SquadRepo::add_member(
+                pool,
+                &w,
+                "sq-1",
+                &ActorRef::new(ActorKind::Agent, m.clone()).unwrap(),
+            )
+            .await
+            .unwrap();
+        }
+        // A human member (email is the label).
+        let human = ainb_hangar_store::repo::member::MemberRepo::add(
+            pool,
+            &w,
+            "hank@example.com",
+            ainb_hangar_store::repo::member::MemberRole::Member,
+        )
+        .await
+        .unwrap();
+        SquadRepo::add_member(
+            pool,
+            &w,
+            "sq-1",
+            &ActorRef::new(ActorKind::Member, human.user_id.clone()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let briefing = build_squad_leader_briefing(pool, &w, "sq-1", &leader.id)
+            .await
+            .expect("leader claim gets a briefing");
+
+        assert!(
+            briefing.contains("## Squad Operating Protocol"),
+            "protocol present"
+        );
+        assert!(briefing.contains("## Squad Roster"), "roster present");
+        assert!(
+            briefing.contains("Leader (you):"),
+            "leader self-row present"
+        );
+        assert!(briefing.contains("captain"), "leader name present");
+        assert!(briefing.contains("scout"), "member A present");
+        assert!(briefing.contains("medic"), "member B present");
+        assert!(
+            briefing.contains("hank@example.com"),
+            "human member present"
+        );
+        assert!(
+            !briefing.contains("ghost"),
+            "archived agent C must be skipped"
+        );
+
+        // A member claiming (not the leader) gets no briefing.
+        assert_eq!(
+            build_squad_leader_briefing(pool, &w, "sq-1", &a.id).await,
+            None
+        );
+        // An unknown squad id → None (dangling-id guard).
+        assert_eq!(
+            build_squad_leader_briefing(pool, &w, "nope", &leader.id).await,
+            None
+        );
+    }
+
+    /// A human-leader squad briefs nobody (no agent runtime to brief).
+    #[tokio::test]
+    async fn human_leader_squad_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws_id = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        let w = ws(&ws_id);
+        let human = ainb_hangar_store::repo::member::MemberRepo::add(
+            pool,
+            &w,
+            "boss@example.com",
+            ainb_hangar_store::repo::member::MemberRole::Owner,
+        )
+        .await
+        .unwrap();
+        SquadRepo::create(
+            pool,
+            &w,
+            "sq-h",
+            "humans",
+            &ActorRef::new(ActorKind::Member, human.user_id.clone()).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            build_squad_leader_briefing(pool, &w, "sq-h", &human.user_id).await,
+            None,
+            "a human leader cannot brief an agent runtime"
+        );
+    }
+
+    /// A solo leader (no other members) renders the lone-member roster line.
+    #[tokio::test]
+    async fn solo_leader_renders_lone_member_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws_id = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        let w = ws(&ws_id);
+        let leader = bootstrap::create_agent(pool, &ws_id, "solo", "claude", None).await.unwrap();
+        SquadRepo::create(
+            pool,
+            &w,
+            "sq-solo",
+            "lonely",
+            &ActorRef::new(ActorKind::Agent, leader.id.clone()).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
+
+        let briefing = build_squad_leader_briefing(pool, &w, "sq-solo", &leader.id).await.unwrap();
+        assert!(
+            briefing.contains("(none — you are the only member of this squad)"),
+            "lone-member line present"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
@@ -216,6 +216,67 @@ impl SquadRepo {
         Ok(squads)
     }
 
+    /// Resolve ONE squad by id within `workspace` (leader + ordered members), or
+    /// `None`.
+    ///
+    /// Workspace-scoped: a squad id from another tenant, or an unknown / hard-
+    /// deleted id (there is no FK on `agent_task_queue.squad_id` — see migration
+    /// 0045), resolves to `None`. The daemon's claim-time briefing injection keys
+    /// off this: a `None` return = skip injection silently (no stale briefing),
+    /// mirroring multica's dangling-`squad_id` guard.
+    ///
+    /// Reuses the same [`decode_actor`] + `(member_type, member_id)` ordering as
+    /// [`list`](Self::list), just filtered to the one id (an id-keyed single-row
+    /// read + one member sub-select, not an O(squads) scan).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if a query or actor-ref decode fails.
+    pub async fn get(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        squad_id: &str,
+    ) -> Result<Option<Squad>, sqlx::Error> {
+        use sqlx::Row;
+        let Some(r) = sqlx::query(
+            "SELECT id, name, leader_type, leader_id FROM squad \
+             WHERE id = ? AND workspace_id = ?",
+        )
+        .bind(squad_id)
+        .bind(workspace.as_str())
+        .fetch_optional(pool)
+        .await?
+        else {
+            return Ok(None);
+        };
+
+        let id: String = r.try_get("id")?;
+        let leader = decode_actor(
+            &r.try_get::<String, _>("leader_type")?,
+            &r.try_get::<String, _>("leader_id")?,
+        )?;
+        let member_rows = sqlx::query(
+            "SELECT member_type, member_id FROM squad_member \
+             WHERE squad_id = ? ORDER BY member_type, member_id",
+        )
+        .bind(&id)
+        .fetch_all(pool)
+        .await?;
+        let mut members = Vec::with_capacity(member_rows.len());
+        for m in &member_rows {
+            members.push(decode_actor(
+                &m.try_get::<String, _>("member_type")?,
+                &m.try_get::<String, _>("member_id")?,
+            )?);
+        }
+        Ok(Some(Squad {
+            id,
+            name: r.try_get("name")?,
+            leader,
+            members,
+        }))
+    }
+
     /// Resolve `squad` to its LEADER's agent id, the seam that makes leader-routing
     /// take effect.
     ///
@@ -497,6 +558,46 @@ mod tests {
         seed_ws(pool, "ws-b").await;
         let foreign = SquadRepo::member_agent_ids(pool, &ws("ws-b"), "s1").await.unwrap();
         assert!(foreign.is_empty(), "a foreign tenant sees no members");
+    }
+
+    /// `get` resolves ONE squad by id with leader + ordered members, returns
+    /// `None` for an unknown id, and is workspace-scoped (a foreign-tenant id
+    /// resolves to `None`) — the claim-time briefing lookup seam.
+    #[tokio::test]
+    async fn get_resolves_one_squad_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_ws(pool, "ws-b").await;
+        SquadRepo::create(pool, &ws("ws-a"), "s1", "alpha", &agent("a-lead"), 1)
+            .await
+            .unwrap();
+        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent("a-2")).await.unwrap();
+        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent("a-1")).await.unwrap();
+        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &member("u-1")).await.unwrap();
+
+        let got = SquadRepo::get(pool, &ws("ws-a"), "s1").await.unwrap().expect("squad present");
+        assert_eq!(got.id, "s1");
+        assert_eq!(got.name, "alpha");
+        assert_eq!(got.leader, agent("a-lead"));
+        assert_eq!(
+            got.members,
+            vec![agent("a-1"), agent("a-2"), member("u-1")],
+            "members ordered by (type, id)"
+        );
+
+        // Unknown id → None.
+        assert_eq!(
+            SquadRepo::get(pool, &ws("ws-a"), "nope").await.unwrap(),
+            None
+        );
+        // Foreign-tenant id → None (tenant guard).
+        assert_eq!(
+            SquadRepo::get(pool, &ws("ws-b"), "s1").await.unwrap(),
+            None,
+            "a foreign tenant cannot resolve the squad"
+        );
     }
 
     /// `leader_agent_id` resolves an agent leader to its agent id (the routing


### PR DESCRIPTION
## Multica parity — Gap #7: squad-leader briefing injected at claim

Closes the gap where a hangar squad-leader task claimed and dispatched with **zero** squad context. The claim-time injection **seam** already existed on main, but the briefing body was a deliberate no-op (`squad_briefing_hook` returned `None`, then `let _ = briefing`), so the materialised run prompt carried no roster. This lands the body.

### What changed
- **`SquadRepo::get`** (store) — id-keyed single-squad lookup (leader + ordered members), workspace-scoped. `None` for an unknown / foreign-tenant id (the dangling-`squad_id` guard the claim path keys off), avoiding an O(squads) `list` scan.
- **`squad_briefing.rs`** (daemon, new) — ports multica's `buildSquadLeaderBriefing`: a hard-coded `## Squad Operating Protocol` constant + a `## Squad Roster` (leader self-row + one row per non-archived member). Returns `Some` **only** when the claiming agent is the squad's leader agent; member tasks, non-squad tasks, human-leader squads and dangling ids all return `None`.
- **`run_loop.rs`** — replaces the no-op hook. Folds the briefing into the single `write_context_prompt` seam so ONE `CLAUDE.md` carries the workspace context prompt **then** the briefing (append-only, briefing last). The observable hook log line (`squad briefing hook: …`, carrying `squad_id` + `task_id`) is preserved inline.

### Faithful where it matters, honest where hangar differs
- **No @mention dispatch.** Multica roster rows carry `[@Name](mention://…)` strings that round-trip through its mention pipeline; hangar has no such trigger, so the protocol describes coordination over the roster and rows carry `name — <agent|human> — <id>` only.
- **No skills / role / `squad.instructions`.** Those columns are downstream gaps (not landed), so the `## Squad Instructions` section is omitted entirely — parity with multica's blank-omit.
- Leader-vs-member is discriminated by `task.agent_id == squad leader agent id` (the natural hangar equivalent of multica's `IsLeaderTask` flag + defensive `LeaderID == Agent.ID` re-check).

**No migration** — 0045 already added `agent_task_queue.squad_id`. No wire/proto change — the briefing is a file in the run CWD, never crosses the JSON-RPC boundary.

### Tests (fail-before / pass-after)
- `SquadRepo::get` — resolves one squad with ordered members; `None` for unknown + foreign-tenant id.
- Builder unit tests — leader claim returns protocol + roster + self-row + members, **skips** the archived agent, lists the human member; member claimer / unknown squad / human-leader squad all `None`; solo leader renders the lone-member line.
- **Extended claim tripwire** (`execute_claimed_injects_the_squad_leader_briefing_before_spawn`) — after a real leader-task claim (nonexistent provider, injection is pre-spawn) the on-disk `CLAUDE.md` contains `## Squad Operating Protocol`, `## Squad Roster`, `Leader (you)`, `captain`, `scout`; a member task's prompt has no roster; the hook log line still fires exactly once. Verified RED against the old no-op (leader `CLAUDE.md` not materialised).

### Verification
- `cargo test -p ainb-hangar-store --lib` (178) and `-p ainb-hangar-daemon --lib` (346) green.
- `cargo clippy` on both touched crates: no new lints.
- `cargo fmt` clean (known-drift `live_e2e.rs` left untouched).
- `cargo build -p ainb` green.

### Real end-to-end acceptance (proven, not just unit)
Drove the live binary + real daemon headlessly under an isolated `AINB_HANGAR_HOME`:
`agent create captain` + `agent create scout` → `squad create alpha --leader agent:captain` → `squad add-member scout` → `squad assign alpha`. The real `assign_to_leader` enqueued a leader task carrying `agent_id=captain` + the `squad_id`. Ran `hangar daemon run`; it claimed the leader task, logged the `squad briefing hook` line, and materialised the run's `CLAUDE.md`. On-disk assertions all PASS: contains `## Squad Operating Protocol`, `## Squad Roster`, `Leader (you)`, `captain` (leader self-row), and `scout` (member row). Isolated home only — repo `git status` stays clean.

### CI honesty (both reds are pre-existing on `main`, not introduced here)
- **Rustfmt** — the only diff is `crates/ainb-hangar-daemon/tests/live_e2e.rs` (a known nightly/stable drift file this PR does not touch). Our four changed files are `cargo fmt` clean.
- **hangar-e2e (ubuntu)** — `ran=59 failed=7`, all 7 the documented full-suite-contention `tripwire_*` flakes (`ccc_*`, `tcp_card_*`, `create_flow_round_trip`, `daemon_health_sparkline`, `p2_answer_flip`) — none touch squad code and all exist on `main`. **hangar-e2e (macOS) passed the identical suite.** Failed jobs re-run to clear the contention.
- Green: Test (macOS + ubuntu), ainb-hooks (macOS + ubuntu), hangar-e2e (macOS), CodeRabbit, CLI-reference, Cargo-Machete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Squad leaders now receive an Operating Protocol and Squad Roster briefing when claiming a task.
  * Briefings identify the leader and active squad members, including both agents and human members.
  * Archived or unavailable members are excluded from rosters.
* **Bug Fixes**
  * Squad briefings are no longer provided to squad members, non-leader tasks, or invalid squad claims.
  * Squad data is correctly scoped to the relevant workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
