### PR TITLE
feat(hangar): agent metadata — description, avatar, unique names, system kind, service tier (parity #23)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -499,6 +499,16 @@ pub struct AgentCreateArgs {
     /// Optional instructions / system prompt for the agent.
     #[arg(long)]
     pub instructions: Option<String>,
+    /// Optional short blurb rendered beside the agent (≤255 characters).
+    #[arg(long)]
+    pub description: Option<String>,
+    /// Optional avatar token (e.g. `emoji:🦊`); omitted mints a random emoji.
+    #[arg(long)]
+    pub avatar: Option<String>,
+    /// Optional Codex service tier (e.g. `priority`); omitted inherits the local
+    /// Codex config. Stored + surfaced only — no dispatch-time override yet.
+    #[arg(long = "service-tier")]
+    pub service_tier: Option<String>,
     /// Workspace slug to create the agent in. Defaults to the bootstrapped
     /// `default` workspace (created if absent).
     #[arg(long)]
@@ -578,6 +588,24 @@ pub struct AgentEditArgs {
     /// Clear the token budget (back to unlimited); omitted leaves it.
     #[arg(long = "clear-token-budget")]
     pub clear_token_budget: bool,
+    /// New description (≤255 characters); omitted leaves it. Pass `--description ""`
+    /// to blank it (the column is NOT NULL, so `""` IS its cleared state).
+    #[arg(long)]
+    pub description: Option<String>,
+    /// New avatar token; omitted leaves it. Mutually exclusive with
+    /// `--clear-avatar`.
+    #[arg(long, conflicts_with = "clear_avatar")]
+    pub avatar: Option<String>,
+    /// Clear the avatar; omitted leaves it.
+    #[arg(long = "clear-avatar")]
+    pub clear_avatar: bool,
+    /// New Codex service tier; omitted leaves it. Mutually exclusive with
+    /// `--clear-service-tier`.
+    #[arg(long = "service-tier", conflicts_with = "clear_service_tier")]
+    pub service_tier: Option<String>,
+    /// Clear the service tier (back to inheriting the local Codex config).
+    #[arg(long = "clear-service-tier")]
+    pub clear_service_tier: bool,
     /// Workspace slug the agent belongs to. Defaults to the bootstrapped
     /// `default` workspace.
     #[arg(long)]
@@ -2062,6 +2090,21 @@ async fn run_agent_can_invoke(store: &Store, args: AgentCanInvokeArgs) -> Result
     Ok(())
 }
 
+/// Validate an optional `--description` against the 255-CODE-POINT cap
+/// (migration 0050 / multica 060), returning the trimmed value.
+///
+/// Counted in `chars()`, not bytes, so an emoji-heavy blurb measures the way the
+/// schema's `length()` CHECK measures it. Rejecting here gives the operator the
+/// actionable message instead of an opaque store fault.
+fn validated_description(desc: Option<&str>) -> Result<Option<String>> {
+    let Some(desc) = desc else { return Ok(None) };
+    let trimmed = desc.trim();
+    if trimmed.chars().count() > ainb_hangar_store::repo::agent::MAX_DESCRIPTION_CHARS {
+        anyhow::bail!("description must be 255 characters or fewer");
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
 /// `hangar agent create`: create one agent from scratch, filling the workspace /
 /// runtime / owner FKs behind the scenes. Prints the created agent's name (never
 /// the id). An unsupported provider or empty name is a CLI error.
@@ -2072,6 +2115,7 @@ async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
     }
     let provider = ainb_hangar_store::bootstrap::normalize_provider(args.provider.as_deref())
         .map_err(|e| anyhow::anyhow!(e))?;
+    let description = validated_description(args.description.as_deref())?.unwrap_or_default();
     // An explicit --workspace must exist; the default is ensured (created if absent).
     let workspace_id = match args.workspace.as_deref() {
         Some(slug) => {
@@ -2084,15 +2128,31 @@ async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
         }
         None => ensure_default_workspace(store).await?,
     };
-    let agent = ainb_hangar_store::bootstrap::create_agent(
+    let agent = ainb_hangar_store::bootstrap::create_agent_from(
         store.pool(),
         &workspace_id,
-        name,
-        &provider,
-        args.instructions,
+        ainb_hangar_store::bootstrap::AgentDraft {
+            name: name.to_string(),
+            provider,
+            instructions: args.instructions,
+            description,
+            avatar_url: args.avatar,
+            service_tier: args.service_tier,
+            // `--model` rides the follow-up write below (unchanged); `kind` /
+            // `system_key` are internal-only (a system agent is never CLI-minted).
+            ..ainb_hangar_store::bootstrap::AgentDraft::default()
+        },
     )
     .await
-    .context("create agent")?;
+    .map_err(|e| {
+        if ainb_hangar_store::repo::agent::is_duplicate_name(&e) {
+            // Multica 046's 409 equivalent: a clear refusal + non-zero exit, never
+            // a silent second identically-named actor the picker cannot tell apart.
+            anyhow::anyhow!("an agent named `{name}` already exists in this workspace")
+        } else {
+            anyhow::Error::new(e).context("create agent")
+        }
+    })?;
     // Optional model override: mirror the daemon's create-time follow-up so the
     // CLI create path persists the model too. A blank value is treated as absent
     // (leaves `model` NULL rather than writing an empty string).
@@ -2164,9 +2224,14 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
     let agent_env = (!args.env.is_empty()).then_some(args.env);
 
     let token_budget = clear_or_set(args.clear_token_budget, args.token_budget);
+    // Migration 0050: `description` is NOT NULL so it has no clear-flag (`""` IS
+    // its cleared state); avatar / service tier follow the clear-flag pattern.
+    let description = validated_description(args.description.as_deref())?;
+    let avatar_url = clear_or_set(args.clear_avatar, args.avatar);
+    let service_tier = clear_or_set(args.clear_service_tier, args.service_tier);
 
     let update = AgentConfigUpdate {
-        name: args.name,
+        name: args.name.clone(),
         instructions,
         model,
         cli_args,
@@ -2174,19 +2239,33 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
         thinking,
         agent_env,
         token_budget,
+        description,
+        avatar_url,
+        service_tier,
     };
 
     if update.is_empty() {
         anyhow::bail!(
             "nothing to update: pass at least one of --name / --instructions / --clear-instructions \
              / --model / --clear-model / --arg / --mcp / --clear-mcp / --thinking / --clear-thinking \
-             / --env / --token-budget / --clear-token-budget"
+             / --env / --token-budget / --clear-token-budget / --description / --avatar / \
+             --clear-avatar / --service-tier / --clear-service-tier"
         );
     }
 
     let touched = AgentRepo::update_config(store.pool(), &workspace_id, &args.id, &update)
         .await
-        .with_context(|| format!("update agent {}", args.id))?;
+        .map_err(|e| {
+            // A RENAME onto a taken name is the same refusal create gives.
+            if ainb_hangar_store::repo::agent::is_duplicate_name(&e) {
+                anyhow::anyhow!(
+                    "an agent named `{}` already exists in this workspace",
+                    args.name.as_deref().unwrap_or_default()
+                )
+            } else {
+                anyhow::Error::new(e).context(format!("update agent {}", args.id))
+            }
+        })?;
     if touched {
         println!("updated agent {}", args.id);
     } else {
@@ -5042,24 +5121,32 @@ fn render_agent_list(agents: &[ainb_hangar_store::repo::agent::Agent], format: O
     }
 }
 
-/// One-line text summary of an agent (id, name, archived badge, model).
+/// One-line text summary of an agent (id, name, archived badge, model, blurb).
 fn agent_line(a: &ainb_hangar_store::repo::agent::Agent) -> String {
+    // The blurb (migration 0050) is appended only when set, so a metadata-less
+    // agent's line is byte-identical to the pre-0050 rendering.
+    let blurb = if a.description.is_empty() {
+        String::new()
+    } else {
+        format!("  — {}", a.description)
+    };
     format!(
-        "{}  {}{}  model={}  args={}  env={}",
+        "{}  {}{}  model={}  args={}  env={}{}",
         a.id,
         a.name,
         if a.archived { "  [archived]" } else { "" },
         a.model.as_deref().unwrap_or("-"),
         a.cli_args.len(),
         a.agent_env.len(),
+        blurb,
     )
 }
 const fn agent_csv_header() -> &'static str {
-    "id,name,archived,model,thinking,args,env"
+    "id,name,archived,model,thinking,args,env,description"
 }
 fn agent_csv_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     format!(
-        "{},{},{},{},{},{},{}",
+        "{},{},{},{},{},{},{},{}",
         csv_field(a.id.as_str()),
         csv_field(a.name.as_str()),
         a.archived,
@@ -5067,15 +5154,16 @@ fn agent_csv_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         csv_field(a.thinking.as_deref().unwrap_or("")),
         a.cli_args.len(),
         a.agent_env.len(),
+        csv_field(a.description.as_str()),
     )
 }
 const fn agent_md_header() -> &'static str {
-    "| id | name | archived | model | thinking | args | env |\n\
-     | --- | --- | --- | --- | --- | --- | --- |\n"
+    "| id | name | archived | model | thinking | args | env | description |\n\
+     | --- | --- | --- | --- | --- | --- | --- | --- |\n"
 }
 fn agent_md_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     format!(
-        "| {} | {} | {} | {} | {} | {} | {} |",
+        "| {} | {} | {} | {} | {} | {} | {} | {} |",
         md_cell(a.id.as_str()),
         md_cell(a.name.as_str()),
         a.archived,
@@ -5083,6 +5171,7 @@ fn agent_md_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         md_cell(a.thinking.as_deref().unwrap_or("-")),
         a.cli_args.len(),
         a.agent_env.len(),
+        md_cell(a.description.as_str()),
     )
 }
 /// Minimal stable JSON object for one agent (id, name, archived + config knobs).
@@ -5097,7 +5186,7 @@ fn agent_to_json(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         .collect::<Vec<_>>()
         .join(",");
     format!(
-        "{{\"id\":{},\"name\":{},\"archived\":{},\"model\":{},\"thinking\":{},\"args\":{},\"env\":{{{}}}}}",
+        "{{\"id\":{},\"name\":{},\"archived\":{},\"model\":{},\"thinking\":{},\"args\":{},\"env\":{{{}}},\"description\":{}}}",
         json_string(a.id.as_str()),
         json_string(a.name.as_str()),
         a.archived,
@@ -5105,6 +5194,7 @@ fn agent_to_json(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         thinking,
         args,
         env,
+        json_string(a.description.as_str()),
     )
 }
 

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -639,6 +639,141 @@ fn agent_create_on_fresh_home_inserts_and_lists() {
     );
 }
 
+/// The user-visible proof for migration 0050 (multica gap #23): a description
+/// supplied at `agent create` survives into `agent list --format json`, and a
+/// SECOND create with the same name is REFUSED — a non-zero exit and a clear
+/// message, never a silent second identically-named row.
+#[test]
+fn agent_create_persists_description_and_refuses_a_duplicate_name() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            "a",
+            "--description",
+            "runs the build",
+        ],
+    );
+    assert!(ok, "agent create should exit 0; out={out}");
+
+    let (ok, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    assert!(ok, "agent list should exit 0; out={shown}");
+    assert!(
+        shown.contains(r#""description":"runs the build""#),
+        "the description must survive into the json listing:\n{shown}"
+    );
+
+    // A SECOND create with the same name fails loudly.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "agent", "create", "--name", "a", "--description", "second"],
+    );
+    assert!(!ok, "a duplicate agent name must exit non-zero; out={out}");
+    assert!(
+        out.contains("already exists"),
+        "the refusal must say the name is taken:\n{out}"
+    );
+
+    // …and wrote nothing: still exactly one agent named `a`.
+    let (_, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    assert_eq!(
+        shown.matches(r#""name":"a""#).count(),
+        1,
+        "the refused create must not have added a second row:\n{shown}"
+    );
+}
+
+/// An over-long `--description` is refused before anything is written (the
+/// 255-code-point cap, multica 060).
+#[test]
+fn agent_create_rejects_an_over_long_description() {
+    let tmp = tempfile::tempdir().unwrap();
+    let too_long = "x".repeat(256);
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            "toolong",
+            "--description",
+            &too_long,
+        ],
+    );
+    assert!(!ok, "a 256-character description must exit non-zero; out={out}");
+    assert!(
+        out.contains("255 characters or fewer"),
+        "the message must state the cap:\n{out}"
+    );
+
+    let (_, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    assert!(
+        !shown.contains("toolong"),
+        "the rejected create must not have written an agent:\n{shown}"
+    );
+}
+
+/// `agent edit --description` rewrites the blurb, and a rename onto a taken
+/// name is refused with the agent's name intact.
+#[test]
+fn agent_edit_rewrites_description_and_refuses_a_colliding_rename() {
+    let tmp = tempfile::tempdir().unwrap();
+    for name in ["alpha", "beta"] {
+        let (ok, out) = run(tmp.path(), &["hangar", "agent", "create", "--name", name]);
+        assert!(ok, "create {name} should exit 0; out={out}");
+    }
+    // Pull beta's id out of the json listing.
+    let (_, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    let rows: serde_json::Value = serde_json::from_str(shown.trim()).expect("json listing parses");
+    let beta_id = rows
+        .as_array()
+        .expect("array")
+        .iter()
+        .find(|r| r["name"] == "beta")
+        .expect("beta listed")["id"]
+        .as_str()
+        .expect("id")
+        .to_string();
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "agent",
+            "edit",
+            &beta_id,
+            "--description",
+            "reviews every PR",
+        ],
+    );
+    assert!(ok, "a description-only edit should exit 0; out={out}");
+    let (_, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    assert!(
+        shown.contains(r#""description":"reviews every PR""#),
+        "the edited blurb must show in the listing:\n{shown}"
+    );
+
+    // Renaming beta onto alpha is refused, and beta keeps its name.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "agent", "edit", &beta_id, "--name", "alpha"],
+    );
+    assert!(!ok, "a colliding rename must exit non-zero; out={out}");
+    assert!(out.contains("already exists"), "refusal message:\n{out}");
+    let (_, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    assert!(
+        shown.contains(r#""name":"beta""#),
+        "the refused rename must leave beta's name alone:\n{shown}"
+    );
+}
+
 /// Create an issue via the CLI and return its id (pulled from the create ack).
 fn create_issue(home: &std::path::Path, title: &str) -> String {
     let (ok, out) = run(home, &["hangar", "issue", "create", "--title", title]);

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -430,14 +430,7 @@ fn seed_agent(home: &std::path::Path) {
                 visibility: "workspace".into(),
                 permission_mode: "private".into(),
                 owner_id,
-                archived: false,
-                model: None,
-                cli_args: Vec::new(),
-                mcp_config: None,
-                thinking: None,
-                agent_env: Vec::new(),
-                provider: None,
-                token_budget: None,
+                ..Agent::default()
             },
         )
         .await
@@ -1122,14 +1115,7 @@ fn seed_assignable_agent(home: &std::path::Path) {
                 visibility: "workspace".into(),
                 permission_mode: "private".into(),
                 owner_id: owner_id.clone(),
-                archived: false,
-                model: None,
-                cli_args: Vec::new(),
-                mcp_config: None,
-                thinking: None,
-                agent_env: Vec::new(),
-                provider: None,
-                token_budget: None,
+                ..Agent::default()
             },
         )
         .await

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -671,7 +671,15 @@ fn agent_create_persists_description_and_refuses_a_duplicate_name() {
     // A SECOND create with the same name fails loudly.
     let (ok, out) = run(
         tmp.path(),
-        &["hangar", "agent", "create", "--name", "a", "--description", "second"],
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            "a",
+            "--description",
+            "second",
+        ],
     );
     assert!(!ok, "a duplicate agent name must exit non-zero; out={out}");
     assert!(
@@ -707,7 +715,10 @@ fn agent_create_rejects_an_over_long_description() {
             &too_long,
         ],
     );
-    assert!(!ok, "a 256-character description must exit non-zero; out={out}");
+    assert!(
+        !ok,
+        "a 256-character description must exit non-zero; out={out}"
+    );
     assert!(
         out.contains("255 characters or fewer"),
         "the message must state the cap:\n{out}"

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_autopilot_fire.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_autopilot_fire.rs
@@ -188,14 +188,7 @@ async fn seed_minimal_tenancy(pool: &sqlx::SqlitePool) {
             visibility: "workspace".to_string(),
             permission_mode: "private".to_string(),
             owner_id: USER_ID.to_string(),
-            archived: false,
-            model: None,
-            cli_args: Vec::new(),
-            mcp_config: None,
-            thinking: None,
-            agent_env: Vec::new(),
-            provider: None,
-            token_budget: None,
+            ..Agent::default()
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_squads_journey.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_squads_journey.rs
@@ -160,14 +160,7 @@ async fn seed_agent(
             visibility: "workspace".into(),
             permission_mode: "private".into(),
             owner_id: "user-1".into(),
-            archived: false,
-            model: None,
-            cli_args: Vec::new(),
-            mcp_config: None,
-            thinking: None,
-            agent_env: Vec::new(),
-            provider: None,
-            token_budget: None,
+            ..Agent::default()
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3972,7 +3972,9 @@ fn validate_description(desc: Option<&str>) -> Result<Option<String>, RpcError> 
     let Some(desc) = desc else { return Ok(None) };
     let trimmed = desc.trim();
     if trimmed.chars().count() > ainb_hangar_store::repo::agent::MAX_DESCRIPTION_CHARS {
-        return Err(invalid_params("description must be 255 characters or fewer"));
+        return Err(invalid_params(
+            "description must be 255 characters or fewer",
+        ));
     }
     Ok(Some(trimmed.to_string()))
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3810,25 +3810,35 @@ async fn handle_agent_create(
 ) -> Result<serde_json::Value, RpcError> {
     let params: ainb_hangar_proto::snapshots::AgentCreateParams = parse_params(
         req,
-        "{ workspace_id?, name, provider?, model?, instructions? }",
+        "{ workspace_id?, name, provider?, model?, instructions?, description?, avatar_url?, \
+         service_tier? }",
     )?;
     let name = params.name.trim();
     if name.is_empty() {
         return Err(invalid_params("agent name must not be empty"));
     }
+    let description = validate_description(params.description.as_deref())?.unwrap_or_default();
     let provider = ainb_hangar_store::bootstrap::normalize_provider(params.provider.as_deref())
         .map_err(|e| invalid_params(&e))?;
     let wire = params.workspace_id.as_deref().unwrap_or("").trim();
     let ws = resolve_or_bootstrap_default(pool, wire).await?;
-    let created = ainb_hangar_store::bootstrap::create_agent(
+    let created = ainb_hangar_store::bootstrap::create_agent_from(
         pool,
         ws.as_str(),
-        name,
-        &provider,
-        params.instructions,
+        ainb_hangar_store::bootstrap::AgentDraft {
+            name: name.to_string(),
+            provider,
+            instructions: params.instructions,
+            description,
+            avatar_url: params.avatar_url,
+            service_tier: params.service_tier,
+            // `model` rides the create-time follow-up write below (unchanged), and
+            // `kind`/`system_key` are never client-settable — see AgentCreateParams.
+            ..ainb_hangar_store::bootstrap::AgentDraft::default()
+        },
     )
     .await
-    .map_err(|e| store_err(&e))?;
+    .map_err(|e| duplicate_name_or_store_err(&e, name))?;
     // Optional create-time model override (gap #9) + token budget (0042): applied
     // as a single follow-up config write rather than widening create_agent's
     // signature across every caller. A blank model is treated as absent (no
@@ -3915,16 +3925,20 @@ async fn handle_agent_update(
     let params: ainb_hangar_proto::snapshots::AgentUpdateParams = parse_params(
         req,
         "{ workspace_id, agent_id, name?, instructions?, model?, cli_args?, mcp_config?, \
-         thinking?, agent_env? }",
+         thinking?, agent_env?, description?, avatar_url?, service_tier? }",
     )?;
     // The mutating handler must not silently no-op on a typo'd workspace.
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    // Same 255-code-point cap as create — an over-long blurb is refused with the
+    // actionable message before it can reach the schema CHECK.
+    validate_description(params.description.as_deref())?;
     let update = agent_config_update_from_params(&params);
     // An edit with no field set is a client error: there is nothing to write.
     if update.is_empty() {
         return Err(invalid_params(
             "nothing to update: set at least one of \
-             name/instructions/model/cli_args/mcp_config/thinking/agent_env",
+             name/instructions/model/cli_args/mcp_config/thinking/agent_env/\
+             description/avatar_url/service_tier",
         ));
     }
     let row = snapshots::agent_update(
@@ -3935,7 +3949,9 @@ async fn handle_agent_update(
         SystemClock.now_ms(),
     )
     .await
-    .map_err(|e| store_err(&e))?;
+    // A RENAME onto a name already taken in this workspace is the same refusal
+    // create gives (migration 0050), not an opaque store fault.
+    .map_err(|e| duplicate_name_or_store_err(&e, params.name.as_deref().unwrap_or_default()))?;
     let Some(row) = row else {
         return Err(invalid_params(&format!(
             "no agent `{}` in this workspace",
@@ -3943,6 +3959,40 @@ async fn handle_agent_update(
         )));
     };
     to_value(&row)
+}
+
+/// Validate an optional wire `description` against multica's 255-CODE-POINT cap
+/// (migration 0050 / multica 060), returning the trimmed value.
+///
+/// Counted in `chars()`, not bytes, so an emoji-heavy blurb is measured the way
+/// multica's `utf8.RuneCountInString` measures it and the way the schema's
+/// `length()` CHECK does. Rejecting here (rather than letting the CHECK fire)
+/// gives the user the actionable message instead of an opaque store fault.
+fn validate_description(desc: Option<&str>) -> Result<Option<String>, RpcError> {
+    let Some(desc) = desc else { return Ok(None) };
+    let trimmed = desc.trim();
+    if trimmed.chars().count() > ainb_hangar_store::repo::agent::MAX_DESCRIPTION_CHARS {
+        return Err(invalid_params("description must be 255 characters or fewer"));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+/// Turn a failed agent create/rename into either the duplicate-name refusal
+/// (multica's 409-equivalent, migration 0050) or the generic store error.
+///
+/// The `data.reason` marker follows the precedent [`handle_agent_delete`] set with
+/// `active_tasks` / `has_history`, so the TUI branches on a token rather than
+/// string-matching the message.
+fn duplicate_name_or_store_err(e: &sqlx::Error, name: &str) -> RpcError {
+    if ainb_hangar_store::repo::agent::is_duplicate_name(e) {
+        RpcError {
+            code: INVALID_PARAMS,
+            message: format!("an agent named `{name}` already exists in this workspace"),
+            data: Some(serde_json::json!({ "reason": "duplicate_name" })),
+        }
+    } else {
+        store_err(e)
+    }
 }
 
 /// Map the wire [`AgentUpdateParams`] onto the store's [`AgentConfigUpdate`].
@@ -3966,6 +4016,11 @@ fn agent_config_update_from_params(
         thinking: field_to_nested(&params.thinking),
         token_budget: field_to_nested(&params.token_budget),
         agent_env: params.agent_env.clone(),
+        // Migration 0050. `description` is NOT NULL, so it maps straight through
+        // like `name`; the other two are nullable and use the FieldUpdate bridge.
+        description: params.description.as_deref().map(|d| d.trim().to_string()),
+        avatar_url: field_to_nested(&params.avatar_url),
+        service_tier: field_to_nested(&params.service_tier),
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -486,6 +486,8 @@ pub async fn agents_list(
             workload: Workload::Idle,
             is_agent: false,
             recent_rank: None,
+            // A human member carries no agent metadata.
+            ..ActorRow::default()
         });
     }
 
@@ -836,6 +838,10 @@ async fn agent_actor_row_with_counts(
         workload: Workload::derive(running, queued),
         is_agent: true,
         recent_rank: None,
+        // Migration 0050 metadata. Both are omitted from the wire when empty, so
+        // a metadata-less agent serialises exactly as it did pre-0050.
+        description: agent.description.clone(),
+        avatar: agent.avatar_url.clone().unwrap_or_default(),
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -4143,14 +4143,7 @@ mod tests {
             visibility: "workspace".into(),
             permission_mode: "private".into(),
             owner_id: owner,
-            archived: false,
-            model: None,
-            cli_args: Vec::new(),
-            mcp_config: None,
-            thinking: None,
-            agent_env: Vec::new(),
-            provider: None,
-            token_budget: None,
+            ..Agent::default()
         };
         AgentRepo::insert(pool, &bare).await.unwrap();
         let disp = resolve_dispatch(pool, "bare-agent", None, Mode::Headless).await.unwrap();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/seed.rs
@@ -202,14 +202,7 @@ async fn seed_runtime_and_agent(pool: &SqlitePool, now: i64) -> Result<(), sqlx:
             visibility: "workspace".into(),
             permission_mode: "private".into(),
             owner_id: "user-1".into(),
-            archived: false,
-            model: None,
-            cli_args: Vec::new(),
-            mcp_config: None,
-            thinking: None,
-            agent_env: Vec::new(),
-            provider: None,
-            token_budget: None,
+            ..Agent::default()
         },
     )
     .await?;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
@@ -482,7 +482,15 @@ async fn live_dispatch_remote_repo_source_branch() {
     run_ainb(
         &ainb,
         home.path(),
-        &["hangar", "agent", "create", "--name", &agent_name, "--provider", "claude"],
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            &agent_name,
+            "--provider",
+            "claude",
+        ],
     );
     let pool = open_pool(&db_path).await;
     let (agent_id, runtime_id) = agent_ids_by_name(&pool, &agent_name).await;
@@ -492,7 +500,12 @@ async fn live_dispatch_remote_repo_source_branch() {
         &["hangar", "agent", "edit", &agent_id, "--model", "haiku"],
     );
 
-    let daemon = LiveDaemon::spawn(&home.path().join("daemon.log"), home.path(), &runtime_id, &claude);
+    let daemon = LiveDaemon::spawn(
+        &home.path().join("daemon.log"),
+        home.path(),
+        &runtime_id,
+        &claude,
+    );
 
     // Enqueue with the REMOTE repo + the feature source branch. The CLI clones
     // the remote into the shared cache and persists the LOCAL path + the branch
@@ -510,7 +523,14 @@ async fn live_dispatch_remote_repo_source_branch() {
         );
     }
     let mut args: Vec<&str> = vec![
-        "hangar", "issue", "create", "--title", &brief, "--assign", &agent_id, "--repo",
+        "hangar",
+        "issue",
+        "create",
+        "--title",
+        &brief,
+        "--assign",
+        &agent_id,
+        "--repo",
         &remote_url,
     ];
     if !break_source {
@@ -556,7 +576,10 @@ async fn live_dispatch_remote_repo_source_branch() {
     assert_eq!(got.trim(), nonce, "artifact exists but nonce mismatch");
 
     // 4. Only now is `done` trustworthy.
-    assert_eq!(status, "done", "sentinel + nonce present but status={status:?}, not done");
+    assert_eq!(
+        status, "done",
+        "sentinel + nonce present but status={status:?}, not done"
+    );
 
     eprintln!(
         "LIVE E2E BRANCH OK: task {task_id} done; worktree on feature/x verified at {wd:?}; \
@@ -572,7 +595,11 @@ fn make_branchy_bare_remote(dir: &Path) -> String {
     std::fs::create_dir_all(&work).expect("mk work");
     let git = |args: &[&str]| {
         let out = Command::new("git").arg("-C").arg(&work).args(args).output().expect("git");
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     };
     git(&["init", "--quiet"]);
     git(&["config", "user.email", "t@e.com"]);
@@ -602,7 +629,11 @@ fn make_branchy_bare_remote(dir: &Path) -> String {
         ])
         .output()
         .expect("bare clone");
-    assert!(out.status.success(), "bare clone: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "bare clone: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     format!("file://{}", bare.display())
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_metadata.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_metadata.rs
@@ -155,7 +155,6 @@ async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
     (socket_path, store)
 }
 
-
 /// The `agents_list` row for `actor_ref`, or `None` when absent.
 async fn actor_row(c: &mut Client, actor_ref: &str) -> Option<serde_json::Value> {
     let list = c
@@ -230,7 +229,10 @@ async fn agent_create_persists_description_and_mints_an_avatar() {
     let actor_ref = row["actor_ref"].as_str().unwrap().to_string();
     let fresh = actor_row(&mut c, &actor_ref).await.expect("agent in agents_list");
     assert_eq!(fresh["description"], "ships the backend");
-    assert_eq!(fresh["avatar"], serde_json::Value::String(avatar.to_string()));
+    assert_eq!(
+        fresh["avatar"],
+        serde_json::Value::String(avatar.to_string())
+    );
 }
 
 /// (b) A SECOND create with the same name is refused with the machine-readable
@@ -242,9 +244,7 @@ async fn duplicate_agent_create_is_refused_with_a_reason_marker() {
     let mut c = Client::connect(&socket_path).await;
     c.auth_from_file(dir.path()).await;
 
-    let create = |name: &str| {
-        serde_json::json!({ "workspace_id": WS_SLUG, "name": name })
-    };
+    let create = |name: &str| serde_json::json!({ "workspace_id": WS_SLUG, "name": name });
     let first = c.call(methods::HANGAR_AGENT_CREATE, create("builder")).await;
     assert!(first["error"].is_null(), "the first create acks: {first}");
 
@@ -289,16 +289,13 @@ async fn over_long_description_is_rejected_at_the_boundary() {
         )
         .await;
     let err = &resp["error"];
-    assert!(!err.is_null(), "a 256-char description must be refused: {resp}");
-    assert_eq!(
-        err["code"], -32602,
-        "the refusal is INVALID_PARAMS: {err}"
-    );
     assert!(
-        err["message"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("255 characters or fewer"),
+        !err.is_null(),
+        "a 256-char description must be refused: {resp}"
+    );
+    assert_eq!(err["code"], -32602, "the refusal is INVALID_PARAMS: {err}");
+    assert!(
+        err["message"].as_str().unwrap_or_default().contains("255 characters or fewer"),
         "the message states the cap: {err}"
     );
     assert_eq!(
@@ -319,7 +316,10 @@ async fn over_long_description_is_rejected_at_the_boundary() {
             }),
         )
         .await;
-    assert!(resp["error"].is_null(), "255 characters is accepted: {resp}");
+    assert!(
+        resp["error"].is_null(),
+        "255 characters is accepted: {resp}"
+    );
 }
 
 /// (d) Renaming agent B onto agent A's name is refused the same way, and B
@@ -390,7 +390,10 @@ async fn agent_update_edits_the_description() {
             }),
         )
         .await;
-    assert!(resp["error"].is_null(), "a description-only edit acks: {resp}");
+    assert!(
+        resp["error"].is_null(),
+        "a description-only edit acks: {resp}"
+    );
     assert_eq!(resp["result"]["description"], "reviews every PR");
 
     let row = actor_row(&mut c, "agent:agent-1").await.expect("agent-1 present");

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_metadata.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_metadata.rs
@@ -1,0 +1,398 @@
+//! Integration: the migration-0050 agent metadata surface over a real framed
+//! `UnixStream` (multica gap #23).
+//!
+//! Drives the REAL dispatcher (not the store) and asserts the user-visible
+//! contract:
+//!   (a) `hangar/agent_create` with a `description` acks, and the following
+//!       `agents_list` row carries that description AND a non-empty avatar,
+//!   (b) a SECOND create with the same name is REFUSED with
+//!       `data.reason == "duplicate_name"` and a message naming the agent — and
+//!       the roster still holds exactly one agent by that name,
+//!   (c) a 256-CHARACTER description is `INVALID_PARAMS` and writes nothing,
+//!   (d) renaming agent B onto agent A's name is refused the same way, and B
+//!       keeps its old name.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        tokio::time::timeout(timeout, self.read_frame_inner()).await.ok()
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(5))
+                .await
+                .unwrap_or_else(|| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    /// Snapshot the active agent ids in `workspace`'s `agents_list` (agents only,
+    /// not human members).
+    async fn active_agent_ids(&mut self, workspace: &str) -> Vec<String> {
+        let list = self
+            .call(
+                methods::HANGAR_AGENTS_LIST,
+                serde_json::json!({ "workspace_id": workspace }),
+            )
+            .await;
+        list["result"]["actors"]
+            .as_array()
+            .expect("actors array")
+            .iter()
+            .filter(|a| a["is_agent"] == true)
+            .map(|a| a["actor_ref"].as_str().unwrap().to_string())
+            .collect()
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+
+/// The `agents_list` row for `actor_ref`, or `None` when absent.
+async fn actor_row(c: &mut Client, actor_ref: &str) -> Option<serde_json::Value> {
+    let list = c
+        .call(
+            methods::HANGAR_AGENTS_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    list["result"]["actors"]
+        .as_array()
+        .expect("actors array")
+        .iter()
+        .find(|a| a["actor_ref"] == actor_ref)
+        .cloned()
+}
+
+/// How many agents in the roster carry `name` as their display name.
+async fn count_named(c: &mut Client, name: &str) -> usize {
+    let list = c
+        .call(
+            methods::HANGAR_AGENTS_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    list["result"]["actors"]
+        .as_array()
+        .expect("actors array")
+        .iter()
+        .filter(|a| a["is_agent"] == true && a["display_name"] == name)
+        .count()
+}
+
+/// (a) A create carrying a `description` acks, and the roster row the client
+/// renders carries BOTH the description and a minted avatar.
+#[tokio::test]
+async fn agent_create_persists_description_and_mints_an_avatar() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "name": "builder",
+                "description": "ships the backend",
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "create must ack: {resp}");
+
+    let row = resp["result"]["actors"]
+        .as_array()
+        .expect("the create answers with the refreshed roster")
+        .iter()
+        .find(|a| a["display_name"] == "builder")
+        .cloned()
+        .expect("the new agent is in the answered roster");
+    assert_eq!(
+        row["description"], "ships the backend",
+        "the create reply's row carries the blurb: {row}"
+    );
+    let avatar = row["avatar"].as_str().unwrap_or_default();
+    assert!(
+        avatar.starts_with("emoji:"),
+        "an agent is never avatar-less, got {avatar:?}"
+    );
+
+    // And it survives into an independently-fetched snapshot, not just the reply.
+    let actor_ref = row["actor_ref"].as_str().unwrap().to_string();
+    let fresh = actor_row(&mut c, &actor_ref).await.expect("agent in agents_list");
+    assert_eq!(fresh["description"], "ships the backend");
+    assert_eq!(fresh["avatar"], serde_json::Value::String(avatar.to_string()));
+}
+
+/// (b) A SECOND create with the same name is refused with the machine-readable
+/// `duplicate_name` marker, and the roster still holds exactly one such agent.
+#[tokio::test]
+async fn duplicate_agent_create_is_refused_with_a_reason_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let create = |name: &str| {
+        serde_json::json!({ "workspace_id": WS_SLUG, "name": name })
+    };
+    let first = c.call(methods::HANGAR_AGENT_CREATE, create("builder")).await;
+    assert!(first["error"].is_null(), "the first create acks: {first}");
+
+    let second = c.call(methods::HANGAR_AGENT_CREATE, create("builder")).await;
+    let err = &second["error"];
+    assert!(!err.is_null(), "a duplicate name must be refused: {second}");
+    assert_eq!(
+        err["data"]["reason"], "duplicate_name",
+        "the refusal carries the machine-readable marker: {err}"
+    );
+    let msg = err["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("builder") && msg.contains("already exists"),
+        "the message names the agent: {msg:?}"
+    );
+
+    assert_eq!(
+        count_named(&mut c, "builder").await,
+        1,
+        "the refused create wrote no second row"
+    );
+}
+
+/// (c) An over-long description is `INVALID_PARAMS` and writes nothing; the
+/// boundary (exactly 255 characters) is accepted.
+#[tokio::test]
+async fn over_long_description_is_rejected_at_the_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let too_long = "x".repeat(256);
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "name": "toolong",
+                "description": too_long,
+            }),
+        )
+        .await;
+    let err = &resp["error"];
+    assert!(!err.is_null(), "a 256-char description must be refused: {resp}");
+    assert_eq!(
+        err["code"], -32602,
+        "the refusal is INVALID_PARAMS: {err}"
+    );
+    assert!(
+        err["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("255 characters or fewer"),
+        "the message states the cap: {err}"
+    );
+    assert_eq!(
+        count_named(&mut c, "toolong").await,
+        0,
+        "the rejected create wrote no agent"
+    );
+
+    // Exactly 255 is fine — the cap is inclusive.
+    let ok = "y".repeat(255);
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "name": "justright",
+                "description": ok,
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "255 characters is accepted: {resp}");
+}
+
+/// (d) Renaming agent B onto agent A's name is refused the same way, and B
+/// keeps its old name (no partial write).
+#[tokio::test]
+async fn renaming_onto_a_taken_name_is_refused_and_leaves_the_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    // The seed lays down `claude-agent` (agent-1); add a second agent `beta`.
+    let created = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "name": "beta" }),
+        )
+        .await;
+    assert!(created["error"].is_null(), "create beta acks: {created}");
+    let beta_ref = created["result"]["actors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["display_name"] == "beta")
+        .expect("beta in the roster")["actor_ref"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let beta_id = beta_ref.strip_prefix("agent:").unwrap().to_string();
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": beta_id,
+                "name": "claude-agent",
+            }),
+        )
+        .await;
+    let err = &resp["error"];
+    assert!(!err.is_null(), "a colliding rename must be refused: {resp}");
+    assert_eq!(err["data"]["reason"], "duplicate_name", "{err}");
+
+    let row = actor_row(&mut c, &beta_ref).await.expect("beta still exists");
+    assert_eq!(
+        row["display_name"], "beta",
+        "the refused rename left the row untouched"
+    );
+}
+
+/// An `agent_update` may edit the description alone, and the refreshed row the
+/// mutation answers with carries the new blurb (not just a later list).
+#[tokio::test]
+async fn agent_update_edits_the_description() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": "agent-1",
+                "description": "reviews every PR",
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "a description-only edit acks: {resp}");
+    assert_eq!(resp["result"]["description"], "reviews every PR");
+
+    let row = actor_row(&mut c, "agent:agent-1").await.expect("agent-1 present");
+    assert_eq!(row["description"], "reviews every PR", "the edit persisted");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_workload.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_workload.rs
@@ -120,13 +120,7 @@ async fn agents_list_workload_tracks_lifecycle_and_agent_update_agrees() {
         AGENT,
         &AgentConfigUpdate {
             name: Some(AGENT.to_string()),
-            instructions: None,
-            model: None,
-            cli_args: None,
-            mcp_config: None,
-            thinking: None,
-            agent_env: None,
-            token_budget: None,
+            ..AgentConfigUpdate::default()
         },
         NOW,
     )

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
@@ -178,14 +178,7 @@ async fn seed_second_agent(store: &Store) {
             visibility: "workspace".into(),
             permission_mode: "private".into(),
             owner_id: "user-1".into(),
-            archived: false,
-            model: None,
-            cli_args: Vec::new(),
-            mcp_config: None,
-            thinking: None,
-            agent_env: Vec::new(),
-            provider: None,
-            token_budget: None,
+            ..Agent::default()
         },
     )
     .await
@@ -225,14 +218,7 @@ async fn seed_agent_on(store: &Store, agent_id: &str, runtime_id: &str) {
             visibility: "workspace".into(),
             permission_mode: "private".into(),
             owner_id: "user-1".into(),
-            archived: false,
-            model: None,
-            cli_args: Vec::new(),
-            mcp_config: None,
-            thinking: None,
-            agent_env: Vec::new(),
-            provider: None,
-            token_budget: None,
+            ..Agent::default()
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -941,7 +941,10 @@ mod tests {
             ..Default::default()
         };
         let out = serde_json::to_string(&row).unwrap();
-        assert!(out.contains("\"description\":\"ships the backend\""), "{out}");
+        assert!(
+            out.contains("\"description\":\"ships the backend\""),
+            "{out}"
+        );
         assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), row);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -527,6 +527,36 @@ pub struct ActorRow {
     /// Recent-use rank: `Some(n)` pins the actor in the `RECENT` section (lower
     /// `n` = more recent); `None` falls into the alphabetical body.
     pub recent_rank: Option<u32>,
+    /// The agent's short blurb (migration 0050); empty for members and for a
+    /// pre-0050 producer. Omitted from the wire when empty so the shape only
+    /// grows for a producer that supplies it.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// The agent's avatar token (e.g. `"emoji:🦊"`, migration 0050); empty when
+    /// unset and for members. Omitted from the wire when empty.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub avatar: String,
+}
+
+impl Default for ActorRow {
+    /// The neutral row: an unnamed, offline, idle member with no metadata.
+    ///
+    /// Exists so fixtures can spread it (`ActorRow { display_name: …,
+    /// ..Default::default() }`) and a later append-only field is one struct edit
+    /// rather than a sweep across every test that builds a row.
+    fn default() -> Self {
+        Self {
+            actor_ref: String::new(),
+            display_name: String::new(),
+            subtitle: String::new(),
+            presence: PresenceState::Offline,
+            workload: Workload::default(),
+            is_agent: false,
+            recent_rank: None,
+            description: String::new(),
+            avatar: String::new(),
+        }
+    }
 }
 
 /// A wire-side skill row for the skill-manager list (`hangar/skills_list`).
@@ -872,10 +902,46 @@ mod tests {
             presence: PresenceState::Online,
             workload: Workload::Working,
             is_agent: true,
-            recent_rank: None,
+            ..Default::default()
         };
         let out = serde_json::to_string(&row).unwrap();
         assert!(out.contains("\"workload\":\"working\""), "{out}");
+        assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), row);
+    }
+
+    /// A PRE-0050 producer's payload — no `description`, no `avatar` — still
+    /// deserializes, both fields defaulting to empty. This is the append-only
+    /// proof (a full round-trip alone would not catch a missing `serde(default)`).
+    #[test]
+    fn actor_row_decodes_a_pre_0050_payload() {
+        let legacy = r#"{"actor_ref":"agent:a1","display_name":"bot","subtitle":"agent",
+            "presence":"online","is_agent":true,"recent_rank":null}"#;
+        let row: ActorRow = serde_json::from_str(legacy).expect("pre-0050 payload decodes");
+        assert_eq!(row.description, "", "absent description defaults to empty");
+        assert_eq!(row.avatar, "", "absent avatar defaults to empty");
+        // And a row with no metadata re-serialises WITHOUT the new keys, so the
+        // wire only grows for a producer that actually supplies them.
+        let out = serde_json::to_string(&row).unwrap();
+        assert!(
+            !out.contains("description") && !out.contains("avatar"),
+            "empty metadata must be omitted from the wire: {out}"
+        );
+    }
+
+    /// Populated metadata round-trips verbatim (the other half of append-only).
+    #[test]
+    fn actor_row_metadata_round_trips() {
+        let row = ActorRow {
+            actor_ref: "agent:a1".into(),
+            display_name: "builder".into(),
+            presence: PresenceState::Online,
+            is_agent: true,
+            description: "ships the backend".into(),
+            avatar: "emoji:\u{1F98A}".into(),
+            ..Default::default()
+        };
+        let out = serde_json::to_string(&row).unwrap();
+        assert!(out.contains("\"description\":\"ships the backend\""), "{out}");
         assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), row);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1119,6 +1119,19 @@ pub struct AgentUpdateParams {
     /// (back to unlimited), a value sets it (migration 0042).
     #[serde(default, skip_serializing_if = "FieldUpdate::is_keep")]
     pub token_budget: FieldUpdate<i64>,
+    /// New description, ≤255 CHARACTERS; `None` leaves it unchanged (the column
+    /// is NOT NULL — its cleared state is `""`, so no [`FieldUpdate`]).
+    /// Append-only field: an old client omits it, an old daemon ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// New avatar token; omitted leaves it, `null` clears it, a value sets it
+    /// (migration 0050).
+    #[serde(default, skip_serializing_if = "FieldUpdate::is_keep")]
+    pub avatar_url: FieldUpdate<String>,
+    /// New Codex service tier; omitted leaves it, `null` clears it (back to
+    /// inheriting the local config), a value sets it (migration 0050).
+    #[serde(default, skip_serializing_if = "FieldUpdate::is_keep")]
+    pub service_tier: FieldUpdate<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_AGENT_CREATE`]: create one agent from
@@ -1152,6 +1165,24 @@ pub struct AgentCreateParams {
     /// Optional token budget (rtk/headroom); absent = unlimited (migration 0042).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<i64>,
+    /// Optional short blurb, ≤255 CHARACTERS (migration 0050); absent = `""`.
+    /// The daemon rejects an over-long value with `INVALID_PARAMS`.
+    /// Append-only field: an old client omits it, an old daemon ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional avatar token (e.g. `"emoji:🦊"`); absent/blank makes the daemon
+    /// mint a random emoji so an agent is never avatar-less (migration 0050).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+    /// Optional Codex service tier (runtime-native catalog id, e.g. `"priority"`);
+    /// absent = inherit the local Codex config (migration 0050). Stored +
+    /// surfaced only — no dispatch-time override reads it yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+    // NOTE: `kind` / `system_key` are DELIBERATELY absent from the create wire.
+    // A `system` agent is a hidden internal carrier minted by the agent-builder
+    // (gap #9-rest), never by a client, so exposing it here would let any peer
+    // manufacture an agent no roster can see.
 }
 
 /// Params for [`crate::methods::HANGAR_AGENT_ARCHIVE`] (e38.15): archive or
@@ -2206,6 +2237,7 @@ mod tests {
                 workload: Workload::Working,
                 is_agent: true,
                 recent_rank: Some(0),
+                ..Default::default()
             }],
         };
         let s = serde_json::to_string(&actors).unwrap();
@@ -2613,6 +2645,9 @@ mod tests {
             thinking: FieldUpdate::Set("high".into()),
             agent_env: Some(vec![("FOO".into(), "bar".into())]),
             token_budget: FieldUpdate::Set(500_000),
+            description: Some("ships the backend".into()),
+            avatar_url: FieldUpdate::Set("emoji:\u{1F98A}".into()),
+            service_tier: FieldUpdate::Set("priority".into()),
         };
         let s = serde_json::to_string(&full).unwrap();
         assert_eq!(serde_json::from_str::<AgentUpdateParams>(&s).unwrap(), full);
@@ -2628,6 +2663,11 @@ mod tests {
         assert!(p.mcp_config.is_keep(), "absent mcp_config leaves it");
         assert!(p.thinking.is_keep(), "absent thinking leaves it");
         assert_eq!(p.agent_env, None, "absent agent_env leaves it");
+        // Migration-0050 metadata: a PRE-0050 producer sends none of these keys,
+        // and each must decode to leave-unchanged (the append-only proof).
+        assert_eq!(p.description, None, "absent description leaves it");
+        assert!(p.avatar_url.is_keep(), "absent avatar_url leaves it");
+        assert!(p.service_tier.is_keep(), "absent service_tier leaves it");
         assert_eq!(serde_json::to_string(&p).unwrap(), minimal);
 
         // An explicit `null` is the CLEAR instruction, distinct from omission.
@@ -2664,6 +2704,9 @@ mod tests {
             instructions: Some("be terse".into()),
             model: Some("gpt-5-codex".into()),
             token_budget: Some(250_000),
+            description: Some("reviews every PR".into()),
+            avatar_url: Some("emoji:\u{1F98A}".into()),
+            service_tier: Some("priority".into()),
         };
         let s = serde_json::to_string(&full).unwrap();
         assert_eq!(serde_json::from_str::<AgentCreateParams>(&s).unwrap(), full);
@@ -2675,6 +2718,11 @@ mod tests {
         assert!(minimal.provider.is_none());
         assert!(minimal.instructions.is_none());
         assert!(minimal.model.is_none());
+        // Migration-0050 metadata: a PRE-0050 payload carries none of these keys
+        // and still deserializes, each defaulting to "unset" (append-only proof).
+        assert!(minimal.description.is_none());
+        assert!(minimal.avatar_url.is_none());
+        assert!(minimal.service_tier.is_none());
         // The optional fields are omitted from the serialized form when absent.
         assert_eq!(
             serde_json::to_string(&minimal).unwrap(),

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0050_agent_metadata.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0050_agent_metadata.sql
@@ -1,0 +1,46 @@
+-- Hangar v1 schema, migration 0050: agent metadata columns + name uniqueness.
+--
+-- Multica parity (gap #23): migrations 046_agent_unique_name, 060_agent_description_length,
+-- 163_agent_builder, 172_agent_system_identity_index, 212_agent_service_tier.
+--
+-- ALTER ... ADD COLUMN with a CONSTANT literal default is an O(1) catalog change in SQLite
+-- (no table rewrite), safe on populated DBs — the same shape 0047 used for permission_mode.
+--
+-- DEVIATION from multica 046: multica DELETEs duplicate-named rows before adding the
+-- constraint. Hangar agents are FK-pinned by agent_task_queue / usage / autopilot rows
+-- (AgentRepo::delete's HasHistory guard), so a DELETE here would trip a FOREIGN KEY
+-- constraint and abort the migration — which bricks daemon boot on a populated home.
+-- Duplicates are RENAMED instead (lossless): the id is appended, which is unique by
+-- construction, so the rename can never manufacture a fresh collision.
+--
+-- DEVIATION 2: `service_tier` is STORED + SURFACED ONLY in this milestone — no
+-- dispatch-time Codex RPC override reads it yet (exactly how `token_budget` landed in
+-- 0042). Do not assume it is wired.
+--
+-- DEVIATION 3: `kind` / `system_key` ship as schema + store + read-filter support only.
+-- No RPC mints a system agent yet; the agent-builder that does is gap #9-rest.
+
+ALTER TABLE agent ADD COLUMN description TEXT NOT NULL DEFAULT ''
+    CHECK (length(description) <= 255);
+ALTER TABLE agent ADD COLUMN avatar_url TEXT;
+ALTER TABLE agent ADD COLUMN kind TEXT NOT NULL DEFAULT 'user'
+    CHECK (kind IN ('user', 'system'));
+ALTER TABLE agent ADD COLUMN system_key TEXT;
+ALTER TABLE agent ADD COLUMN service_tier TEXT;
+
+-- Pre-flight de-collision: keep the FIRST row (lowest rowid) under its name; every later
+-- duplicate gets its id appended so the unique index below can be created.
+UPDATE agent
+   SET name = name || ' (' || id || ')'
+ WHERE rowid NOT IN (SELECT MIN(rowid) FROM agent GROUP BY workspace_id, name);
+
+-- Multica 046: one agent name per workspace, so create answers a clear conflict instead of
+-- silently making a second identically-named actor the picker cannot disambiguate.
+CREATE UNIQUE INDEX agent_workspace_name_unique ON agent (workspace_id, name);
+
+-- Multica 172: a system agent's identity key is unique per (workspace, owner, runtime).
+-- Partial (WHERE system_key IS NOT NULL) so the ordinary user agents — all NULL — are
+-- unconstrained. Unblocks the agent-builder carrier lookup (gap #9-rest).
+CREATE UNIQUE INDEX agent_system_identity_unique
+    ON agent (workspace_id, owner_id, runtime_id, system_key)
+    WHERE system_key IS NOT NULL;

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -284,6 +284,90 @@ pub async fn create_agent(
     provider: &str,
     instructions: Option<String>,
 ) -> Result<Agent, sqlx::Error> {
+    create_agent_from(
+        pool,
+        workspace_id,
+        AgentDraft {
+            name: name.to_string(),
+            provider: provider.to_string(),
+            instructions,
+            ..AgentDraft::default()
+        },
+    )
+    .await
+}
+
+/// Everything a create may specify about a new agent (migration 0050).
+///
+/// `Default` is the plain `claude`, user-kind, no-metadata agent, so a caller sets
+/// only what it means and a later column add is one struct field, not a signature
+/// break across ~20 call sites.
+#[derive(Debug, Clone, Default)]
+pub struct AgentDraft {
+    /// Human-readable agent name. Must be unique within the workspace (migration
+    /// 0050) — a collision surfaces as a `sqlx` error for which
+    /// [`crate::repo::agent::is_duplicate_name`] is `true`.
+    pub name: String,
+    /// Provider token, already through [`normalize_provider`]. Empty = the
+    /// [`DEFAULT_PROVIDER`].
+    pub provider: String,
+    /// Free-form system prompt / instructions.
+    pub instructions: Option<String>,
+    /// Short blurb (multica 060). Trimmed here; the ≤255-char cap is validated by
+    /// the CALLER (handler/CLI) so the user sees a clear message, with the schema
+    /// `CHECK` as the last line of defence.
+    pub description: String,
+    /// Avatar token. Absent/blank mints a random `"emoji:…"` value so an agent is
+    /// never avatar-less (multica `newAgentAvatar`).
+    pub avatar_url: Option<String>,
+    /// Provider model override; `None` = the provider default.
+    pub model: Option<String>,
+    /// Codex service tier (runtime-native catalog id). Stored + surfaced only.
+    pub service_tier: Option<String>,
+    /// `None` (the default) = `"user"`. `Some("system")` mints a hidden carrier
+    /// agent — internal callers only (gap #9-rest); no RPC exposes this.
+    pub kind: Option<String>,
+    /// Identity key for a system agent; `None` for user agents.
+    pub system_key: Option<String>,
+}
+
+/// Multica's 24-emoji avatar palette (`agent_avatar.go:13-25`). One is picked at
+/// create when the caller supplies no avatar, so every agent renders a glyph.
+const AVATAR_EMOJI: [&str; 24] = [
+    "🐙", "🦊", "🦉", "🐝", "🐼", "🐸", "🐯", "🦁", "🐨", "🐵", "🐧", "🐳", "🦋", "🌞", "🌙", "⭐",
+    "🔥", "⚡", "🍀", "🌈", "🚀", "🤖", "👾", "🧠",
+];
+
+/// Mint a `"emoji:<glyph>"` avatar token from [`AVATAR_EMOJI`].
+///
+/// The pick is derived from the wall clock rather than an RNG dependency — the
+/// value is cosmetic, so "varies between creates" is the whole requirement.
+fn random_emoji_avatar() -> String {
+    let idx = usize::try_from(SystemClock.now_ms().unsigned_abs() % AVATAR_EMOJI.len() as u64)
+        .unwrap_or(0);
+    format!("emoji:{}", AVATAR_EMOJI[idx])
+}
+
+/// Create one agent from a [`AgentDraft`], filling every FK behind the scenes
+/// (migration 0050's metadata-aware entry point).
+///
+/// Keeps every invariant of [`create_agent`] (ensure the runtime and bind the id
+/// that upsert SETTLED on, resolve the default owner, mint a ULID,
+/// `visibility: "workspace"`, `permission_mode: "private"`) and additionally
+/// defaults the avatar to a random emoji token, trims the description, and
+/// defaults `kind` to `"user"`.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if there is no workspace / owner user yet, if the
+/// runtime upsert fails, or if the insert fails — notably the migration-0050
+/// `(workspace_id, name)` UNIQUE violation, for which
+/// [`crate::repo::agent::is_duplicate_name`] is `true`.
+pub async fn create_agent_from(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    draft: AgentDraft,
+) -> Result<Agent, sqlx::Error> {
     let now = SystemClock.now_ms();
     // ONE atomic upsert: ensure the runtime FK exists (a fresh home may have none
     // — the CLI create path runs with no daemon) and take back the id it settled
@@ -295,12 +379,25 @@ pub async fn create_agent(
 
     let owner_id = default_owner_id(pool).await?.ok_or_else(|| sqlx::Error::RowNotFound)?;
 
+    let provider = if draft.provider.is_empty() {
+        DEFAULT_PROVIDER.to_string()
+    } else {
+        draft.provider
+    };
+    // An agent is never avatar-less: a blank/absent token mints one (multica
+    // `newAgentAvatar`), so every roster row renders a glyph.
+    let avatar_url = draft
+        .avatar_url
+        .map(|a| a.trim().to_string())
+        .filter(|a| !a.is_empty())
+        .unwrap_or_else(random_emoji_avatar);
+
     let agent = Agent {
         id: SystemIdGen.new_ulid(),
         workspace_id: workspace_id.to_string(),
-        name: name.to_string(),
+        name: draft.name,
         runtime_id,
-        instructions,
+        instructions: draft.instructions,
         visibility: "workspace".to_string(),
         // Deny-by-default invocation (migration 0047): a freshly created agent is
         // private (owner-only) until explicitly shared via an invocation target.
@@ -309,13 +406,20 @@ pub async fn create_agent(
         permission_mode: "private".to_string(),
         owner_id,
         archived: false,
-        model: None,
+        model: draft.model,
         cli_args: Vec::new(),
         mcp_config: None,
         thinking: None,
         agent_env: Vec::new(),
-        provider: Some(provider.to_string()),
+        provider: Some(provider),
         token_budget: None,
+        description: draft.description.trim().to_string(),
+        avatar_url: Some(avatar_url),
+        kind: draft
+            .kind
+            .unwrap_or_else(|| crate::repo::agent::AGENT_KIND_USER.to_string()),
+        system_key: draft.system_key,
+        service_tier: draft.service_tier,
     };
     AgentRepo::insert(pool, &agent).await?;
     Ok(agent)

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -415,9 +415,7 @@ pub async fn create_agent_from(
         token_budget: None,
         description: draft.description.trim().to_string(),
         avatar_url: Some(avatar_url),
-        kind: draft
-            .kind
-            .unwrap_or_else(|| crate::repo::agent::AGENT_KIND_USER.to_string()),
+        kind: draft.kind.unwrap_or_else(|| crate::repo::agent::AGENT_KIND_USER.to_string()),
         system_key: draft.system_key,
         service_tier: draft.service_tier,
     };

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -90,6 +90,80 @@ pub struct Agent {
     /// unlimited (migration 0042). Stored + surfaced only in this milestone —
     /// dispatch-time enforcement is a later feature.
     pub token_budget: Option<i64>,
+    /// Short blurb rendered next to the agent in rosters/pickers; `""` when unset.
+    /// Capped at 255 characters by the schema (migration 0050, multica 060).
+    pub description: String,
+    /// Optional avatar token; hangar mints `"emoji:🦊"`-style values at create so an
+    /// agent is never avatar-less (multica `newAgentAvatar`). `None` only for rows
+    /// created before migration 0050.
+    pub avatar_url: Option<String>,
+    /// `"user"` (an ordinary agent) or `"system"` (a hidden carrier agent, e.g. the
+    /// agent-builder). Roster/picker reads filter to `"user"` (migration 0050).
+    pub kind: String,
+    /// Identity key for a system agent (e.g. `"agent_builder:<flow>"`); `None` for user
+    /// agents. Unique per `(workspace, owner, runtime)` where not null (migration 0050).
+    pub system_key: Option<String>,
+    /// Optional per-agent Codex service-tier override (runtime-native catalog id such as
+    /// `"priority"`); `None` = inherit the local Codex config. Stored + surfaced only in
+    /// this milestone — dispatch-time consumption is a later feature (as `token_budget` was).
+    pub service_tier: Option<String>,
+}
+
+impl Default for Agent {
+    /// The neutral, never-inserted-as-is shape: an ordinary `"user"`-kind,
+    /// `"private"` agent with no metadata. Fixture sites spread this
+    /// (`Agent { name: …, ..Default::default() }`) so a later schema add is one
+    /// struct edit, not another brittle-fixture sweep.
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            workspace_id: String::new(),
+            name: String::new(),
+            runtime_id: String::new(),
+            instructions: None,
+            visibility: "private".to_string(),
+            permission_mode: "private".to_string(),
+            owner_id: String::new(),
+            archived: false,
+            model: None,
+            cli_args: Vec::new(),
+            mcp_config: None,
+            thinking: None,
+            agent_env: Vec::new(),
+            provider: None,
+            token_budget: None,
+            description: String::new(),
+            avatar_url: None,
+            kind: AGENT_KIND_USER.to_string(),
+            system_key: None,
+            service_tier: None,
+        }
+    }
+}
+
+/// The ordinary agent kind — the only one rosters, pickers and search surface.
+pub const AGENT_KIND_USER: &str = "user";
+/// The hidden carrier kind (e.g. the agent-builder). Never in a roster; reached
+/// only by [`AgentRepo::find_system`].
+pub const AGENT_KIND_SYSTEM: &str = "system";
+
+/// Maximum `description` length in CHARACTERS (code points), matching multica's
+/// `utf8.RuneCountInString` cap and the schema `CHECK (length(description) <= 255)`.
+/// Callers validate against this so the user sees a clear message; the schema
+/// CHECK is the last line of defence.
+pub const MAX_DESCRIPTION_CHARS: usize = 255;
+
+/// Whether a `sqlx` error is the `(workspace_id, name)` uniqueness violation from
+/// migration 0050 — i.e. "an agent by that name already exists here" rather than
+/// any other store fault. Callers map it to multica's 409-equivalent refusal.
+///
+/// SQLite's message is `UNIQUE constraint failed: agent.workspace_id, agent.name`;
+/// the `agent.name` substring separates it from the `system_key` index and from an
+/// id PK collision.
+#[must_use]
+pub fn is_duplicate_name(e: &sqlx::Error) -> bool {
+    e.as_database_error()
+        .is_some_and(|db| db.is_unique_violation() && db.message().contains("agent.name"))
 }
 
 /// A partial-edit instruction for one agent's mutable config (e38.15).
@@ -128,6 +202,15 @@ pub struct AgentConfigUpdate {
     /// New token budget: `None` leaves it, `Some(None)` clears it (back to
     /// unlimited), `Some(Some(_))` sets it.
     pub token_budget: Option<Option<i64>>,
+    /// New description, or `None` to leave it unchanged. The column is NOT NULL
+    /// (its "cleared" state is `""`), so this is a single `Option` like `name`.
+    pub description: Option<String>,
+    /// New avatar token: `None` leaves it, `Some(None)` clears it,
+    /// `Some(Some(_))` sets it (migration 0050).
+    pub avatar_url: Option<Option<String>>,
+    /// New Codex service tier: `None` leaves it, `Some(None)` clears it (back to
+    /// inheriting the local Codex config), `Some(Some(_))` sets it (migration 0050).
+    pub service_tier: Option<Option<String>>,
 }
 
 impl AgentConfigUpdate {
@@ -143,6 +226,9 @@ impl AgentConfigUpdate {
             && self.thinking.is_none()
             && self.agent_env.is_none()
             && self.token_budget.is_none()
+            && self.description.is_none()
+            && self.avatar_url.is_none()
+            && self.service_tier.is_none()
     }
 }
 
@@ -206,8 +292,8 @@ impl AgentRepo {
             "INSERT INTO agent \
              (id, workspace_id, name, runtime_id, instructions, visibility, permission_mode, \
               owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, provider, \
-              token_budget) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              token_budget, description, avatar_url, kind, system_key, service_tier) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&agent.id)
         .bind(&agent.workspace_id)
@@ -225,12 +311,22 @@ impl AgentRepo {
         .bind(env_to_json(&agent.agent_env))
         .bind(&agent.provider)
         .bind(agent.token_budget)
+        .bind(&agent.description)
+        .bind(&agent.avatar_url)
+        .bind(&agent.kind)
+        .bind(&agent.system_key)
+        .bind(&agent.service_tier)
         .execute(pool)
         .await?;
         Ok(())
     }
 
     /// Fetch one [`Agent`] by primary key, or `None` if absent.
+    ///
+    /// Deliberately **kind-blind** (migration 0050): this is the internal by-id
+    /// lookup every dispatch/edit path uses, so a `"system"` agent resolved by an
+    /// id it already holds must still read back. Multica's `GetAgent` is likewise
+    /// unfiltered — only the roster/picker LISTS filter to `kind = 'user'`.
     ///
     /// # Errors
     ///
@@ -259,7 +355,7 @@ impl AgentRepo {
         workspace_id: &str,
     ) -> Result<Vec<Agent>, sqlx::Error> {
         sqlx::query_as::<_, Agent>(&format!(
-            "{SELECT_COLS} WHERE workspace_id = ? AND archived = 0 ORDER BY name"
+            "{SELECT_COLS} WHERE workspace_id = ? AND archived = 0 AND kind = 'user' ORDER BY name"
         ))
         .bind(workspace_id)
         .fetch_all(pool)
@@ -277,7 +373,7 @@ impl AgentRepo {
         workspace_id: &str,
     ) -> Result<Vec<Agent>, sqlx::Error> {
         sqlx::query_as::<_, Agent>(&format!(
-            "{SELECT_COLS} WHERE workspace_id = ? ORDER BY name"
+            "{SELECT_COLS} WHERE workspace_id = ? AND kind = 'user' ORDER BY name"
         ))
         .bind(workspace_id)
         .fetch_all(pool)
@@ -300,10 +396,35 @@ impl AgentRepo {
         runtime_id: &str,
     ) -> Result<Vec<String>, sqlx::Error> {
         sqlx::query_scalar::<_, String>(
-            "SELECT id FROM agent WHERE runtime_id = ? AND archived = 0 ORDER BY name",
+            "SELECT id FROM agent WHERE runtime_id = ? AND archived = 0 AND kind = 'user' \
+             ORDER BY name",
         )
         .bind(runtime_id)
         .fetch_all(pool)
+        .await
+    }
+
+    /// Look up a hidden `"system"` agent by its identity key within a workspace
+    /// (migration 0050, multica `chat.sql:433` — the agent-builder carrier lookup).
+    ///
+    /// This is the ONLY read that returns a system agent by search: every roster,
+    /// picker and search query filters to `kind = 'user'`, so a carrier agent is
+    /// invisible everywhere else.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails (a missing row is `Ok(None)`).
+    pub async fn find_system(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        system_key: &str,
+    ) -> Result<Option<Agent>, sqlx::Error> {
+        sqlx::query_as::<_, Agent>(&format!(
+            "{SELECT_COLS} WHERE workspace_id = ? AND system_key = ? AND kind = 'system'"
+        ))
+        .bind(workspace_id)
+        .bind(system_key)
+        .fetch_optional(pool)
         .await
     }
 
@@ -322,7 +443,9 @@ impl AgentRepo {
     ///
     /// # Errors
     ///
-    /// Returns a [`sqlx::Error`] if the update fails.
+    /// Returns a [`sqlx::Error`] if the update fails — including a RENAME onto a
+    /// name another agent in the same workspace already holds, for which
+    /// [`is_duplicate_name`] is `true` (migration 0050).
     pub async fn update_config(
         pool: &SqlitePool,
         workspace_id: &str,
@@ -362,6 +485,15 @@ impl AgentRepo {
         if update.token_budget.is_some() {
             sets.push("token_budget = ?");
         }
+        if update.description.is_some() {
+            sets.push("description = ?");
+        }
+        if update.avatar_url.is_some() {
+            sets.push("avatar_url = ?");
+        }
+        if update.service_tier.is_some() {
+            sets.push("service_tier = ?");
+        }
         let sql = format!(
             "UPDATE agent SET {} WHERE id = ? AND workspace_id = ?",
             sets.join(", ")
@@ -393,6 +525,15 @@ impl AgentRepo {
         }
         if let Some(token_budget) = &update.token_budget {
             query = query.bind(token_budget);
+        }
+        if let Some(description) = &update.description {
+            query = query.bind(description);
+        }
+        if let Some(avatar_url) = &update.avatar_url {
+            query = query.bind(avatar_url);
+        }
+        if let Some(service_tier) = &update.service_tier {
+            query = query.bind(service_tier);
         }
         let res = query.bind(id).bind(workspace_id).execute(pool).await?;
         Ok(res.rows_affected() == 1)
@@ -696,7 +837,7 @@ fn is_foreign_key_violation(e: &sqlx::Error) -> bool {
 /// single constant keeps the read queries in lockstep with the `FromRow` impl.
 const SELECT_COLS: &str = "SELECT id, workspace_id, name, runtime_id, instructions, visibility, \
      permission_mode, owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, \
-     provider, token_budget FROM agent";
+     provider, token_budget, description, avatar_url, kind, system_key, service_tier FROM agent";
 
 /// Serialize a CLI-args list into the JSON-array text the `cli_args` column
 /// stores. An empty list yields `"[]"` (the column default).
@@ -876,6 +1017,11 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Agent {
             agent_env: env_from_json(&row.try_get::<String, _>("agent_env")?)?,
             provider: row.try_get("provider")?,
             token_budget: row.try_get("token_budget")?,
+            description: row.try_get("description")?,
+            avatar_url: row.try_get("avatar_url")?,
+            kind: row.try_get("kind")?,
+            system_key: row.try_get("system_key")?,
+            service_tier: row.try_get("service_tier")?,
         })
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/search.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/search.rs
@@ -328,8 +328,11 @@ mod tests {
         let pool = store.pool();
         seed_ws(pool, "ws-a").await;
         seed_runtime(pool, "ws-a", "rt").await;
+        // Distinct names: agent names are unique per workspace (migration 0050),
+        // and archiving does NOT release a name. Both still LIKE-match "scout",
+        // which is all this test needs — only the ACTIVE one may come back.
         seed_agent(pool, "ws-a", "a-active", "scout", false).await;
-        seed_agent(pool, "ws-a", "a-archived", "scout", true).await;
+        seed_agent(pool, "ws-a", "a-archived", "scout (retired)", true).await;
 
         let hits = cross_entity_search(pool, "ws-a", "scout").await.unwrap();
         let ids: Vec<&str> = hits.iter().map(|h| h.id.as_str()).collect();

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/search.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/search.rs
@@ -124,7 +124,14 @@ pub async fn cross_entity_search(
     // One substring query per entity table; the kind tags the rows.
     let tables: [(SearchHitKind, &str, &str, &str); 4] = [
         (SearchHitKind::Issue, "issue", "title", ""),
-        (SearchHitKind::Agent, "agent", "name", " AND archived = 0"),
+        // Hidden `system` agents (migration 0050) never surface in the palette —
+        // the same filter every roster/picker read carries (multica agent.sql:1258).
+        (
+            SearchHitKind::Agent,
+            "agent",
+            "name",
+            " AND archived = 0 AND kind = 'user'",
+        ),
         (SearchHitKind::Skill, "skill", "name", ""),
         (SearchHitKind::Autopilot, "autopilot", "name", ""),
     ];

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -639,14 +639,7 @@ mod tests {
                 visibility: "workspace".into(),
                 permission_mode: "private".into(),
                 owner_id: owner_id.into(),
-                archived: false,
-                model: None,
-                cli_args: Vec::new(),
-                mcp_config: None,
-                thinking: None,
-                agent_env: Vec::new(),
-                provider: None,
-                token_budget: None,
+                ..Agent::default()
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/claim_task_integration.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/claim_task_integration.rs
@@ -77,7 +77,10 @@ async fn seed_graph(
     )
     .bind(agent_id)
     .bind("ws-1")
-    .bind("Agent")
+    // Names are unique per workspace (migration 0050), and several tests seed
+    // TWO agents into `ws-1`, so the name is derived from the caller's agent id
+    // rather than a shared literal.
+    .bind(format!("Agent {agent_id}"))
     .bind(runtime_id)
     .bind("workspace")
     .bind("user-1")

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0050_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0050_upgrade.rs
@@ -80,7 +80,11 @@ async fn seed_populated(pool: &SqlitePool) {
     .expect("insert runtime");
 
     // Two agents sharing a name in ws-1, plus one in ws-2 under the same name.
-    for (id, ws) in [("a-first", "ws-1"), ("a-second", "ws-1"), ("a-other", "ws-2")] {
+    for (id, ws) in [
+        ("a-first", "ws-1"),
+        ("a-second", "ws-1"),
+        ("a-other", "ws-2"),
+    ] {
         insert_agent(pool, id, ws, "dup").await.expect("seed agent");
     }
     // FK-pin BOTH ws-1 agents with a terminal task: a migration that DELETEd the
@@ -184,7 +188,13 @@ async fn migration_0050_renames_duplicates_and_backfills_on_a_populated_database
     );
 
     // (d) The new columns backfill to their documented defaults on old rows.
-    let row: (String, Option<String>, String, Option<String>, Option<String>) = sqlx::query_as(
+    let row: (
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+        Option<String>,
+    ) = sqlx::query_as(
         "SELECT description, avatar_url, kind, system_key, service_tier \
          FROM agent WHERE id = 'a-first'",
     )
@@ -226,7 +236,8 @@ async fn migration_0050_constraints_are_enforced_after_upgrade() {
         .await
         .expect_err("a duplicate name must now be refused");
     assert!(
-        err.as_database_error().is_some_and(sqlx::error::DatabaseError::is_unique_violation),
+        err.as_database_error()
+            .is_some_and(sqlx::error::DatabaseError::is_unique_violation),
         "the refusal is a UNIQUE violation, got: {err}"
     );
     assert!(
@@ -297,12 +308,15 @@ async fn migration_0050_system_identity_index_is_partial() {
         }
     };
 
-    insert_system("sys-1", "carrier-1", "agent_builder").await.expect("first system agent");
+    insert_system("sys-1", "carrier-1", "agent_builder")
+        .await
+        .expect("first system agent");
     let err = insert_system("sys-2", "carrier-2", "agent_builder")
         .await
         .expect_err("a second system agent with the same key must collide");
     assert!(
-        err.as_database_error().is_some_and(sqlx::error::DatabaseError::is_unique_violation),
+        err.as_database_error()
+            .is_some_and(sqlx::error::DatabaseError::is_unique_violation),
         "the refusal is a UNIQUE violation, got: {err}"
     );
     assert!(
@@ -311,11 +325,10 @@ async fn migration_0050_system_identity_index_is_partial() {
     );
 
     // NULL system_key rows are unconstrained — three of them already coexist.
-    let null_keyed: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM agent WHERE system_key IS NULL")
-            .fetch_one(&pool)
-            .await
-            .expect("count null-keyed agents");
+    let null_keyed: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent WHERE system_key IS NULL")
+        .fetch_one(&pool)
+        .await
+        .expect("count null-keyed agents");
     assert!(
         null_keyed >= 3,
         "the partial index leaves NULL-keyed agents unconstrained (got {null_keyed})"

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0050_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0050_upgrade.rs
@@ -1,0 +1,325 @@
+//! Upgrade-from-populated test for migration 0050 (agent metadata columns +
+//! `UNIQUE (workspace_id, name)`, multica gap #23).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the migration is safe on a REAL populated database — the state every
+//! upgrading install carries:
+//!
+//! 1. apply only the PRIOR migrations (0001..0049),
+//! 2. seed TWO agents named `dup` in one workspace, each with an FK-PINNED
+//!    terminal task row (the exact case multica's DELETE-then-constrain would
+//!    abort on, bricking daemon boot),
+//! 3. apply the embedded migrations (which adds 0050),
+//! 4. assert both agents SURVIVE, exactly one still reads `dup`, the loser was
+//!    RENAMED with its id appended, the new columns backfill to their defaults,
+//!    the constraints now bite, and a double-apply is a no-op.
+
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+use ainb_hangar_store::apply_migrations;
+
+/// `sqlx` version number of the migration under test (`0050_agent_metadata.sql`).
+const NEW_MIGRATION_VERSION: i64 = 50;
+
+/// Open a fresh on-disk WAL pool in `dir` and apply only the migrations PRIOR to
+/// [`NEW_MIGRATION_VERSION`], reproducing the schema an existing install runs
+/// before upgrading.
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let db_path = dir.join("hangar.db");
+    let opts = SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(
+        !migrator.migrations.is_empty(),
+        "prior-migration set must not be empty"
+    );
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+/// Seed two workspaces, an owner, a runtime, and the agents the upgrade must
+/// survive: two `dup`-named agents in `ws-1` (each FK-pinned by a terminal task)
+/// plus a same-named agent in `ws-2` (proving the constraint is per-workspace).
+async fn seed_populated(pool: &SqlitePool) {
+    for id in ["ws-1", "ws-2"] {
+        sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+            .bind(id)
+            .bind(id)
+            .bind(id)
+            .execute(pool)
+            .await
+            .expect("insert workspace");
+    }
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('user-1','a@x.com',0)")
+        .execute(pool)
+        .await
+        .expect("insert user");
+    sqlx::query(
+        "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','user-1','owner')",
+    )
+    .execute(pool)
+    .await
+    .expect("insert member");
+    sqlx::query(
+        "INSERT INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
+         VALUES ('rt-1','ws-1','d-1','claude','local',0,'online')",
+    )
+    .execute(pool)
+    .await
+    .expect("insert runtime");
+
+    // Two agents sharing a name in ws-1, plus one in ws-2 under the same name.
+    for (id, ws) in [("a-first", "ws-1"), ("a-second", "ws-1"), ("a-other", "ws-2")] {
+        insert_agent(pool, id, ws, "dup").await.expect("seed agent");
+    }
+    // FK-pin BOTH ws-1 agents with a terminal task: a migration that DELETEd the
+    // duplicate (multica 046's shape) would trip FOREIGN KEY here and abort.
+    for (task, agent) in [("t-1", "a-first"), ("t-2", "a-second")] {
+        sqlx::query(
+            "INSERT INTO agent_task_queue \
+             (id, workspace_id, runtime_id, agent_id, status, created_at) \
+             VALUES (?, 'ws-1', 'rt-1', ?, 'done', 0)",
+        )
+        .bind(task)
+        .bind(agent)
+        .execute(pool)
+        .await
+        .expect("insert terminal task");
+    }
+}
+
+/// Insert one agent at the pre-0050 column set; returns the store result so a
+/// test can assert on either success or a constraint refusal.
+async fn insert_agent(
+    pool: &SqlitePool,
+    id: &str,
+    workspace_id: &str,
+    name: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES (?, ?, ?, 'rt-1', 'workspace', 'user-1')",
+    )
+    .bind(id)
+    .bind(workspace_id)
+    .bind(name)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Read one agent's stored `name`.
+async fn name_of(pool: &SqlitePool, id: &str) -> String {
+    sqlx::query_scalar("SELECT name FROM agent WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .expect("read agent name")
+}
+
+/// Migration 0050 on a populated DB: nothing is deleted, the duplicate is
+/// renamed, and the new columns backfill to their documented defaults.
+#[tokio::test]
+async fn migration_0050_renames_duplicates_and_backfills_on_a_populated_database() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+
+    // Before: three agents, two of them colliding on `dup` inside ws-1.
+    let before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent")
+        .fetch_one(&pool)
+        .await
+        .expect("count agents");
+    assert_eq!(before, 3);
+
+    apply_migrations(&pool).await.expect("upgrade applies 0050");
+
+    // (a) NOTHING was deleted — the FK-pinned history is intact.
+    let after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent")
+        .fetch_one(&pool)
+        .await
+        .expect("count agents");
+    assert_eq!(
+        after, 3,
+        "the migration must RENAME duplicates, never delete FK-pinned rows"
+    );
+    let tasks: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue")
+        .fetch_one(&pool)
+        .await
+        .expect("count tasks");
+    assert_eq!(tasks, 2, "the pinned history survives untouched");
+
+    // (b) Exactly one ws-1 agent still reads `dup`; the later one carries its id.
+    let first = name_of(&pool, "a-first").await;
+    let second = name_of(&pool, "a-second").await;
+    assert_eq!(first, "dup", "the first row keeps the plain name");
+    assert_eq!(
+        second, "dup (a-second)",
+        "the later duplicate is renamed with its id appended"
+    );
+    let still_dup: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM agent WHERE workspace_id='ws-1' AND name='dup'")
+            .fetch_one(&pool)
+            .await
+            .expect("count dup");
+    assert_eq!(still_dup, 1);
+
+    // (c) A same-named agent in ANOTHER workspace was NOT renamed — the
+    //     constraint is per-workspace, not global.
+    assert_eq!(
+        name_of(&pool, "a-other").await,
+        "dup",
+        "a same-named agent in a different workspace is untouched"
+    );
+
+    // (d) The new columns backfill to their documented defaults on old rows.
+    let row: (String, Option<String>, String, Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT description, avatar_url, kind, system_key, service_tier \
+         FROM agent WHERE id = 'a-first'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read new columns");
+    assert_eq!(row.0, "", "description defaults to the empty string");
+    assert_eq!(row.1, None, "a pre-0050 row has no avatar");
+    assert_eq!(row.2, "user", "every pre-0050 agent is user-kind");
+    assert_eq!(row.3, None);
+    assert_eq!(row.4, None);
+
+    // (e) Migration 0050 is recorded exactly once, and a double-apply changes
+    //     nothing (no second rename pass mangling the already-renamed row).
+    let recorded: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?")
+            .bind(NEW_MIGRATION_VERSION)
+            .fetch_one(&pool)
+            .await
+            .expect("read 0050 record");
+    assert_eq!(recorded, 1, "0050 recorded as applied exactly once");
+    apply_migrations(&pool).await.expect("second apply is a no-op");
+    assert_eq!(name_of(&pool, "a-second").await, "dup (a-second)");
+
+    pool.close().await;
+}
+
+/// After the upgrade the constraints BITE: a fresh duplicate insert fails, the
+/// same name in another workspace is fine, and the description cap is enforced.
+#[tokio::test]
+async fn migration_0050_constraints_are_enforced_after_upgrade() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+    apply_migrations(&pool).await.expect("upgrade applies 0050");
+
+    // A fresh duplicate INSERT is now refused (the name `dup` is taken in ws-1).
+    let err = insert_agent(&pool, "a-third", "ws-1", "dup")
+        .await
+        .expect_err("a duplicate name must now be refused");
+    assert!(
+        err.as_database_error().is_some_and(sqlx::error::DatabaseError::is_unique_violation),
+        "the refusal is a UNIQUE violation, got: {err}"
+    );
+    assert!(
+        ainb_hangar_store::repo::agent::is_duplicate_name(&err),
+        "is_duplicate_name must classify the (workspace_id, name) violation: {err}"
+    );
+
+    // The SAME name in a DIFFERENT workspace inserts fine (per-workspace scope).
+    insert_agent(&pool, "a-ws2-second", "ws-2", "fresh")
+        .await
+        .expect("a name free in ws-2 inserts");
+    insert_agent(&pool, "a-ws1-fresh", "ws-1", "fresh")
+        .await
+        .expect("the same name in the other workspace inserts");
+
+    // The description CHECK: 255 characters is accepted, 256 is refused.
+    let ok = "x".repeat(255);
+    let too_long = "x".repeat(256);
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id, description) \
+         VALUES ('a-desc-ok', 'ws-1', 'desc-ok', 'rt-1', 'workspace', 'user-1', ?)",
+    )
+    .bind(&ok)
+    .execute(&pool)
+    .await
+    .expect("a 255-character description is accepted");
+    let err = sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id, description) \
+         VALUES ('a-desc-bad', 'ws-1', 'desc-bad', 'rt-1', 'workspace', 'user-1', ?)",
+    )
+    .bind(&too_long)
+    .execute(&pool)
+    .await
+    .expect_err("a 256-character description must be refused");
+    assert!(
+        err.to_string().contains("CHECK"),
+        "the refusal names the CHECK constraint, got: {err}"
+    );
+
+    pool.close().await;
+}
+
+/// The partial system-identity index constrains only NON-NULL `system_key`s: two
+/// system agents sharing `(workspace, owner, runtime, key)` collide, but the
+/// ordinary NULL-keyed agents are unconstrained (the whole point of `WHERE
+/// system_key IS NOT NULL`).
+#[tokio::test]
+async fn migration_0050_system_identity_index_is_partial() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+    apply_migrations(&pool).await.expect("upgrade applies 0050");
+
+    let insert_system = |id: &'static str, name: &'static str, key: &'static str| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query(
+                "INSERT INTO agent \
+                 (id, workspace_id, name, runtime_id, visibility, owner_id, kind, system_key) \
+                 VALUES (?, 'ws-1', ?, 'rt-1', 'workspace', 'user-1', 'system', ?)",
+            )
+            .bind(id)
+            .bind(name)
+            .bind(key)
+            .execute(&pool)
+            .await
+            .map(|_| ())
+        }
+    };
+
+    insert_system("sys-1", "carrier-1", "agent_builder").await.expect("first system agent");
+    let err = insert_system("sys-2", "carrier-2", "agent_builder")
+        .await
+        .expect_err("a second system agent with the same key must collide");
+    assert!(
+        err.as_database_error().is_some_and(sqlx::error::DatabaseError::is_unique_violation),
+        "the refusal is a UNIQUE violation, got: {err}"
+    );
+    assert!(
+        !ainb_hangar_store::repo::agent::is_duplicate_name(&err),
+        "a system_key collision must NOT be misread as a duplicate NAME: {err}"
+    );
+
+    // NULL system_key rows are unconstrained — three of them already coexist.
+    let null_keyed: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM agent WHERE system_key IS NULL")
+            .fetch_one(&pool)
+            .await
+            .expect("count null-keyed agents");
+    assert!(
+        null_keyed >= 3,
+        "the partial index leaves NULL-keyed agents unconstrained (got {null_keyed})"
+    );
+
+    pool.close().await;
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -64,14 +64,7 @@ async fn insert_and_get_agent_roundtrip() {
         visibility: "workspace".to_string(),
         permission_mode: "private".to_string(),
         owner_id,
-        archived: false,
-        model: None,
-        cli_args: Vec::new(),
-        mcp_config: None,
-        thinking: None,
-        agent_env: Vec::new(),
-        provider: None,
-        token_budget: None,
+        ..Agent::default()
     };
 
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
@@ -103,14 +96,7 @@ async fn update_config_persists_and_is_partial() {
         visibility: "workspace".to_string(),
         permission_mode: "private".to_string(),
         owner_id,
-        archived: false,
-        model: None,
-        cli_args: Vec::new(),
-        mcp_config: None,
-        thinking: None,
-        agent_env: Vec::new(),
-        provider: None,
-        token_budget: None,
+        ..Agent::default()
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 
@@ -182,14 +168,7 @@ async fn update_config_is_workspace_scoped_and_empty_is_noop() {
         visibility: "workspace".to_string(),
         permission_mode: "private".to_string(),
         owner_id,
-        archived: false,
-        model: None,
-        cli_args: Vec::new(),
-        mcp_config: None,
-        thinking: None,
-        agent_env: Vec::new(),
-        provider: None,
-        token_budget: None,
+        ..Agent::default()
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 
@@ -233,14 +212,7 @@ async fn archive_flips_flag_and_hides_from_active_list() {
         visibility: "workspace".to_string(),
         permission_mode: "private".to_string(),
         owner_id,
-        archived: false,
-        model: None,
-        cli_args: Vec::new(),
-        mcp_config: None,
-        thinking: None,
-        agent_env: Vec::new(),
-        provider: None,
-        token_budget: None,
+        ..Agent::default()
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -110,6 +110,7 @@ async fn update_config_persists_and_is_partial() {
         thinking: Some(Some("high".to_string())),
         agent_env: Some(vec![("FOO".to_string(), "bar".to_string())]),
         token_budget: Some(Some(750_000)),
+        ..AgentConfigUpdate::default()
     };
     let touched = AgentRepo::update_config(store.pool(), &workspace_id, "agent-1", &update)
         .await
@@ -255,4 +256,276 @@ async fn archive_flips_flag_and_hides_from_active_list() {
         .await
         .expect("cross-tenant archive");
     assert!(!touched, "a foreign workspace must archive no row");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Migration 0050: agent metadata + name uniqueness + the system-agent kind,
+// exercised through the REPO / BOOTSTRAP API rather than raw SQL.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// A description supplied at create round-trips through BOTH read paths, and the
+/// created agent is never avatar-less (hangar mints an emoji token).
+#[tokio::test]
+async fn create_agent_from_round_trips_description_and_mints_an_avatar() {
+    use ainb_hangar_store::bootstrap::{AgentDraft, create_agent_from, ensure_default_workspace};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let ws = ensure_default_workspace(store.pool()).await.expect("bootstrap workspace");
+
+    let created = create_agent_from(
+        store.pool(),
+        &ws,
+        AgentDraft {
+            name: "builder".into(),
+            provider: "claude".into(),
+            description: "  ships the backend  ".into(),
+            ..AgentDraft::default()
+        },
+    )
+    .await
+    .expect("create agent");
+    assert_eq!(
+        created.description, "ships the backend",
+        "the description is trimmed on the way in"
+    );
+    let avatar = created.avatar_url.clone().expect("an agent is never avatar-less");
+    assert!(
+        avatar.starts_with("emoji:"),
+        "the minted avatar is an emoji token, got {avatar}"
+    );
+    assert_eq!(created.kind, "user", "a plain create is user-kind");
+
+    // Both read paths carry the metadata, not just the create return value.
+    let got = AgentRepo::get(store.pool(), &created.id).await.unwrap().expect("agent persisted");
+    assert_eq!(got.description, "ships the backend");
+    assert_eq!(got.avatar_url, created.avatar_url);
+    let listed = AgentRepo::list_by_workspace(store.pool(), &ws).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].description, "ships the backend");
+}
+
+/// A second create with the SAME name in the SAME workspace is refused, and the
+/// refusal is classified by `is_duplicate_name` (so callers can answer multica's
+/// 409 instead of an opaque store fault). The same name in ANOTHER workspace is
+/// fine.
+#[tokio::test]
+async fn duplicate_agent_name_is_refused_per_workspace() {
+    use ainb_hangar_store::bootstrap::{AgentDraft, create_agent_from, ensure_default_workspace};
+    use ainb_hangar_store::repo::agent::is_duplicate_name;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let ws = ensure_default_workspace(store.pool()).await.expect("bootstrap workspace");
+
+    let draft = |name: &str| AgentDraft {
+        name: name.to_string(),
+        provider: "claude".into(),
+        ..AgentDraft::default()
+    };
+    create_agent_from(store.pool(), &ws, draft("builder")).await.expect("first create");
+    let err = create_agent_from(store.pool(), &ws, draft("builder"))
+        .await
+        .expect_err("a duplicate name must be refused");
+    assert!(
+        is_duplicate_name(&err),
+        "the refusal must classify as a duplicate name, got: {err}"
+    );
+    assert_eq!(
+        AgentRepo::list_by_workspace(store.pool(), &ws).await.unwrap().len(),
+        1,
+        "the refused create wrote no second row"
+    );
+
+    // A second workspace may hold its own `builder` — the constraint is scoped
+    // to (workspace_id, name), not global. Inserted through the repo directly
+    // because `create_agent_from` always binds the DEFAULT workspace's runtime.
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-2','other','O',1)")
+        .execute(store.pool())
+        .await
+        .expect("insert second workspace");
+    let first = AgentRepo::list_by_workspace(store.pool(), &ws).await.unwrap().remove(0);
+    AgentRepo::insert(
+        store.pool(),
+        &Agent {
+            id: "ws2-builder".into(),
+            workspace_id: "ws-2".into(),
+            name: "builder".into(),
+            runtime_id: first.runtime_id.clone(),
+            owner_id: first.owner_id.clone(),
+            ..Agent::default()
+        },
+    )
+    .await
+    .expect("the same name in another workspace is fine");
+}
+
+/// A `system`-kind agent is INVISIBLE to every roster read but reachable through
+/// `find_system` — the shape the agent-builder carrier needs (gap #9-rest).
+#[tokio::test]
+async fn system_agents_are_hidden_from_rosters_but_found_by_key() {
+    use ainb_hangar_store::bootstrap::{AgentDraft, create_agent_from, ensure_default_workspace};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let ws = ensure_default_workspace(store.pool()).await.expect("bootstrap workspace");
+
+    let user = create_agent_from(
+        store.pool(),
+        &ws,
+        AgentDraft {
+            name: "visible".into(),
+            provider: "claude".into(),
+            ..AgentDraft::default()
+        },
+    )
+    .await
+    .expect("create user agent");
+    let hidden = create_agent_from(
+        store.pool(),
+        &ws,
+        AgentDraft {
+            name: "carrier".into(),
+            provider: "claude".into(),
+            kind: Some("system".into()),
+            system_key: Some("agent_builder".into()),
+            ..AgentDraft::default()
+        },
+    )
+    .await
+    .expect("create system agent");
+
+    let names = |rows: Vec<ainb_hangar_store::repo::agent::Agent>| {
+        rows.into_iter().map(|a| a.name).collect::<Vec<_>>()
+    };
+    assert_eq!(
+        names(AgentRepo::list_by_workspace(store.pool(), &ws).await.unwrap()),
+        ["visible"],
+        "the active roster hides the system agent"
+    );
+    assert_eq!(
+        names(
+            AgentRepo::list_by_workspace_including_archived(store.pool(), &ws)
+                .await
+                .unwrap()
+        ),
+        ["visible"],
+        "even the include-archived roster hides it"
+    );
+    let ids = AgentRepo::list_ids_by_runtime(store.pool(), &user.runtime_id).await.unwrap();
+    assert_eq!(
+        ids,
+        [user.id.clone()],
+        "the presence fan-out never addresses a system agent"
+    );
+    // The command palette must not surface it either.
+    let hits = ainb_hangar_store::repo::search::cross_entity_search(store.pool(), &ws, "carrier")
+        .await
+        .unwrap();
+    assert!(
+        hits.is_empty(),
+        "a hidden system agent must not surface in search, got {hits:?}"
+    );
+
+    // But the by-key lookup and the kind-blind by-id get both reach it.
+    let found = AgentRepo::find_system(store.pool(), &ws, "agent_builder")
+        .await
+        .unwrap()
+        .expect("find_system reaches the carrier");
+    assert_eq!(found.id, hidden.id);
+    assert!(
+        AgentRepo::get(store.pool(), &hidden.id).await.unwrap().is_some(),
+        "the internal by-id get stays kind-blind"
+    );
+    assert!(
+        AgentRepo::find_system(store.pool(), &ws, "no-such-key").await.unwrap().is_none()
+    );
+}
+
+/// `update_config` writes, rewrites and CLEARS the three new metadata fields.
+#[tokio::test]
+async fn update_config_sets_and_clears_agent_metadata() {
+    use ainb_hangar_store::bootstrap::{AgentDraft, create_agent_from, ensure_default_workspace};
+    use ainb_hangar_store::repo::agent::AgentConfigUpdate;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let ws = ensure_default_workspace(store.pool()).await.expect("bootstrap workspace");
+    let agent = create_agent_from(
+        store.pool(),
+        &ws,
+        AgentDraft {
+            name: "builder".into(),
+            provider: "claude".into(),
+            description: "first".into(),
+            ..AgentDraft::default()
+        },
+    )
+    .await
+    .expect("create agent");
+
+    // Set: rewrite the description, set an avatar and a service tier.
+    let set = AgentConfigUpdate {
+        description: Some("second".into()),
+        avatar_url: Some(Some("emoji:🦊".into())),
+        service_tier: Some(Some("priority".into())),
+        ..AgentConfigUpdate::default()
+    };
+    assert!(
+        AgentRepo::update_config(store.pool(), &ws, &agent.id, &set).await.unwrap()
+    );
+    let got = AgentRepo::get(store.pool(), &agent.id).await.unwrap().unwrap();
+    assert_eq!(got.description, "second");
+    assert_eq!(got.avatar_url.as_deref(), Some("emoji:🦊"));
+    assert_eq!(got.service_tier.as_deref(), Some("priority"));
+
+    // Clear: the two nullable fields go back to NULL, the description untouched.
+    let clear = AgentConfigUpdate {
+        avatar_url: Some(None),
+        service_tier: Some(None),
+        ..AgentConfigUpdate::default()
+    };
+    assert!(
+        AgentRepo::update_config(store.pool(), &ws, &agent.id, &clear).await.unwrap()
+    );
+    let got = AgentRepo::get(store.pool(), &agent.id).await.unwrap().unwrap();
+    assert_eq!(got.avatar_url, None, "the avatar cleared to NULL");
+    assert_eq!(got.service_tier, None, "the service tier cleared to NULL");
+    assert_eq!(
+        got.description, "second",
+        "an untouched field is left alone by a partial edit"
+    );
+}
+
+/// RENAMING an agent onto a name a SIBLING already holds is refused by the same
+/// unique index, and the loser keeps its old name (no partial write).
+#[tokio::test]
+async fn renaming_onto_a_taken_name_is_refused() {
+    use ainb_hangar_store::bootstrap::{AgentDraft, create_agent_from, ensure_default_workspace};
+    use ainb_hangar_store::repo::agent::{AgentConfigUpdate, is_duplicate_name};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let ws = ensure_default_workspace(store.pool()).await.expect("bootstrap workspace");
+    let draft = |name: &str| AgentDraft {
+        name: name.to_string(),
+        provider: "claude".into(),
+        ..AgentDraft::default()
+    };
+    create_agent_from(store.pool(), &ws, draft("alpha")).await.expect("create alpha");
+    let beta = create_agent_from(store.pool(), &ws, draft("beta")).await.expect("create beta");
+
+    let rename = AgentConfigUpdate {
+        name: Some("alpha".into()),
+        ..AgentConfigUpdate::default()
+    };
+    let err = AgentRepo::update_config(store.pool(), &ws, &beta.id, &rename)
+        .await
+        .expect_err("renaming onto a taken name must be refused");
+    assert!(is_duplicate_name(&err), "classified as a duplicate name: {err}");
+    assert_eq!(
+        AgentRepo::get(store.pool(), &beta.id).await.unwrap().unwrap().name,
+        "beta",
+        "the refused rename left the row untouched"
+    );
 }

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -297,7 +297,10 @@ async fn create_agent_from_round_trips_description_and_mints_an_avatar() {
     assert_eq!(created.kind, "user", "a plain create is user-kind");
 
     // Both read paths carry the metadata, not just the create return value.
-    let got = AgentRepo::get(store.pool(), &created.id).await.unwrap().expect("agent persisted");
+    let got = AgentRepo::get(store.pool(), &created.id)
+        .await
+        .unwrap()
+        .expect("agent persisted");
     assert_eq!(got.description, "ships the backend");
     assert_eq!(got.avatar_url, created.avatar_url);
     let listed = AgentRepo::list_by_workspace(store.pool(), &ws).await.unwrap();
@@ -323,7 +326,9 @@ async fn duplicate_agent_name_is_refused_per_workspace() {
         provider: "claude".into(),
         ..AgentDraft::default()
     };
-    create_agent_from(store.pool(), &ws, draft("builder")).await.expect("first create");
+    create_agent_from(store.pool(), &ws, draft("builder"))
+        .await
+        .expect("first create");
     let err = create_agent_from(store.pool(), &ws, draft("builder"))
         .await
         .expect_err("a duplicate name must be refused");
@@ -438,7 +443,10 @@ async fn system_agents_are_hidden_from_rosters_but_found_by_key() {
         "the internal by-id get stays kind-blind"
     );
     assert!(
-        AgentRepo::find_system(store.pool(), &ws, "no-such-key").await.unwrap().is_none()
+        AgentRepo::find_system(store.pool(), &ws, "no-such-key")
+            .await
+            .unwrap()
+            .is_none()
     );
 }
 
@@ -471,9 +479,7 @@ async fn update_config_sets_and_clears_agent_metadata() {
         service_tier: Some(Some("priority".into())),
         ..AgentConfigUpdate::default()
     };
-    assert!(
-        AgentRepo::update_config(store.pool(), &ws, &agent.id, &set).await.unwrap()
-    );
+    assert!(AgentRepo::update_config(store.pool(), &ws, &agent.id, &set).await.unwrap());
     let got = AgentRepo::get(store.pool(), &agent.id).await.unwrap().unwrap();
     assert_eq!(got.description, "second");
     assert_eq!(got.avatar_url.as_deref(), Some("emoji:🦊"));
@@ -485,9 +491,7 @@ async fn update_config_sets_and_clears_agent_metadata() {
         service_tier: Some(None),
         ..AgentConfigUpdate::default()
     };
-    assert!(
-        AgentRepo::update_config(store.pool(), &ws, &agent.id, &clear).await.unwrap()
-    );
+    assert!(AgentRepo::update_config(store.pool(), &ws, &agent.id, &clear).await.unwrap());
     let got = AgentRepo::get(store.pool(), &agent.id).await.unwrap().unwrap();
     assert_eq!(got.avatar_url, None, "the avatar cleared to NULL");
     assert_eq!(got.service_tier, None, "the service tier cleared to NULL");
@@ -512,7 +516,9 @@ async fn renaming_onto_a_taken_name_is_refused() {
         provider: "claude".into(),
         ..AgentDraft::default()
     };
-    create_agent_from(store.pool(), &ws, draft("alpha")).await.expect("create alpha");
+    create_agent_from(store.pool(), &ws, draft("alpha"))
+        .await
+        .expect("create alpha");
     let beta = create_agent_from(store.pool(), &ws, draft("beta")).await.expect("create beta");
 
     let rename = AgentConfigUpdate {
@@ -522,7 +528,10 @@ async fn renaming_onto_a_taken_name_is_refused() {
     let err = AgentRepo::update_config(store.pool(), &ws, &beta.id, &rename)
         .await
         .expect_err("renaming onto a taken name must be refused");
-    assert!(is_duplicate_name(&err), "classified as a duplicate name: {err}");
+    assert!(
+        is_duplicate_name(&err),
+        "classified as a duplicate name: {err}"
+    );
     assert_eq!(
         AgentRepo::get(store.pool(), &beta.id).await.unwrap().unwrap().name,
         "beta",

--- a/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/workspace_data_isolation.rs
@@ -146,14 +146,7 @@ async fn seed_agent(
             visibility: "workspace".to_string(),
             permission_mode: "private".to_string(),
             owner_id: owner_id.to_string(),
-            archived: false,
-            model: None,
-            cli_args: Vec::new(),
-            mcp_config: None,
-            thinking: None,
-            agent_env: Vec::new(),
-            provider: None,
-            token_budget: None,
+            ..Agent::default()
         },
     )
     .await

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -6282,7 +6282,7 @@ mod tests {
             workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent: false,
             recent_rank: Some(0),
-        ..ActorRow::default()
+            ..ActorRow::default()
         }]);
         p
     }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -988,6 +988,11 @@ impl HangarPlugin {
                 self.apply_agents(resp);
                 if let Some(e) = &resp.error {
                     self.screens.squads.note_err(format!("agent create failed: {}", e.message));
+                    // The create can be raised from EITHER pane, so the refusal
+                    // (e.g. migration 0050's duplicate name) must also land on the
+                    // Agents screen — otherwise the wizard closes and nothing at
+                    // all is said about why no agent appeared.
+                    self.screens.agents.note_err(e.message.clone());
                 } else {
                     self.screens.squads.note_ok("agent created");
                 }
@@ -2773,21 +2778,23 @@ impl HangarPlugin {
         let (id, method, params) = match action {
             AgentsAction::Create {
                 name,
+                description,
                 provider,
                 model,
                 instructions,
             } => (
                 AGENT_CREATE_REQ_ID,
                 daemon_methods::HANGAR_AGENT_CREATE,
-                // `model` / `instructions` are `Option`s; the proto's
-                // `skip_serializing_if` drops them when absent so the wire stays
-                // clean and the daemon leaves those columns at their defaults.
+                // `model` / `instructions` / `description` are `Option`s; the
+                // proto's `skip_serializing_if` drops them when absent so the wire
+                // stays clean and the daemon leaves those columns at their defaults.
                 serde_json::json!({
                     "workspace_id": ws,
                     "name": name,
                     "provider": provider,
                     "model": model,
                     "instructions": instructions,
+                    "description": description,
                 }),
             ),
             AgentsAction::Delete { actor_ref } => {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -6275,6 +6275,7 @@ mod tests {
             workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent: false,
             recent_rank: Some(0),
+        ..ActorRow::default()
         }]);
         p
     }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agent_picker.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agent_picker.rs
@@ -406,6 +406,7 @@ mod render_tests {
             workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank,
+            ..ActorRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -61,6 +61,28 @@ pub struct AgentView {
     /// Live workload — the orthogonal second dimension (multica `Workload`),
     /// derived by the daemon from the agent's live task counts.
     pub workload: Workload,
+    /// The agent's short blurb (migration 0050); empty when unset. Rendered
+    /// muted after the subtitle and clipped to the remaining row width.
+    pub description: String,
+    /// The agent's avatar token (e.g. `"emoji:🦊"`, migration 0050); empty when
+    /// unset. Rendered as the leading glyph, never as the raw `emoji:` token.
+    pub avatar: String,
+}
+
+impl Default for AgentView {
+    /// The neutral row: unnamed, offline, idle, no metadata. Fixtures spread it
+    /// so the next wire field is one struct edit, not a test sweep.
+    fn default() -> Self {
+        Self {
+            actor_ref: String::new(),
+            name: String::new(),
+            subtitle: String::new(),
+            presence: PresenceState::Offline,
+            workload: Workload::Idle,
+            description: String::new(),
+            avatar: String::new(),
+        }
+    }
 }
 
 /// The fixed provider choices the create wizard cycles through — mirrors
@@ -78,6 +100,8 @@ const SUPPORTED_PROVIDERS: [&str; 3] = ["claude", "codex", "copilot"];
 pub struct CreateDraft {
     /// The new agent's name (required, non-blank to advance past the `Name` step).
     pub name: String,
+    /// The optional short blurb (≤255 characters); blank = none.
+    pub description: String,
     /// The chosen provider — one of [`SUPPORTED_PROVIDERS`]; defaults to `claude`.
     pub provider: String,
     /// The optional per-agent model override; blank = the provider default.
@@ -90,6 +114,7 @@ impl Default for CreateDraft {
     fn default() -> Self {
         Self {
             name: String::new(),
+            description: String::new(),
             provider: SUPPORTED_PROVIDERS[0].to_string(),
             model: String::new(),
             instructions: String::new(),
@@ -97,12 +122,14 @@ impl Default for CreateDraft {
     }
 }
 
-/// The step the guided create wizard is on. Enter advances `Name → Provider →
-/// Model → Instructions → Confirm`; Enter on `Confirm` fires the create.
+/// The step the guided create wizard is on. Enter advances `Name → Description →
+/// Provider → Model → Instructions → Confirm`; Enter on `Confirm` fires the create.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CreateStep {
     /// Type the agent name (required).
     Name,
+    /// Type an optional short blurb (blank = none, migration 0050).
+    Description,
     /// Pick the provider from the fixed list (a picker, never free text).
     Provider,
     /// Type an optional model override (blank = provider default).
@@ -160,6 +187,8 @@ impl AgentsState {
                 subtitle: a.subtitle.clone(),
                 presence: a.presence,
                 workload: a.workload,
+                description: a.description.clone(),
+                avatar: a.avatar.clone(),
             })
             .collect();
         Self::new(agents)
@@ -296,13 +325,17 @@ pub enum AgentsEvent {
 /// delete by id).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentsIntent {
-    /// Create an AGENT from the guided wizard (`n` → name → provider → model →
-    /// instructions → confirm) — `hangar/agent_create`; the glue fires it with no
-    /// ids (the daemon fills workspace / runtime / owner) and folds the refreshed
-    /// roster back. Carries the full structured draft, not just a name.
+    /// Create an AGENT from the guided wizard (`n` → name → description →
+    /// provider → model → instructions → confirm) — `hangar/agent_create`; the
+    /// glue fires it with no ids (the daemon fills workspace / runtime / owner)
+    /// and folds the refreshed roster back. Carries the full structured draft,
+    /// not just a name.
     CreateAgent {
         /// The new agent's name (non-blank).
         name: String,
+        /// The optional short blurb — `None` when the description step was left
+        /// blank (migration 0050).
+        description: Option<String>,
         /// The chosen provider (one of [`SUPPORTED_PROVIDERS`]).
         provider: String,
         /// The optional model override — `None` when the model step was left blank.
@@ -360,6 +393,11 @@ fn reduce_create_key(state: &AgentsState, c: char) -> AgentsReduction {
     };
     match step {
         CreateStep::Name => reduce_text_step(state, draft, c, CreateStep::Name, |d| &mut d.name),
+        CreateStep::Description => {
+            reduce_text_step(state, draft, c, CreateStep::Description, |d| {
+                &mut d.description
+            })
+        }
         CreateStep::Model => reduce_text_step(state, draft, c, CreateStep::Model, |d| &mut d.model),
         CreateStep::Instructions => {
             reduce_text_step(state, draft, c, CreateStep::Instructions, |d| {
@@ -375,7 +413,8 @@ fn reduce_create_key(state: &AgentsState, c: char) -> AgentsReduction {
 /// advancing, so it is handled by [`reduce_confirm_step`], never here).
 const fn next_step(step: CreateStep) -> CreateStep {
     match step {
-        CreateStep::Name => CreateStep::Provider,
+        CreateStep::Name => CreateStep::Description,
+        CreateStep::Description => CreateStep::Provider,
         CreateStep::Provider => CreateStep::Model,
         CreateStep::Model => CreateStep::Instructions,
         CreateStep::Instructions | CreateStep::Confirm => CreateStep::Confirm,
@@ -458,6 +497,7 @@ fn reduce_confirm_step(state: &AgentsState, draft: CreateDraft, c: char) -> Agen
         next,
         AgentsIntent::CreateAgent {
             name: draft.name.trim().to_string(),
+            description: non_blank(&draft.description),
             provider: draft.provider,
             model,
             instructions,
@@ -686,8 +726,24 @@ fn render_create_wizard(
             let line = format!("Name: {}▏", draft.name);
             put_str(buf, 0, y.saturating_add(1), &line, GOLD, area_w);
         }
+        CreateStep::Description => {
+            show_field(buf, y, "Name", &draft.name);
+            y = y.saturating_add(1);
+            put_str(
+                buf,
+                0,
+                y,
+                "Optional description, Enter to continue (blank = none)",
+                MUTED_GRAY,
+                area_w,
+            );
+            let line = format!("Description: {}▏", draft.description);
+            put_str(buf, 0, y.saturating_add(1), &line, GOLD, area_w);
+        }
         CreateStep::Provider => {
             show_field(buf, y, "Name", &draft.name);
+            y = y.saturating_add(1);
+            show_field(buf, y, "Description", blurb_or_none(&draft.description));
             y = y.saturating_add(1);
             put_str(
                 buf,
@@ -704,6 +760,8 @@ fn render_create_wizard(
         CreateStep::Model => {
             show_field(buf, y, "Name", &draft.name);
             y = y.saturating_add(1);
+            show_field(buf, y, "Description", blurb_or_none(&draft.description));
+            y = y.saturating_add(1);
             show_field(buf, y, "Provider", &draft.provider);
             y = y.saturating_add(1);
             put_str(
@@ -719,6 +777,8 @@ fn render_create_wizard(
         }
         CreateStep::Instructions => {
             show_field(buf, y, "Name", &draft.name);
+            y = y.saturating_add(1);
+            show_field(buf, y, "Description", blurb_or_none(&draft.description));
             y = y.saturating_add(1);
             show_field(buf, y, "Provider", &draft.provider);
             y = y.saturating_add(1);
@@ -745,6 +805,8 @@ fn render_create_wizard(
             y = y.saturating_add(1);
             show_field(buf, y, "Name", &draft.name);
             y = y.saturating_add(1);
+            show_field(buf, y, "Description", blurb_or_none(&draft.description));
+            y = y.saturating_add(1);
             show_field(buf, y, "Provider", &draft.provider);
             y = y.saturating_add(1);
             let model = if draft.model.trim().is_empty() {
@@ -763,6 +825,13 @@ fn render_create_wizard(
             show_field(buf, y, "Instructions", instr);
         }
     }
+}
+
+/// Render a draft blurb for the wizard's review rows: the trimmed text, or the
+/// explicit `(none)` placeholder so a skipped step reads as deliberate.
+fn blurb_or_none(description: &str) -> &str {
+    let t = description.trim();
+    if t.is_empty() { "(none)" } else { t }
 }
 
 /// The first-visible row index for a viewport of `visible_rows` rows that must keep
@@ -786,11 +855,16 @@ fn render_action_hints(buf: &mut WireBuffer, row: u16, area_w: u16) {
 }
 
 /// Render one agent row:
-/// `▶ <name>  <dot> <presence> · <wl-glyph> <workload>  · <subtitle>`.
+/// `▶ <avatar> <name>  <dot> <presence> · <wl-glyph> <workload>  · <subtitle>  — <blurb>`.
 ///
 /// The two dimensions are painted side by side (multica `presence × workload`):
 /// the availability dot+word, then ` · ` + the workload glyph+word colour-coded
 /// by its state, so an `online` agent visibly reads `working` vs `idle`.
+///
+/// The avatar glyph (migration 0050) leads the row when the agent carries one,
+/// and the blurb trails it muted. Both are pure additions: an agent with neither
+/// renders exactly as it did pre-0050. `put_str` clips at `area_w`, so a long
+/// blurb is truncated rather than wrapping onto the next agent's row.
 fn render_agent_row(
     buf: &mut WireBuffer,
     row: u16,
@@ -807,6 +881,10 @@ fn render_agent_row(
         SELECTION_GREEN,
         area_w,
     );
+    if let Some(glyph) = avatar_glyph(&agent.avatar) {
+        x = put_cell(buf, x, row, glyph, GOLD, area_w);
+        x = put_str(buf, x, row, " ", MUTED_GRAY, area_w);
+    }
     x = put_str(
         buf,
         x,
@@ -835,8 +913,23 @@ fn render_agent_row(
     x = put_str(buf, x, row, workload_word(agent.workload), wl_color, area_w);
     if !agent.subtitle.is_empty() {
         x = put_str(buf, x, row, "  · ", MUTED_GRAY, area_w);
-        put_str(buf, x, row, &agent.subtitle, MUTED_GRAY, area_w);
+        x = put_str(buf, x, row, &agent.subtitle, MUTED_GRAY, area_w);
     }
+    if !agent.description.is_empty() {
+        x = put_str(buf, x, row, "  — ", MUTED_GRAY, area_w);
+        put_str(buf, x, row, &agent.description, MUTED_GRAY, area_w);
+    }
+}
+
+/// Decode an avatar token into the glyph to paint, or `None` when there is
+/// nothing renderable.
+///
+/// Hangar mints `"emoji:<glyph>"` tokens (multica `newAgentAvatar`). Only that
+/// form renders, and only its FIRST character — an empty token, a bare string,
+/// or a URL-style token (a future avatar backend) paints nothing rather than
+/// leaking the raw `emoji:` prefix into the roster.
+fn avatar_glyph(avatar: &str) -> Option<char> {
+    avatar.strip_prefix("emoji:")?.chars().next()
 }
 
 /// The lowercase presence word rendered next to the dot.
@@ -966,8 +1059,9 @@ mod tests {
     }
 
     /// `n` opens the wizard at `Name`; the full step sequence collects
-    /// name → provider → model → instructions and Enter on `Confirm` emits the
-    /// widened `CreateAgent` intent with every field; a single Esc cancels.
+    /// name → description → provider → model → instructions and Enter on
+    /// `Confirm` emits the widened `CreateAgent` intent with every field; a
+    /// single Esc cancels.
     #[test]
     fn create_flow_raises_intent_and_esc_cancels() {
         let state = AgentsState::from_actors(&snapshot());
@@ -976,12 +1070,14 @@ mod tests {
         assert_eq!(opened.create_draft().map(|d| d.name.as_str()), Some(""));
         assert!(opened.is_capturing());
 
-        // Name "qa" + Enter -> Provider; '→'(l) cycles claude->codex; Enter -> Model;
-        // type model + Enter -> Instructions; type text + Enter -> Confirm.
+        // Name "qa" + Enter -> Description; type blurb + Enter -> Provider;
+        // '→'(l) cycles claude->codex; Enter -> Model; type model + Enter ->
+        // Instructions; type text + Enter -> Confirm.
         let at_confirm = drive(
             &opened,
             &[
-                'q', 'a', '\n', // Name -> Provider
+                'q', 'a', '\n', // Name -> Description
+                'r', 'u', 'n', 's', ' ', 'Q', 'A', '\n', // Description -> Provider
                 'l', '\n', // pick codex -> Model
                 'g', 'p', 't', '\n', // Model -> Instructions
                 'b', 'e', ' ', 't', 'e', 'r', 's', 'e', '\n', // -> Confirm
@@ -1001,6 +1097,7 @@ mod tests {
             out.intent,
             Some(AgentsIntent::CreateAgent {
                 name: "qa".into(),
+                description: Some("runs QA".into()),
                 provider: "codex".into(),
                 model: Some("gpt".into()),
                 instructions: Some("be terse".into()),
@@ -1036,16 +1133,17 @@ mod tests {
     fn wizard_blank_optionals_are_none() {
         let state = AgentsState::from_actors(&snapshot());
         let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
-        // Name "bot" + Enter; Provider Enter (leave claude); Model Enter (blank);
-        // Instructions Enter (blank); Confirm Enter.
+        // Name "bot" + Enter; Description Enter (blank); Provider Enter (leave
+        // claude); Model Enter (blank); Instructions Enter (blank); Confirm Enter.
         let out = drive(
             &opened,
-            &['b', 'o', 't', '\n', '\n', '\n', '\n', '\n'],
+            &['b', 'o', 't', '\n', '\n', '\n', '\n', '\n', '\n'],
         );
         assert_eq!(
             out.intent,
             Some(AgentsIntent::CreateAgent {
                 name: "bot".into(),
+                description: None,
                 provider: "claude".into(),
                 model: None,
                 instructions: None,
@@ -1059,7 +1157,8 @@ mod tests {
     fn wizard_esc_cancels_from_any_step() {
         let state = AgentsState::from_actors(&snapshot());
         let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
-        let at_provider = drive(&opened, &['a', '\n']).state;
+        // Name, then Enter through the blank Description step to reach Provider.
+        let at_provider = drive(&opened, &['a', '\n', '\n']).state;
         assert_eq!(at_provider.create_step(), Some(CreateStep::Provider));
         let cancelled = reduce_agents(&at_provider, AgentsEvent::Esc);
         assert!(!cancelled.state.is_creating(), "one Esc closes the wizard");
@@ -1071,7 +1170,7 @@ mod tests {
     fn wizard_provider_picker_cycles() {
         let state = AgentsState::from_actors(&snapshot());
         let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
-        let at_provider = drive(&opened, &['a', '\n']).state;
+        let at_provider = drive(&opened, &['a', '\n', '\n']).state;
         assert_eq!(
             at_provider.create_draft().map(|d| d.provider.as_str()),
             Some("claude")
@@ -1214,6 +1313,7 @@ mod tests {
                 subtitle: "claude".into(),
                 presence: PresenceState::Online,
                 workload: Workload::Working,
+            ..AgentView::default()
             },
             AgentView {
                 actor_ref: "agent:a-2".into(),
@@ -1221,6 +1321,7 @@ mod tests {
                 subtitle: "claude".into(),
                 presence: PresenceState::Online,
                 workload: Workload::Queued,
+            ..AgentView::default()
             },
         ]);
         let mut buf = WireBuffer::new(80, 24);
@@ -1246,6 +1347,7 @@ mod tests {
             subtitle: "claude".into(),
             presence: PresenceState::Online,
             workload: Workload::Idle,
+        ..AgentView::default()
         }]);
         let mut buf = WireBuffer::new(80, 24);
         render_agents(&mut buf, 80, 1, 23, &state);
@@ -1263,7 +1365,8 @@ mod tests {
         let at_confirm = drive(
             &opened,
             &[
-                'q', 'a', '\n', // Name -> Provider
+                'q', 'a', '\n', // Name -> Description
+                's', 'h', 'i', 'p', 's', '\n', // Description -> Provider
                 'l', '\n', // codex -> Model
                 'g', 'p', 't', '-', '5', '\n', // Model -> Instructions
                 'b', 'e', ' ', 't', 'e', 'r', 's', 'e', '\n', // -> Confirm
@@ -1275,6 +1378,10 @@ mod tests {
         render_agents(&mut buf, 80, 1, 23, &at_confirm);
         let text = buffer_text(&buf, 80, 24);
         assert!(text.contains("codex"), "confirm shows the chosen provider");
+        assert!(
+            text.contains("ships"),
+            "confirm lists the typed description"
+        );
         assert!(text.contains("gpt-5"), "confirm shows the chosen model");
         assert!(
             text.contains("be terse"),
@@ -1287,8 +1394,8 @@ mod tests {
     fn render_provider_step_shows_choice() {
         let state = AgentsState::from_actors(&snapshot());
         let opened = reduce_agents(&state, AgentsEvent::Key('n')).state;
-        // Name + Enter -> Provider, then cycle to codex.
-        let at_provider = drive(&opened, &['a', '\n', 'l']).state;
+        // Name + Enter -> Description, blank Enter -> Provider, then cycle to codex.
+        let at_provider = drive(&opened, &['a', '\n', '\n', 'l']).state;
         assert_eq!(at_provider.create_step(), Some(CreateStep::Provider));
         let mut buf = WireBuffer::new(80, 24);
         render_agents(&mut buf, 80, 1, 23, &at_provider);
@@ -1297,6 +1404,59 @@ mod tests {
             text.contains("codex"),
             "the provider picker shows the current choice"
         );
+    }
+
+    /// A roster row renders its blurb VERBATIM after the subtitle (migration
+    /// 0050) — the exact substring, not merely "the screen shows something".
+    #[test]
+    fn render_shows_the_agent_description() {
+        let state = AgentsState::new(vec![AgentView {
+            actor_ref: "agent:a-1".into(),
+            name: "builder".into(),
+            subtitle: "agent".into(),
+            presence: PresenceState::Online,
+            description: "ships the backend".into(),
+            ..AgentView::default()
+        }]);
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(
+            text.contains("ships the backend"),
+            "the blurb must render verbatim on the roster row: {text:?}"
+        );
+    }
+
+    /// An `emoji:` avatar renders the GLYPH and never leaks the raw token; an
+    /// agent with no avatar renders no leading glyph at all.
+    #[test]
+    fn render_shows_the_avatar_glyph_not_the_token() {
+        let state = AgentsState::new(vec![AgentView {
+            actor_ref: "agent:a-1".into(),
+            name: "builder".into(),
+            presence: PresenceState::Online,
+            avatar: "emoji:🦊".into(),
+            ..AgentView::default()
+        }]);
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(text.contains('🦊'), "the avatar glyph must render: {text:?}");
+        assert!(
+            !text.contains("emoji:"),
+            "the raw avatar token must never leak to the roster: {text:?}"
+        );
+    }
+
+    /// The avatar decoder only accepts the `emoji:` form: an empty token, a bare
+    /// string, and a URL all paint nothing rather than a stray character.
+    #[test]
+    fn avatar_glyph_only_decodes_the_emoji_form() {
+        assert_eq!(avatar_glyph("emoji:🦊"), Some('🦊'));
+        assert_eq!(avatar_glyph(""), None);
+        assert_eq!(avatar_glyph("🦊"), None, "a bare glyph is not a token");
+        assert_eq!(avatar_glyph("https://x/y.png"), None);
+        assert_eq!(avatar_glyph("emoji:"), None, "an empty emoji token is nothing");
     }
 
     /// Reassemble the buffer text for render assertions.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -912,6 +912,7 @@ mod tests {
             workload: Workload::Idle,
             is_agent,
             recent_rank: None,
+        ..ActorRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -461,10 +461,7 @@ fn reduce_text_step(
 /// `h`/`k` (or `←`/`↑`) cycle backward through [`SUPPORTED_PROVIDERS`], Enter
 /// advances. The picker can only ever land on a supported provider.
 fn reduce_provider_step(state: &AgentsState, mut draft: CreateDraft, c: char) -> AgentsReduction {
-    let cur = SUPPORTED_PROVIDERS
-        .iter()
-        .position(|p| *p == draft.provider)
-        .unwrap_or(0);
+    let cur = SUPPORTED_PROVIDERS.iter().position(|p| *p == draft.provider).unwrap_or(0);
     let len = SUPPORTED_PROVIDERS.len();
     let next_idx = match c {
         '\n' => {
@@ -1005,7 +1002,7 @@ mod tests {
             workload: Workload::Idle,
             is_agent,
             recent_rank: None,
-        ..ActorRow::default()
+            ..ActorRow::default()
         }
     }
 
@@ -1177,7 +1174,10 @@ mod tests {
         );
         // Forward: claude -> codex -> copilot -> claude (wrap).
         let fwd = drive(&at_provider, &['l', 'l', 'l']).state;
-        assert_eq!(fwd.create_draft().map(|d| d.provider.as_str()), Some("claude"));
+        assert_eq!(
+            fwd.create_draft().map(|d| d.provider.as_str()),
+            Some("claude")
+        );
         // Backward from claude wraps to copilot.
         let back = drive(&at_provider, &['h']).state;
         assert_eq!(
@@ -1313,7 +1313,7 @@ mod tests {
                 subtitle: "claude".into(),
                 presence: PresenceState::Online,
                 workload: Workload::Working,
-            ..AgentView::default()
+                ..AgentView::default()
             },
             AgentView {
                 actor_ref: "agent:a-2".into(),
@@ -1321,7 +1321,7 @@ mod tests {
                 subtitle: "claude".into(),
                 presence: PresenceState::Online,
                 workload: Workload::Queued,
-            ..AgentView::default()
+                ..AgentView::default()
             },
         ]);
         let mut buf = WireBuffer::new(80, 24);
@@ -1347,7 +1347,7 @@ mod tests {
             subtitle: "claude".into(),
             presence: PresenceState::Online,
             workload: Workload::Idle,
-        ..AgentView::default()
+            ..AgentView::default()
         }]);
         let mut buf = WireBuffer::new(80, 24);
         render_agents(&mut buf, 80, 1, 23, &state);
@@ -1441,7 +1441,10 @@ mod tests {
         let mut buf = WireBuffer::new(80, 24);
         render_agents(&mut buf, 80, 1, 23, &state);
         let text = buffer_text(&buf, 80, 24);
-        assert!(text.contains('🦊'), "the avatar glyph must render: {text:?}");
+        assert!(
+            text.contains('🦊'),
+            "the avatar glyph must render: {text:?}"
+        );
         assert!(
             !text.contains("emoji:"),
             "the raw avatar token must never leak to the roster: {text:?}"
@@ -1456,7 +1459,11 @@ mod tests {
         assert_eq!(avatar_glyph(""), None);
         assert_eq!(avatar_glyph("🦊"), None, "a bare glyph is not a token");
         assert_eq!(avatar_glyph("https://x/y.png"), None);
-        assert_eq!(avatar_glyph("emoji:"), None, "an empty emoji token is nothing");
+        assert_eq!(
+            avatar_glyph("emoji:"),
+            None,
+            "an empty emoji token is nothing"
+        );
     }
 
     /// Reassemble the buffer text for render assertions.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -496,6 +496,8 @@ pub enum AgentsAction {
     Create {
         /// The new agent's name.
         name: String,
+        /// The optional short blurb (`None` = left blank, migration 0050).
+        description: Option<String>,
         /// The chosen provider (`claude`/`codex`/`copilot`).
         provider: String,
         /// The optional per-agent model override (`None` = provider default).
@@ -2271,11 +2273,13 @@ fn route_agents(states: &mut ScreenStates, key: &KeyEvent) {
     states.pending_agents_action = match out.intent {
         Some(AgentsIntent::CreateAgent {
             name,
+            description,
             provider,
             model,
             instructions,
         }) => Some(AgentsAction::Create {
             name,
+            description,
             provider,
             model,
             instructions,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
@@ -786,7 +786,7 @@ mod tests {
             workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank: None,
-        ..ActorRow::default()
+            ..ActorRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
@@ -786,6 +786,7 @@ mod tests {
             workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank: None,
+        ..ActorRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/actor_row.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/actor_row.rs
@@ -156,6 +156,7 @@ mod tests {
             workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank: None,
+        ..ActorRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/actor_row.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/actor_row.rs
@@ -156,7 +156,7 @@ mod tests {
             workload: ainb_hangar_proto::events::Workload::Idle,
             is_agent,
             recent_rank: None,
-        ..ActorRow::default()
+            ..ActorRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_reducer_test.rs
@@ -37,6 +37,7 @@ fn actor(
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: recent,
+    ..ActorRow::default()
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_reducer_test.rs
@@ -37,7 +37,7 @@ fn actor(
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: recent,
-    ..ActorRow::default()
+        ..ActorRow::default()
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_routing_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_routing_test.rs
@@ -27,6 +27,7 @@ fn actor() -> ActorRow {
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent: true,
         recent_rank: Some(0),
+    ..ActorRow::default()
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_routing_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/agent_picker_routing_test.rs
@@ -27,7 +27,7 @@ fn actor() -> ActorRow {
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent: true,
         recent_rank: Some(0),
-    ..ActorRow::default()
+        ..ActorRow::default()
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
@@ -25,7 +25,7 @@ fn actor(actor_ref: &str, name: &str, presence: PresenceState, is_agent: bool) -
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: None,
-    ..ActorRow::default()
+        ..ActorRow::default()
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
@@ -25,6 +25,7 @@ fn actor(actor_ref: &str, name: &str, presence: PresenceState, is_agent: bool) -
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: None,
+    ..ActorRow::default()
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -115,7 +115,7 @@ fn seeded_agents() -> serde_json::Value {
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: None,
-    ..ActorRow::default()
+        ..ActorRow::default()
     };
     serde_json::to_value(AgentsListResult {
         actors: vec![

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -115,6 +115,7 @@ fn seeded_agents() -> serde_json::Value {
         workload: ainb_hangar_proto::events::Workload::Idle,
         is_agent,
         recent_rank: None,
+    ..ActorRow::default()
     };
     serde_json::to_value(AgentsListResult {
         actors: vec![

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -3652,6 +3652,9 @@ Options:
       --provider <PROVIDER>          Provider to record (`claude`/`codex`/`copilot`); defaults to `claude`
       --model <MODEL>                Optional per-agent model override (e.g. `sonnet`, `gpt-5-codex`)
       --instructions <INSTRUCTIONS>  Optional instructions / system prompt for the agent
+      --description <DESCRIPTION>    Optional short blurb rendered beside the agent (≤255 characters)
+      --avatar <AVATAR>              Optional avatar token (e.g. `emoji:🦊`); omitted mints a random emoji
+      --service-tier <SERVICE_TIER>  Optional Codex service tier (e.g. `priority`); omitted inherits the local Codex config. Stored + surfaced only — no dispatch-time override yet
       --workspace <WORKSPACE>        Workspace slug to create the agent in. Defaults to the bootstrapped `default` workspace (created if absent)
   -h, --help                         Print help
 ```
@@ -3701,6 +3704,11 @@ Options:
       --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable). When ANY `--env` is given the whole env map is REPLACED with the values
       --token-budget <TOKEN_BUDGET>  New token budget (rtk/headroom, migration 0042); omitted leaves it. Mutually exclusive with `--clear-token-budget`
       --clear-token-budget           Clear the token budget (back to unlimited); omitted leaves it
+      --description <DESCRIPTION>    New description (≤255 characters); omitted leaves it. Pass `--description ""` to blank it (the column is NOT NULL, so `""` IS its cleared state)
+      --avatar <AVATAR>              New avatar token; omitted leaves it. Mutually exclusive with `--clear-avatar`
+      --clear-avatar                 Clear the avatar; omitted leaves it
+      --service-tier <SERVICE_TIER>  New Codex service tier; omitted leaves it. Mutually exclusive with `--clear-service-tier`
+      --clear-service-tier           Clear the service tier (back to inheriting the local Codex config)
       --workspace <WORKSPACE>        Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                         Print help
 ```


### PR DESCRIPTION
## Parity gap #23 — agent metadata: description, avatar, name uniqueness, system kind, service tier

Multica's agent record carries more than a name + runtime. This closes the gap in the
smallest shape that matches its behaviour, across store → proto → daemon → CLI → TUI.

Multica references covered: `046_agent_unique_name`, `060_agent_description_length`,
`163_agent_builder`, `172_agent_system_identity_index`, `212_agent_service_tier`,
`agent_avatar.go` (`newAgentAvatar`).

```
┌──────────┐   ┌───────┐   ┌────────┐   ┌─────┐   ┌─────────┐
│ TUI/CLI  │──▶│ proto │──▶│ daemon │──▶│ repo│──▶│ 0050 DB │
└──────────┘   └───────┘   └────────┘   └─────┘   └─────────┘
 wizard step    append-only  validate +   kind-      unique
 + roster       fields       409-equiv    filtered   indexes
 blurb/avatar                 refusal     lists
```

### What landed

**Migration 0050** (next free number) adds `description`, `avatar_url`, `kind`,
`system_key`, `service_tier` to `agent`, plus two indexes:

- `agent_workspace_name_unique (workspace_id, name)` — multica 046. One agent name per
  workspace, so create answers a clear conflict instead of silently making a second
  identically-named actor the picker cannot disambiguate.
- `agent_system_identity_unique (workspace_id, owner_id, runtime_id, system_key)
  WHERE system_key IS NOT NULL` — multica 172, partial so ordinary user agents (all
  NULL) are unconstrained.

**Deliberate deviation from multica 046:** multica `DELETE`s duplicate-named rows before
adding the constraint. Hangar agents are FK-pinned by `agent_task_queue` / usage /
autopilot rows (`AgentRepo::delete`'s `HasHistory` guard), so a `DELETE` here would trip a
`FOREIGN KEY` constraint and abort the migration, bricking daemon boot on a populated
home. Duplicates are **renamed** instead (`name || ' (' || id || ')'`), which is lossless
and cannot manufacture a fresh collision since the id is unique by construction.

**Store** — `Agent` carries the five new fields and gains a `Default` so fixture sites
spread rather than freeze a positional literal. New `bootstrap::AgentDraft` +
`create_agent_from` (the old `create_agent` is preserved as a thin wrapper, so no caller
broke). A blank avatar mints a random `emoji:…` token from multica's 24-glyph palette, so
no agent is ever avatar-less. `list_*` / `ids_for_runtime` / search filter to
`kind = 'user'`; `find_by_id` stays deliberately kind-blind (dispatch resolves a system
agent by an id it already holds, exactly as multica's `GetAgent` does); `find_system`
is the one search that returns a carrier agent.

**Proto** — `AgentCreateParams` / `AgentUpdateParams` / `ActorRow` grow append-only
fields (`serde(default)` + `skip_serializing_if`), so an old client omits them and an old
daemon ignores them. `kind` / `system_key` are **deliberately absent from the create
wire**: a system agent is an internal carrier minted by the agent-builder (gap #9-rest),
never by a peer.

**Daemon** — validates the description against multica's 255-**code-point** cap
(`chars()`, not bytes, matching `utf8.RuneCountInString` and the schema `CHECK`) and maps
the unique violation to a duplicate-name refusal carrying
`data.reason = "duplicate_name"`, following the `active_tasks` / `has_history` precedent
so the TUI branches on a token rather than string-matching prose. Applies to a colliding
**rename** too, not just create.

**CLI** — `hangar agent create --description/--avatar/--service-tier`;
`hangar agent edit --description/--avatar/--clear-avatar/--service-tier/--clear-service-tier`.
`description` is NOT NULL so `--description ""` *is* its cleared state (no clear flag).

**TUI** — the create wizard gains a Description step (`Name → Description → Provider →
Model → Instructions → Confirm`); the roster renders the avatar glyph and the muted
blurb. A create refusal now also lands on the Agents screen — previously it only went to
Squads, so raising the wizard from the Agents pane closed it silently on a duplicate name.

### Scope honesty

- `service_tier` is **stored + surfaced only**. No dispatch-time Codex override reads it
  yet — the same shape `token_budget` landed in with 0042.
- `kind` / `system_key` are schema + store + read-filter support only. No RPC mints a
  system agent; the agent-builder that does is gap #9-rest.

### Tests (fail-before / pass-after)

- `migration_0050_upgrade.rs` — 0050 applied to a **populated, FK-pinned** database:
  duplicates renamed not deleted, backfill values, both indexes enforced after upgrade,
  the system-identity index proven *partial*.
- `repo_agent.rs` — metadata round-trip, avatar minting, duplicate refusal, colliding
  rename refusal, system agents hidden from rosters but found by key, set/clear via
  `update_config`.
- `rpc_agent_metadata.rs` — the five behaviours over the **real framed socket**:
  persist + mint, duplicate create refused with the `reason` marker, over-long
  description rejected at the boundary, colliding rename refused *and the row left
  intact*, description edited.
- `hangar_cli_integration.rs` — description round-trip, over-long rejection, and
  duplicate-name / colliding-rename refusals end to end through the CLI binary.
- `events.rs` — a **pre-0050 payload** (no `description`, no `avatar`) still decodes,
  which a plain round-trip would not catch.

### Fixtures this change drifted, fixed in the same PR

- `claim_task_integration.rs` seeded every agent into `ws-1` under the shared literal
  `"Agent"`; three tests seed two agents, so they hit the new unique index. The name is
  now derived from the caller's agent id rather than freezing another literal.
- `repo::search::tests::search_excludes_archived_agents` seeded an active and an archived
  agent both called `"scout"`. Archiving does **not** release a name, so they are now
  distinct (`"scout"` / `"scout (retired)"`) — both still LIKE-match the query, so the
  assertion still proves exactly what it did before.
- ~20 struct-literal fixture sites across store / daemon / plugin now spread
  `..Default::default()` on `Agent` / `ActorRow` / `AgentConfigUpdate` / `AgentView`, so
  the *next* schema add is one struct edit instead of another fixture sweep.

### Local gate

| Step | Result |
|---|---|
| `cargo build -p ainb` | green |
| `cargo nextest run --lib --tests --all-features -E 'not binary(/^tripwire_/)'` | **4102 passed**, 0 failed, 18 skipped |
| `cargo nextest run --workspace --lib` (added — the mandated line has no `-p`, so it only builds default-members, which is exactly how the store fixture drifted unnoticed) | **3924 passed**, 0 failed, 3 skipped |
| `scripts/hangar/run_all_tripwires.sh` | **62 ran, 0 failed** |
| `scripts/hangar/run_acceptance_tests.sh` | **147 ran, 0 failed** |

All four green in a single clean run (`BUILD=0 NEXTEST=0 WSLIB=0 TRIP=0 ACC=0`).

One flake seen on an earlier round and attributed, not papered over:
`ainb-hangar-daemon::worktree_integration::worktree_reuse_on_resume` failed once with
`gpg: signing failed: Cannot allocate memory` — the test's throwaway repo inherits the
machine's global `commit.gpgsign=true` and gpg-agent ran out of memory under 10-way
nextest parallelism. It passes on every serial run and on the clean final run; it is
environmental and untouched by this change.

`cargo fmt --all -- --check` is clean under the pinned 1.96.0 toolchain (one
`style(hangar):` commit covers it). Clippy is not gated in CI by design — `ci.yml` says
so explicitly — and the only `-D warnings` hits under this diff's crates are in
untouched files (`ainb-hangar-core/src/profile.rs`, `ainb-hangar-proto/src/methods.rs`,
`fleet.rs`, and `snapshots.rs` regions far from the added params).
