### PR TITLE
feat(hangar): typed issue dependency graph (blocked_by / blocks / related)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1206,6 +1206,77 @@ pub enum IssueCommand {
     /// Inspect or tick off an issue's acceptance criteria.
     #[command(subcommand)]
     Criteria(IssueCriteriaCommand),
+    /// Add, remove, or list an issue's typed links to other issues.
+    #[command(subcommand)]
+    Link(IssueLinkCommand),
+}
+
+/// `hangar issue link <verb>` (multica parity #20).
+///
+/// An issue relates to another with a KIND: `blocked-by` (the gating relation —
+/// the issue refuses to run until the other finishes), `blocks` (the same
+/// relation authored from the other end), or `related` (a plain association that
+/// NEVER gates and never auto-runs). Talks to the store repo directly, exactly
+/// like `issue criteria`, so it works with no daemon running.
+#[derive(Subcommand, Debug)]
+pub enum IssueLinkCommand {
+    /// Link two issues. Re-adding a pair with a new kind replaces the kind.
+    Add(IssueLinkArgs),
+    /// Remove a link between two issues. Idempotent.
+    Remove(IssueLinkArgs),
+    /// List an issue's links (`🔒`/`✓` blocked-by, `→` blocks, `~` related).
+    List(IssueLinkListArgs),
+}
+
+/// The `--kind` selector for `hangar issue link add|remove`.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LinkKindArg {
+    /// This issue is blocked by the other — the gating default.
+    #[default]
+    BlockedBy,
+    /// This issue blocks the other (stored as the reverse gating link).
+    Blocks,
+    /// The two issues are merely associated: never gating, never auto-running.
+    Related,
+}
+
+impl LinkKindArg {
+    /// The store-side kind this selector authors.
+    fn to_kind(self) -> ainb_hangar_store::repo::card_dependency::LinkKind {
+        use ainb_hangar_store::repo::card_dependency::LinkKind;
+        match self {
+            Self::BlockedBy => LinkKind::BlockedBy,
+            Self::Blocks => LinkKind::Blocks,
+            Self::Related => LinkKind::Related,
+        }
+    }
+}
+
+/// Arguments for `hangar issue link add|remove`.
+#[derive(Args, Debug)]
+pub struct IssueLinkArgs {
+    /// Issue id (ULID) the link is authored ON.
+    pub id: String,
+    /// The OTHER issue id (ULID) at the far end of the link.
+    pub other: String,
+    /// The link kind. Defaults to `blocked-by`, the gating relation.
+    #[arg(long, value_enum, default_value_t = LinkKindArg::BlockedBy)]
+    pub kind: LinkKindArg,
+    /// Workspace slug both issues belong to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Arguments for `hangar issue link list`.
+#[derive(Args, Debug)]
+pub struct IssueLinkListArgs {
+    /// Issue id (ULID) whose links to list.
+    pub id: String,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// `hangar issue criteria <verb>` (multica parity #11-rest).
@@ -3629,6 +3700,7 @@ async fn dispatch_issue(cmd: IssueCommand, format: OutputFormat) -> Result<()> {
         IssueCommand::Delete(args) => run_issue_delete(&store, args).await,
         IssueCommand::Label(cmd) => run_issue_label(&store, cmd).await,
         IssueCommand::Criteria(cmd) => run_issue_criteria(&store, cmd).await,
+        IssueCommand::Link(cmd) => run_issue_link(&store, cmd).await,
     }
 }
 
@@ -3856,6 +3928,136 @@ async fn run_issue_criteria(store: &Store, cmd: IssueCriteriaCommand) -> Result<
         println!("{}", criterion_line(idx + 1, criterion));
     }
     Ok(())
+}
+
+/// `hangar issue link add|remove|list`: author and read an issue's TYPED links
+/// (multica parity #20).
+///
+/// Routes through the SAME [`CardDependencyRepo`] seam the daemon RPCs use, so
+/// there is exactly one mutator: a `blocks` link normalises into the reverse
+/// `blocked_by` row, a `related` link is symmetric and never gates, and a
+/// self-link / cycle / cross-tenant endpoint is a NON-ZERO exit rather than a
+/// silent no-op.
+///
+/// [`CardDependencyRepo`]: ainb_hangar_store::repo::card_dependency::CardDependencyRepo
+async fn run_issue_link(store: &Store, cmd: IssueLinkCommand) -> Result<()> {
+    use ainb_hangar_store::repo::card_dependency::{CardDependencyError, CardDependencyRepo};
+
+    let (id, workspace) = match &cmd {
+        IssueLinkCommand::Add(a) | IssueLinkCommand::Remove(a) => {
+            (a.id.clone(), a.workspace.clone())
+        }
+        IssueLinkCommand::List(a) => (a.id.clone(), a.workspace.clone()),
+    };
+    let workspace_id = resolve_skills_workspace(store, workspace.as_deref()).await?;
+
+    match &cmd {
+        IssueLinkCommand::Add(args) => {
+            let now = ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock);
+            let ws = ainb_hangar_core::ids::WorkspaceId::from_str(workspace_id.clone())
+                .map_err(|e| anyhow::anyhow!("bad workspace id: {e}"))?;
+            CardDependencyRepo::add_link(
+                store.pool(),
+                &ws,
+                &args.id,
+                &args.other,
+                args.kind.to_kind(),
+                now,
+            )
+            .await
+            .map_err(|e| match e {
+                CardDependencyError::SelfDependency => {
+                    anyhow::anyhow!("a card cannot link to itself")
+                }
+                CardDependencyError::Cycle => {
+                    anyhow::anyhow!("that link would create a dependency cycle")
+                }
+                CardDependencyError::NotFound => anyhow::anyhow!(
+                    "both issues must exist in this workspace ({} / {})",
+                    args.id,
+                    args.other
+                ),
+                CardDependencyError::Db(db) => anyhow::Error::new(db).context("add issue link"),
+            })?;
+        }
+        IssueLinkCommand::Remove(args) => {
+            let ws = ainb_hangar_core::ids::WorkspaceId::from_str(workspace_id.clone())
+                .map_err(|e| anyhow::anyhow!("bad workspace id: {e}"))?;
+            CardDependencyRepo::remove_link(
+                store.pool(),
+                &ws,
+                &args.id,
+                &args.other,
+                args.kind.to_kind(),
+            )
+            .await
+            .context("remove issue link")?;
+        }
+        IssueLinkCommand::List(_) => {}
+    }
+
+    print_issue_links(store, &workspace_id, &id).await
+}
+
+/// Print one issue's typed links, one row per link:
+/// `<glyph>  <kind>  <display-id>  <title>`. `🔒` marks a blocker that is still
+/// UNFINISHED (so it gates), `✓` one that has finished, `→` what this issue
+/// blocks, and `~` a related issue. No links ⇒ `no links`.
+async fn print_issue_links(store: &Store, workspace_id: &str, issue_id: &str) -> Result<()> {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let blockers = CardDependencyRepo::blockers_of(store.pool(), issue_id)
+        .await
+        .context("read blockers")?;
+    let unfinished = CardDependencyRepo::unfinished_blockers_of(store.pool(), issue_id)
+        .await
+        .context("read unfinished blockers")?;
+    let blocks = CardDependencyRepo::blocks_of(store.pool(), issue_id)
+        .await
+        .context("read blocked cards")?;
+    let related = CardDependencyRepo::related_of(store.pool(), issue_id)
+        .await
+        .context("read related cards")?;
+
+    if blockers.is_empty() && blocks.is_empty() && related.is_empty() {
+        println!("no links");
+        return Ok(());
+    }
+
+    for (kind, ids) in [
+        ("blocked-by", &blockers),
+        ("blocks", &blocks),
+        ("related", &related),
+    ] {
+        for other in ids {
+            let glyph = match kind {
+                "blocked-by" if unfinished.iter().any(|u| u == other) => "🔒",
+                "blocked-by" => "✓",
+                "blocks" => "→",
+                _ => "~",
+            };
+            let row =
+                IssueRepo::get_by_id(store.pool(), other).await.context("read linked issue")?;
+            let title = row.as_ref().map_or_else(String::new, |r| r.title.clone());
+            let reference = match &row {
+                Some(_) => issue_display_ref(store, workspace_id, other).await?,
+                None => other.clone(),
+            };
+            println!("{glyph}  {kind:<10}  {reference:<10}  {title}");
+        }
+    }
+    Ok(())
+}
+
+/// The human display id (`HGR-<n>`) of an issue, falling back to its raw id.
+async fn issue_display_ref(store: &Store, workspace_id: &str, issue_id: &str) -> Result<String> {
+    let seq = IssueRepo::workspace_seq(store.pool(), workspace_id, issue_id)
+        .await
+        .context("read issue ordinal")?;
+    Ok(seq.map_or_else(
+        || issue_id.to_string(),
+        |n| ainb_hangar_store::repo::workspace::issue_display_id(None, n),
+    ))
 }
 
 /// `hangar issue update`: edit a subset of an issue's mutable fields,
@@ -4415,9 +4617,36 @@ async fn run_issue_show(store: &Store, args: IssueShowArgs, format: OutputFormat
                     println!("  {}", criterion_line(idx + 1, criterion));
                 }
             }
+            // multica parity #20: the issue's typed links, so the CLI proof of a
+            // blocked_by / blocks / related relation needs no daemon and no TUI.
+            // Silent when the issue has none (`print_issue_links` prints
+            // `no links`, which we suppress here by checking first).
+            if issue_has_links(store, &issue.id).await? {
+                println!("Links:");
+                print_issue_links(store, &issue.workspace_id, &issue.id).await?;
+            }
         }
     }
     Ok(())
+}
+
+/// Whether an issue carries ANY typed link (multica parity #20) — so
+/// `issue show` can omit the `Links:` section entirely rather than printing an
+/// empty header.
+async fn issue_has_links(store: &Store, issue_id: &str) -> Result<bool> {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+    Ok(!CardDependencyRepo::blockers_of(store.pool(), issue_id)
+        .await
+        .context("read blockers")?
+        .is_empty()
+        || !CardDependencyRepo::blocks_of(store.pool(), issue_id)
+            .await
+            .context("read blocked cards")?
+            .is_empty()
+        || !CardDependencyRepo::related_of(store.pool(), issue_id)
+            .await
+            .context("read related cards")?
+            .is_empty())
 }
 
 /// Dispatch the `hangar task` verbs.

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -2319,3 +2319,147 @@ fn issue_criteria_list_check_uncheck_round_trip() {
     );
     assert!(!ok, "an unknown criterion id must exit non-zero; out={out}");
 }
+
+/// multica parity #20, the sqlite half of the acceptance, with NO daemon: a link
+/// authored as `blocked-by` persists as `blocked_by`, renders with 🔒 while the
+/// blocker is unfinished, and shows up on `issue show`; the reverse `blocks`
+/// direction renders from the other end; a `related` link persists as `related`
+/// and renders with `~`; and NO `'blocks'` row is ever written.
+#[test]
+fn issue_link_add_list_persists_typed_links() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let create = |title: &str| -> String {
+        let (ok, out) = run(tmp.path(), &["hangar", "issue", "create", "--title", title]);
+        assert!(ok, "issue create should exit 0; out={out}");
+        out.lines()
+            .find_map(|l| l.strip_prefix("created issue "))
+            .expect("create prints the new issue id")
+            .trim()
+            .to_string()
+    };
+    let schema = create("schema");
+    let parser = create("parser");
+    let docs = create("docs");
+
+    // parser is blocked-by schema; parser is related to docs.
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "issue",
+            "link",
+            "add",
+            &parser,
+            &schema,
+            "--kind",
+            "blocked-by",
+        ],
+    );
+    assert!(ok, "link add should exit 0; out={out}");
+    assert!(
+        out.contains("🔒") && out.contains("blocked-by") && out.contains("schema"),
+        "the add prints the refreshed link list with a lock:\n{out}"
+    );
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar", "issue", "link", "add", &parser, &docs, "--kind", "related",
+        ],
+    );
+    assert!(ok, "related link add should exit 0; out={out}");
+
+    // parser's links: a locked blocker AND a related card.
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "link", "list", &parser]);
+    assert!(ok, "link list should exit 0; out={out}");
+    let blocked_line = out
+        .lines()
+        .find(|l| l.contains("blocked-by"))
+        .unwrap_or_else(|| panic!("a blocked-by row in:\n{out}"));
+    assert!(
+        blocked_line.contains('🔒') && blocked_line.contains("schema"),
+        "an unfinished blocker renders locked: {blocked_line}"
+    );
+    let related_line = out
+        .lines()
+        .find(|l| l.contains("related"))
+        .unwrap_or_else(|| panic!("a related row in:\n{out}"));
+    assert!(
+        related_line.contains('~') && related_line.contains("docs"),
+        "a related link renders with ~: {related_line}"
+    );
+
+    // The REVERSE direction renders from schema's end.
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "link", "list", &schema]);
+    assert!(ok, "link list should exit 0; out={out}");
+    let blocks_line = out
+        .lines()
+        .find(|l| l.contains("blocks"))
+        .unwrap_or_else(|| panic!("a blocks row in:\n{out}"));
+    assert!(
+        blocks_line.contains('→') && blocks_line.contains("parser"),
+        "the blocker renders what it blocks: {blocks_line}"
+    );
+
+    // `issue show` carries the same section.
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "show", &parser]);
+    assert!(ok, "issue show should exit 0; out={out}");
+    assert!(out.contains("Links:"), "the show block:\n{out}");
+    assert!(out.contains("blocked-by"), "the gating link:\n{out}");
+
+    // An issue with NO links shows no section and says so on `link list`.
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "link", "list", &docs]);
+    assert!(ok, "link list should exit 0; out={out}");
+    assert!(
+        out.contains("related"),
+        "docs reads the symmetric relation back:\n{out}"
+    );
+
+    // Removing the related link from the OTHER end works (it is symmetric).
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar", "issue", "link", "remove", &docs, &parser, "--kind", "related",
+        ],
+    );
+    assert!(ok, "link remove should exit 0; out={out}");
+    assert!(out.contains("no links"), "docs has no links left:\n{out}");
+}
+
+/// A self-link and a cycle are refused with a NON-ZERO exit, never a silent
+/// no-op.
+#[test]
+fn issue_link_refuses_a_self_link_and_a_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let create = |title: &str| -> String {
+        let (ok, out) = run(tmp.path(), &["hangar", "issue", "create", "--title", title]);
+        assert!(ok, "issue create should exit 0; out={out}");
+        out.lines()
+            .find_map(|l| l.strip_prefix("created issue "))
+            .expect("create prints the new issue id")
+            .trim()
+            .to_string()
+    };
+    let a = create("a");
+    let b = create("b");
+
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "link", "add", &a, &a]);
+    assert!(!ok, "a self-link must exit non-zero; out={out}");
+    assert!(out.contains("itself"), "kind-agnostic refusal:\n{out}");
+
+    let (ok, _) = run(tmp.path(), &["hangar", "issue", "link", "add", &a, &b]);
+    assert!(ok, "the first gating link lands");
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "link", "add", &b, &a]);
+    assert!(!ok, "the closing edge must exit non-zero; out={out}");
+    assert!(out.contains("cycle"), "cycle refusal:\n{out}");
+
+    // A `related` pair in BOTH orientations is fine — it gates nothing.
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar", "issue", "link", "add", &b, &a, "--kind", "related",
+        ],
+    );
+    assert!(ok, "a related link is cycle-exempt; out={out}");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -194,6 +194,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -236,6 +236,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -806,6 +806,9 @@ async fn handle(
         methods::HANGAR_BOARD_CARD_ASSIGN_SQUAD => handle_board_card_assign_squad(pool, req).await,
         methods::HANGAR_BOARD_CARD_DEP_ADD => handle_board_card_dep(pool, req, true).await,
         methods::HANGAR_BOARD_CARD_DEP_REMOVE => handle_board_card_dep(pool, req, false).await,
+        methods::HANGAR_ISSUE_LINK_ADD => handle_issue_link(pool, req, true).await,
+        methods::HANGAR_ISSUE_LINK_REMOVE => handle_issue_link(pool, req, false).await,
+        methods::HANGAR_ISSUE_LINKS => handle_issue_links(pool, req).await,
         methods::HANGAR_BOARD_CARD_SET_AUTO_RUN => handle_board_card_set_auto_run(pool, req).await,
         methods::HANGAR_REPO_LIST => handle_repo_list(req),
         methods::FLEET_SNAPSHOT => handle_fleet_snapshot(pool).await,
@@ -5793,8 +5796,9 @@ async fn handle_board_card_dep(
 
     let params: ainb_hangar_proto::snapshots::BoardCardDepParams = parse_params(
         req,
-        "{ workspace_id, board_id, dependent_issue_id, blocker_issue_id }",
+        "{ workspace_id, board_id, dependent_issue_id, blocker_issue_id, link_type? }",
     )?;
+    let kind = link_kind_of(params.link_type);
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
 
     // Both endpoints must be cards on this board — a dependency is a board
@@ -5806,26 +5810,113 @@ async fn handle_board_card_dep(
     }
 
     if add {
-        CardDependencyRepo::add_edge(
+        CardDependencyRepo::add_link(
             pool,
             &ws,
             &params.dependent_issue_id,
             &params.blocker_issue_id,
+            kind,
             SystemClock.now_ms(),
         )
         .await
         .map_err(|e| card_dep_err(&e))?;
     } else {
-        CardDependencyRepo::remove_edge(
+        CardDependencyRepo::remove_link(
             pool,
             &ws,
             &params.dependent_issue_id,
             &params.blocker_issue_id,
+            kind,
         )
         .await
         .map_err(|e| store_err(&e))?;
     }
     boards_list_value(pool, &ws).await
+}
+
+/// Translate the wire kind onto the store's [`LinkKind`] (multica parity #20).
+/// The wire default (`blocked_by`) is the historical gating edge, so an old client
+/// that omits the field lands here unchanged.
+///
+/// [`LinkKind`]: ainb_hangar_store::repo::card_dependency::LinkKind
+fn link_kind_of(
+    wire: ainb_hangar_proto::snapshots::LinkKindWire,
+) -> ainb_hangar_store::repo::card_dependency::LinkKind {
+    use ainb_hangar_proto::snapshots::LinkKindWire;
+    use ainb_hangar_store::repo::card_dependency::LinkKind;
+    match wire {
+        LinkKindWire::Blocks => LinkKind::Blocks,
+        LinkKindWire::BlockedBy => LinkKind::BlockedBy,
+        LinkKindWire::Related => LinkKind::Related,
+    }
+}
+
+/// `hangar/issue_link_add` (`add = true`) / `hangar/issue_link_remove`
+/// (`add = false`) (multica parity #20): author a TYPED link between two issues,
+/// independent of any board.
+///
+/// Board-free counterpart of [`handle_board_card_dep`] — the link lives on the
+/// issues, so it is authorable from the issue list / detail card / CLI with no
+/// board in the picture. Same workspace scoping and the same
+/// [`card_dep_err`] mapping. Answers with the refreshed link list.
+async fn handle_issue_link(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    add: bool,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let params: ainb_hangar_proto::snapshots::IssueLinkParams = parse_params(
+        req,
+        "{ workspace_id, issue_id, other_issue_id, link_type? }",
+    )?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let kind = link_kind_of(params.link_type);
+
+    if add {
+        CardDependencyRepo::add_link(
+            pool,
+            &ws,
+            &params.issue_id,
+            &params.other_issue_id,
+            kind,
+            SystemClock.now_ms(),
+        )
+        .await
+        .map_err(|e| card_dep_err(&e))?;
+    } else {
+        CardDependencyRepo::remove_link(pool, &ws, &params.issue_id, &params.other_issue_id, kind)
+            .await
+            .map_err(|e| store_err(&e))?;
+    }
+    issue_links_value(pool, &ws, &params.issue_id).await
+}
+
+/// `hangar/issue_links` (multica parity #20): read one issue's whole typed link
+/// graph, in render order (`blocked_by`, then `blocks`, then `related`).
+async fn handle_issue_links(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::snapshots::IssueLinksParams =
+        parse_params(req, "{ workspace_id, issue_id }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    issue_links_value(pool, &ws, &params.issue_id).await
+}
+
+/// Build the `IssueLinksResult` payload for one issue.
+async fn issue_links_value(
+    pool: &SqlitePool,
+    ws: &ainb_hangar_core::ids::WorkspaceId,
+    issue_id: &str,
+) -> Result<serde_json::Value, RpcError> {
+    let links = crate::rpc::snapshots::issue_link_rows(pool, ws.as_str(), issue_id)
+        .await
+        .map_err(|e| store_err(&e))?;
+    Ok(
+        serde_json::to_value(ainb_hangar_proto::snapshots::IssueLinksResult { links })
+            .unwrap_or(serde_json::Value::Null),
+    )
 }
 
 /// `hangar/board_card_set_auto_run` (tcp T4 / F7): flip a card's auto-run flag.
@@ -5864,7 +5955,7 @@ async fn handle_board_card_set_auto_run(
 fn card_dep_err(e: &ainb_hangar_store::repo::card_dependency::CardDependencyError) -> RpcError {
     use ainb_hangar_store::repo::card_dependency::CardDependencyError;
     match e {
-        CardDependencyError::SelfDependency => invalid_params("a card cannot depend on itself"),
+        CardDependencyError::SelfDependency => invalid_params("a card cannot link to itself"),
         CardDependencyError::Cycle => invalid_params("that dependency would create a cycle"),
         CardDependencyError::NotFound => invalid_params("both cards must be on this board"),
         CardDependencyError::Db(db) => store_err(db),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -151,6 +151,7 @@ pub async fn issues_list(
                 acceptance_criteria: criteria_texts(&issue.acceptance_criteria),
                 acceptance: issue.acceptance_criteria,
                 context_refs: issue.context_refs,
+                dependencies: Vec::new(),
             });
         }
     }
@@ -322,6 +323,7 @@ pub async fn issues_search(
             acceptance_criteria: criteria_texts(&issue.acceptance_criteria),
             acceptance: issue.acceptance_criteria,
             context_refs: issue.context_refs,
+            dependencies: Vec::new(),
         });
     }
     Ok(out)
@@ -731,6 +733,8 @@ async fn enrich_board_card(
         member_states,
         blocked_by,
         auto_run,
+        blocks: Vec::new(),
+        related: Vec::new(),
     })
 }
 
@@ -1776,6 +1780,7 @@ pub async fn issue_row(
         acceptance_criteria: criteria_texts(&issue.acceptance_criteria),
         acceptance: issue.acceptance_criteria,
         context_refs: issue.context_refs,
+        dependencies: Vec::new(),
     }))
 }
 
@@ -1920,6 +1925,7 @@ async fn read_issue_row(
         acceptance_criteria: criteria_texts(&issue.acceptance_criteria),
         acceptance: issue.acceptance_criteria,
         context_refs: issue.context_refs,
+        dependencies: Vec::new(),
     }))
 }
 
@@ -2171,6 +2177,7 @@ pub async fn issue_create(
         acceptance_criteria: criteria_texts(&minted_criteria),
         acceptance: minted_criteria,
         context_refs: context_refs.to_vec(),
+        dependencies: Vec::new(),
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -720,6 +720,19 @@ async fn enrich_board_card(
         .map(|b| short_display_id(b))
         .collect();
     let auto_run = CardDependencyRepo::get_auto_run(pool, issue_id).await?;
+    // multica parity #20: the REVERSE direction (`blocks`) and the non-gating
+    // `related` set. Render-only — neither touches `blocked_by` (still UNFINISHED
+    // blockers only) nor the card's runnable state.
+    let blocks = CardDependencyRepo::blocks_of(pool, issue_id)
+        .await?
+        .iter()
+        .map(|b| short_display_id(b))
+        .collect();
+    let related = CardDependencyRepo::related_of(pool, issue_id)
+        .await?
+        .iter()
+        .map(|b| short_display_id(b))
+        .collect();
 
     Ok(ainb_hangar_proto::snapshots::BoardCardWireRow {
         issue_id: issue_id.to_string(),
@@ -733,8 +746,8 @@ async fn enrich_board_card(
         member_states,
         blocked_by,
         auto_run,
-        blocks: Vec::new(),
-        related: Vec::new(),
+        blocks,
+        related,
     })
 }
 
@@ -1751,6 +1764,10 @@ pub async fn issue_row(
     let pr_url = latest_pr_url_for_issue(pool, workspace_id, &issue.id).await?;
     let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
     let extras = issue_card_fields(pool, &issue.id).await?;
+    // multica parity #20: the DETAIL path (and only it) carries the typed link
+    // graph — a list snapshot leaves `dependencies` empty on purpose, because
+    // filling it there would be an N-query fan-out per row.
+    let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
         id,
         display_id,
@@ -1780,8 +1797,58 @@ pub async fn issue_row(
         acceptance_criteria: criteria_texts(&issue.acceptance_criteria),
         acceptance: issue.acceptance_criteria,
         context_refs: issue.context_refs,
-        dependencies: Vec::new(),
+        dependencies,
     }))
+}
+
+/// One issue's TYPED links (multica parity #20), in render order: `blocked_by`
+/// first (each flagged `satisfied` once that blocker has finished, so the detail
+/// card can show ✓ vs 🔒), then the reverse `blocks` direction, then the
+/// non-gating `related` set.
+///
+/// Every row is stated from the SUBJECT issue's point of view and carries the
+/// OTHER issue's display id / title / state, resolved through the same
+/// [`issue_display_row`] helper the list snapshot uses, so a link renders
+/// identically to the issue it points at.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault.
+pub async fn issue_link_rows(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    issue_id: &str,
+) -> Result<Vec<ainb_hangar_proto::events::IssueLinkRow>, sqlx::Error> {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let prefix = workspace_issue_prefix(pool, workspace_id).await?;
+    let blockers = CardDependencyRepo::blockers_of(pool, issue_id).await?;
+    let unfinished = CardDependencyRepo::unfinished_blockers_of(pool, issue_id).await?;
+    let blocks = CardDependencyRepo::blocks_of(pool, issue_id).await?;
+    let related = CardDependencyRepo::related_of(pool, issue_id).await?;
+
+    let mut out = Vec::with_capacity(blockers.len() + blocks.len() + related.len());
+    for (kind, ids) in [
+        ("blocked_by", &blockers),
+        ("blocks", &blocks),
+        ("related", &related),
+    ] {
+        for other in ids {
+            let display_id =
+                issue_display_row(pool, workspace_id, other, prefix.as_deref()).await?;
+            let row = IssueRepo::get_by_id(pool, other).await?;
+            out.push(ainb_hangar_proto::events::IssueLinkRow {
+                kind: kind.to_string(),
+                issue_id: other.clone(),
+                display_id,
+                title: row.as_ref().map(|r| r.title.clone()).unwrap_or_default(),
+                state: row.as_ref().map(|r| r.state.clone()).unwrap_or_default(),
+                // Only a blocker can be satisfied; `blocks` / `related` never gate.
+                satisfied: kind == "blocked_by" && !unfinished.contains(other),
+            });
+        }
+    }
+    Ok(out)
 }
 
 /// Attach a label to an issue, scoped to `workspace_id`, then re-read the issue
@@ -1896,6 +1963,10 @@ async fn read_issue_row(
     let pr_url = latest_pr_url_for_issue(pool, workspace_id, &issue.id).await?;
     let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
     let extras = issue_card_fields(pool, &issue.id).await?;
+    // multica parity #20: the DETAIL path (and only it) carries the typed link
+    // graph — a list snapshot leaves `dependencies` empty on purpose, because
+    // filling it there would be an N-query fan-out per row.
+    let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
         id,
         display_id,
@@ -1925,7 +1996,7 @@ async fn read_issue_row(
         acceptance_criteria: criteria_texts(&issue.acceptance_criteria),
         acceptance: issue.acceptance_criteria,
         context_refs: issue.context_refs,
-        dependencies: Vec::new(),
+        dependencies,
     }))
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -229,6 +229,7 @@ fn issue_event() -> HangarEvent {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_links.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_links.rs
@@ -1,0 +1,618 @@
+//! Integration: TYPED issue links over a real framed `UnixStream` against a real
+//! sqlite (multica parity #20).
+//!
+//! The acceptance in two halves, both proven over the wire:
+//!
+//! 1. **dispatch gating** — a link authored with an explicit `blocked_by`
+//!    `link_type` refuses `hangar/issue_run` while the blocker is unfinished, and
+//!    NO task row is written (the assertion counts rows, it does not trust the
+//!    error text);
+//! 2. **the negative control** — the SAME shape authored as `related` dispatches
+//!    normally, so `related` is proven non-gating rather than merely untested.
+//!
+//! Plus the append-only wire proof: raw JSON params that OMIT `link_type`
+//! entirely (a pre-#20 client) still create a GATING edge.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// Seed `n` fresh issues named `link-<tag>-<i>` into the fixture workspace.
+///
+/// Each test owns its OWN issues on purpose: `run_card` serialises launches
+/// through a PROCESS-GLOBAL slot keyed on the issue id alone, so two tests that
+/// run the same seeded issue in parallel race for that slot and one gets the
+/// "already active" refusal instead of the refusal it asserts on.
+async fn seed_issues(store: &Store, tag: &str, n: usize) -> Vec<String> {
+    use ainb_hangar_core::clock::HangarClock;
+    let now = ainb_hangar_core::clock::SystemClock.now_ms();
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let id = format!("link-{tag}-{i}");
+        sqlx::query(
+            "INSERT INTO issue \
+             (id, workspace_id, title, description, state, creator_type, creator_id, created_at) \
+             VALUES (?, ?, ?, ?, 'open', 'member', 'user-1', ?)",
+        )
+        .bind(&id)
+        .bind(ainb_hangar_daemon::seed::WS_ID)
+        .bind(format!("Link fixture {i}"))
+        // A non-empty brief: `run_card` refuses an empty card BEFORE it reaches
+        // the dependency gate, which would mask the refusal under test.
+        .bind(format!("Seeded body for link fixture {i}"))
+        .bind(now)
+        .execute(store.pool())
+        .await
+        .expect("seed issue");
+        ids.push(id);
+    }
+    ids
+}
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(11),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    /// Send `method` and return the first frame carrying an `id` (interleaved
+    /// event notifications are discarded).
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame_inner())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    /// Author a link with an explicit kind token.
+    async fn link(&mut self, from: &str, to: &str, kind: &str) -> serde_json::Value {
+        self.call(
+            methods::HANGAR_ISSUE_LINK_ADD,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": from,
+                "other_issue_id": to,
+                "link_type": kind,
+            }),
+        )
+        .await
+    }
+
+    async fn links_of(&mut self, issue: &str) -> Vec<serde_json::Value> {
+        let resp = self
+            .call(
+                methods::HANGAR_ISSUE_LINKS,
+                serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": issue }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "issue_links must ack: {resp}");
+        resp["result"]["links"].as_array().cloned().unwrap_or_default()
+    }
+
+    async fn run(&mut self, issue: &str) -> serde_json::Value {
+        self.call(
+            methods::HANGAR_ISSUE_RUN,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": issue,
+                "mode": "headless",
+            }),
+        )
+        .await
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+async fn task_count(store: &Store, issue: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = ?")
+        .bind(issue)
+        .fetch_one(store.pool())
+        .await
+        .expect("count tasks")
+}
+
+/// The at-rest `link_type` of one ordered pair, read with raw SQL — the reply is
+/// not evidence of a write.
+async fn stored_kind(store: &Store, dependent: &str, blocker: &str) -> Option<String> {
+    sqlx::query_scalar(
+        "SELECT link_type FROM card_dependency \
+         WHERE dependent_issue_id = ? AND blocker_issue_id = ?",
+    )
+    .bind(dependent)
+    .bind(blocker)
+    .fetch_optional(store.pool())
+    .await
+    .expect("read link_type")
+}
+
+/// The acceptance's DISPATCH-GATING half, through the NEW typed write path.
+#[tokio::test]
+async fn issue_link_add_blocked_by_then_run_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "gate", 2).await;
+    let (dep, blocker) = (&ids[0], &ids[1]);
+
+    let resp = c.link(dep, blocker, "blocked_by").await;
+    assert!(resp["error"].is_null(), "link add must ack: {resp}");
+    assert_eq!(
+        stored_kind(&store, dep, blocker).await.as_deref(),
+        Some("blocked_by"),
+        "the link persisted with its authored kind"
+    );
+
+    let run = c.run(dep).await;
+    assert!(
+        !run["error"].is_null(),
+        "a blocked card must refuse to run: {run}"
+    );
+    let message = run["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("blocked"),
+        "the refusal must say the card is blocked, got {message:?}"
+    );
+    assert_eq!(
+        task_count(&store, dep).await,
+        0,
+        "a refused run must enqueue nothing"
+    );
+}
+
+/// The negative control: the SAME shape authored as `related` NEVER gates — the
+/// run gets past the dependency check instead of being refused as blocked, and
+/// the store agrees the card has no unfinished blockers.
+#[tokio::test]
+async fn issue_link_add_related_then_run_dispatches() {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "related-run", 2).await;
+    let (a, b) = (&ids[0], &ids[1]);
+
+    let resp = c.link(a, b, "related").await;
+    assert!(resp["error"].is_null(), "related link must ack: {resp}");
+    assert_eq!(stored_kind(&store, a, b).await.as_deref(), Some("related"));
+
+    assert!(
+        CardDependencyRepo::unfinished_blockers_of(store.pool(), a)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a related link leaves the card with no unfinished blockers"
+    );
+
+    let run = c.run(a).await;
+    let message = run["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        !message.contains("blocked"),
+        "a related link must never refuse a run as blocked, got {message:?}"
+    );
+}
+
+/// The APPEND-ONLY wire proof: raw params that OMIT `link_type` (a pre-#20
+/// client) still create a GATING edge.
+#[tokio::test]
+async fn issue_link_add_without_link_type_still_creates_a_blocking_edge() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "oldclient", 2).await;
+    let (dep, blocker) = (&ids[0], &ids[1]);
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_LINK_ADD,
+            // No `link_type` key at all.
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": dep,
+                "other_issue_id": blocker,
+            }),
+        )
+        .await;
+    assert!(
+        resp["error"].is_null(),
+        "an old client's params must ack: {resp}"
+    );
+    assert_eq!(
+        stored_kind(&store, dep, blocker).await.as_deref(),
+        Some("blocked_by"),
+        "an omitted link_type means the historical gating edge"
+    );
+
+    let run = c.run(dep).await;
+    let message = run["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("blocked"),
+        "the pre-#20 edge still gates dispatch, got {message:?}"
+    );
+}
+
+/// All three kinds list back, each carrying the OTHER issue's identity, with
+/// `satisfied` set only for a blocker that has finished.
+#[tokio::test]
+async fn issue_links_lists_all_three_kinds_with_satisfied_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "list", 4).await;
+    let (subject, blocker, blocked, friend) = (&ids[0], &ids[1], &ids[2], &ids[3]);
+
+    c.link(subject, blocker, "blocked_by").await;
+    c.link(subject, blocked, "blocks").await;
+    c.link(subject, friend, "related").await;
+
+    let links = c.links_of(subject).await;
+    let kinds: Vec<&str> = links.iter().filter_map(|l| l["kind"].as_str()).collect();
+    for want in ["blocked_by", "blocks", "related"] {
+        assert!(kinds.contains(&want), "{want} missing from {links:?}");
+    }
+
+    let by_kind = |k: &str| {
+        links
+            .iter()
+            .find(|l| l["kind"] == k)
+            .unwrap_or_else(|| panic!("a {k} row in {links:?}"))
+            .clone()
+    };
+
+    let b = by_kind("blocked_by");
+    assert_eq!(b["issue_id"], blocker.as_str());
+    assert!(
+        b["title"].as_str().is_some_and(|t| !t.is_empty()),
+        "the link carries the other issue's title: {b}"
+    );
+    assert!(
+        b["display_id"].as_str().is_some_and(|d| !d.is_empty()),
+        "the link carries the other issue's display id: {b}"
+    );
+    assert_eq!(
+        b["satisfied"], false,
+        "an unfinished blocker is not satisfied"
+    );
+
+    assert_eq!(by_kind("blocks")["issue_id"], blocked.as_str());
+    assert_eq!(by_kind("related")["issue_id"], friend.as_str());
+    assert_eq!(
+        by_kind("related")["satisfied"],
+        false,
+        "a related link is never a satisfied blocker"
+    );
+
+    // The reverse read from the OTHER end shows the mirrored kind.
+    let other = c.links_of(blocked).await;
+    assert!(
+        other
+            .iter()
+            .any(|l| l["kind"] == "blocked_by" && l["issue_id"] == subject.as_str()),
+        "the blocked card reads the same relation as blocked_by: {other:?}"
+    );
+}
+
+/// A `related` link is symmetric: removing it from the OTHER end deletes the one
+/// stored row.
+#[tokio::test]
+async fn issue_link_remove_related_is_symmetric() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "rm", 2).await;
+    let (a, b) = (&ids[0], &ids[1]);
+
+    c.link(a, b, "related").await;
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_LINK_REMOVE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": b,
+                "other_issue_id": a,
+                "link_type": "related",
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "remove must ack: {resp}");
+    assert_eq!(
+        stored_kind(&store, a, b).await,
+        None,
+        "the mirrored remove deleted the symmetric row"
+    );
+}
+
+/// A self-link is refused with a kind-agnostic message, for every kind.
+#[tokio::test]
+async fn a_self_link_is_refused_over_the_wire() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "self", 1).await;
+
+    for kind in ["blocked_by", "blocks", "related"] {
+        let resp = c.link(&ids[0], &ids[0], kind).await;
+        assert!(!resp["error"].is_null(), "{kind} self-link must be refused");
+        assert_eq!(resp["error"]["code"], -32602, "refused as INVALID_PARAMS");
+        let message = resp["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains("itself"),
+            "the refusal is kind-agnostic, got {message:?}"
+        );
+    }
+}
+
+/// The acceptance's BOARD-RENDER half: a card row carries the reverse `blocks`
+/// direction and the `related` set, while `blocked_by` keeps its exact meaning
+/// (UNFINISHED blockers only) — and a `related` link never turns a card blocked.
+#[tokio::test]
+async fn board_snapshot_card_carries_blocks_and_related() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "board", 3).await;
+    let (subject, blocker, friend) = (&ids[0], &ids[1], &ids[2]);
+
+    let created = c
+        .call(
+            methods::HANGAR_BOARD_CREATE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "name": "Links" }),
+        )
+        .await;
+    let board_id = created["result"]["boards"][0]["id"].as_str().expect("board id").to_string();
+    let with_col = c
+        .call(
+            methods::HANGAR_BOARD_COLUMN_ADD,
+            serde_json::json!({ "workspace_id": WS_SLUG, "board_id": board_id, "name": "Todo" }),
+        )
+        .await;
+    let column_id = with_col["result"]["boards"][0]["columns"][0]["id"]
+        .as_str()
+        .expect("column id")
+        .to_string();
+    for issue in [subject, blocker, friend] {
+        let added = c
+            .call(
+                methods::HANGAR_BOARD_CARD_ADD,
+                serde_json::json!({
+                    "workspace_id": WS_SLUG,
+                    "board_id": board_id,
+                    "issue_id": issue,
+                    "column_id": column_id,
+                }),
+            )
+            .await;
+        assert!(added["error"].is_null(), "card_add must ack: {added}");
+    }
+
+    // subject is blocked_by blocker, blocks nobody yet, and is related to friend.
+    c.link(subject, blocker, "blocked_by").await;
+    c.link(subject, friend, "related").await;
+
+    let list = c
+        .call(
+            methods::HANGAR_BOARDS_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    let cards = list["result"]["boards"][0]["columns"][0]["cards"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let card = |issue: &str| {
+        cards
+            .iter()
+            .find(|c| c["issue_id"] == issue)
+            .unwrap_or_else(|| panic!("card for {issue} in {cards:?}"))
+            .clone()
+    };
+
+    let subject_card = card(subject);
+    assert_eq!(
+        subject_card["blocked_by"].as_array().map(Vec::len),
+        Some(1),
+        "the unfinished blocker still renders 🔒: {subject_card}"
+    );
+    assert_eq!(
+        subject_card["related"].as_array().map(Vec::len),
+        Some(1),
+        "the related card renders on the subject: {subject_card}"
+    );
+
+    // The reverse direction renders on the BLOCKER's card, and it is not blocked.
+    let blocker_card = card(blocker);
+    assert_eq!(
+        blocker_card["blocks"].as_array().map(Vec::len),
+        Some(1),
+        "the blocker card renders what it blocks: {blocker_card}"
+    );
+    assert!(
+        blocker_card["blocked_by"].as_array().is_none_or(Vec::is_empty),
+        "the blocker itself is not blocked: {blocker_card}"
+    );
+
+    // The RELATED card is neither blocked nor blocking — the whole point.
+    let friend_card = card(friend);
+    assert!(
+        friend_card["blocked_by"].as_array().is_none_or(Vec::is_empty),
+        "a related card is never blocked: {friend_card}"
+    );
+    assert!(
+        friend_card["blocks"].as_array().is_none_or(Vec::is_empty),
+        "a related card blocks nothing: {friend_card}"
+    );
+    assert_eq!(
+        friend_card["related"].as_array().map(Vec::len),
+        Some(1),
+        "the relation renders from the other end too: {friend_card}"
+    );
+}
+
+/// The finalize-seam NEGATIVE: a `related` card is invisible to
+/// `dependents_of`, so when the other card finishes it can never be auto-run.
+/// The seam itself is UNCHANGED code — this pins that the store filter is what
+/// makes it kind-correct.
+#[tokio::test]
+async fn a_related_card_is_never_a_finalize_seam_dependent() {
+    use ainb_hangar_store::repo::card_dependency::{CardDependencyRepo, LinkKind};
+
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    let ids = seed_issues(&store, "seam", 3).await;
+    let (blocker, dependent, friend) = (&ids[0], &ids[1], &ids[2]);
+
+    c.link(dependent, blocker, "blocked_by").await;
+    c.link(friend, blocker, "related").await;
+    // Opt BOTH into auto-run, so only the link kind can explain the difference.
+    for issue in [dependent, friend] {
+        CardDependencyRepo::set_auto_run(
+            store.pool(),
+            &ainb_hangar_core::ids::WorkspaceId::from_str(
+                ainb_hangar_daemon::seed::WS_ID.to_string(),
+            )
+            .unwrap(),
+            issue,
+            true,
+        )
+        .await
+        .unwrap();
+    }
+
+    let dependents = CardDependencyRepo::dependents_of(store.pool(), blocker).await.unwrap();
+    assert_eq!(
+        dependents,
+        vec![dependent.clone()],
+        "only the blocked_by card is a finalize-seam dependent"
+    );
+    assert!(
+        !dependents.contains(friend),
+        "a related card is never auto-launched when the other finishes"
+    );
+    assert_eq!(
+        CardDependencyRepo::add_link(
+            store.pool(),
+            &ainb_hangar_core::ids::WorkspaceId::from_str(
+                ainb_hangar_daemon::seed::WS_ID.to_string()
+            )
+            .unwrap(),
+            friend,
+            blocker,
+            LinkKind::Related,
+            0,
+        )
+        .await
+        .is_ok(),
+        true,
+        "re-authoring the same related link stays idempotent"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
@@ -776,6 +776,11 @@ pub const T4_SQUAD_INSTRUCTIONS: &str = "Route schema work to the DB owner.";
 pub const T4_DEP_BLOCKER_ISSUE: &str = "issue-dep-a";
 /// The dependency-chain DEPENDENT card's issue id (card B, depends-on A, auto-run on).
 pub const T4_DEP_DEPENDENT_ISSUE: &str = "issue-dep-b";
+/// The card RELATED to the blocker (multica parity #20): it is seeded into the
+/// SAME dep-chain pipeline (a second pipeline would double the fixture cost, and
+/// this suite already flakes under concurrency) with `auto_run` ON, so the only
+/// thing that can explain it never auto-running is its link KIND.
+pub const T4_REL_ISSUE: &str = "issue-dep-r";
 
 /// An agent actor-ref for the T4 squad seeding.
 fn t4_agent_ref(id: &str) -> ainb_hangar_core::actor::ActorRef {
@@ -988,6 +993,26 @@ pub fn prepare_pipeline_dep_chain() -> Pipeline {
                 CardDependencyRepo::set_auto_run(pool, &ws, T4_DEP_DEPENDENT_ISSUE, true)
                     .await
                     .expect("B auto-run on");
+
+                // multica parity #20: R is RELATED to A and also opts into
+                // auto-run. A related link never gates and is invisible to the
+                // finalize seam, so R must neither refuse a run nor gain a task
+                // when A finishes — with auto_run equal on B and R, the LINK KIND
+                // is the only difference between them.
+                seed_card_issue(pool, T4_REL_ISSUE, "DepRelatedR", &repo_path, now + 2).await;
+                CardDependencyRepo::add_link(
+                    pool,
+                    &ws,
+                    T4_REL_ISSUE,
+                    T4_DEP_BLOCKER_ISSUE,
+                    ainb_hangar_store::repo::card_dependency::LinkKind::Related,
+                    now,
+                )
+                .await
+                .expect("R related-to A");
+                CardDependencyRepo::set_auto_run(pool, &ws, T4_REL_ISSUE, true)
+                    .await
+                    .expect("R auto-run on");
                 free_fixture_running_task(pool).await;
             });
         },

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_dependency_chain_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_dependency_chain_e2e.rs
@@ -28,9 +28,9 @@ use std::time::{Duration, Instant};
 mod common;
 use common::{
     BOARD_RUN_BOARD, DaemonRpc, INTERACTIVE_RELEASE_SENTINEL, T4_DEP_BLOCKER_ISSUE,
-    T4_DEP_DEPENDENT_ISSUE, budget_scale, daemon_bin, git_available, latest_task_status_for_issue,
-    newest_active_task_for_issue, prepare_pipeline_dep_chain, prepare_pipeline_squad_dep_chain,
-    skip, task_count_for_issue, task_status_by_id,
+    T4_DEP_DEPENDENT_ISSUE, T4_REL_ISSUE, budget_scale, daemon_bin, git_available,
+    latest_task_status_for_issue, newest_active_task_for_issue, prepare_pipeline_dep_chain,
+    prepare_pipeline_squad_dep_chain, skip, task_count_for_issue, task_status_by_id,
 };
 
 #[test]
@@ -323,4 +323,88 @@ fn poll_until(deadline: Instant, pred: impl Fn() -> bool) -> bool {
         }
         std::thread::sleep(Duration::from_millis(150));
     }
+}
+
+/// multica parity #20 — a `related` card NEVER blocks and NEVER auto-runs.
+///
+/// The positive control lives in
+/// [`dependent_card_refuses_until_blocker_done_then_auto_runs`]: card B is
+/// `blocked_by` A, so it refuses until A is done and then auto-runs. Card R sits in
+/// the SAME pipeline, `related` to A, with the SAME `auto_run = 1` flag — so the
+/// only difference between B and R is the LINK KIND. Against the real daemon:
+///
+///   * running R while A is unfinished SUCCEEDS (it is never refused as blocked);
+///   * when A completes, R gains no ADDITIONAL task from the finalize seam.
+#[test]
+fn related_card_never_blocks_and_never_auto_runs() {
+    if daemon_bin().is_none() || !git_available() {
+        skip("tcp_card_related_link_e2e");
+        return;
+    }
+
+    let pipe = prepare_pipeline_dep_chain();
+    let scale = budget_scale();
+    let mut rpc = DaemonRpc::connect_and_auth(pipe.home());
+
+    // NOT BLOCKED: R is only `related` to the unfinished A, so its run is accepted.
+    let run_r = rpc.call(
+        ainb_hangar_proto::methods::HANGAR_BOARD_CARD_RUN,
+        run_params(T4_REL_ISSUE),
+    );
+    assert!(
+        run_r["error"].is_null(),
+        "a related card must never be refused as blocked: {run_r}"
+    );
+    let after_manual_run = task_count_for_issue(pipe.home(), T4_REL_ISSUE);
+    assert!(
+        after_manual_run >= 1,
+        "R's own manual run enqueued a task ({after_manual_run})"
+    );
+
+    // Meanwhile B — blocked_by the same A — IS refused. Same fixture, same flag,
+    // different kind.
+    let refused_b = rpc.call(
+        ainb_hangar_proto::methods::HANGAR_BOARD_CARD_RUN,
+        run_params(T4_DEP_DEPENDENT_ISSUE),
+    );
+    assert!(
+        !refused_b["error"].is_null(),
+        "the blocked_by card is still refused: {refused_b}"
+    );
+
+    // COMPLETE A, then release, so the finalize seam runs for real.
+    let run_a = rpc.call(
+        ainb_hangar_proto::methods::HANGAR_BOARD_CARD_RUN,
+        run_params(T4_DEP_BLOCKER_ISSUE),
+    );
+    assert!(run_a["error"].is_null(), "blocker A must run: {run_a}");
+    let claimed = poll_until(Instant::now() + Duration::from_secs(30 * scale), || {
+        matches!(
+            latest_task_status_for_issue(pipe.home(), T4_DEP_BLOCKER_ISSUE).as_deref(),
+            Some("dispatched" | "running")
+        )
+    });
+    assert!(claimed, "the claim loop must pick up A");
+    std::fs::write(pipe.home().join(INTERACTIVE_RELEASE_SENTINEL), "go")
+        .expect("write release sentinel");
+
+    // The seam DID fire: B (blocked_by) gains its auto-run task.
+    let b_ran = poll_until(Instant::now() + Duration::from_secs(45 * scale), || {
+        task_count_for_issue(pipe.home(), T4_DEP_DEPENDENT_ISSUE) >= 1
+    });
+
+    let r_after = task_count_for_issue(pipe.home(), T4_REL_ISSUE);
+
+    drop(rpc);
+    drop(pipe);
+
+    assert!(
+        b_ran,
+        "the positive control: the blocked_by card auto-ran when A completed"
+    );
+    assert_eq!(
+        r_after, after_manual_run,
+        "the related card gained NO additional task from the finalize seam \
+         (had {after_manual_run}, now {r_after})"
+    );
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -508,6 +508,40 @@ pub struct IssueRow {
     /// pre-0048 snapshot decodes to `[]`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_refs: Vec<String>,
+    /// This issue's TYPED links (multica parity #20), driving the task-detail
+    /// card's `Links:` block.
+    ///
+    /// Populated ONLY on the single-issue DETAIL path — a list snapshot leaves it
+    /// empty on purpose, because filling it would need an N-query fan-out per row.
+    /// Do not "fix" that by adding one. Empty by default and omitted from the wire
+    /// when empty (append-only), so a pre-#20 daemon decodes to `[]` and the
+    /// detail card simply renders no `Links:` block.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<IssueLinkRow>,
+}
+
+/// One TYPED link on an issue's detail card (multica parity #20), always stated
+/// from the SUBJECT issue's point of view: `kind` says what the subject is to the
+/// other issue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueLinkRow {
+    /// The rendered kind token: `"blocks"`, `"blocked_by"` or `"related"`.
+    pub kind: String,
+    /// The OTHER issue's id (the subject is whichever issue was queried).
+    pub issue_id: String,
+    /// The other issue's human display id (`HGR-<n>`), when resolvable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_id: Option<String>,
+    /// The other issue's title (empty when unresolvable).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub title: String,
+    /// The other issue's state (empty when unresolvable).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub state: String,
+    /// `blocked_by` ONLY: whether that blocker has FINISHED, so it no longer gates
+    /// the subject. Always `false` for `blocks` / `related` (neither gates).
+    #[serde(default)]
+    pub satisfied: bool,
 }
 
 /// A wire-side actor row for the agent-picker snapshot (`hangar/agents_list`).

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -901,6 +901,40 @@ pub const HANGAR_BOARD_CARD_DEP_ADD: &str = "hangar/board_card_dep_add";
 /// no-op. Mutating + workspace-scoped via the board.
 pub const HANGAR_BOARD_CARD_DEP_REMOVE: &str = "hangar/board_card_dep_remove";
 
+/// `hangar/issue_link_add` — add a TYPED link between two issues (multica parity
+/// #20), independent of any board.
+///
+/// Params: [`crate::snapshots::IssueLinkParams`] (`{ workspace_id, issue_id,
+/// other_issue_id, link_type? }`). Result: the refreshed
+/// [`crate::snapshots::IssueLinksResult`]. `link_type` defaults to `blocked_by`
+/// (the gating relation, identical to `board_card_dep_add`); `blocks` is
+/// normalised into the reverse `blocked_by` row; `related` is a symmetric
+/// NON-gating association that never refuses a run and never auto-launches a card.
+/// A self-link, a cycle (gating kinds only), or an endpoint outside the workspace
+/// is rejected (`INVALID_PARAMS`). Re-adding a pair with a new kind replaces the
+/// kind. Mutating + workspace-scoped.
+pub const HANGAR_ISSUE_LINK_ADD: &str = "hangar/issue_link_add";
+
+/// `hangar/issue_link_remove` — remove a TYPED link between two issues (multica
+/// parity #20).
+///
+/// Params: [`crate::snapshots::IssueLinkParams`]. Result: the refreshed
+/// [`crate::snapshots::IssueLinksResult`]. Removing an absent link is an
+/// idempotent no-op; a `related` link is removed from EITHER orientation (it is
+/// symmetric). Mutating + workspace-scoped.
+pub const HANGAR_ISSUE_LINK_REMOVE: &str = "hangar/issue_link_remove";
+
+/// `hangar/issue_links` — read one issue's whole TYPED link graph (multica parity
+/// #20).
+///
+/// Params: [`crate::snapshots::IssueLinksParams`] (`{ workspace_id, issue_id }`).
+/// Result: [`crate::snapshots::IssueLinksResult`] — one
+/// [`crate::events::IssueLinkRow`] per link in render order (`blocked_by`, then
+/// `blocks`, then `related`), each carrying the OTHER issue's display id, title
+/// and state, plus `satisfied` for a blocker that has already finished.
+/// Read-only + workspace-scoped.
+pub const HANGAR_ISSUE_LINKS: &str = "hangar/issue_links";
+
 /// `hangar/board_card_set_auto_run` — flip a card's auto-run flag (tcp T4 / F7).
 ///
 /// Params: [`crate::snapshots::BoardCardAutoRunParams`] (`{ workspace_id, board_id,
@@ -1189,6 +1223,11 @@ pub const ALL_METHODS: &[&str] = &[
     // Agent delete (Agents screen `x` remove) is APPENDED at the catalogue tail —
     // append-only wire.
     HANGAR_AGENT_DELETE,
+    // Typed issue links (multica parity #20) are APPENDED at the catalogue tail —
+    // append-only wire.
+    HANGAR_ISSUE_LINK_ADD,
+    HANGAR_ISSUE_LINK_REMOVE,
+    HANGAR_ISSUE_LINKS,
     // Fleet control-plane methods are appended at the wire catalogue tail.
     FLEET_SNAPSHOT,
     FLEET_SUBSCRIBE,
@@ -1409,6 +1448,9 @@ mod tests {
             HANGAR_DAEMON_CONFIG_LIST,
             HANGAR_ISSUE_DELETE,
             HANGAR_ISSUE_CANCEL_ACTIVE,
+            HANGAR_ISSUE_LINK_ADD,
+            HANGAR_ISSUE_LINK_REMOVE,
+            HANGAR_ISSUE_LINKS,
             FLEET_SNAPSHOT,
             FLEET_SUBSCRIBE,
             FLEET_ACTION,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2166,13 +2166,13 @@ impl LinkKindWire {
     /// pre-#20 meaning, so an old client sees an unchanged payload.
     #[must_use]
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn is_default(&self) -> bool {
+    pub const fn is_default(&self) -> bool {
         matches!(self, Self::BlockedBy)
     }
 
     /// The rendered token (`"blocks"` / `"blocked_by"` / `"related"`).
     #[must_use]
-    pub fn as_token(self) -> &'static str {
+    pub const fn as_token(self) -> &'static str {
         match self {
             Self::Blocks => "blocks",
             Self::BlockedBy => "blocked_by",
@@ -3584,7 +3584,7 @@ mod tests {
         );
     }
 
-    /// Every wire kind round-trips through its snake_case token.
+    /// Every wire kind round-trips through its `snake_case` token.
     #[test]
     fn link_kind_wire_round_trips_snake_case() {
         for (kind, token) in [
@@ -3592,7 +3592,10 @@ mod tests {
             (LinkKindWire::BlockedBy, "blocked_by"),
             (LinkKindWire::Related, "related"),
         ] {
-            assert_eq!(serde_json::to_string(&kind).unwrap(), format!("\"{token}\""));
+            assert_eq!(
+                serde_json::to_string(&kind).unwrap(),
+                format!("\"{token}\"")
+            );
             assert_eq!(kind.as_token(), token);
             assert_eq!(
                 serde_json::from_str::<LinkKindWire>(&format!("\"{token}\"")).unwrap(),
@@ -3611,9 +3614,16 @@ mod tests {
         )
         .expect("a pre-#20 card row still decodes");
         assert!(row.blocks.is_empty() && row.related.is_empty());
-        assert_eq!(row.blocked_by, vec!["HGR-2"], "blocked_by keeps its meaning");
+        assert_eq!(
+            row.blocked_by,
+            vec!["HGR-2"],
+            "blocked_by keeps its meaning"
+        );
 
         let s = serde_json::to_string(&row).unwrap();
-        assert!(!s.contains("\"blocks\"") && !s.contains("\"related\""), "{s}");
+        assert!(
+            !s.contains("\"blocks\"") && !s.contains("\"related\""),
+            "{s}"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1684,6 +1684,16 @@ pub struct BoardCardWireRow {
     /// F7). APPEND-ONLY: default `false` (explicit run stays the default).
     #[serde(default, skip_serializing_if = "is_false")]
     pub auto_run: bool,
+    /// The DISPLAY IDS of the cards this card BLOCKS — the reverse read direction
+    /// of its `blocked_by` rows (multica parity #20). Render-only: it neither
+    /// gates this card nor changes its runnable state. APPEND-ONLY.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blocks: Vec<String>,
+    /// The DISPLAY IDS of this card's RELATED cards (multica parity #20) — a
+    /// symmetric, NON-gating association. Never affects dispatch or auto-run; the
+    /// board renders a `↔n` count and the detail card the full list. APPEND-ONLY.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related: Vec<String>,
 }
 
 /// One squad member's task chip on a fanned-out card (tcp T4 / F7): which agent
@@ -2131,20 +2141,104 @@ pub struct BoardCardAssignSquadParams {
     pub squad_id: Option<String>,
 }
 
+/// The KIND of a card link on the wire (multica parity #20), mirroring
+/// `ainb_hangar_store::repo::card_dependency::LinkKind`.
+///
+/// `BlockedBy` is the DEFAULT, and that is the append-only contract: a pre-#20
+/// client that omits `link_type` gets exactly today's gating edge, and the daemon
+/// omits the field when it is the default so the wire stays byte-identical.
+/// `Blocks` is a write/read DIRECTION — the daemon normalises it into a swapped
+/// `blocked_by` row, so it is never a stored value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkKindWire {
+    /// FROM blocks TO (stored as the reverse `blocked_by` row).
+    Blocks,
+    /// FROM is blocked by TO — the gating relation, and the wire default.
+    #[default]
+    BlockedBy,
+    /// FROM and TO are associated: symmetric, never gating, never auto-running.
+    Related,
+}
+
+impl LinkKindWire {
+    /// serde `skip_serializing_if` helper: omit the field when it carries the
+    /// pre-#20 meaning, so an old client sees an unchanged payload.
+    #[must_use]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::BlockedBy)
+    }
+
+    /// The rendered token (`"blocks"` / `"blocked_by"` / `"related"`).
+    #[must_use]
+    pub fn as_token(self) -> &'static str {
+        match self {
+            Self::Blocks => "blocks",
+            Self::BlockedBy => "blocked_by",
+            Self::Related => "related",
+        }
+    }
+}
+
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_DEP_ADD`] and
-/// [`crate::methods::HANGAR_BOARD_CARD_DEP_REMOVE`] (tcp T4 / F7): a `depends-on`
-/// edge between two cards on the board. The DEPENDENT is blocked until the BLOCKER
-/// finishes.
+/// [`crate::methods::HANGAR_BOARD_CARD_DEP_REMOVE`] (tcp T4 / F7): a typed link
+/// between two cards on the board.
+///
+/// Since multica parity #20 the two positional fields are FROM
+/// (`dependent_issue_id`) and TO (`blocker_issue_id`) and their meaning depends on
+/// `link_type`; the historical names are KEPT for wire compatibility. With the
+/// default `link_type` (`blocked_by`) they read exactly as before: the DEPENDENT
+/// is blocked until the BLOCKER finishes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BoardCardDepParams {
     /// The subscribed workspace the board belongs to (tenant guard).
     pub workspace_id: String,
     /// The board both cards sit on.
     pub board_id: String,
-    /// The DEPENDENT card's issue (the one that gets blocked).
+    /// The FROM card's issue (the DEPENDENT under the default `blocked_by`).
     pub dependent_issue_id: String,
-    /// The BLOCKER card's issue (must finish before the dependent runs).
+    /// The TO card's issue (the BLOCKER under the default `blocked_by`).
     pub blocker_issue_id: String,
+    /// The link's kind (multica parity #20). APPEND-ONLY: omitted ⇒ `blocked_by`,
+    /// i.e. exactly the pre-#20 gating edge.
+    #[serde(default, skip_serializing_if = "LinkKindWire::is_default")]
+    pub link_type: LinkKindWire,
+}
+
+/// Params for [`crate::methods::HANGAR_ISSUE_LINK_ADD`] /
+/// [`crate::methods::HANGAR_ISSUE_LINK_REMOVE`] (multica parity #20): a typed link
+/// between two issues, independent of any board.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueLinkParams {
+    /// The subscribed workspace both issues belong to (tenant guard).
+    pub workspace_id: String,
+    /// The FROM issue (the one the link is authored on).
+    pub issue_id: String,
+    /// The TO issue (the other end).
+    pub other_issue_id: String,
+    /// The link's kind. APPEND-ONLY: omitted ⇒ `blocked_by`.
+    #[serde(default, skip_serializing_if = "LinkKindWire::is_default")]
+    pub link_type: LinkKindWire,
+}
+
+/// Params for [`crate::methods::HANGAR_ISSUE_LINKS`] (multica parity #20): read
+/// one issue's whole typed link graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueLinksParams {
+    /// The subscribed workspace the issue belongs to (tenant guard).
+    pub workspace_id: String,
+    /// The issue whose links to read.
+    pub issue_id: String,
+}
+
+/// Result of [`crate::methods::HANGAR_ISSUE_LINKS`]: every link on one issue, in
+/// render order (`blocked_by`, then `blocks`, then `related`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueLinksResult {
+    /// The issue's typed links. Empty ⇒ the issue has none.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<crate::events::IssueLinkRow>,
 }
 
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_SET_AUTO_RUN`] (tcp T4 / F7):
@@ -2401,6 +2495,7 @@ mod tests {
                 acceptance_criteria: Vec::new(),
                 acceptance: Vec::new(),
                 context_refs: Vec::new(),
+                dependencies: Vec::new(),
             }],
         };
         let s = serde_json::to_string(&issues).unwrap();
@@ -3280,6 +3375,8 @@ mod tests {
                         member_states: Vec::new(),
                         blocked_by: Vec::new(),
                         auto_run: false,
+                        blocks: Vec::new(),
+                        related: Vec::new(),
                     }],
                 }],
                 unmapped: Vec::new(),
@@ -3334,6 +3431,8 @@ mod tests {
             ],
             blocked_by: vec!["ock-2".into()],
             auto_run: true,
+            blocks: Vec::new(),
+            related: Vec::new(),
         };
         let s = serde_json::to_string(&squad_card).unwrap();
         assert_eq!(
@@ -3361,6 +3460,8 @@ mod tests {
             member_states: Vec::new(),
             blocked_by: Vec::new(),
             auto_run: false,
+            blocks: Vec::new(),
+            related: Vec::new(),
         };
         let s = serde_json::to_string(&plain).unwrap();
         for k in ["squad_id", "member_states", "blocked_by", "auto_run"] {
@@ -3449,5 +3550,70 @@ mod tests {
         assert_eq!(over.repo_ref.as_deref(), Some("/repos/app"));
         assert_eq!(over.agent.as_deref(), Some("claude"));
         assert_eq!(over.invoker_user_id.as_deref(), Some("bob"));
+    }
+
+    /// multica parity #20 append-only contract: a PRE-#20 client omits
+    /// `link_type` and gets the gating `blocked_by` edge, and the daemon omits the
+    /// field from the wire when it carries that default — so the payload an old
+    /// client sees is byte-identical to before.
+    #[test]
+    fn board_card_dep_params_link_type_is_append_only() {
+        let old: BoardCardDepParams = serde_json::from_str(
+            r#"{"workspace_id":"ws-1","board_id":"b1","dependent_issue_id":"i2","blocker_issue_id":"i1"}"#,
+        )
+        .expect("a pre-#20 payload still decodes");
+        assert_eq!(
+            old.link_type,
+            LinkKindWire::BlockedBy,
+            "an omitted link_type means the historical gating edge"
+        );
+        assert!(
+            !serde_json::to_string(&old).unwrap().contains("link_type"),
+            "the default kind is omitted from the wire"
+        );
+
+        let related = BoardCardDepParams {
+            link_type: LinkKindWire::Related,
+            ..old
+        };
+        let s = serde_json::to_string(&related).unwrap();
+        assert!(s.contains(r#""link_type":"related""#), "{s}");
+        assert_eq!(
+            serde_json::from_str::<BoardCardDepParams>(&s).unwrap(),
+            related
+        );
+    }
+
+    /// Every wire kind round-trips through its snake_case token.
+    #[test]
+    fn link_kind_wire_round_trips_snake_case() {
+        for (kind, token) in [
+            (LinkKindWire::Blocks, "blocks"),
+            (LinkKindWire::BlockedBy, "blocked_by"),
+            (LinkKindWire::Related, "related"),
+        ] {
+            assert_eq!(serde_json::to_string(&kind).unwrap(), format!("\"{token}\""));
+            assert_eq!(kind.as_token(), token);
+            assert_eq!(
+                serde_json::from_str::<LinkKindWire>(&format!("\"{token}\"")).unwrap(),
+                kind
+            );
+        }
+        assert_eq!(LinkKindWire::default(), LinkKindWire::BlockedBy);
+    }
+
+    /// A pre-#20 card row (no `blocks` / `related`) decodes, and an empty typed
+    /// graph is omitted from the wire.
+    #[test]
+    fn board_card_wire_row_typed_links_are_append_only() {
+        let row: BoardCardWireRow = serde_json::from_str(
+            r#"{"issue_id":"i1","title":"t","display_id":"HGR-1","blocked_by":["HGR-2"]}"#,
+        )
+        .expect("a pre-#20 card row still decodes");
+        assert!(row.blocks.is_empty() && row.related.is_empty());
+        assert_eq!(row.blocked_by, vec!["HGR-2"], "blocked_by keeps its meaning");
+
+        let s = serde_json::to_string(&row).unwrap();
+        assert!(!s.contains("\"blocks\"") && !s.contains("\"related\""), "{s}");
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -59,6 +59,7 @@ fn sample_issue() -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0055_card_dependency_link_type.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0055_card_dependency_link_type.sql
@@ -1,0 +1,32 @@
+-- Hangar v1 schema, migration 0055: TYPED card dependency links (multica parity #20).
+--
+-- multica's `issue_dependency` carries `type IN ('blocks','blocked_by','related')`
+-- (server/migrations/001_init.up.sql:88-94) — schema only, it ships no code over
+-- that table. hangar's `card_dependency` row is already the `blocked_by` relation
+-- (dependent -> blocker), with gating, a DFS cycle guard, and auto-run on top.
+-- This migration adds the KIND dimension so `related` (a non-gating association)
+-- can be recorded alongside it.
+--
+-- Domain AT REST: {'blocked_by','related'}. `blocks` is the SAME edge read from
+-- the other end and is normalised at write into a swapped `blocked_by` row, so one
+-- logical relation can never be stored two ways. (No CHECK constraint: SQLite
+-- cannot add one via ALTER, and this crate keeps PRAGMA foreign_keys off — the
+-- domain is enforced in `CardDependencyRepo` and asserted by a store test, exactly
+-- as endpoint existence and workspace scoping already are for 0036.)
+--
+-- The composite PK `(dependent_issue_id, blocker_issue_id)` from 0036 is
+-- UNCHANGED, so an ordered pair holds at most one relation: a pair is EITHER
+-- gating OR related, never both. Re-adding a pair with a different kind replaces
+-- the kind (`ON CONFLICT ... DO UPDATE SET link_type = excluded.link_type`).
+--
+-- BACKFILL IS THE DEFAULT: every pre-0055 row IS a blocked_by edge, so the
+-- constant DEFAULT 'blocked_by' reproduces today's semantics for existing data
+-- with no rewrite (ADD COLUMN with a constant default is catalog-only, O(1) on a
+-- populated database).
+
+ALTER TABLE card_dependency
+    ADD COLUMN link_type TEXT NOT NULL DEFAULT 'blocked_by';
+
+-- Serves the per-workspace typed graph read (`links_of_workspace`) and lets the
+-- gating queries skip 'related' rows without a scan.
+CREATE INDEX idx_card_dependency_ws_type ON card_dependency(workspace_id, link_type);

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
@@ -15,8 +15,8 @@
 //!     dependent's blockers that have not FINISHED (their active set drained with a
 //!     `done`; a card with any unfinished blocker refuses to run and is never
 //!     auto-dispatched);
-//!   - [`CardDependencyRepo::edges_of_workspace`] — every edge in the workspace,
-//!     for the board snapshot's 🔒 blocked-state render;
+//!   - [`CardDependencyRepo::links_of_workspace`] — every typed link in the
+//!     workspace, for the board snapshot's 🔒 blocked-state render;
 //!   - [`CardDependencyRepo::set_auto_run`] / [`CardDependencyRepo::get_auto_run`]
 //!     — the per-card auto-run flag (default OFF) the finalize seam consults when
 //!     the last blocker completes.
@@ -43,9 +43,97 @@
 //! no task, with any still-active task in its latest generation, or whose latest
 //! generation ended `failed`/`cancelled` (no `done`) is UNFINISHED, so the dependent
 //! stays blocked. See [`CardDependencyRepo::unfinished_blockers_of`].
+//!
+//! # Typed links (multica parity #20, migration 0055)
+//!
+//! Every row carries a [`LinkKind`]. At rest the domain is
+//! `{'blocked_by', 'related'}`: `blocks` is the SAME edge read from the other end
+//! and is normalised at write into a swapped `blocked_by` row, so one logical
+//! relation can never be stored two ways. `related` is symmetric, exempt from the
+//! cycle guard, and INVISIBLE to every gating read
+//! ([`CardDependencyRepo::blockers_of`], [`CardDependencyRepo::dependents_of`],
+//! [`CardDependencyRepo::unfinished_blockers_of`], the cycle DFS) — so a related
+//! card can neither refuse a run nor be auto-launched by the finalize seam.
 
 use ainb_hangar_core::ids::WorkspaceId;
 use sqlx::{Row, SqlitePool};
+
+/// The KIND of a card link (multica parity #20, migration 0055).
+///
+/// multica's `issue_dependency.type` is `IN ('blocks','blocked_by','related')`.
+/// hangar's row is already directional (`dependent -> blocker` == "dependent is
+/// *blocked_by* blocker"), so [`LinkKind::Blocks`] is a write/read DIRECTION, never
+/// a stored value: authoring `A blocks B` normalises into the row
+/// `(dependent = B, blocker = A, link_type = 'blocked_by')`. The at-rest domain is
+/// therefore `{'blocked_by', 'related'}` — see [`LinkKind::as_stored`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LinkKind {
+    /// FROM blocks TO — normalised at write into the reverse `BlockedBy` row.
+    Blocks,
+    /// FROM is blocked by TO — the gating relation (the historical edge).
+    #[default]
+    BlockedBy,
+    /// FROM and TO are associated. Symmetric, NEVER gating, never auto-runs, and
+    /// exempt from the cycle guard.
+    Related,
+}
+
+impl LinkKind {
+    /// The value persisted in `card_dependency.link_type`. `Blocks` shares
+    /// `BlockedBy`'s storage because the endpoints are swapped at write.
+    #[must_use]
+    pub fn as_stored(self) -> &'static str {
+        match self {
+            Self::Blocks | Self::BlockedBy => LINK_TYPE_BLOCKED_BY,
+            Self::Related => LINK_TYPE_RELATED,
+        }
+    }
+
+    /// Parse a wire / CLI token. Accepts `blocks`, `blocked_by`, `blocked-by` and
+    /// `related` (case-insensitively); anything else is `None`.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "blocks" => Some(Self::Blocks),
+            "blocked_by" | "blocked-by" | "blockedby" => Some(Self::BlockedBy),
+            "related" => Some(Self::Related),
+            _ => None,
+        }
+    }
+
+    /// Whether links of this kind gate dispatch (and drive the auto-run seam).
+    /// `Related` never does.
+    #[must_use]
+    pub fn is_gating(self) -> bool {
+        !matches!(self, Self::Related)
+    }
+
+    /// The rendered token (`"blocks"` / `"blocked_by"` / `"related"`).
+    #[must_use]
+    pub fn as_token(self) -> &'static str {
+        match self {
+            Self::Blocks => "blocks",
+            Self::BlockedBy => LINK_TYPE_BLOCKED_BY,
+            Self::Related => LINK_TYPE_RELATED,
+        }
+    }
+}
+
+/// The gating value stored in `card_dependency.link_type`.
+pub const LINK_TYPE_BLOCKED_BY: &str = "blocked_by";
+/// The non-gating value stored in `card_dependency.link_type`.
+pub const LINK_TYPE_RELATED: &str = "related";
+
+/// One typed link with both endpoints, in AUTHORED (row) order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CardLink {
+    /// The `dependent` endpoint of the stored row.
+    pub dependent_issue_id: String,
+    /// The `blocker` endpoint of the stored row.
+    pub blocker_issue_id: String,
+    /// The stored kind (never [`LinkKind::Blocks`] — see [`LinkKind`]).
+    pub kind: LinkKind,
+}
 
 /// Stateless typed wrapper over the `card_dependency` table + the `issue.auto_run`
 /// flag (tcp T4 / F7).
@@ -54,9 +142,10 @@ pub struct CardDependencyRepo;
 /// Why a dependency edge could not be added.
 #[derive(Debug, thiserror::Error)]
 pub enum CardDependencyError {
-    /// The dependent and blocker are the same card — a card cannot depend on
-    /// itself (the trivial cycle). Rejected.
-    #[error("a card cannot depend on itself")]
+    /// Both endpoints are the same card — a card cannot link to itself (for
+    /// `blocked_by` that is the trivial cycle; for `related` it is meaningless).
+    /// Rejected for EVERY [`LinkKind`].
+    #[error("a card cannot link to itself")]
     SelfDependency,
     /// The edge would create a dependency CYCLE (the blocker already depends,
     /// transitively, on the dependent). Rejected so the graph stays acyclic and a
@@ -93,35 +182,141 @@ impl CardDependencyRepo {
         blocker_issue_id: &str,
         created_at: i64,
     ) -> Result<(), CardDependencyError> {
-        if dependent_issue_id == blocker_issue_id {
+        Self::add_link(
+            pool,
+            workspace,
+            dependent_issue_id,
+            blocker_issue_id,
+            LinkKind::BlockedBy,
+            created_at,
+        )
+        .await
+    }
+
+    /// Add a TYPED link `from -> to` in `workspace`, idempotently (multica parity
+    /// #20).
+    ///
+    /// - [`LinkKind::Blocks`] is normalised by SWAPPING the endpoints and storing
+    ///   the equivalent `blocked_by` row, so one logical relation is never stored
+    ///   two ways.
+    /// - [`LinkKind::BlockedBy`] keeps the historical behaviour verbatim: both
+    ///   endpoints resolved in `workspace`, then the DFS cycle guard, inside one
+    ///   transaction.
+    /// - [`LinkKind::Related`] is SYMMETRIC and NON-GATING: an existing row in
+    ///   EITHER orientation is retyped to `related` (so `A~B` then `B~A` is one
+    ///   row), and the cycle guard is skipped entirely — a `related` edge can
+    ///   never gate anything, so it cannot deadlock a graph.
+    ///
+    /// Re-adding an existing pair with a different kind REPLACES the kind (the
+    /// composite PK holds at most one relation per ordered pair).
+    ///
+    /// # Errors
+    ///
+    /// [`CardDependencyError::SelfDependency`] (for EVERY kind — a card cannot
+    /// link to itself) / [`CardDependencyError::Cycle`] /
+    /// [`CardDependencyError::NotFound`] / [`CardDependencyError::Db`].
+    pub async fn add_link(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        from_issue_id: &str,
+        to_issue_id: &str,
+        kind: LinkKind,
+        created_at: i64,
+    ) -> Result<(), CardDependencyError> {
+        if from_issue_id == to_issue_id {
             return Err(CardDependencyError::SelfDependency);
         }
+        // `blocks` is the same edge read from the other end: swap and store as
+        // `blocked_by`.
+        let (dependent_issue_id, blocker_issue_id) = match kind {
+            LinkKind::Blocks => (to_issue_id, from_issue_id),
+            LinkKind::BlockedBy | LinkKind::Related => (from_issue_id, to_issue_id),
+        };
+
         let mut tx = pool.begin().await?;
         Self::ensure_issue_in_ws(&mut tx, workspace, dependent_issue_id).await?;
         Self::ensure_issue_in_ws(&mut tx, workspace, blocker_issue_id).await?;
+
+        if kind == LinkKind::Related {
+            // Symmetric: retype an existing row in EITHER orientation rather than
+            // adding a mirrored second row.
+            let updated = sqlx::query(
+                "UPDATE card_dependency SET link_type = ? \
+                 WHERE workspace_id = ? \
+                   AND ((dependent_issue_id = ? AND blocker_issue_id = ?) \
+                     OR (dependent_issue_id = ? AND blocker_issue_id = ?))",
+            )
+            .bind(LINK_TYPE_RELATED)
+            .bind(workspace.as_str())
+            .bind(dependent_issue_id)
+            .bind(blocker_issue_id)
+            .bind(blocker_issue_id)
+            .bind(dependent_issue_id)
+            .execute(&mut *tx)
+            .await?;
+            if updated.rows_affected() == 0 {
+                Self::insert_row(
+                    &mut tx,
+                    workspace,
+                    dependent_issue_id,
+                    blocker_issue_id,
+                    LinkKind::Related,
+                    created_at,
+                )
+                .await?;
+            }
+            tx.commit().await?;
+            return Ok(());
+        }
 
         // Cycle guard: the new edge says "dependent depends on blocker". A cycle
         // exists iff `blocker` can already reach `dependent` by following
         // depends-on edges (blocker -> ... -> dependent) — adding
         // dependent -> blocker would then close the loop. DFS from `blocker` over
-        // its own blockers; if it reaches `dependent`, reject.
+        // its own blockers; if it reaches `dependent`, reject. `related` rows are
+        // invisible to the DFS (they gate nothing).
         if Self::reaches(&mut tx, blocker_issue_id, dependent_issue_id).await? {
             return Err(CardDependencyError::Cycle);
         }
 
+        Self::insert_row(
+            &mut tx,
+            workspace,
+            dependent_issue_id,
+            blocker_issue_id,
+            LinkKind::BlockedBy,
+            created_at,
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Insert one already-normalised link row, replacing the KIND of an existing
+    /// row for the same ordered pair (the composite PK holds one relation per
+    /// pair, so a re-add with a new kind retypes rather than erroring).
+    async fn insert_row(
+        tx: &mut sqlx::SqliteConnection,
+        workspace: &WorkspaceId,
+        dependent_issue_id: &str,
+        blocker_issue_id: &str,
+        kind: LinkKind,
+        created_at: i64,
+    ) -> Result<(), sqlx::Error> {
         sqlx::query(
             "INSERT INTO card_dependency \
-             (workspace_id, dependent_issue_id, blocker_issue_id, created_at) \
-             VALUES (?, ?, ?, ?) \
-             ON CONFLICT (dependent_issue_id, blocker_issue_id) DO NOTHING",
+             (workspace_id, dependent_issue_id, blocker_issue_id, created_at, link_type) \
+             VALUES (?, ?, ?, ?, ?) \
+             ON CONFLICT (dependent_issue_id, blocker_issue_id) \
+             DO UPDATE SET link_type = excluded.link_type",
         )
         .bind(workspace.as_str())
         .bind(dependent_issue_id)
         .bind(blocker_issue_id)
         .bind(created_at)
+        .bind(kind.as_stored())
         .execute(&mut *tx)
         .await?;
-        tx.commit().await?;
         Ok(())
     }
 
@@ -138,20 +333,68 @@ impl CardDependencyRepo {
         dependent_issue_id: &str,
         blocker_issue_id: &str,
     ) -> Result<(), sqlx::Error> {
+        Self::remove_link(
+            pool,
+            workspace,
+            dependent_issue_id,
+            blocker_issue_id,
+            LinkKind::BlockedBy,
+        )
+        .await
+    }
+
+    /// Remove the TYPED link `from -> to`, idempotently. `Blocks` swaps the
+    /// endpoints (mirroring [`CardDependencyRepo::add_link`]); `Related` deletes
+    /// the row in EITHER orientation, since a related link is symmetric.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn remove_link(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        from_issue_id: &str,
+        to_issue_id: &str,
+        kind: LinkKind,
+    ) -> Result<(), sqlx::Error> {
+        let (dependent_issue_id, blocker_issue_id) = match kind {
+            LinkKind::Blocks => (to_issue_id, from_issue_id),
+            LinkKind::BlockedBy | LinkKind::Related => (from_issue_id, to_issue_id),
+        };
+        if kind == LinkKind::Related {
+            sqlx::query(
+                "DELETE FROM card_dependency \
+                 WHERE workspace_id = ? AND link_type = ? \
+                   AND ((dependent_issue_id = ? AND blocker_issue_id = ?) \
+                     OR (dependent_issue_id = ? AND blocker_issue_id = ?))",
+            )
+            .bind(workspace.as_str())
+            .bind(LINK_TYPE_RELATED)
+            .bind(dependent_issue_id)
+            .bind(blocker_issue_id)
+            .bind(blocker_issue_id)
+            .bind(dependent_issue_id)
+            .execute(pool)
+            .await?;
+            return Ok(());
+        }
         sqlx::query(
             "DELETE FROM card_dependency \
-             WHERE workspace_id = ? AND dependent_issue_id = ? AND blocker_issue_id = ?",
+             WHERE workspace_id = ? AND dependent_issue_id = ? AND blocker_issue_id = ? \
+               AND link_type = ?",
         )
         .bind(workspace.as_str())
         .bind(dependent_issue_id)
         .bind(blocker_issue_id)
+        .bind(LINK_TYPE_BLOCKED_BY)
         .execute(pool)
         .await?;
         Ok(())
     }
 
     /// The blocker issue ids the dependent card depends on (its direct blockers),
-    /// ordered by insertion time then id for a stable render.
+    /// ordered by insertion time then id for a stable render. GATING links only —
+    /// `related` rows are excluded (migration 0055).
     ///
     /// # Errors
     ///
@@ -162,9 +405,49 @@ impl CardDependencyRepo {
     ) -> Result<Vec<String>, sqlx::Error> {
         sqlx::query_scalar(
             "SELECT blocker_issue_id FROM card_dependency \
-             WHERE dependent_issue_id = ? ORDER BY created_at, blocker_issue_id",
+             WHERE dependent_issue_id = ? AND link_type = 'blocked_by' \
+             ORDER BY created_at, blocker_issue_id",
         )
         .bind(dependent_issue_id)
+        .fetch_all(pool)
+        .await
+    }
+
+    /// The issue ids this card BLOCKS — the reverse read direction of its
+    /// `blocked_by` rows (multica parity #20). Identical to
+    /// [`CardDependencyRepo::dependents_of`]; named for the render, which shows it
+    /// as a `blocks` link on the detail card.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn blocks_of(
+        pool: &SqlitePool,
+        blocker_issue_id: &str,
+    ) -> Result<Vec<String>, sqlx::Error> {
+        Self::dependents_of(pool, blocker_issue_id).await
+    }
+
+    /// This card's RELATED issue ids — the union of both orientations, since a
+    /// `related` link is symmetric. Ordered by insertion time then id for a stable
+    /// render. Never gates and never auto-runs.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn related_of(
+        pool: &SqlitePool,
+        issue_id: &str,
+    ) -> Result<Vec<String>, sqlx::Error> {
+        sqlx::query_scalar(
+            "SELECT CASE WHEN dependent_issue_id = ?1 THEN blocker_issue_id \
+                         ELSE dependent_issue_id END AS other \
+             FROM card_dependency \
+             WHERE link_type = 'related' \
+               AND (dependent_issue_id = ?1 OR blocker_issue_id = ?1) \
+             ORDER BY created_at, other",
+        )
+        .bind(issue_id)
         .fetch_all(pool)
         .await
     }
@@ -181,7 +464,8 @@ impl CardDependencyRepo {
     ) -> Result<Vec<String>, sqlx::Error> {
         sqlx::query_scalar(
             "SELECT dependent_issue_id FROM card_dependency \
-             WHERE blocker_issue_id = ? ORDER BY created_at, dependent_issue_id",
+             WHERE blocker_issue_id = ? AND link_type = 'blocked_by' \
+             ORDER BY created_at, dependent_issue_id",
         )
         .bind(blocker_issue_id)
         .fetch_all(pool)
@@ -238,6 +522,7 @@ impl CardDependencyRepo {
         sqlx::query_scalar(
             "SELECT d.blocker_issue_id FROM card_dependency d \
              WHERE d.dependent_issue_id = ? \
+               AND d.link_type = 'blocked_by' \
                AND NOT ( \
                      EXISTS ( \
                        SELECT 1 FROM agent_task_queue t \
@@ -260,19 +545,20 @@ impl CardDependencyRepo {
         .await
     }
 
-    /// Every dependency edge in `workspace` as `(dependent, blocker)` pairs, for
-    /// the board snapshot's blocked-state render. Ordered by dependent then blocker
-    /// for a deterministic snapshot.
+    /// Every TYPED link in `workspace`, for the board snapshot's blocked-state
+    /// render and the whole-graph read. Ordered by dependent then blocker for a
+    /// deterministic snapshot. An unrecognised stored `link_type` (only reachable
+    /// by a hand-edited database) reads back as the gating default.
     ///
     /// # Errors
     ///
     /// Returns a [`sqlx::Error`] on a store fault.
-    pub async fn edges_of_workspace(
+    pub async fn links_of_workspace(
         pool: &SqlitePool,
         workspace: &WorkspaceId,
-    ) -> Result<Vec<(String, String)>, sqlx::Error> {
+    ) -> Result<Vec<CardLink>, sqlx::Error> {
         let rows = sqlx::query(
-            "SELECT dependent_issue_id, blocker_issue_id FROM card_dependency \
+            "SELECT dependent_issue_id, blocker_issue_id, link_type FROM card_dependency \
              WHERE workspace_id = ? ORDER BY dependent_issue_id, blocker_issue_id",
         )
         .bind(workspace.as_str())
@@ -280,10 +566,12 @@ impl CardDependencyRepo {
         .await?;
         rows.iter()
             .map(|r| {
-                Ok((
-                    r.try_get("dependent_issue_id")?,
-                    r.try_get("blocker_issue_id")?,
-                ))
+                let raw: String = r.try_get("link_type")?;
+                Ok(CardLink {
+                    dependent_issue_id: r.try_get("dependent_issue_id")?,
+                    blocker_issue_id: r.try_get("blocker_issue_id")?,
+                    kind: LinkKind::parse(&raw).unwrap_or_default(),
+                })
             })
             .collect()
     }
@@ -342,8 +630,11 @@ impl CardDependencyRepo {
             if !visited.insert(node.clone()) {
                 continue;
             }
+            // Only GATING edges can form a deadlocking cycle; `related` rows are
+            // invisible here (migration 0055).
             let next: Vec<String> = sqlx::query_scalar(
-                "SELECT blocker_issue_id FROM card_dependency WHERE dependent_issue_id = ?",
+                "SELECT blocker_issue_id FROM card_dependency \
+                 WHERE dependent_issue_id = ? AND link_type = 'blocked_by'",
             )
             .bind(&node)
             .fetch_all(&mut *tx)
@@ -472,7 +763,7 @@ mod tests {
         deps.sort();
         assert_eq!(deps, vec!["b", "c"]);
         assert_eq!(
-            CardDependencyRepo::edges_of_workspace(pool, &ws("ws-a")).await.unwrap().len(),
+            CardDependencyRepo::links_of_workspace(pool, &ws("ws-a")).await.unwrap().len(),
             2,
             "the idempotent re-add did not double the edge"
         );
@@ -520,7 +811,7 @@ mod tests {
 
         // The two rejected edges were never written.
         assert_eq!(
-            CardDependencyRepo::edges_of_workspace(pool, &ws("ws-a")).await.unwrap().len(),
+            CardDependencyRepo::links_of_workspace(pool, &ws("ws-a")).await.unwrap().len(),
             2
         );
     }
@@ -552,7 +843,7 @@ mod tests {
             "got {foreign:?}"
         );
         assert!(
-            CardDependencyRepo::edges_of_workspace(pool, &ws("ws-a"))
+            CardDependencyRepo::links_of_workspace(pool, &ws("ws-a"))
                 .await
                 .unwrap()
                 .is_empty()

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
@@ -62,10 +62,11 @@ use sqlx::{Row, SqlitePool};
 ///
 /// multica's `issue_dependency.type` is `IN ('blocks','blocked_by','related')`.
 /// hangar's row is already directional (`dependent -> blocker` == "dependent is
-/// *blocked_by* blocker"), so [`LinkKind::Blocks`] is a write/read DIRECTION, never
+/// `blocked_by` blocker"), so [`LinkKind::Blocks`] is a write/read DIRECTION, never
 /// a stored value: authoring `A blocks B` normalises into the row
 /// `(dependent = B, blocker = A, link_type = 'blocked_by')`. The at-rest domain is
 /// therefore `{'blocked_by', 'related'}` — see [`LinkKind::as_stored`].
+///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LinkKind {
     /// FROM blocks TO — normalised at write into the reverse `BlockedBy` row.
@@ -79,10 +80,12 @@ pub enum LinkKind {
 }
 
 impl LinkKind {
-    /// The value persisted in `card_dependency.link_type`. `Blocks` shares
-    /// `BlockedBy`'s storage because the endpoints are swapped at write.
+    /// The value persisted in `card_dependency.link_type`.
+    ///
+    /// `Blocks` shares `BlockedBy`'s storage because the endpoints are swapped at
+    /// write.
     #[must_use]
-    pub fn as_stored(self) -> &'static str {
+    pub const fn as_stored(self) -> &'static str {
         match self {
             Self::Blocks | Self::BlockedBy => LINK_TYPE_BLOCKED_BY,
             Self::Related => LINK_TYPE_RELATED,
@@ -101,16 +104,17 @@ impl LinkKind {
         }
     }
 
-    /// Whether links of this kind gate dispatch (and drive the auto-run seam).
-    /// `Related` never does.
+    /// Whether links of this kind gate dispatch.
+    ///
+    /// Gating kinds also drive the auto-run seam; `Related` never does either.
     #[must_use]
-    pub fn is_gating(self) -> bool {
+    pub const fn is_gating(self) -> bool {
         !matches!(self, Self::Related)
     }
 
     /// The rendered token (`"blocks"` / `"blocked_by"` / `"related"`).
     #[must_use]
-    pub fn as_token(self) -> &'static str {
+    pub const fn as_token(self) -> &'static str {
         match self {
             Self::Blocks => "blocks",
             Self::BlockedBy => LINK_TYPE_BLOCKED_BY,
@@ -435,10 +439,7 @@ impl CardDependencyRepo {
     /// # Errors
     ///
     /// Returns a [`sqlx::Error`] on a store fault.
-    pub async fn related_of(
-        pool: &SqlitePool,
-        issue_id: &str,
-    ) -> Result<Vec<String>, sqlx::Error> {
+    pub async fn related_of(pool: &SqlitePool, issue_id: &str) -> Result<Vec<String>, sqlx::Error> {
         sqlx::query_scalar(
             "SELECT CASE WHEN dependent_issue_id = ?1 THEN blocker_issue_id \
                          ELSE dependent_issue_id END AS other \

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_card_dependency_typed.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_card_dependency_typed.rs
@@ -1,0 +1,354 @@
+//! Typed card links (multica parity #20, migration 0055).
+//!
+//! multica's `issue_dependency` carries `type IN ('blocks','blocked_by','related')`
+//! and nothing else — no gating, no cycle guard, no auto-run. These tests pin the
+//! semantics hangar layers on top of that kind dimension:
+//!
+//!   - a `blocked_by` link GATES a run until the blocker finishes (the acceptance,
+//!     re-proven through the NEW typed write path);
+//!   - a `blocks` link is the SAME relation authored from the other end and is
+//!     normalised into a swapped `blocked_by` row — never stored as `'blocks'`;
+//!   - a `related` link is symmetric, NEVER gates, and is exempt from the cycle
+//!     guard.
+
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::card_dependency::{CardDependencyError, CardDependencyRepo, LinkKind};
+use sqlx::SqlitePool;
+
+fn ws(id: &str) -> WorkspaceId {
+    WorkspaceId::from_str(id.to_string()).unwrap()
+}
+
+async fn open() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    (dir, store)
+}
+
+async fn seed_ws(pool: &SqlitePool, id: &str) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(id)
+        .bind(id)
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn seed_issue(pool: &SqlitePool, ws: &str, id: &str) {
+    sqlx::query(
+        "INSERT INTO issue (id, workspace_id, title, creator_type, creator_id, created_at) \
+         VALUES (?, ?, ?, 'member', 'm1', 0)",
+    )
+    .bind(id)
+    .bind(ws)
+    .bind(id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Seed the FK chain then one task on `issue_id` with `status`, so the
+/// blocker-finished check has something to read.
+async fn seed_task(pool: &SqlitePool, ws: &str, issue_id: &str, task_id: &str, status: &str) {
+    sqlx::query("INSERT OR IGNORE INTO user (id, email, created_at) VALUES ('u','u@e.com',0)")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT OR IGNORE INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode, status) VALUES ('rt', ?, 'd','claude','local','online')")
+        .bind(ws).execute(pool).await.unwrap();
+    sqlx::query("INSERT OR IGNORE INTO agent (id, workspace_id, name, runtime_id, instructions, visibility, owner_id) VALUES ('ag', ?, 'A','rt','x','workspace','u')")
+        .bind(ws).execute(pool).await.unwrap();
+    sqlx::query(
+        "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at) \
+         VALUES (?, ?, 'rt', 'ag', ?, ?, 0)",
+    )
+    .bind(task_id).bind(ws).bind(issue_id).bind(status)
+    .execute(pool).await.unwrap();
+}
+
+async fn setup(ids: &[&str]) -> (tempfile::TempDir, Store) {
+    let (dir, store) = open().await;
+    seed_ws(store.pool(), "ws-a").await;
+    for id in ids {
+        seed_issue(store.pool(), "ws-a", id).await;
+    }
+    (dir, store)
+}
+
+/// The at-rest `link_type` values, deduplicated.
+async fn stored_kinds(pool: &SqlitePool) -> Vec<String> {
+    let mut v: Vec<String> =
+        sqlx::query_scalar("SELECT DISTINCT link_type FROM card_dependency ORDER BY 1")
+            .fetch_all(pool)
+            .await
+            .unwrap();
+    v.sort();
+    v
+}
+
+/// A `related` link NEVER gates a run — in either direction.
+#[tokio::test]
+async fn related_link_never_gates_a_run() {
+    let (_d, store) = setup(&["a", "b"]).await;
+    let pool = store.pool();
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "b", LinkKind::Related, 1)
+        .await
+        .unwrap();
+
+    assert!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "a")
+            .await
+            .unwrap()
+            .is_empty(),
+        "a related link must not gate the authoring card"
+    );
+    assert!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "b")
+            .await
+            .unwrap()
+            .is_empty(),
+        "a related link must not gate the other card either"
+    );
+    assert!(
+        CardDependencyRepo::blockers_of(pool, "a").await.unwrap().is_empty(),
+        "a related link is invisible to the blocker adjacency"
+    );
+    assert!(
+        CardDependencyRepo::dependents_of(pool, "b").await.unwrap().is_empty(),
+        "a related link is invisible to the finalize-seam reverse lookup"
+    );
+}
+
+/// Authoring `A blocks B` stores the SAME row as `B blocked_by A`.
+#[tokio::test]
+async fn blocks_is_normalised_into_the_reverse_blocked_by_edge() {
+    let (_d, store) = setup(&["a", "b"]).await;
+    let pool = store.pool();
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "b", LinkKind::Blocks, 1)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "b").await.unwrap(),
+        vec!["a"],
+        "`a blocks b` gates b, not a"
+    );
+    assert!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "a")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        CardDependencyRepo::blocks_of(pool, "a").await.unwrap(),
+        vec!["b"],
+        "the reverse read direction renders a's `blocks` link"
+    );
+    assert_eq!(stored_kinds(pool).await, vec!["blocked_by"]);
+}
+
+/// The item's acceptance at the store layer, authored with an EXPLICIT
+/// `LinkKind::BlockedBy`: the dependent is gated until the blocker's latest
+/// generation drains with a `done`.
+#[tokio::test]
+async fn blocked_by_link_gates_until_the_blocker_finishes() {
+    let (_d, store) = setup(&["blk", "dep"]).await;
+    let pool = store.pool();
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "dep", "blk", LinkKind::BlockedBy, 1)
+        .await
+        .unwrap();
+    assert_eq!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "dep").await.unwrap(),
+        vec!["blk"],
+        "a never-ran blocker gates the dependent"
+    );
+
+    seed_task(pool, "ws-a", "blk", "t1", "running").await;
+    assert_eq!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "dep").await.unwrap(),
+        vec!["blk"],
+        "an in-flight blocker still gates"
+    );
+
+    sqlx::query("UPDATE agent_task_queue SET status = 'done' WHERE id = 't1'")
+        .execute(pool)
+        .await
+        .unwrap();
+    assert!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "dep")
+            .await
+            .unwrap()
+            .is_empty(),
+        "the blocker drained with a done — the dependent is runnable"
+    );
+}
+
+/// `related` is symmetric: authoring it both ways yields ONE row, readable from
+/// either end.
+#[tokio::test]
+async fn related_is_symmetric_and_idempotent() {
+    let (_d, store) = setup(&["a", "b"]).await;
+    let pool = store.pool();
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "b", LinkKind::Related, 1)
+        .await
+        .unwrap();
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "b", "a", LinkKind::Related, 2)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        CardDependencyRepo::links_of_workspace(pool, &ws("ws-a")).await.unwrap().len(),
+        1,
+        "the mirrored re-add did not create a second row"
+    );
+    assert_eq!(CardDependencyRepo::related_of(pool, "a").await.unwrap(), vec!["b"]);
+    assert_eq!(CardDependencyRepo::related_of(pool, "b").await.unwrap(), vec!["a"]);
+
+    // And it can be removed from either end.
+    CardDependencyRepo::remove_link(pool, &ws("ws-a"), "b", "a", LinkKind::Related)
+        .await
+        .unwrap();
+    assert!(CardDependencyRepo::related_of(pool, "a").await.unwrap().is_empty());
+}
+
+/// A `related` pair in both orientations is fine (it gates nothing so it cannot
+/// deadlock); the same pair as `blocked_by` is still a rejected cycle.
+#[tokio::test]
+async fn related_links_are_exempt_from_the_cycle_guard() {
+    let (_d, store) = setup(&["a", "b", "c", "d"]).await;
+    let pool = store.pool();
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "b", LinkKind::Related, 1)
+        .await
+        .unwrap();
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "b", "a", LinkKind::Related, 2)
+        .await
+        .expect("a symmetric related pair is not a cycle");
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "c", "d", LinkKind::BlockedBy, 3)
+        .await
+        .unwrap();
+    let err = CardDependencyRepo::add_link(pool, &ws("ws-a"), "d", "c", LinkKind::BlockedBy, 4)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CardDependencyError::Cycle), "got {err:?}");
+}
+
+/// A self-link is rejected for EVERY kind, not just the gating one.
+#[tokio::test]
+async fn a_self_link_is_rejected_for_every_kind() {
+    let (_d, store) = setup(&["a"]).await;
+    let pool = store.pool();
+    for kind in [LinkKind::Blocks, LinkKind::BlockedBy, LinkKind::Related] {
+        let err = CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "a", kind, 1)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, CardDependencyError::SelfDependency),
+            "{kind:?} self-link: got {err:?}"
+        );
+    }
+}
+
+/// The at-rest domain invariant: authoring all three kinds never persists a
+/// `'blocks'` row.
+#[tokio::test]
+async fn no_blocks_row_is_ever_persisted() {
+    let (_d, store) = setup(&["a", "b", "c", "d"]).await;
+    let pool = store.pool();
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "b", LinkKind::Blocks, 1)
+        .await
+        .unwrap();
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "c", "d", LinkKind::BlockedBy, 2)
+        .await
+        .unwrap();
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "c", LinkKind::Related, 3)
+        .await
+        .unwrap();
+
+    let kinds = stored_kinds(pool).await;
+    assert_eq!(
+        kinds,
+        vec!["blocked_by", "related"],
+        "the at-rest domain is {{blocked_by, related}} — `blocks` is a read direction"
+    );
+}
+
+/// Every pre-0055 row IS a blocked_by edge: the column default backfills it, it
+/// still gates, and `related_of` ignores it.
+#[tokio::test]
+async fn pre_0055_rows_read_back_as_blocked_by_and_still_gate() {
+    let (_d, store) = setup(&["blk", "dep"]).await;
+    let pool = store.pool();
+
+    // Exactly the INSERT shape a pre-0055 hangar wrote — no `link_type` column.
+    sqlx::query(
+        "INSERT INTO card_dependency (workspace_id, dependent_issue_id, blocker_issue_id, created_at) \
+         VALUES ('ws-a', 'dep', 'blk', 7)",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    assert_eq!(stored_kinds(pool).await, vec!["blocked_by"]);
+    assert_eq!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "dep").await.unwrap(),
+        vec!["blk"],
+        "a legacy row still gates"
+    );
+    assert!(
+        CardDependencyRepo::related_of(pool, "dep").await.unwrap().is_empty(),
+        "a legacy row is not a related link"
+    );
+}
+
+/// The composite PK holds ONE relation per ordered pair, so re-adding with a new
+/// kind retypes the row (and stops it gating).
+#[tokio::test]
+async fn re_adding_a_pair_with_a_new_kind_replaces_the_kind() {
+    let (_d, store) = setup(&["a", "b"]).await;
+    let pool = store.pool();
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "b", LinkKind::BlockedBy, 1)
+        .await
+        .unwrap();
+    assert_eq!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "a").await.unwrap(),
+        vec!["b"]
+    );
+
+    CardDependencyRepo::add_link(pool, &ws("ws-a"), "a", "b", LinkKind::Related, 2)
+        .await
+        .unwrap();
+
+    let links = CardDependencyRepo::links_of_workspace(pool, &ws("ws-a")).await.unwrap();
+    assert_eq!(links.len(), 1, "still one row for the pair");
+    assert_eq!(links[0].kind, LinkKind::Related);
+    assert!(
+        CardDependencyRepo::unfinished_blockers_of(pool, "a")
+            .await
+            .unwrap()
+            .is_empty(),
+        "retyped to related — no longer gating"
+    );
+}
+
+/// `LinkKind::parse` accepts every token the wire / CLI can send.
+#[test]
+fn link_kind_parses_wire_and_cli_tokens() {
+    assert_eq!(LinkKind::parse("blocks"), Some(LinkKind::Blocks));
+    assert_eq!(LinkKind::parse("blocked_by"), Some(LinkKind::BlockedBy));
+    assert_eq!(LinkKind::parse("blocked-by"), Some(LinkKind::BlockedBy));
+    assert_eq!(LinkKind::parse("RELATED"), Some(LinkKind::Related));
+    assert_eq!(LinkKind::parse("nonsense"), None);
+    assert_eq!(LinkKind::default(), LinkKind::BlockedBy);
+    assert!(!LinkKind::Related.is_gating());
+    assert!(LinkKind::Blocks.is_gating() && LinkKind::BlockedBy.is_gating());
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_card_dependency_typed.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_card_dependency_typed.rs
@@ -99,17 +99,11 @@ async fn related_link_never_gates_a_run() {
         .unwrap();
 
     assert!(
-        CardDependencyRepo::unfinished_blockers_of(pool, "a")
-            .await
-            .unwrap()
-            .is_empty(),
+        CardDependencyRepo::unfinished_blockers_of(pool, "a").await.unwrap().is_empty(),
         "a related link must not gate the authoring card"
     );
     assert!(
-        CardDependencyRepo::unfinished_blockers_of(pool, "b")
-            .await
-            .unwrap()
-            .is_empty(),
+        CardDependencyRepo::unfinished_blockers_of(pool, "b").await.unwrap().is_empty(),
         "a related link must not gate the other card either"
     );
     assert!(
@@ -137,12 +131,7 @@ async fn blocks_is_normalised_into_the_reverse_blocked_by_edge() {
         vec!["a"],
         "`a blocks b` gates b, not a"
     );
-    assert!(
-        CardDependencyRepo::unfinished_blockers_of(pool, "a")
-            .await
-            .unwrap()
-            .is_empty()
-    );
+    assert!(CardDependencyRepo::unfinished_blockers_of(pool, "a").await.unwrap().is_empty());
     assert_eq!(
         CardDependencyRepo::blocks_of(pool, "a").await.unwrap(),
         vec!["b"],
@@ -207,8 +196,14 @@ async fn related_is_symmetric_and_idempotent() {
         1,
         "the mirrored re-add did not create a second row"
     );
-    assert_eq!(CardDependencyRepo::related_of(pool, "a").await.unwrap(), vec!["b"]);
-    assert_eq!(CardDependencyRepo::related_of(pool, "b").await.unwrap(), vec!["a"]);
+    assert_eq!(
+        CardDependencyRepo::related_of(pool, "a").await.unwrap(),
+        vec!["b"]
+    );
+    assert_eq!(
+        CardDependencyRepo::related_of(pool, "b").await.unwrap(),
+        vec!["a"]
+    );
 
     // And it can be removed from either end.
     CardDependencyRepo::remove_link(pool, &ws("ws-a"), "b", "a", LinkKind::Related)
@@ -332,10 +327,7 @@ async fn re_adding_a_pair_with_a_new_kind_replaces_the_kind() {
     assert_eq!(links.len(), 1, "still one row for the pair");
     assert_eq!(links[0].kind, LinkKind::Related);
     assert!(
-        CardDependencyRepo::unfinished_blockers_of(pool, "a")
-            .await
-            .unwrap()
-            .is_empty(),
+        CardDependencyRepo::unfinished_blockers_of(pool, "a").await.unwrap().is_empty(),
         "retyped to related — no longer gating"
     );
 }

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
@@ -171,9 +171,13 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
         .execute(pool)
         .await
         .expect("card");
+    // One GATING and one RELATED link (multica parity #20 / migration 0055): the
+    // cascade is kind-blind, so a `related` row must go too — otherwise deleting an
+    // issue would leave a dangling association behind.
     sqlx::query(
-        "INSERT INTO card_dependency (workspace_id, dependent_issue_id, blocker_issue_id, created_at) \
-         VALUES ('ws-a', 'i-1', 'i-2', 0), ('ws-a', 'i-2', 'i-1', 0)",
+        "INSERT INTO card_dependency \
+         (workspace_id, dependent_issue_id, blocker_issue_id, created_at, link_type) \
+         VALUES ('ws-a', 'i-1', 'i-2', 0, 'blocked_by'), ('ws-a', 'i-2', 'i-1', 0, 'related')",
     )
     .execute(pool)
     .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
@@ -1362,3 +1362,42 @@ async fn migration_0047_adds_permission_mode_and_invocation_target() {
 
     pool.close().await;
 }
+
+#[tokio::test]
+async fn migration_0055_types_card_dependency_links() {
+    // multica parity #20: `issue_dependency.type IN ('blocks','blocked_by','related')`.
+    // hangar's row IS the blocked_by relation, so 0055 adds the KIND column with a
+    // constant DEFAULT 'blocked_by' — every pre-0055 row backfills to today's
+    // semantics with no table rewrite — plus the (workspace_id, link_type) index the
+    // typed graph read uses. 0036 is UNTOUCHED (an applied migration is immutable).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = fresh_pool(dir.path()).await;
+
+    let cols = sqlx::query("PRAGMA table_info(card_dependency)")
+        .fetch_all(&pool)
+        .await
+        .expect("table_info");
+    let link_type = cols
+        .iter()
+        .find(|r| {
+            let name: String = r.get("name");
+            name == "link_type"
+        })
+        .expect("card_dependency.link_type exists");
+    let notnull: i64 = link_type.get("notnull");
+    let dflt: Option<String> = link_type.get("dflt_value");
+    assert_eq!(notnull, 1, "link_type is NOT NULL");
+    assert_eq!(
+        dflt.as_deref().map(|d| d.trim_matches('\'')),
+        Some("blocked_by"),
+        "the constant default backfills every pre-0055 row as a gating edge"
+    );
+
+    let idx = index_sql(&pool, "idx_card_dependency_ws_type").await;
+    assert!(
+        idx.contains("card_dependency") && idx.contains("link_type"),
+        "idx_card_dependency_ws_type serves the typed graph read: {idx}"
+    );
+
+    pool.close().await;
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -4354,6 +4354,7 @@ impl HangarPlugin {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         };
         // Seed the run's branch (tcp T2, agents-in-a-box-ch3) from the clicked
         // card so the detail view surfaces `ainb/<slug>` exactly as the card does.
@@ -5779,6 +5780,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }]);
         p
     }
@@ -5934,6 +5936,7 @@ mod tests {
                 acceptance_criteria: Vec::new(),
                 acceptance: Vec::new(),
                 context_refs: Vec::new(),
+                dependencies: Vec::new(),
             },
             IssueRow {
                 id: ainb_hangar_core::ids::IssueId::from_str("issue-2").unwrap(),
@@ -5964,6 +5967,7 @@ mod tests {
                 acceptance_criteria: Vec::new(),
                 acceptance: Vec::new(),
                 context_refs: Vec::new(),
+                dependencies: Vec::new(),
             },
         ]);
 
@@ -6155,6 +6159,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }]);
         p.rebuild_hit_map(120, 24);
 
@@ -6245,6 +6250,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }]);
         // The card starts in Backlog.
         assert_eq!(p.screens.issue_list.column_count(IssueColumn::Backlog), 1);
@@ -6327,6 +6333,7 @@ mod tests {
                 acceptance_criteria: Vec::new(),
                 acceptance: Vec::new(),
                 context_refs: Vec::new(),
+                dependencies: Vec::new(),
             })
             .collect();
         p.screens.set_issues(rows);
@@ -6413,6 +6420,7 @@ mod tests {
                 acceptance_criteria: Vec::new(),
                 acceptance: Vec::new(),
                 context_refs: Vec::new(),
+                dependencies: Vec::new(),
             },
             IssueRow {
                 id: ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap(),
@@ -6443,6 +6451,7 @@ mod tests {
                 acceptance_criteria: Vec::new(),
                 acceptance: Vec::new(),
                 context_refs: Vec::new(),
+                dependencies: Vec::new(),
             },
         ]);
         p.screens.set_actors(vec![ActorRow {
@@ -6868,6 +6877,8 @@ mod tests {
                                 member_states: Vec::new(),
                                 blocked_by: Vec::new(),
                                 auto_run: false,
+                                blocks: Vec::new(),
+                                related: Vec::new(),
                             },
                             BoardCardWireRow {
                                 issue_id: "issue-2".into(),
@@ -6881,6 +6892,8 @@ mod tests {
                                 member_states: Vec::new(),
                                 blocked_by: Vec::new(),
                                 auto_run: false,
+                                blocks: Vec::new(),
+                                related: Vec::new(),
                             },
                         ],
                     },
@@ -7182,6 +7195,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         };
         let tid = ainb_hangar_core::ids::TaskId::from_str("task-1").unwrap();
         p.screens.open_task_detail(tid.clone(), issue, None);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -2702,10 +2702,11 @@ impl HangarPlugin {
                 board_id,
                 dependent_issue_id,
                 blocker_issue_id,
+                link_type,
             } => (
                 BOARDS_REQ_ID,
                 daemon_methods::HANGAR_BOARD_CARD_DEP_ADD,
-                serde_json::json!({ "workspace_id": ws, "board_id": board_id, "dependent_issue_id": dependent_issue_id, "blocker_issue_id": blocker_issue_id }),
+                serde_json::json!({ "workspace_id": ws, "board_id": board_id, "dependent_issue_id": dependent_issue_id, "blocker_issue_id": blocker_issue_id, "link_type": link_type }),
             ),
             BoardsAction::CardSetAutoRun {
                 board_id,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -315,10 +315,13 @@ pub enum BoardsAction {
     CardDepAdd {
         /// The board both cards sit on.
         board_id: String,
-        /// The DEPENDENT card's issue.
+        /// The FROM card's issue (the DEPENDENT under the default kind).
         dependent_issue_id: String,
-        /// The BLOCKER card's issue.
+        /// The TO card's issue (the BLOCKER under the default kind).
         blocker_issue_id: String,
+        /// The link KIND to author (multica parity #20); `BlockedBy` reproduces
+        /// the pre-#20 gating edge.
+        link_type: ainb_hangar_proto::snapshots::LinkKindWire,
     },
     /// Flip a card's auto-run flag (`R`) — `hangar/board_card_set_auto_run`
     /// (tcp T4 / F7).
@@ -2037,6 +2040,9 @@ fn overlay_key_event(key: &KeyEvent) -> Option<BoardsEvent> {
         KeyCode::Up => BoardsKey::Up,
         KeyCode::Down => BoardsKey::Down,
         KeyCode::Char { ch } => BoardsKey::Char(*ch),
+        // Overlay-local only: the dep picker cycles its link kind (multica parity
+        // #20). No global binding is added, so no host-reserved key is touched.
+        KeyCode::Tab => BoardsKey::Tab,
         _ => return None,
     };
     Some(BoardsEvent::Key(k))
@@ -2160,10 +2166,12 @@ fn lift_boards_intent(intent: Option<BoardsIntent>) -> Option<BoardsAction> {
             board_id,
             dependent_issue_id,
             blocker_issue_id,
+            link_type,
         } => Some(BoardsAction::CardDepAdd {
             board_id,
             dependent_issue_id,
             blocker_issue_id,
+            link_type: link_type.to_wire(),
         }),
         BoardsIntent::ToggleAutoRun {
             board_id,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -205,6 +205,14 @@ pub struct CardView {
     pub blocked_by: Vec<String>,
     /// Whether this card auto-launches when its last blocker completes (tcp T4 / F7).
     pub auto_run: bool,
+    /// The DISPLAY IDS of the cards this card BLOCKS — the reverse read direction
+    /// (multica parity #20). Render-only: it never makes THIS card blocked.
+    pub blocks: Vec<String>,
+    /// The DISPLAY IDS of this card's RELATED cards (multica parity #20). A
+    /// symmetric NON-gating association: it never blocks and never auto-runs, so
+    /// the board renders only a `↔n` count and the full list lives on the detail
+    /// card.
+    pub related: Vec<String>,
 }
 
 impl CardView {
@@ -221,6 +229,8 @@ impl CardView {
             member_states: w.member_states.clone(),
             blocked_by: w.blocked_by.clone(),
             auto_run: w.auto_run,
+            blocks: w.blocks.clone(),
+            related: w.related.clone(),
         }
     }
 
@@ -564,7 +574,59 @@ pub enum BoardsOverlay {
         dependent_issue_id: String,
         /// The highlighted candidate blocker (index into the other-cards list).
         cursor: usize,
+        /// The link KIND the Enter will author (multica parity #20), cycled with
+        /// Tab. Defaults to `blocked-by`, so the overlay behaves exactly as it did
+        /// before typed links unless the user asks for another kind.
+        kind: LinkKindPick,
     },
+}
+
+/// The link kind the depends-on overlay will author (multica parity #20).
+///
+/// Overlay-local: cycled with Tab, never bound globally (the host reserves its own
+/// keys, and `w` already opens this overlay).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LinkKindPick {
+    /// The focused card is blocked by the pick — the gating default.
+    #[default]
+    BlockedBy,
+    /// The focused card blocks the pick (stored as the reverse gating edge).
+    Blocks,
+    /// The two cards are merely associated — never gating.
+    Related,
+}
+
+impl LinkKindPick {
+    /// The next kind in the `blocked-by -> blocks -> related -> blocked-by` cycle.
+    #[must_use]
+    pub fn next(self) -> Self {
+        match self {
+            Self::BlockedBy => Self::Blocks,
+            Self::Blocks => Self::Related,
+            Self::Related => Self::BlockedBy,
+        }
+    }
+
+    /// The label rendered on the overlay header.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::BlockedBy => "blocked-by",
+            Self::Blocks => "blocks",
+            Self::Related => "related",
+        }
+    }
+
+    /// The wire kind this pick authors.
+    #[must_use]
+    pub fn to_wire(self) -> ainb_hangar_proto::snapshots::LinkKindWire {
+        use ainb_hangar_proto::snapshots::LinkKindWire;
+        match self {
+            Self::BlockedBy => LinkKindWire::BlockedBy,
+            Self::Blocks => LinkKindWire::Blocks,
+            Self::Related => LinkKindWire::Related,
+        }
+    }
 }
 
 /// A raw key folded into an open [`BoardsOverlay`]. The reducer interprets each
@@ -572,6 +634,9 @@ pub enum BoardsOverlay {
 /// `Up`/`Down` move a picker cursor but are ignored in an input).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoardsKey {
+    /// Tab — overlay-local kind cycling in the depends-on picker (multica parity
+    /// #20). Ignored by every other overlay.
+    Tab,
     /// A printable character.
     Char(char),
     /// Backspace (delete the last input char).
@@ -1152,10 +1217,13 @@ pub enum BoardsIntent {
     AddDependency {
         /// The board both cards sit on.
         board_id: String,
-        /// The DEPENDENT card's issue (the one that gets blocked).
+        /// The FROM card's issue (the DEPENDENT under the default kind).
         dependent_issue_id: String,
-        /// The BLOCKER card's issue (must finish first).
+        /// The TO card's issue (the BLOCKER under the default kind).
         blocker_issue_id: String,
+        /// The link KIND authored (multica parity #20). `BlockedBy` is the
+        /// default and reproduces the pre-#20 gating edge.
+        link_type: LinkKindPick,
     },
     /// Flip the card's auto-run flag (`hangar/board_card_set_auto_run`, tcp T4 / F7).
     ToggleAutoRun {
@@ -1262,6 +1330,7 @@ pub fn reduce_boards(state: &BoardsState, ev: BoardsEvent) -> BoardsReduction {
         BoardsEvent::AddDependency => open_overlay(state, |_, c| BoardsOverlay::DepPick {
             dependent_issue_id: c.issue_id.clone(),
             cursor: 0,
+            kind: LinkKindPick::default(),
         }),
         // Toggle-auto-run flips the focused card's flag directly (no overlay — a
         // single boolean the daemon persists).
@@ -1315,7 +1384,8 @@ fn reduce_overlay_key(state: &BoardsState, key: BoardsKey) -> BoardsReduction {
         BoardsOverlay::DepPick {
             dependent_issue_id,
             cursor,
-        } => dep_pick_key(state, &dependent_issue_id, cursor, key),
+            kind,
+        } => dep_pick_key(state, &dependent_issue_id, cursor, kind, key),
     }
 }
 
@@ -1386,7 +1456,7 @@ fn squad_pick_key(
                 }),
             }
         }
-        BoardsKey::Char(_) | BoardsKey::Backspace => set_overlay(
+        BoardsKey::Char(_) | BoardsKey::Backspace | BoardsKey::Tab => set_overlay(
             state,
             BoardsOverlay::SquadPick {
                 issue_id: issue_id.to_string(),
@@ -1420,25 +1490,25 @@ fn dep_pick_key(
     state: &BoardsState,
     dependent_issue_id: &str,
     cursor: usize,
+    kind: LinkKindPick,
     key: BoardsKey,
 ) -> BoardsReduction {
     let candidates = dep_candidate_ids(state, dependent_issue_id);
+    let repick = |cursor: usize, kind: LinkKindPick| BoardsOverlay::DepPick {
+        dependent_issue_id: dependent_issue_id.to_string(),
+        cursor,
+        kind,
+    };
     match key {
         BoardsKey::Esc => close_overlay(state),
-        BoardsKey::Up => set_overlay(
-            state,
-            BoardsOverlay::DepPick {
-                dependent_issue_id: dependent_issue_id.to_string(),
-                cursor: cursor.saturating_sub(1),
-            },
-        ),
+        BoardsKey::Up => set_overlay(state, repick(cursor.saturating_sub(1), kind)),
         BoardsKey::Down => set_overlay(
             state,
-            BoardsOverlay::DepPick {
-                dependent_issue_id: dependent_issue_id.to_string(),
-                cursor: (cursor + 1).min(candidates.len().saturating_sub(1)),
-            },
+            repick((cursor + 1).min(candidates.len().saturating_sub(1)), kind),
         ),
+        // multica parity #20: Tab cycles the KIND in place, leaving the highlighted
+        // candidate alone, so one overlay authors all three relations.
+        BoardsKey::Tab => set_overlay(state, repick(cursor, kind.next())),
         BoardsKey::Enter => {
             let Some(board) = state.focused_board() else {
                 return close_overlay(state);
@@ -1455,16 +1525,11 @@ fn dep_pick_key(
                     board_id: board.id.clone(),
                     dependent_issue_id: dependent_issue_id.to_string(),
                     blocker_issue_id: blocker.clone(),
+                    link_type: kind,
                 }),
             }
         }
-        BoardsKey::Char(_) | BoardsKey::Backspace => set_overlay(
-            state,
-            BoardsOverlay::DepPick {
-                dependent_issue_id: dependent_issue_id.to_string(),
-                cursor,
-            },
-        ),
+        BoardsKey::Char(_) | BoardsKey::Backspace => set_overlay(state, repick(cursor, kind)),
     }
 }
 
@@ -1490,7 +1555,11 @@ fn remove_confirm_key(state: &BoardsState, issue_id: &str, key: BoardsKey) -> Bo
             }
         }
         BoardsKey::Esc => close_overlay(state),
-        BoardsKey::Char(_) | BoardsKey::Backspace | BoardsKey::Up | BoardsKey::Down => set_overlay(
+        BoardsKey::Char(_)
+        | BoardsKey::Backspace
+        | BoardsKey::Up
+        | BoardsKey::Down
+        | BoardsKey::Tab => set_overlay(
             state,
             BoardsOverlay::RemoveConfirm {
                 issue_id: issue_id.to_string(),
@@ -1522,7 +1591,11 @@ fn cancel_confirm_key(state: &BoardsState, issue_id: &str, key: BoardsKey) -> Bo
             }
         }
         BoardsKey::Esc => close_overlay(state),
-        BoardsKey::Char(_) | BoardsKey::Backspace | BoardsKey::Up | BoardsKey::Down => set_overlay(
+        BoardsKey::Char(_)
+        | BoardsKey::Backspace
+        | BoardsKey::Up
+        | BoardsKey::Down
+        | BoardsKey::Tab => set_overlay(
             state,
             BoardsOverlay::CancelConfirm {
                 issue_id: issue_id.to_string(),
@@ -1551,6 +1624,15 @@ fn card_title_key(
                 },
             )
         }
+        // Tab carries no meaning in a text input — ignore it rather than typing a
+        // stray glyph into the title.
+        BoardsKey::Tab => set_overlay(
+            state,
+            BoardsOverlay::CardTitle {
+                column_id: column_id.to_string(),
+                title,
+            },
+        ),
         BoardsKey::Char(c) => {
             title.push(c);
             set_overlay(
@@ -1652,6 +1734,8 @@ fn card_repo_key(
             query.pop();
             reopen(state, query, Some(0))
         }
+        // Tab is the dep picker's kind cycle; here it is inert.
+        (Some(cursor), BoardsKey::Tab) => reopen(state, query, Some(cursor)),
         (Some(cursor), BoardsKey::Up) => reopen(state, query, Some(cursor.saturating_sub(1))),
         (Some(cursor), BoardsKey::Down) => {
             let n = repo_candidates(state.repos(), &query).len();
@@ -1762,7 +1846,7 @@ fn card_agent_key(
                 },
             ),
         },
-        BoardsKey::Char(_) | BoardsKey::Backspace => reopen(state, cursor),
+        BoardsKey::Char(_) | BoardsKey::Backspace | BoardsKey::Tab => reopen(state, cursor),
     }
 }
 
@@ -1815,7 +1899,7 @@ fn card_profile_key(
                 }),
             }
         }
-        BoardsKey::Char(_) | BoardsKey::Backspace => reopen(state, cursor),
+        BoardsKey::Char(_) | BoardsKey::Backspace | BoardsKey::Tab => reopen(state, cursor),
     }
 }
 
@@ -1846,7 +1930,7 @@ fn column_rename_key(
             name.push(c);
             reopen(state, name)
         }
-        BoardsKey::Up | BoardsKey::Down => reopen(state, name),
+        BoardsKey::Up | BoardsKey::Down | BoardsKey::Tab => reopen(state, name),
         BoardsKey::Enter => {
             if name.trim().is_empty() {
                 return reopen(state, name);
@@ -1908,7 +1992,7 @@ fn run_mode_key(
                 }),
             }
         }
-        BoardsKey::Char(_) | BoardsKey::Backspace => set_overlay(
+        BoardsKey::Char(_) | BoardsKey::Backspace | BoardsKey::Tab => set_overlay(
             state,
             BoardsOverlay::RunMode {
                 issue_id: issue_id.to_string(),
@@ -2428,15 +2512,15 @@ fn render_overlay(
         BoardsOverlay::DepPick {
             dependent_issue_id,
             cursor,
+            kind,
         } => {
-            put_str(
-                buf,
-                0,
-                row,
-                "Depends on (↑↓ pick a blocker card, Enter commit, Esc cancel):",
-                GOLD,
-                area_w,
+            // The header carries the KIND selector (multica parity #20): Tab cycles
+            // it in place, so one overlay authors blocked-by / blocks / related.
+            let header = format!(
+                "Link [{}] (Tab kind, ↑↓ pick a card, Enter commit, Esc cancel):",
+                kind.label()
             );
+            put_str(buf, 0, row, &header, GOLD, area_w);
             let candidates = dep_candidate_ids(state, dependent_issue_id);
             if candidates.is_empty() {
                 put_str(
@@ -2657,6 +2741,12 @@ fn card_title_with_t4_badges(c: &CardView) -> String {
     let mut title = c.title.clone();
     if !c.blocked_by.is_empty() {
         title.push_str(&format!(" 🔒[{}]", c.blocked_by.join(",")));
+    }
+    // multica parity #20: a COUNT only — the board stays dense, and the full typed
+    // graph lives on the detail card. `related` never gates, so this badge is
+    // deliberately distinct from the 🔒 above.
+    if !c.related.is_empty() {
+        title.push_str(&format!(" ↔{}", c.related.len()));
     }
     if !c.member_states.is_empty() {
         let chips = c
@@ -3800,6 +3890,46 @@ mod tests {
         assert!(bc.title.contains('⏵'), "auto-run marker: {}", bc.title);
     }
 
+    /// multica parity #20: a `related` card renders the `↔n` COUNT badge and is
+    /// NOT blocked; a `blocked_by` card still renders `🔒[…]`. The two dimensions
+    /// are independent — `related` never turns `is_blocked()` on.
+    #[test]
+    fn related_renders_a_count_badge_and_never_blocks() {
+        let related_only = CardView::from_wire(&BoardCardWireRow {
+            related: vec!["HGR-7".into(), "HGR-9".into()],
+            ..card("issue-1", "Docs", None)
+        });
+        assert!(
+            !related_only.is_blocked(),
+            "a related link never blocks the card"
+        );
+        let bc = card_view_to_board_card(&related_only);
+        assert!(bc.title.contains("↔2"), "related count badge: {}", bc.title);
+        assert!(!bc.title.contains('🔒'), "no lock badge: {}", bc.title);
+        assert!(
+            !bc.display_id.starts_with("🔒 #"),
+            "no blocked marker: {}",
+            bc.display_id
+        );
+
+        // A card carrying BOTH renders both badges, and stays blocked.
+        let both = CardView::from_wire(&BoardCardWireRow {
+            blocked_by: vec!["ock-9".into()],
+            related: vec!["HGR-7".into()],
+            blocks: vec!["HGR-2".into()],
+            ..card("issue-2", "Parser", None)
+        });
+        assert!(both.is_blocked(), "the blocked_by dimension is untouched");
+        assert_eq!(
+            both.blocks,
+            vec!["HGR-2".to_string()],
+            "the reverse direction is carried"
+        );
+        let bc = card_view_to_board_card(&both);
+        assert!(bc.title.contains("🔒[ock-9]"), "lock badge: {}", bc.title);
+        assert!(bc.title.contains("↔1"), "related badge: {}", bc.title);
+    }
+
     /// `q` opens the squad picker; Enter on the "clear" row (cursor 0) emits an
     /// AssignSquad with `squad_id: None`, Enter on a roster row assigns that squad.
     #[test]
@@ -3942,8 +4072,48 @@ mod tests {
                 board_id: "b1".into(),
                 dependent_issue_id: "issue-1".into(),
                 blocker_issue_id: "issue-2".into(),
+                link_type: LinkKindPick::BlockedBy,
             }),
-            "the dependent is the focused card; the blocker is the other card"
+            "the dependent is the focused card; the blocker is the other card, \
+             and the kind defaults to the pre-#20 gating edge"
+        );
+    }
+
+    /// multica parity #20: Tab cycles the KIND in the depends-on overlay without
+    /// moving the highlighted candidate, and Enter authors that kind.
+    #[test]
+    fn tab_cycles_the_link_kind_in_the_dep_picker() {
+        let state = BoardsState::from_snapshot(&one_board());
+        let opened = reduce_boards(&state, BoardsEvent::AddDependency);
+        let kind_of = |s: &BoardsState| match s.overlay() {
+            Some(BoardsOverlay::DepPick { kind, .. }) => *kind,
+            other => panic!("expected the dep picker, got {other:?}"),
+        };
+        assert_eq!(kind_of(&opened.state), LinkKindPick::BlockedBy, "default");
+
+        let mut cur = opened.state;
+        for want in [
+            LinkKindPick::Blocks,
+            LinkKindPick::Related,
+            LinkKindPick::BlockedBy,
+        ] {
+            cur = reduce_boards(&cur, BoardsEvent::Key(BoardsKey::Tab)).state;
+            assert_eq!(kind_of(&cur), want, "the cycle wraps");
+        }
+
+        // Two Tabs land on `related`; Enter authors exactly that.
+        cur = reduce_boards(&cur, BoardsEvent::Key(BoardsKey::Tab)).state;
+        cur = reduce_boards(&cur, BoardsEvent::Key(BoardsKey::Tab)).state;
+        let picked = reduce_boards(&cur, BoardsEvent::Key(BoardsKey::Enter));
+        assert_eq!(
+            picked.intent,
+            Some(BoardsIntent::AddDependency {
+                board_id: "b1".into(),
+                dependent_issue_id: "issue-1".into(),
+                blocker_issue_id: "issue-2".into(),
+                link_type: LinkKindPick::Related,
+            }),
+            "Enter authors the kind the header shows"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -2707,6 +2707,8 @@ mod tests {
             member_states: Vec::new(),
             blocked_by: Vec::new(),
             auto_run: false,
+            blocks: Vec::new(),
+            related: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -3697,6 +3697,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -45,7 +45,7 @@
 
 use ainb_hangar_core::acceptance::{AcceptanceCriterion, checked_count, legacy_placeholder_id};
 use ainb_hangar_core::ids::TaskId;
-use ainb_hangar_proto::events::{HangarEvent, IssueRow, MessageKind, TaskResult};
+use ainb_hangar_proto::events::{HangarEvent, IssueLinkRow, IssueRow, MessageKind, TaskResult};
 use ainb_hangar_proto::pr_status::{CiRollup, MergeState, Mergeable, PrStatus};
 use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
 
@@ -1192,6 +1192,28 @@ fn render_detail_card(
         }
     }
 
+    // --- Typed links (multica parity #20): one line per link, glyphed by kind so
+    //     the gating ones read differently from the associations —
+    //     🔒 an UNFINISHED blocker, ✓ a satisfied one, → what this card blocks,
+    //     ~ a related card. Rendered ONLY when non-empty, so an old daemon (which
+    //     sends no `dependencies`) leaves the card byte-identical. ---
+    if !issue.dependencies.is_empty() {
+        card_field_row(buf, card_w, row, &[("Links:", CARD_LABEL)]);
+        row = row.saturating_add(1);
+        for link in &issue.dependencies {
+            let (glyph, kind_label) = link_glyph_and_label(link);
+            let reference = link.display_id.clone().unwrap_or_else(|| link.issue_id.clone());
+            let head = format!("  {glyph} {kind_label:<10} {reference}  ");
+            card_field_row(
+                buf,
+                card_w,
+                row,
+                &[(&head, CARD_LABEL), (&link.title, CARD_VALUE)],
+            );
+            row = row.saturating_add(1);
+        }
+    }
+
     // --- divider ---
     draw_card_divider(buf, row, card_w);
     row = row.saturating_add(1);
@@ -1271,6 +1293,23 @@ fn acceptance_view(issue: &IssueRow) -> Vec<AcceptanceCriterion> {
 /// Draw one card content row: the `│` left+right edges in the border colour, then
 /// the label/value `segments` laid out left-to-right from the inner column,
 /// clipped by **chars** at the right edge (63d, utf8-safe).
+/// The glyph + rendered kind label for one typed link (multica parity #20).
+///
+/// `blocked_by` is the only kind that can gate, so it is the only one whose glyph
+/// varies: 🔒 while the blocker is unfinished, ✓ once it is satisfied. An
+/// unrecognised kind token (a newer daemon) falls back to the neutral association
+/// glyph rather than being dropped.
+fn link_glyph_and_label(
+    link: &ainb_hangar_proto::events::IssueLinkRow,
+) -> (&'static str, &'static str) {
+    match link.kind.as_str() {
+        "blocked_by" if link.satisfied => ("✓", "blocked-by"),
+        "blocked_by" => ("🔒", "blocked-by"),
+        "blocks" => ("→", "blocks"),
+        _ => ("~", "related"),
+    }
+}
+
 fn card_field_row(buf: &mut WireBuffer, card_w: u16, row: u16, segments: &[(&str, Color)]) {
     let inner_right = card_w.saturating_sub(2);
     // Edges first; the content overlays the interior between them.
@@ -1579,6 +1618,66 @@ mod card_tests {
         assert!(
             !painted_text(&buf).contains("Linked: "),
             "an unlinked issue shows no Linked line"
+        );
+    }
+
+    /// One typed link row for the render tests.
+    fn link_row(kind: &str, display: &str, title: &str, satisfied: bool) -> IssueLinkRow {
+        IssueLinkRow {
+            kind: kind.into(),
+            issue_id: format!("issue-{display}"),
+            display_id: Some(display.into()),
+            title: title.into(),
+            state: "open".into(),
+            satisfied,
+        }
+    }
+
+    /// multica parity #20: all three kinds render in a `Links:` block, each with
+    /// its own glyph — 🔒 for an unfinished blocker, ✓ once it is satisfied,
+    /// → for what this card blocks, ~ for a related card.
+    #[test]
+    fn detail_card_renders_a_links_block_per_kind() {
+        let mut issue = full_issue();
+        issue.dependencies = vec![
+            link_row("blocked_by", "HGR-4", "Build the parser", false),
+            link_row("blocked_by", "HGR-3", "Land the schema", true),
+            link_row("blocks", "HGR-9", "Ship the CLI", false),
+            link_row("related", "HGR-7", "Docs sweep", false),
+        ];
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 40);
+        render_task_detail(&mut buf, 80, 0, 39, &s);
+        let text = painted_text(&buf);
+
+        assert!(text.contains("Links:"), "the block header: {text}");
+        for want in [
+            "🔒 blocked-by HGR-4",
+            "✓ blocked-by HGR-3",
+            "→ blocks",
+            "~ related",
+        ] {
+            let squashed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+            let want_squashed = want.split_whitespace().collect::<Vec<_>>().join(" ");
+            assert!(
+                squashed.contains(&want_squashed),
+                "missing {want:?} in {text}"
+            );
+        }
+        assert!(text.contains("Build the parser"), "the link title: {text}");
+        assert!(text.contains("Docs sweep"), "the related title: {text}");
+    }
+
+    /// An issue with NO links renders no `Links:` line at all — an old daemon
+    /// sends no `dependencies`, so the card degrades to exactly today's render.
+    #[test]
+    fn detail_card_omits_the_links_block_when_empty() {
+        let s = state_for(full_issue());
+        let mut buf = WireBuffer::new(80, 40);
+        render_task_detail(&mut buf, 80, 0, 39, &s);
+        assert!(
+            !painted_text(&buf).contains("Links:"),
+            "no links ⇒ no block (an old daemon leaves the card unchanged)"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1462,6 +1462,7 @@ mod card_tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -145,6 +145,7 @@ mod tests {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
@@ -50,6 +50,7 @@ fn row(id: &str, state: &str, priority: i64, labels: &[&str]) -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
@@ -57,6 +57,7 @@ fn row(id: &str, display: &str, state: &str, priority: i64, assignee: Option<&st
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -47,6 +47,7 @@ fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
@@ -51,6 +51,7 @@ fn issue_with_pr(pr_url: Option<&str>) -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
@@ -50,6 +50,7 @@ fn issue(pr_url: Option<&str>) -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_boards.rs
@@ -30,6 +30,8 @@ fn card(issue: &str, title: &str, state: Option<&str>) -> BoardCardWireRow {
         member_states: Vec::new(),
         blocked_by: Vec::new(),
         auto_run: false,
+        blocks: Vec::new(),
+        related: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -50,6 +50,7 @@ fn issue_row() -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
@@ -47,6 +47,7 @@ fn issue_row() -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
@@ -122,6 +122,7 @@ fn row(id: &str, title: &str, criteria: Vec<AcceptanceCriterion>) -> IssueRow {
         acceptance_criteria: criteria.iter().map(|c| c.text.clone()).collect(),
         acceptance: criteria,
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
@@ -137,6 +137,7 @@ fn row(id: &str, title: &str, state: &str) -> IssueRow {
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
@@ -126,6 +126,7 @@ fn row(id: &str, title: &str, state: &str, priority: i64, labels: &[&str]) -> Is
         acceptance_criteria: Vec::new(),
         acceptance: Vec::new(),
         context_refs: Vec::new(),
+        dependencies: Vec::new(),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -160,6 +160,7 @@ fn seeded_issues() -> serde_json::Value {
             acceptance_criteria: Vec::new(),
             acceptance: Vec::new(),
             context_refs: Vec::new(),
+            dependencies: Vec::new(),
         }],
     })
     .unwrap()

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2871,6 +2871,7 @@ Commands:
   delete    Delete an issue and all its history (dry-run without `--yes`)
   label     Attach or detach a label on an issue
   criteria  Inspect or tick off an issue's acceptance criteria
+  link      Add, remove, or list an issue's typed links to other issues
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3114,6 +3115,27 @@ Commands:
   check    Tick a criterion off (by id or 1-based ordinal). Idempotent
   uncheck  Un-tick a criterion (by id or 1-based ordinal). Idempotent
   help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar issue link`
+
+Add, remove, or list an issue's typed links to other issues
+
+```console
+$ ainb hangar issue link --help
+Add, remove, or list an issue's typed links to other issues
+
+Usage: ainb hangar issue link [OPTIONS] <COMMAND>
+
+Commands:
+  add     Link two issues. Re-adding a pair with a new kind replaces the kind
+  remove  Remove a link between two issues. Idempotent
+  list    List an issue's links (`🔒`/`✓` blocked-by, `→` blocks, `~` related)
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]


### PR DESCRIPTION
Multica parity item **20**: issue dependencies carry a KIND —
`blocks` / `blocked_by` / `related` — not just an untyped edge.

multica's `issue_dependency` declares `type IN ('blocks','blocked_by','related')`
(`server/migrations/001_init.up.sql:88-94`) and ships **no Go code over that
table** — no gating, no cycle guard, no auto-run. So the only thing multica
contributes here is the three-value typed relation; hangar already exceeded it on
every mechanic. This PR adds that KIND dimension and makes every existing
mechanic respect it.

## Design: normalise `blocks`, store `blocked_by` + `related`

hangar's `card_dependency` row is already directional (`dependent -> blocker`,
i.e. "dependent is *blocked_by* blocker"), so `blocks` is the same edge read from
the other end. Authoring `A blocks B` is **normalised at write** into
`(dependent=B, blocker=A, link_type='blocked_by')`, so one logical relation can
never be stored two ways. At rest the domain is `{'blocked_by','related'}` —
asserted by a store test.

`related` is symmetric, non-gating, exempt from the cycle guard, and invisible to
`blockers_of` / `dependents_of` / `unfinished_blockers_of` / the cycle DFS.

```
 author: "A blocks B"          author: "B blocked-by A"        author: "A related B"
        │                              │                                │
        └──────── normalise ───────────┘                                │
                    ▼                                                   ▼
   row(dependent=B, blocker=A, link_type='blocked_by')   row(dependent=A, blocker=B,
                    │                                              link_type='related')
        ┌───────────┴────────────┐                                      │
        ▼                        ▼                                      ▼
  gates B's dispatch      auto-runs B when A                    NEVER gates, NEVER
  (🔒 on the card)        finishes (if auto_run)                auto-runs, no cycle check
```

## What changed

- **Migration 0055** — `card_dependency.link_type TEXT NOT NULL DEFAULT
  'blocked_by'` + `idx_card_dependency_ws_type`. The constant default backfills
  every pre-0055 row with today's exact semantics (catalog-only, O(1)). **0036 is
  byte-untouched** (applied migrations are immutable).
- **Store** — `LinkKind` domain type + `add_link` / `remove_link` / `blocks_of` /
  `related_of` / `links_of_workspace`. `add_edge` / `remove_edge` stay as
  `BlockedBy` shims so every existing call site is unchanged. Every gating query
  filters `link_type = 'blocked_by'` — **that filter is the whole correctness
  surface**.
- **Proto** — `LinkKindWire` (default `BlockedBy`, `skip_serializing_if` default),
  `BoardCardDepParams.link_type`, `BoardCardWireRow.blocks` / `.related`,
  `IssueRow.dependencies`, `IssueLinkRow`, and three `hangar/issue_link*` methods.
  Every field is append-only and serde-default.
- **Daemon** — `board_card_dep_add/remove` honour `link_type`; new board-free
  `hangar/issue_link_add|remove|links`. **The run gate
  (`rpc/mod.rs:5511`) and the finalize seam (`board.rs`) are unchanged code** —
  they become kind-correct purely through the store filter, and tests pin that.
- **Plugin** — detail card grows a `Links:` block (🔒 / ✓ / → / ~ per kind,
  omitted entirely when empty, so an old daemon renders byte-identically); board
  cards grow a `↔n` count for `related` while `🔒[…]` is untouched; the `w`
  depends-on overlay grows a Tab-cycled kind selector (overlay-local, no reserved
  key bound — `no_screen_binds_a_reserved_key` stays green).
- **CLI** — `ainb hangar issue link add|remove|list [--kind …]`, plus the same
  `Links:` section on `issue show`. Talks to the store repo directly, so it works
  with no daemon.

## Acceptance proof

Manual sqlite run against a throwaway `$AINB_HANGAR_HOME`, with a locally built
`ainb`:

```
$ ainb hangar issue link add "$B" "$A" --kind blocked-by
$ ainb hangar issue link add "$B" "$C" --kind related
$ ainb hangar issue link list "$B"
🔒  blocked-by  HGR-1       schema
~  related     HGR-3       docs
$ ainb hangar issue link list "$A"
→  blocks      HGR-2       parser
$ sqlite3 "$AINB_HANGAR_HOME/hangar.db" "SELECT link_type, count(*) FROM card_dependency GROUP BY 1;"
blocked_by|1
related|1              # NO 'blocks' row — the at-rest domain invariant
$ ainb hangar issue show "$B"
01KYFYNC36PW96GBY7WK68ZR7Z  [open]  priority=0  parser
Links:
🔒  blocked-by  HGR-1       schema
~  related     HGR-3       docs
```

The dispatch half is proven over a real socket in
`crates/ainb-hangar-daemon/tests/rpc_issue_links.rs` (a `blocked_by` link refuses
`hangar/issue_run` and **enqueues zero task rows**; the same shape as `related`
dispatches), and end-to-end against the real daemon binary + claim loop in
`tripwire_tcp_card_dependency_chain_e2e.rs::related_card_never_blocks_and_never_auto_runs`
— card R is `related` to the same blocker with the **same `auto_run = 1` flag** as
the `blocked_by` control, so the link kind is the only difference between them.

## Tests

- `ainb-hangar-store/tests/repo_card_dependency_typed.rs` (10) — related never
  gates, `blocks` normalises, an explicit `blocked_by` gates until the blocker
  drains, related is symmetric + cycle-exempt, no `'blocks'` row is ever
  persisted, pre-0055 rows backfill and still gate, re-adding a pair retypes it.
- `tripwire_migrations_apply.rs` — `link_type` is `NOT NULL DEFAULT 'blocked_by'`
  and the index exists (no exact table/migration counts added).
- `ainb-hangar-daemon/tests/rpc_issue_links.rs` (8) — including the append-only
  proof: raw params **omitting** `link_type` still create a gating edge.
- Plugin render/reducer tests for the `Links:` block, the `↔n` badge, and the Tab
  kind cycle; CLI integration tests for persistence, the reverse render, symmetric
  removal, and the self/cycle refusals.
- The existing `repo_issue_delete` cascade test now carries one `related` row, so
  the kind-blind cascade is pinned.

## Fixture drift fixed in this PR

`IssueRow.dependencies` and `BoardCardWireRow.blocks/related` are exhaustive
struct-literal fields, so 21 files across `ainb-hangar-daemon`, `ainb-hangar-proto`
and `ainb-plugin-hangar` needed them filled. All are in the
`chore(hangar): fill the new wire fields…` commit.

## Local gate (all green)

```
cargo build -p ainb                                       OK
cargo nextest run --lib --tests --all-features …          4142 passed, 0 failed
bash ../scripts/hangar/run_all_tripwires.sh               ran=63 failed=0 skipped=0
bash ../scripts/hangar/run_acceptance_tests.sh            ran=158 failed=0 skipped=0
```

Clippy `-D warnings` is broadly pre-existing-red across these crates on `main`
(`ainb-hangar-core/src/webhook.rs`, `repo/agent.rs`, `repo/board.rs`,
`proto/fleet.rs`, …). Every lint this PR introduced was fixed; no pre-existing one
was chased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed issue links: **blocked by**, **blocks**, and **related**.
  * Manage links from the CLI and Boards screen, including listing and removal.
  * Issue details now show linked issues with status-aware labels and icons.
  * Boards display related and blocking relationships with directional indicators.
* **Bug Fixes**
  * Related links no longer block work or trigger automatic runs.
  * Prevented self-links and invalid dependency cycles.
* **Tests**
  * Added comprehensive coverage for CLI, UI, RPC, persistence, and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->