### PR TITLE
feat(hangar): author priority, due date and labels in the issue create wizard (multica parity 28)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1164,8 +1164,9 @@ pub struct IssueCreateArgs {
     pub due: Option<i64>,
     /// A label to attach to the issue (repeatable: `--label bug --label p0`).
     ///
-    /// Persisted as the issue's label list. The full labels table + attach/detach
-    /// is a separate concern; create just records the labels it is handed.
+    /// Each name is resolve-or-created in the workspace and joined to the issue
+    /// through the `label` / `issue_label` tables (migration 0016), so a repeated
+    /// name yields exactly one attachment.
     #[arg(long = "label", action = clap::ArgAction::Append)]
     pub labels: Vec<String>,
     /// An acceptance criterion (repeatable: `--acceptance "x" --acceptance "y"`).
@@ -1210,13 +1211,9 @@ pub struct IssueCreateArgs {
 /// Returns a human-readable message if the input is not a valid `YYYY-MM-DD`
 /// date (surfaced by clap as the flag's value error).
 fn parse_due_date(raw: &str) -> Result<i64, String> {
-    let date = chrono::NaiveDate::parse_from_str(raw, "%Y-%m-%d")
-        .map_err(|_| format!("expected a YYYY-MM-DD date, got {raw:?}"))?;
-    let dt = date
-        .and_hms_opt(0, 0, 0)
-        .ok_or_else(|| format!("invalid time-of-day for date {raw:?}"))?
-        .and_utc();
-    Ok(dt.timestamp_millis())
+    // One parser, one error message, shared with the TUI create wizard so a
+    // calendar day typed in either place resolves to the same UTC-midnight ms.
+    ainb_hangar_proto::dates::parse_calendar_date_ms(raw)
 }
 
 /// Arguments for `hangar issue list`.
@@ -3375,7 +3372,11 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         created_at: now,
         priority: args.priority,
         due_date: args.due,
-        labels: args.labels.clone(),
+        // 0016: labels go through the `label` / `issue_label` join below (the
+        // source of truth), never straight into this JSON read-cache — writing
+        // the cache alone left `hangar issue create --label` invisible to every
+        // label query and diverged the CLI from the daemon's create.
+        labels: Vec::new(),
         // 0048: trim-drop blank elements — an empty criterion / ref is not data.
         acceptance_criteria: args
             .acceptance_criteria
@@ -3395,6 +3396,22 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         stage: None,
     };
     IssueRepo::insert(pool, &new).await.context("insert issue")?;
+
+    // 0016: attach each `--label` through the join — `LabelRepo::attach` resolves
+    // or creates the label in the workspace, writes the `issue_label` row
+    // (ON CONFLICT DO NOTHING, so a repeated flag is one row) and re-derives the
+    // `issue.labels` cache from the join. Same path the daemon's create takes, so
+    // a CLI-created and a TUI-created issue read back identically.
+    if !args.labels.is_empty() {
+        use ainb_hangar_store::repo::label::LabelRepo;
+        let ws = ainb_hangar_core::ids::WorkspaceId::from_str(workspace_id.clone())
+            .context("workspace id")?;
+        for name in args.labels.iter().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+            LabelRepo::attach(pool, &ws, &id, name, None)
+                .await
+                .with_context(|| format!("attach label `{name}`"))?;
+        }
+    }
 
     // Resolve + persist the repo / branches (0032/0042). A remote repo token is
     // cloned once into the shared clone cache (the board card-create parity),

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -704,6 +704,57 @@ fn issue_label_attach_then_detach_persist_through_show() {
     );
 }
 
+/// Parity 28: `hangar issue create --label` routes through the 0016 label join,
+/// not just the `issue.labels` JSON cache — so a created label is visible to the
+/// SAME reads a later `label attach` would produce, and a repeated `--label` is
+/// idempotent (one chip, not two).
+#[test]
+fn issue_create_labels_route_through_the_label_join() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar", "issue", "create", "--title", "Labelled at birth", "--label", "bug",
+            "--label", "bug", "--label", "p0",
+        ],
+    );
+    assert!(ok, "issue create --label should exit 0; out={out}");
+    let id = out
+        .lines()
+        .find_map(|l| l.strip_prefix("created issue "))
+        .map(|s| s.trim().to_string())
+        .expect("create output carries an id");
+
+    // The read-cache reflects the join (attach re-derives it), deduped.
+    let (ok, out) = run(
+        tmp.path(),
+        &["--format", "json", "hangar", "issue", "show", &id],
+    );
+    assert!(ok, "json show should exit 0; out={out}");
+    assert!(
+        out.contains("\"labels\":[\"bug\",\"p0\"]"),
+        "create labels missing / duplicated in json show:\n{out}"
+    );
+
+    // The join is the source of truth: detaching through the label verb (which
+    // only ever touches `issue_label`) must be able to REMOVE what create wrote.
+    // Before this change create wrote the cache only, so the detach was a no-op.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "issue", "label", "detach", &id, "bug"],
+    );
+    assert!(ok, "label detach should exit 0; out={out}");
+    let (ok, out) = run(
+        tmp.path(),
+        &["--format", "json", "hangar", "issue", "show", &id],
+    );
+    assert!(ok, "json show should exit 0; out={out}");
+    assert!(
+        out.contains("\"labels\":[\"p0\"]"),
+        "detach did not remove a create-authored label:\n{out}"
+    );
+}
+
 /// `ainb hangar issue label attach` against an unknown issue id is an error
 /// (exit non-zero), never a silent no-op.
 #[test]

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -711,13 +711,21 @@ fn issue_label_attach_then_detach_persist_through_show() {
 #[test]
 fn issue_create_labels_route_through_the_label_join() {
     let tmp = tempfile::tempdir().unwrap();
-    let (ok, out) = run(
-        tmp.path(),
-        &[
-            "hangar", "issue", "create", "--title", "Labelled at birth", "--label", "bug",
-            "--label", "bug", "--label", "p0",
-        ],
-    );
+    // `bug` twice on purpose: the repeat must collapse to one attachment.
+    let args = [
+        "hangar",
+        "issue",
+        "create",
+        "--title",
+        "Labelled at birth",
+        "--label",
+        "bug",
+        "--label",
+        "bug",
+        "--label",
+        "p0",
+    ];
+    let (ok, out) = run(tmp.path(), &args);
     assert!(ok, "issue create --label should exit 0; out={out}");
     let id = out
         .lines()

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3079,7 +3079,7 @@ async fn handle_issue_create(
 
     let params: ainb_hangar_proto::snapshots::IssueCreateParams = parse_params(
         req,
-        "{ workspace_id, title, description?, creator, external_ref?, acceptance_criteria?, context_refs? }",
+        "{ workspace_id, title, description?, creator, external_ref?, acceptance_criteria?, context_refs?, priority?, due_date?, labels? }",
     )?;
     // The mutating handler must not silently no-op on a typo'd workspace.
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
@@ -3115,6 +3115,26 @@ async fn handle_issue_create(
         .filter(|s| !s.is_empty())
         .map(ToString::to_string)
         .collect();
+    // 0014 priority: `0..3` (P3..P0). An out-of-vocabulary value is a client
+    // error, mirroring multica's `validateIssueEnum` — NEVER silently clamped,
+    // which would persist an urgency the author did not ask for.
+    let priority = params.priority.unwrap_or(0);
+    if !(0..=3).contains(&priority) {
+        return Err(invalid_params("issue priority must be 0..3 (P3..P0)"));
+    }
+    // 0014 due date: the wire carries epoch ms at UTC midnight (the client parses
+    // the `YYYY-MM-DD` calendar day with `proto::dates::parse_calendar_date_ms`),
+    // so any i64 is accepted here — a pre-1970 deadline is legal, if odd.
+    let due_date = params.due_date;
+    // 0016 labels: trim-drop blanks like the other lists, and dedupe preserving
+    // first-seen order. `LabelRepo::attach` is idempotent so a duplicate would not
+    // corrupt the join, but the response row must not imply the repeat mattered.
+    let mut labels: Vec<String> = Vec::new();
+    for name in params.labels.iter().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+        if !labels.iter().any(|seen| seen == name) {
+            labels.push(name.to_string());
+        }
+    }
     if let Some(parent) = parent_issue_id {
         let ok = ainb_hangar_store::repo::issue::IssueRepo::get_by_id(pool, parent)
             .await
@@ -3130,14 +3150,19 @@ async fn handle_issue_create(
         pool,
         &SystemIdGen,
         &SystemClock,
-        ws.as_str(),
-        &params.title,
-        params.description.as_deref(),
-        &creator,
-        external_ref,
-        parent_issue_id,
-        &acceptance_criteria,
-        &context_refs,
+        &snapshots::IssueCreateInput {
+            workspace_id: ws.as_str(),
+            title: &params.title,
+            description: params.description.as_deref(),
+            creator: &creator,
+            external_ref,
+            parent_issue_id,
+            acceptance_criteria: &acceptance_criteria,
+            context_refs: &context_refs,
+            priority,
+            due_date,
+            labels: &labels,
+        },
     )
     .await
     .map_err(|e| store_err(&e))?;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -1759,16 +1759,52 @@ pub async fn refresh_pr_status(
     Ok((status, row))
 }
 
+/// Everything the caller supplies for one `hangar/issue_create` — the daemon
+/// mints the id, stamps `created_at`, and picks the `open` state itself.
+///
+/// Exists so [`issue_create`] stays under the argument-count lint as the create
+/// surface grows: every new authored attribute lands here instead of on the
+/// signature. Borrowed throughout — the struct is built and consumed within one
+/// handler call.
+#[derive(Debug, Clone, Copy)]
+pub struct IssueCreateInput<'a> {
+    /// The tenant-isolation guard: the resolved workspace the issue belongs to.
+    pub workspace_id: &'a str,
+    /// The issue title (already validated non-blank at the handler boundary).
+    pub title: &'a str,
+    /// Optional free-form body text.
+    pub description: Option<&'a str>,
+    /// The creating actor (already parsed from its `kind:id` wire form).
+    pub creator: &'a ActorRef,
+    /// Optional upstream-issue link (migration 0043).
+    pub external_ref: Option<&'a str>,
+    /// Optional parent issue, making this a sub-issue (migration 0046).
+    pub parent_issue_id: Option<&'a str>,
+    /// Ordered acceptance criteria (migration 0048).
+    pub acceptance_criteria: &'a [String],
+    /// Ordered context references (migration 0048).
+    pub context_refs: &'a [String],
+    /// Urgency `0..3` (P3..P0, HIGHER = MORE URGENT, migration 0014); `0` is the
+    /// schema default. Range-validated at the handler boundary.
+    pub priority: i64,
+    /// Optional deadline as epoch ms at UTC midnight (migration 0014).
+    pub due_date: Option<i64>,
+    /// Label NAMES to attach (migration 0016): each resolve-or-created in the
+    /// workspace and joined to the new issue.
+    pub labels: &'a [String],
+}
+
 /// Create one new issue in `workspace_id`, then return it as a wire [`IssueRow`]
 /// (`hangar/issue_create`, e38.29).
 ///
 /// Mints a fresh ULID via `idgen`, stamps `created_at` from `clock`, and inserts
 /// through [`IssueRepo::insert`] in the `open` lifecycle state. The new issue is
-/// unassigned (the create flow only captures title + description); `creator` is
-/// the already-parsed actor-ref. The re-wrapped [`IssueRow`] mirrors the
-/// `issues_list` shape (a freshly-created issue has no completed task, so
-/// `pr_url` is always `None`), so the response row and the pushed `IssueCreated`
-/// event are byte-identical to a list snapshot of the row.
+/// unassigned (the create flow captures attributes, never an assignee);
+/// `creator` is the already-parsed actor-ref. Authored labels are attached
+/// through the 0016 join and read back from it, so the re-wrapped [`IssueRow`]
+/// mirrors the `issues_list` shape (a freshly-created issue has no completed
+/// task, so `pr_url` is always `None`) — the response row and the pushed
+/// `IssueCreated` event stay byte-identical to a list snapshot of the row.
 ///
 /// # Errors
 ///
@@ -1778,18 +1814,24 @@ pub async fn issue_create(
     pool: &SqlitePool,
     idgen: &dyn IdGen,
     clock: &dyn HangarClock,
-    workspace_id: &str,
-    title: &str,
-    description: Option<&str>,
-    creator: &ActorRef,
-    external_ref: Option<&str>,
-    parent_issue_id: Option<&str>,
-    acceptance_criteria: &[String],
-    context_refs: &[String],
+    input: &IssueCreateInput<'_>,
 ) -> Result<IssueRow, sqlx::Error> {
     use ainb_hangar_store::repo::card_parity::CardParityRepo;
     use ainb_hangar_store::repo::issue::NewIssue;
 
+    let &IssueCreateInput {
+        workspace_id,
+        title,
+        description,
+        creator,
+        external_ref,
+        parent_issue_id,
+        acceptance_criteria,
+        context_refs,
+        priority,
+        due_date,
+        labels,
+    } = input;
     let id = idgen.new_ulid();
     let created_at = clock.now_ms();
     // e38.21: apply the workspace's issue_prefix to the new title so the prefix
@@ -1809,8 +1851,11 @@ pub async fn issue_create(
             assignee: None,
             creator: creator.clone(),
             created_at,
-            priority: 0,
-            due_date: None,
+            priority,
+            due_date,
+            // 0016: labels are written through the `label` / `issue_label` join
+            // below, never straight into the JSON cache — the join is the source
+            // of truth and `LabelRepo::attach` re-derives the cache from it.
             labels: Vec::new(),
             acceptance_criteria: acceptance_criteria.to_vec(),
             context_refs: context_refs.to_vec(),
@@ -1823,6 +1868,29 @@ pub async fn issue_create(
     // post-insert card-parity pattern as source/target branches). A `None` /
     // blank ref is a no-op, so a link-less create leaves `external_ref` NULL.
     CardParityRepo::set_issue_external_ref(pool, workspace_id, &id, external_ref).await?;
+    // 0016: attach the authored labels through the join (resolve-or-create per
+    // name, `ON CONFLICT DO NOTHING` on the join row, `issue.labels` re-derived
+    // inside the same transaction). Attach is idempotent, so a repeated name is
+    // one join row. The re-read below is what the response + pushed event carry,
+    // so they match a later `issues_list` snapshot byte-for-byte.
+    let stored_labels = if labels.is_empty() {
+        Vec::new()
+    } else {
+        let ws = WorkspaceId::from_str(workspace_id.to_string()).map_err(|e| {
+            sqlx::Error::ColumnDecode {
+                index: "workspace_id".to_string(),
+                source: format!("malformed workspace id {workspace_id:?}: {e}").into(),
+            }
+        })?;
+        for name in labels {
+            LabelRepo::attach(pool, &ws, &id, name, None).await.map_err(|e| match e {
+                LabelRepoError::Db(db) => db,
+                // Unreachable: the issue was just inserted into THIS workspace.
+                LabelRepoError::IssueNotFound => sqlx::Error::RowNotFound,
+            })?;
+        }
+        LabelRepo::labels_for_issue(pool, &ws, &id).await?
+    };
     let issue_id = IssueId::from_str(id.clone()).map_err(|e| sqlx::Error::ColumnDecode {
         index: "id".to_string(),
         source: format!("malformed issue id {id:?}: {e}").into(),
@@ -1842,9 +1910,13 @@ pub async fn issue_create(
         assignee: None,
         creator: format!("{}:{}", creator.kind().as_str(), creator.id()),
         created_at,
-        priority: 0,
-        due_date: None,
-        labels: Vec::new(),
+        // The urgency + deadline the create captured (0014), echoed so the
+        // response row and the pushed IssueCreated event match a list snapshot.
+        priority,
+        due_date,
+        // Read back from the 0016 join (ORDER BY name), exactly what a later
+        // `issues_list` shows — never the caller's unsorted input.
+        labels: stored_labels,
         pr_url: None,
         // A freshly-created issue has no tasks yet, so no committed branch, and no
         // repo / agent / branches pinned until the follow-up issue_update (63d).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_create_priority_due_labels.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_create_priority_due_labels.rs
@@ -1,0 +1,344 @@
+//! Integration (parity 28): `hangar/issue_create` persists the wizard-authored
+//! `priority` / `due_date` / `labels` against a REAL sqlite store over a real
+//! framed `UnixStream`.
+//!
+//! Before this, the daemon hardcoded `priority: 0`, `due_date: None`,
+//! `labels: []` on every created issue — so every issue authored from the TUI
+//! was P3, deadline-less and label-less no matter what the client sent.
+//!
+//! Asserted here: (1) the create response row echoes all three; (2) the `issue`
+//! table matches; (3) labels land in the 0016 `label` / `issue_label` JOIN (the
+//! source of truth), not merely the `issue.labels` JSON read-cache; (4) an
+//! out-of-vocabulary priority is REJECTED rather than clamped (multica's
+//! `validateIssueEnum` contract); (5) a payload omitting all three still creates
+//! (old-client back-compat); (6) a duplicate label name yields exactly one join
+//! row.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// `2026-08-01` at UTC midnight in epoch milliseconds.
+const DUE_2026_08_01: i64 = 1_785_542_400_000;
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn call_ok(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let resp = self.call(method, params).await;
+        assert!(resp["error"].is_null(), "{method} must succeed: {resp}");
+        resp["result"].clone()
+    }
+
+    async fn read_frame(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// The label NAMES joined to `issue_id` through the 0016 join tables, ordered by
+/// name. Deliberately does NOT read `issue.labels` — the join is the source of
+/// truth and the point of the assertion is that the create wrote it.
+async fn joined_labels(store: &Store, issue_id: &str) -> Vec<String> {
+    sqlx::query_scalar(
+        "SELECT l.name FROM label l JOIN issue_label il ON il.label_id = l.id \
+         WHERE il.issue_id = ? ORDER BY l.name",
+    )
+    .bind(issue_id)
+    .fetch_all(store.pool())
+    .await
+    .expect("read joined labels")
+}
+
+/// A create carrying all three new attributes persists them: the response row,
+/// the `issue` row, and the 0016 label join all agree.
+#[tokio::test]
+async fn issue_create_persists_priority_due_date_and_joined_labels() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let row = c
+        .call_ok(
+            methods::HANGAR_ISSUE_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "title": "ship the deadline",
+                "creator": "member:user-1",
+                "priority": 3,
+                "due_date": DUE_2026_08_01,
+                "labels": ["bug", "p0"],
+            }),
+        )
+        .await;
+    let id = row["id"].as_str().expect("minted issue id").to_string();
+
+    // (1) the response row echoes what was persisted.
+    assert_eq!(row["priority"], 3, "response priority: {row}");
+    assert_eq!(row["due_date"], DUE_2026_08_01, "response due_date: {row}");
+    assert_eq!(
+        row["labels"],
+        serde_json::json!(["bug", "p0"]),
+        "response labels: {row}"
+    );
+
+    // (2) the stored row matches (not just the wire echo).
+    let (priority, due_date): (i64, Option<i64>) =
+        sqlx::query_as("SELECT priority, due_date FROM issue WHERE id = ?")
+            .bind(&id)
+            .fetch_one(store.pool())
+            .await
+            .expect("read stored issue");
+    assert_eq!(priority, 3, "stored priority");
+    assert_eq!(due_date, Some(DUE_2026_08_01), "stored due_date");
+
+    // (3) labels went through the 0016 JOIN, not only the JSON read-cache.
+    assert_eq!(
+        joined_labels(&store, &id).await,
+        vec!["bug".to_string(), "p0".to_string()],
+        "labels must be attached through label/issue_label"
+    );
+
+    // A later snapshot shows the same chips (the create response is not special).
+    let list = c
+        .call_ok(
+            methods::HANGAR_ISSUES_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    let listed = list["issues"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["id"] == serde_json::Value::String(id.clone()))
+        .expect("created issue in the snapshot")
+        .clone();
+    assert_eq!(listed["priority"], 3, "snapshot priority: {listed}");
+    assert_eq!(listed["due_date"], DUE_2026_08_01, "snapshot due_date");
+    assert_eq!(listed["labels"], serde_json::json!(["bug", "p0"]));
+}
+
+/// An out-of-vocabulary priority is a client error, NEVER a silent clamp to 3 —
+/// multica's `validateIssueEnum` contract. No row is written.
+#[tokio::test]
+async fn issue_create_rejects_out_of_range_priority() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+
+    for bad in [7, -1] {
+        let resp = c
+            .call(
+                methods::HANGAR_ISSUE_CREATE,
+                serde_json::json!({
+                    "workspace_id": WS_SLUG,
+                    "title": "bad urgency",
+                    "creator": "member:user-1",
+                    "priority": bad,
+                }),
+            )
+            .await;
+        assert!(
+            !resp["error"].is_null(),
+            "priority {bad} must be rejected, got {resp}"
+        );
+        assert!(
+            resp["error"]["message"].as_str().unwrap_or_default().contains("priority"),
+            "the rejection must name the offending field: {resp}"
+        );
+    }
+
+    let after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(after, before, "a rejected create must write no row");
+}
+
+/// An OLD client's payload — no `priority` / `due_date` / `labels` keys at all —
+/// still creates, landing on the schema defaults. Append-only back-compat.
+#[tokio::test]
+async fn issue_create_without_the_new_keys_uses_schema_defaults() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let row = c
+        .call_ok(
+            methods::HANGAR_ISSUE_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "title": "plain create",
+                "creator": "member:user-1",
+            }),
+        )
+        .await;
+    let id = row["id"].as_str().expect("minted issue id").to_string();
+
+    assert_eq!(row["priority"], 0, "default priority is 0 (P3): {row}");
+    assert!(row["due_date"].is_null(), "default due_date is null: {row}");
+    // `IssueRow.labels` is `skip_serializing_if = "Vec::is_empty"`, so an
+    // un-labelled row omits the key entirely — absent OR `[]` both mean "none".
+    assert!(
+        row["labels"].as_array().is_none_or(Vec::is_empty),
+        "default labels must be empty: {row}"
+    );
+
+    let due_date: Option<i64> = sqlx::query_scalar("SELECT due_date FROM issue WHERE id = ?")
+        .bind(&id)
+        .fetch_one(store.pool())
+        .await
+        .expect("read stored issue");
+    assert_eq!(due_date, None, "stored due_date stays NULL");
+    assert!(
+        joined_labels(&store, &id).await.is_empty(),
+        "no join rows for a label-less create"
+    );
+}
+
+/// A repeated label name is deduped at the boundary and idempotent in the join:
+/// exactly one `issue_label` row, one chip on the row.
+#[tokio::test]
+async fn issue_create_dedupes_repeated_label_names() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let row = c
+        .call_ok(
+            methods::HANGAR_ISSUE_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "title": "repeat labels",
+                "creator": "member:user-1",
+                // Blank + duplicate + whitespace-padded: all normalised away.
+                "labels": ["bug", " bug ", "", "  "],
+            }),
+        )
+        .await;
+    let id = row["id"].as_str().expect("minted issue id").to_string();
+
+    assert_eq!(
+        row["labels"],
+        serde_json::json!(["bug"]),
+        "one chip survives: {row}"
+    );
+    let joins: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue_label WHERE issue_id = ?")
+        .bind(&id)
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(joins, 1, "exactly one join row for a repeated name");
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/dates.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/dates.rs
@@ -1,0 +1,58 @@
+//! Calendar-date parsing shared by every hangar client that authors a deadline.
+//!
+//! `issue.due_date` is stored as epoch **milliseconds at UTC midnight**
+//! (migration 0014) — a calendar DAY, not an instant. multica reached the same
+//! shape the hard way: its migration 112 converted `TIMESTAMPTZ → DATE` precisely
+//! to kill a timezone bug where a deadline typed in one zone read back as the
+//! previous day in another. Parsing at UTC midnight in ONE place keeps the TUI
+//! wizard, the CLI, and any future client byte-identical.
+
+/// Parse a calendar date (`YYYY-MM-DD`) into epoch milliseconds at UTC midnight.
+///
+/// The hangar mirror of multica's `util.ParseCalendarDate`: the format is exact
+/// (no `2026/08/01`, no `31-12-2026`, no trailing time), and a rejected input is
+/// a caller error surfaced verbatim — never silently coerced to "no due date".
+///
+/// # Errors
+///
+/// Returns the human-readable reason when `raw` is not exactly `%Y-%m-%d` (which
+/// includes an out-of-range month/day such as `2026-13-01`).
+pub fn parse_calendar_date_ms(raw: &str) -> Result<i64, String> {
+    let date = chrono::NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .map_err(|_| format!("expected a YYYY-MM-DD date, got {raw:?}"))?;
+    let dt = date
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| format!("invalid time-of-day for date {raw:?}"))?
+        .and_utc();
+    Ok(dt.timestamp_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_calendar_date_ms;
+
+    #[test]
+    fn parses_at_utc_midnight() {
+        assert_eq!(parse_calendar_date_ms("2026-08-01"), Ok(1_785_542_400_000));
+        assert_eq!(parse_calendar_date_ms("1970-01-01"), Ok(0));
+        // Pre-epoch dates are legal (a negative deadline is nonsense but the
+        // parser is not the policy layer).
+        assert!(parse_calendar_date_ms("1969-12-31").is_ok_and(|ms| ms < 0));
+    }
+
+    #[test]
+    fn rejects_non_iso_shapes() {
+        for bad in [
+            "31-12-2026",
+            "2026-13-01",
+            "2026/08/01",
+            "",
+            "2026-08-01T00:00:00",
+        ] {
+            assert!(
+                parse_calendar_date_ms(bad).is_err(),
+                "{bad:?} must be rejected, not coerced"
+            );
+        }
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
@@ -14,6 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod auth;
+pub mod dates;
 pub mod events;
 pub mod fleet;
 pub mod lifecycle;

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1049,6 +1049,25 @@ pub struct IssueCreateParams {
     /// field: an old client omits it, an old daemon ignores it.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_refs: Vec<String>,
+    /// New issue urgency `0..3` (P3..P0, HIGHER = MORE URGENT, migration 0014).
+    /// `None` = the schema default 0 (P3). An out-of-range value is REJECTED by
+    /// the daemon (multica's `validateIssueEnum` contract), never clamped.
+    /// Append-only field: an old client omits it, an old daemon ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i64>,
+    /// Optional deadline as epoch milliseconds at UTC midnight (migration 0014).
+    /// Clients author a `YYYY-MM-DD` calendar day and convert with
+    /// [`crate::dates::parse_calendar_date_ms`]; `None` = no due date.
+    /// Append-only field: an old client omits it, an old daemon ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub due_date: Option<i64>,
+    /// Label NAMES to attach at create (migration 0016): each is resolve-or-created
+    /// in the workspace and joined to the new issue through the `label` /
+    /// `issue_label` tables (the join is the source of truth; `issue.labels` stays
+    /// the derived read-cache). Append-only field: an old client omits it, an old
+    /// daemon ignores it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_AGENT_UPDATE`] (e38.15): edit one agent's

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -297,15 +297,14 @@ fn issue_row_subtask_fields_roundtrip_and_default() {
 fn issue_create_params_parent_is_additive() {
     use ainb_hangar_proto::snapshots::IssueCreateParams;
 
+    // `..Default::default()` on purpose: this fixture asserts ONE field, so a
+    // later append-only field must not red-gate it (the exhaustive literal did).
     let sub = IssueCreateParams {
         workspace_id: "default".to_string(),
         title: "child".to_string(),
-        description: None,
         creator: "member:alice".to_string(),
-        external_ref: None,
         parent_issue_id: Some("parent-1".to_string()),
-        acceptance_criteria: Vec::new(),
-        context_refs: Vec::new(),
+        ..Default::default()
     };
     let json = serde_json::to_string(&sub).expect("encode");
     let back: IssueCreateParams = serde_json::from_str(&json).expect("decode");
@@ -329,6 +328,72 @@ fn issue_create_params_parent_is_additive() {
         legacy_row.parent_issue_id, None,
         "default parent_issue_id is None"
     );
+}
+
+/// Parity 28: `parse_calendar_date_ms` is the ONE calendar-date parser every
+/// hangar client uses — exact `YYYY-MM-DD`, UTC midnight, loud on anything else
+/// (multica's `util.ParseCalendarDate` contract).
+#[test]
+fn calendar_date_parses_at_utc_midnight_and_rejects_other_shapes() {
+    use ainb_hangar_proto::dates::parse_calendar_date_ms;
+
+    assert_eq!(
+        parse_calendar_date_ms("2026-08-01"),
+        Ok(1_785_542_400_000),
+        "2026-08-01 is UTC midnight epoch ms"
+    );
+    assert_eq!(parse_calendar_date_ms("1970-01-01"), Ok(0));
+    for bad in ["31-12-2026", "2026-13-01", "", "2026/08/01"] {
+        assert!(
+            parse_calendar_date_ms(bad).is_err(),
+            "{bad:?} must be rejected, never coerced to a silent no-due-date"
+        );
+    }
+}
+
+/// Parity 28: `priority` / `due_date` / `labels` are append-only on
+/// `IssueCreateParams` — absent from the wire when defaulted, and a pre-28
+/// payload decodes them to `None` / `None` / `[]`.
+#[test]
+fn issue_create_params_priority_due_labels_are_additive() {
+    use ainb_hangar_proto::snapshots::IssueCreateParams;
+
+    let rich = IssueCreateParams {
+        workspace_id: "default".to_string(),
+        title: "urgent".to_string(),
+        creator: "member:alice".to_string(),
+        priority: Some(3),
+        due_date: Some(1_785_542_400_000),
+        labels: vec!["bug".to_string(), "p0".to_string()],
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&rich).expect("encode");
+    let back: IssueCreateParams = serde_json::from_str(&json).expect("decode");
+    assert_eq!(back.priority, Some(3));
+    assert_eq!(back.due_date, Some(1_785_542_400_000));
+    assert_eq!(back.labels, vec!["bug".to_string(), "p0".to_string()]);
+
+    // An unadorned create's wire shape is byte-identical to pre-28.
+    let plain = IssueCreateParams {
+        priority: None,
+        due_date: None,
+        labels: Vec::new(),
+        ..rich
+    };
+    let json = serde_json::to_string(&plain).expect("encode");
+    for key in ["priority", "due_date", "labels"] {
+        assert!(
+            !json.contains(key),
+            "{key} must be omitted when unset, got {json}"
+        );
+    }
+
+    // A pre-28 payload decodes to the schema defaults.
+    let legacy = r#"{"workspace_id":"default","title":"t","creator":"member:alice"}"#;
+    let legacy_row: IssueCreateParams = serde_json::from_str(legacy).expect("decode legacy");
+    assert_eq!(legacy_row.priority, None, "default priority is None (P3)");
+    assert_eq!(legacy_row.due_date, None, "default due_date is None");
+    assert!(legacy_row.labels.is_empty(), "default labels is empty");
 }
 
 #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3068,6 +3068,9 @@ impl HangarPlugin {
             external_ref,
             acceptance_criteria,
             context_refs,
+            priority,
+            due_date,
+            labels,
             repo_ref,
             source_branch,
             target_branch,
@@ -3110,6 +3113,18 @@ impl HangarPlugin {
         }
         if !context_refs.is_empty() {
             params["context_refs"] = serde_json::json!(context_refs);
+        }
+        // 0014/0016: the wizard's Priority / Due / Labels rows. Each key is added
+        // ONLY when the author moved it off its default, so an unadorned create's
+        // wire shape stays byte-identical to pre-parity-28 (append-only).
+        if priority != 0 {
+            params["priority"] = serde_json::json!(priority);
+        }
+        if let Some(due) = due_date {
+            params["due_date"] = serde_json::json!(due);
+        }
+        if !labels.is_empty() {
+            params["labels"] = serde_json::json!(labels);
         }
         let Ok(body) = encode_request(
             ISSUE_CREATE_REQ_ID,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -402,6 +402,16 @@ pub enum IssueCreateAction {
         /// `issue.context_refs` and rendered on the detail card. Empty when the
         /// wizard's Context row was left blank.
         context_refs: Vec<String>,
+        /// The urgency picked on the wizard's Priority row (migration 0014), on
+        /// the wire scale `0..3` (P3..P0, HIGHER = MORE URGENT). `0` (P3) when the
+        /// row was left alone.
+        priority: i64,
+        /// The deadline typed on the wizard's Due row (migration 0014) as epoch ms
+        /// at UTC midnight; `None` when the row was blank.
+        due_date: Option<i64>,
+        /// The label NAMES typed on the wizard's Labels row (migration 0016),
+        /// resolve-or-created and joined to the new issue. Empty when blank.
+        labels: Vec<String>,
         /// The picked repo (REQUIRED): an absolute path, `scratch`, or a remote
         /// indicator the daemon clones.
         repo_ref: String,
@@ -1716,6 +1726,9 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
             external_ref,
             acceptance_criteria,
             context_refs,
+            priority,
+            due_date,
+            labels,
             repo_ref,
             source_branch,
             target_branch,
@@ -1729,6 +1742,9 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
                 external_ref,
                 acceptance_criteria,
                 context_refs,
+                priority,
+                due_date,
+                labels,
                 repo_ref,
                 source_branch,
                 target_branch,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -755,6 +755,20 @@ pub enum WizardRow {
     /// reference (URL / `owner/repo#123` / note), stored as `issue.context_refs`
     /// (migration 0048). Enter here inserts a NEWLINE (like `Brief`).
     Context,
+    /// The priority PICKER row (←/→ cycle `0..3`, wrapping; migration 0014).
+    /// The wire scale is HIGHER = MORE URGENT, so `0` is P3 (routine, the
+    /// default) and `3` is P0. Typing / Backspace are ignored here, exactly like
+    /// `Agent`.
+    Priority,
+    /// The due-date text row (OPTIONAL, single-line): a `YYYY-MM-DD` calendar day
+    /// parsed at UTC midnight into `issue.due_date` (migration 0014). Blank = no
+    /// deadline; an unparseable buffer paints red and BLOCKS create (focus jumps
+    /// back here) rather than silently dropping the date.
+    Due,
+    /// The labels text row (OPTIONAL, single-line): comma-separated label NAMES,
+    /// each resolve-or-created in the workspace and joined to the new issue
+    /// (migration 0016). Blanks and repeats are dropped.
+    Labels,
     /// The repo picker row (REQUIRED — `@` fuzzy dropdown or ←/→ cycle; a
     /// repo-less create is impossible).
     Repo,
@@ -767,14 +781,18 @@ pub enum WizardRow {
 }
 
 impl WizardRow {
-    /// The rows in render / focus-cycle order (Title → Brief → Link → Acceptance →
-    /// Context → Repo → Source → Target → Agent).
-    pub const ALL: [Self; 9] = [
+    /// The rows in render / focus-cycle order: the issue's own attributes first
+    /// (Title → Brief → Link → Acceptance → Context → Priority → Due → Labels),
+    /// then the dispatch tail (Repo → Source → Target → Agent).
+    pub const ALL: [Self; 12] = [
         Self::Title,
         Self::Brief,
         Self::Link,
         Self::Acceptance,
         Self::Context,
+        Self::Priority,
+        Self::Due,
+        Self::Labels,
         Self::Repo,
         Self::Source,
         Self::Target,
@@ -835,6 +853,17 @@ pub struct CreateWizard {
     /// newlines; each non-blank line becomes one `issue.context_refs` element
     /// (migration 0048). Blank is allowed.
     context: String,
+    /// The picked urgency on the wire scale `0..3` (P3..P0, HIGHER = MORE
+    /// URGENT; migration 0014). Defaults to `0` (P3), the schema default, so an
+    /// untouched wizard creates exactly what it did before this row existed.
+    priority: i64,
+    /// The single-line due-date buffer (OPTIONAL): a `YYYY-MM-DD` calendar day
+    /// converted to epoch ms at UTC midnight for `issue.due_date`. Blank = no
+    /// deadline; an unparseable value BLOCKS create rather than being dropped.
+    due: String,
+    /// The single-line labels buffer (OPTIONAL): comma-separated label names
+    /// attached through the 0016 join at create. Blank is allowed.
+    labels: String,
     /// The picked repo's wire ref, or `None` until one is chosen (REQUIRED).
     repo_ref: Option<String>,
     /// The post-`@` fuzzy query filtering the repo dropdown.
@@ -870,6 +899,9 @@ impl Default for CreateWizard {
             link: String::new(),
             acceptance: String::new(),
             context: String::new(),
+            priority: 0,
+            due: String::new(),
+            labels: String::new(),
             repo_ref: None,
             repo_query: String::new(),
             repo_dropdown: None,
@@ -920,6 +952,26 @@ impl CreateWizard {
     #[must_use]
     pub fn context(&self) -> &str {
         &self.context
+    }
+
+    /// The picked urgency on the wire scale `0..3` (P3..P0, HIGHER = MORE
+    /// URGENT). `0` on an untouched wizard.
+    #[must_use]
+    pub const fn priority(&self) -> i64 {
+        self.priority
+    }
+
+    /// The raw due-date buffer typed so far (a `YYYY-MM-DD` calendar day; may be
+    /// empty, and may be mid-typing and therefore unparseable).
+    #[must_use]
+    pub fn due(&self) -> &str {
+        &self.due
+    }
+
+    /// The raw comma-separated labels buffer typed so far (may be empty).
+    #[must_use]
+    pub fn labels(&self) -> &str {
+        &self.labels
     }
 
     /// The parent issue's wire id when this wizard is an "add sub-issue" (`s` /
@@ -1727,6 +1779,19 @@ pub enum IssueListIntent {
         /// the Context row, carried through to `issue.context_refs`. Empty when the
         /// row was left blank.
         context_refs: Vec<String>,
+        /// The urgency picked on the Priority row (migration 0014), on the wire
+        /// scale `0..3` (P3..P0, HIGHER = MORE URGENT). `0` when the row was left
+        /// alone — the schema default.
+        priority: i64,
+        /// The deadline typed on the Due row (migration 0014) as epoch ms at UTC
+        /// midnight. `None` when the row was left blank. A non-blank but
+        /// unparseable buffer never reaches here: the create guard keeps the
+        /// wizard open on the Due row instead.
+        due_date: Option<i64>,
+        /// The label NAMES typed on the Labels row (migration 0016), comma-split,
+        /// trimmed, blank-and-duplicate-dropped. Each is resolve-or-created in the
+        /// workspace and joined to the new issue. Empty when the row was blank.
+        labels: Vec<String>,
         /// The repo picked in stage 2 (REQUIRED — an absolute path, `scratch`, or
         /// a remote indicator the daemon clones).
         repo_ref: String,
@@ -2160,11 +2225,20 @@ fn wizard_cycle_value(
             };
             wizard.agent_cursor = ring_step(wizard.agent_cursor, n, forward);
         }
+        WizardRow::Priority => {
+            // 0014: cycle the four-value urgency ring (P3..P0), wrapping — the
+            // same idiom as the Agent row. `usize` for `ring_step`, back to the
+            // wire scalar after.
+            let cur = usize::try_from(wizard.priority).unwrap_or(0).min(3);
+            wizard.priority = i64::try_from(ring_step(cur, 4, forward)).unwrap_or(0);
+        }
         WizardRow::Title
         | WizardRow::Brief
         | WizardRow::Link
         | WizardRow::Acceptance
         | WizardRow::Context
+        | WizardRow::Due
+        | WizardRow::Labels
         | WizardRow::Source
         | WizardRow::Target => {}
     }
@@ -2186,6 +2260,8 @@ fn wizard_type_char(
         WizardRow::Link => wizard.link.push(c),
         WizardRow::Acceptance => wizard.acceptance.push(c),
         WizardRow::Context => wizard.context.push(c),
+        WizardRow::Due => wizard.due.push(c),
+        WizardRow::Labels => wizard.labels.push(c),
         WizardRow::Source => wizard.source_branch.push(c),
         WizardRow::Target => wizard.target_branch.push(c),
         WizardRow::Repo => {
@@ -2197,7 +2273,8 @@ fn wizard_type_char(
             // Any non-`@` char on the closed repo row is ignored — the picker is
             // driven by `@` / ←→, not free text.
         }
-        WizardRow::Agent => {}
+        // Picker rows: ←→ only, never free text.
+        WizardRow::Priority | WizardRow::Agent => {}
     }
     set_wizard(state, wizard)
 }
@@ -2221,13 +2298,19 @@ fn wizard_backspace(state: &IssueListState, mut wizard: CreateWizard) -> IssueLi
         WizardRow::Context => {
             wizard.context.pop();
         }
+        WizardRow::Due => {
+            wizard.due.pop();
+        }
+        WizardRow::Labels => {
+            wizard.labels.pop();
+        }
         WizardRow::Source => {
             wizard.source_branch.pop();
         }
         WizardRow::Target => {
             wizard.target_branch.pop();
         }
-        WizardRow::Repo | WizardRow::Agent => {}
+        WizardRow::Repo | WizardRow::Priority | WizardRow::Agent => {}
     }
     set_wizard(state, wizard)
 }
@@ -2299,11 +2382,44 @@ fn split_lines(raw: &str) -> Vec<String> {
         .collect()
 }
 
+/// Split the single-line Labels buffer into label NAMES: comma-separated, each
+/// trimmed, blanks dropped, repeats dropped preserving first-seen order (0016).
+/// `LabelRepo::attach` is idempotent so a repeat could not corrupt the join, but
+/// the create payload should not imply the repetition meant anything.
+fn split_labels(raw: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for name in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if !out.iter().any(|seen| seen == name) {
+            out.push(name.to_string());
+        }
+    }
+    out
+}
+
+/// The Due row's buffer as epoch ms at UTC midnight: `Ok(None)` when blank (no
+/// deadline), `Ok(Some(ms))` for a valid `YYYY-MM-DD`, `Err(())` when the buffer
+/// is non-blank and unparseable — which the create guard turns into "stay open,
+/// focus the row" and the renderer paints red.
+fn wizard_due_ms(raw: &str) -> Result<Option<i64>, ()> {
+    let t = raw.trim();
+    if t.is_empty() {
+        return Ok(None);
+    }
+    ainb_hangar_proto::dates::parse_calendar_date_ms(t).map(Some).map_err(|_| ())
+}
+
 fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueListReduction {
     if wizard.title.trim().is_empty() {
         wizard.focus = WizardRow::Title;
         return set_wizard(state, wizard);
     }
+    // 0014: a typed-but-invalid deadline must never be silently dropped — the
+    // same "guide, never silently block" contract the Title / Repo guards use.
+    // The row itself paints the error, so no note plumbing is needed.
+    let Ok(due_date) = wizard_due_ms(&wizard.due) else {
+        wizard.focus = WizardRow::Due;
+        return set_wizard(state, wizard);
+    };
     let Some(repo_ref) = wizard.repo_ref.clone() else {
         // Repo REQUIRED: guide the user to it with the dropdown open at scratch.
         wizard.focus = WizardRow::Repo;
@@ -2358,6 +2474,11 @@ fn wizard_try_create(state: &IssueListState, mut wizard: CreateWizard) -> IssueL
             // lines — each surviving line is one list element (order-preserving).
             acceptance_criteria: split_lines(&wizard.acceptance),
             context_refs: split_lines(&wizard.context),
+            // 0014/0016: the authored urgency, the parsed deadline (already
+            // validated above), and the comma-split label names.
+            priority: wizard.priority,
+            due_date,
+            labels: split_labels(&wizard.labels),
             repo_ref,
             source_branch: opt(&wizard.source_branch),
             target_branch: opt(&wizard.target_branch),
@@ -2757,13 +2878,13 @@ const CARD_BACKDROP: Color = Color::rgb(20, 20, 28);
 const WIZARD_TITLE: &str = "✦ New task";
 /// The in-card footer hint naming the nav keys.
 const WIZARD_HINT: &str = "↑↓ row   ←→ value   Enter create   Esc cancel";
-/// The card's FIXED-row height: top border + the 6 single-line field rows
-/// (Title / Link / Repo / Source / Target / Agent) + spacer + hint + bottom
-/// border. The multi-line Brief row adds `brief_rows` on top of this, and the `@`
-/// repo picker adds its visible dropdown rows while open (see [`render_wizard`]);
-/// the card is exactly this tall only in the degenerate all-empty
-/// single-line-brief case.
-const WIZARD_CARD_H: u16 = 10;
+/// The card's FIXED-row height: top border + the 9 single-line field rows
+/// (Title / Link / Priority / Due / Labels / Repo / Source / Target / Agent) +
+/// spacer + hint + bottom border. The multi-line Brief / Acceptance / Context
+/// rows add their wrapped-line counts on top of this, and the `@` repo picker
+/// adds its visible dropdown rows while open (see [`render_wizard`]); the card is
+/// exactly this tall only in the degenerate all-empty single-line-brief case.
+const WIZARD_CARD_H: u16 = 13;
 /// The most wrapped Brief lines the card shows at once; a longer brief
 /// scroll-follows the newest text within this window. Bounds card growth so the
 /// Brief never blows the viewport.
@@ -3032,6 +3153,14 @@ const BRIEF_PLACEHOLDER: &str = "(optional — describe the task)";
 const ACCEPTANCE_PLACEHOLDER: &str = "(optional — one criterion per line)";
 /// The placeholder for the empty, unfocused Context row (one reference / line).
 const CONTEXT_PLACEHOLDER: &str = "(optional — one reference per line)";
+/// The placeholder for the empty, unfocused Due row — it also DOCUMENTS the only
+/// accepted format, so the red invalid state is reachable only by ignoring it.
+const DUE_PLACEHOLDER: &str = "YYYY-MM-DD";
+/// The placeholder for the empty, unfocused Labels row (comma-separated names).
+const LABELS_PLACEHOLDER: &str = "bug, p0";
+/// The colour a non-blank, unparseable Due buffer paints in: the always-visible
+/// "Enter will not create with this" signal.
+const DUE_INVALID: Color = Color::rgb(220, 90, 90);
 
 /// Render the multi-line Brief value at `(x, y)` over `rows` lines (see
 /// [`render_multiline`]).
@@ -3109,6 +3238,9 @@ const fn wizard_row_label(row: WizardRow) -> &'static str {
         WizardRow::Link => "Linked",
         WizardRow::Acceptance => "Accept",
         WizardRow::Context => "Context",
+        WizardRow::Priority => "Priority",
+        WizardRow::Due => "Due",
+        WizardRow::Labels => "Labels",
         WizardRow::Repo => "Repo",
         WizardRow::Source => "Source",
         WizardRow::Target => "Target",
@@ -3160,6 +3292,48 @@ fn render_wizard_field(
                 raw.to_string()
             };
             let colour = if !focused && raw.is_empty() {
+                MUTED_GRAY
+            } else {
+                value_colour
+            };
+            put_card_str(buf, cx, y, &shown, colour, right, true);
+        }
+        WizardRow::Priority => {
+            // 0014: `P0..P3` plus the urgency word, painted in the SAME chip
+            // colour the board cards use so the two surfaces read alike. A
+            // focused row takes the gold focus colour instead.
+            let chip = crate::widgets::card_board::PriorityChip::from_priority(wizard.priority());
+            let colour = if focused { GOLD } else { chip.color() };
+            let shown = format!("{}  {}", priority_label(wizard.priority()), chip.label());
+            put_card_str(buf, cx, y, &shown, colour, right, true);
+        }
+        WizardRow::Due => {
+            // A non-blank, unparseable buffer paints RED: the always-visible
+            // signal that Enter will refuse to create (never a silent drop).
+            let raw = wizard.due();
+            let invalid = wizard_due_ms(raw).is_err();
+            let shown = if raw.is_empty() && !focused {
+                DUE_PLACEHOLDER.to_string()
+            } else {
+                text(raw)
+            };
+            let colour = if invalid {
+                DUE_INVALID
+            } else if raw.is_empty() && !focused {
+                MUTED_GRAY
+            } else {
+                value_colour
+            };
+            put_card_str(buf, cx, y, &shown, colour, right, true);
+        }
+        WizardRow::Labels => {
+            let raw = wizard.labels();
+            let shown = if raw.is_empty() && !focused {
+                LABELS_PLACEHOLDER.to_string()
+            } else {
+                text(raw)
+            };
+            let colour = if raw.is_empty() && !focused {
                 MUTED_GRAY
             } else {
                 value_colour
@@ -3913,11 +4087,7 @@ mod tests {
         s.set_repos(repo_roster());
         let s = type_into(&s, "Fix");
         // Move focus past Brief to the Repo row, then open the dropdown.
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
+        let s = focus_wizard_row(s, WizardRow::Repo);
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
         let mut buf = WireBuffer::new(120, 24);
         render_issue_list(&mut buf, 120, 1, 23, &s, 0);
@@ -3961,11 +4131,7 @@ mod tests {
         s.set_repos(repo_roster());
         let s = type_into(&s, "Fix");
         // Focus Repo (past Brief), cycle ←→ to pick `rosetta` (scratch=0, rosetta=1).
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
+        let s = focus_wizard_row(s, WizardRow::Repo);
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Right)).state; // scratch
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Right)).state; // rosetta
         assert_eq!(
@@ -4003,11 +4169,7 @@ mod tests {
         let mut s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         s.set_repos(roster);
         let s = type_into(&s, "Fix");
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
+        let s = focus_wizard_row(s, WizardRow::Repo);
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
         let mut buf = WireBuffer::new(120, 24);
         render_issue_list(&mut buf, 120, 1, 23, &s, 0);
@@ -4053,11 +4215,7 @@ mod tests {
             reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         base.set_repos(repo_roster());
         let base = type_into(&base, "Fix");
-        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
-        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
-        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
-        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
-        let base = reduce_issue_list(&base, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
+        let base = focus_wizard_row(base, WizardRow::Repo);
 
         let painted_row_span = |s: &IssueListState| -> u16 {
             let mut buf = WireBuffer::new(120, 24);
@@ -4090,6 +4248,65 @@ mod tests {
         );
     }
 
+    /// Parity 28: the card paints the three new rows, the Priority row shows the
+    /// picked `P0` + its urgency word after →×3, and a non-blank unparseable Due
+    /// buffer paints in the error colour (the always-visible "Enter will refuse"
+    /// signal) while a valid one does not.
+    #[test]
+    fn wizard_card_paints_priority_due_and_labels_rows() {
+        let s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
+        let s = type_into(&s, "Fix");
+
+        let paint = |s: &IssueListState| -> String {
+            let mut buf = WireBuffer::new(120, 30);
+            render_issue_list(&mut buf, 120, 1, 29, s, 0);
+            painted_text(&buf)
+        };
+
+        // The three labels are on the card at rest.
+        let text = paint(&s);
+        for needle in [
+            "Priority",
+            "Due",
+            "Labels",
+            DUE_PLACEHOLDER,
+            LABELS_PLACEHOLDER,
+        ] {
+            assert!(text.contains(needle), "missing {needle:?}:\n{text}");
+        }
+        assert!(text.contains("P3"), "the default urgency reads P3:\n{text}");
+
+        // →×3 on the Priority row paints P0 + the Urgent chip word.
+        let s = focus_wizard_row(s, WizardRow::Priority);
+        let s = (0..3).fold(s, |s, _| {
+            reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Right)).state
+        });
+        let text = paint(&s);
+        assert!(text.contains("P0"), "→×3 must paint P0:\n{text}");
+        assert!(
+            text.contains("Urgent"),
+            "the urgency word is shown:\n{text}"
+        );
+
+        // A garbage Due buffer paints red; a valid one does not.
+        let painted_in_error = |s: &IssueListState| -> bool {
+            let mut buf = WireBuffer::new(120, 30);
+            render_issue_list(&mut buf, 120, 1, 29, s, 0);
+            buf.cells.iter().any(|(_, c)| c.fg == Some(DUE_INVALID))
+        };
+        let s = focus_wizard_row(s, WizardRow::Due);
+        let bad = type_into(&s, "31-12-2026");
+        assert!(
+            painted_in_error(&bad),
+            "an unparseable due date must paint in the error colour"
+        );
+        let good = type_into(&s, "2026-08-01");
+        assert!(
+            !painted_in_error(&good),
+            "a valid due date must not paint in the error colour"
+        );
+    }
+
     /// A roster longer than the visible window scrolls: paging the cursor Down past
     /// the window reveals a later candidate that was off-screen at open.
     #[test]
@@ -4105,11 +4322,7 @@ mod tests {
         let mut s = reduce_issue_list(&IssueListState::default(), IssueListEvent::Key('c')).state;
         s.set_repos(roster);
         let s = type_into(&s, "Fix");
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Brief
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Link
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Acceptance
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Context
-        let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Down)).state; // Repo
+        let s = focus_wizard_row(s, WizardRow::Repo);
         let s = reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char('@'))).state;
 
         // At open the last repo is off-window (13 candidates incl. scratch, window 6).
@@ -4147,6 +4360,19 @@ mod tests {
     }
 
     /// Type a string into the focused wizard row, char by char.
+    /// Move the open wizard's focus to `row` by pressing Down until it lands
+    /// there. Position-INDEPENDENT so adding a wizard row does not re-number
+    /// every render fixture below.
+    fn focus_wizard_row(mut state: IssueListState, row: WizardRow) -> IssueListState {
+        for _ in 0..=WizardRow::ALL.len() {
+            if state.wizard().expect("wizard is open").focus() == row {
+                return state;
+            }
+            state = reduce_issue_list(&state, IssueListEvent::Wizard(WizardKey::Down)).state;
+        }
+        panic!("focus never reached {row:?}");
+    }
+
     fn type_into(state: &IssueListState, text: &str) -> IssueListState {
         text.chars().fold(state.clone(), |s, ch| {
             reduce_issue_list(&s, IssueListEvent::Wizard(WizardKey::Char(ch))).state

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1018,17 +1018,25 @@ fn render_detail_card(
     );
     row = row.saturating_add(1);
 
-    // --- Labels ---
+    // --- Labels / Due (0014: the deadline shares the Labels row, so the card
+    //     height is unchanged and an issue's whole triage state reads in one
+    //     glance: Priority above, Labels + Due here) ---
     let labels = if issue.labels.is_empty() {
         CARD_UNSET.to_string()
     } else {
         issue.labels.iter().map(|l| format!("[{l}]")).collect::<Vec<_>>().join(" ")
     };
+    let due = issue.due_date.map_or_else(|| CARD_UNSET.to_string(), fmt_card_date);
     card_field_row(
         buf,
         card_w,
         row,
-        &[("Labels: ", CARD_LABEL), (&labels, CARD_VALUE)],
+        &[
+            ("Labels: ", CARD_LABEL),
+            (&labels, CARD_VALUE),
+            ("   Due: ", CARD_LABEL),
+            (&due, CARD_VALUE),
+        ],
     );
     row = row.saturating_add(1);
 
@@ -1380,6 +1388,33 @@ mod card_tests {
             "em-dash placeholder for unset repo/agent"
         );
         assert!(text.contains("no description"), "unset description");
+    }
+
+    /// Parity 28: the deadline renders on the card next to the labels — a real
+    /// `YYYY-MM-DD` when set, the unset placeholder when not. Without this the
+    /// wizard could author a due date the user could never see.
+    #[test]
+    fn detail_card_renders_the_due_date() {
+        // Set: the calendar day appears under a `Due:` label.
+        let mut issue = full_issue();
+        issue.due_date = Some(1_785_542_400_000); // 2026-08-01 UTC midnight
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+        assert!(text.contains("Due: "), "due label: {text}");
+        assert!(text.contains("2026-08-01"), "due value: {text}");
+
+        // Unset: the label still renders, with the em-dash placeholder.
+        let s = state_for(full_issue());
+        let mut buf = WireBuffer::new(80, 30);
+        render_task_detail(&mut buf, 80, 0, 29, &s);
+        let text = painted_text(&buf);
+        assert!(text.contains("Due: "), "due label when unset: {text}");
+        assert!(
+            !text.contains("2026-08-01"),
+            "no stale date on a deadline-less issue: {text}"
+        );
     }
 
     /// A linked upstream issue (0043) renders a subtle `Linked: ⧉ <ref>` line on

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -137,6 +137,19 @@ fn type_str(mut s: IssueListState, text: &str) -> IssueListState {
     s
 }
 
+/// Move focus to `row` by pressing Down until it lands there (bounded by the row
+/// count). Position-INDEPENDENT on purpose: adding a wizard row must not
+/// re-number every fixture in this file.
+fn focus_row(mut s: IssueListState, row: WizardRow) -> IssueListState {
+    for _ in 0..=WizardRow::ALL.len() {
+        if s.wizard().expect("wizard is open").focus() == row {
+            return s;
+        }
+        s = wiz(&s, WizardKey::Down).state;
+    }
+    panic!("focus never reached {row:?}");
+}
+
 /// Open a fresh wizard focused on the Title row (the `c` entry point).
 fn open_wizard() -> IssueListState {
     reduce_issue_list(&seeded_state(), IssueListEvent::Key('c')).state
@@ -148,16 +161,11 @@ fn ready_to_create() -> IssueListState {
     let s = open_wizard();
     let s = type_str(s, "Fix login");
     // Move past Brief to Repo, open the dropdown (cursor at scratch), pick it.
-    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     let s = wiz(&s, WizardKey::Char('@')).state;
     let s = wiz(&s, WizardKey::Enter).state; // pick scratch, dropdown closes
     // Land focus on the Agent row.
-    let s = wiz(&s, WizardKey::Down).state; // Repo → Source
-    let s = wiz(&s, WizardKey::Down).state; // Source → Target
+    let s = focus_row(s, WizardRow::Target);
     wiz(&s, WizardKey::Down).state // Target → Agent
 }
 
@@ -182,37 +190,56 @@ fn c_opens_wizard_focused_on_title() {
 }
 
 /// ↓ / Tab advance the focused row, ↑ / Shift+Tab retreat, both wrapping around
-/// the nine rows (Title → Brief → Link → Acceptance → Context → Repo → Source →
-/// Target → Agent; mirrors the host new-session Configure form).
+/// EVERY row in [`WizardRow::ALL`] order (mirrors the host new-session Configure
+/// form). Driven off `ALL` rather than a frozen literal list, so adding a row
+/// extends the coverage instead of breaking the fixture.
 #[test]
 fn wizard_focus_moves_and_wraps() {
     let s = open_wizard();
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Title);
+    assert_eq!(
+        WizardRow::ALL.first(),
+        Some(&WizardRow::Title),
+        "a fresh wizard opens on the first row"
+    );
 
+    // Down / Tab walk the whole ring forward and land back on the first row.
+    let mut s = s;
+    for (i, expected) in WizardRow::ALL.iter().enumerate().skip(1) {
+        // Alternate the two forward keys — they must be interchangeable.
+        let key = if i % 2 == 0 {
+            WizardKey::Tab
+        } else {
+            WizardKey::Down
+        };
+        s = wiz(&s, key).state;
+        assert_eq!(
+            s.wizard().unwrap().focus(),
+            *expected,
+            "row {i} of the forward walk"
+        );
+    }
     let s = wiz(&s, WizardKey::Down).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
-    let s = wiz(&s, WizardKey::Tab).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Link);
-    let s = wiz(&s, WizardKey::Tab).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Acceptance);
-    let s = wiz(&s, WizardKey::Tab).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Context);
-    let s = wiz(&s, WizardKey::Tab).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Repo);
-    let s = wiz(&s, WizardKey::Tab).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Source);
+    assert_eq!(
+        s.wizard().unwrap().focus(),
+        WizardRow::Title,
+        "forward wraps off the last row"
+    );
 
-    // Wrap forward: Agent → Title.
-    let s = wiz(&s, WizardKey::Down).state; // Target
-    let s = wiz(&s, WizardKey::Down).state; // Agent
-    let s = wiz(&s, WizardKey::Down).state; // wraps → Title
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Title);
+    // Up walks the ring backward from Title, wrapping onto the last row first.
+    let mut s = s;
+    for expected in WizardRow::ALL.iter().rev() {
+        s = wiz(&s, WizardKey::Up).state;
+        assert_eq!(s.wizard().unwrap().focus(), *expected, "backward walk");
+    }
 
-    // Wrap backward: Title → Agent.
-    let s = wiz(&s, WizardKey::Up).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Agent);
+    // Shift+Tab is the same retreat as ↑ (checked once, from the first row).
     let s = wiz(&s, WizardKey::BackTab).state;
-    assert_eq!(s.wizard().unwrap().focus(), WizardRow::Target);
+    assert_eq!(
+        s.wizard().unwrap().focus(),
+        *WizardRow::ALL.last().unwrap(),
+        "Shift+Tab retreats and wraps like ↑"
+    );
 }
 
 /// ←/→ cycle the Agent picker through `AgentChip::ALL`, wrapping; the branch text
@@ -242,8 +269,7 @@ fn wizard_left_right_cycles_agent_only() {
     );
 
     // ←/→ on a text row is a no-op (Source keeps its prefill).
-    let s = wiz(&s, WizardKey::Up).state; // Agent → Target
-    let s = wiz(&s, WizardKey::Up).state; // Target → Source
+    let s = focus_row(s, WizardRow::Source);
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Source);
     let out = wiz(&s, WizardKey::Right);
     assert_eq!(out.state.wizard().unwrap().source_branch(), "main");
@@ -255,11 +281,7 @@ fn wizard_left_right_cycles_agent_only() {
 fn wizard_left_right_cycles_repo() {
     let s = open_wizard();
     let s = type_str(s, "Fix");
-    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     assert_eq!(s.wizard().unwrap().repo_ref(), None);
 
     // → picks the first candidate (scratch is always index 0).
@@ -275,12 +297,7 @@ fn wizard_typing_edits_focused_text_row() {
     assert_eq!(s.wizard().unwrap().title(), "Title text");
 
     // Focus Source, clear the "main" prefill, type a custom ref.
-    let s = wiz(&s, WizardKey::Down).state; // Brief
-    let s = wiz(&s, WizardKey::Down).state; // Link
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Context
-    let s = wiz(&s, WizardKey::Down).state; // Repo
-    let s = wiz(&s, WizardKey::Down).state; // Source
+    let s = focus_row(s, WizardRow::Source);
     let s = (0..4).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
     let s = type_str(s, "feature/x");
     let w = s.wizard().unwrap();
@@ -299,11 +316,7 @@ fn wizard_typing_edits_focused_text_row() {
 fn wizard_at_opens_repo_dropdown() {
     let s = open_wizard();
     let s = type_str(s, "Fix");
-    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     assert_eq!(s.wizard().unwrap().repo_dropdown(), None);
 
     let s = wiz(&s, WizardKey::Char('@')).state;
@@ -322,11 +335,7 @@ fn wizard_at_opens_repo_dropdown() {
 fn wizard_tab_from_dropdown_commits_highlight() {
     let s = open_wizard();
     let s = type_str(s, "Fix");
-    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     let s = wiz(&s, WizardKey::Char('@')).state; // open dropdown, cursor on scratch
 
     let out = wiz(&s, WizardKey::Tab);
@@ -395,6 +404,11 @@ fn wizard_complete_form_commits_create_and_run() {
             external_ref: None,
             acceptance_criteria: Vec::new(),
             context_refs: Vec::new(),
+            // An untouched Priority / Due / Labels row creates exactly what it
+            // did before those rows existed (parity 28).
+            priority: 0,
+            due_date: None,
+            labels: Vec::new(),
             repo_ref: "scratch".to_string(),
             source_branch: Some("main".to_string()),
             target_branch: Some("main".to_string()),
@@ -436,13 +450,7 @@ fn wizard_brief_enter_inserts_newline_not_create() {
     // Even a create-ready form (title + repo picked) must not commit from Brief.
     let s = ready_to_create();
     // Walk focus back to the Brief row (Agent → … → Brief).
-    let s = wiz(&s, WizardKey::Up).state; // Target
-    let s = wiz(&s, WizardKey::Up).state; // Source
-    let s = wiz(&s, WizardKey::Up).state; // Repo
-    let s = wiz(&s, WizardKey::Up).state; // Context
-    let s = wiz(&s, WizardKey::Up).state; // Acceptance
-    let s = wiz(&s, WizardKey::Up).state; // Link
-    let s = wiz(&s, WizardKey::Up).state; // Brief
+    let s = focus_row(s, WizardRow::Brief);
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Brief);
 
     let s = type_str(s, "line one");
@@ -468,17 +476,14 @@ fn wizard_link_carries_to_create_intent() {
     let s = open_wizard();
     let s = type_str(s, "Fix login");
     // Title → Brief → Link, then type the upstream ref.
-    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
+    let s = focus_row(s, WizardRow::Link);
     assert_eq!(s.wizard().unwrap().focus(), WizardRow::Link);
     let s = type_str(s, "  acme/api#42  "); // surrounding whitespace is trimmed
     assert_eq!(s.wizard().unwrap().link(), "  acme/api#42  ");
     // Backspace edits the single line.
     let s = wiz(&s, WizardKey::Backspace).state; // drop a trailing space
     // Move to Repo, pick scratch, commit.
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
     let out = wiz(&s, WizardKey::Enter);
     match out.intent {
@@ -520,10 +525,7 @@ fn wizard_brief_carries_to_create_intent() {
     let s = wiz(&s, WizardKey::Down).state; // Title → Brief
     let s = type_str(s, "Reproduce then patch");
     // Move to Repo, pick scratch, then commit from the Repo row.
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
 
     let out = wiz(&s, WizardKey::Enter);
@@ -552,10 +554,7 @@ fn wizard_brief_preserved_verbatim_on_intent() {
     let s = type_str(s, "then summarise findings");
     let s = wiz(&s, WizardKey::Enter).state; // trailing newline
     // Commit from the Repo row.
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
 
     let out = wiz(&s, WizardKey::Enter);
@@ -591,8 +590,7 @@ fn wizard_blank_brief_is_none_on_intent() {
 fn wizard_branch_edits_and_blanks_round_trip() {
     let s = ready_to_create();
     // Focus Source (Agent → up twice), retype it, then blank Target.
-    let s = wiz(&s, WizardKey::Up).state; // Target
-    let s = wiz(&s, WizardKey::Up).state; // Source
+    let s = focus_row(s, WizardRow::Source);
     let s = (0..4).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
     let s = type_str(s, "feature/x");
     let s = wiz(&s, WizardKey::Down).state; // Target
@@ -609,6 +607,11 @@ fn wizard_branch_edits_and_blanks_round_trip() {
             external_ref: None,
             acceptance_criteria: Vec::new(),
             context_refs: Vec::new(),
+            // An untouched Priority / Due / Labels row creates exactly what it
+            // did before those rows existed (parity 28).
+            priority: 0,
+            due_date: None,
+            labels: Vec::new(),
             repo_ref: "scratch".to_string(),
             source_branch: Some("feature/x".to_string()),
             target_branch: None,
@@ -632,11 +635,7 @@ fn wizard_required_guard_blocks_incomplete_creates() {
 
     // Repo only, no title → Enter never creates.
     let s = open_wizard();
-    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     let s = wiz(&s, WizardKey::Right).state; // pick scratch
     assert_eq!(s.wizard().unwrap().repo_ref(), Some("scratch"));
     assert!(wiz(&s, WizardKey::Enter).intent.is_none());
@@ -888,16 +887,10 @@ fn subissue_wizard_commit_carries_parent_issue_id() {
     // Open via `s`, then fill exactly like `ready_to_create` (title + repo + agent).
     let s = reduce_issue_list(&s, IssueListEvent::Key('s')).state;
     let s = type_str(s, "Fix login");
-    let s = wiz(&s, WizardKey::Down).state; // Title → Brief
-    let s = wiz(&s, WizardKey::Down).state; // Brief → Link
-    let s = wiz(&s, WizardKey::Down).state; // Link → Acceptance
-    let s = wiz(&s, WizardKey::Down).state; // Acceptance → Context
-    let s = wiz(&s, WizardKey::Down).state; // Context → Repo
+    let s = focus_row(s, WizardRow::Repo);
     let s = wiz(&s, WizardKey::Char('@')).state;
     let s = wiz(&s, WizardKey::Enter).state; // pick scratch
-    let s = wiz(&s, WizardKey::Down).state; // Repo → Source
-    let s = wiz(&s, WizardKey::Down).state; // Source → Target
-    let s = wiz(&s, WizardKey::Down).state; // Target → Agent
+    let s = focus_row(s, WizardRow::Agent);
 
     let out = wiz(&s, WizardKey::Enter);
 
@@ -1199,4 +1192,131 @@ fn assignee_facet_filters_by_actor_kind() {
     )
     .state;
     assert_eq!(visible_ids(&s), vec!["d_nolbl".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// Parity 28: the wizard authors priority / due date / labels
+// ---------------------------------------------------------------------------
+
+/// `2026-08-01` at UTC midnight in epoch milliseconds.
+const DUE_2026_08_01: i64 = 1_785_542_400_000;
+
+/// Driving REAL keys through the wizard — ←/→ on Priority, typing on Due and
+/// Labels — carries all three onto the raised `CreateAndRun`, with the labels
+/// comma-split, trimmed, blank-dropped and deduped (first-seen order kept).
+#[test]
+fn wizard_priority_due_labels_carry_to_create_intent() {
+    let s = open_wizard();
+    let s = type_str(s, "Fix login");
+
+    // Priority is a PICKER: → three times walks 0 → 3 (P3 → P0).
+    let s = focus_row(s, WizardRow::Priority);
+    let s = wiz(&s, WizardKey::Right).state;
+    let s = wiz(&s, WizardKey::Right).state;
+    let s = wiz(&s, WizardKey::Right).state;
+    assert_eq!(s.wizard().unwrap().priority(), 3, "→×3 reaches P0");
+
+    // Due + Labels are single-line TEXT rows.
+    let s = focus_row(s, WizardRow::Due);
+    let s = type_str(s, "2026-08-01");
+    let s = focus_row(s, WizardRow::Labels);
+    let s = type_str(s, "bug, p0, ,bug");
+
+    let s = focus_row(s, WizardRow::Repo);
+    let s = wiz(&s, WizardKey::Right).state; // pick scratch
+
+    let out = wiz(&s, WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun {
+            priority,
+            due_date,
+            labels,
+            ..
+        }) => {
+            assert_eq!(priority, 3, "the picked urgency reaches the intent");
+            assert_eq!(
+                due_date,
+                Some(DUE_2026_08_01),
+                "the typed calendar day is parsed at UTC midnight"
+            );
+            assert_eq!(
+                labels,
+                vec!["bug".to_string(), "p0".to_string()],
+                "blank dropped, duplicate dropped, first-seen order kept"
+            );
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
+}
+
+/// Priority wraps like every other picker ring: ← from the default 0 lands on 3.
+#[test]
+fn wizard_priority_ring_wraps_and_ignores_typing() {
+    let s = focus_row(open_wizard(), WizardRow::Priority);
+    assert_eq!(s.wizard().unwrap().priority(), 0, "default is P3");
+
+    let s = wiz(&s, WizardKey::Left).state;
+    assert_eq!(s.wizard().unwrap().priority(), 3, "← wraps 0 → 3");
+
+    // A picker row ignores text: typing and Backspace leave it alone.
+    let s = type_str(s, "9");
+    let s = wiz(&s, WizardKey::Backspace).state;
+    assert_eq!(
+        s.wizard().unwrap().priority(),
+        3,
+        "typing never edits a picker row"
+    );
+}
+
+/// An unparseable due date NEVER silently drops the deadline: Enter refuses to
+/// create, the wizard stays open, and focus lands on the offending row.
+#[test]
+fn wizard_invalid_due_blocks_create_and_focuses_the_row() {
+    let s = open_wizard();
+    let s = type_str(s, "Fix login");
+    let s = focus_row(s, WizardRow::Due);
+    let s = type_str(s, "31-12-2026"); // valid-looking, wrong order
+    let s = focus_row(s, WizardRow::Repo);
+    let s = wiz(&s, WizardKey::Right).state; // pick scratch — form is otherwise complete
+
+    let out = wiz(&s, WizardKey::Enter);
+
+    assert!(out.intent.is_none(), "a bad due date must not create");
+    assert_eq!(out.state.mode(), IssueListMode::CreateInput);
+    assert_eq!(
+        out.state.wizard().expect("wizard still open").focus(),
+        WizardRow::Due,
+        "focus guides the user to the offending row"
+    );
+
+    // Correcting it unblocks the create (the guard is not a dead end).
+    let s = out.state;
+    let s = (0.."31-12-2026".len()).fold(s, |s, _| wiz(&s, WizardKey::Backspace).state);
+    let s = type_str(s, "2026-08-01");
+    let out = wiz(&s, WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun { due_date, .. }) => {
+            assert_eq!(due_date, Some(DUE_2026_08_01));
+        }
+        other => panic!("expected CreateAndRun after the fix, got {other:?}"),
+    }
+}
+
+/// A blank Due row is NOT an error — it simply means "no deadline".
+#[test]
+fn wizard_blank_due_creates_without_a_deadline() {
+    let out = wiz(&ready_to_create(), WizardKey::Enter);
+    match out.intent {
+        Some(IssueListIntent::CreateAndRun {
+            priority,
+            due_date,
+            labels,
+            ..
+        }) => {
+            assert_eq!(priority, 0, "untouched Priority stays P3");
+            assert_eq!(due_date, None, "blank Due means no deadline");
+            assert!(labels.is_empty(), "blank Labels means no labels");
+        }
+        other => panic!("expected CreateAndRun, got {other:?}"),
+    }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_wizard_rpc_over_socket.rs
@@ -368,7 +368,12 @@ async fn wizard_commit_issues_create_update_and_run() {
         send_key(&mut host_write, KeyCode::Down).await; // Brief → Link
         send_key(&mut host_write, KeyCode::Down).await; // Link → Acceptance
         send_key(&mut host_write, KeyCode::Down).await; // Acceptance → Context
-        send_key(&mut host_write, KeyCode::Down).await; // Context → Repo
+        // Parity 28 rows, all left at their defaults on this walk: the create's
+        // wire shape must stay byte-identical to pre-28 (asserted below).
+        send_key(&mut host_write, KeyCode::Down).await; // Context → Priority
+        send_key(&mut host_write, KeyCode::Down).await; // Priority → Due
+        send_key(&mut host_write, KeyCode::Down).await; // Due → Labels
+        send_key(&mut host_write, KeyCode::Down).await; // Labels → Repo
         send_key(&mut host_write, KeyCode::Char { ch: '@' }).await;
         send_key(&mut host_write, KeyCode::Enter).await;
         send_key(&mut host_write, KeyCode::Enter).await;
@@ -449,10 +454,149 @@ async fn wizard_commit_issues_create_update_and_run() {
             "issue_update must precede issue_run (update @ {update_ix}, run @ {run_ix})"
         );
 
+        // Parity 28 append-only guarantee: a walk that leaves Priority / Due /
+        // Labels alone emits a create payload with NONE of the three keys, so the
+        // wire shape an old daemon sees is unchanged.
+        let create_params = calls
+            .iter()
+            .find(|(m, _)| m == daemon_methods::HANGAR_ISSUE_CREATE)
+            .map(|(_, p)| p.clone())
+            .expect("issue_create was sent");
+        for key in ["priority", "due_date", "labels"] {
+            assert!(
+                create_params.get(key).is_none(),
+                "an untouched {key} row must not reach the wire: {create_params}"
+            );
+        }
+
         drop(host_write);
         server.abort();
     };
     tokio::time::timeout(BUDGET, body)
         .await
         .expect("exceeded wizard-dispatch budget");
+}
+
+/// Parity 28, the positive half: a wizard walk that PICKS a priority, types a
+/// due date and types labels emits a `hangar/issue_create` payload carrying all
+/// three, in wire form (`priority` scalar, `due_date` epoch ms, `labels` array of
+/// names). Drives real key events end-to-end over the plugin's host protocol —
+/// the shape the daemon actually receives, not a reducer-level intent.
+#[tokio::test]
+async fn wizard_priority_due_labels_reach_the_create_payload() {
+    let body = async {
+        let home = tempfile::tempdir().expect("home");
+        std::env::set_var("AINB_HANGAR_HOME", home.path());
+        let stream_id = format!("sock-wizard-attrs-{}", std::process::id());
+        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+
+        let state = home.path().join("hangar").join("state.toml");
+        std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
+        std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+
+        let socket_path = home.path().join("hangar.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind daemon");
+        spawn_daemon(listener, seen.clone());
+
+        let (host_side, plugin_side) = tokio::io::duplex(256 * 1024);
+        let (plugin_read, plugin_write) = tokio::io::split(plugin_side);
+        let server = tokio::spawn(Server::new(HangarPlugin::new()).run(plugin_read, plugin_write));
+
+        let (host_read_half, mut host_write) = tokio::io::split(host_side);
+        let mut host_read = BufReader::new(host_read_half);
+
+        let daemon = init_and_dial(&mut host_write, &mut host_read, &socket_path, &stream_id).await;
+        let (daemon_read, mut daemon_write) = daemon.into_split();
+        let mut daemon_reader = BufReader::new(daemon_read);
+
+        let ack = read_one_raw_frame(&mut daemon_reader).await.expect("subscribe ack");
+        push_data(&mut host_write, &stream_id, &ack).await;
+        pump_snapshots(
+            &mut host_write,
+            &mut host_read,
+            &mut daemon_reader,
+            &mut daemon_write,
+            &stream_id,
+        )
+        .await;
+
+        // `c` → title → tab down to Priority, →×3 (P3 → P0) → Due, type the
+        // calendar day → Labels, type a comma list (with a blank and a repeat) →
+        // Repo, pick scratch → Enter commits.
+        send_key(&mut host_write, KeyCode::Char { ch: 'c' }).await;
+        for ch in "Urgent task".chars() {
+            send_key(&mut host_write, KeyCode::Char { ch }).await;
+        }
+        for _ in 0..5 {
+            send_key(&mut host_write, KeyCode::Down).await; // Title → … → Priority
+        }
+        for _ in 0..3 {
+            send_key(&mut host_write, KeyCode::Right).await; // P3 → P0
+        }
+        send_key(&mut host_write, KeyCode::Down).await; // Priority → Due
+        for ch in "2026-08-01".chars() {
+            send_key(&mut host_write, KeyCode::Char { ch }).await;
+        }
+        send_key(&mut host_write, KeyCode::Down).await; // Due → Labels
+        for ch in "bug, p0, ,bug".chars() {
+            send_key(&mut host_write, KeyCode::Char { ch }).await;
+        }
+        send_key(&mut host_write, KeyCode::Down).await; // Labels → Repo
+        send_key(&mut host_write, KeyCode::Char { ch: '@' }).await;
+        send_key(&mut host_write, KeyCode::Enter).await; // pick scratch
+        send_key(&mut host_write, KeyCode::Enter).await; // commit
+
+        let mut created: Option<serde_json::Value> = None;
+        for _ in 0..60 {
+            relay_one_send_or_render(
+                &mut host_write,
+                &mut host_read,
+                &mut daemon_reader,
+                &mut daemon_write,
+                &stream_id,
+            )
+            .await;
+            let calls: Vec<(String, serde_json::Value)> = seen.lock().unwrap().clone();
+            created = calls
+                .iter()
+                .find(|(m, p)| {
+                    m == daemon_methods::HANGAR_ISSUE_CREATE
+                        && p.get("title").and_then(serde_json::Value::as_str) == Some("Urgent task")
+                })
+                .map(|(_, p)| p.clone());
+            if created.is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let params = created.unwrap_or_else(|| {
+            panic!(
+                "wizard commit must send issue_create; saw: {:?}",
+                seen.lock().unwrap()
+            )
+        });
+
+        assert_eq!(
+            params.get("priority"),
+            Some(&serde_json::json!(3)),
+            "the picked P0 must reach the wire: {params}"
+        );
+        assert_eq!(
+            params.get("due_date"),
+            // 2026-08-01 at UTC midnight.
+            Some(&serde_json::json!(1_785_542_400_000_i64)),
+            "the typed calendar day must reach the wire as epoch ms: {params}"
+        );
+        assert_eq!(
+            params.get("labels"),
+            Some(&serde_json::json!(["bug", "p0"])),
+            "labels must reach the wire comma-split, deduped: {params}"
+        );
+
+        drop(host_write);
+        server.abort();
+    };
+    tokio::time::timeout(BUDGET, body)
+        .await
+        .expect("exceeded wizard-attribute budget");
 }

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2925,7 +2925,7 @@ Options:
       --label <LABELS>
           A label to attach to the issue (repeatable: `--label bug --label p0`).
           
-          Persisted as the issue's label list. The full labels table + attach/detach is a separate concern; create just records the labels it is handed.
+          Each name is resolve-or-created in the workspace and joined to the issue through the `label` / `issue_label` tables (migration 0016), so a repeated name yields exactly one attachment.
 
       --acceptance <ACCEPTANCE_CRITERIA>
           An acceptance criterion (repeatable: `--acceptance "x" --acceptance "y"`).


### PR DESCRIPTION
## What

Closes multica parity gap 28. Before this, every issue created from the TUI was
`P3`, deadline-less and label-less **unconditionally** — the schema had the
columns since migrations 0014/0016, but nothing above the store could set them:
the wizard had no rows, the wire params had no fields, and
`snapshots::issue_create` hardcoded `priority: 0`, `due_date: None`,
`labels: Vec::new()`.

Five single-concern commits, proto → daemon → cli → wizard → card:

| Commit | Layer |
|---|---|
| `846ded57` | proto: append-only `priority` / `due_date` / `labels` on `IssueCreateParams`, plus `dates::parse_calendar_date_ms` (the shared `YYYY-MM-DD` → UTC-midnight-ms parser) |
| `7573ec6f` | daemon: persist all three; labels through the 0016 `label`/`issue_label` join; `IssueCreateInput` collapses the 11-arg signature |
| `0fc11997` | cli: `--label` on create now goes through the join too (it wrote only the JSON cache); `parse_due_date` delegates to the shared parser |
| `e7ab0dde` | plugin: Priority / Due / Labels rows in the create wizard |
| `3f59f763` | plugin: render `Due:` on the issue detail card |

## Behaviour notes

- **Priority** is a picker ring over `0..3` (P3..P0, higher = more urgent). The
  daemon **rejects** an out-of-range value with `INVALID_PARAMS` rather than
  clamping — multica's `validateIssueEnum` contract.
- **Due date** is a calendar DAY parsed at UTC midnight (multica migration 112
  converted `TIMESTAMPTZ → DATE` to kill exactly this timezone bug). A typed but
  unparseable value paints red and **blocks** Enter with focus jumping back to the
  row; it is never silently dropped.
- **Labels** are comma-separated NAMES, resolve-or-created via `LabelRepo::attach`
  so the 0016 join stays the source of truth and `issue.labels` stays its derived
  read-cache. Deviation from multica (which requires pre-existing label ids)
  is deliberate: hangar has no label-picker inventory in the wizard, and `attach`
  already resolve-or-creates idempotently.
- **Append-only wire shape**: each key is added to `hangar/issue_create` only when
  the author moved it off its default, so an unadorned create's payload is
  byte-identical to before. A pre-28 payload decodes to `None`/`None`/`[]`.

**No new migration** — 0014 and 0016 already hold every column and the join.

## Tests (fail-before / pass-after)

- `ainb-hangar-proto`: calendar-date parse/reject, additive serde round-trip.
- `ainb-hangar-daemon` (new `rpc_issue_create_priority_due_labels.rs`, real sqlite
  over a real `UnixStream`): response row + `issue` row + join rows agree; a later
  `issues_list` snapshot matches; `priority: 7` and `-1` rejected with no row
  written; a payload omitting all three still creates on the defaults; duplicate
  label names yield exactly one join row.
- `ainb-plugin-hangar` reducer: real key events through `reduce_issue_list` —
  →×3 on Priority + typed due + `bug, p0, ,bug` → `priority 3`, `due_date
  1785542400000`, `labels ["bug","p0"]`; the ring wraps and ignores typing; a bad
  due date raises no intent, keeps the wizard open and focuses the Due row (and
  correcting it unblocks the create); an untouched wizard still creates `0`/
  `None`/`[]`.
- `ainb-plugin-hangar` render: the card paints the three rows, `P0` + `Urgent`
  after →×3, and the error colour only for an unparseable due buffer.
- `ainb-plugin-hangar` over-socket: an authored walk puts all three on the wire
  in wire form; an untouched walk puts **none** of the keys on it.
- `ainb-plugin-hangar` detail card: `Due: 2026-08-01` when set, placeholder when not.
- `ainb` CLI: `--label bug --label bug` yields one join row, and `label detach`
  can now remove a create-authored label (it could not before).

### Fixture-drift work carried in the same PR

Both are drift *prevention*, not assertion loosening:

- The exhaustive `IssueCreateParams` literal in `event_roundtrip_test.rs` becomes
  `..Default::default()` so future append-only fields stop red-gating an
  unrelated assertion.
- Wizard fixtures in `issue_list_reducer_test.rs` and the in-crate render tests
  moved from hardcoded `Down`-counts to a `focus_row` helper, and
  `wizard_focus_moves_and_wraps` now walks `WizardRow::ALL` instead of a frozen
  literal list — so adding a row extends coverage rather than re-numbering every
  fixture.

## Local gate (all green on this branch)

```
cargo build -p ainb                                          ok
cargo nextest run --lib --tests --all-features --no-fail-fast \
  -E 'not binary(/^tripwire_/)'      4072 passed, 0 failed, 18 skipped
bash scripts/hangar/run_all_tripwires.sh        ran=60  failed=0 skipped=0
bash scripts/hangar/run_acceptance_tests.sh     ran=141 failed=0 skipped=0
```

Not done: no live daemon + TUI recording of the flow — the proof here is the
real-sqlite daemon test plus the real-key-event plugin tests, not a manual run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Priority, Due date, and Labels fields to the issue creation wizard.
  * Created issues now save and display priority, deadlines, and labels.
  * Added label trimming, deduplication, and workspace label resolution.
  * Added due dates to issue details.
  * Extended issue creation requests to support the new fields.

* **Bug Fixes**
  * Standardized date validation and UTC date handling.
  * Ensured labels can be detached after being added during issue creation.
  * Invalid priorities and due dates are now rejected without creating an issue.

* **Tests**
  * Added coverage for CLI, wizard, and request-based issue creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->