### PR TITLE
feat(hangar): agent custom_env redaction contract (multica parity #30)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -463,6 +463,23 @@ pub enum AgentCommand {
     Allow(AgentAllowArgs),
     /// Report whether a user (or agent actor) may invoke an agent (`ALLOW`/`DENY`).
     CanInvoke(AgentCanInvokeArgs),
+    /// Show an agent's per-agent env: variable NAMES only, values masked.
+    Env(AgentEnvArgs),
+}
+
+/// Arguments for `hangar agent env` — the REDACTED read of one agent's env.
+///
+/// Deliberately has no `--reveal` (parity #30 deviation D-1): hangar masks
+/// unconditionally, so there is exactly one plaintext egress (the provider
+/// child's environment at exec) and no CLI affordance that re-opens the hole.
+#[derive(Args, Debug)]
+pub struct AgentEnvArgs {
+    /// Agent id (ULID) to inspect.
+    pub id: String,
+    /// Workspace slug the agent belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// Arguments for `hangar agent permission`.
@@ -632,8 +649,21 @@ pub struct AgentEditArgs {
     pub clear_thinking: bool,
     /// A `KEY=VALUE` env var for the agent (repeatable). When ANY `--env` is
     /// given the whole env map is REPLACED with the values.
-    #[arg(long = "env", value_parser = parse_env_kv, action = clap::ArgAction::Append)]
+    ///
+    /// **Secrets on argv are visible in `ps` / `/proc/<pid>/cmdline` / shell
+    /// history** — prefer `--env-stdin` or `--env-file` for secret material.
+    #[arg(long = "env", value_parser = parse_env_kv, action = clap::ArgAction::Append,
+          conflicts_with_all = ["env_stdin", "env_file"])]
     pub env: Vec<(String, String)>,
+    /// Read the whole env map as a JSON object of string→string from STDIN
+    /// (`{"SECRET_TOKEN":"sk-live-…"}`). Exists to keep secret material off
+    /// argv; `{}` clears the map, and empty input is an ERROR, not a clear.
+    #[arg(long = "env-stdin", conflicts_with_all = ["env", "env_file"])]
+    pub env_stdin: bool,
+    /// Read the whole env map as a JSON object of string→string from a FILE.
+    /// Same contract as `--env-stdin`.
+    #[arg(long = "env-file", conflicts_with_all = ["env", "env_stdin"])]
+    pub env_file: Option<std::path::PathBuf>,
     /// New token budget (rtk/headroom, migration 0042); omitted leaves it.
     /// Mutually exclusive with `--clear-token-budget`.
     #[arg(long = "token-budget", conflicts_with = "clear_token_budget")]
@@ -964,14 +994,48 @@ pub struct SquadAssignArgs {
 ///
 /// # Errors
 ///
-/// Returns a human-readable message if the input has no `=` or an empty key.
+/// Returns a CONTENT-FREE message if the input has no `=` or an empty key.
+/// The message deliberately never echoes `raw` (parity #30, multica
+/// `cmd_agent.go:757-759`): the whole point of `--env` is that the argument
+/// carries a secret, and clap prints a `value_parser` error to stderr, which
+/// lands in shell logs and CI transcripts.
 fn parse_env_kv(raw: &str) -> Result<(String, String), String> {
     let (key, value) =
-        raw.split_once('=').ok_or_else(|| format!("expected KEY=VALUE, got {raw:?}"))?;
+        raw.split_once('=').ok_or_else(|| "--env: expected KEY=VALUE".to_string())?;
     if key.is_empty() {
-        return Err(format!("env var name must not be empty in {raw:?}"));
+        return Err("--env: env var name must not be empty".to_string());
     }
     Ok((key.to_string(), value.to_string()))
+}
+
+/// Decode a JSON-object-of-strings env payload from `--env-file` / `--env-stdin`.
+///
+/// Ported shape-for-shape from multica's `resolveCustomEnv`
+/// (`server/cmd/multica/cmd_agent.go:788-852`):
+///
+/// * empty / whitespace-only input is an **error**, never a clear — an empty
+///   read almost always means a broken upstream pipe, and treating it as a clear
+///   would silently wipe the agent's secrets;
+/// * the explicit `{}` is the only clear;
+/// * a parse failure is CONTENT-FREE — `serde_json`'s message quotes fragments
+///   of the input, which here IS the secret.
+///
+/// # Errors
+///
+/// Returns a value-free message when the payload is blank or is not a JSON
+/// object of string keys to string values.
+fn parse_env_json(raw: &str, flag: &str) -> Result<Vec<(String, String)>, String> {
+    if raw.trim().is_empty() {
+        return Err(format!("{flag}: empty input; pass '{{}}' to clear the env"));
+    }
+    let shape = format!("{flag} must be a valid JSON object of string keys and string values");
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|_| shape.clone())?;
+    let obj = value.as_object().ok_or_else(|| shape.clone())?;
+    obj.iter()
+        .map(|(k, v)| {
+            v.as_str().map(|s| (k.clone(), s.to_string())).ok_or_else(|| shape.clone())
+        })
+        .collect()
 }
 
 /// `hangar templates <verb>`.
@@ -2382,6 +2446,7 @@ async fn dispatch_agent(cmd: AgentCommand, format: OutputFormat) -> Result<()> {
         AgentCommand::Permission(args) => run_agent_permission(&store, args).await,
         AgentCommand::Allow(args) => run_agent_allow(&store, args).await,
         AgentCommand::CanInvoke(args) => run_agent_can_invoke(&store, args).await,
+        AgentCommand::Env(args) => run_agent_env(&store, args, format).await,
     }
 }
 
@@ -2645,6 +2710,92 @@ async fn run_agent_list(store: &Store, args: AgentListArgs, format: OutputFormat
     Ok(())
 }
 
+/// Resolve which of the three mutually-exclusive env write channels was used,
+/// returning `None` when none was (leave the map unchanged).
+///
+/// `--env` is the argv channel (convenient, but the value lands in `ps` and
+/// shell history); `--env-stdin` / `--env-file` are the SECRET channels multica
+/// added for exactly that reason (`cmd_agent.go:788-852`). Clap already bars
+/// combining them, so at most one arm can fire.
+///
+/// # Errors
+///
+/// Returns a value-free error when the JSON payload is blank or malformed, or
+/// when the file cannot be read.
+fn resolve_agent_env_write(args: &AgentEditArgs) -> Result<Option<Vec<(String, String)>>> {
+    if !args.env.is_empty() {
+        return Ok(Some(args.env.clone()));
+    }
+    if args.env_stdin {
+        use std::io::Read as _;
+        let mut raw = String::new();
+        std::io::stdin().read_to_string(&mut raw).context("read --env-stdin")?;
+        return parse_env_json(&raw, "--env-stdin").map(Some).map_err(|e| anyhow::anyhow!(e));
+    }
+    if let Some(path) = args.env_file.as_deref() {
+        // The read error names the PATH, never the contents.
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("read --env-file {}", path.display()))?;
+        return parse_env_json(&raw, "--env-file").map(Some).map_err(|e| anyhow::anyhow!(e));
+    }
+    Ok(None)
+}
+
+/// `hangar agent env <id>`: print one agent's env with every VALUE masked.
+///
+/// The redacted-GET parity (multica `ListAgents`/`GetAgent` + `redactEnv`).
+/// There is no plaintext mode — see [`AgentEnvArgs`].
+///
+/// # Errors
+///
+/// Returns an error when the workspace cannot be resolved, the store read
+/// fails, or no agent with that id exists in the workspace.
+async fn run_agent_env(store: &Store, args: AgentEnvArgs, format: OutputFormat) -> Result<()> {
+    use ainb_hangar_store::repo::agent::AgentRepo;
+
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let agent = AgentRepo::get(store.pool(), &args.id)
+        .await
+        .context("read agent")?
+        .filter(|a| a.workspace_id == workspace_id)
+        .ok_or_else(|| anyhow::anyhow!("no agent {} in this workspace", args.id))?;
+
+    let redacted = agent.agent_env.redacted_pairs();
+    match format {
+        OutputFormat::Json => {
+            let body = redacted
+                .iter()
+                .map(|(k, mask)| format!("{}:{}", json_string(k), json_string(mask)))
+                .collect::<Vec<_>>()
+                .join(",");
+            println!(
+                "{{\"env\":{{{body}}},\"env_key_count\":{},\"env_redacted\":{}}}",
+                redacted.len(),
+                !redacted.is_empty()
+            );
+        }
+        OutputFormat::Csv => {
+            println!("key,value");
+            for (k, mask) in &redacted {
+                println!("{k},{mask}");
+            }
+        }
+        OutputFormat::Markdown => {
+            println!("| key | value |\n| --- | --- |");
+            for (k, mask) in &redacted {
+                println!("| {} | {mask} |", md_cell(k));
+            }
+        }
+        OutputFormat::Text => {
+            for (k, mask) in &redacted {
+                println!("{k}={mask}");
+            }
+            println!("{} keys (values hidden)", redacted.len());
+        }
+    }
+    Ok(())
+}
+
 /// `hangar agent edit`: map the present flags onto an [`AgentConfigUpdate`] and
 /// drive the workspace-scoped edit. An empty edit (no field flag) is rejected;
 /// an agent id outside the workspace is reported as a not-found error.
@@ -2653,6 +2804,11 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
 
     let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
 
+    // `--env` / `--env-stdin` / `--env-file` are mutually exclusive at the clap
+    // layer; whichever is present REPLACES the whole map (parity #30). Resolved
+    // FIRST because it borrows `args` whole (the reads below move out of it).
+    let agent_env = resolve_agent_env_write(&args)?
+        .map(ainb_hangar_core::agent_env::AgentEnv::from_pairs);
     // Each nullable text field uses its clear-flag to distinguish "clear to none"
     // from "leave unchanged" (a clap conflict already bars setting both).
     let instructions = clear_or_set(args.clear_instructions, args.instructions);
@@ -2662,7 +2818,6 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
     // `--arg` / `--env` REPLACE the list when any value is given (an empty Vec
     // means "no flag passed" → leave unchanged).
     let cli_args = (!args.args.is_empty()).then_some(args.args);
-    let agent_env = (!args.env.is_empty()).then_some(args.env);
 
     let token_budget = clear_or_set(args.clear_token_budget, args.token_budget);
     // Migration 0050: `description` is NOT NULL so it has no clear-flag (`""` IS
@@ -2689,7 +2844,8 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
         anyhow::bail!(
             "nothing to update: pass at least one of --name / --instructions / --clear-instructions \
              / --model / --clear-model / --arg / --mcp / --clear-mcp / --thinking / --clear-thinking \
-             / --env / --token-budget / --clear-token-budget / --description / --avatar / \
+             / --env / --env-stdin / --env-file / --token-budget / --clear-token-budget / \
+             --description / --avatar / \
              --clear-avatar / --service-tier / --clear-service-tier"
         );
     }
@@ -6453,14 +6609,18 @@ fn agent_to_json(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         |actor| json_string(&actor.to_string()),
     );
     let args = json_string_array(a.cli_args.iter().map(String::as_str));
+    // Parity #30 / multica `redactEnv` (`agent.go:552-562`): KEYS are preserved,
+    // every VALUE becomes the `****` mask, and `env_redacted` says so. This used
+    // to print `"env":{"SECRET_TOKEN":"sk-live-…"}` — full plaintext on stdout.
     let env = a
         .agent_env
-        .iter()
-        .map(|(k, v)| format!("{}:{}", json_string(k), json_string(v)))
+        .redacted_pairs()
+        .into_iter()
+        .map(|(k, mask)| format!("{}:{}", json_string(k), json_string(mask)))
         .collect::<Vec<_>>()
         .join(",");
     format!(
-        "{{\"id\":{},\"name\":{},\"archived\":{},\"archived_at\":{},\"archived_by\":{},\"model\":{},\"thinking\":{},\"args\":{},\"env\":{{{}}},\"description\":{}}}",
+        "{{\"id\":{},\"name\":{},\"archived\":{},\"archived_at\":{},\"archived_by\":{},\"model\":{},\"thinking\":{},\"args\":{},\"env\":{{{}}},\"env_key_count\":{},\"env_redacted\":{},\"description\":{}}}",
         json_string(a.id.as_str()),
         json_string(a.name.as_str()),
         a.archived,
@@ -6470,6 +6630,8 @@ fn agent_to_json(a: &ainb_hangar_store::repo::agent::Agent) -> String {
         thinking,
         args,
         env,
+        a.agent_env.len(),
+        !a.agent_env.is_empty(),
         json_string(a.description.as_str()),
     )
 }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1032,9 +1032,7 @@ fn parse_env_json(raw: &str, flag: &str) -> Result<Vec<(String, String)>, String
     let value: serde_json::Value = serde_json::from_str(raw).map_err(|_| shape.clone())?;
     let obj = value.as_object().ok_or_else(|| shape.clone())?;
     obj.iter()
-        .map(|(k, v)| {
-            v.as_str().map(|s| (k.clone(), s.to_string())).ok_or_else(|| shape.clone())
-        })
+        .map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())).ok_or_else(|| shape.clone()))
         .collect()
 }
 
@@ -2807,8 +2805,8 @@ async fn run_agent_edit(store: &Store, args: AgentEditArgs) -> Result<()> {
     // `--env` / `--env-stdin` / `--env-file` are mutually exclusive at the clap
     // layer; whichever is present REPLACES the whole map (parity #30). Resolved
     // FIRST because it borrows `args` whole (the reads below move out of it).
-    let agent_env = resolve_agent_env_write(&args)?
-        .map(ainb_hangar_core::agent_env::AgentEnv::from_pairs);
+    let agent_env =
+        resolve_agent_env_write(&args)?.map(ainb_hangar_core::agent_env::AgentEnv::from_pairs);
     // Each nullable text field uses its clear-flag to distinguish "clear to none"
     // from "leave unchanged" (a clap conflict already bars setting both).
     let instructions = clear_or_set(args.clear_instructions, args.instructions);
@@ -7204,7 +7202,10 @@ mod tests {
     #[test]
     fn agent_json_masks_env_values() {
         let out = agent_to_json(&agent_with_secret_env());
-        assert!(!out.contains(ENV_SECRET), "agent JSON leaked the env value: {out}");
+        assert!(
+            !out.contains(ENV_SECRET),
+            "agent JSON leaked the env value: {out}"
+        );
         assert!(out.contains(r#""SECRET_TOKEN":"****""#), "{out}");
         assert!(out.contains(r#""env_key_count":1"#), "{out}");
         assert!(out.contains(r#""env_redacted":true"#), "{out}");
@@ -7224,10 +7225,15 @@ mod tests {
     #[test]
     fn parse_env_kv_error_never_echoes_the_value() {
         let no_eq = parse_env_kv(ENV_SECRET).expect_err("missing '=' must error");
-        assert!(!no_eq.contains(ENV_SECRET), "error echoed the value: {no_eq}");
-        let empty_key =
-            parse_env_kv(&format!("={ENV_SECRET}")).expect_err("empty key must error");
-        assert!(!empty_key.contains("sk-live-"), "error echoed the value: {empty_key}");
+        assert!(
+            !no_eq.contains(ENV_SECRET),
+            "error echoed the value: {no_eq}"
+        );
+        let empty_key = parse_env_kv(&format!("={ENV_SECRET}")).expect_err("empty key must error");
+        assert!(
+            !empty_key.contains("sk-live-"),
+            "error echoed the value: {empty_key}"
+        );
     }
 
     /// Clap must refuse any two of the three env write channels together, so a
@@ -7257,10 +7263,16 @@ mod tests {
     fn env_file_empty_is_an_error_but_brace_brace_clears() {
         let err = parse_env_json("   \n ", "--env-file").expect_err("blank input must error");
         assert!(err.contains("pass '{}' to clear"), "{err}");
-        assert_eq!(parse_env_json("{}", "--env-file").expect("{} clears"), Vec::new());
         assert_eq!(
-            parse_env_json(&format!(r#"{{"SECRET_TOKEN":"{ENV_SECRET}"}}"#), "--env-file")
-                .expect("valid object"),
+            parse_env_json("{}", "--env-file").expect("{} clears"),
+            Vec::new()
+        );
+        assert_eq!(
+            parse_env_json(
+                &format!(r#"{{"SECRET_TOKEN":"{ENV_SECRET}"}}"#),
+                "--env-file"
+            )
+            .expect("valid object"),
             vec![("SECRET_TOKEN".to_string(), ENV_SECRET.to_string())]
         );
     }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7182,6 +7182,119 @@ mod tests {
         HangarCommand::from_arg_matches(sub).expect("extract HangarCommand")
     }
 
+    // ──────────────────────────────────────────────────────────────────
+    // Parity #30 — the per-agent env redaction contract at the CLI boundary.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// The canary. Any appearance of this literal in rendered output is a leak.
+    const ENV_SECRET: &str = "sk-live-DEADBEEF01";
+
+    /// An agent row carrying one secret env var.
+    fn agent_with_secret_env() -> ainb_hangar_store::repo::agent::Agent {
+        ainb_hangar_store::repo::agent::Agent {
+            id: "agent-1".to_string(),
+            name: "secretive".to_string(),
+            agent_env: vec![("SECRET_TOKEN".to_string(), ENV_SECRET.to_string())].into(),
+            ..ainb_hangar_store::repo::agent::Agent::default()
+        }
+    }
+
+    /// `hangar agent list --format json` used to print `"env":{"K":"<plaintext>"}`.
+    /// Multica's contract is keep-keys / mask-values plus a `redacted` flag.
+    #[test]
+    fn agent_json_masks_env_values() {
+        let out = agent_to_json(&agent_with_secret_env());
+        assert!(!out.contains(ENV_SECRET), "agent JSON leaked the env value: {out}");
+        assert!(out.contains(r#""SECRET_TOKEN":"****""#), "{out}");
+        assert!(out.contains(r#""env_key_count":1"#), "{out}");
+        assert!(out.contains(r#""env_redacted":true"#), "{out}");
+    }
+
+    /// An env-less agent reports the honest zero/false, not a redacted-looking
+    /// empty map with `env_redacted: true`.
+    #[test]
+    fn agent_json_env_less_agent_is_not_marked_redacted() {
+        let out = agent_to_json(&ainb_hangar_store::repo::agent::Agent::default());
+        assert!(out.contains(r#""env_key_count":0"#), "{out}");
+        assert!(out.contains(r#""env_redacted":false"#), "{out}");
+    }
+
+    /// A malformed `--env` used to echo the WHOLE raw argument (the secret) into
+    /// stderr via clap's `value_parser` error.
+    #[test]
+    fn parse_env_kv_error_never_echoes_the_value() {
+        let no_eq = parse_env_kv(ENV_SECRET).expect_err("missing '=' must error");
+        assert!(!no_eq.contains(ENV_SECRET), "error echoed the value: {no_eq}");
+        let empty_key =
+            parse_env_kv(&format!("={ENV_SECRET}")).expect_err("empty key must error");
+        assert!(!empty_key.contains("sk-live-"), "error echoed the value: {empty_key}");
+    }
+
+    /// Clap must refuse any two of the three env write channels together, so a
+    /// secret-bearing file can never be silently overridden by an argv value.
+    #[test]
+    fn env_file_and_env_stdin_and_env_are_mutually_exclusive() {
+        let registry = CommandRegistry::built_ins();
+        for extra in [
+            vec!["--env", "A=b", "--env-stdin"],
+            vec!["--env", "A=b", "--env-file", "/tmp/e.json"],
+            vec!["--env-stdin", "--env-file", "/tmp/e.json"],
+        ] {
+            let mut argv = vec!["ainb", "hangar", "agent", "edit", "agent-1"];
+            argv.extend(extra.iter().copied());
+            let app = registry.build_clap(crate::cli::root_clap_command());
+            assert!(
+                app.try_get_matches_from(&argv).is_err(),
+                "clap accepted mutually exclusive env channels: {argv:?}"
+            );
+        }
+    }
+
+    /// Multica's empty-input rule (`cmd_agent.go:750-762`): a blank payload is an
+    /// ERROR (it almost always means a broken upstream pipe, and treating it as a
+    /// clear silently wipes secrets); only the explicit `{}` clears.
+    #[test]
+    fn env_file_empty_is_an_error_but_brace_brace_clears() {
+        let err = parse_env_json("   \n ", "--env-file").expect_err("blank input must error");
+        assert!(err.contains("pass '{}' to clear"), "{err}");
+        assert_eq!(parse_env_json("{}", "--env-file").expect("{} clears"), Vec::new());
+        assert_eq!(
+            parse_env_json(&format!(r#"{{"SECRET_TOKEN":"{ENV_SECRET}"}}"#), "--env-file")
+                .expect("valid object"),
+            vec![("SECRET_TOKEN".to_string(), ENV_SECRET.to_string())]
+        );
+    }
+
+    /// A JSON parse failure must not reflect the payload back — `serde_json`
+    /// messages quote the offending scalar, which here IS the secret.
+    #[test]
+    fn env_json_parse_error_never_echoes_the_payload() {
+        let err = parse_env_json(&format!(r#"{{"K":"{ENV_SECRET}"#), "--env-stdin")
+            .expect_err("truncated JSON must error");
+        assert!(!err.contains("sk-live-"), "{err}");
+        let err = parse_env_json(r#"{"K":31337}"#, "--env-stdin")
+            .expect_err("non-string value must error");
+        assert!(!err.contains("31337"), "{err}");
+    }
+
+    /// The redacted read verb parses, and carries NO `--reveal` (deviation D-1).
+    #[test]
+    fn parses_agent_env_verb_and_has_no_reveal_flag() {
+        let cmd = parse_hangar(&["ainb", "hangar", "agent", "env", "agent-1"]);
+        let HangarCommand::Agent(AgentCommand::Env(args)) = cmd else {
+            panic!("expected agent env, got {cmd:?}");
+        };
+        assert_eq!(args.id, "agent-1");
+
+        let registry = CommandRegistry::built_ins();
+        let app = registry.build_clap(crate::cli::root_clap_command());
+        assert!(
+            app.try_get_matches_from(["ainb", "hangar", "agent", "env", "agent-1", "--reveal"])
+                .is_err(),
+            "there must be no plaintext escape hatch on the CLI"
+        );
+    }
+
     #[test]
     fn parses_issue_create_with_title_and_description() {
         let cmd = parse_hangar(&[

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -647,21 +647,17 @@ pub struct AgentEditArgs {
     /// Clear the thinking level; omitted leaves it.
     #[arg(long = "clear-thinking")]
     pub clear_thinking: bool,
-    /// A `KEY=VALUE` env var for the agent (repeatable). When ANY `--env` is
-    /// given the whole env map is REPLACED with the values.
-    ///
-    /// **Secrets on argv are visible in `ps` / `/proc/<pid>/cmdline` / shell
-    /// history** — prefer `--env-stdin` or `--env-file` for secret material.
+    // NOTE: each of the three env flags keeps a SINGLE-paragraph doc comment on
+    // purpose — a second paragraph flips clap's whole `agent edit` help into the
+    // long-help layout, which churns the generated `docs/tui/cli.md` reference.
+    /// A `KEY=VALUE` env var for the agent (repeatable; ANY `--env` REPLACES the whole map). Visible in `ps` / shell history — prefer `--env-stdin` / `--env-file` for secrets.
     #[arg(long = "env", value_parser = parse_env_kv, action = clap::ArgAction::Append,
           conflicts_with_all = ["env_stdin", "env_file"])]
     pub env: Vec<(String, String)>,
-    /// Read the whole env map as a JSON object of string→string from STDIN
-    /// (`{"SECRET_TOKEN":"sk-live-…"}`). Exists to keep secret material off
-    /// argv; `{}` clears the map, and empty input is an ERROR, not a clear.
+    /// Read the whole env map from STDIN as a JSON object of string→string, keeping secrets off argv; `{}` clears it and empty input is an ERROR, not a clear
     #[arg(long = "env-stdin", conflicts_with_all = ["env", "env_file"])]
     pub env_stdin: bool,
-    /// Read the whole env map as a JSON object of string→string from a FILE.
-    /// Same contract as `--env-stdin`.
+    /// Read the whole env map from a FILE as a JSON object of string→string (same contract as `--env-stdin`)
     #[arg(long = "env-file", conflicts_with_all = ["env", "env_stdin"])]
     pub env_file: Option<std::path::PathBuf>,
     /// New token budget (rtk/headroom, migration 0042); omitted leaves it.

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -496,9 +496,33 @@ fn agent_edit_and_archive_round_trip() {
         shown.contains("\"thinking\":\"high\""),
         "thinking not persisted:\n{shown}"
     );
+    // Parity #30: the env is persisted but RENDERED REDACTED — the key survives,
+    // the value is masked, and the count/flag say so. The value's round-trip is
+    // proven at the store boundary (`repo_agent_env_redaction`), which is the
+    // only layer allowed to see it.
     assert!(
-        shown.contains("\"FOO\":\"bar\""),
-        "env not persisted:\n{shown}"
+        shown.contains("\"FOO\":\"****\""),
+        "env key not persisted (or the value leaked):\n{shown}"
+    );
+    assert!(
+        !shown.contains("\"bar\""),
+        "the env value must never be rendered:\n{shown}"
+    );
+    assert!(
+        shown.contains("\"env_key_count\":1") && shown.contains("\"env_redacted\":true"),
+        "the redaction metadata must accompany the masked map:\n{shown}"
+    );
+
+    // The dedicated redacted read verb agrees.
+    let (ok, env_out) = run(tmp.path(), &["hangar", "agent", "env", "agent-1"]);
+    assert!(ok, "agent env should exit 0; out={env_out}");
+    assert!(
+        env_out.contains("FOO=****"),
+        "agent env must mask the value:\n{env_out}"
+    );
+    assert!(
+        env_out.contains("1 keys (values hidden)"),
+        "agent env must report the count:\n{env_out}"
     );
 
     // Archive it: the active list no longer shows it.

--- a/ainb-tui/crates/ainb-hangar-core/src/agent_env.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/agent_env.rs
@@ -1,0 +1,323 @@
+//! Per-agent environment variables with a REDACT-BY-CONSTRUCTION contract
+//! (multica parity #30, `server/internal/handler/agent.go:552-562`).
+//!
+//! # The invariant
+//!
+//! > The plaintext of an [`AgentEnv`] leaves the process by exactly one route:
+//! > the environment of the provider child process, via
+//! > [`AgentEnv::expose_for_child_env`]. Every other route — `Debug`,
+//! > `Display`, `Serialize`, the RPC wire, the CLI renderers, the TUI, tracing
+//! > — is redacted by construction. Adding a new egress means calling
+//! > `expose_for_child_env`, which is grep-able and reviewable.
+//!
+//! The mask itself is multica's: **keys are preserved, every value becomes
+//! [`REDACTED_VALUE`]**, and the accompanying wire flag (multica's
+//! `custom_env_redacted`) says the caller is looking at a masked map.
+//!
+//! # Deviations from multica (deliberate)
+//!
+//! * **D-1 — hangar masks unconditionally.** Multica has a `canViewAgentEnv()`
+//!   owner/admin branch that serves PLAINTEXT to an authorised viewer. That is
+//!   a multi-tenant server concept; hangar is a local, single-user control
+//!   plane where the operator can already `sqlite3` the DB. A `--reveal`
+//!   affordance would re-open exactly the hole this type exists to close, so
+//!   there is none.
+//! * **D-2 — the authoritative `agent.agent_env` column keeps plaintext.** The
+//!   exec seam needs the value and there is no session key to encrypt with; the
+//!   DB lives under the operator's own account. What the redaction contract
+//!   buys is that *no other persisted artefact* (another table, the daemon log,
+//!   a per-task log dir, the interactive wrapper after teardown, any rendered
+//!   output) ever contains the value. A keychain-backed value-of-record is a
+//!   follow-up, out of scope here.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// The mask multica writes (`agent.go:558`). Byte-identical on purpose so a
+/// reader that knows multica's contract reads hangar's output unchanged.
+pub const REDACTED_VALUE: &str = "****";
+
+/// An agent's per-agent environment: plaintext INSIDE, redacted on every egress
+/// except [`AgentEnv::expose_for_child_env`].
+///
+/// Ordered key-value list rather than a map so the DB encoding is deterministic
+/// (this preserves the exact `0015_agent_archive_and_config.sql` column shape —
+/// a JSON object of string→string).
+///
+/// `Debug` / `Display` / `Serialize` are hand-written and all mask values.
+/// There is deliberately **no `Deserialize`**: `****` must never round-trip back
+/// into the DB. The write path uses [`AgentEnvInput`] instead.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct AgentEnv {
+    pairs: Vec<(String, String)>,
+}
+
+impl AgentEnv {
+    /// Build from an ordered key-value list (the DB / CLI / RPC write shape).
+    #[must_use]
+    pub const fn from_pairs(pairs: Vec<(String, String)>) -> Self {
+        Self { pairs }
+    }
+
+    /// `true` when the agent carries no per-agent env at all.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.pairs.is_empty()
+    }
+
+    /// How many variables are set (the only count any renderer needs).
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.pairs.len()
+    }
+
+    /// The variable NAMES, in stored order. Names are not secret — multica
+    /// ships them too — so this is the safe read for every UI.
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.pairs.iter().map(|(k, _)| k.as_str())
+    }
+
+    /// Multica's `redactEnv()` map: keys preserved, every value replaced with
+    /// [`REDACTED_VALUE`].
+    #[must_use]
+    pub fn redacted_pairs(&self) -> Vec<(&str, &'static str)> {
+        self.pairs.iter().map(|(k, _)| (k.as_str(), REDACTED_VALUE)).collect()
+    }
+
+    /// **The ONE plaintext escape.**
+    ///
+    /// The only call site permitted is the exec seam that builds a provider
+    /// child process's environment — grep this name in review; any other hit is
+    /// a leak.
+    #[must_use]
+    pub fn expose_for_child_env(self) -> Vec<(String, String)> {
+        self.pairs
+    }
+
+    /// Encode into the JSON-object text the `agent_env` column stores. An empty
+    /// env yields `"{}"` (the column default), matching the pre-`AgentEnv`
+    /// bytes exactly — this is why item 30 needs no migration.
+    #[must_use]
+    pub fn to_db_json(&self) -> String {
+        let map: serde_json::Map<String, serde_json::Value> = self
+            .pairs
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect();
+        serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Decode the `agent_env` column's JSON-object text, preserving the stored
+    /// object's key order.
+    ///
+    /// # Errors
+    ///
+    /// Returns a short, VALUE-FREE reason string when the cell is not a JSON
+    /// object of string→string. The message never echoes the offending input:
+    /// `serde_json` errors quote scalars, which for this column is the secret.
+    pub fn try_from_db_json(raw: &str) -> Result<Self, &'static str> {
+        let value: serde_json::Value =
+            serde_json::from_str(raw).map_err(|_| "stored env is not valid JSON")?;
+        let obj = value.as_object().ok_or("stored env is not a JSON object")?;
+        let pairs = obj
+            .iter()
+            .map(|(k, v)| {
+                v.as_str().map(|s| (k.clone(), s.to_string())).ok_or("env value is not a string")
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { pairs })
+    }
+
+    /// Lossy decode: a corrupt cell degrades to an empty env rather than taking
+    /// the caller down. Used where a broken row must not be fatal.
+    #[must_use]
+    pub fn from_db_json(raw: &str) -> Self {
+        Self::try_from_db_json(raw).unwrap_or_default()
+    }
+}
+
+impl From<Vec<(String, String)>> for AgentEnv {
+    fn from(pairs: Vec<(String, String)>) -> Self {
+        Self::from_pairs(pairs)
+    }
+}
+
+/// Redacted: `AgentEnv { SECRET_TOKEN: "****" }`. This is what structurally
+/// kills the `tracing::debug!(?dispatch)` / `anyhow` context / panic-message
+/// leak class — no reviewer vigilance required.
+impl fmt::Debug for AgentEnv {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut dbg = f.debug_struct("AgentEnv");
+        for key in self.keys() {
+            dbg.field(key, &REDACTED_VALUE);
+        }
+        dbg.finish()
+    }
+}
+
+/// Redacted: `2 keys (hidden)`.
+impl fmt::Display for AgentEnv {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} keys (hidden)", self.pairs.len())
+    }
+}
+
+/// Emits the REDACTED map, so an accidental `serde_json::to_*` of a row that
+/// embeds an `AgentEnv` is safe by construction.
+impl Serialize for AgentEnv {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap as _;
+        let mut map = serializer.serialize_map(Some(self.pairs.len()))?;
+        for key in self.keys() {
+            map.serialize_entry(key, REDACTED_VALUE)?;
+        }
+        map.end()
+    }
+}
+
+/// The WRITE-side carrier (RPC params, CLI flags).
+///
+/// Serialises PLAINTEXT — it is a PUT body, the value has to reach the daemon —
+/// but its `Debug` is redacted, so a params dump or an error context can't leak
+/// it. `#[serde(transparent)]` over `Vec<(String, String)>` keeps the EXISTING
+/// wire bytes (`"agent_env": [["FOO","bar"]]`): this is a pure type change with
+/// zero wire break.
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentEnvInput(Vec<(String, String)>);
+
+impl AgentEnvInput {
+    /// Build from an ordered key-value list.
+    #[must_use]
+    pub const fn from_pairs(pairs: Vec<(String, String)>) -> Self {
+        Self(pairs)
+    }
+
+    /// Promote a validated write into the redact-by-construction domain type.
+    #[must_use]
+    pub fn into_agent_env(self) -> AgentEnv {
+        AgentEnv::from_pairs(self.0)
+    }
+
+    /// Borrow the raw pairs (the CLI needs them to build the RPC body).
+    #[must_use]
+    pub fn as_pairs(&self) -> &[(String, String)] {
+        &self.0
+    }
+
+    /// `true` when the write carries no variables (an explicit CLEAR).
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// How many variables the write carries.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl From<Vec<(String, String)>> for AgentEnvInput {
+    fn from(pairs: Vec<(String, String)>) -> Self {
+        Self::from_pairs(pairs)
+    }
+}
+
+/// Redacted, exactly like [`AgentEnv`] — a `Debug` of the RPC params struct is
+/// a real leak vector (it lands in `INVALID_PARAMS` contexts and trace spans).
+impl fmt::Debug for AgentEnvInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut dbg = f.debug_struct("AgentEnvInput");
+        for (key, _) in &self.0 {
+            dbg.field(key, &REDACTED_VALUE);
+        }
+        dbg.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "sk-live-DEADBEEF01";
+
+    fn one() -> AgentEnv {
+        AgentEnv::from_pairs(vec![("SECRET_TOKEN".into(), SECRET.into())])
+    }
+
+    #[test]
+    fn debug_masks_values_and_keeps_keys() {
+        let rendered = format!("{:?}", one());
+        assert!(!rendered.contains(SECRET), "Debug leaked the value: {rendered}");
+        assert!(rendered.contains("SECRET_TOKEN"), "{rendered}");
+        assert!(rendered.contains(REDACTED_VALUE), "{rendered}");
+    }
+
+    #[test]
+    fn display_is_key_count() {
+        assert_eq!(one().to_string(), "1 keys (hidden)");
+        assert_eq!(AgentEnv::default().to_string(), "0 keys (hidden)");
+    }
+
+    #[test]
+    fn serialize_emits_the_mask() {
+        let out = serde_json::to_string(&one()).unwrap();
+        assert_eq!(out, r#"{"SECRET_TOKEN":"****"}"#);
+        assert!(!out.contains(SECRET));
+    }
+
+    #[test]
+    fn redacted_pairs_keep_keys_and_mask_values() {
+        assert_eq!(one().redacted_pairs(), vec![("SECRET_TOKEN", "****")]);
+    }
+
+    #[test]
+    fn exec_seam_is_the_one_plaintext_escape() {
+        assert_eq!(
+            one().expose_for_child_env(),
+            vec![("SECRET_TOKEN".to_string(), SECRET.to_string())]
+        );
+    }
+
+    #[test]
+    fn input_serialize_is_plaintext_and_wire_compatible() {
+        let input = AgentEnvInput::from_pairs(vec![("FOO".into(), "bar".into())]);
+        assert_eq!(serde_json::to_string(&input).unwrap(), r#"[["FOO","bar"]]"#);
+        let back: AgentEnvInput = serde_json::from_str(r#"[["FOO","bar"]]"#).unwrap();
+        assert_eq!(back, input);
+    }
+
+    #[test]
+    fn input_debug_is_redacted() {
+        let input = AgentEnvInput::from_pairs(vec![("SECRET_TOKEN".into(), SECRET.into())]);
+        let rendered = format!("{input:?}");
+        assert!(!rendered.contains(SECRET), "{rendered}");
+        assert!(rendered.contains("SECRET_TOKEN"), "{rendered}");
+    }
+
+    #[test]
+    fn db_json_round_trips() {
+        let env = one();
+        let json = env.to_db_json();
+        assert_eq!(json, r#"{"SECRET_TOKEN":"sk-live-DEADBEEF01"}"#);
+        assert_eq!(AgentEnv::from_db_json(&json), env);
+        assert_eq!(AgentEnv::default().to_db_json(), "{}");
+    }
+
+    #[test]
+    fn corrupt_db_json_degrades_to_empty() {
+        assert!(AgentEnv::from_db_json("not json").is_empty());
+        assert!(AgentEnv::from_db_json("[1,2]").is_empty());
+        assert!(AgentEnv::from_db_json(r#"{"K":31337}"#).is_empty());
+    }
+
+    #[test]
+    fn decode_errors_never_echo_the_input() {
+        let err = AgentEnv::try_from_db_json(&format!(r#"{{"K":"{SECRET}"#)).unwrap_err();
+        assert!(!err.contains(SECRET), "{err}");
+        let err = AgentEnv::try_from_db_json(r#"{"K":31337}"#).unwrap_err();
+        assert!(!err.contains("31337"), "{err}");
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/agent_env.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/agent_env.rs
@@ -123,7 +123,9 @@ impl AgentEnv {
         let pairs = obj
             .iter()
             .map(|(k, v)| {
-                v.as_str().map(|s| (k.clone(), s.to_string())).ok_or("env value is not a string")
+                v.as_str()
+                    .map(|s| (k.clone(), s.to_string()))
+                    .ok_or("env value is not a string")
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self { pairs })
@@ -250,7 +252,10 @@ mod tests {
     #[test]
     fn debug_masks_values_and_keeps_keys() {
         let rendered = format!("{:?}", one());
-        assert!(!rendered.contains(SECRET), "Debug leaked the value: {rendered}");
+        assert!(
+            !rendered.contains(SECRET),
+            "Debug leaked the value: {rendered}"
+        );
         assert!(rendered.contains("SECRET_TOKEN"), "{rendered}");
         assert!(rendered.contains(REDACTED_VALUE), "{rendered}");
     }

--- a/ainb-tui/crates/ainb-hangar-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/lib.rs
@@ -14,6 +14,10 @@
 pub mod acceptance;
 /// Polymorphic actor references (`member:<id>` / `agent:<id>`).
 pub mod actor;
+/// Per-agent environment variables with a redact-by-construction contract
+/// (multica parity #30): plaintext inside, masked on every egress except the
+/// single named exec seam ([`agent_env::AgentEnv::expose_for_child_env`]).
+pub mod agent_env;
 /// The card provider-agent kind (`claude`/`codex`/`copilot`) + the task-create
 /// default cascade (spec F4).
 pub mod agent_kind;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/interactive.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/interactive.rs
@@ -402,7 +402,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let run = run_with_exit(dir.path(), Some("0"));
         let wrapper = dir.path().join(WRAPPER_FILE);
-        std::fs::write(&wrapper, "#!/bin/sh\nenv -i SECRET_TOKEN='sk-live-DEADBEEF01' x\n").unwrap();
+        std::fs::write(
+            &wrapper,
+            "#!/bin/sh\nenv -i SECRET_TOKEN='sk-live-DEADBEEF01' x\n",
+        )
+        .unwrap();
         assert!(wrapper.exists(), "precondition: the wrapper is on disk");
 
         let _ = run.outcome_from_exit_file();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/interactive.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/interactive.rs
@@ -78,6 +78,11 @@ pub(crate) async fn kill_session(session_name: &str) {
 pub struct TmuxRun {
     session_name: String,
     exit_file: PathBuf,
+    /// The generated pane wrapper. Held so the run can UNLINK it at teardown:
+    /// the script embeds the plaintext child env (a codex agent's `agent_env`,
+    /// keychain-resident API keys), and before parity #30 it lingered on disk
+    /// forever at 0700 (see [`TmuxRun::purge_wrapper`]).
+    wrapper: PathBuf,
     max_runtime: Duration,
 }
 
@@ -157,6 +162,7 @@ pub async fn spawn(
     Ok(TmuxRun {
         session_name: session_name.to_string(),
         exit_file,
+        wrapper,
         max_runtime,
     })
 }
@@ -179,10 +185,13 @@ impl TmuxRun {
         let deadline = Instant::now() + self.max_runtime;
         loop {
             if !tmux_session_exists(&self.session_name).await {
+                // `outcome_from_exit_file` IS the finalize seam — it purges the
+                // wrapper (parity #30).
                 return Ok(self.outcome_from_exit_file());
             }
             if Instant::now() >= deadline {
                 self.kill_and_confirm_reaped().await;
+                self.purge_wrapper();
                 tracing::warn!(
                     session = %self.session_name,
                     reason = "timeout",
@@ -207,10 +216,26 @@ impl TmuxRun {
     /// reason.
     pub async fn abort(&self, reason: FailureReason) -> RunOutcome {
         self.kill_and_confirm_reaped().await;
+        self.purge_wrapper();
         RunOutcome::Failed {
             reason,
             result: interactive_result(None),
         }
+    }
+
+    /// Best-effort UNLINK of the pane wrapper, at the FINALIZE seam only.
+    ///
+    /// The wrapper bakes the plaintext child env into a file on disk. The
+    /// headless path passes that env in-process and never persists it, so the
+    /// interactive path must not leave a durable copy behind once the run is
+    /// over (parity #30 — the acceptance sweep greps the task's logs dir).
+    ///
+    /// Timing matters: this runs AFTER teardown is confirmed, never mid-run,
+    /// because `/bin/sh` re-reads a running script and unlinking it early would
+    /// break a live session. Failure is ignored — a run's outcome must not hinge
+    /// on a cleanup unlink.
+    fn purge_wrapper(&self) {
+        let _ = std::fs::remove_file(&self.wrapper);
     }
 
     /// Kill the session by its EXACT name (never a wildcard / kill-server) and
@@ -242,7 +267,10 @@ impl TmuxRun {
     /// Read the wrapper's recorded exit code and classify it, mirroring the
     /// headless runner's outcome mapping (`0` → success, `75` → retryable
     /// runtime offline, any other / missing → terminal agent error).
+    /// The session is gone by the time this runs, so it is also the FINALIZE
+    /// seam that unlinks the secret-bearing pane wrapper.
     fn outcome_from_exit_file(&self) -> RunOutcome {
+        self.purge_wrapper();
         let code = std::fs::read_to_string(&self.exit_file)
             .ok()
             .and_then(|s| s.trim().parse::<i32>().ok());
@@ -359,8 +387,30 @@ mod tests {
         TmuxRun {
             session_name: "tmux_hangar-test".to_string(),
             exit_file,
+            wrapper: dir.join(WRAPPER_FILE),
             max_runtime: Duration::from_secs(1),
         }
+    }
+
+    /// Parity #30: the pane wrapper bakes the plaintext child env onto disk, so
+    /// once the run reaches a terminal outcome (the session is gone and the exit
+    /// code is being classified) the file MUST be unlinked. Before this, it
+    /// lingered forever at 0700 and every `sk-…` an agent ran with stayed
+    /// greppable under the task's logs dir.
+    #[test]
+    fn terminal_outcome_unlinks_the_secret_bearing_wrapper() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = run_with_exit(dir.path(), Some("0"));
+        let wrapper = dir.path().join(WRAPPER_FILE);
+        std::fs::write(&wrapper, "#!/bin/sh\nenv -i SECRET_TOKEN='sk-live-DEADBEEF01' x\n").unwrap();
+        assert!(wrapper.exists(), "precondition: the wrapper is on disk");
+
+        let _ = run.outcome_from_exit_file();
+
+        assert!(
+            !wrapper.exists(),
+            "the wrapper embeds the plaintext child env and must not survive teardown"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -2698,6 +2698,28 @@ fn parse_params<T: serde::de::DeserializeOwned>(
     })
 }
 
+/// Deserialize a SECRET-BEARING request's `params` into `T` with a CONTENT-FREE
+/// error message.
+///
+/// Identical to [`parse_params`] except the `serde_json` error is DROPPED. That
+/// is deliberate, and it is multica's rule (`cmd_agent.go:757-759`): serde
+/// echoes the offending scalar in its message (`invalid type: integer \`31337\`,
+/// expected a string`), so a malformed `agent_env` value would be reflected
+/// straight back to the caller — and into whatever log captured the response.
+///
+/// Only the two handlers that accept `agent_env` use this; every other handler
+/// keeps [`parse_params`] and its richer diagnostics.
+fn parse_params_secret<T: serde::de::DeserializeOwned>(
+    req: &RpcRequest,
+    shape: &str,
+) -> Result<T, RpcError> {
+    serde_json::from_value(req.params.clone()).map_err(|_| RpcError {
+        code: INVALID_PARAMS,
+        message: format!("expected {shape}"),
+        data: None,
+    })
+}
+
 /// Resolve a wire workspace identifier (slug OR id) to the real row id,
 /// returning `None` when no workspace matches and mapping a store fault to an
 /// internal error. The id-bearing P6.5 handlers use this (they carry their own
@@ -3905,7 +3927,9 @@ async fn handle_agent_create(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    let params: ainb_hangar_proto::snapshots::AgentCreateParams = parse_params(
+    // Content-free parse error: this params shape is adjacent to the secret
+    // `agent_env` write channel, so it uses the same rule as agent_update.
+    let params: ainb_hangar_proto::snapshots::AgentCreateParams = parse_params_secret(
         req,
         "{ workspace_id?, name, provider?, model?, instructions?, description?, avatar_url?, \
          service_tier? }",
@@ -4019,7 +4043,9 @@ async fn handle_agent_update(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    let params: ainb_hangar_proto::snapshots::AgentUpdateParams = parse_params(
+    // `agent_env` carries SECRETS, so a shape mismatch must not echo the input
+    // back (parity #30 / multica `cmd_agent.go:757-759`).
+    let params: ainb_hangar_proto::snapshots::AgentUpdateParams = parse_params_secret(
         req,
         "{ workspace_id, agent_id, name?, instructions?, model?, cli_args?, mcp_config?, \
          thinking?, agent_env?, description?, avatar_url?, service_tier? }",
@@ -4114,7 +4140,10 @@ fn agent_config_update_from_params(
         mcp_config: field_to_nested(&params.mcp_config),
         thinking: field_to_nested(&params.thinking),
         token_budget: field_to_nested(&params.token_budget),
-        agent_env: params.agent_env.clone(),
+        agent_env: params
+            .agent_env
+            .clone()
+            .map(ainb_hangar_core::agent_env::AgentEnvInput::into_agent_env),
         // Migration 0050. `description` is NOT NULL, so it maps straight through
         // like `name`; the other two are nullable and use the FieldUpdate bridge.
         description: params.description.as_deref().map(|d| d.trim().to_string()),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -903,6 +903,13 @@ async fn agent_actor_row_with_counts(
         // it did before.
         archived_at: agent.archived_at,
         archived_by: agent.archived_by.as_ref().map(ToString::to_string).unwrap_or_default(),
+        // Parity #30. This is the ONLY place a per-agent env reaches the wire,
+        // and it carries KEY NAMES + a count — never a value. All three are
+        // omitted when the agent has no env, so an env-less agent serialises
+        // exactly as it did pre-#30.
+        agent_env_key_count: u32::try_from(agent.agent_env.len()).unwrap_or(u32::MAX),
+        agent_env_keys: agent.agent_env.keys().map(ToString::to_string).collect(),
+        agent_env_redacted: !agent.agent_env.is_empty(),
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -1312,7 +1312,8 @@ async fn execute_claimed(
                     .run_codex_in(
                         &env,
                         task_env,
-                        dispatch.agent_env,
+                        // The ONE permitted plaintext escape: the child env.
+                        dispatch.agent_env.expose_for_child_env(),
                         &dispatch.invocation,
                         &location,
                     )
@@ -1322,7 +1323,8 @@ async fn execute_claimed(
                     .run_copilot_in(
                         &env,
                         task_env,
-                        dispatch.agent_env,
+                        // The ONE permitted plaintext escape: the child env.
+                        dispatch.agent_env.expose_for_child_env(),
                         &dispatch.invocation,
                         &location,
                     )
@@ -1464,7 +1466,8 @@ async fn run_interactive(
     // agent's `agent_env`; the claude path layers nothing (parity with
     // `execute_claimed`).
     let extra_env = match dispatch.backend {
-        Backend::Codex | Backend::Copilot => dispatch.agent_env.clone(),
+        // The ONE permitted plaintext escape: the child env.
+        Backend::Codex | Backend::Copilot => dispatch.agent_env.clone().expose_for_child_env(),
         Backend::Claude => Vec::new(),
     };
     let child_env = crate::runner::compose_child_env(task_env, extra_env);
@@ -2281,7 +2284,12 @@ struct ResolvedDispatch {
     invocation: ProviderInvocation,
     /// The agent's per-agent env (`agent_env`), layered onto the child env
     /// after the deny-by-default ambient allowlist.
-    agent_env: Vec<(String, String)>,
+    ///
+    /// Typed [`AgentEnv`](ainb_hangar_core::agent_env::AgentEnv), so this
+    /// struct's derived `Debug` (a `tracing::debug!(?dispatch)`, an `anyhow`
+    /// context, a panic message) masks the VALUES (parity #30). The plaintext
+    /// is reached only at the compose seam, via `expose_for_child_env`.
+    agent_env: ainb_hangar_core::agent_env::AgentEnv,
 }
 
 /// The `tasks.mode` column value that asks for an attachable session (ccc / D6,
@@ -2328,7 +2336,7 @@ impl ResolvedDispatch {
                 model: None,
                 cli_args: Vec::new(),
             },
-            agent_env: Vec::new(),
+            agent_env: ainb_hangar_core::agent_env::AgentEnv::default(),
         }
     }
 }
@@ -4033,7 +4041,7 @@ mod tests {
             backend,
             mode: dispatch_mode("interactive"),
             invocation: inv.clone(),
-            agent_env: Vec::new(),
+            agent_env: ainb_hangar_core::agent_env::AgentEnv::default(),
         };
 
         // The argv an INTERACTIVE task row actually gets, through the same
@@ -4117,7 +4125,7 @@ mod tests {
                 backend: Backend::Codex,
                 mode: dispatch_mode("interactive"),
                 invocation: inv.clone(),
-                agent_env: Vec::new(),
+                agent_env: ainb_hangar_core::agent_env::AgentEnv::default(),
             },
         );
         assert!(

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_crud.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_crud.rs
@@ -374,10 +374,17 @@ async fn agent_env_value_never_reaches_the_wire() {
     assert!(resp["error"].is_null(), "update must ack: {resp}");
 
     let body = resp.to_string();
-    assert!(!body.contains("sk-live-"), "the update response leaked the env value: {body}");
+    assert!(
+        !body.contains("sk-live-"),
+        "the update response leaked the env value: {body}"
+    );
     let row = &resp["result"];
     assert_eq!(row["agent_env_key_count"], 1, "{resp}");
-    assert_eq!(row["agent_env_keys"], serde_json::json!(["SECRET_TOKEN"]), "{resp}");
+    assert_eq!(
+        row["agent_env_keys"],
+        serde_json::json!(["SECRET_TOKEN"]),
+        "{resp}"
+    );
     assert_eq!(row["agent_env_redacted"], true, "{resp}");
 
     // Same contract on the list snapshot — the surface every TUI actually reads.
@@ -388,7 +395,10 @@ async fn agent_env_value_never_reaches_the_wire() {
         )
         .await;
     let body = list.to_string();
-    assert!(!body.contains("sk-live-"), "agents_list leaked the env value: {body}");
+    assert!(
+        !body.contains("sk-live-"),
+        "agents_list leaked the env value: {body}"
+    );
     let agent = list["result"]["actors"]
         .as_array()
         .unwrap()
@@ -396,7 +406,11 @@ async fn agent_env_value_never_reaches_the_wire() {
         .find(|a| a["actor_ref"] == "agent:agent-1")
         .expect("agent-1 present");
     assert_eq!(agent["agent_env_key_count"], 1, "{list}");
-    assert_eq!(agent["agent_env_keys"], serde_json::json!(["SECRET_TOKEN"]), "{list}");
+    assert_eq!(
+        agent["agent_env_keys"],
+        serde_json::json!(["SECRET_TOKEN"]),
+        "{list}"
+    );
     assert_eq!(agent["agent_env_redacted"], true, "{list}");
 }
 
@@ -424,9 +438,21 @@ async fn malformed_agent_env_error_echoes_neither_key_nor_value() {
             }),
         )
         .await;
-    assert!(!resp["error"].is_null(), "a non-string env value must be rejected: {resp}");
+    assert!(
+        !resp["error"].is_null(),
+        "a non-string env value must be rejected: {resp}"
+    );
     let message = resp["error"]["message"].as_str().unwrap_or_default();
-    assert!(!message.contains("31337"), "the error echoed the value: {message}");
-    assert!(!message.contains("SECRET_TOKEN"), "the error echoed the key: {message}");
-    assert!(message.starts_with("expected "), "the message still names the shape: {message}");
+    assert!(
+        !message.contains("31337"),
+        "the error echoed the value: {message}"
+    );
+    assert!(
+        !message.contains("SECRET_TOKEN"),
+        "the error echoed the key: {message}"
+    );
+    assert!(
+        message.starts_with("expected "),
+        "the message still names the shape: {message}"
+    );
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_crud.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_crud.rs
@@ -343,3 +343,90 @@ async fn agent_update_with_no_fields_is_rejected() {
         "an empty edit must be rejected: {resp}"
     );
 }
+
+/// Parity #30 — the acceptance the RPC layer owns: a per-agent env VALUE never
+/// reaches the wire, in either the write response or a later list snapshot.
+///
+/// The response instead carries the multica-shaped metadata (key names, a count,
+/// and the `redacted` flag), which is everything a UI needs and nothing an
+/// attacker does. This test FAILS on `main` — before the change the response
+/// simply had no `agent_env_*` keys and the daemon had no redaction concept.
+#[tokio::test]
+async fn agent_env_value_never_reaches_the_wire() {
+    const SECRET: &str = "sk-live-DEADBEEF01";
+
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": "agent-1",
+                "agent_env": [["SECRET_TOKEN", SECRET]],
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "update must ack: {resp}");
+
+    let body = resp.to_string();
+    assert!(!body.contains("sk-live-"), "the update response leaked the env value: {body}");
+    let row = &resp["result"];
+    assert_eq!(row["agent_env_key_count"], 1, "{resp}");
+    assert_eq!(row["agent_env_keys"], serde_json::json!(["SECRET_TOKEN"]), "{resp}");
+    assert_eq!(row["agent_env_redacted"], true, "{resp}");
+
+    // Same contract on the list snapshot — the surface every TUI actually reads.
+    let list = c
+        .call(
+            methods::HANGAR_AGENTS_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    let body = list.to_string();
+    assert!(!body.contains("sk-live-"), "agents_list leaked the env value: {body}");
+    let agent = list["result"]["actors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["actor_ref"] == "agent:agent-1")
+        .expect("agent-1 present");
+    assert_eq!(agent["agent_env_key_count"], 1, "{list}");
+    assert_eq!(agent["agent_env_keys"], serde_json::json!(["SECRET_TOKEN"]), "{list}");
+    assert_eq!(agent["agent_env_redacted"], true, "{list}");
+}
+
+/// Parity #30 — a malformed `agent_env` is rejected with a CONTENT-FREE message.
+///
+/// `serde_json` quotes the offending scalar (`invalid type: integer `31337`,
+/// expected a string`), which for this field IS the secret, and the error text
+/// lands in the caller's logs. Multica drops the underlying error for exactly
+/// this reason (`cmd_agent.go:757-759`).
+#[tokio::test]
+async fn malformed_agent_env_error_echoes_neither_key_nor_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "agent_id": "agent-1",
+                "agent_env": [["SECRET_TOKEN", 31337]],
+            }),
+        )
+        .await;
+    assert!(!resp["error"].is_null(), "a non-string env value must be rejected: {resp}");
+    let message = resp["error"]["message"].as_str().unwrap_or_default();
+    assert!(!message.contains("31337"), "the error echoed the value: {message}");
+    assert!(!message.contains("SECRET_TOKEN"), "the error echoed the key: {message}");
+    assert!(message.starts_with("expected "), "the message still names the shape: {message}");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
@@ -270,17 +270,26 @@ async fn codex_dispatch_tracing_never_contains_the_agent_env_value() {
 
     let tmp = TempDir::new().expect("tmp");
     let env = exec_env_in(tmp.path());
+    // The fake PROVES it received the value by touching a marker file rather
+    // than printing it: a child that echoes its own secret is the child's leak,
+    // and it would land in `codex.jsonl` and (via the contract-drift warning)
+    // in the log — drowning out the thing actually under test.
+    let marker = tmp.path().join("child-saw-secret");
     let script = write_script(
         tmp.path(),
         "fake-codex.sh",
-        r#"echo '{"type":"system","session_id":"s"}'
-echo "SECRET_TOKEN=${SECRET_TOKEN:-<absent>}"
-exit 0"#,
+        &format!(
+            "if [ \"${{SECRET_TOKEN}}\" = '{SECRET}' ]; then : > '{}'; fi\n\
+             echo '{{\"type\":\"system\",\"session_id\":\"s\"}}'\n\
+             echo '{{\"type\":\"result\",\"content\":\"ok\"}}'\n\
+             exit 0",
+            marker.display()
+        ),
     );
     let runner = Runner::new(cfg_with_codex(script));
     let extra_env = [("SECRET_TOKEN".to_string(), SECRET.to_string())];
 
-    let outcome = runner
+    runner
         .run_codex_with_env(
             &env,
             std::iter::empty(),
@@ -291,7 +300,7 @@ exit 0"#,
         .expect("run");
 
     assert!(
-        outcome.result().stdout_tail.contains(&format!("SECRET_TOKEN={SECRET}")),
+        marker.exists(),
         "precondition: the child really does receive the value"
     );
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/runner_codex.rs
@@ -226,6 +226,82 @@ exit 0"#,
     );
 }
 
+/// Parity #30 — the other half of the contract above: the value that reaches the
+/// CHILD must never reach the LOG.
+///
+/// The positive half (`codex_exec_passes_agent_env_but_strips_ambient_secret`)
+/// proves dispatch still works; this proves the tracing emitted across the whole
+/// run never contains the value. It is the reason `ResolvedDispatch` /
+/// `AgentEnv` carry a hand-written redacting `Debug`: a single
+/// `tracing::debug!(?dispatch)` added later cannot silently re-open the leak.
+#[tokio::test]
+async fn codex_dispatch_tracing_never_contains_the_agent_env_value() {
+    use std::io::Write as _;
+    use std::sync::{Arc, Mutex};
+
+    const SECRET: &str = "sk-live-DEADBEEF01";
+
+    /// A `MakeWriter` that appends every emitted log line to a shared buffer.
+    #[derive(Clone)]
+    struct Capture(Arc<Mutex<Vec<u8>>>);
+    impl std::io::Write for Capture {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log lock").write(buf)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Capture {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(Capture(Arc::clone(&log)))
+        .with_max_level(tracing::Level::TRACE)
+        .finish();
+    // `#[tokio::test]` is a current-thread runtime, so a thread-local default
+    // subscriber captures the whole dispatch.
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let tmp = TempDir::new().expect("tmp");
+    let env = exec_env_in(tmp.path());
+    let script = write_script(
+        tmp.path(),
+        "fake-codex.sh",
+        r#"echo '{"type":"system","session_id":"s"}'
+echo "SECRET_TOKEN=${SECRET_TOKEN:-<absent>}"
+exit 0"#,
+    );
+    let runner = Runner::new(cfg_with_codex(script));
+    let extra_env = [("SECRET_TOKEN".to_string(), SECRET.to_string())];
+
+    let outcome = runner
+        .run_codex_with_env(
+            &env,
+            std::iter::empty(),
+            extra_env.iter().cloned(),
+            &brief_invocation(),
+        )
+        .await
+        .expect("run");
+
+    assert!(
+        outcome.result().stdout_tail.contains(&format!("SECRET_TOKEN={SECRET}")),
+        "precondition: the child really does receive the value"
+    );
+
+    let captured = String::from_utf8_lossy(&log.lock().expect("log lock")).to_string();
+    assert!(
+        !captured.contains("sk-live-"),
+        "the dispatch tracing leaked the agent_env value:\n{captured}"
+    );
+}
+
 #[tokio::test]
 async fn codex_exec_nonzero_exit_marks_agent_error() {
     let tmp = TempDir::new().expect("tmp");

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_agent_env_no_leak.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_agent_env_no_leak.rs
@@ -169,16 +169,30 @@ async fn agent_env_value_leaks_into_no_persisted_or_rendered_artefact() {
     assert_clean_tree(&task_logs, "the task logs directory");
 
     // ── (d) `ainb hangar agent list --format json` stdout ───────────────────
-    let listed = run_ainb(&ainb, home.path(), &["hangar", "agent", "list", "--format", "json"]);
-    assert!(!listed.contains(SECRET), "agent list --format json leaked the value:\n{listed}");
+    let listed = run_ainb(
+        &ainb,
+        home.path(),
+        &["hangar", "agent", "list", "--format", "json"],
+    );
+    assert!(
+        !listed.contains(SECRET),
+        "agent list --format json leaked the value:\n{listed}"
+    );
     assert!(
         listed.contains(r#""SECRET_TOKEN":"****""#),
         "agent list --format json must keep the KEY and mask the value:\n{listed}"
     );
 
     // ── (e) `ainb hangar agent env <id>` stdout ─────────────────────────────
-    let env_out = run_ainb(&ainb, home.path(), &["hangar", "agent", "env", &codex_agent_id]);
-    assert!(!env_out.contains(SECRET), "agent env leaked the value:\n{env_out}");
+    let env_out = run_ainb(
+        &ainb,
+        home.path(),
+        &["hangar", "agent", "env", &codex_agent_id],
+    );
+    assert!(
+        !env_out.contains(SECRET),
+        "agent env leaked the value:\n{env_out}"
+    );
     assert!(
         env_out.contains("SECRET_TOKEN=****"),
         "agent env must print the masked pair:\n{env_out}"

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_agent_env_no_leak.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_agent_env_no_leak.rs
@@ -1,0 +1,249 @@
+//! Parity #30 ACCEPTANCE SWEEP: a per-agent env value never lands anywhere it
+//! can be read back.
+//!
+//! ```text
+//!   agent(agent_env = {SECRET_TOKEN: sk-live-DEADBEEF01})
+//!        │
+//!        ▼  one REAL dispatch through the real daemon binary
+//!   fake codex ──▶ writes $HOME/child-saw-secret  (proves the child GOT it)
+//!        │
+//!        ▼  sweep for the literal `sk-live-DEADBEEF01`
+//!   ┌───────────────────────────────────────────────────────────┐
+//!   │ every TEXT column of every hangar.db table  … EXCEPT      │
+//!   │   agent.agent_env (the authoritative store — deviation D2)│
+//!   │ the daemon log files                                      │
+//!   │ every file under the task's logs dir (post-teardown)      │
+//!   │ `ainb hangar agent list --format json` stdout             │
+//!   │ `ainb hangar agent env <id>` stdout                       │
+//!   └───────────────────────────────────────────────────────────┘
+//!   all must be CLEAN.
+//! ```
+//!
+//! This is the test the acceptance sentence rests on: it FAILS on `main` (the
+//! `agent list --format json` arm printed the plaintext value outright) and
+//! passes after the change, while the `child-saw-secret` marker proves the
+//! redaction was not achieved by breaking dispatch.
+//!
+//! Skips cleanly (never fails) when tmux or the `ainb` binary is unavailable, so
+//! a CI image lacking either does not red the suite.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+mod tripwire_support;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, SqlitePool};
+use tripwire_support::{
+    DaemonSession, ainb_bin, daemon_bin, seed_codex_agent, seed_world, wait_for_db,
+};
+
+/// The canary. Every assertion below is "this literal is absent".
+const SECRET: &str = "sk-live-DEADBEEF01";
+
+#[tokio::test]
+async fn agent_env_value_leaks_into_no_persisted_or_rendered_artefact() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping agent-env leak sweep");
+        return;
+    }
+    let Some(ainb) = ainb_bin() else {
+        eprintln!("ainb binary not built; skipping agent-env leak sweep");
+        return;
+    };
+
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    let pool = open_pool(&db_path).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    let (codex_runtime_id, codex_agent_id) = seed_codex_agent(&pool, &ids).await;
+
+    // The agent carries the secret in its per-agent env — the ONE place it is
+    // allowed to be at rest (deviation D-2).
+    sqlx::query("UPDATE agent SET agent_env = ? WHERE id = ?")
+        .bind(format!(r#"{{"SECRET_TOKEN":"{SECRET}"}}"#))
+        .bind(&codex_agent_id)
+        .execute(&pool)
+        .await
+        .expect("set agent_env");
+
+    // A fake codex that PROVES it received the value without ever printing it:
+    // printing would be the child's own leak, and would land in codex.jsonl —
+    // a genuine artefact this sweep is right to fail on.
+    let marker = home.path().join("child-saw-secret");
+    let fake_codex = write_executable(
+        home.path(),
+        "fake-codex.sh",
+        &format!(
+            "#!/bin/sh\n\
+             if [ \"${{SECRET_TOKEN}}\" = '{SECRET}' ]; then : > '{}'; fi\n\
+             echo '{{\"type\":\"system\",\"session_id\":\"codex-sid\"}}'\n\
+             echo '{{\"type\":\"result\",\"content\":\"codex-ok\"}}'\n\
+             exit 0\n",
+            marker.display()
+        ),
+    );
+
+    let session = DaemonSession::spawn(
+        &daemon_bin(),
+        home.path(),
+        &[
+            ("AINB_HANGAR_HOME", home.path().to_str().unwrap()),
+            ("HANGAR_DAEMON_RUNTIME_ID", &codex_runtime_id),
+            ("HANGAR_CODEX_PATH", fake_codex.to_str().unwrap()),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+        ],
+    );
+
+    let task_id = "task-env-leak";
+    sqlx::query(
+        "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, created_at) \
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(task_id)
+    .bind(&ids.workspace_id)
+    .bind(&codex_runtime_id)
+    .bind(&codex_agent_id)
+    .bind(tripwire_support::now_ms())
+    .execute(&pool)
+    .await
+    .expect("enqueue task");
+
+    let row = wait_for_db(&pool, task_id, "done", Duration::from_secs(30)).await;
+    drop(session);
+
+    // ── PRECONDITION: dispatch really did carry the plaintext to the child ──
+    assert!(
+        marker.exists(),
+        "the provider child never received the agent_env value — a leak sweep \
+         over a broken dispatch proves nothing"
+    );
+
+    // ── (a) every TEXT column of every table, except agent.agent_env ────────
+    let tables: Vec<String> =
+        sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type = 'table'")
+            .fetch_all(&pool)
+            .await
+            .expect("list tables");
+    for table in &tables {
+        if table.starts_with("sqlite_") || table.starts_with("_sqlx") {
+            continue;
+        }
+        let cols: Vec<String> = sqlx::query(&format!("PRAGMA table_info({table})"))
+            .fetch_all(&pool)
+            .await
+            .expect("table_info")
+            .into_iter()
+            .map(|r| r.get::<String, _>("name"))
+            .collect();
+        for col in cols {
+            // The authoritative store of record: plaintext here is the design
+            // (deviation D-2), and `repo_agent_env_redaction` pins its bytes.
+            if table == "agent" && col == "agent_env" {
+                continue;
+            }
+            let hits: i64 = sqlx::query_scalar(&format!(
+                "SELECT COUNT(*) FROM \"{table}\" WHERE CAST(\"{col}\" AS TEXT) LIKE ?"
+            ))
+            .bind(format!("%{SECRET}%"))
+            .fetch_one(&pool)
+            .await
+            .unwrap_or(0);
+            assert_eq!(hits, 0, "the env value leaked into {table}.{col}");
+        }
+    }
+
+    // ── (b) the daemon's own log files ─────────────────────────────────────
+    let logs_root = home.path().join("hangar").join("logs");
+    assert_clean_tree(&logs_root, "the daemon log directory");
+
+    // ── (c) every file under the task's logs dir, AFTER teardown ───────────
+    // This is what proves the interactive wrapper unlink and that no provider
+    // log captured the value.
+    let work_dir: String = row.get::<Option<String>, _>("work_dir").expect("work_dir populated");
+    let task_logs = PathBuf::from(&work_dir).parent().expect("shortID root").join("logs");
+    assert_clean_tree(&task_logs, "the task logs directory");
+
+    // ── (d) `ainb hangar agent list --format json` stdout ───────────────────
+    let listed = run_ainb(&ainb, home.path(), &["hangar", "agent", "list", "--format", "json"]);
+    assert!(!listed.contains(SECRET), "agent list --format json leaked the value:\n{listed}");
+    assert!(
+        listed.contains(r#""SECRET_TOKEN":"****""#),
+        "agent list --format json must keep the KEY and mask the value:\n{listed}"
+    );
+
+    // ── (e) `ainb hangar agent env <id>` stdout ─────────────────────────────
+    let env_out = run_ainb(&ainb, home.path(), &["hangar", "agent", "env", &codex_agent_id]);
+    assert!(!env_out.contains(SECRET), "agent env leaked the value:\n{env_out}");
+    assert!(
+        env_out.contains("SECRET_TOKEN=****"),
+        "agent env must print the masked pair:\n{env_out}"
+    );
+    assert!(
+        env_out.contains("1 keys (values hidden)"),
+        "agent env must report the count:\n{env_out}"
+    );
+}
+
+/// Assert no file anywhere under `root` contains the canary. A missing tree is
+/// vacuously clean (a run that produced no logs cannot have leaked into them).
+fn assert_clean_tree(root: &Path, what: &str) {
+    if !root.exists() {
+        return;
+    }
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if let Ok(body) = std::fs::read(&path) {
+                assert!(
+                    !String::from_utf8_lossy(&body).contains(SECRET),
+                    "the env value leaked into {what}: {}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+/// Run the real `ainb` CLI against the temp Hangar home and return its stdout.
+fn run_ainb(bin: &Path, home: &Path, args: &[&str]) -> String {
+    let out = std::process::Command::new(bin)
+        .args(args)
+        .env("AINB_HANGAR_HOME", home)
+        .output()
+        .unwrap_or_else(|e| panic!("run ainb {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "ainb {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// Write an executable shell script under `dir`.
+fn write_executable(dir: &Path, name: &str, body: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt as _;
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write script");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    path
+}
+
+/// Open a pool against the tripwire's temp DB file.
+async fn open_pool(db_path: &Path) -> SqlitePool {
+    SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect(&format!("sqlite://{}?mode=rwc", db_path.display()))
+        .await
+        .expect("open pool")
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -603,6 +603,37 @@ pub struct ActorRow {
     /// when active / unknown / unattributed. Omitted from the wire when empty.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub archived_by: String,
+    /// How many per-agent env vars the agent carries (multica parity #30,
+    /// multica's derived `has_custom_env` is simply `> 0`). `0` for members and
+    /// for a pre-#30 producer. Omitted from the wire when zero.
+    ///
+    /// This is a COUNT, never a value: the wire deliberately has no field that
+    /// can carry an env VALUE, so no consumer can render one.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub agent_env_key_count: u32,
+    /// The per-agent env var NAMES, in stored order (multica ships keys too —
+    /// only values are secret). Empty for members and for a pre-#30 producer.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agent_env_keys: Vec<String>,
+    /// Mirrors multica's `custom_env_redacted` (`agent.go:42`): `true` iff the
+    /// agent has env vars, i.e. what the caller sees is a MASKED view. Hangar
+    /// masks unconditionally (deviation D-1), so this is always
+    /// `agent_env_key_count > 0`. Omitted from the wire when `false`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub agent_env_redacted: bool,
+}
+
+/// `skip_serializing_if` helper: omit a zero count from the wire so a
+/// metadata-less agent serialises byte-identically to a pre-#30 producer.
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde requires the `&` signature
+const fn is_zero_u32(n: &u32) -> bool {
+    *n == 0
+}
+
+/// `skip_serializing_if` helper: omit a `false` flag from the wire.
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde requires the `&` signature
+const fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl Default for ActorRow {
@@ -624,6 +655,9 @@ impl Default for ActorRow {
             avatar: String::new(),
             archived_at: None,
             archived_by: String::new(),
+            agent_env_key_count: 0,
+            agent_env_keys: Vec::new(),
+            agent_env_redacted: false,
         }
     }
 }
@@ -1133,5 +1167,38 @@ mod tests {
         let out = serde_json::to_string(&stamped).unwrap();
         assert!(out.contains("\"archived_by\":\"member:user-1\""), "{out}");
         assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), stamped);
+    }
+
+    /// The parity-#30 per-agent-env metadata is APPEND-ONLY on `ActorRow`: a
+    /// pre-#30 payload decodes with all three fields at their neutral values,
+    /// an env-less row emits none of the keys, and a populated row round-trips.
+    ///
+    /// It also pins the shape itself: the wire carries KEY NAMES and a COUNT,
+    /// never a value — there is no field a consumer could render a secret from.
+    #[test]
+    fn actor_row_agent_env_metadata_is_append_only_and_value_free() {
+        let legacy = r#"{"actor_ref":"agent:a1","display_name":"bot","subtitle":"agent",
+            "presence":"online","is_agent":true,"recent_rank":null}"#;
+        let row: ActorRow = serde_json::from_str(legacy).expect("pre-#30 payload decodes");
+        assert_eq!(row.agent_env_key_count, 0);
+        assert!(row.agent_env_keys.is_empty());
+        assert!(!row.agent_env_redacted);
+        let out = serde_json::to_string(&row).unwrap();
+        assert!(
+            !out.contains("agent_env"),
+            "an env-less row must not emit any agent_env key: {out}"
+        );
+
+        let with_env = ActorRow {
+            agent_env_key_count: 1,
+            agent_env_keys: vec!["SECRET_TOKEN".into()],
+            agent_env_redacted: true,
+            ..row
+        };
+        let out = serde_json::to_string(&with_env).unwrap();
+        assert!(out.contains("\"agent_env_key_count\":1"), "{out}");
+        assert!(out.contains("\"agent_env_keys\":[\"SECRET_TOKEN\"]"), "{out}");
+        assert!(out.contains("\"agent_env_redacted\":true"), "{out}");
+        assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), with_env);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -1197,7 +1197,10 @@ mod tests {
         };
         let out = serde_json::to_string(&with_env).unwrap();
         assert!(out.contains("\"agent_env_key_count\":1"), "{out}");
-        assert!(out.contains("\"agent_env_keys\":[\"SECRET_TOKEN\"]"), "{out}");
+        assert!(
+            out.contains("\"agent_env_keys\":[\"SECRET_TOKEN\"]"),
+            "{out}"
+        );
         assert!(out.contains("\"agent_env_redacted\":true"), "{out}");
         assert_eq!(serde_json::from_str::<ActorRow>(&out).unwrap(), with_env);
     }

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -12,6 +12,7 @@
 //! These are **pure wire types** — `serde` only, no host deps — matching the
 //! rest of `ainb-hangar-proto`.
 
+use ainb_hangar_core::agent_env::AgentEnvInput;
 use ainb_hangar_core::channel::ChannelSet;
 use serde::{Deserialize, Serialize};
 
@@ -1245,8 +1246,13 @@ pub struct AgentUpdateParams {
     pub thinking: FieldUpdate<String>,
     /// New per-agent env map (ordered key-value pairs); `None` leaves it (an
     /// empty list is a valid "no env").
+    ///
+    /// Typed [`AgentEnvInput`] rather than a bare `Vec` so a `Debug` of these
+    /// params (an `INVALID_PARAMS` context, a trace span) masks the VALUES
+    /// (multica parity #30). `#[serde(transparent)]` keeps the wire bytes
+    /// (`[["FOO","bar"]]`) byte-identical — a pure type change.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_env: Option<Vec<(String, String)>>,
+    pub agent_env: Option<AgentEnvInput>,
     /// New token budget (rtk/headroom); omitted leaves it, `null` clears it
     /// (back to unlimited), a value sets it (migration 0042).
     #[serde(default, skip_serializing_if = "FieldUpdate::is_keep")]
@@ -3136,7 +3142,7 @@ mod tests {
             cli_args: Some(vec!["--verbose".into()]),
             mcp_config: FieldUpdate::Set(r#"{"servers":{}}"#.into()),
             thinking: FieldUpdate::Set("high".into()),
-            agent_env: Some(vec![("FOO".into(), "bar".into())]),
+            agent_env: Some(vec![("FOO".into(), "bar".into())].into()),
             token_budget: FieldUpdate::Set(500_000),
             description: Some("ships the backend".into()),
             avatar_url: FieldUpdate::Set("emoji:\u{1F98A}".into()),

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -413,7 +413,7 @@ pub async fn create_agent_from(
         cli_args: Vec::new(),
         mcp_config: None,
         thinking: None,
-        agent_env: Vec::new(),
+        agent_env: ainb_hangar_core::agent_env::AgentEnv::default(),
         provider: Some(provider),
         token_budget: None,
         description: draft.description.trim().to_string(),

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -25,6 +25,7 @@
 //! provider EXEC consumption of these knobs is a separate bead (e38.16).
 
 use ainb_hangar_core::actor::ActorRef;
+use ainb_hangar_core::agent_env::AgentEnv;
 use ainb_hangar_core::skill::SkillName;
 use sqlx::SqlitePool;
 
@@ -91,7 +92,12 @@ pub struct Agent {
     pub thinking: Option<String>,
     /// Per-agent environment variables (stored as a JSON-object `agent_env`
     /// column), kept as an ordered key-value list for deterministic encoding.
-    pub agent_env: Vec<(String, String)>,
+    ///
+    /// Typed [`AgentEnv`], not a bare `Vec`, so the VALUES are redacted on every
+    /// egress — including this struct's derived `Debug` (multica parity #30).
+    /// The exec seam reaches the plaintext via
+    /// [`AgentEnv::expose_for_child_env`], and nothing else may.
+    pub agent_env: AgentEnv,
     /// Optional per-agent provider override (`"claude"`/`"codex"`/`"copilot"`),
     /// recorded at create time (migration 0041); `None` = fall back to the
     /// runtime's advertised provider. Honoured at dispatch: the agent binds the
@@ -156,7 +162,7 @@ impl Default for Agent {
             cli_args: Vec::new(),
             mcp_config: None,
             thinking: None,
-            agent_env: Vec::new(),
+            agent_env: AgentEnv::default(),
             provider: None,
             token_budget: None,
             description: String::new(),
@@ -224,9 +230,9 @@ pub struct AgentConfigUpdate {
     /// New thinking level: `None` leaves it, `Some(None)` clears it,
     /// `Some(Some(_))` sets it.
     pub thinking: Option<Option<String>>,
-    /// New per-agent env map, or `None` to leave it unchanged (an empty `Vec` is
+    /// New per-agent env map, or `None` to leave it unchanged (an empty map is
     /// a valid "no env" value, distinct from leaving it).
-    pub agent_env: Option<Vec<(String, String)>>,
+    pub agent_env: Option<AgentEnv>,
     /// New token budget: `None` leaves it, `Some(None)` clears it (back to
     /// unlimited), `Some(Some(_))` sets it.
     pub token_budget: Option<Option<i64>>,
@@ -337,7 +343,7 @@ impl AgentRepo {
         .bind(cli_args_to_json(&agent.cli_args))
         .bind(agent.mcp_config.clone().unwrap_or_else(|| "{}".to_string()))
         .bind(&agent.thinking)
-        .bind(env_to_json(&agent.agent_env))
+        .bind(agent.agent_env.to_db_json())
         .bind(&agent.provider)
         .bind(agent.token_budget)
         .bind(&agent.description)
@@ -553,7 +559,7 @@ impl AgentRepo {
             query = query.bind(thinking);
         }
         if let Some(agent_env) = &update.agent_env {
-            query = query.bind(env_to_json(agent_env));
+            query = query.bind(agent_env.to_db_json());
         }
         if let Some(token_budget) = &update.token_budget {
             query = query.bind(token_budget);
@@ -957,32 +963,16 @@ fn disabled_runtime_skills_from_json(raw: &str) -> Vec<String> {
     serde_json::from_str(raw).unwrap_or_default()
 }
 
-/// Serialize a per-agent env map into the JSON-object text the `agent_env`
-/// column stores. The ordered key-value list encodes as a JSON object; an empty
-/// list yields `"{}"` (the column default).
-fn env_to_json(env: &[(String, String)]) -> String {
-    let map: serde_json::Map<String, serde_json::Value> = env
-        .iter()
-        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-        .collect();
-    serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
-}
-
 /// Re-assemble a per-agent env map from the `agent_env` column's JSON-object
 /// text, preserving the stored object's key order.
-fn env_from_json(raw: &str) -> Result<Vec<(String, String)>, sqlx::Error> {
-    let value: serde_json::Value =
-        serde_json::from_str(raw).map_err(|e| decode_err("agent_env", &e.to_string()))?;
-    let obj = value
-        .as_object()
-        .ok_or_else(|| decode_err("agent_env", "stored env is not a JSON object"))?;
-    obj.iter()
-        .map(|(k, v)| {
-            v.as_str()
-                .map(|s| (k.clone(), s.to_string()))
-                .ok_or_else(|| decode_err("agent_env", "env value is not a string"))
-        })
-        .collect()
+///
+/// The codec itself lives on [`AgentEnv`] (encode via
+/// [`AgentEnv::to_db_json`]) so the redaction contract and the storage bytes
+/// are defined in one place. The decode error is deliberately VALUE-FREE — a
+/// `serde_json` message quotes the offending scalar, which for this column is
+/// the secret.
+fn env_from_json(raw: &str) -> Result<AgentEnv, sqlx::Error> {
+    AgentEnv::try_from_db_json(raw).map_err(|reason| decode_err("agent_env", reason))
 }
 
 /// Map the empty-object MCP-config default `'{}'` back to `None` so a config-less

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -108,7 +108,7 @@ async fn update_config_persists_and_is_partial() {
         cli_args: Some(vec!["--verbose".to_string()]),
         mcp_config: Some(Some(r#"{"servers":{}}"#.to_string())),
         thinking: Some(Some("high".to_string())),
-        agent_env: Some(vec![("FOO".to_string(), "bar".to_string())]),
+        agent_env: Some(vec![("FOO".to_string(), "bar".to_string())].into()),
         token_budget: Some(Some(750_000)),
         ..AgentConfigUpdate::default()
     };
@@ -124,7 +124,7 @@ async fn update_config_persists_and_is_partial() {
     assert_eq!(got.cli_args, vec!["--verbose".to_string()]);
     assert_eq!(got.mcp_config.as_deref(), Some(r#"{"servers":{}}"#));
     assert_eq!(got.thinking.as_deref(), Some("high"));
-    assert_eq!(got.agent_env, vec![("FOO".to_string(), "bar".to_string())]);
+    assert_eq!(got.agent_env.expose_for_child_env(), vec![("FOO".to_string(), "bar".to_string())]);
     assert_eq!(
         got.token_budget,
         Some(750_000),

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent.rs
@@ -124,7 +124,10 @@ async fn update_config_persists_and_is_partial() {
     assert_eq!(got.cli_args, vec!["--verbose".to_string()]);
     assert_eq!(got.mcp_config.as_deref(), Some(r#"{"servers":{}}"#));
     assert_eq!(got.thinking.as_deref(), Some("high"));
-    assert_eq!(got.agent_env.expose_for_child_env(), vec![("FOO".to_string(), "bar".to_string())]);
+    assert_eq!(
+        got.agent_env.expose_for_child_env(),
+        vec![("FOO".to_string(), "bar".to_string())]
+    );
     assert_eq!(
         got.token_budget,
         Some(750_000),

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_env_redaction.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_env_redaction.rs
@@ -67,7 +67,10 @@ async fn seeded_agent(store: &Store) -> Agent {
         ..Agent::default()
     };
     AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
-    AgentRepo::get(store.pool(), "agent-secret").await.expect("get agent").expect("agent exists")
+    AgentRepo::get(store.pool(), "agent-secret")
+        .await
+        .expect("get agent")
+        .expect("agent exists")
 }
 
 #[tokio::test]
@@ -77,9 +80,18 @@ async fn stored_env_never_appears_in_the_row_debug() {
     let agent = seeded_agent(&store).await;
 
     let rendered = format!("{agent:?}");
-    assert!(!rendered.contains(SECRET), "row Debug leaked the env value: {rendered}");
-    assert!(rendered.contains("SECRET_TOKEN"), "row Debug should keep the key: {rendered}");
-    assert!(rendered.contains("****"), "row Debug should show the mask: {rendered}");
+    assert!(
+        !rendered.contains(SECRET),
+        "row Debug leaked the env value: {rendered}"
+    );
+    assert!(
+        rendered.contains("SECRET_TOKEN"),
+        "row Debug should keep the key: {rendered}"
+    );
+    assert!(
+        rendered.contains("****"),
+        "row Debug should show the mask: {rendered}"
+    );
 }
 
 #[tokio::test]
@@ -91,7 +103,10 @@ async fn serde_of_the_row_env_masks_values() {
     let json = serde_json::to_string(&agent.agent_env).expect("serialize env");
     assert!(!json.contains(SECRET), "serde leaked the env value: {json}");
     assert!(json.contains("****"), "serde should emit the mask: {json}");
-    assert!(json.contains("SECRET_TOKEN"), "serde should keep the key: {json}");
+    assert!(
+        json.contains("SECRET_TOKEN"),
+        "serde should keep the key: {json}"
+    );
 }
 
 #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_env_redaction.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_agent_env_redaction.rs
@@ -1,0 +1,127 @@
+//! Behavioural proof of the per-agent-env redaction contract (multica parity #30).
+//!
+//! An agent's `agent_env` values are secrets. This file asserts the four things
+//! that must simultaneously hold at the STORE boundary:
+//!
+//! 1. reading a row back never renders the value (`Debug`),
+//! 2. serialising the row's env never renders the value (`Serialize`),
+//! 3. the exec seam still gets the PLAINTEXT (redaction must not be achieved by
+//!    breaking dispatch),
+//! 4. the stored column bytes are byte-identical to what a pre-change build
+//!    wrote — which is why item 30 needs no migration and an old DB reads the
+//!    same.
+
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::agent::{Agent, AgentRepo};
+
+/// The canary. Any appearance of this literal outside the exec seam is a leak.
+const SECRET: &str = "sk-live-DEADBEEF01";
+
+/// Seed the FK chain (workspace -> user -> `agent_runtime`) an `agent` row needs.
+async fn seed_fk_chain(store: &Store) -> (String, String, String) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, ?)")
+        .bind("ws-1")
+        .bind("alpha")
+        .bind("Alpha")
+        .bind(0_i64)
+        .execute(store.pool())
+        .await
+        .expect("insert workspace");
+
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, ?)")
+        .bind("user-1")
+        .bind("a@example.com")
+        .bind(0_i64)
+        .execute(store.pool())
+        .await
+        .expect("insert user");
+
+    sqlx::query(
+        "INSERT INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, status) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind("rt-1")
+    .bind("ws-1")
+    .bind("daemon-1")
+    .bind("claude")
+    .bind("local")
+    .bind("online")
+    .execute(store.pool())
+    .await
+    .expect("insert agent_runtime");
+
+    ("ws-1".to_string(), "rt-1".to_string(), "user-1".to_string())
+}
+
+/// Insert a secret-carrying agent and read it back through the typed repo.
+async fn seeded_agent(store: &Store) -> Agent {
+    let (workspace_id, runtime_id, owner_id) = seed_fk_chain(store).await;
+    let agent = Agent {
+        id: "agent-secret".to_string(),
+        workspace_id,
+        name: "secretive".to_string(),
+        runtime_id,
+        owner_id,
+        agent_env: vec![("SECRET_TOKEN".to_string(), SECRET.to_string())].into(),
+        ..Agent::default()
+    };
+    AgentRepo::insert(store.pool(), &agent).await.expect("insert agent");
+    AgentRepo::get(store.pool(), "agent-secret").await.expect("get agent").expect("agent exists")
+}
+
+#[tokio::test]
+async fn stored_env_never_appears_in_the_row_debug() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let agent = seeded_agent(&store).await;
+
+    let rendered = format!("{agent:?}");
+    assert!(!rendered.contains(SECRET), "row Debug leaked the env value: {rendered}");
+    assert!(rendered.contains("SECRET_TOKEN"), "row Debug should keep the key: {rendered}");
+    assert!(rendered.contains("****"), "row Debug should show the mask: {rendered}");
+}
+
+#[tokio::test]
+async fn serde_of_the_row_env_masks_values() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let agent = seeded_agent(&store).await;
+
+    let json = serde_json::to_string(&agent.agent_env).expect("serialize env");
+    assert!(!json.contains(SECRET), "serde leaked the env value: {json}");
+    assert!(json.contains("****"), "serde should emit the mask: {json}");
+    assert!(json.contains("SECRET_TOKEN"), "serde should keep the key: {json}");
+}
+
+#[tokio::test]
+async fn exec_seam_still_gets_the_plaintext() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let agent = seeded_agent(&store).await;
+
+    assert_eq!(
+        agent.agent_env.expose_for_child_env(),
+        vec![("SECRET_TOKEN".to_string(), SECRET.to_string())],
+        "the child env must still receive the real value — redaction must not break dispatch"
+    );
+}
+
+#[tokio::test]
+async fn db_column_bytes_are_unchanged() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    let _ = seeded_agent(&store).await;
+
+    let raw: String = sqlx::query_scalar("SELECT agent_env FROM agent WHERE id = ?")
+        .bind("agent-secret")
+        .fetch_one(store.pool())
+        .await
+        .expect("read raw agent_env");
+
+    assert_eq!(
+        raw,
+        format!(r#"{{"SECRET_TOKEN":"{SECRET}"}}"#),
+        "the column still stores the pre-change JSON-object bytes — no migration needed"
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -67,6 +67,12 @@ pub struct AgentView {
     /// The agent's avatar token (e.g. `"emoji:🦊"`, migration 0050); empty when
     /// unset. Rendered as the leading glyph, never as the raw `emoji:` token.
     pub avatar: String,
+    /// How many per-agent env vars the agent carries (parity #30). Rendered as
+    /// `env <n> (hidden)`; `0` renders nothing.
+    ///
+    /// A COUNT, never a value — the wire has no field that can carry an env
+    /// value, so this screen has no way to render one even by mistake.
+    pub agent_env_key_count: u32,
 }
 
 impl Default for AgentView {
@@ -81,6 +87,7 @@ impl Default for AgentView {
             workload: Workload::Idle,
             description: String::new(),
             avatar: String::new(),
+            agent_env_key_count: 0,
         }
     }
 }
@@ -189,6 +196,7 @@ impl AgentsState {
                 workload: a.workload,
                 description: a.description.clone(),
                 avatar: a.avatar.clone(),
+                agent_env_key_count: a.agent_env_key_count,
             })
             .collect();
         Self::new(agents)
@@ -912,6 +920,19 @@ fn render_agent_row(
         x = put_str(buf, x, row, "  · ", MUTED_GRAY, area_w);
         x = put_str(buf, x, row, &agent.subtitle, MUTED_GRAY, area_w);
     }
+    // Parity #30: the per-agent env is surfaced as a COUNT only. There is no
+    // value on the wire to render, by construction.
+    if agent.agent_env_key_count > 0 {
+        x = put_str(buf, x, row, "  · ", MUTED_GRAY, area_w);
+        x = put_str(
+            buf,
+            x,
+            row,
+            &format!("env {} (hidden)", agent.agent_env_key_count),
+            MUTED_GRAY,
+            area_w,
+        );
+    }
     if !agent.description.is_empty() {
         x = put_str(buf, x, row, "  — ", MUTED_GRAY, area_w);
         put_str(buf, x, row, &agent.description, MUTED_GRAY, area_w);
@@ -1464,6 +1485,67 @@ mod tests {
             None,
             "an empty emoji token is nothing"
         );
+    }
+
+    /// Parity #30: an agent with per-agent env renders a COUNT (`env 1 (hidden)`)
+    /// and — necessarily — no value, because the wire carries none. The
+    /// `ActorRow` the screen is built from is what makes the leak impossible:
+    /// it has a key-name list and a count, and no value-bearing field at all.
+    #[test]
+    fn render_agent_row_shows_env_key_count_not_values() {
+        let row = ActorRow {
+            actor_ref: "agent:a-1".into(),
+            display_name: "builder".into(),
+            subtitle: "agent".into(),
+            presence: PresenceState::Online,
+            is_agent: true,
+            agent_env_key_count: 1,
+            agent_env_keys: vec!["SECRET_TOKEN".into()],
+            agent_env_redacted: true,
+            ..ActorRow::default()
+        };
+        let state = AgentsState::from_actors(&[row]);
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(
+            text.contains("env 1 (hidden)"),
+            "the roster must surface the env COUNT: {text:?}"
+        );
+        assert!(
+            !text.contains("sk-live-"),
+            "no value may reach the frame: {text:?}"
+        );
+    }
+
+    /// An env-less agent renders no env affordance at all (pure addition).
+    #[test]
+    fn render_agent_row_omits_env_when_the_agent_has_none() {
+        let state = AgentsState::new(vec![AgentView {
+            actor_ref: "agent:a-1".into(),
+            name: "builder".into(),
+            presence: PresenceState::Online,
+            ..AgentView::default()
+        }]);
+        let mut buf = WireBuffer::new(80, 24);
+        render_agents(&mut buf, 80, 1, 23, &state);
+        let text = buffer_text(&buf, 80, 24);
+        assert!(!text.contains("env "), "an env-less agent renders nothing: {text:?}");
+    }
+
+    /// A PRE-#30 `agents_list` payload (no `agent_env_*` keys) still decodes, and
+    /// the screen simply shows no env affordance — the append-only proof from
+    /// the consumer's side.
+    #[test]
+    fn pre_parity_30_actor_row_payload_decodes_with_no_env_metadata() {
+        let legacy = r#"{"actor_ref":"agent:a-1","display_name":"builder",
+            "subtitle":"agent","presence":"online","is_agent":true,"recent_rank":null}"#;
+        let row: ActorRow = serde_json::from_str(legacy).expect("pre-#30 payload decodes");
+        assert_eq!(row.agent_env_key_count, 0);
+        assert!(row.agent_env_keys.is_empty());
+        assert!(!row.agent_env_redacted);
+        let state = AgentsState::from_actors(&[row]);
+        assert_eq!(state.agents()[0].agent_env_key_count, 0);
     }
 
     /// Reassemble the buffer text for render assertions.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/agents.rs
@@ -1530,7 +1530,10 @@ mod tests {
         let mut buf = WireBuffer::new(80, 24);
         render_agents(&mut buf, 80, 1, 23, &state);
         let text = buffer_text(&buf, 80, 24);
-        assert!(!text.contains("env "), "an env-less agent renders nothing: {text:?}");
+        assert!(
+            !text.contains("env "),
+            "an env-less agent renders nothing: {text:?}"
+        );
     }
 
     /// A PRE-#30 `agents_list` payload (no `agent_env_*` keys) still decodes, and

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -3748,6 +3748,7 @@ Commands:
   permission  Set an agent's invocation permission mode (gap #8: `private`/`public_to`)
   allow       Manage an agent's invocation allow-list (add/revoke/list a target)
   can-invoke  Report whether a user (or agent actor) may invoke an agent (`ALLOW`/`DENY`)
+  env         Show an agent's per-agent env: variable NAMES only, values masked
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3820,7 +3821,9 @@ Options:
       --clear-mcp                    Clear the MCP config; omitted leaves it
       --thinking <THINKING>          New thinking level (e.g. `low`/`medium`/`high`); omitted leaves it. Mutually exclusive with `--clear-thinking`
       --clear-thinking               Clear the thinking level; omitted leaves it
-      --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable). When ANY `--env` is given the whole env map is REPLACED with the values
+      --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable; ANY `--env` REPLACES the whole map). Visible in `ps` / shell history — prefer `--env-stdin` / `--env-file` for secrets
+      --env-stdin                    Read the whole env map from STDIN as a JSON object of string→string, keeping secrets off argv; `{}` clears it and empty input is an ERROR, not a clear
+      --env-file <ENV_FILE>          Read the whole env map from a FILE as a JSON object of string→string (same contract as `--env-stdin`)
       --token-budget <TOKEN_BUDGET>  New token budget (rtk/headroom, migration 0042); omitted leaves it. Mutually exclusive with `--clear-token-budget`
       --clear-token-budget           Clear the token budget (back to unlimited); omitted leaves it
       --description <DESCRIPTION>    New description (≤255 characters); omitted leaves it. Pass `--description ""` to blank it (the column is NOT NULL, so `""` IS its cleared state)
@@ -3941,6 +3944,25 @@ Options:
       --as <AS_USER>           The invoking user id or email to judge the run by
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --actor <ACTOR>          Treat the invoker as an `agent` actor (no resolved originator) rather than a `member`. Exercises the A2A / workspaceBroad path
+      --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar agent env`
+
+Show an agent's per-agent env: variable NAMES only, values masked
+
+```console
+$ ainb hangar agent env --help
+Show an agent's per-agent env: variable NAMES only, values masked
+
+Usage: ainb hangar agent env [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Agent id (ULID) to inspect
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```


### PR DESCRIPTION
## Parity #30 — agent `custom_env` redaction contract

**Acceptance:** a redacted env var never appears in logs / render / output; stored redacted (test-proven).

Multica's contract (`server/internal/handler/agent.go:552-562` `redactEnv`) is **keys preserved, every value replaced with `****`**, plus a `custom_env_redacted` flag. This ports that, with the plaintext confined to one named, grep-able seam.

### The invariant (stated once, in `agent_env.rs`)

> The plaintext of an `AgentEnv` leaves the process by exactly one route: the environment of the provider child process, via `expose_for_child_env`. Every other route — `Debug`, `Display`, `Serialize`, the RPC wire, the CLI renderers, the TUI, tracing — is redacted by construction.

### The four leak sites this closes

| # | Site | Was |
|---|---|---|
| L1 | `cli/hangar/mod.rs` `agent_to_json` | `hangar agent list --format json` printed `"env":{"SECRET_TOKEN":"sk-live-…"}` — **full plaintext on stdout** |
| L2 | `parse_env_kv` | a malformed `--env` echoed the whole raw argument (i.e. the secret) to stderr |
| L3 | `Agent`, `AgentConfigUpdate`, `ResolvedDispatch`, `AgentUpdateParams` | all derived `Debug` over plaintext — one `tracing::debug!(?dispatch)` away from a leak, with only a comment as the barrier |
| L4 | `--env KEY=VALUE` | the only write channel put secrets on argv (`ps`, `/proc/<pid>/cmdline`, shell history) |

Plus a fifth found while sweeping: `interactive.rs` wrote the pane wrapper — which **bakes the plaintext child env into a file** — and never unlinked it, so every secret an interactive run used stayed greppable under the task's logs dir forever at 0700. It is now unlinked at the finalize seam (never mid-run — `/bin/sh` re-reads a running script).

### What changed

* **`ainb-hangar-core/src/agent_env.rs` (new)** — `AgentEnv` (plaintext inside, hand-written redacting `Debug`/`Display`/`Serialize`, **no `Deserialize`** so `****` can never round-trip into the DB) + `AgentEnvInput` (write side: plaintext `Serialize`, redacted `Debug`, `#[serde(transparent)]`).
* **Store** — `Agent.agent_env` / `AgentConfigUpdate.agent_env` are typed. Column bytes unchanged.
* **Proto** — `ActorRow` gains `agent_env_key_count` / `agent_env_keys` / `agent_env_redacted`, all `serde(default)` + skip-when-empty. The wire carries key NAMES and a count and has **no field that can hold a value**.
* **Daemon** — the actor-row snapshot is the only place env reaches the wire; `agent_create`/`agent_update` parse via a new `parse_params_secret` whose message drops the `serde_json` error (serde quotes the offending scalar, which here IS the secret — multica `cmd_agent.go:757-759`).
* **CLI** — masked JSON + `env_key_count`/`env_redacted`; content-free `--env` errors; `--env-stdin` / `--env-file` (mutually exclusive with `--env`; `{}` clears, blank input is an **error**, parse failures are content-free); new `hangar agent env <id>`.
* **Plugin** — the roster row shows `env N (hidden)`.

### Deviations from multica (documented in the module doc)

* **D-1 — hangar masks unconditionally.** Multica's `canViewAgentEnv()` owner/admin plaintext branch is a multi-tenant server concept; hangar is a local single-user control plane where the operator can already `sqlite3` the DB. There is deliberately **no `--reveal`** (a test asserts clap rejects it).
* **D-2 — the `agent.agent_env` column keeps plaintext.** The exec seam needs the value and there is no session key. What the sweep proves is that *no other* artefact contains it. Keychain-backed storage is a follow-up.

### Honest correction to our own reference doc

`docs/explorations/multica-reference/agent.md` / `README.md:211` claim custom_env is "never serialized … read/write via dedicated audited `GET/PUT /api/agents/{id}/env`". The multica source does **not** support that: there is no such route, no `has_custom_env`/`custom_env_key_count` field, and no audit table. This PR matches the SOURCE (mask-values / keep-keys / `custom_env_redacted`); the key-count idea is kept as a *derived* wire field because it is cheaper for the TUI than shipping a `****` map.

### No migration

`agent.agent_env` keeps its exact `0015` shape and on-disk JSON-object bytes — pinned by `db_column_bytes_are_unchanged`, which asserts the raw `SELECT agent_env` still returns `{"SECRET_TOKEN":"sk-live-DEADBEEF01"}`. Next free number (`0058`) is left unclaimed.

### Fail-before / pass-after, verified by mutation

The acceptance sweep is `tripwire_agent_env_no_leak.rs`: it drives **one real dispatch through the real daemon binary** with an agent carrying `SECRET_TOKEN=sk-live-DEADBEEF01`, then greps for that literal in every TEXT column of every `hangar.db` table (except `agent.agent_env`), the daemon logs, every file under the task's logs dir post-teardown, `agent list --format json` stdout, and `agent env <id>` stdout.

I mutated `agent_to_json` back to plaintext and confirmed the sweep fails with the real leaked payload:

```
agent list --format json leaked the value:
[…,"env":{"SECRET_TOKEN":"sk-live-DEADBEEF01"},"env_key_count":1,…]
```

Redaction is **not** achieved by breaking the feature: the fake provider only touches its marker file when `$SECRET_TOKEN` actually equals the secret, and the sweep asserts that marker exists before it asserts anything else. `exec_seam_still_gets_the_plaintext` (store) pins the same thing at the type level.

### Fixtures this PR drifted, fixed here

* `hangar_cli_integration::agent_edit_and_archive_round_trip` asserted `"FOO":"bar"` in the list JSON — now asserts the masked map + `env_key_count`/`env_redacted` + the new `agent env` verb.
* `runner_codex`'s new tracing test originally used a fake that echoed the value; under `--all-features` the provider-contract-drift warning re-printed that stdout tail. The fake now proves receipt via a marker file instead.

Assertions are membership-based (key present, mask present, count/flag present), not frozen whole-string literals.

### Local gate — all green

```
cargo build -p ainb                                                        ok
cargo nextest run --lib --tests --all-features -E 'not binary(/^tripwire_/)'
    → 4195 tests run: 4195 passed, 18 skipped
bash scripts/hangar/run_all_tripwires.sh   → ran=64  failed=0 skipped=0
bash scripts/hangar/run_acceptance_tests.sh → ran=163 failed=0 skipped=0
```

CI note: `Rustfmt` is red on `main` for the documented toolchain drift (the repo's `rustfmt.toml` uses nightly-only options); this branch is `cargo fmt`-clean on stable and touches only its own files.
