### PR TITLE
feat(hangar): generic activity log + per-issue timeline (multica parity #13)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1351,6 +1351,23 @@ pub enum IssueCommand {
     /// Explain why an issue did (or did not) dispatch — its admission history.
     #[command(alias = "dispatch-log")]
     Why(IssueWhyArgs),
+    /// Show one issue's activity timeline: state changes, assignments, comments.
+    #[command(alias = "activity")]
+    Timeline(IssueTimelineArgs),
+}
+
+/// Arguments for `hangar issue timeline` (multica parity #13).
+#[derive(Args, Debug)]
+pub struct IssueTimelineArgs {
+    /// Issue id (ULID) whose narrative to print.
+    pub id: String,
+    /// How many entries to show — the newest window, printed oldest-first.
+    #[arg(long, default_value_t = 200)]
+    pub limit: i64,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// Arguments for `hangar issue why` (multica parity #12).
@@ -4170,6 +4187,7 @@ async fn dispatch_issue(cmd: IssueCommand, format: OutputFormat) -> Result<()> {
         IssueCommand::Criteria(cmd) => run_issue_criteria(&store, cmd).await,
         IssueCommand::Link(cmd) => run_issue_link(&store, cmd).await,
         IssueCommand::Why(args) => run_issue_why(&store, args, format).await,
+        IssueCommand::Timeline(args) => run_issue_timeline(&store, args, format).await,
     }
 }
 
@@ -4607,6 +4625,14 @@ async fn run_issue_update(store: &Store, args: IssueUpdateArgs) -> Result<()> {
         None
     };
 
+    // multica parity #13: the FULL pre-edit row, so the post-edit diff can write
+    // one activity row per changed field. Deliberately separate from
+    // `prev_state` above, which only carries the state token for the cascade.
+    let before_issue = IssueRepo::get_by_id(store.pool(), &args.id)
+        .await
+        .with_context(|| format!("read issue {} before update", args.id))?
+        .filter(|i| i.workspace_id == workspace_id);
+
     let touched = IssueRepo::update_fields(store.pool(), &workspace_id, &args.id, &update)
         .await
         .with_context(|| format!("update issue {}", args.id))?;
@@ -4614,6 +4640,30 @@ async fn run_issue_update(store: &Store, args: IssueUpdateArgs) -> Result<()> {
         anyhow::bail!("no issue with id {} in this workspace", args.id);
     }
     println!("updated issue {}", args.id);
+
+    // multica parity #13: diff the pre-edit row against the committed one and
+    // record one activity row per changed field. The CLI shares the daemon's
+    // diff service so the two writers cannot drift. Best-effort throughout.
+    if let Some(before) = before_issue.as_ref() {
+        if let Ok(Some(after)) = IssueRepo::get_by_id(store.pool(), &args.id).await {
+            let owner = ainb_hangar_store::bootstrap::default_owner_id(store.pool())
+                .await
+                .ok()
+                .flatten();
+            let actor =
+                ainb_hangar_core::activity::ActivityActor::member_or_system(owner.as_deref());
+            ainb_hangar_store::service::activity::ActivityService::record_issue_diff(
+                store.pool(),
+                &SystemIdGen,
+                &SystemClock,
+                &workspace_id,
+                &actor,
+                before,
+                &after,
+            )
+            .await;
+        }
+    }
 
     // 0046: a CLI-driven completion also posts the parent roll-up comment, so
     // CLI and TUI behaviour stay aligned (the CLI has no daemon, so there is no
@@ -4870,6 +4920,9 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
     let id = idgen.new_ulid();
     let creator = ActorRef::new(ActorKind::Member, DEFAULT_CREATOR_ID)
         .expect("default creator id is non-empty");
+    // A second handle for the parity-#13 `created` activity row: `creator` is
+    // moved into `NewIssue` below, and the audit write happens after the insert.
+    let activity_creator = creator.clone();
 
     // Resolve the assignee (if any). The token is polymorphic: an AGENT
     // (`agent:<id>` or a bare id) must exist in the workspace and its runtime is
@@ -4958,6 +5011,19 @@ async fn run_issue_create(store: &Store, args: IssueCreateArgs) -> Result<()> {
         stage: None,
     };
     IssueRepo::insert(pool, &new).await.context("insert issue")?;
+    // multica parity #13: open the card's narrative. Best-effort — an audit
+    // failure never fails the create.
+    ainb_hangar_store::service::activity::ActivityService::record(
+        pool,
+        &idgen,
+        &clock,
+        &workspace_id,
+        &id,
+        &ainb_hangar_core::activity::ActivityActor::Actor(activity_creator),
+        ainb_hangar_core::activity::ActivityAction::Created,
+        serde_json::json!({}),
+    )
+    .await;
     // 0056: stamp the resolved provenance post-insert, the same pattern the
     // daemon's create uses, so a CLI-created and a TUI-created issue read back
     // identically.
@@ -5287,6 +5353,191 @@ async fn run_issue_why(store: &Store, args: IssueWhyArgs, format: OutputFormat) 
         }
     }
     Ok(())
+}
+
+/// `hangar issue timeline <id>` (multica parity #13): the card's NARRATIVE,
+/// oldest first — creation, state moves, re-assignments, priority/title/due-date
+/// edits, task outcomes, and the comments merged in by timestamp.
+///
+/// Reads the store directly (like `issue why`), so the whole activity-log proof
+/// is runnable against nothing but sqlite with no daemon. `--format json` emits
+/// the `TimelineEntryRow` wire shape verbatim, so the CLI and
+/// `hangar/issue_timeline` agree.
+async fn run_issue_timeline(
+    store: &Store,
+    args: IssueTimelineArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    // Resolve the workspace so a typo'd `--workspace` is an error, not a silently
+    // empty timeline.
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let entries = read_issue_timeline(store, &workspace_id, &args.id, args.limit.max(1)).await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string())
+            );
+        }
+        OutputFormat::Csv => {
+            println!("kind,actor,action,detail,created_at");
+            for e in &entries {
+                println!(
+                    "{},{},{},{},{}",
+                    e.kind,
+                    timeline_actor(e),
+                    e.action.as_deref().unwrap_or_default(),
+                    csv_field(&timeline_detail(e)),
+                    e.created_at
+                );
+            }
+        }
+        OutputFormat::Markdown => {
+            println!("| when | who | what | detail |");
+            println!("|---|---|---|---|");
+            for e in &entries {
+                println!(
+                    "| {} | {} | {} | {} |",
+                    fmt_epoch_ms_utc(e.created_at),
+                    timeline_actor(e),
+                    e.action.as_deref().unwrap_or("comment"),
+                    timeline_detail(e)
+                );
+            }
+        }
+        OutputFormat::Text => {
+            if entries.is_empty() {
+                println!("no activity recorded for {}", args.id);
+            } else {
+                for e in &entries {
+                    println!(
+                        "{}  {:<18} {:<17} {}",
+                        fmt_epoch_ms_utc(e.created_at),
+                        timeline_actor(e),
+                        e.action.as_deref().unwrap_or("comment"),
+                        timeline_detail(e)
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Merge the card's activity rows with its comments into the wire
+/// [`TimelineEntryRow`] shape, oldest first — the store-side twin of the
+/// daemon's `snapshots::issue_timeline` (parity #13).
+async fn read_issue_timeline(
+    store: &Store,
+    workspace_id: &str,
+    issue_id: &str,
+    limit: i64,
+) -> Result<Vec<ainb_hangar_proto::snapshots::TimelineEntryRow>> {
+    use ainb_hangar_proto::snapshots::{
+        TIMELINE_KIND_ACTIVITY, TIMELINE_KIND_COMMENT, TimelineEntryRow,
+    };
+    use ainb_hangar_store::repo::activity::ActivityRepo;
+    use ainb_hangar_store::repo::comment::CommentRepo;
+
+    let activities = ActivityRepo::list_for_issue(store.pool(), issue_id, limit)
+        .await
+        .context("read issue activity")?;
+    let comments = CommentRepo::list_by_issue(store.pool(), workspace_id, issue_id)
+        .await
+        .context("read issue comments")?;
+
+    let mut entries: Vec<TimelineEntryRow> = Vec::with_capacity(activities.len() + comments.len());
+    for a in activities {
+        if a.workspace_id != workspace_id {
+            continue;
+        }
+        let details = a.details_json();
+        entries.push(TimelineEntryRow {
+            kind: TIMELINE_KIND_ACTIVITY.to_string(),
+            id: a.id,
+            actor_type: a.actor_type,
+            actor_id: a.actor_id,
+            created_at: a.created_at,
+            action: Some(a.action),
+            details: (!details.as_object().is_some_and(serde_json::Map::is_empty))
+                .then_some(details),
+            body: None,
+        });
+    }
+    for c in comments {
+        entries.push(TimelineEntryRow {
+            kind: TIMELINE_KIND_COMMENT.to_string(),
+            id: c.id,
+            actor_type: Some(c.author.kind().as_str().to_string()),
+            actor_id: Some(c.author.id().to_string()),
+            created_at: c.created_at,
+            action: None,
+            details: None,
+            body: Some(c.body),
+        });
+    }
+    entries.sort_by(|a, b| a.created_at.cmp(&b.created_at).then_with(|| a.id.cmp(&b.id)));
+    let cap = usize::try_from(limit.max(0)).unwrap_or(usize::MAX);
+    if entries.len() > cap {
+        entries.drain(..entries.len() - cap);
+    }
+    Ok(entries)
+}
+
+/// `member:<id>` / `agent:<id>` / `system` for one timeline entry.
+fn timeline_actor(e: &ainb_hangar_proto::snapshots::TimelineEntryRow) -> String {
+    match (e.actor_type.as_deref(), e.actor_id.as_deref()) {
+        (Some("system") | None, _) => "system".to_string(),
+        (Some(kind), Some(id)) => format!("{kind}:{id}"),
+        (Some(kind), None) => kind.to_string(),
+    }
+}
+
+/// The human-readable right-hand column: the comment body, or the change the
+/// activity's details describe (`open → in_progress`).
+fn timeline_detail(e: &ainb_hangar_proto::snapshots::TimelineEntryRow) -> String {
+    if let Some(body) = e.body.as_deref() {
+        return body.replace('\n', " ");
+    }
+    let Some(details) = e.details.as_ref() else {
+        return String::new();
+    };
+    let render = |v: Option<&serde_json::Value>| -> String {
+        match v {
+            None | Some(serde_json::Value::Null) => "—".to_string(),
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+        }
+    };
+    // The assignee shape carries `*_type` + `*_id` halves, each side omitted when
+    // absent; every other shape is a plain `from`/`to` pair.
+    if details.get("from_type").is_some() || details.get("to_type").is_some() {
+        let side = |t: &str, i: &str| match (details.get(t), details.get(i)) {
+            (Some(serde_json::Value::String(t)), Some(serde_json::Value::String(i))) => {
+                format!("{t}:{i}")
+            }
+            _ => "—".to_string(),
+        };
+        return format!(
+            "{} → {}",
+            side("from_type", "from_id"),
+            side("to_type", "to_id")
+        );
+    }
+    if details.get("from").is_some() || details.get("to").is_some() {
+        let via = details
+            .get("via")
+            .and_then(serde_json::Value::as_str)
+            .map(|v| format!(" (via {v})"))
+            .unwrap_or_default();
+        return format!(
+            "{} → {}{via}",
+            render(details.get("from")),
+            render(details.get("to"))
+        );
+    }
+    details.to_string()
 }
 
 /// One dispatch attempt as the `DispatchAttemptRow` wire shape, so

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -4199,8 +4199,11 @@ async fn run_issue_delete(store: &Store, args: IssueDeleteArgs) -> Result<()> {
         // DRY RUN: report what a real delete would remove and exit untouched.
         println!("would delete issue {} \"{}\"", args.id, preview.title);
         println!(
-            "  removes: {} comment(s), {} task(s), {} board placement(s), plus label links, dependency edges, and usage rows",
-            preview.summary.comments, preview.summary.tasks, preview.summary.placements
+            "  removes: {} comment(s), {} task(s), {} board placement(s), {} activity row(s), plus label links, dependency edges, and usage rows",
+            preview.summary.comments,
+            preview.summary.tasks,
+            preview.summary.placements,
+            preview.summary.activities
         );
         if preview.active_tasks > 0 {
             println!(
@@ -4216,8 +4219,13 @@ async fn run_issue_delete(store: &Store, args: IssueDeleteArgs) -> Result<()> {
     match IssueRepo::delete_cascade(store.pool(), &workspace_id, &args.id).await {
         Ok(summary) => {
             println!(
-                "deleted issue {} \"{}\" ({} comment(s), {} task(s), {} placement(s))",
-                args.id, preview.title, summary.comments, summary.tasks, summary.placements
+                "deleted issue {} \"{}\" ({} comment(s), {} task(s), {} placement(s), {} activity row(s))",
+                args.id,
+                preview.title,
+                summary.comments,
+                summary.tasks,
+                summary.placements,
+                summary.activities
             );
             Ok(())
         }

--- a/ainb-tui/crates/ainb-core/tests/hangar_issue_timeline_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_issue_timeline_cli.rs
@@ -1,0 +1,137 @@
+//! ACCEPTANCE (CLI half): `ainb hangar issue timeline` prints the card's
+//! narrative (multica parity #13).
+//!
+//! Drives the REAL `ainb` binary against an isolated `AINB_HANGAR_HOME`, with
+//! no daemon and no network — nothing but sqlite + the CLI. It proves the write
+//! sites and the read verb agree: a create records `created`, an edit records
+//! one row per changed field with multica's details shape, and the text form
+//! renders the change (`open → in_progress`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+/// Run one `ainb hangar …` invocation inside the isolated home, returning stdout.
+fn ainb(home: &std::path::Path, args: &[&str]) -> String {
+    let out = Command::new(ainb_bin())
+        .args(args)
+        .env("AINB_HANGAR_HOME", home)
+        .env("HOME", home)
+        .output()
+        .expect("run ainb");
+    assert!(
+        out.status.success(),
+        "`ainb {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// The `created issue <ULID>` ack's id.
+fn created_id(ack: &str) -> String {
+    ack.split_whitespace()
+        .last()
+        .unwrap_or_else(|| panic!("no id in ack {ack:?}"))
+        .to_string()
+}
+
+#[test]
+fn create_then_update_writes_and_prints_the_activity_timeline() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+
+    let issue_id = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "Wire the timeline"],
+    ));
+
+    // A brand-new card already has its opening line.
+    let json = ainb(
+        h,
+        &["hangar", "issue", "timeline", &issue_id, "--format", "json"],
+    );
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("timeline json");
+    let actions: Vec<&str> = rows
+        .iter()
+        .filter_map(|r| r.get("action").and_then(serde_json::Value::as_str))
+        .collect();
+    assert_eq!(
+        actions,
+        ["created"],
+        "a fresh card opens its narrative: {json}"
+    );
+
+    // Two changed fields in one edit → two rows, in the service's field order.
+    ainb(
+        h,
+        &[
+            "hangar",
+            "issue",
+            "update",
+            &issue_id,
+            "--state",
+            "in_progress",
+            "--priority",
+            "3",
+        ],
+    );
+
+    let json = ainb(
+        h,
+        &["hangar", "issue", "timeline", &issue_id, "--format", "json"],
+    );
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("timeline json");
+    let actions: Vec<&str> = rows
+        .iter()
+        .filter_map(|r| r.get("action").and_then(serde_json::Value::as_str))
+        .collect();
+    assert_eq!(
+        actions,
+        ["created", "status_changed", "priority_changed"],
+        "one row per changed field, oldest first: {json}"
+    );
+
+    // multica's exact details shape on the move.
+    let status = rows
+        .iter()
+        .find(|r| r.get("action").and_then(serde_json::Value::as_str) == Some("status_changed"))
+        .expect("a status_changed row");
+    assert_eq!(
+        status.get("details"),
+        Some(&serde_json::json!({"from": "open", "to": "in_progress"}))
+    );
+
+    // …and the text form renders the change a human reads.
+    let text = ainb(h, &["hangar", "issue", "timeline", &issue_id]);
+    assert!(
+        text.contains("open → in_progress"),
+        "the text timeline must render the transition: {text}"
+    );
+    assert!(
+        text.contains("status_changed"),
+        "the text timeline names the action: {text}"
+    );
+}
+
+/// A card with nothing recorded prints an honest empty line, and the `activity`
+/// alias resolves to the same verb.
+#[test]
+fn the_activity_alias_resolves_to_the_timeline_verb() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+
+    let issue_id = created_id(&ainb(h, &["hangar", "issue", "create", "--title", "Alias"]));
+    let via_alias = ainb(
+        h,
+        &["hangar", "issue", "activity", &issue_id, "--format", "json"],
+    );
+    let via_name = ainb(
+        h,
+        &["hangar", "issue", "timeline", &issue_id, "--format", "json"],
+    );
+    assert_eq!(via_alias, via_name);
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/activity.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/activity.rs
@@ -1,0 +1,224 @@
+//! Per-issue ACTIVITY vocabulary (multica parity #13, migration 0059).
+//!
+//! The stable `created | status_changed | assignee_changed | …` token set shared
+//! by the layer that DECIDES an issue changed (the diff service) and the layer
+//! that SERIALIZES it (the repo + the wire), so the two cannot drift. Same shape
+//! as [`crate::dispatch_reason`], the parity #12 precedent.
+//!
+//! # Tolerant reads
+//!
+//! [`ActivityAction::parse`] returns `None` for a token this binary does not
+//! know: a row written by a newer daemon renders as its raw string instead of
+//! poisoning the read path. That is why the `action` column carries no `CHECK`
+//! (see the migration's comment block).
+//!
+//! # The third actor kind
+//!
+//! [`crate::actor::ActorKind`] is `member | agent`, and widening it would ripple
+//! into the `CHECK` constraints on `issue`, `comment` and `agent_task_queue`.
+//! Activity rows need a third, activity-only kind for a daemon-driven transition
+//! with no human or agent author, so [`ActivityActor`] wraps an [`ActorRef`]
+//! alongside a `System` variant. multica's own `actor_type` `CHECK` admits
+//! `'system'` for the same reason.
+//!
+//! # multica DEVIATION
+//!
+//! multica also emits `description_updated`. hangar's `IssueFieldUpdate` has no
+//! `description` field and `IssueUpdateParams` carries no description, so there
+//! is no description-edit path to instrument. The variant is deliberately
+//! omitted rather than added dead; adding it later is append-only.
+
+use crate::actor::{ActorKind, ActorRef};
+
+/// One entry in the per-issue narrative.
+///
+/// The wire/DB token is [`Self::as_db_str`]; the human render text is
+/// [`Self::label`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ActivityAction {
+    /// The issue was created.
+    Created,
+    /// `state` moved between two lifecycle values.
+    StatusChanged,
+    /// `assignee` was set, cleared, or re-pointed.
+    AssigneeChanged,
+    /// `priority` changed (hangar priority is `0..3`, so the details carry
+    /// NUMBERS where multica carries a string enum).
+    PriorityChanged,
+    /// `title` was edited.
+    TitleChanged,
+    /// `due_date` was set, cleared, or moved.
+    DueDateChanged,
+    /// A task on the issue finished successfully.
+    TaskCompleted,
+    /// A task on the issue failed.
+    TaskFailed,
+}
+
+impl ActivityAction {
+    /// The stable token stored in `activity_log.action` and put on the wire.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::StatusChanged => "status_changed",
+            Self::AssigneeChanged => "assignee_changed",
+            Self::PriorityChanged => "priority_changed",
+            Self::TitleChanged => "title_changed",
+            Self::DueDateChanged => "due_date_changed",
+            Self::TaskCompleted => "task_completed",
+            Self::TaskFailed => "task_failed",
+        }
+    }
+
+    /// Decode a stored token. **Tolerant**: an unknown token is `None`, and the
+    /// caller renders the raw string.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "created" => Some(Self::Created),
+            "status_changed" => Some(Self::StatusChanged),
+            "assignee_changed" => Some(Self::AssigneeChanged),
+            "priority_changed" => Some(Self::PriorityChanged),
+            "title_changed" => Some(Self::TitleChanged),
+            "due_date_changed" => Some(Self::DueDateChanged),
+            "task_completed" => Some(Self::TaskCompleted),
+            "task_failed" => Some(Self::TaskFailed),
+            _ => None,
+        }
+    }
+
+    /// Short human render text for the timeline surfaces.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::StatusChanged => "moved",
+            Self::AssigneeChanged => "assigned",
+            Self::PriorityChanged => "priority",
+            Self::TitleChanged => "renamed",
+            Self::DueDateChanged => "due date",
+            Self::TaskCompleted => "task completed",
+            Self::TaskFailed => "task failed",
+        }
+    }
+}
+
+/// Who an activity row is attributed to.
+///
+/// [`Self::System`] is the activity-only third kind: a daemon-driven transition
+/// (a board card move, a PR-merged auto-done) with no human or agent author. It
+/// stores `actor_type='system', actor_id=NULL`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivityActor {
+    /// A real hangar actor (`member:<id>` / `agent:<id>`).
+    Actor(ActorRef),
+    /// The daemon itself.
+    System,
+}
+
+impl ActivityActor {
+    /// The `'member' | 'agent' | 'system'` token stored in `actor_type`.
+    #[must_use]
+    pub fn type_str(&self) -> &'static str {
+        match self {
+            Self::Actor(a) => a.kind().as_str(),
+            Self::System => "system",
+        }
+    }
+
+    /// The `actor_id` half; `None` for [`Self::System`].
+    #[must_use]
+    pub fn id(&self) -> Option<&str> {
+        match self {
+            Self::Actor(a) => Some(a.id()),
+            Self::System => None,
+        }
+    }
+
+    /// Rebuild from a stored `(actor_type, actor_id)` pair.
+    ///
+    /// `None` for a malformed row (an unknown kind, or a `member`/`agent` row
+    /// with no id) — the caller renders it raw rather than failing the read.
+    #[must_use]
+    pub fn parse(ty: &str, id: Option<&str>) -> Option<Self> {
+        if ty == "system" {
+            return Some(Self::System);
+        }
+        let kind: ActorKind = ty.parse().ok()?;
+        ActorRef::new(kind, id?).ok().map(Self::Actor)
+    }
+
+    /// Convenience constructor for a member-attributed row.
+    ///
+    /// Returns [`Self::System`] when `member_id` is `None` or empty — hangar has
+    /// no per-request auth context, so a write with no resolvable owner is a
+    /// system fact, never a fabricated member.
+    #[must_use]
+    pub fn member_or_system(member_id: Option<&str>) -> Self {
+        member_id
+            .filter(|id| !id.is_empty())
+            .and_then(|id| ActorRef::new(ActorKind::Member, id).ok())
+            .map_or(Self::System, Self::Actor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_action_token_round_trips() {
+        for a in [
+            ActivityAction::Created,
+            ActivityAction::StatusChanged,
+            ActivityAction::AssigneeChanged,
+            ActivityAction::PriorityChanged,
+            ActivityAction::TitleChanged,
+            ActivityAction::DueDateChanged,
+            ActivityAction::TaskCompleted,
+            ActivityAction::TaskFailed,
+        ] {
+            assert_eq!(ActivityAction::parse(a.as_db_str()), Some(a));
+            assert!(!a.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn unknown_action_token_decodes_to_none() {
+        assert_eq!(ActivityAction::parse("teleported"), None);
+    }
+
+    #[test]
+    fn system_actor_stores_no_id() {
+        let s = ActivityActor::System;
+        assert_eq!(s.type_str(), "system");
+        assert_eq!(s.id(), None);
+        assert_eq!(ActivityActor::parse("system", None), Some(s));
+    }
+
+    #[test]
+    fn actor_round_trips_through_parse() {
+        let a = ActivityActor::Actor(ActorRef::new(ActorKind::Agent, "a1").unwrap());
+        assert_eq!(ActivityActor::parse(a.type_str(), a.id()), Some(a));
+    }
+
+    #[test]
+    fn malformed_actor_pair_is_none() {
+        assert_eq!(ActivityActor::parse("member", None), None);
+        assert_eq!(ActivityActor::parse("frog", Some("x")), None);
+    }
+
+    #[test]
+    fn member_or_system_falls_back_to_system() {
+        assert_eq!(ActivityActor::member_or_system(None), ActivityActor::System);
+        assert_eq!(
+            ActivityActor::member_or_system(Some("")),
+            ActivityActor::System
+        );
+        assert_eq!(
+            ActivityActor::member_or_system(Some("m1")).type_str(),
+            "member"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/activity.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/activity.rs
@@ -120,7 +120,7 @@ pub enum ActivityActor {
 impl ActivityActor {
     /// The `'member' | 'agent' | 'system'` token stored in `actor_type`.
     #[must_use]
-    pub fn type_str(&self) -> &'static str {
+    pub const fn type_str(&self) -> &'static str {
         match self {
             Self::Actor(a) => a.kind().as_str(),
             Self::System => "system",

--- a/ainb-tui/crates/ainb-hangar-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/lib.rs
@@ -14,6 +14,11 @@
 pub mod acceptance;
 /// Polymorphic actor references (`member:<id>` / `agent:<id>`).
 pub mod actor;
+/// Per-issue ACTIVITY vocabulary (multica parity #13): the stable
+/// `created | status_changed | assignee_changed | …` action tokens plus the
+/// activity-only `system` actor kind, shared by the diff service that decides a
+/// change happened and the repo/wire that serialize it.
+pub mod activity;
 /// Per-agent environment variables with a redact-by-construction contract
 /// (multica parity #30): plaintext inside, masked on every egress except the
 /// single named exec seam ([`agent_env::AgentEnv::expose_for_child_env`]).

--- a/ainb-tui/crates/ainb-hangar-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/lib.rs
@@ -12,13 +12,13 @@
 /// (multica parity #11-rest), plus the tolerant legacy/structured JSON codec
 /// shared by the store column and the wire.
 pub mod acceptance;
-/// Polymorphic actor references (`member:<id>` / `agent:<id>`).
-pub mod actor;
 /// Per-issue ACTIVITY vocabulary (multica parity #13): the stable
 /// `created | status_changed | assignee_changed | …` action tokens plus the
 /// activity-only `system` actor kind, shared by the diff service that decides a
 /// change happened and the repo/wire that serialize it.
 pub mod activity;
+/// Polymorphic actor references (`member:<id>` / `agent:<id>`).
+pub mod actor;
 /// Per-agent environment variables with a redact-by-construction contract
 /// (multica parity #30): plaintext inside, masked on every egress except the
 /// single named exec seam ([`agent_env::AgentEnv::expose_for_child_env`]).

--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -20,12 +20,17 @@
 //! committed, and an auto-move failure must never down the claim loop. A task
 //! with no matching auto-move column is a silent no-op.
 
+use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::clock::SystemClock;
+use ainb_hangar_core::idgen::SystemIdGen;
 use ainb_hangar_core::ids::WorkspaceId;
 use ainb_hangar_proto::lifecycle::IssueLifecycle;
 use ainb_hangar_store::repo::board::BoardRepo;
 use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
 use ainb_hangar_store::repo::issue::IssueRepo;
 use ainb_hangar_store::repo::task::Task;
+use ainb_hangar_store::service::activity::ActivityService;
 use sqlx::SqlitePool;
 
 use crate::events::EventSink;
@@ -162,13 +167,33 @@ pub async fn advance_issue_lifecycle_after_transition(
         return;
     }
     match IssueRepo::update_state(pool, issue_id, target.as_str()).await {
-        Ok(()) => tracing::info!(
-            task_id = %task.id,
-            issue_id = %issue_id,
-            from = %current.state,
-            to = target.as_str(),
-            "issue lifecycle advanced"
-        ),
+        Ok(()) => {
+            // multica parity #13: a daemon-driven move is a `system` activity row
+            // carrying `via:"board"`, so the narrative distinguishes it from an
+            // owner edit. Best-effort — never fails the advance.
+            ActivityService::record(
+                pool,
+                &SystemIdGen,
+                &SystemClock,
+                &current.workspace_id,
+                issue_id,
+                &ActivityActor::System,
+                ActivityAction::StatusChanged,
+                serde_json::json!({
+                    "from": current.state,
+                    "to": target.as_str(),
+                    "via": "board",
+                }),
+            )
+            .await;
+            tracing::info!(
+                task_id = %task.id,
+                issue_id = %issue_id,
+                from = %current.state,
+                to = target.as_str(),
+                "issue lifecycle advanced"
+            );
+        }
         Err(e) => {
             tracing::warn!(error = %e, task_id = %task.id, "issue lifecycle advance failed; proceeding");
         }
@@ -363,6 +388,40 @@ async fn auto_run_dependent(pool: &SqlitePool, ws: &WorkspaceId, issue_id: &str)
             tracing::warn!(issue = %issue_id, "auto-run refused (no repo/agent or store fault)")
         }
     }
+}
+
+/// Record a task's terminal OUTCOME on its issue's narrative (multica parity
+/// #13, write sites 8 + 9).
+///
+/// Attributed to `agent:<agent_id>` — the run's own agent, matching multica's
+/// listeners, which force the actor for `task:completed` / `task:failed`
+/// regardless of who triggered the run. `details` carries the task id (additive
+/// over multica's `{}`; the column is free-form).
+///
+/// Best-effort and no-op for a chat task with no issue: the task's terminal
+/// state has already committed and an audit write must never down the run loop.
+pub async fn record_task_outcome(pool: &SqlitePool, task: &Task, completed: bool) {
+    let Some(issue_id) = task.issue_id.as_deref() else {
+        return;
+    };
+    let actor = ActorRef::new(ActorKind::Agent, task.agent_id.clone())
+        .map_or(ActivityActor::System, ActivityActor::Actor);
+    let action = if completed {
+        ActivityAction::TaskCompleted
+    } else {
+        ActivityAction::TaskFailed
+    };
+    ActivityService::record(
+        pool,
+        &SystemIdGen,
+        &SystemClock,
+        &task.workspace_id,
+        issue_id,
+        &actor,
+        action,
+        serde_json::json!({ "task_id": task.id }),
+    )
+    .await;
 }
 
 /// Advance the issue lifecycle, then cascade a completed sub-issue to its parent.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -45,13 +45,16 @@ use std::sync::Arc;
 use std::sync::{OnceLock, RwLock};
 use std::time::Instant;
 
+use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
 use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
+use ainb_hangar_core::idgen::SystemIdGen;
 use ainb_hangar_core::ids::{AgentId, AutopilotId, SkillId, WorkspaceId};
 use ainb_hangar_proto::lifecycle::IssueLifecycle;
 use ainb_hangar_proto::methods;
 use ainb_hangar_proto::settings::{DaemonHealthSnapshot, HealthSnapshot};
 use ainb_hangar_proto::{RpcError, RpcId, RpcRequest, RpcResponse};
+use ainb_hangar_store::service::activity::ActivityService;
 use futures_util::future::join_all;
 use sqlx::SqlitePool;
 
@@ -813,6 +816,7 @@ async fn handle(
         methods::HANGAR_ISSUE_LINK_REMOVE => handle_issue_link(pool, req, false).await,
         methods::HANGAR_ISSUE_LINKS => handle_issue_links(pool, req).await,
         methods::HANGAR_DISPATCH_ATTEMPTS_LIST => handle_dispatch_attempts_list(pool, req).await,
+        methods::HANGAR_ISSUE_TIMELINE => handle_issue_timeline(pool, req).await,
         methods::HANGAR_BOARD_CARD_SET_AUTO_RUN => handle_board_card_set_auto_run(pool, req).await,
         methods::HANGAR_REPO_LIST => handle_repo_list(req),
         methods::FLEET_SNAPSHOT => handle_fleet_snapshot(pool).await,
@@ -3217,6 +3221,21 @@ async fn handle_issue_create(
     )
     .await
     .map_err(|e| store_err(&e))?;
+    // multica parity #13: open the card's narrative. Attributed to the
+    // wire-supplied creator (hangar has no request-auth context, so that is the
+    // most honest actor available here). Best-effort — an audit failure never
+    // fails the create.
+    ActivityService::record(
+        pool,
+        &SystemIdGen,
+        &SystemClock,
+        ws.as_str(),
+        &row.id.to_string(),
+        &ActivityActor::Actor(creator.clone()),
+        ActivityAction::Created,
+        serde_json::json!({}),
+    )
+    .await;
     // A committed insert announces the new issue to subscribers.
     events.emit(ws.as_str(), HangarEvent::IssueCreated(row.clone()));
     to_value(&row)
@@ -3488,6 +3507,18 @@ async fn handle_issue_update(
     // requested) so a completion can fire the child-done → parent cascade below.
     let prev_state = issue_prev_state_for_cascade(pool, &ws, &params.issue_id, &update).await?;
 
+    // multica parity #13: the FULL pre-edit row, so the post-edit diff can write
+    // one activity row per changed field. Deliberately separate from
+    // `prev_state` above, which only carries the state token for the cascade.
+    let before_issue = if update.is_empty() {
+        None
+    } else {
+        ainb_hangar_store::repo::issue::IssueRepo::get_by_id(pool, &params.issue_id)
+            .await
+            .map_err(|e| store_err(&e))?
+            .filter(|i| i.workspace_id == ws.as_str())
+    };
+
     // F6 card edit: the card's repo + chosen agent are persisted on the durable
     // card (the issue) exactly as `board_card_create` does — trim the repo, drop an
     // unrecognised agent token (the F4 cascade decides), and only write when a
@@ -3547,6 +3578,28 @@ async fn handle_issue_update(
             target_branch,
         )
         .await?;
+    }
+
+    // multica parity #13: diff the pre-edit row against the committed one and
+    // record one activity row per changed field. Best-effort throughout.
+    if let Some(before) = before_issue.as_ref() {
+        if let Some(after) =
+            ainb_hangar_store::repo::issue::IssueRepo::get_by_id(pool, &params.issue_id)
+                .await
+                .map_err(|e| store_err(&e))?
+        {
+            let actor = acting_actor(pool).await;
+            ActivityService::record_issue_diff(
+                pool,
+                &SystemIdGen,
+                &SystemClock,
+                ws.as_str(),
+                &actor,
+                before,
+                &after,
+            )
+            .await;
+        }
     }
 
     // A committed edit announces the refreshed row to subscribers. Re-read AFTER
@@ -6348,6 +6401,59 @@ async fn handle_dispatch_attempts_list(
         .collect();
 
     to_value(&ainb_hangar_proto::snapshots::DispatchAttemptsListResult { attempts })
+}
+
+/// Who a daemon-side owner edit is attributed to (multica parity #13).
+///
+/// hangar has no per-request auth context, so an owner-driven edit is credited
+/// to the single bootstrapped default member; when none resolves (or the lookup
+/// faults) the row is a `system` fact rather than a fabricated member. When
+/// per-request actor identity lands (parity #1's member work), swap this body —
+/// no call site changes.
+async fn acting_actor(pool: &SqlitePool) -> ainb_hangar_core::activity::ActivityActor {
+    let owner = ainb_hangar_store::bootstrap::default_owner_id(pool).await.ok().flatten();
+    ainb_hangar_core::activity::ActivityActor::member_or_system(owner.as_deref())
+}
+
+/// `hangar/issue_timeline` (multica parity #13): one card's merged activity +
+/// comment narrative, **oldest first**.
+///
+/// Read-only and workspace-scoped through the same tenant guard as
+/// [`handle_dispatch_attempts_list`]. An `(issue_id, workspace)` pair that
+/// resolves to no issue is `INVALID_PARAMS`, never a silent empty list — an
+/// empty timeline and a cross-tenant probe must not look identical.
+async fn handle_issue_timeline(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    /// Default window when the caller does not ask for one.
+    const DEFAULT_LIMIT: u32 = 200;
+    /// multica's `timelineHardCap`.
+    const MAX_LIMIT: u32 = 2000;
+
+    let params: ainb_hangar_proto::snapshots::IssueTimelineParams =
+        parse_params(req, "{ workspace_id, issue_id, limit? }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let limit = i64::from(params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT));
+
+    // Resolve the card inside the tenant BEFORE reading, so a foreign id is a
+    // clean rejection rather than an empty list that leaks nothing but also
+    // tells the caller nothing.
+    let known = ainb_hangar_store::repo::issue::IssueRepo::get_by_id(pool, &params.issue_id)
+        .await
+        .map_err(|e| store_err(&e))?
+        .is_some_and(|i| i.workspace_id == ws.as_str());
+    if !known {
+        return Err(invalid_params(&format!(
+            "no issue `{}` in this workspace",
+            params.issue_id
+        )));
+    }
+
+    let entries = snapshots::issue_timeline(pool, ws.as_str(), &params.issue_id, limit)
+        .await
+        .map_err(|e| store_err(&e))?;
+    to_value(&ainb_hangar_proto::snapshots::IssueTimelineResult { entries })
 }
 
 /// `hangar/board_card_set_auto_run` (tcp T4 / F7): flip a card's auto-run flag.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -30,9 +30,10 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use ainb_hangar_core::acceptance::AcceptanceCriterion;
+use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
 use ainb_hangar_core::actor::{ActorKind, ActorRef};
-use ainb_hangar_core::clock::HangarClock;
-use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_core::clock::{HangarClock, SystemClock};
+use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use ainb_hangar_core::ids::{AgentId, AutopilotId, CommentId, IssueId, SkillId, WorkspaceId};
 use ainb_hangar_core::origin::IssueOrigin;
 use ainb_hangar_core::task_status::TaskStatus;
@@ -40,7 +41,9 @@ use ainb_hangar_proto::events::{
     ActorRow, AgentSkillLinkRow, AttentionRow, AutopilotRow, AutopilotRunRow, CommentRow,
     InboxEntryRow, IssueRow, PresenceState, SkillFile, SkillRow, TaskCardRow, Workload,
 };
-use ainb_hangar_proto::snapshots::{AgentSkillsListResult, SkillDetail, SkillsSyncResult};
+use ainb_hangar_proto::snapshots::{
+    AgentSkillsListResult, SkillDetail, SkillsSyncResult, TimelineEntryRow,
+};
 use ainb_hangar_store::repo::agent::AgentRepo;
 use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
 use ainb_hangar_store::repo::attention::AttentionRepo;
@@ -58,6 +61,7 @@ use ainb_hangar_store::repo::skill::{SkillRepo, SkillRepoError};
 use ainb_hangar_store::repo::task::TaskRepo;
 use ainb_hangar_store::repo::usage::UsageRepo;
 use ainb_hangar_store::repo::workspace::{apply_issue_prefix, issue_display_id};
+use ainb_hangar_store::service::activity::ActivityService;
 use sqlx::{Row, SqlitePool};
 
 /// Every Hangar issue lifecycle state, queried per-state and concatenated so the
@@ -2224,7 +2228,26 @@ pub async fn refresh_pr_status(
     if issue.state == PR_MERGED_DONE_STATE {
         return Ok((status, None));
     }
+    let prev_state = issue.state.clone();
     IssueRepo::update_state(pool, issue_id, PR_MERGED_DONE_STATE).await?;
+    // multica parity #13: a daemon-driven transition is a `system` activity row
+    // carrying `via` so the narrative distinguishes "a human moved this" from
+    // "the merged PR moved this". Best-effort — never fails the transition.
+    ActivityService::record(
+        pool,
+        &SystemIdGen,
+        &SystemClock,
+        workspace_id,
+        issue_id,
+        &ActivityActor::System,
+        ActivityAction::StatusChanged,
+        serde_json::json!({
+            "from": prev_state,
+            "to": PR_MERGED_DONE_STATE,
+            "via": "pr_merged",
+        }),
+    )
+    .await;
     // Re-read the now-Done row so the caller can push `IssueUpdated`.
     let row = read_issue_row(pool, workspace_id, issue_id).await?;
     Ok((status, row))
@@ -3335,4 +3358,76 @@ mod pr_fetch_bound_tests {
             "no urls → no fetches spawned"
         );
     }
+}
+
+/// Merge one issue's activity rows and comments into the wire timeline,
+/// **oldest first**, sorted by `(created_at, id)` — multica's `mergeTimeline`
+/// (parity #13).
+///
+/// Comments are NOT duplicated as `activity_log` rows; they are merged here at
+/// READ time so the comment body stays the single source of truth. Each side is
+/// fetched independently and capped at `limit`; the merged list keeps the NEWEST
+/// `limit` entries and renders them oldest-first.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault.
+pub async fn issue_timeline(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    issue_id: &str,
+    limit: i64,
+) -> Result<Vec<TimelineEntryRow>, sqlx::Error> {
+    use ainb_hangar_proto::snapshots::{TIMELINE_KIND_ACTIVITY, TIMELINE_KIND_COMMENT};
+    use ainb_hangar_store::repo::activity::ActivityRepo;
+    use ainb_hangar_store::repo::comment::CommentRepo;
+
+    let activities = ActivityRepo::list_for_issue(pool, issue_id, limit).await?;
+    let comments = CommentRepo::list_by_issue(pool, workspace_id, issue_id).await?;
+
+    let mut entries: Vec<TimelineEntryRow> = Vec::with_capacity(activities.len() + comments.len());
+    for a in activities {
+        // Re-assert the tenant: the per-issue query keys on the issue id, and the
+        // activity row carries its own workspace column.
+        if a.workspace_id != workspace_id {
+            continue;
+        }
+        let details = a.details_json();
+        entries.push(TimelineEntryRow {
+            kind: TIMELINE_KIND_ACTIVITY.to_string(),
+            id: a.id,
+            actor_type: a.actor_type,
+            actor_id: a.actor_id,
+            created_at: a.created_at,
+            action: Some(a.action),
+            // An empty details object adds no information — omit it so the frame
+            // stays small and an activity with nothing to say looks like one.
+            details: (!details.as_object().is_some_and(serde_json::Map::is_empty))
+                .then_some(details),
+            body: None,
+        });
+    }
+    for c in comments {
+        entries.push(TimelineEntryRow {
+            kind: TIMELINE_KIND_COMMENT.to_string(),
+            id: c.id,
+            actor_type: Some(c.author.kind().as_str().to_string()),
+            actor_id: Some(c.author.id().to_string()),
+            created_at: c.created_at,
+            action: None,
+            details: None,
+            body: Some(c.body),
+        });
+    }
+
+    // `(created_at, id)` ascending — the id is a deterministic tiebreak for two
+    // entries recorded in the same millisecond.
+    entries.sort_by(|a, b| a.created_at.cmp(&b.created_at).then_with(|| a.id.cmp(&b.id)));
+    // Keep the NEWEST window when the merged list overflows, then render it
+    // oldest-first (multica's flat contract).
+    let cap = usize::try_from(limit.max(0)).unwrap_or(usize::MAX);
+    if entries.len() > cap {
+        entries.drain(..entries.len() - cap);
+    }
+    Ok(entries)
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -1671,6 +1671,9 @@ async fn finalize_success(
     // card does not slide to `done` while its leader / other members still run.
     // Best-effort; never blocks.
     crate::board::auto_move_after_terminal(pool, task).await;
+    // multica parity #13: the run's own outcome on the card's narrative,
+    // attributed to the agent that ran it. Best-effort.
+    crate::board::record_task_outcome(pool, task, true).await;
     // Twin the durable-card move on the issue's own `state` (the default board
     // buckets by it): an aggregate-`done` set promotes the issue to `done`;
     // failed/cancelled sets leave it untouched. Advance-only + best-effort.
@@ -1870,6 +1873,8 @@ async fn finalize_failure(
     // and one failed sibling lands the whole card in the `failed` column (aggregate
     // precedence). Best-effort; never blocks.
     crate::board::auto_move_after_terminal(pool, task).await;
+    // multica parity #13: the run's own outcome on the card's narrative.
+    crate::board::record_task_outcome(pool, task, false).await;
     // Twin on `issue.state`: the aggregate is `failed`/`cancelled` here (this
     // task's own failure is in the set), so this no-ops — but it keeps the
     // lifecycle seam symmetric with the board seam. Advance-only + best-effort.
@@ -1994,6 +1999,8 @@ async fn finalize_setup_failure(
         clock,
     );
     crate::board::auto_move_after_terminal(pool, task).await;
+    // multica parity #13: the run's own outcome on the card's narrative.
+    crate::board::record_task_outcome(pool, task, false).await;
     // Twin on `issue.state`; no-ops on the failed aggregate, kept for symmetry
     // with the board seam. Advance-only + best-effort.
     crate::board::advance_and_cascade_child(pool, task, events).await;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_timeline.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_timeline.rs
@@ -1,0 +1,280 @@
+//! Integration: `hangar/issue_timeline` (multica parity #13) over a real framed
+//! `UnixStream`.
+//!
+//! The ACCEPTANCE proof for the parity item: an issue is created, moved,
+//! re-assigned and commented on through the real RPC dispatcher, and the
+//! timeline read back must carry the merged activity + comment narrative in
+//! ascending `created_at` order, with the exact multica details shapes.
+//!
+//! Also pins the tenant contract: an `issue_id` that does not resolve inside the
+//! named workspace is `INVALID_PARAMS`, never a silent empty list (an empty
+//! timeline and a cross-tenant probe must not look identical).
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        tokio::time::timeout(timeout, self.read_frame_inner()).await.ok()
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(5))
+                .await
+                .unwrap_or_else(|| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// create → move → assign → comment → timeline: the merged narrative comes back
+/// oldest-first with multica's exact `status_changed` details shape.
+#[tokio::test]
+async fn timeline_merges_activity_and_comments_oldest_first() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let created = c
+        .call(
+            methods::HANGAR_ISSUE_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "title": "parity 13 proof",
+                "creator": "member:user-1",
+            }),
+        )
+        .await;
+    assert!(
+        created["error"].is_null(),
+        "issue_create must ack: {created}"
+    );
+    let issue_id = created["result"]["id"].as_str().expect("created issue id").to_string();
+
+    let moved = c
+        .call(
+            methods::HANGAR_ISSUE_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": issue_id,
+                "state": "in_progress",
+            }),
+        )
+        .await;
+    assert!(moved["error"].is_null(), "issue_update state: {moved}");
+
+    let assigned = c
+        .call(
+            methods::HANGAR_ISSUE_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": issue_id,
+                "assignee": "agent:agent-1",
+            }),
+        )
+        .await;
+    assert!(
+        assigned["error"].is_null(),
+        "issue_update assignee: {assigned}"
+    );
+
+    let commented = c
+        .call(
+            methods::HANGAR_COMMENT_ADD,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": issue_id,
+                "author": "agent:agent-1",
+                "body": "picked this up, starting now",
+            }),
+        )
+        .await;
+    assert!(commented["error"].is_null(), "comment_add: {commented}");
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_TIMELINE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": issue_id }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "issue_timeline must ack: {resp}");
+    let entries = resp["result"]["entries"].as_array().expect("entries array").clone();
+
+    // Ascending by created_at — the flat multica contract.
+    let times: Vec<i64> =
+        entries.iter().map(|e| e["created_at"].as_i64().expect("created_at")).collect();
+    let mut sorted = times.clone();
+    sorted.sort_unstable();
+    assert_eq!(times, sorted, "entries must be oldest-first: {entries:#?}");
+
+    // The three activity rows, in order.
+    let actions: Vec<&str> = entries
+        .iter()
+        .filter(|e| e["kind"] == "activity")
+        .map(|e| e["action"].as_str().expect("action"))
+        .collect();
+    assert_eq!(
+        actions,
+        ["created", "status_changed", "assignee_changed"],
+        "activity narrative: {entries:#?}"
+    );
+
+    // …with multica's exact details shape on the move.
+    let status = entries
+        .iter()
+        .find(|e| e["action"] == "status_changed")
+        .expect("a status_changed entry");
+    assert_eq!(
+        status["details"],
+        serde_json::json!({"from": "open", "to": "in_progress"})
+    );
+
+    // The comment is MERGED from the comment table, not duplicated as activity.
+    let comments: Vec<&serde_json::Value> =
+        entries.iter().filter(|e| e["kind"] == "comment").collect();
+    assert_eq!(comments.len(), 1, "one merged comment: {entries:#?}");
+    assert_eq!(comments[0]["body"], "picked this up, starting now");
+    assert_eq!(comments[0]["actor_type"], "agent");
+    assert_eq!(comments[0]["actor_id"], "agent-1");
+    assert!(
+        comments[0]["action"].is_null(),
+        "a comment entry carries no activity-only keys: {}",
+        comments[0]
+    );
+}
+
+/// An issue id that does not resolve inside the named workspace is rejected —
+/// never an empty list, which would make a cross-tenant probe indistinguishable
+/// from a card with no history yet.
+#[tokio::test]
+async fn timeline_rejects_an_issue_outside_the_workspace() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_TIMELINE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": "definitely-not-an-issue-in-this-tenant",
+            }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "an unresolvable issue must be rejected, not an empty timeline: {resp}"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -322,6 +322,28 @@ pub const HANGAR_ISSUE_RUN: &str = "hangar/issue_run";
 /// every other list method, so a sibling tenant's attempts are never returned.
 pub const HANGAR_DISPATCH_ATTEMPTS_LIST: &str = "hangar/dispatch_attempts_list";
 
+/// `hangar/issue_timeline` — read one issue's merged activity + comment
+/// timeline (multica parity #13, migration 0059).
+///
+/// The per-issue NARRATIVE: creation, state moves, re-assignments,
+/// priority/title/due-date edits and task outcomes from `activity_log`, merged
+/// at READ time with the issue's comments (comments are never duplicated as
+/// activity rows — the comment body stays the single source of truth, matching
+/// multica's `mergeTimeline`).
+///
+/// Params: [`crate::snapshots::IssueTimelineParams`]
+/// (`{ workspace_id, issue_id, limit? }`); result:
+/// [`crate::snapshots::IssueTimelineResult`] — entries **oldest first**, default
+/// `limit` 200, hard cap 2000 (multica's `timelineHardCap`). Read-only and
+/// workspace-scoped through the same tenant guard as
+/// [`HANGAR_DISPATCH_ATTEMPTS_LIST`]; an `issue_id` that does not resolve inside
+/// the workspace is `INVALID_PARAMS`, never a silent empty list.
+///
+/// **No live push.** multica broadcasts an `activity:created` WS event; hangar
+/// deliberately does not add a `HangarEvent` variant for it — the surfaces fetch
+/// on open and on refresh. Adding one later is append-only.
+pub const HANGAR_ISSUE_TIMELINE: &str = "hangar/issue_timeline";
+
 /// `hangar/issue_label_attach` — attach a label to one issue (e38.10).
 ///
 /// Params: [`crate::snapshots::IssueLabelParams`]
@@ -1276,6 +1298,9 @@ pub const ALL_METHODS: &[&str] = &[
     // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
     // tail, append-only wire.
     HANGAR_DISPATCH_ATTEMPTS_LIST,
+    // Per-issue activity timeline (multica parity #13) — APPENDED at the
+    // catalogue tail, append-only wire.
+    HANGAR_ISSUE_TIMELINE,
 ];
 
 #[cfg(test)]
@@ -1503,6 +1528,7 @@ mod tests {
             FLEET_ACTION,
             FLEET_BROADCAST,
             HANGAR_DISPATCH_ATTEMPTS_LIST,
+            HANGAR_ISSUE_TIMELINE,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2566,6 +2566,67 @@ pub struct DispatchAttemptRow {
     pub created_at: i64,
 }
 
+/// Params for [`crate::methods::HANGAR_ISSUE_TIMELINE`] (multica parity #13):
+/// read one card's merged activity + comment narrative.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueTimelineParams {
+    /// The subscribed workspace (tenant guard).
+    pub workspace_id: String,
+    /// The card whose timeline to read.
+    pub issue_id: String,
+    /// Max entries: the newest window, rendered oldest-first. Defaults to 200,
+    /// hard-capped at 2000 by the daemon (multica's `timelineHardCap`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+/// Result of [`crate::methods::HANGAR_ISSUE_TIMELINE`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueTimelineResult {
+    /// The merged entries, **oldest first** (multica's default flat contract).
+    #[serde(default)]
+    pub entries: Vec<TimelineEntryRow>,
+}
+
+/// One merged timeline entry (multica parity #13).
+///
+/// [`Self::kind`] discriminates `"activity"` from `"comment"`; every optional
+/// field is `serde(default, skip_serializing_if)` so an older client decodes a
+/// newer daemon's frame and a newer client decodes an older daemon's frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TimelineEntryRow {
+    /// `"activity"` | `"comment"` — a raw string, not an enum, so an unknown
+    /// future kind renders as text instead of failing the decode.
+    pub kind: String,
+    /// The source row's primary key (an `activity_log.id` or a `comment.id`).
+    pub id: String,
+    /// `"member"` | `"agent"` | `"system"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_type: Option<String>,
+    /// The actor's id; absent for a `system` entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    /// When it happened (epoch millis). The primary sort key.
+    pub created_at: i64,
+    /// Activity-only: the stable action token
+    /// (`ActivityAction::as_db_str`). Decode tolerantly with
+    /// `ActivityAction::parse` — an unknown token renders raw.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    /// Activity-only: the free-form details object (`{"from":…,"to":…}` and
+    /// friends).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+    /// Comment-only: the comment body.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
+/// The `kind` discriminant for an activity entry.
+pub const TIMELINE_KIND_ACTIVITY: &str = "activity";
+/// The `kind` discriminant for a comment entry.
+pub const TIMELINE_KIND_COMMENT: &str = "comment";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3865,5 +3926,55 @@ mod tests {
             !s.contains("\"blocks\"") && !s.contains("\"related\""),
             "{s}"
         );
+    }
+
+    /// Parity #13: the timeline entry is append-only — every optional field is
+    /// omitted when absent, so an older daemon's frame decodes and a comment
+    /// entry never carries activity-only keys.
+    #[test]
+    fn timeline_entry_omits_absent_fields_and_roundtrips() {
+        let comment = TimelineEntryRow {
+            kind: TIMELINE_KIND_COMMENT.into(),
+            id: "c-1".into(),
+            actor_type: Some("agent".into()),
+            actor_id: Some("a-1".into()),
+            created_at: 100,
+            body: Some("picked this up".into()),
+            ..Default::default()
+        };
+        let s = serde_json::to_string(&comment).unwrap();
+        assert!(!s.contains("\"action\""), "{s}");
+        assert!(!s.contains("\"details\""), "{s}");
+        assert_eq!(
+            serde_json::from_str::<TimelineEntryRow>(&s).unwrap(),
+            comment
+        );
+
+        let activity = TimelineEntryRow {
+            kind: TIMELINE_KIND_ACTIVITY.into(),
+            id: "a-1".into(),
+            actor_type: Some("system".into()),
+            created_at: 101,
+            action: Some("status_changed".into()),
+            details: Some(serde_json::json!({"from": "open", "to": "done"})),
+            ..Default::default()
+        };
+        let s = serde_json::to_string(&activity).unwrap();
+        assert!(!s.contains("\"body\""), "{s}");
+        assert!(!s.contains("\"actor_id\""), "{s}");
+        assert_eq!(
+            serde_json::from_str::<TimelineEntryRow>(&s).unwrap(),
+            activity
+        );
+
+        // A minimal legacy frame decodes with every optional field defaulted.
+        let bare: TimelineEntryRow =
+            serde_json::from_str(r#"{"kind":"activity","id":"x","created_at":1}"#).unwrap();
+        assert_eq!(bare.action, None);
+        assert_eq!(bare.body, None);
+
+        // An empty result decodes from an absent `entries` key.
+        let empty: IssueTimelineResult = serde_json::from_str("{}").unwrap();
+        assert!(empty.entries.is_empty());
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0059_activity_log.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0059_activity_log.sql
@@ -1,0 +1,67 @@
+-- Hangar v1 schema, migration 0059: GENERIC ACTIVITY LOG (multica parity #13).
+--
+-- multica's `activity_log` (001_init.up.sql:156) is the per-issue NARRATIVE:
+-- every state change, re-assignment, priority/title/due-date edit and task
+-- outcome, attributed to a polymorphic actor. hangar had three narrower logs
+-- (`run_history` = execution cost, `dispatch_attempt` = admission decisions,
+-- `event_log` = the replay outbox) and no per-issue story at all.
+--
+-- FIVE DELIBERATE SCHEMA DECISIONS:
+--
+-- 1. NO CHECK ON `action` (nor on `actor_type`). Same rule 0058 established:
+--    SQLite cannot widen a CHECK without a full table rebuild, and this
+--    vocabulary is append-only by design. The domain lives in Rust
+--    (`ainb_hangar_core::activity::ActivityAction`), whose parse is TOLERANT --
+--    an unknown token written by a newer daemon decodes to None and renders as
+--    raw text rather than poisoning the read path.
+--
+-- 2. `actor_type` ADMITS 'system'. hangar's `ActorKind` is member|agent only,
+--    and widening it would ripple into the CHECK constraints on issue, comment
+--    and agent_task_queue. Instead this column is TEXT and the Rust writer uses
+--    `ActivityActor::{Actor(ActorRef), System}`; a system row stores
+--    actor_type='system', actor_id=NULL. This matches multica, whose own CHECK
+--    admits 'system'.
+--
+-- 3. FK ONLY ON `workspace_id`. `issue_id` and `actor_id` carry no FK: the row
+--    is a historical FACT that must survive the death of what it describes, and
+--    a best-effort recorder must never fail on a race with a concurrent delete.
+--    `IssueRepo::delete_cascade` is what reaps rows for a deleted issue,
+--    matching how `dispatch_attempt` and `agent_task_queue` are handled.
+--
+-- 4. `details` IS JSON TEXT, NOT JSONB. SQLite has no JSONB type; the column
+--    holds the serialised `serde_json::Value` object and defaults to '{}'. No
+--    `json_valid` CHECK -- the only writer is `serde_json::to_string` on a
+--    `Value::Object`, and a CHECK would be a rebuild-blocker for no gain.
+--
+-- 5. NOT TRIMMED. Unlike `dispatch_attempt` (0058, bounded to 20/issue) this log
+--    is the narrative and must stay complete -- trimming would silently erase the
+--    beginning of an issue's story. Growth is bounded in practice by the issue
+--    count (a handful of rows per issue lifecycle) and reaped by the issue
+--    delete cascade. If unbounded growth ever bites, the fix is a workspace-level
+--    retention sweep, not a per-issue trim.
+--
+-- SCOPED OUT: the Beads bridge (`daemon/src/beads_sync/`) also writes issue
+-- state. It is an external MIRROR reconcile that can rewrite state in bulk;
+-- instrumenting it would flood the narrative with mirror noise, so it is
+-- deliberately not recorded.
+--
+-- `created_at` is epoch MILLISECONDS (`HangarClock::now_ms`), matching every
+-- other hangar timestamp column.
+
+CREATE TABLE activity_log (
+    id            TEXT PRIMARY KEY,                 -- ULID
+    workspace_id  TEXT NOT NULL REFERENCES workspace(id),
+    issue_id      TEXT,                             -- NULL for a future issue-less activity
+    actor_type    TEXT,                             -- 'member' | 'agent' | 'system'
+    actor_id      TEXT,                             -- NULL iff actor_type = 'system'
+    action        TEXT NOT NULL,                    -- ActivityAction::as_db_str()
+    details       TEXT NOT NULL DEFAULT '{}',       -- serialised JSON object
+    created_at    INTEGER NOT NULL                  -- epoch millis
+);
+
+-- The per-issue timeline read (multica 068's keyset shape). ULIDs are monotonic
+-- within a millisecond so `id` is a deterministic tiebreaker.
+CREATE INDEX idx_activity_log_issue ON activity_log(issue_id, created_at DESC, id DESC);
+
+-- The workspace-scoped feed (future "what happened today" surface).
+CREATE INDEX idx_activity_log_ws    ON activity_log(workspace_id, created_at DESC);

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/activity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/activity.rs
@@ -1,0 +1,241 @@
+//! Typed repository over the `activity_log` table (multica parity #13,
+//! migration 0059).
+//!
+//! One row per **narrative fact** about an issue: it was created, its state
+//! moved, it was re-assigned, its priority/title/due-date was edited, a task on
+//! it completed or failed. Attributed to a polymorphic
+//! [`ActivityActor`] (`member` / `agent` / `system`).
+//!
+//! # Best-effort by contract
+//!
+//! An audit write must NEVER fail the mutation it describes (multica's
+//! `slog.Error`-and-return listener contract). Every call site wraps
+//! [`ActivityRepo::record`] in `if let Err(e) = … { tracing::warn!(…) }`; the
+//! repo itself still returns the error so tests can assert on it.
+//!
+//! # Not trimmed
+//!
+//! Unlike `dispatch_attempt` (0058, bounded to 20 rows per issue), this log is
+//! the complete story and is only reaped by
+//! [`crate::repo::issue::IssueRepo::delete_cascade`].
+//!
+//! # Lenient reads
+//!
+//! [`Activity::action`] and [`Activity::actor_type`] are kept as raw strings and
+//! decoded on demand ([`Activity::code`] / [`Activity::actor`]): a token written
+//! by a newer daemon decodes to `None` and is rendered raw rather than failing
+//! the read. [`Activity::details`] is likewise raw JSON text, decoded by
+//! [`Activity::details_json`].
+
+use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
+
+/// An activity row to record.
+#[derive(Debug, Clone)]
+pub struct NewActivity<'a> {
+    /// Owning tenant. The one FK on the table.
+    pub workspace_id: &'a str,
+    /// The card the fact is about; `None` for a future issue-less activity.
+    pub issue_id: Option<&'a str>,
+    /// Who did it.
+    pub actor: &'a ActivityActor,
+    /// What happened.
+    pub action: ActivityAction,
+    /// The free-form details object. Must be a JSON **object**; `{}` when there
+    /// is nothing to say.
+    pub details: serde_json::Value,
+    /// Epoch millis.
+    pub created_at: i64,
+}
+
+/// A read-back `activity_log` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Activity {
+    /// ULID primary key.
+    pub id: String,
+    /// Owning tenant.
+    pub workspace_id: String,
+    /// The card the fact is about.
+    pub issue_id: Option<String>,
+    /// The raw stored actor kind (`member` / `agent` / `system`).
+    pub actor_type: Option<String>,
+    /// The raw stored actor id; `NULL` for a system row.
+    pub actor_id: Option<String>,
+    /// The raw stored action token; decode with [`Self::code`].
+    pub action: String,
+    /// The raw stored details JSON text; decode with [`Self::details_json`].
+    pub details: String,
+    /// Epoch millis.
+    pub created_at: i64,
+}
+
+impl Activity {
+    /// Decode [`Self::action`] into the typed vocabulary. `None` for a token
+    /// this binary does not know (render the raw string in that case).
+    #[must_use]
+    pub fn code(&self) -> Option<ActivityAction> {
+        ActivityAction::parse(&self.action)
+    }
+
+    /// Decode the `(actor_type, actor_id)` pair. `None` for a malformed or
+    /// unknown pair.
+    #[must_use]
+    pub fn actor(&self) -> Option<ActivityActor> {
+        ActivityActor::parse(self.actor_type.as_deref()?, self.actor_id.as_deref())
+    }
+
+    /// Decode [`Self::details`]. Unparseable text yields an empty object rather
+    /// than an error — a details blob is decoration, never load-bearing.
+    #[must_use]
+    pub fn details_json(&self) -> serde_json::Value {
+        serde_json::from_str(&self.details)
+            .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()))
+    }
+
+    fn from_row(row: &sqlx::sqlite::SqliteRow) -> Self {
+        Self {
+            id: row.get("id"),
+            workspace_id: row.get("workspace_id"),
+            issue_id: row.get("issue_id"),
+            actor_type: row.get("actor_type"),
+            actor_id: row.get("actor_id"),
+            action: row.get("action"),
+            details: row.get("details"),
+            created_at: row.get("created_at"),
+        }
+    }
+}
+
+const SELECT_COLS: &str =
+    "id, workspace_id, issue_id, actor_type, actor_id, action, details, created_at";
+
+/// Stateless repo over `activity_log`.
+pub struct ActivityRepo;
+
+impl ActivityRepo {
+    /// Insert one activity row.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault (for example a `workspace_id`
+    /// FK violation). Callers log and continue — see the module docs.
+    pub async fn record(
+        pool: &SqlitePool,
+        id: &str,
+        new: &NewActivity<'_>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(INSERT_SQL)
+            .bind(id)
+            .bind(new.workspace_id)
+            .bind(new.issue_id)
+            .bind(new.actor.type_str())
+            .bind(new.actor.id())
+            .bind(new.action.as_db_str())
+            .bind(details_text(&new.details))
+            .bind(new.created_at)
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Insert one activity row inside an open transaction (so a mutation and
+    /// its audit row commit together when the caller wants that).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn record_in_tx(
+        tx: &mut Transaction<'_, Sqlite>,
+        id: &str,
+        new: &NewActivity<'_>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(INSERT_SQL)
+            .bind(id)
+            .bind(new.workspace_id)
+            .bind(new.issue_id)
+            .bind(new.actor.type_str())
+            .bind(new.actor.id())
+            .bind(new.action.as_db_str())
+            .bind(details_text(&new.details))
+            .bind(new.created_at)
+            .execute(&mut **tx)
+            .await?;
+        Ok(())
+    }
+
+    /// A card's activity history, **newest first**.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn list_for_issue(
+        pool: &SqlitePool,
+        issue_id: &str,
+        limit: i64,
+    ) -> Result<Vec<Activity>, sqlx::Error> {
+        let rows = sqlx::query(&format!(
+            "SELECT {SELECT_COLS} FROM activity_log \
+             WHERE issue_id = ? ORDER BY created_at DESC, id DESC LIMIT ?"
+        ))
+        .bind(issue_id)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.iter().map(Activity::from_row).collect())
+    }
+
+    /// The workspace-scoped feed, newest first. Never returns a sibling
+    /// tenant's rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn list_by_workspace(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        limit: i64,
+    ) -> Result<Vec<Activity>, sqlx::Error> {
+        let rows = sqlx::query(&format!(
+            "SELECT {SELECT_COLS} FROM activity_log \
+             WHERE workspace_id = ? ORDER BY created_at DESC, id DESC LIMIT ?"
+        ))
+        .bind(workspace_id)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.iter().map(Activity::from_row).collect())
+    }
+
+    /// Reap a deleted card's activity rows. Called from
+    /// [`crate::repo::issue::IssueRepo::delete_cascade`]'s explicit cascade (the
+    /// table carries no FK on `issue_id` on purpose — see the migration).
+    /// Returns how many rows fell.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn delete_for_issue(
+        tx: &mut Transaction<'_, Sqlite>,
+        issue_id: &str,
+    ) -> Result<u64, sqlx::Error> {
+        let res = sqlx::query("DELETE FROM activity_log WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut **tx)
+            .await?;
+        Ok(res.rows_affected())
+    }
+}
+
+const INSERT_SQL: &str = "INSERT INTO activity_log \
+     (id, workspace_id, issue_id, actor_type, actor_id, action, details, created_at) \
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+
+/// Serialise a details value, falling back to `{}` for anything that is not a
+/// JSON object (the column's documented contract).
+fn details_text(v: &serde_json::Value) -> String {
+    if v.is_object() {
+        v.to_string()
+    } else {
+        "{}".to_string()
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -177,6 +177,9 @@ pub struct IssueDeleteSummary {
     pub tasks: i64,
     /// Board placements (cards) referencing the issue.
     pub placements: i64,
+    /// Activity-log rows recording the issue's narrative (migration 0059). The
+    /// table carries no FK on `issue_id`, so the cascade reaps these explicitly.
+    pub activities: i64,
 }
 
 /// A dry-run preview of an issue delete: the human title, the dependent counts,
@@ -254,10 +257,16 @@ async fn count_dependents(
         .bind(issue_id)
         .fetch_one(&mut *conn)
         .await?;
+    let activities: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM activity_log WHERE issue_id = ?")
+            .bind(issue_id)
+            .fetch_one(&mut *conn)
+            .await?;
     Ok(IssueDeleteSummary {
         comments,
         tasks,
         placements,
+        activities,
     })
 }
 
@@ -887,6 +896,11 @@ impl IssueRepo {
         //     same shape as the `agent_task_queue` delete above.
         crate::repo::dispatch_attempt::DispatchAttemptRepo::delete_for_issue(&mut tx, issue_id)
             .await?;
+
+        // 4c. The card's activity-log narrative (migration 0059). Same shape and
+        //     same rationale as 4b: no FK on `issue_id` by design, so the reap is
+        //     explicit. The narrative is scoped to the card, so it dies with it.
+        crate::repo::activity::ActivityRepo::delete_for_issue(&mut tx, issue_id).await?;
 
         // 5. The issue's directly-linked rows. First orphan any sub-issues: the
         //    `parent_issue_id` self-FK is `ON DELETE SET NULL` (migration 0046),

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
@@ -5,6 +5,7 @@
 //! [`crate::Store::pool`]) rather than owning a connection, so a single pool is
 //! shared across every repo call.
 
+pub mod activity;
 pub mod agent;
 pub mod agent_invocation_target;
 pub mod agent_runtime;

--- a/ainb-tui/crates/ainb-hangar-store/src/service/activity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/activity.rs
@@ -1,0 +1,168 @@
+//! The issue-activity DIFF engine (multica parity #13).
+//!
+//! hangar has TWO independent issue-update writers — the daemon's
+//! `handle_issue_update` and the CLI's `run_issue_update` — and multica's
+//! "one row per CHANGED FIELD" semantics must be identical on both. That
+//! decision lives here, once, so the two cannot drift.
+//!
+//! # Best-effort, always
+//!
+//! Every method here swallows store faults after logging them: an audit write
+//! must NEVER fail the mutation it describes (multica's listeners
+//! `slog.Error`-and-return). [`ActivityService::record_issue_diff`] returns how
+//! many rows it managed to write and keeps going after a per-row failure.
+//!
+//! # Field order
+//!
+//! A multi-field edit writes its rows in a STABLE order —
+//! `state → assignee → priority → title → due_date` — so a timeline rendered
+//! from a single update call reads deterministically.
+//!
+//! # multica DEVIATIONS (deliberate)
+//!
+//! * `priority_changed` details carry NUMBERS (`{"from":1,"to":3}`). hangar's
+//!   priority is an `i64` `0..3`; multica's is a string enum. Rendering the
+//!   number is the honest hangar shape.
+//! * `due_date_changed` details carry epoch-millis numbers or a typed `null`,
+//!   where multica writes `""` for an absent side.
+//! * `task_completed` / `task_failed` details carry `{"task_id":"…"}`, additive
+//!   over multica's `{}` — `details` is free-form, so this is append-only.
+//! * There is no `description_updated`: hangar's `IssueFieldUpdate` has no
+//!   description field, so no description-edit path exists to instrument.
+//! * hangar has no request-auth context, so an owner-driven edit is attributed
+//!   to the single bootstrapped default member (or `system` when none resolves).
+//!   When per-request actor identity lands, the CALLERS' actor helpers change —
+//!   nothing here does.
+
+use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
+use ainb_hangar_core::clock::HangarClock;
+use ainb_hangar_core::idgen::IdGen;
+use serde_json::{Value, json};
+use sqlx::SqlitePool;
+
+use crate::repo::activity::{ActivityRepo, NewActivity};
+use crate::repo::issue::Issue;
+
+/// Stateless diff + record helpers over `activity_log`.
+pub struct ActivityService;
+
+impl ActivityService {
+    /// Diff `before` vs `after` and record one activity row per CHANGED field.
+    ///
+    /// Returns how many rows were written (`0` for a no-op edit). Best-effort:
+    /// a per-row store fault is logged and the remaining fields are still
+    /// attempted.
+    pub async fn record_issue_diff(
+        pool: &SqlitePool,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+        workspace_id: &str,
+        actor: &ActivityActor,
+        before: &Issue,
+        after: &Issue,
+    ) -> usize {
+        let mut written = 0usize;
+        for (action, details) in issue_diff(before, after) {
+            if Self::record(
+                pool,
+                idgen,
+                clock,
+                workspace_id,
+                &after.id,
+                actor,
+                action,
+                details,
+            )
+            .await
+            {
+                written += 1;
+            }
+        }
+        written
+    }
+
+    /// Record one activity row. Returns `false` (after logging) when the write
+    /// failed — the caller carries on regardless.
+    pub async fn record(
+        pool: &SqlitePool,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+        workspace_id: &str,
+        issue_id: &str,
+        actor: &ActivityActor,
+        action: ActivityAction,
+        details: Value,
+    ) -> bool {
+        let new = NewActivity {
+            workspace_id,
+            issue_id: Some(issue_id),
+            actor,
+            action,
+            details,
+            created_at: clock.now_ms(),
+        };
+        match ActivityRepo::record(pool, &idgen.new_ulid(), &new).await {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(
+                    issue_id,
+                    action = action.as_db_str(),
+                    error = %e,
+                    "failed to record issue activity (mutation itself is unaffected)"
+                );
+                false
+            }
+        }
+    }
+}
+
+/// The pure diff: the ordered `(action, details)` pairs for what changed between
+/// two full issue rows. Exposed for tests and for any future caller that wants
+/// the decision without the write.
+#[must_use]
+pub fn issue_diff(before: &Issue, after: &Issue) -> Vec<(ActivityAction, Value)> {
+    let mut out = Vec::new();
+
+    if before.state != after.state {
+        out.push((
+            ActivityAction::StatusChanged,
+            json!({ "from": before.state, "to": after.state }),
+        ));
+    }
+
+    if before.assignee != after.assignee {
+        let mut d = serde_json::Map::new();
+        if let Some(a) = &before.assignee {
+            d.insert("from_type".into(), json!(a.kind().as_str()));
+            d.insert("from_id".into(), json!(a.id()));
+        }
+        if let Some(a) = &after.assignee {
+            d.insert("to_type".into(), json!(a.kind().as_str()));
+            d.insert("to_id".into(), json!(a.id()));
+        }
+        out.push((ActivityAction::AssigneeChanged, Value::Object(d)));
+    }
+
+    if before.priority != after.priority {
+        out.push((
+            ActivityAction::PriorityChanged,
+            json!({ "from": before.priority, "to": after.priority }),
+        ));
+    }
+
+    if before.title != after.title {
+        out.push((
+            ActivityAction::TitleChanged,
+            json!({ "from": before.title, "to": after.title }),
+        ));
+    }
+
+    if before.due_date != after.due_date {
+        out.push((
+            ActivityAction::DueDateChanged,
+            json!({ "from": before.due_date, "to": after.due_date }),
+        ));
+    }
+
+    out
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/service/activity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/activity.rs
@@ -18,6 +18,15 @@
 //! `state → assignee → priority → title → due_date` — so a timeline rendered
 //! from a single update call reads deterministically.
 //!
+//! That order has to survive the READ, and the timeline sorts by
+//! `(created_at, id)`. A whole diff runs well inside one millisecond, and
+//! `ulid::Ulid::new()` is NOT monotonic within a millisecond (its low bits are
+//! random, not a counter), so a shared `created_at` would let the id tiebreak
+//! shuffle the fields arbitrarily. [`ActivityService::record_issue_diff`]
+//! therefore reads the clock ONCE and stamps row `i` at `base + i` ms: the
+//! written order is the read order, deterministically, at the cost of a few
+//! milliseconds of skew on a multi-field edit.
+//!
 //! # multica DEVIATIONS (deliberate)
 //!
 //! * `priority_changed` details carry NUMBERS (`{"from":1,"to":3}`). hangar's
@@ -52,6 +61,7 @@ impl ActivityService {
     /// Returns how many rows were written (`0` for a no-op edit). Best-effort:
     /// a per-row store fault is logged and the remaining fields are still
     /// attempted.
+    #[allow(clippy::too_many_arguments)]
     pub async fn record_issue_diff(
         pool: &SqlitePool,
         idgen: &dyn IdGen,
@@ -61,17 +71,21 @@ impl ActivityService {
         before: &Issue,
         after: &Issue,
     ) -> usize {
+        let base = clock.now_ms();
         let mut written = 0usize;
-        for (action, details) in issue_diff(before, after) {
-            if Self::record(
+        for (i, (action, details)) in issue_diff(before, after).into_iter().enumerate() {
+            // `base + i` ms: see the module docs — a shared timestamp would let
+            // the non-monotonic ULID tiebreak shuffle the field order on read.
+            let at = base.saturating_add(i64::try_from(i).unwrap_or(0));
+            if Self::record_at(
                 pool,
                 idgen,
-                clock,
                 workspace_id,
                 &after.id,
                 actor,
                 action,
                 details,
+                at,
             )
             .await
             {
@@ -83,6 +97,7 @@ impl ActivityService {
 
     /// Record one activity row. Returns `false` (after logging) when the write
     /// failed — the caller carries on regardless.
+    #[allow(clippy::too_many_arguments)]
     pub async fn record(
         pool: &SqlitePool,
         idgen: &dyn IdGen,
@@ -93,13 +108,39 @@ impl ActivityService {
         action: ActivityAction,
         details: Value,
     ) -> bool {
+        Self::record_at(
+            pool,
+            idgen,
+            workspace_id,
+            issue_id,
+            actor,
+            action,
+            details,
+            clock.now_ms(),
+        )
+        .await
+    }
+
+    /// [`Self::record`] with an explicit `created_at`, so a diff can stamp its
+    /// rows at increasing timestamps inside one clock read.
+    #[allow(clippy::too_many_arguments)]
+    async fn record_at(
+        pool: &SqlitePool,
+        idgen: &dyn IdGen,
+        workspace_id: &str,
+        issue_id: &str,
+        actor: &ActivityActor,
+        action: ActivityAction,
+        details: Value,
+        created_at: i64,
+    ) -> bool {
         let new = NewActivity {
             workspace_id,
             issue_id: Some(issue_id),
             actor,
             action,
             details,
-            created_at: clock.now_ms(),
+            created_at,
         };
         match ActivityRepo::record(pool, &idgen.new_ulid(), &new).await {
             Ok(()) => true,

--- a/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
@@ -14,6 +14,11 @@
 //! [`finalize`] idempotent-transition primitive; P1.5 adds [`retry`], which
 //! spawns a `parent_task_id`-chained child row when a failed task is eligible.
 
+/// The issue-ACTIVITY diff engine (multica parity #13): one `activity_log` row
+/// per changed field, shared by the daemon and CLI issue-update writers so the
+/// two cannot drift on what counts as a change.
+pub mod activity;
+
 pub mod claim;
 
 /// The shared idempotent-finalize primitive.

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0059_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0059_upgrade.rs
@@ -1,0 +1,220 @@
+//! Upgrade-from-populated test for migration 0059 (`activity_log` — multica
+//! parity #13).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the migration is safe on a REAL populated database:
+//!
+//! 1. apply only the PRIOR migrations (0001..0058),
+//! 2. seed a workspace / user / issue / comment graph,
+//! 3. apply the embedded migrations (which adds 0059),
+//! 4. assert the pre-existing rows survived, the table + both indexes exist, a
+//!    record-and-read round-trips, `details` defaults to `{}`, the FK on
+//!    `workspace_id` is enforced while `issue_id` deliberately is NOT, and the
+//!    un-CHECKed `action` / `actor_type` columns accept tokens this binary does
+//!    not know (the append-only vocabulary contract).
+
+use ainb_hangar_store::apply_migrations;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test (`0059_activity_log.sql`).
+const NEW_MIGRATION_VERSION: i64 = 59;
+
+/// Open a fresh on-disk WAL pool in `dir` and apply only the migrations PRIOR to
+/// [`NEW_MIGRATION_VERSION`], with foreign keys ON (the crate's production
+/// setting).
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let db_path = dir.join("hangar.db");
+    let opts = SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(opts)
+        .await
+        .expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator
+        .migrations
+        .to_mut()
+        .retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(
+        !migrator.migrations.is_empty(),
+        "prior-migration set must not be empty"
+    );
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+async fn seed_populated(pool: &SqlitePool) {
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-1','a@example.com',0)",
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('iss-1','ws-1','Card','open','member','user-1',0)",
+        "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+         VALUES ('cmt-1','iss-1','member','user-1','hello',10)",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+async fn table_exists(pool: &SqlitePool, name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("sqlite_master")
+        > 0
+}
+
+#[tokio::test]
+async fn upgrades_populated_db_and_creates_the_activity_table() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+
+    // Pre-condition: the table genuinely does not exist yet.
+    assert!(
+        !table_exists(&pool, "activity_log").await,
+        "activity_log must not predate 0059"
+    );
+    seed_populated(&pool).await;
+
+    apply_migrations(&pool).await.expect("0059 applies");
+
+    assert!(table_exists(&pool, "activity_log").await);
+
+    // The pre-existing graph survived untouched.
+    let issues: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue")
+        .fetch_one(&pool)
+        .await
+        .expect("count issues");
+    assert_eq!(issues, 1);
+    let comments: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM comment")
+        .fetch_one(&pool)
+        .await
+        .expect("count comments");
+    assert_eq!(comments, 1);
+
+    // Both indexes from the migration exist.
+    let indexes: Vec<String> = sqlx::query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'activity_log' \
+         ORDER BY name",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("index list")
+    .iter()
+    .map(|r| r.get::<String, _>("name"))
+    .collect();
+    assert!(
+        indexes.iter().any(|n| n == "idx_activity_log_issue"),
+        "per-issue index missing: {indexes:?}"
+    );
+    assert!(
+        indexes.iter().any(|n| n == "idx_activity_log_ws"),
+        "per-workspace index missing: {indexes:?}"
+    );
+
+    // A record + read works on the upgraded database.
+    sqlx::query(
+        "INSERT INTO activity_log \
+         (id, workspace_id, issue_id, actor_type, actor_id, action, details, created_at) \
+         VALUES ('act-1','ws-1','iss-1','member','user-1','status_changed', \
+                 '{\"from\":\"open\",\"to\":\"in_progress\"}',200)",
+    )
+    .execute(&pool)
+    .await
+    .expect("record on upgraded db");
+    let row = sqlx::query(
+        "SELECT actor_type, actor_id, action, details FROM activity_log WHERE id = 'act-1'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read back");
+    assert_eq!(row.get::<String, _>("action"), "status_changed");
+    assert_eq!(
+        row.get::<Option<String>, _>("actor_type").as_deref(),
+        Some("member")
+    );
+    assert_eq!(
+        row.get::<String, _>("details"),
+        "{\"from\":\"open\",\"to\":\"in_progress\"}"
+    );
+
+    // `details` defaults to an empty object when omitted, and a system row
+    // stores a NULL actor_id.
+    sqlx::query(
+        "INSERT INTO activity_log (id, workspace_id, issue_id, actor_type, action, created_at) \
+         VALUES ('act-2','ws-1','iss-1','system','created',201)",
+    )
+    .execute(&pool)
+    .await
+    .expect("default details");
+    let row = sqlx::query("SELECT details, actor_id FROM activity_log WHERE id = 'act-2'")
+        .fetch_one(&pool)
+        .await
+        .expect("read defaults");
+    assert_eq!(row.get::<String, _>("details"), "{}");
+    assert_eq!(row.get::<Option<String>, _>("actor_id"), None);
+
+    assert!(
+        sqlx::query("PRAGMA foreign_key_check")
+            .fetch_all(&pool)
+            .await
+            .expect("fk check")
+            .is_empty(),
+        "no dangling foreign keys after the upgrade"
+    );
+}
+
+/// Migration decision 1: no CHECK on `action` / `actor_type`, so a future
+/// daemon's token persists. Decision 3: `workspace_id` is the ONLY foreign key,
+/// so an activity row survives the death of the issue / actor it describes.
+#[tokio::test]
+async fn vocabulary_is_open_and_only_workspace_is_a_foreign_key() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+    apply_migrations(&pool).await.expect("0059 applies");
+
+    // An unknown action + an unknown actor kind store fine (append-only
+    // vocabulary, enforced in Rust).
+    sqlx::query(
+        "INSERT INTO activity_log (id, workspace_id, issue_id, actor_type, action, created_at) \
+         VALUES ('act-future','ws-1','iss-1','robot','teleported_from_2027',1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("unknown action/actor accepted (no CHECK by design)");
+
+    // Ids that carry no FK: a row about entities that never existed is legal,
+    // which is what lets the narrative outlive what it describes.
+    sqlx::query(
+        "INSERT INTO activity_log \
+         (id, workspace_id, issue_id, actor_type, actor_id, action, created_at) \
+         VALUES ('act-ghost','ws-1','iss-gone','member','user-gone','created',2)",
+    )
+    .execute(&pool)
+    .await
+    .expect("no FK on issue/actor by design");
+
+    // …but the one FK that IS declared is enforced.
+    let bad_ws = sqlx::query(
+        "INSERT INTO activity_log (id, workspace_id, action, created_at) \
+         VALUES ('act-bad','ws-nope','created',3)",
+    )
+    .execute(&pool)
+    .await;
+    assert!(bad_ws.is_err(), "workspace_id FK must be enforced");
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0059_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0059_upgrade.rs
@@ -31,20 +31,14 @@ async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
         .create_if_missing(true)
         .foreign_keys(true)
         .journal_mode(SqliteJournalMode::Wal);
-    let pool = SqlitePoolOptions::new()
-        .connect_with(opts)
-        .await
-        .expect("open pool");
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
 
     let mut migrator = sqlx::migrate::Migrator::new(
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
     )
     .await
     .expect("load migrations directory");
-    migrator
-        .migrations
-        .to_mut()
-        .retain(|m| m.version < NEW_MIGRATION_VERSION);
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
     assert!(
         !migrator.migrations.is_empty(),
         "prior-migration set must not be empty"

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_activity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_activity.rs
@@ -1,0 +1,195 @@
+//! The `activity_log` narrative repo (multica parity #13, migration 0059).
+//!
+//! Pins the persistence half against real sqlite: record/read round-trip with
+//! the action decoding back through `ActivityAction::parse`, the newest-first
+//! ordering including the same-millisecond id tiebreak, tenant scoping on the
+//! workspace feed, the `system` actor's NULL id, and the tolerant read of a
+//! token this binary does not know.
+
+use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::activity::{ActivityRepo, NewActivity};
+
+/// Seed two workspaces so tenant scoping is assertable.
+async fn open() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-2','beta','Beta',0)",
+    ] {
+        sqlx::query(sql).execute(store.pool()).await.expect(sql);
+    }
+    (dir, store)
+}
+
+async fn record(
+    store: &Store,
+    id: &str,
+    workspace_id: &str,
+    issue_id: &str,
+    actor: &ActivityActor,
+    action: ActivityAction,
+    details: serde_json::Value,
+    created_at: i64,
+) {
+    ActivityRepo::record(
+        store.pool(),
+        id,
+        &NewActivity {
+            workspace_id,
+            issue_id: Some(issue_id),
+            actor,
+            action,
+            details,
+            created_at,
+        },
+    )
+    .await
+    .expect("record activity");
+}
+
+fn member(id: &str) -> ActivityActor {
+    ActivityActor::Actor(ActorRef::new(ActorKind::Member, id).expect("member"))
+}
+
+#[tokio::test]
+async fn records_and_reads_back_newest_first_with_id_tiebreak() {
+    let (_dir, store) = open().await;
+    let m = member("u1");
+
+    record(
+        &store,
+        "act-1",
+        "ws-1",
+        "iss-1",
+        &m,
+        ActivityAction::Created,
+        serde_json::json!({}),
+        100,
+    )
+    .await;
+    // Two rows in the SAME millisecond: the ULID-shaped id is the tiebreaker.
+    record(
+        &store,
+        "act-2",
+        "ws-1",
+        "iss-1",
+        &m,
+        ActivityAction::StatusChanged,
+        serde_json::json!({"from": "open", "to": "in_progress"}),
+        200,
+    )
+    .await;
+    record(
+        &store,
+        "act-3",
+        "ws-1",
+        "iss-1",
+        &m,
+        ActivityAction::PriorityChanged,
+        serde_json::json!({"from": 1, "to": 3}),
+        200,
+    )
+    .await;
+
+    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 50)
+        .await
+        .expect("list");
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, ["act-3", "act-2", "act-1"], "newest first, id tiebreak");
+
+    let status = &rows[1];
+    assert_eq!(status.code(), Some(ActivityAction::StatusChanged));
+    assert_eq!(
+        status.details_json(),
+        serde_json::json!({"from": "open", "to": "in_progress"})
+    );
+    assert_eq!(status.actor(), Some(member("u1")));
+}
+
+#[tokio::test]
+async fn workspace_feed_never_returns_a_sibling_tenants_rows() {
+    let (_dir, store) = open().await;
+    let m = member("u1");
+    record(
+        &store,
+        "act-mine",
+        "ws-1",
+        "iss-1",
+        &m,
+        ActivityAction::Created,
+        serde_json::json!({}),
+        1,
+    )
+    .await;
+    record(
+        &store,
+        "act-theirs",
+        "ws-2",
+        "iss-2",
+        &m,
+        ActivityAction::Created,
+        serde_json::json!({}),
+        2,
+    )
+    .await;
+
+    let mine = ActivityRepo::list_by_workspace(store.pool(), "ws-1", 50)
+        .await
+        .expect("list ws-1");
+    let ids: Vec<&str> = mine.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, ["act-mine"]);
+}
+
+#[tokio::test]
+async fn system_row_stores_no_actor_id() {
+    let (_dir, store) = open().await;
+    record(
+        &store,
+        "act-sys",
+        "ws-1",
+        "iss-1",
+        &ActivityActor::System,
+        ActivityAction::StatusChanged,
+        serde_json::json!({"from": "open", "to": "done", "via": "pr_merged"}),
+        5,
+    )
+    .await;
+
+    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 10)
+        .await
+        .expect("list");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].actor_type.as_deref(), Some("system"));
+    assert_eq!(rows[0].actor_id, None);
+    assert_eq!(rows[0].actor(), Some(ActivityActor::System));
+    assert_eq!(
+        rows[0].details_json().get("via").and_then(|v| v.as_str()),
+        Some("pr_merged")
+    );
+}
+
+/// The tolerant-read contract: a token written by a newer daemon reads back raw
+/// with `code() == None` instead of failing the read.
+#[tokio::test]
+async fn unknown_action_token_reads_back_raw() {
+    let (_dir, store) = open().await;
+    sqlx::query(
+        "INSERT INTO activity_log (id, workspace_id, issue_id, actor_type, action, created_at) \
+         VALUES ('act-future','ws-1','iss-1','system','teleported_from_2027',9)",
+    )
+    .execute(store.pool())
+    .await
+    .expect("raw insert");
+
+    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 10)
+        .await
+        .expect("list");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].action, "teleported_from_2027");
+    assert_eq!(rows[0].code(), None);
+    // …and the default details blob decodes to an empty object.
+    assert_eq!(rows[0].details_json(), serde_json::json!({}));
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_activity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_activity.rs
@@ -24,6 +24,7 @@ async fn open() -> (tempfile::TempDir, Store) {
     (dir, store)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn record(
     store: &Store,
     id: &str,

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_activity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_activity.rs
@@ -94,11 +94,13 @@ async fn records_and_reads_back_newest_first_with_id_tiebreak() {
     )
     .await;
 
-    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 50)
-        .await
-        .expect("list");
+    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 50).await.expect("list");
     let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
-    assert_eq!(ids, ["act-3", "act-2", "act-1"], "newest first, id tiebreak");
+    assert_eq!(
+        ids,
+        ["act-3", "act-2", "act-1"],
+        "newest first, id tiebreak"
+    );
 
     let status = &rows[1];
     assert_eq!(status.code(), Some(ActivityAction::StatusChanged));
@@ -158,9 +160,7 @@ async fn system_row_stores_no_actor_id() {
     )
     .await;
 
-    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 10)
-        .await
-        .expect("list");
+    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 10).await.expect("list");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].actor_type.as_deref(), Some("system"));
     assert_eq!(rows[0].actor_id, None);
@@ -184,9 +184,7 @@ async fn unknown_action_token_reads_back_raw() {
     .await
     .expect("raw insert");
 
-    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 10)
-        .await
-        .expect("list");
+    let rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 10).await.expect("list");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].action, "teleported_from_2027");
     assert_eq!(rows[0].code(), None);

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_delete.rs
@@ -220,6 +220,20 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
     .await
     .expect("dispatch attempts");
 
+    // Activity-log narrative rows (migration 0059). Same contract as the
+    // dispatch attempts above: no FK on `issue_id`, so the reap is an EXPLICIT
+    // cascade step. The sibling issue's row must survive.
+    sqlx::query(
+        "INSERT INTO activity_log \
+         (id, workspace_id, issue_id, actor_type, actor_id, action, details, created_at) \
+         VALUES ('al-1','ws-a','i-1','member','user-ws-a','created','{}',0), \
+                ('al-2','ws-a','i-1','system',NULL,'status_changed','{}',1), \
+                ('al-sibling','ws-a','i-2','system',NULL,'created','{}',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("activity rows");
+
     // Preview agrees with what the cascade is about to do.
     let preview = IssueRepo::delete_preview(pool, "ws-a", "i-1")
         .await
@@ -229,12 +243,14 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
     assert_eq!(preview.summary.comments, 2);
     assert_eq!(preview.summary.tasks, 2);
     assert_eq!(preview.summary.placements, 1);
+    assert_eq!(preview.summary.activities, 2);
     assert_eq!(preview.active_tasks, 0, "both tasks are terminal");
 
     let summary = IssueRepo::delete_cascade(pool, "ws-a", "i-1").await.expect("delete");
     assert_eq!(summary.comments, 2);
     assert_eq!(summary.tasks, 2);
     assert_eq!(summary.placements, 1);
+    assert_eq!(summary.activities, 2);
 
     // The issue and every dependent row are gone.
     assert!(IssueRepo::get_by_id(pool, "i-1").await.expect("get").is_none());
@@ -266,6 +282,10 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
         (
             "SELECT COUNT(*) FROM dispatch_attempt WHERE issue_id = ?",
             "dispatch attempts",
+        ),
+        (
+            "SELECT COUNT(*) FROM activity_log WHERE issue_id = ?",
+            "activity rows",
         ),
     ] {
         let n = if what == "dependency edges" {
@@ -319,6 +339,16 @@ async fn delete_cascade_removes_dependents_and_keeps_run_history() {
         .await,
         1,
         "the sibling issue's dispatch attempt survives"
+    );
+    assert_eq!(
+        count(
+            pool,
+            "SELECT COUNT(*) FROM activity_log WHERE issue_id = ?",
+            "i-2"
+        )
+        .await,
+        1,
+        "the sibling issue's activity row survives"
     );
     // Cost history survives, detached from the vanished task.
     let (runs, linked): (i64, i64) = (

--- a/ainb-tui/crates/ainb-hangar-store/tests/service_activity_diff.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/service_activity_diff.rs
@@ -118,13 +118,9 @@ async fn edit_and_diff(
     )
     .await;
 
-    let mut rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 100)
-        .await
-        .expect("list");
+    let mut rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 100).await.expect("list");
     rows.reverse(); // repo is newest-first; the timeline reads oldest-first
-    rows.into_iter()
-        .map(|r| (r.action.clone(), r.details_json()))
-        .collect()
+    rows.into_iter().map(|r| (r.action.clone(), r.details_json())).collect()
 }
 
 #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-store/tests/service_activity_diff.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/service_activity_diff.rs
@@ -1,0 +1,288 @@
+//! The issue-activity DIFF engine (multica parity #13).
+//!
+//! multica writes one `activity_log` row per CHANGED FIELD, not one per update
+//! call. These tests drive the real `IssueRepo::update_fields` → re-read →
+//! `ActivityService::record_issue_diff` path against sqlite and assert exactly
+//! which rows land, in which order, with which details — the contract both the
+//! daemon and the CLI issue-update writers share.
+
+use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::clock::HangarClock;
+use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::activity::ActivityRepo;
+use ainb_hangar_store::repo::issue::{Issue, IssueFieldUpdate, IssueRepo, NewIssue};
+use ainb_hangar_store::service::activity::ActivityService;
+
+/// A monotonic id source: `act-0000`, `act-0001`, … so ordering assertions are
+/// stable without depending on ULID entropy. The counter is process-global so a
+/// test that calls the helper twice cannot collide on the primary key (which,
+/// under the best-effort contract, would be swallowed rather than raised).
+static NEXT_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+struct SeqIds;
+impl IdGen for SeqIds {
+    fn new_ulid(&self) -> String {
+        let n = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        format!("act-{n:04}")
+    }
+}
+
+/// A clock that ticks one millisecond per read, so rows written inside a single
+/// diff call are still distinguishable by `created_at`.
+struct TickClock(std::sync::atomic::AtomicI64);
+impl HangarClock for TickClock {
+    fn now_ms(&self) -> i64 {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+fn member(id: &str) -> ActivityActor {
+    ActivityActor::Actor(ActorRef::new(ActorKind::Member, id).expect("member"))
+}
+
+async fn open() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','a','A',0)")
+        .execute(store.pool())
+        .await
+        .expect("workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u1','a@example.com',0)")
+        .execute(store.pool())
+        .await
+        .expect("user");
+    (dir, store)
+}
+
+async fn seed_issue(store: &Store) -> Issue {
+    IssueRepo::insert(
+        store.pool(),
+        &NewIssue {
+            id: "iss-1".into(),
+            workspace_id: "ws-1".into(),
+            title: "Wire the timeline".into(),
+            description: None,
+            state: "open".into(),
+            assignee: None,
+            creator: ActorRef::new(ActorKind::Member, "u1").unwrap(),
+            created_at: 1,
+            priority: 1,
+            due_date: None,
+            labels: vec![],
+            acceptance_criteria: vec![],
+            context_refs: vec![],
+            parent_issue_id: None,
+            stage: None,
+        },
+    )
+    .await
+    .expect("insert issue");
+    IssueRepo::get_by_id(store.pool(), "iss-1")
+        .await
+        .expect("get")
+        .expect("issue exists")
+}
+
+/// Apply an edit and record the diff, returning the `(action, details)` pairs
+/// that landed in `activity_log`, OLDEST FIRST.
+async fn edit_and_diff(
+    store: &Store,
+    update: &IssueFieldUpdate,
+) -> Vec<(String, serde_json::Value)> {
+    let ids = SeqIds;
+    let clock = TickClock(std::sync::atomic::AtomicI64::new(
+        NEXT_ID.load(std::sync::atomic::Ordering::SeqCst) as i64 * 100 + 1000,
+    ));
+    let before = IssueRepo::get_by_id(store.pool(), "iss-1")
+        .await
+        .expect("get before")
+        .expect("issue");
+    IssueRepo::update_fields(store.pool(), "ws-1", "iss-1", update)
+        .await
+        .expect("update");
+    let after = IssueRepo::get_by_id(store.pool(), "iss-1")
+        .await
+        .expect("get after")
+        .expect("issue");
+
+    ActivityService::record_issue_diff(
+        store.pool(),
+        &ids,
+        &clock,
+        "ws-1",
+        &member("u1"),
+        &before,
+        &after,
+    )
+    .await;
+
+    let mut rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 100)
+        .await
+        .expect("list");
+    rows.reverse(); // repo is newest-first; the timeline reads oldest-first
+    rows.into_iter()
+        .map(|r| (r.action.clone(), r.details_json()))
+        .collect()
+}
+
+#[tokio::test]
+async fn a_state_only_edit_writes_exactly_one_row() {
+    let (_dir, store) = open().await;
+    seed_issue(&store).await;
+
+    let rows = edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            state: Some("in_progress".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert_eq!(rows.len(), 1, "one changed field → one row: {rows:?}");
+    assert_eq!(rows[0].0, ActivityAction::StatusChanged.as_db_str());
+    assert_eq!(
+        rows[0].1,
+        serde_json::json!({"from": "open", "to": "in_progress"})
+    );
+}
+
+#[tokio::test]
+async fn a_three_field_edit_writes_three_rows_in_field_order() {
+    let (_dir, store) = open().await;
+    seed_issue(&store).await;
+
+    let rows = edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            state: Some("in_progress".into()),
+            assignee: Some(Some(ActorRef::new(ActorKind::Member, "u1").unwrap())),
+            priority: Some(3),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let actions: Vec<&str> = rows.iter().map(|(a, _)| a.as_str()).collect();
+    assert_eq!(
+        actions,
+        ["status_changed", "assignee_changed", "priority_changed"],
+        "stable field order: state → assignee → priority → title → due_date"
+    );
+    // hangar priority is numeric (multica's is a string enum) — DEVIATION.
+    assert_eq!(rows[2].1, serde_json::json!({"from": 1, "to": 3}));
+}
+
+#[tokio::test]
+async fn a_no_op_edit_writes_nothing() {
+    let (_dir, store) = open().await;
+    seed_issue(&store).await;
+
+    // Setting every field to the value it already holds.
+    let rows = edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            state: Some("open".into()),
+            title: Some("Wire the timeline".into()),
+            priority: Some(1),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert!(rows.is_empty(), "no field changed → no rows: {rows:?}");
+}
+
+#[tokio::test]
+async fn assignment_and_unassignment_omit_the_absent_side() {
+    let (_dir, store) = open().await;
+    seed_issue(&store).await;
+
+    // Unassigned → assigned: only the `to_*` keys are present.
+    let rows = edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            assignee: Some(Some(ActorRef::new(ActorKind::Agent, "agent-7").unwrap())),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "assignee_changed");
+    assert_eq!(
+        rows[0].1,
+        serde_json::json!({"to_type": "agent", "to_id": "agent-7"}),
+        "the nil FROM side is omitted entirely, not written as null"
+    );
+
+    // Assigned → unassigned: only the `from_*` keys are present.
+    let rows = edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            assignee: Some(None),
+            ..Default::default()
+        },
+    )
+    .await;
+    let unassign = rows.last().expect("an unassign row");
+    assert_eq!(unassign.0, "assignee_changed");
+    assert_eq!(
+        unassign.1,
+        serde_json::json!({"from_type": "agent", "from_id": "agent-7"})
+    );
+}
+
+#[tokio::test]
+async fn clearing_a_due_date_records_a_typed_null() {
+    let (_dir, store) = open().await;
+    seed_issue(&store).await;
+
+    edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            due_date: Some(Some(1_700_000_000_000)),
+            ..Default::default()
+        },
+    )
+    .await;
+    let rows = edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            due_date: Some(None),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let cleared = rows.last().expect("a due-date row");
+    assert_eq!(cleared.0, "due_date_changed");
+    assert_eq!(
+        cleared.1,
+        serde_json::json!({"from": 1_700_000_000_000i64, "to": serde_json::Value::Null}),
+        "hangar writes a typed null where multica writes an empty string"
+    );
+}
+
+#[tokio::test]
+async fn a_title_edit_records_both_sides() {
+    let (_dir, store) = open().await;
+    seed_issue(&store).await;
+
+    let rows = edit_and_diff(
+        &store,
+        &IssueFieldUpdate {
+            title: Some("Wire the timeline modal".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "title_changed");
+    assert_eq!(
+        rows[0].1,
+        serde_json::json!({"from": "Wire the timeline", "to": "Wire the timeline modal"})
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/service_activity_diff.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/service_activity_diff.rs
@@ -282,3 +282,66 @@ async fn a_title_edit_records_both_sides() {
         serde_json::json!({"from": "Wire the timeline", "to": "Wire the timeline modal"})
     );
 }
+
+/// REGRESSION: a whole diff runs inside one millisecond, and `ulid::Ulid::new()`
+/// is not monotonic within a millisecond — so a shared `created_at` let the
+/// timeline's `(created_at, id)` sort shuffle the fields arbitrarily. The
+/// service stamps row `i` at `base + i`, which is what makes the written field
+/// order the read order.
+#[tokio::test]
+async fn a_frozen_clock_still_preserves_field_order_on_read() {
+    struct FrozenClock;
+    impl HangarClock for FrozenClock {
+        fn now_ms(&self) -> i64 {
+            1_700_000_000_000
+        }
+    }
+
+    let (_dir, store) = open().await;
+    seed_issue(&store).await;
+
+    let before = IssueRepo::get_by_id(store.pool(), "iss-1")
+        .await
+        .expect("get before")
+        .expect("issue");
+    IssueRepo::update_fields(
+        store.pool(),
+        "ws-1",
+        "iss-1",
+        &IssueFieldUpdate {
+            state: Some("in_progress".into()),
+            priority: Some(3),
+            title: Some("Renamed".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("update");
+    let after = IssueRepo::get_by_id(store.pool(), "iss-1")
+        .await
+        .expect("get after")
+        .expect("issue");
+
+    // Random ULIDs, one frozen clock reading: only the per-row stamp can keep
+    // the order stable.
+    let written = ActivityService::record_issue_diff(
+        store.pool(),
+        &ainb_hangar_core::idgen::SystemIdGen,
+        &FrozenClock,
+        "ws-1",
+        &member("u1"),
+        &before,
+        &after,
+    )
+    .await;
+    assert_eq!(written, 3);
+
+    let mut rows = ActivityRepo::list_for_issue(store.pool(), "iss-1", 100).await.expect("list");
+    rows.reverse();
+    let actions: Vec<&str> = rows.iter().map(|r| r.action.as_str()).collect();
+    assert_eq!(
+        actions,
+        ["status_changed", "priority_changed", "title_changed"],
+        "field order must survive a same-millisecond write"
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -171,6 +171,7 @@ fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)> {
         Screen::IssueList => {
             vec![
                 ("a", "assign"),
+                ("y", "activity"),
                 ("c", "create"),
                 ("s", "sub-issue"),
                 ("d", "done"),
@@ -188,6 +189,7 @@ fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)> {
             ("t", "tick"),
         ],
         Screen::AgentPicker(_) => vec![("enter", "assign"), ("esc", "close")],
+        Screen::ActivityTimeline(_) => vec![("j/k", "scroll"), ("r", "refresh"), ("esc", "close")],
         Screen::SkillManager => vec![("i", "import"), ("/", "filter")],
         Screen::Autopilots => vec![("a", "add"), ("r", "run"), ("d", "disable"), ("e", "edit")],
         Screen::Kanban => vec![("←→", "focus"), ("⇧←→", "move"), ("R", "retry")],

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -263,6 +263,10 @@ const AGENT_SKILLS_LIST_REQ_ID: i64 = 62;
 /// #11-rest). Fired by the task-detail `t` key; the reply is an `IssueRow` and
 /// the daemon's `IssueUpdated` push re-renders the card.
 const ISSUE_CRITERION_SET_REQ_ID: i64 = 63;
+
+/// `hangar/issue_timeline` — the per-issue activity + comment narrative behind
+/// the `y` modal (multica parity #13).
+const ISSUE_TIMELINE_REQ_ID: i64 = 64;
 /// The actor-ref the plugin authors comments as (e38.5).
 ///
 /// The plugin has no per-user auth/identity layer yet (a later concern), so a
@@ -1030,6 +1034,7 @@ impl HangarPlugin {
             RpcId::Number(USAGE_ROLLUP_REQ_ID) => self.apply_usage(resp),
             RpcId::Number(RUN_HISTORY_REQ_ID) => self.apply_run_history(resp),
             RpcId::Number(PR_STATUS_REFRESH_REQ_ID) => self.apply_pr_status(resp),
+            RpcId::Number(ISSUE_TIMELINE_REQ_ID) => self.apply_issue_timeline(resp),
             RpcId::Number(MEMBERS_REQ_ID) => self.apply_members(resp),
             // tcp T5: the notification routing grid snapshot.
             RpcId::Number(NOTIFY_RULES_REQ_ID) => self.apply_notify_rules(resp),
@@ -3169,6 +3174,48 @@ impl HangarPlugin {
         }
     }
 
+    /// Fold a `hangar/issue_timeline` reply into the open activity modal
+    /// (multica parity #13).
+    ///
+    /// A no-op when the modal has since closed (a stale reply for a dismissed
+    /// overlay), and an error leaves the modal in its loading state rather than
+    /// showing a fabricated empty narrative.
+    fn apply_issue_timeline(&mut self, resp: &ainb_hangar_proto::RpcResponse) {
+        let Some(result) = resp.result.as_ref() else {
+            return;
+        };
+        let Ok(parsed) = serde_json::from_value::<ainb_hangar_proto::snapshots::IssueTimelineResult>(
+            result.clone(),
+        ) else {
+            return;
+        };
+        if let Some(activity) = self.screens.activity.as_mut() {
+            activity.apply_entries(parsed.entries);
+        }
+        self.conn.on_event();
+    }
+
+    /// Fire a deferred `hangar/issue_timeline` fetch for the open activity modal
+    /// (multica parity #13). A send failure is logged but non-fatal — the modal
+    /// keeps its loading state and `r` retries.
+    async fn fire_issue_timeline(&mut self, host: &HostClient, issue_id: String) {
+        let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
+            return;
+        };
+        let ws = self.app_state().ws_id.as_str().to_string();
+        let params = serde_json::json!({ "workspace_id": ws, "issue_id": issue_id });
+        let Ok(body) = encode_request(
+            ISSUE_TIMELINE_REQ_ID,
+            daemon_methods::HANGAR_ISSUE_TIMELINE,
+            params,
+        ) else {
+            return;
+        };
+        if let Err(e) = host.unix_socket_send(stream_id, body).await {
+            let _ = host.log_info(format!("hangar: issue timeline send failed: {e}")).await;
+        }
+    }
+
     /// Fire the deferred `hangar/pr_status_refresh` for the just-opened
     /// task-detail's issue (e38.34).
     ///
@@ -4686,6 +4733,24 @@ impl HangarPlugin {
                 let reduction = crate::screen::reduce(app, AppEvent::OpenAgentPicker(issue_id));
                 self.app = Some(reduction.state);
             }
+            // multica parity #13: open the card's activity timeline AND arm the
+            // fetch — the modal opens immediately in its loading state and the
+            // `render` pass fires `hangar/issue_timeline`.
+            NavIntent::OpenActivityTimeline(issue_id) => {
+                let title = self
+                    .screens
+                    .issue_list
+                    .visible_rows()
+                    .find(|r| r.id == issue_id)
+                    .map_or_else(|| issue_id.as_str().to_string(), |r| r.title.clone());
+                self.screens.activity = Some(crate::screen::activity::ActivityState::loading(
+                    &issue_id, title,
+                ));
+                self.screens.pending_activity_fetch = Some(issue_id.as_str().to_string());
+                let reduction =
+                    crate::screen::reduce(app, AppEvent::OpenActivityTimeline(issue_id));
+                self.app = Some(reduction.state);
+            }
             NavIntent::OpenTaskForIssue(issue_id) => {
                 // Open task detail bound to the issue's row + the running task.
                 let issue =
@@ -5171,6 +5236,12 @@ impl Plugin for HangarPlugin {
         // auto-moved to Done daemon-side (announced via `IssueUpdated`).
         if let Some(issue_id) = self.pending_pr_status_refresh.take() {
             self.fire_pr_status_refresh(host, issue_id).await;
+        }
+        // multica parity #13: drain a deferred activity-timeline fetch (armed by
+        // `y` opening the modal, or `r` inside it) and fire
+        // `hangar/issue_timeline`. The reply folds the merged narrative in.
+        if let Some(issue_id) = self.screens.pending_activity_fetch.take() {
+            self.fire_issue_timeline(host, issue_id).await;
         }
         // P8.6: the logs pane reads the daemon's structured-log file directly
         // (not a daemon RPC). Re-read on every render while it is the active

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/activity.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/activity.rs
@@ -1,0 +1,376 @@
+//! Per-issue ACTIVITY TIMELINE modal (multica parity #13).
+//!
+//! Opened with `y` on a selected issue-list row (or on the task-detail screen),
+//! the activity timeline is a modal overlay — the same shape as the agent picker
+//! — over whatever screen launched it. It shows the card's narrative: creation,
+//! state moves, re-assignments, priority/title/due-date edits, task outcomes,
+//! and the comments merged in by timestamp, oldest first.
+//!
+//! The rows come from the daemon's `hangar/issue_timeline` RPC
+//! ([`TimelineEntryRow`]); the plugin owns zero domain data — it caches the
+//! snapshot for render and nothing more.
+//!
+//! As with every Hangar screen the reducer ([`reduce_activity`]) is **pure**:
+//! `j`/`k` scroll, `r` asks the glue to re-fetch, Esc is handled by the router.
+
+use ainb_hangar_core::activity::ActivityAction;
+use ainb_hangar_core::ids::IssueId;
+use ainb_hangar_proto::snapshots::TimelineEntryRow;
+use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
+
+/// Cornflower-blue modal border (ainb-tui chrome accent).
+const BORDER: Color = Color::rgb(100, 149, 237);
+/// Gold modal title + hotkey letters in the bottom bar.
+const TITLE: Color = Color::rgb(255, 215, 0);
+/// Selected-row cursor + text.
+const SELECTION: Color = Color::rgb(100, 200, 100);
+/// Muted timestamps + help-bar descriptions.
+const MUTED: Color = Color::rgb(120, 120, 140);
+/// Body text.
+const TEXT: Color = Color::rgb(220, 220, 230);
+/// Opaque panel background painted across the whole modal rect (the host
+/// composites the plugin buffer as a SPARSE overlay, so unwritten cells would
+/// leak the screen underneath).
+const PANEL_BG: Color = Color::rgb(30, 30, 40);
+
+/// The render-state cache for the activity-timeline modal.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ActivityState {
+    issue_id: String,
+    issue_title: String,
+    entries: Vec<TimelineEntryRow>,
+    selected: usize,
+    loading: bool,
+}
+
+impl ActivityState {
+    /// A fresh, still-loading timeline for `issue_id`.
+    #[must_use]
+    pub fn loading(issue_id: &IssueId, issue_title: impl Into<String>) -> Self {
+        Self {
+            issue_id: issue_id.as_str().to_string(),
+            issue_title: issue_title.into(),
+            entries: Vec::new(),
+            selected: 0,
+            loading: true,
+        }
+    }
+
+    /// Fold in a fetched timeline, clamping the selection into the new list.
+    pub fn apply_entries(&mut self, entries: Vec<TimelineEntryRow>) {
+        self.entries = entries;
+        self.loading = false;
+        if self.selected >= self.entries.len() {
+            self.selected = self.entries.len().saturating_sub(1);
+        }
+    }
+
+    /// The issue the modal was opened for.
+    #[must_use]
+    pub fn issue_id(&self) -> &str {
+        &self.issue_id
+    }
+
+    /// The issue title rendered in the modal header.
+    #[must_use]
+    pub fn issue_title(&self) -> &str {
+        &self.issue_title
+    }
+
+    /// The cached entries, oldest first.
+    #[must_use]
+    pub fn entries(&self) -> &[TimelineEntryRow] {
+        &self.entries
+    }
+
+    /// The current selection index.
+    #[must_use]
+    pub const fn selected_index(&self) -> usize {
+        self.selected
+    }
+
+    /// Whether the first fetch is still in flight.
+    #[must_use]
+    pub const fn is_loading(&self) -> bool {
+        self.loading
+    }
+}
+
+/// An input the activity reducer folds into [`ActivityState`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityEvent {
+    /// A printable key (`'j'`, `'k'`, `'r'`, …).
+    Key(char),
+}
+
+/// A side-effect the plugin glue performs after an activity reduction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivityIntent {
+    /// Re-fetch the timeline for the issue (`r`).
+    Refresh {
+        /// The issue whose timeline to re-read.
+        issue_id: String,
+    },
+}
+
+/// The result of folding one [`ActivityEvent`] into an [`ActivityState`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityReduction {
+    /// The next state.
+    pub state: ActivityState,
+    /// A side-effect for the plugin glue, if any.
+    pub intent: Option<ActivityIntent>,
+}
+
+/// Fold one [`ActivityEvent`] into `state`. Pure: no IO, no input mutation.
+///
+/// Esc is deliberately NOT handled here — the router owns modal dismissal so
+/// every modal closes the same way.
+#[must_use]
+pub fn reduce_activity(state: &ActivityState, ev: ActivityEvent) -> ActivityReduction {
+    let ActivityEvent::Key(c) = ev;
+    match c {
+        'j' => {
+            let mut next = state.clone();
+            let max = next.entries.len().saturating_sub(1);
+            next.selected = (next.selected + 1).min(max);
+            ActivityReduction {
+                state: next,
+                intent: None,
+            }
+        }
+        'k' => {
+            let mut next = state.clone();
+            next.selected = next.selected.saturating_sub(1);
+            ActivityReduction {
+                state: next,
+                intent: None,
+            }
+        }
+        'r' => ActivityReduction {
+            state: state.clone(),
+            intent: Some(ActivityIntent::Refresh {
+                issue_id: state.issue_id.clone(),
+            }),
+        },
+        _ => ActivityReduction {
+            state: state.clone(),
+            intent: None,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Row formatting (shared with the tests, so the assertion is on real text)
+// ---------------------------------------------------------------------------
+
+/// `hh:mm` for an epoch-millis timestamp, UTC. Deliberately clock-free (pure
+/// integer math) so a render snapshot is deterministic.
+#[must_use]
+pub fn hhmm(ms: i64) -> String {
+    let secs = ms.div_euclid(1000).rem_euclid(86_400);
+    format!("{:02}:{:02}", secs / 3600, (secs % 3600) / 60)
+}
+
+/// The WHO column: `you` for a member, the agent id (or its resolved name) for
+/// an agent, `system` for a daemon-driven row.
+#[must_use]
+pub fn actor_label(e: &TimelineEntryRow, resolve_agent: &dyn Fn(&str) -> Option<String>) -> String {
+    match (e.actor_type.as_deref(), e.actor_id.as_deref()) {
+        (Some("member"), _) => "you".to_string(),
+        (Some("agent"), Some(id)) => resolve_agent(id).unwrap_or_else(|| id.to_string()),
+        (Some("system") | None, _) => "system".to_string(),
+        (Some(other), _) => other.to_string(),
+    }
+}
+
+/// The WHAT column: the action's human label, or `💬` for a comment. An action
+/// token this binary does not know renders RAW (the tolerant-read contract).
+#[must_use]
+pub fn action_label(e: &TimelineEntryRow) -> String {
+    e.action.as_deref().map_or_else(
+        || "💬".to_string(),
+        |raw| ActivityAction::parse(raw).map_or_else(|| raw.to_string(), |a| a.label().to_string()),
+    )
+}
+
+/// The DETAIL column: the comment body, or the change the details describe
+/// (`open → in_progress`).
+#[must_use]
+pub fn detail_label(e: &TimelineEntryRow) -> String {
+    if let Some(body) = e.body.as_deref() {
+        return body.replace('\n', " ");
+    }
+    let Some(details) = e.details.as_ref() else {
+        return String::new();
+    };
+
+    let render = |v: Option<&serde_json::Value>| -> String {
+        match v {
+            None | Some(serde_json::Value::Null) => "—".to_string(),
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+        }
+    };
+    if details.get("from_type").is_some() || details.get("to_type").is_some() {
+        let side = |t: &str, i: &str| match (details.get(t), details.get(i)) {
+            (Some(serde_json::Value::String(t)), Some(serde_json::Value::String(i))) => {
+                format!("{t}:{i}")
+            }
+            _ => "—".to_string(),
+        };
+        return format!(
+            "{} → {}",
+            side("from_type", "from_id"),
+            side("to_type", "to_id")
+        );
+    }
+    if details.get("from").is_some() || details.get("to").is_some() {
+        return format!(
+            "{} → {}",
+            render(details.get("from")),
+            render(details.get("to"))
+        );
+    }
+    String::new()
+}
+
+// ---------------------------------------------------------------------------
+// Width-aware modal render
+// ---------------------------------------------------------------------------
+
+/// Render the timeline as a centred modal over an `area_w` × `area_h` area.
+pub fn render_activity(buf: &mut WireBuffer, area_w: u16, area_h: u16, state: &ActivityState) {
+    let modal_w = (area_w * 8 / 10).clamp(40, area_w);
+    let modal_h = (area_h * 7 / 10).clamp(8, area_h);
+    let x0 = (area_w.saturating_sub(modal_w)) / 2;
+    let y0 = (area_h.saturating_sub(modal_h)) / 2;
+
+    fill_background(buf, x0, y0, modal_w, modal_h);
+    draw_border(buf, x0, y0, modal_w, modal_h);
+
+    let right = x0 + modal_w;
+    let title = format!(" 🕘 Activity · {} ", state.issue_title());
+    put_str(buf, x0 + 2, y0, &title, TITLE, right.saturating_sub(1));
+
+    let inner_x = x0 + 2;
+    let mut row = y0 + 1;
+    // The last interior row carries the help bar.
+    let bottom = y0 + modal_h - 2;
+
+    if state.is_loading() {
+        put_str(buf, inner_x, row, "loading…", MUTED, right - 1);
+    } else if state.entries().is_empty() {
+        put_str(buf, inner_x, row, "no activity yet", MUTED, right - 1);
+    } else {
+        for (i, e) in state.entries().iter().enumerate() {
+            if row >= bottom {
+                break;
+            }
+            let selected = i == state.selected_index();
+            let cursor = if selected { "▶ " } else { "  " };
+            put_str(
+                buf,
+                inner_x,
+                row,
+                cursor,
+                if selected { SELECTION } else { MUTED },
+                right - 1,
+            );
+            let mut cx = inner_x + 2;
+            cx = put_str(
+                buf,
+                cx,
+                row,
+                &format!("{}  ", hhmm(e.created_at)),
+                MUTED,
+                right - 1,
+            );
+            let who = actor_label(e, &|_| None);
+            cx = put_str(
+                buf,
+                cx,
+                row,
+                &format!("{who:<12} "),
+                if selected { SELECTION } else { TEXT },
+                right - 1,
+            );
+            cx = put_str(
+                buf,
+                cx,
+                row,
+                &format!("{:<10} ", action_label(e)),
+                TEXT,
+                right - 1,
+            );
+            put_str(buf, cx, row, &detail_label(e), TEXT, right - 1);
+            row += 1;
+        }
+    }
+
+    // Bottom help bar: gold keys + muted descriptions.
+    let bar = y0 + modal_h - 1;
+    let mut cx = inner_x;
+    for (key, desc) in [
+        ("j/k", " scroll   "),
+        ("r", " refresh   "),
+        ("esc", " back"),
+    ] {
+        cx = put_str(buf, cx, bar, key, TITLE, right - 1);
+        cx = put_str(buf, cx, bar, desc, MUTED, right - 1);
+    }
+}
+
+/// Fill every cell of the `w` × `h` rect at `(x0, y0)` with an opaque space.
+fn fill_background(buf: &mut WireBuffer, x0: u16, y0: u16, w: u16, h: u16) {
+    let x1 = x0 + w - 1;
+    let y1 = y0 + h - 1;
+    for y in y0..=y1 {
+        for x in x0..=x1 {
+            let mut cell = Cell::new(" ");
+            cell.bg = Some(PANEL_BG);
+            buf.push(Coord::new(x, y), cell);
+        }
+    }
+}
+
+/// Draw a rounded border rectangle of `w` × `h` at `(x0, y0)`.
+fn draw_border(buf: &mut WireBuffer, x0: u16, y0: u16, w: u16, h: u16) {
+    let x1 = x0 + w - 1;
+    let y1 = y0 + h - 1;
+    for x in x0..=x1 {
+        put_char(buf, x, y0, '─', BORDER);
+        put_char(buf, x, y1, '─', BORDER);
+    }
+    for y in y0..=y1 {
+        put_char(buf, x0, y, '│', BORDER);
+        put_char(buf, x1, y, '│', BORDER);
+    }
+    put_char(buf, x0, y0, '╭', BORDER);
+    put_char(buf, x1, y0, '╮', BORDER);
+    put_char(buf, x0, y1, '╰', BORDER);
+    put_char(buf, x1, y1, '╯', BORDER);
+}
+
+/// Write `s` at `(x, row)` in `color`, clipping at column `right`. Returns the
+/// column after the last written cell.
+fn put_str(buf: &mut WireBuffer, x: u16, row: u16, s: &str, color: Color, right: u16) -> u16 {
+    let mut cx = x;
+    for ch in s.chars() {
+        if cx >= right {
+            break;
+        }
+        let mut cell = Cell::new(ch.to_string());
+        cell.fg = Some(color);
+        buf.push(Coord::new(cx, row), cell);
+        cx = cx.saturating_add(1);
+    }
+    cx
+}
+
+/// Write one `ch` at `(x, row)` in `color`.
+fn put_char(buf: &mut WireBuffer, x: u16, row: u16, ch: char, color: Color) {
+    let mut cell = Cell::new(ch.to_string());
+    cell.fg = Some(color);
+    buf.push(Coord::new(x, row), cell);
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -633,6 +633,12 @@ pub struct ScreenStates {
     pub task_detail: Option<TaskDetailState>,
     /// Agent-picker modal cache (present only while the modal is open).
     pub agent_picker: Option<AgentPickerState>,
+    /// Activity-timeline modal cache (multica parity #13; present only while the
+    /// modal is open).
+    pub activity: Option<super::activity::ActivityState>,
+    /// An issue id whose `hangar/issue_timeline` fetch is armed, awaiting the
+    /// `render` pass to fire it over the daemon socket. `None` when idle.
+    pub pending_activity_fetch: Option<String>,
     /// Command-palette modal cache (present only while the palette is open,
     /// e38.13).
     pub command_palette: Option<CommandPaletteState>,
@@ -1247,6 +1253,9 @@ impl ScreenStates {
 pub enum NavIntent {
     /// Open the agent-picker modal for an issue (raised by `a`).
     OpenAgentPicker(ainb_hangar_core::ids::IssueId),
+    /// Open the activity-timeline modal for an issue (raised by `y`, multica
+    /// parity #13).
+    OpenActivityTimeline(ainb_hangar_core::ids::IssueId),
     /// Open task detail for the issue under the selection (raised by Enter).
     OpenTaskForIssue(ainb_hangar_core::ids::IssueId),
     /// 0046 sub-issues: mark an issue Done from the keyboard (`d`). The glue moves
@@ -1358,6 +1367,16 @@ pub fn render_body(buf: &mut WireBuffer, w: u16, h: u16, app: &AppState, states:
             }
             if let Some(picker) = &states.agent_picker {
                 super::agent_picker::render_agent_picker(buf, w, h, picker);
+            }
+        }
+        Screen::ActivityTimeline(_) => {
+            // The timeline is a modal: paint the screen it overlays first, then
+            // the modal centred over the whole area (multica parity #13).
+            if let Some(prior) = &app.prior_screen {
+                render_prior(buf, w, h, prior, states);
+            }
+            if let Some(activity) = &states.activity {
+                super::activity::render_activity(buf, w, h, activity);
             }
         }
         Screen::CommandPalette => {
@@ -1591,6 +1610,7 @@ pub fn route_key(app: &AppState, states: &mut ScreenStates, key: &KeyEvent) -> O
         }
         Screen::TaskDetail(_) => route_task_detail(states, key),
         Screen::AgentPicker(_) => route_agent_picker(states, key),
+        Screen::ActivityTimeline(_) => route_activity(states, key),
         Screen::CommandPalette => route_command_palette(states, key),
         Screen::Logs => {
             // The logs pane owns the level-filter chips (`a`/`i`/`w`/`e`). A
@@ -1773,6 +1793,10 @@ fn route_issue_list(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavInte
     states.issue_list = out.state;
     match out.intent {
         Some(IssueListIntent::OpenAgentPicker(id)) => Some(NavIntent::OpenAgentPicker(id)),
+        // multica parity #13: `y` opens the card's activity timeline.
+        Some(IssueListIntent::OpenActivityTimeline(id)) => {
+            Some(NavIntent::OpenActivityTimeline(id))
+        }
         Some(IssueListIntent::OpenTaskDetail(id)) => Some(NavIntent::OpenTaskForIssue(id)),
         // 0046: `d` marks the highlighted issue Done, surfaced as a NavIntent the
         // glue lifts into the SAME optimistic-move + `hangar/issue_update{state}`
@@ -2452,6 +2476,32 @@ fn route_agent_picker(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavIn
     } else {
         None
     }
+}
+
+/// Activity-timeline key routing (multica parity #13): fold the key into the
+/// pure reducer, then act on the reduction.
+///
+/// `j`/`k` scroll, `r` arms a re-fetch the `render` pass fires, Esc dismisses
+/// the modal back to the screen that opened it (the host reserves only Ctrl+C,
+/// so a modal MUST offer its own way out).
+fn route_activity(states: &mut ScreenStates, key: &KeyEvent) -> Option<NavIntent> {
+    use super::activity::{ActivityEvent, ActivityIntent, reduce_activity};
+
+    if matches!(key.code, KeyCode::Esc) {
+        states.activity = None;
+        return Some(NavIntent::CloseModal);
+    }
+    let state = states.activity.take()?;
+    let Some(c) = key_char(key) else {
+        states.activity = Some(state);
+        return None;
+    };
+    let out = reduce_activity(&state, ActivityEvent::Key(c));
+    if let Some(ActivityIntent::Refresh { issue_id }) = out.intent {
+        states.pending_activity_fetch = Some(issue_id);
+    }
+    states.activity = Some(out.state);
+    None
 }
 
 /// Command-palette key routing (e38.13): fold the key into the pure reducer, then

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -1780,6 +1780,10 @@ pub enum IssueListIntent {
     OpenTaskDetail(IssueId),
     /// Open the agent-picker modal for the issue under the selection.
     OpenAgentPicker(IssueId),
+    /// Open the activity-timeline modal for the issue under the selection
+    /// (raised by `y`, multica parity #13). `y` is free: the host reserves only
+    /// the uppercase tab keys plus `,` `?` and `1-4`.
+    OpenActivityTimeline(IssueId),
     /// Commit the create wizard (Phase 5): create the issue AND dispatch it.
     /// Raised ONLY by Enter on the wizard's final Agent stage — there is no path
     /// to this intent without an agent, so a title-only inert issue (assignee
@@ -1938,6 +1942,17 @@ fn reduce_normal_key(state: &IssueListState, c: char) -> IssueListReduction {
                 with_intent(
                     state.clone(),
                     IssueListIntent::OpenAgentPicker(row.id.clone()),
+                )
+            },
+        ),
+        // multica parity #13: the card's activity timeline. A no-op with no row
+        // selected — never a modal opened on nothing.
+        'y' => state.selected_row().map_or_else(
+            || unchanged(state),
+            |row| {
+                with_intent(
+                    state.clone(),
+                    IssueListIntent::OpenActivityTimeline(row.id.clone()),
                 )
             },
         ),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
@@ -13,6 +13,7 @@
 //! The shared chrome (top tab bar + footer) that wraps every screen lives in
 //! [`crate::chrome`]; this module owns only the routing state it renders from.
 
+pub mod activity;
 pub mod agent_picker;
 pub mod agents;
 pub mod app_screens;
@@ -61,6 +62,9 @@ pub enum Screen {
     TaskDetail(TaskId),
     /// Agent-picker modal overlay opened for a specific issue (hotkey `a`).
     AgentPicker(IssueId),
+    /// Activity-timeline modal overlay opened for a specific issue (hotkey `y`,
+    /// multica parity #13) — the card's merged activity + comment narrative.
+    ActivityTimeline(IssueId),
     /// Skill manager (hotkey `3`).
     SkillManager,
     /// Autopilot manager (hotkey `4`).
@@ -122,6 +126,7 @@ impl Screen {
             Self::IssueList => "Issues",
             Self::TaskDetail(_) => "Task",
             Self::AgentPicker(_) => "Agent",
+            Self::ActivityTimeline(_) => "Activity",
             Self::SkillManager => "Skills",
             Self::Autopilots => "Autopilots",
             Self::Kanban => "Kanban",
@@ -148,7 +153,7 @@ impl Screen {
     pub const fn is_modal(&self) -> bool {
         matches!(
             self,
-            Self::AgentPicker(_) | Self::Help | Self::CommandPalette
+            Self::AgentPicker(_) | Self::ActivityTimeline(_) | Self::Help | Self::CommandPalette
         )
     }
 }
@@ -220,6 +225,9 @@ pub enum AppEvent {
     /// Open the agent-picker modal for a specific issue (raised by `a` on a
     /// selected issue-list row; carries the issue id the row addresses).
     OpenAgentPicker(IssueId),
+    /// Open the activity-timeline modal for a specific issue (raised by `y` on a
+    /// selected issue-list row, multica parity #13).
+    OpenActivityTimeline(IssueId),
     /// Open the global command-palette modal (raised by `Ctrl+P` from any
     /// screen, e38.13). Carries no payload — the palette starts empty.
     OpenCommandPalette,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
@@ -81,6 +81,7 @@ pub fn reduce(state: &AppState, ev: AppEvent) -> Reduction {
         AppEvent::Key(c) => reduce_key(state, c),
         AppEvent::Esc => reduce_esc(state),
         AppEvent::OpenAgentPicker(issue) => open_modal(state, Screen::AgentPicker(issue)),
+        AppEvent::OpenActivityTimeline(issue) => open_modal(state, Screen::ActivityTimeline(issue)),
         AppEvent::OpenCommandPalette => open_modal(state, Screen::CommandPalette),
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/activity_timeline_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/activity_timeline_reducer_test.rs
@@ -1,0 +1,269 @@
+//! Activity-timeline modal reducer + render (multica parity #13).
+//!
+//! Pins the keyboard contract and the render text a user actually reads:
+//!
+//! * `y` on a selected issue-list row raises `OpenActivityTimeline(row.id)`;
+//!   `y` with NO selection is a no-op (never a modal opened on nothing).
+//! * `j`/`k` move the cursor, clamped at both ends.
+//! * `r` raises the refresh intent carrying the issue id.
+//! * Applying an `IssueTimelineResult` populates the entries in order.
+//! * The render shows the EXACT change text (`open → in_progress`), the comment
+//!   body, the `▶` cursor and the `j/k scroll  r refresh  esc back` bar.
+
+use ainb_hangar_core::ids::IssueId;
+use ainb_hangar_proto::snapshots::TimelineEntryRow;
+use ainb_plugin_hangar::screen::activity::{
+    ActivityEvent, ActivityIntent, ActivityState, reduce_activity, render_activity,
+};
+use ainb_plugin_hangar::screen::issue_list::{
+    IssueListEvent, IssueListIntent, IssueListState, reduce_issue_list,
+};
+use ainb_plugin_sdk::WireBuffer;
+
+fn issue_id(s: &str) -> IssueId {
+    IssueId::from_str(s).expect("valid id")
+}
+
+fn activity(id: &str, at: i64, action: &str, details: serde_json::Value) -> TimelineEntryRow {
+    TimelineEntryRow {
+        kind: "activity".into(),
+        id: id.into(),
+        actor_type: Some("member".into()),
+        actor_id: Some("u1".into()),
+        created_at: at,
+        action: Some(action.into()),
+        details: Some(details),
+        body: None,
+    }
+}
+
+fn comment(id: &str, at: i64, body: &str) -> TimelineEntryRow {
+    TimelineEntryRow {
+        kind: "comment".into(),
+        id: id.into(),
+        actor_type: Some("agent".into()),
+        actor_id: Some("claude".into()),
+        created_at: at,
+        action: None,
+        details: None,
+        body: Some(body.into()),
+    }
+}
+
+/// The seeded narrative used by both the reducer and render tests.
+fn seeded() -> ActivityState {
+    let mut state = ActivityState::loading(&issue_id("i1"), "Wire the timeline");
+    state.apply_entries(vec![
+        activity("a1", 36_840_000, "created", serde_json::json!({})),
+        activity(
+            "a2",
+            36_900_000,
+            "status_changed",
+            serde_json::json!({"from": "open", "to": "in_progress"}),
+        ),
+        comment("c1", 36_960_000, "picked this up, starting now"),
+    ]);
+    state
+}
+
+// ---------------------------------------------------------------------------
+// The `y` affordance on the issue list
+// ---------------------------------------------------------------------------
+
+/// One issue row with only the fields this test cares about set.
+fn row(id: &str) -> ainb_hangar_proto::events::IssueRow {
+    ainb_hangar_proto::events::IssueRow {
+        last_dispatch_reason: None,
+        last_dispatch_detail: None,
+        last_dispatch_at: None,
+        origin_type: None,
+        origin_id: None,
+        id: issue_id(id),
+        display_id: None,
+        workspace_id: "ws".to_string(),
+        title: "Wire the timeline".to_string(),
+        description: None,
+        state: "open".to_string(),
+        assignee: None,
+        creator: "member:u1".to_string(),
+        created_at: 0,
+        priority: 0,
+        due_date: None,
+        labels: Vec::new(),
+        pr_url: None,
+        branch: None,
+        repo_ref: None,
+        agent: None,
+        source_branch: None,
+        target_branch: None,
+        external_ref: None,
+        run_count: 0,
+        last_run_status: None,
+        last_run_at: None,
+        parent_id: None,
+        child_total: 0,
+        child_done: 0,
+        acceptance_criteria: Vec::new(),
+        acceptance: Vec::new(),
+        context_refs: Vec::new(),
+        dependencies: Vec::new(),
+    }
+}
+
+#[test]
+fn y_on_a_selected_row_opens_the_activity_timeline() {
+    let state = IssueListState::with_rows(vec![row("i1")]);
+    let out = reduce_issue_list(&state, IssueListEvent::Key('y'));
+    assert_eq!(
+        out.intent,
+        Some(IssueListIntent::OpenActivityTimeline(issue_id("i1"))),
+        "`y` on a selected row must open that row's timeline"
+    );
+}
+
+#[test]
+fn y_with_no_selection_is_a_no_op() {
+    let state = IssueListState::default();
+    let out = reduce_issue_list(&state, IssueListEvent::Key('y'));
+    assert_eq!(
+        out.intent, None,
+        "`y` on an empty list must not open a modal on nothing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The modal's own reducer
+// ---------------------------------------------------------------------------
+
+#[test]
+fn j_and_k_move_the_cursor_and_clamp() {
+    let state = seeded();
+    assert_eq!(state.selected_index(), 0);
+
+    let down = reduce_activity(&state, ActivityEvent::Key('j')).state;
+    assert_eq!(down.selected_index(), 1);
+    let down = reduce_activity(&down, ActivityEvent::Key('j')).state;
+    assert_eq!(down.selected_index(), 2);
+    // Clamped at the last entry.
+    let down = reduce_activity(&down, ActivityEvent::Key('j')).state;
+    assert_eq!(down.selected_index(), 2);
+
+    let up = reduce_activity(&down, ActivityEvent::Key('k')).state;
+    assert_eq!(up.selected_index(), 1);
+    let up = reduce_activity(&up, ActivityEvent::Key('k')).state;
+    let up = reduce_activity(&up, ActivityEvent::Key('k')).state;
+    assert_eq!(up.selected_index(), 0, "clamped at the first entry");
+}
+
+#[test]
+fn r_raises_the_refresh_intent_for_the_open_issue() {
+    let out = reduce_activity(&seeded(), ActivityEvent::Key('r'));
+    assert_eq!(
+        out.intent,
+        Some(ActivityIntent::Refresh {
+            issue_id: "i1".to_string()
+        })
+    );
+}
+
+#[test]
+fn applying_a_result_populates_entries_in_order_and_clears_loading() {
+    let mut state = ActivityState::loading(&issue_id("i1"), "Wire the timeline");
+    assert!(state.is_loading());
+    assert!(state.entries().is_empty());
+
+    state.apply_entries(vec![
+        activity("a1", 1, "created", serde_json::json!({})),
+        activity(
+            "a2",
+            2,
+            "status_changed",
+            serde_json::json!({"from": "open", "to": "done"}),
+        ),
+    ]);
+    assert!(!state.is_loading());
+    let ids: Vec<&str> = state.entries().iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(ids, ["a1", "a2"]);
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+/// Flatten the buffer into a `\n`-joined glyph map, each line `trim_end`-ed.
+fn glyph_map(buf: &WireBuffer, cols: u16) -> String {
+    let mut grid = vec![vec![' '; cols as usize]; buf.height as usize];
+    for (coord, cell) in &buf.cells {
+        if coord.y < buf.height && coord.x < cols {
+            if let Some(ch) = cell.symbol.chars().next() {
+                grid[coord.y as usize][coord.x as usize] = ch;
+            }
+        }
+    }
+    grid.into_iter()
+        .map(|r| r.into_iter().collect::<String>().trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn render_shows_the_exact_change_text_the_cursor_and_the_help_bar() {
+    let state = seeded();
+    let mut buf = WireBuffer::new(100, 20);
+    render_activity(&mut buf, 100, 20, &state);
+    let full = glyph_map(&buf, 100);
+
+    assert!(
+        full.contains("Activity · Wire the timeline"),
+        "the modal title names the card:\n{full}"
+    );
+    // The EXACT change text, not a substring-OR — the whole point of the item.
+    assert!(
+        full.contains("open → in_progress"),
+        "the state move must render as its from → to text:\n{full}"
+    );
+    assert!(
+        full.contains("moved"),
+        "the status_changed action renders as its human label:\n{full}"
+    );
+    assert!(
+        full.contains("picked this up, starting now"),
+        "the merged comment body must render:\n{full}"
+    );
+    assert!(
+        full.contains("claude"),
+        "an agent entry is attributed to the agent:\n{full}"
+    );
+    assert!(
+        full.contains("you"),
+        "a member entry renders as `you`:\n{full}"
+    );
+    assert!(
+        full.contains('▶'),
+        "the selection cursor must render:\n{full}"
+    );
+    assert!(
+        full.contains("j/k scroll   r refresh   esc back"),
+        "the bottom help bar must advertise the exits:\n{full}"
+    );
+}
+
+/// The tolerant-read contract at the render layer: an action token this binary
+/// does not know renders RAW rather than vanishing.
+#[test]
+fn an_unknown_action_token_renders_raw() {
+    let mut state = ActivityState::loading(&issue_id("i1"), "Card");
+    state.apply_entries(vec![activity(
+        "a1",
+        1,
+        "teleported_from_2027",
+        serde_json::json!({}),
+    )]);
+    let mut buf = WireBuffer::new(100, 20);
+    render_activity(&mut buf, 100, 20, &state);
+    let full = glyph_map(&buf, 100);
+    assert!(
+        full.contains("teleported"),
+        "an unknown token must render raw, not be dropped:\n{full}"
+    );
+}

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2873,6 +2873,7 @@ Commands:
   criteria  Inspect or tick off an issue's acceptance criteria
   link      Add, remove, or list an issue's typed links to other issues
   why       Explain why an issue did (or did not) dispatch — its admission history
+  timeline  Show one issue's activity timeline: state changes, assignments, comments
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3169,6 +3170,26 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --limit <LIMIT>          How many attempts to show, newest first [default: 20]
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar issue timeline`
+
+Show one issue's activity timeline: state changes, assignments, comments
+
+```console
+$ ainb hangar issue timeline --help
+Show one issue's activity timeline: state changes, assignments, comments
+
+Usage: ainb hangar issue timeline [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Issue id (ULID) whose narrative to print
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --limit <LIMIT>          How many entries to show — the newest window, printed oldest-first [default: 200]
       --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```


### PR DESCRIPTION
Closes multica parity item **#13** — the generic activity / audit log plus a per-issue timeline.

Before this, hangar had three narrower logs and no per-issue story at all: `run_history` (execution cost), `dispatch_attempt` (admission decisions only, and trimmed to 20 rows/issue), `event_log` (the workspace-scoped replay outbox). Comments existed but had no read RPC, so reopening a card showed an empty transcript.

## What lands

```
   ainb hangar issue timeline <id>          plugin `y` → Activity modal
              │                                      │
              │  (direct store read)                 │ hangar/issue_timeline
              ▼                                      ▼
      ┌────────────────────────────────────────────────────┐
      │  daemon: handle_issue_timeline                      │
      │  merge(ActivityRepo::list_for_issue, CommentRepo)   │
      └───────────────────┬────────────────────────────────┘
                          │
          ┌───────────────┴───────────────┐
          ▼                               ▼
   ┌──────────────┐               ┌──────────────┐
   │ activity_log │◀── record ────│   comment    │
   │  (mig 0059)  │               │  (mig 0003)  │
   └──────────────┘               └──────────────┘
```

- **Migration 0059 `activity_log`** — `(workspace_id FK, issue_id, actor_type, actor_id, action, details JSON text, created_at)` plus the keyset index `(issue_id, created_at DESC, id DESC)` and a workspace feed index. No `CHECK` on `action`/`actor_type` (SQLite cannot widen one without a table rebuild, and the vocabulary is append-only); no FK on `issue_id`/`actor_id` (a historical fact must survive what it describes); **not trimmed** — unlike `dispatch_attempt`, the narrative must stay complete.
- **`ainb_hangar_core::activity`** — `ActivityAction` (`created`/`status_changed`/`assignee_changed`/`priority_changed`/`title_changed`/`due_date_changed`/`task_completed`/`task_failed`) with a **tolerant** parse, and `ActivityActor::{Actor, System}` — the activity-only third kind for a daemon-driven transition.
- **`ActivityService::record_issue_diff`** — the diff engine both issue-update writers (daemon + CLI) share, so they cannot drift on what counts as a change. One row per **changed field**, in a stable order.
- **Write sites** — daemon issue create/update, CLI issue create/update, the task-driven board advance (`system`, `via:"board"`), the PR-merged auto-done (`system`, `via:"pr_merged"`), and task completed/failed (attributed to the run's agent). Every write is best-effort: a failed audit row never fails the mutation it describes.
- **`hangar/issue_timeline`** — merges activity rows with the issue's comments at READ time (comments are never duplicated as activity rows), oldest first by `(created_at, id)`, default 200 / hard cap 2000. An `issue_id` that does not resolve in the workspace is `INVALID_PARAMS`, never a silent empty list.
- **`ainb hangar issue timeline <id>`** (alias `activity`) — a direct store read, no daemon needed, in text/json/csv/markdown.
- **TUI** — `y` on a selected issue-list row opens an Activity modal; `j`/`k` scroll, `r` re-fetches, `esc` restores the screen underneath.
- **Delete cascade** — `activity_log` rows are reaped explicitly (no FK by design), and `IssueDeleteSummary` gains an `activities` count surfaced in both CLI delete lines.

## One real bug the gate caught

The first acceptance run went red on field ordering. A whole diff runs inside one millisecond, and `ulid::Ulid::new()` is **not** monotonic within a millisecond (its low bits are random, not a counter) — so a shared `created_at` let the timeline's `(created_at, id)` sort shuffle the fields arbitrarily. `record_issue_diff` now reads the clock once and stamps row `i` at `base + i`, making the written order the read order. `a_frozen_clock_still_preserves_field_order_on_read` drives the diff under a frozen clock so the regression cannot come back.

## Acceptance proof

Real `ainb` binary, isolated `$AINB_HANGAR_HOME`, no daemon:

```
$ ainb hangar issue create --title "parity 13 proof"
$ ainb hangar issue update <id> --state in_progress
$ ainb hangar issue update <id> --assign agent:<agent-id>
$ sqlite3 $HOME/hangar.db "SELECT action, details FROM activity_log WHERE issue_id='<id>' ORDER BY created_at"
created|{}
status_changed|{"from":"open","to":"in_progress"}
assignee_changed|{"to_id":"01KYGW75WQSRNJT8T9JA1QXC6B","to_type":"agent"}

$ ainb hangar issue timeline <id>
2026-07-27T04:09:37Z  member:stevie      created
2026-07-27T04:09:37Z  member:01KYGW…     status_changed    open → in_progress
2026-07-27T04:09:38Z  member:01KYGW…     assignee_changed  — → agent:01KYGW75WQ…
```

Note the `assignee_changed` details omit the `from_*` half entirely (the card was unassigned) — multica's exact shape.

The merged-comment half is proved over the real RPC socket in `rpc_issue_timeline.rs`: create → update state → assign agent → `comment_add` → `issue_timeline` returns `["created","status_changed","assignee_changed"]` in ascending `created_at` order plus one `kind:"comment"` entry carrying the body, with `status_changed.details == {"from":"open","to":"in_progress"}`. A foreign-workspace `issue_id` is rejected, not answered with an empty list.

## Tests

| File | What it proves |
|---|---|
| `migration_0059_upgrade.rs` | 0059 applies on a populated pre-0059 DB; rows survive; both indexes land; `details` defaults to `{}`; only `workspace_id` is a FK; unknown `action`/`actor_type` tokens persist |
| `repo_activity.rs` | newest-first ordering with the id tiebreak, tenant-scoped workspace feed, `system` rows storing a NULL actor id, unknown token reading back raw with `code() == None` |
| `service_activity_diff.rs` | one row per changed field; three-field edit in field order; no-op edit writes nothing; assign/unassign omit the absent side; cleared due date is a typed `null`; **frozen-clock ordering regression** |
| `rpc_issue_timeline.rs` | the acceptance test above, over the real framed `UnixStream` |
| `repo_issue_delete.rs` (extended) | the cascade reaps the card's activity rows, the summary counts them, and a sibling issue's row survives |
| `hangar_issue_timeline_cli.rs` | the real `ainb` binary: create + update writes the rows, `--format json` carries the details shape, the text form renders `open → in_progress`, the `activity` alias resolves |
| `activity_timeline_reducer_test.rs` | `y` opens the modal (and is a no-op with no selection), `j`/`k` clamp, `r` refreshes, applying a result populates in order, and the render shows the **exact** `open → in_progress` text, the comment body, the `▶` cursor and the help bar; an unknown token renders raw |
| `snapshots.rs` (proto) | `TimelineEntryRow` omits every absent optional field and decodes a minimal legacy frame |

## Local gate — all green

| Gate | Result |
|---|---|
| `cargo build -p ainb` | ok |
| `cargo nextest run --lib --tests --all-features -E 'not binary(/^tripwire_/)'` | **4209 passed**, 0 failed, 18 skipped |
| `scripts/hangar/run_all_tripwires.sh` | **ran=64 failed=0 skipped=0** |
| `scripts/hangar/run_acceptance_tests.sh` | **ran=176 failed=0 skipped=0** |
| `cargo test -p ainb-hangar-store -p ainb-hangar-proto -p ainb-plugin-hangar --lib --tests` | 109 suites, 0 failures |

No fixture in another crate drifted uncaught: `IssueDeleteSummary` gaining a field and the two CLI delete strings changing were fixed in the same commit as the schema change.

## Deliberately out of scope (honest list)

- **No `HangarEvent::ActivityRecorded` live push.** multica broadcasts `activity:created` over WS; `HangarEvent` is matched exhaustively in `event_outbox.rs` and `inbox_aggregator.rs`, and the surfaces fetch on open and on `r`. Adding the variant later is append-only.
- **The Beads bridge is not instrumented.** `beads_sync/inbound.rs` and `reconcile.rs` also write issue state, but that is an external MIRROR reconcile that rewrites state in bulk — instrumenting it would flood the narrative with mirror noise.
- **No `description_updated` action.** hangar's `IssueFieldUpdate` has no description field, so there is no description-edit path to instrument. Added dead would be worse than omitted.
- **No workspace-wide "what happened today" feed**, though `list_by_workspace` and `idx_activity_log_ws` are already in place for it.
- **Actor attribution is the single bootstrapped default member.** hangar has no per-request auth context; when parity #1's per-request identity lands, only the two `acting_actor` helpers change, no call sites.
- **No tmux tripwire for the modal.** The `y` → modal path is covered by the reducer + render test asserting the exact user-visible text; a tmux tripwire would add a known-flaky target under full-suite concurrency for the same assertion.

### Deviations from multica, each documented in code

- `priority_changed` details carry **numbers** (`{"from":1,"to":3}`) — hangar's priority is an `i64` `0..3` where multica's is a string enum.
- `due_date_changed` carries epoch-millis or a typed `null` where multica writes `""`.
- `task_completed`/`task_failed` carry `{"task_id":…}`, additive over multica's `{}` (`details` is free-form, so append-only).
