### PR TITLE
feat(hangar): derive and write agent availability from the runtime heartbeat

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -1,19 +1,29 @@
-//! Cross-process `O_EXCL` pidfile lock for serialising `bd` writes (P2.2).
+//! Cross-process pidfile lock for serialising `bd` writes (P2.2).
 //!
 //! `bd` mutates a git-backed store; two concurrent writes against the same
 //! `BEADS_DIR` can race on the git head. Cargo runs integration test binaries in
 //! parallel processes, so an in-process `Mutex` is not enough — serialization
-//! must span processes. [`BdLock`] uses an exclusive-create pidfile
-//! (`O_CREAT | O_EXCL`) as the token: whoever creates the file holds the lock;
-//! everyone else spins until it disappears. A crashed holder leaves a stale
-//! file, so a contender whose PID is no longer alive (`kill(pid, 0)` →
-//! `ESRCH`) steals the lock by removing it. Mirrors the project's
-//! `reference_cross_process_test_serialization` pattern.
+//! must span processes. [`BdLock`] uses a pidfile as the token: whoever
+//! publishes the file holds the lock; everyone else spins until it disappears.
+//! A crashed holder leaves a stale file, so a contender whose PID is no longer
+//! alive (`kill(pid, 0)` → `ESRCH`) steals the lock by removing it. Mirrors the
+//! project's `reference_cross_process_test_serialization` pattern.
+//!
+//! **Publication is atomic, and must stay that way.** The pidfile is written to
+//! a private temp file first and only then linked into place with `hard_link`,
+//! which is atomic and fails with `EEXIST` while the lock is held. The naive
+//! `O_CREAT | O_EXCL` + `write!` sequence is *not* safe here: between the create
+//! and the write the pidfile exists but is empty, and an empty pidfile is
+//! indistinguishable from the one a crashed holder leaves behind. A contender
+//! sampling that window takes the crash-recovery path, deletes a *live* holder's
+//! pidfile and acquires alongside it — two holders, two concurrent `bd`
+//! processes, the git-head race the lock exists to prevent.
 
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use super::BdError;
@@ -54,14 +64,13 @@ impl BdLock {
         }
         let deadline = Instant::now() + ACQUIRE_TIMEOUT;
         loop {
-            match OpenOptions::new().write(true).create_new(true).mode(0o600).open(&self.path) {
-                Ok(mut f) => {
-                    let _ = write!(f, "{}", std::process::id());
+            match self.try_publish_pidfile() {
+                Ok(true) => {
                     return Ok(BdLockGuard {
                         path: self.path.clone(),
                     });
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                Ok(false) => {
                     if self.steal_if_stale() {
                         continue;
                     }
@@ -75,13 +84,43 @@ impl BdLock {
         }
     }
 
+    /// Publish a fully-written pidfile atomically; `Ok(false)` means held.
+    ///
+    /// Writes the PID into a private temp file in the same directory, then
+    /// `hard_link`s it onto the lock path. The link is the atomic step and
+    /// returns `EEXIST` while another holder is in place, so the pidfile is
+    /// never observable in a created-but-empty state (see the module doc).
+    fn try_publish_pidfile(&self) -> std::io::Result<bool> {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let name = self.path.file_name().and_then(std::ffi::OsStr::to_str).unwrap_or("bd");
+        let tmp = self.path.with_file_name(format!(
+            ".{name}.{}.{}.tmp",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        {
+            let mut f = OpenOptions::new().write(true).create_new(true).mode(0o600).open(&tmp)?;
+            write!(f, "{}", std::process::id())?;
+            f.sync_all()?;
+        }
+        let linked = std::fs::hard_link(&tmp, &self.path);
+        let _ = std::fs::remove_file(&tmp);
+        match linked {
+            Ok(()) => Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Remove the pidfile if it names a process that is no longer alive.
     ///
     /// Returns `true` when a stale file was removed (caller should retry the
     /// exclusive create immediately).
     fn steal_if_stale(&self) -> bool {
         let Some(pid) = read_pid(&self.path) else {
-            // Unreadable/empty pidfile from a half-written holder: treat as stale.
+            // Crash-recovery backstop only: an unreadable/empty pidfile can no
+            // longer come from a live holder (publication is atomic), so it is
+            // either a pre-fix leftover or a truncated file, i.e. stale.
             return std::fs::remove_file(&self.path).is_ok();
         };
         if pid_alive(pid) {
@@ -119,4 +158,151 @@ fn pid_alive(pid: i32) -> bool {
     use nix::unistd::Pid;
     // `Ok` => exists and signalable; `EPERM` => exists but owned by another user.
     matches!(kill(Pid::from_raw(pid), None), Ok(()) | Err(Errno::EPERM))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::mpsc;
+    use std::sync::{Arc, Barrier};
+
+    /// A PID that is guaranteed dead: spawn a trivial child and reap it.
+    fn dead_pid() -> i32 {
+        let mut child = std::process::Command::new("/usr/bin/true")
+            .spawn()
+            .or_else(|_| std::process::Command::new("/bin/true").spawn())
+            .expect("spawn /bin/true");
+        let pid = i32::try_from(child.id()).expect("pid fits i32");
+        child.wait().expect("reap child");
+        pid
+    }
+
+    /// The invariant the whole lock rests on: a visible pidfile always names its
+    /// holder. Publication is a single atomic link, so there is no window in
+    /// which the file exists but is empty.
+    #[test]
+    fn acquire_publishes_a_populated_pidfile() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("bd.pid");
+        let lock = BdLock::new(path.clone());
+        let guard = lock.acquire().expect("acquire");
+        assert_eq!(
+            read_pid(&path),
+            Some(i32::try_from(std::process::id()).unwrap())
+        );
+        drop(guard);
+        assert!(!path.exists(), "guard drop releases the lock");
+        // No temp turds left behind by the publish step.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "publish left files behind: {leftovers:?}"
+        );
+    }
+
+    /// Regression for the create-then-write race: contenders starting at the same
+    /// instant must never both hold the lock.
+    ///
+    /// Under the old exclusive-create-then-`write!` publish the loser's very next
+    /// syscall sampled the pidfile while it was still empty, mistook a live holder
+    /// for a crashed one, deleted its pidfile and acquired alongside it. Two knobs
+    /// make that observable instead of luck: a [`Barrier`] so every round starts
+    /// the contenders simultaneously (the window only exists at the instant of
+    /// publication), and a short hold inside the critical section so an admitted
+    /// second holder overlaps the first for long enough to be counted. Measured on
+    /// the pre-fix publish this trips within a handful of rounds; the integration
+    /// sibling `test_concurrent_invocations_serialize_per_beads_dir` failed 10/40
+    /// runs from the same defect.
+    #[test]
+    fn contended_acquire_never_admits_two_holders() {
+        const THREADS: usize = 4;
+        const ROUNDS: usize = 60;
+        const HOLD: Duration = Duration::from_millis(2);
+
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let lock = BdLock::new(dir.path().join("bd.pid"));
+        let holders = Arc::new(AtomicUsize::new(0));
+        let overlaps = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(THREADS));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let lock = lock.clone();
+                let holders = Arc::clone(&holders);
+                let overlaps = Arc::clone(&overlaps);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    for _ in 0..ROUNDS {
+                        barrier.wait();
+                        let guard = lock.acquire().expect("acquire");
+                        let before = holders.fetch_add(1, Ordering::SeqCst);
+                        std::thread::sleep(HOLD);
+                        let during = holders.load(Ordering::SeqCst);
+                        holders.fetch_sub(1, Ordering::SeqCst);
+                        drop(guard);
+                        if before != 0 || during != 1 {
+                            overlaps.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread join");
+        }
+        assert_eq!(
+            overlaps.load(Ordering::SeqCst),
+            0,
+            "the lock admitted concurrent holders"
+        );
+    }
+
+    /// Crash recovery still works: a pidfile naming a dead process is stolen
+    /// without waiting out the acquire timeout.
+    #[test]
+    fn pidfile_of_a_dead_holder_is_stolen_promptly() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("bd.pid");
+        std::fs::write(&path, dead_pid().to_string()).expect("seed stale pidfile");
+
+        let started = Instant::now();
+        let guard = BdLock::new(path.clone()).acquire().expect("steal stale lock");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "steal was not prompt"
+        );
+        assert_eq!(
+            read_pid(&path),
+            Some(i32::try_from(std::process::id()).unwrap())
+        );
+        drop(guard);
+    }
+
+    /// A live holder is never stolen from: the contender blocks until release.
+    #[test]
+    fn live_holder_blocks_a_contender_until_release() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let lock = BdLock::new(dir.path().join("bd.pid"));
+        let held = lock.acquire().expect("first acquire");
+
+        let (tx, rx) = mpsc::channel();
+        let contender = std::thread::spawn(move || {
+            let g = lock.acquire().expect("second acquire");
+            tx.send(()).expect("signal acquired");
+            drop(g);
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(300)).is_err(),
+            "contender acquired while the lock was held"
+        );
+        drop(held);
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("contender acquires after release");
+        contender.join().expect("thread join");
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -693,7 +693,9 @@ async fn handle(
         methods::HANGAR_SEARCH => handle_search(pool, req).await,
         methods::HANGAR_AGENTS_LIST => {
             let actors = match resolve(pool, req).await? {
-                Some(ws) => snapshots::agents_list(pool, &ws).await.map_err(|e| store_err(&e))?,
+                Some(ws) => snapshots::agents_list(pool, &ws, SystemClock.now_ms())
+                    .await
+                    .map_err(|e| store_err(&e))?,
                 None => Vec::new(),
             };
             to_value(&ainb_hangar_proto::snapshots::AgentsListResult { actors })
@@ -3830,7 +3832,9 @@ async fn handle_agent_create(
     }
     // Answer with the refreshed roster (the same shape agents_list returns) so
     // the plugin folds the new agent into its cached list and the squad gate clears.
-    let actors = snapshots::agents_list(pool, ws.as_str()).await.map_err(|e| store_err(&e))?;
+    let actors = snapshots::agents_list(pool, ws.as_str(), SystemClock.now_ms())
+        .await
+        .map_err(|e| store_err(&e))?;
     to_value(&ainb_hangar_proto::snapshots::AgentsListResult { actors })
 }
 
@@ -3879,7 +3883,9 @@ async fn handle_agent_delete(
         })?;
     // Answer with the refreshed roster (the same shape agents_list / agent_create
     // return) so the plugin folds the shrunk list into its picker cache.
-    let actors = snapshots::agents_list(pool, ws.as_str()).await.map_err(|e| store_err(&e))?;
+    let actors = snapshots::agents_list(pool, ws.as_str(), SystemClock.now_ms())
+        .await
+        .map_err(|e| store_err(&e))?;
     to_value(&ainb_hangar_proto::snapshots::AgentsListResult { actors })
 }
 
@@ -3902,9 +3908,15 @@ async fn handle_agent_update(
              name/instructions/model/cli_args/mcp_config/thinking/agent_env",
         ));
     }
-    let row = snapshots::agent_update(pool, ws.as_str(), &params.agent_id, &update)
-        .await
-        .map_err(|e| store_err(&e))?;
+    let row = snapshots::agent_update(
+        pool,
+        ws.as_str(),
+        &params.agent_id,
+        &update,
+        SystemClock.now_ms(),
+    )
+    .await
+    .map_err(|e| store_err(&e))?;
     let Some(row) = row else {
         return Err(invalid_params(&format!(
             "no agent `{}` in this workspace",
@@ -3968,9 +3980,15 @@ async fn handle_agent_archive(
     let params: ainb_hangar_proto::snapshots::AgentArchiveParams =
         parse_params(req, "{ workspace_id, agent_id, archived }")?;
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
-    let row = snapshots::agent_archive(pool, ws.as_str(), &params.agent_id, params.archived)
-        .await
-        .map_err(|e| store_err(&e))?;
+    let row = snapshots::agent_archive(
+        pool,
+        ws.as_str(),
+        &params.agent_id,
+        params.archived,
+        SystemClock.now_ms(),
+    )
+    .await
+    .map_err(|e| store_err(&e))?;
     let Some(row) = row else {
         return Err(invalid_params(&format!(
             "no agent `{}` in this workspace",

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -7,12 +7,24 @@
 //!
 //! ## Presence derivation
 //!
-//! An agent's [`PresenceState`] is derived from its backing
-//! [`AgentRuntime::status`]: `"online"` → `Online`, `"unstable"` → `Unstable`,
-//! anything else (`"offline"`, unseen) → `Offline`. A human member has no
-//! runtime, so it is always reported `Online` (a member is "available" in the
-//! picker; the real online/away signal for humans lands with presence tracking
-//! in a later phase).
+//! An agent's [`PresenceState`] folds its backing runtime's stored `status`
+//! together with the AGE of its `last_seen_at` heartbeat, via the shared
+//! [`PresenceState::derive`] (multica `deriveRuntimeHealth` +
+//! `deriveAgentAvailability`): a runtime unseen for more than 5 minutes reads
+//! `Unstable`, more than 10 minutes `Offline`, and the worse of (stored status,
+//! heartbeat age) always wins.
+//!
+//! The age fold lives on the READ side deliberately. Hangar's presence sweeper
+//! runs inside the daemon, so a daemon that dies cannot flip its own row: a
+//! status-only passthrough would pin every agent of a crashed daemon at
+//! `● online` forever. The sweeper still writes the status (so every other
+//! reader sees the truth and the TUI gets an event), but this snapshot is
+//! correct with no live daemon and no tick latency. `now_ms` is injected rather
+//! than read here so the derivation is deterministic under test.
+//!
+//! A human member has no runtime, so it is always reported `Online` (a member is
+//! "available" in the picker; the real online/away signal for humans lands with
+//! presence tracking in a later phase).
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -430,9 +442,14 @@ async fn latest_branch_for_issue(
 /// in one polymorphic [`ActorRow`] list.
 ///
 /// Agents lead (they are the common assignee at v1), each carrying the presence
-/// derived from its runtime; members follow. Recent-use ranking is a later-phase
-/// concern, so every row is `recent_rank: None` (the picker falls back to its
-/// alphabetical body, which is deterministic).
+/// derived from its runtime's status + heartbeat age against `now_ms`; members
+/// follow. Recent-use ranking is a later-phase concern, so every row is
+/// `recent_rank: None` (the picker falls back to its alphabetical body, which is
+/// deterministic).
+///
+/// `now_ms` is injected (production passes
+/// [`SystemClock`](ainb_hangar_core::clock::SystemClock)) so the staleness fold
+/// is deterministic under test.
 ///
 /// # Errors
 ///
@@ -440,6 +457,7 @@ async fn latest_branch_for_issue(
 pub async fn agents_list(
     pool: &SqlitePool,
     workspace_id: &str,
+    now_ms: i64,
 ) -> Result<Vec<ActorRow>, sqlx::Error> {
     let mut out = Vec::new();
 
@@ -449,7 +467,7 @@ pub async fn agents_list(
 
     for agent in AgentRepo::list_by_workspace(pool, workspace_id).await? {
         let (running, queued) = workload_map.get(&agent.id).copied().unwrap_or((0, 0));
-        out.push(agent_actor_row_with_counts(pool, &agent, running, queued).await?);
+        out.push(agent_actor_row_with_counts(pool, &agent, running, queued, now_ms).await?);
     }
 
     for member in members_of(pool, workspace_id).await? {
@@ -760,18 +778,9 @@ pub async fn skills_list(
     Ok(out)
 }
 
-/// Map an `agent_runtime.status` string onto a wire [`PresenceState`].
-fn presence_from_status(status: &str) -> PresenceState {
-    match status {
-        "online" => PresenceState::Online,
-        "unstable" => PresenceState::Unstable,
-        _ => PresenceState::Offline,
-    }
-}
-
 /// Map one store [`Agent`](ainb_hangar_store::repo::agent::Agent) onto its picker
-/// [`ActorRow`], deriving presence from the backing runtime's status and the
-/// workload dimension from the agent's OWN live task counts.
+/// [`ActorRow`], deriving presence from the backing runtime's status + heartbeat
+/// age and the workload dimension from the agent's OWN live task counts.
 ///
 /// Shared by the e38.15 agent-CRUD wrappers ([`agent_update`] / [`agent_archive`])
 /// so the row a mutation answers with is byte-identical to the same agent's
@@ -785,17 +794,19 @@ fn presence_from_status(status: &str) -> PresenceState {
 async fn agent_actor_row(
     pool: &SqlitePool,
     agent: &ainb_hangar_store::repo::agent::Agent,
+    now_ms: i64,
 ) -> Result<ActorRow, sqlx::Error> {
     let (running, queued) = TaskRepo::live_workload_for_agent(pool, &agent.id).await?;
-    agent_actor_row_with_counts(pool, agent, running, queued).await
+    agent_actor_row_with_counts(pool, agent, running, queued, now_ms).await
 }
 
 /// Build one agent's picker [`ActorRow`] from its store row plus already-resolved
-/// live task counts (`running`, `queued`), deriving presence from the runtime and
-/// workload via [`Workload::derive`]. The counts-taking seam lets [`agents_list`]
-/// batch the workload query once for the whole workspace. A missing runtime maps
-/// to `Offline` (the runtime FK is required, but a deleted-out-of-band runtime
-/// must not panic the snapshot).
+/// live task counts (`running`, `queued`), deriving presence from the runtime via
+/// [`PresenceState::derive`] (status folded with heartbeat age, measured against
+/// the injected `now_ms`) and workload via [`Workload::derive`]. The counts-taking
+/// seam lets [`agents_list`] batch the workload query once for the whole
+/// workspace. A missing runtime maps to `Offline` (the runtime FK is required,
+/// but a deleted-out-of-band runtime must not panic the snapshot).
 ///
 /// # Errors
 ///
@@ -805,9 +816,10 @@ async fn agent_actor_row_with_counts(
     agent: &ainb_hangar_store::repo::agent::Agent,
     running: i64,
     queued: i64,
+    now_ms: i64,
 ) -> Result<ActorRow, sqlx::Error> {
     let presence = match AgentRuntimeRepo::get(pool, &agent.runtime_id).await? {
-        Some(rt) => presence_from_status(&rt.status),
+        Some(rt) => PresenceState::derive(&rt.status, rt.last_seen_at, now_ms),
         None => PresenceState::Offline,
     };
     Ok(ActorRow {
@@ -841,13 +853,14 @@ pub async fn agent_update(
     workspace_id: &str,
     agent_id: &str,
     update: &ainb_hangar_store::repo::agent::AgentConfigUpdate,
+    now_ms: i64,
 ) -> Result<Option<ActorRow>, sqlx::Error> {
     let touched = AgentRepo::update_config(pool, workspace_id, agent_id, update).await?;
     if !touched {
         return Ok(None);
     }
     match AgentRepo::get(pool, agent_id).await? {
-        Some(agent) => Ok(Some(agent_actor_row(pool, &agent).await?)),
+        Some(agent) => Ok(Some(agent_actor_row(pool, &agent, now_ms).await?)),
         None => Ok(None),
     }
 }
@@ -869,13 +882,14 @@ pub async fn agent_archive(
     workspace_id: &str,
     agent_id: &str,
     archived: bool,
+    now_ms: i64,
 ) -> Result<Option<ActorRow>, sqlx::Error> {
     let touched = AgentRepo::set_archived(pool, workspace_id, agent_id, archived).await?;
     if !touched {
         return Ok(None);
     }
     match AgentRepo::get(pool, agent_id).await? {
-        Some(agent) => Ok(Some(agent_actor_row(pool, &agent).await?)),
+        Some(agent) => Ok(Some(agent_actor_row(pool, &agent, now_ms).await?)),
         None => Ok(None),
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -22,6 +22,7 @@
 //! | `HANGAR_DAEMON_POLL_MS` | claim-poll interval | `1000` |
 //! | `HANGAR_SWEEP_INTERVAL_MS` | sweep-pass interval | `60000` |
 //! | `HANGAR_GC_INTERVAL_MS` | workspace-GC pass interval (on-disk orphan reclaim) | `3600000` |
+//! | `HANGAR_PRESENCE_SWEEP_MS` | runtime-presence pass interval (heartbeat + availability decay) | `30000` |
 //! | `HANGAR_PROVIDER_MAX_RUNTIME_MS` | provider runtime deadline override (tests) | reference running TTL (2.5h) |
 //! | `HANGAR_SPAWN_SETUP_TIMEOUT_MS` | running→spawn setup-phase umbrella override (tests) | `60000` |
 //! | `HANGAR_SWEEP_DISPATCHED_TTL_MS` | dispatch TTL override (tests) | reference default |
@@ -60,8 +61,8 @@ use crate::health_stats::HealthStats;
 use crate::progress_comment;
 use crate::runner::{Backend, Mode, ProviderInvocation, RunOutcome, Runner, RunnerConfig};
 use crate::sweeper::{
-    SweeperConfig, reclaim_orphaned_on_startup, sweep_expired_queued, sweep_stale_dispatched,
-    sweep_stale_running,
+    SweeperConfig, reclaim_orphaned_on_startup, sweep_expired_queued, sweep_runtime_presence,
+    sweep_stale_dispatched, sweep_stale_running,
 };
 
 /// Default claim-poll interval when `HANGAR_DAEMON_POLL_MS` is unset.
@@ -209,6 +210,12 @@ impl DaemonConfig {
         // tighten it to drive a reclaim within a bounded budget.
         if let Some(ms) = env_u64_opt("HANGAR_GC_INTERVAL_MS") {
             sweeper.gc_interval = Duration::from_millis(ms);
+        }
+        // The runtime-presence cadence is independently tunable so a tripwire can
+        // observe an availability decay inside a bounded budget rather than
+        // waiting out the 30s production tick.
+        if let Some(ms) = env_u64_opt("HANGAR_PRESENCE_SWEEP_MS") {
+            sweeper.presence_interval = Duration::from_millis(ms);
         }
         if let Some(ms) = env_u64_opt("HANGAR_SWEEP_DISPATCHED_TTL_MS") {
             sweeper.dispatched_ttl = Duration::from_millis(ms);
@@ -446,6 +453,18 @@ pub async fn run(
         hangar_home(),
         cfg.sweeper.gc_interval,
         Arc::new(SystemClock),
+    );
+
+    // Runtime presence (multica gap #6): heartbeat our own runtime and decay
+    // every stale one, pushing an `AgentPresence` event per moved agent.
+    // Deliberately spawned BEFORE the `disable_claim` early-return: that mode is
+    // "sweepers only" by its own log line, and presence is a sweeper.
+    let _presence = spawn_runtime_presence(
+        pool.clone(),
+        cfg.runtime_id.clone(),
+        cfg.sweeper.presence_interval,
+        Arc::new(SystemClock),
+        events.clone(),
     );
 
     let Some(runtime_id) = cfg.runtime_id.clone().filter(|_| !cfg.disable_claim) else {
@@ -696,6 +715,88 @@ pub fn spawn_gc_sweeper(
             }
         }
     })
+}
+
+/// Schedule the runtime-presence pass: beat for our own runtime, decay everyone
+/// else's by heartbeat age, and push an `AgentPresence` event per agent whose
+/// availability moved (multica gap #6, the availability half).
+///
+/// This is the WRITER half of the presence derivation. The snapshot read folds
+/// the heartbeat age itself, so the Agents screen is correct without a live
+/// daemon; this loop makes the persisted `agent_runtime.status` truthful for
+/// every other reader and — via the event — makes an attached TUI re-render
+/// without polling (the plugin arms `fetch_snapshots` on any non-`TaskMessage`
+/// event, so it needs no change). The reference publishes
+/// `EventDaemonRegister{stale_sweep}` on its own bus for exactly this reason.
+///
+/// `runtime_id` is this daemon's own runtime, beaten first each pass so the
+/// daemon can never sweep itself; `None` for a daemon that advertises none.
+/// A failed pass is logged and the loop continues — presence is observability,
+/// never a reason to down the daemon. Returns the [`JoinHandle`] so a caller can
+/// stop it; the production daemon drops it and relies on process exit, mirroring
+/// [`spawn_gc_sweeper`].
+///
+/// [`JoinHandle`]: tokio::task::JoinHandle
+#[must_use]
+pub fn spawn_runtime_presence(
+    pool: SqlitePool,
+    runtime_id: Option<String>,
+    interval: Duration,
+    clock: Arc<dyn HangarClock>,
+    events: EventSink,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        loop {
+            tick.tick().await;
+            match sweep_runtime_presence(&pool, clock.as_ref(), runtime_id.as_deref()).await {
+                Ok(sweep) => emit_presence_events(&pool, &events, &sweep).await,
+                Err(e) => tracing::error!(error = %e, kind = "presence", "sweeper pass failed"),
+            }
+        }
+    })
+}
+
+/// Fan an `AgentPresence` event out for every agent backed by a runtime the
+/// presence sweep just moved.
+///
+/// One event per AGENT (not per runtime): the plugin renders agents, and a
+/// runtime typically backs several. A lookup fault is logged and skipped — a
+/// missing notification must never abort the remaining fan-out or the loop.
+async fn emit_presence_events(
+    pool: &SqlitePool,
+    events: &EventSink,
+    sweep: &ainb_hangar_store::repo::agent_runtime::PresenceSweep,
+) {
+    use ainb_hangar_proto::events::{HangarEvent, PresenceState};
+    use ainb_hangar_store::repo::agent::AgentRepo;
+
+    for (runtimes, state) in [
+        (&sweep.to_unstable, PresenceState::Unstable),
+        (&sweep.to_offline, PresenceState::Offline),
+    ] {
+        for rt in runtimes {
+            match AgentRepo::list_ids_by_runtime(pool, &rt.id).await {
+                Ok(agent_ids) => {
+                    for agent_id in agent_ids {
+                        // A stored PK is non-empty by construction; a malformed
+                        // row is skipped rather than panicking the loop.
+                        let Ok(agent_id) = ainb_hangar_core::ids::AgentId::from_str(agent_id)
+                        else {
+                            continue;
+                        };
+                        events.emit(
+                            &rt.workspace_id,
+                            HangarEvent::AgentPresence { agent_id, state },
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, runtime_id = %rt.id, "presence fan-out failed");
+                }
+            }
+        }
+    }
 }
 
 /// Resolve the claude credential env for `backend`, bounded and off the async

--- a/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
@@ -219,6 +219,7 @@ async fn seed_runtime_and_agent(pool: &SqlitePool, now: i64) -> Result<(), sqlx:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ainb_hangar_core::clock::SystemClock;
     use ainb_hangar_store::Store;
 
     #[tokio::test]
@@ -231,7 +232,9 @@ mod tests {
         assert_eq!(issues.len(), 3, "three seeded issues");
         assert!(issues.iter().any(|i| i.title == "Refactor API"));
 
-        let actors = crate::rpc::snapshots::agents_list(store.pool(), WS_ID).await.unwrap();
+        let actors = crate::rpc::snapshots::agents_list(store.pool(), WS_ID, SystemClock.now_ms())
+            .await
+            .unwrap();
         assert!(actors.iter().any(|a| a.display_name == "claude-agent" && a.is_agent));
         assert!(actors.iter().any(|a| !a.is_agent), "member present");
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
@@ -50,6 +50,8 @@
 use std::time::Duration;
 
 use ainb_hangar_core::clock::HangarClock;
+use ainb_hangar_proto::events::PresenceState;
+use ainb_hangar_store::repo::agent_runtime::{AgentRuntimeRepo, PresenceSweep};
 use sqlx::SqlitePool;
 
 /// How long a `queued` task may wait before it is failed. Reference:
@@ -89,6 +91,12 @@ pub const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 /// `HANGAR_GC_INTERVAL_MS` for deterministic / tight-budget tests.
 pub const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(3_600);
 
+/// Default interval between runtime-presence passes (heartbeat + availability
+/// decay). Reference: `runtime_sweeper.go:21` (`sweepInterval` = 30s).
+/// Overridable via `HANGAR_PRESENCE_SWEEP_MS` so a tripwire can land several
+/// ticks inside its budget.
+pub const DEFAULT_PRESENCE_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Tunable thresholds for the sweepers.
 ///
 /// Production constructs [`SweeperConfig::default`] (the reference defaults);
@@ -108,6 +116,8 @@ pub struct SweeperConfig {
     pub sweep_interval: Duration,
     /// Interval between workspace-GC passes (on-disk orphan/Full reclaim).
     pub gc_interval: Duration,
+    /// Interval between runtime-presence passes (heartbeat + availability decay).
+    pub presence_interval: Duration,
     /// Maximum rows mutated per pass.
     pub batch_size: i64,
 }
@@ -121,6 +131,7 @@ impl Default for SweeperConfig {
             running_ttl: RUNNING_TTL,
             sweep_interval: DEFAULT_SWEEP_INTERVAL,
             gc_interval: DEFAULT_GC_INTERVAL,
+            presence_interval: DEFAULT_PRESENCE_INTERVAL,
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
@@ -316,6 +327,51 @@ pub async fn sweep_stale_dispatched(
         );
     }
     Ok(DispatchSweepOutcome { reclaimed, failed })
+}
+
+/// One runtime-presence pass: beat for our own runtime, then age-sweep the rest.
+///
+/// Unlike the task sweepers this one has a WRITE side of its own: the daemon
+/// stamps `own_runtime_id`'s heartbeat FIRST, so its own row can never be
+/// decayed by its own sweep, then walks every other runtime through
+/// `online → unstable → offline` by heartbeat age. The thresholds come from
+/// [`PresenceState`], the single definition the read-side fold also uses.
+///
+/// `own_runtime_id` is `None` for a daemon that advertises no runtime of its own
+/// (the claim-disabled "sweepers only" mode), in which case the pass is purely
+/// the age sweep.
+///
+/// Returns the rows that moved so the caller can fan `AgentPresence` events out
+/// (the reference publishes `EventDaemonRegister{stale_sweep}` for the same
+/// reason: clients must re-read the runtime list).
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the heartbeat or either sweep statement fails.
+pub async fn sweep_runtime_presence(
+    pool: &SqlitePool,
+    clock: &dyn HangarClock,
+    own_runtime_id: Option<&str>,
+) -> Result<PresenceSweep, sqlx::Error> {
+    let now = clock.now_ms();
+    if let Some(id) = own_runtime_id {
+        AgentRuntimeRepo::heartbeat(pool, id, now).await?;
+    }
+    let sweep = AgentRuntimeRepo::sweep_presence_by_age(
+        pool,
+        now,
+        PresenceState::UNSTABLE_AFTER_MS,
+        PresenceState::OFFLINE_AFTER_MS,
+    )
+    .await?;
+    if !sweep.is_empty() {
+        tracing::info!(
+            to_unstable = sweep.to_unstable.len(),
+            to_offline = sweep.to_offline.len(),
+            "runtime_presence_swept",
+        );
+    }
+    Ok(sweep)
 }
 
 /// Reclaim a crashed daemon's orphaned in-flight tasks back to `queued` at

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_presence_grace.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_presence_grace.rs
@@ -1,0 +1,241 @@
+//! Integration: availability decays with the runtime heartbeat (multica gap #6,
+//! the availability half — the sibling of `rpc_agent_workload.rs`).
+//!
+//! Two layers are proven independently because both are load-bearing:
+//!
+//! * the READ fold — `agents_list` derives `ActorRow.presence` from the runtime's
+//!   `last_seen_at` age, so the Agents screen is correct on any snapshot pull
+//!   even with no live daemon and no tick latency;
+//! * the WRITER — `sweep_runtime_presence` moves the persisted
+//!   `agent_runtime.status` (and beats for the daemon's own runtime first), so
+//!   every other reader sees the truth and the TUI gets an `AgentPresence` event
+//!   to re-render on.
+//!
+//! A read-only fold would pass the snapshot assertions and silently fail the
+//! stored-status ones, which is why both are here.
+
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_daemon::events::EventBroker;
+use ainb_hangar_daemon::rpc::snapshots;
+use ainb_hangar_daemon::sweeper::sweep_runtime_presence;
+use ainb_hangar_proto::events::{HangarEvent, PresenceState, Workload};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
+
+const WS: &str = "ws-a";
+const RT: &str = "rt-a";
+const AGENT: &str = "agent-a";
+/// The instant the seeded runtime last beat.
+const T: i64 = 1_700_000_000_000;
+const MIN: i64 = 60_000;
+
+/// Seed a workspace with one runtime that beat at `T` and one agent on it.
+async fn seed(store: &Store) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(WS)
+        .bind(WS)
+        .bind(WS)
+        .execute(store.pool())
+        .await
+        .expect("ws");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u', 'u@x.test', 0)")
+        .execute(store.pool())
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
+         VALUES (?, ?, 'd', 'claude', 'local', ?, 'online')",
+    )
+    .bind(RT)
+    .bind(WS)
+    .bind(T)
+    .execute(store.pool())
+    .await
+    .expect("runtime");
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES (?, ?, ?, ?, 'workspace', 'u')",
+    )
+    .bind(AGENT)
+    .bind(WS)
+    .bind(AGENT)
+    .bind(RT)
+    .execute(store.pool())
+    .await
+    .expect("agent");
+}
+
+/// The agent's row in an `agents_list` snapshot taken at `now_ms`.
+async fn agent_row(store: &Store, now_ms: i64) -> ainb_hangar_proto::events::ActorRow {
+    snapshots::agents_list(store.pool(), WS, now_ms)
+        .await
+        .expect("agents_list")
+        .into_iter()
+        .find(|a| a.actor_ref == format!("agent:{AGENT}"))
+        .expect("agent row present")
+}
+
+/// The runtime's persisted liveness status.
+async fn stored_status(store: &Store) -> String {
+    AgentRuntimeRepo::get(store.pool(), RT)
+        .await
+        .expect("get")
+        .expect("runtime present")
+        .status
+}
+
+#[tokio::test]
+async fn agents_list_presence_decays_with_the_heartbeat_age() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    let row = agent_row(&store, T + MIN).await;
+    assert_eq!(
+        row.presence,
+        PresenceState::Online,
+        "a fresh beat is online"
+    );
+    assert_eq!(
+        row.workload,
+        Workload::Idle,
+        "availability and workload stay independent dimensions",
+    );
+
+    assert_eq!(
+        agent_row(&store, T + 6 * MIN).await.presence,
+        PresenceState::Unstable,
+        "past the 5min threshold the dot goes amber",
+    );
+    assert_eq!(
+        agent_row(&store, T + 11 * MIN).await.presence,
+        PresenceState::Offline,
+        "past the 10min grace window the agent is gone",
+    );
+
+    assert_eq!(
+        stored_status(&store).await,
+        "online",
+        "the read fold is pure: reading a snapshot never writes",
+    );
+}
+
+#[tokio::test]
+async fn sweep_writes_the_decayed_status_and_is_idempotent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(T + 6 * MIN), None)
+        .await
+        .expect("sweep");
+    assert_eq!(
+        sweep.to_unstable.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        vec![RT],
+    );
+    assert_eq!(
+        stored_status(&store).await,
+        "unstable",
+        "the WRITER moved the row in sqlite, not just the snapshot",
+    );
+
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(T + 11 * MIN), None)
+        .await
+        .expect("sweep");
+    assert_eq!(
+        sweep.to_offline.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        vec![RT],
+    );
+    assert_eq!(stored_status(&store).await, "offline");
+
+    let again = sweep_runtime_presence(store.pool(), &FixedClock(T + 11 * MIN), None)
+        .await
+        .expect("sweep");
+    assert!(
+        again.is_empty(),
+        "a repeat pass over the same backlog moves nothing"
+    );
+}
+
+#[tokio::test]
+async fn a_returning_daemon_heals_its_runtime_via_the_heartbeat() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    // Decay it all the way out first.
+    sweep_runtime_presence(store.pool(), &FixedClock(T + 11 * MIN), None)
+        .await
+        .expect("sweep");
+    assert_eq!(stored_status(&store).await, "offline");
+
+    AgentRuntimeRepo::heartbeat(store.pool(), RT, T + 12 * MIN)
+        .await
+        .expect("heartbeat");
+    assert_eq!(stored_status(&store).await, "online");
+    assert_eq!(
+        agent_row(&store, T + 12 * MIN + 1_000).await.presence,
+        PresenceState::Online,
+        "the snapshot follows the fresh beat straight back to online",
+    );
+}
+
+#[tokio::test]
+async fn a_daemon_never_sweeps_its_own_runtime() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    // Far past the grace window — but this pass owns RT, so it beats first.
+    let far_future = T + 24 * 60 * MIN;
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(far_future), Some(RT))
+        .await
+        .expect("sweep");
+    assert!(
+        sweep.is_empty(),
+        "our own runtime was beaten before the sweep saw it"
+    );
+    assert_eq!(stored_status(&store).await, "online");
+    assert_eq!(
+        agent_row(&store, far_future).await.presence,
+        PresenceState::Online,
+    );
+}
+
+#[tokio::test]
+async fn a_sweep_pushes_agent_presence_on_the_workspace_stream() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed(&store).await;
+
+    let broker = EventBroker::new();
+    let mut rx = broker.subscribe();
+    let handle = ainb_hangar_daemon::run_loop::spawn_runtime_presence(
+        store.pool().clone(),
+        None,
+        std::time::Duration::from_millis(20),
+        std::sync::Arc::new(FixedClock(T + 6 * MIN)),
+        broker.sink(),
+    );
+
+    let scoped = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("an AgentPresence event within the budget")
+        .expect("event channel open");
+    handle.abort();
+
+    assert_eq!(scoped.workspace_id, WS, "scoped to the runtime's workspace");
+    match scoped.event {
+        HangarEvent::AgentPresence { agent_id, state } => {
+            assert_eq!(agent_id.as_str(), AGENT);
+            assert_eq!(state, PresenceState::Unstable);
+        }
+        other => panic!("expected AgentPresence, got {other:?}"),
+    }
+    assert_eq!(
+        stored_status(&store).await,
+        "unstable",
+        "the loop wrote the row it announced",
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_workload.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_workload.rs
@@ -68,9 +68,14 @@ fn new_task(id: &str) -> NewTask {
     }
 }
 
+/// A fixed "now" for the snapshot reads. The seeded runtime carries a NULL
+/// `last_seen_at`, so the availability fold reads its status verbatim and this
+/// value never moves presence — workload stays the only dimension under test.
+const NOW: i64 = 1_700_000_000_000;
+
 /// The agent row's workload in the current `agents_list` snapshot.
 async fn agent_row(store: &Store) -> ainb_hangar_proto::events::ActorRow {
-    snapshots::agents_list(store.pool(), WS)
+    snapshots::agents_list(store.pool(), WS, NOW)
         .await
         .expect("agents_list")
         .into_iter()
@@ -123,6 +128,7 @@ async fn agents_list_workload_tracks_lifecycle_and_agent_update_agrees() {
             agent_env: None,
             token_budget: None,
         },
+        NOW,
     )
     .await
     .expect("agent_update")

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_hangar_presence_amber.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_hangar_presence_amber.rs
@@ -1,0 +1,119 @@
+//! ACCEPTANCE tripwire (multica gap #6, availability): an agent whose runtime
+//! stops beating renders **amber `◐ unstable`**, then **`○ offline`**, on the
+//! real Agents screen — proven by poking `agent_runtime.last_seen_at` in sqlite.
+//!
+//! This is the whole parity item end to end through the real stack: real `ainb`
+//! binary in tmux, real daemon, real staged plugin, real db. It covers BOTH
+//! halves — the render (the snapshot fold turns heartbeat age into the dot) and
+//! the writer (the daemon's presence sweeper moves the persisted `status`), so a
+//! read-only implementation would fail the final assertion.
+//!
+//! The decaying agent is a GHOST runtime the daemon does not own
+//! (`prepare_pipeline_ghost_runtime`): the daemon beats for its own runtime
+//! every tick, so that one could never decay.
+//!
+//! Follows the `tmux-ui-tripwire` rules: SKIP without tmux/binaries/plugin,
+//! `poll_capture` with a deadline (never a bare sleep), exact-name
+//! `kill-session` only (via `TuiSession`'s drop), and per-ROW assertions rather
+//! than whole-pane substring-ORs.
+
+use std::time::{Duration, Instant};
+
+#[path = "tripwire_p4_common.rs"]
+mod common;
+use common::{
+    GHOST_AGENT_NAME, GHOST_RUNTIME_ID, TuiSession, backdate_runtime_heartbeat, can_run_tripwire,
+    prepare_pipeline_ghost_runtime, press_until, runtime_status, skip,
+};
+
+/// The ghost agent's own line in the pane, or `None` while it is not rendered.
+/// Every assertion is made against THIS line, never the whole pane — a
+/// pane-wide `contains("unstable")` would pass on any other row's chrome.
+fn ghost_line(capture: &str) -> Option<&str> {
+    capture.lines().find(|l| l.contains(GHOST_AGENT_NAME))
+}
+
+#[test]
+fn agent_presence_decays_to_amber_then_offline_on_the_agents_screen() {
+    if !can_run_tripwire() {
+        skip("hangar_presence_amber");
+        return;
+    }
+    // A 1s sweep cadence: several ticks land inside each poll budget below.
+    let pipe = prepare_pipeline_ghost_runtime("1000");
+    let bin = common::ainb_bin().expect("gated by can_run_tripwire");
+    let (sess, _landing) = TuiSession::launch_to_hangar(&bin, pipe.home());
+
+    // Agents tab (`A` in the plugin chrome tab strip).
+    let baseline = press_until(&sess, "A", Instant::now() + Duration::from_secs(20), |c| {
+        ghost_line(c).is_some_and(|l| l.contains("online"))
+    })
+    .unwrap_or_else(|| {
+        panic!(
+            "Agents screen never showed the ghost agent:\n{}",
+            sess.capture()
+        )
+    });
+
+    // POSITIVE baseline + the NEGATIVE that makes the later flip meaningful.
+    let line = ghost_line(&baseline).expect("polled on it");
+    assert!(
+        line.contains('●'),
+        "baseline should render the green online dot:\n{line}"
+    );
+    assert!(
+        !line.contains("unstable"),
+        "baseline must not already be amber, else the flip proves nothing:\n{line}"
+    );
+
+    // Poke sqlite: the ghost runtime last beat 7 minutes ago — inside the amber
+    // band (>5min stale, <=10min).
+    backdate_runtime_heartbeat(pipe.home(), GHOST_RUNTIME_ID, 7 * 60_000);
+
+    let amber = sess
+        .poll_capture(Instant::now() + Duration::from_secs(20), |c| {
+            ghost_line(c).is_some_and(|l| l.contains("unstable"))
+        })
+        .unwrap_or_else(|| panic!("ghost agent never went amber:\n{}", sess.capture()));
+    let line = ghost_line(&amber).expect("polled on it");
+    assert!(
+        line.contains('◐'),
+        "amber band must render the half dot:\n{line}"
+    );
+    assert!(
+        !line.contains("online"),
+        "the online label must be gone once unstable:\n{line}"
+    );
+
+    // Poke again: 20 minutes stale is past the grace window.
+    backdate_runtime_heartbeat(pipe.home(), GHOST_RUNTIME_ID, 20 * 60_000);
+
+    let gone = sess
+        .poll_capture(Instant::now() + Duration::from_secs(20), |c| {
+            ghost_line(c).is_some_and(|l| l.contains("offline"))
+        })
+        .unwrap_or_else(|| panic!("ghost agent never went offline:\n{}", sess.capture()));
+    let line = ghost_line(&gone).expect("polled on it");
+    assert!(
+        line.contains('○'),
+        "offline band must render the hollow dot:\n{line}"
+    );
+    assert!(
+        !line.contains("unstable"),
+        "the amber label must be gone once offline:\n{line}"
+    );
+
+    // The WRITER half: the sweeper moved the persisted row, not just the render.
+    // Poll — the flip lands on the next presence tick, not synchronously.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut stored = runtime_status(pipe.home(), GHOST_RUNTIME_ID);
+    while stored.as_deref() != Some("offline") && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(500));
+        stored = runtime_status(pipe.home(), GHOST_RUNTIME_ID);
+    }
+    assert_eq!(
+        stored.as_deref(),
+        Some("offline"),
+        "the presence sweeper must WRITE agent_runtime.status, not only derive it",
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
@@ -2149,6 +2149,114 @@ pub fn seed_autopilot(home: &Path) {
     });
 }
 
+/// The ghost runtime's id — a SECOND runtime the daemon does not own, so the
+/// presence sweeper decays it instead of heart-beating it every tick.
+pub const GHOST_RUNTIME_ID: &str = "rt-ghost";
+/// The agent bound to [`GHOST_RUNTIME_ID`]; its Agents-screen row is the one
+/// whose availability dot walks online → unstable → offline.
+pub const GHOST_AGENT_NAME: &str = "ghostrider";
+
+/// Like [`prepare_pipeline`], plus a SECOND (`rt-ghost`) runtime carrying a
+/// fresh heartbeat and one agent (`ghostrider`) bound to it — for the
+/// availability-decay tripwire.
+///
+/// It must not be the daemon's OWN runtime: the daemon beats for that one every
+/// tick, so it could never decay. The unique index is
+/// `(workspace_id, daemon_id, provider)`, hence the distinct `daemon_id` /
+/// `provider`. `presence_sweep_ms` tightens the sweep cadence so several ticks
+/// land inside the tripwire's budget.
+pub fn prepare_pipeline_ghost_runtime(presence_sweep_ms: &str) -> Pipeline {
+    prepare_pipeline_seeded(
+        &[
+            ("HANGAR_DAEMON_DISABLE_CLAIM", "1"),
+            ("HANGAR_PRESENCE_SWEEP_MS", presence_sweep_ms),
+        ],
+        seed_ghost_runtime,
+    )
+}
+
+/// Seed the ghost runtime + agent into an already-seeded fixture db.
+pub fn seed_ghost_runtime(home: &Path) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
+    let hangar_dir = home.join(".agents-in-a-box");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("ghost-seed runtime");
+    rt.block_on(async {
+        let store = ainb_hangar_store::Store::open_in(&hangar_dir)
+            .await
+            .expect("open ghost-seed store");
+        sqlx::query(
+            "INSERT INTO agent_runtime \
+             (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
+             VALUES (?, ?, 'daemon-ghost', 'ghost', 'local', ?, 'online')",
+        )
+        .bind(GHOST_RUNTIME_ID)
+        .bind(ainb_hangar_daemon::seed::WS_ID)
+        .bind(now)
+        .execute(store.pool())
+        .await
+        .expect("seed ghost runtime");
+        sqlx::query(
+            "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+             VALUES ('ag-ghost', ?, ?, ?, 'workspace', 'user-1')",
+        )
+        .bind(ainb_hangar_daemon::seed::WS_ID)
+        .bind(GHOST_AGENT_NAME)
+        .bind(GHOST_RUNTIME_ID)
+        .execute(store.pool())
+        .await
+        .expect("seed ghost agent");
+    });
+}
+
+/// Backdate one runtime's heartbeat by `age_ms` relative to now — the sqlite
+/// poke the availability tripwire drives the decay with.
+pub fn backdate_runtime_heartbeat(home: &Path, runtime_id: &str, age_ms: i64) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
+    let hangar_dir = home.join(".agents-in-a-box");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("backdate runtime");
+    rt.block_on(async {
+        let store = ainb_hangar_store::Store::open_in(&hangar_dir)
+            .await
+            .expect("open backdate store");
+        sqlx::query("UPDATE agent_runtime SET last_seen_at = ? WHERE id = ?")
+            .bind(now - age_ms)
+            .bind(runtime_id)
+            .execute(store.pool())
+            .await
+            .expect("backdate heartbeat");
+    });
+}
+
+/// The PERSISTED liveness status of one runtime — proves the sweeper wrote the
+/// row, not merely that the snapshot derived a value.
+#[must_use]
+pub fn runtime_status(home: &Path, runtime_id: &str) -> Option<String> {
+    let hangar_dir = home.join(".agents-in-a-box");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime-status runtime");
+    rt.block_on(async {
+        let store = ainb_hangar_store::Store::open_in(&hangar_dir).await.ok()?;
+        sqlx::query_scalar::<_, String>("SELECT status FROM agent_runtime WHERE id = ?")
+            .bind(runtime_id)
+            .fetch_optional(store.pool())
+            .await
+            .ok()
+            .flatten()
+    })
+}
+
 /// A greppable marker embedded in the seeded log line's message, distinctive
 /// enough that it can never collide with a real daemon log message.
 pub const LOGS_TRIPWIRE_MARKER: &str = "LOGS_TRIPWIRE_MARKER_42";

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -238,6 +238,80 @@ pub enum PresenceState {
     Offline,
 }
 
+impl PresenceState {
+    /// Heartbeat staleness beyond which a runtime is *degraded* (amber).
+    ///
+    /// Multica `derive-health.ts` `FIVE_MINUTES_MS`. Multica gates its amber band
+    /// behind a server-side 150s liveness sweeper; hangar has no liveness
+    /// authority outside the DB heartbeat, so the band is shifted to "stale for
+    /// longer than 5 minutes" — 10 missed beats at the 30s sweep cadence, the
+    /// same order of margin multica buys with its 15s/150s ratio.
+    pub const UNSTABLE_AFTER_MS: i64 = 5 * 60 * 1000;
+
+    /// End of the unstable grace window — past this the runtime is gone.
+    pub const OFFLINE_AFTER_MS: i64 = 10 * 60 * 1000;
+
+    /// Map a stored `agent_runtime.status` string onto a presence
+    /// (`"online"` → [`Online`](Self::Online), `"unstable"` →
+    /// [`Unstable`](Self::Unstable), anything else → [`Offline`](Self::Offline)).
+    #[must_use]
+    pub fn from_status(status: &str) -> Self {
+        match status {
+            "online" => Self::Online,
+            "unstable" => Self::Unstable,
+            _ => Self::Offline,
+        }
+    }
+
+    /// Severity order for the "worse wins" fold: `Offline` < `Unstable` <
+    /// `Online`. Deliberately NOT a `PartialOrd` derive — the public variant
+    /// order is wire-visible through the serde renames and must not be reordered.
+    const fn rank(self) -> u8 {
+        match self {
+            Self::Offline => 0,
+            Self::Unstable => 1,
+            Self::Online => 2,
+        }
+    }
+
+    /// Fold the stored runtime status together with its heartbeat age (multica
+    /// `deriveRuntimeHealth` + `deriveAgentAvailability`).
+    ///
+    /// `last_seen_at == None` yields the status verbatim: a row that never
+    /// carried a heartbeat signal (legacy / CLI-seeded) must not decay just
+    /// because it has no beat to measure.
+    ///
+    /// Otherwise the **worse** of (stored status, heartbeat age) wins, so a
+    /// deregistered runtime with a fresh beat still reads `Offline`, and a
+    /// crashed daemon whose row is frozen at `"online"` still decays to
+    /// `Unstable` then `Offline`. The age fold is the primary mechanism, not
+    /// defence in depth: hangar's sweeper lives INSIDE the daemon, so nothing
+    /// can flip a dead daemon's own row.
+    ///
+    /// Age is `now_ms.saturating_sub(seen)`, so a future stamp (clock skew)
+    /// reads as fresh rather than panicking or flipping.
+    #[must_use]
+    pub fn derive(status: &str, last_seen_at: Option<i64>, now_ms: i64) -> Self {
+        let stored = Self::from_status(status);
+        let Some(seen) = last_seen_at else {
+            return stored;
+        };
+        let age = now_ms.saturating_sub(seen);
+        let by_age = if age > Self::OFFLINE_AFTER_MS {
+            Self::Offline
+        } else if age > Self::UNSTABLE_AFTER_MS {
+            Self::Unstable
+        } else {
+            Self::Online
+        };
+        if by_age.rank() < stored.rank() {
+            by_age
+        } else {
+            stored
+        }
+    }
+}
+
 /// Workload dimension (multica `Workload`), orthogonal to availability.
 ///
 /// Derived from LIVE task counts only — terminal tasks
@@ -684,6 +758,92 @@ mod tests {
         assert_eq!(Workload::derive(2, 0), Workload::Working);
         // running wins even when both are non-zero.
         assert_eq!(Workload::derive(1, 5), Workload::Working);
+    }
+
+    /// `PresenceState::derive` folds the stored status with the heartbeat age
+    /// across every band (multica `deriveRuntimeHealth` +
+    /// `deriveAgentAvailability`, with the hangar band shift).
+    #[test]
+    fn presence_derive_bands() {
+        const NOW: i64 = 1_700_000_000_000;
+        const UNSTABLE: i64 = PresenceState::UNSTABLE_AFTER_MS;
+        const OFFLINE: i64 = PresenceState::OFFLINE_AFTER_MS;
+        // (status, last_seen_at, expected, why)
+        let cases: &[(&str, Option<i64>, PresenceState, &str)] = &[
+            (
+                "online",
+                None,
+                PresenceState::Online,
+                "legacy row, verbatim",
+            ),
+            ("offline", None, PresenceState::Offline, "verbatim"),
+            ("online", Some(NOW - 10_000), PresenceState::Online, "fresh"),
+            (
+                "online",
+                Some(NOW - (UNSTABLE - 1)),
+                PresenceState::Online,
+                "band edge is inclusive of Online",
+            ),
+            (
+                "online",
+                Some(NOW - (UNSTABLE + 1)),
+                PresenceState::Unstable,
+                "the amber band opens",
+            ),
+            (
+                "online",
+                Some(NOW - OFFLINE),
+                PresenceState::Unstable,
+                "grace boundary is inclusive of Unstable",
+            ),
+            (
+                "online",
+                Some(NOW - (OFFLINE + 1)),
+                PresenceState::Offline,
+                "grace expired",
+            ),
+            (
+                "offline",
+                Some(NOW - 10_000),
+                PresenceState::Offline,
+                "worse wins: a deregistered runtime is not online",
+            ),
+            (
+                "unstable",
+                Some(NOW - 10_000),
+                PresenceState::Unstable,
+                "worse wins: a stored degraded status survives a fresh beat",
+            ),
+            (
+                "online",
+                Some(NOW + 3_600_000),
+                PresenceState::Online,
+                "clock skew must not panic or flip",
+            ),
+        ];
+        for (status, seen, expect, why) in cases {
+            assert_eq!(
+                PresenceState::derive(status, *seen, NOW),
+                *expect,
+                "status={status} last_seen={seen:?}: {why}"
+            );
+        }
+    }
+
+    /// The status mapper is the inverse of the render vocabulary and treats an
+    /// unknown string as `Offline` (never as available).
+    #[test]
+    fn presence_from_status_defaults_offline() {
+        assert_eq!(PresenceState::from_status("online"), PresenceState::Online);
+        assert_eq!(
+            PresenceState::from_status("unstable"),
+            PresenceState::Unstable
+        );
+        assert_eq!(
+            PresenceState::from_status("offline"),
+            PresenceState::Offline
+        );
+        assert_eq!(PresenceState::from_status("weird"), PresenceState::Offline);
     }
 
     /// An `ActorRow` JSON without a `workload` key decodes to `Idle` (a

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -284,6 +284,29 @@ impl AgentRepo {
         .await
     }
 
+    /// List the ids of every ACTIVE agent bound to one runtime, ordered by
+    /// `name`.
+    ///
+    /// The presence sweeper's event fan-out is the caller: when a runtime's
+    /// liveness flips, every agent backed by it changed availability, and only
+    /// the ids are needed to address the event. Archived agents are excluded —
+    /// they are absent from the picker, so no surface would render their dot.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn list_ids_by_runtime(
+        pool: &SqlitePool,
+        runtime_id: &str,
+    ) -> Result<Vec<String>, sqlx::Error> {
+        sqlx::query_scalar::<_, String>(
+            "SELECT id FROM agent WHERE runtime_id = ? AND archived = 0 ORDER BY name",
+        )
+        .bind(runtime_id)
+        .fetch_all(pool)
+        .await
+    }
+
     /// Edit a subset of one agent's mutable config, scoped to a workspace
     /// (e38.15).
     ///

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent_runtime.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent_runtime.rs
@@ -31,6 +31,40 @@ pub struct AgentRuntime {
     pub status: String,
 }
 
+/// One runtime moved by [`AgentRuntimeRepo::sweep_presence_by_age`].
+///
+/// Carries the workspace alongside the id so the caller can fan an event out on
+/// the right workspace stream without a second lookup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweptRuntime {
+    /// The runtime whose `status` changed.
+    pub id: String,
+    /// The runtime's owning workspace (`workspace.id`).
+    pub workspace_id: String,
+}
+
+/// The outcome of one [`AgentRuntimeRepo::sweep_presence_by_age`] pass.
+///
+/// Both bands are reported separately (and by row, not just by count) because
+/// the daemon fans an `AgentPresence` event out per flipped runtime and needs to
+/// know which state each landed in.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PresenceSweep {
+    /// Runtimes moved `online → unstable` (stale past the unstable threshold).
+    pub to_unstable: Vec<SweptRuntime>,
+    /// Runtimes moved `online|unstable → offline` (past the grace window).
+    pub to_offline: Vec<SweptRuntime>,
+}
+
+impl PresenceSweep {
+    /// Whether the pass moved nothing (the steady state — used to keep the
+    /// sweeper's log quiet on an idle tick).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.to_unstable.is_empty() && self.to_offline.is_empty()
+    }
+}
+
 /// Stateless typed wrapper over the `agent_runtime` table.
 pub struct AgentRuntimeRepo;
 
@@ -91,6 +125,92 @@ impl AgentRuntimeRepo {
         .bind(workspace_id)
         .fetch_all(pool)
         .await
+    }
+
+    /// Refresh one runtime's heartbeat: stamp `last_seen_at = now_ms` and return
+    /// the row to `"online"`.
+    ///
+    /// The status write is what lets a runtime that decayed to
+    /// `"unstable"`/`"offline"` self-heal the moment its daemon comes back,
+    /// without a separate re-register. Targeted by primary key, so a daemon can
+    /// only ever beat for its OWN runtime and never revives a foreign one.
+    /// Returns `true` when the row existed and was updated.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn heartbeat(pool: &SqlitePool, id: &str, now_ms: i64) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "UPDATE agent_runtime SET last_seen_at = ?, status = 'online' WHERE id = ?",
+        )
+        .bind(now_ms)
+        .bind(id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    /// Age-based presence sweep over every runtime that carries a heartbeat.
+    ///
+    /// Two source-status-constrained `UPDATE`s — `online → unstable` inside the
+    /// grace window, then `online|unstable → offline` past it — so the pass is
+    /// idempotent: a second run over the same backlog moves nothing. A runtime
+    /// with a `NULL` `last_seen_at` is never touched (it carries no liveness
+    /// signal to age; legacy / CLI-seeded rows must not decay).
+    ///
+    /// Both thresholds are PARAMETERS, not literals, so the store never depends
+    /// on the wire crate that defines them; the daemon passes
+    /// `PresenceState::UNSTABLE_AFTER_MS` / `OFFLINE_AFTER_MS`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if either statement fails.
+    pub async fn sweep_presence_by_age(
+        pool: &SqlitePool,
+        now_ms: i64,
+        unstable_after_ms: i64,
+        offline_after_ms: i64,
+    ) -> Result<PresenceSweep, sqlx::Error> {
+        // Offline first: the wider band is evaluated against the pre-sweep
+        // statuses, so a row past the grace window lands `offline` directly
+        // rather than being reported in both bands on one pass.
+        let to_offline = sqlx::query_as::<_, SweptRuntime>(
+            "UPDATE agent_runtime SET status = 'offline' \
+             WHERE last_seen_at IS NOT NULL AND status IN ('online', 'unstable') \
+               AND (?1 - last_seen_at) > ?2 \
+             RETURNING id, workspace_id",
+        )
+        .bind(now_ms)
+        .bind(offline_after_ms)
+        .fetch_all(pool)
+        .await?;
+
+        let to_unstable = sqlx::query_as::<_, SweptRuntime>(
+            "UPDATE agent_runtime SET status = 'unstable' \
+             WHERE last_seen_at IS NOT NULL AND status = 'online' \
+               AND (?1 - last_seen_at) > ?2 AND (?1 - last_seen_at) <= ?3 \
+             RETURNING id, workspace_id",
+        )
+        .bind(now_ms)
+        .bind(unstable_after_ms)
+        .bind(offline_after_ms)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(PresenceSweep {
+            to_unstable,
+            to_offline,
+        })
+    }
+}
+
+impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for SweptRuntime {
+    fn from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        Ok(Self {
+            id: row.try_get("id")?,
+            workspace_id: row.try_get("workspace_id")?,
+        })
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_runtime_presence.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_runtime_presence.rs
@@ -1,0 +1,237 @@
+//! Integration tests for the runtime-presence WRITER (multica gap #6, the
+//! availability half): [`AgentRuntimeRepo::heartbeat`] and
+//! [`AgentRuntimeRepo::sweep_presence_by_age`].
+//!
+//! These prove the persisted `agent_runtime.status` actually MOVES — a read-side
+//! derivation alone would leave every other reader (CLI, squads, a future web
+//! surface) looking at a row frozen at `online` forever. The properties under
+//! test are the two age bands, band exclusivity, idempotency, the `NULL`
+//! `last_seen_at` immunity, and heartbeat self-healing.
+
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::agent::AgentRepo;
+use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
+
+const WS: &str = "ws-a";
+const UNSTABLE_AFTER: i64 = 5 * 60 * 1000;
+const OFFLINE_AFTER: i64 = 10 * 60 * 1000;
+const T0: i64 = 1_700_000_000_000;
+
+/// Seed the workspace + user FK chain the runtime/agent rows hang off.
+async fn seed_workspace(store: &Store) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(WS)
+        .bind(WS)
+        .bind(WS)
+        .execute(store.pool())
+        .await
+        .expect("ws");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u', 'u@x.test', 0)")
+        .execute(store.pool())
+        .await
+        .expect("user");
+}
+
+/// Insert one runtime with an explicit `(last_seen_at, status)` pair.
+async fn seed_runtime(store: &Store, id: &str, last_seen_at: Option<i64>, status: &str) {
+    sqlx::query(
+        "INSERT INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
+         VALUES (?, ?, ?, ?, 'local', ?, ?)",
+    )
+    .bind(id)
+    .bind(WS)
+    // The unique index is (workspace_id, daemon_id, provider): key both on the
+    // runtime id so several runtimes coexist in one workspace.
+    .bind(format!("daemon-{id}"))
+    .bind(format!("provider-{id}"))
+    .bind(last_seen_at)
+    .bind(status)
+    .execute(store.pool())
+    .await
+    .expect("runtime");
+}
+
+/// The persisted status of one runtime.
+async fn status_of(store: &Store, id: &str) -> String {
+    AgentRuntimeRepo::get(store.pool(), id)
+        .await
+        .expect("get")
+        .expect("runtime present")
+        .status
+}
+
+#[tokio::test]
+async fn sweep_walks_online_through_unstable_to_offline_and_is_idempotent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed_workspace(&store).await;
+    seed_runtime(&store, "rt", Some(T0), "online").await;
+
+    // Fresh: inside the unstable threshold, nothing moves.
+    let sweep = AgentRuntimeRepo::sweep_presence_by_age(
+        store.pool(),
+        T0 + 60_000,
+        UNSTABLE_AFTER,
+        OFFLINE_AFTER,
+    )
+    .await
+    .expect("sweep");
+    assert!(sweep.is_empty(), "a fresh heartbeat moves nothing");
+    assert_eq!(status_of(&store, "rt").await, "online");
+
+    // Past the unstable threshold: amber, persisted.
+    let sweep = AgentRuntimeRepo::sweep_presence_by_age(
+        store.pool(),
+        T0 + 6 * 60_000,
+        UNSTABLE_AFTER,
+        OFFLINE_AFTER,
+    )
+    .await
+    .expect("sweep");
+    assert_eq!(
+        sweep.to_unstable.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        vec!["rt"],
+    );
+    assert!(sweep.to_offline.is_empty(), "still inside the grace window");
+    assert_eq!(
+        sweep.to_unstable[0].workspace_id, WS,
+        "workspace carried for the event fan-out"
+    );
+    assert_eq!(
+        status_of(&store, "rt").await,
+        "unstable",
+        "the row itself moved"
+    );
+
+    // A second pass at the same instant is a no-op (source-status constrained).
+    let again = AgentRuntimeRepo::sweep_presence_by_age(
+        store.pool(),
+        T0 + 6 * 60_000,
+        UNSTABLE_AFTER,
+        OFFLINE_AFTER,
+    )
+    .await
+    .expect("sweep");
+    assert!(again.is_empty(), "idempotent: the backlog already moved");
+
+    // Past the grace window: offline, from unstable.
+    let sweep = AgentRuntimeRepo::sweep_presence_by_age(
+        store.pool(),
+        T0 + 11 * 60_000,
+        UNSTABLE_AFTER,
+        OFFLINE_AFTER,
+    )
+    .await
+    .expect("sweep");
+    assert_eq!(
+        sweep.to_offline.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        vec!["rt"],
+    );
+    assert_eq!(status_of(&store, "rt").await, "offline");
+
+    // And once offline it stays put.
+    let again = AgentRuntimeRepo::sweep_presence_by_age(
+        store.pool(),
+        T0 + 60 * 60_000,
+        UNSTABLE_AFTER,
+        OFFLINE_AFTER,
+    )
+    .await
+    .expect("sweep");
+    assert!(again.is_empty(), "terminal band is idempotent too");
+}
+
+#[tokio::test]
+async fn sweep_bands_are_exclusive_and_null_heartbeat_is_immune() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed_workspace(&store).await;
+    seed_runtime(&store, "fresh", Some(T0), "online").await;
+    seed_runtime(&store, "amber", Some(T0 - 6 * 60_000), "online").await;
+    seed_runtime(&store, "gone", Some(T0 - 20 * 60_000), "online").await;
+    seed_runtime(&store, "legacy", None, "online").await;
+
+    let sweep =
+        AgentRuntimeRepo::sweep_presence_by_age(store.pool(), T0, UNSTABLE_AFTER, OFFLINE_AFTER)
+            .await
+            .expect("sweep");
+
+    let unstable: Vec<&str> = sweep.to_unstable.iter().map(|r| r.id.as_str()).collect();
+    let offline: Vec<&str> = sweep.to_offline.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(unstable, vec!["amber"], "only the mid-band row is amber");
+    assert_eq!(
+        offline,
+        vec!["gone"],
+        "a row past the grace window skips amber entirely"
+    );
+
+    assert_eq!(status_of(&store, "fresh").await, "online");
+    assert_eq!(status_of(&store, "amber").await, "unstable");
+    assert_eq!(status_of(&store, "gone").await, "offline");
+    assert_eq!(
+        status_of(&store, "legacy").await,
+        "online",
+        "a NULL last_seen_at carries no liveness signal and must never decay",
+    );
+}
+
+#[tokio::test]
+async fn heartbeat_stamps_last_seen_and_heals_a_decayed_runtime() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed_workspace(&store).await;
+    seed_runtime(&store, "rt", Some(T0 - 30 * 60_000), "offline").await;
+    seed_runtime(&store, "other", Some(T0 - 30 * 60_000), "offline").await;
+
+    assert!(
+        AgentRuntimeRepo::heartbeat(store.pool(), "rt", T0).await.expect("heartbeat"),
+        "an existing runtime reports the update",
+    );
+    let row = AgentRuntimeRepo::get(store.pool(), "rt").await.expect("get").expect("present");
+    assert_eq!(row.status, "online", "a beat heals a decayed runtime");
+    assert_eq!(row.last_seen_at, Some(T0));
+
+    assert_eq!(
+        status_of(&store, "other").await,
+        "offline",
+        "a beat is targeted by id and never revives a foreign runtime",
+    );
+
+    assert!(
+        !AgentRuntimeRepo::heartbeat(store.pool(), "no-such-runtime", T0)
+            .await
+            .expect("heartbeat"),
+        "an unknown id updates nothing",
+    );
+}
+
+#[tokio::test]
+async fn list_ids_by_runtime_returns_active_agents_of_that_runtime_only() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    seed_workspace(&store).await;
+    seed_runtime(&store, "rt", Some(T0), "online").await;
+    seed_runtime(&store, "rt2", Some(T0), "online").await;
+    for (id, runtime, archived) in [
+        ("a-live", "rt", 0),
+        ("a-archived", "rt", 1),
+        ("a-elsewhere", "rt2", 0),
+    ] {
+        sqlx::query(
+            "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id, archived) \
+             VALUES (?, ?, ?, ?, 'workspace', 'u', ?)",
+        )
+        .bind(id)
+        .bind(WS)
+        .bind(id)
+        .bind(runtime)
+        .bind(archived)
+        .execute(store.pool())
+        .await
+        .expect("agent");
+    }
+
+    let ids = AgentRepo::list_ids_by_runtime(store.pool(), "rt").await.expect("list");
+    assert_eq!(ids, vec!["a-live".to_string()]);
+}


### PR DESCRIPTION
## What

Parity item **6-rest** — availability derivation. `PresenceState::Unstable` and its amber `◐` dot were unreachable dead code: nothing wrote `"unstable"`, nothing swept `agent_runtime`, and `agents_list` passed the stored `status` straight through, so a daemon that died left its agents reading `● online` forever.

This makes availability real, in two independent layers:

```
┌────────────────┐  every 30s   ┌───────────────────────────────────────┐
│ daemon presence│─(a) heartbeat│ UPDATE agent_runtime                  │
│  loop (new)    │─────────────▶│  last_seen_at=now, status='online'    │
│                │─(b) sweep───▶│ 'online'  →'unstable' if age > 5min   │
│                │              │ 'online'|'unstable'→'offline' > 10min │
└────────┬───────┘              └───────────────────────────────────────┘
         │ (c) AgentPresence per flipped agent
         ▼
┌────────────────┐   arms fetch_snapshots  ┌────────────────────────┐
│ plugin         │◀────────────────────────│ agents_list snapshot   │
│ (no change)    │◀────────────────────────│ presence = derive(     │
│  ● / ◐ / ○     │                         │  status,last_seen,now) │
└────────────────┘                         └────────────────────────┘
```

* **Read fold** (`PresenceState::derive`) makes the Agents screen correct on any snapshot pull, with no live daemon and no tick latency.
* **Writer** (`sweep_runtime_presence` + `spawn_runtime_presence`) makes the persisted row truthful for every other reader (CLI, squads, future web) and pushes the event that re-renders an attached TUI.

## Acceptance

> an agent whose runtime has not been seen for >5 min renders unstable / amber, then offline; proven by sqlite `last_seen_at` manipulation + the Agents screen.

`crates/ainb-hangar-daemon/tests/tripwire_hangar_presence_amber.rs` does exactly that: real `ainb` in tmux → real daemon → staged plugin → Agents tab, a ghost runtime the daemon does not own, `UPDATE agent_runtime SET last_seen_at = ...` in sqlite, then asserts the ghost's OWN line walks `● online → ◐ unstable → ○ offline`, and finally reads `agent_runtime.status` back out (so a read-only implementation fails the last assertion).

## Deliberate adaptations from multica

| Multica | Here | Why |
|---|---|---|
| `status === "online"` short-circuits the age check | age wins for any row with a non-NULL `last_seen_at` (worse-of-the-two) | Multica's sweeper runs in the **server**, which outlives the daemon, so `status` is trustworthy. Ours runs **inside** the daemon: when the daemon dies nothing can flip its own row, so a status-first read would pin a dead daemon at `● online` forever — the exact bug. The read fold is the primary mechanism, not defence in depth. |
| `unstable` = recently lost (`< 5 min`, gated behind a 150s sweeper → effective amber band ≈ 2.5–5 min) | `unstable` = `> 5 min` stale, `offline` = `> 10 min` (a 5-minute grace window) | No Redis liveness authority here; the DB heartbeat is the only signal, so the first band must clear the 30s heartbeat interval by a wide margin (10 missed beats), matching multica's 15s/150s ratio. It is also literally what the acceptance sentence asks for. |
| `about_to_gc` (6d) + 7d runtime GC | out of scope | There is no runtime GC in hangar; folding it in is a separate parity item. |
| `EventDaemonRegister{stale_sweep}` broadcast | `HangarEvent::AgentPresence` (already in the vocabulary, previously zero emit sites) | The plugin already arms `fetch_snapshots` on any non-`TaskMessage` event, so the plugin needs **zero** changes. |
| `115_agent_runtime_last_seen_at_index` (CONCURRENT index) | not ported | `agent_runtime` holds one row per (workspace, daemon, provider) — single digits. An index would cost more than the scan. |

`NULL last_seen_at` keeps the stored status verbatim: a row that never carried a heartbeat signal (legacy / CLI-seeded) must not decay just because it has no beat to measure. That rule is why the existing `rpc_agent_workload` fixture stays green by design, and it is asserted explicitly.

## No migration, no wire change

`agent_runtime.last_seen_at INTEGER` exists since `0002`, and `status TEXT NOT NULL DEFAULT 'offline'` has no CHECK constraint, so writing `'unstable'` is legal today. `ActorRow.presence` already exists and already carries all three variants. No existing migration was touched.

## Tests

* `ainb-hangar-proto` — table test over the pure fold, one row per band (both boundaries, worse-wins for `offline`/`unstable`, and a future stamp for clock skew).
* `ainb-hangar-store/tests/repo_agent_runtime_presence.rs` — heartbeat self-heal, targeted-by-id (never revives a foreign runtime), band exclusivity, idempotency, `NULL` immunity.
* `ainb-hangar-daemon/tests/rpc_agent_presence_grace.rs` — the read fold across all three bands with injected `now_ms`, the writer moving sqlite, sweep idempotency, recovery via heartbeat, own-runtime immunity, and the `AgentPresence` event landing on the workspace stream.
* `ainb-hangar-daemon/tests/tripwire_hangar_presence_amber.rs` — the acceptance tripwire above.

## Local gate (all green on this branch)

| Gate | Result |
|---|---|
| `cargo build -p ainb` | ok |
| `cargo nextest run --lib --tests --all-features -E 'not binary(/^tripwire_/)'` | **4077 passed**, 0 failed |
| `scripts/hangar/run_all_tripwires.sh` | **ran=61 failed=0 skipped=0** |
| `scripts/hangar/run_acceptance_tests.sh` | **ran=143 failed=0 skipped=0** |

No fixture in another crate drifted — the `now_ms` parameter is the only signature change, and every call site is updated in this PR. The pre-existing clippy/rustfmt toolchain drift on `ainb-hangar-core` and the untouched parts of `rpc/mod.rs` is unchanged by this branch; none of the new code produces a lint.



---

## Unrelated pre-existing fix carried on this branch

`249b93d6 fix(hangar-daemon): publish the bd pidfile atomically so the lock cannot admit two holders`

**This is not part of the parity item** and touches nothing in the presence diff
(`git diff origin/main...HEAD -- '*beads*'` was empty before this commit). It is here
because it is what was turning **Test (ubuntu-latest)** red on this PR, and it is a real
pre-existing defect on `main`, not a flake.

**Root cause.** `BdLock::acquire` created the pidfile with `O_CREAT | O_EXCL` and only
then wrote the PID into it. Between those two syscalls the file exists but is empty, and
an empty pidfile is exactly what a crashed holder leaves behind. A contender sampling
that window took the crash-recovery branch in `steal_if_stale`, deleted a **live**
holder's pidfile and acquired alongside it — two holders, two concurrent `bd` processes
racing on the git head of the beads store, which is the exact thing the lock exists to
prevent. `test_concurrent_invocations_serialize_per_beads_dir` caught it as an
interleaved `start/start` in its sentinel log.

**Not a flake, measured on an idle laptop** with only `lock.rs` differing:

| build | runs | failures |
|---|---|---|
| `main`'s lock (create-then-write) | 40 | **10** |
| atomic publish (this commit) | 60 | **0** |

**Fix.** Write the PID into a private temp file, then `hard_link` it onto the lock path.
The link is atomic and returns `EEXIST` while the lock is held, so the pidfile is never
observable in a created-but-empty state. The empty-is-stale branch stays as a
crash-recovery backstop for pre-fix leftovers; it is now unreachable from the race path.

**Production impact, stated honestly.** The integration test amplifies the window with
same-process threads, where no spawn latency masks it. In production the contenders are
separate processes (`ainb hangar reconcile`, the inbound poll loop, outbound sync), so
the window is narrower — but the defect is identical and is not test-only.

**New coverage.** `contended_acquire_never_admits_two_holders` is a deterministic-enough
unit regression: it barrier-syncs four contenders per round and holds the critical
section long enough for an admitted second holder to be counted. It **fails 3/3 on the
old publish** and is green 25/25 on the new one. `pidfile_of_a_dead_holder_is_stolen_promptly`
pins that genuine crash recovery still works.

It is kept as a separate single-concern commit so it can be read (or reverted)
independently of the presence work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent availability now automatically transitions from online to unstable and offline based on heartbeat age.
  * Active runtimes send regular heartbeats and can recover to online when they reconnect.
  * Presence changes are propagated to agent views and workspace events.
  * Added configuration for the presence sweep interval.

* **Bug Fixes**
  * Agent lists and mutation responses now consistently reflect time-based availability.

* **Tests**
  * Added coverage for presence decay, recovery, event propagation, and UI status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
