### PR TITLE
feat(hangar): api autopilot trigger + skipped run status (multica parity 15)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -229,8 +229,13 @@ pub enum AutopilotCommand {
     Disable(AutopilotIdArgs),
     /// Re-enable an autopilot, recomputing its next tick from now.
     Enable(AutopilotIdArgs),
-    /// Fire one tick immediately (manual run), bypassing the schedule.
-    Run(AutopilotIdArgs),
+    /// Fire one tick immediately, bypassing the schedule (`--source` picks the
+    /// trigger recorded on the run: `manual` by default, or `api`).
+    Run(AutopilotRunNowArgs),
+    /// Arm (or `--disable`) the bare programmatic `api` trigger.
+    ApiTrigger(AutopilotIdArgs),
+    /// List the autopilot's recent runs (status, trigger source, reason).
+    Runs(AutopilotRunsArgs),
     /// Configure the HTTP webhook trigger (enable/disable, rotate secret, filter).
     Webhook(AutopilotWebhookArgs),
     /// List the autopilot's recent webhook deliveries (audit log).
@@ -373,11 +378,57 @@ pub struct AutopilotListArgs {
     pub workspace: Option<String>,
 }
 
-/// Arguments for the id-only autopilot verbs (`disable`, `enable`, `run`).
+/// Arguments for the id-only autopilot verbs (`disable`, `enable`,
+/// `api-trigger`).
 #[derive(Args, Debug)]
 pub struct AutopilotIdArgs {
     /// The autopilot id (`autopilot.id`).
     pub id: String,
+    /// Turn the trigger OFF instead of on (`api-trigger` only).
+    #[arg(long)]
+    pub disable: bool,
+    /// Workspace slug the autopilot belongs to. Defaults to `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Which trigger a manual `hangar autopilot run` records on the run it creates
+/// (`autopilot_run.source`, migration 0057).
+///
+/// `manual` is the operator's explicit override and always allowed. `api` is the
+/// bare programmatic trigger and is REFUSED unless the autopilot has armed it
+/// (`hangar autopilot api-trigger <id>`) — a half-configured trigger is never
+/// firable, exactly like the webhook one.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RunSourceArg {
+    /// An operator firing by hand (the default).
+    #[default]
+    Manual,
+    /// The bare programmatic `api` trigger; requires it to be armed.
+    Api,
+}
+
+/// Arguments for `hangar autopilot run <id>`.
+#[derive(Args, Debug)]
+pub struct AutopilotRunNowArgs {
+    /// The autopilot id (`autopilot.id`).
+    pub id: String,
+    /// Which trigger to record on the run (`manual` | `api`).
+    #[arg(long, value_enum, default_value_t = RunSourceArg::Manual)]
+    pub source: RunSourceArg,
+    /// Workspace slug the autopilot belongs to. Defaults to `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Arguments for `hangar autopilot runs <id>` (the run-history read surface).
+#[derive(Args, Debug)]
+pub struct AutopilotRunsArgs {
+    /// The autopilot id (`autopilot.id`).
+    pub id: String,
+    /// Maximum number of runs to show (latest-first).
+    #[arg(long, default_value_t = 20)]
+    pub limit: u32,
     /// Workspace slug the autopilot belongs to. Defaults to `default`.
     #[arg(long)]
     pub workspace: Option<String>,
@@ -1917,6 +1968,8 @@ async fn dispatch_autopilot(cmd: AutopilotCommand, format: OutputFormat) -> Resu
         AutopilotCommand::Disable(args) => run_autopilot_set_enabled(&store, args, false).await,
         AutopilotCommand::Enable(args) => run_autopilot_set_enabled(&store, args, true).await,
         AutopilotCommand::Run(args) => run_autopilot_run_now(&store, args).await,
+        AutopilotCommand::ApiTrigger(args) => run_autopilot_api_trigger(&store, args).await,
+        AutopilotCommand::Runs(args) => run_autopilot_runs(&store, args, format).await,
         AutopilotCommand::Webhook(args) => run_autopilot_webhook(&store, args).await,
         AutopilotCommand::Deliveries(args) => run_autopilot_deliveries(&store, args, format).await,
     }
@@ -1941,6 +1994,7 @@ async fn run_autopilot_create(store: &Store, args: AutopilotCreateArgs) -> Resul
         max_concurrent_runs: args.max_concurrent_runs,
         execution_mode: args.execution_mode.into(),
         concurrency_policy: args.concurrency_policy.into(),
+        api_trigger_enabled: false,
     };
 
     let id = AutopilotRepo::create(store.pool(), &SystemClock, &req)
@@ -2028,12 +2082,24 @@ async fn run_autopilot_set_enabled(
     Ok(())
 }
 
-/// `hangar autopilot run <id>`: fire one tick immediately via the P7.4 enqueue
-/// path, bypassing the schedule. Workspace-scoped: a foreign id is rejected.
-async fn run_autopilot_run_now(store: &Store, args: AutopilotIdArgs) -> Result<()> {
+/// `hangar autopilot run <id> [--source manual|api]`: dispatch one tick
+/// immediately, bypassing the schedule. Workspace-scoped: a foreign id is
+/// rejected.
+///
+/// `--source api` is REFUSED unless the autopilot has armed its api trigger —
+/// a half-configured trigger is never firable (the same discipline as the
+/// webhook one).
+///
+/// The dispatch goes through the SAME admission gate the scheduler uses, so at
+/// the concurrency limit under the `skip` policy it is DECLINED and recorded as
+/// a terminal `skipped` run. That is a successful, no-op dispatch (exit 0), not
+/// an error — matching multica's dispatch contract.
+async fn run_autopilot_run_now(store: &Store, args: AutopilotRunNowArgs) -> Result<()> {
     use ainb_hangar_core::ids::{AutopilotId, WorkspaceId};
     use ainb_hangar_store::repo::autopilot::AutopilotRepo;
-    use ainb_hangar_store::repo::autopilot_run::fire_autopilot_tick;
+    use ainb_hangar_store::repo::autopilot_run::{
+        DispatchOutcome, RunSource, dispatch_with_admission,
+    };
 
     let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
     let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
@@ -2044,10 +2110,80 @@ async fn run_autopilot_run_now(store: &Store, args: AutopilotIdArgs) -> Result<(
         .context("look up autopilot")?
         .with_context(|| format!("no autopilot `{}` in this workspace", args.id))?;
 
-    let (run_id, task_id) = fire_autopilot_tick(store.pool(), &SystemClock, &autopilot)
+    let source = match args.source {
+        RunSourceArg::Manual => RunSource::Manual,
+        RunSourceArg::Api => {
+            anyhow::ensure!(
+                autopilot.api_trigger_enabled,
+                "api trigger not enabled for autopilot {} — run `ainb hangar autopilot api-trigger {}`",
+                args.id,
+                args.id
+            );
+            RunSource::Api
+        }
+    };
+
+    match dispatch_with_admission(store.pool(), &SystemClock, &autopilot, source)
         .await
-        .with_context(|| format!("fire autopilot `{}`", args.id))?;
-    println!("fired autopilot {} → run {run_id} task {task_id}", args.id);
+        .with_context(|| format!("fire autopilot `{}`", args.id))?
+    {
+        DispatchOutcome::Fired {
+            run_id, task_id, ..
+        } => println!("fired autopilot {} → run {run_id} task {task_id}", args.id),
+        DispatchOutcome::Skipped { run_id, reason, .. } => {
+            println!("skipped autopilot {} → run {run_id} ({reason})", args.id);
+        }
+    }
+    Ok(())
+}
+
+/// `hangar autopilot api-trigger <id> [--disable]`: arm (or disarm) the bare
+/// programmatic `api` trigger (migration 0057). Workspace-scoped.
+async fn run_autopilot_api_trigger(store: &Store, args: AutopilotIdArgs) -> Result<()> {
+    use ainb_hangar_core::ids::{AutopilotId, WorkspaceId};
+    use ainb_hangar_store::repo::autopilot::AutopilotRepo;
+
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
+    let id = AutopilotId::from_str(args.id.clone()).context("autopilot id was empty")?;
+    let enabled = !args.disable;
+
+    let updated = AutopilotRepo::set_api_trigger_enabled(store.pool(), &ws, &id, enabled)
+        .await
+        .with_context(|| format!("set api trigger for autopilot `{}`", args.id))?;
+    anyhow::ensure!(updated, "no autopilot `{}` in this workspace", args.id);
+
+    if enabled {
+        println!("enabled api trigger for autopilot {}", args.id);
+        println!(
+            "  fire with: ainb hangar autopilot run {} --source api",
+            args.id
+        );
+    } else {
+        println!("disabled api trigger for autopilot {}", args.id);
+    }
+    Ok(())
+}
+
+/// `hangar autopilot runs <id>`: the run-history read surface — every run with
+/// its status, the trigger that fired it, and (for a declined dispatch) the
+/// admission reason. Workspace-scoped: a foreign id yields an empty set.
+async fn run_autopilot_runs(
+    store: &Store,
+    args: AutopilotRunsArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    use ainb_hangar_core::ids::{AutopilotId, WorkspaceId};
+    use ainb_hangar_store::repo::autopilot::AutopilotRepo;
+
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
+    let id = AutopilotId::from_str(args.id.clone()).context("autopilot id was empty")?;
+
+    let runs = AutopilotRepo::list_runs(store.pool(), &ws, &id, args.limit)
+        .await
+        .context("list autopilot runs")?;
+    render_autopilot_runs(&runs, format);
     Ok(())
 }
 
@@ -5812,6 +5948,80 @@ const fn autopilot_badge(enabled: bool) -> &'static str {
     if enabled { "enabled" } else { "disabled" }
 }
 
+/// Render an autopilot's run history (`hangar autopilot runs <id>`).
+///
+/// Carries the two columns migration 0057 added: `SOURCE` (which trigger fired
+/// the run) and `REASON` (why a `skipped` dispatch was declined).
+fn render_autopilot_runs(
+    rows: &[ainb_hangar_store::repo::autopilot::AutopilotRun],
+    format: OutputFormat,
+) {
+    match format {
+        OutputFormat::Json => {
+            let body = rows.iter().map(autopilot_run_to_json).collect::<Vec<_>>().join(",");
+            println!("[{body}]");
+        }
+        OutputFormat::Csv => {
+            println!("id,status,source,started_at,completed_at,failure_reason");
+            for r in rows {
+                println!(
+                    "{},{},{},{},{},{}",
+                    csv_field(&r.id),
+                    csv_field(&r.status),
+                    csv_field(&r.source),
+                    r.started_at,
+                    r.completed_at.map_or_else(String::new, |v| v.to_string()),
+                    csv_field(r.failure_reason.as_deref().unwrap_or("")),
+                );
+            }
+        }
+        OutputFormat::Markdown => {
+            println!("| run id | status | source | started | reason |");
+            println!("| --- | --- | --- | --- | --- |");
+            for r in rows {
+                println!(
+                    "| {} | {} | {} | {} | {} |",
+                    md_cell(&r.id),
+                    md_cell(&r.status),
+                    md_cell(&r.source),
+                    r.started_at,
+                    md_cell(r.failure_reason.as_deref().unwrap_or("-")),
+                );
+            }
+        }
+        OutputFormat::Text => {
+            if rows.is_empty() {
+                println!("no autopilot runs");
+            } else {
+                for r in rows {
+                    println!(
+                        "{}  {}  source={}  started={}  reason={}",
+                        r.id,
+                        r.status,
+                        r.source,
+                        r.started_at,
+                        r.failure_reason.as_deref().unwrap_or("-"),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// One autopilot run as a JSON object (for the `--format json` surface).
+fn autopilot_run_to_json(r: &ainb_hangar_store::repo::autopilot::AutopilotRun) -> String {
+    serde_json::json!({
+        "id": r.id,
+        "autopilot_id": r.autopilot_id,
+        "status": r.status,
+        "source": r.source,
+        "started_at": r.started_at,
+        "completed_at": r.completed_at,
+        "failure_reason": r.failure_reason,
+    })
+    .to_string()
+}
+
 /// Render the webhook delivery audit log (`hangar autopilot deliveries <id>`).
 fn render_webhook_deliveries(
     rows: &[ainb_hangar_store::repo::autopilot_webhook::WebhookDelivery],
@@ -5897,7 +6107,7 @@ fn autopilot_line(a: &Autopilot, last_run: Option<&str>) -> String {
         a.next_tick_at.map_or_else(|| "-".to_string(), |v| v.to_string()),
         last_run.unwrap_or("-"),
         autopilot_badge(a.enabled),
-    )
+    ) + if a.api_trigger_enabled { " [api]" } else { "" }
 }
 
 const fn autopilot_csv_header() -> &'static str {
@@ -5939,7 +6149,7 @@ fn autopilot_to_json(a: &Autopilot, last_run: Option<&str>) -> String {
         "{{\"id\":{},\"workspace_id\":{},\"agent_id\":{},\"name\":{},\"instructions\":{},\
           \"cron_expr\":{},\"max_concurrent_runs\":{},\"execution_mode\":{},\
           \"concurrency_policy\":{},\"next_tick_at\":{},\"enabled\":{},\
-          \"last_run\":{}}}",
+          \"api_trigger_enabled\":{},\"last_run\":{}}}",
         json_string(&a.id),
         json_string(&a.workspace_id),
         json_string(&a.agent_id),
@@ -5951,6 +6161,7 @@ fn autopilot_to_json(a: &Autopilot, last_run: Option<&str>) -> String {
         json_string(a.concurrency_policy.as_str()),
         next_tick,
         a.enabled,
+        a.api_trigger_enabled,
         last,
     )
 }
@@ -8005,17 +8216,111 @@ mod tests {
 
     #[test]
     fn parses_autopilot_disable_enable_run_with_id() {
-        for (verb, is) in [("disable", "disable"), ("enable", "enable"), ("run", "run")] {
+        for (verb, is) in [("disable", "disable"), ("enable", "enable")] {
             let cmd = parse_hangar(&["ainb", "hangar", "autopilot", verb, "ap-1"]);
             match (is, cmd) {
                 ("disable", HangarCommand::Autopilot(AutopilotCommand::Disable(a)))
-                | ("enable", HangarCommand::Autopilot(AutopilotCommand::Enable(a)))
-                | ("run", HangarCommand::Autopilot(AutopilotCommand::Run(a))) => {
+                | ("enable", HangarCommand::Autopilot(AutopilotCommand::Enable(a))) => {
                     assert_eq!(a.id, "ap-1");
                 }
                 (_, other) => panic!("expected autopilot {verb}, got {other:?}"),
             }
         }
+        let cmd = parse_hangar(&["ainb", "hangar", "autopilot", "run", "ap-1"]);
+        let HangarCommand::Autopilot(AutopilotCommand::Run(a)) = cmd else {
+            panic!("expected autopilot run, got {cmd:?}");
+        };
+        assert_eq!(a.id, "ap-1");
+        assert_eq!(
+            a.source,
+            RunSourceArg::Manual,
+            "an unqualified `run` is the operator's MANUAL fire"
+        );
+    }
+
+    /// The `api`-trigger verbs parse (migration 0057 / parity item 15): the
+    /// arm/disarm toggle, the `--source api` fire, and the run-history read.
+    #[test]
+    fn parses_autopilot_api_trigger_verbs() {
+        let cmd = parse_hangar(&["ainb", "hangar", "autopilot", "api-trigger", "ap-1"]);
+        let HangarCommand::Autopilot(AutopilotCommand::ApiTrigger(a)) = cmd else {
+            panic!("expected autopilot api-trigger, got {cmd:?}");
+        };
+        assert_eq!(a.id, "ap-1");
+        assert!(!a.disable, "the bare verb ARMS the trigger");
+
+        let cmd = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "autopilot",
+            "api-trigger",
+            "ap-1",
+            "--disable",
+        ]);
+        let HangarCommand::Autopilot(AutopilotCommand::ApiTrigger(a)) = cmd else {
+            panic!("expected autopilot api-trigger, got {cmd:?}");
+        };
+        assert!(a.disable);
+
+        let cmd = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "autopilot",
+            "run",
+            "ap-1",
+            "--source",
+            "api",
+        ]);
+        let HangarCommand::Autopilot(AutopilotCommand::Run(a)) = cmd else {
+            panic!("expected autopilot run, got {cmd:?}");
+        };
+        assert_eq!(a.source, RunSourceArg::Api);
+
+        let cmd = parse_hangar(&["ainb", "hangar", "autopilot", "runs", "ap-1"]);
+        let HangarCommand::Autopilot(AutopilotCommand::Runs(a)) = cmd else {
+            panic!("expected autopilot runs, got {cmd:?}");
+        };
+        assert_eq!(a.id, "ap-1");
+        assert_eq!(a.limit, 20, "the history read defaults to a bounded window");
+    }
+
+    /// The list surface makes an armed api trigger visible, and the JSON
+    /// surface carries the flag.
+    #[test]
+    fn autopilot_renderers_surface_the_api_trigger() {
+        let mut ap = sample_autopilot(true);
+        assert!(
+            !autopilot_line(&ap, None).contains("[api]"),
+            "an unarmed trigger shows no badge"
+        );
+        assert!(autopilot_to_json(&ap, None).contains("\"api_trigger_enabled\":false"));
+
+        ap.api_trigger_enabled = true;
+        assert!(
+            autopilot_line(&ap, None).contains("[api]"),
+            "an armed api trigger must be visible: {}",
+            autopilot_line(&ap, None)
+        );
+        assert!(autopilot_to_json(&ap, None).contains("\"api_trigger_enabled\":true"));
+    }
+
+    /// The run-history renderers carry the trigger source and the admission
+    /// reason — without them a recorded skip is unreadable from the CLI.
+    #[test]
+    fn autopilot_run_renderers_carry_source_and_reason() {
+        let run = ainb_hangar_store::repo::autopilot::AutopilotRun {
+            id: "01RUN".into(),
+            autopilot_id: "01AP".into(),
+            started_at: 1_767_258_000_000,
+            completed_at: Some(1_767_258_000_000),
+            status: "skipped".into(),
+            source: "api".into(),
+            failure_reason: Some("concurrency limit: 1/1 in flight".into()),
+        };
+        let json = autopilot_run_to_json(&run);
+        assert!(json.contains("\"status\":\"skipped\""), "{json}");
+        assert!(json.contains("\"source\":\"api\""), "{json}");
+        assert!(json.contains("concurrency limit"), "{json}");
     }
 
     /// Build a stored autopilot fixture for the render tests.
@@ -8032,6 +8337,7 @@ mod tests {
             concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::Skip,
             next_tick_at: Some(1_767_258_000_000),
             enabled,
+            api_trigger_enabled: false,
             created_at: 0,
         }
     }

--- a/ainb-tui/crates/ainb-core/tests/hangar_autopilot_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_autopilot_cli.rs
@@ -280,3 +280,179 @@ async fn cli_autopilot_create_rejects_invalid_cron_before_insert() {
         .expect("count autopilots");
     assert_eq!(count, 0, "a malformed cron must leave zero autopilot rows");
 }
+
+/// The `api` trigger + the `skipped` run status, end to end through the real
+/// binary (multica parity item 15).
+///
+/// The full operator transcript from the spec's acceptance proof:
+///
+/// 1. `run --source api` FAILS while the trigger is unarmed (non-zero exit,
+///    naming the fix) — a half-configured trigger is never firable;
+/// 2. `api-trigger <id>` arms it, and `list` shows the armed badge;
+/// 3. `run --source api` fires, stamping `source='api'` on the run;
+/// 4. `run --source api` again, at `max_concurrent_runs = 1` under the default
+///    `skip` policy, is DECLINED and RECORDED — it prints `skipped`, exits 0 (a
+///    successful, declined dispatch), enqueues no second task, and leaves a
+///    `status='skipped', source='api'` row readable via `runs --format json`.
+#[tokio::test]
+async fn cli_autopilot_api_trigger_fires_and_records_skipped() {
+    let tmp = tempfile::tempdir().unwrap();
+    {
+        let store = Store::open_in(tmp.path()).await.expect("open store");
+        seed_agent(store.pool()).await;
+    }
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "autopilot",
+            "create",
+            "--name",
+            "apitrig",
+            "--cron",
+            "0 9 * * *",
+            "--agent",
+            "ag-1",
+            "--max-concurrent-runs",
+            "1",
+        ],
+    );
+    assert!(ok, "autopilot create should exit 0; out={out}");
+    let id = out
+        .split_whitespace()
+        .nth(2)
+        .map(str::to_string)
+        .expect("create output carries an id");
+
+    // 1. Unarmed: the api fire is REFUSED, and the message names the fix.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "autopilot", "run", &id, "--source", "api"],
+    );
+    assert!(
+        !ok,
+        "an unarmed api trigger must not fire (exit non-zero); out={out}"
+    );
+    assert!(
+        out.contains("api trigger not enabled") && out.contains("api-trigger"),
+        "the refusal must name the fix:\n{out}"
+    );
+
+    // 2. Arm it.
+    let (ok, out) = run(tmp.path(), &["hangar", "autopilot", "api-trigger", &id]);
+    assert!(ok, "api-trigger should exit 0; out={out}");
+    assert!(
+        out.contains("enabled api trigger"),
+        "missing arm ack:\n{out}"
+    );
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "autopilot", "list", "--format", "json"],
+    );
+    assert!(ok, "autopilot list should exit 0; out={out}");
+    assert!(
+        out.contains("\"api_trigger_enabled\":true"),
+        "the armed trigger must be visible on the list surface:\n{out}"
+    );
+
+    // 3. Armed: the api fire works.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "autopilot", "run", &id, "--source", "api"],
+    );
+    assert!(ok, "an armed api fire should exit 0; out={out}");
+    assert!(out.contains("fired autopilot"), "missing fire ack:\n{out}");
+
+    // 4. At the limit: DECLINED, recorded, and still a successful command.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "autopilot", "run", &id, "--source", "api"],
+    );
+    assert!(
+        ok,
+        "a declined dispatch is a successful no-op, not an error; out={out}"
+    );
+    assert!(
+        out.contains("skipped autopilot") && out.contains("concurrency limit"),
+        "the decline must be reported with its reason:\n{out}"
+    );
+
+    // The read-back surface carries both runs, with their provenance.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "autopilot", "runs", &id, "--format", "json"],
+    );
+    assert!(ok, "autopilot runs should exit 0; out={out}");
+    let runs: Vec<serde_json::Value> = serde_json::from_str(out.trim()).expect("runs json");
+    assert_eq!(runs.len(), 2, "one fired run and one recorded skip:\n{out}");
+    assert_eq!(
+        runs.iter().filter(|r| r["status"] == "running" && r["source"] == "api").count(),
+        1,
+        "the fired run is stamped with its api provenance:\n{out}"
+    );
+    let skipped = runs
+        .iter()
+        .find(|r| r["status"] == "skipped")
+        .expect("the declined dispatch is readable from the CLI, not just logged");
+    assert_eq!(skipped["source"], "api");
+    assert!(
+        skipped["failure_reason"]
+            .as_str()
+            .is_some_and(|r| r.starts_with("concurrency limit")),
+        "the admission reason is persisted:\n{out}"
+    );
+    assert!(
+        skipped["completed_at"].is_i64(),
+        "a skipped run is TERMINAL:\n{out}"
+    );
+
+    // The skip enqueued no work.
+    let store = Store::open_in(tmp.path()).await.expect("reopen store");
+    let tasks: i64 = sqlx::query_scalar("SELECT count(*) FROM agent_task_queue")
+        .fetch_one(store.pool())
+        .await
+        .expect("count tasks");
+    assert_eq!(tasks, 1, "a declined dispatch must enqueue no second task");
+}
+
+/// `api-trigger --disable` disarms it again, and the refusal comes back.
+#[tokio::test]
+async fn cli_autopilot_api_trigger_can_be_disarmed() {
+    let tmp = tempfile::tempdir().unwrap();
+    {
+        let store = Store::open_in(tmp.path()).await.expect("open store");
+        seed_agent(store.pool()).await;
+    }
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "autopilot",
+            "create",
+            "--name",
+            "disarm",
+            "--cron",
+            "0 9 * * *",
+            "--agent",
+            "ag-1",
+        ],
+    );
+    assert!(ok, "create should exit 0; out={out}");
+    let id = out.split_whitespace().nth(2).map(str::to_string).unwrap();
+
+    let (ok, _) = run(tmp.path(), &["hangar", "autopilot", "api-trigger", &id]);
+    assert!(ok);
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "autopilot", "api-trigger", &id, "--disable"],
+    );
+    assert!(ok, "disarm should exit 0; out={out}");
+    assert!(out.contains("disabled api trigger"), "{out}");
+
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "autopilot", "run", &id, "--source", "api"],
+    );
+    assert!(!ok, "a disarmed trigger must refuse again; out={out}");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_autopilot_fire.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_autopilot_fire.rs
@@ -101,6 +101,7 @@ fn main() {
                 max_concurrent_runs: 1,
                 execution_mode: ExecutionMode::default(),
                 concurrency_policy: ConcurrencyPolicy::default(),
+                api_trigger_enabled: false,
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -751,7 +751,9 @@ async fn handle(
         methods::HANGAR_AUTOPILOTS_LIST
         | methods::HANGAR_AUTOPILOT_RUNS
         | methods::HANGAR_AUTOPILOT_FIRE_NOW
-        | methods::HANGAR_AUTOPILOT_SET_ENABLED => handle_autopilot(pool, req, events).await,
+        | methods::HANGAR_AUTOPILOT_SET_ENABLED
+        | methods::HANGAR_AUTOPILOT_TRIGGER_API
+        | methods::HANGAR_AUTOPILOT_SET_API_TRIGGER => handle_autopilot(pool, req, events).await,
         methods::HANGAR_TASKS_LIST => handle_tasks_list(pool, req).await,
         methods::HANGAR_TASK_TRANSITION => handle_task_transition(pool, req, events).await,
         methods::HANGAR_TASK_RETRY => handle_task_retry(pool, req, events).await,
@@ -6490,7 +6492,8 @@ async fn agent_skills_list(
     serde_json::to_value(result).map_err(|e| internal(&format!("encode agent skills: {e}")))
 }
 
-/// Dispatch the four P7.5 autopilot-manager RPCs. Each resolves + scopes by
+/// Dispatch the autopilot-manager RPCs (the four P7.5 ones plus the two `api`
+/// trigger verbs of migration 0057). Each resolves + scopes by
 /// workspace (a foreign id yields an empty snapshot for the reads, fires/toggles
 /// nothing for the mutations) and drives the workspace-scoped autopilot snapshot
 /// mappers. The two mutations publish their matching [`HangarEvent`] onto
@@ -6566,6 +6569,89 @@ async fn handle_autopilot(
                 }
             }
             Ok(serde_json::json!({}))
+        }
+        methods::HANGAR_AUTOPILOT_TRIGGER_API => {
+            let params: ainb_hangar_proto::snapshots::AutopilotTriggerApiParams =
+                parse_params(req, "{ workspace_id, autopilot_id }")?;
+            let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+            let id = autopilot_id(&params.autopilot_id)?;
+            let outcome = snapshots::autopilot_trigger_api(pool, &SystemClock, &ws, &id)
+                .await
+                .map_err(|e| internal(&format!("autopilot api trigger: {e}")))?;
+            // Announce exactly what the scheduler path announces, so the manager
+            // pane refreshes identically whichever trigger fired. `not_found` /
+            // `disabled` wrote nothing, so they announce nothing.
+            let result = match outcome {
+                snapshots::ApiTriggerOutcome::NotFound => {
+                    ainb_hangar_proto::snapshots::AutopilotTriggerApiResult {
+                        outcome: "not_found".to_string(),
+                        run_id: None,
+                        task_id: None,
+                        reason: None,
+                    }
+                }
+                snapshots::ApiTriggerOutcome::Disabled => {
+                    ainb_hangar_proto::snapshots::AutopilotTriggerApiResult {
+                        outcome: "disabled".to_string(),
+                        run_id: None,
+                        task_id: None,
+                        reason: None,
+                    }
+                }
+                snapshots::ApiTriggerOutcome::Fired { run_id, task_id } => {
+                    events.emit(
+                        ws.as_str(),
+                        ainb_hangar_proto::events::HangarEvent::AutopilotRunChanged {
+                            autopilot_id: id.to_string(),
+                            status: "running".to_string(),
+                        },
+                    );
+                    ainb_hangar_proto::snapshots::AutopilotTriggerApiResult {
+                        outcome: "fired".to_string(),
+                        run_id: Some(run_id),
+                        task_id: Some(task_id),
+                        reason: None,
+                    }
+                }
+                snapshots::ApiTriggerOutcome::Skipped { run_id, reason } => {
+                    events.emit(
+                        ws.as_str(),
+                        ainb_hangar_proto::events::HangarEvent::AutopilotRunChanged {
+                            autopilot_id: id.to_string(),
+                            status: "skipped".to_string(),
+                        },
+                    );
+                    ainb_hangar_proto::snapshots::AutopilotTriggerApiResult {
+                        outcome: "skipped".to_string(),
+                        run_id: Some(run_id),
+                        task_id: None,
+                        reason: Some(reason),
+                    }
+                }
+            };
+            to_value(&result)
+        }
+        methods::HANGAR_AUTOPILOT_SET_API_TRIGGER => {
+            let params: ainb_hangar_proto::snapshots::AutopilotSetApiTriggerParams =
+                parse_params(req, "{ workspace_id, autopilot_id, enabled }")?;
+            let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+            let id = autopilot_id(&params.autopilot_id)?;
+            let updated = snapshots::autopilot_set_api_trigger(pool, &ws, &id, params.enabled)
+                .await
+                .map_err(|e| autopilot_repo_err(&e))?;
+            // Push the refreshed row so the manager table shows the armed badge
+            // in place — the same best-effort shape as `set_enabled`.
+            if updated {
+                if let Ok(rows) = snapshots::autopilots_list(pool, &ws).await {
+                    if let Some(row) = rows.into_iter().find(|r| r.id == id.as_str()) {
+                        events.emit(
+                            ws.as_str(),
+                            ainb_hangar_proto::events::HangarEvent::AutopilotUpdated(row),
+                        );
+                    }
+                }
+            }
+            to_value(&ainb_hangar_proto::snapshots::AutopilotSetApiTriggerResult { updated })
         }
         other => Err(RpcError {
             code: METHOD_NOT_FOUND,
@@ -8036,6 +8122,7 @@ mod tests {
                 execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
                 concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(
                 ),
+                api_trigger_enabled: false,
             },
         )
         .await
@@ -8112,6 +8199,7 @@ mod tests {
                 execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
                 concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(
                 ),
+                api_trigger_enabled: false,
             },
         )
         .await
@@ -8171,6 +8259,7 @@ mod tests {
                 execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
                 concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(
                 ),
+                api_trigger_enabled: false,
             },
         )
         .await
@@ -8217,6 +8306,7 @@ mod tests {
                 execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
                 concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(
                 ),
+                api_trigger_enabled: false,
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -45,7 +45,9 @@ use ainb_hangar_store::repo::agent::AgentRepo;
 use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
 use ainb_hangar_store::repo::attention::AttentionRepo;
 use ainb_hangar_store::repo::autopilot::{AutopilotRepo, AutopilotRepoError};
-use ainb_hangar_store::repo::autopilot_run::{FireError, fire_autopilot_tick};
+use ainb_hangar_store::repo::autopilot_run::{
+    DispatchOutcome, FireError, RunSource, dispatch_with_admission, fire_autopilot_tick_with_source,
+};
 use ainb_hangar_store::repo::comment::{CommentRepo, NewComment};
 use ainb_hangar_store::repo::inbox::InboxRepo;
 use ainb_hangar_store::repo::issue::{CriterionError, IssueRepo};
@@ -1265,6 +1267,7 @@ pub async fn autopilots_list(
             enabled: ap.enabled,
             last_run_status: last.as_ref().map(|r| r.status.clone()),
             last_run_at: last.as_ref().map(|r| r.started_at),
+            api_trigger_enabled: ap.api_trigger_enabled,
         });
     }
     Ok(out)
@@ -1294,6 +1297,8 @@ pub async fn autopilot_runs(
             started_at: r.started_at,
             completed_at: r.completed_at,
             status: r.status,
+            source: r.source,
+            failure_reason: r.failure_reason,
         })
         .collect())
 }
@@ -1320,8 +1325,107 @@ pub async fn autopilot_fire_now(
     let Some(autopilot) = AutopilotRepo::get(pool, workspace, autopilot_id).await? else {
         return Ok(false);
     };
-    fire_autopilot_tick(pool, clock, &autopilot).await?;
+    // A MANUAL fire: the operator's explicit override, stamped as such on the
+    // run so the history can tell it from a scheduled or api-triggered tick.
+    fire_autopilot_tick_with_source(pool, clock, &autopilot, RunSource::Manual).await?;
     Ok(true)
+}
+
+/// What [`autopilot_trigger_api`] did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApiTriggerOutcome {
+    /// No such autopilot in this workspace. A foreign id leaks nothing.
+    NotFound,
+    /// The autopilot exists but has not armed `api_trigger_enabled`. NOTHING is
+    /// written: the trigger does not exist, so there is nothing to skip (a
+    /// `skipped` run records an ADMISSION decision, not a missing trigger).
+    Disabled,
+    /// The admission gate declined the dispatch; a terminal `skipped` run
+    /// records it.
+    Skipped {
+        /// The recorded `skipped` run.
+        run_id: String,
+        /// The admission reason.
+        reason: String,
+    },
+    /// The dispatch was admitted.
+    Fired {
+        /// The new run.
+        run_id: String,
+        /// The task enqueued against it.
+        task_id: String,
+    },
+}
+
+/// Fire one autopilot through its bare programmatic `api` trigger
+/// (`hangar/autopilot_trigger_api`, migration 0057 / multica parity item 15),
+/// scoped to `workspace`.
+///
+/// The `api` trigger is the third trigger surface after cron and webhook: no
+/// cron expression, no HMAC — a caller with normal API access fires the
+/// autopilot directly (multica `handler/autopilot.go:441`, where
+/// `kind IN ('schedule','webhook','api')` and only `schedule` requires a cron
+/// expression).
+///
+/// Two guards, in order:
+///
+/// 1. the autopilot must exist IN THIS WORKSPACE ([`ApiTriggerOutcome::NotFound`]),
+/// 2. it must have armed `api_trigger_enabled` ([`ApiTriggerOutcome::Disabled`],
+///    writing nothing).
+///
+/// Then it goes through the SAME [`dispatch_with_admission`] gate the scheduler
+/// uses, so an api fire at the concurrency limit under the `skip` policy is
+/// declined and recorded as a terminal `skipped` run stamped `source = 'api'`.
+///
+/// # Errors
+///
+/// Returns [`AutopilotFireError::Repo`] on a store failure resolving the row, or
+/// [`AutopilotFireError::Fire`] when the dispatch fails (e.g. the autopilot's
+/// agent was deleted).
+pub async fn autopilot_trigger_api(
+    pool: &SqlitePool,
+    clock: &dyn HangarClock,
+    workspace: &WorkspaceId,
+    autopilot_id: &AutopilotId,
+) -> Result<ApiTriggerOutcome, AutopilotFireError> {
+    let Some(autopilot) = AutopilotRepo::get(pool, workspace, autopilot_id).await? else {
+        return Ok(ApiTriggerOutcome::NotFound);
+    };
+    if !autopilot.api_trigger_enabled {
+        return Ok(ApiTriggerOutcome::Disabled);
+    }
+    Ok(
+        match dispatch_with_admission(pool, clock, &autopilot, RunSource::Api).await? {
+            DispatchOutcome::Fired {
+                run_id, task_id, ..
+            } => ApiTriggerOutcome::Fired {
+                run_id: run_id.to_string(),
+                task_id: task_id.to_string(),
+            },
+            DispatchOutcome::Skipped { run_id, reason, .. } => ApiTriggerOutcome::Skipped {
+                run_id: run_id.to_string(),
+                reason,
+            },
+        },
+    )
+}
+
+/// Arm or disarm one autopilot's `api` trigger
+/// (`hangar/autopilot_set_api_trigger`), scoped to `workspace`.
+///
+/// Returns `false` when the id resolved to no autopilot in this tenant (nothing
+/// written).
+///
+/// # Errors
+///
+/// Returns an [`AutopilotRepoError`] on a store failure.
+pub async fn autopilot_set_api_trigger(
+    pool: &SqlitePool,
+    workspace: &WorkspaceId,
+    autopilot_id: &AutopilotId,
+    enabled: bool,
+) -> Result<bool, AutopilotRepoError> {
+    AutopilotRepo::set_api_trigger_enabled(pool, workspace, autopilot_id, enabled).await
 }
 
 /// Enable or disable one autopilot (`hangar/autopilot_set_enabled`, P7.5),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/scheduler.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/scheduler.rs
@@ -20,7 +20,8 @@
 //! Each iteration: read the enabled autopilots (`next_tick_at IS NOT NULL`),
 //! pick the one firing soonest, sleep until that instant **or** the
 //! [`CancellationToken`] trips, then — re-checking the concurrency limit *at
-//! fire time* — either fire ([`fire_autopilot_tick`]) or skip, and in both cases
+//! fire time* — either fire or record a skip (both through the store's shared
+//! [`dispatch_with_admission`] admission gate), and in both cases
 //! recompute and persist the next `next_tick_at`. With no enabled autopilots the
 //! loop re-polls after [`NO_WORK_REPOLL`].
 //!
@@ -37,20 +38,28 @@
 //!
 //! # Concurrency policy at the in-flight limit (e38.19)
 //!
-//! Before firing, the loop counts the autopilot's in-flight runs
-//! (`autopilot_run WHERE autopilot_id = ? AND completed_at IS NULL`). When that
-//! count has reached `max_concurrent_runs`, the autopilot's
-//! [`ConcurrencyPolicy`] decides what happens — and the three policies genuinely
+//! Before firing, the store's shared [`dispatch_with_admission`] gate counts the
+//! autopilot's in-flight runs (`autopilot_run WHERE autopilot_id = ? AND
+//! completed_at IS NULL`). That gate is SHARED with every other trigger surface
+//! (manual fire-now, the webhook ingress, the `api` trigger) so none can drift
+//! from the policy this loop is tested against. When the count has reached
+//! `max_concurrent_runs`, the autopilot's
+//! [`ConcurrencyPolicy`](ainb_hangar_store::repo::autopilot::ConcurrencyPolicy)
+//! decides what happens — and the three policies genuinely
 //! change what the scheduler DOES, not just a stored flag:
 //!
-//! - `skip` (the v1 default): drop the tick. No `autopilot_run` /
-//!   `agent_task_queue` row is created, a `tracing::warn!` is emitted, an
-//!   [`SchedulerEvent::TickSkipped`] is published.
+//! - `skip` (the v1 default): drop the tick. NO `agent_task_queue` row is
+//!   created, a `tracing::warn!` is emitted, an [`SchedulerEvent::TickSkipped`]
+//!   is published — and, since migration 0057, a TERMINAL `autopilot_run` row
+//!   with `status = 'skipped'` and the admission reason is recorded, so a
+//!   declined dispatch is visible to every read path instead of existing only
+//!   as a log line. It stamps `completed_at`, so it never counts as in flight.
 //! - `queue`: fire the tick ANYWAY (create the run + task). The shared
 //!   claim/dispatch queue then drains the enqueued tasks in order, so the second
 //!   tick RUNS AFTER the in-flight one rather than being dropped.
 //! - `replace`: supersede the in-flight run(s) — cancel each open run + its task
-//!   ([`supersede_in_flight`]) — then fire a fresh run + task. The latest tick
+//!   ([`supersede_in_flight`](ainb_hangar_store::repo::autopilot_run::supersede_in_flight))
+//!   — then fire a fresh run + task. The latest tick
 //!   wins; the stale in-flight work is abandoned.
 //!
 //! In every case `next_tick_at` is still advanced so the autopilot rejoins the
@@ -95,8 +104,8 @@ use ainb_hangar_core::autopilot::cron::{
     millis_to_utc, next_tick_after, parse_cron, utc_to_millis,
 };
 use ainb_hangar_core::clock::HangarClock;
-use ainb_hangar_store::repo::autopilot::{Autopilot, ConcurrencyPolicy};
-use ainb_hangar_store::repo::autopilot_run::{fire_autopilot_tick, supersede_in_flight};
+use ainb_hangar_store::repo::autopilot::Autopilot;
+use ainb_hangar_store::repo::autopilot_run::{DispatchOutcome, RunSource, dispatch_with_admission};
 use sqlx::SqlitePool;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::UnboundedSender;
@@ -246,7 +255,7 @@ impl HangarClock for AdvanceableClock {
 ///
 /// Reconciled against the committed P7.1/P7.2/P7.4 surfaces: it owns a
 /// [`SqlitePool`] + an injected [`HangarClock`] and fires through P7.4's
-/// [`fire_autopilot_tick`] (there is no `TaskService` — the stale plan struct's
+/// fire path via [`dispatch_with_admission`] (there is no `TaskService` — the stale plan struct's
 /// `task_service` field does not exist). A [`CancellationToken`] exits the loop
 /// cooperatively within one sleep.
 pub struct AutopilotScheduler {
@@ -365,7 +374,7 @@ impl AutopilotScheduler {
         sqlx::query_as::<_, Autopilot>(
             "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
                     max_concurrent_runs, execution_mode, concurrency_policy, \
-                    next_tick_at, enabled, created_at \
+                    next_tick_at, enabled, api_trigger_enabled, created_at \
              FROM autopilot \
              WHERE enabled = 1 AND next_tick_at IS NOT NULL \
              ORDER BY next_tick_at ASC",
@@ -379,30 +388,21 @@ impl AutopilotScheduler {
     /// skipped autopilot rejoins the schedule at its next slot. All errors are
     /// logged and swallowed.
     async fn fire_or_skip(&self, ap: &Autopilot) {
-        let in_flight = match self.count_in_flight(&ap.id).await {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::error!(autopilot_id = %ap.id, error = %e, "in-flight count failed; skipping fire");
-                // Still reschedule so a transient count error does not wedge the
-                // autopilot off the schedule forever.
-                self.reschedule(ap).await;
-                return;
-            }
-        };
-
-        let at_limit = in_flight >= ap.max_concurrent_runs;
-        // The concurrency policy only matters AT the limit. Under the limit, every
-        // policy simply fires.
-        match (at_limit, ap.concurrency_policy) {
-            // Under the limit: fire normally regardless of policy.
-            (false, _) => self.fire(ap).await,
-
-            // At the limit + skip: drop the tick (the v1 behaviour).
-            (true, ConcurrencyPolicy::Skip) => {
+        // The admission gate (count in flight → apply the concurrency policy →
+        // fire or record a skip) lives in the store as
+        // `dispatch_with_admission`, so the `api` trigger, the webhook ingress
+        // and manual fire-now all run the SAME policy the scheduler does and
+        // cannot drift from it. The scheduler keeps exactly what is its own job:
+        // the events it publishes and the reschedule.
+        match dispatch_with_admission(&self.pool, &*self.clock, ap, RunSource::Schedule).await {
+            Ok(DispatchOutcome::Skipped {
+                reason, in_flight, ..
+            }) => {
                 tracing::warn!(
                     autopilot_id = %ap.id,
                     in_flight,
                     max = ap.max_concurrent_runs,
+                    %reason,
                     "autopilot.tick_skipped — concurrency limit"
                 );
                 self.emit(SchedulerEvent::TickSkipped {
@@ -412,56 +412,23 @@ impl AutopilotScheduler {
                 });
                 self.emit_run_changed(ap, "skipped");
             }
-
-            // At the limit + queue: fire ANYWAY. The shared claim/dispatch queue
-            // drains the enqueued tasks in order, so the second tick runs AFTER
-            // the in-flight one rather than being dropped.
-            (true, ConcurrencyPolicy::Queue) => {
-                tracing::info!(
-                    autopilot_id = %ap.id,
-                    in_flight,
-                    "autopilot.tick_queued — firing despite the concurrency limit"
-                );
-                self.fire(ap).await;
-            }
-
-            // At the limit + replace: supersede the in-flight run(s) — cancel each
-            // open run + its task — then fire a fresh one. The latest tick wins.
-            (true, ConcurrencyPolicy::Replace) => {
-                match supersede_in_flight(&self.pool, &*self.clock, &ap.id).await {
-                    Ok(superseded) => {
-                        tracing::info!(
-                            autopilot_id = %ap.id,
-                            superseded,
-                            "autopilot.tick_replaced — superseded in-flight runs, firing fresh"
-                        );
-                        // The cancelled run(s) changed state; announce it so the
-                        // run-history pane updates before the fresh fire.
-                        if superseded > 0 {
-                            self.emit_run_changed(ap, "cancelled");
-                        }
-                        self.fire(ap).await;
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            autopilot_id = %ap.id,
-                            error = %e,
-                            "autopilot replace: supersede failed; not firing"
-                        );
-                    }
+            Ok(DispatchOutcome::Fired {
+                run_id,
+                task_id,
+                superseded,
+            }) => {
+                // The `replace` policy cancelled the stale run(s) before firing;
+                // announce that FIRST so the run-history pane sees the
+                // cancellation ahead of the fresh run (the pre-existing
+                // ordering).
+                if superseded > 0 {
+                    tracing::info!(
+                        autopilot_id = %ap.id,
+                        superseded,
+                        "autopilot.tick_replaced — superseded in-flight runs, firing fresh"
+                    );
+                    self.emit_run_changed(ap, "cancelled");
                 }
-            }
-        }
-
-        self.reschedule(ap).await;
-    }
-
-    /// Fire one autopilot tick through the P7.4 enqueue path, emitting the
-    /// `Fired` event + a `running` run-change on success. Errors are logged and
-    /// swallowed (one bad fire must not down the loop).
-    async fn fire(&self, ap: &Autopilot) {
-        match fire_autopilot_tick(&self.pool, &*self.clock, ap).await {
-            Ok((run_id, task_id)) => {
                 tracing::info!(
                     autopilot_id = %ap.id,
                     run_id = %run_id,
@@ -476,21 +443,13 @@ impl AutopilotScheduler {
                 self.emit_run_changed(ap, "running");
             }
             Err(e) => {
-                tracing::error!(autopilot_id = %ap.id, error = %e, "autopilot fire failed");
+                tracing::error!(autopilot_id = %ap.id, error = %e, "autopilot dispatch failed");
             }
         }
-    }
 
-    /// Count the autopilot's in-flight (not-yet-completed) runs — the
-    /// concurrency-policy denominator.
-    async fn count_in_flight(&self, autopilot_id: &str) -> Result<i64, sqlx::Error> {
-        sqlx::query_scalar::<_, i64>(
-            "SELECT count(*) FROM autopilot_run \
-             WHERE autopilot_id = ? AND completed_at IS NULL",
-        )
-        .bind(autopilot_id)
-        .fetch_one(&self.pool)
-        .await
+        // Every path reschedules, so neither a skip nor a transient error wedges
+        // the autopilot off the schedule forever.
+        self.reschedule(ap).await;
     }
 
     /// Recompute `next_tick_at` from the just-fired tick (not `clock.now()`) and
@@ -628,6 +587,7 @@ mod tests {
             concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::Skip,
             next_tick_at,
             enabled: true,
+            api_trigger_enabled: false,
             created_at: 0,
         }
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_autopilot_api_trigger.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_autopilot_api_trigger.rs
@@ -1,0 +1,300 @@
+//! Integration: the bare programmatic `api` autopilot trigger + the `skipped`
+//! run status, over a real framed `UnixStream` (multica parity item 15).
+//!
+//! This drives the WHOLE path the way `boot()` wires it — the real dispatch
+//! table, the real handler, the real store — not the snapshot functions in
+//! isolation. It proves both halves of the item end-to-end:
+//!
+//! 1. an autopilot with an unarmed `api` trigger reports `disabled` and writes
+//!    NOTHING (the trigger does not exist, so there is nothing to skip);
+//! 2. `hangar/autopilot_set_api_trigger` arms it, and `hangar/autopilots_list`
+//!    reports `api_trigger_enabled: true`;
+//! 3. `hangar/autopilot_trigger_api` then FIRES, and `hangar/autopilot_runs`
+//!    shows a `running` run stamped `source: "api"`;
+//! 4. a second fire at `max_concurrent_runs = 1` under the `skip` policy is
+//!    DECLINED and RECORDED — `outcome: "skipped"` with a reason, and a
+//!    `status: "skipped", source: "api"` row in the run history;
+//! 5. a foreign autopilot id reports `not_found` and writes nothing.
+//!
+//! Mutating the handler to ignore `api_trigger_enabled` breaks (1); mutating the
+//! admission gate to drop the skip row breaks (4).
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_ID};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame_inner())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    async fn ok(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let resp = self.call(method, params).await;
+        assert!(resp["error"].is_null(), "{method} must ack: {resp}");
+        resp["result"].clone()
+    }
+
+    async fn trigger_api(&mut self, autopilot_id: &str) -> serde_json::Value {
+        self.ok(
+            methods::HANGAR_AUTOPILOT_TRIGGER_API,
+            serde_json::json!({ "workspace_id": WS_ID, "autopilot_id": autopilot_id }),
+        )
+        .await
+    }
+
+    async fn runs(&mut self, autopilot_id: &str) -> Vec<serde_json::Value> {
+        let r = self
+            .ok(
+                methods::HANGAR_AUTOPILOT_RUNS,
+                serde_json::json!({
+                    "workspace_id": WS_ID, "autopilot_id": autopilot_id, "limit": 50
+                }),
+            )
+            .await;
+        r["runs"].as_array().cloned().unwrap_or_default()
+    }
+}
+
+/// Bind + serve the real listener over a seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// Insert one autopilot bound to the fixture agent, `max_concurrent_runs = 1`
+/// and the default `skip` policy, with the api trigger UNARMED.
+async fn seed_autopilot(store: &Store) -> String {
+    let id = "01HANGARFIXTUREAP000000000".to_string();
+    sqlx::query(
+        "INSERT INTO autopilot \
+         (id, workspace_id, agent_id, name, cron_expr, max_concurrent_runs, \
+          concurrency_policy, next_tick_at, enabled, created_at) \
+         VALUES (?, ?, 'agent-1', 'daily', '0 9 * * *', 1, 'skip', NULL, 1, 0)",
+    )
+    .bind(&id)
+    .bind(WS_ID)
+    .execute(store.pool())
+    .await
+    .expect("insert autopilot");
+    id
+}
+
+/// The whole api-trigger contract in one transcript.
+#[tokio::test]
+async fn api_trigger_arms_fires_and_records_a_skipped_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    let ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    // 1. UNARMED: the trigger does not exist. Nothing is fired, nothing written.
+    let r = c.trigger_api(&ap).await;
+    assert_eq!(
+        r["outcome"], "disabled",
+        "an unarmed api trigger must decline the call: {r}"
+    );
+    assert!(
+        c.runs(&ap).await.is_empty(),
+        "a disabled trigger must write NO run — not even a skipped one"
+    );
+
+    // 2. Arm it, and see it on the list snapshot.
+    let armed = c
+        .ok(
+            methods::HANGAR_AUTOPILOT_SET_API_TRIGGER,
+            serde_json::json!({ "workspace_id": WS_ID, "autopilot_id": ap, "enabled": true }),
+        )
+        .await;
+    assert_eq!(armed["updated"], true);
+    let list = c
+        .ok(
+            methods::HANGAR_AUTOPILOTS_LIST,
+            serde_json::json!({ "workspace_id": WS_ID }),
+        )
+        .await;
+    let row = list["autopilots"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["id"] == ap.as_str())
+        .expect("the autopilot is listed")
+        .clone();
+    assert_eq!(
+        row["api_trigger_enabled"], true,
+        "the armed trigger is visible on the wire row: {row}"
+    );
+
+    // 3. Armed: the dispatch fires, stamped with its api provenance.
+    let fired = c.trigger_api(&ap).await;
+    assert_eq!(fired["outcome"], "fired", "{fired}");
+    assert!(fired["run_id"].is_string() && fired["task_id"].is_string());
+    let runs = c.runs(&ap).await;
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0]["status"], "running");
+    assert_eq!(
+        runs[0]["source"], "api",
+        "the run records WHICH trigger fired it: {:?}",
+        runs[0]
+    );
+
+    // 4. At the limit under `skip`: DECLINED, and recorded as a skipped run.
+    let skipped = c.trigger_api(&ap).await;
+    assert_eq!(
+        skipped["outcome"], "skipped",
+        "a dispatch at the concurrency limit is declined: {skipped}"
+    );
+    assert!(
+        skipped["reason"]
+            .as_str()
+            .is_some_and(|r| r.starts_with("concurrency limit")),
+        "the admission reason is reported: {skipped}"
+    );
+    assert!(skipped["task_id"].is_null(), "a skip enqueues no task");
+
+    let runs = c.runs(&ap).await;
+    let skip_row = runs
+        .iter()
+        .find(|r| r["status"] == "skipped")
+        .expect("the declined dispatch is READABLE in the run history, not just logged");
+    assert_eq!(skip_row["source"], "api");
+    assert!(
+        skip_row["failure_reason"]
+            .as_str()
+            .is_some_and(|r| r.starts_with("concurrency limit")),
+        "the reason is persisted: {skip_row}"
+    );
+    assert!(
+        skip_row["completed_at"].is_i64(),
+        "a skipped run is TERMINAL, or it would wedge the in-flight count: {skip_row}"
+    );
+    assert_eq!(
+        runs.iter().filter(|r| r["status"] == "running").count(),
+        1,
+        "the skip created no second live run: {runs:?}"
+    );
+}
+
+/// A foreign autopilot id reports `not_found` and writes nothing — the id is not
+/// probed for existence in another tenant.
+#[tokio::test]
+async fn api_trigger_on_a_foreign_id_reports_not_found_and_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    let _ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    let r = c.trigger_api("01HANGARNOSUCHAUTOPILOT000").await;
+    assert_eq!(r["outcome"], "not_found", "{r}");
+
+    let total: i64 = sqlx::query_scalar("SELECT count(*) FROM autopilot_run")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(total, 0, "a foreign id must write no run row");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_autopilot_api_trigger.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_autopilot_api_trigger.rs
@@ -249,9 +249,7 @@ async fn api_trigger_arms_fires_and_records_a_skipped_run() {
         "a dispatch at the concurrency limit is declined: {skipped}"
     );
     assert!(
-        skipped["reason"]
-            .as_str()
-            .is_some_and(|r| r.starts_with("concurrency limit")),
+        skipped["reason"].as_str().is_some_and(|r| r.starts_with("concurrency limit")),
         "the admission reason is reported: {skipped}"
     );
     assert!(skipped["task_id"].is_null(), "a skip enqueues no task");

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/scheduler_concurrency_policies.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/scheduler_concurrency_policies.rs
@@ -79,6 +79,7 @@ async fn seed_autopilot_with_policy(
         max_concurrent_runs: 1,
         execution_mode: ExecutionMode::RunOnly,
         concurrency_policy: policy,
+        api_trigger_enabled: false,
     };
     let create_clock = FixedClock(T0);
     ainb_hangar_store::repo::autopilot::AutopilotRepo::create(pool, &create_clock, &req)
@@ -132,7 +133,8 @@ async fn skip_policy_drops_the_second_tick_under_contention() {
     );
     assert_eq!(count(&pool, "SELECT count(*) FROM autopilot_run").await, 1);
 
-    // advance #2: at the limit (run #1 still in flight) → SKIPPED, no new rows.
+    // advance #2: at the limit (run #1 still in flight) → SKIPPED: no new task,
+    // and the decline recorded as a terminal `skipped` run (migration 0057).
     clock.advance(FIVE_MIN_MS);
     let ev = next_event(&mut rx, Duration::from_secs(2)).await;
     assert!(
@@ -145,15 +147,35 @@ async fn skip_policy_drops_the_second_tick_under_contention() {
         ),
         "second tick at the limit must be skipped, got {ev:?}"
     );
+    // The skip enqueues NO work (the invariant that matters) …
     assert_eq!(
-        count(&pool, "SELECT count(*) FROM autopilot_run").await,
+        count(
+            &pool,
+            "SELECT count(*) FROM autopilot_run WHERE status <> 'skipped'"
+        )
+        .await,
         1,
-        "skip must not create a second run"
+        "skip must not create a second LIVE run"
     );
     assert_eq!(
         count(&pool, "SELECT count(*) FROM agent_task_queue").await,
         1,
         "skip must not enqueue a second task"
+    );
+    // … but since migration 0057 it IS recorded: a terminal `skipped` run with
+    // its trigger source and the admission reason, so a declined dispatch is
+    // visible to every read path instead of existing only as a log line.
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT count(*) FROM autopilot_run \
+             WHERE status = 'skipped' AND source = 'schedule' \
+               AND completed_at IS NOT NULL \
+               AND failure_reason LIKE 'concurrency limit%'"
+        )
+        .await,
+        1,
+        "the declined dispatch must be persisted as a skipped run"
     );
 
     shutdown.cancel();

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/scheduler_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/scheduler_loop.rs
@@ -223,11 +223,32 @@ async fn skip_when_prior_run_in_flight() {
         }
         other => panic!("expected TickSkipped, got {other:?}"),
     }
-    // No new run, no new task — only the pre-seeded run remains.
-    assert_eq!(count(&pool, "SELECT count(*) FROM autopilot_run").await, 1);
+    // No new LIVE run, no task — only the pre-seeded run remains …
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT count(*) FROM autopilot_run WHERE status <> 'skipped'"
+        )
+        .await,
+        1
+    );
     assert_eq!(
         count(&pool, "SELECT count(*) FROM agent_task_queue").await,
         0
+    );
+    // … but the decline itself IS recorded (migration 0057): a terminal
+    // `skipped` run carrying the trigger source and the admission reason, so it
+    // is visible to every read path instead of only to the log.
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT count(*) FROM autopilot_run \
+             WHERE status = 'skipped' AND source = 'schedule' \
+               AND completed_at IS NOT NULL \
+               AND failure_reason LIKE 'concurrency limit%'"
+        )
+        .await,
+        1
     );
     // But it was still rescheduled forward (rejoins the schedule next slot).
     let next: Option<i64> = sqlx::query("SELECT next_tick_at FROM autopilot WHERE id = 'ap-skip'")

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilot_fires_on_schedule.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilot_fires_on_schedule.rs
@@ -117,6 +117,7 @@ async fn autopilot_fires_on_schedule_after_clock_advance() {
         max_concurrent_runs: 1,
         execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
         concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(),
+        api_trigger_enabled: false,
     };
     let create_clock = ainb_hangar_core::clock::FixedClock(T0);
     let autopilot_id = AutopilotRepo::create(&pool, &create_clock, &req)

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilot_skips_when_running.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilot_skips_when_running.rs
@@ -94,6 +94,7 @@ async fn autopilot_skips_tick_when_prior_run_in_flight() {
         execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::RunOnly,
         // The default policy: a tick at the in-flight limit is dropped.
         concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::Skip,
+        api_trigger_enabled: false,
     };
     let create_clock = FixedClock(T0);
     let autopilot_id = AutopilotRepo::create(&pool, &create_clock, &req)
@@ -130,7 +131,7 @@ async fn autopilot_skips_tick_when_prior_run_in_flight() {
         .unwrap()
         .get(0);
 
-    // ── advance #2: at the limit → skipped, no new rows ─────────────────────
+    // ── advance #2: at the limit → skipped: no new task, decline recorded ───
     clock.advance(FIVE_MIN_MS);
     let ev = next_event(&mut rx, Duration::from_secs(2)).await;
     match ev {
@@ -142,16 +143,35 @@ async fn autopilot_skips_tick_when_prior_run_in_flight() {
         }
         other => panic!("expected TickSkipped(concurrency), got {other:?}"),
     }
-    // The skip is REAL — the queue and run table are genuinely untouched.
+    // The skip enqueues NO work (the invariant that matters) …
     assert_eq!(
-        count(&pool, "SELECT count(*) FROM autopilot_run").await,
+        count(
+            &pool,
+            "SELECT count(*) FROM autopilot_run WHERE status <> 'skipped'"
+        )
+        .await,
         1,
-        "skip must not create a second run"
+        "skip must not create a second LIVE run"
     );
     assert_eq!(
         count(&pool, "SELECT count(*) FROM agent_task_queue").await,
         1,
         "skip must not enqueue a second task"
+    );
+    // … but since migration 0057 it IS recorded: a terminal `skipped` run with
+    // its trigger source and the admission reason, so a declined dispatch is
+    // visible to every read path instead of existing only as a log line.
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT count(*) FROM autopilot_run \
+             WHERE status = 'skipped' AND source = 'schedule' \
+               AND completed_at IS NOT NULL \
+               AND failure_reason LIKE 'concurrency limit%'"
+        )
+        .await,
+        1,
+        "the declined dispatch must be persisted as a skipped run"
     );
 
     // ── complete #1, freeing the concurrency slot ───────────────────────────
@@ -191,9 +211,13 @@ async fn autopilot_skips_tick_when_prior_run_in_flight() {
         "with the slot freed, the next tick fires; got {ev:?}"
     );
     assert_eq!(
-        count(&pool, "SELECT count(*) FROM autopilot_run").await,
+        count(
+            &pool,
+            "SELECT count(*) FROM autopilot_run WHERE status <> 'skipped'"
+        )
+        .await,
         2,
-        "a second run now exists"
+        "a second LIVE run now exists (the recorded skip is not one)"
     );
     assert_eq!(
         count(&pool, "SELECT count(*) FROM agent_task_queue").await,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
@@ -2220,6 +2220,7 @@ pub fn seed_autopilot(home: &Path) {
                 execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
                 concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(
                 ),
+                api_trigger_enabled: false,
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -688,7 +688,7 @@ pub struct SkillFile {
 /// A cron-scheduled autopilot (P7). The manager table (P7.5) renders these; the
 /// daemon flattens its rich store row (typed ids, epoch-ms `next_tick_at`) into
 /// this flat shape. The plugin owns zero domain data — it only renders the row.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AutopilotRow {
     /// The autopilot id (ULID string, the stable id the table rows carry).
     pub id: String,
@@ -711,13 +711,19 @@ pub struct AutopilotRow {
     pub last_run_status: Option<String>,
     /// The most recent run's start instant (epoch-ms), or `None` when never run.
     pub last_run_at: Option<i64>,
+    /// Whether the bare programmatic `api` trigger is armed (migration 0057).
+    ///
+    /// Append-only + `serde(default)`: a pre-0057 daemon's payload omits it and
+    /// deserialises as `false`, and an older plugin ignores it.
+    #[serde(default)]
+    pub api_trigger_enabled: bool,
 }
 
 /// A wire-side autopilot run row for the history pane (`hangar/autopilot_runs`).
 ///
 /// One firing of an autopilot. The run-history pane (P7.5) renders these
 /// latest-first below the selected autopilot.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AutopilotRunRow {
     /// The run id (ULID string).
     pub id: String,
@@ -728,8 +734,17 @@ pub struct AutopilotRunRow {
     /// When the run finished (epoch-ms); `None` while in flight.
     pub completed_at: Option<i64>,
     /// Lifecycle status (`running` / `completed` / `failed` / `cancelled` /
-    /// `skipped`).
+    /// `skipped`). `skipped` is terminal — a dispatch the admission gate
+    /// intentionally declined (migration 0057).
     pub status: String,
+    /// Which trigger fired this run: `schedule` | `manual` | `webhook` | `api`.
+    /// Empty when produced by a pre-0057 daemon.
+    #[serde(default)]
+    pub source: String,
+    /// Why a `skipped` run was declined (the admission reason); `None` for every
+    /// other status, and for pre-0057 payloads.
+    #[serde(default)]
+    pub failure_reason: Option<String>,
 }
 
 /// A wire-side task card row for the Kanban board (`hangar/tasks_list`, P8.4).

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -162,6 +162,28 @@ pub const HANGAR_AUTOPILOT_FIRE_NOW: &str = "hangar/autopilot_fire_now";
 /// `d` key toggles the selected autopilot (P7.5). Workspace-scoped.
 pub const HANGAR_AUTOPILOT_SET_ENABLED: &str = "hangar/autopilot_set_enabled";
 
+/// `hangar/autopilot_trigger_api` — fire one autopilot through its bare
+/// programmatic `api` trigger (migration 0057).
+///
+/// Params: `{ workspace_id: String, autopilot_id: String }`. Result: a
+/// [`crate::snapshots::AutopilotTriggerApiResult`]. Unlike
+/// [`HANGAR_AUTOPILOT_FIRE_NOW`] (an operator's manual override), this is the
+/// `api` TRIGGER: it only fires when the autopilot has explicitly armed
+/// `api_trigger_enabled`, and it runs the SAME admission gate the scheduler
+/// does — so a dispatch at the concurrency limit under the `skip` policy is
+/// declined and recorded as a terminal `skipped` run rather than silently
+/// dropped. Workspace-scoped: a foreign id reports `not_found` and fires
+/// nothing.
+pub const HANGAR_AUTOPILOT_TRIGGER_API: &str = "hangar/autopilot_trigger_api";
+
+/// `hangar/autopilot_set_api_trigger` — arm or disarm the `api` trigger.
+///
+/// Params: `{ workspace_id: String, autopilot_id: String, enabled: bool }`.
+/// Result: `{ updated: bool }` (`false` when the id is foreign / absent).
+/// Mirrors [`HANGAR_AUTOPILOT_SET_ENABLED`]: a trigger surface is armed by an
+/// explicit operator action, never implicitly at create time. Workspace-scoped.
+pub const HANGAR_AUTOPILOT_SET_API_TRIGGER: &str = "hangar/autopilot_set_api_trigger";
+
 /// `hangar/tasks_list` — snapshot the task queue of a workspace for the Kanban
 /// board (P8.4).
 ///
@@ -1123,6 +1145,8 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_AUTOPILOT_RUNS,
     HANGAR_AUTOPILOT_FIRE_NOW,
     HANGAR_AUTOPILOT_SET_ENABLED,
+    HANGAR_AUTOPILOT_TRIGGER_API,
+    HANGAR_AUTOPILOT_SET_API_TRIGGER,
     HANGAR_TASKS_LIST,
     HANGAR_TASK_TRANSITION,
     HANGAR_TASK_RETRY,
@@ -1303,6 +1327,8 @@ mod tests {
             HANGAR_AUTOPILOT_RUNS,
             HANGAR_AUTOPILOT_FIRE_NOW,
             HANGAR_AUTOPILOT_SET_ENABLED,
+            HANGAR_AUTOPILOT_TRIGGER_API,
+            HANGAR_AUTOPILOT_SET_API_TRIGGER,
             HANGAR_TASKS_LIST,
             HANGAR_TASK_TRANSITION,
             HANGAR_TASK_RETRY,
@@ -1377,6 +1403,8 @@ mod tests {
             HANGAR_AUTOPILOT_RUNS,
             HANGAR_AUTOPILOT_FIRE_NOW,
             HANGAR_AUTOPILOT_SET_ENABLED,
+            HANGAR_AUTOPILOT_TRIGGER_API,
+            HANGAR_AUTOPILOT_SET_API_TRIGGER,
             HANGAR_TASKS_LIST,
             HANGAR_TASK_TRANSITION,
             HANGAR_TASK_RETRY,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -370,6 +370,63 @@ pub struct AutopilotSetEnabledParams {
     pub enabled: bool,
 }
 
+/// Params for [`crate::methods::HANGAR_AUTOPILOT_TRIGGER_API`]: the workspace
+/// (tenant guard) plus the autopilot to fire through its `api` trigger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotTriggerApiParams {
+    /// The subscribed workspace the autopilot must belong to.
+    pub workspace_id: String,
+    /// The autopilot to fire.
+    pub autopilot_id: String,
+}
+
+/// Result of [`crate::methods::HANGAR_AUTOPILOT_TRIGGER_API`].
+///
+/// Four outcomes, discriminated by [`outcome`](Self::outcome):
+///
+/// - `fired` — admitted; `run_id` + `task_id` are set.
+/// - `skipped` — the admission gate declined it (concurrency limit under the
+///   `skip` policy); `run_id` names the recorded terminal `skipped` run and
+///   `reason` carries the admission reason. This is a SUCCESSFUL, declined
+///   dispatch, not an error.
+/// - `disabled` — the autopilot has not armed `api_trigger_enabled`; nothing was
+///   written (the trigger does not exist, so there is nothing to skip).
+/// - `not_found` — no such autopilot in this workspace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotTriggerApiResult {
+    /// `fired` | `skipped` | `disabled` | `not_found`.
+    pub outcome: String,
+    /// The run created (`fired`) or recorded (`skipped`).
+    #[serde(default)]
+    pub run_id: Option<String>,
+    /// The task enqueued; only set on `fired`.
+    #[serde(default)]
+    pub task_id: Option<String>,
+    /// The admission reason; only set on `skipped`.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Params for [`crate::methods::HANGAR_AUTOPILOT_SET_API_TRIGGER`]: the
+/// workspace (tenant guard), the autopilot, and the target armed flag.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotSetApiTriggerParams {
+    /// The subscribed workspace the autopilot must belong to.
+    pub workspace_id: String,
+    /// The autopilot to arm / disarm.
+    pub autopilot_id: String,
+    /// `true` arms the `api` trigger; `false` disarms it.
+    pub enabled: bool,
+}
+
+/// Result of [`crate::methods::HANGAR_AUTOPILOT_SET_API_TRIGGER`]: whether a row
+/// was actually updated (`false` when the id is foreign / absent).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotSetApiTriggerResult {
+    /// `true` when the autopilot existed in this workspace and was updated.
+    pub updated: bool,
+}
+
 /// Result of [`crate::methods::HANGAR_TASKS_LIST`]: every task in the workspace
 /// for the Kanban board (P8.4).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2737,6 +2794,7 @@ mod tests {
                 enabled: true,
                 last_run_status: Some("completed".into()),
                 last_run_at: Some(1_699_000_000_000),
+                api_trigger_enabled: true,
             }],
         };
         let s = serde_json::to_string(&list).unwrap();
@@ -2763,6 +2821,8 @@ mod tests {
                 started_at: 1_699_000_000_000,
                 completed_at: Some(1_699_000_120_000),
                 status: "completed".into(),
+                source: "api".into(),
+                failure_reason: None,
             }],
         };
         let s = serde_json::to_string(&runs).unwrap();
@@ -2791,6 +2851,89 @@ mod tests {
             serde_json::from_str::<AutopilotSetEnabledParams>(&s).unwrap(),
             toggle
         );
+    }
+
+    /// The `api`-trigger envelopes (migration 0057 / parity item 15) round-trip,
+    /// and the two wire structs stay BACKWARDS-COMPATIBLE: a pre-0057 daemon's
+    /// payload — no `api_trigger_enabled`, no `source`, no `failure_reason` —
+    /// still deserialises, via the serde defaults.
+    #[test]
+    fn autopilot_api_trigger_envelopes_roundtrip_and_stay_backwards_compatible() {
+        let params = AutopilotTriggerApiParams {
+            workspace_id: "ws-1".into(),
+            autopilot_id: "ap-1".into(),
+        };
+        let s = serde_json::to_string(&params).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AutopilotTriggerApiParams>(&s).unwrap(),
+            params
+        );
+
+        for result in [
+            AutopilotTriggerApiResult {
+                outcome: "fired".into(),
+                run_id: Some("run-1".into()),
+                task_id: Some("task-1".into()),
+                reason: None,
+            },
+            AutopilotTriggerApiResult {
+                outcome: "skipped".into(),
+                run_id: Some("run-2".into()),
+                task_id: None,
+                reason: Some("concurrency limit: 1/1 in flight".into()),
+            },
+            AutopilotTriggerApiResult {
+                outcome: "disabled".into(),
+                run_id: None,
+                task_id: None,
+                reason: None,
+            },
+        ] {
+            let s = serde_json::to_string(&result).unwrap();
+            assert_eq!(
+                serde_json::from_str::<AutopilotTriggerApiResult>(&s).unwrap(),
+                result
+            );
+        }
+
+        let arm = AutopilotSetApiTriggerParams {
+            workspace_id: "ws-1".into(),
+            autopilot_id: "ap-1".into(),
+            enabled: true,
+        };
+        let s = serde_json::to_string(&arm).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AutopilotSetApiTriggerParams>(&s).unwrap(),
+            arm
+        );
+        assert!(
+            serde_json::from_str::<AutopilotSetApiTriggerResult>(r#"{"updated":true}"#)
+                .unwrap()
+                .updated
+        );
+
+        // A pre-0057 daemon's payloads, verbatim.
+        let legacy_ap: AutopilotRow = serde_json::from_str(
+            r#"{"id":"ap-1","workspace_id":"ws-1","agent_id":"agent-1","name":"daily",
+                "cron_expr":"0 9 * * *","next_tick_at":null,"enabled":true,
+                "last_run_status":null,"last_run_at":null}"#,
+        )
+        .expect("a pre-0057 AutopilotRow must still deserialise");
+        assert!(
+            !legacy_ap.api_trigger_enabled,
+            "an omitted api trigger flag means UNARMED"
+        );
+
+        let legacy_run: AutopilotRunRow = serde_json::from_str(
+            r#"{"id":"run-1","autopilot_id":"ap-1","started_at":1,"completed_at":null,
+                "status":"running"}"#,
+        )
+        .expect("a pre-0057 AutopilotRunRow must still deserialise");
+        assert_eq!(
+            legacy_run.source, "",
+            "an omitted source is empty, not a guessed provenance"
+        );
+        assert_eq!(legacy_run.failure_reason, None);
     }
 
     /// The P8.4 Kanban task envelopes round-trip through JSON.

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -127,6 +127,7 @@ fn all_variants() -> Vec<HangarEvent> {
             enabled: true,
             last_run_status: Some("completed".to_string()),
             last_run_at: Some(1_699_999_000_000),
+            api_trigger_enabled: true,
         }),
         HangarEvent::AutopilotRunChanged {
             autopilot_id: "ap-1".to_string(),

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0057_autopilot_api_trigger_and_skipped_run.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0057_autopilot_api_trigger_and_skipped_run.sql
@@ -1,0 +1,103 @@
+-- Hangar v1 schema, migration 0057: the bare `api` autopilot trigger + a
+-- first-class `skipped` run status (multica parity item 15).
+--
+-- Two independent, related changes:
+--
+--   (a) `autopilot.api_trigger_enabled` — the THIRD trigger surface after cron
+--       (0009) and webhook (0018). Multica models triggers as rows in a separate
+--       `autopilot_trigger` table with `kind IN ('schedule','webhook','api')`
+--       (`server/migrations/042_autopilot.up.sql:31`); hangar collapses trigger
+--       config into columns on `autopilot` — exactly how 0018 modelled webhook —
+--       so `api` is one boolean column, not a new table.
+--
+--       `api` is the BARE programmatic fire: no cron expression, no webhook
+--       token/HMAC. A caller with normal API access (the daemon RPC, or the
+--       local CLI) fires the autopilot directly. Multica validates that only
+--       `schedule` requires a cron expression (`handler/autopilot.go:445-448`);
+--       `api` requires nothing beyond the autopilot existing.
+--
+--   (b) `autopilot_run` gains `skipped` as a terminal status, plus `source` and
+--       `failure_reason`. Multica's rationale
+--       (`079_autopilot_run_skipped_status.up.sql`): "the admission gate needs a
+--       non-failure terminal status to record dispatches that were intentionally
+--       declined … Reusing `failed` would pollute the failure-rate signal."
+--       Before this migration a skip was an EVENT only (`SchedulerEvent::
+--       TickSkipped`) and wrote no row, so declined dispatches were invisible to
+--       any read path.
+--
+-- # (a) is a plain ADD COLUMN (catalog-only, no rewrite)
+--
+-- Default 0: every pre-existing autopilot stays api-OFF until an operator opts
+-- in, mirroring `webhook_enabled` (0018) exactly — half-configured means
+-- un-firable.
+ALTER TABLE autopilot ADD COLUMN api_trigger_enabled INTEGER NOT NULL DEFAULT 0
+    CHECK (api_trigger_enabled IN (0, 1));
+
+-- # (b) needs a table rebuild, and the rebuild order matters
+--
+-- SQLite has no `ALTER TABLE … ADD/DROP CONSTRAINT`, so widening the 0009
+-- `status` CHECK (which actively REJECTS 'skipped') requires recreating the
+-- table. The trigger-based dodge used by `0049_issue_state_blocked_cancelled`
+-- does not apply here — that column had no constraint to widen.
+--
+-- `PRAGMA foreign_keys` is ON in this crate (`src/store.rs`, asserted by
+-- `fk_enforcement_is_on_and_rejects_orphans`) and
+-- `agent_task_queue.autopilot_run_id REFERENCES autopilot_run(id)` (0010) is the
+-- only inbound FK. That rules out the naive create-new / copy / drop / RENAME
+-- sequence: the deferred-FK counter incremented by `DROP TABLE`'s implicit
+-- delete is never decremented (the child rows were inserted BEFORE the drop), so
+-- `COMMIT` fails with `FOREIGN KEY constraint failed`.
+--
+-- The sequence below is the verified one: copy → drop → recreate UNDER THE REAL
+-- NAME → re-insert. Because the parent rows come back after the drop, the
+-- deferred violation counter returns to zero and COMMIT succeeds. No
+-- `ALTER … RENAME` is used, so there is no `legacy_alter_table` schema-reparse
+-- hazard and `agent_task_queue`'s FK clause text is untouched.
+--
+-- sqlx runs each migration inside a transaction; `PRAGMA foreign_keys` cannot be
+-- toggled inside one, but `defer_foreign_keys` CAN (the same trick as
+-- `repo/workspace.rs`) and resets to OFF at commit.
+PRAGMA defer_foreign_keys = ON;
+
+CREATE TABLE autopilot_run_copy AS SELECT * FROM autopilot_run;
+
+DROP TABLE autopilot_run;
+
+CREATE TABLE autopilot_run (
+    id             TEXT PRIMARY KEY,
+    autopilot_id   TEXT NOT NULL REFERENCES autopilot(id),
+    started_at     INTEGER NOT NULL,
+    completed_at   INTEGER,
+    status         TEXT NOT NULL DEFAULT 'running'
+                   CHECK (status IN ('running', 'completed', 'failed', 'cancelled', 'skipped')),
+    -- Which trigger fired this run. Multica stamps the same discriminant on
+    -- every dispatch (`042_autopilot.up.sql:54`,
+    -- `DispatchAutopilot(ctx, autopilot, triggerID, source, payload)`).
+    source         TEXT NOT NULL DEFAULT 'schedule'
+                   CHECK (source IN ('schedule', 'manual', 'webhook', 'api')),
+    -- Why a declined (`skipped`) dispatch was declined — the admission reason.
+    -- NULL for every other status.
+    failure_reason TEXT
+);
+
+-- Pre-existing rows backfill to `source = 'schedule'` (the only unattended path
+-- that existed before this migration) and `failure_reason = NULL`. Manual and
+-- webhook history is NOT retroactively re-attributed — we do not invent
+-- provenance for rows that never recorded it.
+INSERT INTO autopilot_run (id, autopilot_id, started_at, completed_at, status)
+    SELECT id, autopilot_id, started_at, completed_at, status FROM autopilot_run_copy;
+
+DROP TABLE autopilot_run_copy;
+
+-- `idx_autopilot_run_autopilot_started` (0009) is dropped with the table and
+-- MUST be recreated: it serves both `list_runs` and the scheduler's in-flight
+-- count.
+CREATE INDEX idx_autopilot_run_autopilot_started
+    ON autopilot_run(autopilot_id, started_at DESC);
+
+-- Note for writers: `skipped` is TERMINAL. Every writer MUST stamp
+-- `completed_at`, otherwise the in-flight count (`WHERE completed_at IS NULL`)
+-- would count skips as in flight and wedge the autopilot at its limit forever.
+--
+-- `autopilot_webhook_delivery.run_id` (0018) deliberately has no FK, so it is
+-- unaffected by the rebuild.

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
@@ -154,6 +154,13 @@ pub struct Autopilot {
     pub next_tick_at: Option<i64>,
     /// Whether the scheduler considers this autopilot (the `0/1` column).
     pub enabled: bool,
+    /// Whether the bare programmatic `api` trigger is armed (migration 0057).
+    ///
+    /// The third trigger surface after cron (0009) and webhook (0018): no cron
+    /// expression, no HMAC — a caller with normal API access fires the autopilot
+    /// directly. Defaults to `false`, mirroring `webhook_enabled`: a
+    /// half-configured autopilot is never firable.
+    pub api_trigger_enabled: bool,
     /// Creation time (epoch-ms).
     pub created_at: i64,
 }
@@ -169,8 +176,17 @@ pub struct AutopilotRun {
     pub started_at: i64,
     /// When the run finished (epoch-ms); `None` while in flight.
     pub completed_at: Option<i64>,
-    /// Lifecycle status (`running` / `completed` / `failed` / `cancelled`).
+    /// Lifecycle status (`running` / `completed` / `failed` / `cancelled` /
+    /// `skipped`). `skipped` (migration 0057) is TERMINAL — a dispatch the
+    /// admission gate intentionally declined, kept distinct from `failed` so it
+    /// does not pollute the failure-rate signal.
     pub status: String,
+    /// Which trigger fired this run: `schedule` | `manual` | `webhook` | `api`
+    /// (migration 0057). Pre-0057 rows backfilled to `schedule`.
+    pub source: String,
+    /// Why a `skipped` run was declined (the admission reason); `None` for every
+    /// other status.
+    pub failure_reason: Option<String>,
 }
 
 /// The inputs to [`AutopilotRepo::create`]. `cron_expr` is validated by `create`.
@@ -193,6 +209,9 @@ pub struct NewAutopilot {
     /// What the scheduler does when a tick comes due at the in-flight limit
     /// (migration 0019).
     pub concurrency_policy: ConcurrencyPolicy,
+    /// Whether to arm the bare programmatic `api` trigger at create time
+    /// (migration 0057). `false` is the safe default.
+    pub api_trigger_enabled: bool,
 }
 
 /// Stateless typed wrapper over the autopilot tables.
@@ -227,8 +246,8 @@ impl AutopilotRepo {
             "INSERT INTO autopilot \
              (id, workspace_id, agent_id, name, instructions, cron_expr, \
               max_concurrent_runs, execution_mode, concurrency_policy, \
-              next_tick_at, enabled, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)",
+              next_tick_at, enabled, api_trigger_enabled, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)",
         )
         .bind(&id)
         .bind(req.workspace_id.as_str())
@@ -240,6 +259,7 @@ impl AutopilotRepo {
         .bind(req.execution_mode.as_str())
         .bind(req.concurrency_policy.as_str())
         .bind(next_tick_at)
+        .bind(i64::from(req.api_trigger_enabled))
         .bind(now_ms)
         .execute(pool)
         .await?;
@@ -261,7 +281,8 @@ impl AutopilotRepo {
     ) -> Result<Vec<Autopilot>, AutopilotRepoError> {
         let rows = sqlx::query_as::<_, Autopilot>(
             "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
-                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, created_at \
+                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, \
+                    api_trigger_enabled, created_at \
              FROM autopilot WHERE workspace_id = ? ORDER BY name",
         )
         .bind(workspace.as_str())
@@ -282,7 +303,8 @@ impl AutopilotRepo {
     ) -> Result<Option<Autopilot>, AutopilotRepoError> {
         let row = sqlx::query_as::<_, Autopilot>(
             "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
-                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, created_at \
+                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, \
+                    api_trigger_enabled, created_at \
              FROM autopilot WHERE id = ? AND workspace_id = ?",
         )
         .bind(id.as_str())
@@ -308,7 +330,8 @@ impl AutopilotRepo {
     ) -> Result<Option<Autopilot>, AutopilotRepoError> {
         let row = sqlx::query_as::<_, Autopilot>(
             "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
-                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, created_at \
+                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, \
+                    api_trigger_enabled, created_at \
              FROM autopilot WHERE id = ?",
         )
         .bind(id.as_str())
@@ -395,7 +418,8 @@ impl AutopilotRepo {
         limit: u32,
     ) -> Result<Vec<AutopilotRun>, AutopilotRepoError> {
         let rows = sqlx::query_as::<_, AutopilotRun>(
-            "SELECT r.id, r.autopilot_id, r.started_at, r.completed_at, r.status \
+            "SELECT r.id, r.autopilot_id, r.started_at, r.completed_at, r.status, \
+                    r.source, r.failure_reason \
              FROM autopilot_run r \
              JOIN autopilot a ON a.id = r.autopilot_id \
              WHERE r.autopilot_id = ? AND a.workspace_id = ? \
@@ -408,6 +432,34 @@ impl AutopilotRepo {
         .fetch_all(pool)
         .await?;
         Ok(rows)
+    }
+
+    /// Arm (or disarm) the bare programmatic `api` trigger, scoped to
+    /// `workspace` (migration 0057). A foreign / absent id touches no row.
+    ///
+    /// Mirrors [`AutopilotWebhookRepo::set_config`](super::autopilot_webhook::AutopilotWebhookRepo::set_config):
+    /// a trigger surface is armed by an explicit operator action, never
+    /// implicitly at create time.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutopilotRepoError::Db`] on a SQL failure.
+    pub async fn set_api_trigger_enabled(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        id: &AutopilotId,
+        enabled: bool,
+    ) -> Result<bool, AutopilotRepoError> {
+        let affected = sqlx::query(
+            "UPDATE autopilot SET api_trigger_enabled = ? WHERE id = ? AND workspace_id = ?",
+        )
+        .bind(i64::from(enabled))
+        .bind(id.as_str())
+        .bind(workspace.as_str())
+        .execute(pool)
+        .await?
+        .rows_affected();
+        Ok(affected > 0)
     }
 
     /// Insert one `autopilot_run` row (test/seed helper for run-history reads).
@@ -492,6 +544,7 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Autopilot {
             next_tick_at: row.try_get("next_tick_at")?,
             // SQLite stores the boolean as INTEGER 0/1.
             enabled: row.try_get::<i64, _>("enabled")? != 0,
+            api_trigger_enabled: row.try_get::<i64, _>("api_trigger_enabled")? != 0,
             created_at: row.try_get("created_at")?,
         })
     }
@@ -506,6 +559,8 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for AutopilotRun {
             started_at: row.try_get("started_at")?,
             completed_at: row.try_get("completed_at")?,
             status: row.try_get("status")?,
+            source: row.try_get("source")?,
+            failure_reason: row.try_get("failure_reason")?,
         })
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
@@ -43,8 +43,81 @@ use ainb_hangar_core::ids::{AutopilotRunId, IdError, TaskId};
 use ainb_hangar_core::origin::IssueOrigin;
 use sqlx::{Row, SqlitePool};
 
-use super::autopilot::{Autopilot, ExecutionMode};
+use super::autopilot::{Autopilot, ConcurrencyPolicy, ExecutionMode};
 use super::task::{NewTask, TaskRepo};
+
+/// Which trigger fired an [`Autopilot`] — the `autopilot_run.source` column
+/// (migration 0057).
+///
+/// Multica stamps the same discriminant on every dispatch
+/// (`DispatchAutopilot(ctx, autopilot, triggerID, source, payload)`,
+/// `service/autopilot.go:44-51`) so a run's provenance survives into analytics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RunSource {
+    /// The cron scheduler's tick loop (the pre-0057 path, and the column default).
+    #[default]
+    Schedule,
+    /// An operator fired it by hand (`hangar/autopilot_fire_now`, the manager
+    /// pane's "run now", `ainb hangar autopilot run`).
+    Manual,
+    /// The authenticated HMAC webhook ingress (migration 0018).
+    Webhook,
+    /// The bare programmatic `api` trigger (migration 0057): no cron, no HMAC —
+    /// a caller with normal API access fires it directly.
+    Api,
+}
+
+impl RunSource {
+    /// The literal stored in the `source` column.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Schedule => "schedule",
+            Self::Manual => "manual",
+            Self::Webhook => "webhook",
+            Self::Api => "api",
+        }
+    }
+
+    /// Parse a stored `source` value. An unrecognised string falls back to
+    /// [`Schedule`](Self::Schedule) — the column default, and the same tolerant
+    /// shape as [`ConcurrencyPolicy::from_db_str`]; the column `CHECK` already
+    /// rejects junk on write.
+    #[must_use]
+    pub fn from_db_str(s: &str) -> Self {
+        match s {
+            "manual" => Self::Manual,
+            "webhook" => Self::Webhook,
+            "api" => Self::Api,
+            _ => Self::Schedule,
+        }
+    }
+}
+
+/// What [`dispatch_with_admission`] did with a dispatch request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchOutcome {
+    /// The dispatch was admitted: a run + task exist.
+    Fired {
+        /// The new run.
+        run_id: AutopilotRunId,
+        /// The task enqueued against it.
+        task_id: TaskId,
+        /// How many in-flight runs the `replace` policy superseded first (`0`
+        /// for every other policy).
+        superseded: u64,
+    },
+    /// The admission gate declined the dispatch. A TERMINAL `skipped` run row
+    /// records it; no task was enqueued.
+    Skipped {
+        /// The recorded `skipped` run.
+        run_id: AutopilotRunId,
+        /// Why it was declined (persisted as `failure_reason`).
+        reason: String,
+        /// The in-flight count that tripped the limit.
+        in_flight: i64,
+    },
+}
 
 /// Error surface for [`fire_autopilot_tick`].
 #[derive(Debug, thiserror::Error)]
@@ -85,15 +158,36 @@ impl From<IdError> for FireError {
 /// - [`FireError::Db`] on any SQL failure — notably a task-insert FK violation,
 ///   after which the run insert is rolled back too.
 /// - [`FireError::EmptyId`] on the unreachable empty-PK invariant break.
-#[tracing::instrument(
-    name = "autopilot.tick",
-    skip(pool, clock, autopilot),
-    fields(autopilot_id = %autopilot.id, cron_expr = %autopilot.cron_expr)
-)]
 pub async fn fire_autopilot_tick(
     pool: &SqlitePool,
     clock: &dyn HangarClock,
     autopilot: &Autopilot,
+) -> Result<(AutopilotRunId, TaskId), FireError> {
+    fire_autopilot_tick_with_source(pool, clock, autopilot, RunSource::Schedule).await
+}
+
+/// Fire one autopilot tick, stamping WHICH trigger fired it onto the run
+/// (`autopilot_run.source`, migration 0057).
+///
+/// This holds the real fire body; [`fire_autopilot_tick`] is the legacy
+/// `schedule`-sourced delegate. Every production caller should name its source
+/// explicitly so the run history carries honest provenance.
+///
+/// Returns the new `(autopilot_run.id, agent_task_queue.id)` on commit.
+///
+/// # Errors
+///
+/// Same surface as [`fire_autopilot_tick`].
+#[tracing::instrument(
+    name = "autopilot.tick",
+    skip(pool, clock, autopilot),
+    fields(autopilot_id = %autopilot.id, cron_expr = %autopilot.cron_expr, source = source.as_db_str())
+)]
+pub async fn fire_autopilot_tick_with_source(
+    pool: &SqlitePool,
+    clock: &dyn HangarClock,
+    autopilot: &Autopilot,
+    source: RunSource,
 ) -> Result<(AutopilotRunId, TaskId), FireError> {
     let now = clock.now_ms();
     let run_id = SystemIdGen.new_ulid();
@@ -103,12 +197,13 @@ pub async fn fire_autopilot_tick(
 
     // 1. The run row, in-flight.
     sqlx::query(
-        "INSERT INTO autopilot_run (id, autopilot_id, started_at, status) \
-         VALUES (?, ?, ?, 'running')",
+        "INSERT INTO autopilot_run (id, autopilot_id, started_at, status, source) \
+         VALUES (?, ?, ?, 'running', ?)",
     )
     .bind(&run_id)
     .bind(&autopilot.id)
     .bind(now)
+    .bind(source.as_db_str())
     .execute(&mut *tx)
     .await?;
 
@@ -273,4 +368,137 @@ pub async fn supersede_in_flight(
 
     tx.commit().await?;
     Ok(runs)
+}
+
+/// Count an autopilot's in-flight (not-yet-completed) runs — the
+/// concurrency-policy denominator.
+///
+/// A `skipped` run is terminal (it stamps `completed_at`), so declined
+/// dispatches never inflate this count.
+///
+/// # Errors
+///
+/// Returns [`FireError::Db`] on a SQL failure.
+pub async fn count_in_flight(pool: &SqlitePool, autopilot_id: &str) -> Result<i64, FireError> {
+    let n = sqlx::query_scalar::<_, i64>(
+        "SELECT count(*) FROM autopilot_run \
+         WHERE autopilot_id = ? AND completed_at IS NULL",
+    )
+    .bind(autopilot_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(n)
+}
+
+/// Record a dispatch the admission gate intentionally DECLINED, as a terminal
+/// `skipped` run row (migration 0057).
+///
+/// The direct analogue of multica's `recordSkippedRun`
+/// (`service/autopilot.go:389-435`): persist a run carrying `status='skipped'`,
+/// the originating `source`, and `failure_reason = <reason>` — no task, no
+/// issue — so a declined dispatch is visible to every read path instead of
+/// existing only as a log line. `skipped` is deliberately NOT `failed`: reusing
+/// `failed` would pollute the failure-rate signal.
+///
+/// `started_at` and `completed_at` are BOTH stamped with `clock.now_ms()`. That
+/// is load-bearing, not cosmetic: [`count_in_flight`] counts
+/// `completed_at IS NULL`, so a skip left open would permanently inflate the
+/// in-flight count and wedge the autopilot at its limit forever.
+///
+/// # Errors
+///
+/// Returns [`FireError::Db`] on a SQL failure (e.g. an `autopilot_id` FK
+/// violation), or [`FireError::EmptyId`] on the unreachable empty-PK invariant
+/// break.
+pub async fn record_skipped_run(
+    pool: &SqlitePool,
+    clock: &dyn HangarClock,
+    autopilot: &Autopilot,
+    source: RunSource,
+    reason: &str,
+) -> Result<AutopilotRunId, FireError> {
+    let now = clock.now_ms();
+    let run_id = SystemIdGen.new_ulid();
+    sqlx::query(
+        "INSERT INTO autopilot_run \
+         (id, autopilot_id, started_at, completed_at, status, source, failure_reason) \
+         VALUES (?, ?, ?, ?, 'skipped', ?, ?)",
+    )
+    .bind(&run_id)
+    .bind(&autopilot.id)
+    .bind(now)
+    .bind(now)
+    .bind(source.as_db_str())
+    .bind(reason)
+    .execute(pool)
+    .await?;
+    Ok(AutopilotRunId::from_str(run_id)?)
+}
+
+/// The SHARED admission gate: apply the autopilot's concurrency policy, then
+/// either fire or record a `skipped` run.
+///
+/// This is the deep module behind a shallow interface every trigger surface
+/// (cron scheduler, manual fire-now, webhook ingress, the `api` trigger) calls,
+/// so no path can drift from the tested policy. It is the exact analogue of
+/// multica running its admission gate on EVERY dispatch whatever the source
+/// (`service/autopilot.go:51-53`).
+///
+/// The policy branch is lifted verbatim from the scheduler's `fire_or_skip`,
+/// minus the event emission and the reschedule (both remain the scheduler's
+/// job):
+///
+/// - under the limit → fire (`superseded: 0`), regardless of policy;
+/// - at the limit + [`ConcurrencyPolicy::Skip`] → record a terminal `skipped`
+///   run and enqueue NOTHING;
+/// - at the limit + [`ConcurrencyPolicy::Queue`] → fire anyway (the claim queue
+///   serialises the work);
+/// - at the limit + [`ConcurrencyPolicy::Replace`] → [`supersede_in_flight`]
+///   first, then fire, reporting how many runs were superseded.
+///
+/// The only behavioural change versus the pre-0057 scheduler is that the `Skip`
+/// branch now WRITES a row; it still enqueues no work.
+///
+/// # Errors
+///
+/// - [`FireError::Db`] on any SQL failure (the in-flight count, the skip insert,
+///   the supersede, or the fire transaction).
+/// - [`FireError::AgentNotFound`] when the fire path cannot resolve the agent.
+/// - [`FireError::EmptyId`] on the unreachable empty-PK invariant break.
+pub async fn dispatch_with_admission(
+    pool: &SqlitePool,
+    clock: &dyn HangarClock,
+    autopilot: &Autopilot,
+    source: RunSource,
+) -> Result<DispatchOutcome, FireError> {
+    let in_flight = count_in_flight(pool, &autopilot.id).await?;
+    let at_limit = in_flight >= autopilot.max_concurrent_runs;
+
+    // The concurrency policy only matters AT the limit. Under the limit, every
+    // policy simply fires.
+    let superseded = match (at_limit, autopilot.concurrency_policy) {
+        (false, _) | (true, ConcurrencyPolicy::Queue) => 0,
+        (true, ConcurrencyPolicy::Skip) => {
+            let reason = format!(
+                "concurrency limit: {in_flight}/{} in flight",
+                autopilot.max_concurrent_runs
+            );
+            let run_id = record_skipped_run(pool, clock, autopilot, source, &reason).await?;
+            return Ok(DispatchOutcome::Skipped {
+                run_id,
+                reason,
+                in_flight,
+            });
+        }
+        (true, ConcurrencyPolicy::Replace) => {
+            supersede_in_flight(pool, clock, &autopilot.id).await?
+        }
+    };
+
+    let (run_id, task_id) = fire_autopilot_tick_with_source(pool, clock, autopilot, source).await?;
+    Ok(DispatchOutcome::Fired {
+        run_id,
+        task_id,
+        superseded,
+    })
 }

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0057_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0057_upgrade.rs
@@ -1,0 +1,223 @@
+//! Upgrade-from-populated test for migration 0057 (`autopilot.api_trigger_enabled`
+//! + `autopilot_run.{status skipped, source, failure_reason}` — multica parity
+//! item 15).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the migration is safe on a REAL populated database, which matters far
+//! more here than for the usual ADD COLUMN migration: 0057 REBUILDS
+//! `autopilot_run` (SQLite cannot widen a `CHECK` in place) while
+//! `agent_task_queue.autopilot_run_id` holds a live foreign key into it.
+//!
+//! 1. apply only the PRIOR migrations (0001..0056),
+//! 2. seed a workspace / user / runtime / agent / autopilot, two
+//!    `autopilot_run` rows (one in-flight `running`, one `completed`) and an
+//!    `agent_task_queue` row whose `autopilot_run_id` points at the in-flight run,
+//! 3. apply the embedded migrations (which adds 0057),
+//! 4. assert the rows survived byte-identically, backfilled their new columns,
+//!    the child FK still resolves (`PRAGMA foreign_key_check` empty), the
+//!    dropped-with-the-table index is back, and the widened CHECK accepts
+//!    `skipped` / `api` while still rejecting junk.
+
+use ainb_hangar_store::apply_migrations;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test
+/// (`0057_autopilot_api_trigger_and_skipped_run.sql`).
+const NEW_MIGRATION_VERSION: i64 = 57;
+
+/// Open a fresh on-disk WAL pool in `dir` and apply only the migrations PRIOR to
+/// [`NEW_MIGRATION_VERSION`]. Foreign keys are ON (the crate's production
+/// setting) — that is exactly the condition the naive rebuild would fail under.
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let db_path = dir.join("hangar.db");
+    let opts = SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(opts)
+        .await
+        .expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator
+        .migrations
+        .to_mut()
+        .retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(
+        !migrator.migrations.is_empty(),
+        "prior-migration set must not be empty"
+    );
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+/// Seed the full FK chain plus two runs and a task pointing at the in-flight run.
+async fn seed_populated(pool: &SqlitePool) {
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-1','a@example.com',0)",
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','daemon-1','claude','local')",
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('agent-1','ws-1','Agent','rt-1','workspace','user-1')",
+        "INSERT INTO autopilot (id, workspace_id, agent_id, name, cron_expr, created_at) \
+         VALUES ('ap-1','ws-1','agent-1','daily','0 9 * * *',0)",
+        "INSERT INTO autopilot_run (id, autopilot_id, started_at, completed_at, status) \
+         VALUES ('run-open','ap-1',100,NULL,'running')",
+        "INSERT INTO autopilot_run (id, autopilot_id, started_at, completed_at, status) \
+         VALUES ('run-done','ap-1',50,80,'completed')",
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, status, created_at, autopilot_run_id) \
+         VALUES ('task-1','ws-1','rt-1','agent-1','queued',100,'run-open')",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+/// The load-bearing upgrade proof: the rebuild preserves the table and its
+/// inbound foreign key.
+#[tokio::test]
+async fn upgrades_populated_db_preserving_runs_and_child_fk() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+
+    // Pre-condition: `skipped` is genuinely rejected today.
+    let rejected = sqlx::query(
+        "INSERT INTO autopilot_run (id, autopilot_id, started_at, status) \
+         VALUES ('run-pre','ap-1',1,'skipped')",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+        rejected.is_err(),
+        "pre-0057 schema must reject status='skipped'"
+    );
+
+    // THE COMMIT THAT USED TO FAIL: the rebuild under an enforced inbound FK.
+    apply_migrations(&pool).await.expect("0057 applies");
+
+    // Both run rows survive with identical identity/time/status columns…
+    let rows = sqlx::query(
+        "SELECT id, autopilot_id, started_at, completed_at, status, source, failure_reason \
+         FROM autopilot_run ORDER BY started_at",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("read runs");
+    assert_eq!(rows.len(), 2, "no run row was lost by the rebuild");
+
+    let done = &rows[0];
+    assert_eq!(done.get::<String, _>("id"), "run-done");
+    assert_eq!(done.get::<String, _>("autopilot_id"), "ap-1");
+    assert_eq!(done.get::<i64, _>("started_at"), 50);
+    assert_eq!(done.get::<Option<i64>, _>("completed_at"), Some(80));
+    assert_eq!(done.get::<String, _>("status"), "completed");
+
+    let open = &rows[1];
+    assert_eq!(open.get::<String, _>("id"), "run-open");
+    assert_eq!(open.get::<i64, _>("started_at"), 100);
+    assert_eq!(open.get::<Option<i64>, _>("completed_at"), None);
+    assert_eq!(open.get::<String, _>("status"), "running");
+
+    // …and backfill to the documented defaults. Provenance is NOT invented.
+    for row in &rows {
+        assert_eq!(
+            row.get::<String, _>("source"),
+            "schedule",
+            "pre-0057 rows backfill to source='schedule'"
+        );
+        assert_eq!(row.get::<Option<String>, _>("failure_reason"), None);
+    }
+
+    // The child FK still resolves: the task was neither orphaned nor deleted.
+    let task_run: Option<String> =
+        sqlx::query_scalar("SELECT autopilot_run_id FROM agent_task_queue WHERE id = 'task-1'")
+            .fetch_one(&pool)
+            .await
+            .expect("read task");
+    assert_eq!(task_run.as_deref(), Some("run-open"));
+
+    let violations = sqlx::query("PRAGMA foreign_key_check")
+        .fetch_all(&pool)
+        .await
+        .expect("foreign_key_check");
+    assert!(
+        violations.is_empty(),
+        "the rebuild must leave no dangling foreign keys"
+    );
+
+    // The index dropped with the table is recreated (it serves `list_runs` AND
+    // the scheduler's in-flight count).
+    let idx: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM sqlite_master \
+         WHERE type = 'index' AND name = 'idx_autopilot_run_autopilot_started'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read sqlite_master");
+    assert_eq!(idx, 1, "idx_autopilot_run_autopilot_started must be back");
+}
+
+/// The CHECK was WIDENED, not dropped: `skipped`/`api` are accepted, junk is not.
+#[tokio::test]
+async fn widened_checks_accept_skipped_and_api_but_still_reject_junk() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+    apply_migrations(&pool).await.expect("0057 applies");
+
+    sqlx::query(
+        "INSERT INTO autopilot_run \
+         (id, autopilot_id, started_at, completed_at, status, source, failure_reason) \
+         VALUES ('run-skip','ap-1',200,200,'skipped','api','concurrency limit: 1/1 in flight')",
+    )
+    .execute(&pool)
+    .await
+    .expect("status='skipped' + source='api' must now be accepted");
+
+    let bad_status = sqlx::query(
+        "INSERT INTO autopilot_run (id, autopilot_id, started_at, status) \
+         VALUES ('run-bogus','ap-1',1,'bogus')",
+    )
+    .execute(&pool)
+    .await;
+    assert!(bad_status.is_err(), "status CHECK must still reject junk");
+
+    let bad_source = sqlx::query(
+        "INSERT INTO autopilot_run (id, autopilot_id, started_at, status, source) \
+         VALUES ('run-bogus2','ap-1',1,'running','bogus')",
+    )
+    .execute(&pool)
+    .await;
+    assert!(bad_source.is_err(), "source CHECK must reject junk");
+}
+
+/// Pre-existing autopilots stay api-OFF until an operator opts in.
+#[tokio::test]
+async fn preexisting_autopilots_read_api_trigger_disabled() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+    apply_migrations(&pool).await.expect("0057 applies");
+
+    let enabled: i64 =
+        sqlx::query_scalar("SELECT api_trigger_enabled FROM autopilot WHERE id = 'ap-1'")
+            .fetch_one(&pool)
+            .await
+            .expect("read api_trigger_enabled");
+    assert_eq!(enabled, 0, "api trigger defaults OFF for upgraded rows");
+
+    let bad = sqlx::query("UPDATE autopilot SET api_trigger_enabled = 7 WHERE id = 'ap-1'")
+        .execute(&pool)
+        .await;
+    assert!(bad.is_err(), "api_trigger_enabled CHECK must reject non-0/1");
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0057_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0057_upgrade.rs
@@ -37,20 +37,14 @@ async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
         .create_if_missing(true)
         .foreign_keys(true)
         .journal_mode(SqliteJournalMode::Wal);
-    let pool = SqlitePoolOptions::new()
-        .connect_with(opts)
-        .await
-        .expect("open pool");
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
 
     let mut migrator = sqlx::migrate::Migrator::new(
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
     )
     .await
     .expect("load migrations directory");
-    migrator
-        .migrations
-        .to_mut()
-        .retain(|m| m.version < NEW_MIGRATION_VERSION);
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
     assert!(
         !migrator.migrations.is_empty(),
         "prior-migration set must not be empty"
@@ -219,5 +213,8 @@ async fn preexisting_autopilots_read_api_trigger_disabled() {
     let bad = sqlx::query("UPDATE autopilot SET api_trigger_enabled = 7 WHERE id = 'ap-1'")
         .execute(&pool)
         .await;
-    assert!(bad.is_err(), "api_trigger_enabled CHECK must reject non-0/1");
+    assert!(
+        bad.is_err(),
+        "api_trigger_enabled CHECK must reject non-0/1"
+    );
 }

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot.rs
@@ -101,6 +101,7 @@ fn new_req(ws_id: &str, agent: &str, name: &str, cron: &str) -> NewAutopilot {
         max_concurrent_runs: 1,
         execution_mode: ExecutionMode::default(),
         concurrency_policy: ConcurrencyPolicy::default(),
+        api_trigger_enabled: false,
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_api_trigger.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_api_trigger.rs
@@ -1,0 +1,415 @@
+//! The `api` trigger + the `skipped` run status at the store layer (multica
+//! parity item 15).
+//!
+//! Before migration 0057, a declined dispatch was an EVENT only: the scheduler
+//! logged `tick_skipped` and wrote no row, so no read path could ever tell a
+//! declined dispatch from a tick that never came due. These tests pin the two
+//! halves of the fix against real sqlite:
+//!
+//! 1. [`record_skipped_run`] persists a TERMINAL `skipped` run (its
+//!    `completed_at` stamped, so it never inflates the in-flight count),
+//! 2. [`dispatch_with_admission`] — the shared gate every trigger surface calls —
+//!    applies the SAME concurrency policy the scheduler always did, now writing
+//!    a `skipped` row on the `skip` branch and stamping `source` on every run.
+
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_core::ids::{AgentId, AutopilotId, WorkspaceId};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::autopilot::{
+    Autopilot, AutopilotRepo, ConcurrencyPolicy, ExecutionMode, NewAutopilot,
+};
+use ainb_hangar_store::repo::autopilot_run::{
+    DispatchOutcome, RunSource, count_in_flight, dispatch_with_admission, fire_autopilot_tick,
+    fire_autopilot_tick_with_source, record_skipped_run,
+};
+use sqlx::Row;
+
+/// Fixed clock instant all tests fire at (epoch-ms, 2026-01-01T00:00:00Z).
+const T0: i64 = 1_767_225_600_000;
+
+/// Seed the workspace + user + runtime + agent FK chain every autopilot needs.
+async fn seed_graph(store: &Store) {
+    let pool = store.pool();
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-2','beta','Beta',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-1','a@example.com',0)",
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','daemon-1','claude','local')",
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('agent-1','ws-1','Agent','rt-1','workspace','user-1')",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+/// Create one autopilot with the given policy/limit and read it back.
+async fn seed_autopilot(
+    store: &Store,
+    policy: ConcurrencyPolicy,
+    max_concurrent_runs: i64,
+) -> Autopilot {
+    let clock = FixedClock(T0);
+    let id = AutopilotRepo::create(
+        store.pool(),
+        &clock,
+        &NewAutopilot {
+            workspace_id: WorkspaceId::from_str("ws-1").unwrap(),
+            agent_id: AgentId::from_str("agent-1").unwrap(),
+            name: "daily".to_string(),
+            instructions: Some("do the thing".to_string()),
+            cron_expr: "0 9 * * *".to_string(),
+            max_concurrent_runs,
+            execution_mode: ExecutionMode::default(),
+            concurrency_policy: policy,
+            api_trigger_enabled: false,
+        },
+    )
+    .await
+    .expect("create autopilot");
+    reload(store, &id).await
+}
+
+async fn reload(store: &Store, id: &AutopilotId) -> Autopilot {
+    AutopilotRepo::get(store.pool(), &WorkspaceId::from_str("ws-1").unwrap(), id)
+        .await
+        .expect("get autopilot")
+        .expect("autopilot present")
+}
+
+async fn count(store: &Store, sql: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(sql)
+        .fetch_one(store.pool())
+        .await
+        .unwrap_or_else(|e| panic!("{sql}: {e}"))
+}
+
+async fn open(dir: &tempfile::TempDir) -> Store {
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    store
+}
+
+/// A skipped run is a real row, and it is TERMINAL: it never counts as in flight,
+/// so a later dispatch still fires.
+#[tokio::test]
+async fn record_skipped_run_writes_one_terminal_row_and_does_not_block_the_next_fire() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = open(&dir).await;
+    let autopilot = seed_autopilot(&store, ConcurrencyPolicy::Skip, 1).await;
+    let clock = FixedClock(T0);
+
+    let run_id = record_skipped_run(
+        store.pool(),
+        &clock,
+        &autopilot,
+        RunSource::Api,
+        "concurrency limit: 1/1 in flight",
+    )
+    .await
+    .expect("record skipped run");
+
+    let row = sqlx::query(
+        "SELECT started_at, completed_at, status, source, failure_reason \
+         FROM autopilot_run WHERE id = ?",
+    )
+    .bind(run_id.as_str())
+    .fetch_one(store.pool())
+    .await
+    .expect("skipped run row present");
+    assert_eq!(row.get::<String, _>("status"), "skipped");
+    assert_eq!(row.get::<String, _>("source"), "api");
+    assert_eq!(
+        row.get::<Option<String>, _>("failure_reason").as_deref(),
+        Some("concurrency limit: 1/1 in flight")
+    );
+    assert_eq!(row.get::<i64, _>("started_at"), T0);
+    assert_eq!(
+        row.get::<Option<i64>, _>("completed_at"),
+        Some(T0),
+        "a skipped run MUST stamp completed_at or it wedges the in-flight count"
+    );
+
+    // Exactly one row, and it enqueued no work.
+    assert_eq!(count(&store, "SELECT count(*) FROM autopilot_run").await, 1);
+    assert_eq!(
+        count(&store, "SELECT count(*) FROM agent_task_queue").await,
+        0
+    );
+
+    // The in-flight count is unchanged, so the gate still admits the next fire.
+    assert_eq!(
+        count_in_flight(store.pool(), &autopilot.id).await.expect("count in flight"),
+        0
+    );
+    let outcome = dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+        .await
+        .expect("dispatch after a skip");
+    assert!(matches!(outcome, DispatchOutcome::Fired { .. }));
+}
+
+/// At the limit under `skip`, an api dispatch is declined AND recorded — the one
+/// path that proves both halves of parity item 15 at once.
+#[tokio::test]
+async fn dispatch_at_limit_with_skip_records_a_skipped_api_run_and_no_task() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = open(&dir).await;
+    let autopilot = seed_autopilot(&store, ConcurrencyPolicy::Skip, 1).await;
+    let clock = FixedClock(T0);
+
+    let first = dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+        .await
+        .expect("first dispatch");
+    assert!(matches!(first, DispatchOutcome::Fired { .. }));
+
+    let second = dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+        .await
+        .expect("second dispatch");
+    let DispatchOutcome::Skipped {
+        reason, in_flight, ..
+    } = second
+    else {
+        panic!("at the limit under `skip` the dispatch must be declined, got {second:?}");
+    };
+    assert_eq!(in_flight, 1);
+    assert!(
+        reason.starts_with("concurrency limit"),
+        "reason names the admission gate: {reason}"
+    );
+
+    // One task (the skip enqueued nothing) …
+    assert_eq!(
+        count(&store, "SELECT count(*) FROM agent_task_queue").await,
+        1,
+        "a skip must enqueue no work"
+    );
+    // … one live run …
+    assert_eq!(
+        count(
+            &store,
+            "SELECT count(*) FROM autopilot_run WHERE status <> 'skipped'"
+        )
+        .await,
+        1
+    );
+    // … and exactly one recorded skip, stamped `api`, terminal, with a reason.
+    assert_eq!(
+        count(
+            &store,
+            "SELECT count(*) FROM autopilot_run \
+             WHERE status = 'skipped' AND source = 'api' \
+               AND completed_at IS NOT NULL \
+               AND failure_reason LIKE 'concurrency limit%'"
+        )
+        .await,
+        1,
+        "the declined dispatch must be persisted, not just logged"
+    );
+}
+
+/// `queue` still fires at the limit (regression guard on the lifted logic).
+#[tokio::test]
+async fn dispatch_at_limit_with_queue_fires_anyway() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = open(&dir).await;
+    let autopilot = seed_autopilot(&store, ConcurrencyPolicy::Queue, 1).await;
+    let clock = FixedClock(T0);
+
+    for _ in 0..2 {
+        let outcome = dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+            .await
+            .expect("dispatch");
+        assert!(
+            matches!(outcome, DispatchOutcome::Fired { superseded: 0, .. }),
+            "queue fires without superseding, got {outcome:?}"
+        );
+    }
+    assert_eq!(
+        count(&store, "SELECT count(*) FROM agent_task_queue").await,
+        2
+    );
+    assert_eq!(
+        count(
+            &store,
+            "SELECT count(*) FROM autopilot_run WHERE status = 'skipped'"
+        )
+        .await,
+        0,
+        "queue never records a skip"
+    );
+}
+
+/// `replace` supersedes the in-flight run then fires (regression guard).
+#[tokio::test]
+async fn dispatch_at_limit_with_replace_supersedes_then_fires() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = open(&dir).await;
+    let autopilot = seed_autopilot(&store, ConcurrencyPolicy::Replace, 1).await;
+    let clock = FixedClock(T0);
+
+    let first = dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+        .await
+        .expect("first dispatch");
+    let DispatchOutcome::Fired {
+        run_id: first_run, ..
+    } = first
+    else {
+        panic!("under the limit every policy fires, got {first:?}");
+    };
+
+    let second = dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+        .await
+        .expect("second dispatch");
+    assert!(
+        matches!(second, DispatchOutcome::Fired { superseded: 1, .. }),
+        "replace supersedes exactly the one in-flight run, got {second:?}"
+    );
+
+    let status: String = sqlx::query_scalar("SELECT status FROM autopilot_run WHERE id = ?")
+        .bind(first_run.as_str())
+        .fetch_one(store.pool())
+        .await
+        .expect("read the superseded run");
+    assert_eq!(status, "cancelled");
+    assert_eq!(
+        count(
+            &store,
+            "SELECT count(*) FROM autopilot_run WHERE status = 'skipped'"
+        )
+        .await,
+        0,
+        "replace never records a skip"
+    );
+}
+
+/// Provenance: the sourced fire stamps `api`; the legacy delegate still stamps
+/// `schedule`, so no existing caller silently changes meaning.
+#[tokio::test]
+async fn fire_stamps_the_source_and_the_legacy_entry_point_stays_schedule() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = open(&dir).await;
+    let autopilot = seed_autopilot(&store, ConcurrencyPolicy::Queue, 5).await;
+    let clock = FixedClock(T0);
+
+    let (api_run, _) =
+        fire_autopilot_tick_with_source(store.pool(), &clock, &autopilot, RunSource::Api)
+            .await
+            .expect("sourced fire");
+    let (legacy_run, _) = fire_autopilot_tick(store.pool(), &clock, &autopilot)
+        .await
+        .expect("legacy fire");
+
+    async fn source_of(store: &Store, id: &str) -> String {
+        sqlx::query_scalar::<_, String>("SELECT source FROM autopilot_run WHERE id = ?")
+            .bind(id)
+            .fetch_one(store.pool())
+            .await
+            .expect("read source")
+    }
+    assert_eq!(source_of(&store, api_run.as_str()).await, "api");
+    assert_eq!(source_of(&store, legacy_run.as_str()).await, "schedule");
+}
+
+/// `set_api_trigger_enabled` is workspace-scoped: a foreign workspace touches no
+/// row, exactly like every other by-id mutation on this repo.
+#[tokio::test]
+async fn set_api_trigger_enabled_is_workspace_scoped() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = open(&dir).await;
+    let autopilot = seed_autopilot(&store, ConcurrencyPolicy::Skip, 1).await;
+    let id = AutopilotId::from_str(autopilot.id.clone()).unwrap();
+    assert!(
+        !autopilot.api_trigger_enabled,
+        "the api trigger starts disarmed"
+    );
+
+    // A foreign workspace: no row touched, no arm.
+    let updated = AutopilotRepo::set_api_trigger_enabled(
+        store.pool(),
+        &WorkspaceId::from_str("ws-2").unwrap(),
+        &id,
+        true,
+    )
+    .await
+    .expect("foreign-workspace update");
+    assert!(!updated, "a foreign workspace must touch no row");
+    assert!(!reload(&store, &id).await.api_trigger_enabled);
+
+    // The owning workspace arms it, and can disarm it again.
+    let updated = AutopilotRepo::set_api_trigger_enabled(
+        store.pool(),
+        &WorkspaceId::from_str("ws-1").unwrap(),
+        &id,
+        true,
+    )
+    .await
+    .expect("owner update");
+    assert!(updated);
+    assert!(reload(&store, &id).await.api_trigger_enabled);
+
+    AutopilotRepo::set_api_trigger_enabled(
+        store.pool(),
+        &WorkspaceId::from_str("ws-1").unwrap(),
+        &id,
+        false,
+    )
+    .await
+    .expect("disarm");
+    assert!(!reload(&store, &id).await.api_trigger_enabled);
+}
+
+/// The run-history read surfaces the new columns (the CLI + plugin read path).
+#[tokio::test]
+async fn list_runs_surfaces_source_and_failure_reason() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = open(&dir).await;
+    let autopilot = seed_autopilot(&store, ConcurrencyPolicy::Skip, 1).await;
+    let id = AutopilotId::from_str(autopilot.id.clone()).unwrap();
+    let clock = FixedClock(T0);
+
+    dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+        .await
+        .expect("fire");
+    dispatch_with_admission(store.pool(), &clock, &autopilot, RunSource::Api)
+        .await
+        .expect("skip");
+
+    let runs = AutopilotRepo::list_runs(
+        store.pool(),
+        &WorkspaceId::from_str("ws-1").unwrap(),
+        &id,
+        10,
+    )
+    .await
+    .expect("list runs");
+    assert_eq!(runs.len(), 2);
+    assert!(
+        runs.iter().all(|r| r.source == "api"),
+        "both runs carry their api provenance: {runs:?}"
+    );
+    let skipped = runs
+        .iter()
+        .find(|r| r.status == "skipped")
+        .expect("the skipped run is readable through list_runs");
+    assert!(
+        skipped
+            .failure_reason
+            .as_deref()
+            .is_some_and(|r| r.starts_with("concurrency limit")),
+        "the admission reason is readable: {skipped:?}"
+    );
+}
+
+/// `RunSource::from_db_str` is tolerant: unknown values fall back to the column
+/// default rather than erroring a whole read.
+#[test]
+fn run_source_from_db_str_falls_back_to_schedule() {
+    assert_eq!(RunSource::from_db_str("api"), RunSource::Api);
+    assert_eq!(RunSource::from_db_str("manual"), RunSource::Manual);
+    assert_eq!(RunSource::from_db_str("webhook"), RunSource::Webhook);
+    assert_eq!(RunSource::from_db_str("schedule"), RunSource::Schedule);
+    assert_eq!(
+        RunSource::from_db_str("from-the-future"),
+        RunSource::Schedule
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_enqueue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_enqueue.rs
@@ -92,6 +92,7 @@ async fn seed_autopilot(store: &Store) -> ainb_hangar_store::repo::autopilot::Au
             max_concurrent_runs: 1,
             execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
             concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(),
+            api_trigger_enabled: false,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/service_spans_emit.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/service_spans_emit.rs
@@ -250,6 +250,7 @@ async fn store_fsm_and_autopilot_emit_named_spans_with_required_fields() {
             max_concurrent_runs: 1,
             execution_mode: ainb_hangar_store::repo::autopilot::ExecutionMode::default(),
             concurrency_policy: ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::default(),
+            api_trigger_enabled: false,
         },
     )
     .await

--- a/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/tripwire_migrations_apply.rs
@@ -655,13 +655,21 @@ async fn migration_0009_creates_autopilot_tables_with_scoping_indexes() {
         run.contains("completed_at INTEGER"),
         "autopilot_run.completed_at nullable: {run}"
     );
+    // Per-token membership rather than a frozen whole-CHECK literal: 0057
+    // WIDENS this constraint (adding `skipped`) and later migrations may widen
+    // it again, but every token below must survive and the default must stay
+    // `running`.
     assert!(
-        run.contains(
-            "status TEXT NOT NULL DEFAULT 'running' CHECK (status IN \
-             ('running', 'completed', 'failed', 'cancelled'))"
-        ),
-        "autopilot_run.status default + CHECK: {run}"
+        run.contains("status TEXT NOT NULL DEFAULT 'running'"),
+        "autopilot_run.status default: {run}"
     );
+    let status_check = &run[run.find("CHECK (status IN").expect("status CHECK present")..];
+    for token in ["'running'", "'completed'", "'failed'", "'cancelled'"] {
+        assert!(
+            status_check.contains(token),
+            "autopilot_run.status CHECK must still admit {token}: {run}"
+        );
+    }
 
     pool.close().await;
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/autopilots.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/autopilots.rs
@@ -109,10 +109,18 @@ impl AutopilotsState {
             .map(|ap| {
                 let last = ap.last_run_status.clone().unwrap_or_else(|| "never".into());
                 let state = if ap.enabled { "enabled" } else { "disabled" };
+                // An armed `api` trigger (migration 0057) is a second way this
+                // autopilot can fire, so it belongs on the card next to the
+                // schedule state.
+                let api = if ap.api_trigger_enabled {
+                    " · api"
+                } else {
+                    ""
+                };
                 BoardCard {
                     issue_id: ap.id.clone(),
                     display_id: ap.name.clone(),
-                    title: format!("{} · {state} · last {last}", ap.cron_expr),
+                    title: format!("{} · {state}{api} · last {last}", ap.cron_expr),
                     priority: PriorityChip::from_priority(0),
                     assignee_initial: ap.name.chars().next(),
                     linked: false,
@@ -448,7 +456,16 @@ fn render_run(buf: &mut WireBuffer, row: u16, area_w: u16, run: &AutopilotRunRow
         "completed" => SELECTION_GREEN,
         _ => SOFT_WHITE,
     };
-    let line = format!("{}  {}", run.started_at, run.status);
+    // `·source` names WHICH trigger fired the run, and a declined (`skipped`)
+    // dispatch appends its admission reason — both migration 0057. The reason is
+    // clipped by `put_str` at the pane width.
+    let mut line = format!("{}  {}", run.started_at, run.status);
+    if !run.source.is_empty() {
+        line.push_str(&format!("  ·{}", run.source));
+    }
+    if let Some(reason) = run.failure_reason.as_deref().filter(|r| !r.is_empty()) {
+        line.push_str(&format!(" — {reason}"));
+    }
     put_str(buf, 0, row, &line, color, area_w);
 }
 
@@ -483,6 +500,7 @@ mod tests {
             enabled,
             last_run_status: Some("completed".into()),
             last_run_at: Some(1),
+            api_trigger_enabled: false,
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/autopilots_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/autopilots_reducer_test.rs
@@ -21,6 +21,7 @@ fn autopilot(id: &str, name: &str, enabled: bool) -> AutopilotRow {
         enabled,
         last_run_status: Some("completed".into()),
         last_run_at: Some(1_699_000_000_000),
+        api_trigger_enabled: false,
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/autopilots_screen_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/autopilots_screen_snapshot.rs
@@ -29,6 +29,7 @@ fn autopilot(id: &str, name: &str, cron: &str, enabled: bool, last: Option<&str>
         enabled,
         last_run_status: last.map(str::to_string),
         last_run_at: last.map(|_| 1_699_000_000_000),
+        api_trigger_enabled: false,
     }
 }
 
@@ -195,6 +196,8 @@ fn render_run_history_below_selection() {
                     started_at: 1_700_000_120_000,
                     completed_at: Some(1_700_000_300_000),
                     status: "completed".into(),
+                    source: "schedule".into(),
+                    failure_reason: None,
                 },
                 AutopilotRunRow {
                     id: "run-2".into(),
@@ -202,6 +205,8 @@ fn render_run_history_below_selection() {
                     started_at: 1_699_999_000_000,
                     completed_at: Some(1_699_999_100_000),
                     status: "completed".into(),
+                    source: "schedule".into(),
+                    failure_reason: None,
                 },
             ],
         },
@@ -245,6 +250,8 @@ fn render_skipped_run_marked() {
                 started_at: 1_700_000_000_000,
                 completed_at: None,
                 status: "skipped".into(),
+                source: "schedule".into(),
+                failure_reason: None,
             }],
         },
     )
@@ -268,5 +275,74 @@ fn render_skipped_run_marked() {
     assert!(
         red_skipped,
         "the skipped run must be marked with the warn-red accent"
+    );
+}
+
+/// A declined dispatch is READABLE in the history pane: its trigger source and
+/// the admission reason render alongside the `skipped` status (migration 0057 /
+/// multica parity item 15). Without this the only record of a decline is a log
+/// line the operator never sees.
+#[test]
+fn render_skipped_run_shows_source_and_reason() {
+    let state = AutopilotsState::new(three_autopilots());
+    let loaded = reduce_autopilots(
+        &state,
+        AutopilotsEvent::RunsLoaded {
+            autopilot_id: "ap-1".into(),
+            runs: vec![AutopilotRunRow {
+                id: "run-x".into(),
+                autopilot_id: "ap-1".into(),
+                started_at: 1_700_000_000_000,
+                completed_at: Some(1_700_000_000_000),
+                status: "skipped".into(),
+                source: "api".into(),
+                failure_reason: Some("concurrency limit: 1/1 in flight".into()),
+            }],
+        },
+    )
+    .state;
+
+    let mut buf = WireBuffer::new(120, 14);
+    render_autopilots(&mut buf, 120, 0, 14, &loaded);
+    let full = glyph_map(&buf, 120);
+
+    assert!(full.contains("skipped"), "status missing:\n{full}");
+    assert!(
+        full.contains("api"),
+        "the trigger that fired the run must be visible:\n{full}"
+    );
+    assert!(
+        full.contains("concurrency limit"),
+        "the admission reason must be visible:\n{full}"
+    );
+}
+
+/// An armed `api` trigger is visible on the autopilot card, next to the
+/// enabled/disabled state — it is a second way the autopilot can fire.
+#[test]
+fn board_card_shows_the_armed_api_trigger() {
+    let mut armed = autopilot("ap-1", "daily-triage", "0 9 * * *", true, Some("completed"));
+    armed.api_trigger_enabled = true;
+    let unarmed = autopilot(
+        "ap-2",
+        "nightly-clean",
+        "0 3 * * *",
+        true,
+        Some("completed"),
+    );
+
+    let state = AutopilotsState::new(vec![armed, unarmed]);
+    let columns = state.board_columns();
+    let cards = &columns[0].cards;
+
+    assert!(
+        cards[0].title.contains("api"),
+        "an armed api trigger must show on the card: {}",
+        cards[0].title
+    );
+    assert!(
+        !cards[1].title.contains("api"),
+        "an unarmed one must not: {}",
+        cards[1].title
     );
 }

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -4319,14 +4319,16 @@ Create and control cron-scheduled autopilots
 Usage: ainb hangar autopilot [OPTIONS] <COMMAND>
 
 Commands:
-  create      Create a cron-scheduled autopilot (rejects an invalid cron expression)
-  list        List the workspace's autopilots (cron, next tick, last run, enabled)
-  disable     Disable an autopilot so the scheduler stops firing it
-  enable      Re-enable an autopilot, recomputing its next tick from now
-  run         Fire one tick immediately (manual run), bypassing the schedule
-  webhook     Configure the HTTP webhook trigger (enable/disable, rotate secret, filter)
-  deliveries  List the autopilot's recent webhook deliveries (audit log)
-  help        Print this message or the help of the given subcommand(s)
+  create       Create a cron-scheduled autopilot (rejects an invalid cron expression)
+  list         List the workspace's autopilots (cron, next tick, last run, enabled)
+  disable      Disable an autopilot so the scheduler stops firing it
+  enable       Re-enable an autopilot, recomputing its next tick from now
+  run          Fire one tick immediately, bypassing the schedule (`--source` picks the trigger recorded on the run: `manual` by default, or `api`)
+  api-trigger  Arm (or `--disable`) the bare programmatic `api` trigger
+  runs         List the autopilot's recent runs (status, trigger source, reason)
+  webhook      Configure the HTTP webhook trigger (enable/disable, rotate secret, filter)
+  deliveries   List the autopilot's recent webhook deliveries (audit log)
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -4423,6 +4425,7 @@ Arguments:
   <ID>  The autopilot id (`autopilot.id`)
 
 Options:
+      --disable                Turn the trigger OFF instead of on (`api-trigger` only)
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
   -h, --help                   Print help
@@ -4442,6 +4445,7 @@ Arguments:
   <ID>  The autopilot id (`autopilot.id`)
 
 Options:
+      --disable                Turn the trigger OFF instead of on (`api-trigger` only)
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
   -h, --help                   Print help
@@ -4449,19 +4453,77 @@ Options:
 
 #### `ainb hangar autopilot run`
 
-Fire one tick immediately (manual run), bypassing the schedule
+Fire one tick immediately, bypassing the schedule (`--source` picks the trigger recorded on the run: `manual` by default, or `api`)
 
 ```console
 $ ainb hangar autopilot run --help
-Fire one tick immediately (manual run), bypassing the schedule
+Fire one tick immediately, bypassing the schedule (`--source` picks the trigger recorded on the run: `manual` by default, or `api`)
 
 Usage: ainb hangar autopilot run [OPTIONS] <ID>
+
+Arguments:
+  <ID>
+          The autopilot id (`autopilot.id`)
+
+Options:
+      --format <format>
+          Output format
+          
+          [default: text]
+          [possible values: text, json, csv, markdown]
+
+      --source <SOURCE>
+          Which trigger to record on the run (`manual` | `api`)
+
+          Possible values:
+          - manual: An operator firing by hand (the default)
+          - api:    The bare programmatic `api` trigger; requires it to be armed
+          
+          [default: manual]
+
+      --workspace <WORKSPACE>
+          Workspace slug the autopilot belongs to. Defaults to `default`
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+#### `ainb hangar autopilot api-trigger`
+
+Arm (or `--disable`) the bare programmatic `api` trigger
+
+```console
+$ ainb hangar autopilot api-trigger --help
+Arm (or `--disable`) the bare programmatic `api` trigger
+
+Usage: ainb hangar autopilot api-trigger [OPTIONS] <ID>
+
+Arguments:
+  <ID>  The autopilot id (`autopilot.id`)
+
+Options:
+      --disable                Turn the trigger OFF instead of on (`api-trigger` only)
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
+  -h, --help                   Print help
+```
+
+#### `ainb hangar autopilot runs`
+
+List the autopilot's recent runs (status, trigger source, reason)
+
+```console
+$ ainb hangar autopilot runs --help
+List the autopilot's recent runs (status, trigger source, reason)
+
+Usage: ainb hangar autopilot runs [OPTIONS] <ID>
 
 Arguments:
   <ID>  The autopilot id (`autopilot.id`)
 
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --limit <LIMIT>          Maximum number of runs to show (latest-first) [default: 20]
       --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
   -h, --help                   Print help
 ```


### PR DESCRIPTION
Multica parity item 15: the bare programmatic `api` autopilot trigger, and
`skipped` as a first-class terminal run status.

## What was missing on main

- No `api` trigger anywhere. Hangar's trigger surfaces were cron (`autopilot.cron_expr`
  + the scheduler) and the webhook columns (migration 0018), plus the manual
  `autopilot_fire_now`.
- `skipped` was **not persistable**: migration 0009 constrains
  `autopilot_run.status` to `('running','completed','failed','cancelled')`. A skip
  was an EVENT only — the scheduler emitted `TickSkipped` and wrote no row, so a
  declined dispatch was invisible to every read path. Tests asserted that absence
  explicitly.
- `autopilot_run` had no `source` column, so even a fired run could not say which
  trigger fired it.

## What this PR does

**Migration 0057** (next free number, re-verified against every in-flight parity
branch at cut time):

- `autopilot.api_trigger_enabled` — a plain `ADD COLUMN` defaulting to 0, mirroring
  `webhook_enabled` exactly: half-configured means un-firable.
- `autopilot_run` gains `skipped` in its status CHECK, plus `source`
  (`schedule|manual|webhook|api`) and `failure_reason`.

SQLite cannot widen a CHECK in place, so the second half is a **table rebuild**
under a live inbound foreign key (`agent_task_queue.autopilot_run_id`, and
`PRAGMA foreign_keys` is ON in this crate). The naive create-new / copy / drop /
RENAME sequence COMMITs with `FOREIGN KEY constraint failed` — the deferred
violation counter incremented by `DROP TABLE`'s implicit delete is never
decremented. The migration uses `defer_foreign_keys` + copy → drop → recreate
under the real name → re-insert, so the counter returns to zero. Pre-existing rows
backfill to `source='schedule'` (the only unattended path that existed); manual /
webhook history is **not** retroactively re-attributed. The index dropped with the
table is recreated.

**A shared admission gate.** `dispatch_with_admission` in the store now holds the
policy branch that used to live in `scheduler.rs::fire_or_skip` — count in flight,
apply `skip`/`queue`/`replace`, fire or record. Every trigger surface (cron, manual
fire-now, webhook, api) goes through it, so the new path cannot drift from the
tested one. The scheduler keeps only what is its own job: the events it publishes
and the reschedule. **The only behavioural change for the schedule path is that the
`skip` branch now also writes a row** — it still enqueues no work.

`record_skipped_run` stamps `completed_at` as well as `started_at`. That is
load-bearing: `count_in_flight` filters `completed_at IS NULL`, so an open skip
would inflate the in-flight count and wedge the autopilot at its limit forever.

**Surfaces.** Two new RPCs (`hangar/autopilot_trigger_api`,
`hangar/autopilot_set_api_trigger`), append-only serde-default wire fields on
`AutopilotRow`/`AutopilotRunRow`, three CLI verbs
(`autopilot api-trigger`, `autopilot run --source manual|api`,
`autopilot runs`), and the plugin's history line + card badge.

`autopilot fire_now` (the operator's manual override) now stamps `source='manual'`
rather than `schedule` — honest provenance for an existing path, no behaviour change.

## Deliberately not ported

Multica's separate `autopilot_trigger` table (hangar collapses trigger config into
columns on `autopilot`, exactly as 0018 did for webhook) and its
`pending`/`issue_created` intermediate statuses (hangar's fire path is a single
transaction).

## Acceptance proof (real binary, real sqlite)

```
$ ainb hangar autopilot run $AP --source api
Error: api trigger not enabled for autopilot 01KYG... — run `ainb hangar autopilot api-trigger 01KYG...`
$ ainb hangar autopilot api-trigger $AP
enabled api trigger for autopilot 01KYG...
$ ainb hangar autopilot run $AP --source api
fired autopilot 01KYG... → run 01KYG... task 01KYG...
$ ainb hangar autopilot run $AP --source api
skipped autopilot 01KYG... → run 01KYG... (concurrency limit: 1/1 in flight)

$ sqlite3 hangar.db "SELECT status, source, failure_reason FROM autopilot_run ORDER BY started_at;"
running|api|
skipped|api|concurrency limit: 1/1 in flight
$ sqlite3 hangar.db "SELECT api_trigger_enabled FROM autopilot WHERE id='$AP';"
1
```

## Tests

Behavioral, fail-before/pass-after:

- `ainb-hangar-store::migration_0057_upgrade` — the rebuild on a POPULATED db with
  a live child FK: rows survive, `PRAGMA foreign_key_check` is empty, the index is
  back, the CHECK is widened (accepts `skipped`/`api`) and still rejects junk. The
  test asserts the pre-condition (`skipped` rejected today) before applying.
- `ainb-hangar-store::repo_autopilot_api_trigger` — 8 tests over real sqlite:
  terminal skip that does not block the next fire; skip/queue/replace at the limit;
  source stamping; workspace scoping of the arm.
- `ainb-hangar-daemon::rpc_autopilot_api_trigger` — the whole contract over a real
  framed UnixStream (disabled → arm → fire → skip → foreign id).
- `ainb::hangar_autopilot_cli` — the acceptance transcript through the real binary.
- Proto roundtrip incl. an explicit **backwards-compat** case: a pre-0057
  `AutopilotRow`/`AutopilotRunRow` JSON still deserialises via the serde defaults.
- Existing skip tests updated from "skip writes nothing" to the invariant that
  actually matters, "skip enqueues no work", plus a positive assertion on the
  recorded row. The queue/replace cases pass **unmodified** — the proof the lift
  was behaviour-preserving.
- One brittle whole-string assertion in `tripwire_migrations_apply` on the 0009
  status CHECK was made per-token, so widening the constraint no longer red-gates
  unrelated PRs.

## Local gate

All green in the worktree:

- `cargo build -p ainb`
- `cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'` → **4177 passed, 0 failed**
- `scripts/hangar/run_all_tripwires.sh` → **ran=63 failed=0**
- `scripts/hangar/run_acceptance_tests.sh` → **ran=162 failed=0**
- `cargo clippy` on the four changed crates: no new warnings (the remaining ones
  are pre-existing in files this PR does not touch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional API-triggered autopilot runs, with commands to arm, disarm, and trigger them.
  * Added autopilot run-history listings showing trigger source and skip reasons.
  * Added API-trigger status indicators to autopilot views and run-history details.
* **Bug Fixes**
  * Concurrency-limited runs are now clearly recorded as skipped with timestamps and reasons.
  * Unified scheduling and manual/API triggering behavior for consistent concurrency handling.
* **Documentation**
  * Updated scheduler behavior documentation to describe shared admission controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->