### PR TITLE
feat(hangar): dispatch reason codes — persist and surface why a card did not run (multica parity #12)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1348,6 +1348,23 @@ pub enum IssueCommand {
     /// Add, remove, or list an issue's typed links to other issues.
     #[command(subcommand)]
     Link(IssueLinkCommand),
+    /// Explain why an issue did (or did not) dispatch — its admission history.
+    #[command(alias = "dispatch-log")]
+    Why(IssueWhyArgs),
+}
+
+/// Arguments for `hangar issue why` (multica parity #12).
+#[derive(Args, Debug)]
+pub struct IssueWhyArgs {
+    /// Issue id (ULID) whose dispatch history to explain.
+    pub id: String,
+    /// How many attempts to show, newest first.
+    #[arg(long, default_value_t = 20)]
+    pub limit: i64,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// `hangar issue link <verb>` (multica parity #20).
@@ -4152,6 +4169,7 @@ async fn dispatch_issue(cmd: IssueCommand, format: OutputFormat) -> Result<()> {
         IssueCommand::Label(cmd) => run_issue_label(&store, cmd).await,
         IssueCommand::Criteria(cmd) => run_issue_criteria(&store, cmd).await,
         IssueCommand::Link(cmd) => run_issue_link(&store, cmd).await,
+        IssueCommand::Why(args) => run_issue_why(&store, args, format).await,
     }
 }
 
@@ -4669,16 +4687,29 @@ async fn enqueue_assigned_task(
     issue_id: &str,
     agent_id: &str,
 ) -> Result<Option<String>> {
+    use ainb_hangar_core::dispatch_reason::DispatchReason;
     use ainb_hangar_store::repo::card_parity::CardParityRepo;
     use ainb_hangar_store::repo::task::NewTask;
 
     // One active run per card: an in-flight (queued/dispatched/running) task keeps
     // the issue; recovery only re-dispatches once the prior run is terminal.
-    if TaskRepo::active_task_for_issue(pool, workspace_id, issue_id)
+    if let Some(active) = TaskRepo::active_task_for_issue(pool, workspace_id, issue_id)
         .await
         .context("check for an active run before re-dispatch")?
-        .is_some()
     {
+        // multica parity #12: this used to be a bare `Ok(None)` — no record, no
+        // message, no way for the user to learn why assigning an agent did not
+        // start anything. Record it.
+        record_cli_dispatch_attempt(
+            pool,
+            workspace_id,
+            issue_id,
+            Some(agent_id),
+            None,
+            DispatchReason::AlreadyActive,
+            Some(&format!("a run is already active ({})", active.status)),
+        )
+        .await;
         return Ok(None);
     }
 
@@ -4694,6 +4725,17 @@ async fn enqueue_assigned_task(
         .context("read issue repo/agent for re-dispatch")?
         .unwrap_or((None, None));
     let Some(repo_ref) = card_repo else {
+        // multica parity #12: the other silent `Ok(None)`.
+        record_cli_dispatch_attempt(
+            pool,
+            workspace_id,
+            issue_id,
+            Some(agent_id),
+            None,
+            DispatchReason::TargetUnavailable,
+            Some("no repo pinned on this card"),
+        )
+        .await;
         return Ok(None);
     };
     let source_branch = CardParityRepo::get_issue_branches(pool, issue_id)
@@ -4752,7 +4794,58 @@ async fn enqueue_assigned_task(
         .await
         .context("persist re-dispatched task source branch")?;
     tx.commit().await.context("commit re-dispatch tx")?;
+    record_cli_dispatch_attempt(
+        pool,
+        workspace_id,
+        issue_id,
+        Some(agent_id),
+        Some(&task_id),
+        DispatchReason::Queued,
+        Some(&format!("task {task_id}")),
+    )
+    .await;
     Ok(Some(task_id))
+}
+
+/// Record one `dispatch_attempt` row from a CLI path (multica parity #12).
+///
+/// The CLI talks to the store DIRECTLY (no daemon), so it cannot ride the
+/// daemon's `run_card` recording seam — this is its equivalent. Best-effort by
+/// the same contract: a record fault warns and never changes the caller's
+/// outcome, because an audit write must not be able to break an assignment that
+/// otherwise succeeded.
+///
+/// `source` is always [`DispatchSource::Assign`]: every CLI producer today is the
+/// assignee re-dispatch.
+async fn record_cli_dispatch_attempt(
+    pool: &sqlx::SqlitePool,
+    workspace_id: &str,
+    issue_id: &str,
+    agent_id: Option<&str>,
+    task_id: Option<&str>,
+    reason: ainb_hangar_core::dispatch_reason::DispatchReason,
+    detail: Option<&str>,
+) {
+    use ainb_hangar_store::repo::dispatch_attempt::{DispatchAttemptRepo, NewDispatchAttempt};
+
+    let record = NewDispatchAttempt {
+        workspace_id,
+        issue_id: Some(issue_id),
+        agent_id,
+        runtime_id: None,
+        task_id,
+        reason,
+        detail,
+        source: ainb_hangar_core::dispatch_reason::DispatchSource::Assign,
+        created_at: ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock),
+    };
+    if let Err(e) = DispatchAttemptRepo::record(pool, &SystemIdGen.new_ulid(), &record).await {
+        tracing::warn!(
+            error = %e,
+            issue_id,
+            "dispatch attempt record failed (audit only; the assignment is unchanged)"
+        );
+    }
 }
 
 /// `hangar issue create`: bootstrap a workspace if absent, then insert.
@@ -5102,9 +5195,125 @@ async fn run_issue_show(store: &Store, args: IssueShowArgs, format: OutputFormat
                 println!("Links:");
                 print_issue_links(store, &issue.workspace_id, &issue.id).await?;
             }
+            // multica parity #12: WHY this card is not running, when its newest
+            // admission decision was a decline. Silent on a healthy card, so
+            // existing output is unchanged. `issue why` shows the full history.
+            if let Some((code, detail)) = latest_dispatch_decline(store, &issue.id).await? {
+                match detail {
+                    Some(d) => println!("Not dispatched: {code} — {d}"),
+                    None => println!("Not dispatched: {code}"),
+                }
+            }
         }
     }
     Ok(())
+}
+
+/// `hangar issue why <id>` (multica parity #12): the card's ADMISSION history,
+/// newest first — the persisted answer to "why is this not running".
+///
+/// Reads the store directly (like `issue criteria` / `issue link`), so it needs
+/// no daemon: the whole dispatch-reason proof is runnable against nothing but
+/// sqlite. Honours the shared `--format json`, which emits the
+/// `DispatchAttemptRow` wire shape verbatim.
+async fn run_issue_why(store: &Store, args: IssueWhyArgs, format: OutputFormat) -> Result<()> {
+    use ainb_hangar_store::repo::dispatch_attempt::DispatchAttemptRepo;
+
+    // Resolve the workspace so a typo'd `--workspace` is an error, not a silently
+    // empty list; the attempts themselves are keyed on the issue id.
+    let _workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let attempts = DispatchAttemptRepo::list_for_issue(store.pool(), &args.id, args.limit.max(1))
+        .await
+        .context("read dispatch attempts")?;
+
+    match format {
+        OutputFormat::Json => {
+            let rows: Vec<serde_json::Value> = attempts.iter().map(dispatch_attempt_json).collect();
+            println!(
+                "{}",
+                serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string())
+            );
+        }
+        OutputFormat::Csv => {
+            println!("id,reason,detail,source,task_id,created_at");
+            for a in &attempts {
+                println!(
+                    "{},{},{},{},{},{}",
+                    a.id,
+                    a.reason,
+                    csv_field(a.detail.as_deref().unwrap_or_default()),
+                    a.source,
+                    a.task_id.as_deref().unwrap_or_default(),
+                    a.created_at
+                );
+            }
+        }
+        OutputFormat::Markdown => {
+            println!("| reason | detail | source | when |");
+            println!("|---|---|---|---|");
+            for a in &attempts {
+                println!(
+                    "| {} | {} | {} | {} |",
+                    a.reason,
+                    a.detail.as_deref().unwrap_or("—"),
+                    a.source,
+                    fmt_epoch_ms_utc(a.created_at)
+                );
+            }
+        }
+        OutputFormat::Text => {
+            if attempts.is_empty() {
+                println!("no dispatch attempts recorded for {}", args.id);
+            } else {
+                println!("{:<22} {:<8} {:<22} detail", "reason", "source", "when");
+                for a in &attempts {
+                    println!(
+                        "{:<22} {:<8} {:<22} {}",
+                        a.reason,
+                        a.source,
+                        fmt_epoch_ms_utc(a.created_at),
+                        a.detail.as_deref().unwrap_or("—")
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// One dispatch attempt as the `DispatchAttemptRow` wire shape, so
+/// `issue why --format json` and `hangar/dispatch_attempts_list` agree.
+fn dispatch_attempt_json(
+    a: &ainb_hangar_store::repo::dispatch_attempt::DispatchAttempt,
+) -> serde_json::Value {
+    serde_json::json!({
+        "id": a.id,
+        "issue_id": a.issue_id,
+        "agent_id": a.agent_id,
+        "runtime_id": a.runtime_id,
+        "task_id": a.task_id,
+        "reason": a.reason,
+        "detail": a.detail,
+        "source": a.source,
+        "created_at": a.created_at,
+    })
+}
+
+/// The newest DECLINED dispatch attempt for an issue, as
+/// `(code, detail)` — what `issue show` prints as its `Not dispatched:` line.
+/// `None` when the card never tried to dispatch, or its newest attempt succeeded.
+async fn latest_dispatch_decline(
+    store: &Store,
+    issue_id: &str,
+) -> Result<Option<(String, Option<String>)>> {
+    use ainb_hangar_store::repo::dispatch_attempt::DispatchAttemptRepo;
+    Ok(
+        DispatchAttemptRepo::latest_for_issue(store.pool(), issue_id)
+            .await
+            .context("read latest dispatch attempt")?
+            .filter(|a| !a.is_dispatched())
+            .map(|a| (a.reason, a.detail)),
+    )
 }
 
 /// Whether an issue carries ANY typed link (multica parity #20) — so

--- a/ainb-tui/crates/ainb-core/tests/tripwire_hangar_dispatch_why.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_hangar_dispatch_why.rs
@@ -1,0 +1,160 @@
+//! ACCEPTANCE (CLI half): `ainb hangar issue why` explains a non-dispatch
+//! (multica parity #12).
+//!
+//! Drives the REAL `ainb` binary against an isolated `AINB_HANGAR_HOME`, with
+//! no daemon and no network — nothing but sqlite + the CLI. It reproduces the
+//! exact silent hole item 12 closes:
+//!
+//!   `enqueue_assigned_task` returned a bare `Ok(None)` when a card had no repo
+//!   pinned, so `issue update --assign <agent>` printed "updated issue" and
+//!   nothing ran, with no record and no message anywhere.
+//!
+//! Now the same flow records `target_unavailable`, `issue why` prints it, and
+//! `issue show` states it. Delete the `record_cli_dispatch_attempt` call from
+//! the no-repo branch and this test goes RED.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+/// Run one `ainb hangar …` invocation inside the isolated home, returning stdout.
+fn ainb(home: &std::path::Path, args: &[&str]) -> String {
+    let out = Command::new(ainb_bin())
+        .args(args)
+        .env("AINB_HANGAR_HOME", home)
+        .env("HOME", home)
+        .output()
+        .expect("run ainb");
+    assert!(
+        out.status.success(),
+        "`ainb {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// The `created issue <ULID>` ack's id.
+fn created_id(ack: &str) -> String {
+    ack.split_whitespace()
+        .last()
+        .unwrap_or_else(|| panic!("no id in ack {ack:?}"))
+        .to_string()
+}
+
+#[test]
+fn assigning_an_agent_to_a_repoless_card_records_and_explains_the_non_dispatch() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+
+    // A card with NO repo pinned — the case that used to vanish into `Ok(None)`.
+    let issue_id = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "RepolessCard"],
+    ));
+    ainb(h, &["hangar", "agent", "create", "--name", "bot"]);
+
+    // Before the assign there is nothing to explain.
+    let empty = ainb(
+        h,
+        &["hangar", "issue", "why", &issue_id, "--format", "json"],
+    );
+    assert_eq!(empty.trim(), "[]", "no attempts before any dispatch");
+
+    // Resolve the agent id from the CLI's own listing (the create ack prints the
+    // name, not the id) — still no daemon, still the real binary.
+    let agents = ainb(h, &["hangar", "agent", "list", "--format", "json"]);
+    let agents: serde_json::Value = serde_json::from_str(&agents).expect("agent list json");
+    let agent_id = agents
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|a| a.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .expect("one agent listed")
+        .to_string();
+
+    // The assign SUCCEEDS (the edit is committed) but dispatches nothing.
+    let updated = ainb(
+        h,
+        &[
+            "hangar", "issue", "update", &issue_id, "--assign", &agent_id,
+        ],
+    );
+    assert!(updated.contains("updated issue"), "{updated}");
+
+    // …and that is now RECORDED, with the stable code.
+    let json = ainb(
+        h,
+        &["hangar", "issue", "why", &issue_id, "--format", "json"],
+    );
+    let rows: serde_json::Value = serde_json::from_str(&json).expect("why json");
+    let rows = rows.as_array().expect("array");
+    assert_eq!(rows.len(), 1, "exactly one attempt: {json}");
+    let row = &rows[0];
+    assert_eq!(
+        row.get("reason").and_then(serde_json::Value::as_str),
+        Some("target_unavailable")
+    );
+    assert_eq!(
+        row.get("detail").and_then(serde_json::Value::as_str),
+        Some("no repo pinned on this card")
+    );
+    assert_eq!(
+        row.get("source").and_then(serde_json::Value::as_str),
+        Some("assign"),
+        "the trigger surface is recorded, not just the code"
+    );
+    assert!(
+        row.get("task_id").is_some_and(serde_json::Value::is_null),
+        "no task was enqueued: {json}"
+    );
+    assert_eq!(
+        row.get("issue_id").and_then(serde_json::Value::as_str),
+        Some(issue_id.as_str())
+    );
+
+    // The text surface says the same thing.
+    let text = ainb(h, &["hangar", "issue", "why", &issue_id]);
+    assert!(text.contains("target_unavailable"), "{text}");
+    assert!(text.contains("no repo pinned on this card"), "{text}");
+    assert!(text.contains("assign"), "{text}");
+
+    // And `issue show` states it inline, so the operator does not need to know
+    // `why` exists to find out.
+    let show = ainb(h, &["hangar", "issue", "show", &issue_id]);
+    assert!(
+        show.contains("Not dispatched: target_unavailable — no repo pinned on this card"),
+        "issue show must state the decline: {show}"
+    );
+
+    // `--alias dispatch-log` reaches the same verb.
+    let aliased = ainb(h, &["hangar", "issue", "dispatch-log", &issue_id]);
+    assert!(aliased.contains("target_unavailable"), "{aliased}");
+}
+
+/// A healthy card says nothing extra: `issue show` is byte-unchanged from
+/// pre-#12 for a card that never had a declined dispatch. The negative twin, so
+/// the line above is proven conditional rather than always-on.
+#[test]
+fn a_card_with_no_declined_dispatch_shows_no_extra_line() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+    let issue_id = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "QuietCard"],
+    ));
+
+    let show = ainb(h, &["hangar", "issue", "show", &issue_id]);
+    assert!(
+        !show.contains("Not dispatched"),
+        "an untouched card shows no dispatch line: {show}"
+    );
+    let why = ainb(h, &["hangar", "issue", "why", &issue_id]);
+    assert!(
+        why.contains("no dispatch attempts recorded"),
+        "an untouched card explains itself as having no history: {why}"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
@@ -244,11 +244,7 @@ mod tests {
     use super::{DispatchReason, DispatchSource};
 
     fn serde_token(r: DispatchReason) -> String {
-        serde_json::to_value(r)
-            .expect("serialize")
-            .as_str()
-            .expect("string")
-            .to_owned()
+        serde_json::to_value(r).expect("serialize").as_str().expect("string").to_owned()
     }
 
     #[test]
@@ -257,11 +253,8 @@ mod tests {
             assert_eq!(serde_token(r), r.as_db_str(), "drift on {r:?}");
         }
         for s in DispatchSource::ALL {
-            let tok = serde_json::to_value(s)
-                .expect("serialize")
-                .as_str()
-                .expect("string")
-                .to_owned();
+            let tok =
+                serde_json::to_value(s).expect("serialize").as_str().expect("string").to_owned();
             assert_eq!(tok, s.as_db_str(), "drift on {s:?}");
         }
     }

--- a/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
@@ -50,8 +50,8 @@ use serde::{Deserialize, Serialize};
 /// Serializes to the `snake_case` tokens the reference's `dispatch.ReasonCode`
 /// uses, which is also the exact token persisted to `dispatch_attempt.reason`.
 ///
-/// The set is **append-only by design** and there is deliberately no SQLite
-/// `CHECK` constraint on the column (SQLite cannot widen a `CHECK` without a
+/// The set is **append-only by design** and there is deliberately no `SQLite`
+/// `CHECK` constraint on the column (`SQLite` cannot widen a `CHECK` without a
 /// full table rebuild). The domain is enforced in Rust instead: [`Self::as_db_str`]
 /// is the only writer, and [`Self::parse`] is the tolerant reader (an unknown
 /// token decodes to `None` and renders as raw text rather than poisoning a read).

--- a/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
@@ -1,0 +1,332 @@
+//! **Dispatch reason codes** — the admission-time decision vocabulary
+//! (multica parity #12).
+//!
+//! multica carries this in a dedicated *leaf* package,
+//! `server/internal/dispatch/reason.go` (MUL-4525), deliberately separate from
+//! failure classification: [`crate::…`]-side `FailureReason`
+//! (`ainb_hangar_store::service::fail::FailureReason`) answers "why did a run
+//! that STARTED end badly"; [`DispatchReason`] answers "why did (or did not) a
+//! trigger turn into a run at all". Keeping the two vocabularies apart is what
+//! stops declined dispatches polluting the failure-rate signal — the same
+//! reasoning migration `0057` used when it gave `autopilot_run` a non-failure
+//! `skipped` status.
+//!
+//! # Two properties carried over verbatim from the reference
+//!
+//! 1. **Deliberately generic where enumeration-safety matters.**
+//!    [`DispatchReason::InvocationNotAllowed`] does *not* distinguish "the
+//!    agent is private" from "the agent does not exist", so the code can never
+//!    be used as an existence oracle by a caller probing ids. The specifics
+//!    live in the free-text `detail`, never in the code.
+//! 2. **One vocabulary shared by the decider and the serializer.** The service
+//!    layer that decides and the handler layer that writes it to the wire read
+//!    the same enum, so the two cannot drift.
+//!
+//! # The mapping this vocabulary is applied through
+//!
+//! The normative `run_card`-outcome → code table lives on the daemon's
+//! recorder (`ainb-hangar-daemon/src/rpc/mod.rs`, `record_dispatch_attempt`),
+//! next to the code that applies it. Two hangar divergences from the reference
+//! are documented there: `runtime_offline` still *enqueues* (hangar's runtime
+//! rows are per-`(daemon, provider)` and flip `offline` on a heartbeat grace
+//! timer, so refusing would turn a transient gap into a hard failure), and
+//! `Blocked` maps to [`DispatchReason::Deferred`] because hangar genuinely
+//! promotes it later when the last blocker finishes.
+//!
+//! # Reserved variants
+//!
+//! [`DispatchReason::Coalesced`], [`DispatchReason::AttributionBlocked`] and
+//! [`DispatchReason::SelfTriggerSuppressed`] ship with **no producer** at this
+//! stage. That is deliberate, not an oversight: the vocabulary is a *wire
+//! contract*, so a reader must already accept codes a future writer will emit.
+//! Those three belong to the mention-routing layer, which is unstarted. The
+//! [`DispatchReason::RESERVED`] list pins the set — a future change that adds a
+//! producer has to remove its variant from that list deliberately.
+
+use serde::{Deserialize, Serialize};
+
+/// Why a trigger did — or did not — become a dispatched run.
+///
+/// Serializes to the `snake_case` tokens the reference's `dispatch.ReasonCode`
+/// uses, which is also the exact token persisted to `dispatch_attempt.reason`.
+///
+/// The set is **append-only by design** and there is deliberately no SQLite
+/// `CHECK` constraint on the column (SQLite cannot widen a `CHECK` without a
+/// full table rebuild). The domain is enforced in Rust instead: [`Self::as_db_str`]
+/// is the only writer, and [`Self::parse`] is the tolerant reader (an unknown
+/// token decodes to `None` and renders as raw text rather than poisoning a read).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchReason {
+    // --- dispatch happened, or will ---
+    /// A task row was written; the claim loop will pick it up.
+    Queued,
+    /// Folded into an existing pending task rather than creating a second one.
+    ///
+    /// **Reserved** — no producer yet (see the module docs).
+    Coalesced,
+    /// Admitted but parked: a later event promotes it. hangar's producer is a
+    /// card blocked by unfinished dependencies, which `board::auto_run_dependent`
+    /// fires once the last blocker finishes.
+    Deferred,
+    // --- declined ---
+    /// The invoker may not run this target. Deliberately generic: it covers
+    /// "the agent is private", "you are not on its allow-list", "the issue is
+    /// cancelled" and "interactive mode is not supported for a squad" with one
+    /// code, so it is never an existence oracle.
+    InvocationNotAllowed,
+    /// There is nothing to dispatch *to*: no agent in the workspace, no repo
+    /// pinned on the card, or a provider that is not wired for dispatch.
+    TargetUnavailable,
+    /// The resolved agent's runtime is not `online`.
+    ///
+    /// In hangar this is **recorded, not refused** — the task row still exists
+    /// (see the divergence note in the daemon recorder). It is nonetheless a
+    /// *decline* for surfacing purposes: it is the answer to "why is my task
+    /// sitting there doing nothing".
+    RuntimeOffline,
+    /// The trigger could not be attributed to an authorised actor.
+    ///
+    /// **Reserved** — no producer yet (see the module docs).
+    AttributionBlocked,
+    /// A run for this card is already active, so a second one was not started.
+    AlreadyActive,
+    /// The trigger was produced by the same agent it would have targeted, and
+    /// was suppressed to stop a self-driving loop.
+    ///
+    /// **Reserved** — no producer yet (see the module docs).
+    SelfTriggerSuppressed,
+    /// The admission path itself faulted (e.g. a database error).
+    InternalError,
+}
+
+impl DispatchReason {
+    /// Every variant, in declaration order. Kept exhaustive by
+    /// [`Self::as_db_str`]'s wildcard-free `match` plus the
+    /// `all_covers_every_variant` test.
+    pub const ALL: [Self; 10] = [
+        Self::Queued,
+        Self::Coalesced,
+        Self::Deferred,
+        Self::InvocationNotAllowed,
+        Self::TargetUnavailable,
+        Self::RuntimeOffline,
+        Self::AttributionBlocked,
+        Self::AlreadyActive,
+        Self::SelfTriggerSuppressed,
+        Self::InternalError,
+    ];
+
+    /// Variants that ship in the vocabulary with **no producer** in this
+    /// codebase (see the module docs). Pinned by a test so adding a producer is
+    /// a deliberate edit here, and so the list can never quietly grow.
+    pub const RESERVED: [Self; 3] = [
+        Self::Coalesced,
+        Self::AttributionBlocked,
+        Self::SelfTriggerSuppressed,
+    ];
+
+    /// The `snake_case` token persisted to `dispatch_attempt.reason` and put on
+    /// the wire.
+    ///
+    /// Kept byte-identical to the [`Serialize`] `rename_all = "snake_case"`
+    /// derive (guarded by `as_db_str_matches_serde_for_all_variants`), but
+    /// written as a direct `match` so the persist path needs no serializer.
+    /// No wildcard arm: a future variant breaks the build here first.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Coalesced => "coalesced",
+            Self::Deferred => "deferred",
+            Self::InvocationNotAllowed => "invocation_not_allowed",
+            Self::TargetUnavailable => "target_unavailable",
+            Self::RuntimeOffline => "runtime_offline",
+            Self::AttributionBlocked => "attribution_blocked",
+            Self::AlreadyActive => "already_active",
+            Self::SelfTriggerSuppressed => "self_trigger_suppressed",
+            Self::InternalError => "internal_error",
+        }
+    }
+
+    /// Wire/DB token → variant. Unknown tokens return `None` (the reader stays
+    /// tolerant of a newer writer's vocabulary).
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|r| r.as_db_str() == s)
+    }
+
+    /// Did a task row actually get written (or folded into one)?
+    ///
+    /// Note [`Self::RuntimeOffline`] is deliberately **not** dispatched for this
+    /// predicate even though hangar does write the row: the surfacing layers key
+    /// "tell the user why nothing is happening" off `!is_dispatched()`, and an
+    /// offline runtime is exactly that case.
+    #[must_use]
+    pub const fn is_dispatched(self) -> bool {
+        matches!(self, Self::Queued | Self::Coalesced)
+    }
+
+    /// A short human phrase for the TUI detail card and the CLI.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Coalesced => "coalesced into a pending run",
+            Self::Deferred => "waiting on blockers",
+            Self::InvocationNotAllowed => "invocation not allowed",
+            Self::TargetUnavailable => "no dispatch target",
+            Self::RuntimeOffline => "runtime offline",
+            Self::AttributionBlocked => "attribution blocked",
+            Self::AlreadyActive => "a run is already active",
+            Self::SelfTriggerSuppressed => "self-trigger suppressed",
+            Self::InternalError => "internal error",
+        }
+    }
+}
+
+/// Which trigger surface made a dispatch attempt.
+///
+/// Mirrors `autopilot_run.source` from migration 0057 (`schedule|manual|webhook|api`),
+/// widened to the card-dispatch surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchSource {
+    /// A human pressed run (`hangar/issue_run`, `hangar/board_card_run`).
+    Manual,
+    /// An assignee was set, which re-dispatches the card.
+    Assign,
+    /// The board's dependency cascade fired it (blocker finished / child done).
+    AutoRun,
+    /// A cron / webhook autopilot fired it.
+    Autopilot,
+    /// Squad fan-out.
+    Squad,
+    /// A programmatic API caller.
+    Api,
+}
+
+impl DispatchSource {
+    /// Every variant, in declaration order.
+    pub const ALL: [Self; 6] = [
+        Self::Manual,
+        Self::Assign,
+        Self::AutoRun,
+        Self::Autopilot,
+        Self::Squad,
+        Self::Api,
+    ];
+
+    /// The `snake_case` token persisted to `dispatch_attempt.source`.
+    ///
+    /// Byte-identical to the serde derive (guarded by a test); no wildcard arm.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::Assign => "assign",
+            Self::AutoRun => "auto_run",
+            Self::Autopilot => "autopilot",
+            Self::Squad => "squad",
+            Self::Api => "api",
+        }
+    }
+
+    /// Wire/DB token → variant; unknown → `None`.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|r| r.as_db_str() == s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DispatchReason, DispatchSource};
+
+    fn serde_token(r: DispatchReason) -> String {
+        serde_json::to_value(r)
+            .expect("serialize")
+            .as_str()
+            .expect("string")
+            .to_owned()
+    }
+
+    #[test]
+    fn as_db_str_matches_serde_for_all_variants() {
+        for r in DispatchReason::ALL {
+            assert_eq!(serde_token(r), r.as_db_str(), "drift on {r:?}");
+        }
+        for s in DispatchSource::ALL {
+            let tok = serde_json::to_value(s)
+                .expect("serialize")
+                .as_str()
+                .expect("string")
+                .to_owned();
+            assert_eq!(tok, s.as_db_str(), "drift on {s:?}");
+        }
+    }
+
+    #[test]
+    fn parse_roundtrips_every_variant() {
+        for r in DispatchReason::ALL {
+            assert_eq!(DispatchReason::parse(r.as_db_str()), Some(r));
+        }
+        for s in DispatchSource::ALL {
+            assert_eq!(DispatchSource::parse(s.as_db_str()), Some(s));
+        }
+        assert_eq!(DispatchReason::parse("nonsense_code"), None);
+        assert_eq!(DispatchSource::parse("nonsense_source"), None);
+    }
+
+    #[test]
+    fn all_covers_every_variant() {
+        // A new variant that is not added to ALL makes this fail, because the
+        // token set would be short of the match arms in `as_db_str`.
+        let mut tokens: Vec<&str> = DispatchReason::ALL.iter().map(|r| r.as_db_str()).collect();
+        tokens.sort_unstable();
+        tokens.dedup();
+        assert_eq!(tokens.len(), DispatchReason::ALL.len(), "duplicate token");
+        assert_eq!(DispatchReason::ALL.len(), 10);
+        assert_eq!(DispatchSource::ALL.len(), 6);
+    }
+
+    #[test]
+    fn is_dispatched_only_for_queued_and_coalesced() {
+        for r in DispatchReason::ALL {
+            let expect = matches!(r, DispatchReason::Queued | DispatchReason::Coalesced);
+            assert_eq!(r.is_dispatched(), expect, "on {r:?}");
+        }
+        // The acceptance case: an offline runtime DOES write a task row but is
+        // still surfaced as "not dispatched".
+        assert!(!DispatchReason::RuntimeOffline.is_dispatched());
+    }
+
+    #[test]
+    fn every_variant_has_a_documented_producer_or_is_listed_reserved() {
+        // Pins the reserved set: adding a producer means deliberately removing
+        // the variant from `RESERVED` here.
+        assert_eq!(
+            DispatchReason::RESERVED,
+            [
+                DispatchReason::Coalesced,
+                DispatchReason::AttributionBlocked,
+                DispatchReason::SelfTriggerSuppressed,
+            ]
+        );
+        for r in DispatchReason::RESERVED {
+            assert!(
+                DispatchReason::ALL.contains(&r),
+                "reserved variant {r:?} missing from ALL"
+            );
+        }
+    }
+
+    #[test]
+    fn label_is_non_empty_and_distinct() {
+        let mut labels: Vec<&str> = DispatchReason::ALL.iter().map(|r| r.label()).collect();
+        assert!(labels.iter().all(|l| !l.is_empty()));
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(labels.len(), DispatchReason::ALL.len());
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/lib.rs
@@ -34,6 +34,12 @@ pub mod clock;
 /// typed descriptor registry both the TUI Settings pane and the
 /// `ainb hangar daemon config` CLI iterate (keys, kinds, defaults, validation).
 pub mod daemon_config;
+/// ADMISSION-TIME dispatch reason codes (multica parity #12): the stable
+/// `queued | deferred | already_active | target_unavailable | …` vocabulary
+/// shared by the service layer that decides and the handler layer that
+/// serializes it, so the two cannot drift. Distinct from the post-hoc run
+/// `FailureReason` by design.
+pub mod dispatch_reason;
 /// Environment allowlist policy (P5.3): allowlist passthrough with a hardcoded
 /// deny family that always overrides. Pure + IO-free; the TOML loader and
 /// daemon wiring live in `ainb-hangar-daemon`.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -339,7 +339,19 @@ async fn auto_run_dependent(pool: &SqlitePool, ws: &WorkspaceId, issue_id: &str)
     // Board-agnostic (the auto-run seam does not know which board); the F4 board
     // tier is skipped, the cascade still resolves the agent. Headless run.
     match crate::rpc::run_card(
-        pool, ws, None, &issue, "headless", None, None, None, None, None,
+        pool,
+        ws,
+        None,
+        &issue,
+        "headless",
+        None,
+        None,
+        None,
+        None,
+        None,
+        // multica parity #12: the dependency cascade is an AUTO_RUN trigger
+        // surface. Its refusals used to be a `debug!` line and nothing else.
+        ainb_hangar_core::dispatch_reason::DispatchSource::AutoRun,
     )
     .await
     {
@@ -479,6 +491,8 @@ pub async fn maybe_cascade_child_done(
         None,
         Some(assignee),
         None,
+        // multica parity #12: the child-done cascade is an AUTO_RUN surface too.
+        ainb_hangar_core::dispatch_reason::DispatchSource::AutoRun,
     )
     .await
     {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -166,6 +166,9 @@ mod tests {
 
     fn issue_row(id: &str) -> IssueRow {
         IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -208,6 +208,9 @@ mod tests {
 
     fn issue_row(id: &str, title: &str) -> IssueRow {
         IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -46,6 +46,7 @@ use std::sync::{OnceLock, RwLock};
 use std::time::Instant;
 
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
+use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
 use ainb_hangar_core::ids::{AgentId, AutopilotId, SkillId, WorkspaceId};
 use ainb_hangar_proto::lifecycle::IssueLifecycle;
 use ainb_hangar_proto::methods;
@@ -811,6 +812,7 @@ async fn handle(
         methods::HANGAR_ISSUE_LINK_ADD => handle_issue_link(pool, req, true).await,
         methods::HANGAR_ISSUE_LINK_REMOVE => handle_issue_link(pool, req, false).await,
         methods::HANGAR_ISSUE_LINKS => handle_issue_links(pool, req).await,
+        methods::HANGAR_DISPATCH_ATTEMPTS_LIST => handle_dispatch_attempts_list(pool, req).await,
         methods::HANGAR_BOARD_CARD_SET_AUTO_RUN => handle_board_card_set_auto_run(pool, req).await,
         methods::HANGAR_REPO_LIST => handle_repo_list(req),
         methods::FLEET_SNAPSHOT => handle_fleet_snapshot(pool).await,
@@ -3588,6 +3590,9 @@ async fn handle_issue_update(
                     None,
                     Some(actor),
                     None, // owner-invoked recovery re-dispatch
+                    // multica parity #12: setting an assignee re-dispatches; its
+                    // refusals used to be an `info!` line and nothing else.
+                    DispatchSource::Assign,
                 )
                 .await
                 {
@@ -5234,33 +5239,46 @@ async fn handle_board_card_run(
         // does. Omitted (`None`) defaults to the workspace owner inside `run_card` —
         // the ordinary single-operator TUI Run, which the gate always admits.
         params.invoker_user_id.as_deref().map(str::trim).filter(|s| !s.is_empty()),
+        DispatchSource::Manual,
     )
     .await
     .map_err(card_run_err)?;
 
+    // multica parity #12: the handler serializes the SAME code the service
+    // decided — `queued`, or `runtime_offline` when the task was keyed to a
+    // runtime that is not `online` (which is still enqueued; see divergence D1).
+    let reason = if outcome.runtime_status().is_some() {
+        DispatchReason::RuntimeOffline
+    } else {
+        DispatchReason::Queued
+    };
     let result = match outcome {
         CardRunOutcome::Single {
             task_id,
             agent_id,
             runtime_id,
+            ..
         } => ainb_hangar_proto::snapshots::BoardCardRunResult {
             task_id,
             agent_id,
             runtime_id,
             mode: mode.to_string(),
             member_task_ids: Vec::new(),
+            reason: Some(reason.as_db_str().to_string()),
         },
         CardRunOutcome::Squad {
             leader_task_id,
             leader_agent_id,
             leader_runtime_id,
             member_task_ids,
+            ..
         } => ainb_hangar_proto::snapshots::BoardCardRunResult {
             task_id: leader_task_id,
             agent_id: leader_agent_id,
             runtime_id: leader_runtime_id,
             mode: mode.to_string(),
             member_task_ids,
+            reason: Some(reason.as_db_str().to_string()),
         },
     };
     to_value(&result)
@@ -5361,33 +5379,46 @@ async fn handle_issue_run(
         source_override,
         assignee_override.as_ref(),
         invoker,
+        DispatchSource::Manual,
     )
     .await
     .map_err(card_run_err)?;
 
+    // multica parity #12: the handler serializes the SAME code the service
+    // decided — `queued`, or `runtime_offline` when the task was keyed to a
+    // runtime that is not `online` (which is still enqueued; see divergence D1).
+    let reason = if outcome.runtime_status().is_some() {
+        DispatchReason::RuntimeOffline
+    } else {
+        DispatchReason::Queued
+    };
     let result = match outcome {
         CardRunOutcome::Single {
             task_id,
             agent_id,
             runtime_id,
+            ..
         } => ainb_hangar_proto::snapshots::BoardCardRunResult {
             task_id,
             agent_id,
             runtime_id,
             mode: mode.to_string(),
             member_task_ids: Vec::new(),
+            reason: Some(reason.as_db_str().to_string()),
         },
         CardRunOutcome::Squad {
             leader_task_id,
             leader_agent_id,
             leader_runtime_id,
             member_task_ids,
+            ..
         } => ainb_hangar_proto::snapshots::BoardCardRunResult {
             task_id: leader_task_id,
             agent_id: leader_agent_id,
             runtime_id: leader_runtime_id,
             mode: mode.to_string(),
             member_task_ids,
+            reason: Some(reason.as_db_str().to_string()),
         },
     };
     to_value(&result)
@@ -5401,13 +5432,60 @@ pub(crate) enum CardRunOutcome {
         task_id: String,
         agent_id: String,
         runtime_id: String,
+        /// The resolved runtime's status when it is NOT `online` (multica parity
+        /// #12): `Some("offline")` / `Some("unstable")`, else `None`. Carried out
+        /// of [`run_card_inner`] so the [`run_card`] wrapper can record
+        /// [`DispatchReason::RuntimeOffline`] — see divergence D1 there.
+        runtime_status: Option<String>,
     },
     Squad {
         leader_task_id: String,
         leader_agent_id: String,
         leader_runtime_id: String,
         member_task_ids: Vec<String>,
+        /// The LEADER runtime's status when it is not `online`; see
+        /// [`CardRunOutcome::Single::runtime_status`].
+        runtime_status: Option<String>,
     },
+}
+
+impl CardRunOutcome {
+    /// The task id a caller reports (the leader's, for a squad).
+    fn primary_task_id(&self) -> &str {
+        match self {
+            Self::Single { task_id, .. } => task_id,
+            Self::Squad { leader_task_id, .. } => leader_task_id,
+        }
+    }
+
+    /// The agent the run routed to (the leader, for a squad).
+    fn primary_agent_id(&self) -> &str {
+        match self {
+            Self::Single { agent_id, .. } => agent_id,
+            Self::Squad {
+                leader_agent_id, ..
+            } => leader_agent_id,
+        }
+    }
+
+    /// The runtime the task was keyed to (the leader's, for a squad).
+    fn primary_runtime_id(&self) -> &str {
+        match self {
+            Self::Single { runtime_id, .. } => runtime_id,
+            Self::Squad {
+                leader_runtime_id, ..
+            } => leader_runtime_id,
+        }
+    }
+
+    /// The non-`online` runtime status, when there is one.
+    fn runtime_status(&self) -> Option<&str> {
+        match self {
+            Self::Single { runtime_status, .. } | Self::Squad { runtime_status, .. } => {
+                runtime_status.as_deref()
+            }
+        }
+    }
 }
 
 /// Why a card could not be launched. The RPC handler maps each to an
@@ -5446,7 +5524,29 @@ pub(crate) enum CardRunError {
 }
 
 /// Map a [`CardRunError`] onto an RPC error for the `board_card_run` handler.
+///
+/// multica parity #12: the reply also carries the STABLE admission code in
+/// `error.data.reason`, alongside today's human message — so a client can branch
+/// on the machine vocabulary instead of string-matching prose, and the code it
+/// sees is the same one the audit row persisted. Clients that ignore `data` are
+/// unaffected (the field is `skip_serializing_if = "Option::is_none"` and was
+/// simply absent before).
 fn card_run_err(e: CardRunError) -> RpcError {
+    // Compute the code from the SAME classifier the audit recorder uses, so the
+    // code a client sees on the wire can never disagree with the code persisted
+    // for the very same refusal.
+    let outcome: Result<CardRunOutcome, CardRunError> = Err(e);
+    let (reason, _detail) = classify_dispatch(&outcome);
+    let Err(e) = outcome else {
+        unreachable!("constructed as Err just above")
+    };
+    let mut err = card_run_message(e);
+    err.data = Some(serde_json::json!({ "reason": reason.as_db_str() }));
+    err
+}
+
+/// The human-readable half of [`card_run_err`].
+fn card_run_message(e: CardRunError) -> RpcError {
     match e {
         CardRunError::Blocked(refs) => invalid_params(&format!(
             "this card is blocked by unfinished cards ({}); finish them (or remove the dependency) first",
@@ -5516,6 +5616,202 @@ impl Drop for CardLaunchSlot {
     }
 }
 
+/// THE ONE RECORDING SEAM for admission decisions (multica parity #12).
+///
+/// A thin wrapper over [`run_card_inner`] (the historical `run_card` body) that
+/// records exactly one `dispatch_attempt` row per invocation, so all five launch
+/// paths — `handle_issue_run`, `handle_board_card_run`, the `issue_update`
+/// assignee re-dispatch, `board::auto_run_dependent` and the child-done cascade —
+/// are covered without sprinkling recorders through them. Before this, every one
+/// of those five threw the refusal away: two turned it into an ephemeral RPC
+/// error string, three logged it at debug/info and returned.
+///
+/// # The normative mapping — `run_card` result → [`DispatchReason`]
+///
+/// | result | code | `detail` |
+/// |---|---|---|
+/// | `Ok(..)` with an `online` runtime | `queued` | `"task <id>"` / `"leader <id> + <n> members"` |
+/// | `Ok(..)` with a non-`online` runtime | `runtime_offline` | `"task <id> queued; runtime <rt> is <status>"` |
+/// | `Err(Blocked(refs))` | `deferred` | `"blocked by HGR-3, HGR-7"` |
+/// | `Err(ActiveRun(status))` | `already_active` | `"a run is already active (<status>)"` |
+/// | `Err(NoAgent)` / `Err(NoRepo)` / `Err(NotDispatchable)` | `target_unavailable` | the specific cause |
+/// | `Err(Squad(..))` | `target_unavailable`, or `invocation_not_allowed` for its permission variant | the `SquadAssignError` display |
+/// | `Err(NotInvocable)` / `Err(Cancelled)` / `Err(InteractiveSquad)` | `invocation_not_allowed` | the specific cause |
+/// | `Err(Db(e))` | `internal_error` | the sqlx error string |
+///
+/// The coarseness is deliberate and copied from the reference: `NoAgent` /
+/// `NoRepo` / `NotDispatchable` all collapse to `target_unavailable`, and
+/// `Cancelled` / `NotInvocable` / `InteractiveSquad` all collapse to
+/// `invocation_not_allowed` — so the code can never be used as an existence
+/// oracle. The specifics live in the free-text `detail`.
+///
+/// # Divergence D1 — `runtime_offline` records, it does not refuse
+///
+/// multica DECLINES a dispatch whose runtime is offline. hangar still ENQUEUES
+/// and records `runtime_offline` with the `task_id` set. hangar's runtime rows
+/// are per-`(daemon_id, provider)`, so a codex runtime can be stale while the
+/// deciding daemon is very much alive, and the presence sweeper flips a row to
+/// `offline` on a grace timer — refusing would turn a transient heartbeat gap
+/// into a hard user-visible failure and regress the "queue it, the claim loop
+/// will take it" model. Recording buys the observability multica gets (the user
+/// is finally told WHY nothing is happening) without changing dispatch
+/// behaviour. `unstable` records the code too; the detail names the real status.
+///
+/// # Divergence D2 — `Blocked` is `deferred`, not a refusal code
+///
+/// hangar genuinely promotes a blocked card later: `board::auto_run_dependent`
+/// fires the run when the last blocker finishes, the direct analogue of the
+/// reference's `PromoteDueDeferredTasksForRuntime`.
+///
+/// Recording is BEST-EFFORT: a record fault is logged and never changes the run
+/// outcome — the audit must not be able to fail a dispatch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_card(
+    pool: &SqlitePool,
+    ws: &WorkspaceId,
+    board_id: Option<&str>,
+    issue: &ainb_hangar_store::repo::issue::Issue,
+    mode: &str,
+    repo_override: Option<&str>,
+    agent_override: Option<ainb_hangar_core::agent_kind::AgentKind>,
+    source_branch_override: Option<&str>,
+    assignee_override: Option<&ainb_hangar_core::actor::ActorRef>,
+    invoker_user_id: Option<&str>,
+    source: DispatchSource,
+) -> Result<CardRunOutcome, CardRunError> {
+    let outcome = run_card_inner(
+        pool,
+        ws,
+        board_id,
+        issue,
+        mode,
+        repo_override,
+        agent_override,
+        source_branch_override,
+        assignee_override,
+        invoker_user_id,
+    )
+    .await;
+    record_dispatch_attempt(pool, ws, issue.id.as_str(), source, &outcome).await;
+    outcome
+}
+
+/// Classify a [`run_card_inner`] result into the stable admission vocabulary +
+/// its free-text detail. Pure, so the mapping table above is unit-testable
+/// without a database.
+fn classify_dispatch(
+    outcome: &Result<CardRunOutcome, CardRunError>,
+) -> (DispatchReason, Option<String>) {
+    use ainb_hangar_store::service::squad_assign::SquadAssignError;
+    match outcome {
+        Ok(out) => {
+            let base = match out {
+                CardRunOutcome::Single { task_id, .. } => format!("task {task_id}"),
+                CardRunOutcome::Squad {
+                    leader_task_id,
+                    member_task_ids,
+                    ..
+                } => format!(
+                    "leader {leader_task_id} + {} members",
+                    member_task_ids.len()
+                ),
+            };
+            out.runtime_status().map_or_else(
+                || (DispatchReason::Queued, Some(base.clone())),
+                |status| {
+                    (
+                        DispatchReason::RuntimeOffline,
+                        Some(format!(
+                            "{base} queued; runtime {} is {status}",
+                            out.primary_runtime_id()
+                        )),
+                    )
+                },
+            )
+        }
+        Err(CardRunError::Blocked(refs)) => (
+            DispatchReason::Deferred,
+            Some(format!("blocked by {}", refs.join(", "))),
+        ),
+        Err(CardRunError::ActiveRun(status)) => (
+            DispatchReason::AlreadyActive,
+            Some(format!("a run is already active ({status})")),
+        ),
+        Err(CardRunError::NoAgent) => (
+            DispatchReason::TargetUnavailable,
+            Some("no agent in this workspace to run on".to_string()),
+        ),
+        Err(CardRunError::NoRepo) => (
+            DispatchReason::TargetUnavailable,
+            Some("no repo pinned on this card".to_string()),
+        ),
+        Err(CardRunError::NotDispatchable(kind)) => (
+            DispatchReason::TargetUnavailable,
+            Some(format!("provider {kind} is not wired for dispatch")),
+        ),
+        // The squad PERMISSION variant is an invocation refusal like
+        // `NotInvocable`; every other squad fault is "there is nothing coherent to
+        // dispatch to".
+        Err(CardRunError::Squad(se @ SquadAssignError::NotInvocable { .. })) => {
+            (DispatchReason::InvocationNotAllowed, Some(se.to_string()))
+        }
+        Err(CardRunError::Squad(se)) => (DispatchReason::TargetUnavailable, Some(se.to_string())),
+        Err(CardRunError::NotInvocable { agent_id, .. }) => (
+            DispatchReason::InvocationNotAllowed,
+            Some(format!(
+                "agent {agent_id} is private or you are not on its allow-list"
+            )),
+        ),
+        Err(CardRunError::Cancelled) => (
+            DispatchReason::InvocationNotAllowed,
+            Some("issue is cancelled".to_string()),
+        ),
+        Err(CardRunError::InteractiveSquad) => (
+            DispatchReason::InvocationNotAllowed,
+            Some("interactive mode is not supported for a squad".to_string()),
+        ),
+        Err(CardRunError::Db(e)) => (DispatchReason::InternalError, Some(e.to_string())),
+    }
+}
+
+/// Persist one `dispatch_attempt` row for a [`run_card`] invocation.
+///
+/// Best-effort by contract: any store fault is logged at `warn` and swallowed,
+/// because an audit write must never be able to fail a dispatch that otherwise
+/// succeeded.
+async fn record_dispatch_attempt(
+    pool: &SqlitePool,
+    ws: &WorkspaceId,
+    issue_id: &str,
+    source: DispatchSource,
+    outcome: &Result<CardRunOutcome, CardRunError>,
+) {
+    use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
+    use ainb_hangar_store::repo::dispatch_attempt::{DispatchAttemptRepo, NewDispatchAttempt};
+
+    let (reason, detail) = classify_dispatch(outcome);
+    let ok = outcome.as_ref().ok();
+    let record = NewDispatchAttempt {
+        workspace_id: ws.as_str(),
+        issue_id: Some(issue_id),
+        agent_id: ok.map(CardRunOutcome::primary_agent_id),
+        runtime_id: ok.map(CardRunOutcome::primary_runtime_id),
+        task_id: ok.map(CardRunOutcome::primary_task_id),
+        reason,
+        detail: detail.as_deref(),
+        source,
+        created_at: SystemClock.now_ms(),
+    };
+    if let Err(e) = DispatchAttemptRepo::record(pool, &SystemIdGen.new_ulid(), &record).await {
+        tracing::warn!(
+            error = %e,
+            issue_id,
+            reason = reason.as_db_str(),
+            "dispatch attempt record failed (audit only; the run outcome is unchanged)"
+        );
+    }
+}
+
 /// Launch a card's issue NOW — the shared core behind the `board_card_run` RPC and
 /// the F7 auto-run seam (tcp T4).
 ///
@@ -5540,7 +5836,7 @@ impl Drop for CardLaunchSlot {
 /// provisions its OWN worktree; otherwise it enqueues ONE task on the card's
 /// assignee agent (the pre-T4 single-agent path). `board_id` scopes the F4 board
 /// tier (pass `None` from the auto-run seam, which is board-agnostic).
-pub(crate) async fn run_card(
+async fn run_card_inner(
     pool: &SqlitePool,
     ws: &WorkspaceId,
     board_id: Option<&str>,
@@ -5685,11 +5981,18 @@ pub(crate) async fn run_card(
         )
         .await
         .map_err(CardRunError::Squad)?;
+        // multica parity #12: a run keyed to a runtime that is not `online` is
+        // still enqueued (divergence D1 on `run_card`) but the status is carried
+        // out so the wrapper records `runtime_offline` — otherwise the card just
+        // sits `queued` until the 2h TTL relabels it `timeout`, with nothing
+        // anywhere saying why.
+        let runtime_status = non_online_runtime_status(pool, &fanout.leader.runtime_id).await;
         return Ok(CardRunOutcome::Squad {
             leader_task_id: fanout.leader.task_id,
             leader_agent_id: fanout.leader.leader_agent_id,
             leader_runtime_id: fanout.leader.runtime_id,
             member_task_ids: fanout.members.into_iter().map(|m| m.task_id).collect(),
+            runtime_status,
         });
     }
 
@@ -5756,11 +6059,31 @@ pub(crate) async fn run_card(
         .map_err(CardRunError::Db)?;
     tx.commit().await.map_err(CardRunError::Db)?;
 
+    // multica parity #12 (divergence D1): record, do not refuse. See `run_card`.
+    let runtime_status = non_online_runtime_status(pool, &agent.runtime_id).await;
     Ok(CardRunOutcome::Single {
         task_id,
         agent_id: agent.id,
         runtime_id: agent.runtime_id,
+        runtime_status,
     })
+}
+
+/// The runtime's status when it is NOT `online` (`offline` / `unstable` / any
+/// future token), else `None`.
+///
+/// Best-effort: a read fault or a missing row reports `None` rather than
+/// inventing a decline — the audit must never manufacture a problem the dispatch
+/// did not have.
+async fn non_online_runtime_status(pool: &SqlitePool, runtime_id: &str) -> Option<String> {
+    match ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo::get(pool, runtime_id).await {
+        Ok(Some(rt)) if rt.status != "online" => Some(rt.status),
+        Ok(_) => None,
+        Err(e) => {
+            tracing::warn!(error = %e, runtime_id, "runtime status pre-flight failed");
+            None
+        }
+    }
 }
 
 /// Resolve the agent a card run routes to (the issue's assignee agent when it names
@@ -5974,6 +6297,57 @@ async fn issue_links_value(
         serde_json::to_value(ainb_hangar_proto::snapshots::IssueLinksResult { links })
             .unwrap_or(serde_json::Value::Null),
     )
+}
+
+/// `hangar/dispatch_attempts_list` (multica parity #12): the admission-decision
+/// audit feed, newest first.
+///
+/// Workspace-scoped through the same `resolve_wire_or_reject` tenant guard every
+/// other list method uses, so a sibling tenant's attempts are never returned.
+/// `limit` defaults to 50 and is hard-capped at 200; passing `issue_id` narrows
+/// to one card's history ("why is THIS not running").
+async fn handle_dispatch_attempts_list(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::dispatch_attempt::DispatchAttemptRepo;
+
+    /// Default page size when the caller does not ask for one.
+    const DEFAULT_LIMIT: u32 = 50;
+    /// Hard ceiling, so one call can never drag the whole table over the socket.
+    const MAX_LIMIT: u32 = 200;
+
+    let params: ainb_hangar_proto::snapshots::DispatchAttemptsListParams =
+        parse_params(req, "{ workspace_id, issue_id?, limit? }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let limit = i64::from(params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT));
+
+    let rows = match params.issue_id.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(issue_id) => DispatchAttemptRepo::list_for_issue(pool, issue_id, limit).await,
+        None => DispatchAttemptRepo::list_by_workspace(pool, ws.as_str(), limit).await,
+    }
+    .map_err(|e| store_err(&e))?;
+
+    // A per-issue query is keyed on the issue id, which carries no workspace
+    // column on the audit row — so re-assert the tenant here rather than trusting
+    // the caller's issue id to belong to the workspace it named.
+    let attempts = rows
+        .into_iter()
+        .filter(|r| r.workspace_id == ws.as_str())
+        .map(|r| ainb_hangar_proto::snapshots::DispatchAttemptRow {
+            id: r.id,
+            issue_id: r.issue_id,
+            agent_id: r.agent_id,
+            runtime_id: r.runtime_id,
+            task_id: r.task_id,
+            reason: r.reason,
+            detail: r.detail,
+            source: r.source,
+            created_at: r.created_at,
+        })
+        .collect();
+
+    to_value(&ainb_hangar_proto::snapshots::DispatchAttemptsListResult { attempts })
 }
 
 /// `hangar/board_card_set_auto_run` (tcp T4 / F7): flip a card's auto-run flag.
@@ -9619,6 +9993,7 @@ mod tests {
             None,
             None,
             None,
+            DispatchSource::Manual,
         )
         .await;
 
@@ -9704,6 +10079,7 @@ mod tests {
             None,
             Some(&override_ref),
             None,
+            DispatchSource::Manual,
         )
         .await;
 
@@ -9785,6 +10161,7 @@ mod tests {
             None,
             None,
             None,
+            DispatchSource::Manual,
         )
         .await;
 
@@ -9996,6 +10373,7 @@ mod tests {
             None,
             None,
             Some(&bob.user_id),
+            DispatchSource::Manual,
         )
         .await;
         assert!(
@@ -10020,6 +10398,7 @@ mod tests {
             None,
             None,
             None,
+            DispatchSource::Manual,
         )
         .await;
         assert!(
@@ -10057,6 +10436,7 @@ mod tests {
             None,
             None,
             Some(&bob.user_id),
+            DispatchSource::Manual,
         )
         .await;
         assert!(
@@ -10180,6 +10560,7 @@ mod tests {
             None,
             None,
             Some(&bob.user_id),
+            DispatchSource::Manual,
         )
         .await;
         assert!(
@@ -10203,6 +10584,7 @@ mod tests {
             None,
             None,
             None,
+            DispatchSource::Manual,
         )
         .await;
         assert!(owner_run.is_ok(), "the owner's squad run must fan out");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -126,9 +126,12 @@ pub async fn issues_list(
             // task-detail card.
             let extras = issue_card_fields(pool, &issue.id).await?;
             out.push(IssueRow {
-                last_dispatch_reason: None,
-                last_dispatch_detail: None,
-                last_dispatch_at: None,
+                // multica parity #12: WHY this card is not running, from the newest
+                // dispatch_attempt when that attempt was a decline. All `None` on a
+                // healthy card, so the row grows by zero keys.
+                last_dispatch_reason: extras.last_dispatch_reason,
+                last_dispatch_detail: extras.last_dispatch_detail,
+                last_dispatch_at: extras.last_dispatch_at,
                 // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
                 // row a snapshot carries and the row an event pushes agree.
                 origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
@@ -194,6 +197,13 @@ struct IssueCardExtras {
     /// children. Drives the parent card's `⊟ done/total` badge.
     child_done: u32,
     child_total: u32,
+    /// WHY this card is not running (multica parity #12): the stable code +
+    /// detail + timestamp of the newest `dispatch_attempt`, filled ONLY when that
+    /// attempt was a DECLINE. All `None` on a healthy card, so the wire row grows
+    /// by zero keys for one that is running fine.
+    last_dispatch_reason: Option<String>,
+    last_dispatch_detail: Option<String>,
+    last_dispatch_at: Option<i64>,
 }
 
 /// Read the task-detail card extras for one issue (63d): the `repo_ref` / `agent`
@@ -238,6 +248,16 @@ async fn issue_card_fields(
             .await?
             .flatten();
     let (child_done, child_total) = IssueRepo::child_progress(pool, issue_id).await?;
+    // multica parity #12: the newest admission decision, surfaced ONLY when it
+    // was a decline — the field means "why this is not running", so a healthy card
+    // carries no extra bytes. `runtime_offline` counts as a decline even though a
+    // task row exists: that is exactly the invisible-but-queued case.
+    let latest_attempt =
+        ainb_hangar_store::repo::dispatch_attempt::DispatchAttemptRepo::latest_for_issue(
+            pool, issue_id,
+        )
+        .await?
+        .filter(|a| !a.is_dispatched());
     Ok(IssueCardExtras {
         repo_ref,
         agent: agent.map(|a| a.as_str().to_string()),
@@ -249,6 +269,9 @@ async fn issue_card_fields(
         parent_id,
         child_done: u32::try_from(child_done).unwrap_or(u32::MAX),
         child_total: u32::try_from(child_total).unwrap_or(u32::MAX),
+        last_dispatch_reason: latest_attempt.as_ref().map(|a| a.reason.clone()),
+        last_dispatch_detail: latest_attempt.as_ref().and_then(|a| a.detail.clone()),
+        last_dispatch_at: latest_attempt.as_ref().map(|a| a.created_at),
     })
 }
 
@@ -305,9 +328,12 @@ pub async fn issues_search(
         let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
         let extras = issue_card_fields(pool, &issue.id).await?;
         out.push(IssueRow {
-            last_dispatch_reason: None,
-            last_dispatch_detail: None,
-            last_dispatch_at: None,
+            // multica parity #12: WHY this card is not running, from the newest
+            // dispatch_attempt when that attempt was a decline. All `None` on a
+            // healthy card, so the row grows by zero keys.
+            last_dispatch_reason: extras.last_dispatch_reason,
+            last_dispatch_detail: extras.last_dispatch_detail,
+            last_dispatch_at: extras.last_dispatch_at,
             // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
             // row a snapshot carries and the row an event pushes agree.
             origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
@@ -1895,9 +1921,12 @@ pub async fn issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
-        last_dispatch_reason: None,
-        last_dispatch_detail: None,
-        last_dispatch_at: None,
+        // multica parity #12: WHY this card is not running, from the newest
+        // dispatch_attempt when that attempt was a decline. All `None` on a
+        // healthy card, so the row grows by zero keys.
+        last_dispatch_reason: extras.last_dispatch_reason,
+        last_dispatch_detail: extras.last_dispatch_detail,
+        last_dispatch_at: extras.last_dispatch_at,
         // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
         // row a snapshot carries and the row an event pushes agree.
         origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
@@ -2101,9 +2130,12 @@ async fn read_issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
-        last_dispatch_reason: None,
-        last_dispatch_detail: None,
-        last_dispatch_at: None,
+        // multica parity #12: WHY this card is not running, from the newest
+        // dispatch_attempt when that attempt was a decline. All `None` on a
+        // healthy card, so the row grows by zero keys.
+        last_dispatch_reason: extras.last_dispatch_reason,
+        last_dispatch_detail: extras.last_dispatch_detail,
+        last_dispatch_at: extras.last_dispatch_at,
         // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
         // row a snapshot carries and the row an event pushes agree.
         origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -126,6 +126,9 @@ pub async fn issues_list(
             // task-detail card.
             let extras = issue_card_fields(pool, &issue.id).await?;
             out.push(IssueRow {
+                last_dispatch_reason: None,
+                last_dispatch_detail: None,
+                last_dispatch_at: None,
                 // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
                 // row a snapshot carries and the row an event pushes agree.
                 origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
@@ -302,6 +305,9 @@ pub async fn issues_search(
         let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
         let extras = issue_card_fields(pool, &issue.id).await?;
         out.push(IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
             // row a snapshot carries and the row an event pushes agree.
             origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
@@ -1889,6 +1895,9 @@ pub async fn issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
         // row a snapshot carries and the row an event pushes agree.
         origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
@@ -2092,6 +2101,9 @@ async fn read_issue_row(
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
     Ok(Some(IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         // ORIGIN PROVENANCE (0056): echoed from the stored pair so the wire
         // row a snapshot carries and the row an event pushes agree.
         origin_type: issue.origin.as_ref().map(|o| o.kind_db_str().to_string()),
@@ -2347,6 +2359,9 @@ pub async fn issue_create(
     // shows.
     let display_id = issue_display_row(pool, workspace_id, &id, prefix.as_deref()).await?;
     Ok(IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         // ORIGIN PROVENANCE (0056): echo exactly what was just stamped, so the
         // response row and the pushed IssueCreated event stay byte-identical to
         // a later list snapshot of the same issue.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_dispatch_reason.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_dispatch_reason.rs
@@ -1,0 +1,565 @@
+//! ACCEPTANCE: dispatch reason codes (multica parity #12).
+//!
+//! *"an issue with no assignee, or an offline agent, records + surfaces a reason
+//! code explaining non-dispatch (sqlite + wire)."*
+//!
+//! Everything here is driven through the REAL RPC handlers (`rpc::dispatch`)
+//! against a real sqlite, then asserted in TWO places: the persisted
+//! `dispatch_attempt` row, and the surface a client actually reads (the RPC reply
+//! plus `IssueRow.last_dispatch_reason` on the next `issues_list`).
+//!
+//! # Mutation proof
+//!
+//! Delete the `record_dispatch_attempt(...)` call from the `run_card` wrapper →
+//! every test in this file goes RED. Neuter the runtime-status pre-flight (make
+//! `non_online_runtime_status` return `None`) → `offline_runtime_records_and_surfaces_runtime_offline`
+//! alone goes RED.
+
+use ainb_hangar_daemon::events::{EventBroker, EventSink};
+use ainb_hangar_daemon::health_stats::HealthStats;
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::bootstrap;
+use ainb_hangar_store::repo::card_parity::CardParityRepo;
+use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+use std::sync::Arc;
+use std::time::Instant;
+
+fn health() -> DaemonHealth {
+    DaemonHealth {
+        socket_path: "/tmp/dispatch-reason.sock".into(),
+        pid: 1,
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: Arc::new(HealthStats::default()),
+    }
+}
+
+fn sink() -> EventSink {
+    EventBroker::new().sink()
+}
+
+fn req(method: &str, params: serde_json::Value) -> RpcRequest {
+    RpcRequest {
+        jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+        id: RpcId::Number(1),
+        method: method.into(),
+        params,
+    }
+}
+
+/// A workspace with a runtime, ready for agents. Returns `(store, workspace_id)`.
+/// The `TempDir` is returned so the caller keeps the database alive.
+async fn fixture() -> (tempfile::TempDir, Store, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    let ws = bootstrap::ensure_default_workspace(store.pool()).await.expect("workspace");
+    bootstrap::ensure_runtime(store.pool(), &bootstrap::default_runtime_id(), 1)
+        .await
+        .expect("runtime");
+    (dir, store, ws)
+}
+
+/// A runnable card: non-empty brief (so the brief-or-link guard passes) and a
+/// pinned `scratch` repo (so the F2 repo guard passes) — every refusal under test
+/// is therefore the one it claims to be, not one of those two.
+async fn seed_card(store: &Store, ws: &str, id: &str) -> ainb_hangar_store::repo::issue::Issue {
+    IssueRepo::insert(
+        store.pool(),
+        &NewIssue {
+            id: id.to_string(),
+            workspace_id: ws.to_string(),
+            title: format!("card {id}"),
+            description: Some("do the work".into()),
+            state: "todo".into(),
+            creator: ainb_hangar_core::actor::ActorRef::new(
+                ainb_hangar_core::actor::ActorKind::Member,
+                "stevie",
+            )
+            .expect("actor"),
+            created_at: 1,
+            priority: 0,
+            assignee: None,
+            due_date: None,
+            labels: Vec::new(),
+            parent_issue_id: None,
+            stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
+        },
+    )
+    .await
+    .expect("insert issue");
+    CardParityRepo::set_issue_repo_agent(store.pool(), ws, id, Some("scratch"), None)
+        .await
+        .expect("pin repo");
+    IssueRepo::get_by_id(store.pool(), id)
+        .await
+        .expect("get")
+        .expect("issue present")
+}
+
+async fn issue_run(store: &Store, ws: &str, issue_id: &str) -> ainb_hangar_proto::RpcResponse {
+    rpc::dispatch(
+        store.pool(),
+        &req(
+            methods::HANGAR_ISSUE_RUN,
+            serde_json::json!({ "workspace_id": ws, "issue_id": issue_id, "mode": "headless" }),
+        ),
+        &health(),
+        &sink(),
+    )
+    .await
+}
+
+/// Every `dispatch_attempt` row for one card, newest first, as
+/// `(reason, detail, task_id, source)`.
+async fn attempts(
+    store: &Store,
+    issue_id: &str,
+) -> Vec<(String, Option<String>, Option<String>, String)> {
+    sqlx::query_as(
+        "SELECT reason, detail, task_id, source FROM dispatch_attempt \
+         WHERE issue_id = ? ORDER BY created_at DESC, id DESC",
+    )
+    .bind(issue_id)
+    .fetch_all(store.pool())
+    .await
+    .expect("select attempts")
+}
+
+async fn task_count(store: &Store, issue_id: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = ?")
+        .bind(issue_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("count tasks")
+}
+
+/// The wire `IssueRow` for one card, as raw JSON, straight off `hangar/issues_list`
+/// — so absence of a key is assertable, not just its value.
+async fn issue_row_json(store: &Store, ws: &str, issue_id: &str) -> serde_json::Value {
+    let resp = rpc::dispatch(
+        store.pool(),
+        &req(
+            methods::HANGAR_ISSUES_LIST,
+            serde_json::json!({ "workspace_id": ws }),
+        ),
+        &health(),
+        &sink(),
+    )
+    .await;
+    assert!(resp.error.is_none(), "issues_list failed: {:?}", resp.error);
+    resp.result
+        .expect("result")
+        .get("issues")
+        .expect("issues array")
+        .as_array()
+        .expect("array")
+        .iter()
+        .find(|r| r.get("id").and_then(serde_json::Value::as_str) == Some(issue_id))
+        .cloned()
+        .unwrap_or_else(|| panic!("issue {issue_id} missing from the list"))
+}
+
+fn error_reason(resp: &ainb_hangar_proto::RpcResponse) -> Option<String> {
+    resp.error
+        .as_ref()?
+        .data
+        .as_ref()?
+        .get("reason")?
+        .as_str()
+        .map(ToOwned::to_owned)
+}
+
+// ---------------------------------------------------------------------------
+// (a) no agent to dispatch to
+// ---------------------------------------------------------------------------
+
+/// The headline acceptance case #1: an issue with no assignee in a workspace with
+/// NO agent. Before #12 this was an RPC error string that scrolled past and
+/// nothing else; now it is persisted AND on the next snapshot of the card.
+#[tokio::test]
+async fn no_agent_records_and_surfaces_target_unavailable() {
+    let (_dir, store, ws) = fixture().await;
+    // Deliberately NO agent created.
+    let issue = seed_card(&store, &ws, "dr-no-agent").await;
+
+    let resp = issue_run(&store, &ws, issue.id.as_str()).await;
+    assert!(resp.error.is_some(), "a card with no agent must be refused");
+    assert_eq!(
+        error_reason(&resp).as_deref(),
+        Some("target_unavailable"),
+        "the refusal reply carries the stable code in error.data.reason"
+    );
+
+    let rows = attempts(&store, issue.id.as_str()).await;
+    assert_eq!(rows.len(), 1, "exactly one attempt recorded");
+    let (reason, detail, task_id, source) = &rows[0];
+    assert_eq!(reason, "target_unavailable");
+    assert_eq!(
+        detail.as_deref(),
+        Some("no agent in this workspace to run on")
+    );
+    assert_eq!(*task_id, None, "a refusal writes no task row");
+    assert_eq!(source, "manual");
+    assert_eq!(task_count(&store, issue.id.as_str()).await, 0);
+
+    // …and the card itself now says why it is not running.
+    let row = issue_row_json(&store, &ws, issue.id.as_str()).await;
+    assert_eq!(
+        row.get("last_dispatch_reason").and_then(|v| v.as_str()),
+        Some("target_unavailable")
+    );
+    assert_eq!(
+        row.get("last_dispatch_detail").and_then(|v| v.as_str()),
+        Some("no agent in this workspace to run on")
+    );
+    assert!(row.get("last_dispatch_at").is_some());
+}
+
+// ---------------------------------------------------------------------------
+// (b) offline runtime — the invisible-but-queued case
+// ---------------------------------------------------------------------------
+
+/// The headline acceptance case #2, and the one that was worse than silent:
+/// nothing checked `agent_runtime.status` before enqueuing, so a run keyed to an
+/// offline runtime sat `queued` until the 2h TTL relabelled it `timeout`, with
+/// no statement of why anywhere.
+///
+/// hangar's divergence D1 from the reference: the run is still ENQUEUED (the row
+/// exists, `task_id` is set) — only the observability is added.
+#[tokio::test]
+async fn offline_runtime_records_and_surfaces_runtime_offline() {
+    let (_dir, store, ws) = fixture().await;
+    let agent = bootstrap::create_agent(store.pool(), &ws, "bot", "claude", None)
+        .await
+        .expect("agent");
+    sqlx::query("UPDATE agent_runtime SET status = 'offline' WHERE id = ?")
+        .bind(&agent.runtime_id)
+        .execute(store.pool())
+        .await
+        .expect("mark runtime offline");
+    let issue = seed_card(&store, &ws, "dr-offline").await;
+
+    let resp = issue_run(&store, &ws, issue.id.as_str()).await;
+    assert!(
+        resp.error.is_none(),
+        "an offline runtime does NOT refuse in hangar (divergence D1): {:?}",
+        resp.error
+    );
+    let result = resp.result.expect("result");
+    assert_eq!(
+        result.get("reason").and_then(|v| v.as_str()),
+        Some("runtime_offline"),
+        "the handler serializes the code the service decided"
+    );
+
+    let rows = attempts(&store, issue.id.as_str()).await;
+    assert_eq!(rows.len(), 1);
+    let (reason, detail, task_id, _source) = &rows[0];
+    assert_eq!(reason, "runtime_offline");
+    assert!(task_id.is_some(), "the task row IS written (divergence D1)");
+    let detail = detail.as_deref().expect("a detail naming the runtime");
+    assert!(
+        detail.contains(&agent.runtime_id) && detail.contains("offline"),
+        "detail must name the runtime and its status, got {detail:?}"
+    );
+    assert_eq!(task_count(&store, issue.id.as_str()).await, 1);
+
+    let row = issue_row_json(&store, &ws, issue.id.as_str()).await;
+    assert_eq!(
+        row.get("last_dispatch_reason").and_then(|v| v.as_str()),
+        Some("runtime_offline"),
+        "an offline runtime is a DECLINE for surfacing even though the row exists"
+    );
+}
+
+/// `unstable` (the heartbeat-gap band, not yet fully offline) records the same
+/// code, with the detail naming the ACTUAL status — so the surface never claims
+/// `offline` for a runtime that is merely lagging.
+#[tokio::test]
+async fn unstable_runtime_records_runtime_offline_naming_the_real_status() {
+    let (_dir, store, ws) = fixture().await;
+    let agent = bootstrap::create_agent(store.pool(), &ws, "bot", "claude", None)
+        .await
+        .expect("agent");
+    sqlx::query("UPDATE agent_runtime SET status = 'unstable' WHERE id = ?")
+        .bind(&agent.runtime_id)
+        .execute(store.pool())
+        .await
+        .expect("mark runtime unstable");
+    let issue = seed_card(&store, &ws, "dr-unstable").await;
+
+    let resp = issue_run(&store, &ws, issue.id.as_str()).await;
+    assert!(resp.error.is_none(), "{:?}", resp.error);
+
+    let rows = attempts(&store, issue.id.as_str()).await;
+    assert_eq!(rows[0].0, "runtime_offline");
+    let detail = rows[0].1.as_deref().expect("detail");
+    assert!(detail.contains("unstable"), "got {detail:?}");
+}
+
+// ---------------------------------------------------------------------------
+// (c) blocked → deferred (divergence D2)
+// ---------------------------------------------------------------------------
+
+/// A card with an unfinished blocker records `deferred`, NOT a refusal code:
+/// hangar genuinely promotes it later when the blocker finishes
+/// (`board::auto_run_dependent`).
+#[tokio::test]
+async fn blocked_card_records_deferred() {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let (_dir, store, ws) = fixture().await;
+    bootstrap::create_agent(store.pool(), &ws, "bot", "claude", None)
+        .await
+        .expect("agent");
+    let blocker = seed_card(&store, &ws, "dr-blocker").await;
+    let dependent = seed_card(&store, &ws, "dr-dependent").await;
+    let ws_id = WorkspaceId::from_str(ws.clone()).expect("ws id");
+    CardDependencyRepo::add_edge(
+        store.pool(),
+        &ws_id,
+        dependent.id.as_str(),
+        blocker.id.as_str(),
+        1,
+    )
+    .await
+    .expect("add edge");
+
+    let resp = issue_run(&store, &ws, dependent.id.as_str()).await;
+    assert!(resp.error.is_some(), "a blocked card refuses to run");
+    assert_eq!(error_reason(&resp).as_deref(), Some("deferred"));
+
+    let rows = attempts(&store, dependent.id.as_str()).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "deferred");
+    let detail = rows[0].1.as_deref().expect("detail");
+    assert!(detail.starts_with("blocked by "), "got {detail:?}");
+    assert_eq!(task_count(&store, dependent.id.as_str()).await, 0);
+
+    let row = issue_row_json(&store, &ws, dependent.id.as_str()).await;
+    assert_eq!(
+        row.get("last_dispatch_reason").and_then(|v| v.as_str()),
+        Some("deferred")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) second run of a live card
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn second_run_records_already_active_without_a_second_task() {
+    let (_dir, store, ws) = fixture().await;
+    bootstrap::create_agent(store.pool(), &ws, "bot", "claude", None)
+        .await
+        .expect("agent");
+    let issue = seed_card(&store, &ws, "dr-twice").await;
+
+    let first = issue_run(&store, &ws, issue.id.as_str()).await;
+    assert!(first.error.is_none(), "{:?}", first.error);
+    let second = issue_run(&store, &ws, issue.id.as_str()).await;
+    assert!(second.error.is_some(), "the second run must be refused");
+    assert_eq!(error_reason(&second).as_deref(), Some("already_active"));
+
+    let rows = attempts(&store, issue.id.as_str()).await;
+    assert_eq!(rows.len(), 2, "both attempts recorded");
+    assert_eq!(rows[0].0, "already_active", "newest first");
+    assert_eq!(rows[1].0, "queued");
+    assert_eq!(
+        task_count(&store, issue.id.as_str()).await,
+        1,
+        "still exactly one task"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) invocation gate
+// ---------------------------------------------------------------------------
+
+/// A PRIVATE agent invoked by a non-owner member: `invocation_not_allowed`, and
+/// NO task row. The code is deliberately generic — it says nothing about whether
+/// the agent exists — so it can never be an existence oracle.
+#[tokio::test]
+async fn private_agent_records_invocation_not_allowed_and_writes_no_task() {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::member::{MemberRepo, MemberRole};
+
+    let (_dir, store, ws) = fixture().await;
+    // `create_agent` yields a PRIVATE agent (default permission mode).
+    bootstrap::create_agent(store.pool(), &ws, "secret-bot", "claude", None)
+        .await
+        .expect("agent");
+    let ws_id = WorkspaceId::from_str(ws.clone()).expect("ws id");
+    let bob = MemberRepo::add(store.pool(), &ws_id, "bob@example.com", MemberRole::Member)
+        .await
+        .expect("member");
+    let issue = seed_card(&store, &ws, "dr-private").await;
+
+    let resp = rpc::dispatch(
+        store.pool(),
+        &req(
+            methods::HANGAR_ISSUE_RUN,
+            serde_json::json!({
+                "workspace_id": ws,
+                "issue_id": issue.id.as_str(),
+                "mode": "headless",
+                "invoker_user_id": bob.user_id,
+            }),
+        ),
+        &health(),
+        &sink(),
+    )
+    .await;
+    assert!(
+        resp.error.is_some(),
+        "a non-owner must not invoke a private agent"
+    );
+    assert_eq!(
+        error_reason(&resp).as_deref(),
+        Some("invocation_not_allowed")
+    );
+
+    let rows = attempts(&store, issue.id.as_str()).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "invocation_not_allowed");
+    assert_eq!(rows[0].2, None, "no task id on a denied attempt");
+    assert_eq!(task_count(&store, issue.id.as_str()).await, 0);
+}
+
+// ---------------------------------------------------------------------------
+// (f) the healthy path
+// ---------------------------------------------------------------------------
+
+/// A healthy run records `queued` WITH the task id — and the card's wire row
+/// grows by ZERO keys, because the surfacing fields mean "why this is NOT
+/// running". Absence is asserted on the raw JSON, so a `null` would fail.
+#[tokio::test]
+async fn healthy_run_records_queued_and_the_card_grows_no_keys() {
+    let (_dir, store, ws) = fixture().await;
+    bootstrap::create_agent(store.pool(), &ws, "bot", "claude", None)
+        .await
+        .expect("agent");
+    let issue = seed_card(&store, &ws, "dr-healthy").await;
+
+    let resp = issue_run(&store, &ws, issue.id.as_str()).await;
+    assert!(resp.error.is_none(), "{:?}", resp.error);
+    let result = resp.result.expect("result");
+    assert_eq!(
+        result.get("reason").and_then(|v| v.as_str()),
+        Some("queued")
+    );
+    let task_id = result.get("task_id").and_then(|v| v.as_str()).expect("task id").to_string();
+
+    let rows = attempts(&store, issue.id.as_str()).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "queued");
+    assert_eq!(rows[0].2.as_deref(), Some(task_id.as_str()));
+    assert_eq!(
+        rows[0].1.as_deref(),
+        Some(format!("task {task_id}").as_str())
+    );
+
+    let row = issue_row_json(&store, &ws, issue.id.as_str()).await;
+    let obj = row.as_object().expect("object");
+    for key in [
+        "last_dispatch_reason",
+        "last_dispatch_detail",
+        "last_dispatch_at",
+    ] {
+        assert!(
+            !obj.contains_key(key),
+            "{key} must be ABSENT (not null) on a healthy card: {row}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (g) the read side
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_attempts_list_is_newest_first_limited_and_tenant_scoped() {
+    let (_dir, store, ws) = fixture().await;
+    bootstrap::create_agent(store.pool(), &ws, "bot", "claude", None)
+        .await
+        .expect("agent");
+    let issue = seed_card(&store, &ws, "dr-feed").await;
+
+    // queued, then already_active, then already_active again.
+    for _ in 0..3 {
+        let _ = issue_run(&store, &ws, issue.id.as_str()).await;
+    }
+
+    let list = |params: serde_json::Value| {
+        let pool = store.pool();
+        async move {
+            let resp = rpc::dispatch(
+                pool,
+                &req(methods::HANGAR_DISPATCH_ATTEMPTS_LIST, params),
+                &health(),
+                &sink(),
+            )
+            .await;
+            assert!(resp.error.is_none(), "list failed: {:?}", resp.error);
+            resp.result
+                .expect("result")
+                .get("attempts")
+                .expect("attempts")
+                .as_array()
+                .expect("array")
+                .clone()
+        }
+    };
+
+    let all = list(serde_json::json!({ "workspace_id": ws, "issue_id": issue.id.as_str() })).await;
+    assert_eq!(all.len(), 3);
+    let codes: Vec<&str> = all
+        .iter()
+        .map(|a| a.get("reason").and_then(serde_json::Value::as_str).expect("reason"))
+        .collect();
+    assert_eq!(
+        codes,
+        ["already_active", "already_active", "queued"],
+        "newest first"
+    );
+    assert_eq!(
+        all[0].get("source").and_then(serde_json::Value::as_str),
+        Some("manual")
+    );
+
+    // `limit` is honoured, and still newest-first.
+    let capped =
+        list(serde_json::json!({ "workspace_id": ws, "issue_id": issue.id.as_str(), "limit": 1 }))
+            .await;
+    assert_eq!(capped.len(), 1);
+    assert_eq!(
+        capped[0].get("reason").and_then(serde_json::Value::as_str),
+        Some("already_active")
+    );
+
+    // The workspace-wide feed sees them too.
+    let ws_feed = list(serde_json::json!({ "workspace_id": ws })).await;
+    assert_eq!(ws_feed.len(), 3);
+
+    // A foreign workspace is rejected, never silently answered with someone
+    // else's rows.
+    let foreign = rpc::dispatch(
+        store.pool(),
+        &req(
+            methods::HANGAR_DISPATCH_ATTEMPTS_LIST,
+            serde_json::json!({ "workspace_id": "ws-does-not-exist" }),
+        ),
+        &health(),
+        &sink(),
+    )
+    .await;
+    assert!(
+        foreign.error.is_some(),
+        "an unknown workspace must be rejected"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -201,6 +201,9 @@ async fn wait_for_inbox_count(store: &Store, ws_id: &str, want: i64) {
 
 fn issue_event() -> HangarEvent {
     HangarEvent::IssueCreated(IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str("issue-1").unwrap(),

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -531,6 +531,32 @@ pub struct IssueRow {
     /// detail card simply renders no `Links:` block.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<IssueLinkRow>,
+    /// WHY this card is not running — the stable admission code of its newest
+    /// `dispatch_attempt` (multica parity #12, migration 0058), e.g.
+    /// `target_unavailable` / `runtime_offline` / `deferred` / `already_active`.
+    ///
+    /// Filled ONLY when that newest attempt is a DECLINE
+    /// (`!DispatchReason::is_dispatched()`), so the field means "why nothing is
+    /// happening" and a healthy card carries no extra bytes. `runtime_offline`
+    /// counts as a decline even though hangar does write the task row — that is
+    /// exactly the invisible-but-queued case this exists to surface.
+    ///
+    /// Kept as a raw `String` rather than the typed enum so a token from a newer
+    /// daemon renders as raw text instead of failing the decode. Append-only:
+    /// omitted from the wire when `None` (`skip_serializing_if`), so a pre-#12
+    /// snapshot decodes to `None` and a healthy row serializes byte-identically
+    /// to today.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_dispatch_reason: Option<String>,
+    /// The free-text specifics behind [`Self::last_dispatch_reason`] (the code is
+    /// deliberately generic — the detail names the runtime, the blockers, the
+    /// missing repo). Same append-only contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_dispatch_detail: Option<String>,
+    /// When that declined attempt was recorded (epoch millis). Same append-only
+    /// contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_dispatch_at: Option<i64>,
 }
 
 /// One TYPED link on an issue's detail card (multica parity #20), always stated

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -306,6 +306,22 @@ pub const FLEET_BROADCAST: &str = "fleet/broadcast";
 /// caller cares about the enqueued task, not the surface it launched from).
 pub const HANGAR_ISSUE_RUN: &str = "hangar/issue_run";
 
+/// `hangar/dispatch_attempts_list` — the ADMISSION-DECISION audit feed (multica
+/// parity #12, migration 0058).
+///
+/// Every dispatch attempt — the ones that queued a run and the ones that were
+/// declined — is persisted with a stable [`ainb_hangar_core::dispatch_reason::DispatchReason`]
+/// code, a free-text detail, and the trigger surface that made it. This method is
+/// the read side: "why is this card not running", answerable after the fact
+/// rather than only in the RPC error that scrolled past.
+///
+/// Params: [`crate::snapshots::DispatchAttemptsListParams`]
+/// (`{ workspace_id, issue_id?, limit? }`); result:
+/// [`crate::snapshots::DispatchAttemptsListResult`] — newest first, default
+/// `limit` 50, hard cap 200. Workspace-scoped through the same tenant guard as
+/// every other list method, so a sibling tenant's attempts are never returned.
+pub const HANGAR_DISPATCH_ATTEMPTS_LIST: &str = "hangar/dispatch_attempts_list";
+
 /// `hangar/issue_label_attach` — attach a label to one issue (e38.10).
 ///
 /// Params: [`crate::snapshots::IssueLabelParams`]
@@ -1257,6 +1273,9 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_SUBSCRIBE,
     FLEET_ACTION,
     FLEET_BROADCAST,
+    // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
+    // tail, append-only wire.
+    HANGAR_DISPATCH_ATTEMPTS_LIST,
 ];
 
 #[cfg(test)]
@@ -1483,6 +1502,7 @@ mod tests {
             FLEET_SUBSCRIBE,
             FLEET_ACTION,
             FLEET_BROADCAST,
+            HANGAR_DISPATCH_ATTEMPTS_LIST,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2545,6 +2545,9 @@ mod tests {
 
         let issues = IssuesListResult {
             issues: vec![IssueRow {
+                last_dispatch_reason: None,
+                last_dispatch_detail: None,
+                last_dispatch_at: None,
                 origin_type: None,
                 origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("i1").unwrap(),

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2136,6 +2136,17 @@ pub struct BoardCardRunResult {
     /// pre-T4 single-agent run serializes byte-identically.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub member_task_ids: Vec<String>,
+    /// The admission code the daemon RECORDED for this dispatch (multica parity
+    /// #12): `queued` on the healthy path, `runtime_offline` when the task was
+    /// written against a runtime that is not `online`.
+    ///
+    /// This is the reference's stated invariant made concrete — the handler
+    /// serializes the SAME vocabulary the service decided
+    /// (`DispatchReason::as_db_str`), so decider and serializer cannot drift.
+    /// Append-only: omitted when `None`, so a pre-#12 result decodes and a
+    /// pre-#12 client ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_CANCEL`] (tcp T3 / F6): cancel
@@ -2494,6 +2505,65 @@ pub struct DaemonConfigListResult {
     /// One entry per [`ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY`]
     /// descriptor, in registry order.
     pub entries: Vec<DaemonConfigEntry>,
+}
+
+/// Params for [`crate::methods::HANGAR_DISPATCH_ATTEMPTS_LIST`] (multica parity
+/// #12): read the admission-decision audit, workspace-scoped and optionally
+/// narrowed to one card.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DispatchAttemptsListParams {
+    /// The subscribed workspace (tenant guard).
+    pub workspace_id: String,
+    /// Narrow to one card's history. Omit for the whole workspace feed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_id: Option<String>,
+    /// How many rows to return, newest first. Defaults to 50, hard-capped at 200
+    /// by the daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+/// Result of [`crate::methods::HANGAR_DISPATCH_ATTEMPTS_LIST`]: the attempts,
+/// **newest first**.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DispatchAttemptsListResult {
+    /// The matching attempts, newest first.
+    pub attempts: Vec<DispatchAttemptRow>,
+}
+
+/// One `dispatch_attempt` row on the wire (multica parity #12, migration 0058).
+///
+/// [`Self::reason`] and [`Self::source`] are carried as raw strings, not typed
+/// enums, so a token minted by a newer daemon renders as raw text instead of
+/// failing the decode — the append-only vocabulary contract. Decode with
+/// `DispatchReason::parse` / `DispatchSource::parse`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DispatchAttemptRow {
+    /// ULID primary key.
+    pub id: String,
+    /// The card the attempt was for; `None` for an issue-less trigger.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_id: Option<String>,
+    /// The resolved target agent, when one resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// The target agent's runtime, when one resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_id: Option<String>,
+    /// Set iff a task row was actually written. Present on `queued` AND on
+    /// `runtime_offline` (hangar enqueues then records — see the daemon's
+    /// divergence note).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    /// The stable admission code (`DispatchReason::as_db_str`).
+    pub reason: String,
+    /// Free-text specifics the deliberately-generic code omits.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// Which trigger surface made the attempt (`DispatchSource::as_db_str`).
+    pub source: String,
+    /// When it was recorded (epoch millis).
+    pub created_at: i64,
 }
 
 #[cfg(test)]
@@ -3647,6 +3717,7 @@ mod tests {
             runtime_id: "rt-lead".into(),
             mode: "headless".into(),
             member_task_ids: vec!["t-m1".into(), "t-m2".into()],
+            reason: None,
         };
         let s = serde_json::to_string(&run).unwrap();
         assert_eq!(serde_json::from_str::<BoardCardRunResult>(&s).unwrap(), run);

--- a/ainb-tui/crates/ainb-hangar-proto/tests/dispatch_reason_wire.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/dispatch_reason_wire.rs
@@ -1,0 +1,191 @@
+//! Wire-compatibility goldens for the dispatch-reason surface (multica parity #12).
+//!
+//! The contract these pin is APPEND-ONLY growth: a pre-#12 payload must decode
+//! unchanged, and a row with nothing to report must serialize byte-identically
+//! to what a pre-#12 daemon emitted. Plus the invariant the reference names
+//! explicitly — the handler serializes the SAME vocabulary the service decided,
+//! so `DispatchReason` round-trips serde ↔ `as_db_str` ↔ `parse`.
+
+use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
+use ainb_hangar_core::ids::IssueId;
+use ainb_hangar_proto::events::IssueRow;
+use ainb_hangar_proto::methods::{ALL_METHODS, HANGAR_DISPATCH_ATTEMPTS_LIST};
+use ainb_hangar_proto::snapshots::{
+    BoardCardRunResult, DispatchAttemptRow, DispatchAttemptsListParams, DispatchAttemptsListResult,
+};
+
+fn bare_issue_json() -> &'static str {
+    // Exactly the shape a PRE-item-12 daemon emitted: no `last_dispatch_*` keys.
+    r#"{
+        "id": "issue-1",
+        "workspace_id": "ws-1",
+        "title": "A card",
+        "description": null,
+        "state": "open",
+        "assignee": null,
+        "creator": "member:user-1",
+        "created_at": 100
+    }"#
+}
+
+/// A pre-item-12 `IssueRow` payload decodes, with the three new fields absent.
+#[test]
+fn pre_item_12_issue_row_decodes() {
+    let row: IssueRow = serde_json::from_str(bare_issue_json()).expect("decode legacy row");
+    assert_eq!(row.last_dispatch_reason, None);
+    assert_eq!(row.last_dispatch_detail, None);
+    assert_eq!(row.last_dispatch_at, None);
+}
+
+/// Byte-identical growth proof: a row with nothing to report serializes to a
+/// JSON object carrying NONE of the three new keys (not `null`s).
+#[test]
+fn issue_row_without_a_decline_grows_by_zero_keys() {
+    let row: IssueRow = serde_json::from_str(bare_issue_json()).expect("decode");
+    let value = serde_json::to_value(&row).expect("serialize");
+    let obj = value.as_object().expect("object");
+    for key in [
+        "last_dispatch_reason",
+        "last_dispatch_detail",
+        "last_dispatch_at",
+    ] {
+        assert!(!obj.contains_key(key), "{key} must be omitted when empty");
+    }
+}
+
+/// …and when a decline IS present, the keys appear and round-trip.
+#[test]
+fn issue_row_with_a_decline_round_trips() {
+    let mut row: IssueRow = serde_json::from_str(bare_issue_json()).expect("decode");
+    row.last_dispatch_reason = Some(DispatchReason::RuntimeOffline.as_db_str().to_string());
+    row.last_dispatch_detail = Some("runtime rt-1 is offline".to_string());
+    row.last_dispatch_at = Some(1_700_000_000_000);
+
+    let json = serde_json::to_string(&row).expect("serialize");
+    assert!(
+        json.contains("\"last_dispatch_reason\":\"runtime_offline\""),
+        "{json}"
+    );
+    let back: IssueRow = serde_json::from_str(&json).expect("decode");
+    assert_eq!(back.id, IssueId::from_str("issue-1").unwrap());
+    assert_eq!(
+        back.last_dispatch_reason.as_deref(),
+        Some("runtime_offline")
+    );
+    assert_eq!(
+        back.last_dispatch_detail.as_deref(),
+        Some("runtime rt-1 is offline")
+    );
+    assert_eq!(back.last_dispatch_at, Some(1_700_000_000_000));
+}
+
+/// A pre-#12 `BoardCardRunResult` (no `reason`) decodes, and an empty one
+/// serializes without the new key.
+#[test]
+fn board_card_run_result_reason_is_append_only() {
+    let legacy = r#"{"task_id":"t-1","agent_id":"a-1","runtime_id":"rt-1","mode":"headless"}"#;
+    let decoded: BoardCardRunResult = serde_json::from_str(legacy).expect("decode legacy result");
+    assert_eq!(decoded.reason, None);
+
+    let json = serde_json::to_string(&decoded).expect("serialize");
+    assert!(!json.contains("reason"), "{json}");
+
+    let with_reason = BoardCardRunResult {
+        reason: Some(DispatchReason::Queued.as_db_str().to_string()),
+        ..decoded
+    };
+    let json = serde_json::to_string(&with_reason).expect("serialize");
+    assert!(json.contains("\"reason\":\"queued\""), "{json}");
+    let back: BoardCardRunResult = serde_json::from_str(&json).expect("decode");
+    assert_eq!(back, with_reason);
+}
+
+/// The invariant the reference states: the decider's vocabulary IS the
+/// serializer's vocabulary. serde token == `as_db_str` == what `parse` accepts.
+#[test]
+fn dispatch_reason_round_trips_serde_db_str_and_parse() {
+    for reason in DispatchReason::ALL {
+        let token = serde_json::to_value(reason)
+            .expect("serialize")
+            .as_str()
+            .expect("string")
+            .to_owned();
+        assert_eq!(token, reason.as_db_str());
+        assert_eq!(DispatchReason::parse(&token), Some(reason));
+        let back: DispatchReason =
+            serde_json::from_str(&format!("\"{token}\"")).expect("deserialize");
+        assert_eq!(back, reason);
+    }
+    for source in DispatchSource::ALL {
+        let token = serde_json::to_value(source)
+            .expect("serialize")
+            .as_str()
+            .expect("string")
+            .to_owned();
+        assert_eq!(token, source.as_db_str());
+        assert_eq!(DispatchSource::parse(&token), Some(source));
+    }
+}
+
+/// The list method is registered, and its params/result envelopes round-trip
+/// with the optional fields omitted when empty.
+#[test]
+fn dispatch_attempts_list_envelopes_round_trip() {
+    assert!(
+        ALL_METHODS.contains(&HANGAR_DISPATCH_ATTEMPTS_LIST),
+        "the new method must be in the wire catalogue"
+    );
+
+    let params = DispatchAttemptsListParams {
+        workspace_id: "ws-1".to_string(),
+        issue_id: Some("issue-1".to_string()),
+        limit: Some(10),
+    };
+    let json = serde_json::to_string(&params).expect("serialize");
+    assert_eq!(
+        serde_json::from_str::<DispatchAttemptsListParams>(&json).expect("decode"),
+        params
+    );
+
+    // A minimal params payload omits the optionals entirely and still decodes.
+    let minimal: DispatchAttemptsListParams =
+        serde_json::from_str(r#"{"workspace_id":"ws-1"}"#).expect("decode minimal");
+    assert_eq!(minimal.issue_id, None);
+    assert_eq!(minimal.limit, None);
+    let json = serde_json::to_string(&minimal).expect("serialize");
+    assert_eq!(json, r#"{"workspace_id":"ws-1"}"#);
+
+    let result = DispatchAttemptsListResult {
+        attempts: vec![DispatchAttemptRow {
+            id: "att-1".to_string(),
+            issue_id: Some("issue-1".to_string()),
+            agent_id: None,
+            runtime_id: None,
+            task_id: None,
+            reason: DispatchReason::TargetUnavailable.as_db_str().to_string(),
+            detail: Some("no agent in this workspace to run on".to_string()),
+            source: DispatchSource::Assign.as_db_str().to_string(),
+            created_at: 1_700_000_000_000,
+        }],
+    };
+    let json = serde_json::to_string(&result).expect("serialize");
+    assert!(json.contains("\"reason\":\"target_unavailable\""), "{json}");
+    assert!(json.contains("\"source\":\"assign\""), "{json}");
+    assert_eq!(
+        serde_json::from_str::<DispatchAttemptsListResult>(&json).expect("decode"),
+        result
+    );
+}
+
+/// A token this binary does not know survives the wire and simply fails to
+/// decode into the enum — it is never dropped or coerced.
+#[test]
+fn unknown_wire_code_survives_as_raw_text() {
+    let row: DispatchAttemptRow = serde_json::from_str(
+        r#"{"id":"att-1","reason":"a_code_from_2027","source":"a_surface_from_2027","created_at":1}"#,
+    )
+    .expect("decode unknown code");
+    assert_eq!(row.reason, "a_code_from_2027");
+    assert_eq!(DispatchReason::parse(&row.reason), None);
+    assert_eq!(DispatchSource::parse(&row.source), None);
+}

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -31,6 +31,9 @@ fn comment_id(s: &str) -> CommentId {
 
 fn sample_issue() -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: issue_id("issue-1"),

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0058_dispatch_attempt.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0058_dispatch_attempt.sql
@@ -1,0 +1,62 @@
+-- Hangar v1 schema, migration 0058: DISPATCH ATTEMPT AUDIT (multica parity #12).
+--
+-- multica carries an admission-time reason vocabulary in a dedicated leaf
+-- package (`server/internal/dispatch/reason.go`, MUL-4525) so the layer that
+-- DECIDES a dispatch and the layer that SERIALIZES the decision share one set of
+-- codes and cannot drift. hangar had the decision (`CardRunError` in the daemon's
+-- `run_card`) but threw it away at every call site: two paths turned it into an
+-- ephemeral JSON-RPC error string, three others logged it at debug/info and
+-- returned, and the CLI assign path swallowed it as a bare `Ok(None)`. Nothing
+-- was persisted, so "why is my card not running" had no answer.
+--
+-- This table is that answer: one row per dispatch attempt, carrying the stable
+-- code (`DispatchReason::as_db_str`), a free-text detail, and which trigger
+-- surface made the attempt (`DispatchSource::as_db_str`).
+--
+-- The precedent is migration 0057, which gave `autopilot_run` a non-failure
+-- `skipped` status for exactly this reason ("reusing `failed` would pollute the
+-- failure-rate signal"). 0058 generalises it from autopilot concurrency skips to
+-- EVERY admission decision, and upgrades free-text to a stable code + detail.
+--
+-- THREE DELIBERATE SCHEMA DECISIONS:
+--
+-- 1. NO CHECK CONSTRAINT on `reason` (nor on `source`). SQLite cannot widen a
+--    CHECK without a full table rebuild — 0057 needed a defer_foreign_keys +
+--    copy/drop/recreate dance for precisely that. This vocabulary is append-only
+--    by design, so the rebuild would recur on every future variant. The domain is
+--    enforced in Rust instead: `DispatchReason::as_db_str` is the only writer and
+--    `DispatchReason::parse` is the tolerant reader (an unknown token decodes to
+--    None and renders as raw text rather than poisoning the read path).
+--
+-- 2. FK ONLY ON `workspace_id`. `issue_id` / `agent_id` / `runtime_id` /
+--    `task_id` carry no FK deliberately: the audit row is a historical FACT that
+--    must survive the death of what it describes (a declined dispatch of an issue
+--    deleted next week still happened), and a recorder must never fail on a race
+--    with a concurrent delete. The explicit cascade in `IssueRepo::delete` is what
+--    reaps rows for a deleted issue, matching how `agent_task_queue` is handled.
+--
+-- 3. BOUNDED BY CONSTRUCTION, NOT BY A SWEEPER. `DispatchAttemptRepo::record`
+--    trims to the newest DISPATCH_ATTEMPT_KEEP (20) rows per issue in the same
+--    statement batch as the insert, so a hot auto-run cascade cannot grow the
+--    table without bound and no new sweeper job is needed.
+
+CREATE TABLE dispatch_attempt (
+    id            TEXT PRIMARY KEY,              -- ULID
+    workspace_id  TEXT NOT NULL REFERENCES workspace(id),
+    issue_id      TEXT,                          -- NULL for a future issue-less trigger
+    agent_id      TEXT,                          -- the resolved target, when one resolved
+    runtime_id    TEXT,
+    task_id       TEXT,                          -- set iff a task row was actually written
+    reason        TEXT NOT NULL,                 -- DispatchReason::as_db_str()
+    detail        TEXT,
+    source        TEXT NOT NULL DEFAULT 'manual',-- DispatchSource::as_db_str()
+    created_at    INTEGER NOT NULL               -- epoch millis
+);
+
+-- The per-card read ("why is THIS not running"): newest-first, id as the
+-- tiebreaker so two attempts inside one millisecond still order deterministically
+-- (ULIDs are monotonic within a millisecond).
+CREATE INDEX idx_dispatch_attempt_issue ON dispatch_attempt(issue_id, created_at DESC, id DESC);
+
+-- The workspace-scoped feed behind `hangar/dispatch_attempts_list`.
+CREATE INDEX idx_dispatch_attempt_ws    ON dispatch_attempt(workspace_id, created_at DESC);

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
@@ -30,7 +30,7 @@
 //! than failing the read.
 
 use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
-use sqlx::{Row, SqlitePool, Sqlite, Transaction};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
 /// How many attempts are retained per issue. The recorder trims to this on every
 /// insert (migration 0058, decision 3).

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
@@ -1,0 +1,249 @@
+//! Typed repository over the `dispatch_attempt` audit table (multica parity #12,
+//! migration 0058).
+//!
+//! One row per **admission decision**: a trigger surface tried to turn a card
+//! into a run, and this is the stable code
+//! ([`ainb_hangar_core::dispatch_reason::DispatchReason`]) plus the free-text
+//! detail for what happened. It is the persistent answer to "why is my card not
+//! running", which before 0058 existed only as an ephemeral RPC error string or
+//! a debug log line.
+//!
+//! # Bounded by construction
+//!
+//! [`DispatchAttemptRepo::record`] trims the issue's history to the newest
+//! [`DISPATCH_ATTEMPT_KEEP`] rows in the same call as the insert, so a hot
+//! auto-run cascade cannot grow the table without bound and no sweeper job is
+//! needed (see the migration's comment block).
+//!
+//! # Workspace scoping
+//!
+//! [`DispatchAttemptRepo::list_by_workspace`] is `workspace_id`-scoped like every
+//! other repo here, so a sibling tenant's attempts are never returned.
+//! [`DispatchAttemptRepo::latest_for_issue`] / [`DispatchAttemptRepo::list_for_issue`]
+//! key on the issue id, which is already tenant-resolved by every caller.
+//!
+//! # Lenient reads
+//!
+//! [`DispatchAttempt::reason`] is kept as the raw `String` and decoded on demand
+//! via [`DispatchAttempt::code`]: a token written by a newer daemon that this
+//! binary does not know decodes to `None` and is rendered as raw text rather
+//! than failing the read.
+
+use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
+use sqlx::{Row, SqlitePool, Sqlite, Transaction};
+
+/// How many attempts are retained per issue. The recorder trims to this on every
+/// insert (migration 0058, decision 3).
+pub const DISPATCH_ATTEMPT_KEEP: i64 = 20;
+
+/// An attempt to record.
+#[derive(Debug, Clone)]
+pub struct NewDispatchAttempt<'a> {
+    /// Owning tenant. The one FK on the table.
+    pub workspace_id: &'a str,
+    /// The card the attempt was for; `None` for a future issue-less trigger.
+    pub issue_id: Option<&'a str>,
+    /// The resolved target agent, when one resolved.
+    pub agent_id: Option<&'a str>,
+    /// The target agent's runtime, when one resolved.
+    pub runtime_id: Option<&'a str>,
+    /// Set iff a task row was actually written.
+    pub task_id: Option<&'a str>,
+    /// The stable admission code.
+    pub reason: DispatchReason,
+    /// Free text carrying the specifics the code deliberately omits.
+    pub detail: Option<&'a str>,
+    /// Which trigger surface made the attempt.
+    pub source: DispatchSource,
+    /// Epoch millis.
+    pub created_at: i64,
+}
+
+/// A read-back `dispatch_attempt` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchAttempt {
+    /// ULID primary key.
+    pub id: String,
+    /// Owning tenant.
+    pub workspace_id: String,
+    /// The card the attempt was for.
+    pub issue_id: Option<String>,
+    /// The resolved target agent.
+    pub agent_id: Option<String>,
+    /// The target agent's runtime.
+    pub runtime_id: Option<String>,
+    /// The task row written, when one was.
+    pub task_id: Option<String>,
+    /// The raw stored code. Kept as text so an unknown future token survives a
+    /// read; decode with [`Self::code`].
+    pub reason: String,
+    /// Free-text specifics.
+    pub detail: Option<String>,
+    /// The raw stored trigger surface.
+    pub source: String,
+    /// Epoch millis.
+    pub created_at: i64,
+}
+
+impl DispatchAttempt {
+    /// Decode [`Self::reason`] into the typed vocabulary. `None` for a token
+    /// this binary does not know (render the raw string in that case).
+    #[must_use]
+    pub fn code(&self) -> Option<DispatchReason> {
+        DispatchReason::parse(&self.reason)
+    }
+
+    /// Decode [`Self::source`]; `None` for an unknown token.
+    #[must_use]
+    pub fn source_code(&self) -> Option<DispatchSource> {
+        DispatchSource::parse(&self.source)
+    }
+
+    /// Did this attempt actually produce (or fold into) a run?
+    ///
+    /// An unknown code is treated as **not** dispatched: an older binary reading
+    /// a newer daemon's token should surface it rather than hide it.
+    #[must_use]
+    pub fn is_dispatched(&self) -> bool {
+        self.code().is_some_and(DispatchReason::is_dispatched)
+    }
+
+    fn from_row(row: &sqlx::sqlite::SqliteRow) -> Self {
+        Self {
+            id: row.get("id"),
+            workspace_id: row.get("workspace_id"),
+            issue_id: row.get("issue_id"),
+            agent_id: row.get("agent_id"),
+            runtime_id: row.get("runtime_id"),
+            task_id: row.get("task_id"),
+            reason: row.get("reason"),
+            detail: row.get("detail"),
+            source: row.get("source"),
+            created_at: row.get("created_at"),
+        }
+    }
+}
+
+const SELECT_COLS: &str = "id, workspace_id, issue_id, agent_id, runtime_id, task_id, \
+                           reason, detail, source, created_at";
+
+/// Stateless repo over `dispatch_attempt`.
+pub struct DispatchAttemptRepo;
+
+impl DispatchAttemptRepo {
+    /// Insert one attempt, then trim the issue's history to the newest
+    /// [`DISPATCH_ATTEMPT_KEEP`] rows. Returns the new row's id.
+    ///
+    /// The trim is a no-op for an issue-less attempt (`issue_id IS NULL`);
+    /// those are workspace-scoped facts with no natural per-card bound, and no
+    /// producer mints them today.
+    pub async fn record(
+        pool: &SqlitePool,
+        id: &str,
+        new: &NewDispatchAttempt<'_>,
+    ) -> Result<String, sqlx::Error> {
+        let mut tx = pool.begin().await?;
+        sqlx::query(
+            "INSERT INTO dispatch_attempt \
+             (id, workspace_id, issue_id, agent_id, runtime_id, task_id, reason, detail, source, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(id)
+        .bind(new.workspace_id)
+        .bind(new.issue_id)
+        .bind(new.agent_id)
+        .bind(new.runtime_id)
+        .bind(new.task_id)
+        .bind(new.reason.as_db_str())
+        .bind(new.detail)
+        .bind(new.source.as_db_str())
+        .bind(new.created_at)
+        .execute(&mut *tx)
+        .await?;
+
+        if let Some(issue_id) = new.issue_id {
+            sqlx::query(
+                "DELETE FROM dispatch_attempt \
+                 WHERE issue_id = ? \
+                   AND id NOT IN ( \
+                       SELECT id FROM dispatch_attempt \
+                       WHERE issue_id = ? \
+                       ORDER BY created_at DESC, id DESC \
+                       LIMIT ? \
+                   )",
+            )
+            .bind(issue_id)
+            .bind(issue_id)
+            .bind(DISPATCH_ATTEMPT_KEEP)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(id.to_owned())
+    }
+
+    /// The newest attempt for a card, if any.
+    pub async fn latest_for_issue(
+        pool: &SqlitePool,
+        issue_id: &str,
+    ) -> Result<Option<DispatchAttempt>, sqlx::Error> {
+        let row = sqlx::query(&format!(
+            "SELECT {SELECT_COLS} FROM dispatch_attempt \
+             WHERE issue_id = ? ORDER BY created_at DESC, id DESC LIMIT 1"
+        ))
+        .bind(issue_id)
+        .fetch_optional(pool)
+        .await?;
+        Ok(row.as_ref().map(DispatchAttempt::from_row))
+    }
+
+    /// A card's attempt history, newest first.
+    pub async fn list_for_issue(
+        pool: &SqlitePool,
+        issue_id: &str,
+        limit: i64,
+    ) -> Result<Vec<DispatchAttempt>, sqlx::Error> {
+        let rows = sqlx::query(&format!(
+            "SELECT {SELECT_COLS} FROM dispatch_attempt \
+             WHERE issue_id = ? ORDER BY created_at DESC, id DESC LIMIT ?"
+        ))
+        .bind(issue_id)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.iter().map(DispatchAttempt::from_row).collect())
+    }
+
+    /// The workspace-scoped feed, newest first. Never returns a sibling
+    /// tenant's rows.
+    pub async fn list_by_workspace(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        limit: i64,
+    ) -> Result<Vec<DispatchAttempt>, sqlx::Error> {
+        let rows = sqlx::query(&format!(
+            "SELECT {SELECT_COLS} FROM dispatch_attempt \
+             WHERE workspace_id = ? ORDER BY created_at DESC, id DESC LIMIT ?"
+        ))
+        .bind(workspace_id)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.iter().map(DispatchAttempt::from_row).collect())
+    }
+
+    /// Reap a deleted card's attempts. Called from `IssueRepo::delete`'s
+    /// explicit cascade (the table carries no FK on `issue_id` on purpose —
+    /// see the migration).
+    pub async fn delete_for_issue(
+        tx: &mut Transaction<'_, Sqlite>,
+        issue_id: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM dispatch_attempt WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut **tx)
+            .await?;
+        Ok(())
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -881,6 +881,13 @@ impl IssueRepo {
             .execute(&mut *tx)
             .await?;
 
+        // 4b. The card's dispatch-attempt audit rows (migration 0058). The table
+        //     carries no FK on `issue_id` on purpose (an audit row must survive a
+        //     race with a concurrent delete), so the reap is explicit here — the
+        //     same shape as the `agent_task_queue` delete above.
+        crate::repo::dispatch_attempt::DispatchAttemptRepo::delete_for_issue(&mut tx, issue_id)
+            .await?;
+
         // 5. The issue's directly-linked rows. First orphan any sub-issues: the
         //    `parent_issue_id` self-FK is `ON DELETE SET NULL` (migration 0046),
         //    so children are NULLed automatically at the final DELETE, but FK

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
@@ -19,6 +19,7 @@ pub mod card_dependency;
 pub mod card_parity;
 pub mod comment;
 pub mod daemon_config;
+pub mod dispatch_attempt;
 pub mod event_log;
 pub mod fleet;
 pub mod inbox;

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0058_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0058_upgrade.rs
@@ -30,20 +30,14 @@ async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
         .create_if_missing(true)
         .foreign_keys(true)
         .journal_mode(SqliteJournalMode::Wal);
-    let pool = SqlitePoolOptions::new()
-        .connect_with(opts)
-        .await
-        .expect("open pool");
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
 
     let mut migrator = sqlx::migrate::Migrator::new(
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
     )
     .await
     .expect("load migrations directory");
-    migrator
-        .migrations
-        .to_mut()
-        .retain(|m| m.version < NEW_MIGRATION_VERSION);
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
     assert!(
         !migrator.migrations.is_empty(),
         "prior-migration set must not be empty"
@@ -139,13 +133,18 @@ async fn upgrades_populated_db_and_creates_the_audit_table() {
     .execute(&pool)
     .await
     .expect("record on upgraded db");
-    let row = sqlx::query("SELECT reason, detail, task_id, source FROM dispatch_attempt WHERE id = 'att-1'")
-        .fetch_one(&pool)
-        .await
-        .expect("read back");
+    let row = sqlx::query(
+        "SELECT reason, detail, task_id, source FROM dispatch_attempt WHERE id = 'att-1'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read back");
     assert_eq!(row.get::<String, _>("reason"), "runtime_offline");
     assert_eq!(row.get::<String, _>("source"), "manual");
-    assert_eq!(row.get::<Option<String>, _>("task_id").as_deref(), Some("task-1"));
+    assert_eq!(
+        row.get::<Option<String>, _>("task_id").as_deref(),
+        Some("task-1")
+    );
     assert_eq!(
         row.get::<Option<String>, _>("detail").as_deref(),
         Some("rt-1 is offline")
@@ -159,11 +158,10 @@ async fn upgrades_populated_db_and_creates_the_audit_table() {
     .execute(&pool)
     .await
     .expect("default source");
-    let src: String =
-        sqlx::query_scalar("SELECT source FROM dispatch_attempt WHERE id = 'att-2'")
-            .fetch_one(&pool)
-            .await
-            .expect("read source");
+    let src: String = sqlx::query_scalar("SELECT source FROM dispatch_attempt WHERE id = 'att-2'")
+        .fetch_one(&pool)
+        .await
+        .expect("read source");
     assert_eq!(src, "manual");
 
     assert!(

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0058_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0058_upgrade.rs
@@ -1,0 +1,217 @@
+//! Upgrade-from-populated test for migration 0058 (`dispatch_attempt` —
+//! multica parity #12).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the migration is safe on a REAL populated database:
+//!
+//! 1. apply only the PRIOR migrations (0001..0057),
+//! 2. seed a workspace / user / runtime / agent / issue / task graph,
+//! 3. apply the embedded migrations (which adds 0058),
+//! 4. assert the pre-existing rows survived, the table + both indexes exist, a
+//!    record-and-read works, the FK on `workspace_id` is enforced while
+//!    `issue_id` deliberately is NOT, and the un-CHECKed `reason` column accepts
+//!    a token this binary does not know (the append-only vocabulary contract).
+
+use ainb_hangar_store::apply_migrations;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test (`0058_dispatch_attempt.sql`).
+const NEW_MIGRATION_VERSION: i64 = 58;
+
+/// Open a fresh on-disk WAL pool in `dir` and apply only the migrations PRIOR to
+/// [`NEW_MIGRATION_VERSION`], with foreign keys ON (the crate's production
+/// setting).
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let db_path = dir.join("hangar.db");
+    let opts = SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(opts)
+        .await
+        .expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator
+        .migrations
+        .to_mut()
+        .retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(
+        !migrator.migrations.is_empty(),
+        "prior-migration set must not be empty"
+    );
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+async fn seed_populated(pool: &SqlitePool) {
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-1','a@example.com',0)",
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode, status) \
+         VALUES ('rt-1','ws-1','daemon-1','claude','local','online')",
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('agent-1','ws-1','Agent','rt-1','workspace','user-1')",
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('iss-1','ws-1','Card','open','member','user-1',0)",
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at) \
+         VALUES ('task-1','ws-1','rt-1','agent-1','iss-1','queued',100)",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+async fn table_exists(pool: &SqlitePool, name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("sqlite_master")
+        > 0
+}
+
+#[tokio::test]
+async fn upgrades_populated_db_and_creates_the_audit_table() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+
+    // Pre-condition: the table genuinely does not exist yet.
+    assert!(
+        !table_exists(&pool, "dispatch_attempt").await,
+        "dispatch_attempt must not predate 0058"
+    );
+    seed_populated(&pool).await;
+
+    apply_migrations(&pool).await.expect("0058 applies");
+
+    assert!(table_exists(&pool, "dispatch_attempt").await);
+
+    // The pre-existing graph survived untouched.
+    let issues: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue")
+        .fetch_one(&pool)
+        .await
+        .expect("count issues");
+    assert_eq!(issues, 1);
+    let tasks: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue")
+        .fetch_one(&pool)
+        .await
+        .expect("count tasks");
+    assert_eq!(tasks, 1);
+
+    // Both indexes from the migration exist.
+    let indexes: Vec<String> = sqlx::query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'dispatch_attempt' \
+         ORDER BY name",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("index list")
+    .iter()
+    .map(|r| r.get::<String, _>("name"))
+    .collect();
+    assert!(
+        indexes.iter().any(|n| n == "idx_dispatch_attempt_issue"),
+        "per-issue index missing: {indexes:?}"
+    );
+    assert!(
+        indexes.iter().any(|n| n == "idx_dispatch_attempt_ws"),
+        "per-workspace index missing: {indexes:?}"
+    );
+
+    // A record + read works on the upgraded database.
+    sqlx::query(
+        "INSERT INTO dispatch_attempt \
+         (id, workspace_id, issue_id, agent_id, runtime_id, task_id, reason, detail, source, created_at) \
+         VALUES ('att-1','ws-1','iss-1','agent-1','rt-1','task-1','runtime_offline','rt-1 is offline','manual',200)",
+    )
+    .execute(&pool)
+    .await
+    .expect("record on upgraded db");
+    let row = sqlx::query("SELECT reason, detail, task_id, source FROM dispatch_attempt WHERE id = 'att-1'")
+        .fetch_one(&pool)
+        .await
+        .expect("read back");
+    assert_eq!(row.get::<String, _>("reason"), "runtime_offline");
+    assert_eq!(row.get::<String, _>("source"), "manual");
+    assert_eq!(row.get::<Option<String>, _>("task_id").as_deref(), Some("task-1"));
+    assert_eq!(
+        row.get::<Option<String>, _>("detail").as_deref(),
+        Some("rt-1 is offline")
+    );
+
+    // `source` defaults when omitted.
+    sqlx::query(
+        "INSERT INTO dispatch_attempt (id, workspace_id, issue_id, reason, created_at) \
+         VALUES ('att-2','ws-1','iss-1','queued',201)",
+    )
+    .execute(&pool)
+    .await
+    .expect("default source");
+    let src: String =
+        sqlx::query_scalar("SELECT source FROM dispatch_attempt WHERE id = 'att-2'")
+            .fetch_one(&pool)
+            .await
+            .expect("read source");
+    assert_eq!(src, "manual");
+
+    assert!(
+        sqlx::query("PRAGMA foreign_key_check")
+            .fetch_all(&pool)
+            .await
+            .expect("fk check")
+            .is_empty(),
+        "no dangling foreign keys after the upgrade"
+    );
+}
+
+/// Migration decision 1: no CHECK on `reason`, so a future daemon's token
+/// persists. Decision 2: `workspace_id` is the ONLY foreign key, so an audit row
+/// survives the death of the issue / agent / task it describes.
+#[tokio::test]
+async fn vocabulary_is_open_and_only_workspace_is_a_foreign_key() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+    apply_migrations(&pool).await.expect("0058 applies");
+
+    // An unknown code stores fine (append-only vocabulary, enforced in Rust).
+    sqlx::query(
+        "INSERT INTO dispatch_attempt (id, workspace_id, issue_id, reason, created_at) \
+         VALUES ('att-future','ws-1','iss-1','a_code_from_2027',1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("unknown reason accepted (no CHECK by design)");
+
+    // Ids that carry no FK: a row about entities that never existed is legal,
+    // which is what lets the audit outlive what it describes.
+    sqlx::query(
+        "INSERT INTO dispatch_attempt \
+         (id, workspace_id, issue_id, agent_id, runtime_id, task_id, reason, created_at) \
+         VALUES ('att-ghost','ws-1','iss-gone','agent-gone','rt-gone','task-gone','already_active',2)",
+    )
+    .execute(&pool)
+    .await
+    .expect("no FK on issue/agent/runtime/task by design");
+
+    // …but the one FK that IS declared is enforced.
+    let bad_ws = sqlx::query(
+        "INSERT INTO dispatch_attempt (id, workspace_id, reason, created_at) \
+         VALUES ('att-bad','ws-nope','queued',3)",
+    )
+    .execute(&pool)
+    .await;
+    assert!(bad_ws.is_err(), "workspace_id FK must be enforced");
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_dispatch_attempt.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_dispatch_attempt.rs
@@ -188,7 +188,11 @@ async fn trim_is_scoped_to_one_issue() {
     let other = DispatchAttemptRepo::list_for_issue(store.pool(), "iss-2", 100)
         .await
         .expect("list");
-    assert_eq!(other.len(), 1, "sibling card's history must survive the trim");
+    assert_eq!(
+        other.len(),
+        1,
+        "sibling card's history must survive the trim"
+    );
 }
 
 /// Mirrors `workspace_data_isolation.rs`: a sibling tenant's attempts are never

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_dispatch_attempt.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_dispatch_attempt.rs
@@ -1,0 +1,289 @@
+//! The `dispatch_attempt` audit repo (multica parity #12, migration 0058).
+//!
+//! Before 0058 an admission refusal was ephemeral: an RPC error string, a debug
+//! log line, or (on the CLI assign path) a bare `Ok(None)`. These tests pin the
+//! persistence half of the fix against real sqlite — record/read round-trip with
+//! the code decoding back through `DispatchReason::parse`, the
+//! bounded-by-construction trim, and tenant scoping.
+
+use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::dispatch_attempt::{
+    DISPATCH_ATTEMPT_KEEP, DispatchAttemptRepo, NewDispatchAttempt,
+};
+
+/// Seed two workspaces so tenant scoping is assertable.
+async fn seed(store: &Store) {
+    let pool = store.pool();
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-2','beta','Beta',0)",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+/// A migrated store in a tempdir. The `TempDir` is returned so the caller keeps
+/// it alive for the test's duration.
+async fn open() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed(&store).await;
+    (dir, store)
+}
+
+async fn record(
+    store: &Store,
+    id: &str,
+    workspace_id: &str,
+    issue_id: Option<&str>,
+    reason: DispatchReason,
+    detail: Option<&str>,
+    created_at: i64,
+) {
+    DispatchAttemptRepo::record(
+        store.pool(),
+        id,
+        &NewDispatchAttempt {
+            workspace_id,
+            issue_id,
+            agent_id: None,
+            runtime_id: None,
+            task_id: None,
+            reason,
+            detail,
+            source: DispatchSource::Manual,
+            created_at,
+        },
+    )
+    .await
+    .expect("record attempt");
+}
+
+#[tokio::test]
+async fn record_then_latest_for_issue_round_trips_the_code() {
+    let (_dir, store) = open().await;
+    record(
+        &store,
+        "att-1",
+        "ws-1",
+        Some("iss-1"),
+        DispatchReason::TargetUnavailable,
+        Some("no agent in this workspace to run on"),
+        1_000,
+    )
+    .await;
+
+    let latest = DispatchAttemptRepo::latest_for_issue(store.pool(), "iss-1")
+        .await
+        .expect("query")
+        .expect("one attempt recorded");
+
+    assert_eq!(latest.id, "att-1");
+    assert_eq!(latest.reason, "target_unavailable");
+    // The stored token decodes back through the shared vocabulary — the whole
+    // point of one enum for the decider and the serializer.
+    assert_eq!(latest.code(), Some(DispatchReason::TargetUnavailable));
+    assert_eq!(latest.source_code(), Some(DispatchSource::Manual));
+    assert!(!latest.is_dispatched());
+    assert_eq!(
+        latest.detail.as_deref(),
+        Some("no agent in this workspace to run on")
+    );
+}
+
+#[tokio::test]
+async fn newest_first_and_queued_reads_as_dispatched() {
+    let (_dir, store) = open().await;
+    record(
+        &store,
+        "att-old",
+        "ws-1",
+        Some("iss-1"),
+        DispatchReason::AlreadyActive,
+        None,
+        1_000,
+    )
+    .await;
+    record(
+        &store,
+        "att-new",
+        "ws-1",
+        Some("iss-1"),
+        DispatchReason::Queued,
+        Some("task t-1"),
+        2_000,
+    )
+    .await;
+
+    let rows = DispatchAttemptRepo::list_for_issue(store.pool(), "iss-1", 10)
+        .await
+        .expect("list");
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, ["att-new", "att-old"], "newest first");
+    assert!(rows[0].is_dispatched());
+    assert!(!rows[1].is_dispatched());
+
+    let latest = DispatchAttemptRepo::latest_for_issue(store.pool(), "iss-1")
+        .await
+        .expect("query")
+        .expect("present");
+    assert_eq!(latest.id, "att-new");
+}
+
+/// Bounded by construction: 25 records leave exactly the newest 20, so a hot
+/// auto-run cascade cannot grow the table without bound (migration decision 3).
+#[tokio::test]
+async fn record_trims_to_the_newest_keep_rows_per_issue() {
+    let (_dir, store) = open().await;
+    for i in 0..25_i64 {
+        record(
+            &store,
+            &format!("att-{i:02}"),
+            "ws-1",
+            Some("iss-1"),
+            DispatchReason::AlreadyActive,
+            None,
+            1_000 + i,
+        )
+        .await;
+    }
+
+    let rows = DispatchAttemptRepo::list_for_issue(store.pool(), "iss-1", 100)
+        .await
+        .expect("list");
+    assert_eq!(rows.len(), usize::try_from(DISPATCH_ATTEMPT_KEEP).unwrap());
+    // …and they are the NEWEST 20, not the first 20.
+    assert_eq!(rows.first().expect("head").id, "att-24");
+    assert_eq!(rows.last().expect("tail").id, "att-05");
+}
+
+/// The trim is per-issue: a sibling card's history is untouched.
+#[tokio::test]
+async fn trim_is_scoped_to_one_issue() {
+    let (_dir, store) = open().await;
+    record(
+        &store,
+        "other-1",
+        "ws-1",
+        Some("iss-2"),
+        DispatchReason::Deferred,
+        None,
+        1,
+    )
+    .await;
+    for i in 0..25_i64 {
+        record(
+            &store,
+            &format!("att-{i:02}"),
+            "ws-1",
+            Some("iss-1"),
+            DispatchReason::AlreadyActive,
+            None,
+            1_000 + i,
+        )
+        .await;
+    }
+
+    let other = DispatchAttemptRepo::list_for_issue(store.pool(), "iss-2", 100)
+        .await
+        .expect("list");
+    assert_eq!(other.len(), 1, "sibling card's history must survive the trim");
+}
+
+/// Mirrors `workspace_data_isolation.rs`: a sibling tenant's attempts are never
+/// returned by the workspace feed.
+#[tokio::test]
+async fn list_by_workspace_never_leaks_a_sibling_tenant() {
+    let (_dir, store) = open().await;
+    record(
+        &store,
+        "mine",
+        "ws-1",
+        Some("iss-1"),
+        DispatchReason::RuntimeOffline,
+        None,
+        1_000,
+    )
+    .await;
+    record(
+        &store,
+        "theirs",
+        "ws-2",
+        Some("iss-9"),
+        DispatchReason::RuntimeOffline,
+        None,
+        2_000,
+    )
+    .await;
+
+    let mine = DispatchAttemptRepo::list_by_workspace(store.pool(), "ws-1", 50)
+        .await
+        .expect("list");
+    let ids: Vec<&str> = mine.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, ["mine"]);
+
+    let theirs = DispatchAttemptRepo::list_by_workspace(store.pool(), "ws-2", 50)
+        .await
+        .expect("list");
+    assert_eq!(theirs.len(), 1);
+    assert_eq!(theirs[0].id, "theirs");
+
+    // A workspace with nothing recorded is empty, not an error.
+    let empty = DispatchAttemptRepo::list_by_workspace(store.pool(), "ws-absent", 50)
+        .await
+        .expect("list");
+    assert!(empty.is_empty());
+}
+
+#[tokio::test]
+async fn list_honours_its_limit() {
+    let (_dir, store) = open().await;
+    for i in 0..5_i64 {
+        record(
+            &store,
+            &format!("att-{i}"),
+            "ws-1",
+            Some("iss-1"),
+            DispatchReason::AlreadyActive,
+            None,
+            1_000 + i,
+        )
+        .await;
+    }
+    let capped = DispatchAttemptRepo::list_for_issue(store.pool(), "iss-1", 2)
+        .await
+        .expect("list");
+    assert_eq!(capped.len(), 2);
+    assert_eq!(capped[0].id, "att-4");
+
+    let ws_capped = DispatchAttemptRepo::list_by_workspace(store.pool(), "ws-1", 3)
+        .await
+        .expect("list");
+    assert_eq!(ws_capped.len(), 3);
+}
+
+/// A token this binary does not know decodes to `None` and reads as raw text —
+/// an older binary never fails a read against a newer daemon's vocabulary.
+#[tokio::test]
+async fn unknown_stored_code_reads_as_raw_text_not_an_error() {
+    let (_dir, store) = open().await;
+    sqlx::query(
+        "INSERT INTO dispatch_attempt \
+         (id, workspace_id, issue_id, reason, source, created_at) \
+         VALUES ('att-future','ws-1','iss-1','nonsense_code','nonsense_source',1)",
+    )
+    .execute(store.pool())
+    .await
+    .expect("insert future token");
+
+    let latest = DispatchAttemptRepo::latest_for_issue(store.pool(), "iss-1")
+        .await
+        .expect("query")
+        .expect("present");
+    assert_eq!(latest.reason, "nonsense_code");
+    assert_eq!(latest.code(), None);
+    assert_eq!(latest.source_code(), None);
+    // Unknown => surfaced (NOT hidden as "dispatched").
+    assert!(!latest.is_dispatched());
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
@@ -205,6 +205,21 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
     .await
     .expect("inbox entries");
 
+    // Dispatch-attempt audit rows (migration 0058). The table carries no FK on
+    // `issue_id` on purpose, so the reap is an EXPLICIT step in the cascade —
+    // deleting it strands the rows and turns the assertion below RED. The
+    // sibling issue's attempt must survive.
+    sqlx::query(
+        "INSERT INTO dispatch_attempt \
+         (id, workspace_id, issue_id, reason, detail, source, created_at) \
+         VALUES ('da-1','ws-a','i-1','target_unavailable','no agent','manual',0), \
+                ('da-2','ws-a','i-1','already_active',NULL,'auto_run',1), \
+                ('da-sibling','ws-a','i-2','deferred',NULL,'manual',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("dispatch attempts");
+
     // Preview agrees with what the cascade is about to do.
     let preview = IssueRepo::delete_preview(pool, "ws-a", "i-1")
         .await
@@ -248,6 +263,10 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
             "SELECT COUNT(*) FROM beads_mapping WHERE hangar_id = ?",
             "beads mapping",
         ),
+        (
+            "SELECT COUNT(*) FROM dispatch_attempt WHERE issue_id = ?",
+            "dispatch attempts",
+        ),
     ] {
         let n = if what == "dependency edges" {
             sqlx::query_scalar::<_, i64>(sql)
@@ -290,6 +309,16 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
         .await,
         1,
         "the sibling issue's inbox entry survives"
+    );
+    assert_eq!(
+        count(
+            pool,
+            "SELECT COUNT(*) FROM dispatch_attempt WHERE issue_id = ?",
+            "i-2"
+        )
+        .await,
+        1,
+        "the sibling issue's dispatch attempt survives"
     );
     // Cost history survives, detached from the vanished task.
     let (runs, linked): (i64, i64) = (

--- a/ainb-tui/crates/ainb-plugin-hangar/src/board_mouse.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/board_mouse.rs
@@ -147,6 +147,7 @@ mod tests {
                 glyph: '○',
                 name: "queued".into(),
                 cards: vec![BoardCard {
+                    not_dispatched: false,
                     issue_id: "task-A".into(),
                     display_id: "#A".into(),
                     title: "build the thing".into(),
@@ -161,6 +162,7 @@ mod tests {
                 glyph: '◔',
                 name: "running".into(),
                 cards: vec![BoardCard {
+                    not_dispatched: false,
                     issue_id: "task-B".into(),
                     display_id: "#B".into(),
                     title: "run the thing".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/mouse.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/mouse.rs
@@ -535,6 +535,7 @@ mod tests {
                 glyph: '☰',
                 name: "Backlog".into(),
                 cards: vec![BoardCard {
+                    not_dispatched: false,
                     issue_id: "HGR-1".into(),
                     display_id: "HGR-1".into(),
                     title: "Triage".into(),
@@ -549,6 +550,7 @@ mod tests {
                 glyph: '○',
                 name: "Todo".into(),
                 cards: vec![BoardCard {
+                    not_dispatched: false,
                     issue_id: "HGR-2".into(),
                     display_id: "HGR-2".into(),
                     title: "Write".into(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -4316,6 +4316,9 @@ impl HangarPlugin {
         // renders the task's title + status; the streaming transcript folds events
         // addressed to this task id, exactly as the issue board's open does.
         let issue = ainb_hangar_proto::events::IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str(format!("task-{task_id}")).unwrap_or_else(
@@ -5755,6 +5758,9 @@ mod tests {
         p.conn.on_dialed("s1");
         p.conn.on_subscribe_ack();
         p.screens.set_issues(vec![IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
@@ -5913,6 +5919,9 @@ mod tests {
         // more than one column (the press must resolve the RIGHT card).
         p.screens.set_issues(vec![
             IssueRow {
+                last_dispatch_reason: None,
+                last_dispatch_detail: None,
+                last_dispatch_at: None,
                 origin_type: None,
                 origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
@@ -5946,6 +5955,9 @@ mod tests {
                 dependencies: Vec::new(),
             },
             IssueRow {
+                last_dispatch_reason: None,
+                last_dispatch_detail: None,
+                last_dispatch_at: None,
                 origin_type: None,
                 origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("issue-2").unwrap(),
@@ -6140,6 +6152,9 @@ mod tests {
 
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
@@ -6233,6 +6248,9 @@ mod tests {
 
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),
@@ -6318,6 +6336,9 @@ mod tests {
         // Several Todo cards so a scroll offset is observable.
         let rows: Vec<IssueRow> = (0..4)
             .map(|i| IssueRow {
+                last_dispatch_reason: None,
+                last_dispatch_detail: None,
+                last_dispatch_at: None,
                 origin_type: None,
                 origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str(format!("t{i}")).unwrap(),
@@ -6407,6 +6428,9 @@ mod tests {
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![
             IssueRow {
+                last_dispatch_reason: None,
+                last_dispatch_detail: None,
+                last_dispatch_at: None,
                 origin_type: None,
                 origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("card-a").unwrap(),
@@ -6440,6 +6464,9 @@ mod tests {
                 dependencies: Vec::new(),
             },
             IssueRow {
+                last_dispatch_reason: None,
+                last_dispatch_detail: None,
+                last_dispatch_at: None,
                 origin_type: None,
                 origin_id: None,
                 id: ainb_hangar_core::ids::IssueId::from_str("card-b").unwrap(),
@@ -7188,6 +7215,9 @@ mod tests {
 
         // Open the task detail for a fresh issue.
         let issue = IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: ainb_hangar_core::ids::IssueId::from_str("issue-1").unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/autopilots.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/autopilots.rs
@@ -118,6 +118,7 @@ impl AutopilotsState {
                     ""
                 };
                 BoardCard {
+                    not_dispatched: false,
                     issue_id: ap.id.clone(),
                     display_id: ap.name.clone(),
                     title: format!("{} · {state}{api} · last {last}", ap.cron_expr),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -2723,6 +2723,7 @@ fn card_view_to_board_card(c: &CardView) -> BoardCard {
         "#"
     };
     BoardCard {
+        not_dispatched: false,
         issue_id: c.issue_id.clone(),
         display_id: format!("{marker}{}", c.display_id),
         title: card_title_with_t4_badges(c),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -3669,6 +3669,9 @@ mod tests {
 
     fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
         IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -1487,6 +1487,13 @@ impl IssueListState {
                             // `⊟ done/total` badge that flips to gold `1/1` when its
                             // last child completes. `None` for a childless issue.
                             subtasks: (r.child_total > 0).then_some((r.child_done, r.child_total)),
+                            // multica parity #12: the card wears a ⚠ when its
+                            // newest dispatch attempt was declined, so "not
+                            // running, and why" is discoverable from the board.
+                            not_dispatched: r
+                                .last_dispatch_reason
+                                .as_deref()
+                                .is_some_and(|c| !c.trim().is_empty()),
                         })
                         .collect::<Vec<_>>();
                 // Clamp the stored offset to the column's card count so a column

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/kanban.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/kanban.rs
@@ -220,6 +220,7 @@ impl KanbanState {
                     .cards
                     .iter()
                     .map(|c| BoardCard {
+                        not_dispatched: false,
                         issue_id: c.task_id.clone(),
                         display_id: format!("#{}", c.short_id),
                         title: card_title(c, now_ms),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/skill_manager.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/skill_manager.rs
@@ -202,6 +202,7 @@ impl SkillManagerState {
             .visible_skills()
             .into_iter()
             .map(|s| BoardCard {
+                not_dispatched: false,
                 issue_id: s.slug.clone(),
                 display_id: s.name.clone(),
                 // Attachment-based `used`/`unused` (deviation D3 — the filter

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1149,6 +1149,24 @@ fn render_detail_card(
         row = row.saturating_add(1);
     }
 
+    // --- Why this card is NOT running (multica parity #12, migration 0058):
+    //     the newest DECLINED dispatch attempt, rendered only when there is one.
+    //     A card that ran fine reads exactly as before — the whole point is that
+    //     "queued forever with no explanation" becomes a stated cause. Amber,
+    //     matching the `unstable` presence band: it is a warning, not a failure. ---
+    if let Some(line) = dispatch_decline_line(
+        issue.last_dispatch_reason.as_deref(),
+        issue.last_dispatch_detail.as_deref(),
+    ) {
+        card_field_row(
+            buf,
+            card_w,
+            row,
+            &[("⚠ Not dispatched: ", CARD_LABEL), (&line, STATUS_AMBER)],
+        );
+        row = row.saturating_add(1);
+    }
+
     // --- Acceptance criteria (0048 + #11-rest): a `Acceptance: <done>/<total>`
     //     header then one `☑`/`☐ <criterion>` line per element, rendered ONLY when
     //     non-empty so an issue without them reads unchanged (mirrors the Linked
@@ -1336,6 +1354,29 @@ fn origin_badge(origin_type: Option<&str>) -> Option<&'static str> {
         "comment_mention" => Some("💬 comment mention"),
         _ => None,
     }
+}
+
+/// The human phrase for a declined dispatch (multica parity #12): the code's
+/// [`DispatchReason::label`] plus the free-text detail, e.g.
+/// `runtime offline — task 01J… queued; runtime rt-1 is offline`.
+///
+/// Returns `None` when there is no code, so a healthy card renders no line at
+/// all. A code this build does not know falls back to the RAW token rather than
+/// hiding the line — an older plugin against a newer daemon must still tell the
+/// user something is wrong, and the detail carries the specifics regardless.
+fn dispatch_decline_line(reason: Option<&str>, detail: Option<&str>) -> Option<String> {
+    let raw = reason?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let label: &str = match ainb_hangar_core::dispatch_reason::DispatchReason::parse(raw) {
+        Some(code) => code.label(),
+        None => raw,
+    };
+    Some(match detail.map(str::trim).filter(|d| !d.is_empty()) {
+        Some(d) => format!("{label} — {d}"),
+        None => label.to_string(),
+    })
 }
 
 fn card_field_row(buf: &mut WireBuffer, card_w: u16, row: u16, segments: &[(&str, Color)]) {
@@ -1685,6 +1726,80 @@ mod card_tests {
                 "no badge for {manual:?}"
             );
         }
+    }
+
+    /// multica parity #12: a card whose newest dispatch attempt was DECLINED
+    /// renders `⚠ Not dispatched: <human label> — <detail>`, so "queued forever
+    /// with no explanation" becomes a stated cause on the card the user opens.
+    #[test]
+    fn detail_card_renders_the_not_dispatched_line() {
+        let mut issue = full_issue();
+        issue.last_dispatch_reason = Some("runtime_offline".into());
+        issue.last_dispatch_detail = Some("task 01J9 queued; runtime rt-1 is offline".into());
+        issue.last_dispatch_at = Some(1_700_000_000_000);
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(100, 40);
+        render_task_detail(&mut buf, 100, 0, 39, &s);
+        let text = painted_text(&buf);
+        assert!(text.contains("Not dispatched: "), "label: {text}");
+        assert!(
+            text.contains("runtime offline"),
+            "the HUMAN label, not the raw token: {text}"
+        );
+        assert!(text.contains("runtime rt-1 is offline"), "detail: {text}");
+    }
+
+    /// The negative twin (mirroring `detail_card_renders_linked_line_only_when_linked`):
+    /// a healthy card paints NO such line, so the card reads exactly as it did
+    /// before parity #12.
+    #[test]
+    fn detail_card_omits_the_not_dispatched_line_when_healthy() {
+        let s = state_for(full_issue());
+        let mut buf = WireBuffer::new(100, 40);
+        render_task_detail(&mut buf, 100, 0, 39, &s);
+        assert!(
+            !painted_text(&buf).contains("Not dispatched"),
+            "a healthy card shows no dispatch warning"
+        );
+    }
+
+    /// A code this build does not know renders the RAW token rather than hiding
+    /// the line or panicking — an older plugin against a newer daemon must still
+    /// tell the user something is wrong.
+    #[test]
+    fn detail_card_renders_an_unknown_dispatch_code_verbatim() {
+        let mut issue = full_issue();
+        issue.last_dispatch_reason = Some("nonsense_code".into());
+        issue.last_dispatch_detail = Some("something new happened".into());
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(100, 40);
+        render_task_detail(&mut buf, 100, 0, 39, &s);
+        let text = painted_text(&buf);
+        assert!(
+            text.contains("Not dispatched: "),
+            "line still painted: {text}"
+        );
+        assert!(text.contains("nonsense_code"), "raw token kept: {text}");
+    }
+
+    /// The line composer itself, unit-level: known code → human label, unknown
+    /// code → raw token, empty / absent code → no line at all.
+    #[test]
+    fn dispatch_decline_line_maps_codes_and_details() {
+        assert_eq!(
+            dispatch_decline_line(Some("target_unavailable"), Some("no agent")),
+            Some("no dispatch target — no agent".to_string())
+        );
+        assert_eq!(
+            dispatch_decline_line(Some("deferred"), None),
+            Some("waiting on blockers".to_string())
+        );
+        assert_eq!(
+            dispatch_decline_line(Some("future_code"), None),
+            Some("future_code".to_string())
+        );
+        assert_eq!(dispatch_decline_line(None, Some("orphan detail")), None);
+        assert_eq!(dispatch_decline_line(Some("   "), None), None);
     }
 
     /// The badge mapper itself: only the two platform kinds earn a badge, and an

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1501,6 +1501,9 @@ mod card_tests {
     /// A fully-populated issue row for the card render assertions (63d).
     fn full_issue() -> IssueRow {
         IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: IssueId::from_str("i1").unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/card_board.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/card_board.rs
@@ -183,6 +183,11 @@ pub struct BoardCard {
     /// complete — so a parent card visibly flips to `1/1` when its last child
     /// finishes (the board-observable side of the child-done cascade).
     pub subtasks: Option<(u32, u32)>,
+    /// Whether the card's newest dispatch attempt was DECLINED (multica parity
+    /// #12, `IssueRow.last_dispatch_reason`): drives an amber `⚠` on the id line
+    /// so "this is not running, and there is a reason" is discoverable from the
+    /// board without opening the card. The reason itself is on the detail card.
+    pub not_dispatched: bool,
 }
 
 /// One status column's input to the board.
@@ -308,6 +313,9 @@ const COLUMN_BORDER: Color = Color::rgb(52, 58, 80);
 const CARD_BORDER: Color = Color::rgb(70, 80, 110);
 /// Card fill behind content: the palette panel background, one step above the
 /// app background so cards sit on a raised surface.
+/// Amber warning accent — the same band `unstable` presence uses. Marks a card
+/// whose newest dispatch attempt was declined (multica parity #12).
+const WARN_AMBER: Color = Color::rgb(230, 190, 90);
 const CARD_BG: Color = Color::rgb(30, 30, 40);
 /// Selected-card fill (the palette list-highlight background).
 const CARD_BG_SELECTED: Color = Color::rgb(40, 40, 60);
@@ -601,6 +609,18 @@ fn render_card(buf: &mut WireBuffer, rect: Rect, card: &BoardCard, selected: boo
         let glyph_x = inner_right.saturating_sub(1);
         if glyph_x >= inner_x {
             put_char_bg(buf, glyph_x, id_y, '⧉', ID_ACCENT, fill, inner_right);
+        }
+    }
+    // multica parity #12: an amber `⚠` immediately after the display id marks a
+    // card whose newest dispatch attempt was DECLINED. Placed left (beside the id)
+    // rather than flush-right so it never contends with the `⧉` link glyph, and so
+    // a card can carry both.
+    if card.not_dispatched {
+        let glyph_x = inner_x.saturating_add(
+            u16::try_from(card.display_id.chars().count().min(usize::from(inner_w))).unwrap_or(0),
+        );
+        if glyph_x < inner_right {
+            put_char_bg(buf, glyph_x, id_y, '⚠', WARN_AMBER, fill, inner_right);
         }
     }
 
@@ -948,6 +968,7 @@ mod tests {
     /// A board card with the given id, title, priority and assignee.
     fn card(id: &str, title: &str, priority: PriorityChip, assignee: Option<char>) -> BoardCard {
         BoardCard {
+            not_dispatched: false,
             issue_id: id.to_string(),
             display_id: id.to_string(),
             title: title.to_string(),
@@ -1179,6 +1200,34 @@ mod tests {
         assert!(
             has_red,
             "the urgent chip must be painted in the urgent colour"
+        );
+    }
+
+    /// multica parity #12: a card whose newest dispatch attempt was DECLINED
+    /// wears an amber `⚠` beside its id, so "this is not running" is discoverable
+    /// from the board without opening the card. A healthy card wears none.
+    #[test]
+    fn undispatched_card_shows_the_warning_glyph() {
+        let mut warned = card("HGR-9", "Ship it", PriorityChip::Low, Some('a'));
+        warned.not_dispatched = true;
+        let cols = vec![column('☰', "Backlog", vec![warned])];
+        let mut buf = WireBuffer::new(120, 24);
+        let _ = render_card_board(&mut buf, 120, 0, 23, &cols, None);
+        assert!(
+            painted_text(&buf).contains('⚠'),
+            "a declined card shows the ⚠ glyph"
+        );
+        assert!(
+            buf.cells.iter().any(|(_, c)| c.fg == Some(WARN_AMBER)),
+            "the warning glyph is painted amber, not the default text colour"
+        );
+
+        // A healthy card (the default) paints no glyph.
+        let mut buf = WireBuffer::new(120, 24);
+        let _ = render_card_board(&mut buf, 120, 0, 23, &five_columns(), None);
+        assert!(
+            !painted_text(&buf).contains('⚠'),
+            "healthy cards show no warning glyph"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -117,6 +117,9 @@ mod tests {
 
     fn issue(description: Option<&str>, assignee: Option<&str>) -> IssueRow {
         IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: IssueId::from_str("i1").unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
@@ -22,6 +22,9 @@ use ainb_plugin_sdk::WireBuffer;
 /// A wire row with explicit state / priority / labels for facet rendering.
 fn row(id: &str, state: &str, priority: i64, labels: &[&str]) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
@@ -29,6 +29,9 @@ const CLAY: Color = Color::rgb(210, 130, 90);
 /// urgency so the card anatomy (id line + priority chip) renders predictably.
 fn row(id: &str, display: &str, state: &str, priority: i64, assignee: Option<&str>) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -19,6 +19,9 @@ use ainb_plugin_hangar::screen::issue_list::{
 /// member/agent filter chips.
 fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
@@ -23,6 +23,9 @@ use ainb_plugin_sdk::WireBuffer;
 
 fn issue_with_pr(pr_url: Option<&str>) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str("i1").unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
@@ -22,6 +22,9 @@ const fn key(ch: char) -> KeyEvent {
 
 fn issue(pr_url: Option<&str>) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str("issue-1").unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -22,6 +22,9 @@ fn task() -> TaskId {
 
 fn issue_row() -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str("i1").unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
@@ -19,6 +19,9 @@ use ainb_plugin_sdk::WireBuffer;
 
 fn issue_row() -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str("i1").unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
@@ -94,6 +94,9 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// One wire row carrying `criteria` as its structured acceptance list.
 fn row(id: &str, title: &str, criteria: Vec<AcceptanceCriterion>) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
@@ -109,6 +109,9 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// One wire row. `state` is what buckets the card into a board column.
 fn row(id: &str, title: &str, state: &str) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
@@ -98,6 +98,9 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// `2` = P1); `state` drives the board column; `labels` drive the label facet.
 fn row(id: &str, title: &str, state: &str, priority: i64, labels: &[&str]) -> IssueRow {
     IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
         origin_type: None,
         origin_id: None,
         id: IssueId::from_str(id).unwrap(),

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -132,6 +132,9 @@ fn seeded_agents() -> serde_json::Value {
 fn seeded_issues() -> serde_json::Value {
     serde_json::to_value(IssuesListResult {
         issues: vec![IssueRow {
+            last_dispatch_reason: None,
+            last_dispatch_detail: None,
+            last_dispatch_at: None,
             origin_type: None,
             origin_id: None,
             id: IssueId::from_str("issue-1").unwrap(),

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2872,6 +2872,7 @@ Commands:
   label     Attach or detach a label on an issue
   criteria  Inspect or tick off an issue's acceptance criteria
   link      Add, remove, or list an issue's typed links to other issues
+  why       Explain why an issue did (or did not) dispatch — its admission history
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3150,6 +3151,26 @@ Commands:
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
   -h, --help             Print help
+```
+
+#### `ainb hangar issue why`
+
+Explain why an issue did (or did not) dispatch — its admission history
+
+```console
+$ ainb hangar issue why --help
+Explain why an issue did (or did not) dispatch — its admission history
+
+Usage: ainb hangar issue why [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Issue id (ULID) whose dispatch history to explain
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --limit <LIMIT>          How many attempts to show, newest first [default: 20]
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
 ```
 
 ### `ainb hangar task`


### PR DESCRIPTION
## multica parity #12 — dispatch reason codes

**Before:** hangar had the admission decision (`CardRunError` in the daemon's `run_card`) and threw it away at every one of its five call sites. Two turned it into an ephemeral JSON-RPC error string, three logged it at `debug`/`info` and returned, and the CLI assign path swallowed it as a bare `Ok(None)`. Nothing was persisted, so "why is my card not running" had no answer after the message scrolled past.

Worse, nothing anywhere checked `agent_runtime.status` before enqueuing: a run keyed to an `offline` runtime inserted a `queued` row that sat until the 2h TTL sweeper relabelled it `timeout`, with no statement of why. That is the *invisible-but-queued* case the acceptance names.

**After:** one leaf vocabulary, one recording seam, three surfaces.

```
 issue_run / board_card_run / issue_update(assign) / auto_run / child-cascade
                              │
                              ▼
                    ┌────────────────────┐
                    │  run_card (daemon) │  ← the ONE seam, all 5 callers
                    └─────────┬──────────┘
                              ▼
                 ┌─────────────────────────────┐
                 │ DispatchReason (core, leaf) │  stable vocabulary
                 └─────────────┬───────────────┘
                               ▼
              ┌──────────────────────────────────┐
              │ dispatch_attempt  (sqlite, 0058) │  code + detail + source
              └───────┬──────────────────┬───────┘
                      │                  │
        IssueRow.last_dispatch_*   hangar/dispatch_attempts_list
                      │                  │
                      ▼                  ▼
             TUI detail card      `ainb hangar issue why <id>`
             "⚠ Not dispatched: …"
```

### What landed

| Layer | Change |
|---|---|
| `ainb-hangar-core` | `dispatch_reason.rs` — `DispatchReason` (10 variants) + `DispatchSource`, `as_db_str` / `parse` / `is_dispatched` / `label`, wildcard-free matches, guard tests |
| `ainb-hangar-store` | migration `0058_dispatch_attempt.sql` + `DispatchAttemptRepo`; `IssueRepo::delete` reaps the rows |
| `ainb-hangar-proto` | `IssueRow.last_dispatch_{reason,detail,at}`, `BoardCardRunResult.reason`, `hangar/dispatch_attempts_list` + its shapes |
| `ainb-hangar-daemon` | `run_card` → thin wrapper over `run_card_inner` recording exactly one attempt; runtime-status pre-flight; `error.data.reason`; `issue_card_fields` fills the wire fields; the list handler |
| `ainb-plugin-hangar` | `⚠ Not dispatched: <label> — <detail>` on the detail card; `⚠` on board cards |
| `ainb-core` (CLI) | `ainb hangar issue why <id>` (alias `dispatch-log`); `enqueue_assigned_task` records at all three exits; `issue show` states the newest decline |

### Deliberate design choices

**No `CHECK` on `reason`.** SQLite cannot widen a `CHECK` without a full table rebuild (0057 needed a `defer_foreign_keys` + copy/drop/recreate dance for exactly that). The vocabulary is append-only by design, so the rebuild would recur on every future variant. The domain is enforced in Rust: `as_db_str` is the only writer, `parse` is the tolerant reader.

**FK only on `workspace_id`.** `issue_id` / `agent_id` / `runtime_id` / `task_id` carry no FK, so the audit row survives the death of what it describes and a recorder never fails on a race with a delete. `IssueRepo::delete` reaps explicitly instead.

**Bounded by construction.** `record` trims to the newest 20 rows per issue in the same batch as the insert — no sweeper job, and a hot auto-run cascade cannot grow the table.

**Deliberate coarseness, copied from the reference.** `NoAgent` / `NoRepo` / `NotDispatchable` all collapse to `target_unavailable`; `Cancelled` / `NotInvocable` / `InteractiveSquad` all collapse to `invocation_not_allowed`. The code can never be used as an existence oracle; the specifics live in the free-text `detail`.

### Two documented divergences from multica

**D1 — `runtime_offline` records, it does not refuse.** multica declines the dispatch. hangar still enqueues and records the code with `task_id` set. hangar's runtime rows are per-`(daemon_id, provider)`, so a codex runtime can be stale while the deciding daemon is very much alive, and the presence sweeper flips a row to `offline` on a grace timer — refusing would turn a transient heartbeat gap into a hard user-visible failure and regress the "queue it, the claim loop will take it" model. Recording buys the observability without changing dispatch behaviour. `unstable` records the same code with the real status in the detail.

**D2 — `Blocked` maps to `deferred`, not a refusal code.** hangar genuinely promotes it later: `board::auto_run_dependent` fires the run when the last blocker finishes.

### Reserved variants, stated not hidden

`coalesced`, `attribution_blocked` and `self_trigger_suppressed` ship with **no producer**. That is deliberate — the vocabulary is a wire contract a reader must already accept, and those three belong to the mention-routing layer, which is unstarted. `DispatchReason::RESERVED` pins the set and a test asserts it, so adding a producer is a deliberate edit.

---

## Acceptance proof

> *"an issue with no assignee, or an offline agent, records+surfaces a reason code explaining non-dispatch (sqlite + TUI)"*

### 1. sqlite — no agent to dispatch to

`ainb hangar issue create` → `agent create` → `issue update --assign <agent>` on a repo-less card, real binary, isolated `AINB_HANGAR_HOME`, no daemon:

```
$ sqlite3 -header $DB "SELECT reason, detail, task_id, source FROM dispatch_attempt WHERE issue_id='01KYGNW8AVDRE7X3090C39A0NQ'"
reason|detail|task_id|source
target_unavailable|no repo pinned on this card||assign
```

(The RPC path's `no agent in this workspace to run on` variant is pinned by `no_agent_records_and_surfaces_target_unavailable`.)

### 2. sqlite — offline agent

From `offline_runtime_records_and_surfaces_runtime_offline`, the recorded row (`reason|detail|task_id`):

```
runtime_offline|task 01KYGP218XTAE74QH525CDQ8JD queued; runtime default is offline|01KYGP218XTAE74QH525CDQ8JD
```

Note the `task_id` IS set — divergence D1: the run is enqueued, only the observability is added.

### 3. CLI surface

```
$ ainb hangar issue why 01KYGNW8AVDRE7X3090C39A0NQ
reason                 source   when                   detail
target_unavailable     assign   2026-07-27T02:18:48Z   no repo pinned on this card

$ ainb hangar issue why 01KYGNW8AVDRE7X3090C39A0NQ --format json
[{"agent_id":"01KYGNW8BSBS8G7EW15NPA8SHH","created_at":1785118728616,"detail":"no repo pinned on this card","id":"01KYGNW8D83NYNVBH3YA30QAGE","issue_id":"01KYGNW8AVDRE7X3090C39A0NQ","reason":"target_unavailable","runtime_id":null,"source":"assign","task_id":null}]

$ ainb hangar issue show 01KYGNW8AVDRE7X3090C39A0NQ
01KYGNW8AVDRE7X3090C39A0NQ  [open]  priority=0  RepolessCard  assignee=agent:01KYGNW8BSBS8G7EW15NPA8SHH
Origin: manual
Not dispatched: target_unavailable — no repo pinned on this card
```

### 4. TUI surface

In-file render tests over the real paint buffer (`screen/task_detail.rs`, `widgets/card_board.rs`):

- `detail_card_renders_the_not_dispatched_line` — asserts the painted text contains `Not dispatched: `, the **human** label `runtime offline` (not the raw token), and the detail substring;
- `detail_card_omits_the_not_dispatched_line_when_healthy` — the negative twin: a healthy card paints no such line;
- `detail_card_renders_an_unknown_dispatch_code_verbatim` — an unknown code paints its raw token rather than hiding the line;
- `undispatched_card_shows_the_warning_glyph` — a board card wears an amber `⚠`, asserted on both the glyph and its colour; a healthy card wears none.

### 5. Mutation proof

Both run and reported honestly:

| Mutation | Result |
|---|---|
| Delete `record_dispatch_attempt(...)` from the `run_card` wrapper | **8 / 8 RED** in `rpc_dispatch_reason` |
| Neuter the runtime-status pre-flight (`Ok(Some(rt)) if false`) | **2 RED** (`offline_runtime_…`, `unstable_runtime_…`), other 6 stay green |

### 6. Wire growth

`issue_row_without_a_decline_grows_by_zero_keys` (proto) and `healthy_run_records_queued_and_the_card_grows_no_keys` (daemon, over the real `issues_list` JSON) both assert the three new keys are **absent** — not `null` — on a healthy card. `pre_item_12_issue_row_decodes` and `board_card_run_result_reason_is_append_only` prove a pre-#12 payload still decodes.

---

## Fixture drift, fixed in this PR

Adding three fields to `IssueRow` broke 58 exhaustive struct literals across `ainb-hangar-proto`, `ainb-hangar-daemon` and `ainb-plugin-hangar`; adding `not_dispatched` to `BoardCard` broke 8 more. **All are updated in this PR** (commit `188bbdae` and `de2cacb9`) so no later parity PR is red-gated by the drift.

## Local gate

```
cargo build -p ainb
cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'
bash ../scripts/hangar/run_all_tripwires.sh
bash ../scripts/hangar/run_acceptance_tests.sh
```

All four green on this branch:

| Gate | Result |
|---|---|
| `cargo build -p ainb` | ok |
| `cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'` | **4205 run, 4205 passed, 18 skipped** |
| `run_all_tripwires.sh` | **ran=64 failed=0 skipped=0** |
| `run_acceptance_tests.sh` | **ran=170 failed=0 skipped=0** |

No flake attribution was needed — nothing failed on the first run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ainb hangar issue why` to explain why an issue was not dispatched.
  * Added dispatch history visibility through issue details, structured output, and a new dispatch-attempt listing API.
  * Issue cards now show an amber warning indicator when dispatch is declined.
  * Dispatch responses include machine-readable reason codes and relevant details.

* **Bug Fixes**
  * Dispatch attempts are now recorded consistently, including previously silent outcomes.
  * Issue deletion removes associated dispatch history while preserving unrelated records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->