### PR TITLE
feat(hangar): actor-polymorphic inbox (parity 1-rest)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-core/src/actor.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/actor.rs
@@ -116,6 +116,28 @@ impl FromStr for ActorRef {
     }
 }
 
+/// The id half of the local human's actor ref (`member:me`).
+pub const LOCAL_MEMBER_ID: &str = "me";
+
+/// The canonical ref for the local human ("me").
+///
+/// This is the actor the TUI authors issues and comments as (the plugin's
+/// `SELF_AUTHOR_REF`) and the default inbox recipient when a caller omits one
+/// (migration 0060). Hangar has no per-user auth layer yet; this is the single
+/// definition every layer shares, so the plugin, the daemon's wire default and
+/// the migration's backfill can never drift apart. When a real signed-in
+/// identity lands, only this function changes.
+///
+/// # Panics
+///
+/// Never: [`LOCAL_MEMBER_ID`] is a non-empty compile-time constant, the only
+/// invariant [`ActorRef::new`] enforces.
+#[must_use]
+pub fn local_member() -> ActorRef {
+    ActorRef::new(ActorKind::Member, LOCAL_MEMBER_ID)
+        .expect("LOCAL_MEMBER_ID is a non-empty constant")
+}
+
 /// Failure modes when constructing or parsing an [`ActorRef`] / [`ActorKind`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ActorParseError {
@@ -174,6 +196,16 @@ mod tests {
             "memberabc".parse::<ActorRef>(),
             Err(ActorParseError::MissingSeparator)
         );
+    }
+
+    #[test]
+    fn local_member_is_the_canonical_member_me_ref() {
+        let me = local_member();
+        assert_eq!(me.kind(), ActorKind::Member);
+        assert_eq!(me.id(), LOCAL_MEMBER_ID);
+        assert_eq!(me.to_string(), "member:me");
+        // Round-trips through the canonical textual form the wire carries.
+        assert_eq!("member:me".parse::<ActorRef>().unwrap(), me);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -459,7 +459,9 @@ mod tests {
     /// Aggregate one event and return every `(recipient, subject_id)` that landed.
     async fn aggregate(store: &Store, event: HangarEvent) -> Vec<(String, String)> {
         let idgen = SystemIdGen;
-        aggregate_one(store.pool(), &idgen, 1_000, &scoped(event)).await.expect("aggregate");
+        aggregate_one(store.pool(), &idgen, 1_000, &scoped(event))
+            .await
+            .expect("aggregate");
         let mut out = Vec::new();
         for recipient in [
             ActorRef::new(ActorKind::Member, "user-1").unwrap(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -36,9 +36,14 @@
 //! fell behind the broadcast capacity) skips the dropped events and keeps going —
 //! the next snapshot pull reconciles.
 
+use ainb_hangar_core::actor::{ActorKind, ActorRef, local_member};
 use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_core::ids::WorkspaceId;
 use ainb_hangar_proto::events::HangarEvent;
 use ainb_hangar_store::repo::inbox::{InboxKind, InboxRepo, NewInboxEntry};
+use ainb_hangar_store::repo::issue::IssueRepo;
+use ainb_hangar_store::repo::member::MemberRepo;
+use ainb_hangar_store::repo::task::TaskRepo;
 use sqlx::SqlitePool;
 use tokio::sync::broadcast;
 
@@ -132,11 +137,134 @@ pub fn entry_for_event(event: &HangarEvent) -> Option<InboxFields> {
     }
 }
 
-/// Aggregate one scoped event into the inbox: map it, mint an id, insert.
+/// Parse a stored/wire actor token (`member:<id>` / `agent:<id>`), dropping a
+/// malformed one rather than addressing a notification to nobody.
+fn actor(raw: &str) -> Option<ActorRef> {
+    raw.parse::<ActorRef>().ok()
+}
+
+/// The last-resort recipient for an event with no derivable participant: the
+/// workspace's OWNER member, else the local human.
 ///
-/// Returns `Ok(true)` when a row landed, `Ok(false)` when the event is not one
-/// the inbox aggregates. A store fault propagates so the caller can log it (the
-/// caller never lets it down the daemon).
+/// Mirrors the reference's guarantee that a notification is never dropped on the
+/// floor — an event we cannot attribute still lands *somewhere* a human reads,
+/// rather than vanishing.
+async fn fallback_recipient(pool: &SqlitePool, workspace_id: &str) -> ActorRef {
+    let Ok(ws) = WorkspaceId::from_str(workspace_id.to_string()) else {
+        return local_member();
+    };
+    let members = MemberRepo::list(pool, &ws).await.unwrap_or_default();
+    members
+        .iter()
+        .find(|m| m.role == "owner")
+        .and_then(|m| ActorRef::new(ActorKind::Member, m.user_id.clone()).ok())
+        .unwrap_or_else(local_member)
+}
+
+/// The participants of an issue: its creator plus its assignee (when set).
+async fn issue_participants(pool: &SqlitePool, issue_id: &str) -> Vec<ActorRef> {
+    match IssueRepo::get_by_id(pool, issue_id).await {
+        Ok(Some(issue)) => {
+            let mut out = vec![issue.creator];
+            out.extend(issue.assignee);
+            out
+        }
+        Ok(None) => Vec::new(),
+        Err(e) => {
+            tracing::warn!(error = %e, issue_id, "inbox recipient lookup failed");
+            Vec::new()
+        }
+    }
+}
+
+/// Who an aggregated event is FOR — the reference's `notifySubscribers`
+/// (participants minus the actor) plus `notifyDirect` (a targeted actor),
+/// expressed against hangar's schema.
+///
+/// **Deviation from multica, deliberate:** hangar has no `issue_subscriber`
+/// table, so "subscribers" is approximated by the issue's PARTICIPANTS (its
+/// creator plus its assignee) minus the actor who caused the event — you are
+/// never notified of your own action (multica
+/// `notification_listeners.go:316`). An event with no derivable participant
+/// falls back to the workspace OWNER, then to [`local_member`], so a
+/// notification is never silently dropped.
+async fn recipients_for(pool: &SqlitePool, scoped: &ScopedEvent) -> Vec<ActorRef> {
+    let ws = scoped.workspace_id.as_str();
+    let mut out: Vec<ActorRef> = match &scoped.event {
+        // The creator caused it, so the ASSIGNEE hears about it. An unassigned
+        // issue lands in its creator's own tracking inbox (the single-user flow),
+        // which is the only way a solo human sees their own board move.
+        HangarEvent::IssueCreated(row) => {
+            let creator = actor(&row.creator);
+            match row.assignee.as_deref().and_then(actor) {
+                Some(a) if Some(&a) != creator.as_ref() => vec![a],
+                _ => creator.into_iter().collect(),
+            }
+        }
+        // The wire event carries no mutator, so nobody can be excluded: both
+        // participants hear about the edit.
+        HangarEvent::IssueUpdated(row) => {
+            let mut v: Vec<ActorRef> = actor(&row.creator).into_iter().collect();
+            v.extend(row.assignee.as_deref().and_then(actor));
+            v
+        }
+        // The row is already gone; there is nothing left to look up.
+        HangarEvent::IssueDeleted { .. } => Vec::new(),
+        // The comment's participants minus its author — the closest hangar has
+        // to `notifySubscribers`.
+        HangarEvent::CommentAdded(row) => {
+            let author = actor(&row.author);
+            let participants = issue_participants(pool, row.issue_id.as_str()).await;
+            participants.into_iter().filter(|p| Some(p) != author.as_ref()).collect()
+        }
+        // `notifyDirect` with an AGENT recipient: the agent's own work queue.
+        // This is the row that proves an agent has an inbox of its own.
+        HangarEvent::TaskQueued { agent_id, .. } => {
+            ActorRef::new(ActorKind::Agent, agent_id.as_str()).into_iter().collect()
+        }
+        // "Your task started / finished": the issue's creator hears it; a task
+        // with no issue reports back to its own agent.
+        HangarEvent::TaskStarted { task_id, .. } | HangarEvent::TaskFinished { task_id, .. } => {
+            task_recipients(pool, task_id.as_str()).await
+        }
+        _ => Vec::new(),
+    };
+    // Dedupe by canonical form, preserving order.
+    let mut seen = std::collections::HashSet::new();
+    out.retain(|a| seen.insert(a.to_string()));
+    if out.is_empty() {
+        out.push(fallback_recipient(pool, ws).await);
+    }
+    out
+}
+
+/// Recipients for a task lifecycle event: the originating issue's creator, or
+/// the executing agent when the task has no issue.
+async fn task_recipients(pool: &SqlitePool, task_id: &str) -> Vec<ActorRef> {
+    let task = match TaskRepo::get_by_id(pool, task_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => return Vec::new(),
+        Err(e) => {
+            tracing::warn!(error = %e, task_id, "inbox task recipient lookup failed");
+            return Vec::new();
+        }
+    };
+    if let Some(issue_id) = task.issue_id.as_deref() {
+        match IssueRepo::get_by_id(pool, issue_id).await {
+            Ok(Some(issue)) => return vec![issue.creator],
+            Ok(None) => {}
+            Err(e) => tracing::warn!(error = %e, issue_id, "inbox issue lookup failed"),
+        }
+    }
+    ActorRef::new(ActorKind::Agent, task.agent_id).into_iter().collect()
+}
+
+/// Aggregate one scoped event into the inbox: map it, resolve its recipients,
+/// mint an id and insert ONE ROW PER RECIPIENT.
+///
+/// Returns `Ok(true)` when at least one row landed, `Ok(false)` when the event is
+/// not one the inbox aggregates. A store fault propagates so the caller can log
+/// it (the caller never lets it down the daemon).
 async fn aggregate_one(
     pool: &SqlitePool,
     idgen: &dyn IdGen,
@@ -146,19 +274,22 @@ async fn aggregate_one(
     let Some(fields) = entry_for_event(&scoped.event) else {
         return Ok(false);
     };
-    InboxRepo::insert(
-        pool,
-        &NewInboxEntry {
-            id: idgen.new_ulid(),
-            workspace_id: scoped.workspace_id.clone(),
-            kind: fields.kind,
-            event: fields.event.to_string(),
-            subject_id: fields.subject_id,
-            summary: fields.summary,
-            created_at: now_ms,
-        },
-    )
-    .await?;
+    for recipient in recipients_for(pool, scoped).await {
+        InboxRepo::insert(
+            pool,
+            &NewInboxEntry {
+                id: idgen.new_ulid(),
+                workspace_id: scoped.workspace_id.clone(),
+                recipient,
+                kind: fields.kind,
+                event: fields.event.to_string(),
+                subject_id: fields.subject_id.clone(),
+                summary: fields.summary.clone(),
+                created_at: now_ms,
+            },
+        )
+        .await?;
+    }
     Ok(true)
 }
 
@@ -281,6 +412,143 @@ mod tests {
         assert_eq!(f.kind, InboxKind::Task);
         assert_eq!(f.event, "task_finished");
         assert_eq!(f.subject_id, "t-1");
+    }
+
+    // --- Recipient fan-out (store-backed): who an event is FOR -------------
+
+    use ainb_hangar_core::idgen::SystemIdGen;
+    use ainb_hangar_core::ids::AgentId;
+    use ainb_hangar_store::Store;
+    use ainb_hangar_store::repo::inbox::InboxRepo;
+
+    /// Seed a workspace with an owner member and an issue created by
+    /// `member:user-1` and assigned to `agent:a1`.
+    ///
+    /// No `agent` row is needed: the recipient columns are FK-less by design
+    /// (migration 0060), exactly like every other polymorphic actor column.
+    async fn seed(pool: &sqlx::SqlitePool) {
+        for sql in [
+            "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-a','ws-a','A',0)",
+            "INSERT INTO user (id, email, created_at) VALUES ('user-1','o@example.com',0)",
+            "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-a','user-1','owner')",
+            "INSERT INTO issue (id, workspace_id, title, state, creator_type, creator_id, \
+             assignee_type, assignee_id, created_at) \
+             VALUES ('issue-1','ws-a','Fix it','open','member','user-1','agent','a1',0)",
+        ] {
+            sqlx::query(sql).execute(pool).await.expect(sql);
+        }
+    }
+
+    fn scoped(event: HangarEvent) -> ScopedEvent {
+        ScopedEvent {
+            workspace_id: "ws-a".into(),
+            event,
+        }
+    }
+
+    fn comment_by(author: &str) -> HangarEvent {
+        HangarEvent::CommentAdded(CommentRow {
+            id: CommentId::from_str("c-1").unwrap(),
+            issue_id: IssueId::from_str("issue-1").unwrap(),
+            author: author.into(),
+            body: "lgtm".into(),
+            created_at: 0,
+        })
+    }
+
+    /// Aggregate one event and return every `(recipient, subject_id)` that landed.
+    async fn aggregate(store: &Store, event: HangarEvent) -> Vec<(String, String)> {
+        let idgen = SystemIdGen;
+        aggregate_one(store.pool(), &idgen, 1_000, &scoped(event)).await.expect("aggregate");
+        let mut out = Vec::new();
+        for recipient in [
+            ActorRef::new(ActorKind::Member, "user-1").unwrap(),
+            local_member(),
+            ActorRef::new(ActorKind::Agent, "a1").unwrap(),
+        ] {
+            for e in InboxRepo::list(store.pool(), "ws-a", &recipient, 100).await.unwrap() {
+                out.push((e.recipient.to_string(), e.subject_id));
+            }
+        }
+        out
+    }
+
+    /// A comment BY the assigned agent notifies the issue's creator, never the
+    /// agent that wrote it (self-notification suppressed).
+    #[tokio::test]
+    async fn comment_by_agent_targets_the_issue_creator_not_the_author() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed(store.pool()).await;
+
+        let landed = aggregate(&store, comment_by("agent:a1")).await;
+        assert_eq!(
+            landed,
+            vec![("member:user-1".to_string(), "c-1".to_string())],
+            "exactly the creator, and only once"
+        );
+    }
+
+    /// The mirror: a comment BY the human notifies the assigned agent, and the
+    /// human gets nothing.
+    #[tokio::test]
+    async fn comment_by_member_targets_the_assignee_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed(store.pool()).await;
+
+        let landed = aggregate(&store, comment_by("member:user-1")).await;
+        assert_eq!(
+            landed,
+            vec![("agent:a1".to_string(), "c-1".to_string())],
+            "exactly the assigned agent, never the author"
+        );
+    }
+
+    /// A queued task lands in the AGENT's own inbox — the row that proves an
+    /// agent is a first-class inbox recipient.
+    #[tokio::test]
+    async fn task_queued_lands_in_the_agents_inbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed(store.pool()).await;
+
+        let landed = aggregate(
+            &store,
+            HangarEvent::TaskQueued {
+                task_id: TaskId::from_str("t-1").unwrap(),
+                issue_id: IssueId::from_str("issue-1").unwrap(),
+                agent_id: AgentId::from_str("a1".to_string()).unwrap(),
+            },
+        )
+        .await;
+        assert_eq!(
+            landed,
+            vec![("agent:a1".to_string(), "t-1".to_string())],
+            "the agent's own work queue"
+        );
+    }
+
+    /// An event with no derivable participant (a deleted issue: the row is gone)
+    /// still lands — on the workspace OWNER — rather than being dropped.
+    #[tokio::test]
+    async fn event_with_no_derivable_participant_falls_back_to_the_workspace_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed(store.pool()).await;
+
+        let landed = aggregate(
+            &store,
+            HangarEvent::IssueDeleted {
+                issue_id: IssueId::from_str("issue-gone").unwrap(),
+            },
+        )
+        .await;
+        assert_eq!(
+            landed,
+            vec![("member:user-1".to_string(), "issue-gone".to_string())],
+            "the owner is the last-resort recipient, so nothing is dropped"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -46,6 +46,7 @@ use std::sync::{OnceLock, RwLock};
 use std::time::Instant;
 
 use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
+use ainb_hangar_core::actor::{ActorRef, local_member};
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
 use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
 use ainb_hangar_core::idgen::SystemIdGen;
@@ -7187,16 +7188,50 @@ async fn handle_daemon_health(
     to_value(&snapshot)
 }
 
-/// Dispatch `hangar/inbox_list` (e38.14): snapshot the workspace's aggregated
-/// inbox + unread count. A read like `hangar/issues_list`: an unknown workspace
-/// yields an empty list + zero unread (no `INVALID_PARAMS` rejection). Split out
-/// of [`handle`] to keep that dispatcher within the line cap.
+/// Resolve the inbox recipient a request addresses (store migration 0060).
+///
+/// The parsed `recipient` param, or the LOCAL HUMAN when omitted — the
+/// append-only wire default that keeps a pre-0060 surface reading exactly one
+/// actor's inbox rather than the union of everyone's. A MALFORMED ref is
+/// `INVALID_PARAMS`, mirroring the `creator` / `assignee` parse rejections: a
+/// typo must never silently fall back to someone else's inbox.
+fn inbox_recipient(param: Option<&str>) -> Result<ActorRef, RpcError> {
+    match param {
+        None => Ok(local_member()),
+        Some(raw) => raw.parse::<ActorRef>().map_err(|e| {
+            invalid_params(&format!(
+                "recipient must be 'member:<id>' or 'agent:<id>': {e}"
+            ))
+        }),
+    }
+}
+
+/// Parse the `{ workspace_id, recipient? }` params both inbox methods take.
+fn inbox_params(
+    req: &RpcRequest,
+) -> Result<(String, ActorRef), RpcError> {
+    let params: ainb_hangar_proto::snapshots::InboxScopedParams =
+        parse_params(req, "{ workspace_id, recipient? }")?;
+    let recipient = inbox_recipient(params.recipient.as_deref())?;
+    Ok((params.workspace_id, recipient))
+}
+
+/// Dispatch `hangar/inbox_list` (e38.14): snapshot ONE ACTOR's aggregated inbox
+/// + their unread count. A read like `hangar/issues_list`: an unknown workspace
+/// yields an empty list + zero unread (no `INVALID_PARAMS` rejection), but a
+/// malformed `recipient` IS rejected (a typo must not read another inbox). An
+/// omitted recipient is the local human. Split out of [`handle`] to keep that
+/// dispatcher within the line cap.
 async fn handle_inbox_list(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    let (entries, unread) = match resolve(pool, req).await? {
-        Some(ws) => snapshots::inbox_list(pool, &ws).await.map_err(|e| store_err(&e))?,
+    let (wire, recipient) = inbox_params(req)?;
+    let resolved = resolve_workspace_id(pool, &wire).await.map_err(|e| store_err(&e))?;
+    let (entries, unread) = match resolved {
+        Some(ws) => snapshots::inbox_list(pool, &ws, &recipient)
+            .await
+            .map_err(|e| store_err(&e))?,
         None => (Vec::new(), 0),
     };
     to_value(&ainb_hangar_proto::snapshots::InboxListResult { entries, unread })
@@ -7209,14 +7244,15 @@ async fn handle_inbox_list(
 /// A mutating handler: it resolves the workspace and **rejects** a mistyped one
 /// with `INVALID_PARAMS` (never a silent no-op, mirroring [`handle_comment_add`]),
 /// so a typo'd workspace can never quietly "succeed" while marking nothing. The
-/// sweep is workspace-scoped, so a sibling tenant's inbox is never touched.
+/// sweep is scoped to the workspace AND to the calling actor's own entries, so
+/// neither a sibling tenant's nor a sibling actor's inbox is ever touched.
 async fn handle_inbox_mark_read(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    let wire = workspace_id(req)?;
+    let (wire, recipient) = inbox_params(req)?;
     let ws = resolve_wire_or_reject(pool, &wire).await?;
-    let (marked, unread) = snapshots::inbox_mark_read(pool, &SystemClock, ws.as_str())
+    let (marked, unread) = snapshots::inbox_mark_read(pool, &SystemClock, ws.as_str(), &recipient)
         .await
         .map_err(|e| store_err(&e))?;
     to_value(&ainb_hangar_proto::snapshots::InboxMarkReadResult { marked, unread })

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -7207,9 +7207,7 @@ fn inbox_recipient(param: Option<&str>) -> Result<ActorRef, RpcError> {
 }
 
 /// Parse the `{ workspace_id, recipient? }` params both inbox methods take.
-fn inbox_params(
-    req: &RpcRequest,
-) -> Result<(String, ActorRef), RpcError> {
+fn inbox_params(req: &RpcRequest) -> Result<(String, ActorRef), RpcError> {
     let params: ainb_hangar_proto::snapshots::InboxScopedParams =
         parse_params(req, "{ workspace_id, recipient? }")?;
     let recipient = inbox_recipient(params.recipient.as_deref())?;
@@ -7229,9 +7227,9 @@ async fn handle_inbox_list(
     let (wire, recipient) = inbox_params(req)?;
     let resolved = resolve_workspace_id(pool, &wire).await.map_err(|e| store_err(&e))?;
     let (entries, unread) = match resolved {
-        Some(ws) => snapshots::inbox_list(pool, &ws, &recipient)
-            .await
-            .map_err(|e| store_err(&e))?,
+        Some(ws) => {
+            snapshots::inbox_list(pool, &ws, &recipient).await.map_err(|e| store_err(&e))?
+        }
         None => (Vec::new(), 0),
     };
     to_value(&ainb_hangar_proto::snapshots::InboxListResult { entries, unread })

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -1636,14 +1636,15 @@ fn task_pr_url(result_json: Option<&str>) -> Option<String> {
 /// for the screen, and the bound keeps a long-lived workspace's snapshot small.
 const INBOX_LIST_LIMIT: i64 = 200;
 
-/// Snapshot a workspace's aggregated inbox + its unread count
-/// (`hangar/inbox_list`, e38.14).
+/// Snapshot ONE ACTOR's aggregated inbox + their unread count in a workspace
+/// (`hangar/inbox_list`, e38.14; per-recipient since store migration 0060).
 ///
 /// Reads the durable `inbox_entry` rows the daemon's aggregator folds live
-/// issue / comment / task events into, newest-first and capped at
-/// [`INBOX_LIST_LIMIT`], plus the count of unread (`read_at IS NULL`) entries.
-/// Workspace-scoped: a foreign / unknown workspace yields an empty list + zero
-/// unread.
+/// issue / comment / task events into and ADDRESSES to a single actor,
+/// newest-first and capped at [`INBOX_LIST_LIMIT`], plus that recipient's count
+/// of unread (`read_at IS NULL`) entries. Scoped on both axes: a foreign /
+/// unknown workspace yields an empty list + zero unread, and another actor's
+/// entries are never returned.
 ///
 /// # Errors
 ///
@@ -1651,9 +1652,10 @@ const INBOX_LIST_LIMIT: i64 = 200;
 pub async fn inbox_list(
     pool: &SqlitePool,
     workspace_id: &str,
+    recipient: &ActorRef,
 ) -> Result<(Vec<InboxEntryRow>, i64), sqlx::Error> {
-    let entries = InboxRepo::list(pool, workspace_id, INBOX_LIST_LIMIT).await?;
-    let unread = InboxRepo::unread_count(pool, workspace_id).await?;
+    let entries = InboxRepo::list(pool, workspace_id, recipient, INBOX_LIST_LIMIT).await?;
+    let unread = InboxRepo::unread_count(pool, workspace_id, recipient).await?;
     let rows = entries
         .into_iter()
         .map(|e| InboxEntryRow {
@@ -1662,6 +1664,7 @@ pub async fn inbox_list(
             event: e.event,
             subject_id: e.subject_id,
             summary: e.summary,
+            recipient: e.recipient.to_string(),
             created_at: e.created_at,
             read_at: e.read_at,
         })
@@ -1812,14 +1815,16 @@ pub async fn run_history(
     })
 }
 
-/// Mark every currently-unread inbox entry in `workspace` as read, returning
-/// `(marked, unread_after)` (`hangar/inbox_mark_read`, e38.14).
+/// Mark every currently-unread inbox entry ADDRESSED TO `recipient` in
+/// `workspace` as read, returning `(marked, unread_after)`
+/// (`hangar/inbox_mark_read`, e38.14; per-recipient since store migration 0060).
 ///
-/// `marked` is how many rows the sweep flipped (the unread count before);
-/// `unread_after` is the unread count once the sweep commits, which is `0` for
-/// this whole-workspace sweep. Idempotent — a re-sweep flips nothing. The daemon
-/// resolves + rejects a mistyped workspace before this call, so a missing
-/// workspace never reaches here.
+/// `marked` is how many of that recipient's rows the sweep flipped (their unread
+/// count before); `unread_after` is THEIR unread count once the sweep commits,
+/// which is `0`. A sibling actor's unread rows are neither swept nor counted.
+/// Idempotent — a re-sweep flips nothing. The daemon resolves + rejects a
+/// mistyped workspace before this call, so a missing workspace never reaches
+/// here.
 ///
 /// # Errors
 ///
@@ -1828,9 +1833,10 @@ pub async fn inbox_mark_read(
     pool: &SqlitePool,
     clock: &dyn HangarClock,
     workspace_id: &str,
+    recipient: &ActorRef,
 ) -> Result<(i64, i64), sqlx::Error> {
-    let marked = InboxRepo::mark_all_read(pool, workspace_id, clock.now_ms()).await?;
-    let unread = InboxRepo::unread_count(pool, workspace_id).await?;
+    let marked = InboxRepo::mark_all_read(pool, workspace_id, recipient, clock.now_ms()).await?;
+    let unread = InboxRepo::unread_count(pool, workspace_id, recipient).await?;
     Ok((i64::try_from(marked).unwrap_or(i64::MAX), unread))
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -372,7 +372,10 @@ async fn mark_read_clears_unread_count() {
         )
         .await;
     assert!(resp["error"].is_null(), "mark_read must ack: {resp}");
-    assert_eq!(resp["result"]["marked"], 1, "the owner's entry flipped: {resp}");
+    assert_eq!(
+        resp["result"]["marked"], 1,
+        "the owner's entry flipped: {resp}"
+    );
     assert_eq!(resp["result"]["unread"], 0, "unread drops to 0: {resp}");
 
     // After: list reports zero unread, and every entry now carries a read_at.
@@ -485,7 +488,11 @@ async fn inbox_entries_are_visible_only_to_their_recipient() {
 
     // 5. The agent sees exactly the HUMAN's comment.
     let (theirs, theirs_unread) = c.inbox_list(WS_SLUG, "agent:a1").await;
-    assert_eq!(theirs.len(), 1, "the agent sees exactly one entry: {theirs:?}");
+    assert_eq!(
+        theirs.len(),
+        1,
+        "the agent sees exactly one entry: {theirs:?}"
+    );
     assert_eq!(
         theirs[0]["subject_id"], "c-human",
         "the agent is notified of the human's comment: {theirs:?}"
@@ -501,7 +508,10 @@ async fn inbox_entries_are_visible_only_to_their_recipient() {
         )
         .await;
     assert!(resp["error"].is_null(), "mark_read must ack: {resp}");
-    assert_eq!(resp["result"]["marked"], 1, "only the human's row flips: {resp}");
+    assert_eq!(
+        resp["result"]["marked"], 1,
+        "only the human's row flips: {resp}"
+    );
     assert_eq!(resp["result"]["unread"], 0, "{resp}");
 
     let (_, mine_after) = c.inbox_list(WS_SLUG, LOCAL_HUMAN).await;
@@ -561,7 +571,10 @@ async fn inbox_list_without_recipient_defaults_to_the_local_human() {
             serde_json::json!({ "workspace_id": WS_SLUG }),
         )
         .await;
-    assert!(resp["error"].is_null(), "an omitted recipient must ack: {resp}");
+    assert!(
+        resp["error"].is_null(),
+        "an omitted recipient must ack: {resp}"
+    );
     let entries = resp["result"]["entries"].as_array().cloned().unwrap_or_default();
     assert_eq!(
         entries.len(),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -33,6 +33,18 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 
+/// The workspace OWNER the P4 fixture seeds (`member` role `owner`, user-1).
+/// Events whose participants cannot be derived fall back to this actor, so it is
+/// the recipient the fixture's issue / comment / task events land on.
+const OWNER: &str = "member:user-1";
+
+/// The local human — the recipient an omitted `recipient` param defaults to.
+const LOCAL_HUMAN: &str = "member:me";
+
+/// The agent the P4 fixture assigns `issue-1` to. A comment BY the owner on that
+/// issue is routed to this actor (its other participant).
+const FIXTURE_AGENT: &str = "agent:agent-1";
+
 /// One test client connection: a persistent buffered reader + writer half.
 struct Client {
     reader: BufReader<OwnedReadHalf>,
@@ -122,12 +134,12 @@ impl Client {
         assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
     }
 
-    /// List the inbox via RPC, returning `(entries, unread)`.
-    async fn inbox_list(&mut self, ws: &str) -> (Vec<serde_json::Value>, i64) {
+    /// List ONE ACTOR's inbox via RPC, returning `(entries, unread)`.
+    async fn inbox_list(&mut self, ws: &str, recipient: &str) -> (Vec<serde_json::Value>, i64) {
         let resp = self
             .call(
                 methods::HANGAR_INBOX_LIST,
-                serde_json::json!({ "workspace_id": ws }),
+                serde_json::json!({ "workspace_id": ws, "recipient": recipient }),
             )
             .await;
         assert!(resp["error"].is_null(), "inbox_list must ack: {resp}");
@@ -274,28 +286,57 @@ async fn events_aggregate_into_inbox_with_unread_count() {
     let mut c = Client::connect(&socket_path).await;
     c.auth_from_file(dir.path()).await;
 
-    let (entries, unread) = c.inbox_list(WS_SLUG).await;
+    // The owner is notified of the issue they created and of the task on it; the
+    // comment they wrote goes to the issue's OTHER participant, the assigned
+    // agent (you are never notified of your own action). Assert per recipient
+    // rather than on one flat workspace list.
+    let (mine, mine_unread) = c.inbox_list(WS_SLUG, OWNER).await;
+    let (theirs, theirs_unread) = c.inbox_list(WS_SLUG, FIXTURE_AGENT).await;
     assert_eq!(
-        entries.len(),
-        3,
-        "all three families aggregated: {entries:?}"
+        mine_unread,
+        i64::try_from(mine.len()).unwrap(),
+        "every fresh entry is unread: {mine:?}"
     );
-    assert_eq!(unread, 3, "every fresh entry is unread");
+    assert_eq!(
+        theirs_unread,
+        i64::try_from(theirs.len()).unwrap(),
+        "every fresh entry is unread: {theirs:?}"
+    );
+    assert_eq!(
+        mine_unread + theirs_unread,
+        3,
+        "all three events aggregated across the two recipients"
+    );
 
-    // The kinds cover all three families.
+    // The kinds cover all three families across the two inboxes, and every entry
+    // names the actor it is addressed to.
+    let all: Vec<&serde_json::Value> = mine.iter().chain(theirs.iter()).collect();
     let kinds: std::collections::HashSet<&str> =
-        entries.iter().filter_map(|e| e["kind"].as_str()).collect();
+        all.iter().filter_map(|e| e["kind"].as_str()).collect();
     assert!(kinds.contains("issue"), "an issue entry landed: {kinds:?}");
     assert!(
         kinds.contains("comment"),
         "a comment entry landed: {kinds:?}"
     );
     assert!(kinds.contains("task"), "a task entry landed: {kinds:?}");
+    assert!(
+        mine.iter().all(|e| e["recipient"] == OWNER),
+        "the owner's list carries only their own entries: {mine:?}"
+    );
+    assert!(
+        theirs.iter().all(|e| e["recipient"] == FIXTURE_AGENT),
+        "the agent's list carries only its own entries: {theirs:?}"
+    );
+    assert_eq!(
+        theirs.iter().filter(|e| e["kind"] == "comment").count(),
+        1,
+        "the owner's comment is routed to the assigned agent: {theirs:?}"
+    );
 
     // Every fresh entry is unread (no read_at key on the wire).
     assert!(
-        entries.iter().all(|e| e.get("read_at").is_none()),
-        "fresh entries carry no read_at: {entries:?}"
+        all.iter().all(|e| e.get("read_at").is_none()),
+        "fresh entries carry no read_at: {all:?}"
     );
 }
 
@@ -316,38 +357,49 @@ async fn mark_read_clears_unread_count() {
     let mut c = Client::connect(&socket_path).await;
     c.auth_from_file(dir.path()).await;
 
-    // Before: two unread.
-    let (_, unread_before) = c.inbox_list(WS_SLUG).await;
-    assert_eq!(unread_before, 2, "two unread before the sweep");
+    // Before: the owner has the issue entry unread (their comment went to the
+    // issue's other participant, the assigned agent).
+    let (_, unread_before) = c.inbox_list(WS_SLUG, OWNER).await;
+    assert_eq!(unread_before, 1, "the owner's own entry is unread");
+    let (_, agent_before) = c.inbox_list(WS_SLUG, FIXTURE_AGENT).await;
+    assert_eq!(agent_before, 1, "the agent's entry is unread");
 
     // Mark read: the response reports both flipped and zero unread after.
     let resp = c
         .call(
             methods::HANGAR_INBOX_MARK_READ,
-            serde_json::json!({ "workspace_id": WS_SLUG }),
+            serde_json::json!({ "workspace_id": WS_SLUG, "recipient": OWNER }),
         )
         .await;
     assert!(resp["error"].is_null(), "mark_read must ack: {resp}");
-    assert_eq!(resp["result"]["marked"], 2, "both entries flipped: {resp}");
+    assert_eq!(resp["result"]["marked"], 1, "the owner's entry flipped: {resp}");
     assert_eq!(resp["result"]["unread"], 0, "unread drops to 0: {resp}");
 
     // After: list reports zero unread, and every entry now carries a read_at.
-    let (entries, unread_after) = c.inbox_list(WS_SLUG).await;
+    let (entries, unread_after) = c.inbox_list(WS_SLUG, OWNER).await;
     assert_eq!(unread_after, 0, "unread count is 0 after the sweep");
     assert!(
         entries.iter().all(|e| e["read_at"].is_i64()),
         "every entry has a read_at stamp after mark-read: {entries:?}"
     );
 
-    // The read_at is persisted in the store (not just the wire).
+    // The read_at is persisted in the store (not just the wire) for the swept
+    // recipient, and only for them.
     let null_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM inbox_entry WHERE workspace_id = ? AND read_at IS NULL",
+        "SELECT COUNT(*) FROM inbox_entry \
+         WHERE workspace_id = ? AND recipient_type = 'member' AND recipient_id = 'user-1' \
+         AND read_at IS NULL",
     )
     .bind(WS_ID)
     .fetch_one(store.pool())
     .await
     .unwrap();
-    assert_eq!(null_count, 0, "no unread rows remain in the store");
+    assert_eq!(null_count, 0, "no unread rows remain for the swept actor");
+    let (_, agent_after) = c.inbox_list(WS_SLUG, FIXTURE_AGENT).await;
+    assert_eq!(
+        agent_after, 1,
+        "the agent's unread survives another actor's sweep"
+    );
 }
 
 /// `hangar/inbox_mark_read` rejects an unknown workspace (never a silent no-op).
@@ -369,4 +421,153 @@ async fn mark_read_rejects_unknown_workspace() {
         !resp["error"].is_null(),
         "an unknown workspace must be rejected, not a silent no-op: {resp}"
     );
+}
+
+/// Seed an issue created by the LOCAL HUMAN and assigned to `agent:a1`, so a
+/// comment on it has two distinct participants to route between.
+///
+/// Written with raw SQL rather than the repo so the fixture states exactly the
+/// `(creator, assignee)` pair the routing depends on. The recipient columns are
+/// FK-less by design, so no `agent` row is required.
+async fn seed_two_party_issue(store: &Store) {
+    sqlx::query(
+        "INSERT INTO issue (id, workspace_id, title, state, creator_type, creator_id, \
+         assignee_type, assignee_id, created_at) \
+         VALUES ('i1', ?, 'Two-party issue', 'open', 'member', 'me', 'agent', 'a1', 1000)",
+    )
+    .bind(WS_ID)
+    .execute(store.pool())
+    .await
+    .expect("seed two-party issue");
+}
+
+fn comment_on_i1(id: &str, author: &str) -> HangarEvent {
+    HangarEvent::CommentAdded(CommentRow {
+        id: CommentId::from_str(id).unwrap(),
+        issue_id: IssueId::from_str("i1").unwrap(),
+        author: author.into(),
+        body: "over to you".into(),
+        created_at: 2_000,
+    })
+}
+
+/// THE ACCEPTANCE PROOF (multica parity #1): an inbox entry targets a specific
+/// actor and only that actor sees it — over the real socket, through the real
+/// aggregator.
+///
+/// MUTATION GUARD: dropping the recipient predicate from the store's `list` /
+/// `mark_all_read` makes each actor see BOTH comments and makes the human's
+/// sweep clear the agent's unread, failing steps 4-6.
+#[tokio::test]
+async fn inbox_entries_are_visible_only_to_their_recipient() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store, sink) = start_server_with_aggregator(dir.path()).await;
+    seed_two_party_issue(&store).await;
+
+    // The agent comments (the human hears about it), then the human comments
+    // (the agent hears about it). Neither is notified of their own comment.
+    sink.emit(WS_ID, comment_on_i1("c-agent", "agent:a1"));
+    sink.emit(WS_ID, comment_on_i1("c-human", "member:me"));
+    wait_for_inbox_count(&store, WS_ID, 2).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    // 4. The human sees exactly the AGENT's comment.
+    let (mine, mine_unread) = c.inbox_list(WS_SLUG, LOCAL_HUMAN).await;
+    assert_eq!(mine.len(), 1, "the human sees exactly one entry: {mine:?}");
+    assert_eq!(
+        mine[0]["subject_id"], "c-agent",
+        "the human is notified of the agent's comment, not their own: {mine:?}"
+    );
+    assert_eq!(mine[0]["recipient"], LOCAL_HUMAN, "{mine:?}");
+    assert_eq!(mine_unread, 1);
+
+    // 5. The agent sees exactly the HUMAN's comment.
+    let (theirs, theirs_unread) = c.inbox_list(WS_SLUG, "agent:a1").await;
+    assert_eq!(theirs.len(), 1, "the agent sees exactly one entry: {theirs:?}");
+    assert_eq!(
+        theirs[0]["subject_id"], "c-human",
+        "the agent is notified of the human's comment: {theirs:?}"
+    );
+    assert_eq!(theirs[0]["recipient"], "agent:a1", "{theirs:?}");
+    assert_eq!(theirs_unread, 1);
+
+    // 6. The human's mark-read sweep does not cross actors.
+    let resp = c
+        .call(
+            methods::HANGAR_INBOX_MARK_READ,
+            serde_json::json!({ "workspace_id": WS_SLUG, "recipient": LOCAL_HUMAN }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "mark_read must ack: {resp}");
+    assert_eq!(resp["result"]["marked"], 1, "only the human's row flips: {resp}");
+    assert_eq!(resp["result"]["unread"], 0, "{resp}");
+
+    let (_, mine_after) = c.inbox_list(WS_SLUG, LOCAL_HUMAN).await;
+    assert_eq!(mine_after, 0, "the human's inbox is clear");
+    let (theirs_after, theirs_unread_after) = c.inbox_list(WS_SLUG, "agent:a1").await;
+    assert_eq!(
+        theirs_unread_after, 1,
+        "the agent's unread survives another actor's sweep"
+    );
+    assert!(
+        theirs_after.iter().all(|e| e.get("read_at").is_none()),
+        "the agent's entry is still unread: {theirs_after:?}"
+    );
+}
+
+/// A malformed `recipient` is `INVALID_PARAMS` — a typo must never silently
+/// fall back to reading someone else's inbox.
+#[tokio::test]
+async fn inbox_list_rejects_a_malformed_recipient() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store, _sink) = start_server_with_aggregator(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    for bad in ["not-an-actor", "frog:a1", "member:"] {
+        let resp = c
+            .call(
+                methods::HANGAR_INBOX_LIST,
+                serde_json::json!({ "workspace_id": WS_SLUG, "recipient": bad }),
+            )
+            .await;
+        assert!(
+            !resp["error"].is_null(),
+            "a malformed recipient {bad:?} must be rejected: {resp}"
+        );
+    }
+}
+
+/// Wire back-compat: a caller that omits `recipient` (a pre-0060 surface) reads
+/// the LOCAL HUMAN's inbox — not the union of every actor's entries.
+#[tokio::test]
+async fn inbox_list_without_recipient_defaults_to_the_local_human() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store, sink) = start_server_with_aggregator(dir.path()).await;
+    seed_two_party_issue(&store).await;
+
+    sink.emit(WS_ID, comment_on_i1("c-agent", "agent:a1"));
+    sink.emit(WS_ID, comment_on_i1("c-human", "member:me"));
+    wait_for_inbox_count(&store, WS_ID, 2).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_INBOX_LIST,
+            serde_json::json!({ "workspace_id": WS_SLUG }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "an omitted recipient must ack: {resp}");
+    let entries = resp["result"]["entries"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        entries.len(),
+        1,
+        "an omitted recipient reads ONE actor's inbox, not everyone's: {entries:?}"
+    );
+    assert_eq!(entries[0]["recipient"], LOCAL_HUMAN, "{entries:?}");
+    assert_eq!(resp["result"]["unread"], 1, "{resp}");
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -878,6 +878,12 @@ pub struct InboxEntryRow {
     pub subject_id: String,
     /// A short pre-rendered human line for the list row.
     pub summary: String,
+    /// The actor this entry is addressed to, as `"member:<id>"` / `"agent:<id>"`
+    /// (store migration 0060, multica parity #1). Every entry targets exactly one
+    /// actor and only that actor's reads return it. Append-only: defaults to the
+    /// empty string when an older daemon omits the field.
+    #[serde(default)]
+    pub recipient: String,
     /// Creation timestamp (epoch milliseconds) — drives ordering + age.
     pub created_at: i64,
     /// When the entry was marked read (epoch milliseconds), or `None` when UNREAD.

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -698,31 +698,42 @@ pub const HANGAR_USAGE_ROLLUP: &str = "hangar/usage_rollup";
 /// error).
 pub const HANGAR_PR_STATUS_REFRESH: &str = "hangar/pr_status_refresh";
 
-/// `hangar/inbox_list` — snapshot the aggregated notification inbox of a
-/// workspace (e38.14).
+/// `hangar/inbox_list` — snapshot ONE ACTOR's aggregated notification inbox in a
+/// workspace (e38.14; per-recipient since store migration 0060).
 ///
-/// Params: [`crate::snapshots::WorkspaceScopedParams`] (`{ workspace_id }`).
-/// Result: [`crate::snapshots::InboxListResult`] — the workspace's inbox entries
-/// (newest-first) plus the unread count. Drives the Inbox screen's list + unread
-/// badge. The entries are the durable aggregate the daemon's inbox writer folds
-/// live issue / comment / task events into (store migration 0021), so an event
-/// that fired while no plugin was attached is still here. Workspace-scoped like
-/// every snapshot: a foreign / unknown workspace yields an empty list + zero
-/// unread (a read, so no `INVALID_PARAMS` rejection — mirrors `issues_list`).
+/// Params: [`crate::snapshots::InboxScopedParams`]
+/// (`{ workspace_id, recipient? }`).
+/// Result: [`crate::snapshots::InboxListResult`] — that recipient's inbox entries
+/// (newest-first) plus THEIR unread count. Drives the Inbox screen's list +
+/// unread badge. The entries are the durable aggregate the daemon's inbox writer
+/// folds live issue / comment / task events into, each addressed to exactly one
+/// actor, so an event that fired while no plugin was attached is still here and
+/// another actor's notifications never leak in.
+///
+/// Scoped on both axes: a foreign / unknown workspace yields an empty list +
+/// zero unread (a read, so no `INVALID_PARAMS` rejection — mirrors
+/// `issues_list`), and only the named recipient's rows are returned. An OMITTED
+/// `recipient` defaults to the LOCAL HUMAN (`member:me`) — never the union of
+/// every actor's entries; a MALFORMED one is rejected with `INVALID_PARAMS`.
 pub const HANGAR_INBOX_LIST: &str = "hangar/inbox_list";
 
-/// `hangar/inbox_mark_read` — mark a workspace's inbox entries read (e38.14).
+/// `hangar/inbox_mark_read` — mark ONE ACTOR's inbox entries read in a workspace
+/// (e38.14; per-recipient since store migration 0060).
 ///
-/// Params: [`crate::snapshots::WorkspaceScopedParams`] (`{ workspace_id }`).
-/// Result: [`crate::snapshots::InboxMarkReadResult`] — how many entries the sweep
-/// flipped + the unread count after (which is `0` for a whole-workspace sweep).
-/// This is the mark-read sweep: it stamps `read_at` on every currently-unread
-/// entry so the unread count drops to zero. Idempotent (a re-sweep flips nothing
-/// and leaves already-read entries on their original timestamp).
+/// Params: [`crate::snapshots::InboxScopedParams`]
+/// (`{ workspace_id, recipient? }`).
+/// Result: [`crate::snapshots::InboxMarkReadResult`] — how many of THAT
+/// recipient's entries the sweep flipped + their unread count after (which is
+/// `0` once their own sweep commits). It stamps `read_at` on every currently-
+/// unread entry addressed to that actor so their unread count drops to zero.
+/// Idempotent (a re-sweep flips nothing and leaves already-read entries on their
+/// original timestamp).
 ///
-/// Mutating + workspace-scoped: the daemon resolves the workspace and rejects a
-/// mistyped one with `INVALID_PARAMS` (never a silent no-op, mirroring
-/// `hangar/task_transition`); a sibling tenant's inbox is never touched.
+/// Mutating + scoped on both axes: the daemon resolves the workspace and rejects
+/// a mistyped one with `INVALID_PARAMS` (never a silent no-op, mirroring
+/// `hangar/task_transition`); neither a sibling tenant's nor a sibling ACTOR's
+/// entries are ever touched. An omitted `recipient` sweeps the LOCAL HUMAN's
+/// inbox (`member:me`); a malformed one is `INVALID_PARAMS`.
 pub const HANGAR_INBOX_MARK_READ: &str = "hangar/inbox_mark_read";
 
 /// `hangar/boards_list` — snapshot the user-defined kanban boards of a workspace

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -33,6 +33,25 @@ pub struct WorkspaceScopedParams {
     pub workspace_id: String,
 }
 
+/// Params for [`crate::methods::HANGAR_INBOX_LIST`] and
+/// [`crate::methods::HANGAR_INBOX_MARK_READ`]: the workspace plus the actor
+/// whose inbox is being read / swept (store migration 0060, multica parity #1).
+///
+/// `recipient` is the canonical `"member:<id>"` / `"agent:<id>"` actor form. It
+/// is append-only-optional: a surface written before 0060 omits it and gets the
+/// LOCAL HUMAN's inbox (`member:me`) — never another actor's, and never the
+/// union of everyone's, which would defeat the per-actor scoping. A malformed
+/// value is rejected with `INVALID_PARAMS` rather than silently defaulted, so a
+/// typo can never read someone else's inbox.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InboxScopedParams {
+    /// The workspace whose inbox to read / sweep.
+    pub workspace_id: String,
+    /// The actor whose inbox this is; `None` means the local human.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipient: Option<String>,
+}
+
 /// Params for [`crate::methods::WORKSPACE_SUBSCRIBE`] — the workspace to stream,
 /// plus an optional resume cursor (T1 event-bus catch-up).
 ///
@@ -3976,5 +3995,49 @@ mod tests {
         // An empty result decodes from an absent `entries` key.
         let empty: IssueTimelineResult = serde_json::from_str("{}").unwrap();
         assert!(empty.entries.is_empty());
+    }
+
+    /// The inbox params are append-only: a pre-0060 caller that sends only
+    /// `workspace_id` still decodes (recipient absent = the local human), and a
+    /// `None` recipient is omitted from the encoded frame entirely.
+    #[test]
+    fn inbox_scoped_params_recipient_is_append_only_optional() {
+        let legacy: InboxScopedParams =
+            serde_json::from_str(r#"{"workspace_id":"ws-1"}"#).unwrap();
+        assert_eq!(legacy.recipient, None, "an omitted recipient is absent");
+
+        let scoped: InboxScopedParams =
+            serde_json::from_str(r#"{"workspace_id":"ws-1","recipient":"agent:a1"}"#).unwrap();
+        assert_eq!(scoped.recipient.as_deref(), Some("agent:a1"));
+
+        let encoded = serde_json::to_string(&legacy).unwrap();
+        assert!(
+            !encoded.contains("recipient"),
+            "a None recipient is skipped on the wire: {encoded}"
+        );
+        assert_eq!(
+            serde_json::from_str::<InboxScopedParams>(&encoded).unwrap(),
+            legacy
+        );
+    }
+
+    /// `InboxEntryRow.recipient` is append-only too: an older daemon's frame
+    /// without the field still decodes, and a fresh one round-trips it.
+    #[test]
+    fn inbox_entry_row_recipient_round_trips_and_defaults() {
+        let legacy: crate::events::InboxEntryRow = serde_json::from_str(
+            r#"{"id":"ie-1","kind":"issue","event":"issue_created","subject_id":"i1","summary":"s","created_at":1}"#,
+        )
+        .unwrap();
+        assert_eq!(legacy.recipient, "", "an older daemon omits the recipient");
+
+        let mut fresh = legacy.clone();
+        fresh.recipient = "member:me".into();
+        let encoded = serde_json::to_string(&fresh).unwrap();
+        assert!(encoded.contains("\"recipient\":\"member:me\""), "{encoded}");
+        assert_eq!(
+            serde_json::from_str::<crate::events::InboxEntryRow>(&encoded).unwrap(),
+            fresh
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -4002,8 +4002,7 @@ mod tests {
     /// `None` recipient is omitted from the encoded frame entirely.
     #[test]
     fn inbox_scoped_params_recipient_is_append_only_optional() {
-        let legacy: InboxScopedParams =
-            serde_json::from_str(r#"{"workspace_id":"ws-1"}"#).unwrap();
+        let legacy: InboxScopedParams = serde_json::from_str(r#"{"workspace_id":"ws-1"}"#).unwrap();
         assert_eq!(legacy.recipient, None, "an omitted recipient is absent");
 
         let scoped: InboxScopedParams =

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0060_inbox_recipient.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0060_inbox_recipient.sql
@@ -1,0 +1,36 @@
+-- Hangar v1 schema, migration 0060: the inbox becomes ACTOR-POLYMORPHIC
+-- (multica parity #1-rest).
+--
+-- Migration 0021 made `inbox_entry` workspace-scoped: every actor on a
+-- workspace read the identical list, so a human "member" was a name on an
+-- assignee, never a collaborator with an inbox of their own. The reference
+-- (`inbox_item`, multica 001_init.up.sql:110) addresses every notification to
+-- exactly one actor -- `recipient_type IN ('member','agent')` + `recipient_id`
+-- -- and every read and every mark-read sweep is keyed on that pair.
+--
+--   - `recipient_type`  the actor family the entry is FOR: `member` or `agent`.
+--                       CHECK-constrained like every other polymorphic actor
+--                       column (0003's assignee/creator/author).
+--   - `recipient_id`    the member's `user.id` or the agent's `agent.id`. No FK:
+--                       the id may live in either table and SQLite cannot express
+--                       a conditional FK (same rationale as 0003).
+--
+-- Both are NOT NULL with a constant DEFAULT so the ADD COLUMN backfills every
+-- pre-existing row in one O(1) catalog change: legacy workspace-wide entries
+-- become the LOCAL HUMAN's entries (`member:me`, the ref the TUI authors
+-- everything as), so no upgrading install loses a notification. Re-applying is
+-- a no-op via the migrator's version ledger.
+
+ALTER TABLE inbox_entry ADD COLUMN recipient_type TEXT NOT NULL DEFAULT 'member'
+    CHECK (recipient_type IN ('member','agent'));
+ALTER TABLE inbox_entry ADD COLUMN recipient_id TEXT NOT NULL DEFAULT 'me';
+
+-- Every read is now (workspace, recipient) + newest-first; this index replaces
+-- 0021's workspace-only ordering index as the list's covering path.
+CREATE INDEX idx_inbox_entry_recipient_created
+    ON inbox_entry(workspace_id, recipient_type, recipient_id, created_at);
+
+-- Partial index over just the unread rows for the per-recipient badge count.
+CREATE INDEX idx_inbox_entry_recipient_unread
+    ON inbox_entry(workspace_id, recipient_type, recipient_id)
+    WHERE read_at IS NULL;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/inbox.rs
@@ -10,12 +10,26 @@
 //! `read_at` (epoch milliseconds, nullable) is the whole unread model: `NULL` =
 //! unread, a stamped value = read. [`InboxRepo::unread_count`] counts the `NULL`
 //! rows; [`InboxRepo::mark_all_read`] stamps every currently-unread row so the
-//! count drops to zero (the mark-read sweep). Every method is **workspace-scoped**
-//! by the `workspace_id` column, mirroring the tenant isolation the issue/comment
-//! repos enforce: a foreign tenant's inbox is never read or mutated.
+//! count drops to zero (the mark-read sweep).
+//!
+//! ## Recipient scoping (migration 0060, multica parity #1)
+//!
+//! Every entry is addressed to exactly ONE actor — a `member` or an `agent` —
+//! via the `(recipient_type, recipient_id)` pair the repo carries as a typed
+//! [`ActorRef`]. Every read and every sweep therefore takes `(workspace,
+//! recipient)`: an entry addressed to `agent:a1` is invisible to `member:me`,
+//! and `member:me`'s mark-read sweep never clears the agent's unread rows.
+//! Workspace scoping is unchanged and still enforced alongside, mirroring the
+//! tenant isolation the issue/comment repos enforce: a foreign tenant's inbox is
+//! never read or mutated.
+//!
+//! The recipient is a REQUIRED, typed field on [`NewInboxEntry`], not an
+//! optional column: a writer that forgets who a notification is for is a compile
+//! error, not a silently-invisible row.
 //!
 //! [`HangarEvent`]: ../../../ainb_hangar_proto/events/enum.HangarEvent.html
 
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
 use sqlx::{Row, SqlitePool};
 
 /// The entity family an [`InboxEntry`] is about — the `kind` column, CHECK-
@@ -68,6 +82,10 @@ pub struct NewInboxEntry {
     pub id: String,
     /// The owning workspace's resolved row id (never the slug).
     pub workspace_id: String,
+    /// The single actor this entry is addressed TO (migration 0060). Required by
+    /// design: an inbox entry with no recipient would be invisible to everyone,
+    /// so the type system refuses to build one.
+    pub recipient: ActorRef,
     /// The entity family the entry is about.
     pub kind: InboxKind,
     /// The wire event discriminant that produced this entry (e.g.
@@ -88,6 +106,8 @@ pub struct InboxEntry {
     pub id: String,
     /// The owning workspace.
     pub workspace_id: String,
+    /// The single actor this entry is addressed to (migration 0060).
+    pub recipient: ActorRef,
     /// The entity family the entry is about.
     pub kind: InboxKind,
     /// The wire event discriminant.
@@ -121,11 +141,13 @@ impl InboxRepo {
     pub async fn insert(pool: &SqlitePool, entry: &NewInboxEntry) -> Result<(), sqlx::Error> {
         sqlx::query(
             "INSERT INTO inbox_entry \
-             (id, workspace_id, kind, event, subject_id, summary, created_at, read_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
+             (id, workspace_id, recipient_type, recipient_id, kind, event, subject_id, summary, created_at, read_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
         )
         .bind(&entry.id)
         .bind(&entry.workspace_id)
+        .bind(entry.recipient.kind().as_str())
+        .bind(entry.recipient.id())
         .bind(entry.kind.as_str())
         .bind(&entry.event)
         .bind(&entry.subject_id)
@@ -136,61 +158,78 @@ impl InboxRepo {
         Ok(())
     }
 
-    /// List a workspace's inbox entries, newest first, capped at `limit`.
+    /// List the entries addressed to `recipient` in a workspace, newest first,
+    /// capped at `limit`.
     ///
-    /// Workspace-scoped by the `workspace_id` column: a foreign tenant's entries
-    /// are never returned, and an unknown workspace yields an empty list. Ordered
-    /// `created_at DESC, id DESC` so the newest notification is the first row (the
-    /// `id` tiebreak keeps two same-millisecond entries deterministic).
+    /// Scoped on BOTH axes: the `workspace_id` column (a foreign tenant's entries
+    /// are never returned, an unknown workspace yields an empty list) and the
+    /// `(recipient_type, recipient_id)` pair (another actor's entries are never
+    /// returned — migration 0060). Ordered `created_at DESC, id DESC` so the
+    /// newest notification is the first row (the `id` tiebreak keeps two
+    /// same-millisecond entries deterministic).
     ///
     /// # Errors
     ///
-    /// Returns a [`sqlx::Error`] if the query fails or a stored `kind` token is
-    /// malformed (impossible given the CHECK constraint).
+    /// Returns a [`sqlx::Error`] if the query fails or a stored `kind` /
+    /// recipient token is malformed (impossible given the CHECK constraints).
     pub async fn list(
         pool: &SqlitePool,
         workspace_id: &str,
+        recipient: &ActorRef,
         limit: i64,
     ) -> Result<Vec<InboxEntry>, sqlx::Error> {
         let rows = sqlx::query(
-            "SELECT id, workspace_id, kind, event, subject_id, summary, created_at, read_at \
+            "SELECT id, workspace_id, recipient_type, recipient_id, kind, event, subject_id, \
+             summary, created_at, read_at \
              FROM inbox_entry \
-             WHERE workspace_id = ? \
+             WHERE workspace_id = ? AND recipient_type = ? AND recipient_id = ? \
              ORDER BY created_at DESC, id DESC \
              LIMIT ?",
         )
         .bind(workspace_id)
+        .bind(recipient.kind().as_str())
+        .bind(recipient.id())
         .bind(limit)
         .fetch_all(pool)
         .await?;
         rows.iter().map(entry_from_row).collect()
     }
 
-    /// Count a workspace's UNREAD entries (`read_at IS NULL`).
+    /// Count `recipient`'s UNREAD entries (`read_at IS NULL`) in a workspace.
     ///
-    /// Workspace-scoped: a foreign tenant's unread entries never count. This is the
-    /// figure the inbox badge renders and the mark-read sweep drives to zero.
+    /// Scoped on both the workspace and the recipient: neither a foreign tenant's
+    /// nor a sibling actor's unread entries ever count. This is the figure the
+    /// inbox badge renders and the mark-read sweep drives to zero.
     ///
     /// # Errors
     ///
     /// Returns a [`sqlx::Error`] if the count query fails.
-    pub async fn unread_count(pool: &SqlitePool, workspace_id: &str) -> Result<i64, sqlx::Error> {
+    pub async fn unread_count(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        recipient: &ActorRef,
+    ) -> Result<i64, sqlx::Error> {
         sqlx::query_scalar(
-            "SELECT COUNT(*) FROM inbox_entry WHERE workspace_id = ? AND read_at IS NULL",
+            "SELECT COUNT(*) FROM inbox_entry \
+             WHERE workspace_id = ? AND recipient_type = ? AND recipient_id = ? \
+             AND read_at IS NULL",
         )
         .bind(workspace_id)
+        .bind(recipient.kind().as_str())
+        .bind(recipient.id())
         .fetch_one(pool)
         .await
     }
 
-    /// Mark every currently-unread entry in a workspace as read, stamping
-    /// `read_at = now_ms`. Returns the number of rows flipped (which equals the
-    /// unread count before the sweep).
+    /// Mark every currently-unread entry addressed to `recipient` in a workspace
+    /// as read, stamping `read_at = now_ms`. Returns the number of rows flipped
+    /// (which equals that recipient's unread count before the sweep).
     ///
     /// Idempotent: a second sweep touches no row (every entry already has a
     /// `read_at`), so the count stays at zero. Only `NULL`-`read_at` rows are
     /// stamped, so an already-read entry keeps its original read timestamp.
-    /// Workspace-scoped: a foreign tenant's entries are never touched.
+    /// Scoped on both axes: neither a foreign tenant's nor a sibling actor's
+    /// entries are ever touched.
     ///
     /// # Errors
     ///
@@ -198,14 +237,18 @@ impl InboxRepo {
     pub async fn mark_all_read(
         pool: &SqlitePool,
         workspace_id: &str,
+        recipient: &ActorRef,
         now_ms: i64,
     ) -> Result<u64, sqlx::Error> {
         let res = sqlx::query(
             "UPDATE inbox_entry SET read_at = ? \
-             WHERE workspace_id = ? AND read_at IS NULL",
+             WHERE workspace_id = ? AND recipient_type = ? AND recipient_id = ? \
+             AND read_at IS NULL",
         )
         .bind(now_ms)
         .bind(workspace_id)
+        .bind(recipient.kind().as_str())
+        .bind(recipient.id())
         .execute(pool)
         .await?;
         Ok(res.rows_affected())
@@ -219,9 +262,21 @@ fn entry_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<InboxEntry, sqlx::Err
         index: "kind".to_string(),
         source: format!("unknown inbox kind {kind_token:?}").into(),
     })?;
+    let recipient_type: String = row.try_get("recipient_type")?;
+    let recipient_id: String = row.try_get("recipient_id")?;
+    let recipient = recipient_type
+        .parse::<ActorKind>()
+        .map_err(|e| e.to_string())
+        .and_then(|kind| ActorRef::new(kind, recipient_id.clone()).map_err(|e| e.to_string()))
+        .map_err(|source| sqlx::Error::ColumnDecode {
+            index: "recipient_type".to_string(),
+            source: format!("malformed inbox recipient {recipient_type}:{recipient_id} ({source})")
+                .into(),
+        })?;
     Ok(InboxEntry {
         id: row.try_get("id")?,
         workspace_id: row.try_get("workspace_id")?,
+        recipient,
         kind,
         event: row.try_get("event")?,
         subject_id: row.try_get("subject_id")?,
@@ -248,10 +303,31 @@ mod tests {
             .unwrap();
     }
 
+    /// The local human — the default recipient the pre-0060 tests implicitly used.
+    fn me() -> ActorRef {
+        ainb_hangar_core::actor::local_member()
+    }
+
+    fn agent(id: &str) -> ActorRef {
+        ActorRef::new(ActorKind::Agent, id).unwrap()
+    }
+
     fn entry(id: &str, ws: &str, kind: InboxKind, subject: &str, ts: i64) -> NewInboxEntry {
+        entry_for(id, ws, me(), kind, subject, ts)
+    }
+
+    fn entry_for(
+        id: &str,
+        ws: &str,
+        recipient: ActorRef,
+        kind: InboxKind,
+        subject: &str,
+        ts: i64,
+    ) -> NewInboxEntry {
         NewInboxEntry {
             id: id.into(),
             workspace_id: ws.into(),
+            recipient,
             kind,
             event: "issue_created".into(),
             subject_id: subject.into(),
@@ -275,7 +351,7 @@ mod tests {
             .unwrap();
         }
 
-        let list = InboxRepo::list(store.pool(), "ws-a", 100).await.unwrap();
+        let list = InboxRepo::list(store.pool(), "ws-a", &me(), 100).await.unwrap();
         let ids: Vec<_> = list.iter().map(|e| e.id.as_str()).collect();
         assert_eq!(ids, ["e3", "e2", "e1"], "newest first");
         assert!(
@@ -283,7 +359,7 @@ mod tests {
             "fresh entries are unread"
         );
         assert_eq!(
-            InboxRepo::unread_count(store.pool(), "ws-a").await.unwrap(),
+            InboxRepo::unread_count(store.pool(), "ws-a", &me()).await.unwrap(),
             3
         );
     }
@@ -302,25 +378,25 @@ mod tests {
             .unwrap();
         }
         assert_eq!(
-            InboxRepo::unread_count(store.pool(), "ws-a").await.unwrap(),
+            InboxRepo::unread_count(store.pool(), "ws-a", &me()).await.unwrap(),
             2
         );
 
-        let flipped = InboxRepo::mark_all_read(store.pool(), "ws-a", 5000).await.unwrap();
+        let flipped = InboxRepo::mark_all_read(store.pool(), "ws-a", &me(), 5000).await.unwrap();
         assert_eq!(flipped, 2, "both unread rows flip");
         assert_eq!(
-            InboxRepo::unread_count(store.pool(), "ws-a").await.unwrap(),
+            InboxRepo::unread_count(store.pool(), "ws-a", &me()).await.unwrap(),
             0,
             "unread count drops to zero after the sweep"
         );
         // The read entries kept their stamp.
-        let list = InboxRepo::list(store.pool(), "ws-a", 100).await.unwrap();
+        let list = InboxRepo::list(store.pool(), "ws-a", &me(), 100).await.unwrap();
         assert!(list.iter().all(|e| e.read_at == Some(5000)));
 
         // A second sweep touches no row (idempotent).
-        let again = InboxRepo::mark_all_read(store.pool(), "ws-a", 9999).await.unwrap();
+        let again = InboxRepo::mark_all_read(store.pool(), "ws-a", &me(), 9999).await.unwrap();
         assert_eq!(again, 0, "a re-sweep flips nothing");
-        let list = InboxRepo::list(store.pool(), "ws-a", 100).await.unwrap();
+        let list = InboxRepo::list(store.pool(), "ws-a", &me(), 100).await.unwrap();
         assert!(
             list.iter().all(|e| e.read_at == Some(5000)),
             "already-read entries keep their original read timestamp"
@@ -347,31 +423,118 @@ mod tests {
         .unwrap();
 
         // ws-a sees only its own entry, and its unread count is its own.
-        let list_a = InboxRepo::list(store.pool(), "ws-a", 100).await.unwrap();
+        let list_a = InboxRepo::list(store.pool(), "ws-a", &me(), 100).await.unwrap();
         assert_eq!(list_a.len(), 1);
         assert_eq!(list_a[0].id, "a1");
         assert_eq!(
-            InboxRepo::unread_count(store.pool(), "ws-a").await.unwrap(),
+            InboxRepo::unread_count(store.pool(), "ws-a", &me()).await.unwrap(),
             1
         );
 
         // Marking ws-a read does not touch ws-b's unread entry.
-        InboxRepo::mark_all_read(store.pool(), "ws-a", 5000).await.unwrap();
+        InboxRepo::mark_all_read(store.pool(), "ws-a", &me(), 5000).await.unwrap();
         assert_eq!(
-            InboxRepo::unread_count(store.pool(), "ws-a").await.unwrap(),
+            InboxRepo::unread_count(store.pool(), "ws-a", &me()).await.unwrap(),
             0
         );
         assert_eq!(
-            InboxRepo::unread_count(store.pool(), "ws-b").await.unwrap(),
+            InboxRepo::unread_count(store.pool(), "ws-b", &me()).await.unwrap(),
             1,
             "a sibling tenant's inbox is untouched by another's mark-read"
         );
 
         // An unknown workspace yields an empty list + zero unread.
-        assert!(InboxRepo::list(store.pool(), "ws-nope", 100).await.unwrap().is_empty());
+        assert!(InboxRepo::list(store.pool(), "ws-nope", &me(), 100).await.unwrap().is_empty());
         assert_eq!(
-            InboxRepo::unread_count(store.pool(), "ws-nope").await.unwrap(),
+            InboxRepo::unread_count(store.pool(), "ws-nope", &me()).await.unwrap(),
             0
         );
+    }
+
+    /// The parity acceptance at the store layer: two actors on ONE workspace see
+    /// disjoint inboxes. Dropping the recipient predicate from `list` /
+    /// `unread_count` makes both actors see both rows and fails this test.
+    #[tokio::test]
+    async fn entry_addressed_to_one_actor_is_invisible_to_another() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_workspace(store.pool(), "ws-a").await;
+
+        InboxRepo::insert(
+            store.pool(),
+            &entry_for("m1", "ws-a", me(), InboxKind::Comment, "i1", 1000),
+        )
+        .await
+        .unwrap();
+        InboxRepo::insert(
+            store.pool(),
+            &entry_for("g1", "ws-a", agent("a1"), InboxKind::Task, "t1", 2000),
+        )
+        .await
+        .unwrap();
+
+        let mine = InboxRepo::list(store.pool(), "ws-a", &me(), 100).await.unwrap();
+        assert_eq!(
+            mine.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["m1"],
+            "the human sees only the entry addressed to them"
+        );
+        assert_eq!(mine[0].recipient, me(), "the recipient round-trips");
+
+        let theirs = InboxRepo::list(store.pool(), "ws-a", &agent("a1"), 100).await.unwrap();
+        assert_eq!(
+            theirs.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["g1"],
+            "the agent sees only the entry addressed to it"
+        );
+        assert_eq!(theirs[0].recipient, agent("a1"));
+
+        assert_eq!(
+            InboxRepo::unread_count(store.pool(), "ws-a", &me()).await.unwrap(),
+            1
+        );
+        assert_eq!(
+            InboxRepo::unread_count(store.pool(), "ws-a", &agent("a1")).await.unwrap(),
+            1
+        );
+        // A third actor with no entries has an empty inbox, not everyone's.
+        assert!(
+            InboxRepo::list(store.pool(), "ws-a", &agent("a2"), 100).await.unwrap().is_empty()
+        );
+    }
+
+    /// The mark-read sweep never crosses actors: sweeping the human leaves the
+    /// agent's row unread and its `read_at` NULL.
+    #[tokio::test]
+    async fn mark_all_read_is_recipient_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_workspace(store.pool(), "ws-a").await;
+        InboxRepo::insert(
+            store.pool(),
+            &entry_for("m1", "ws-a", me(), InboxKind::Comment, "i1", 1000),
+        )
+        .await
+        .unwrap();
+        InboxRepo::insert(
+            store.pool(),
+            &entry_for("g1", "ws-a", agent("a1"), InboxKind::Task, "t1", 2000),
+        )
+        .await
+        .unwrap();
+
+        let flipped = InboxRepo::mark_all_read(store.pool(), "ws-a", &me(), 5000).await.unwrap();
+        assert_eq!(flipped, 1, "only the human's own row flips");
+        assert_eq!(
+            InboxRepo::unread_count(store.pool(), "ws-a", &me()).await.unwrap(),
+            0
+        );
+        assert_eq!(
+            InboxRepo::unread_count(store.pool(), "ws-a", &agent("a1")).await.unwrap(),
+            1,
+            "a sibling actor's inbox is untouched by another's mark-read"
+        );
+        let theirs = InboxRepo::list(store.pool(), "ws-a", &agent("a1"), 100).await.unwrap();
+        assert_eq!(theirs[0].read_at, None, "the agent's row stays unread");
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/inbox.rs
@@ -499,7 +499,10 @@ mod tests {
         );
         // A third actor with no entries has an empty inbox, not everyone's.
         assert!(
-            InboxRepo::list(store.pool(), "ws-a", &agent("a2"), 100).await.unwrap().is_empty()
+            InboxRepo::list(store.pool(), "ws-a", &agent("a2"), 100)
+                .await
+                .unwrap()
+                .is_empty()
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0060_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0060_upgrade.rs
@@ -1,0 +1,199 @@
+//! Upgrade-from-populated test for migration 0060 (`inbox_entry.recipient_type`
+//! / `recipient_id` — multica parity #1).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the migration is safe on a REAL populated database that already has
+//! pre-0060, workspace-wide inbox rows:
+//!
+//! 1. apply only the PRIOR migrations (0001..0059),
+//! 2. seed a workspace / user / member / issue graph plus a legacy `inbox_entry`
+//!    row written with the pre-0060 column list,
+//! 3. apply the embedded migrations (which adds 0060),
+//! 4. assert the legacy row SURVIVES and backfills to the local human
+//!    (`member:me`) so no upgrading install loses a notification, that the
+//!    recipient CHECK rejects a foreign family, that both new indexes exist, and
+//!    that a second apply is a no-op.
+
+use ainb_hangar_store::apply_migrations;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test (`0060_inbox_recipient.sql`).
+const NEW_MIGRATION_VERSION: i64 = 60;
+
+/// Open a fresh on-disk WAL pool in `dir` and apply only the migrations PRIOR to
+/// [`NEW_MIGRATION_VERSION`], with foreign keys ON (the crate's production
+/// setting).
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let db_path = dir.join("hangar.db");
+    let opts = SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(
+        !migrator.migrations.is_empty(),
+        "prior-migration set must not be empty"
+    );
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+/// Seed the pre-0060 world: a workspace with a member, an issue, and ONE legacy
+/// inbox row written with the pre-0060 column list (no recipient columns exist
+/// yet, so this insert is only possible before the upgrade).
+async fn seed_populated(pool: &SqlitePool) {
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-1','a@example.com',0)",
+        "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','user-1','owner')",
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('iss-1','ws-1','Card','open','member','user-1',0)",
+        "INSERT INTO inbox_entry \
+         (id, workspace_id, kind, event, subject_id, summary, created_at, read_at) \
+         VALUES ('ie-legacy','ws-1','issue','issue_created','iss-1','New issue: Card',100,NULL)",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+async fn index_exists(pool: &SqlitePool, name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("sqlite_master")
+        > 0
+}
+
+async fn column_exists(pool: &SqlitePool, table: &str, column: &str) -> bool {
+    sqlx::query(&format!("PRAGMA table_info({table})"))
+        .fetch_all(pool)
+        .await
+        .expect("table_info")
+        .iter()
+        .any(|r| r.get::<String, _>("name") == column)
+}
+
+#[tokio::test]
+async fn migration_0060_backfills_legacy_rows_to_the_local_human() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+
+    // Pre-condition: the recipient columns genuinely do not exist yet.
+    assert!(
+        !column_exists(&pool, "inbox_entry", "recipient_type").await,
+        "recipient_type must not exist before 0060"
+    );
+
+    apply_migrations(&pool).await.expect("upgrade applies 0060");
+    let recorded: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?")
+            .bind(NEW_MIGRATION_VERSION)
+            .fetch_one(&pool)
+            .await
+            .expect("read migration version");
+    assert_eq!(recorded, 1, "0060 recorded as applied");
+
+    // 1. The legacy row survives and is now addressed to the LOCAL HUMAN, so an
+    //    upgrading install loses nothing from the human's inbox.
+    let row = sqlx::query(
+        "SELECT recipient_type, recipient_id, summary, read_at FROM inbox_entry WHERE id = ?",
+    )
+    .bind("ie-legacy")
+    .fetch_one(&pool)
+    .await
+    .expect("legacy row survives");
+    assert_eq!(row.get::<String, _>("recipient_type"), "member");
+    assert_eq!(row.get::<String, _>("recipient_id"), "me");
+    assert_eq!(row.get::<String, _>("summary"), "New issue: Card");
+    assert_eq!(
+        row.get::<Option<i64>, _>("read_at"),
+        None,
+        "the legacy row keeps its unread state"
+    );
+
+    // 2. A recipient-scoped read finds it under `member:me` and nowhere else.
+    let mine: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM inbox_entry \
+         WHERE workspace_id = ? AND recipient_type = 'member' AND recipient_id = 'me'",
+    )
+    .bind("ws-1")
+    .fetch_one(&pool)
+    .await
+    .expect("count member:me");
+    assert_eq!(mine, 1, "the backfilled row reads under member:me");
+    let theirs: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM inbox_entry \
+         WHERE workspace_id = ? AND recipient_type = 'agent'",
+    )
+    .bind("ws-1")
+    .fetch_one(&pool)
+    .await
+    .expect("count agents");
+    assert_eq!(theirs, 0, "no agent inherits the legacy row");
+
+    // 3. An agent-addressed insert lands and is disjoint from the human's rows.
+    sqlx::query(
+        "INSERT INTO inbox_entry \
+         (id, workspace_id, recipient_type, recipient_id, kind, event, subject_id, summary, created_at) \
+         VALUES ('ie-agent', ?, 'agent', 'a1', 'task', 'task_queued', 't-1', 'Task queued: t-1', 200)",
+    )
+    .bind("ws-1")
+    .execute(&pool)
+    .await
+    .expect("agent-addressed insert");
+    let mine_again: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM inbox_entry \
+         WHERE workspace_id = ? AND recipient_type = 'member' AND recipient_id = 'me'",
+    )
+    .bind("ws-1")
+    .fetch_one(&pool)
+    .await
+    .expect("count member:me again");
+    assert_eq!(
+        mine_again, 1,
+        "the agent's entry does not appear in the human's inbox"
+    );
+
+    // 4. The CHECK constraint rejects a foreign recipient family.
+    let bad = sqlx::query(
+        "INSERT INTO inbox_entry \
+         (id, workspace_id, recipient_type, recipient_id, kind, event, subject_id, summary, created_at) \
+         VALUES ('ie-bad', ?, 'bogus', 'x', 'issue', 'issue_created', 'iss-1', 'm', 300)",
+    )
+    .bind("ws-1")
+    .execute(&pool)
+    .await;
+    assert!(
+        bad.is_err(),
+        "an unknown recipient_type must violate the CHECK constraint"
+    );
+
+    // 5. Both recipient indexes exist (the list + badge covering paths).
+    assert!(index_exists(&pool, "idx_inbox_entry_recipient_created").await);
+    assert!(index_exists(&pool, "idx_inbox_entry_recipient_unread").await);
+
+    // 6. Double-apply is idempotent: nothing re-runs, the rows stay as they are.
+    apply_migrations(&pool).await.expect("second apply is a no-op");
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM inbox_entry")
+        .fetch_one(&pool)
+        .await
+        .expect("count after re-apply");
+    assert_eq!(total, 2, "double-apply must not change any row");
+
+    pool.close().await;
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -275,6 +275,17 @@ const ISSUE_TIMELINE_REQ_ID: i64 = 64;
 /// `comment.author_type` CHECK), so this is accepted as-is; swapping in the real
 /// signed-in member is a drop-in change once identity lands.
 const SELF_AUTHOR_REF: &str = "member:me";
+
+/// Params for the two inbox RPCs: the workspace plus WHOSE inbox this is.
+///
+/// Every inbox entry is addressed to exactly one actor (store migration 0060),
+/// so the Inbox screen is THE LOCAL HUMAN's inbox, not a workspace-wide feed:
+/// the request names [`SELF_AUTHOR_REF`] as the recipient, and the daemon
+/// returns / sweeps only that actor's rows. When a real signed-in identity
+/// lands, only that constant changes.
+fn inbox_params(ws: &str) -> serde_json::Value {
+    serde_json::json!({ "workspace_id": ws, "recipient": SELF_AUTHOR_REF })
+}
 /// How many trailing log lines the logs pane reads from the newest `daemon.*`
 /// file on each refresh (P8.6). Bounded so a huge log file never blows up the
 /// pane; the daily rotation keeps a single day's file the practical ceiling.
@@ -1299,7 +1310,9 @@ impl HangarPlugin {
             if let Ok(r) = serde_json::from_value::<ainb_hangar_proto::snapshots::InboxListResult>(
                 result.clone(),
             ) {
-                self.screens.set_inbox(r.entries, r.unread);
+                // The snapshot was requested for the local human, so the screen
+                // is tagged with the actor it belongs to.
+                self.screens.set_inbox(r.entries, r.unread, SELF_AUTHOR_REF.to_string());
             }
         }
     }
@@ -1725,7 +1738,8 @@ impl HangarPlugin {
             return;
         };
         let ws = self.app_state().ws_id.as_str().to_string();
-        let params = serde_json::json!({ "workspace_id": ws });
+        // The sweep names the local human: it must never clear an agent's rows.
+        let params = inbox_params(&ws);
         let Ok(body) = encode_request(
             INBOX_MARK_READ_REQ_ID,
             daemon_methods::HANGAR_INBOX_MARK_READ,
@@ -2103,7 +2117,7 @@ impl HangarPlugin {
             return;
         };
         let ws = self.app_state().ws_id.as_str().to_string();
-        let scoped = serde_json::json!({ "workspace_id": ws });
+        let scoped = serde_json::json!({ "workspace_id": ws.clone() });
         let requests = [
             (
                 ISSUES_REQ_ID,
@@ -2166,10 +2180,14 @@ impl HangarPlugin {
                 daemon_methods::HANGAR_DAEMON_CONFIG_LIST,
                 serde_json::json!({}),
             ),
+            // The Inbox screen is THE LOCAL HUMAN's inbox, not the workspace's:
+            // every entry is addressed to one actor (store migration 0060), so
+            // the request names whose inbox this is. When a real signed-in
+            // identity lands, only `SELF_AUTHOR_REF` changes.
             (
                 INBOX_LIST_REQ_ID,
                 daemon_methods::HANGAR_INBOX_LIST,
-                scoped.clone(),
+                inbox_params(&ws),
             ),
             // The control-center board is FLEET-WIDE (every workspace + the
             // no-workspace host sessions), so its feed is unscoped by design.
@@ -5357,6 +5375,35 @@ impl Plugin for HangarPlugin {
 mod tests {
     use super::*;
     use ainb_plugin_protocol::manifest::{CapabilityGrant, Manifest};
+
+    /// Both inbox RPCs must carry the local human as the `recipient`, or the
+    /// daemon silently answers with `member:me`'s inbox by default while the
+    /// screen claims to be someone else's.
+    ///
+    /// MUTATION GUARD: dropping `recipient` from [`inbox_params`] fails this,
+    /// and both `hangar/inbox_list` and `hangar/inbox_mark_read` are encoded
+    /// from it, so the wire shape is pinned end to end.
+    #[test]
+    fn inbox_requests_name_the_local_human_as_recipient() {
+        let params = inbox_params("default");
+        assert_eq!(params["workspace_id"], "default");
+        assert_eq!(
+            params["recipient"], SELF_AUTHOR_REF,
+            "the inbox request must name whose inbox it reads: {params}"
+        );
+
+        for method in [
+            daemon_methods::HANGAR_INBOX_LIST,
+            daemon_methods::HANGAR_INBOX_MARK_READ,
+        ] {
+            let frame = encode_request(29, method, inbox_params("default")).expect("encode");
+            let body = String::from_utf8(frame).expect("utf8 frame");
+            assert!(
+                body.contains("\"recipient\":\"member:me\""),
+                "{method} must carry the recipient on the wire: {body}"
+            );
+        }
+    }
 
     #[test]
     fn manifest_returns_canonical_toml() {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -885,8 +885,9 @@ impl ScreenStates {
         &mut self,
         entries: Vec<ainb_hangar_proto::events::InboxEntryRow>,
         unread: i64,
+        recipient: String,
     ) {
-        self.inbox = InboxState::from_snapshot(entries, unread);
+        self.inbox = InboxState::from_snapshot(entries, unread, recipient);
     }
 
     /// Take the pending mark-all-read request (`r` pressed), if any (e38.14).

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/inbox.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/inbox.rs
@@ -35,19 +35,37 @@ pub struct InboxState {
     entries: Vec<InboxEntryRow>,
     /// The unread count (`read_at IS NULL`) the badge renders.
     unread: i64,
+    /// The actor whose inbox this is (`member:me` today), painted in the header
+    /// so the screen visibly proves WHOSE notifications these are.
+    recipient: String,
 }
 
 impl InboxState {
-    /// Build the state from an `hangar/inbox_list` snapshot result.
+    /// Build the state from an `hangar/inbox_list` snapshot result, tagged with
+    /// the actor the snapshot was requested for.
     #[must_use]
-    pub const fn from_snapshot(entries: Vec<InboxEntryRow>, unread: i64) -> Self {
-        Self { entries, unread }
+    pub const fn from_snapshot(
+        entries: Vec<InboxEntryRow>,
+        unread: i64,
+        recipient: String,
+    ) -> Self {
+        Self {
+            entries,
+            unread,
+            recipient,
+        }
     }
 
     /// The unread count (read accessor for the glue / tests).
     #[must_use]
     pub const fn unread(&self) -> i64 {
         self.unread
+    }
+
+    /// The actor whose inbox this is (read accessor for the glue / tests).
+    #[must_use]
+    pub fn recipient(&self) -> &str {
+        &self.recipient
     }
 
     /// The aggregated entries (read accessor for tests).
@@ -62,7 +80,7 @@ impl InboxState {
 /// Layout (top-to-bottom):
 ///
 /// ```text
-/// Inbox  [3 unread]
+/// Inbox (member:me)  [3 unread]
 /// r mark all read
 /// issue    New issue: Refactor API
 /// comment  New comment on issue-1
@@ -77,8 +95,15 @@ impl InboxState {
 pub fn render_inbox(buf: &mut WireBuffer, area_w: u16, top: u16, bottom: u16, state: &InboxState) {
     let mut row = top;
 
-    // Title + unread badge.
+    // Title + the actor this inbox belongs to + unread badge. Every entry is
+    // addressed to exactly one actor (store migration 0060), so the header names
+    // whose inbox is on screen rather than implying a workspace-wide feed.
     let mut x = put_str(buf, 0, row, "Inbox", GOLD, area_w);
+    if !state.recipient.is_empty() {
+        x = put_str(buf, x, row, " (", MUTED_GRAY, area_w);
+        x = put_str(buf, x, row, &state.recipient, MUTED_GRAY, area_w);
+        x = put_str(buf, x, row, ")", MUTED_GRAY, area_w);
+    }
     if state.unread > 0 {
         x = put_str(buf, x, row, "  ", MUTED_GRAY, area_w);
         x = put_str(buf, x, row, "[", MUTED_GRAY, area_w);
@@ -172,6 +197,7 @@ mod tests {
             event: "issue_created".into(),
             subject_id: "s-1".into(),
             summary: summary.into(),
+            recipient: "member:me".into(),
             created_at: 0,
             read_at: if read { Some(100) } else { None },
         }
@@ -199,6 +225,7 @@ mod tests {
                 entry("comment", "New comment on issue-1", false),
             ],
             2,
+            "member:me".into(),
         );
         let mut buf = WireBuffer::new(60, 24);
         render_inbox(&mut buf, 60, 0, 20, &state);
@@ -222,9 +249,44 @@ mod tests {
         );
     }
 
+    /// The header names WHOSE inbox is on screen, and the pane paints only the
+    /// entries it was handed.
+    ///
+    /// MUTATION GUARD: dropping the recipient from the title line fails the
+    /// header assertion — the screen would imply a workspace-wide feed while the
+    /// data plane returns one actor's rows.
+    #[test]
+    fn header_names_the_recipient_and_only_their_entries_render() {
+        let state = InboxState::from_snapshot(
+            vec![entry("comment", "New comment on issue-1", false)],
+            1,
+            "member:me".into(),
+        );
+        let mut buf = WireBuffer::new(60, 24);
+        render_inbox(&mut buf, 60, 0, 20, &state);
+
+        let title = row_text(&buf, 0, 60);
+        assert!(
+            title.contains("member:me"),
+            "the header names the recipient: {title:?}"
+        );
+        assert!(title.starts_with("Inbox"), "title: {title:?}");
+        assert_eq!(state.recipient(), "member:me");
+
+        // Only the one handed-in entry paints; no other actor's row appears.
+        let body = (3..8).map(|r| row_text(&buf, r, 60)).collect::<Vec<_>>().join("\n");
+        assert!(body.contains("New comment on issue-1"), "{body}");
+        assert_eq!(
+            body.lines().filter(|l| !l.trim().is_empty()).count(),
+            1,
+            "exactly the entries handed to the screen render: {body}"
+        );
+    }
+
     #[test]
     fn unread_entries_render_amber_read_entries_white() {
-        let state = InboxState::from_snapshot(vec![entry("task", "Task finished", true)], 0);
+        let state =
+            InboxState::from_snapshot(vec![entry("task", "Task finished", true)], 0, String::new());
         let mut buf = WireBuffer::new(60, 24);
         render_inbox(&mut buf, 60, 0, 20, &state);
 


### PR DESCRIPTION
## What

Closes parity row **1-rest** — the actor-polymorphic inbox. Every `inbox_entry`
is now addressed to exactly one actor (`member:<id>` / `agent:<id>`), and every
read and every mark-read sweep is keyed on that recipient.

Before this, migration 0021's `inbox_entry` was **workspace-scoped**: every actor
on a workspace saw the identical list, so a human "member" was a name on an
assignee rather than a collaborator with an inbox of their own, and an agent had
no inbox at all.

## How

- **Migration 0060** adds `recipient_type` (CHECK `IN ('member','agent')`) +
  `recipient_id`, both `NOT NULL DEFAULT` so the `ADD COLUMN` backfills every
  pre-existing row in one O(1) catalog change. Legacy rows become the **local
  human's** (`member:me`), so an upgrading install loses no notification. Two
  covering indexes for the per-recipient list + badge count. FK-less by design,
  same rationale as 0003's polymorphic actor columns.
- **`ainb-hangar-core`** gains `actor::local_member()` / `LOCAL_MEMBER_ID` so the
  plugin's `SELF_AUTHOR_REF`, the daemon's wire default and the migration's
  backfill share one definition instead of three string literals.
- **`InboxRepo`** carries the recipient as a **required, typed `ActorRef`** —
  a writer that forgets who a notification is for is a compile error, not a
  silently-invisible row. `list` / `unread_count` / `mark_all_read` all take it.
- **Wire**: `InboxEntryRow.recipient` is append-only `#[serde(default)]`; the two
  inbox methods get their own `InboxScopedParams { workspace_id, recipient? }` so
  `WorkspaceScopedParams` (shared by many methods) is untouched. An omitted
  `recipient` means the **local human**, never the union of every actor's rows;
  a malformed one is `INVALID_PARAMS`.
- **Aggregator fan-out** (`recipients_for`): the issue's participants (creator +
  assignee) minus the actor who caused the event, a queued task's own agent, a
  task lifecycle event's originating issue creator, with a workspace-owner →
  `member:me` fallback so nothing is dropped. One row per recipient, deduped.
- **Plugin**: both inbox RPCs name `member:me`; the Inbox header renders
  `Inbox (member:me)` so the screen visibly states whose notifications it shows.

### Deviation from the reference, called out

multica routes on an `issue_subscriber` table. hangar has none, so "subscribers"
is approximated by the issue's **participants** (creator + assignee). Documented
in `recipients_for`'s doc comment.

### Out of scope (each is its own parity row)

`archived`, `severity`, `title`/`body` split, the `actor_type`/`actor_id` (who
*caused* it) axis, notification preferences/muting, a `hangar inbox` CLI.

## Proof

- `crates/ainb-hangar-daemon/tests/rpc_inbox.rs::inbox_entries_are_visible_only_to_their_recipient`
  — over a real `UnixStream`, through the real `EventBroker` +
  `inbox_aggregator::spawn`: the agent's comment reaches the human, the human's
  comment reaches the agent, **neither is notified of their own action**, and the
  human's mark-read sweep leaves the agent's unread at 1. Fails before this
  change (both actors saw both rows); fails again if the recipient predicate is
  dropped from the store queries.
- `inbox_list_rejects_a_malformed_recipient`, and
  `inbox_list_without_recipient_defaults_to_the_local_human` (wire back-compat:
  one actor's rows, not everyone's).
- `crates/ainb-hangar-store/tests/migration_0060_upgrade.rs` — on a real
  migrator-built DB seeded at 0001..0059 with a legacy pre-0060 inbox row: the
  row survives and backfills to `member:me`, an agent-addressed insert is
  disjoint from it, the CHECK rejects a foreign family, both indexes exist, and a
  second apply is a no-op.
- Store: `entry_addressed_to_one_actor_is_invisible_to_another`,
  `mark_all_read_is_recipient_scoped`.
- Aggregator (store-backed): comment-by-agent → creator, comment-by-member →
  assignee agent, `TaskQueued` → `agent:<id>`, undeducible event → workspace owner.
- Plugin: `inbox_requests_name_the_local_human_as_recipient` asserts the encoded
  frame for BOTH inbox methods carries `"recipient":"member:me"` (dropping the
  field fails it); `header_names_the_recipient_and_only_their_entries_render`.

No tmux tripwire: the Inbox screen has none today and the suite is a known flake
source under concurrency; the socket-level e2e + the render test are the
user-visible proof.

## Local gate (all green on this branch)

| Gate | Result |
|---|---|
| `cargo build -p ainb` | ok |
| `cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'` | 4216 passed, 0 failed, 18 skipped |
| `scripts/hangar/run_all_tripwires.sh` | ran=64 failed=0 skipped=0 |
| `scripts/hangar/run_acceptance_tests.sh` | ran=177 failed=0 skipped=0 |
| `cargo fmt --all` (stable, matching the CI job) | applied, only this PR's files |

Three pre-existing fixtures drifted on the schema/behaviour change and are fixed
in this PR: the store repo tests, and the three `rpc_inbox` tests, whose
assertions move from one flat workspace list to per-recipient lists (which is
what the aggregation now produces) rather than staying frozen on a total count.

The parity matrix row is deliberately not edited here to avoid colliding with the
campaign's own bookkeeping commit on `docs/explorations/multica-reference/README.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inbox notifications are now separated by recipient, so members and agents see only entries addressed to them.
  * Inbox views display the active recipient and maintain recipient-specific unread counts.
  * Comments, queued tasks, and other events are routed to the appropriate recipients.
  * Inbox read actions affect only the selected recipient’s notifications.

* **Bug Fixes**
  * Prevented notifications and read-status changes from crossing between actors.
  * Legacy inbox data remains available and is assigned to the local member by default.
  * Invalid recipient values now return a clear request error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->