### PR TITLE
feat(hangar): guided agent-create wizard (provider/model/instructions) — multica gap #9

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -493,6 +493,9 @@ pub struct AgentCreateArgs {
     /// Provider to record (`claude`/`codex`/`copilot`); defaults to `claude`.
     #[arg(long)]
     pub provider: Option<String>,
+    /// Optional per-agent model override (e.g. `sonnet`, `gpt-5-codex`).
+    #[arg(long)]
+    pub model: Option<String>,
     /// Optional instructions / system prompt for the agent.
     #[arg(long)]
     pub instructions: Option<String>,
@@ -2071,6 +2074,28 @@ async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
     )
     .await
     .context("create agent")?;
+    // Optional model override: mirror the daemon's create-time follow-up so the
+    // CLI create path persists the model too. A blank value is treated as absent
+    // (leaves `model` NULL rather than writing an empty string).
+    if let Some(model) = args
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let update = ainb_hangar_store::repo::agent::AgentConfigUpdate {
+            model: Some(Some(model.to_string())),
+            ..Default::default()
+        };
+        ainb_hangar_store::repo::agent::AgentRepo::update_config(
+            store.pool(),
+            &workspace_id,
+            &agent.id,
+            &update,
+        )
+        .await
+        .context("apply agent model override")?;
+    }
     println!("created agent {}", agent.name);
     Ok(())
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3745,7 +3745,7 @@ async fn handle_agent_create(
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
     let params: ainb_hangar_proto::snapshots::AgentCreateParams =
-        parse_params(req, "{ workspace_id?, name, provider?, instructions? }")?;
+        parse_params(req, "{ workspace_id?, name, provider?, model?, instructions? }")?;
     let name = params.name.trim();
     if name.is_empty() {
         return Err(invalid_params("agent name must not be empty"));
@@ -3763,11 +3763,19 @@ async fn handle_agent_create(
     )
     .await
     .map_err(|e| store_err(&e))?;
-    // Optional create-time token budget (0042): applied as a follow-up config
-    // write rather than widening create_agent's signature across every caller.
-    if let Some(budget) = params.token_budget {
+    // Optional create-time model override (gap #9) + token budget (0042): applied
+    // as a single follow-up config write rather than widening create_agent's
+    // signature across every caller. A blank model is treated as absent (no
+    // spurious empty-string write, so an unset model stays NULL).
+    let model = params
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if model.is_some() || params.token_budget.is_some() {
         let update = ainb_hangar_store::repo::agent::AgentConfigUpdate {
-            token_budget: Some(Some(budget)),
+            model: model.map(|m| Some(m.to_string())),
+            token_budget: params.token_budget.map(Some),
             ..Default::default()
         };
         ainb_hangar_store::repo::agent::AgentRepo::update_config(
@@ -7265,6 +7273,80 @@ mod tests {
             !still_there,
             "the deleted agent must be gone from the roster"
         );
+    }
+
+    /// The guided-create wire (gap #9) persists the FULL structured draft:
+    /// `agent_create` with provider + model + instructions writes all three onto
+    /// the row, not just the name — the load-bearing proof the widened wire lands.
+    #[tokio::test]
+    async fn agent_create_persists_provider_model_and_instructions() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let created = dispatch(
+            store.pool(),
+            &req(
+                methods::HANGAR_AGENT_CREATE,
+                serde_json::json!({
+                    "workspace_id": "default",
+                    "name": "guidedbot",
+                    "provider": "codex",
+                    "model": "gpt-5-codex",
+                    "instructions": "be terse",
+                }),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(created.error.is_none(), "{created:?}");
+
+        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT provider, model, instructions FROM agent WHERE name = 'guidedbot'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(row.0, "codex", "provider persisted");
+        assert_eq!(row.1.as_deref(), Some("gpt-5-codex"), "model persisted");
+        assert_eq!(
+            row.2.as_deref(),
+            Some("be terse"),
+            "instructions persisted"
+        );
+    }
+
+    /// A create that omits `model` leaves the column NULL — no spurious
+    /// empty-string write from the create-time follow-up.
+    #[tokio::test]
+    async fn agent_create_without_model_leaves_model_null() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let created = dispatch(
+            store.pool(),
+            &req(
+                methods::HANGAR_AGENT_CREATE,
+                serde_json::json!({
+                    "workspace_id": "default",
+                    "name": "nomodelbot",
+                    "provider": "claude",
+                }),
+            ),
+            &health(),
+            &sink(),
+        )
+        .await;
+        assert!(created.error.is_none(), "{created:?}");
+
+        let model: Option<String> =
+            sqlx::query_scalar("SELECT model FROM agent WHERE name = 'nomodelbot'")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+        assert!(model.is_none(), "model stays NULL when not supplied");
     }
 
     /// An unknown agent id is rejected (not a silent no-op), mirroring the mutating

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1114,6 +1114,10 @@ pub struct AgentCreateParams {
     /// Optional free-form system prompt / instructions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Optional per-agent model override (e.g. `sonnet`, `gpt-5-codex`); absent =
+    /// the provider default. Applied as a create-time config follow-up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
     /// Optional token budget (rtk/headroom); absent = unlimited (migration 0042).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<i64>,
@@ -2610,6 +2614,7 @@ mod tests {
             name: "reviewer".into(),
             provider: Some("codex".into()),
             instructions: Some("be terse".into()),
+            model: Some("gpt-5-codex".into()),
             token_budget: Some(250_000),
         };
         let s = serde_json::to_string(&full).unwrap();
@@ -2621,6 +2626,7 @@ mod tests {
         assert!(minimal.workspace_id.is_none());
         assert!(minimal.provider.is_none());
         assert!(minimal.instructions.is_none());
+        assert!(minimal.model.is_none());
         // The optional fields are omitted from the serialized form when absent.
         assert_eq!(
             serde_json::to_string(&minimal).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -2771,10 +2771,24 @@ impl HangarPlugin {
         };
         let ws = self.app_state().ws_id.as_str().to_string();
         let (id, method, params) = match action {
-            AgentsAction::Create { name } => (
+            AgentsAction::Create {
+                name,
+                provider,
+                model,
+                instructions,
+            } => (
                 AGENT_CREATE_REQ_ID,
                 daemon_methods::HANGAR_AGENT_CREATE,
-                serde_json::json!({ "workspace_id": ws, "name": name }),
+                // `model` / `instructions` are `Option`s; the proto's
+                // `skip_serializing_if` drops them when absent so the wire stays
+                // clean and the daemon leaves those columns at their defaults.
+                serde_json::json!({
+                    "workspace_id": ws,
+                    "name": name,
+                    "provider": provider,
+                    "model": model,
+                    "instructions": instructions,
+                }),
             ),
             AgentsAction::Delete { actor_ref } => {
                 // Extract the bare agent id from the canonical `agent:<id>` ref; a

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -15,8 +15,11 @@
 //! data (`project_ainb_plugin_owns_data_plane`); the roster comes from the daemon.
 //!
 //! Keys:
-//!   * `n` — create: an inline "New agent name:" input (the exact Squads create
-//!     idiom); Enter on a non-blank name emits [`AgentsIntent::CreateAgent`].
+//!   * `n` — create: a guided wizard (name → provider picker → model →
+//!     instructions → confirm) that collects the real config fields, not just a
+//!     name, and shows a structured draft for review before Enter on the confirm
+//!     step emits [`AgentsIntent::CreateAgent`]. The faithful hangar analog of
+//!     multica's chat → structured-draft → confirm builder, minus the LLM turn.
 //!   * `x` — delete the selected agent behind a confirm overlay (the issue-list
 //!     delete-confirm pattern); Enter confirms → [`AgentsIntent::DeleteAgent`].
 //!   * `j`/`k` — move the selection.
@@ -60,10 +63,60 @@ pub struct AgentView {
     pub workload: Workload,
 }
 
+/// The fixed provider choices the create wizard cycles through — mirrors
+/// `bootstrap::SUPPORTED_PROVIDERS` so the daemon's `normalize_provider` never
+/// rejects a wizard pick (the picker can only land on a supported value).
+const SUPPORTED_PROVIDERS: [&str; 3] = ["claude", "codex", "copilot"];
+
+/// A structured agent draft accumulated across the guided create wizard.
+///
+/// This is the faithful hangar analog of multica's `<agent_draft>` block (minus the
+/// LLM turn): the user reviews it on the `Confirm` step before it fires a real
+/// create. Kept a plain, serializable-shaped struct so a future LLM-draft parser
+/// (agent-reference §1c fast-follow) can target it unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateDraft {
+    /// The new agent's name (required, non-blank to advance past the `Name` step).
+    pub name: String,
+    /// The chosen provider — one of [`SUPPORTED_PROVIDERS`]; defaults to `claude`.
+    pub provider: String,
+    /// The optional per-agent model override; blank = the provider default.
+    pub model: String,
+    /// The optional free-form instructions / system prompt; blank = none.
+    pub instructions: String,
+}
+
+impl Default for CreateDraft {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            provider: SUPPORTED_PROVIDERS[0].to_string(),
+            model: String::new(),
+            instructions: String::new(),
+        }
+    }
+}
+
+/// The step the guided create wizard is on. Enter advances `Name → Provider →
+/// Model → Instructions → Confirm`; Enter on `Confirm` fires the create.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateStep {
+    /// Type the agent name (required).
+    Name,
+    /// Pick the provider from the fixed list (a picker, never free text).
+    Provider,
+    /// Type an optional model override (blank = provider default).
+    Model,
+    /// Type optional instructions (blank = none).
+    Instructions,
+    /// Review the structured draft; Enter creates, Esc cancels.
+    Confirm,
+}
+
 /// The render-state cache for the Agents screen.
 ///
-/// Holds the resolved agents, the list selection, an optional create-name input
-/// buffer (`Some` only while `n` is open), and an optional pending-delete
+/// Holds the resolved agents, the list selection, an optional guided create wizard
+/// (`Some((draft, step))` only while `n` is open), and an optional pending-delete
 /// confirm target (`Some(actor_ref)` only while the `x` overlay is open). The two
 /// overlays are mutually exclusive (only one input at a time). All fields private;
 /// tests and the renderer read through accessors. The scroll offset is derived per
@@ -72,7 +125,7 @@ pub struct AgentView {
 pub struct AgentsState {
     agents: Vec<AgentView>,
     selected: usize,
-    create_input: Option<String>,
+    create: Option<(CreateDraft, CreateStep)>,
     confirm_delete: Option<String>,
     /// A transient ERROR note rendered red above the list — a delete/create
     /// refusal (active tasks, FK-pinned history) so the rejection is never silent.
@@ -87,7 +140,7 @@ impl AgentsState {
         Self {
             agents,
             selected: 0,
-            create_input: None,
+            create: None,
             confirm_delete: None,
             note: None,
         }
@@ -124,16 +177,22 @@ impl AgentsState {
         self.selected
     }
 
-    /// Whether the create-name input is open.
+    /// Whether the guided create wizard is open.
     #[must_use]
     pub const fn is_creating(&self) -> bool {
-        self.create_input.is_some()
+        self.create.is_some()
     }
 
-    /// The current create-name buffer, if the input is open.
+    /// The in-flight create draft, if the wizard is open (render + tests read it).
     #[must_use]
-    pub fn create_buffer(&self) -> Option<&str> {
-        self.create_input.as_deref()
+    pub fn create_draft(&self) -> Option<&CreateDraft> {
+        self.create.as_ref().map(|(draft, _)| draft)
+    }
+
+    /// The current wizard step, if the wizard is open.
+    #[must_use]
+    pub fn create_step(&self) -> Option<CreateStep> {
+        self.create.as_ref().map(|(_, step)| *step)
     }
 
     /// Whether the `x` delete-confirm overlay is open.
@@ -153,13 +212,20 @@ impl AgentsState {
     /// into this screen's reducer rather than letting them switch tabs.
     #[must_use]
     pub const fn is_capturing(&self) -> bool {
-        self.create_input.is_some() || self.confirm_delete.is_some()
+        self.create.is_some() || self.confirm_delete.is_some()
     }
 
-    /// Restore (or clear) the create-name buffer after a snapshot refresh, so a
-    /// background roster refresh mid-typing does not wipe the half-typed name.
-    pub fn set_create_buffer(&mut self, buf: Option<String>) {
-        self.create_input = buf;
+    /// Snapshot the in-flight wizard (draft + step) so a background roster refresh
+    /// can restore it — a refresh mid-wizard must not wipe the collected draft.
+    #[must_use]
+    pub fn create_state(&self) -> Option<(CreateDraft, CreateStep)> {
+        self.create.clone()
+    }
+
+    /// Restore (or clear) the guided create wizard after a snapshot refresh, so a
+    /// background roster refresh mid-wizard does not wipe the collected draft.
+    pub fn set_create_state(&mut self, create: Option<(CreateDraft, CreateStep)>) {
+        self.create = create;
     }
 
     /// Restore (or clear) the delete-confirm target after a refresh — but ONLY when
@@ -230,12 +296,19 @@ pub enum AgentsEvent {
 /// delete by id).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentsIntent {
-    /// Create an AGENT named `name` (`n` + Enter) — `hangar/agent_create`; the glue
-    /// fires it with no ids (the daemon fills workspace / runtime / owner) and folds
-    /// the refreshed roster back.
+    /// Create an AGENT from the guided wizard (`n` → name → provider → model →
+    /// instructions → confirm) — `hangar/agent_create`; the glue fires it with no
+    /// ids (the daemon fills workspace / runtime / owner) and folds the refreshed
+    /// roster back. Carries the full structured draft, not just a name.
     CreateAgent {
         /// The new agent's name (non-blank).
         name: String,
+        /// The chosen provider (one of [`SUPPORTED_PROVIDERS`]).
+        provider: String,
+        /// The optional model override — `None` when the model step was left blank.
+        model: Option<String>,
+        /// The optional instructions — `None` when the step was left blank.
+        instructions: Option<String>,
     },
     /// Delete `actor_ref` (Enter on the `x` confirm overlay) — `hangar/agent_delete`;
     /// the glue extracts the id from the ref and scopes the delete to the workspace.
@@ -259,7 +332,7 @@ pub struct AgentsReduction {
 pub fn reduce_agents(state: &AgentsState, ev: AgentsEvent) -> AgentsReduction {
     match ev {
         AgentsEvent::Key(c) => {
-            if state.create_input.is_some() {
+            if state.create.is_some() {
                 reduce_create_key(state, c)
             } else if state.confirm_delete.is_some() {
                 reduce_confirm_key(state, c)
@@ -271,35 +344,135 @@ pub fn reduce_agents(state: &AgentsState, ev: AgentsEvent) -> AgentsReduction {
     }
 }
 
-/// Handle a key while the create-name input is open: Enter submits (when non-blank)
-/// and emits [`AgentsIntent::CreateAgent`], Backspace deletes, any other printable
-/// char appends. Mirrors the Squads create idiom exactly.
+/// Handle a key while the guided create wizard is open. Step-aware:
+///
+/// * `Name` / `Model` / `Instructions` are free-text fields — printable chars
+///   append, Backspace pops, Enter advances (blank `Name` is a no-op, preserving
+///   the old name-only guard; blank `Model` / `Instructions` are allowed).
+/// * `Provider` is a **picker** — `←`/`→` (mapped to `h`/`l`) or `k`/`j` cycle the
+///   fixed [`SUPPORTED_PROVIDERS`] list; Enter advances. Free text never lands an
+///   unsupported provider, so the daemon's `normalize_provider` never rejects.
+/// * `Confirm` reviews the structured draft — Enter emits the full
+///   [`AgentsIntent::CreateAgent`] and closes the wizard; other keys hold.
 fn reduce_create_key(state: &AgentsState, c: char) -> AgentsReduction {
-    let mut buf = state.create_input.clone().unwrap_or_default();
+    let Some((draft, step)) = state.create.clone() else {
+        return unchanged(state);
+    };
+    match step {
+        CreateStep::Name => reduce_text_step(state, draft, c, CreateStep::Name, |d| &mut d.name),
+        CreateStep::Model => reduce_text_step(state, draft, c, CreateStep::Model, |d| &mut d.model),
+        CreateStep::Instructions => {
+            reduce_text_step(state, draft, c, CreateStep::Instructions, |d| {
+                &mut d.instructions
+            })
+        }
+        CreateStep::Provider => reduce_provider_step(state, draft, c),
+        CreateStep::Confirm => reduce_confirm_step(state, draft, c),
+    }
+}
+
+/// The next wizard step after `step` (Enter advances; `Confirm` fires instead of
+/// advancing, so it is handled by [`reduce_confirm_step`], never here).
+const fn next_step(step: CreateStep) -> CreateStep {
+    match step {
+        CreateStep::Name => CreateStep::Provider,
+        CreateStep::Provider => CreateStep::Model,
+        CreateStep::Model => CreateStep::Instructions,
+        CreateStep::Instructions | CreateStep::Confirm => CreateStep::Confirm,
+    }
+}
+
+/// Fold a key into one free-text wizard step (`Name` / `Model` / `Instructions`).
+/// `field` selects which draft field the step edits. Enter advances to the next
+/// step — except a blank `Name`, which is a no-op (keeps the old name-only guard).
+fn reduce_text_step(
+    state: &AgentsState,
+    mut draft: CreateDraft,
+    c: char,
+    step: CreateStep,
+    field: impl Fn(&mut CreateDraft) -> &mut String,
+) -> AgentsReduction {
     match c {
         '\n' => {
-            let name = buf.trim().to_string();
-            if name.is_empty() {
-                // Blank submit is a no-op — keep the input open.
+            if matches!(step, CreateStep::Name) && draft.name.trim().is_empty() {
+                // Blank name is a no-op — the wizard stays on the Name step.
                 return unchanged(state);
             }
             let mut next = state.clone();
-            next.create_input = None;
-            with_intent(next, AgentsIntent::CreateAgent { name })
+            next.create = Some((draft, next_step(step)));
+            no_intent(next)
         }
         '\u{8}' => {
-            buf.pop();
+            field(&mut draft).pop();
             let mut next = state.clone();
-            next.create_input = Some(buf);
+            next.create = Some((draft, step));
             no_intent(next)
         }
         c if !c.is_control() => {
-            buf.push(c);
+            field(&mut draft).push(c);
             let mut next = state.clone();
-            next.create_input = Some(buf);
+            next.create = Some((draft, step));
             no_intent(next)
         }
         _ => unchanged(state),
+    }
+}
+
+/// Fold a key into the `Provider` picker step: `l`/`j` (or `→`/`↓`) cycle forward,
+/// `h`/`k` (or `←`/`↑`) cycle backward through [`SUPPORTED_PROVIDERS`], Enter
+/// advances. The picker can only ever land on a supported provider.
+fn reduce_provider_step(state: &AgentsState, mut draft: CreateDraft, c: char) -> AgentsReduction {
+    let cur = SUPPORTED_PROVIDERS
+        .iter()
+        .position(|p| *p == draft.provider)
+        .unwrap_or(0);
+    let len = SUPPORTED_PROVIDERS.len();
+    let next_idx = match c {
+        '\n' => {
+            let mut next = state.clone();
+            next.create = Some((draft, next_step(CreateStep::Provider)));
+            return no_intent(next);
+        }
+        'l' | 'j' => (cur + 1) % len,
+        'h' | 'k' => (cur + len - 1) % len,
+        _ => return unchanged(state),
+    };
+    draft.provider = SUPPORTED_PROVIDERS[next_idx].to_string();
+    let mut next = state.clone();
+    next.create = Some((draft, CreateStep::Provider));
+    no_intent(next)
+}
+
+/// Fold a key into the `Confirm` review step: Enter emits the full
+/// [`AgentsIntent::CreateAgent`] (blank model / instructions collapse to `None`)
+/// and closes the wizard; any other key holds the review open.
+fn reduce_confirm_step(state: &AgentsState, draft: CreateDraft, c: char) -> AgentsReduction {
+    if c != '\n' {
+        return unchanged(state);
+    }
+    let model = non_blank(&draft.model);
+    let instructions = non_blank(&draft.instructions);
+    let mut next = state.clone();
+    next.create = None;
+    with_intent(
+        next,
+        AgentsIntent::CreateAgent {
+            name: draft.name.trim().to_string(),
+            provider: draft.provider,
+            model,
+            instructions,
+        },
+    )
+}
+
+/// Trim a draft field, collapsing a blank value to `None` (so a skipped optional
+/// step never writes an empty string).
+fn non_blank(s: &str) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_string())
     }
 }
 
@@ -327,7 +500,7 @@ fn reduce_key(state: &AgentsState, c: char) -> AgentsReduction {
     match c {
         'n' => {
             let mut next = state.clone();
-            next.create_input = Some(String::new());
+            next.create = Some((CreateDraft::default(), CreateStep::Name));
             // A fresh interaction clears any stale refusal note.
             next.note = None;
             no_intent(next)
@@ -366,9 +539,10 @@ fn reduce_esc(state: &AgentsState) -> AgentsReduction {
         let mut next = state.clone();
         next.confirm_delete = None;
         no_intent(next)
-    } else if state.create_input.is_some() {
+    } else if state.create.is_some() {
+        // A single Esc cancels the whole wizard from ANY step (not step-by-step).
         let mut next = state.clone();
-        next.create_input = None;
+        next.create = None;
         no_intent(next)
     } else {
         unchanged(state)
@@ -423,18 +597,11 @@ pub fn render_agents(
         row = row.saturating_add(1);
     }
 
-    // Create-name input takes over the body while open (the `n` prompt).
-    if let Some(buffer) = state.create_buffer() {
-        let line = format!("New agent name: {buffer}▏");
-        put_str(
-            buf,
-            0,
-            row,
-            "Enter an agent name, Esc to cancel",
-            MUTED_GRAY,
-            area_w,
-        );
-        put_str(buf, 0, row.saturating_add(1), &line, GOLD, area_w);
+    // The guided create wizard takes over the body while open (the `n` flow). It
+    // shows the accumulated draft, then the current step's prompt — and on the
+    // final `Confirm` step the full structured draft for review before create.
+    if let Some((draft, step)) = state.create.as_ref() {
+        render_create_wizard(buf, area_w, row, draft, *step);
         return;
     }
 
@@ -482,6 +649,119 @@ pub fn render_agents(
         }
         render_agent_row(buf, y, area_w, agent, idx == state.selected_index());
         y = y.saturating_add(1);
+    }
+}
+
+/// Render the guided create wizard body from `row` down: a title, the draft
+/// collected so far, and the active step's prompt. On the final `Confirm` step it
+/// paints the full structured draft (name / provider / model / instructions) as the
+/// review beat before the create fires — the faithful analog of multica's
+/// draft-then-confirm.
+fn render_create_wizard(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    row: u16,
+    draft: &CreateDraft,
+    step: CreateStep,
+) {
+    put_str(buf, 0, row, "✦ New agent", GOLD, area_w);
+    let mut y = row.saturating_add(1);
+
+    // The accumulated draft above the active prompt (only fields already entered).
+    let show_field = |buf: &mut WireBuffer, y: u16, label: &str, val: &str| {
+        let line = format!("{label}: {val}");
+        put_str(buf, 0, y, &line, MUTED_GRAY, area_w);
+    };
+
+    match step {
+        CreateStep::Name => {
+            put_str(
+                buf,
+                0,
+                y,
+                "Name the agent, Enter to continue, Esc to cancel",
+                MUTED_GRAY,
+                area_w,
+            );
+            let line = format!("Name: {}▏", draft.name);
+            put_str(buf, 0, y.saturating_add(1), &line, GOLD, area_w);
+        }
+        CreateStep::Provider => {
+            show_field(buf, y, "Name", &draft.name);
+            y = y.saturating_add(1);
+            put_str(
+                buf,
+                0,
+                y,
+                "Pick a provider (←/→), Enter to continue, Esc to cancel",
+                MUTED_GRAY,
+                area_w,
+            );
+            // The current choice, framed so the picker reads as a selectable value.
+            let line = format!("Provider: ‹ {} ›", draft.provider);
+            put_str(buf, 0, y.saturating_add(1), &line, GOLD, area_w);
+        }
+        CreateStep::Model => {
+            show_field(buf, y, "Name", &draft.name);
+            y = y.saturating_add(1);
+            show_field(buf, y, "Provider", &draft.provider);
+            y = y.saturating_add(1);
+            put_str(
+                buf,
+                0,
+                y,
+                "Optional model override, Enter to continue (blank = default)",
+                MUTED_GRAY,
+                area_w,
+            );
+            let line = format!("Model: {}▏", draft.model);
+            put_str(buf, 0, y.saturating_add(1), &line, GOLD, area_w);
+        }
+        CreateStep::Instructions => {
+            show_field(buf, y, "Name", &draft.name);
+            y = y.saturating_add(1);
+            show_field(buf, y, "Provider", &draft.provider);
+            y = y.saturating_add(1);
+            put_str(
+                buf,
+                0,
+                y,
+                "Optional instructions, Enter to continue (blank = none)",
+                MUTED_GRAY,
+                area_w,
+            );
+            let line = format!("Instructions: {}▏", draft.instructions);
+            put_str(buf, 0, y.saturating_add(1), &line, GOLD, area_w);
+        }
+        CreateStep::Confirm => {
+            put_str(
+                buf,
+                0,
+                y,
+                "Review the draft — Enter to create, Esc to cancel",
+                MUTED_GRAY,
+                area_w,
+            );
+            y = y.saturating_add(1);
+            show_field(buf, y, "Name", &draft.name);
+            y = y.saturating_add(1);
+            show_field(buf, y, "Provider", &draft.provider);
+            y = y.saturating_add(1);
+            let model = if draft.model.trim().is_empty() {
+                "(default)"
+            } else {
+                draft.model.trim()
+            };
+            show_field(buf, y, "Model", model);
+            y = y.saturating_add(1);
+            let first_line = draft.instructions.lines().next().unwrap_or("");
+            let instr = if first_line.trim().is_empty() {
+                "(none)"
+            } else {
+                first_line
+            };
+            show_field(buf, y, "Instructions", instr);
+        }
     }
 }
 
@@ -669,38 +949,72 @@ mod tests {
         assert_eq!(up.selected_index(), 0);
     }
 
-    /// `n` opens the create input; typing appends; Enter (non-blank) emits a
-    /// `CreateAgent` intent; a single Esc cancels it outright.
+    /// Drive the whole wizard by pressing the given keys in order, returning the
+    /// final reduction (state + any emitted intent).
+    fn drive(state: &AgentsState, keys: &[char]) -> AgentsReduction {
+        let mut cur = state.clone();
+        let mut last = AgentsReduction {
+            state: cur.clone(),
+            intent: None,
+        };
+        for &c in keys {
+            last = reduce_agents(&cur, AgentsEvent::Key(c));
+            cur = last.state.clone();
+        }
+        last
+    }
+
+    /// `n` opens the wizard at `Name`; the full step sequence collects
+    /// name → provider → model → instructions and Enter on `Confirm` emits the
+    /// widened `CreateAgent` intent with every field; a single Esc cancels.
     #[test]
     fn create_flow_raises_intent_and_esc_cancels() {
         let state = AgentsState::from_actors(&snapshot());
         let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
-        assert_eq!(opened.create_buffer(), Some(""), "n opens the create input");
+        assert_eq!(opened.create_step(), Some(CreateStep::Name), "n opens Name");
+        assert_eq!(opened.create_draft().map(|d| d.name.as_str()), Some(""));
         assert!(opened.is_capturing());
 
-        // Type "qa".
-        let typed = reduce_agents(&opened, AgentsEvent::Key('q')).state;
-        let typed = reduce_agents(&typed, AgentsEvent::Key('a')).state;
-        assert_eq!(typed.create_buffer(), Some("qa"));
+        // Name "qa" + Enter -> Provider; '→'(l) cycles claude->codex; Enter -> Model;
+        // type model + Enter -> Instructions; type text + Enter -> Confirm.
+        let at_confirm = drive(
+            &opened,
+            &[
+                'q', 'a', '\n', // Name -> Provider
+                'l', '\n', // pick codex -> Model
+                'g', 'p', 't', '\n', // Model -> Instructions
+                'b', 'e', ' ', 't', 'e', 'r', 's', 'e', '\n', // -> Confirm
+            ],
+        )
+        .state;
+        assert_eq!(at_confirm.create_step(), Some(CreateStep::Confirm));
+        assert_eq!(
+            at_confirm.create_draft().map(|d| d.provider.as_str()),
+            Some("codex"),
+            "the provider picker landed on codex"
+        );
 
-        // Enter submits and closes the input.
-        let out = reduce_agents(&typed, AgentsEvent::Key('\n'));
+        // Enter on Confirm fires the full structured intent and closes the wizard.
+        let out = reduce_agents(&at_confirm, AgentsEvent::Key('\n'));
         assert_eq!(
             out.intent,
-            Some(AgentsIntent::CreateAgent { name: "qa".into() })
+            Some(AgentsIntent::CreateAgent {
+                name: "qa".into(),
+                provider: "codex".into(),
+                model: Some("gpt".into()),
+                instructions: Some("be terse".into()),
+            })
         );
-        assert!(
-            out.state.create_buffer().is_none(),
-            "input closes on submit"
-        );
+        assert!(!out.state.is_creating(), "wizard closes on create");
 
-        // A single Esc on the open input cancels with no intent.
-        let cancel = reduce_agents(&typed, AgentsEvent::Esc);
-        assert!(cancel.state.create_buffer().is_none());
+        // A single Esc mid-wizard (from the Confirm step) cancels with no intent.
+        let cancel = reduce_agents(&at_confirm, AgentsEvent::Esc);
+        assert!(!cancel.state.is_creating());
         assert!(cancel.intent.is_none());
     }
 
-    /// A blank create submit is a no-op — the input stays open, no intent.
+    /// A blank name Enter is a no-op — the wizard stays on the `Name` step, no
+    /// intent (preserves the old name-only guard).
     #[test]
     fn blank_create_submit_is_a_noop() {
         let state = AgentsState::from_actors(&snapshot());
@@ -708,9 +1022,67 @@ mod tests {
         let out = reduce_agents(&opened, AgentsEvent::Key('\n'));
         assert!(out.intent.is_none());
         assert_eq!(
-            out.state.create_buffer(),
-            Some(""),
-            "blank submit keeps the input open"
+            out.state.create_step(),
+            Some(CreateStep::Name),
+            "blank name keeps the wizard on the Name step"
+        );
+    }
+
+    /// Blank model AND blank instructions collapse to `None` on the emitted intent
+    /// (no spurious empty-string write), and the default provider (`claude`) is
+    /// carried when the picker is left untouched.
+    #[test]
+    fn wizard_blank_optionals_are_none() {
+        let state = AgentsState::from_actors(&snapshot());
+        let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
+        // Name "bot" + Enter; Provider Enter (leave claude); Model Enter (blank);
+        // Instructions Enter (blank); Confirm Enter.
+        let out = drive(
+            &opened,
+            &['b', 'o', 't', '\n', '\n', '\n', '\n', '\n'],
+        );
+        assert_eq!(
+            out.intent,
+            Some(AgentsIntent::CreateAgent {
+                name: "bot".into(),
+                provider: "claude".into(),
+                model: None,
+                instructions: None,
+            })
+        );
+    }
+
+    /// A single Esc at the `Provider` step (not the last one) cancels the whole
+    /// wizard in one press — never steps back to `Name`.
+    #[test]
+    fn wizard_esc_cancels_from_any_step() {
+        let state = AgentsState::from_actors(&snapshot());
+        let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
+        let at_provider = drive(&opened, &['a', '\n']).state;
+        assert_eq!(at_provider.create_step(), Some(CreateStep::Provider));
+        let cancelled = reduce_agents(&at_provider, AgentsEvent::Esc);
+        assert!(!cancelled.state.is_creating(), "one Esc closes the wizard");
+        assert!(cancelled.intent.is_none());
+    }
+
+    /// The provider picker cycles the fixed list forward AND backward, wrapping.
+    #[test]
+    fn wizard_provider_picker_cycles() {
+        let state = AgentsState::from_actors(&snapshot());
+        let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
+        let at_provider = drive(&opened, &['a', '\n']).state;
+        assert_eq!(
+            at_provider.create_draft().map(|d| d.provider.as_str()),
+            Some("claude")
+        );
+        // Forward: claude -> codex -> copilot -> claude (wrap).
+        let fwd = drive(&at_provider, &['l', 'l', 'l']).state;
+        assert_eq!(fwd.create_draft().map(|d| d.provider.as_str()), Some("claude"));
+        // Backward from claude wraps to copilot.
+        let back = drive(&at_provider, &['h']).state;
+        assert_eq!(
+            back.create_draft().map(|d| d.provider.as_str()),
+            Some("copilot")
         );
     }
 
@@ -878,6 +1250,52 @@ mod tests {
         render_agents(&mut buf, 80, 1, 23, &state);
         let text = buffer_text(&buf, 80, 24);
         assert!(text.contains("idle"), "an idle agent renders `idle`");
+    }
+
+    /// The `Confirm` step render shows the structured draft for review: the chosen
+    /// provider AND model AND a slice of the instructions are all visible before the
+    /// create fires.
+    #[test]
+    fn render_confirm_step_shows_structured_draft() {
+        let state = AgentsState::from_actors(&snapshot());
+        let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
+        let at_confirm = drive(
+            &opened,
+            &[
+                'q', 'a', '\n', // Name -> Provider
+                'l', '\n', // codex -> Model
+                'g', 'p', 't', '-', '5', '\n', // Model -> Instructions
+                'b', 'e', ' ', 't', 'e', 'r', 's', 'e', '\n', // -> Confirm
+            ],
+        )
+        .state;
+        assert_eq!(at_confirm.create_step(), Some(CreateStep::Confirm));
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &at_confirm);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(text.contains("codex"), "confirm shows the chosen provider");
+        assert!(text.contains("gpt-5"), "confirm shows the chosen model");
+        assert!(
+            text.contains("be terse"),
+            "confirm shows a slice of the instructions"
+        );
+    }
+
+    /// The `Provider` picker step renders the current provider choice.
+    #[test]
+    fn render_provider_step_shows_choice() {
+        let state = AgentsState::from_actors(&snapshot());
+        let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
+        // Name + Enter -> Provider, then cycle to codex.
+        let at_provider = drive(&opened, &['a', '\n', 'l']).state;
+        assert_eq!(at_provider.create_step(), Some(CreateStep::Provider));
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &at_provider);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(
+            text.contains("codex"),
+            "the provider picker shows the current choice"
+        );
     }
 
     /// Reassemble the buffer text for render assertions.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -470,11 +470,20 @@ pub enum SquadAction {
 /// `set_actors` seam the pickers use.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentsAction {
-    /// Create an AGENT named `name` (`n` + Enter) — `hangar/agent_create`; the glue
-    /// fires it with no ids (the daemon fills workspace / runtime / owner).
+    /// Create an AGENT from the guided wizard (`n` → name → provider → model →
+    /// instructions → confirm) — `hangar/agent_create`; the glue fires it with no
+    /// ids (the daemon fills workspace / runtime / owner) and carries the collected
+    /// provider / model / instructions through so the created row is fully
+    /// configured, not just named.
     Create {
         /// The new agent's name.
         name: String,
+        /// The chosen provider (`claude`/`codex`/`copilot`).
+        provider: String,
+        /// The optional per-agent model override (`None` = provider default).
+        model: Option<String>,
+        /// The optional free-form instructions (`None` = left blank).
+        instructions: Option<String>,
     },
     /// Delete `actor_ref` (Enter on the `x` confirm) — `hangar/agent_delete`; the
     /// glue extracts the id and scopes the delete to the workspace.
@@ -914,12 +923,12 @@ impl ScreenStates {
         // background refresh mid-interaction does not wipe the user's input. A
         // delete-confirm whose agent vanished (this delete landed) is dropped.
         let selected = self.agents.selected_index();
-        let creating = self.agents.create_buffer().map(str::to_string);
+        let creating = self.agents.create_state();
         let confirming = self.agents.confirm_target().map(str::to_string);
         let note = self.agents.note().map(str::to_string);
         let mut next_agents = AgentsState::from_actors(&actors);
         next_agents.set_selected(selected);
-        next_agents.set_create_buffer(creating);
+        next_agents.set_create_state(creating);
         next_agents.restore_confirm(confirming);
         next_agents.set_note(note);
         self.agents = next_agents;
@@ -2170,6 +2179,11 @@ fn route_agents(states: &mut ScreenStates, key: &KeyEvent) {
         AgentsEvent::Key('k')
     } else if matches!(key.code, KeyCode::Down) {
         AgentsEvent::Key('j')
+    } else if matches!(key.code, KeyCode::Left) {
+        // `←`/`→` drive the create wizard's provider picker (mapped to `h`/`l`).
+        AgentsEvent::Key('h')
+    } else if matches!(key.code, KeyCode::Right) {
+        AgentsEvent::Key('l')
     } else if let Some(c) = key_char(key) {
         AgentsEvent::Key(c)
     } else {
@@ -2178,7 +2192,17 @@ fn route_agents(states: &mut ScreenStates, key: &KeyEvent) {
     let out = reduce_agents(&states.agents, ev);
     states.agents = out.state;
     states.pending_agents_action = match out.intent {
-        Some(AgentsIntent::CreateAgent { name }) => Some(AgentsAction::Create { name }),
+        Some(AgentsIntent::CreateAgent {
+            name,
+            provider,
+            model,
+            instructions,
+        }) => Some(AgentsAction::Create {
+            name,
+            provider,
+            model,
+            instructions,
+        }),
         Some(AgentsIntent::DeleteAgent { actor_ref }) => Some(AgentsAction::Delete { actor_ref }),
         None => None,
     };


### PR DESCRIPTION
## Multica parity — Gap #9: Conversational Agent Builder (guided create → draft → confirm)

Delivers the load-bearing, tmux-provable invariant behind multica's Agent
Builder: **agent create is guided, collects the real config fields
(model / provider / instructions), the user reviews a structured draft, and
confirming persists all of them** — instead of a bare name that left every knob
NULL and forced a drop to `hangar agent edit`.

### What changed
- **Proto** (`AgentCreateParams`): one append-only optional `model` field
  (serde-skipped when absent; name-only payloads unchanged).
- **Daemon** (`handle_agent_create`): folds the model override into the existing
  `token_budget` create-time follow-up, so a create persists provider + model +
  instructions in a single `update_config`. A blank model is treated as absent
  (column stays NULL — no spurious empty-string write).
- **CLI**: `hangar agent create --model` mirrors the same follow-up, giving a
  deterministic persistence path.
- **TUI** (Agents screen): the name-only input becomes a guided wizard
  `Name → Provider (picker) → Model → Instructions → Confirm`. The confirm step
  renders the structured draft for review before Enter fires the create. The
  provider picker only cycles the supported set (`claude/codex/copilot`), so the
  daemon's `normalize_provider` can never reject a wizard pick. A single Esc
  cancels from any step.
- **Glue**: `AgentsIntent::CreateAgent` / `AgentsAction::Create` and
  `apply_agents_action` widened to carry provider/model/instructions through.

### Honest parity note — what is scoped OUT (not silently dropped)
This is the **guided-wizard** analog of multica's builder — the deterministic,
tmux-provable core beat (structured draft → review → confirm). The full
**live-LLM conversational** builder (hidden `kind='system'` carrier agent, a
`chat_session`, the `<agent_draft>` parse loop, per-runtime available-models
catalog) is a documented fast-follow, because it is (1) blocked on `kind` /
`system_key` columns hangar does not have, and (2) not deterministically
tmux-provable (needs a live LLM to emit the draft). The wizard's `CreateDraft`
struct is authored so that future LLM-draft parser can target it unchanged.
Per-provider model catalog/validation and skills/description/permission_scope in
the draft are separate agent-reference gaps, out of scope here.

### No migration
Every target column already exists (`instructions` 0002, `model` 0015,
`provider` 0041); migration head stays `0047`. This is a wire + TUI + daemon-glue
change only. Append-only wire (`model` additive/optional; no field
removed/renumbered).

### Tests / verification
- **Daemon integration** (`ainb-hangar-daemon`): `agent_create` with
  provider+model+instructions persists all three onto the row; a create omitting
  `model` leaves the column NULL.
- **Reducer** (`ainb-plugin-hangar`): full wizard step sequence emits the widened
  `CreateAgent` intent; blank name is a no-op; blank model/instructions collapse
  to `None`; one Esc cancels from any step; provider picker cycles/wraps.
- **Render**: the Confirm step shows provider + model + a slice of instructions;
  the picker step shows the current choice.
- **CLI end-to-end** (isolated `AINB_HANGAR_HOME`, debug binary):
  `agent create --name clibot --provider copilot --model gpt-5 --instructions
  "cli path"` → row reads `copilot|gpt-5|cli path`; a create without `--model`
  leaves `model` NULL.
- `cargo build -p ainb` + touched-crate lib suites green
  (`ainb-hangar-proto` 52, `ainb-plugin-hangar` 385, `ainb-hangar-daemon` 355).
  `cargo fmt --all --check` clean.

**Note:** the pre-existing `snapshot_daemon_health` version-skew snapshot
(`daemon: 1.15.0` hardcoded vs crate `1.16.1`) fails on `main` too and is
unrelated to this change (health pane / version untouched). CI does not gate on
`cargo clippy -D warnings` (acknowledged pre-existing debt); no new clippy lints
are introduced by the added functions.
