### PR TITLE
feat(hangar): issue origin provenance (multica parity #21)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! | path                          | backing impl                                            |
 //! |-------------------------------|---------------------------------------------------------|
-//! | `hangar issue create`         | [`ainb_hangar_store::repo::issue::IssueRepo::insert`]    |
+//! | `hangar issue create`         | [`ainb_hangar_store::repo::issue::IssueRepo::insert`] + [`ainb_hangar_store::repo::issue::IssueRepo::set_origin`] |
 //! | `hangar issue list`           | `IssueRepo::list_by_workspace_state`                     |
 //! | `hangar issue show`           | `IssueRepo::get_by_id`                                   |
 //! | `hangar task list`            | `ainb_hangar_store::repo::task::TaskRepo`                |
@@ -40,6 +40,7 @@ use ainb_hangar_core::acceptance::AcceptanceCriterion;
 use ainb_hangar_core::actor::{ActorKind, ActorRef};
 use ainb_hangar_core::clock::SystemClock;
 use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
+use ainb_hangar_core::origin::IssueOrigin;
 use ainb_hangar_store::Store;
 use ainb_hangar_store::repo::autopilot::Autopilot;
 use ainb_hangar_store::repo::issue::{Issue, IssueRepo, NewIssue};
@@ -1500,6 +1501,49 @@ pub struct IssueCreateArgs {
     /// the lowest unfinished stage cascades a roll-up comment onto the parent.
     #[arg(long)]
     pub parent: Option<String>,
+    /// Provenance of this issue: `autopilot` | `comment_mention` | `manual`
+    /// (migration 0056, multica parity #21).
+    ///
+    /// Defaults to `$HANGAR_ORIGIN_TYPE` — the daemon injects it into a
+    /// dispatched agent's environment, so an issue an agent creates mid-run is
+    /// attributable back to the comment / autopilot that asked for it. With
+    /// neither flag nor env, a create is stamped `manual`.
+    #[arg(long = "origin-type")]
+    pub origin_type: Option<String>,
+    /// The provenance id: the autopilot id for `autopilot`, the comment id for
+    /// `comment_mention`. REQUIRED for every kind except `manual`.
+    ///
+    /// Defaults to `$HANGAR_ORIGIN_ID`. Supplying an id with no
+    /// `--origin-type` is an error, never a silent drop.
+    #[arg(long = "origin-id")]
+    pub origin_id: Option<String>,
+}
+
+/// Resolve an issue create's ORIGIN PROVENANCE from flags, then env, then the
+/// `manual` default (migration 0056, multica parity #21).
+///
+/// Precedence rule: an explicit `--origin-type` suppresses the env pair
+/// ENTIRELY, so a flag kind is never mixed with an inherited env id. Only when
+/// NEITHER flag is given does the daemon-injected `HANGAR_ORIGIN_TYPE` /
+/// `HANGAR_ORIGIN_ID` pair apply.
+///
+/// # Errors
+///
+/// Returns an error for an id without a kind, a kind outside the allow-list, or
+/// a kind that requires an id and got none — the same messages the RPC handler
+/// produces, so both surfaces say the same thing.
+fn resolve_cli_origin(
+    flag_type: Option<&str>,
+    flag_id: Option<&str>,
+    env_type: Option<&str>,
+    env_id: Option<&str>,
+) -> Result<IssueOrigin> {
+    let (kind, id) = if flag_type.is_some() || flag_id.is_some() {
+        (flag_type, flag_id)
+    } else {
+        (env_type, env_id)
+    };
+    Ok(IssueOrigin::from_wire(kind, id)?.unwrap_or_else(IssueOrigin::manual))
 }
 
 /// Parse a `--due` value (`YYYY-MM-DD`) into an epoch-millisecond timestamp at
@@ -4348,6 +4392,16 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         anyhow::ensure!(ok, "parent issue `{parent}` not found in this workspace");
     }
 
+    // 0056: resolve the ORIGIN PROVENANCE BEFORE any write (like the assignee and
+    // parent resolves above) — a bad origin must fail the command before the
+    // insert, never leave a half-provenanced issue behind.
+    let origin = resolve_cli_origin(
+        args.origin_type.as_deref(),
+        args.origin_id.as_deref(),
+        std::env::var("HANGAR_ORIGIN_TYPE").ok().as_deref(),
+        std::env::var("HANGAR_ORIGIN_ID").ok().as_deref(),
+    )?;
+
     // e38.21: apply the workspace's issue_prefix to the new title so the prefix
     // actually takes effect on a created issue. An unconfigured workspace leaves
     // the title verbatim (the v1 behaviour). Read after the assignee resolve so a
@@ -4396,6 +4450,12 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         stage: None,
     };
     IssueRepo::insert(pool, &new).await.context("insert issue")?;
+    // 0056: stamp the resolved provenance post-insert, the same pattern the
+    // daemon's create uses, so a CLI-created and a TUI-created issue read back
+    // identically.
+    IssueRepo::set_origin(pool, &workspace_id, &id, &origin)
+        .await
+        .context("stamp issue origin")?;
 
     // 0016: attach each `--label` through the join — `LabelRepo::attach` resolves
     // or creates the label in the workspace, writes the `issue_label` row
@@ -4605,6 +4665,16 @@ async fn run_issue_show(store: &Store, args: IssueShowArgs, format: OutputFormat
         }
         OutputFormat::Text => {
             println!("{}", issue_line(&issue));
+            // 0056 / multica parity #21: the provenance, so the "an issue created
+            // by autopilot or by a comment mention records its origin" proof needs
+            // no daemon and no TUI. Omitted entirely for a pre-0056 row, whose
+            // provenance is genuinely unknown.
+            if let Some(origin) = issue.origin.as_ref() {
+                match origin.id() {
+                    Some(id) => println!("Origin: {} ({id})", origin.kind_db_str()),
+                    None => println!("Origin: {}", origin.kind_db_str()),
+                }
+            }
             // #11-rest: the definition-of-done, with its per-criterion ☑/☐ state,
             // so the CLI proof does not depend on the TUI.
             if !issue.acceptance_criteria.is_empty() {
@@ -8045,5 +8115,144 @@ mod tests {
         )
         .await
         .expect("a padded key must resolve on get too");
+    }
+
+    // ---- ORIGIN PROVENANCE (0056, multica parity #21) ----------------------
+
+    /// The precedence rule: flags win, else the daemon-injected env pair, else
+    /// `manual`. An explicit `--origin-type` suppresses the env pair ENTIRELY, so
+    /// a flag kind is never married to an inherited env id.
+    #[test]
+    fn cli_origin_precedence_is_flags_then_env_then_manual() {
+        // Neither: manual.
+        let o = resolve_cli_origin(None, None, None, None).unwrap();
+        assert_eq!(o.kind_db_str(), "manual");
+        assert_eq!(o.id(), None);
+
+        // Env only: the daemon's injection is the default (the mention chain).
+        let o = resolve_cli_origin(None, None, Some("comment_mention"), Some("c-1")).unwrap();
+        assert_eq!(o.kind_db_str(), "comment_mention");
+        assert_eq!(o.id(), Some("c-1"));
+
+        // Flags beat env, and the env ID does NOT leak into a flag kind.
+        let o =
+            resolve_cli_origin(Some("manual"), None, Some("comment_mention"), Some("c-1")).unwrap();
+        assert_eq!(o.kind_db_str(), "manual");
+        assert_eq!(
+            o.id(),
+            None,
+            "an explicit flag kind never inherits the env id"
+        );
+    }
+
+    /// A bad origin is a hard error at resolve time, with the same wording the
+    /// RPC handler produces.
+    #[test]
+    fn cli_origin_rejects_a_bad_pair() {
+        let err = resolve_cli_origin(Some("quick_create"), Some("x"), None, None).unwrap_err();
+        assert!(err.to_string().contains("unsupported origin_type"));
+
+        let err = resolve_cli_origin(None, Some("c-1"), None, None).unwrap_err();
+        assert!(err.to_string().contains("must be provided together"));
+
+        let err = resolve_cli_origin(Some("autopilot"), None, None, None).unwrap_err();
+        assert!(err.to_string().contains("requires an origin_id"));
+    }
+
+    /// End-to-end: `hangar issue create --origin-type … --origin-id …` stamps the
+    /// pair onto the created row, and `issue show`'s read surface reads it back.
+    #[tokio::test]
+    async fn issue_create_stamps_the_authored_origin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+
+        let HangarCommand::Issue(IssueCommand::Create(args)) = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "issue",
+            "create",
+            "--title",
+            "Split this out",
+            "--origin-type",
+            "comment_mention",
+            "--origin-id",
+            "c-42",
+        ]) else {
+            panic!("expected issue create");
+        };
+        run_issue_create(&store, args).await.expect("create issue");
+
+        let (kind, id): (String, Option<String>) =
+            sqlx::query_as("SELECT origin_type, origin_id FROM issue LIMIT 1")
+                .fetch_one(store.pool())
+                .await
+                .expect("read origin");
+        assert_eq!(kind, "comment_mention");
+        assert_eq!(id.as_deref(), Some("c-42"));
+    }
+
+    /// A create with no origin flags (and no daemon env) is stamped `manual` —
+    /// never left NULL, so `origin_type IS NULL` keeps meaning exactly one thing:
+    /// "created before provenance existed".
+    #[tokio::test]
+    async fn issue_create_without_flags_stamps_manual() {
+        // The env pair is a DAEMON injection into a dispatched agent child; a test
+        // process never has it, and mutating process env from a test is unsound
+        // (and lint-denied here), so this asserts the plain no-flag-no-env path.
+        // `cli_origin_precedence_is_flags_then_env_then_manual` covers the env
+        // legs directly, with no process-global state.
+        assert!(
+            std::env::var("HANGAR_ORIGIN_TYPE").is_err(),
+            "a test process must not inherit the daemon's origin injection"
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+        let HangarCommand::Issue(IssueCommand::Create(args)) =
+            parse_hangar(&["ainb", "hangar", "issue", "create", "--title", "By hand"])
+        else {
+            panic!("expected issue create");
+        };
+        run_issue_create(&store, args).await.expect("create issue");
+
+        let (kind, id): (String, Option<String>) =
+            sqlx::query_as("SELECT origin_type, origin_id FROM issue LIMIT 1")
+                .fetch_one(store.pool())
+                .await
+                .expect("read origin");
+        assert_eq!(kind, "manual");
+        assert_eq!(id, None);
+    }
+
+    /// A bogus `--origin-type` fails BEFORE any write: the issue table is still
+    /// empty afterwards (the resolve is deliberately ahead of the insert, like
+    /// the assignee / parent resolves).
+    #[tokio::test]
+    async fn issue_create_with_a_bad_origin_writes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+
+        let HangarCommand::Issue(IssueCommand::Create(args)) = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "issue",
+            "create",
+            "--title",
+            "Nope",
+            "--origin-type",
+            "bogus",
+            "--origin-id",
+            "x",
+        ]) else {
+            panic!("expected issue create");
+        };
+        let err = run_issue_create(&store, args).await.unwrap_err();
+        assert!(err.to_string().contains("unsupported origin_type"));
+
+        let count: i64 = sqlx::query_scalar("SELECT count(*) FROM issue")
+            .fetch_one(store.pool())
+            .await
+            .expect("count issues");
+        assert_eq!(count, 0, "a bad origin must fail ahead of the insert");
     }
 }

--- a/ainb-tui/crates/ainb-hangar-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/lib.rs
@@ -41,6 +41,10 @@ pub mod ids;
 /// Structured-log line model + `daemon.<date>` reader shared by the
 /// `ainb hangar logs tail` CLI verb and the TUI `LogsScreen` (P8.6).
 pub mod logs;
+/// Issue / task ORIGIN PROVENANCE: the validated `(origin_type, origin_id)`
+/// pair over the closed `{autopilot, comment_mention, manual}` allow-list
+/// (multica parity #21, migration 0056).
+pub mod origin;
 /// The single source of truth for the Hangar home directory
 /// ([`paths::hangar_home`], re-exported at the crate root). Every Hangar
 /// resolver delegates here so the `$AINB_HANGAR_HOME`-else-`~/.agents-in-a-box`

--- a/ainb-tui/crates/ainb-hangar-core/src/origin.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/origin.rs
@@ -1,0 +1,355 @@
+//! Issue / task **origin provenance** — the `(origin_type, origin_id)` pair
+//! (multica parity #21, migration 0056).
+//!
+//! multica stamps every platform-created issue with an origin pair
+//! (`server/migrations/042_autopilot.up.sql:74-77`, widened by
+//! `060_issue_origin_quick_create.up.sql`). It is load-bearing, not decorative:
+//! the completion handler resolves "the issue this run produced" by a
+//! **deterministic by-origin lookup** (`service/task.go:1836 GetIssueByOrigin`)
+//! rather than "the agent's most recent issue", which races when one agent
+//! creates several issues concurrently; and run/analytics attribution reads the
+//! pair back (`service/autopilot.go:251`, `service/task.go:257`).
+//!
+//! # The kind set
+//!
+//! hangar's closed allow-list is [`OriginKind::Autopilot`],
+//! [`OriginKind::CommentMention`] and [`OriginKind::Manual`].
+//! `comment_mention` is the structural analogue of multica's `quick_create`:
+//! hangar has no quick-create RPC, its agent-triggering flow is the `@handle`
+//! comment mention, so the daemon injects that provenance into the agent
+//! child's env and an issue the agent creates mid-run carries it.
+//!
+//! # `origin_id` semantics
+//!
+//! | kind | `origin_id` |
+//! |---|---|
+//! | `autopilot` | `autopilot.id` — the **rule**, not the run (multica passes `ap.ID`, `service/autopilot.go:145`) |
+//! | `comment_mention` | `comment.id` |
+//! | `manual` | `NULL` |
+//!
+//! # Strict on write, lenient on read
+//!
+//! [`OriginKind::parse`] is the **single write-side gate** — every wire, CLI and
+//! repo write funnels through it, so a rogue caller cannot mint an arbitrary
+//! label (multica enforces the same allow-list at its handler,
+//! `internal/handler/issue.go:1213-1231`). [`OriginKind::from_db_str`] is
+//! deliberately **lenient** (unknown → `Manual`, mirroring
+//! `ConcurrencyPolicy::from_db_str`) so a newer daemon writing a future kind
+//! cannot make an older binary fail a read.
+
+use std::fmt;
+
+/// The closed allow-list of provenance kinds.
+///
+/// Stored as the TEXT `origin_type` column; there is deliberately no SQLite
+/// `CHECK` (SQLite cannot `ALTER TABLE … ADD CONSTRAINT`, and this crate
+/// already enforces column domains in the repo layer — see 0055's `link_type`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OriginKind {
+    /// An autopilot rule firing in create-issue mode produced this row.
+    /// `origin_id` is the **autopilot** id.
+    Autopilot,
+    /// The row was produced by (or during) a run spawned from an `@handle`
+    /// comment mention. `origin_id` is the **comment** id.
+    CommentMention,
+    /// A human authored it. `origin_id` is `NULL`.
+    ///
+    /// Note this is stamped *explicitly*, which makes the column a complete
+    /// record: `origin_type IS NULL` means "created before provenance existed /
+    /// unknown", `'manual'` means "a human authored it". Pre-0056 rows are
+    /// deliberately **not** backfilled.
+    Manual,
+}
+
+impl OriginKind {
+    /// The exact string persisted in `origin_type` and carried on the wire.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Autopilot => "autopilot",
+            Self::CommentMention => "comment_mention",
+            Self::Manual => "manual",
+        }
+    }
+
+    /// STRICT parse — the write-side gate.
+    ///
+    /// # Errors
+    ///
+    /// [`OriginParseError::UnknownKind`] for any string outside the allow-list.
+    pub fn parse(s: &str) -> Result<Self, OriginParseError> {
+        match s.trim() {
+            "autopilot" => Ok(Self::Autopilot),
+            "comment_mention" => Ok(Self::CommentMention),
+            "manual" => Ok(Self::Manual),
+            other => Err(OriginParseError::UnknownKind(other.to_string())),
+        }
+    }
+
+    /// LENIENT read-side decode: an unrecognised stored value degrades to
+    /// [`Self::Manual`] rather than failing the row.
+    #[must_use]
+    pub fn from_db_str(s: &str) -> Self {
+        Self::parse(s).unwrap_or(Self::Manual)
+    }
+
+    /// Whether this kind REQUIRES an `origin_id` (multica's pair rule:
+    /// `internal/handler/issue.go:1214`). Only `manual` may omit it.
+    #[must_use]
+    pub const fn requires_id(self) -> bool {
+        !matches!(self, Self::Manual)
+    }
+}
+
+impl fmt::Display for OriginKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_db_str())
+    }
+}
+
+/// Why an `(origin_type, origin_id)` pair was rejected at a write boundary.
+///
+/// Each variant maps to one distinct client-error message so the CLI and the
+/// RPC handler say the same thing (multica's wording, `handler/issue.go:1215`
+/// and `:1221`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OriginParseError {
+    /// `origin_type` was outside the allow-list.
+    UnknownKind(String),
+    /// An `origin_id` was supplied with no `origin_type`.
+    IdWithoutKind,
+    /// A kind that [`OriginKind::requires_id`] was supplied with no (or a
+    /// blank) `origin_id`.
+    MissingId(OriginKind),
+}
+
+impl fmt::Display for OriginParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownKind(got) => write!(
+                f,
+                "unsupported origin_type '{got}' (expected one of: autopilot, comment_mention, manual)"
+            ),
+            Self::IdWithoutKind => {
+                f.write_str("origin_type and origin_id must be provided together")
+            }
+            Self::MissingId(kind) => write!(f, "origin_type '{kind}' requires an origin_id"),
+        }
+    }
+}
+
+impl std::error::Error for OriginParseError {}
+
+/// A validated provenance pair.
+///
+/// The only way to build one is through a constructor that enforces the pair
+/// rule, so an `IssueOrigin` in hand is always a legal `(origin_type,
+/// origin_id)` write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueOrigin {
+    kind: OriginKind,
+    id: Option<String>,
+}
+
+impl IssueOrigin {
+    /// Build a pair, enforcing the pair rule and rejecting a blank id.
+    ///
+    /// # Errors
+    ///
+    /// [`OriginParseError::MissingId`] when `kind.requires_id()` and `id` is
+    /// absent or blank. A `manual` kind silently drops any supplied id (there
+    /// is nothing meaningful to point at).
+    pub fn new(kind: OriginKind, id: Option<String>) -> Result<Self, OriginParseError> {
+        let id = id.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+        if kind.requires_id() && id.is_none() {
+            return Err(OriginParseError::MissingId(kind));
+        }
+        let id = if kind.requires_id() { id } else { None };
+        Ok(Self { kind, id })
+    }
+
+    /// The human-authored origin: `('manual', NULL)`.
+    #[must_use]
+    pub fn manual() -> Self {
+        Self {
+            kind: OriginKind::Manual,
+            id: None,
+        }
+    }
+
+    /// `('autopilot', <autopilot.id>)` — the RULE id, not the run id.
+    ///
+    /// # Errors
+    ///
+    /// [`OriginParseError::MissingId`] when `autopilot_id` is blank.
+    pub fn autopilot(autopilot_id: impl Into<String>) -> Result<Self, OriginParseError> {
+        Self::new(OriginKind::Autopilot, Some(autopilot_id.into()))
+    }
+
+    /// `('comment_mention', <comment.id>)`.
+    ///
+    /// # Errors
+    ///
+    /// [`OriginParseError::MissingId`] when `comment_id` is blank.
+    pub fn comment_mention(comment_id: impl Into<String>) -> Result<Self, OriginParseError> {
+        Self::new(OriginKind::CommentMention, Some(comment_id.into()))
+    }
+
+    /// Decode an optional wire/CLI pair. `(None, None)` ⇒ `Ok(None)` — the
+    /// caller then applies its own default (the daemon stamps `manual`).
+    ///
+    /// # Errors
+    ///
+    /// [`OriginParseError::IdWithoutKind`] for an id with no kind,
+    /// [`OriginParseError::UnknownKind`] for a kind outside the allow-list, and
+    /// [`OriginParseError::MissingId`] for a kind that needs an id and got none.
+    pub fn from_wire(
+        kind: Option<&str>,
+        id: Option<&str>,
+    ) -> Result<Option<Self>, OriginParseError> {
+        let kind = kind.map(str::trim).filter(|s| !s.is_empty());
+        let id = id.map(str::trim).filter(|s| !s.is_empty());
+        match (kind, id) {
+            (None, None) => Ok(None),
+            (None, Some(_)) => Err(OriginParseError::IdWithoutKind),
+            (Some(k), id) => {
+                let kind = OriginKind::parse(k)?;
+                Self::new(kind, id.map(ToString::to_string)).map(Some)
+            }
+        }
+    }
+
+    /// LENIENT read-side decode of the two stored columns. A NULL
+    /// `origin_type` (every pre-0056 row) yields `None`; a stored kind outside
+    /// the allow-list degrades to `manual` rather than failing the row.
+    #[must_use]
+    pub fn from_db(kind: Option<String>, id: Option<String>) -> Option<Self> {
+        let kind = OriginKind::from_db_str(kind?.as_str());
+        let id = id.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+        Some(Self {
+            kind,
+            id: if kind.requires_id() { id } else { None },
+        })
+    }
+
+    /// The provenance kind.
+    #[must_use]
+    pub const fn kind(&self) -> OriginKind {
+        self.kind
+    }
+
+    /// The provenance id (`None` for `manual`).
+    #[must_use]
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+
+    /// The `origin_type` column value.
+    #[must_use]
+    pub const fn kind_db_str(&self) -> &'static str {
+        self.kind.as_db_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_is_strict_over_the_allow_list() {
+        assert_eq!(OriginKind::parse("autopilot"), Ok(OriginKind::Autopilot));
+        assert_eq!(
+            OriginKind::parse("comment_mention"),
+            Ok(OriginKind::CommentMention)
+        );
+        assert_eq!(OriginKind::parse("manual"), Ok(OriginKind::Manual));
+        for bogus in ["quick_create", "Autopilot", "", "webhook", "autopilot "] {
+            let got = OriginKind::parse(bogus);
+            if bogus.trim() == "autopilot" {
+                assert!(got.is_ok(), "surrounding whitespace is trimmed");
+            } else {
+                assert!(
+                    matches!(got, Err(OriginParseError::UnknownKind(_))),
+                    "{bogus:?} must be rejected by the write-side gate"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn from_db_str_is_lenient_so_a_future_kind_cannot_break_an_old_reader() {
+        assert_eq!(OriginKind::from_db_str("autopilot"), OriginKind::Autopilot);
+        assert_eq!(
+            OriginKind::from_db_str("a_kind_from_the_future"),
+            OriginKind::Manual
+        );
+    }
+
+    #[test]
+    fn pair_rule_requires_an_id_for_every_kind_but_manual() {
+        assert!(OriginKind::Autopilot.requires_id());
+        assert!(OriginKind::CommentMention.requires_id());
+        assert!(!OriginKind::Manual.requires_id());
+
+        assert_eq!(
+            IssueOrigin::new(OriginKind::Autopilot, None),
+            Err(OriginParseError::MissingId(OriginKind::Autopilot))
+        );
+        assert_eq!(
+            IssueOrigin::new(OriginKind::CommentMention, Some("   ".into())),
+            Err(OriginParseError::MissingId(OriginKind::CommentMention)),
+            "a blank id is not an id"
+        );
+        let manual = IssueOrigin::new(OriginKind::Manual, Some("ignored".into())).unwrap();
+        assert_eq!(manual.id(), None, "manual never carries an id");
+    }
+
+    #[test]
+    fn from_wire_absent_pair_is_not_an_error() {
+        assert_eq!(IssueOrigin::from_wire(None, None), Ok(None));
+    }
+
+    #[test]
+    fn from_wire_rejects_an_id_without_a_kind() {
+        assert_eq!(
+            IssueOrigin::from_wire(None, Some("c-1")),
+            Err(OriginParseError::IdWithoutKind)
+        );
+        assert_eq!(
+            IssueOrigin::from_wire(None, Some("c-1")).unwrap_err().to_string(),
+            "origin_type and origin_id must be provided together",
+            "multica's wording, verbatim"
+        );
+    }
+
+    #[test]
+    fn from_wire_rejects_an_unknown_kind() {
+        let err = IssueOrigin::from_wire(Some("quick_create"), Some("x")).unwrap_err();
+        assert!(matches!(err, OriginParseError::UnknownKind(ref k) if k == "quick_create"));
+        assert!(err.to_string().starts_with("unsupported origin_type"));
+    }
+
+    #[test]
+    fn from_wire_accepts_the_allow_listed_pairs() {
+        let ap = IssueOrigin::from_wire(Some("autopilot"), Some("ap-1")).unwrap().unwrap();
+        assert_eq!(ap.kind(), OriginKind::Autopilot);
+        assert_eq!(ap.id(), Some("ap-1"));
+
+        let manual = IssueOrigin::from_wire(Some("manual"), None).unwrap().unwrap();
+        assert_eq!(manual.kind(), OriginKind::Manual);
+        assert_eq!(manual.id(), None);
+    }
+
+    #[test]
+    fn from_db_maps_null_kind_to_no_provenance() {
+        assert_eq!(IssueOrigin::from_db(None, Some("stray".into())), None);
+        assert_eq!(IssueOrigin::from_db(None, None), None);
+    }
+
+    #[test]
+    fn from_db_round_trips_a_stamped_pair() {
+        let o = IssueOrigin::from_db(Some("comment_mention".into()), Some("c-7".into())).unwrap();
+        assert_eq!(o.kind_db_str(), "comment_mention");
+        assert_eq!(o.id(), Some("c-7"));
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -166,6 +166,8 @@ mod tests {
 
     fn issue_row(id: &str) -> IssueRow {
         IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: IssueId::from_str(id).unwrap(),
             display_id: None,
             workspace_id: "ws-a".into(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -208,6 +208,8 @@ mod tests {
 
     fn issue_row(id: &str, title: &str) -> IssueRow {
         IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: IssueId::from_str(id).unwrap(),
             display_id: None,
             workspace_id: "ws-a".into(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3091,7 +3091,7 @@ async fn handle_issue_create(
 
     let params: ainb_hangar_proto::snapshots::IssueCreateParams = parse_params(
         req,
-        "{ workspace_id, title, description?, creator, external_ref?, acceptance_criteria?, context_refs?, priority?, due_date?, labels? }",
+        "{ workspace_id, title, description?, creator, external_ref?, acceptance_criteria?, context_refs?, priority?, due_date?, labels?, origin_type?, origin_id? }",
     )?;
     // The mutating handler must not silently no-op on a typo'd workspace.
     let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
@@ -3147,6 +3147,18 @@ async fn handle_issue_create(
             labels.push(name.to_string());
         }
     }
+    // 0056 ORIGIN PROVENANCE (multica parity #21): validated BEFORE any write,
+    // like the parent resolve below — a bad origin must fail the call, never
+    // land a half-provenanced issue. multica's contract verbatim
+    // (`internal/handler/issue.go:1213-1231`): the two halves must arrive
+    // together and the kind must be on the allow-list, so a rogue caller cannot
+    // mint an arbitrary provenance label. An absent pair is legal and stamps
+    // `manual` downstream.
+    let origin = ainb_hangar_core::origin::IssueOrigin::from_wire(
+        params.origin_type.as_deref(),
+        params.origin_id.as_deref(),
+    )
+    .map_err(|e| invalid_params(&e.to_string()))?;
     if let Some(parent) = parent_issue_id {
         let ok = ainb_hangar_store::repo::issue::IssueRepo::get_by_id(pool, parent)
             .await
@@ -3174,6 +3186,7 @@ async fn handle_issue_create(
             priority,
             due_date,
             labels: &labels,
+            origin: origin.as_ref(),
         },
     )
     .await
@@ -3849,6 +3862,9 @@ async fn handle_comment_add(
         &SystemClock,
         ws.as_str(),
         row.issue_id.as_str(),
+        // 0056: the COMMITTED comment's id is this run's provenance
+        // (`('comment_mention', <comment.id>)`).
+        row.id.as_str(),
         &author,
         &params.body,
     )
@@ -5019,6 +5035,16 @@ async fn handle_board_card_create(
             parent_issue_id: None,
             stage: None,
         },
+    )
+    .await
+    .map_err(|e| store_err(&e))?;
+    // 0056: a board card is authored by the TUI user, so its provenance is
+    // `manual` (stamped explicitly, never left NULL — see migration 0056).
+    IssueRepo::set_origin(
+        pool,
+        ws.as_str(),
+        &issue_id,
+        &ainb_hangar_core::origin::IssueOrigin::manual(),
     )
     .await
     .map_err(|e| store_err(&e))?;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -123,6 +123,8 @@ pub async fn issues_list(
             // task-detail card.
             let extras = issue_card_fields(pool, &issue.id).await?;
             out.push(IssueRow {
+                origin_type: None,
+                origin_id: None,
                 id,
                 display_id,
                 workspace_id: issue.workspace_id,
@@ -295,6 +297,8 @@ pub async fn issues_search(
         let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
         let extras = issue_card_fields(pool, &issue.id).await?;
         out.push(IssueRow {
+            origin_type: None,
+            origin_id: None,
             id,
             display_id,
             workspace_id: issue.workspace_id,
@@ -1769,6 +1773,8 @@ pub async fn issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
+        origin_type: None,
+        origin_id: None,
         id,
         display_id,
         workspace_id: issue.workspace_id,
@@ -1968,6 +1974,8 @@ async fn read_issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
+        origin_type: None,
+        origin_id: None,
         id,
         display_id,
         workspace_id: issue.workspace_id,
@@ -2207,6 +2215,8 @@ pub async fn issue_create(
     // shows.
     let display_id = issue_display_row(pool, workspace_id, &id, prefix.as_deref()).await?;
     Ok(IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: issue_id,
         display_id,
         workspace_id: workspace_id.to_string(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -34,6 +34,7 @@ use ainb_hangar_core::actor::{ActorKind, ActorRef};
 use ainb_hangar_core::clock::HangarClock;
 use ainb_hangar_core::idgen::IdGen;
 use ainb_hangar_core::ids::{AgentId, AutopilotId, CommentId, IssueId, SkillId, WorkspaceId};
+use ainb_hangar_core::origin::IssueOrigin;
 use ainb_hangar_core::task_status::TaskStatus;
 use ainb_hangar_proto::events::{
     ActorRow, AgentSkillLinkRow, AttentionRow, AutopilotRow, AutopilotRunRow, CommentRow,
@@ -123,8 +124,10 @@ pub async fn issues_list(
             // task-detail card.
             let extras = issue_card_fields(pool, &issue.id).await?;
             out.push(IssueRow {
-                origin_type: None,
-                origin_id: None,
+                // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
+                // row a snapshot carries and the row an event pushes agree.
+                origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
+                origin_id: issue.origin.as_ref().and_then(|o| o.id().map(ToString::to_string)),
                 id,
                 display_id,
                 workspace_id: issue.workspace_id,
@@ -297,8 +300,10 @@ pub async fn issues_search(
         let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
         let extras = issue_card_fields(pool, &issue.id).await?;
         out.push(IssueRow {
-            origin_type: None,
-            origin_id: None,
+            // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
+            // row a snapshot carries and the row an event pushes agree.
+            origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
+            origin_id: issue.origin.as_ref().and_then(|o| o.id().map(ToString::to_string)),
             id,
             display_id,
             workspace_id: issue.workspace_id,
@@ -1773,8 +1778,10 @@ pub async fn issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
-        origin_type: None,
-        origin_id: None,
+        // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
+        // row a snapshot carries and the row an event pushes agree.
+        origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
+        origin_id: issue.origin.as_ref().and_then(|o| o.id().map(ToString::to_string)),
         id,
         display_id,
         workspace_id: issue.workspace_id,
@@ -1974,8 +1981,10 @@ async fn read_issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
-        origin_type: None,
-        origin_id: None,
+        // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
+        // row a snapshot carries and the row an event pushes agree.
+        origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
+        origin_id: issue.origin.as_ref().and_then(|o| o.id().map(ToString::to_string)),
         id,
         display_id,
         workspace_id: issue.workspace_id,
@@ -2099,6 +2108,10 @@ pub struct IssueCreateInput<'a> {
     /// Label NAMES to attach (migration 0016): each resolve-or-created in the
     /// workspace and joined to the new issue.
     pub labels: &'a [String],
+    /// ORIGIN PROVENANCE for the created issue (migration 0056, multica parity
+    /// #21), already validated against the closed allow-list at the handler
+    /// boundary. `None` => the create stamps `manual` - a human authored it.
+    pub origin: Option<&'a IssueOrigin>,
 }
 
 /// Create one new issue in `workspace_id`, then return it as a wire [`IssueRow`]
@@ -2138,6 +2151,7 @@ pub async fn issue_create(
         priority,
         due_date,
         labels,
+        origin,
     } = input;
     let id = idgen.new_ulid();
     let created_at = clock.now_ms();
@@ -2182,6 +2196,13 @@ pub async fn issue_create(
     // post-insert card-parity pattern as source/target branches). A `None` /
     // blank ref is a no-op, so a link-less create leaves `external_ref` NULL.
     CardParityRepo::set_issue_external_ref(pool, workspace_id, &id, external_ref).await?;
+    // 0056: stamp the ORIGIN PROVENANCE with the same post-insert pattern. An
+    // absent origin is stamped `manual` (never left NULL) so from here on
+    // `origin_type IS NULL` means exactly one thing: "created before provenance
+    // existed". multica leaves human creates NULL; recording them explicitly
+    // makes the column a complete record without needing a backfill.
+    let stamped_origin = origin.cloned().unwrap_or_else(IssueOrigin::manual);
+    IssueRepo::set_origin(pool, workspace_id, &id, &stamped_origin).await?;
     // 0016: attach the authored labels through the join (resolve-or-create per
     // name, `ON CONFLICT DO NOTHING` on the join row, `issue.labels` re-derived
     // inside the same transaction). Attach is idempotent, so a repeated name is
@@ -2215,8 +2236,11 @@ pub async fn issue_create(
     // shows.
     let display_id = issue_display_row(pool, workspace_id, &id, prefix.as_deref()).await?;
     Ok(IssueRow {
-        origin_type: None,
-        origin_id: None,
+        // ORIGIN PROVENANCE (0056): echo exactly what was just stamped, so the
+        // response row and the pushed IssueCreated event stay byte-identical to
+        // a later list snapshot of the same issue.
+        origin_type: Some(stamped_origin.kind_db_str().to_string()),
+        origin_id: stamped_origin.id().map(ToString::to_string),
         id: issue_id,
         display_id,
         workspace_id: workspace_id.to_string(),
@@ -2385,6 +2409,7 @@ pub async fn spawn_mention_tasks(
     clock: &dyn HangarClock,
     workspace_id: &str,
     issue_id: &str,
+    comment_id: &str,
     author: &ainb_hangar_core::actor::ActorRef,
     body: &str,
 ) -> Result<Vec<String>, sqlx::Error> {
@@ -2409,6 +2434,16 @@ pub async fn spawn_mention_tasks(
     // this run so a prior run's terminal rows on the issue do not poison it. Minted
     // once, before the fan-out loop, exactly like the squad fan-out.
     let generation = TaskRepo::next_generation_for_issue(pool, issue_id).await?;
+    // 0056 ORIGIN PROVENANCE: every task this comment spawns is stamped
+    // `('comment_mention', <comment.id>)` — hangar's structural analogue of
+    // multica's `quick_create` provenance. The dispatcher hands it to the agent
+    // child, so an issue the agent creates mid-run is attributable back to the
+    // comment that asked for it.
+    let mention_origin = IssueOrigin::comment_mention(comment_id).map_err(|e| {
+        sqlx::Error::Protocol(format!(
+            "comment {comment_id} is unusable as an origin id: {e}"
+        ))
+    })?;
     let mut spawned = Vec::new();
     for handle in &handles {
         // Resolve by name; an unknown handle simply matches no agent (ignored).
@@ -2444,7 +2479,13 @@ pub async fn spawn_mention_tasks(
             generation,
         };
         match TaskRepo::insert(pool, &task).await {
-            Ok(_) => spawned.push(agent.id.clone()),
+            Ok(_) => {
+                // Stamped per spawned task, INSIDE the per-handle loop and AFTER
+                // the invocation gate: a refused mention writes no row and
+                // therefore no provenance.
+                TaskRepo::set_origin(pool, &task.id, &mention_origin).await?;
+                spawned.push(agent.id.clone());
+            }
             // The agent already has a pending task on this issue (the per-(issue,
             // agent) unique index): coalesce, don't error. The trigger is
             // idempotent — re-mentioning an already-queued agent is a no-op.
@@ -2635,6 +2676,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &owner(),
             "@claude-agent please do X",
         )
@@ -2660,6 +2702,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &owner(),
             "@claude-agent do X",
         )
@@ -2674,6 +2717,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &owner(),
             "@claude-agent again",
         )
@@ -2705,6 +2749,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &owner(),
             "@claude-agent and also @claude-agent",
         )
@@ -2729,6 +2774,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &owner(),
             "@nobody hello and @ghost too",
         )
@@ -2808,6 +2854,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &bob,
             "@claude-agent please do X",
         )
@@ -2828,6 +2875,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &bob,
             "@claude-agent please do X",
         )
@@ -2856,6 +2904,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &bob,
             "@private-bot and @claude-agent please do X",
         )
@@ -2898,6 +2947,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &peer,
             "@claude-agent take this over",
         )
@@ -2930,6 +2980,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &peer,
             "@claude-agent take this over",
         )
@@ -2960,6 +3011,7 @@ mod mention_spawn_tests {
             &SystemClock,
             crate::seed::WS_ID,
             "issue-3",
+            "c-1",
             &me,
             "@claude-agent please do X",
         )

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -903,6 +903,24 @@ async fn prepare_spawn_inputs(
         HANGAR_PARENT_SESSION.to_string(),
     );
 
+    // 0056 / multica parity #21: hand the child its ORIGIN PROVENANCE, the seam
+    // that lets a mention-spawned (or autopilot-fired) run stamp the issues it
+    // creates — multica does the same by injecting the quick-create task id into
+    // the agent's environment (`internal/daemon/daemon.go:1742`). The runner
+    // allowlists both keys; set AFTER `build_task_env` so the daemon's value
+    // always beats an ambient one. A provenance-less task sets NEITHER key, so
+    // an agent's create falls back to `manual` rather than inheriting a stale
+    // pair from the operator's shell.
+    if let Some(origin) = task.origin.as_ref() {
+        task_env.insert(
+            crate::runner::ORIGIN_TYPE_ENV.to_string(),
+            origin.kind_db_str().to_string(),
+        );
+        if let Some(id) = origin.id() {
+            task_env.insert(crate::runner::ORIGIN_ID_ENV.to_string(), id.to_string());
+        }
+    }
+
     // P6.4: materialise the agent's attached skills into the provider's layout,
     // forwarding the `*_HOME` pointer via `task_env`. Non-fatal — a task must
     // still dispatch even if a skill bundle cannot be written.
@@ -4217,5 +4235,134 @@ mod tests {
             Backend::Claude,
             "no per-agent override falls back to the runtime's advertised provider"
         );
+    }
+
+    // ---- ORIGIN PROVENANCE env seam (0056, multica parity #21) -------------
+
+    /// A secret backend that holds nothing — the preamble's credential read is
+    /// irrelevant to the env-key assertions below.
+    struct NoSecretsBackend;
+    impl ainb_hangar_secrets::SecretBackend for NoSecretsBackend {
+        fn get(
+            &self,
+            _: &ainb_hangar_secrets::Scope,
+            _: &str,
+        ) -> ainb_hangar_secrets::Result<Option<ainb_hangar_secrets::SecretBytes>> {
+            Ok(None)
+        }
+        fn put(
+            &self,
+            _: &ainb_hangar_secrets::Scope,
+            _: &str,
+            _: &[u8],
+        ) -> ainb_hangar_secrets::Result<()> {
+            Ok(())
+        }
+        fn delete(
+            &self,
+            _: &ainb_hangar_secrets::Scope,
+            _: &str,
+        ) -> ainb_hangar_secrets::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Build a real queued task, optionally stamped with `origin`, and run the
+    /// dispatch preamble over it. Returns the child `task_env`.
+    async fn task_env_for_origin(
+        origin: Option<&ainb_hangar_core::origin::IssueOrigin>,
+    ) -> std::collections::HashMap<String, String> {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
+        let agent = bootstrap::create_agent(pool, &ws, "worker", "claude", None).await.unwrap();
+        let task_id =
+            ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        TaskRepo::insert(
+            pool,
+            &NewTask {
+                id: task_id.clone(),
+                workspace_id: ws.clone(),
+                runtime_id: bootstrap::default_runtime_id(),
+                agent_id: agent.id.clone(),
+                issue_id: None,
+                work_dir: None,
+                priority: 0,
+                created_at: 1,
+                autopilot_run_id: None,
+                generation: 0,
+            },
+        )
+        .await
+        .unwrap();
+        if let Some(origin) = origin {
+            TaskRepo::set_origin(pool, &task_id, origin).await.unwrap();
+        }
+        let task = TaskRepo::get_by_id(pool, &task_id).await.unwrap().unwrap();
+
+        let root = dir.path().join("task-root");
+        let env = crate::execenv::ExecEnv {
+            workdir: root.join("workdir"),
+            output: root.join("output"),
+            logs: root.join("logs"),
+            gc_meta: root.join(".gc_meta.json"),
+        };
+        // Codex backend + a zero cred timeout: the claude-only credential read is
+        // skipped, so the preamble is just the env build we are asserting on.
+        let (task_env, _cred) = prepare_spawn_inputs(
+            pool,
+            &task,
+            &env,
+            Backend::Codex,
+            Arc::new(NoSecretsBackend),
+            Duration::from_millis(1),
+        )
+        .await;
+        task_env
+    }
+
+    /// A mention-spawned task hands its child BOTH provenance keys — the seam
+    /// that lets the agent's `ainb hangar issue create` stamp the issue it
+    /// creates with the comment that asked for it.
+    #[tokio::test]
+    async fn a_mention_task_carries_its_origin_into_the_child_env() {
+        let origin = ainb_hangar_core::origin::IssueOrigin::comment_mention("c-77").unwrap();
+        let env = task_env_for_origin(Some(&origin)).await;
+        assert_eq!(
+            env.get(crate::runner::ORIGIN_TYPE_ENV).map(String::as_str),
+            Some("comment_mention")
+        );
+        assert_eq!(
+            env.get(crate::runner::ORIGIN_ID_ENV).map(String::as_str),
+            Some("c-77")
+        );
+    }
+
+    /// A provenance-less task sets NEITHER key, so the agent's create falls back
+    /// to `manual` instead of inheriting a stale pair.
+    #[tokio::test]
+    async fn a_task_without_origin_sets_neither_env_key() {
+        let env = task_env_for_origin(None).await;
+        assert!(!env.contains_key(crate::runner::ORIGIN_TYPE_ENV));
+        assert!(!env.contains_key(crate::runner::ORIGIN_ID_ENV));
+    }
+
+    /// `manual` carries no id: the kind key is set, the id key is not.
+    #[tokio::test]
+    async fn a_manual_origin_sets_the_kind_key_only() {
+        let origin = ainb_hangar_core::origin::IssueOrigin::manual();
+        let env = task_env_for_origin(Some(&origin)).await;
+        assert_eq!(
+            env.get(crate::runner::ORIGIN_TYPE_ENV).map(String::as_str),
+            Some("manual")
+        );
+        assert!(!env.contains_key(crate::runner::ORIGIN_ID_ENV));
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -117,7 +117,26 @@ pub const ENV_ALLOWLIST: &[&str] = &[
     // deny-by-default filter, or the lifecycle hook's fleet-membership gate never
     // resolves and the run's AskUserQuestion never reaches the attention pipeline.
     ainb_fleet_core::session_registry::PARENT_ENV,
+    // 0056 (multica parity #21): the ORIGIN PROVENANCE the daemon hands the
+    // child so an issue the agent creates mid-run is attributable back to the
+    // comment / autopilot that asked for it (`ainb hangar issue create` reads
+    // these as its `--origin-*` defaults). Same justification as `PARENT_ENV`:
+    // daemon-stamped config, not an inherited ambient secret, so allowlisting
+    // leaks nothing — and WITHOUT it the deny-by-default filter drops both keys
+    // and the whole provenance chain silently no-ops.
+    ORIGIN_TYPE_ENV,
+    ORIGIN_ID_ENV,
 ];
+
+/// Env key carrying the dispatched task's ORIGIN PROVENANCE KIND to the agent
+/// child (migration 0056). Read by `ainb hangar issue create` as the default
+/// `--origin-type`.
+pub const ORIGIN_TYPE_ENV: &str = "HANGAR_ORIGIN_TYPE";
+
+/// Env key carrying the dispatched task's ORIGIN PROVENANCE ID to the agent
+/// child (migration 0056). Read by `ainb hangar issue create` as the default
+/// `--origin-id`.
+pub const ORIGIN_ID_ENV: &str = "HANGAR_ORIGIN_ID";
 
 /// The POSIX `sysexits.h` `EX_TEMPFAIL` (75): "temporary failure, indicating
 /// something that is not really an error … the request can be retried later".
@@ -2110,6 +2129,28 @@ mod tests {
             tok,
             Some("RESOLVED"),
             "claude child must carry the RESOLVED token, not the ambient leak"
+        );
+    }
+
+    /// 0056 / multica parity #21 silent-no-op guard: both ORIGIN PROVENANCE keys
+    /// must survive the deny-by-default allowlist filter. Drop either from
+    /// `ENV_ALLOWLIST` and the daemon still SETS them in `task_env` while the
+    /// child never SEES them — the whole provenance chain would no-op silently.
+    #[test]
+    fn compose_child_env_passes_the_origin_provenance_keys_through() {
+        let child = compose_child_env(
+            vec![
+                pair(ORIGIN_TYPE_ENV, "comment_mention"),
+                pair(ORIGIN_ID_ENV, "c-7"),
+                pair("SOME_AMBIENT_SECRET", "nope"),
+            ],
+            Vec::new(),
+        );
+        assert!(child.contains(&pair(ORIGIN_TYPE_ENV, "comment_mention")));
+        assert!(child.contains(&pair(ORIGIN_ID_ENV, "c-7")));
+        assert!(
+            !child.iter().any(|(k, _)| k == "SOME_AMBIENT_SECRET"),
+            "the filter is still deny-by-default"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/execenv_layout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/execenv_layout.rs
@@ -32,6 +32,7 @@ const WS_SLUG: &str = "alpha";
 /// Build a fully-materialised [`Task`] with the fields P1.6 reads.
 fn task_fixture(id: &str, issue_id: Option<&str>) -> Task {
     Task {
+        origin: None,
         id: id.to_string(),
         workspace_id: "ws-1".to_string(),
         runtime_id: "rt-1".to_string(),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -201,6 +201,8 @@ async fn wait_for_inbox_count(store: &Store, ws_id: &str, want: i64) {
 
 fn issue_event() -> HangarEvent {
     HangarEvent::IssueCreated(IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str("issue-1").unwrap(),
         display_id: None,
         workspace_id: WS_ID.into(),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_origin_provenance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_origin_provenance.rs
@@ -1,0 +1,360 @@
+//! Integration: ORIGIN PROVENANCE end to end over a real framed `UnixStream`
+//! (migration 0056, multica parity #21).
+//!
+//! **This file is acceptance leg B**: *an issue created by a comment mention
+//! records its origin (sqlite)*. It drives the real chain the daemon runs —
+//!
+//! 1. `hangar/comment_add` with `@claude-agent` commits the comment and fans out
+//!    a task, which is stamped `('comment_mention', <comment.id>)`;
+//! 2. the daemon would hand that pair to the agent child as
+//!    `HANGAR_ORIGIN_TYPE` / `HANGAR_ORIGIN_ID` (asserted in the `run_loop` /
+//!    `runner` unit legs), and the child's `ainb hangar issue create` echoes it
+//!    back over `hangar/issue_create` — replayed here by reading the pair off the
+//!    spawned TASK row and passing it on the create, exactly as the CLI does;
+//! 3. the created ISSUE row is read STRAIGHT FROM SQLITE and must carry the same
+//!    pair.
+//!
+//! The negative legs enforce multica's handler contract verbatim
+//! (`internal/handler/issue.go:1213-1231`): the two halves must arrive together,
+//! the kind must be on the closed allow-list, and a kind that needs an id must
+//! get one — each an `INVALID_PARAMS`, never a silent drop. A plain create with
+//! no origin is stamped `('manual', NULL)`.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_ID, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    /// Send `method`, then drain frames until the response (id-bearing) lands,
+    /// ignoring any interleaved event pushes.
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame_inner())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    async fn subscribe(&mut self, workspace_id: &str) {
+        let resp = self
+            .call(
+                methods::WORKSPACE_SUBSCRIBE,
+                serde_json::json!({ "workspace_id": workspace_id }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "subscribe must ack: {resp}");
+    }
+
+    async fn comment(&mut self, issue_id: &str, body: &str) -> serde_json::Value {
+        let resp = self
+            .call(
+                methods::HANGAR_COMMENT_ADD,
+                serde_json::json!({
+                    "workspace_id": WS_SLUG,
+                    "issue_id": issue_id,
+                    "author": "member:user-1",
+                    "body": body,
+                }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "comment_add must ack: {resp}");
+        resp
+    }
+
+    /// The create an agent child performs: `ainb hangar issue create` forwards
+    /// the origin pair it read from its env.
+    async fn create_issue(
+        &mut self,
+        title: &str,
+        origin: Option<(&str, Option<&str>)>,
+    ) -> serde_json::Value {
+        let mut params = serde_json::json!({
+            "workspace_id": WS_SLUG,
+            "title": title,
+            "creator": "agent:agent-1",
+        });
+        if let Some((kind, id)) = origin {
+            params["origin_type"] = serde_json::Value::String(kind.to_string());
+            if let Some(id) = id {
+                params["origin_id"] = serde_json::Value::String(id.to_string());
+            }
+        }
+        self.call(methods::HANGAR_ISSUE_CREATE, params).await
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// The stored `(origin_type, origin_id)` of one issue, straight from sqlite.
+async fn issue_origin(store: &Store, issue_id: &str) -> (Option<String>, Option<String>) {
+    sqlx::query_as("SELECT origin_type, origin_id FROM issue WHERE id = ?")
+        .bind(issue_id)
+        .fetch_one(store.pool())
+        .await
+        .unwrap()
+}
+
+/// The stored `(origin_type, origin_id)` of the single task on `issue_id`.
+async fn task_origin(store: &Store, issue_id: &str) -> (Option<String>, Option<String>) {
+    sqlx::query_as(
+        "SELECT origin_type, origin_id FROM agent_task_queue \
+         WHERE workspace_id = ?1 AND issue_id = ?2",
+    )
+    .bind(WS_ID)
+    .bind(issue_id)
+    .fetch_one(store.pool())
+    .await
+    .unwrap()
+}
+
+/// **ACCEPTANCE LEG B.** The whole comment-mention provenance chain, ending in
+/// sqlite: a mention stamps the spawned task with the COMMENT's id, and an issue
+/// the mention-spawned agent then creates carries the identical pair.
+#[tokio::test]
+async fn an_issue_created_through_the_comment_mention_chain_records_its_origin() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    // 1. The mention. `issue-3` carries no seeded task, so the spawn is
+    //    unambiguously this comment's doing.
+    let resp = c.comment("issue-3", "@claude-agent please split this out").await;
+    let comment_id = resp["result"]["id"].as_str().expect("comment id").to_string();
+    assert!(!comment_id.is_empty());
+
+    // 2. The spawned TASK carries ('comment_mention', <comment.id>).
+    let (kind, id) = task_origin(&store, "issue-3").await;
+    assert_eq!(kind.as_deref(), Some("comment_mention"));
+    assert_eq!(
+        id.as_deref(),
+        Some(comment_id.as_str()),
+        "the task's provenance id is the COMMENT that asked for it"
+    );
+
+    // 3. Replay what the agent child does: `ainb hangar issue create` forwards
+    //    the pair the daemon put in its env (read here off the task row).
+    let resp = c
+        .create_issue(
+            "Split out the parser",
+            Some(("comment_mention", Some(&comment_id))),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "issue_create must ack: {resp}");
+    let new_issue_id = resp["result"]["id"].as_str().expect("issue id").to_string();
+
+    // The response row carries it too, so the pushed IssueCreated event and a
+    // later list snapshot agree.
+    assert_eq!(resp["result"]["origin_type"], "comment_mention");
+    assert_eq!(resp["result"]["origin_id"], comment_id.as_str());
+
+    // 4. THE ACCEPTANCE READ: sqlite.
+    let (kind, id) = issue_origin(&store, &new_issue_id).await;
+    assert_eq!(kind.as_deref(), Some("comment_mention"));
+    assert_eq!(id.as_deref(), Some(comment_id.as_str()));
+}
+
+/// A plain create — no mention, no origin params — is stamped `('manual', NULL)`
+/// rather than left NULL, so `origin_type IS NULL` keeps meaning exactly one
+/// thing: "created before provenance existed".
+#[tokio::test]
+async fn a_plain_create_is_stamped_manual() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let resp = c.create_issue("By hand", None).await;
+    assert!(resp["error"].is_null(), "issue_create must ack: {resp}");
+    let id = resp["result"]["id"].as_str().unwrap().to_string();
+
+    let (kind, origin_id) = issue_origin(&store, &id).await;
+    assert_eq!(kind.as_deref(), Some("manual"));
+    assert_eq!(origin_id, None);
+}
+
+/// multica `handler/issue.go:1221`: a kind outside the closed allow-list is a
+/// client error, so a rogue caller cannot mint an arbitrary provenance label.
+#[tokio::test]
+async fn an_unknown_origin_type_is_rejected_and_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+
+    let resp = c.create_issue("Nope", Some(("quick_create", Some("x")))).await;
+    let message = resp["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("unsupported origin_type"),
+        "expected the allow-list rejection, got: {resp}"
+    );
+
+    let after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(after, before, "a rejected origin must not land an issue");
+}
+
+/// multica `handler/issue.go:1215`, verbatim wording: the two halves must be
+/// provided together.
+#[tokio::test]
+async fn an_origin_id_without_a_type_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "title": "Nope",
+                "creator": "agent:agent-1",
+                "origin_id": "c-1",
+            }),
+        )
+        .await;
+    let message = resp["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("must be provided together"),
+        "expected multica's pair-rule wording, got: {resp}"
+    );
+}
+
+/// A kind that requires an id and got none is rejected — `autopilot` provenance
+/// with no autopilot to point at is not provenance.
+#[tokio::test]
+async fn an_autopilot_origin_without_an_id_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let resp = c.create_issue("Nope", Some(("autopilot", None))).await;
+    let message = resp["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("requires an origin_id"),
+        "expected the missing-id rejection, got: {resp}"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilot_fires_on_schedule.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilot_fires_on_schedule.rs
@@ -173,6 +173,32 @@ async fn autopilot_fires_on_schedule_after_clock_advance() {
     // The task row exists, linked to the run.
     let (task_id, run_id) = await_autopilot_task(&pool, Duration::from_secs(2)).await;
 
+    // 0056 / multica parity #21 — the REAL-DAEMON provenance leg: the task the
+    // live scheduler fired carries ('autopilot', <autopilot.id>) in sqlite. The
+    // id is the RULE, not the run (multica `service/autopilot.go:145` binds
+    // `ap.ID`), which is what makes "which issues did THIS autopilot create" a
+    // stable query across runs.
+    let origin = sqlx::query("SELECT origin_type, origin_id FROM agent_task_queue WHERE id = ?")
+        .bind(&task_id)
+        .fetch_one(&pool)
+        .await
+        .expect("task origin");
+    assert_eq!(
+        origin.get::<Option<String>, _>("origin_type").as_deref(),
+        Some("autopilot"),
+        "a scheduler-fired task records its provenance kind"
+    );
+    assert_eq!(
+        origin.get::<Option<String>, _>("origin_id").as_deref(),
+        Some(autopilot_id.as_str()),
+        "origin_id is the autopilot id"
+    );
+    assert_ne!(
+        origin.get::<Option<String>, _>("origin_id").as_deref(),
+        Some(run_id.as_str()),
+        "never the run id"
+    );
+
     shutdown.cancel();
     handle.await.expect("scheduler loop joins");
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/worktree_integration.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/worktree_integration.rs
@@ -42,6 +42,7 @@ fn seed_repo_cache() -> TempDir {
 
 fn task_fixture(id: &str, issue_id: Option<&str>) -> Task {
     Task {
+        origin: None,
         id: id.to_string(),
         workspace_id: "ws-1".to_string(),
         runtime_id: "rt-1".to_string(),

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -453,6 +453,19 @@ pub struct IssueRow {
     /// it — a pre-0043 snapshot decodes to `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_ref: Option<String>,
+    /// The card's ORIGIN PROVENANCE kind (`issue.origin_type`, migration 0056,
+    /// multica parity #21): `autopilot` | `comment_mention` | `manual`, or
+    /// `None` for a pre-0056 row whose provenance is unknown. Drives the
+    /// task-detail card's `Origin:` badge. Append-only: omitted from the wire
+    /// when `None` (`skip_serializing_if`), so a pre-0056 snapshot decodes to
+    /// `None` and an old daemon simply never sends it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_type: Option<String>,
+    /// The ORIGIN PROVENANCE id (`issue.origin_id`): the autopilot id for
+    /// `autopilot`, the comment id for `comment_mention`, `None` for `manual`.
+    /// Append-only, same contract as [`Self::origin_type`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_id: Option<String>,
     /// How many tasks (any lifecycle) have ever run against this issue (63d).
     /// `0` for a never-run issue. Drives the task-detail card's `Runs:` history
     /// line, shown only when non-zero. `#[serde(default)]` keeps a pre-63d snapshot

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1091,6 +1091,21 @@ pub struct IssueCreateParams {
     /// it). Append-only field: an old client omits it, an old daemon ignores it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_ref: Option<String>,
+    /// Optional ORIGIN PROVENANCE kind for the created issue (migration 0056,
+    /// multica parity #21): `autopilot` | `comment_mention` | `manual`. ABSENT
+    /// ⇒ the daemon stamps `manual` (a human authored it). Validated against the
+    /// closed allow-list at the handler, with multica's pair rule
+    /// (`internal/handler/issue.go:1213-1231`): supplying one half of the pair
+    /// without the other, or a kind outside the list, is `INVALID_PARAMS` —
+    /// never a silent drop. Append-only field: an old client omits it, an old
+    /// daemon ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_type: Option<String>,
+    /// Optional ORIGIN PROVENANCE id: the autopilot id for `autopilot`, the
+    /// comment id for `comment_mention`. REQUIRED for every kind but `manual`.
+    /// Append-only, same contract as [`Self::origin_type`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_id: Option<String>,
     /// Optional parent issue id: when set, the created issue is a **sub-issue** of
     /// that parent (migration 0046). The daemon validates the parent exists in the
     /// same workspace and rejects a foreign/unknown parent. Append-only field: an
@@ -2467,6 +2482,8 @@ mod tests {
 
         let issues = IssuesListResult {
             issues: vec![IssueRow {
+                origin_type: None,
+                origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("i1").unwrap(),
                 display_id: None,
                 workspace_id: "ws-1".into(),

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -31,6 +31,8 @@ fn comment_id(s: &str) -> CommentId {
 
 fn sample_issue() -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: issue_id("issue-1"),
         display_id: None,
         workspace_id: "default".to_string(),
@@ -208,6 +210,8 @@ fn presence_state_three_states_roundtrip() {
 #[test]
 fn issue_row_pr_url_is_additive() {
     let no_pr = IssueRow {
+        origin_type: None,
+        origin_id: None,
         pr_url: None,
         branch: None,
         ..sample_issue()
@@ -238,6 +242,8 @@ fn issue_row_pr_url_is_additive() {
 #[test]
 fn issue_row_priority_due_date_labels_roundtrip_and_default() {
     let row = IssueRow {
+        origin_type: None,
+        origin_id: None,
         priority: 3,
         due_date: Some(1_700_000_500_000),
         labels: vec!["bug".to_string(), "p0".to_string()],
@@ -262,6 +268,8 @@ fn issue_row_priority_due_date_labels_roundtrip_and_default() {
 #[test]
 fn issue_row_subtask_fields_roundtrip_and_default() {
     let row = IssueRow {
+        origin_type: None,
+        origin_id: None,
         parent_id: Some("parent-issue".to_string()),
         child_total: 3,
         child_done: 1,
@@ -274,6 +282,8 @@ fn issue_row_subtask_fields_roundtrip_and_default() {
     // A top-level issue omits parent_id entirely (skip_serializing_if), and a zero
     // roll-up omits nothing that breaks an old reader.
     let top = IssueRow {
+        origin_type: None,
+        origin_id: None,
         child_total: 0,
         child_done: 0,
         ..sample_issue()
@@ -410,4 +420,85 @@ fn task_result_variants_roundtrip() {
         let back: TaskResult = serde_json::from_value(v).expect("decode");
         assert_eq!(back, r);
     }
+}
+
+// ---- ORIGIN PROVENANCE wire back-compat (migration 0056, parity #21) --------
+
+/// A pre-0056 snapshot carries no `origin_*` keys at all: it must decode, not
+/// fail, and read as "provenance unknown".
+#[test]
+fn issue_row_without_origin_keys_decodes_to_none() {
+    let mut json = serde_json::to_value(sample_issue()).unwrap();
+    let obj = json.as_object_mut().unwrap();
+    obj.remove("origin_type");
+    obj.remove("origin_id");
+    let decoded: IssueRow = serde_json::from_value(json).unwrap();
+    assert_eq!(decoded.origin_type, None);
+    assert_eq!(decoded.origin_id, None);
+}
+
+/// An unstamped row does not GROW the wire: the keys are omitted entirely, so
+/// an old reader sees byte-identical JSON to what it saw pre-0056.
+#[test]
+fn issue_row_with_no_origin_omits_both_keys() {
+    let json = serde_json::to_value(sample_issue()).unwrap();
+    let obj = json.as_object().unwrap();
+    assert!(!obj.contains_key("origin_type"));
+    assert!(!obj.contains_key("origin_id"));
+}
+
+/// A stamped row round-trips both halves.
+#[test]
+fn issue_row_with_origin_round_trips() {
+    let mut row = sample_issue();
+    row.origin_type = Some("comment_mention".to_string());
+    row.origin_id = Some("c-7".to_string());
+    let json = serde_json::to_string(&row).unwrap();
+    assert!(json.contains("\"origin_type\":\"comment_mention\""));
+    let back: IssueRow = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, row);
+}
+
+/// `manual` carries a kind and no id — the id key stays off the wire.
+#[test]
+fn manual_origin_serialises_the_kind_without_an_id() {
+    let mut row = sample_issue();
+    row.origin_type = Some("manual".to_string());
+    let json = serde_json::to_value(&row).unwrap();
+    let obj = json.as_object().unwrap();
+    assert_eq!(
+        obj.get("origin_type").and_then(|v| v.as_str()),
+        Some("manual")
+    );
+    assert!(!obj.contains_key("origin_id"));
+    let back: IssueRow = serde_json::from_value(json).unwrap();
+    assert_eq!(back, row);
+}
+
+/// The CREATE params are append-only in the same way: an old client's payload
+/// (no `origin_*`) decodes with both halves absent, which the daemon reads as
+/// "stamp `manual`".
+#[test]
+fn issue_create_params_origin_is_append_only() {
+    use ainb_hangar_proto::snapshots::IssueCreateParams;
+
+    let old_client = serde_json::json!({
+        "workspace_id": "default",
+        "title": "t",
+        "creator": "member:u-1",
+    });
+    let decoded: IssueCreateParams = serde_json::from_value(old_client).unwrap();
+    assert_eq!(decoded.origin_type, None);
+    assert_eq!(decoded.origin_id, None);
+
+    let stamped = serde_json::json!({
+        "workspace_id": "default",
+        "title": "t",
+        "creator": "member:u-1",
+        "origin_type": "autopilot",
+        "origin_id": "ap-1",
+    });
+    let decoded: IssueCreateParams = serde_json::from_value(stamped).unwrap();
+    assert_eq!(decoded.origin_type.as_deref(), Some("autopilot"));
+    assert_eq!(decoded.origin_id.as_deref(), Some("ap-1"));
 }

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0056_issue_origin_provenance.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0056_issue_origin_provenance.sql
@@ -1,0 +1,43 @@
+-- Hangar v1 schema, migration 0056: ISSUE ORIGIN PROVENANCE (multica parity #21).
+--
+-- multica stamps every platform-created issue with an (origin_type, origin_id)
+-- pair — `042_autopilot.up.sql:74-77` for 'autopilot', widened to 'quick_create'
+-- by `060_issue_origin_quick_create.up.sql`. It is not decorative: the completion
+-- handler looks an issue up BY ORIGIN (`service/task.go:1836 GetIssueByOrigin`)
+-- instead of "the agent's most recent issue", which races when one agent creates
+-- several issues concurrently; and run/analytics attribution reads it
+-- (`service/autopilot.go:251`, `service/task.go:257`).
+--
+-- hangar's kind set is {autopilot, comment_mention, manual}. `comment_mention` is
+-- the structural analogue of multica's `quick_create`: hangar's agent-triggering
+-- flow is the `@handle` comment mention, and the daemon injects that provenance
+-- into the agent child's env so an issue the agent creates mid-run carries it.
+--
+-- origin_id semantics: autopilot -> autopilot.id (the RULE, as multica does —
+-- `service/autopilot.go:145` passes `ap.ID`, not the run id); comment_mention ->
+-- comment.id; manual -> NULL.
+--
+-- NO CHECK CONSTRAINT: SQLite cannot ALTER TABLE ... ADD CONSTRAINT, and this
+-- crate already enforces column domains in the repo layer (see 0055's link_type).
+-- `OriginKind::parse` is the single write-side gate; a store test asserts it.
+--
+-- NOT BACKFILLED: pre-0056 rows keep origin_type NULL, which reads as "provenance
+-- unknown" — distinct from the explicit 'manual' a human create stamps from now
+-- on. ALTER TABLE ... ADD COLUMN with no default is an O(1) catalog change in
+-- SQLite (no table rewrite), safe on populated databases (mirrors 0043).
+
+ALTER TABLE issue ADD COLUMN origin_type TEXT;
+ALTER TABLE issue ADD COLUMN origin_id   TEXT;
+
+-- The by-origin lookup (multica's GetIssueByOrigin) and "which issues did this
+-- autopilot create" list filter. Partial: provenance-less rows stay out of it.
+CREATE INDEX idx_issue_origin ON issue(origin_type, origin_id) WHERE origin_type IS NOT NULL;
+
+-- The TASK carries the same pair so the daemon can hand the agent child its
+-- provenance at dispatch (HANGAR_ORIGIN_TYPE / HANGAR_ORIGIN_ID) — the seam that
+-- lets a mention-spawned run stamp the issues it creates. Mirrors the existing
+-- `autopilot_run_id` linkage column on this table.
+ALTER TABLE agent_task_queue ADD COLUMN origin_type TEXT;
+ALTER TABLE agent_task_queue ADD COLUMN origin_id   TEXT;
+
+CREATE INDEX idx_task_origin ON agent_task_queue(origin_type, origin_id) WHERE origin_type IS NOT NULL;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
@@ -40,6 +40,7 @@
 use ainb_hangar_core::clock::HangarClock;
 use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use ainb_hangar_core::ids::{AutopilotRunId, IdError, TaskId};
+use ainb_hangar_core::origin::IssueOrigin;
 use sqlx::{Row, SqlitePool};
 
 use super::autopilot::{Autopilot, ExecutionMode};
@@ -139,11 +140,16 @@ pub async fn fire_autopilot_tick(
                 .instructions
                 .clone()
                 .unwrap_or_else(|| format!("Autopilot run: {}", autopilot.name));
+            // ORIGIN PROVENANCE (migration 0056, multica parity #21): stamped
+            // INSIDE this INSERT — the exact analogue of multica's
+            // `CreateIssueWithOrigin` (`service/autopilot.go:129-146`), which
+            // binds `ap.ID` (the RULE, not the run) so the completion handler
+            // and analytics can resolve the issue by provenance.
             sqlx::query(
                 "INSERT INTO issue \
                  (id, workspace_id, title, description, state, \
-                  creator_type, creator_id, created_at) \
-                 VALUES (?, ?, ?, ?, 'open', 'agent', ?, ?)",
+                  creator_type, creator_id, created_at, origin_type, origin_id) \
+                 VALUES (?, ?, ?, ?, 'open', 'agent', ?, ?, 'autopilot', ?)",
             )
             .bind(&issue_id)
             .bind(&autopilot.workspace_id)
@@ -151,6 +157,7 @@ pub async fn fire_autopilot_tick(
             .bind(&autopilot.instructions)
             .bind(&autopilot.agent_id)
             .bind(now)
+            .bind(&autopilot.id)
             .execute(&mut *tx)
             .await?;
             Some(issue_id)
@@ -176,6 +183,22 @@ pub async fn fire_autopilot_tick(
             autopilot_run_id: Some(run_id.clone()),
             generation: 0,
         },
+    )
+    .await?;
+
+    // 5. Stamp the task's ORIGIN PROVENANCE inside the SAME transaction, so the
+    //    claim loop can never observe a fired task missing the provenance the
+    //    dispatcher hands its agent child. `origin_id` is the AUTOPILOT id, not
+    //    the run id (multica `service/autopilot.go:145`).
+    TaskRepo::set_origin_in_tx(
+        &mut tx,
+        &task_id,
+        &IssueOrigin::autopilot(&autopilot.id).map_err(|e| {
+            FireError::Db(sqlx::Error::Protocol(format!(
+                "autopilot {} has an unusable id for origin provenance: {e}",
+                autopilot.id
+            )))
+        })?,
     )
     .await?;
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -21,6 +21,7 @@ use ainb_hangar_core::acceptance::{
 };
 use ainb_hangar_core::actor::{ActorKind, ActorRef};
 use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_core::origin::{IssueOrigin, OriginKind};
 use sqlx::{Row, SqlitePool};
 
 /// Parameters for inserting a new `issue` row.
@@ -114,6 +115,11 @@ pub struct Issue {
     /// Optional 1-based **barrier stage** among siblings; `None` = unstaged
     /// (migration 0046).
     pub stage: Option<i64>,
+    /// Who/what created this issue (migration 0056, multica parity #21):
+    /// `('autopilot', <autopilot.id>)`, `('comment_mention', <comment.id>)` or
+    /// `('manual', NULL)`. `None` for every pre-0056 row — "provenance
+    /// unknown", deliberately distinct from an explicit `manual`.
+    pub origin: Option<IssueOrigin>,
 }
 
 /// A partial-edit instruction for one issue's mutable fields (e38.8).
@@ -315,13 +321,110 @@ impl IssueRepo {
         let row = sqlx::query(
             "SELECT id, workspace_id, title, description, state, \
              assignee_type, assignee_id, creator_type, creator_id, created_at, \
-             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage, origin_type, origin_id \
              FROM issue WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(pool)
         .await?;
         row.map(|r| issue_from_row(&r)).transpose()
+    }
+
+    /// Stamp an issue's ORIGIN PROVENANCE post-insert (migration 0056), exactly
+    /// like [`CardParityRepo::set_issue_external_ref`] stamps `external_ref`.
+    ///
+    /// A post-insert setter is deliberate: it keeps [`NewIssue`] — and its ~30
+    /// construction sites — untouched, and mirrors the pattern the crate already
+    /// uses for every "the create flow learned one more fact" column.
+    ///
+    /// Workspace-scoped: an issue id from another tenant matches zero rows and
+    /// changes nothing. Returns `true` when exactly one row was stamped.
+    ///
+    /// [`CardParityRepo::set_issue_external_ref`]: crate::repo::card_parity::CardParityRepo::set_issue_external_ref
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn set_origin(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+        origin: &IssueOrigin,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "UPDATE issue SET origin_type = ?, origin_id = ? WHERE id = ? AND workspace_id = ?",
+        )
+        .bind(origin.kind_db_str())
+        .bind(origin.id())
+        .bind(issue_id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// The DETERMINISTIC by-origin lookup — multica's `GetIssueByOrigin`
+    /// (`service/task.go:1836`), the whole reason the pair exists: resolve "the
+    /// issue this run produced" by its stamped provenance instead of "the
+    /// agent's most recent issue", which races against concurrent creates by the
+    /// same agent.
+    ///
+    /// Served by `idx_issue_origin`. A `manual` origin carries no id and is
+    /// therefore never a useful lookup key — it matches the (potentially many)
+    /// manual rows, so callers should only pass an id-bearing origin. Returns
+    /// the OLDEST match when several exist, so the answer is stable.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails or a row is malformed.
+    pub async fn by_origin(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        origin: &IssueOrigin,
+    ) -> Result<Option<Issue>, sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT id, workspace_id, title, description, state, \
+             assignee_type, assignee_id, creator_type, creator_id, created_at, \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage, origin_type, origin_id \
+             FROM issue \
+             WHERE workspace_id = ? AND origin_type = ? AND origin_id IS ? \
+             ORDER BY created_at, id LIMIT 1",
+        )
+        .bind(workspace_id)
+        .bind(origin.kind_db_str())
+        .bind(origin.id())
+        .fetch_optional(pool)
+        .await?;
+        row.map(|r| issue_from_row(&r)).transpose()
+    }
+
+    /// Every issue in a workspace stamped with `kind` — the "which issues did
+    /// the platform create" list filter multica's `origin_type` was added for
+    /// (`042_autopilot.up.sql:73`, "so they can be filtered in lists").
+    ///
+    /// Oldest first. Served by `idx_issue_origin`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails or a row is malformed.
+    pub async fn list_by_origin_kind(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        kind: OriginKind,
+    ) -> Result<Vec<Issue>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, workspace_id, title, description, state, \
+             assignee_type, assignee_id, creator_type, creator_id, created_at, \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage, origin_type, origin_id \
+             FROM issue \
+             WHERE workspace_id = ? AND origin_type = ? \
+             ORDER BY created_at, id",
+        )
+        .bind(workspace_id)
+        .bind(kind.as_db_str())
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(issue_from_row).collect()
     }
 
     /// Overwrite an issue's lifecycle `state` (e.g. `"open"` → `"done"`).
@@ -436,7 +539,7 @@ impl IssueRepo {
         let rows = sqlx::query(
             "SELECT id, workspace_id, title, description, state, \
              assignee_type, assignee_id, creator_type, creator_id, created_at, \
-             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage, origin_type, origin_id \
              FROM issue WHERE workspace_id = ? AND state = ? ORDER BY created_at",
         )
         .bind(workspace_id)
@@ -464,7 +567,7 @@ impl IssueRepo {
         let rows = sqlx::query(
             "SELECT id, workspace_id, title, description, state, \
              assignee_type, assignee_id, creator_type, creator_id, created_at, \
-             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage \
+             priority, due_date, labels, acceptance_criteria, context_refs, external_ref, parent_issue_id, stage, origin_type, origin_id \
              FROM issue WHERE parent_issue_id = ? \
              ORDER BY stage IS NULL, stage, created_at, id",
         )
@@ -594,7 +697,7 @@ impl IssueRepo {
         let rows = sqlx::query(
             "SELECT i.id, i.workspace_id, i.title, i.description, i.state, \
              i.assignee_type, i.assignee_id, i.creator_type, i.creator_id, i.created_at, \
-             i.priority, i.due_date, i.labels, i.acceptance_criteria, i.context_refs, i.external_ref, i.parent_issue_id, i.stage, \
+             i.priority, i.due_date, i.labels, i.acceptance_criteria, i.context_refs, i.external_ref, i.parent_issue_id, i.stage, i.origin_type, i.origin_id, \
              MAX(CASE \
                  WHEN LOWER(i.title) LIKE ?2 ESCAPE '\\' THEN 3 \
                  WHEN LOWER(i.description) LIKE ?2 ESCAPE '\\' THEN 2 \
@@ -1030,6 +1133,10 @@ fn issue_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Issue, sqlx::Error> {
         external_ref: row.try_get("external_ref")?,
         parent_issue_id: row.try_get("parent_issue_id")?,
         stage: row.try_get("stage")?,
+        // LENIENT by design (migration 0056): a stored kind outside the
+        // allow-list degrades to `manual` instead of failing the whole row, so
+        // a newer daemon's future kind cannot brick an older reader.
+        origin: IssueOrigin::from_db(row.try_get("origin_type")?, row.try_get("origin_id")?),
     })
 }
 
@@ -1719,5 +1826,199 @@ mod tests {
         let hits = IssueRepo::search_ranked(pool, "ws-a", "keyword").await.unwrap();
         let ids: Vec<&str> = hits.iter().map(|i| i.id.as_str()).collect();
         assert_eq!(ids, ["i-a"], "only the owning tenant's issue is returned");
+    }
+
+    // ---- ORIGIN PROVENANCE (migration 0056, multica parity #21) -------------
+
+    /// Every column an unstamped (pre-0056-shaped) create leaves behind reads
+    /// back as "provenance unknown" — NOT as an implicit `manual`.
+    #[tokio::test]
+    async fn an_unstamped_issue_reads_back_with_no_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_issue(pool, "ws-a", "i-1", "t", None, 1).await;
+
+        let issue = IssueRepo::get_by_id(pool, "i-1").await.unwrap().unwrap();
+        assert_eq!(issue.origin, None);
+    }
+
+    /// The post-insert setter writes both columns, and the read side
+    /// re-assembles the typed pair — through `get_by_id`, `list_by_workspace`
+    /// AND `search_ranked`, so no SELECT list is left behind.
+    #[tokio::test]
+    async fn set_origin_round_trips_through_every_read_surface() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_issue(pool, "ws-a", "i-1", "keyword title", None, 1).await;
+
+        let origin = IssueOrigin::autopilot("ap-9").unwrap();
+        assert!(IssueRepo::set_origin(pool, "ws-a", "i-1", &origin).await.unwrap());
+
+        // Raw SQL — the acceptance shape (`SELECT origin_type, origin_id`).
+        let (kind, id): (String, Option<String>) =
+            sqlx::query_as("SELECT origin_type, origin_id FROM issue WHERE id = 'i-1'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!((kind.as_str(), id.as_deref()), ("autopilot", Some("ap-9")));
+
+        assert_eq!(
+            IssueRepo::get_by_id(pool, "i-1").await.unwrap().unwrap().origin,
+            Some(origin.clone())
+        );
+        let listed = IssueRepo::list_by_workspace_state(pool, "ws-a", "open").await.unwrap();
+        assert_eq!(listed[0].origin, Some(origin.clone()));
+        let found = IssueRepo::search_ranked(pool, "ws-a", "keyword").await.unwrap();
+        assert_eq!(found[0].origin, Some(origin));
+    }
+
+    /// A `manual` stamp writes the kind and leaves `origin_id` NULL — the
+    /// column becomes a complete record ("a human authored it"), distinct from
+    /// the NULL kind a pre-0056 row keeps.
+    #[tokio::test]
+    async fn manual_stamps_the_kind_and_a_null_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_issue(pool, "ws-a", "i-1", "t", None, 1).await;
+
+        IssueRepo::set_origin(pool, "ws-a", "i-1", &IssueOrigin::manual())
+            .await
+            .unwrap();
+
+        let (kind, id): (String, Option<String>) =
+            sqlx::query_as("SELECT origin_type, origin_id FROM issue WHERE id = 'i-1'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(kind, "manual");
+        assert_eq!(id, None);
+    }
+
+    /// The setter is workspace-scoped: a foreign tenant's id stamps nothing.
+    #[tokio::test]
+    async fn set_origin_never_crosses_a_tenant_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_ws(pool, "ws-b").await;
+        seed_issue(pool, "ws-a", "i-1", "t", None, 1).await;
+
+        let stamped = IssueRepo::set_origin(
+            pool,
+            "ws-b",
+            "i-1",
+            &IssueOrigin::comment_mention("c-1").unwrap(),
+        )
+        .await
+        .unwrap();
+        assert!(!stamped, "a foreign-tenant stamp matches zero rows");
+        assert_eq!(
+            IssueRepo::get_by_id(pool, "i-1").await.unwrap().unwrap().origin,
+            None
+        );
+    }
+
+    /// The DETERMINISTIC lookup multica added the pair for
+    /// (`GetIssueByOrigin`): the right issue for the right provenance id, and
+    /// `None` for a different id — never "the agent's most recent issue".
+    #[tokio::test]
+    async fn by_origin_resolves_the_stamped_issue_and_only_that_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_issue(pool, "ws-a", "i-1", "first", None, 1).await;
+        seed_issue(pool, "ws-a", "i-2", "second", None, 2).await;
+
+        let mine = IssueOrigin::comment_mention("c-42").unwrap();
+        IssueRepo::set_origin(pool, "ws-a", "i-1", &mine).await.unwrap();
+        // i-2 is the agent's MORE RECENT issue but a different provenance.
+        IssueRepo::set_origin(
+            pool,
+            "ws-a",
+            "i-2",
+            &IssueOrigin::comment_mention("c-99").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let hit = IssueRepo::by_origin(pool, "ws-a", &mine).await.unwrap().unwrap();
+        assert_eq!(hit.id, "i-1", "resolved by provenance, not by recency");
+
+        let miss = IssueOrigin::comment_mention("c-nope").unwrap();
+        assert!(IssueRepo::by_origin(pool, "ws-a", &miss).await.unwrap().is_none());
+        assert!(
+            IssueRepo::by_origin(pool, "ws-b", &mine).await.unwrap().is_none(),
+            "workspace-scoped"
+        );
+    }
+
+    /// The "which issues did the platform create" list filter.
+    #[tokio::test]
+    async fn list_by_origin_kind_filters_to_that_kind_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_issue(pool, "ws-a", "i-1", "a", None, 1).await;
+        seed_issue(pool, "ws-a", "i-2", "b", None, 2).await;
+        seed_issue(pool, "ws-a", "i-3", "c", None, 3).await;
+
+        IssueRepo::set_origin(
+            pool,
+            "ws-a",
+            "i-1",
+            &IssueOrigin::autopilot("ap-1").unwrap(),
+        )
+        .await
+        .unwrap();
+        IssueRepo::set_origin(pool, "ws-a", "i-2", &IssueOrigin::manual())
+            .await
+            .unwrap();
+        IssueRepo::set_origin(
+            pool,
+            "ws-a",
+            "i-3",
+            &IssueOrigin::autopilot("ap-2").unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let fired = IssueRepo::list_by_origin_kind(pool, "ws-a", OriginKind::Autopilot)
+            .await
+            .unwrap();
+        let ids: Vec<&str> = fired.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, ["i-1", "i-3"]);
+        // The unstamped row is in neither bucket.
+        let manual =
+            IssueRepo::list_by_origin_kind(pool, "ws-a", OriginKind::Manual).await.unwrap();
+        assert_eq!(manual.len(), 1);
+    }
+
+    /// A kind written outside the allow-list (only reachable through raw SQL /
+    /// a newer daemon) must not fail the read — it degrades to `manual`.
+    #[tokio::test]
+    async fn an_unknown_stored_kind_degrades_instead_of_failing_the_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_ws(pool, "ws-a").await;
+        seed_issue(pool, "ws-a", "i-1", "t", None, 1).await;
+        sqlx::query(
+            "UPDATE issue SET origin_type = 'from_the_future', origin_id = 'x' WHERE id = 'i-1'",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let issue = IssueRepo::get_by_id(pool, "i-1").await.unwrap().unwrap();
+        assert_eq!(issue.origin.unwrap().kind(), OriginKind::Manual);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -26,6 +26,7 @@
 //! `sweep_expired_queued`). Those belong to the P1 daemon FSM, which builds on
 //! these read/enqueue primitives.
 
+use ainb_hangar_core::origin::IssueOrigin;
 use sqlx::{Row, SqlitePool};
 
 /// Parameters for enqueueing a new task (always inserted as `queued`).
@@ -160,12 +161,64 @@ pub struct Task {
     /// read back so the daemon claim path can key a leader-briefing injection off
     /// it. An infra-retry child copies it verbatim.
     pub squad_id: Option<String>,
+    /// Who/what enqueued this task (migration 0056, multica parity #21). The
+    /// daemon hands it to the agent child as `HANGAR_ORIGIN_TYPE` /
+    /// `HANGAR_ORIGIN_ID` at dispatch, so an issue the agent creates mid-run
+    /// carries the same provenance. `None` for every pre-0056 row.
+    pub origin: Option<IssueOrigin>,
 }
 
 /// Stateless typed wrapper over the `agent_task_queue` table.
 pub struct TaskRepo;
 
 impl TaskRepo {
+    /// Stamp a task's ORIGIN PROVENANCE (migration 0056) WITHIN an enqueue
+    /// transaction — same atomicity contract as
+    /// [`CardParityRepo::set_task_source_branch_in_tx`]: the claim loop can
+    /// never observe a task missing its dispatch inputs, so a task can never
+    /// exist without the provenance the dispatcher hands its child.
+    ///
+    /// [`CardParityRepo::set_task_source_branch_in_tx`]: crate::repo::card_parity::CardParityRepo::set_task_source_branch_in_tx
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn set_origin_in_tx(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        task_id: &str,
+        origin: &IssueOrigin,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE agent_task_queue SET origin_type = ?, origin_id = ? WHERE id = ?")
+            .bind(origin.kind_db_str())
+            .bind(origin.id())
+            .bind(task_id)
+            .execute(&mut **tx)
+            .await?;
+        Ok(())
+    }
+
+    /// Post-insert [`Self::set_origin_in_tx`] for callers outside a transaction.
+    ///
+    /// Returns `true` when exactly one row was stamped.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn set_origin(
+        pool: &SqlitePool,
+        task_id: &str,
+        origin: &IssueOrigin,
+    ) -> Result<bool, sqlx::Error> {
+        let res =
+            sqlx::query("UPDATE agent_task_queue SET origin_type = ?, origin_id = ? WHERE id = ?")
+                .bind(origin.kind_db_str())
+                .bind(origin.id())
+                .bind(task_id)
+                .execute(pool)
+                .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
     /// Enqueue one task as `queued`, leaving every lifecycle/retry column at its
     /// schema default. Returns the new row's `id` on success.
     ///
@@ -662,7 +715,8 @@ impl TaskRepo {
 const COLUMNS: &str = "id, workspace_id, runtime_id, agent_id, issue_id, status, result, \
      session_id, work_dir, attempt, max_attempts, parent_task_id, failure_reason, \
      priority, created_at, dispatched_at, started_at, finished_at, autopilot_run_id, \
-     mode, session_name, repo_ref, agent_kind, branch, generation, source_branch, squad_id";
+     mode, session_name, repo_ref, agent_kind, branch, generation, source_branch, squad_id, \
+     origin_type, origin_id";
 
 /// Map one raw `agent_task_queue` row into a [`Task`].
 fn task_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Task, sqlx::Error> {
@@ -694,6 +748,9 @@ fn task_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Task, sqlx::Error> {
         generation: row.try_get("generation")?,
         source_branch: row.try_get("source_branch")?,
         squad_id: row.try_get("squad_id")?,
+        // LENIENT (migration 0056): an unknown stored kind degrades to `manual`
+        // rather than failing the row — see `IssueOrigin::from_db`.
+        origin: IssueOrigin::from_db(row.try_get("origin_type")?, row.try_get("origin_id")?),
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_enqueue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_enqueue.rs
@@ -582,3 +582,100 @@ async fn count_runs_in_flight(store: &Store) -> i64 {
         .await
         .expect("count in-flight runs")
 }
+
+// ---- ORIGIN PROVENANCE (migration 0056, multica parity #21) -----------------
+
+/// **Acceptance leg A.** An issue created by an autopilot records its origin in
+/// sqlite: `SELECT origin_type, origin_id FROM issue` reads
+/// `('autopilot', <autopilot.id>)` — the RULE id, not the run id (multica
+/// `service/autopilot.go:145` binds `ap.ID`). The task fired alongside it
+/// carries the same pair, written INSIDE the fire transaction so the claim loop
+/// can never see a task without its provenance.
+#[tokio::test]
+async fn autopilot_create_issue_stamps_origin() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let mut autopilot = seed_autopilot(&store).await;
+    autopilot.execution_mode = ainb_hangar_store::repo::autopilot::ExecutionMode::CreateIssue;
+    let clock = FixedClock(T0);
+
+    let (run_id, task_id) = ainb_hangar_store::repo::autopilot_run::fire_autopilot_tick(
+        store.pool(),
+        &clock,
+        &autopilot,
+    )
+    .await
+    .expect("fire tick");
+
+    let issue_row = sqlx::query("SELECT origin_type, origin_id FROM issue LIMIT 1")
+        .fetch_one(store.pool())
+        .await
+        .expect("read created issue");
+    assert_eq!(
+        issue_row.get::<String, _>("origin_type"),
+        "autopilot",
+        "the autopilot-fired issue records its provenance kind"
+    );
+    assert_eq!(
+        issue_row.get::<String, _>("origin_id"),
+        autopilot.id,
+        "origin_id is the AUTOPILOT id, not the run id"
+    );
+    assert_ne!(
+        issue_row.get::<String, _>("origin_id"),
+        run_id.to_string(),
+        "guards the rule-vs-run confusion multica's CreateIssueWithOrigin avoids"
+    );
+
+    let task_row = sqlx::query("SELECT origin_type, origin_id FROM agent_task_queue WHERE id = ?")
+        .bind(task_id.as_str())
+        .fetch_one(store.pool())
+        .await
+        .expect("read fired task");
+    assert_eq!(task_row.get::<String, _>("origin_type"), "autopilot");
+    assert_eq!(task_row.get::<String, _>("origin_id"), autopilot.id);
+
+    // And the typed read model re-assembles the pair.
+    let task = TaskRepo::get_by_id(store.pool(), task_id.as_str())
+        .await
+        .expect("get task")
+        .expect("task present");
+    let origin = task.origin.expect("task carries provenance");
+    assert_eq!(origin.kind_db_str(), "autopilot");
+    assert_eq!(origin.id(), Some(autopilot.id.as_str()));
+}
+
+/// The `run_only` sibling: no issue is created, but the fired task still
+/// carries its autopilot provenance (the dispatcher hands it to the child, so
+/// issues that run creates are attributable).
+#[tokio::test]
+async fn run_only_fire_stamps_the_task_and_creates_no_issue() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let autopilot = seed_autopilot(&store).await;
+    let clock = FixedClock(T0);
+
+    let (_run_id, task_id) = ainb_hangar_store::repo::autopilot_run::fire_autopilot_tick(
+        store.pool(),
+        &clock,
+        &autopilot,
+    )
+    .await
+    .expect("fire tick");
+
+    let issue_count: i64 = sqlx::query_scalar("SELECT count(*) FROM issue")
+        .fetch_one(store.pool())
+        .await
+        .expect("count issues");
+    assert_eq!(issue_count, 0);
+
+    let task_row = sqlx::query("SELECT origin_type, origin_id FROM agent_task_queue WHERE id = ?")
+        .bind(task_id.as_str())
+        .fetch_one(store.pool())
+        .await
+        .expect("read fired task");
+    assert_eq!(task_row.get::<String, _>("origin_type"), "autopilot");
+    assert_eq!(task_row.get::<String, _>("origin_id"), autopilot.id);
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
@@ -1401,3 +1401,51 @@ async fn migration_0055_types_card_dependency_links() {
 
     pool.close().await;
 }
+
+#[tokio::test]
+async fn migration_0056_adds_issue_and_task_origin_provenance() {
+    // multica parity #21: the (origin_type, origin_id) pair on the issue
+    // (`042_autopilot.up.sql:74-77`, widened by `060_issue_origin_quick_create`),
+    // mirrored onto the task so the daemon can hand a dispatched child its
+    // provenance. NULLABLE and NOT backfilled: a pre-0056 row reads NULL, which
+    // means "provenance unknown" — deliberately distinct from the explicit
+    // 'manual' a human create stamps from now on. NO CHECK constraint (SQLite
+    // cannot add one via ALTER); `OriginKind::parse` is the write-side gate.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = fresh_pool(dir.path()).await;
+
+    for (table, index) in [
+        ("issue", "idx_issue_origin"),
+        ("agent_task_queue", "idx_task_origin"),
+    ] {
+        let cols = sqlx::query(&format!("PRAGMA table_info({table})"))
+            .fetch_all(&pool)
+            .await
+            .expect("table_info");
+        for col in ["origin_type", "origin_id"] {
+            let found = cols
+                .iter()
+                .find(|r| {
+                    let name: String = r.get("name");
+                    name == col
+                })
+                .unwrap_or_else(|| panic!("{table}.{col} exists"));
+            let notnull: i64 = found.get("notnull");
+            let dflt: Option<String> = found.get("dflt_value");
+            assert_eq!(notnull, 0, "{table}.{col} is NULLABLE (no backfill)");
+            assert_eq!(dflt, None, "{table}.{col} has no default");
+        }
+
+        let idx = index_sql(&pool, index).await;
+        assert!(
+            idx.contains(table) && idx.contains("origin_type") && idx.contains("origin_id"),
+            "{index} serves the by-origin lookup: {idx}"
+        );
+        assert!(
+            idx.contains("WHERE origin_type IS NOT NULL"),
+            "{index} is PARTIAL so provenance-less rows stay out of it: {idx}"
+        );
+    }
+
+    pool.close().await;
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -4316,6 +4316,8 @@ impl HangarPlugin {
         // renders the task's title + status; the streaming transcript folds events
         // addressed to this task id, exactly as the issue board's open does.
         let issue = ainb_hangar_proto::events::IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str(format!("task-{task_id}")).unwrap_or_else(
                 |_| ainb_hangar_core::ids::IssueId::from_str("task").expect("non-empty"),
             ),
@@ -5753,6 +5755,8 @@ mod tests {
         p.conn.on_dialed("s1");
         p.conn.on_subscribe_ack();
         p.screens.set_issues(vec![IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
             display_id: None,
             workspace_id: "default".into(),
@@ -5909,6 +5913,8 @@ mod tests {
         // more than one column (the press must resolve the RIGHT card).
         p.screens.set_issues(vec![
             IssueRow {
+                origin_type: None,
+                origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
                 display_id: Some("HGR-1".into()),
                 workspace_id: "default".into(),
@@ -5940,6 +5946,8 @@ mod tests {
                 dependencies: Vec::new(),
             },
             IssueRow {
+                origin_type: None,
+                origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("issue-2").unwrap(),
                 display_id: Some("HGR-2".into()),
                 workspace_id: "default".into(),
@@ -6132,6 +6140,8 @@ mod tests {
 
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
             display_id: Some("HGR-1".into()),
             workspace_id: "default".into(),
@@ -6223,6 +6233,8 @@ mod tests {
 
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
             display_id: Some("HGR-1".into()),
             workspace_id: "default".into(),
@@ -6306,6 +6318,8 @@ mod tests {
         // Several Todo cards so a scroll offset is observable.
         let rows: Vec<IssueRow> = (0..4)
             .map(|i| IssueRow {
+                origin_type: None,
+                origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str(format!("t{i}")).unwrap(),
                 display_id: Some(format!("HGR-{i}")),
                 workspace_id: "default".into(),
@@ -6393,6 +6407,8 @@ mod tests {
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![
             IssueRow {
+                origin_type: None,
+                origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("card-a").unwrap(),
                 display_id: Some("HGR-1".into()),
                 workspace_id: "default".into(),
@@ -6424,6 +6440,8 @@ mod tests {
                 dependencies: Vec::new(),
             },
             IssueRow {
+                origin_type: None,
+                origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap(),
                 display_id: Some("HGR-2".into()),
                 workspace_id: "default".into(),
@@ -7168,6 +7186,8 @@ mod tests {
 
         // Open the task detail for a fresh issue.
         let issue = IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
             display_id: None,
             workspace_id: "default".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -3669,6 +3669,8 @@ mod tests {
 
     fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
         IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: IssueId::from_str(id).unwrap(),
             display_id: None,
             workspace_id: "ws".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1136,6 +1136,19 @@ fn render_detail_card(
         row = row.saturating_add(1);
     }
 
+    // --- Origin provenance (0056, multica parity #21): the badge is shown only
+    //     for a PLATFORM-created card. A human-authored card ('manual') and a
+    //     pre-0056 card (no origin_type) need no badge, so they read unchanged. ---
+    if let Some(badge) = origin_badge(issue.origin_type.as_deref()) {
+        card_field_row(
+            buf,
+            card_w,
+            row,
+            &[("Origin: ", CARD_LABEL), (badge, CARD_VALUE)],
+        );
+        row = row.saturating_add(1);
+    }
+
     // --- Acceptance criteria (0048 + #11-rest): a `Acceptance: <done>/<total>`
     //     header then one `☑`/`☐ <criterion>` line per element, rendered ONLY when
     //     non-empty so an issue without them reads unchanged (mirrors the Linked
@@ -1307,6 +1320,21 @@ fn link_glyph_and_label(
         "blocked_by" => ("🔒", "blocked-by"),
         "blocks" => ("→", "blocks"),
         _ => ("~", "related"),
+    }
+}
+
+/// The `Origin:` badge text for a wire `origin_type`, or `None` when no badge
+/// belongs on the card (migration 0056, multica parity #21).
+///
+/// A badge marks a card the PLATFORM created, so it is deliberately suppressed
+/// for `manual` (a human authored it — the unremarkable case) and for a
+/// pre-0056 card whose provenance is simply unknown. An unrecognised value is
+/// treated like `manual` and shows nothing, mirroring the lenient read side.
+fn origin_badge(origin_type: Option<&str>) -> Option<&'static str> {
+    match origin_type?.trim() {
+        "autopilot" => Some("⚙ autopilot"),
+        "comment_mention" => Some("💬 comment mention"),
+        _ => None,
     }
 }
 
@@ -1621,6 +1649,54 @@ mod card_tests {
             !painted_text(&buf).contains("Linked: "),
             "an unlinked issue shows no Linked line"
         );
+    }
+
+    /// 0056 / multica parity #21: a PLATFORM-created card wears an `Origin:`
+    /// badge naming the provenance kind; a human-authored (`manual`) or
+    /// provenance-less card wears none.
+    #[test]
+    fn detail_card_renders_origin_badge_only_for_platform_created_cards() {
+        for (kind, expected) in [
+            ("autopilot", "autopilot"),
+            ("comment_mention", "comment mention"),
+        ] {
+            let mut issue = full_issue();
+            issue.origin_type = Some(kind.into());
+            issue.origin_id = Some("prov-1".into());
+            let s = state_for(issue);
+            let mut buf = WireBuffer::new(80, 30);
+            render_task_detail(&mut buf, 80, 0, 29, &s);
+            let text = painted_text(&buf);
+            assert!(text.contains("Origin: "), "origin label for {kind}: {text}");
+            assert!(text.contains(expected), "origin value for {kind}: {text}");
+        }
+
+        for manual in [Some("manual".to_string()), None] {
+            let mut issue = full_issue();
+            issue.origin_type = manual.clone();
+            let s = state_for(issue);
+            let mut buf = WireBuffer::new(80, 30);
+            render_task_detail(&mut buf, 80, 0, 29, &s);
+            assert!(
+                !painted_text(&buf).contains("Origin: "),
+                "no badge for {manual:?}"
+            );
+        }
+    }
+
+    /// The badge mapper itself: only the two platform kinds earn a badge, and an
+    /// unrecognised (future) kind degrades to no badge rather than painting a raw
+    /// token.
+    #[test]
+    fn origin_badge_is_platform_kinds_only() {
+        assert_eq!(origin_badge(Some("autopilot")), Some("⚙ autopilot"));
+        assert_eq!(
+            origin_badge(Some("comment_mention")),
+            Some("💬 comment mention")
+        );
+        assert_eq!(origin_badge(Some("manual")), None);
+        assert_eq!(origin_badge(None), None);
+        assert_eq!(origin_badge(Some("from_the_future")), None);
     }
 
     /// One typed link row for the render tests.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1473,6 +1473,8 @@ mod card_tests {
     /// A fully-populated issue row for the card render assertions (63d).
     fn full_issue() -> IssueRow {
         IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: IssueId::from_str("i1").unwrap(),
             display_id: Some("HGR-1".into()),
             workspace_id: "ws".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -117,6 +117,8 @@ mod tests {
 
     fn issue(description: Option<&str>, assignee: Option<&str>) -> IssueRow {
         IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: IssueId::from_str("i1").unwrap(),
             display_id: None,
             workspace_id: "acme".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
@@ -22,6 +22,8 @@ use ainb_plugin_sdk::WireBuffer;
 /// A wire row with explicit state / priority / labels for facet rendering.
 fn row(id: &str, state: &str, priority: i64, labels: &[&str]) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str(id).unwrap(),
         display_id: Some(id.to_uppercase()),
         workspace_id: "default".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
@@ -29,6 +29,8 @@ const CLAY: Color = Color::rgb(210, 130, 90);
 /// urgency so the card anatomy (id line + priority chip) renders predictably.
 fn row(id: &str, display: &str, state: &str, priority: i64, assignee: Option<&str>) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str(id).unwrap(),
         display_id: Some(display.into()),
         workspace_id: "default".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -19,6 +19,8 @@ use ainb_plugin_hangar::screen::issue_list::{
 /// member/agent filter chips.
 fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str(id).unwrap(),
         display_id: None,
         workspace_id: "ws".to_string(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
@@ -23,6 +23,8 @@ use ainb_plugin_sdk::WireBuffer;
 
 fn issue_with_pr(pr_url: Option<&str>) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str("i1").unwrap(),
         display_id: None,
         workspace_id: "ws".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
@@ -22,6 +22,8 @@ const fn key(ch: char) -> KeyEvent {
 
 fn issue(pr_url: Option<&str>) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str("issue-1").unwrap(),
         display_id: None,
         workspace_id: "default".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -22,6 +22,8 @@ fn task() -> TaskId {
 
 fn issue_row() -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str("i1").unwrap(),
         display_id: None,
         workspace_id: "ws".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
@@ -19,6 +19,8 @@ use ainb_plugin_sdk::WireBuffer;
 
 fn issue_row() -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str("i1").unwrap(),
         display_id: None,
         workspace_id: "ws".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
@@ -94,6 +94,8 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// One wire row carrying `criteria` as its structured acceptance list.
 fn row(id: &str, title: &str, criteria: Vec<AcceptanceCriterion>) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str(id).unwrap(),
         display_id: Some(id.to_uppercase()),
         workspace_id: "default".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
@@ -109,6 +109,8 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// One wire row. `state` is what buckets the card into a board column.
 fn row(id: &str, title: &str, state: &str) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str(id).unwrap(),
         display_id: Some(id.to_uppercase()),
         workspace_id: "default".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
@@ -98,6 +98,8 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// `2` = P1); `state` drives the board column; `labels` drive the label facet.
 fn row(id: &str, title: &str, state: &str, priority: i64, labels: &[&str]) -> IssueRow {
     IssueRow {
+        origin_type: None,
+        origin_id: None,
         id: IssueId::from_str(id).unwrap(),
         display_id: Some(id.to_uppercase()),
         workspace_id: "default".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -132,6 +132,8 @@ fn seeded_agents() -> serde_json::Value {
 fn seeded_issues() -> serde_json::Value {
     serde_json::to_value(IssuesListResult {
         issues: vec![IssueRow {
+            origin_type: None,
+            origin_id: None,
             id: IssueId::from_str("issue-1").unwrap(),
             display_id: None,
             workspace_id: "default".into(),

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2953,6 +2953,16 @@ Options:
           
           The parent must exist in the same workspace; completing the last child of the lowest unfinished stage cascades a roll-up comment onto the parent.
 
+      --origin-type <ORIGIN_TYPE>
+          Provenance of this issue: `autopilot` | `comment_mention` | `manual` (migration 0056, multica parity #21).
+          
+          Defaults to `$HANGAR_ORIGIN_TYPE` — the daemon injects it into a dispatched agent's environment, so an issue an agent creates mid-run is attributable back to the comment / autopilot that asked for it. With neither flag nor env, a create is stamped `manual`.
+
+      --origin-id <ORIGIN_ID>
+          The provenance id: the autopilot id for `autopilot`, the comment id for `comment_mention`. REQUIRED for every kind except `manual`.
+          
+          Defaults to `$HANGAR_ORIGIN_ID`. Supplying an id with no `--origin-type` is an error, never a silent drop.
+
   -h, --help
           Print help (see a summary with '-h')
 ```


### PR DESCRIPTION
## Parity #21 — issue origin provenance (`origin_type` / `origin_id`)

**Acceptance:** *an issue created by autopilot or by a comment mention records its origin (sqlite)*.

Before this PR, `rg "origin_type|origin_id" crates/` returned zero hits anywhere in hangar. multica stamps every
platform-created issue with an `(origin_type, origin_id)` pair (`042_autopilot.up.sql:74-77`, widened by
`060_issue_origin_quick_create`) and *uses* it: the completion handler resolves "the issue this run produced" by a
deterministic by-origin lookup (`service/task.go:1836 GetIssueByOrigin`) rather than "the agent's most recent issue",
which races when one agent creates several issues concurrently.

### Shape

```
 comment "@bot split this out"                    autopilot tick (execution_mode = create_issue)
          │ hangar/comment_add                                    │ fire_autopilot_tick  (ONE tx)
          ▼                                                       ▼
   comment row committed                          INSERT issue (… origin_type='autopilot',
          │ spawn_mention_tasks(comment_id)                        origin_id = <autopilot.id>)
          ▼                                       set_origin_in_tx('autopilot', <autopilot.id>) on the task
   task.origin = ('comment_mention', comment.id)                  │
          └───────────────── claim loop ─────────────────────────-┘
                                  ▼
                     prepare_spawn_inputs(task)  → task_env +=
                        HANGAR_ORIGIN_TYPE / HANGAR_ORIGIN_ID     (ENV_ALLOWLIST, like PARENT_ENV)
                                  ▼
                       agent child:  ainb hangar issue create --title …
                                  ▼   (flags override; env is the default)
                     issue.origin_type='comment_mention', origin_id=<comment.id>
```

### What landed

- **Migration 0056** — nullable `origin_type` / `origin_id` on `issue` and `agent_task_queue`, plus a **partial**
  `WHERE origin_type IS NOT NULL` index on each. `ADD COLUMN` with no default is an O(1) catalog change in SQLite.
  **Not backfilled**: a pre-0056 row keeps NULL, which reads as "provenance unknown", deliberately distinct from the
  explicit `manual` a human create stamps from now on.
- **`ainb-hangar-core::origin`** — a typed `IssueOrigin` / `OriginKind` domain over the closed allow-list
  `{autopilot, comment_mention, manual}`. `parse` is **strict** (the single write-side gate, so a rogue caller cannot
  mint an arbitrary label); `from_db_str` is **lenient** (unknown → `manual`) so a newer daemon's future kind cannot
  make an older binary fail a read. `origin_id` is required for every kind but `manual` — multica's pair rule
  (`internal/handler/issue.go:1213-1231`), including its error wording verbatim.
- **Store** — `Issue.origin` / `Task.origin`, the four issue SELECT lists + both row mappers, post-insert
  `set_origin` / `set_origin_in_tx` (the `set_issue_external_ref` pattern, so `NewIssue` / `NewTask` and their ~40
  construction sites are untouched), plus `by_origin` (multica's `GetIssueByOrigin`) and `list_by_origin_kind`.
  The autopilot fire stamps the issue *inside its own INSERT* and the task *inside the same transaction*, binding the
  **autopilot** id, not the run id (multica `service/autopilot.go:145`).
- **Proto** — `origin_type` / `origin_id` on `IssueRow` and `IssueCreateParams`, both
  `#[serde(default, skip_serializing_if = "Option::is_none")]`. Append-only: an unstamped row serialises without the
  keys, so an old reader sees byte-identical JSON. The 58 `IssueRow` struct-literal updates are in the same commit so
  the tree is never red.
- **Daemon** — `issue_create` validates the pair at the handler (`INVALID_PARAMS` on a bad one, never a silent drop)
  and stamps it post-insert, defaulting to `manual`; the create's response row and the pushed `IssueCreated` event
  echo exactly what was stamped, so they stay byte-identical to a later list snapshot. `spawn_mention_tasks` now takes
  the committed comment's id and stamps each spawned task after the invocation gate (a refused mention writes no row
  and no provenance). `board_card_create` stamps `manual`. `prepare_spawn_inputs` hands the child
  `HANGAR_ORIGIN_TYPE` / `HANGAR_ORIGIN_ID` after `build_task_env` (daemon value wins), and both keys are added to
  `ENV_ALLOWLIST` with the `PARENT_ENV` justification — without that the deny-by-default filter drops them and the
  whole chain silently no-ops.
- **CLI** — `--origin-type` / `--origin-id` on `hangar issue create`, resolving *flags → env → manual* **before** any
  write (a bad origin fails ahead of the insert); an explicit `--origin-type` suppresses the env pair entirely so a
  flag kind never inherits an env id. `hangar issue show` prints `Origin: <kind> (<id>)`.
- **Plugin** — an `Origin: ⚙ autopilot` / `Origin: 💬 comment mention` badge beside the existing `Linked:` line,
  suppressed for `manual` and for a provenance-less card.

### Tests (behavioural, fail-before / pass-after)

| Leg | Where |
|---|---|
| **Acceptance A** — autopilot fire ⇒ raw `SELECT origin_type, origin_id FROM issue` = `('autopilot', ap.id)`, same on the task; asserts it is **not** the run id | `store/tests/repo_autopilot_enqueue.rs` |
| **Acceptance B** — full comment-mention chain over a real framed socket, ending in a sqlite read of the created issue; plus the four negatives (unknown kind, id-without-kind, autopilot-without-id, plain create ⇒ `manual`) | `daemon/tests/rpc_issue_origin_provenance.rs` (new) |
| Real-daemon leg — the live scheduler's fired task carries `('autopilot', <ap.id>)` | `tripwire_autopilot_fires_on_schedule` (extended, nothing weakened) |
| Env seam — a `comment_mention` task sets both keys, a provenance-less task sets neither, `manual` sets the kind only; and both keys survive the allowlist filter | `run_loop.rs` + `runner.rs` units |
| CLI — flags/env/manual precedence, `--origin-type bogus` fails with the issue table still empty | `cli/hangar/mod.rs` |
| Wire back-compat — a pre-0056 `IssueRow` JSON decodes to `None`, an unstamped row omits both keys, a stamped row round-trips; same for `IssueCreateParams` | `proto/tests/event_roundtrip_test.rs` |
| Render — badge for both platform kinds, none for `manual` / `None` / an unknown future kind | `plugin-hangar/src/screen/task_detail.rs` |
| Migration shape — both columns nullable with no default on both tables, both indexes partial | `tripwire_migrations_apply.rs` |

### Local gate (all green on this branch)

```
cargo build -p ainb                                                        ok
cargo nextest run --lib --tests --all-features -E 'not binary(/^tripwire_/)'
                                            4161 tests run: 4161 passed, 18 skipped
bash scripts/hangar/run_all_tripwires.sh    ran=63  failed=0
bash scripts/hangar/run_acceptance_tests.sh ran=159 failed=0
cargo fmt --all --check                     clean
cargo clippy --all-targets (6 touched crates)  no errors
```

### Honest notes

- No production hangar flow creates an issue *from* a mention today (a mention creates a task on an existing issue),
  so `comment_mention` lands on issues an agent creates **during** a mention-spawned run — precisely multica's
  `quick_create` mechanism. Acceptance leg B replays that CLI hop over the RPC rather than spawning a real agent.
- The beads inbound-sync create (`beads_sync/reconcile.rs`) is deliberately left unstamped: an externally mirrored
  issue is not one of the three kinds, and widening the allow-list for it is out of scope here.
- Provenance is write-once at create; `issue_update` cannot change it, matching multica.
