### PR TITLE
test(ainb-core): kill the resume-tmux flake with a private tmux server + spawn retry

### DIFF
--- a/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
+++ b/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
@@ -10,11 +10,83 @@
 // tmux was asked to run — independent of whether the CLI binary exists or is
 // authenticated, and whether the pane runs argv-directly or via `sh -c 'exec …'`
 // (the API-key / OTEL injection path). Gated: skips cleanly when tmux is absent.
+//
+// ISOLATION — why this file pins `TMUX_TMPDIR`.
+// These tests used to run against the machine's DEFAULT tmux server, which is
+// also the server every other tmux-driving test (and the developer's own shell)
+// uses. A tmux server exits as soon as its LAST session dies, so one test's
+// `kill-session` teardown could tear the server down at the exact moment a
+// sibling's `new-session` was connecting to it — surfacing as
+// `failed to create tmux session ainb-verify-… / server exited unexpectedly`
+// (seen on CI run 30209167091, job 89812377132).
+//
+// Cure, in two layers:
+//   1. A PRIVATE server. `TMUX_TMPDIR` moves the default socket to a
+//      pid-unique directory, so this process' sessions can never collide with
+//      the ambient server, another test binary, or the user's own tmux. The
+//      env var (not `tmux -L`) is the right lever because
+//      `InteractiveSessionManager` shells out to `tmux` itself and targets the
+//      DEFAULT socket — an env var is inherited by those children, a `-L` flag
+//      on our own calls would not be, and the manager would then respawn into a
+//      pane it cannot see.
+//   2. A bounded retry on `new-session`. Under `cargo test` (threads in one
+//      process) the four tests still share that one private server, so the
+//      shutdown race is narrowed, not eliminated; the retry closes it.
+// Under `cargo nextest` (one process per test) layer 1 alone already gives each
+// test its own server.
 
 use ainb::interactive::session_manager::InteractiveSessionManager;
 use ainb::models::session::SessionAgentType;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// How many times `new_session` will re-attempt a failed `tmux new-session`.
+const NEW_SESSION_ATTEMPTS: usize = 5;
+
+struct TmuxIsolation {
+    /// Value this process forces into `TMUX_TMPDIR`.
+    dir: PathBuf,
+    /// Whatever `TMUX_TMPDIR` was before we overrode it, so a probe can still
+    /// reach the AMBIENT server on purpose.
+    ambient: Option<String>,
+}
+
+/// Redirect every tmux call this process makes onto a private socket dir.
+///
+/// Runs exactly once and BEFORE the first tmux invocation (every helper below
+/// goes through [`tmux`]), so the manager's own `tmux` children inherit it too.
+/// The dir lives under `/tmp` rather than `TMPDIR`: a unix socket path is capped
+/// at 104 bytes on macOS and `$TMPDIR` there is already ~50 of them.
+fn isolation() -> &'static TmuxIsolation {
+    static ISO: OnceLock<TmuxIsolation> = OnceLock::new();
+    ISO.get_or_init(|| {
+        let ambient = std::env::var("TMUX_TMPDIR").ok();
+        let dir = PathBuf::from("/tmp").join(format!("ainb-verify-tmux-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create private tmux socket dir");
+        std::env::set_var("TMUX_TMPDIR", &dir);
+        TmuxIsolation { dir, ambient }
+    })
+}
+
+/// A `tmux` command pinned to this file's private server.
+fn tmux() -> Command {
+    isolation();
+    Command::new("tmux")
+}
+
+/// A `tmux` command pointed back at the AMBIENT (default) server — used only to
+/// PROVE our sessions are not on it.
+fn ambient_tmux() -> Command {
+    let iso = isolation();
+    let mut cmd = Command::new("tmux");
+    match &iso.ambient {
+        Some(v) => cmd.env("TMUX_TMPDIR", v),
+        None => cmd.env_remove("TMUX_TMPDIR"),
+    };
+    cmd
+}
 
 fn tmux_available() -> bool {
     Command::new("tmux")
@@ -24,18 +96,49 @@ fn tmux_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Retry wrapper around a session spawn.
+///
+/// Extracted from [`new_session`] so the race it exists for can be driven
+/// deterministically in a unit test instead of waited on. `backoff` is scaled by
+/// the attempt number; pass `Duration::ZERO` to disable sleeping.
+fn create_session_with_retry(
+    name: &str,
+    backoff: Duration,
+    mut spawn: impl FnMut() -> Result<(), String>,
+) -> Result<(), String> {
+    let mut last = String::new();
+    for attempt in 1..=NEW_SESSION_ATTEMPTS {
+        match spawn() {
+            Ok(()) => return Ok(()),
+            Err(e) => last = e,
+        }
+        if attempt < NEW_SESSION_ATTEMPTS && !backoff.is_zero() {
+            std::thread::sleep(backoff * attempt as u32);
+        }
+    }
+    Err(format!(
+        "failed to create tmux session {name} after {NEW_SESSION_ATTEMPTS} attempts: {last}"
+    ))
+}
+
 fn new_session(name: &str) {
-    let _ = Command::new("tmux").args(["kill-session", "-t", name]).output();
-    let ok = Command::new("tmux")
-        .args(["new-session", "-d", "-s", name, "-x", "80", "-y", "24"])
-        .status()
-        .expect("spawn tmux")
-        .success();
-    assert!(ok, "failed to create tmux session {name}");
+    let _ = tmux().args(["kill-session", "-t", name]).output();
+    let result = create_session_with_retry(name, Duration::from_millis(120), || {
+        let out = tmux()
+            .args(["new-session", "-d", "-s", name, "-x", "80", "-y", "24"])
+            .output()
+            .map_err(|e| format!("spawn tmux: {e}"))?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+        }
+    });
+    result.unwrap_or_else(|e| panic!("{e}"));
 }
 
 fn pane_start_command(name: &str) -> String {
-    let out = Command::new("tmux")
+    let out = tmux()
         .args(["list-panes", "-t", name, "-F", "#{pane_start_command}"])
         .output()
         .expect("tmux list-panes");
@@ -43,7 +146,7 @@ fn pane_start_command(name: &str) -> String {
 }
 
 fn kill(name: &str) {
-    let _ = Command::new("tmux").args(["kill-session", "-t", name]).output();
+    let _ = tmux().args(["kill-session", "-t", name]).output();
 }
 
 /// Launch via the REAL manager and return the command tmux was asked to run.
@@ -156,6 +259,70 @@ async fn copilot_resume_launches_continue() {
         cmd.contains("--yolo"),
         "copilot yolo flag must survive, got: {cmd}"
     );
+}
+
+/// The isolation contract: a session this file creates must NOT exist on the
+/// ambient/default tmux server. Before `TMUX_TMPDIR` was pinned it did, which is
+/// how one test's teardown could kill the server another test was starting on.
+#[test]
+fn sessions_live_on_a_private_tmux_server_not_the_ambient_one() {
+    if !tmux_available() {
+        eprintln!("skip: tmux unavailable");
+        return;
+    }
+    let name = format!("ainb-verify-isolation-{}", std::process::id());
+    new_session(&name);
+
+    let private = tmux()
+        .args(["has-session", "-t", &name])
+        .output()
+        .expect("tmux has-session (private)");
+    let ambient = ambient_tmux()
+        .args(["has-session", "-t", &name])
+        .output()
+        .expect("tmux has-session (ambient)");
+    kill(&name);
+
+    assert!(
+        private.status.success(),
+        "session must exist on this file's private server"
+    );
+    assert!(
+        !ambient.status.success(),
+        "session leaked onto the AMBIENT tmux server — a sibling's teardown can \
+         then kill the server out from under us"
+    );
+    assert!(isolation().dir.is_dir(), "private socket dir must exist");
+}
+
+/// A transient `server exited unexpectedly` must be retried, not fatal.
+#[test]
+fn new_session_retries_past_a_transient_server_shutdown() {
+    let mut calls = 0;
+    let out = create_session_with_retry("ainb-verify-unit", Duration::ZERO, || {
+        calls += 1;
+        if calls < 3 {
+            Err("server exited unexpectedly".to_string())
+        } else {
+            Ok(())
+        }
+    });
+    assert_eq!(out, Ok(()));
+    assert_eq!(calls, 3, "must keep retrying until the spawn succeeds");
+}
+
+/// …but a genuinely broken tmux still fails loudly, with the real stderr.
+#[test]
+fn new_session_gives_up_after_the_attempt_budget() {
+    let mut calls = 0;
+    let out = create_session_with_retry("ainb-verify-unit", Duration::ZERO, || {
+        calls += 1;
+        Err("no such file or directory".to_string())
+    });
+    assert_eq!(calls, NEW_SESSION_ATTEMPTS);
+    let err = out.expect_err("must not report success");
+    assert!(err.contains("ainb-verify-unit"), "got: {err}");
+    assert!(err.contains("no such file or directory"), "got: {err}");
 }
 
 #[tokio::test]

--- a/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
+++ b/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
@@ -63,7 +63,14 @@ fn isolation() -> &'static TmuxIsolation {
     static ISO: OnceLock<TmuxIsolation> = OnceLock::new();
     ISO.get_or_init(|| {
         let ambient = std::env::var("TMUX_TMPDIR").ok();
-        let dir = PathBuf::from("/tmp").join(format!("ainb-verify-tmux-{}", std::process::id()));
+        // pid + nanos: containers recycle low pids, and a leftover dir owned by
+        // another uid would make tmux refuse the socket.
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or_default();
+        let dir =
+            PathBuf::from("/tmp").join(format!("ainb-verify-tmux-{}-{nonce}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("create private tmux socket dir");
         std::env::set_var("TMUX_TMPDIR", &dir);
         TmuxIsolation { dir, ambient }


### PR DESCRIPTION
Test-only hardening. No product code changes.

## The flake

`Test (ubuntu-latest)` went red on run `30209167091` (job `89812377132`) during
PR #486 with 4123 passed / 1 failed:

```
thread 'copilot_resume_launches_continue' panicked at crates/ainb-core/tests/resume_command_tmux.rs:34:5:
failed to create tmux session ainb-verify-copilot-15000
stderr: "server exited unexpectedly"
```

Nothing in #486's diff touches the session-manager/tmux path, and the other
three tests in the same file passed in the same job. Re-running the workflow
was green on every gate, so it was classified as a flake and #486 merged. This
PR removes the flake's cause rather than leaving it to be re-hit.

## Root cause

`resume_command_tmux.rs` drove the machine's **default** tmux server — the same
server every other tmux-driving test binary (and a developer's own shell) uses.
A tmux server exits as soon as its **last** session dies. nextest runs the
file's tests as concurrent processes that each `kill-session` at teardown, so
one test's teardown can tear the server down at the exact moment a sibling's
`new-session` is connecting to it. tmux reports that as
`server exited unexpectedly`, and the helper's bare
`assert!(ok, "failed to create tmux session {name}")` turned it into a hard
failure.

## Fix — two layers

1. **Private server.** `TMUX_TMPDIR` is pinned once per process to
   `/tmp/ainb-verify-tmux-<pid>-<nonce>`, so this file's sessions can never
   share a server with the ambient one, another test binary, or the user's tmux.
   The env var — not `tmux -L` — is the correct lever: `start_cli_in_tmux`
   shells out to `tmux` itself and targets the **default** socket
   (`session_manager.rs:1581,1611,1621`), so it inherits an env var but would
   never see a `-L` flag passed on the helper's own calls; a `-L`-only change
   would leave the manager respawning into a pane it cannot see. Under
   `cargo nextest` (one process per test) this alone gives every test its own
   server.
2. **Bounded retry** (5 attempts, linear backoff) on `new-session`, extracted
   into `create_session_with_retry` so the race is closed under plain
   `cargo test` too, where the four tests are threads sharing one process — and
   therefore still one private server.

The `tmux_available()` skip gate is unchanged; `.github/workflows` untouched.
No `kill-server` / `pkill` anywhere — teardown is still `kill-session -t <exact
name>` only.

## Fail-before / pass-after

Three new tests, both new behaviours mutation-verified RED:

| Mutation | Test | Result |
|---|---|---|
| drop the `set_var("TMUX_TMPDIR", …)` line | `sessions_live_on_a_private_tmux_server_not_the_ambient_one` | RED — `session leaked onto the AMBIENT tmux server — a sibling's teardown can then kill the server out from under us` |
| `NEW_SESSION_ATTEMPTS = 1` | `new_session_retries_past_a_transient_server_shutdown` | RED — `left: Err("failed to create tmux session ainb-verify-unit after 1 attempts: server exited unexpectedly")` |

`new_session_gives_up_after_the_attempt_budget` pins the other side: a
genuinely broken tmux still fails loudly, with the real stderr and the session
name in the message.

Green under both execution models:

```
cargo nextest run -p ainb --test resume_command_tmux   → 7 tests run: 7 passed
cargo test    -p ainb --test resume_command_tmux       → 7 passed; 0 failed
```

## Full local gate

| Gate | Result |
|---|---|
| `cargo build -p ainb` | ok |
| `cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'` | 4130 run: **4129 passed, 1 failed, 18 skipped** — see below |
| `scripts/hangar/run_all_tripwires.sh` | ran=62 failed=0 skipped=0 |
| `scripts/hangar/run_acceptance_tests.sh` | ran=154 failed=0 skipped=0 |

All 7 tests in `resume_command_tmux` passed *inside* that contended 4130-test
run — the exact condition that produced the original flake.

**The one failure is an unrelated load flake, attributed by isolated rerun:**
`ainb-hangar-daemon::rpc_event_push subscribed_connection_receives_task_finished_event`
timed out after 5.4s at `rpc_event_push.rs:229` waiting for a `hangar/event`
frame. Re-run alone: `3 tests run: 3 passed` in 0.39s. This PR touches no daemon
or RPC code — the diff is one `ainb-core` test file.
