### PR TITLE
feat(hangar): issue acceptance criteria + context references (multica gap #11)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1168,6 +1168,18 @@ pub struct IssueCreateArgs {
     /// is a separate concern; create just records the labels it is handed.
     #[arg(long = "label", action = clap::ArgAction::Append)]
     pub labels: Vec<String>,
+    /// An acceptance criterion (repeatable: `--acceptance "x" --acceptance "y"`).
+    ///
+    /// Persisted as the issue's ordered acceptance-criteria list (migration 0048,
+    /// multica parity); rendered on the detail card's `Acceptance:` block.
+    #[arg(long = "acceptance", action = clap::ArgAction::Append)]
+    pub acceptance_criteria: Vec<String>,
+    /// A context reference — URL / `owner/repo#123` / note (repeatable).
+    ///
+    /// Persisted as the issue's ordered context-reference list (migration 0048,
+    /// multica parity); rendered on the detail card's `Context:` block.
+    #[arg(long = "context-ref", action = clap::ArgAction::Append)]
+    pub context_refs: Vec<String>,
     /// The repo the run executes in: an absolute checkout path, the literal
     /// `scratch`, or a REMOTE (`owner/repo`, a full URL, or `git@…`) — a remote
     /// is cloned once into the shared clone cache and the local path persisted,
@@ -2077,12 +2089,7 @@ async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
     // Optional model override: mirror the daemon's create-time follow-up so the
     // CLI create path persists the model too. A blank value is treated as absent
     // (leaves `model` NULL rather than writing an empty string).
-    if let Some(model) = args
-        .model
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
+    if let Some(model) = args.model.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         let update = ainb_hangar_store::repo::agent::AgentConfigUpdate {
             model: Some(Some(model.to_string())),
             ..Default::default()
@@ -3369,6 +3376,21 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         priority: args.priority,
         due_date: args.due,
         labels: args.labels.clone(),
+        // 0048: trim-drop blank elements — an empty criterion / ref is not data.
+        acceptance_criteria: args
+            .acceptance_criteria
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .collect(),
+        context_refs: args
+            .context_refs
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .collect(),
         parent_issue_id: parent_issue_id.map(ToString::to_string),
         stage: None,
     };
@@ -5600,6 +5622,54 @@ mod tests {
         };
         assert_eq!(args.due, None, "no --due means no due date");
         assert!(args.labels.is_empty(), "no --label means no labels");
+    }
+
+    #[test]
+    fn parses_issue_create_acceptance_and_context_refs() {
+        let cmd = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "issue",
+            "create",
+            "--title",
+            "Ship gap 11",
+            "--acceptance",
+            "cargo build is green",
+            "--acceptance",
+            "detail card shows criteria",
+            "--context-ref",
+            "acme/api#42",
+        ]);
+        let HangarCommand::Issue(IssueCommand::Create(args)) = cmd else {
+            panic!("expected issue create, got {cmd:?}");
+        };
+        assert_eq!(
+            args.acceptance_criteria,
+            vec![
+                "cargo build is green".to_string(),
+                "detail card shows criteria".to_string()
+            ],
+            "--acceptance is repeatable and order-preserving"
+        );
+        assert_eq!(
+            args.context_refs,
+            vec!["acme/api#42".to_string()],
+            "--context-ref is repeatable and order-preserving"
+        );
+
+        // Omitted -> both lists empty.
+        let cmd = parse_hangar(&["ainb", "hangar", "issue", "create", "--title", "Plain"]);
+        let HangarCommand::Issue(IssueCommand::Create(args)) = cmd else {
+            panic!("expected issue create, got {cmd:?}");
+        };
+        assert!(
+            args.acceptance_criteria.is_empty(),
+            "no --acceptance means no criteria"
+        );
+        assert!(
+            args.context_refs.is_empty(),
+            "no --context-ref means no context refs"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_boards_journey.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_boards_journey.rs
@@ -92,6 +92,8 @@ fn main() {
                 parent_issue_id: None,
                 stage: None,
 
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_sync/reconcile.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_sync/reconcile.rs
@@ -419,6 +419,8 @@ impl<'a> ReconcileService<'a> {
             priority: 0,
             due_date: None,
             labels: Vec::new(),
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
             parent_issue_id: None,
             stage: None,
         };

--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -191,6 +191,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -233,6 +233,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3079,7 +3079,7 @@ async fn handle_issue_create(
 
     let params: ainb_hangar_proto::snapshots::IssueCreateParams = parse_params(
         req,
-        "{ workspace_id, title, description?, creator, external_ref? }",
+        "{ workspace_id, title, description?, creator, external_ref?, acceptance_criteria?, context_refs? }",
     )?;
     // The mutating handler must not silently no-op on a typo'd workspace.
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
@@ -3099,6 +3099,22 @@ async fn handle_issue_create(
     // foreign/unknown parent is a client error, never a silent cross-tenant link.
     let parent_issue_id =
         params.parent_issue_id.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    // 0048: trim-drop blank list elements at the boundary — an empty-string
+    // criterion / ref is a UI artefact, not data. An empty list is valid (no error).
+    let acceptance_criteria: Vec<String> = params
+        .acceptance_criteria
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    let context_refs: Vec<String> = params
+        .context_refs
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect();
     if let Some(parent) = parent_issue_id {
         let ok = ainb_hangar_store::repo::issue::IssueRepo::get_by_id(pool, parent)
             .await
@@ -3120,6 +3136,8 @@ async fn handle_issue_create(
         &creator,
         external_ref,
         parent_issue_id,
+        &acceptance_criteria,
+        &context_refs,
     )
     .await
     .map_err(|e| store_err(&e))?;
@@ -3744,8 +3762,10 @@ async fn handle_agent_create(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    let params: ainb_hangar_proto::snapshots::AgentCreateParams =
-        parse_params(req, "{ workspace_id?, name, provider?, model?, instructions? }")?;
+    let params: ainb_hangar_proto::snapshots::AgentCreateParams = parse_params(
+        req,
+        "{ workspace_id?, name, provider?, model?, instructions? }",
+    )?;
     let name = params.name.trim();
     if name.is_empty() {
         return Err(invalid_params("agent name must not be empty"));
@@ -3767,11 +3787,7 @@ async fn handle_agent_create(
     // as a single follow-up config write rather than widening create_agent's
     // signature across every caller. A blank model is treated as absent (no
     // spurious empty-string write, so an unset model stays NULL).
-    let model = params
-        .model
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
+    let model = params.model.as_deref().map(str::trim).filter(|s| !s.is_empty());
     if model.is_some() || params.token_budget.is_some() {
         let update = ainb_hangar_store::repo::agent::AgentConfigUpdate {
             model: model.map(|m| Some(m.to_string())),
@@ -4665,6 +4681,8 @@ async fn handle_board_card_create(
             priority: 0,
             due_date: None,
             labels: Vec::new(),
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
             parent_issue_id: None,
             stage: None,
         },
@@ -7310,11 +7328,7 @@ mod tests {
         .unwrap();
         assert_eq!(row.0, "codex", "provider persisted");
         assert_eq!(row.1.as_deref(), Some("gpt-5-codex"), "model persisted");
-        assert_eq!(
-            row.2.as_deref(),
-            Some("be terse"),
-            "instructions persisted"
-        );
+        assert_eq!(row.2.as_deref(), Some("be terse"), "instructions persisted");
     }
 
     /// A create that omits `model` leaves the column NULL — no spurious
@@ -8833,6 +8847,8 @@ mod tests {
                         labels: Vec::new(),
                         parent_issue_id: None,
                         stage: None,
+                        acceptance_criteria: Vec::new(),
+                        context_refs: Vec::new(),
                     },
                 )
                 .await
@@ -8936,6 +8952,8 @@ mod tests {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await
@@ -9016,6 +9034,8 @@ mod tests {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await
@@ -9101,6 +9121,8 @@ mod tests {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await
@@ -9181,6 +9203,8 @@ mod tests {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await
@@ -9303,6 +9327,8 @@ mod tests {
                     labels: Vec::new(),
                     parent_issue_id: None,
                     stage: None,
+                    acceptance_criteria: Vec::new(),
+                    context_refs: Vec::new(),
                 },
             )
             .await
@@ -9450,6 +9476,8 @@ mod tests {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -129,6 +129,8 @@ pub async fn issues_list(
                 parent_id: extras.parent_id,
                 child_total: extras.child_total,
                 child_done: extras.child_done,
+                acceptance_criteria: issue.acceptance_criteria,
+                context_refs: issue.context_refs,
             });
         }
     }
@@ -289,6 +291,8 @@ pub async fn issues_search(
             parent_id: extras.parent_id,
             child_total: extras.child_total,
             child_done: extras.child_done,
+            acceptance_criteria: issue.acceptance_criteria,
+            context_refs: issue.context_refs,
         });
     }
     Ok(out)
@@ -1585,6 +1589,8 @@ pub async fn issue_row(
         parent_id: extras.parent_id,
         child_total: extras.child_total,
         child_done: extras.child_done,
+        acceptance_criteria: issue.acceptance_criteria,
+        context_refs: issue.context_refs,
     }))
 }
 
@@ -1690,6 +1696,8 @@ async fn read_issue_row(
         parent_id: extras.parent_id,
         child_total: extras.child_total,
         child_done: extras.child_done,
+        acceptance_criteria: issue.acceptance_criteria,
+        context_refs: issue.context_refs,
     }))
 }
 
@@ -1776,6 +1784,8 @@ pub async fn issue_create(
     creator: &ActorRef,
     external_ref: Option<&str>,
     parent_issue_id: Option<&str>,
+    acceptance_criteria: &[String],
+    context_refs: &[String],
 ) -> Result<IssueRow, sqlx::Error> {
     use ainb_hangar_store::repo::card_parity::CardParityRepo;
     use ainb_hangar_store::repo::issue::NewIssue;
@@ -1802,6 +1812,8 @@ pub async fn issue_create(
             priority: 0,
             due_date: None,
             labels: Vec::new(),
+            acceptance_criteria: acceptance_criteria.to_vec(),
+            context_refs: context_refs.to_vec(),
             parent_issue_id: parent_issue_id.map(ToString::to_string),
             stage: None,
         },
@@ -1853,6 +1865,10 @@ pub async fn issue_create(
         parent_id: parent_issue_id.map(str::to_string),
         child_total: 0,
         child_done: 0,
+        // The lists the create captured (blank elements already dropped at the
+        // handler boundary), echoed on the response + pushed IssueCreated event.
+        acceptance_criteria: acceptance_criteria.to_vec(),
+        context_refs: context_refs.to_vec(),
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -3658,6 +3658,8 @@ mod tests {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await
@@ -3757,6 +3759,8 @@ mod tests {
                         labels: Vec::new(),
                         parent_issue_id: None,
                         stage: None,
+                        acceptance_criteria: Vec::new(),
+                        context_refs: Vec::new(),
                     },
                 )
                 .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
@@ -129,6 +129,8 @@ pub async fn seed_p4_fixture(pool: &SqlitePool) -> Result<(), sqlx::Error> {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await?;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/beads_sync_spans_emit.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/beads_sync_spans_emit.rs
@@ -161,6 +161,8 @@ async fn seed_issue(store: &Store, ws: &str, id: &str, title: &str) -> Issue {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
     IssueRepo::get_by_id(store.pool(), id)

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbound_sync.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbound_sync.rs
@@ -64,6 +64,8 @@ async fn seed_issue(store: &Store, ws: &str, id: &str, title: &str) -> String {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
     id.to_string()

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/outbound_sync.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/outbound_sync.rs
@@ -64,6 +64,8 @@ async fn seed_issue(
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
     IssueRepo::get_by_id(store.pool(), id)

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/reconcile.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/reconcile.rs
@@ -88,6 +88,8 @@ async fn seed_issue(store: &Store, id: &str, title: &str, state: &str) -> String
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
     id.to_string()

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -226,6 +226,8 @@ fn issue_event() -> HangarEvent {
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issues_search.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issues_search.rs
@@ -136,6 +136,8 @@ async fn insert_issue(
             labels: Vec::new(),
             parent_issue_id: None,
             stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_search.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_search.rs
@@ -131,6 +131,8 @@ async fn insert_issue(pool: &sqlx::SqlitePool, ws: &str, id: &str, title: &str, 
             labels: Vec::new(),
             parent_issue_id: None,
             stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_beads_roundtrip.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_beads_roundtrip.rs
@@ -82,6 +82,8 @@ async fn seed_issue(store: &Store) -> Issue {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
     IssueRepo::get_by_id(store.pool(), HANGAR_ID)

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_board_auto_move_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_board_auto_move_e2e.rs
@@ -72,6 +72,8 @@ async fn board_card_auto_moves_and_greens_on_run_success() {
             labels: Vec::new(),
             parent_issue_id: None,
             stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_workspace_switch_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_workspace_switch_e2e.rs
@@ -97,6 +97,8 @@ fn seed_second_workspace(home: &std::path::Path) {
                 labels: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -409,6 +409,20 @@ pub struct IssueRow {
     /// keeps a pre-0046 snapshot decodable (defaults to `0`).
     #[serde(default)]
     pub child_done: u32,
+    /// Ordered acceptance-criteria strings (`issue.acceptance_criteria`, migration
+    /// 0048): one criterion per element. Drives the task-detail card's
+    /// `Acceptance:` block. Empty by default; omitted from the wire when empty
+    /// (append-only) so an old client omits it and an old daemon ignores it — a
+    /// pre-0048 snapshot decodes to `[]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub acceptance_criteria: Vec<String>,
+    /// Ordered context-reference strings (`issue.context_refs`, migration 0048):
+    /// URL / `owner/repo#123` / free text, one per element. Drives the task-detail
+    /// card's `Context:` block. Empty by default; omitted from the wire when empty
+    /// (append-only) so an old client omits it and an old daemon ignores it — a
+    /// pre-0048 snapshot decodes to `[]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub context_refs: Vec<String>,
 }
 
 /// A wire-side actor row for the agent-picker snapshot (`hangar/agents_list`).

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1037,6 +1037,18 @@ pub struct IssueCreateParams {
     /// old client omits it, an old daemon ignores it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_issue_id: Option<String>,
+    /// Ordered acceptance-criteria strings authored in the create wizard/CLI
+    /// (migration 0048, multica parity): one criterion per element. Persisted on
+    /// the created issue and rendered on the detail card. Append-only field: an
+    /// old client omits it, an old daemon ignores it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub acceptance_criteria: Vec<String>,
+    /// Ordered context-reference strings (URL / `owner/repo#123` / note) authored
+    /// in the create wizard/CLI (migration 0048, multica parity): one per element.
+    /// Persisted on the created issue and rendered on the detail card. Append-only
+    /// field: an old client omits it, an old daemon ignores it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub context_refs: Vec<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_AGENT_UPDATE`] (e38.15): edit one agent's
@@ -2141,6 +2153,8 @@ mod tests {
                 parent_id: None,
                 child_total: 0,
                 child_done: 0,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             }],
         };
         let s = serde_json::to_string(&issues).unwrap();

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -56,6 +56,8 @@ fn sample_issue() -> IssueRow {
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     }
 }
 
@@ -302,6 +304,8 @@ fn issue_create_params_parent_is_additive() {
         creator: "member:alice".to_string(),
         external_ref: None,
         parent_issue_id: Some("parent-1".to_string()),
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     let json = serde_json::to_string(&sub).expect("encode");
     let back: IssueCreateParams = serde_json::from_str(&json).expect("decode");

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0048_issue_acceptance_context.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0048_issue_acceptance_context.sql
@@ -1,0 +1,10 @@
+-- 0048: structured acceptance criteria + context references on an issue
+-- (multica parity, gap #11 / init.up.sql:66-67 acceptance_criteria + context_refs).
+--
+-- Two JSON-array TEXT columns, identical persistence to `labels` (migration 0014):
+-- each holds an ORDERED list of strings — `acceptance_criteria` a list of criterion
+-- lines, `context_refs` a list of linked references (URLs / `owner/repo#123` / free
+-- text). Default `'[]'` keeps every existing row unchanged. ADD COLUMN with a
+-- constant default is an O(1) catalog change in SQLite (no table rewrite).
+ALTER TABLE issue ADD COLUMN acceptance_criteria TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE issue ADD COLUMN context_refs        TEXT NOT NULL DEFAULT '[]';

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -49,6 +49,14 @@ pub struct NewIssue {
     /// column — the minimal persistence the create flow needs (the full labels
     /// table + attach/detach is a separate concern).
     pub labels: Vec<String>,
+    /// Ordered acceptance-criteria strings (one criterion per element). Stored as
+    /// a single JSON-array column, identical persistence to `labels` (migration
+    /// 0048, multica parity `init.up.sql:66` `acceptance_criteria`).
+    pub acceptance_criteria: Vec<String>,
+    /// Ordered context-reference strings (URL / `owner/repo#123` / free text, one
+    /// per element). Stored as a single JSON-array column, identical persistence to
+    /// `labels` (migration 0048, multica parity `init.up.sql:67` `context_refs`).
+    pub context_refs: Vec<String>,
     /// Optional parent issue: a self-link making this a **sub-issue** of another
     /// issue in the same workspace. `None` = a top-level issue (migration 0046).
     pub parent_issue_id: Option<String>,
@@ -84,6 +92,12 @@ pub struct Issue {
     pub due_date: Option<i64>,
     /// Free-form labels, re-assembled from the JSON-array `labels` column.
     pub labels: Vec<String>,
+    /// Ordered acceptance-criteria strings, re-assembled from the JSON-array
+    /// `acceptance_criteria` column (migration 0048).
+    pub acceptance_criteria: Vec<String>,
+    /// Ordered context-reference strings, re-assembled from the JSON-array
+    /// `context_refs` column (migration 0048).
+    pub context_refs: Vec<String>,
     /// Optional upstream-issue reference (URL or `owner/repo#123`), or `None`
     /// (migration 0043).
     pub external_ref: Option<String>,
@@ -251,12 +265,15 @@ impl IssueRepo {
         let (assignee_type, assignee_id) = split_actor(issue.assignee.as_ref());
         let (creator_type, creator_id) = split_actor(Some(&issue.creator));
         let labels_json = labels_to_json(&issue.labels);
+        let acceptance_json = labels_to_json(&issue.acceptance_criteria);
+        let context_refs_json = labels_to_json(&issue.context_refs);
         sqlx::query(
             "INSERT INTO issue \
              (id, workspace_id, title, description, state, \
               assignee_type, assignee_id, creator_type, creator_id, created_at, \
-              priority, due_date, labels, parent_issue_id, stage) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              priority, due_date, labels, acceptance_criteria, context_refs, \
+              parent_issue_id, stage) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&issue.id)
         .bind(&issue.workspace_id)
@@ -271,6 +288,8 @@ impl IssueRepo {
         .bind(issue.priority)
         .bind(issue.due_date)
         .bind(labels_json)
+        .bind(acceptance_json)
+        .bind(context_refs_json)
         .bind(&issue.parent_issue_id)
         .bind(issue.stage)
         .execute(pool)
@@ -289,7 +308,7 @@ impl IssueRepo {
         let row = sqlx::query(
             "SELECT id, workspace_id, title, description, state, \
              assignee_type, assignee_id, creator_type, creator_id, created_at, \
-             priority, due_date, labels, external_ref, parent_issue_id, stage \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage \
              FROM issue WHERE id = ?",
         )
         .bind(id)
@@ -410,7 +429,7 @@ impl IssueRepo {
         let rows = sqlx::query(
             "SELECT id, workspace_id, title, description, state, \
              assignee_type, assignee_id, creator_type, creator_id, created_at, \
-             priority, due_date, labels, external_ref, parent_issue_id, stage \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage \
              FROM issue WHERE workspace_id = ? AND state = ? ORDER BY created_at",
         )
         .bind(workspace_id)
@@ -438,7 +457,7 @@ impl IssueRepo {
         let rows = sqlx::query(
             "SELECT id, workspace_id, title, description, state, \
              assignee_type, assignee_id, creator_type, creator_id, created_at, \
-             priority, due_date, labels, external_ref, parent_issue_id, stage \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage \
              FROM issue WHERE parent_issue_id = ? \
              ORDER BY stage IS NULL, stage, created_at, id",
         )
@@ -568,7 +587,7 @@ impl IssueRepo {
         let rows = sqlx::query(
             "SELECT i.id, i.workspace_id, i.title, i.description, i.state, \
              i.assignee_type, i.assignee_id, i.creator_type, i.creator_id, i.created_at, \
-             i.priority, i.due_date, i.labels, i.external_ref, i.parent_issue_id, i.stage, \
+             i.priority, i.due_date, i.labels, i.acceptance_criteria, i.context_refs, i.external_ref, i.parent_issue_id, i.stage, \
              MAX(CASE \
                  WHEN LOWER(i.title) LIKE ?2 ESCAPE '\\' THEN 3 \
                  WHEN LOWER(i.description) LIKE ?2 ESCAPE '\\' THEN 2 \
@@ -866,6 +885,8 @@ fn issue_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Issue, sqlx::Error> {
     )?
     .ok_or_else(|| decode_err("creator", "creator columns must be non-null"))?;
     let labels = labels_from_json(&row.try_get::<String, _>("labels")?)?;
+    let acceptance_criteria = labels_from_json(&row.try_get::<String, _>("acceptance_criteria")?)?;
+    let context_refs = labels_from_json(&row.try_get::<String, _>("context_refs")?)?;
     Ok(Issue {
         id: row.try_get("id")?,
         workspace_id: row.try_get("workspace_id")?,
@@ -878,6 +899,8 @@ fn issue_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Issue, sqlx::Error> {
         priority: row.try_get("priority")?,
         due_date: row.try_get("due_date")?,
         labels,
+        acceptance_criteria,
+        context_refs,
         external_ref: row.try_get("external_ref")?,
         parent_issue_id: row.try_get("parent_issue_id")?,
         stage: row.try_get("stage")?,
@@ -950,6 +973,8 @@ mod tests {
                 priority: 0,
                 due_date: None,
                 labels: Vec::new(),
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
                 parent_issue_id: None,
                 stage: None,
             },
@@ -1007,6 +1032,67 @@ mod tests {
             unchanged.title, "New title",
             "foreign-tenant edit left the title"
         );
+    }
+
+    /// `acceptance_criteria` + `context_refs` round-trip verbatim and
+    /// order-preserving through insert → `get_by_id`, and a create without them
+    /// reads back as empty (migration 0048 default `'[]'`).
+    #[tokio::test]
+    async fn acceptance_criteria_and_context_refs_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+
+        IssueRepo::insert(
+            pool,
+            &NewIssue {
+                id: "issue-ac".into(),
+                workspace_id: "ws-a".into(),
+                title: "Ship gap 11".into(),
+                description: None,
+                state: "open".into(),
+                assignee: None,
+                creator: member(),
+                created_at: 1,
+                priority: 0,
+                due_date: None,
+                labels: Vec::new(),
+                acceptance_criteria: vec![
+                    "cargo build is green".into(),
+                    "detail card shows criteria".into(),
+                ],
+                context_refs: vec!["acme/api#42".into()],
+                parent_issue_id: None,
+                stage: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let issue = IssueRepo::get_by_id(pool, "issue-ac").await.unwrap().unwrap();
+        assert_eq!(
+            issue.acceptance_criteria,
+            vec![
+                "cargo build is green".to_string(),
+                "detail card shows criteria".to_string()
+            ],
+            "criteria survive verbatim and order-preserving"
+        );
+        assert_eq!(
+            issue.context_refs,
+            vec!["acme/api#42".to_string()],
+            "context refs survive verbatim"
+        );
+
+        // A create without the two lists reads back as the empty default.
+        seed_issue(pool, "ws-a", "issue-plain", "No lists", None, 2).await;
+        let plain = IssueRepo::get_by_id(pool, "issue-plain").await.unwrap().unwrap();
+        assert!(
+            plain.acceptance_criteria.is_empty(),
+            "default empty criteria"
+        );
+        assert!(plain.context_refs.is_empty(), "default empty context refs");
     }
 
     /// A title hit outranks a description hit outranks a comment-only hit; a

--- a/ainb-tui/crates/ainb-hangar-store/src/service/child_done.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/child_done.rs
@@ -274,6 +274,8 @@ mod tests {
                 labels: Vec::new(),
                 parent_issue_id: parent.map(ToString::to_string),
                 stage,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
@@ -404,6 +404,25 @@ async fn assert_added_columns_read_defaults(pool: &SqlitePool) {
         "0046 issue.stage defaults NULL"
     );
 
+    // 0048 issue.acceptance_criteria / issue.context_refs both default to the empty
+    // JSON array `'[]'` on a pre-existing row (a legacy issue carries neither).
+    let issue_lists =
+        sqlx::query("SELECT acceptance_criteria, context_refs FROM issue WHERE id = ?")
+            .bind("issue-1")
+            .fetch_one(pool)
+            .await
+            .expect("issue 0048 columns");
+    assert_eq!(
+        issue_lists.get::<String, _>("acceptance_criteria"),
+        "[]",
+        "0048 issue.acceptance_criteria defaults to []"
+    );
+    assert_eq!(
+        issue_lists.get::<String, _>("context_refs"),
+        "[]",
+        "0048 issue.context_refs defaults to []"
+    );
+
     // 0033 (tcp T2): the run's produced worktree branch defaults NULL on a
     // pre-existing task row (recorded only at finalize when the run committed).
     // 0039 (tcp 8ln): the run generation defaults to 0 on a pre-existing row, so
@@ -625,7 +644,7 @@ async fn full_chain_upgrade_preserves_every_seeded_entity_and_is_idempotent() {
         .fetch_one(&pool)
         .await
         .expect("read head migration version");
-    assert_eq!(head_version, 47, "head is migration 0047");
+    assert_eq!(head_version, 48, "head is migration 0048");
 
     // (b) Every seeded row survived: the population is row-for-row identical.
     let after = population_snapshot(&pool).await;

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue.rs
@@ -44,6 +44,8 @@ async fn insert_issue_with_member_assignee_roundtrips() {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
 
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
@@ -86,6 +88,8 @@ async fn insert_issue_with_agent_assignee_roundtrips() {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
 
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
@@ -134,6 +138,8 @@ async fn insert_issue_roundtrips_priority_due_date_and_labels() {
         labels: vec!["bug".to_string(), "p0".to_string()],
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
 
@@ -176,6 +182,8 @@ async fn insert_issue_defaults_priority_due_date_and_labels() {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
 
@@ -208,6 +216,8 @@ async fn update_state_overwrites_lifecycle_state() {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
 
@@ -253,6 +263,8 @@ async fn update_fields_edits_state_assignee_priority_and_due_date() {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
 
@@ -376,6 +388,8 @@ async fn update_fields_is_workspace_scoped_no_cross_tenant_edit() {
         labels: Vec::new(),
         parent_issue_id: None,
         stage: None,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     };
     IssueRepo::insert(store.pool(), &new).await.expect("insert issue");
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
@@ -66,6 +66,8 @@ async fn seed_issue(pool: &SqlitePool, ws: &str, id: &str) {
             labels: Vec::new(),
             parent_issue_id: None,
             stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
@@ -104,6 +104,8 @@ async fn seed_issue(store: &Store, id: &str, workspace_id: &str, title: &str) {
             labels: Vec::new(),
             parent_issue_id: None,
             stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/workspace_multi_create_isolation.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/workspace_multi_create_isolation.rs
@@ -49,6 +49,8 @@ async fn seed_issue(store: &Store, workspace_id: &str, title: &str) -> String {
             labels: Vec::new(),
             parent_issue_id: None,
             stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         },
     )
     .await

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3066,6 +3066,8 @@ impl HangarPlugin {
             title,
             description,
             external_ref,
+            acceptance_criteria,
+            context_refs,
             repo_ref,
             source_branch,
             target_branch,
@@ -3098,6 +3100,16 @@ impl HangarPlugin {
         // shape only grows when a sub-issue is actually created.
         if let Some(parent) = parent_issue_id {
             params["parent_issue_id"] = serde_json::Value::String(parent);
+        }
+        // 0048: the wizard's Acceptance / Context lists land on
+        // `issue.acceptance_criteria` / `issue.context_refs` and render on the
+        // detail card. Omitted when empty so the wire shape only grows when the
+        // author supplied them (append-only).
+        if !acceptance_criteria.is_empty() {
+            params["acceptance_criteria"] = serde_json::json!(acceptance_criteria);
+        }
+        if !context_refs.is_empty() {
+            params["context_refs"] = serde_json::json!(context_refs);
         }
         let Ok(body) = encode_request(
             ISSUE_CREATE_REQ_ID,
@@ -4159,6 +4171,10 @@ impl HangarPlugin {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            // The Kanban-synthesized header carries no acceptance / context lists of
+            // its own (the daemon owns those on the real issue row).
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         };
         // Seed the run's branch (tcp T2, agents-in-a-box-ch3) from the clicked
         // card so the detail view surfaces `ainb/<slug>` exactly as the card does.
@@ -5572,6 +5588,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }]);
         p
     }
@@ -5724,6 +5742,8 @@ mod tests {
                 parent_id: None,
                 child_total: 0,
                 child_done: 0,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
             IssueRow {
                 id: ainb_hangar_core::ids::IssueId::from_str("issue-2").unwrap(),
@@ -5751,6 +5771,8 @@ mod tests {
                 parent_id: None,
                 child_total: 0,
                 child_done: 0,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         ]);
 
@@ -5939,6 +5961,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }]);
         p.rebuild_hit_map(120, 24);
 
@@ -6026,6 +6050,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }]);
         // The card starts in Backlog.
         assert_eq!(p.screens.issue_list.column_count(IssueColumn::Backlog), 1);
@@ -6105,6 +6131,8 @@ mod tests {
                 parent_id: None,
                 child_total: 0,
                 child_done: 0,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             })
             .collect();
         p.screens.set_issues(rows);
@@ -6188,6 +6216,8 @@ mod tests {
                 parent_id: None,
                 child_total: 0,
                 child_done: 0,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
             IssueRow {
                 id: ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap(),
@@ -6215,6 +6245,8 @@ mod tests {
                 parent_id: None,
                 child_total: 0,
                 child_done: 0,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
             },
         ]);
         p.screens.set_actors(vec![ActorRow {
@@ -6640,6 +6672,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         };
         let tid = ainb_hangar_core::ids::TaskId::from_str("task-1").unwrap();
         p.screens.open_task_detail(tid.clone(), issue, None);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -394,6 +394,14 @@ pub enum IssueCreateAction {
         /// The linked-issue reference (OPTIONAL) persisted as `issue.external_ref`
         /// for traceability and appended to the dispatched brief. `None` when blank.
         external_ref: Option<String>,
+        /// The acceptance criteria (OPTIONAL, migration 0048) persisted as
+        /// `issue.acceptance_criteria` and rendered on the detail card. Empty when
+        /// the wizard's Acceptance row was left blank.
+        acceptance_criteria: Vec<String>,
+        /// The context references (OPTIONAL, migration 0048) persisted as
+        /// `issue.context_refs` and rendered on the detail card. Empty when the
+        /// wizard's Context row was left blank.
+        context_refs: Vec<String>,
         /// The picked repo (REQUIRED): an absolute path, `scratch`, or a remote
         /// indicator the daemon clones.
         repo_ref: String,
@@ -1679,6 +1687,8 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
             title,
             brief,
             external_ref,
+            acceptance_criteria,
+            context_refs,
             repo_ref,
             source_branch,
             target_branch,
@@ -1690,6 +1700,8 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
                 title,
                 description: brief,
                 external_ref,
+                acceptance_criteria,
+                context_refs,
                 repo_ref,
                 source_branch,
                 target_branch,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -322,6 +322,15 @@ pub enum WizardRow {
     /// traceability and appended to the dispatched brief. Enter here commits like
     /// the other single-line rows; blank is fine.
     Link,
+    /// The multi-line acceptance-criteria row (OPTIONAL): each non-blank line is
+    /// one criterion, stored as `issue.acceptance_criteria` (migration 0048).
+    /// Enter here inserts a NEWLINE (like `Brief`); printable chars append,
+    /// Backspace edits.
+    Acceptance,
+    /// The multi-line context-references row (OPTIONAL): each non-blank line is one
+    /// reference (URL / `owner/repo#123` / note), stored as `issue.context_refs`
+    /// (migration 0048). Enter here inserts a NEWLINE (like `Brief`).
+    Context,
     /// The repo picker row (REQUIRED — `@` fuzzy dropdown or ←/→ cycle; a
     /// repo-less create is impossible).
     Repo,
@@ -334,12 +343,14 @@ pub enum WizardRow {
 }
 
 impl WizardRow {
-    /// The rows in render / focus-cycle order (Title → Brief → Link → Repo →
-    /// Source → Target → Agent).
-    pub const ALL: [Self; 7] = [
+    /// The rows in render / focus-cycle order (Title → Brief → Link → Acceptance →
+    /// Context → Repo → Source → Target → Agent).
+    pub const ALL: [Self; 9] = [
         Self::Title,
         Self::Brief,
         Self::Link,
+        Self::Acceptance,
+        Self::Context,
         Self::Repo,
         Self::Source,
         Self::Target,
@@ -392,6 +403,14 @@ pub struct CreateWizard {
     /// The single-line linked-issue reference typed so far (OPTIONAL): a URL or
     /// `owner/repo#123` carried through to `issue.external_ref`. Blank is allowed.
     link: String,
+    /// The multi-line acceptance-criteria buffer (OPTIONAL): free text with
+    /// embedded newlines; each non-blank line becomes one `issue.acceptance_criteria`
+    /// element (migration 0048). Blank is allowed.
+    acceptance: String,
+    /// The multi-line context-references buffer (OPTIONAL): free text with embedded
+    /// newlines; each non-blank line becomes one `issue.context_refs` element
+    /// (migration 0048). Blank is allowed.
+    context: String,
     /// The picked repo's wire ref, or `None` until one is chosen (REQUIRED).
     repo_ref: Option<String>,
     /// The post-`@` fuzzy query filtering the repo dropdown.
@@ -425,6 +444,8 @@ impl Default for CreateWizard {
             title: String::new(),
             brief: String::new(),
             link: String::new(),
+            acceptance: String::new(),
+            context: String::new(),
             repo_ref: None,
             repo_query: String::new(),
             repo_dropdown: None,
@@ -461,6 +482,20 @@ impl CreateWizard {
     #[must_use]
     pub fn link(&self) -> &str {
         &self.link
+    }
+
+    /// The multi-line acceptance-criteria buffer typed so far (may contain embedded
+    /// newlines; may be empty).
+    #[must_use]
+    pub fn acceptance(&self) -> &str {
+        &self.acceptance
+    }
+
+    /// The multi-line context-references buffer typed so far (may contain embedded
+    /// newlines; may be empty).
+    #[must_use]
+    pub fn context(&self) -> &str {
+        &self.context
     }
 
     /// The parent issue's wire id when this wizard is an "add sub-issue" (`s` /
@@ -1095,6 +1130,14 @@ pub enum IssueListIntent {
         /// The linked-issue reference (OPTIONAL): a URL or `owner/repo#123` carried
         /// through to `issue.external_ref` for traceability. `None` when blank.
         external_ref: Option<String>,
+        /// The acceptance criteria (OPTIONAL, migration 0048): each non-blank line
+        /// of the Acceptance row, carried through to `issue.acceptance_criteria`.
+        /// Empty when the row was left blank.
+        acceptance_criteria: Vec<String>,
+        /// The context references (OPTIONAL, migration 0048): each non-blank line of
+        /// the Context row, carried through to `issue.context_refs`. Empty when the
+        /// row was left blank.
+        context_refs: Vec<String>,
         /// The repo picked in stage 2 (REQUIRED — an absolute path, `scratch`, or
         /// a remote indicator the daemon clones).
         repo_ref: String,
@@ -1427,6 +1470,20 @@ fn reduce_wizard_key(state: &IssueListState, key: WizardKey) -> IssueListReducti
             }
             set_wizard(state, wizard)
         }
+        // 0048: the multi-line list rows insert a newline on Enter (each line is
+        // one element), never firing create — same guard as `Brief`.
+        WizardKey::Enter if wizard.focus == WizardRow::Acceptance => {
+            if !wizard.acceptance.is_empty() {
+                wizard.acceptance.push('\n');
+            }
+            set_wizard(state, wizard)
+        }
+        WizardKey::Enter if wizard.focus == WizardRow::Context => {
+            if !wizard.context.is_empty() {
+                wizard.context.push('\n');
+            }
+            set_wizard(state, wizard)
+        }
         WizardKey::Enter => wizard_try_create(state, wizard),
         WizardKey::Tab | WizardKey::Down => wizard_move_focus(state, wizard, true),
         WizardKey::BackTab | WizardKey::Up => wizard_move_focus(state, wizard, false),
@@ -1506,6 +1563,8 @@ fn wizard_cycle_value(
         WizardRow::Title
         | WizardRow::Brief
         | WizardRow::Link
+        | WizardRow::Acceptance
+        | WizardRow::Context
         | WizardRow::Source
         | WizardRow::Target => {}
     }
@@ -1513,7 +1572,8 @@ fn wizard_cycle_value(
 }
 
 /// Type one char into the focused row: append to the focused text row (Title /
-/// Brief / Link / Source / Target), or open the `@` repo dropdown on the Repo row.
+/// Brief / Link / Acceptance / Context / Source / Target), or open the `@` repo
+/// dropdown on the Repo row.
 /// Any other key on a picker row is ignored.
 fn wizard_type_char(
     state: &IssueListState,
@@ -1524,6 +1584,8 @@ fn wizard_type_char(
         WizardRow::Title => wizard.title.push(c),
         WizardRow::Brief => wizard.brief.push(c),
         WizardRow::Link => wizard.link.push(c),
+        WizardRow::Acceptance => wizard.acceptance.push(c),
+        WizardRow::Context => wizard.context.push(c),
         WizardRow::Source => wizard.source_branch.push(c),
         WizardRow::Target => wizard.target_branch.push(c),
         WizardRow::Repo => {
@@ -1552,6 +1614,12 @@ fn wizard_backspace(state: &IssueListState, mut wizard: CreateWizard) -> IssueLi
         }
         WizardRow::Link => {
             wizard.link.pop();
+        }
+        WizardRow::Acceptance => {
+            wizard.acceptance.pop();
+        }
+        WizardRow::Context => {
+            wizard.context.pop();
         }
         WizardRow::Source => {
             wizard.source_branch.pop();
@@ -1620,6 +1688,17 @@ fn wizard_dropdown_key(
 /// field is missing, DO NOT create — jump focus to it (and open the `@` dropdown
 /// for the repo) so the user is guided, never silently blocked. This is the whole
 /// guard: an agent-less / repo-less / title-only issue is impossible to create.
+/// Split a multi-line wizard buffer (Acceptance / Context) into its list elements:
+/// one per line, each trimmed, dropping blank lines (a blank line is a UI artefact,
+/// not data). Order-preserving (migration 0048).
+fn split_lines(raw: &str) -> Vec<String> {
+    raw.lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
 fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueListReduction {
     if wizard.title.trim().is_empty() {
         wizard.focus = WizardRow::Title;
@@ -1675,6 +1754,10 @@ fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueL
             // The linked-issue ref is trimmed (surrounding whitespace in a URL /
             // `owner/repo#123` is never meaningful); blank collapses to `None`.
             external_ref: opt(&wizard.link),
+            // 0048: split each multi-line buffer on newlines, trim, drop blank
+            // lines — each surviving line is one list element (order-preserving).
+            acceptance_criteria: split_lines(&wizard.acceptance),
+            context_refs: split_lines(&wizard.context),
             repo_ref,
             source_branch: opt(&wizard.source_branch),
             target_branch: opt(&wizard.target_branch),
@@ -2012,22 +2095,38 @@ fn render_wizard(
     // [`render_brief`] so the counted rows equal the painted lines).
     let brief_value_w = card_w.saturating_sub(15);
     let brief_rows = brief_visible_rows(wizard, brief_value_w, region_h);
+    // 0048: the Acceptance + Context rows are multi-line like the Brief (each
+    // non-blank line is one list element). Each takes the wrapped-line count within
+    // whatever budget survives after the fixed frame + the earlier multi-line rows,
+    // so the card never spills past `region_h`.
+    let acceptance_rows = multiline_visible_rows(
+        wizard.acceptance(),
+        brief_value_w,
+        region_h.saturating_sub(WIZARD_CARD_H + brief_rows),
+    );
+    let context_rows = multiline_visible_rows(
+        wizard.context(),
+        brief_value_w,
+        region_h.saturating_sub(WIZARD_CARD_H + brief_rows + acceptance_rows),
+    );
+    let multiline_rows = brief_rows + acceptance_rows + context_rows;
     // While the `@` dropdown is open the card GROWS by the number of candidate
     // rows it shows (filter line reuses the Repo row itself). The window is capped
     // at [`REPO_DROPDOWN_WINDOW`] and further shrunk to whatever the viewport can
-    // hold AFTER the Brief has taken its rows, so the card never spills past
-    // `region_h` — compact again on close.
+    // hold AFTER the multi-line rows have taken theirs, so the card never spills
+    // past `region_h` — compact again on close.
     let dropdown_rows =
-        repo_dropdown_visible_rows(wizard, repos, region_h.saturating_sub(brief_rows));
+        repo_dropdown_visible_rows(wizard, repos, region_h.saturating_sub(multiline_rows));
     // 0046: an "add sub-issue" wizard (`s`) shows a read-only `Sub-issue of …`
     // banner on its own row above the fields. It grows the card by 1 only when the
-    // viewport still has room after the Brief + dropdown have taken theirs, so a
-    // tight viewport degrades gracefully (banner dropped, fields intact). A plain
-    // `c` create has no parent, so the card is byte-identical to before.
+    // viewport still has room after the multi-line rows + dropdown have taken
+    // theirs, so a tight viewport degrades gracefully (banner dropped, fields
+    // intact). A plain `c` create has no parent, so the card is byte-identical.
     let banner_rows = u16::from(
-        wizard.parent_display().is_some() && region_h > WIZARD_CARD_H + brief_rows + dropdown_rows,
+        wizard.parent_display().is_some()
+            && region_h > WIZARD_CARD_H + multiline_rows + dropdown_rows,
     );
-    let card_h = WIZARD_CARD_H + brief_rows + dropdown_rows + banner_rows;
+    let card_h = WIZARD_CARD_H + multiline_rows + dropdown_rows + banner_rows;
 
     let left = (area_w.saturating_sub(card_w)) / 2;
     let right = left + card_w; // exclusive
@@ -2081,6 +2180,34 @@ fn render_wizard(
             y = y.saturating_add(brief_rows);
             continue;
         }
+        if field == WizardRow::Acceptance {
+            render_multiline(
+                buf,
+                value_x,
+                y,
+                text_right,
+                wizard.acceptance(),
+                focused,
+                ACCEPTANCE_PLACEHOLDER,
+                acceptance_rows,
+            );
+            y = y.saturating_add(acceptance_rows);
+            continue;
+        }
+        if field == WizardRow::Context {
+            render_multiline(
+                buf,
+                value_x,
+                y,
+                text_right,
+                wizard.context(),
+                focused,
+                CONTEXT_PLACEHOLDER,
+                context_rows,
+            );
+            y = y.saturating_add(context_rows);
+            continue;
+        }
         if field == WizardRow::Repo && wizard.repo_dropdown().is_some() {
             render_repo_dropdown(buf, value_x, y, text_right, wizard, repos, dropdown_rows);
             y = y.saturating_add(1 + dropdown_rows);
@@ -2124,14 +2251,27 @@ fn repo_dropdown_visible_rows(wizard: &CreateWizard, repos: &[RepoOption], regio
 /// card still fits `region_h` (the fixed frame plus these rows). Keeps the growth
 /// bounded and the small-viewport fallback intact.
 fn brief_visible_rows(wizard: &CreateWizard, value_w: u16, region_h: u16) -> u16 {
-    let lines = u16::try_from(wrap_text(wizard.brief(), value_w as usize).len())
+    multiline_visible_rows(
+        wizard.brief(),
+        value_w,
+        region_h.saturating_sub(WIZARD_CARD_H),
+    )
+}
+
+/// How many wrapped lines a multi-line list row (Acceptance / Context) paints:
+/// its wrapped-line count at `value_w`, floored at 1 (an empty row still shows one
+/// placeholder / cursor line), capped at [`BRIEF_WINDOW`], then shrunk to the
+/// caller-supplied `budget` (the rows still free after the fixed frame + the
+/// earlier multi-line rows have taken theirs). Mirrors [`brief_visible_rows`] so
+/// the counted rows equal the painted lines.
+fn multiline_visible_rows(text: &str, value_w: u16, budget: u16) -> u16 {
+    let lines = u16::try_from(wrap_text(text, value_w as usize).len())
         .unwrap_or(u16::MAX)
         .max(1);
     let want = lines.min(BRIEF_WINDOW);
     // The fixed rows always fit (the degenerate check guaranteed region_h >=
     // WIZARD_CARD_H + 1), so the budget is at least 1.
-    let budget = region_h.saturating_sub(WIZARD_CARD_H).max(1);
-    want.min(budget)
+    want.min(budget.max(1))
 }
 
 /// Wrap `text` into display lines at most `width` chars wide, honouring embedded
@@ -2163,13 +2303,13 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
 /// The placeholder shown on an empty, unfocused Brief row so the optional field
 /// reads as skippable rather than broken.
 const BRIEF_PLACEHOLDER: &str = "(optional — describe the task)";
+/// The placeholder for the empty, unfocused Acceptance row (one criterion / line).
+const ACCEPTANCE_PLACEHOLDER: &str = "(optional — one criterion per line)";
+/// The placeholder for the empty, unfocused Context row (one reference / line).
+const CONTEXT_PLACEHOLDER: &str = "(optional — one reference per line)";
 
-/// Render the multi-line Brief value at `(x, y)` over `rows` lines, clipped at
-/// `right`. The focused row gets a `▶` marker + green text and a block cursor on
-/// the last line; unfocused shows soft-white (or the muted placeholder when
-/// empty). A brief longer than `rows` scroll-follows its newest line (an editor
-/// caret stays visible while typing). The marker sits on the first painted line;
-/// continuation lines indent to align under it.
+/// Render the multi-line Brief value at `(x, y)` over `rows` lines (see
+/// [`render_multiline`]).
 fn render_brief(
     buf: &mut WireBuffer,
     x: u16,
@@ -2178,15 +2318,43 @@ fn render_brief(
     wizard: &CreateWizard,
     rows: u16,
 ) {
-    let focused = wizard.focus() == WizardRow::Brief;
+    render_multiline(
+        buf,
+        x,
+        y,
+        right,
+        wizard.brief(),
+        wizard.focus() == WizardRow::Brief,
+        BRIEF_PLACEHOLDER,
+        rows,
+    );
+}
+
+/// Render a multi-line free-text value (`raw`) at `(x, y)` over `rows` lines,
+/// clipped at `right`. The focused row gets a `▶` marker + green text and a block
+/// cursor on the last line; unfocused shows soft-white (or the muted `placeholder`
+/// when empty). A value longer than `rows` scroll-follows its newest line (an
+/// editor caret stays visible while typing). The marker sits on the first painted
+/// line; continuation lines indent to align under it. Shared by the Brief,
+/// Acceptance, and Context rows.
+#[allow(clippy::too_many_arguments)]
+fn render_multiline(
+    buf: &mut WireBuffer,
+    x: u16,
+    y: u16,
+    right: u16,
+    raw: &str,
+    focused: bool,
+    placeholder: &str,
+    rows: u16,
+) {
     let value_colour = if focused { SELECTION_GREEN } else { SOFT_WHITE };
     let marker = if focused { "▶ " } else { "  " };
     let value_x = x.saturating_add(2);
     let width = right.saturating_sub(value_x).max(1) as usize;
-    let raw = wizard.brief();
     if raw.is_empty() && !focused {
         put_card_str(buf, x, y, marker, value_colour, right, true);
-        put_card_str(buf, value_x, y, BRIEF_PLACEHOLDER, MUTED_GRAY, right, true);
+        put_card_str(buf, value_x, y, placeholder, MUTED_GRAY, right, true);
         return;
     }
     let mut lines = wrap_text(raw, width);
@@ -2214,6 +2382,8 @@ const fn wizard_row_label(row: WizardRow) -> &'static str {
         WizardRow::Title => "Title",
         WizardRow::Brief => "Brief",
         WizardRow::Link => "Linked",
+        WizardRow::Acceptance => "Accept",
+        WizardRow::Context => "Context",
         WizardRow::Repo => "Repo",
         WizardRow::Source => "Source",
         WizardRow::Target => "Target",
@@ -2251,9 +2421,10 @@ fn render_wizard_field(
         WizardRow::Title => {
             put_card_str(buf, cx, y, &text(wizard.title()), value_colour, right, true);
         }
-        // The multi-line Brief is painted by [`render_brief`] (it spans several
-        // rows), so the single-row path never routes here.
-        WizardRow::Brief => {}
+        // The multi-line Brief / Acceptance / Context rows are painted by
+        // [`render_multiline`] (they span several rows), so the single-row path
+        // never routes here.
+        WizardRow::Brief | WizardRow::Acceptance | WizardRow::Context => {}
         WizardRow::Link => {
             let raw = wizard.link();
             let shown = if focused {
@@ -2607,6 +2778,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }
     }
 
@@ -3017,6 +3190,8 @@ mod tests {
         // Move focus past Brief to the Repo row, then open the dropdown.
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
         let mut buf = WireBuffer::new(120, 24);
@@ -3063,6 +3238,8 @@ mod tests {
         // Focus Repo (past Brief), cycle ←→ to pick `rosetta` (scratch=0, rosetta=1).
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Right)).state; // scratch
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Right)).state; // rosetta
@@ -3103,6 +3280,8 @@ mod tests {
         let s = type_into(&s, "Fix");
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
         let mut buf = WireBuffer::new(120, 24);
@@ -3151,6 +3330,8 @@ mod tests {
         let base = type_into(&base, "Fix");
         let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
         let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
+        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
+        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
         let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
 
         let painted_row_span = |s: &IssueListState| -> u16 {
@@ -3201,6 +3382,8 @@ mod tests {
         let s = type_into(&s, "Fix");
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
+        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1048,6 +1048,39 @@ fn render_detail_card(
         row = row.saturating_add(1);
     }
 
+    // --- Acceptance criteria (0048): a header row then one `☐ <criterion>` line
+    //     per element, rendered ONLY when non-empty so an issue without them reads
+    //     unchanged (mirrors the Linked conditional). ---
+    if !issue.acceptance_criteria.is_empty() {
+        card_field_row(buf, card_w, row, &[("Acceptance:", CARD_LABEL)]);
+        row = row.saturating_add(1);
+        for criterion in &issue.acceptance_criteria {
+            card_field_row(
+                buf,
+                card_w,
+                row,
+                &[("  ☐ ", CARD_LABEL), (criterion, CARD_VALUE)],
+            );
+            row = row.saturating_add(1);
+        }
+    }
+
+    // --- Context references (0048): a header row then one `⧉ <ref>` line per
+    //     element, rendered ONLY when non-empty. ---
+    if !issue.context_refs.is_empty() {
+        card_field_row(buf, card_w, row, &[("Context:", CARD_LABEL)]);
+        row = row.saturating_add(1);
+        for reference in &issue.context_refs {
+            card_field_row(
+                buf,
+                card_w,
+                row,
+                &[("  ⧉ ", CARD_LABEL), (reference, CARD_VALUE)],
+            );
+            row = row.saturating_add(1);
+        }
+    }
+
     // --- divider ---
     draw_card_divider(buf, row, card_w);
     row = row.saturating_add(1);
@@ -1280,6 +1313,8 @@ mod card_tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }
     }
 
@@ -1369,6 +1404,54 @@ mod card_tests {
         assert!(
             !painted_text(&buf).contains("Linked: "),
             "an unlinked issue shows no Linked line"
+        );
+    }
+
+    /// 0048: an issue carrying acceptance criteria renders an `Acceptance:` header
+    /// then one line per criterion; an empty list renders NO header.
+    #[test]
+    fn detail_card_renders_acceptance_block_only_when_present() {
+        let mut issue = full_issue();
+        issue.acceptance_criteria = vec!["builds".into(), "tests green".into()];
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+        assert!(text.contains("Acceptance:"), "acceptance header: {text}");
+        assert!(text.contains("builds"), "first criterion");
+        assert!(text.contains("tests green"), "second criterion");
+
+        // Empty list: no header at all.
+        let s = state_for(full_issue());
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        assert!(
+            !painted_text(&buf).contains("Acceptance:"),
+            "an issue with no criteria shows no Acceptance header"
+        );
+    }
+
+    /// 0048: an issue carrying context references renders a `Context:` header then
+    /// one line per reference; an empty list renders NO header.
+    #[test]
+    fn detail_card_renders_context_block_only_when_present() {
+        let mut issue = full_issue();
+        issue.context_refs = vec!["acme/api#42".into(), "https://docs".into()];
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+        assert!(text.contains("Context:"), "context header: {text}");
+        assert!(text.contains("acme/api#42"), "first reference");
+        assert!(text.contains("https://docs"), "second reference");
+
+        // Empty list: no header at all.
+        let s = state_for(full_issue());
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        assert!(
+            !painted_text(&buf).contains("Context:"),
+            "an issue with no context refs shows no Context header"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -142,6 +142,8 @@ mod tests {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
@@ -54,6 +54,8 @@ fn row(id: &str, display: &str, state: &str, priority: i64, assignee: Option<&st
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -44,6 +44,8 @@ fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     }
 }
 
@@ -148,7 +150,9 @@ fn ready_to_create() -> IssueListState {
     // Move past Brief to Repo, open the dropdown (cursor at scratch), pick it.
     let s = wiz(&s, WizardKey::Down).state; // Title → Brief
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     let s = wiz(&s, WizardKey::Char('@')).state;
     let s = wiz(&s, WizardKey::Enter).state; // pick scratch, dropdown closes
     // Land focus on the Agent row.
@@ -178,8 +182,8 @@ fn c_opens_wizard_focused_on_title() {
 }
 
 /// ↓ / Tab advance the focused row, ↑ / Shift+Tab retreat, both wrapping around
-/// the seven rows (Title → Brief → Link → Repo → Source → Target → Agent; mirrors
-/// the host new-session Configure form).
+/// the nine rows (Title → Brief → Link → Acceptance → Context → Repo → Source →
+/// Target → Agent; mirrors the host new-session Configure form).
 #[test]
 fn wizard_focus_moves_and_wraps() {
     let s = open_wizard();
@@ -189,6 +193,10 @@ fn wizard_focus_moves_and_wraps() {
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
     let s = wiz(&s, WizardKey::Tab).state;
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Link);
+    let s = wiz(&s, WizardKey::Tab).state;
+    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Acceptance);
+    let s = wiz(&s, WizardKey::Tab).state;
+    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Context);
     let s = wiz(&s, WizardKey::Tab).state;
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Repo);
     let s = wiz(&s, WizardKey::Tab).state;
@@ -249,7 +257,9 @@ fn wizard_left_right_cycles_repo() {
     let s = type_str(s, "Fix");
     let s = wiz(&s, WizardKey::Down).state; // Title → Brief
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     assert_eq!(s.wizard().unwrap().repo_ref(), None);
 
     // → picks the first candidate (scratch is always index 0).
@@ -267,6 +277,8 @@ fn wizard_typing_edits_focused_text_row() {
     // Focus Source, clear the "main" prefill, type a custom ref.
     let s = wiz(&s, WizardKey::Down).state; // Brief
     let s = wiz(&s, WizardKey::Down).state; // Link
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Context
     let s = wiz(&s, WizardKey::Down).state; // Repo
     let s = wiz(&s, WizardKey::Down).state; // Source
     let s = (0..4).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
@@ -289,7 +301,9 @@ fn wizard_at_opens_repo_dropdown() {
     let s = type_str(s, "Fix");
     let s = wiz(&s, WizardKey::Down).state; // Title → Brief
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     assert_eq!(s.wizard().unwrap().repo_dropdown(), None);
 
     let s = wiz(&s, WizardKey::Char('@')).state;
@@ -310,7 +324,9 @@ fn wizard_tab_from_dropdown_commits_highlight() {
     let s = type_str(s, "Fix");
     let s = wiz(&s, WizardKey::Down).state; // Title → Brief
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     let s = wiz(&s, WizardKey::Char('@')).state; // open dropdown, cursor on scratch
 
     let out = wiz(&s, WizardKey::Tab);
@@ -377,6 +393,8 @@ fn wizard_complete_form_commits_create_and_run() {
             title: "Fix login".to_string(),
             brief: None,
             external_ref: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
             repo_ref: "scratch".to_string(),
             source_branch: Some("main".to_string()),
             target_branch: Some("main".to_string()),
@@ -421,6 +439,8 @@ fn wizard_brief_enter_inserts_newline_not_create() {
     let s = wiz(&s, WizardKey::Up).state; // Target
     let s = wiz(&s, WizardKey::Up).state; // Source
     let s = wiz(&s, WizardKey::Up).state; // Repo
+    let s = wiz(&s, WizardKey::Up).state; // Context
+    let s = wiz(&s, WizardKey::Up).state; // Acceptance
     let s = wiz(&s, WizardKey::Up).state; // Link
     let s = wiz(&s, WizardKey::Up).state; // Brief
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
@@ -456,7 +476,9 @@ fn wizard_link_carries_to_create_intent() {
     // Backspace edits the single line.
     let s = wiz(&s, WizardKey::Backspace).state; // drop a trailing space
     // Move to Repo, pick scratch, commit.
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
     let out = wiz(&s, WizardKey::Enter);
     match out.intent {
@@ -499,7 +521,9 @@ fn wizard_brief_carries_to_create_intent() {
     let s = type_str(s, "Reproduce then patch");
     // Move to Repo, pick scratch, then commit from the Repo row.
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
 
     let out = wiz(&s, WizardKey::Enter);
@@ -529,7 +553,9 @@ fn wizard_brief_preserved_verbatim_on_intent() {
     let s = wiz(&s, WizardKey::Enter).state; // trailing newline
     // Commit from the Repo row.
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
 
     let out = wiz(&s, WizardKey::Enter);
@@ -581,6 +607,8 @@ fn wizard_branch_edits_and_blanks_round_trip() {
             title: "Fix login".to_string(),
             brief: None,
             external_ref: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
             repo_ref: "scratch".to_string(),
             source_branch: Some("feature/x".to_string()),
             target_branch: None,
@@ -606,7 +634,9 @@ fn wizard_required_guard_blocks_incomplete_creates() {
     let s = open_wizard();
     let s = wiz(&s, WizardKey::Down).state; // Title → Brief
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
     assert_eq!(s.wizard().unwrap().repo_ref(), Some("scratch"));
     assert!(wiz(&s, WizardKey::Enter).intent.is_none());
@@ -860,7 +890,9 @@ fn subissue_wizard_commit_carries_parent_issue_id() {
     let s = type_str(s, "Fix login");
     let s = wiz(&s, WizardKey::Down).state; // Title → Brief
     let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Repo
+    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
+    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
+    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
     let s = wiz(&s, WizardKey::Char('@')).state;
     let s = wiz(&s, WizardKey::Enter).state; // pick scratch
     let s = wiz(&s, WizardKey::Down).state; // Repo → Source

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
@@ -366,7 +366,9 @@ async fn wizard_commit_issues_create_update_and_run() {
             send_key(&mut host_write, KeyCode::Char { ch }).await;
         }
         send_key(&mut host_write, KeyCode::Down).await; // Brief → Link
-        send_key(&mut host_write, KeyCode::Down).await; // Link → Repo
+        send_key(&mut host_write, KeyCode::Down).await; // Link → Acceptance
+        send_key(&mut host_write, KeyCode::Down).await; // Acceptance → Context
+        send_key(&mut host_write, KeyCode::Down).await; // Context → Repo
         send_key(&mut host_write, KeyCode::Char { ch: '@' }).await;
         send_key(&mut host_write, KeyCode::Enter).await;
         send_key(&mut host_write, KeyCode::Enter).await;

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
@@ -48,6 +48,8 @@ fn issue_with_pr(pr_url: Option<&str>) -> IssueRow {
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
@@ -47,6 +47,8 @@ fn issue(pr_url: Option<&str>) -> IssueRow {
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -47,6 +47,8 @@ fn issue_row() -> IssueRow {
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
@@ -44,6 +44,8 @@ fn issue_row() -> IssueRow {
         parent_id: None,
         child_total: 0,
         child_done: 0,
+        acceptance_criteria: Vec::new(),
+        context_refs: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -155,6 +155,8 @@ fn seeded_issues() -> serde_json::Value {
             parent_id: None,
             child_total: 0,
             child_done: 0,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
         }],
     })
     .unwrap()


### PR DESCRIPTION
## What

Multica parity gap #11: an issue now carries a structured **acceptance-criteria** list and a **context-references** list, authored in the create wizard/CLI, persisted through sqlite + the JSON-RPC wire, and rendered on the task-detail card. Mirrors multica's `issue.acceptance_criteria` / `context_refs` (`init.up.sql:66-67`), modelled exactly like hangar's existing `labels` (`Vec<String>`, JSON-array TEXT column).

Element = plain `String` (one criterion / one ref per element) — the smallest shape that satisfies "structured list" and matches multica's opaque-array semantics. Checkbox state (`{text, checked}`) is deliberately out of scope.

## Changes (per crate)

- **hangar-store**: new migration `0048` adds `acceptance_criteria` + `context_refs` TEXT columns (default `'[]'`, O(1) `ADD COLUMN`, safe on populated DBs); `NewIssue`/`Issue` gain the two fields; insert/select/decoder extended exactly like `labels`.
- **hangar-proto** (append-only wire): `IssueCreateParams` + `IssueRow` gain both fields with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` at the struct tail — an old client omits them, an old daemon ignores them, a pre-0048 snapshot decodes to `[]`.
- **hangar-daemon**: `issue_create` threads the two lists into the row + response; every `IssueRow` builder that reads a stored `Issue` populates them; the create handler trim-drops blank elements at the boundary (empty list is valid, no new error).
- **hangar-cli**: repeatable `--acceptance` / `--context-ref` flags on `hangar issue create` (mirroring `--label`).
- **hangar-plugin**: two multi-line wizard rows (`Accept` / `Context`) between Link and Repo — Enter inserts a newline, each non-blank line is one element; the detail card renders `Acceptance:` (`☐ …`) and `Context:` (`⧉ …`) blocks only when non-empty.

## Tests

- Store round-trip (order-preserving) + migration-chain default (`[]`).
- Proto append-only round-trip.
- Daemon `IssueRow` builders carry the fields.
- CLI clap parse test (both flags collect in order).
- Plugin reducer + detail-card render (present/absent) + RPC-over-socket wizard chain.
- Existing wizard navigation/snapshot tests updated for the two new rows.
- CLI + sqlite acceptance run verified: `["cargo build is green","detail card shows criteria"]` / `["acme/api#42"]`; a create without the flags leaves both columns `[]`.

## Notes / honesty

- One **pre-existing** test failure remains, unrelated to this change: `render_full_health_pane_snapshot` asserts `daemon: 1.15.0` but the workspace version is `1.16.1` (a release-bump snapshot staleness on `main`, not touched here).
- A `beads_adapter` concurrency test flaked once under full-suite contention and passed on isolated rerun (known flake).
- Touched crates: `cargo build -p ainb` green; `cargo fmt` clean (reverted unrelated pre-existing fmt drift in `agents.rs` / `live_e2e.rs`); no new clippy `-D`-level lints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added acceptance criteria and context references to issue creation.
  * Added multiline Acceptance and Context fields to the issue creation wizard.
  * Displayed acceptance criteria and context references in task details when available.
  * Supported these fields across issue lists, searches, events, and creation responses.
  * Added repeatable CLI options for acceptance criteria and context references.

* **Bug Fixes**
  * Preserved compatibility with existing issues by defaulting new fields to empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->