### PR TITLE
feat(hangar): archive audit trail on agent and squad (parity #26)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -2358,10 +2358,16 @@ async fn run_agent_set_archived(
     let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
     let by = effective_archiver(store, &workspace_id, args.by.as_deref()).await?;
     let now = ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock);
-    let touched =
-        AgentRepo::set_archived(store.pool(), &workspace_id, &args.id, archived, by.as_ref(), now)
-            .await
-            .with_context(|| format!("archive agent {}", args.id))?;
+    let touched = AgentRepo::set_archived(
+        store.pool(),
+        &workspace_id,
+        &args.id,
+        archived,
+        by.as_ref(),
+        now,
+    )
+    .await
+    .with_context(|| format!("archive agent {}", args.id))?;
     if touched {
         if archived {
             // Report the audit that was actually written, so the operator can see
@@ -2875,12 +2881,12 @@ fn squad_assign_cli_err(
         SquadAssignError::MemberAgentMissing(id) => {
             anyhow::anyhow!("squad member agent `{id}` not found")
         }
-        // gap #8: the invocation gate refused a dispatch target — no task row was
-        // written. Surfaced verbatim so the CLI exits non-zero with the reason.
-        e @ SquadAssignError::NotInvocable { .. } => anyhow::anyhow!("{e}"),
-        // parity #26: an archived squad refuses new work — no task row was
-        // written. Surfaced verbatim so the CLI exits non-zero with the reason.
-        e @ SquadAssignError::Archived(_) => anyhow::anyhow!("{e}"),
+        // Two pre-flight refusals that write NO task row: the gap-#8 invocation
+        // gate, and the parity-#26 archived-squad guard. Both are surfaced
+        // verbatim so the CLI exits non-zero with the store's own reason.
+        e @ (SquadAssignError::NotInvocable { .. } | SquadAssignError::Archived(_)) => {
+            anyhow::anyhow!("{e}")
+        }
         db @ SquadAssignError::Db(_) => anyhow::Error::new(db).context("squad assign failed"),
     }
 }
@@ -5546,10 +5552,10 @@ fn agent_to_json(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     // The audit pair is `null` (not `0` / `""`) when unstamped — an honest
     // "unknown", distinguishable from an epoch-0 archive by an unattributed actor.
     let archived_at = a.archived_at.map_or_else(|| "null".to_string(), |ms| ms.to_string());
-    let archived_by = a
-        .archived_by
-        .as_ref()
-        .map_or_else(|| "null".to_string(), |actor| json_string(&actor.to_string()));
+    let archived_by = a.archived_by.as_ref().map_or_else(
+        || "null".to_string(),
+        |actor| json_string(&actor.to_string()),
+    );
     let args = json_string_array(a.cli_args.iter().map(String::as_str));
     let env = a
         .agent_env
@@ -5732,9 +5738,10 @@ fn squad_to_json(s: &ainb_hangar_store::repo::squad::Squad) -> String {
         ),
         s.archived,
         s.archived_at.map_or_else(|| "null".to_string(), |ms| ms.to_string()),
-        s.archived_by
-            .as_ref()
-            .map_or_else(|| "null".to_string(), |actor| json_string(&actor.to_string())),
+        s.archived_by.as_ref().map_or_else(
+            || "null".to_string(),
+            |actor| json_string(&actor.to_string())
+        ),
     )
 }
 /// Join a squad's member actor-refs with `, ` for the flat text surfaces.

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -621,6 +621,10 @@ pub struct AgentArchiveArgs {
     /// `default` workspace.
     #[arg(long)]
     pub workspace: Option<String>,
+    /// The `user.id` recorded as the archiving actor (migration 0052). Omitted
+    /// defaults to the workspace owner — the ordinary single-operator archive.
+    #[arg(long)]
+    pub by: Option<String>,
 }
 
 /// `hangar member <verb>`.
@@ -749,6 +753,10 @@ pub enum SquadCommand {
     RemoveMember(SquadMemberArgs),
     /// Route a task to the squad's LEADER (leader routing taking effect).
     Assign(SquadAssignArgs),
+    /// Archive a squad: it leaves the active list and refuses new assignments.
+    Archive(SquadArchiveArgs),
+    /// Restore an archived squad (clears the archive audit stamp).
+    Unarchive(SquadArchiveArgs),
 }
 
 /// Arguments for `hangar squad list`.
@@ -757,6 +765,24 @@ pub struct SquadListArgs {
     /// Workspace slug to list. Defaults to the bootstrapped `default` workspace.
     #[arg(long)]
     pub workspace: Option<String>,
+    /// Include ARCHIVED squads (migration 0052). The default list is active-only.
+    #[arg(long)]
+    pub all: bool,
+}
+
+/// Arguments for `hangar squad archive` / `hangar squad unarchive`.
+#[derive(Args, Debug)]
+pub struct SquadArchiveArgs {
+    /// Squad id to (un)archive.
+    pub id: String,
+    /// Workspace slug the squad belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+    /// The `user.id` recorded as the archiving actor (migration 0052). Omitted
+    /// defaults to the workspace owner.
+    #[arg(long)]
+    pub by: Option<String>,
 }
 
 /// Arguments for `hangar squad create`.
@@ -2330,16 +2356,54 @@ async fn run_agent_set_archived(
     use ainb_hangar_store::repo::agent::AgentRepo;
 
     let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
-    let touched = AgentRepo::set_archived(store.pool(), &workspace_id, &args.id, archived)
-        .await
-        .with_context(|| format!("archive agent {}", args.id))?;
+    let by = effective_archiver(store, &workspace_id, args.by.as_deref()).await?;
+    let now = ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock);
+    let touched =
+        AgentRepo::set_archived(store.pool(), &workspace_id, &args.id, archived, by.as_ref(), now)
+            .await
+            .with_context(|| format!("archive agent {}", args.id))?;
     if touched {
-        let verb = if archived { "archived" } else { "un-archived" };
-        println!("{verb} agent {}", args.id);
+        if archived {
+            // Report the audit that was actually written, so the operator can see
+            // WHO the archive was attributed to without re-reading the row.
+            match &by {
+                Some(actor) => println!("archived agent {} by {actor} at {now}", args.id),
+                None => println!("archived agent {} at {now} (unattributed)", args.id),
+            }
+        } else {
+            println!("un-archived agent {}", args.id);
+        }
     } else {
         anyhow::bail!("no agent with id {} in this workspace", args.id);
     }
     Ok(())
+}
+
+/// Resolve the actor recorded as `archived_by` for a CLI archive (migration 0052),
+/// with the SAME precedence the daemon uses
+/// (`rpc::snapshots::effective_archiver`): an explicit `--by` user id, else the
+/// workspace owner, else `None` (an honestly unattributed archive). Keeping the
+/// two in lockstep means an archive reads identically whether it came from the CLI
+/// or the RPC surface.
+async fn effective_archiver(
+    store: &Store,
+    workspace_id: &str,
+    supplied: Option<&str>,
+) -> Result<Option<ainb_hangar_core::actor::ActorRef>> {
+    use ainb_hangar_core::actor::{ActorKind, ActorRef};
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::workspace::WorkspaceRepo;
+
+    if let Some(id) = supplied.map(str::trim).filter(|s| !s.is_empty()) {
+        return Ok(ActorRef::new(ActorKind::Member, id).ok());
+    }
+    let Ok(ws) = WorkspaceId::from_str(workspace_id.to_string()) else {
+        return Ok(None);
+    };
+    let owner = WorkspaceRepo::owner_id(store.pool(), &ws)
+        .await
+        .context("resolve the workspace owner as the default archiving actor")?;
+    Ok(owner.and_then(|id| ActorRef::new(ActorKind::Member, id).ok()))
 }
 
 /// Collapse a `(clear_flag, optional_value)` pair into the store's nested-`Option`
@@ -2608,7 +2672,37 @@ async fn dispatch_squad(cmd: SquadCommand, format: OutputFormat) -> Result<()> {
         SquadCommand::AddMember(args) => run_squad_member(&store, args, true).await,
         SquadCommand::RemoveMember(args) => run_squad_member(&store, args, false).await,
         SquadCommand::Assign(args) => run_squad_assign(&store, args).await,
+        SquadCommand::Archive(args) => run_squad_set_archived(&store, args, true).await,
+        SquadCommand::Unarchive(args) => run_squad_set_archived(&store, args, false).await,
     }
+}
+
+/// `hangar squad archive|unarchive`: flip the archived flag with its audit stamp,
+/// workspace-scoped (parity #26).
+async fn run_squad_set_archived(
+    store: &Store,
+    args: SquadArchiveArgs,
+    archived: bool,
+) -> Result<()> {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::squad::SquadRepo;
+
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let by = effective_archiver(store, &workspace_id, args.by.as_deref()).await?;
+    let now = ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock);
+    let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
+    SquadRepo::set_archived(store.pool(), &ws, &args.id, archived, by.as_ref(), now)
+        .await
+        .map_err(squad_cli_err)?;
+    if archived {
+        match &by {
+            Some(actor) => println!("archived squad {} by {actor} at {now}", args.id),
+            None => println!("archived squad {} at {now} (unattributed)", args.id),
+        }
+    } else {
+        println!("un-archived squad {}", args.id);
+    }
+    Ok(())
 }
 
 /// `hangar squad list`: render the workspace's squads (name, leader, members).
@@ -2630,7 +2724,12 @@ async fn run_squad_list(store: &Store, args: SquadListArgs, format: OutputFormat
         return Ok(());
     };
     let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
-    let squads = SquadRepo::list(store.pool(), &ws).await.context("list squads")?;
+    let squads = if args.all {
+        SquadRepo::list_including_archived(store.pool(), &ws).await
+    } else {
+        SquadRepo::list(store.pool(), &ws).await
+    }
+    .context("list squads")?;
     render_squad_list(&squads, format);
     Ok(())
 }
@@ -2779,6 +2878,9 @@ fn squad_assign_cli_err(
         // gap #8: the invocation gate refused a dispatch target — no task row was
         // written. Surfaced verbatim so the CLI exits non-zero with the reason.
         e @ SquadAssignError::NotInvocable { .. } => anyhow::anyhow!("{e}"),
+        // parity #26: an archived squad refuses new work — no task row was
+        // written. Surfaced verbatim so the CLI exits non-zero with the reason.
+        e @ SquadAssignError::Archived(_) => anyhow::anyhow!("{e}"),
         db @ SquadAssignError::Db(_) => anyhow::Error::new(db).context("squad assign failed"),
     }
 }
@@ -5368,8 +5470,12 @@ fn agent_line(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     } else {
         format!("  — {}", a.description)
     };
+    // The archive audit (migration 0052) is appended only when the agent actually
+    // carries a stamp, so an ACTIVE agent — and one archived before 0052 existed —
+    // renders byte-identically to the pre-0052 line.
+    let audit = archive_audit_suffix(a.archived_at, a.archived_by.as_ref());
     format!(
-        "{}  {}{}  model={}  args={}  env={}{}",
+        "{}  {}{}  model={}  args={}  env={}{}{}",
         a.id,
         a.name,
         if a.archived { "  [archived]" } else { "" },
@@ -5377,17 +5483,36 @@ fn agent_line(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         a.cli_args.len(),
         a.agent_env.len(),
         blurb,
+        audit,
     )
 }
+
+/// Render the archive audit as a `  archived_by=<ref>@<ms>` suffix, or the EMPTY
+/// string when the row carries no timestamp (active, or archived before migration
+/// 0052). Shared by the agent and squad text lines so the two read the same.
+fn archive_audit_suffix(
+    archived_at: Option<i64>,
+    archived_by: Option<&ainb_hangar_core::actor::ActorRef>,
+) -> String {
+    match archived_at {
+        None => String::new(),
+        Some(ms) => match archived_by {
+            Some(actor) => format!("  archived_by={actor}@{ms}"),
+            None => format!("  archived_at={ms}"),
+        },
+    }
+}
 const fn agent_csv_header() -> &'static str {
-    "id,name,archived,model,thinking,args,env,description"
+    "id,name,archived,archived_at,archived_by,model,thinking,args,env,description"
 }
 fn agent_csv_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     format!(
-        "{},{},{},{},{},{},{},{}",
+        "{},{},{},{},{},{},{},{},{},{}",
         csv_field(a.id.as_str()),
         csv_field(a.name.as_str()),
         a.archived,
+        a.archived_at.map(|ms| ms.to_string()).unwrap_or_default(),
+        csv_field(&a.archived_by.as_ref().map(ToString::to_string).unwrap_or_default()),
         csv_field(a.model.as_deref().unwrap_or("")),
         csv_field(a.thinking.as_deref().unwrap_or("")),
         a.cli_args.len(),
@@ -5396,15 +5521,17 @@ fn agent_csv_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     )
 }
 const fn agent_md_header() -> &'static str {
-    "| id | name | archived | model | thinking | args | env | description |\n\
-     | --- | --- | --- | --- | --- | --- | --- | --- |\n"
+    "| id | name | archived | archived_at | archived_by | model | thinking | args | env | description |\n\
+     | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
 }
 fn agent_md_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     format!(
-        "| {} | {} | {} | {} | {} | {} | {} | {} |",
+        "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
         md_cell(a.id.as_str()),
         md_cell(a.name.as_str()),
         a.archived,
+        md_cell(&a.archived_at.map(|ms| ms.to_string()).unwrap_or_else(|| "-".to_string())),
+        md_cell(&a.archived_by.as_ref().map_or_else(|| "-".to_string(), ToString::to_string)),
         md_cell(a.model.as_deref().unwrap_or("-")),
         md_cell(a.thinking.as_deref().unwrap_or("-")),
         a.cli_args.len(),
@@ -5416,6 +5543,13 @@ fn agent_md_row(a: &ainb_hangar_store::repo::agent::Agent) -> String {
 fn agent_to_json(a: &ainb_hangar_store::repo::agent::Agent) -> String {
     let model = a.model.as_deref().map_or_else(|| "null".to_string(), json_string);
     let thinking = a.thinking.as_deref().map_or_else(|| "null".to_string(), json_string);
+    // The audit pair is `null` (not `0` / `""`) when unstamped — an honest
+    // "unknown", distinguishable from an epoch-0 archive by an unattributed actor.
+    let archived_at = a.archived_at.map_or_else(|| "null".to_string(), |ms| ms.to_string());
+    let archived_by = a
+        .archived_by
+        .as_ref()
+        .map_or_else(|| "null".to_string(), |actor| json_string(&actor.to_string()));
     let args = json_string_array(a.cli_args.iter().map(String::as_str));
     let env = a
         .agent_env
@@ -5424,10 +5558,12 @@ fn agent_to_json(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         .collect::<Vec<_>>()
         .join(",");
     format!(
-        "{{\"id\":{},\"name\":{},\"archived\":{},\"model\":{},\"thinking\":{},\"args\":{},\"env\":{{{}}},\"description\":{}}}",
+        "{{\"id\":{},\"name\":{},\"archived\":{},\"archived_at\":{},\"archived_by\":{},\"model\":{},\"thinking\":{},\"args\":{},\"env\":{{{}}},\"description\":{}}}",
         json_string(a.id.as_str()),
         json_string(a.name.as_str()),
         a.archived,
+        archived_at,
+        archived_by,
         model,
         thinking,
         args,
@@ -5517,13 +5653,16 @@ fn render_squad_list(squads: &[ainb_hangar_store::repo::squad::Squad], format: O
             println!("[{body}]");
         }
         OutputFormat::Csv => {
-            println!("id,name,leader,members");
+            println!("id,name,leader,members,archived,archived_at,archived_by");
             for s in squads {
                 println!("{}", squad_csv_row(s));
             }
         }
         OutputFormat::Markdown => {
-            print!("| id | name | leader | members |\n| --- | --- | --- | --- |\n");
+            print!(
+                "| id | name | leader | members | archived | archived_at | archived_by |\n\
+                 | --- | --- | --- | --- | --- | --- | --- |\n"
+            );
             for s in squads {
                 println!("{}", squad_md_row(s));
             }
@@ -5543,35 +5682,43 @@ fn render_squad_list(squads: &[ainb_hangar_store::repo::squad::Squad], format: O
 /// One-line text summary of a squad (id, name, leader, member actor-refs).
 fn squad_line(s: &ainb_hangar_store::repo::squad::Squad) -> String {
     format!(
-        "{}  {}  leader={}  members=[{}]",
+        "{}  {}  leader={}  members=[{}]{}{}",
         s.id,
         s.name,
         s.leader,
-        squad_members_joined(s)
+        squad_members_joined(s),
+        if s.archived { "  [archived]" } else { "" },
+        archive_audit_suffix(s.archived_at, s.archived_by.as_ref()),
     )
 }
 fn squad_csv_row(s: &ainb_hangar_store::repo::squad::Squad) -> String {
     format!(
-        "{},{},{},{}",
+        "{},{},{},{},{},{},{}",
         csv_field(&s.id),
         csv_field(&s.name),
         csv_field(&s.leader.to_string()),
         csv_field(&squad_members_joined(s)),
+        s.archived,
+        s.archived_at.map(|ms| ms.to_string()).unwrap_or_default(),
+        csv_field(&s.archived_by.as_ref().map(ToString::to_string).unwrap_or_default()),
     )
 }
 fn squad_md_row(s: &ainb_hangar_store::repo::squad::Squad) -> String {
     format!(
-        "| {} | {} | {} | {} |",
+        "| {} | {} | {} | {} | {} | {} | {} |",
         md_cell(&s.id),
         md_cell(&s.name),
         md_cell(&s.leader.to_string()),
         md_cell(&squad_members_joined(s)),
+        s.archived,
+        md_cell(&s.archived_at.map(|ms| ms.to_string()).unwrap_or_else(|| "-".to_string())),
+        md_cell(&s.archived_by.as_ref().map_or_else(|| "-".to_string(), ToString::to_string)),
     )
 }
 /// Minimal stable JSON object for one squad (id, name, leader, members array).
 fn squad_to_json(s: &ainb_hangar_store::repo::squad::Squad) -> String {
     format!(
-        "{{\"id\":{},\"name\":{},\"leader\":{},\"members\":{}}}",
+        "{{\"id\":{},\"name\":{},\"leader\":{},\"members\":{},\"archived\":{},\"archived_at\":{},\"archived_by\":{}}}",
         json_string(&s.id),
         json_string(&s.name),
         json_string(&s.leader.to_string()),
@@ -5583,6 +5730,11 @@ fn squad_to_json(s: &ainb_hangar_store::repo::squad::Squad) -> String {
                 .iter()
                 .map(String::as_str)
         ),
+        s.archived,
+        s.archived_at.map_or_else(|| "null".to_string(), |ms| ms.to_string()),
+        s.archived_by
+            .as_ref()
+            .map_or_else(|| "null".to_string(), |actor| json_string(&actor.to_string())),
     )
 }
 /// Join a squad's member actor-refs with `, ` for the flat text surfaces.

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -1100,6 +1100,151 @@ fn member_remove_rejects_removing_the_only_owner() {
     );
 }
 
+/// The user-visible proof for parity #26 (agent leg): `ainb hangar agent archive`
+/// records WHO and WHEN, both readable back through `agent list --all`. An ACTIVE
+/// agent's JSON carries `null` for both — the honest "never archived".
+#[test]
+fn agent_archive_records_the_audit_trail_readable_from_the_cli() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _) = run(
+        tmp.path(),
+        &["hangar", "issue", "create", "--title", "anchor"],
+    );
+    assert!(ok, "bootstrap create failed");
+    seed_agent(tmp.path());
+
+    // Before: an active agent reports no audit at all.
+    let (ok, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    assert!(ok, "json agent list should exit 0; out={shown}");
+    assert!(
+        shown.contains("\"archived_at\":null") && shown.contains("\"archived_by\":null"),
+        "an active agent must report a null audit pair:\n{shown}"
+    );
+
+    // Archive with an EXPLICIT actor.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "agent", "archive", "agent-1", "--by", "user-2"],
+    );
+    assert!(ok, "archive should exit 0; out={out}");
+    assert!(
+        out.contains("archived agent agent-1 by member:user-2 at "),
+        "the ack must name the archiving actor and the stamp:\n{out}"
+    );
+
+    // Both audit columns are readable back, non-null, through `--all`.
+    let (ok, shown) = run(
+        tmp.path(),
+        &["--format", "json", "hangar", "agent", "list", "--all"],
+    );
+    assert!(ok, "json agent list --all should exit 0; out={shown}");
+    assert!(
+        shown.contains("\"archived_by\":\"member:user-2\""),
+        "archived_by not persisted:\n{shown}"
+    );
+    assert!(
+        !shown.contains("\"archived_at\":null"),
+        "archived_at must be a real epoch-ms stamp, not null:\n{shown}"
+    );
+    // The text line carries the same audit, and only when stamped.
+    let (_, line) = run(tmp.path(), &["hangar", "agent", "list", "--all"]);
+    assert!(
+        line.contains("archived_by=member:user-2@"),
+        "the text line must carry the audit suffix:\n{line}"
+    );
+
+    // Restoring clears BOTH — a restored agent carries no stale attribution.
+    let (ok, _) = run(tmp.path(), &["hangar", "agent", "unarchive", "agent-1"]);
+    assert!(ok, "unarchive should exit 0");
+    let (_, shown) = run(tmp.path(), &["--format", "json", "hangar", "agent", "list"]);
+    assert!(
+        shown.contains("\"archived_at\":null") && shown.contains("\"archived_by\":null"),
+        "restore must clear the audit pair:\n{shown}"
+    );
+    let (_, line) = run(tmp.path(), &["hangar", "agent", "list"]);
+    assert!(
+        !line.contains("archived_by="),
+        "a restored agent's line carries no audit suffix:\n{line}"
+    );
+}
+
+/// The user-visible proof for parity #26 (squad leg): `ainb hangar squad archive`
+/// removes the squad from the default list, `--all` shows it with its stamp, and
+/// `unarchive` restores it.
+#[test]
+fn squad_archive_hides_it_from_list_and_records_the_audit() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_issue(tmp.path(), "Bootstrap the workspace");
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "squad",
+            "create",
+            "shippers",
+            "--leader",
+            "agent:lead-1",
+        ],
+    );
+    assert!(ok, "squad create should exit 0; out={out}");
+    let squad_id = out
+        .lines()
+        .find_map(|l| l.split('(').nth(1).and_then(|s| s.split(')').next()))
+        .expect("create output carries the squad id")
+        .to_string();
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "squad",
+            "archive",
+            &squad_id,
+            "--by",
+            "user-9",
+        ],
+    );
+    assert!(ok, "squad archive should exit 0; out={out}");
+    assert!(
+        out.contains("archived squad") && out.contains("by member:user-9 at "),
+        "the ack must name the archiving actor and the stamp:\n{out}"
+    );
+
+    // The default list is active-only.
+    let (ok, list) = run(tmp.path(), &["hangar", "squad", "list"]);
+    assert!(ok, "squad list should exit 0; out={list}");
+    assert!(
+        !list.contains("shippers"),
+        "an archived squad must leave the default list:\n{list}"
+    );
+
+    // `--all` shows it, with the archive badge and its audit stamp.
+    let (ok, all) = run(tmp.path(), &["hangar", "squad", "list", "--all"]);
+    assert!(ok, "squad list --all should exit 0; out={all}");
+    assert!(
+        all.contains("shippers")
+            && all.contains("[archived]")
+            && all.contains("archived_by=member:user-9@"),
+        "--all must show the archived squad with its audit:\n{all}"
+    );
+
+    // Restoring returns it to the default list and clears the stamp.
+    let (ok, _) = run(tmp.path(), &["hangar", "squad", "unarchive", &squad_id]);
+    assert!(ok, "squad unarchive should exit 0");
+    let (_, json) = run(
+        tmp.path(),
+        &["--format", "json", "hangar", "squad", "list"],
+    );
+    assert!(
+        json.contains("shippers")
+            && json.contains("\"archived\":false")
+            && json.contains("\"archived_at\":null")
+            && json.contains("\"archived_by\":null"),
+        "restore must return the squad active with a cleared audit:\n{json}"
+    );
+}
+
 /// The user-visible proof for e38.17: `ainb hangar squad create` + `... add-member`
 /// build a squad with a leader + members, and `ainb hangar squad list` renders the
 /// status view (squad name, leader, members) — a real-binary round-trip through

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -1196,14 +1196,7 @@ fn squad_archive_hides_it_from_list_and_records_the_audit() {
 
     let (ok, out) = run(
         tmp.path(),
-        &[
-            "hangar",
-            "squad",
-            "archive",
-            &squad_id,
-            "--by",
-            "user-9",
-        ],
+        &["hangar", "squad", "archive", &squad_id, "--by", "user-9"],
     );
     assert!(ok, "squad archive should exit 0; out={out}");
     assert!(
@@ -1232,10 +1225,7 @@ fn squad_archive_hides_it_from_list_and_records_the_audit() {
     // Restoring returns it to the default list and clears the stamp.
     let (ok, _) = run(tmp.path(), &["hangar", "squad", "unarchive", &squad_id]);
     assert!(ok, "squad unarchive should exit 0");
-    let (_, json) = run(
-        tmp.path(),
-        &["--format", "json", "hangar", "squad", "list"],
-    );
+    let (_, json) = run(tmp.path(), &["--format", "json", "hangar", "squad", "list"]);
     assert!(
         json.contains("shippers")
             && json.contains("\"archived\":false")

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4056,8 +4056,10 @@ async fn handle_agent_archive(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    let params: ainb_hangar_proto::snapshots::AgentArchiveParams =
-        parse_params(req, "{ workspace_id, agent_id, archived, archived_by_user_id? }")?;
+    let params: ainb_hangar_proto::snapshots::AgentArchiveParams = parse_params(
+        req,
+        "{ workspace_id, agent_id, archived, archived_by_user_id? }",
+    )?;
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
     let row = snapshots::agent_archive(
         pool,
@@ -4283,8 +4285,10 @@ async fn handle_squad_archive(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    let params: ainb_hangar_proto::snapshots::SquadArchiveParams =
-        parse_params(req, "{ workspace_id, squad_id, archived, archived_by_user_id? }")?;
+    let params: ainb_hangar_proto::snapshots::SquadArchiveParams = parse_params(
+        req,
+        "{ workspace_id, squad_id, archived, archived_by_user_id? }",
+    )?;
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
     let squads = snapshots::squad_archive(
         pool,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -774,6 +774,7 @@ async fn handle(
         methods::HANGAR_SQUAD_MEMBER_ADD => handle_squad_member(pool, req, true).await,
         methods::HANGAR_SQUAD_MEMBER_REMOVE => handle_squad_member(pool, req, false).await,
         methods::HANGAR_SQUAD_ASSIGN => handle_squad_assign(pool, req).await,
+        methods::HANGAR_SQUAD_ARCHIVE => handle_squad_archive(pool, req).await,
         methods::HANGAR_SQUAD_FANOUT => handle_squad_fanout(pool, req).await,
         methods::HANGAR_HEALTH => to_value(&health.snapshot(true)),
         methods::HANGAR_DAEMON_HEALTH => handle_daemon_health(pool, req, health).await,
@@ -4056,13 +4057,14 @@ async fn handle_agent_archive(
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
     let params: ainb_hangar_proto::snapshots::AgentArchiveParams =
-        parse_params(req, "{ workspace_id, agent_id, archived }")?;
+        parse_params(req, "{ workspace_id, agent_id, archived, archived_by_user_id? }")?;
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
     let row = snapshots::agent_archive(
         pool,
         ws.as_str(),
         &params.agent_id,
         params.archived,
+        params.archived_by_user_id.as_deref().map(str::trim).filter(|s| !s.is_empty()),
         SystemClock.now_ms(),
     )
     .await
@@ -4271,6 +4273,38 @@ async fn handle_squad_member(
     squads_list_value(pool, &ws).await
 }
 
+/// Dispatch `hangar/squad_archive` (parity #26): archive or un-archive one squad,
+/// recording WHO and WHEN, and answer with the refreshed ACTIVE squad list.
+///
+/// Mirrors [`handle_squad_member`]'s contract: resolve + reject a mistyped
+/// workspace, then drive the tenant-scoped flip. A `(squad_id, workspace)` pair
+/// that matches no row is a not-found error, never a cross-tenant flip.
+async fn handle_squad_archive(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::snapshots::SquadArchiveParams =
+        parse_params(req, "{ workspace_id, squad_id, archived, archived_by_user_id? }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let squads = snapshots::squad_archive(
+        pool,
+        ws.as_str(),
+        &params.squad_id,
+        params.archived,
+        params.archived_by_user_id.as_deref().map(str::trim).filter(|s| !s.is_empty()),
+        SystemClock.now_ms(),
+    )
+    .await
+    .map_err(|e| store_err(&e))?;
+    let Some(squads) = squads else {
+        return Err(invalid_params(&format!(
+            "no squad `{}` in this workspace",
+            params.squad_id
+        )));
+    };
+    to_value(&ainb_hangar_proto::snapshots::SquadsListResult { squads })
+}
+
 /// Re-read `ws`'s squads and serialize them as a
 /// [`SquadsListResult`](ainb_hangar_proto::snapshots::SquadsListResult) wire
 /// value. Shared by the three squad mutations so each answers with the same
@@ -4457,6 +4491,11 @@ fn squad_assign_err(e: &ainb_hangar_store::service::squad_assign::SquadAssignErr
         // squad path reaches this arm through `CardRunError::Squad`).
         SquadAssignError::NotInvocable { agent_id, invoker } => invalid_params(&format!(
             "agent {agent_id} is not invocable by {invoker} — it is private or you are not on its allow-list"
+        )),
+        // parity #26: an archived squad refuses new work. A client error — the
+        // operator restores the squad and re-issues.
+        SquadAssignError::Archived(id) => invalid_params(&format!(
+            "squad `{id}` is archived — restore it before assigning work"
         )),
         SquadAssignError::Db(db) => store_err(db),
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -979,9 +979,11 @@ pub async fn squad_archive(
     let by = effective_archiver(pool, workspace_id, archived_by).await?;
     match SquadRepo::set_archived(pool, &ws, squad_id, archived, by.as_ref(), now_ms).await {
         Ok(()) => {}
-        Err(SquadRepoError::NotFound) => return Ok(None),
+        // `DuplicateName` is structurally impossible here (an archive never
+        // renames), but folding it into the not-found rejection keeps a future
+        // store change from panicking a live daemon connection.
+        Err(SquadRepoError::NotFound | SquadRepoError::DuplicateName) => return Ok(None),
         Err(SquadRepoError::Db(e)) => return Err(e),
-        Err(SquadRepoError::DuplicateName) => unreachable!("archive never renames a squad"),
     }
     squads_list(pool, workspace_id).await.map(Some)
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -29,7 +29,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use ainb_hangar_core::actor::ActorRef;
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
 use ainb_hangar_core::clock::HangarClock;
 use ainb_hangar_core::idgen::IdGen;
 use ainb_hangar_core::ids::{AgentId, AutopilotId, CommentId, IssueId, SkillId, WorkspaceId};
@@ -561,6 +561,9 @@ pub async fn squads_list(
             name: s.name,
             leader: s.leader.to_string(),
             members: s.members.iter().map(ToString::to_string).collect(),
+            archived: s.archived,
+            archived_at: s.archived_at,
+            archived_by: s.archived_by.as_ref().map(ToString::to_string).unwrap_or_default(),
         })
         .collect())
 }
@@ -842,6 +845,11 @@ async fn agent_actor_row_with_counts(
         // a metadata-less agent serialises exactly as it did pre-0050.
         description: agent.description.clone(),
         avatar: agent.avatar_url.clone().unwrap_or_default(),
+        // Migration 0052 archive audit. Both are omitted from the wire when
+        // unset, so an active (or pre-0052-archived) agent serialises exactly as
+        // it did before.
+        archived_at: agent.archived_at,
+        archived_by: agent.archived_by.as_ref().map(ToString::to_string).unwrap_or_default(),
     })
 }
 
@@ -894,9 +902,13 @@ pub async fn agent_archive(
     workspace_id: &str,
     agent_id: &str,
     archived: bool,
+    archived_by: Option<&str>,
     now_ms: i64,
 ) -> Result<Option<ActorRow>, sqlx::Error> {
-    let touched = AgentRepo::set_archived(pool, workspace_id, agent_id, archived).await?;
+    let by = effective_archiver(pool, workspace_id, archived_by).await?;
+    let touched =
+        AgentRepo::set_archived(pool, workspace_id, agent_id, archived, by.as_ref(), now_ms)
+            .await?;
     if !touched {
         return Ok(None);
     }
@@ -904,6 +916,74 @@ pub async fn agent_archive(
         Some(agent) => Ok(Some(agent_actor_row(pool, &agent, now_ms).await?)),
         None => Ok(None),
     }
+}
+
+/// Resolve the actor recorded as `archived_by` (migration 0052, parity #26):
+///
+/// 1. an explicitly supplied user id (trimmed; blank counts as absent), else
+/// 2. the workspace OWNER — the single-operator default, mirroring the gap-#8
+///    invoker resolution — else
+/// 3. `None`, an honestly unattributed archive (an owner-less workspace).
+///
+/// One helper so the agent and squad handlers can never drift apart on who gets
+/// blamed for an archive.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the owner lookup fails.
+async fn effective_archiver(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    supplied: Option<&str>,
+) -> Result<Option<ActorRef>, sqlx::Error> {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::workspace::WorkspaceRepo;
+
+    if let Some(id) = supplied.map(str::trim).filter(|s| !s.is_empty()) {
+        return Ok(ActorRef::new(ActorKind::Member, id).ok());
+    }
+    let Ok(ws) = WorkspaceId::from_str(workspace_id.to_string()) else {
+        return Ok(None);
+    };
+    let owner = WorkspaceRepo::owner_id(pool, &ws).await?;
+    Ok(owner.and_then(|id| ActorRef::new(ActorKind::Member, id).ok()))
+}
+
+/// Archive or un-archive one squad, scoped to `workspace_id`, recording WHO and
+/// WHEN, then re-read the workspace's ACTIVE squads
+/// (`hangar/squad_archive`, parity #26).
+///
+/// Workspace-scoped through [`SquadRepo::set_archived`]'s tenant guard: a
+/// foreign-tenant squad id flips no row and resolves to `None` (the not-found
+/// case the caller surfaces as an error). The refreshed list is active-only, so
+/// a just-archived squad is absent from the response — which is the observable
+/// outcome the caller renders.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault or a malformed stored row.
+pub async fn squad_archive(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    squad_id: &str,
+    archived: bool,
+    archived_by: Option<&str>,
+    now_ms: i64,
+) -> Result<Option<Vec<ainb_hangar_proto::snapshots::SquadWireRow>>, sqlx::Error> {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::squad::{SquadRepo, SquadRepoError};
+
+    let Ok(ws) = WorkspaceId::from_str(workspace_id.to_string()) else {
+        return Ok(None);
+    };
+    let by = effective_archiver(pool, workspace_id, archived_by).await?;
+    match SquadRepo::set_archived(pool, &ws, squad_id, archived, by.as_ref(), now_ms).await {
+        Ok(()) => {}
+        Err(SquadRepoError::NotFound) => return Ok(None),
+        Err(SquadRepoError::Db(e)) => return Err(e),
+        Err(SquadRepoError::DuplicateName) => unreachable!("archive never renames a squad"),
+    }
+    squads_list(pool, workspace_id).await.map(Some)
 }
 
 /// A workspace member joined with its user record (for the picker row).

--- a/ainb-tui/crates/ainb-hangar-daemon/src/squad_briefing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/squad_briefing.rs
@@ -206,7 +206,7 @@ mod tests {
         let a = bootstrap::create_agent(pool, &ws_id, "scout", "claude", None).await.unwrap();
         let b = bootstrap::create_agent(pool, &ws_id, "medic", "claude", None).await.unwrap();
         let c = bootstrap::create_agent(pool, &ws_id, "ghost", "claude", None).await.unwrap();
-        AgentRepo::set_archived(pool, &ws_id, &c.id, true).await.unwrap();
+        AgentRepo::set_archived(pool, &ws_id, &c.id, true, None, 0).await.unwrap();
 
         SquadRepo::create(
             pool,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_archive_audit.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_archive_audit.rs
@@ -213,8 +213,7 @@ async fn agent_archive_defaults_the_archiver_to_the_workspace_owner() {
         .await;
     assert!(resp["error"].is_null(), "unarchive must ack: {resp}");
     assert!(
-        resp["result"].get("archived_at").is_none()
-            && resp["result"].get("archived_by").is_none(),
+        resp["result"].get("archived_at").is_none() && resp["result"].get("archived_by").is_none(),
         "a restored agent's row must omit the audit keys: {}",
         resp["result"]
     );
@@ -398,10 +397,7 @@ async fn squad_archive_rejects_an_unknown_squad() {
         "an unknown squad must be rejected: {resp}"
     );
     assert!(
-        resp["error"]["message"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("no-such-squad"),
+        resp["error"]["message"].as_str().unwrap_or_default().contains("no-such-squad"),
         "the error must name the squad: {resp}"
     );
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_archive_audit.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_archive_audit.rs
@@ -1,0 +1,418 @@
+//! Integration: the archive AUDIT trail over the real framed dispatcher
+//! (`hangar/agent_archive`, `hangar/squad_archive` — parity #26, migration 0052).
+//!
+//! What this proves end-to-end, over a real `UnixStream`, that no unit test can:
+//!
+//! 1. an archive with NO `archived_by_user_id` is attributed to the WORKSPACE
+//!    OWNER and stamped with the daemon's clock — in the database, not just the
+//!    response;
+//! 2. an explicit `archived_by_user_id` wins over that default;
+//! 3. un-archiving CLEARS both columns and the response OMITS both keys (the
+//!    append-only skip-if-unset wire contract);
+//! 4. a LEGACY client payload `{workspace_id, agent_id, archived}` still parses;
+//! 5. `hangar/squad_archive` round-trips: the archived squad disappears from
+//!    `hangar/squads_list` and the database carries who + when.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// The seeded workspace's OWNER (`seed::seed_p4_fixture`) — the default archiver.
+const SEED_OWNER: &str = "user-1";
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame_inner())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// Read the agent's stored `(archived, archived_at, archived_by)` triple — the
+/// DATABASE truth, not the response echo.
+async fn agent_audit(store: &Store, id: &str) -> (i64, Option<i64>, Option<String>) {
+    sqlx::query_as("SELECT archived, archived_at, archived_by FROM agent WHERE id = ?")
+        .bind(id)
+        .fetch_one(store.pool())
+        .await
+        .expect("read agent audit")
+}
+
+async fn squad_audit(store: &Store, id: &str) -> (i64, Option<i64>, Option<String>) {
+    sqlx::query_as("SELECT archived, archived_at, archived_by FROM squad WHERE id = ?")
+        .bind(id)
+        .fetch_one(store.pool())
+        .await
+        .expect("read squad audit")
+}
+
+/// An archive with no explicit archiver is attributed to the workspace OWNER and
+/// stamped with the daemon's clock; the acked `ActorRow` carries both. Restoring
+/// clears the columns AND omits the keys from the response.
+#[tokio::test]
+async fn agent_archive_defaults_the_archiver_to_the_workspace_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let before_ms = now_ms();
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_ARCHIVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": "agent-1",
+                "archived": true,
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "archive must ack: {resp}");
+    let after_ms = now_ms();
+
+    // (a) The DATABASE carries the audit.
+    let (archived, at, by) = agent_audit(&store, "agent-1").await;
+    assert_eq!(archived, 1);
+    assert_eq!(
+        by.as_deref(),
+        Some(&format!("member:{SEED_OWNER}")[..]),
+        "an unattributed archive defaults to the workspace owner"
+    );
+    let at = at.expect("archived_at stamped");
+    assert!(
+        (before_ms..=after_ms).contains(&at),
+        "archived_at {at} must be the daemon's clock reading, in [{before_ms}, {after_ms}]"
+    );
+
+    // (b) The acked ActorRow proves the audit on the WIRE.
+    assert_eq!(resp["result"]["archived_at"], serde_json::json!(at));
+    assert_eq!(
+        resp["result"]["archived_by"],
+        serde_json::json!(format!("member:{SEED_OWNER}"))
+    );
+
+    // (c) Restoring clears both columns AND omits both keys from the response —
+    //     the skip-if-unset half of the append-only wire contract.
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_ARCHIVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": "agent-1",
+                "archived": false,
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "unarchive must ack: {resp}");
+    assert!(
+        resp["result"].get("archived_at").is_none()
+            && resp["result"].get("archived_by").is_none(),
+        "a restored agent's row must omit the audit keys: {}",
+        resp["result"]
+    );
+    assert_eq!(agent_audit(&store, "agent-1").await, (0, None, None));
+}
+
+/// An explicit `archived_by_user_id` overrides the owner default, and a LEGACY
+/// payload without the field still parses (the serde-default proof).
+#[tokio::test]
+async fn agent_archive_honours_an_explicit_archiver_and_a_legacy_payload() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_ARCHIVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": "agent-1",
+                "archived": true,
+                "archived_by_user_id": "user-2",
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "archive must ack: {resp}");
+    let (_, _, by) = agent_audit(&store, "agent-1").await;
+    assert_eq!(
+        by.as_deref(),
+        Some("member:user-2"),
+        "an explicit archiver wins over the owner default"
+    );
+
+    // A pre-0052 client payload — no `archived_by_user_id` key at all — still
+    // parses and falls back to the owner.
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_ARCHIVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": "agent-1",
+                "archived": true,
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "legacy payload must parse: {resp}");
+    let (_, _, by) = agent_audit(&store, "agent-1").await;
+    assert_eq!(
+        by.as_deref(),
+        Some(&format!("member:{SEED_OWNER}")[..]),
+        "re-archiving re-stamps: last archiver wins"
+    );
+}
+
+/// `hangar/squad_archive` round-trip: the archived squad leaves `squads_list`,
+/// the database carries who + when, and restoring puts it back.
+#[tokio::test]
+async fn squad_archive_hides_the_squad_and_records_the_audit() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    // Create a squad through the RPC surface, then find its id.
+    let created = c
+        .call(
+            methods::HANGAR_SQUAD_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "name": "qa",
+                "leader": "agent:agent-1",
+            }),
+        )
+        .await;
+    assert!(created["error"].is_null(), "create must ack: {created}");
+    let squad_id = created["result"]["squads"]
+        .as_array()
+        .expect("squads array")
+        .iter()
+        .find(|s| s["name"] == "qa")
+        .expect("the new squad is in the refreshed list")["id"]
+        .as_str()
+        .expect("squad id")
+        .to_string();
+
+    let before_ms = now_ms();
+    let resp = c
+        .call(
+            methods::HANGAR_SQUAD_ARCHIVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "squad_id": squad_id,
+                "archived": true,
+                "archived_by_user_id": SEED_OWNER,
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "squad archive must ack: {resp}");
+    let after_ms = now_ms();
+
+    // The refreshed list in the RESPONSE is already active-only.
+    let names: Vec<&str> = resp["result"]["squads"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        !names.contains(&"qa"),
+        "the archived squad must leave the response list: {names:?}"
+    );
+
+    // …and a fresh squads_list snapshot agrees.
+    let list = c
+        .call(
+            methods::HANGAR_SQUADS_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    assert!(
+        !list["result"]["squads"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|s| s["id"] == squad_id.as_str()),
+        "the archived squad must leave squads_list: {}",
+        list["result"]
+    );
+
+    // The DATABASE carries who + when.
+    let (archived, at, by) = squad_audit(&store, &squad_id).await;
+    assert_eq!(archived, 1);
+    assert_eq!(by.as_deref(), Some(&format!("member:{SEED_OWNER}")[..]));
+    let at = at.expect("archived_at stamped");
+    assert!((before_ms..=after_ms).contains(&at), "stamp {at} in range");
+
+    // Restoring returns it to the list and clears the audit pair.
+    let resp = c
+        .call(
+            methods::HANGAR_SQUAD_ARCHIVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "squad_id": squad_id,
+                "archived": false,
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "restore must ack: {resp}");
+    assert!(
+        resp["result"]["squads"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|s| s["id"] == squad_id.as_str()),
+        "a restored squad returns to the list"
+    );
+    assert_eq!(squad_audit(&store, &squad_id).await, (0, None, None));
+}
+
+/// An unknown / foreign squad id is a client error, never a silent no-op.
+#[tokio::test]
+async fn squad_archive_rejects_an_unknown_squad() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_SQUAD_ARCHIVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "squad_id": "no-such-squad",
+                "archived": true,
+            }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "an unknown squad must be rejected: {resp}"
+    );
+    assert!(
+        resp["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("no-such-squad"),
+        "the error must name the squad: {resp}"
+    );
+}
+
+/// Wall-clock epoch ms, used to bracket the daemon's own stamp.
+fn now_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap()
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -536,6 +536,15 @@ pub struct ActorRow {
     /// unset and for members. Omitted from the wire when empty.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub avatar: String,
+    /// When the agent was archived (epoch ms, migration 0052 / parity #26);
+    /// absent for an active agent, for a member, for an archive predating 0052,
+    /// and for a pre-0052 producer. Omitted from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<i64>,
+    /// Who archived the agent, as a canonical actor-ref (migration 0052); empty
+    /// when active / unknown / unattributed. Omitted from the wire when empty.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub archived_by: String,
 }
 
 impl Default for ActorRow {
@@ -555,6 +564,8 @@ impl Default for ActorRow {
             recent_rank: None,
             description: String::new(),
             avatar: String::new(),
+            archived_at: None,
+            archived_by: String::new(),
         }
     }
 }
@@ -973,5 +984,31 @@ mod tests {
             "{out}"
         );
         assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), row);
+    }
+
+    /// The parity-#26 archive audit is APPEND-ONLY on `ActorRow`: a pre-0052
+    /// payload decodes with both fields absent, an unstamped row emits neither
+    /// key, and a stamped row round-trips verbatim.
+    #[test]
+    fn actor_row_archive_audit_is_append_only() {
+        let legacy = r#"{"actor_ref":"agent:a1","display_name":"bot","subtitle":"agent",
+            "presence":"online","is_agent":true,"recent_rank":null}"#;
+        let row: ActorRow = serde_json::from_str(legacy).expect("pre-0052 payload decodes");
+        assert_eq!(row.archived_at, None);
+        assert_eq!(row.archived_by, "");
+        let out = serde_json::to_string(&row).unwrap();
+        assert!(
+            !out.contains("archived_at") && !out.contains("archived_by"),
+            "an unstamped row must not emit the audit keys: {out}"
+        );
+
+        let stamped = ActorRow {
+            archived_at: Some(1_700_000_000_000),
+            archived_by: "member:user-1".into(),
+            ..row
+        };
+        let out = serde_json::to_string(&stamped).unwrap();
+        assert!(out.contains("\"archived_by\":\"member:user-1\""), "{out}");
+        assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), stamped);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -504,6 +504,22 @@ pub const HANGAR_SQUAD_MEMBER_REMOVE: &str = "hangar/squad_member_remove";
 /// or an unknown squad is rejected (`INVALID_PARAMS`).
 pub const HANGAR_SQUAD_ASSIGN: &str = "hangar/squad_assign";
 
+/// `hangar/squad_archive` — archive or un-archive one squad, recording WHO and
+/// WHEN (parity #26, migration 0052).
+///
+/// Params: [`crate::snapshots::SquadArchiveParams`]. Result: the refreshed
+/// [`crate::snapshots::SquadsListResult`] (ACTIVE squads only), so a caller
+/// re-renders from the response without a `squads_list` round-trip — the same
+/// envelope `squad_create` / `squad_member_*` answer with.
+///
+/// Mutating + workspace-scoped like [`HANGAR_SQUAD_CREATE`]: a squad id that does
+/// not belong to the resolved workspace is rejected with `INVALID_PARAMS`, never
+/// a cross-tenant write. Archiving removes the squad from the active list AND
+/// makes it refuse new assignments ([`HANGAR_SQUAD_ASSIGN`] /
+/// [`HANGAR_SQUAD_FANOUT`] answer `INVALID_PARAMS`); un-archiving restores it and
+/// CLEARS the audit pair.
+pub const HANGAR_SQUAD_ARCHIVE: &str = "hangar/squad_archive";
+
 /// `hangar/squad_fanout` — fan an issue out across the WHOLE squad: brief the
 /// LEADER *and* enqueue one task per distinct `agent` member, all on the same
 /// issue (P7).
@@ -1040,6 +1056,7 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_SQUAD_MEMBER_ADD,
     HANGAR_SQUAD_MEMBER_REMOVE,
     HANGAR_SQUAD_ASSIGN,
+    HANGAR_SQUAD_ARCHIVE,
     HANGAR_HEALTH,
     HANGAR_DAEMON_HEALTH,
     HANGAR_USAGE_ROLLUP,
@@ -1211,6 +1228,7 @@ mod tests {
             HANGAR_SQUAD_MEMBER_ADD,
             HANGAR_SQUAD_MEMBER_REMOVE,
             HANGAR_SQUAD_ASSIGN,
+            HANGAR_SQUAD_ARCHIVE,
             HANGAR_HEALTH,
             HANGAR_DAEMON_HEALTH,
             HANGAR_USAGE_ROLLUP,
@@ -1281,6 +1299,7 @@ mod tests {
             HANGAR_SQUAD_MEMBER_ADD,
             HANGAR_SQUAD_MEMBER_REMOVE,
             HANGAR_SQUAD_ASSIGN,
+            HANGAR_SQUAD_ARCHIVE,
             HANGAR_HEALTH,
             HANGAR_DAEMON_HEALTH,
             HANGAR_USAGE_ROLLUP,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2858,7 +2858,10 @@ mod tests {
             archived_by_user_id: Some("user-2".into()),
         };
         let s = serde_json::to_string(&full).unwrap();
-        assert_eq!(serde_json::from_str::<SquadArchiveParams>(&s).unwrap(), full);
+        assert_eq!(
+            serde_json::from_str::<SquadArchiveParams>(&s).unwrap(),
+            full
+        );
 
         // An ACTIVE squad row emits none of the three audit keys, so a pre-0052
         // consumer sees byte-identical JSON to what it saw before.

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1235,6 +1235,13 @@ pub struct AgentArchiveParams {
     pub agent_id: String,
     /// `true` archives (hides from the active picker); `false` restores.
     pub archived: bool,
+    /// The user id recorded as `archived_by` (migration 0052, parity #26).
+    /// APPEND-ONLY: omitted (`None`) defaults to the workspace OWNER — the
+    /// ordinary single-operator archive — mirroring
+    /// [`SquadAssignParams::invoker_user_id`]. An old client omits it; an old
+    /// daemon ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_by_user_id: Option<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_AGENT_DELETE`]: delete one named agent
@@ -1342,7 +1349,7 @@ pub struct MemberRemoveParams {
 /// canonical actor-ref (`member:<id>` / `agent:<id>`) — the actor a squad-assigned
 /// task routes to; `members` are the squad's member actor-refs in the same form.
 /// A pure wire row.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct SquadWireRow {
     /// The squad's id (`squad.id`) — what `squad_member_add`/`remove` key off.
     pub id: String,
@@ -1353,6 +1360,40 @@ pub struct SquadWireRow {
     pub leader: String,
     /// The squad's member actor-refs (`member:<id>` / `agent:<id>`), ordered.
     pub members: Vec<String>,
+    /// `true` when the squad is archived (migration 0052, parity #26).
+    /// APPEND-ONLY: absent on the wire when `false`, so a pre-0052 producer's
+    /// payload still parses and a consumer sees the active default.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub archived: bool,
+    /// When the squad was archived (epoch ms), absent when active / unstamped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<i64>,
+    /// Who archived the squad, as a canonical actor-ref; empty when unknown.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub archived_by: String,
+}
+
+/// Params for [`crate::methods::HANGAR_SQUAD_ARCHIVE`] (parity #26): archive or
+/// un-archive one squad, recording who + when.
+///
+/// `workspace_id` is the tenant-isolation guard — the daemon resolves it and
+/// scopes the flip by `(squad_id, workspace_id)` so a foreign-tenant squad id
+/// archives nothing. `archived: true` removes the squad from the active list and
+/// makes it refuse new assignments; `false` restores it and CLEARS the audit
+/// pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SquadArchiveParams {
+    /// The subscribed workspace the squad must belong to (tenant guard).
+    pub workspace_id: String,
+    /// The squad to (un)archive (`squad.id`).
+    pub squad_id: String,
+    /// `true` archives; `false` restores.
+    pub archived: bool,
+    /// The user id recorded as `archived_by`. APPEND-ONLY: omitted (`None`)
+    /// defaults to the workspace OWNER, same resolution as
+    /// [`AgentArchiveParams::archived_by_user_id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_by_user_id: Option<String>,
 }
 
 /// Result of [`crate::methods::HANGAR_SQUADS_LIST`] and the refreshed view the
@@ -2776,11 +2817,76 @@ mod tests {
             workspace_id: "ws-1".into(),
             agent_id: "agent-1".into(),
             archived: true,
+            archived_by_user_id: Some("user-2".into()),
         };
         let s = serde_json::to_string(&params).unwrap();
         assert_eq!(
             serde_json::from_str::<AgentArchiveParams>(&s).unwrap(),
             params
+        );
+    }
+
+    /// The parity-#26 archive-audit fields are APPEND-ONLY on the wire: a LEGACY
+    /// payload without them still parses (defaulting to "unattributed"), and a
+    /// value-less row does not emit the keys — so an old peer's shape is
+    /// unchanged in both directions.
+    #[test]
+    fn archive_audit_fields_are_append_only_on_the_wire() {
+        // A pre-0052 client payload (no `archived_by_user_id`) still parses.
+        let legacy = r#"{"workspace_id":"ws-1","agent_id":"agent-1","archived":true}"#;
+        let p: AgentArchiveParams = serde_json::from_str(legacy).unwrap();
+        assert_eq!(
+            p.archived_by_user_id, None,
+            "an omitted archiver defaults to None (the daemon then falls back to the owner)"
+        );
+        assert!(
+            !serde_json::to_string(&p).unwrap().contains("archived_by_user_id"),
+            "an unset archiver is not emitted"
+        );
+
+        // The squad params carry the same append-only field.
+        let legacy = r#"{"workspace_id":"ws-1","squad_id":"s1","archived":true}"#;
+        let p: SquadArchiveParams = serde_json::from_str(legacy).unwrap();
+        assert_eq!(p.archived_by_user_id, None);
+        assert!(p.archived);
+
+        // A round-trip with the field present preserves it.
+        let full = SquadArchiveParams {
+            workspace_id: "ws-1".into(),
+            squad_id: "s1".into(),
+            archived: true,
+            archived_by_user_id: Some("user-2".into()),
+        };
+        let s = serde_json::to_string(&full).unwrap();
+        assert_eq!(serde_json::from_str::<SquadArchiveParams>(&s).unwrap(), full);
+
+        // An ACTIVE squad row emits none of the three audit keys, so a pre-0052
+        // consumer sees byte-identical JSON to what it saw before.
+        let active = SquadWireRow {
+            id: "s1".into(),
+            name: "alpha".into(),
+            leader: "agent:a-lead".into(),
+            ..SquadWireRow::default()
+        };
+        let s = serde_json::to_string(&active).unwrap();
+        for key in ["archived", "archived_at", "archived_by"] {
+            assert!(!s.contains(key), "active row must not emit `{key}`: {s}");
+        }
+
+        // An ARCHIVED row carries all three, and a legacy payload without them
+        // parses back to the active default.
+        let archived = SquadWireRow {
+            archived: true,
+            archived_at: Some(1_700_000_000_000),
+            archived_by: "member:user-1".into(),
+            ..active.clone()
+        };
+        let s = serde_json::to_string(&archived).unwrap();
+        assert_eq!(serde_json::from_str::<SquadWireRow>(&s).unwrap(), archived);
+        let legacy_row = r#"{"id":"s1","name":"alpha","leader":"agent:a-lead","members":[]}"#;
+        assert_eq!(
+            serde_json::from_str::<SquadWireRow>(legacy_row).unwrap(),
+            active
         );
     }
 
@@ -2873,6 +2979,7 @@ mod tests {
                 name: "alpha".into(),
                 leader: "agent:a-lead".into(),
                 members: vec!["agent:a-1".into(), "member:u-1".into()],
+                ..SquadWireRow::default()
             }],
         };
         let s = serde_json::to_string(&list).unwrap();

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0052_archive_audit.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0052_archive_audit.sql
@@ -1,0 +1,46 @@
+-- Hangar v1 schema, migration 0052: archive AUDIT TRAIL on agent + squad.
+--
+-- Multica parity (gap #26): migration 031 (agent.archived_at / archived_by) and
+-- 085 (the same pair on squad). Before this migration hangar recorded THAT an
+-- agent was archived (0015's `agent.archived` 0/1) but never WHO or WHEN, and
+-- could not archive a squad at all.
+--
+-- DEVIATION (D1): `agent.archived` stays the AUTHORITATIVE discriminant.
+-- Multica treats `archived_at IS NOT NULL` as the archived truth; here the 0/1
+-- flag is already load-bearing in `list_by_workspace`, `runtime_agent_ids`,
+-- `squad_briefing`, `bootstrap` and `search`. Re-basing truth on a nullable
+-- column would be a large unrelated refactor AND would silently reclassify every
+-- legacy `archived = 1` row (whose `archived_at` is NULL). `archived_at` /
+-- `archived_by` are the audit SIDECAR. `squad` gets the same shape for symmetry.
+--
+-- DEVIATION (D2): `archived_by` is TEXT holding a canonical ACTOR-REF
+-- (`member:<user.id>` / `agent:<id>`), not a `user(id)` FK. This is hangar's
+-- polymorphic-actor convention (`comment.author`, `issue.reporter`), and a squad
+-- or agent may in future be archived by an automation actor. FK-less by design,
+-- matching `squad.leader_id`.
+--
+-- DEVIATION (D3): archiving stays IDEMPOTENT (multica answers 409 on an
+-- already-archived agent). Re-archiving RE-STAMPS `archived_at` / `archived_by`
+-- (last-archiver wins), which is still an honest audit record, and preserves the
+-- existing `AgentRepo::set_archived` contract.
+--
+-- NO BACKFILL. A pre-0052 `agent.archived = 1` row keeps `archived_at IS NULL`
+-- and `archived_by IS NULL` — an honest "unknown", never a fabricated `now()`
+-- stamp for a historical archive. There is deliberately NO CHECK tying
+-- `archived = 1` to a non-null `archived_at`, precisely because legacy rows
+-- would violate it.
+--
+-- All five statements are `ALTER TABLE ... ADD COLUMN` with constant defaults →
+-- O(1) catalog changes in SQLite (no table rewrite), safe on a populated DB, the
+-- same shape 0047/0050/0051 used.
+--
+-- `archived_at` is epoch MILLISECONDS (`HangarClock::now_ms`), matching every
+-- other hangar timestamp column (`squad.created_at`, `task.*_at`).
+
+ALTER TABLE agent ADD COLUMN archived_at INTEGER;
+ALTER TABLE agent ADD COLUMN archived_by TEXT;
+
+ALTER TABLE squad ADD COLUMN archived INTEGER NOT NULL DEFAULT 0
+    CHECK (archived IN (0, 1));
+ALTER TABLE squad ADD COLUMN archived_at INTEGER;
+ALTER TABLE squad ADD COLUMN archived_by TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -406,6 +406,9 @@ pub async fn create_agent_from(
         permission_mode: "private".to_string(),
         owner_id,
         archived: false,
+        // Never archived, so there is nothing to attribute (migration 0052).
+        archived_at: None,
+        archived_by: None,
         model: draft.model,
         cli_args: Vec::new(),
         mcp_config: None,

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -24,6 +24,7 @@
 //! are nullable TEXT carried as `Option<String>`. **Persistence only** — the
 //! provider EXEC consumption of these knobs is a separate bead (e38.16).
 
+use ainb_hangar_core::actor::ActorRef;
 use ainb_hangar_core::skill::SkillName;
 use sqlx::SqlitePool;
 
@@ -64,8 +65,19 @@ pub struct Agent {
     /// Owning user (`user.id`).
     pub owner_id: String,
     /// `true` when the agent is archived (hidden from the active picker). The
-    /// schema stores this as a 0/1 INTEGER (migration 0015).
+    /// schema stores this as a 0/1 INTEGER (migration 0015). This flag — NOT
+    /// [`archived_at`](Self::archived_at) — is the authoritative discriminant.
     pub archived: bool,
+    /// When the agent was archived (epoch ms, migration 0052), or `None` when the
+    /// agent is active — or when it was archived BEFORE 0052 existed. That second
+    /// case is an honest unknown; a historical archive is never given a
+    /// fabricated timestamp.
+    pub archived_at: Option<i64>,
+    /// Who archived the agent, as a canonical actor-ref (migration 0052), or
+    /// `None` when the agent is active / the archive predates 0052 / the archive
+    /// was unattributed. A malformed stored value decodes to `None` rather than
+    /// failing the whole read.
+    pub archived_by: Option<ActorRef>,
     /// Optional provider model override (e.g. `claude-opus-4`); `None` = the
     /// runtime's provider default.
     pub model: Option<String>,
@@ -138,6 +150,8 @@ impl Default for Agent {
             permission_mode: "private".to_string(),
             owner_id: String::new(),
             archived: false,
+            archived_at: None,
+            archived_by: None,
             model: None,
             cli_args: Vec::new(),
             mcp_config: None,
@@ -557,8 +571,18 @@ impl AgentRepo {
         Ok(res.rows_affected() == 1)
     }
 
-    /// Set (or clear) one agent's `archived` flag, scoped to a workspace
-    /// (e38.15).
+    /// Set (or clear) one agent's `archived` flag **and its audit trail**, scoped
+    /// to a workspace (e38.15; audit trail = migration 0052, multica gap #26).
+    ///
+    /// There is deliberately no audit-less archive path: `by` (the archiving
+    /// actor, `None` = unattributed) and `now_ms` are required parameters, so a
+    /// caller cannot flip the flag without deciding what to record.
+    ///
+    /// - archiving (`archived = true`) STAMPS `archived_at = now_ms` and
+    ///   `archived_by = by`. Re-archiving RE-stamps: last archiver wins, which is
+    ///   still an honest record of the most recent archive action.
+    /// - un-archiving (`archived = false`) CLEARS both audit columns (multica
+    ///   `RestoreAgent` parity) — a restored agent carries no stale stamp.
     ///
     /// Workspace-scoped at the SQL boundary: an agent id from another tenant
     /// matches no row and flips nothing. Returns `true` when exactly one row was
@@ -575,13 +599,20 @@ impl AgentRepo {
         workspace_id: &str,
         id: &str,
         archived: bool,
+        by: Option<&ActorRef>,
+        now_ms: i64,
     ) -> Result<bool, sqlx::Error> {
-        let res = sqlx::query("UPDATE agent SET archived = ? WHERE id = ? AND workspace_id = ?")
-            .bind(i64::from(archived))
-            .bind(id)
-            .bind(workspace_id)
-            .execute(pool)
-            .await?;
+        let res = sqlx::query(
+            "UPDATE agent SET archived = ?, archived_at = ?, archived_by = ? \
+             WHERE id = ? AND workspace_id = ?",
+        )
+        .bind(i64::from(archived))
+        .bind(archived.then_some(now_ms))
+        .bind(archived.then(|| by.map(ToString::to_string)).flatten())
+        .bind(id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
         Ok(res.rows_affected() == 1)
     }
 
@@ -887,7 +918,7 @@ fn is_foreign_key_violation(e: &sqlx::Error) -> bool {
 const SELECT_COLS: &str = "SELECT id, workspace_id, name, runtime_id, instructions, visibility, \
      permission_mode, owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, \
      provider, token_budget, description, avatar_url, kind, system_key, service_tier, \
-     disabled_runtime_skills FROM agent";
+     disabled_runtime_skills, archived_at, archived_by FROM agent";
 
 /// Serialize a CLI-args list into the JSON-array text the `cli_args` column
 /// stores. An empty list yields `"[]"` (the column default).
@@ -1101,6 +1132,10 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Agent {
             disabled_runtime_skills: disabled_runtime_skills_from_json(
                 &row.try_get::<String, _>("disabled_runtime_skills")?,
             ),
+            archived_at: row.try_get("archived_at")?,
+            archived_by: row
+                .try_get::<Option<String>, _>("archived_by")?
+                .and_then(|s| s.parse::<ActorRef>().ok()),
         })
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
@@ -441,13 +441,12 @@ impl SquadRepo {
         workspace: &WorkspaceId,
         squad_id: &str,
     ) -> Result<bool, sqlx::Error> {
-        let archived: Option<i64> = sqlx::query_scalar(
-            "SELECT archived FROM squad WHERE id = ? AND workspace_id = ?",
-        )
-        .bind(squad_id)
-        .bind(workspace.as_str())
-        .fetch_optional(pool)
-        .await?;
+        let archived: Option<i64> =
+            sqlx::query_scalar("SELECT archived FROM squad WHERE id = ? AND workspace_id = ?")
+                .bind(squad_id)
+                .bind(workspace.as_str())
+                .fetch_optional(pool)
+                .await?;
         Ok(archived.is_some_and(|a| a != 0))
     }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
@@ -56,6 +56,17 @@ pub struct Squad {
     pub leader: ActorRef,
     /// The squad's member actor-refs (may be empty), ordered by `(type, id)`.
     pub members: Vec<ActorRef>,
+    /// `true` when the squad is archived (migration 0052). Archived squads leave
+    /// [`SquadRepo::list`] and refuse new assignments. This flag — not
+    /// [`archived_at`](Self::archived_at) — is the authoritative discriminant.
+    pub archived: bool,
+    /// When the squad was archived (epoch ms), or `None` when active / archived
+    /// without attribution. Never fabricated for a historical archive.
+    pub archived_at: Option<i64>,
+    /// Who archived the squad, as a canonical actor-ref, or `None` when active /
+    /// unattributed. A malformed stored value decodes to `None` rather than
+    /// failing the read.
+    pub archived_by: Option<ActorRef>,
 }
 
 /// Stateless typed wrapper over the `squad` + `squad_member` tables.
@@ -163,7 +174,13 @@ impl SquadRepo {
         Ok(())
     }
 
-    /// List every squad of `workspace` with its members, ordered by name.
+    /// List the **active** (non-archived) squads of `workspace` with their
+    /// members, ordered by name (multica `ListSquads` parity, migration 0052).
+    ///
+    /// Archived squads are deliberately excluded — use
+    /// [`list_including_archived`](Self::list_including_archived) for the audit
+    /// view. Behavioural no-op on pre-0052 data: every existing row defaults to
+    /// `archived = 0`.
     ///
     /// Workspace-scoped: a foreign / unknown workspace yields an empty vec, never
     /// another tenant's squads. Each squad's `members` are ordered by
@@ -176,14 +193,38 @@ impl SquadRepo {
         pool: &SqlitePool,
         workspace: &WorkspaceId,
     ) -> Result<Vec<Squad>, sqlx::Error> {
+        Self::list_where(pool, workspace, true).await
+    }
+
+    /// List EVERY squad of `workspace` — active and archived — with its members,
+    /// ordered by name (the audit / `--all` read path). Mirrors
+    /// [`AgentRepo::list_by_workspace_including_archived`](crate::repo::agent::AgentRepo::list_by_workspace_including_archived).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if a query or actor-ref decode fails.
+    pub async fn list_including_archived(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+    ) -> Result<Vec<Squad>, sqlx::Error> {
+        Self::list_where(pool, workspace, false).await
+    }
+
+    /// Shared body of [`list`](Self::list) / [`list_including_archived`](Self::list_including_archived).
+    async fn list_where(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        active_only: bool,
+    ) -> Result<Vec<Squad>, sqlx::Error> {
         use sqlx::Row;
-        let squad_rows = sqlx::query(
-            "SELECT id, name, leader_type, leader_id FROM squad \
-             WHERE workspace_id = ? ORDER BY name, id",
-        )
-        .bind(workspace.as_str())
-        .fetch_all(pool)
-        .await?;
+        let sql = if active_only {
+            "SELECT id, name, leader_type, leader_id, archived, archived_at, archived_by \
+             FROM squad WHERE workspace_id = ? AND archived = 0 ORDER BY name, id"
+        } else {
+            "SELECT id, name, leader_type, leader_id, archived, archived_at, archived_by \
+             FROM squad WHERE workspace_id = ? ORDER BY name, id"
+        };
+        let squad_rows = sqlx::query(sql).bind(workspace.as_str()).fetch_all(pool).await?;
 
         let mut squads = Vec::with_capacity(squad_rows.len());
         for r in &squad_rows {
@@ -211,6 +252,9 @@ impl SquadRepo {
                 name: r.try_get("name")?,
                 leader,
                 members,
+                archived: r.try_get::<i64, _>("archived")? != 0,
+                archived_at: r.try_get("archived_at")?,
+                archived_by: decode_archiver(r.try_get::<Option<String>, _>("archived_by")?),
             });
         }
         Ok(squads)
@@ -239,8 +283,8 @@ impl SquadRepo {
     ) -> Result<Option<Squad>, sqlx::Error> {
         use sqlx::Row;
         let Some(r) = sqlx::query(
-            "SELECT id, name, leader_type, leader_id FROM squad \
-             WHERE id = ? AND workspace_id = ?",
+            "SELECT id, name, leader_type, leader_id, archived, archived_at, archived_by \
+             FROM squad WHERE id = ? AND workspace_id = ?",
         )
         .bind(squad_id)
         .bind(workspace.as_str())
@@ -274,6 +318,9 @@ impl SquadRepo {
             name: r.try_get("name")?,
             leader,
             members,
+            archived: r.try_get::<i64, _>("archived")? != 0,
+            archived_at: r.try_get("archived_at")?,
+            archived_by: decode_archiver(r.try_get::<Option<String>, _>("archived_by")?),
         }))
     }
 
@@ -340,6 +387,70 @@ impl SquadRepo {
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
+    /// Set (or clear) one squad's `archived` flag **and its audit trail**
+    /// (migration 0052, multica gap #26 / `DeleteSquad` soft-delete parity).
+    ///
+    /// Same stamp/clear semantics as
+    /// [`AgentRepo::set_archived`](crate::repo::agent::AgentRepo::set_archived):
+    /// archiving stamps `(archived_at = now_ms, archived_by = by)` and re-archiving
+    /// re-stamps (last archiver wins); un-archiving CLEARS both so a restored squad
+    /// carries no stale attribution.
+    ///
+    /// Workspace-scoped through the shared [`ensure_squad_in_ws`](Self::ensure_squad_in_ws)
+    /// guard: a squad id from another tenant is a [`SquadRepoError::NotFound`],
+    /// never a cross-tenant write.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SquadRepoError::NotFound`] when the squad is not in `workspace`,
+    /// or [`SquadRepoError::Db`] on a store failure.
+    pub async fn set_archived(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        squad_id: &str,
+        archived: bool,
+        by: Option<&ActorRef>,
+        now_ms: i64,
+    ) -> Result<(), SquadRepoError> {
+        let mut tx = pool.begin().await?;
+        Self::ensure_squad_in_ws(&mut tx, workspace, squad_id).await?;
+        sqlx::query(
+            "UPDATE squad SET archived = ?, archived_at = ?, archived_by = ? \
+             WHERE id = ? AND workspace_id = ?",
+        )
+        .bind(i64::from(archived))
+        .bind(archived.then_some(now_ms))
+        .bind(archived.then(|| by.map(ToString::to_string)).flatten())
+        .bind(squad_id)
+        .bind(workspace.as_str())
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Whether `squad_id` is archived within `workspace` — the single-scalar read
+    /// the assignment guard uses. An unknown / foreign-tenant id reads `false`
+    /// (the caller's own not-found path then fires, so this never masks it).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn is_archived(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        squad_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let archived: Option<i64> = sqlx::query_scalar(
+            "SELECT archived FROM squad WHERE id = ? AND workspace_id = ?",
+        )
+        .bind(squad_id)
+        .bind(workspace.as_str())
+        .fetch_optional(pool)
+        .await?;
+        Ok(archived.is_some_and(|a| a != 0))
+    }
+
     /// Confirm `squad_id` belongs to `workspace` inside `tx`, erroring with
     /// [`SquadRepoError::NotFound`] otherwise (the tenant guard the member
     /// mutations share).
@@ -368,6 +479,14 @@ fn decode_actor(kind: &str, id: &str) -> Result<ActorRef, sqlx::Error> {
     format!("{kind}:{id}")
         .parse::<ActorRef>()
         .map_err(|e| sqlx::Error::Decode(Box::new(e)))
+}
+
+/// Decode the stored `archived_by` cell into a typed [`ActorRef`], TOLERANTLY: a
+/// malformed value degrades to `None` (an unattributed archive) rather than
+/// failing the whole squad read. The audit sidecar must never make a squad
+/// unreadable.
+fn decode_archiver(raw: Option<String>) -> Option<ActorRef> {
+    raw.and_then(|s| s.parse::<ActorRef>().ok())
 }
 
 /// Whether a `sqlx` error is a `SQLite` UNIQUE-constraint violation (the

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
@@ -269,6 +269,10 @@ impl SquadRepo {
     /// off this: a `None` return = skip injection silently (no stale briefing),
     /// mirroring multica's dangling-`squad_id` guard.
     ///
+    /// Unlike [`list`](Self::list) this does NOT filter archived squads: an
+    /// archived squad must stay resolvable so an audit read can show its stamp and
+    /// the reject-assignment guard can name it (migration 0052).
+    ///
     /// Reuses the same [`decode_actor`] + `(member_type, member_id)` ordering as
     /// [`list`](Self::list), just filtered to the one id (an id-keyed single-row
     /// read + one member sub-select, not an O(squads) scan).

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -1346,9 +1346,16 @@ mod tests {
         SquadRepo::create(pool, &ws("ws-a"), "s1", "alpha", &agent_ref("a-lead"), 1)
             .await
             .unwrap();
-        SquadRepo::set_archived(pool, &ws("ws-a"), "s1", true, Some(&member_ref("user-1")), 5_000)
-            .await
-            .unwrap();
+        SquadRepo::set_archived(
+            pool,
+            &ws("ws-a"),
+            "s1",
+            true,
+            Some(&member_ref("user-1")),
+            5_000,
+        )
+        .await
+        .unwrap();
 
         let err = SquadAssignService::assign_to_leader(
             pool,
@@ -1364,11 +1371,17 @@ mod tests {
             matches!(err, SquadAssignError::Archived(ref id) if id == "s1"),
             "got {err:?}"
         );
-        assert_eq!(queue_len(pool).await, 0, "an archived squad enqueues nothing");
+        assert_eq!(
+            queue_len(pool).await,
+            0,
+            "an archived squad enqueues nothing"
+        );
 
         // Restoring it makes the same assignment succeed — the guard is the only
         // thing that refused, not a broken fixture.
-        SquadRepo::set_archived(pool, &ws("ws-a"), "s1", false, None, 6_000).await.unwrap();
+        SquadRepo::set_archived(pool, &ws("ws-a"), "s1", false, None, 6_000)
+            .await
+            .unwrap();
         SquadAssignService::assign_to_leader(
             pool,
             &ws("ws-a"),
@@ -1396,11 +1409,22 @@ mod tests {
         SquadRepo::create(pool, &ws("ws-a"), "s1", "alpha", &agent_ref("a-lead"), 1)
             .await
             .unwrap();
-        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent_ref("a-m1")).await.unwrap();
-        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent_ref("a-m2")).await.unwrap();
-        SquadRepo::set_archived(pool, &ws("ws-a"), "s1", true, Some(&member_ref("user-1")), 5_000)
+        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent_ref("a-m1"))
             .await
             .unwrap();
+        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent_ref("a-m2"))
+            .await
+            .unwrap();
+        SquadRepo::set_archived(
+            pool,
+            &ws("ws-a"),
+            "s1",
+            true,
+            Some(&member_ref("user-1")),
+            5_000,
+        )
+        .await
+        .unwrap();
 
         let err = SquadAssignService::assign_fanout(
             pool,

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -1332,4 +1332,98 @@ mod tests {
         );
         assert_eq!(queue_len(pool).await, 0, "no task row for a refused assign");
     }
+
+    /// An ARCHIVED squad refuses a leader assignment and writes NO task row
+    /// (migration 0052, multica `DeleteSquad` parity). The no-write half is the
+    /// point: the guard runs pre-flight, so the flag is not merely cosmetic.
+    #[tokio::test]
+    async fn assign_to_leader_refuses_an_archived_squad_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_agent(pool, "ws-a", "a-lead", "rt-lead").await;
+        SquadRepo::create(pool, &ws("ws-a"), "s1", "alpha", &agent_ref("a-lead"), 1)
+            .await
+            .unwrap();
+        SquadRepo::set_archived(pool, &ws("ws-a"), "s1", true, Some(&member_ref("user-1")), 5_000)
+            .await
+            .unwrap();
+
+        let err = SquadAssignService::assign_to_leader(
+            pool,
+            &ws("ws-a"),
+            "s1",
+            &SquadAssignRequest::default(),
+            &FixedIdGen::new(vec!["task-1".to_string()]),
+            &FixedClock(9_000),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, SquadAssignError::Archived(ref id) if id == "s1"),
+            "got {err:?}"
+        );
+        assert_eq!(queue_len(pool).await, 0, "an archived squad enqueues nothing");
+
+        // Restoring it makes the same assignment succeed — the guard is the only
+        // thing that refused, not a broken fixture.
+        SquadRepo::set_archived(pool, &ws("ws-a"), "s1", false, None, 6_000).await.unwrap();
+        SquadAssignService::assign_to_leader(
+            pool,
+            &ws("ws-a"),
+            "s1",
+            &SquadAssignRequest::default(),
+            &FixedIdGen::new(vec!["task-1".to_string()]),
+            &FixedClock(9_000),
+        )
+        .await
+        .expect("a restored squad accepts work again");
+        assert_eq!(queue_len(pool).await, 1);
+    }
+
+    /// The same guard on the FAN-OUT path: an archived squad enqueues neither the
+    /// leader brief nor any member task.
+    #[tokio::test]
+    async fn assign_fanout_refuses_an_archived_squad_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_agent(pool, "ws-a", "a-lead", "rt-lead").await;
+        seed_agent(pool, "ws-a", "a-m1", "rt-m1").await;
+        seed_agent(pool, "ws-a", "a-m2", "rt-m2").await;
+        SquadRepo::create(pool, &ws("ws-a"), "s1", "alpha", &agent_ref("a-lead"), 1)
+            .await
+            .unwrap();
+        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent_ref("a-m1")).await.unwrap();
+        SquadRepo::add_member(pool, &ws("ws-a"), "s1", &agent_ref("a-m2")).await.unwrap();
+        SquadRepo::set_archived(pool, &ws("ws-a"), "s1", true, Some(&member_ref("user-1")), 5_000)
+            .await
+            .unwrap();
+
+        let err = SquadAssignService::assign_fanout(
+            pool,
+            &ws("ws-a"),
+            "s1",
+            &SquadAssignRequest::default(),
+            &FixedIdGen::new(vec![
+                "task-1".to_string(),
+                "task-2".to_string(),
+                "task-3".to_string(),
+            ]),
+            &FixedClock(9_000),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, SquadAssignError::Archived(ref id) if id == "s1"),
+            "got {err:?}"
+        );
+        assert_eq!(
+            queue_len(pool).await,
+            0,
+            "neither the leader brief nor any member task was written"
+        );
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -122,6 +122,11 @@ pub enum SquadAssignError {
         /// has no `owner`-role member to fall back to).
         invoker: String,
     },
+    /// The squad is ARCHIVED, so it refuses new work (migration 0052, multica
+    /// `DeleteSquad` soft-delete parity). The guard runs in the pre-flight resolve
+    /// phase, so NO task row is written — restore the squad to assign to it again.
+    #[error("squad `{0}` is archived — restore it before assigning work")]
+    Archived(String),
     /// An underlying store failure (resolve, lookup, or enqueue).
     #[error(transparent)]
     Db(#[from] sqlx::Error),
@@ -175,6 +180,8 @@ impl SquadAssignService {
     ///
     /// # Errors
     ///
+    /// - [`SquadAssignError::Archived`] when the squad is archived — no task row
+    ///   is written.
     /// - [`SquadAssignError::NoAgentLeader`] when the squad is unknown in the
     ///   workspace or its leader is a human `member`.
     /// - [`SquadAssignError::LeaderAgentMissing`] when the leader agent row is
@@ -193,6 +200,12 @@ impl SquadAssignService {
         idgen: &dyn IdGen,
         clock: &dyn HangarClock,
     ) -> Result<SquadAssignment, SquadAssignError> {
+        // 0. An ARCHIVED squad refuses new work (migration 0052). Checked FIRST,
+        //    in the pre-flight phase, so no task row is written.
+        if SquadRepo::is_archived(pool, workspace, squad_id).await? {
+            return Err(SquadAssignError::Archived(squad_id.to_string()));
+        }
+
         // 1. Resolve the squad to its leader's agent id — the routing seam. A
         //    human-member leader (or unknown squad) resolves to `None`: there is
         //    no agent to dispatch to, so the assignment is rejected.
@@ -273,6 +286,8 @@ impl SquadAssignService {
     ///
     /// # Errors
     ///
+    /// - [`SquadAssignError::Archived`] when the squad is archived — the whole
+    ///   fan-out is refused with zero rows written.
     /// - [`SquadAssignError::NoAgentLeader`] / [`SquadAssignError::LeaderAgentMissing`]
     ///   from the leader brief (an unknown squad, a human leader, a dangling
     ///   leader ref).
@@ -295,6 +310,12 @@ impl SquadAssignService {
         // of leaving the leader (and earlier members) queued. Nothing is inserted
         // until all targets are known-good; then every insert lands in ONE
         // transaction (all-or-nothing).
+
+        // 0. An ARCHIVED squad refuses new work (migration 0052), before any
+        //    resolution and well before `pool.begin()`.
+        if SquadRepo::is_archived(pool, workspace, squad_id).await? {
+            return Err(SquadAssignError::Archived(squad_id.to_string()));
+        }
 
         // 1. Resolve the squad's leader agent — the routing seam. A human-member
         //    leader or unknown squad resolves to `None` and is rejected. The

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0052_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0052_upgrade.rs
@@ -1,0 +1,206 @@
+//! Upgrade-from-populated test for migration 0052 (the archive AUDIT trail on
+//! `agent` + `squad`, multica gap #26).
+//!
+//! Fresh-database column coverage lives in `tripwire_migrations_apply.rs`. This
+//! file proves the migration is safe on a REAL populated database — the state
+//! every upgrading install carries:
+//!
+//! 1. apply only the PRIOR migrations (0001..0051),
+//! 2. seed an agent that is ALREADY archived and a squad, through raw inserts
+//!    that predate the audit columns entirely,
+//! 3. apply the embedded migrations (which adds 0052),
+//! 4. assert the legacy archived agent STILL reads `archived = true` with NULL
+//!    audit columns (no fabricated stamp, no silent reclassification), the
+//!    legacy squad reads `archived = false` and is still listed, and a fresh
+//!    archive then stamps both columns.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_store::apply_migrations;
+use ainb_hangar_store::repo::agent::AgentRepo;
+use ainb_hangar_store::repo::squad::SquadRepo;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test (`0052_archive_audit.sql`).
+const NEW_MIGRATION_VERSION: i64 = 52;
+
+/// A fixed epoch-ms stamp so the assertions are exact rather than "roughly now".
+const STAMP_MS: i64 = 1_700_000_000_000;
+
+/// Open a fresh on-disk WAL pool in `dir` and apply only the migrations PRIOR to
+/// [`NEW_MIGRATION_VERSION`], reproducing the schema an existing install runs
+/// before upgrading.
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let db_path = dir.join("hangar.db");
+    let opts = SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(
+        !migrator.migrations.is_empty(),
+        "prior-migration set must not be empty"
+    );
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+/// Seed workspace → user → runtime → an ALREADY-ARCHIVED agent → a squad,
+/// through raw inserts, i.e. exactly the row shape a pre-0052 install holds.
+async fn seed_legacy_archived(pool: &SqlitePool) {
+    sqlx::query(
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','ws-1','ws-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('user-1','a@x.com',0)")
+        .execute(pool)
+        .await
+        .expect("insert user");
+    sqlx::query(
+        "INSERT INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status) \
+         VALUES ('rt-1','ws-1','d-1','claude','local',0,'online')",
+    )
+    .execute(pool)
+    .await
+    .expect("insert runtime");
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id, archived) \
+         VALUES ('ag-1','ws-1','Retired','rt-1','workspace','user-1',1)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert archived agent");
+    sqlx::query(
+        "INSERT INTO squad (id, workspace_id, name, leader_type, leader_id, created_at) \
+         VALUES ('sq-1','ws-1','alpha','agent','ag-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert squad");
+}
+
+fn ws() -> WorkspaceId {
+    WorkspaceId::from_str("ws-1".to_string()).unwrap()
+}
+
+/// The load-bearing upgrade proof: rows written BEFORE the audit columns existed
+/// keep their meaning afterwards, and nothing is fabricated for them.
+#[tokio::test]
+async fn upgrades_populated_db_without_fabricating_an_audit_stamp() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_legacy_archived(&pool).await;
+
+    // The columns genuinely do not exist yet at the prior schema.
+    let pre = sqlx::query_scalar::<_, Option<i64>>("SELECT archived_at FROM agent")
+        .fetch_one(&pool)
+        .await;
+    assert!(
+        pre.is_err(),
+        "agent.archived_at must not exist before 0052 — otherwise this test proves nothing"
+    );
+
+    apply_migrations(&pool).await.expect("upgrade applies 0052");
+
+    // 1. The legacy archived agent is STILL archived, with an honest unknown
+    //    audit pair — the "no silent reclassification, no fabricated stamp" proof.
+    let agent = AgentRepo::get(&pool, "ag-1").await.expect("get agent").expect("agent present");
+    assert!(
+        agent.archived,
+        "a pre-0052 archived agent must still read as archived"
+    );
+    assert_eq!(
+        agent.archived_at, None,
+        "a historical archive has no honest timestamp — it must stay NULL"
+    );
+    assert_eq!(
+        agent.archived_by, None,
+        "a historical archive has no honest actor — it must stay NULL"
+    );
+
+    // 2. The legacy squad defaults to ACTIVE and is still listed.
+    let squads = SquadRepo::list(&pool, &ws()).await.expect("list squads");
+    assert_eq!(
+        squads.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        vec!["sq-1"],
+        "a pre-0052 squad defaults to active and stays in the list"
+    );
+    assert!(!squads[0].archived, "default archived = false");
+    assert_eq!(squads[0].archived_at, None);
+    assert_eq!(squads[0].archived_by, None);
+
+    // 3. A FRESH archive through the repo now stamps both columns.
+    let by = ActorRef::new(ActorKind::Member, "user-1").unwrap();
+    assert!(
+        AgentRepo::set_archived(&pool, "ws-1", "ag-1", true, Some(&by), STAMP_MS)
+            .await
+            .expect("re-archive"),
+        "re-archiving an already-archived agent still matches its row"
+    );
+    let agent = AgentRepo::get(&pool, "ag-1").await.expect("get agent").expect("agent present");
+    assert_eq!(agent.archived_at, Some(STAMP_MS));
+    assert_eq!(agent.archived_by, Some(by.clone()));
+
+    SquadRepo::set_archived(&pool, &ws(), "sq-1", true, Some(&by), STAMP_MS)
+        .await
+        .expect("archive squad");
+    let all = SquadRepo::list_including_archived(&pool, &ws()).await.expect("list all");
+    assert_eq!(all.len(), 1);
+    assert!(all[0].archived);
+    assert_eq!(all[0].archived_at, Some(STAMP_MS));
+    assert_eq!(all[0].archived_by, Some(by));
+
+    // Re-applying is a no-op (the migrator records 0052 as applied).
+    apply_migrations(&pool).await.expect("double-apply is a no-op");
+}
+
+/// `squad.archived` is a 0/1 INTEGER guarded by a `CHECK` — a stray 2 is refused
+/// at the storage boundary rather than silently meaning "truthy".
+#[tokio::test]
+async fn squad_archived_check_rejects_non_boolean() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = ainb_hangar_store::Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_legacy_archived(pool).await;
+
+    let err = sqlx::query("UPDATE squad SET archived = 2 WHERE id='sq-1'")
+        .execute(pool)
+        .await
+        .expect_err("CHECK (archived IN (0,1)) must reject 2");
+    assert!(
+        err.to_string().to_uppercase().contains("CHECK"),
+        "expected a CHECK-constraint failure, got: {err}"
+    );
+}
+
+/// There is deliberately NO constraint tying `archived = 1` to a non-null
+/// `archived_at`: legacy rows would violate it. A raw archived-without-stamp row
+/// must remain writable.
+#[tokio::test]
+async fn archived_without_a_stamp_is_still_a_legal_row() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = ainb_hangar_store::Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_legacy_archived(pool).await;
+
+    sqlx::query("UPDATE squad SET archived = 1 WHERE id='sq-1'")
+        .execute(pool)
+        .await
+        .expect("archived = 1 with NULL audit columns must be accepted");
+    let stamp: Option<i64> = sqlx::query_scalar("SELECT archived_at FROM squad WHERE id='sq-1'")
+        .fetch_one(pool)
+        .await
+        .expect("read stamp");
+    assert_eq!(stamp, None);
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -222,7 +222,7 @@ async fn archive_flips_flag_and_hides_from_active_list() {
     assert_eq!(active.len(), 1, "active list shows the un-archived agent");
 
     // Archive it (workspace-scoped).
-    let touched = AgentRepo::set_archived(store.pool(), &workspace_id, "agent-1", true)
+    let touched = AgentRepo::set_archived(store.pool(), &workspace_id, "agent-1", true, None, 0)
         .await
         .expect("archive");
     assert!(touched, "archive touches one row");
@@ -241,7 +241,7 @@ async fn archive_flips_flag_and_hides_from_active_list() {
     assert_eq!(all.len(), 1, "include-archived list still returns it");
 
     // Un-archive restores it to the active list.
-    AgentRepo::set_archived(store.pool(), &workspace_id, "agent-1", false)
+    AgentRepo::set_archived(store.pool(), &workspace_id, "agent-1", false, None, 0)
         .await
         .expect("unarchive");
     let active = AgentRepo::list_by_workspace(store.pool(), &workspace_id).await.unwrap();
@@ -252,7 +252,7 @@ async fn archive_flips_flag_and_hides_from_active_list() {
     );
 
     // A foreign workspace archives nothing (workspace-scoped).
-    let touched = AgentRepo::set_archived(store.pool(), "other-ws", "agent-1", true)
+    let touched = AgentRepo::set_archived(store.pool(), "other-ws", "agent-1", true, None, 0)
         .await
         .expect("cross-tenant archive");
     assert!(!touched, "a foreign workspace must archive no row");

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_archive_audit.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_archive_audit.rs
@@ -1,0 +1,279 @@
+//! Behavioural proof of the archive AUDIT trail (migration 0052, multica gap #26).
+//!
+//! What an operator can now answer that they could not before: **who** archived
+//! this agent / squad, and **when**. Each test drives the repo API with an
+//! injected clock reading + actor and reads the answer back, rather than
+//! asserting on SQL shape.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::agent::{Agent, AgentRepo};
+use ainb_hangar_store::repo::squad::SquadRepo;
+use sqlx::SqlitePool;
+
+/// A fixed epoch-ms reading so assertions are exact, not "roughly now".
+const T1: i64 = 1_700_000_000_000;
+/// A LATER reading, to prove a re-archive re-stamps.
+const T2: i64 = 1_800_000_000_000;
+
+fn ws(id: &str) -> WorkspaceId {
+    WorkspaceId::from_str(id.to_string()).unwrap()
+}
+
+fn member(id: &str) -> ActorRef {
+    ActorRef::new(ActorKind::Member, id).unwrap()
+}
+
+/// Seed `workspace → user → runtime → agent` for `ws_id`, returning the agent id.
+async fn seed_agent(pool: &SqlitePool, ws_id: &str, agent_id: &str) -> String {
+    sqlx::query("INSERT OR IGNORE INTO workspace (id, slug, name, created_at) VALUES (?,?,?,0)")
+        .bind(ws_id)
+        .bind(ws_id)
+        .bind(ws_id)
+        .execute(pool)
+        .await
+        .expect("workspace");
+    sqlx::query("INSERT OR IGNORE INTO user (id, email, created_at) VALUES (?,?,0)")
+        .bind(format!("user-{ws_id}"))
+        .bind(format!("{ws_id}@x.com"))
+        .execute(pool)
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT OR IGNORE INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, status) \
+         VALUES (?,?,?,'claude','local','online')",
+    )
+    .bind(format!("rt-{ws_id}"))
+    .bind(ws_id)
+    .bind(format!("d-{ws_id}"))
+    .execute(pool)
+    .await
+    .expect("runtime");
+
+    let agent = Agent {
+        id: agent_id.to_string(),
+        workspace_id: ws_id.to_string(),
+        name: agent_id.to_string(),
+        runtime_id: format!("rt-{ws_id}"),
+        visibility: "workspace".to_string(),
+        owner_id: format!("user-{ws_id}"),
+        ..Agent::default()
+    };
+    AgentRepo::insert(pool, &agent).await.expect("insert agent");
+    agent_id.to_string()
+}
+
+/// Read the raw `(archived, archived_at, archived_by)` triple, so cross-tenant
+/// assertions prove the ROW is untouched rather than trusting a return value.
+async fn raw_agent_audit(pool: &SqlitePool, id: &str) -> (i64, Option<i64>, Option<String>) {
+    sqlx::query_as("SELECT archived, archived_at, archived_by FROM agent WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .expect("read agent audit")
+}
+
+async fn raw_squad_audit(pool: &SqlitePool, id: &str) -> (i64, Option<i64>, Option<String>) {
+    sqlx::query_as("SELECT archived, archived_at, archived_by FROM squad WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .expect("read squad audit")
+}
+
+/// Archiving an agent records WHO and WHEN; re-archiving with a different actor
+/// re-stamps (last archiver wins); un-archiving clears BOTH columns.
+#[tokio::test]
+async fn agent_archive_records_who_and_when_and_restore_clears_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_agent(pool, "ws-1", "ag-1").await;
+
+    // Before: an active agent carries no audit stamp.
+    let before = AgentRepo::get(pool, "ag-1").await.unwrap().unwrap();
+    assert!(!before.archived);
+    assert_eq!(before.archived_at, None);
+    assert_eq!(before.archived_by, None);
+
+    // Archive.
+    assert!(
+        AgentRepo::set_archived(pool, "ws-1", "ag-1", true, Some(&member("user-1")), T1)
+            .await
+            .expect("archive")
+    );
+    let got = AgentRepo::get(pool, "ag-1").await.unwrap().unwrap();
+    assert!(got.archived);
+    assert_eq!(got.archived_at, Some(T1), "the archive stamped WHEN");
+    assert_eq!(
+        got.archived_by,
+        Some(member("user-1")),
+        "the archive stamped WHO, as a canonical actor-ref"
+    );
+
+    // Re-archive by a DIFFERENT actor at a later reading: last archiver wins.
+    assert!(
+        AgentRepo::set_archived(pool, "ws-1", "ag-1", true, Some(&member("user-2")), T2)
+            .await
+            .expect("re-archive is idempotent, not a not-found")
+    );
+    let got = AgentRepo::get(pool, "ag-1").await.unwrap().unwrap();
+    assert_eq!(got.archived_at, Some(T2));
+    assert_eq!(got.archived_by, Some(member("user-2")));
+
+    // Restore clears BOTH audit columns (multica RestoreAgent parity).
+    assert!(
+        AgentRepo::set_archived(pool, "ws-1", "ag-1", false, Some(&member("user-2")), T2)
+            .await
+            .expect("unarchive")
+    );
+    let got = AgentRepo::get(pool, "ag-1").await.unwrap().unwrap();
+    assert!(!got.archived);
+    assert_eq!(
+        (got.archived_at, got.archived_by),
+        (None, None),
+        "a restored agent carries no stale attribution"
+    );
+    assert_eq!(raw_agent_audit(pool, "ag-1").await, (0, None, None));
+}
+
+/// An archive with no attributable actor is still stamped with WHEN — an honest
+/// partial record beats no record.
+#[tokio::test]
+async fn agent_archive_without_an_actor_still_records_when() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_agent(pool, "ws-1", "ag-1").await;
+
+    AgentRepo::set_archived(pool, "ws-1", "ag-1", true, None, T1).await.expect("archive");
+    let got = AgentRepo::get(pool, "ag-1").await.unwrap().unwrap();
+    assert_eq!(got.archived_at, Some(T1));
+    assert_eq!(got.archived_by, None, "unattributed, not fabricated");
+}
+
+/// Archiving another tenant's agent touches NO row — asserted against raw SQL,
+/// not just the boolean return.
+#[tokio::test]
+async fn agent_archive_is_workspace_scoped() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_agent(pool, "ws-1", "ag-1").await;
+    seed_agent(pool, "ws-2", "ag-2").await;
+
+    let touched = AgentRepo::set_archived(pool, "ws-1", "ag-2", true, Some(&member("user-1")), T1)
+        .await
+        .expect("cross-tenant archive");
+    assert!(!touched, "a foreign workspace must archive no row");
+    assert_eq!(
+        raw_agent_audit(pool, "ag-2").await,
+        (0, None, None),
+        "the foreign tenant's row is byte-untouched — flag AND audit columns"
+    );
+}
+
+/// A corrupt `archived_by` cell degrades to `None` rather than failing the whole
+/// agent read: the audit sidecar must never make an agent unreadable.
+#[tokio::test]
+async fn a_malformed_archiver_decodes_to_none_rather_than_failing_the_read() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_agent(pool, "ws-1", "ag-1").await;
+
+    sqlx::query("UPDATE agent SET archived = 1, archived_at = ?, archived_by = 'garbage' WHERE id = 'ag-1'")
+        .bind(T1)
+        .execute(pool)
+        .await
+        .expect("write a corrupt cell");
+
+    let got = AgentRepo::get(pool, "ag-1").await.expect("read still succeeds").unwrap();
+    assert!(got.archived);
+    assert_eq!(got.archived_at, Some(T1));
+    assert_eq!(got.archived_by, None, "tolerant decode");
+}
+
+/// The squad half: archive records who + when, the squad leaves the active list
+/// but stays in the audit list, and restore clears the stamp.
+#[tokio::test]
+async fn squad_archive_records_audit_and_leaves_the_active_list() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_agent(pool, "ws-1", "ag-1").await;
+    SquadRepo::create(pool, &ws("ws-1"), "sq-1", "alpha", &member("user-1"), 0)
+        .await
+        .expect("create squad");
+
+    assert_eq!(SquadRepo::list(pool, &ws("ws-1")).await.unwrap().len(), 1);
+
+    SquadRepo::set_archived(pool, &ws("ws-1"), "sq-1", true, Some(&member("user-1")), T1)
+        .await
+        .expect("archive squad");
+
+    assert!(
+        SquadRepo::list(pool, &ws("ws-1")).await.unwrap().is_empty(),
+        "an archived squad leaves the active list"
+    );
+    let all = SquadRepo::list_including_archived(pool, &ws("ws-1")).await.unwrap();
+    assert_eq!(all.len(), 1, "the audit list still returns it");
+    assert!(all[0].archived);
+    assert_eq!(all[0].archived_at, Some(T1));
+    assert_eq!(all[0].archived_by, Some(member("user-1")));
+
+    // `get` stays UNFILTERED: an archived squad must remain resolvable so the
+    // audit read and the reject-assignment guard can name it.
+    let got = SquadRepo::get(pool, &ws("ws-1"), "sq-1").await.unwrap().expect("still resolvable");
+    assert!(got.archived);
+    assert_eq!(got.archived_by, Some(member("user-1")));
+    assert!(SquadRepo::is_archived(pool, &ws("ws-1"), "sq-1").await.unwrap());
+
+    // Re-archive by a different actor at a later reading: last archiver wins.
+    SquadRepo::set_archived(pool, &ws("ws-1"), "sq-1", true, Some(&member("user-2")), T2)
+        .await
+        .expect("re-archive");
+    assert_eq!(
+        raw_squad_audit(pool, "sq-1").await,
+        (1, Some(T2), Some("member:user-2".to_string()))
+    );
+
+    // Restore clears both and returns it to the active list.
+    SquadRepo::set_archived(pool, &ws("ws-1"), "sq-1", false, Some(&member("user-2")), T2)
+        .await
+        .expect("restore");
+    assert_eq!(raw_squad_audit(pool, "sq-1").await, (0, None, None));
+    assert_eq!(SquadRepo::list(pool, &ws("ws-1")).await.unwrap().len(), 1);
+    assert!(!SquadRepo::is_archived(pool, &ws("ws-1"), "sq-1").await.unwrap());
+}
+
+/// Archiving a squad through the WRONG workspace is a `NotFound` and writes
+/// nothing — the tenant guard, proved against raw SQL.
+#[tokio::test]
+async fn squad_archive_is_workspace_scoped() {
+    use ainb_hangar_store::repo::squad::SquadRepoError;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let pool = store.pool();
+    seed_agent(pool, "ws-1", "ag-1").await;
+    seed_agent(pool, "ws-2", "ag-2").await;
+    SquadRepo::create(pool, &ws("ws-1"), "sq-1", "alpha", &member("user-1"), 0)
+        .await
+        .expect("create squad");
+
+    let err = SquadRepo::set_archived(pool, &ws("ws-2"), "sq-1", true, Some(&member("x")), T1)
+        .await
+        .expect_err("a foreign tenant must not archive the squad");
+    assert!(matches!(err, SquadRepoError::NotFound), "got {err:?}");
+    assert_eq!(
+        raw_squad_audit(pool, "sq-1").await,
+        (0, None, None),
+        "the row is untouched"
+    );
+    // A foreign / unknown id reads as not-archived (never another tenant's state).
+    assert!(!SquadRepo::is_archived(pool, &ws("ws-2"), "sq-1").await.unwrap());
+    assert!(!SquadRepo::is_archived(pool, &ws("ws-1"), "nope").await.unwrap());
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_archive_audit.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_archive_audit.rs
@@ -148,7 +148,9 @@ async fn agent_archive_without_an_actor_still_records_when() {
     let pool = store.pool();
     seed_agent(pool, "ws-1", "ag-1").await;
 
-    AgentRepo::set_archived(pool, "ws-1", "ag-1", true, None, T1).await.expect("archive");
+    AgentRepo::set_archived(pool, "ws-1", "ag-1", true, None, T1)
+        .await
+        .expect("archive");
     let got = AgentRepo::get(pool, "ag-1").await.unwrap().unwrap();
     assert_eq!(got.archived_at, Some(T1));
     assert_eq!(got.archived_by, None, "unattributed, not fabricated");
@@ -184,11 +186,13 @@ async fn a_malformed_archiver_decodes_to_none_rather_than_failing_the_read() {
     let pool = store.pool();
     seed_agent(pool, "ws-1", "ag-1").await;
 
-    sqlx::query("UPDATE agent SET archived = 1, archived_at = ?, archived_by = 'garbage' WHERE id = 'ag-1'")
-        .bind(T1)
-        .execute(pool)
-        .await
-        .expect("write a corrupt cell");
+    sqlx::query(
+        "UPDATE agent SET archived = 1, archived_at = ?, archived_by = 'garbage' WHERE id = 'ag-1'",
+    )
+    .bind(T1)
+    .execute(pool)
+    .await
+    .expect("write a corrupt cell");
 
     let got = AgentRepo::get(pool, "ag-1").await.expect("read still succeeds").unwrap();
     assert!(got.archived);
@@ -226,7 +230,10 @@ async fn squad_archive_records_audit_and_leaves_the_active_list() {
 
     // `get` stays UNFILTERED: an archived squad must remain resolvable so the
     // audit read and the reject-assignment guard can name it.
-    let got = SquadRepo::get(pool, &ws("ws-1"), "sq-1").await.unwrap().expect("still resolvable");
+    let got = SquadRepo::get(pool, &ws("ws-1"), "sq-1")
+        .await
+        .unwrap()
+        .expect("still resolvable");
     assert!(got.archived);
     assert_eq!(got.archived_by, Some(member("user-1")));
     assert!(SquadRepo::is_archived(pool, &ws("ws-1"), "sq-1").await.unwrap());
@@ -241,9 +248,16 @@ async fn squad_archive_records_audit_and_leaves_the_active_list() {
     );
 
     // Restore clears both and returns it to the active list.
-    SquadRepo::set_archived(pool, &ws("ws-1"), "sq-1", false, Some(&member("user-2")), T2)
-        .await
-        .expect("restore");
+    SquadRepo::set_archived(
+        pool,
+        &ws("ws-1"),
+        "sq-1",
+        false,
+        Some(&member("user-2")),
+        T2,
+    )
+    .await
+    .expect("restore");
     assert_eq!(raw_squad_audit(pool, "sq-1").await, (0, None, None));
     assert_eq!(SquadRepo::list(pool, &ws("ws-1")).await.unwrap().len(), 1);
     assert!(!SquadRepo::is_archived(pool, &ws("ws-1"), "sq-1").await.unwrap());

--- a/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
@@ -255,6 +255,33 @@ async fn migration_0002_creates_skill_tables_with_composite_keys() {
         "agent.disabled_runtime_skills (0051): {agent}"
     );
 
+    // Migration 0052 (parity #26, multica 031/085): the archive AUDIT sidecar.
+    // Both columns are NULLABLE with no default — a pre-0052 archived row keeps
+    // NULL (an honest unknown), and there is deliberately no CHECK tying
+    // `archived = 1` to a non-null stamp.
+    assert!(
+        agent.contains("archived_at INTEGER"),
+        "agent.archived_at (0052): {agent}"
+    );
+    assert!(
+        agent.contains("archived_by TEXT"),
+        "agent.archived_by (0052): {agent}"
+    );
+
+    let squad = table_sql(&pool, "squad").await;
+    assert!(
+        squad.contains("archived INTEGER NOT NULL DEFAULT 0"),
+        "squad.archived default-false (0052): {squad}"
+    );
+    assert!(
+        squad.contains("archived_at INTEGER"),
+        "squad.archived_at (0052): {squad}"
+    );
+    assert!(
+        squad.contains("archived_by TEXT"),
+        "squad.archived_by (0052): {squad}"
+    );
+
     pool.close().await;
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -6819,6 +6819,7 @@ mod tests {
                 name: "Platform".into(),
                 leader: "agent:a1".into(),
                 members: vec!["agent:a1".into()],
+                ..SquadWireRow::default()
             }],
         });
         let mut app = p.app_state().clone();

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/squads.rs
@@ -796,6 +796,7 @@ mod tests {
             name: name.into(),
             leader: leader.into(),
             members: members.iter().map(|m| (*m).to_string()).collect(),
+            ..SquadWireRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/squads_screen_snapshot.rs
@@ -35,6 +35,7 @@ fn wire_squad(id: &str, name: &str, leader: &str, members: &[&str]) -> SquadWire
         name: name.into(),
         leader: leader.into(),
         members: members.iter().map(|m| (*m).to_string()).collect(),
+        ..SquadWireRow::default()
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -100,6 +100,7 @@ fn seeded_squads() -> serde_json::Value {
             name: "shippers".into(),
             leader: "agent:agent-lead".into(),
             members: vec!["agent:agent-1".into(), "member:user-1".into()],
+            ..SquadWireRow::default()
         }],
     })
     .unwrap()

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -3794,6 +3794,7 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner — the ordinary single-operator archive
   -h, --help                   Print help
 ```
 
@@ -3813,6 +3814,7 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner — the ordinary single-operator archive
   -h, --help                   Print help
 ```
 
@@ -4035,6 +4037,8 @@ Commands:
   add-member     Add a member actor to a squad (`agent:<id>` / `member:<id>`)
   remove-member  Remove a member actor from a squad (`agent:<id>` / `member:<id>`)
   assign         Route a task to the squad's LEADER (leader routing taking effect)
+  archive        Archive a squad: it leaves the active list and refuses new assignments
+  unarchive      Restore an archived squad (clears the archive audit stamp)
   help           Print this message or the help of the given subcommand(s)
 
 Options:
@@ -4055,6 +4059,7 @@ Usage: ainb hangar squad list [OPTIONS]
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug to list. Defaults to the bootstrapped `default` workspace
+      --all                    Include ARCHIVED squads (migration 0052). The default list is active-only
   -h, --help                   Print help
 ```
 
@@ -4139,6 +4144,46 @@ Options:
       --fanout                 Fan the work out across the WHOLE squad (leader brief + one task per distinct `agent` member) instead of briefing the leader alone
       --invoker <INVOKER>      The user the invocation-permission gate judges this assignment by (a user id or an email). Omitted defaults to the workspace owner — the ordinary single-operator assign, which the gate always admits
       --workspace <WORKSPACE>  Workspace slug the squad belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar squad archive`
+
+Archive a squad: it leaves the active list and refuses new assignments
+
+```console
+$ ainb hangar squad archive --help
+Archive a squad: it leaves the active list and refuses new assignments
+
+Usage: ainb hangar squad archive [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Squad id to (un)archive
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug the squad belongs to. Defaults to the bootstrapped `default` workspace
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner
+  -h, --help                   Print help
+```
+
+#### `ainb hangar squad unarchive`
+
+Restore an archived squad (clears the archive audit stamp)
+
+```console
+$ ainb hangar squad unarchive --help
+Restore an archived squad (clears the archive audit stamp)
+
+Usage: ainb hangar squad unarchive [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Squad id to (un)archive
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug the squad belongs to. Defaults to the bootstrapped `default` workspace
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner
   -h, --help                   Print help
 ```
 


### PR DESCRIPTION
## Parity item 26 — archive audit trail (`archived_at` + `archived_by` on agent and squad)

Before this PR hangar recorded **that** an agent was archived (0015's `agent.archived` 0/1) but never **who** or **when**, and could not archive a squad at all. Multica records both (migration 031 for agent, 085 for squad).

### What changed

**Migration `0052_archive_audit.sql`** — five `ALTER TABLE … ADD COLUMN`s with constant defaults (O(1) catalog changes, safe on a populated DB):
`agent.archived_at`, `agent.archived_by`, `squad.archived`, `squad.archived_at`, `squad.archived_by`.

**Store** — `AgentRepo::set_archived` now *requires* the archiving actor and a clock reading, so no audit-less archive path survives. Archiving stamps the pair; un-archiving clears both (multica `RestoreAgent` parity). `SquadRepo` gains the same `set_archived`, plus `list` (active-only), `list_including_archived`, and `is_archived`.

**The flag is not inert** — `SquadAssignService::assign_to_leader` and `assign_fanout` both refuse an archived squad with a new `SquadAssignError::Archived`, in the pre-flight phase, so a refused assignment writes **zero** task rows.

**Wire (append-only)** — `AgentArchiveParams`/`SquadArchiveParams` carry an optional `archived_by_user_id`; `ActorRow` and `SquadWireRow` carry the audit pair, all `skip_serializing_if` so a pre-0052 peer sees byte-identical JSON. New `hangar/squad_archive` method.

**Daemon** — one `effective_archiver` helper (explicit user id → workspace owner → unattributed) shared by the agent and squad handlers, so they cannot drift on who gets blamed.

**CLI** — `--by` on `agent archive`, new `squad archive`/`unarchive`, `squad list --all`. The text lines gain the audit suffix **only when a stamp exists**, so an active (or pre-0052-archived) agent renders byte-identically to before; csv/markdown/json gain explicit columns.

### Deliberate deviations from multica (documented in the migration header)

| multica | here | why |
|---|---|---|
| `archived_at IS NOT NULL` **is** the archived truth | `archived` 0/1 stays authoritative; the pair is an audit sidecar | the boolean is already load-bearing in `list_by_workspace`, `runtime_agent_ids`, `squad_briefing`, `bootstrap`, `search`. Re-basing truth on a nullable column would silently reclassify every legacy `archived = 1` row. |
| `archived_by UUID REFERENCES user(id)` | `archived_by TEXT` holding a canonical actor-ref | hangar's polymorphic-actor convention; FK-less by design like `squad.leader_id`. |
| 409 on already-archived | stays idempotent; a re-archive **re-stamps** (last archiver wins) | preserves the existing `set_archived` contract; still an honest record. |
| archive cancels live tasks / publishes WS events / transfers squad issues | out of scope | separate parity concerns; not touched. |

**No backfill.** A pre-0052 `archived = 1` row keeps NULL audit columns — an honest "unknown", never a fabricated `now()`. There is deliberately no CHECK tying `archived = 1` to a non-null stamp, precisely because legacy rows would violate it.

### Tests (fail-before / pass-after)

- `migration_0052_upgrade.rs` — applies 0001..0051, seeds an already-archived agent + a squad through raw SQL, upgrades, then asserts the legacy agent still reads archived with NULL audit columns and the legacy squad defaults to active and stays listed.
- `repo_archive_audit.rs` — stamp/re-stamp/clear for both agent and squad, cross-tenant no-write proved against raw SQL, tolerant decode of a corrupt `archived_by`.
- `squad_assign` in-module — archived squad refuses both assign paths with `queue_len == 0`, and a restore makes the same call succeed.
- `rpc_archive_audit.rs` — end-to-end over the framed dispatcher: owner default, explicit archiver, restore omitting the keys, legacy payload parsing, squad round-trip.
- proto round-trips proving the new keys are absent when unset.
- `hangar_cli_integration.rs` — the audit is readable back through `agent list --all` / `squad list --all`.
- `tripwire_migrations_apply.rs` — fresh-DB column sweep extended with the five 0052 columns.

### Local gate (all green)

```
cargo build -p ainb                                     ok
cargo nextest --lib --tests --all-features (non-tripwire) 4117 passed, 0 failed, 18 skipped
scripts/hangar/run_all_tripwires.sh                     ran=62  failed=0 skipped=0
scripts/hangar/run_acceptance_tests.sh                  ran=152 failed=0 skipped=0
```

Plus the manual acceptance proof from the spec, against an isolated `AINB_HANGAR_HOME`:

```
$ ainb hangar agent archive $AG
archived agent 01KYF81MVJSC78Y6F7R87JDXAS by member:01KYF811E79AHMSD2A42SW3JSD at 1785070671184
sqlite> SELECT id, archived, archived_at, archived_by FROM agent WHERE id='$AG';
01KYF81MVJSC78Y6F7R87JDXAS|1|1785070671184|member:01KYF811E79AHMSD2A42SW3JSD

$ ainb hangar agent unarchive $AG
sqlite> SELECT archived, archived_at IS NULL, archived_by IS NULL FROM agent WHERE id='$AG';
0|1|1

$ ainb hangar squad archive $SQ --by $USER_ID
sqlite> SELECT id, archived, archived_at, archived_by FROM squad WHERE id='$SQ';
01KYF81W6ATJSBFZPBHDFEGYGP|1|1785070678450|member:01KYF811E79AHMSD2A42SW3JSD
$ ainb hangar squad list        # squad absent
$ ainb hangar squad list --all  # present, with [archived] archived_by=member:…@1785070678450
```

### Fixture drift fixed in this PR

`SquadWireRow` gained `#[derive(Default)]` and the six literal construction sites across `ainb-hangar-proto`, `ainb-hangar-daemon`, and `ainb-plugin-hangar` now spread `..Default::default()`. The agent CSV/markdown headers gained the two audit columns; no other crate asserted on them (verified by grep before the change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added archive and unarchive commands for squads, including optional attribution with `--by`.
  * Added `--all` to squad listings to show archived squads.
  * Archive records now display who archived an agent or squad and when.
  * Agent and squad list outputs include archive status and audit details across text, CSV, Markdown, and JSON formats.

* **Bug Fixes**
  * Prevented assignments to archived squads with a clear error message.
  * Unarchiving restores active visibility and clears archive audit details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### CI fix (2nd pass)

The first CI run was green on every job except **CLI reference freshness** — the new
`hangar squad archive/unarchive` verbs, `squad list --all` and `agent archive --by`
made `docs/tui/cli.md` stale. Regenerated from the binary
(`AINB_BIN=target/debug/ainb bash ainb-tui/scripts/gen-cli-reference.sh`) and committed;
no source behaviour changed. `toolkit-validation` fails identically on `main`
(pre-existing, unrelated to this branch).
