### PR TITLE
feat(hangar): issue subscribers + reactions (multica parity #22)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -4790,15 +4790,9 @@ async fn run_issue_react(store: &Store, cmd: IssueReactCommand) -> Result<()> {
         }
         IssueReactCommand::Remove(args) => {
             let actor = parse_actor_arg(args.actor.as_deref())?;
-            IssueReactionRepo::remove(
-                store.pool(),
-                &workspace_id,
-                &args.id,
-                &actor,
-                &args.emoji,
-            )
-            .await
-            .map_err(map)?;
+            IssueReactionRepo::remove(store.pool(), &workspace_id, &args.id, &actor, &args.emoji)
+                .await
+                .map_err(map)?;
         }
         IssueReactCommand::List(_) => {}
     }
@@ -4834,16 +4828,13 @@ async fn require_issue_in_workspace(
 
 /// Print one issue's subscriber set, one `<actor>  (<reason>)` row each.
 /// No subscribers ⇒ `no subscribers`.
-async fn print_issue_subscribers(
-    store: &Store,
-    workspace_id: &str,
-    issue_id: &str,
-) -> Result<()> {
+async fn print_issue_subscribers(store: &Store, workspace_id: &str, issue_id: &str) -> Result<()> {
     use ainb_hangar_store::repo::issue_subscriber::IssueSubscriberRepo;
 
     require_issue_in_workspace(store, workspace_id, issue_id).await?;
-    let subs =
-        IssueSubscriberRepo::list(store.pool(), issue_id).await.context("read subscribers")?;
+    let subs = IssueSubscriberRepo::list(store.pool(), issue_id)
+        .await
+        .context("read subscribers")?;
     if subs.is_empty() {
         println!("no subscribers");
         return Ok(());
@@ -4859,8 +4850,9 @@ async fn print_issue_subscribers(
 async fn print_issue_reactions(store: &Store, issue_id: &str) -> Result<()> {
     use ainb_hangar_store::repo::issue_reaction::IssueReactionRepo;
 
-    let tallies =
-        IssueReactionRepo::tallies(store.pool(), issue_id).await.context("read reactions")?;
+    let tallies = IssueReactionRepo::tallies(store.pool(), issue_id)
+        .await
+        .context("read reactions")?;
     if tallies.is_empty() {
         println!("no reactions");
         return Ok(());

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1428,6 +1428,15 @@ pub enum IssueCommand {
     /// Add, remove, or list an issue's typed links to other issues.
     #[command(subcommand)]
     Link(IssueLinkCommand),
+    /// Subscribe an actor to an issue's notifications (multica parity #22).
+    Subscribe(IssueSubscribeArgs),
+    /// Unsubscribe an actor from an issue's notifications. Idempotent.
+    Unsubscribe(IssueSubscribeArgs),
+    /// List who watches an issue, with the reason each one was subscribed.
+    Subscribers(IssueSubscribersArgs),
+    /// Add, remove, or list an issue's emoji reactions.
+    #[command(subcommand)]
+    React(IssueReactCommand),
     /// Explain why an issue did (or did not) dispatch — its admission history.
     #[command(alias = "dispatch-log")]
     Why(IssueWhyArgs),
@@ -1526,6 +1535,65 @@ pub struct IssueLinkArgs {
 pub struct IssueLinkListArgs {
     /// Issue id (ULID) whose links to list.
     pub id: String,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Arguments for `hangar issue subscribe|unsubscribe` (multica parity #22).
+#[derive(Args, Debug)]
+pub struct IssueSubscribeArgs {
+    /// Issue id (ULID) to watch / stop watching.
+    pub id: String,
+    /// The actor, as `member:<id>` / `agent:<id>`. Defaults to the LOCAL HUMAN
+    /// (`member:me`), mirroring the reference's "the target defaults to the
+    /// caller".
+    #[arg(long)]
+    pub actor: Option<String>,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Arguments for `hangar issue subscribers` (multica parity #22).
+#[derive(Args, Debug)]
+pub struct IssueSubscribersArgs {
+    /// Issue id (ULID) whose watchers to list.
+    pub id: String,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// `hangar issue react <verb>` (multica parity #22).
+///
+/// An emoji reaction is unique per `(issue, actor, emoji)`, so `add` is
+/// idempotent and `remove` never errors on an absent one. Talks to the store
+/// repo directly, exactly like `issue link`, so it works with no daemon running.
+#[derive(Subcommand, Debug)]
+pub enum IssueReactCommand {
+    /// React to an issue with an emoji. Idempotent.
+    Add(IssueReactArgs),
+    /// Remove your reaction. Idempotent.
+    Remove(IssueReactArgs),
+    /// List an issue's reactions as `<emoji> <count>` buckets.
+    List(IssueSubscribersArgs),
+}
+
+/// Arguments for `hangar issue react add|remove`.
+#[derive(Args, Debug)]
+pub struct IssueReactArgs {
+    /// Issue id (ULID) to react to.
+    pub id: String,
+    /// The emoji. Required and non-blank (the reference's "emoji is required").
+    #[arg(long)]
+    pub emoji: String,
+    /// The reacting actor. Defaults to the LOCAL HUMAN (`member:me`).
+    #[arg(long)]
+    pub actor: Option<String>,
     /// Workspace slug the issue belongs to. Defaults to the bootstrapped
     /// `default` workspace.
     #[arg(long)]
@@ -4399,6 +4467,13 @@ async fn dispatch_issue(cmd: IssueCommand, format: OutputFormat) -> Result<()> {
         IssueCommand::Label(cmd) => run_issue_label(&store, cmd).await,
         IssueCommand::Criteria(cmd) => run_issue_criteria(&store, cmd).await,
         IssueCommand::Link(cmd) => run_issue_link(&store, cmd).await,
+        IssueCommand::Subscribe(args) => run_issue_subscribe(&store, args, true).await,
+        IssueCommand::Unsubscribe(args) => run_issue_subscribe(&store, args, false).await,
+        IssueCommand::Subscribers(args) => {
+            let ws = resolve_skills_workspace(&store, args.workspace.as_deref()).await?;
+            print_issue_subscribers(&store, &ws, &args.id).await
+        }
+        IssueCommand::React(cmd) => run_issue_react(&store, cmd).await,
         IssueCommand::Why(args) => run_issue_why(&store, args, format).await,
         IssueCommand::Timeline(args) => run_issue_timeline(&store, args, format).await,
     }
@@ -4635,6 +4710,167 @@ async fn run_issue_criteria(store: &Store, cmd: IssueCriteriaCommand) -> Result<
     for (idx, criterion) in issue.acceptance_criteria.iter().enumerate() {
         println!("{}", criterion_line(idx + 1, criterion));
     }
+    Ok(())
+}
+
+/// `hangar issue subscribe|unsubscribe` (multica parity #22): author an issue's
+/// subscriber set.
+///
+/// Routes through the SAME [`IssueSubscriberRepo`] seam the daemon RPC uses, so
+/// there is exactly one mutator. The actor defaults to the LOCAL HUMAN. An
+/// unknown / foreign-tenant issue is a NON-ZERO exit with the daemon's own
+/// phrasing, never a silent no-op. Prints the refreshed set afterwards.
+///
+/// [`IssueSubscriberRepo`]: ainb_hangar_store::repo::issue_subscriber::IssueSubscriberRepo
+async fn run_issue_subscribe(
+    store: &Store,
+    args: IssueSubscribeArgs,
+    subscribe: bool,
+) -> Result<()> {
+    use ainb_hangar_store::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
+
+    let workspace_id = resolve_skills_workspace(store, args.workspace.as_deref()).await?;
+    let actor = parse_actor_arg(args.actor.as_deref())?;
+    // The repo's tenant join makes a foreign / unknown issue a silent no-op, so
+    // resolve the issue FIRST and fail loudly instead.
+    require_issue_in_workspace(store, &workspace_id, &args.id).await?;
+
+    let now = ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock);
+    if subscribe {
+        IssueSubscriberRepo::add(
+            store.pool(),
+            &workspace_id,
+            &args.id,
+            &actor,
+            SubscribeReason::Manual,
+            now,
+        )
+        .await
+        .context("subscribe to issue")?;
+    } else {
+        IssueSubscriberRepo::remove(store.pool(), &workspace_id, &args.id, &actor)
+            .await
+            .context("unsubscribe from issue")?;
+    }
+    print_issue_subscribers(store, &workspace_id, &args.id).await
+}
+
+/// `hangar issue react add|remove|list` (multica parity #22).
+async fn run_issue_react(store: &Store, cmd: IssueReactCommand) -> Result<()> {
+    use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
+    use ainb_hangar_store::repo::issue_reaction::{IssueReactionError, IssueReactionRepo};
+
+    let (id, workspace) = match &cmd {
+        IssueReactCommand::Add(a) | IssueReactCommand::Remove(a) => {
+            (a.id.clone(), a.workspace.clone())
+        }
+        IssueReactCommand::List(a) => (a.id.clone(), a.workspace.clone()),
+    };
+    let workspace_id = resolve_skills_workspace(store, workspace.as_deref()).await?;
+    require_issue_in_workspace(store, &workspace_id, &id).await?;
+
+    let map = |e: IssueReactionError| match e {
+        IssueReactionError::EmptyEmoji => anyhow::anyhow!("emoji is required"),
+        IssueReactionError::Db(db) => anyhow::Error::new(db).context("issue reaction"),
+    };
+    match &cmd {
+        IssueReactCommand::Add(args) => {
+            let actor = parse_actor_arg(args.actor.as_deref())?;
+            IssueReactionRepo::add(
+                store.pool(),
+                &workspace_id,
+                &args.id,
+                &actor,
+                &args.emoji,
+                &SystemIdGen.new_ulid(),
+                ainb_hangar_core::clock::HangarClock::now_ms(&SystemClock),
+            )
+            .await
+            .map_err(map)?;
+        }
+        IssueReactCommand::Remove(args) => {
+            let actor = parse_actor_arg(args.actor.as_deref())?;
+            IssueReactionRepo::remove(
+                store.pool(),
+                &workspace_id,
+                &args.id,
+                &actor,
+                &args.emoji,
+            )
+            .await
+            .map_err(map)?;
+        }
+        IssueReactCommand::List(_) => {}
+    }
+    print_issue_reactions(store, &id).await
+}
+
+/// Parse an `--actor` argument, defaulting to the LOCAL HUMAN (`member:me`).
+fn parse_actor_arg(raw: Option<&str>) -> Result<ainb_hangar_core::actor::ActorRef> {
+    match raw {
+        None => Ok(ainb_hangar_core::actor::local_member()),
+        Some(token) => <ainb_hangar_core::actor::ActorRef as std::str::FromStr>::from_str(token)
+            .map_err(|e| anyhow::anyhow!("bad --actor `{token}`: {e}")),
+    }
+}
+
+/// Fail loudly when `issue_id` does not live in `workspace_id` — the repos'
+/// tenant join would otherwise turn it into a silent no-op.
+async fn require_issue_in_workspace(
+    store: &Store,
+    workspace_id: &str,
+    issue_id: &str,
+) -> Result<()> {
+    let found = IssueRepo::get_by_id(store.pool(), issue_id)
+        .await
+        .context("read issue")?
+        .is_some_and(|i| i.workspace_id == workspace_id);
+    if found {
+        Ok(())
+    } else {
+        anyhow::bail!("no issue `{issue_id}` in this workspace")
+    }
+}
+
+/// Print one issue's subscriber set, one `<actor>  (<reason>)` row each.
+/// No subscribers ⇒ `no subscribers`.
+async fn print_issue_subscribers(
+    store: &Store,
+    workspace_id: &str,
+    issue_id: &str,
+) -> Result<()> {
+    use ainb_hangar_store::repo::issue_subscriber::IssueSubscriberRepo;
+
+    require_issue_in_workspace(store, workspace_id, issue_id).await?;
+    let subs =
+        IssueSubscriberRepo::list(store.pool(), issue_id).await.context("read subscribers")?;
+    if subs.is_empty() {
+        println!("no subscribers");
+        return Ok(());
+    }
+    for s in subs {
+        println!("{}  ({})", s.actor, s.reason_raw);
+    }
+    Ok(())
+}
+
+/// Print one issue's aggregated reactions as `<emoji> <count>`, most-used first.
+/// No reactions ⇒ `no reactions`.
+async fn print_issue_reactions(store: &Store, issue_id: &str) -> Result<()> {
+    use ainb_hangar_store::repo::issue_reaction::IssueReactionRepo;
+
+    let tallies =
+        IssueReactionRepo::tallies(store.pool(), issue_id).await.context("read reactions")?;
+    if tallies.is_empty() {
+        println!("no reactions");
+        return Ok(());
+    }
+    let line = tallies
+        .iter()
+        .map(|t| format!("{} {}", t.emoji, t.count))
+        .collect::<Vec<_>>()
+        .join("  ");
+    println!("{line}");
     Ok(())
 }
 
@@ -5481,6 +5717,34 @@ async fn run_issue_show(store: &Store, args: IssueShowArgs, format: OutputFormat
             if issue_has_links(store, &issue.id).await? {
                 println!("Links:");
                 print_issue_links(store, &issue.workspace_id, &issue.id).await?;
+            }
+            // multica parity #22: who watches this issue and how it was reacted
+            // to — the daemon-free, TUI-free acceptance read. Silent when there
+            // are none, so existing output is unchanged.
+            {
+                use ainb_hangar_store::repo::issue_reaction::IssueReactionRepo;
+                use ainb_hangar_store::repo::issue_subscriber::IssueSubscriberRepo;
+
+                let subs = IssueSubscriberRepo::list(store.pool(), &issue.id)
+                    .await
+                    .context("read subscribers")?;
+                if !subs.is_empty() {
+                    println!("Subscribers: {}", subs.len());
+                    for s in &subs {
+                        println!("  {}  ({})", s.actor, s.reason_raw);
+                    }
+                }
+                let tallies = IssueReactionRepo::tallies(store.pool(), &issue.id)
+                    .await
+                    .context("read reactions")?;
+                if !tallies.is_empty() {
+                    let line = tallies
+                        .iter()
+                        .map(|t| format!("{} {}", t.emoji, t.count))
+                        .collect::<Vec<_>>()
+                        .join("  ");
+                    println!("Reactions: {line}");
+                }
             }
             // multica parity #12: WHY this card is not running, when its newest
             // admission decision was a decline. Silent on a healthy card, so

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -2524,18 +2524,17 @@ fn issue_subscribe_persists_to_sqlite_and_survives_a_new_process() {
         .expect("read issue_subscriber")
     });
     assert!(
-        rows.contains(&(
-            "member".to_string(),
-            "me".to_string(),
-            "manual".to_string()
-        )),
+        rows.contains(&("member".to_string(), "me".to_string(), "manual".to_string())),
         "the manual subscription is at rest in sqlite: {rows:?}"
     );
 
     // A SECOND process still sees it — the persistence half, not asserted but run.
     let (ok, out) = run(tmp.path(), &["hangar", "issue", "subscribers", &id]);
     assert!(ok, "issue subscribers should exit 0; out={out}");
-    assert!(out.contains("member:me"), "still listed after a restart:\n{out}");
+    assert!(
+        out.contains("member:me"),
+        "still listed after a restart:\n{out}"
+    );
 
     // `issue show` surfaces it too, so the read needs neither daemon nor TUI.
     let (ok, out) = run(tmp.path(), &["hangar", "issue", "show", &id]);

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -2487,3 +2487,155 @@ fn issue_link_refuses_a_self_link_and_a_cycle() {
     );
     assert!(ok, "a related link is cycle-exempt; out={out}");
 }
+
+/// THE ACCEPTANCE for multica parity #22: *an actor can subscribe to an issue;
+/// persists (sqlite)*.
+///
+/// A real-binary round trip — `issue create` then `issue subscribe` — followed by
+/// a raw `SELECT` on the same `hangar.db` the binary wrote. The row must read
+/// `member|me|manual`, and a SECOND process invocation must still list it, which
+/// is the "persists" half proven across a process boundary rather than asserted.
+#[test]
+fn issue_subscribe_persists_to_sqlite_and_survives_a_new_process() {
+    let tmp = tempfile::tempdir().unwrap();
+    let id = create_issue(tmp.path(), "Subscribe proof");
+
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "subscribe", &id]);
+    assert!(ok, "issue subscribe should exit 0; out={out}");
+    assert!(
+        out.contains("member:me") && out.contains("(manual)"),
+        "the refreshed set names the local human with its provenance:\n{out}"
+    );
+
+    // The at-rest proof: read the row the binary wrote, in a FRESH connection.
+    let rows = tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let pool = sqlx::SqlitePool::connect(&format!(
+            "sqlite://{}",
+            tmp.path().join("hangar.db").display()
+        ))
+        .await
+        .expect("open the db the binary wrote");
+        sqlx::query_as::<_, (String, String, String)>(
+            "SELECT actor_type, actor_id, reason FROM issue_subscriber WHERE issue_id = ?",
+        )
+        .bind(&id)
+        .fetch_all(&pool)
+        .await
+        .expect("read issue_subscriber")
+    });
+    assert!(
+        rows.contains(&(
+            "member".to_string(),
+            "me".to_string(),
+            "manual".to_string()
+        )),
+        "the manual subscription is at rest in sqlite: {rows:?}"
+    );
+
+    // A SECOND process still sees it — the persistence half, not asserted but run.
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "subscribers", &id]);
+    assert!(ok, "issue subscribers should exit 0; out={out}");
+    assert!(out.contains("member:me"), "still listed after a restart:\n{out}");
+
+    // `issue show` surfaces it too, so the read needs neither daemon nor TUI.
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "show", &id]);
+    assert!(ok, "issue show should exit 0; out={out}");
+    assert!(out.contains("Subscribers:"), "the show block:\n{out}");
+
+    // Unsubscribe really removes the row (the CLI's own creator row survives —
+    // it is a DIFFERENT actor, so this also proves the delete is actor-scoped)
+    // and a second unsubscribe is an idempotent no-op.
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "unsubscribe", &id]);
+    assert!(ok, "unsubscribe should exit 0; out={out}");
+    assert!(
+        !out.contains("member:me"),
+        "the manual subscription is gone:\n{out}"
+    );
+    assert!(
+        out.contains("(creator)"),
+        "the creator's own row is untouched:\n{out}"
+    );
+    let (ok, _) = run(tmp.path(), &["hangar", "issue", "unsubscribe", &id]);
+    assert!(ok, "a second unsubscribe is an idempotent no-op");
+}
+
+/// A create auto-subscribes its CREATOR (multica parity #22), so an issue is
+/// never born with an empty watcher set.
+#[test]
+fn issue_create_auto_subscribes_its_creator() {
+    let tmp = tempfile::tempdir().unwrap();
+    let id = create_issue(tmp.path(), "Auto watched");
+
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "subscribers", &id]);
+    assert!(ok, "issue subscribers should exit 0; out={out}");
+    assert!(
+        out.contains("(creator)"),
+        "the creator is subscribed with `creator` provenance:\n{out}"
+    );
+}
+
+/// `hangar issue react add|remove|list` round trip (multica parity #22), plus the
+/// reference's required-emoji guard.
+#[test]
+fn issue_react_add_remove_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let id = create_issue(tmp.path(), "Reactable");
+
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "issue", "react", "add", &id, "--emoji", "👍"],
+    );
+    assert!(ok, "react add should exit 0; out={out}");
+    assert!(out.contains("👍 1"), "the bucket:\n{out}");
+
+    // Reacting twice is idempotent — still one.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "issue", "react", "add", &id, "--emoji", "👍"],
+    );
+    assert!(ok, "a repeat react is a no-op; out={out}");
+    assert!(out.contains("👍 1"), "still one reactor:\n{out}");
+
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "react", "list", &id]);
+    assert!(ok && out.contains("👍 1"), "list reads it back:\n{out}");
+
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "issue", "react", "remove", &id, "--emoji", "👍"],
+    );
+    assert!(ok, "react remove should exit 0; out={out}");
+    assert!(out.contains("no reactions"), "the set empties:\n{out}");
+
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "issue", "react", "add", &id, "--emoji", "  "],
+    );
+    assert!(!ok, "a blank emoji must exit non-zero; out={out}");
+    assert!(out.contains("emoji is required"), "the guard text:\n{out}");
+}
+
+/// A foreign / unknown issue is a NON-ZERO exit, never a silent no-op — the
+/// repos' tenant join would otherwise swallow it.
+#[test]
+fn issue_subscribe_unknown_id_is_an_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_issue(tmp.path(), "Anchor");
+
+    let (ok, out) = run(tmp.path(), &["hangar", "issue", "subscribe", "no-such-id"]);
+    assert!(!ok, "an unknown issue must exit non-zero; out={out}");
+    assert!(out.contains("no issue"), "the refusal text:\n{out}");
+}
+
+/// A malformed `--actor` token is rejected rather than silently treated as "me".
+#[test]
+fn issue_subscribe_rejects_a_malformed_actor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let id = create_issue(tmp.path(), "Actor guard");
+
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "issue", "subscribe", &id, "--actor", "nonsense"],
+    );
+    assert!(!ok, "a malformed actor must exit non-zero; out={out}");
+    assert!(out.contains("bad --actor"), "the refusal text:\n{out}");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -166,6 +166,9 @@ mod tests {
 
     fn issue_row(id: &str) -> IssueRow {
         IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -42,6 +42,7 @@ use ainb_hangar_core::ids::WorkspaceId;
 use ainb_hangar_proto::events::HangarEvent;
 use ainb_hangar_store::repo::inbox::{InboxKind, InboxRepo, NewInboxEntry};
 use ainb_hangar_store::repo::issue::IssueRepo;
+use ainb_hangar_store::repo::issue_subscriber::IssueSubscriberRepo;
 use ainb_hangar_store::repo::member::MemberRepo;
 use ainb_hangar_store::repo::task::TaskRepo;
 use sqlx::SqlitePool;
@@ -161,6 +162,25 @@ async fn fallback_recipient(pool: &SqlitePool, workspace_id: &str) -> ActorRef {
         .unwrap_or_else(local_member)
 }
 
+/// The issue's SUBSCRIBER set (multica parity #22, migration 0062), falling back
+/// to the participant derivation when the issue has no subscriber rows at all.
+///
+/// The fallback is what makes the conversion upgrade-safe: an issue written by a
+/// path that predates the auto-subscribe writers (or one whose backfill found
+/// nothing) still notifies its creator and assignee, so no upgrade can silence a
+/// notification. Once ANY row exists the table is authoritative — that is how an
+/// unsubscribe actually takes effect.
+async fn issue_subscribers_or_participants(pool: &SqlitePool, issue_id: &str) -> Vec<ActorRef> {
+    match IssueSubscriberRepo::actors(pool, issue_id).await {
+        Ok(subs) if !subs.is_empty() => subs,
+        Ok(_) => issue_participants(pool, issue_id).await,
+        Err(e) => {
+            tracing::warn!(error = %e, issue_id, "inbox subscriber lookup failed");
+            issue_participants(pool, issue_id).await
+        }
+    }
+}
+
 /// The participants of an issue: its creator plus its assignee (when set).
 async fn issue_participants(pool: &SqlitePool, issue_id: &str) -> Vec<ActorRef> {
     match IssueRepo::get_by_id(pool, issue_id).await {
@@ -178,16 +198,16 @@ async fn issue_participants(pool: &SqlitePool, issue_id: &str) -> Vec<ActorRef> 
 }
 
 /// Who an aggregated event is FOR — the reference's `notifySubscribers`
-/// (participants minus the actor) plus `notifyDirect` (a targeted actor),
+/// (subscribers minus the actor) plus `notifyDirect` (a targeted actor),
 /// expressed against hangar's schema.
 ///
-/// **Deviation from multica, deliberate:** hangar has no `issue_subscriber`
-/// table, so "subscribers" is approximated by the issue's PARTICIPANTS (its
-/// creator plus its assignee) minus the actor who caused the event — you are
-/// never notified of your own action (multica
-/// `notification_listeners.go:316`). An event with no derivable participant
-/// falls back to the workspace OWNER, then to [`local_member`], so a
-/// notification is never silently dropped.
+/// Since migration 0062 (multica parity #22) "subscribers" is a REAL
+/// `issue_subscriber` read, not the participant approximation the previous
+/// revision documented: a watcher who is neither creator nor assignee now hears
+/// about a comment, and an actor who unsubscribed does not. You are still never
+/// notified of your own action (multica `notification_listeners.go:316`). An
+/// event with no derivable recipient falls back to the workspace OWNER, then to
+/// [`local_member`], so a notification is never silently dropped.
 async fn recipients_for(pool: &SqlitePool, scoped: &ScopedEvent) -> Vec<ActorRef> {
     let ws = scoped.workspace_id.as_str();
     let mut out: Vec<ActorRef> = match &scoped.event {
@@ -214,8 +234,8 @@ async fn recipients_for(pool: &SqlitePool, scoped: &ScopedEvent) -> Vec<ActorRef
         // to `notifySubscribers`.
         HangarEvent::CommentAdded(row) => {
             let author = actor(&row.author);
-            let participants = issue_participants(pool, row.issue_id.as_str()).await;
-            participants.into_iter().filter(|p| Some(p) != author.as_ref()).collect()
+            let watchers = issue_subscribers_or_participants(pool, row.issue_id.as_str()).await;
+            watchers.into_iter().filter(|p| Some(p) != author.as_ref()).collect()
         }
         // `notifyDirect` with an AGENT recipient: the agent's own work queue.
         // This is the row that proves an agent has an inbox of its own.
@@ -339,6 +359,9 @@ mod tests {
 
     fn issue_row(id: &str, title: &str) -> IssueRow {
         IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -6438,8 +6438,9 @@ async fn handle_issue_subscribe(
     let actor = resolve_actor_param(params.actor.as_deref())?;
     reject_actor_outside_workspace(pool, &ws, &actor).await?;
 
-    let already =
-        IssueSubscriberRepo::is_subscribed(pool, &params.issue_id, &actor).await.map_err(|e| store_err(&e))?;
+    let already = IssueSubscriberRepo::is_subscribed(pool, &params.issue_id, &actor)
+        .await
+        .map_err(|e| store_err(&e))?;
     let changed = if add {
         IssueSubscriberRepo::add(
             pool,
@@ -6521,8 +6522,7 @@ async fn handle_issue_reaction(
         )
         .await
     } else {
-        IssueReactionRepo::remove(pool, ws.as_str(), &params.issue_id, &actor, &params.emoji)
-            .await
+        IssueReactionRepo::remove(pool, ws.as_str(), &params.issue_id, &actor, &params.emoji).await
     };
     match outcome {
         Ok(_) => {}
@@ -6539,13 +6539,12 @@ async fn issue_in_workspace(
     workspace_id: &str,
     issue_id: &str,
 ) -> Result<bool, RpcError> {
-    let n: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM issue WHERE id = ? AND workspace_id = ?")
-            .bind(issue_id)
-            .bind(workspace_id)
-            .fetch_one(pool)
-            .await
-            .map_err(|e| store_err(&e))?;
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue WHERE id = ? AND workspace_id = ?")
+        .bind(issue_id)
+        .bind(workspace_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| store_err(&e))?;
     Ok(n > 0)
 }
 
@@ -6557,10 +6556,10 @@ async fn issue_subscribers_value(
     let subscribers = crate::rpc::snapshots::issue_subscriber_rows(pool, issue_id)
         .await
         .map_err(|e| store_err(&e))?;
-    Ok(serde_json::to_value(
-        ainb_hangar_proto::snapshots::IssueSubscribersResult { subscribers },
+    Ok(
+        serde_json::to_value(ainb_hangar_proto::snapshots::IssueSubscribersResult { subscribers })
+            .unwrap_or(serde_json::Value::Null),
     )
-    .unwrap_or(serde_json::Value::Null))
 }
 
 /// Build the `IssueReactionsResult` payload for one issue, as seen by `viewer`

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -40,16 +40,17 @@ pub mod auth;
 pub mod snapshots;
 
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(any(test, feature = "test-support"))]
 use std::sync::{OnceLock, RwLock};
 use std::time::Instant;
 
 use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
-use ainb_hangar_core::actor::{ActorRef, local_member};
+use ainb_hangar_core::actor::{ActorKind, ActorRef, local_member};
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
 use ainb_hangar_core::dispatch_reason::{DispatchReason, DispatchSource};
-use ainb_hangar_core::idgen::SystemIdGen;
+use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use ainb_hangar_core::ids::{AgentId, AutopilotId, SkillId, WorkspaceId};
 use ainb_hangar_proto::lifecycle::IssueLifecycle;
 use ainb_hangar_proto::methods;
@@ -818,6 +819,11 @@ async fn handle(
         methods::HANGAR_ISSUE_LINK_ADD => handle_issue_link(pool, req, true).await,
         methods::HANGAR_ISSUE_LINK_REMOVE => handle_issue_link(pool, req, false).await,
         methods::HANGAR_ISSUE_LINKS => handle_issue_links(pool, req).await,
+        methods::HANGAR_ISSUE_SUBSCRIBE => handle_issue_subscribe(pool, req, true).await,
+        methods::HANGAR_ISSUE_UNSUBSCRIBE => handle_issue_subscribe(pool, req, false).await,
+        methods::HANGAR_ISSUE_SUBSCRIBERS => handle_issue_subscribers(pool, req).await,
+        methods::HANGAR_ISSUE_REACTION_ADD => handle_issue_reaction(pool, req, true).await,
+        methods::HANGAR_ISSUE_REACTION_REMOVE => handle_issue_reaction(pool, req, false).await,
         methods::HANGAR_DISPATCH_ATTEMPTS_LIST => handle_dispatch_attempts_list(pool, req).await,
         methods::HANGAR_ISSUE_TIMELINE => handle_issue_timeline(pool, req).await,
         methods::HANGAR_BOARD_CARD_SET_AUTO_RUN => handle_board_card_set_auto_run(pool, req).await,
@@ -6351,6 +6357,224 @@ async fn issue_links_value(
         .map_err(|e| store_err(&e))?;
     Ok(
         serde_json::to_value(ainb_hangar_proto::snapshots::IssueLinksResult { links })
+            .unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// Resolve a wire actor token for the #22 subscriber / reaction methods.
+///
+/// An omitted token means the LOCAL HUMAN, mirroring the reference's "the target
+/// defaults to the caller" (`internal/handler/subscriber.go`) — an agent caller
+/// subscribes ITSELF, never the human behind it. A malformed token is
+/// `INVALID_PARAMS` rather than a silent fallback, so a typo is never mistaken
+/// for "me".
+fn resolve_actor_param(raw: Option<&str>) -> Result<ActorRef, RpcError> {
+    match raw {
+        None => Ok(ainb_hangar_core::actor::local_member()),
+        Some(token) => ActorRef::from_str(token)
+            .map_err(|e| invalid_params(&format!("bad actor `{token}`: {e}"))),
+    }
+}
+
+/// The reference's `isWorkspaceEntity` gate (its `403`): the target must belong
+/// to this workspace.
+///
+/// **One documented exemption:** the LOCAL HUMAN (`member:me`) is hangar's
+/// synthetic single-user identity (see [`ainb_hangar_core::actor::local_member`])
+/// and has no `member` row until a real signed-in identity lands — gating it
+/// would reject the default, and therefore the entire single-user flow.
+async fn reject_actor_outside_workspace(
+    pool: &SqlitePool,
+    ws: &WorkspaceId,
+    actor: &ActorRef,
+) -> Result<(), RpcError> {
+    if *actor == ainb_hangar_core::actor::local_member() {
+        return Ok(());
+    }
+    let known = match actor.kind() {
+        ActorKind::Member => {
+            ainb_hangar_store::repo::member::MemberRepo::role(pool, ws, actor.id())
+                .await
+                .map_err(|e| store_err(&e))?
+                .is_some()
+        }
+        ActorKind::Agent => {
+            ainb_hangar_store::repo::agent::AgentRepo::list_by_workspace(pool, ws.as_str())
+                .await
+                .map_err(|e| store_err(&e))?
+                .iter()
+                .any(|a| a.id.as_str() == actor.id())
+        }
+    };
+    if known {
+        Ok(())
+    } else {
+        Err(invalid_params(&format!(
+            "target actor `{actor}` is not in this workspace"
+        )))
+    }
+}
+
+/// `hangar/issue_subscribe` (`add = true`) / `hangar/issue_unsubscribe`
+/// (`add = false`) (multica parity #22).
+///
+/// Same skeleton as [`handle_issue_link`]: tenant guard, then the repo seam,
+/// then the REFRESHED collection as the answer. The write is idempotent and
+/// first-reason-wins, so re-subscribing an existing `creator` still answers
+/// "subscribed" — the caller's intent is already satisfied. A repo `Ok(false)`
+/// on a NON-subscribed actor means the issue does not exist in this workspace,
+/// which is rejected with `handle_comment_add`'s phrasing rather than silently
+/// no-op'd.
+async fn handle_issue_subscribe(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    add: bool,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
+
+    let params: ainb_hangar_proto::snapshots::IssueSubscribeParams =
+        parse_params(req, "{ workspace_id, issue_id, actor? }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let actor = resolve_actor_param(params.actor.as_deref())?;
+    reject_actor_outside_workspace(pool, &ws, &actor).await?;
+
+    let already =
+        IssueSubscriberRepo::is_subscribed(pool, &params.issue_id, &actor).await.map_err(|e| store_err(&e))?;
+    let changed = if add {
+        IssueSubscriberRepo::add(
+            pool,
+            ws.as_str(),
+            &params.issue_id,
+            &actor,
+            SubscribeReason::Manual,
+            SystemClock.now_ms(),
+        )
+        .await
+        .map_err(|e| store_err(&e))?
+    } else {
+        IssueSubscriberRepo::remove(pool, ws.as_str(), &params.issue_id, &actor)
+            .await
+            .map_err(|e| store_err(&e))?
+    };
+    // Nothing changed AND the actor's state did not already match the intent ⇒
+    // the issue is unknown here (the repo's tenant join matched nothing).
+    if !changed && already != add {
+        return Err(invalid_params(&format!(
+            "no issue `{}` in this workspace",
+            params.issue_id
+        )));
+    }
+    issue_subscribers_value(pool, &params.issue_id).await
+}
+
+/// `hangar/issue_subscribers` (multica parity #22): read-only, tenant-guarded.
+async fn handle_issue_subscribers(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::snapshots::IssueSubscribersParams =
+        parse_params(req, "{ workspace_id, issue_id }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    if !issue_in_workspace(pool, ws.as_str(), &params.issue_id).await? {
+        return Err(invalid_params(&format!(
+            "no issue `{}` in this workspace",
+            params.issue_id
+        )));
+    }
+    issue_subscribers_value(pool, &params.issue_id).await
+}
+
+/// `hangar/issue_reaction_add` (`add = true`) / `hangar/issue_reaction_remove`
+/// (`add = false`) (multica parity #22).
+///
+/// A blank emoji is rejected at the repo boundary and surfaced here as
+/// `INVALID_PARAMS` carrying the reference's own text ("emoji is required",
+/// its `400`).
+async fn handle_issue_reaction(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    add: bool,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::issue_reaction::{IssueReactionError, IssueReactionRepo};
+
+    let params: ainb_hangar_proto::snapshots::IssueReactionParams =
+        parse_params(req, "{ workspace_id, issue_id, emoji, actor? }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let actor = resolve_actor_param(params.actor.as_deref())?;
+    reject_actor_outside_workspace(pool, &ws, &actor).await?;
+    if !issue_in_workspace(pool, ws.as_str(), &params.issue_id).await? {
+        return Err(invalid_params(&format!(
+            "no issue `{}` in this workspace",
+            params.issue_id
+        )));
+    }
+
+    let outcome = if add {
+        IssueReactionRepo::add(
+            pool,
+            ws.as_str(),
+            &params.issue_id,
+            &actor,
+            &params.emoji,
+            &SystemIdGen.new_ulid(),
+            SystemClock.now_ms(),
+        )
+        .await
+    } else {
+        IssueReactionRepo::remove(pool, ws.as_str(), &params.issue_id, &actor, &params.emoji)
+            .await
+    };
+    match outcome {
+        Ok(_) => {}
+        Err(IssueReactionError::EmptyEmoji) => return Err(invalid_params("emoji is required")),
+        Err(IssueReactionError::Db(e)) => return Err(store_err(&e)),
+    }
+    issue_reactions_value(pool, &params.issue_id, &actor).await
+}
+
+/// Whether `issue_id` resolves inside `workspace_id` — the read-side twin of the
+/// repos' tenant join.
+async fn issue_in_workspace(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    issue_id: &str,
+) -> Result<bool, RpcError> {
+    let n: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM issue WHERE id = ? AND workspace_id = ?")
+            .bind(issue_id)
+            .bind(workspace_id)
+            .fetch_one(pool)
+            .await
+            .map_err(|e| store_err(&e))?;
+    Ok(n > 0)
+}
+
+/// Build the `IssueSubscribersResult` payload for one issue.
+async fn issue_subscribers_value(
+    pool: &SqlitePool,
+    issue_id: &str,
+) -> Result<serde_json::Value, RpcError> {
+    let subscribers = crate::rpc::snapshots::issue_subscriber_rows(pool, issue_id)
+        .await
+        .map_err(|e| store_err(&e))?;
+    Ok(serde_json::to_value(
+        ainb_hangar_proto::snapshots::IssueSubscribersResult { subscribers },
+    )
+    .unwrap_or(serde_json::Value::Null))
+}
+
+/// Build the `IssueReactionsResult` payload for one issue, as seen by `viewer`
+/// (whose buckets carry `mine = true`).
+async fn issue_reactions_value(
+    pool: &SqlitePool,
+    issue_id: &str,
+    viewer: &ActorRef,
+) -> Result<serde_json::Value, RpcError> {
+    let reactions = crate::rpc::snapshots::issue_reaction_rows(pool, issue_id, viewer)
+        .await
+        .map_err(|e| store_err(&e))?;
+    Ok(
+        serde_json::to_value(ainb_hangar_proto::snapshots::IssueReactionsResult { reactions })
             .unwrap_or(serde_json::Value::Null),
     )
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -58,6 +58,7 @@ use ainb_hangar_store::repo::autopilot_run::{
 use ainb_hangar_store::repo::comment::{CommentRepo, NewComment};
 use ainb_hangar_store::repo::inbox::InboxRepo;
 use ainb_hangar_store::repo::issue::{CriterionError, IssueRepo};
+use ainb_hangar_store::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
 use ainb_hangar_store::repo::label::{LabelRepo, LabelRepoError};
 use ainb_hangar_store::repo::notify_rule::NotifyRuleRepo;
 use ainb_hangar_store::repo::run_history::RunHistoryRepo;
@@ -134,6 +135,9 @@ pub async fn issues_list(
             // task-detail card.
             let extras = issue_card_fields(pool, &issue.id).await?;
             out.push(IssueRow {
+                subscriber_count: 0,
+                subscribed: false,
+                reactions: Vec::new(),
                 // multica parity #12: WHY this card is not running, from the newest
                 // dispatch_attempt when that attempt was a decline. All `None` on a
                 // healthy card, so the row grows by zero keys.
@@ -336,6 +340,9 @@ pub async fn issues_search(
         let branch = latest_branch_for_issue(pool, workspace_id, &issue.id).await?;
         let extras = issue_card_fields(pool, &issue.id).await?;
         out.push(IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             // multica parity #12: WHY this card is not running, from the newest
             // dispatch_attempt when that attempt was a decline. All `None` on a
             // healthy card, so the row grows by zero keys.
@@ -2074,7 +2081,17 @@ pub async fn issue_row(
     // graph — a list snapshot leaves `dependencies` empty on purpose, because
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
+    // multica parity #22: same DETAIL-ONLY rule as `dependencies` above -- the
+    // watcher count / `subscribed` flag / reaction tallies cost extra queries
+    // per row, so a list snapshot leaves them at their `Default`.
+    let viewer = ainb_hangar_core::actor::local_member();
+    let subscriber_count = IssueSubscriberRepo::count(pool, &issue.id).await?;
+    let subscribed = IssueSubscriberRepo::is_subscribed(pool, &issue.id, &viewer).await?;
+    let reactions = issue_reaction_rows(pool, &issue.id, &viewer).await?;
     Ok(Some(IssueRow {
+        subscriber_count,
+        subscribed,
+        reactions,
         // multica parity #12: WHY this card is not running, from the newest
         // dispatch_attempt when that attempt was a decline. All `None` on a
         // healthy card, so the row grows by zero keys.
@@ -2115,6 +2132,54 @@ pub async fn issue_row(
         context_refs: issue.context_refs,
         dependencies,
     }))
+}
+
+/// One issue's SUBSCRIBER set as wire rows (multica parity #22), oldest first.
+///
+/// The `reason` half is the RAW stored token, not the parsed enum, so a
+/// provenance written by a newer daemon renders as text instead of failing the
+/// decode.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault.
+pub async fn issue_subscriber_rows(
+    pool: &SqlitePool,
+    issue_id: &str,
+) -> Result<Vec<ainb_hangar_proto::events::IssueSubscriberRow>, sqlx::Error> {
+    Ok(IssueSubscriberRepo::list(pool, issue_id)
+        .await?
+        .into_iter()
+        .map(|s| ainb_hangar_proto::events::IssueSubscriberRow {
+            actor: s.actor.to_string(),
+            reason: s.reason_raw,
+            created_at: s.created_at,
+        })
+        .collect())
+}
+
+/// One issue's aggregated emoji buckets as wire rows (multica parity #22),
+/// most-used first, with `mine` set for the buckets `viewer` is in.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault.
+pub async fn issue_reaction_rows(
+    pool: &SqlitePool,
+    issue_id: &str,
+    viewer: &ainb_hangar_core::actor::ActorRef,
+) -> Result<Vec<ainb_hangar_proto::events::ReactionRow>, sqlx::Error> {
+    use ainb_hangar_store::repo::issue_reaction::IssueReactionRepo;
+
+    Ok(IssueReactionRepo::tallies(pool, issue_id)
+        .await?
+        .into_iter()
+        .map(|t| ainb_hangar_proto::events::ReactionRow {
+            emoji: t.emoji,
+            count: t.count,
+            mine: t.actors.iter().any(|a| a == viewer),
+        })
+        .collect())
 }
 
 /// One issue's TYPED links (multica parity #20), in render order: `blocked_by`
@@ -2283,7 +2348,17 @@ async fn read_issue_row(
     // graph — a list snapshot leaves `dependencies` empty on purpose, because
     // filling it there would be an N-query fan-out per row.
     let dependencies = issue_link_rows(pool, workspace_id, &issue.id).await?;
+    // multica parity #22: same DETAIL-ONLY rule as `dependencies` above -- the
+    // watcher count / `subscribed` flag / reaction tallies cost extra queries
+    // per row, so a list snapshot leaves them at their `Default`.
+    let viewer = ainb_hangar_core::actor::local_member();
+    let subscriber_count = IssueSubscriberRepo::count(pool, &issue.id).await?;
+    let subscribed = IssueSubscriberRepo::is_subscribed(pool, &issue.id, &viewer).await?;
+    let reactions = issue_reaction_rows(pool, &issue.id, &viewer).await?;
     Ok(Some(IssueRow {
+        subscriber_count,
+        subscribed,
+        reactions,
         // multica parity #12: WHY this card is not running, from the newest
         // dispatch_attempt when that attempt was a decline. All `None` on a
         // healthy card, so the row grows by zero keys.
@@ -2564,6 +2639,9 @@ pub async fn issue_create(
     // shows.
     let display_id = issue_display_row(pool, workspace_id, &id, prefix.as_deref()).await?;
     Ok(IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,
@@ -2650,6 +2728,34 @@ async fn workspace_issue_prefix(
 ///
 /// Returns a [`sqlx::Error`] on a store fault, or a malformed minted id on the
 /// re-wrap (impossible for a ULID).
+/// Auto-subscribe `actor` to `issue_id` (multica parity #22).
+///
+/// BEST EFFORT by design, matching the reference's rule at `service/task.go:1877`:
+/// a failure is logged and swallowed, never propagated, because a subscription
+/// side effect must not turn a successful comment / create / assign into an
+/// error. The write is idempotent and FIRST-REASON-WINS, so calling it from
+/// several seams for the same actor keeps the earliest provenance.
+pub async fn auto_subscribe(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    issue_id: &str,
+    actor: &ActorRef,
+    reason: SubscribeReason,
+    now_ms: i64,
+) {
+    if let Err(e) =
+        IssueSubscriberRepo::add(pool, workspace_id, issue_id, actor, reason, now_ms).await
+    {
+        tracing::warn!(
+            error = %e,
+            issue_id,
+            actor = %actor,
+            reason = reason.as_db_str(),
+            "auto-subscribe failed"
+        );
+    }
+}
+
 pub async fn comment_add(
     pool: &SqlitePool,
     idgen: &dyn IdGen,
@@ -2676,6 +2782,18 @@ pub async fn comment_add(
     if !landed {
         return Ok(None);
     }
+    // multica parity #22: commenting subscribes you to the thread. The reference
+    // seeds `reason='commenter'` the same way; first-reason-wins keeps an
+    // author who also created the issue on `creator`.
+    auto_subscribe(
+        pool,
+        workspace_id,
+        issue_id,
+        author,
+        SubscribeReason::Commenter,
+        created_at,
+    )
+    .await;
     let comment_id = CommentId::from_str(id.clone()).map_err(|e| sqlx::Error::ColumnDecode {
         index: "id".to_string(),
         source: format!("malformed comment id {id:?}: {e}").into(),
@@ -2815,6 +2933,20 @@ pub async fn spawn_mention_tasks(
                 // the invocation gate: a refused mention writes no row and
                 // therefore no provenance.
                 TaskRepo::set_origin(pool, &task.id, &mention_origin).await?;
+                // multica parity #22: being @-mentioned subscribes you.
+                if let Ok(actor) =
+                    ainb_hangar_core::actor::ActorRef::new(ActorKind::Agent, agent.id.clone())
+                {
+                    auto_subscribe(
+                        pool,
+                        workspace_id,
+                        issue_id,
+                        &actor,
+                        SubscribeReason::Mentioned,
+                        now,
+                    )
+                    .await;
+                }
                 spawned.push(agent.id.clone());
             }
             // The agent already has a pending task on this issue (the per-(issue,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
@@ -30,7 +30,11 @@ fn member(id: &str) -> ActorRef {
 
 /// Boot a seeded store with the REAL aggregator draining a shared broker — the
 /// same wiring `boot()` uses — and hand back the emit sink.
-async fn boot() -> (tempfile::TempDir, Store, ainb_hangar_daemon::events::EventSink) {
+async fn boot() -> (
+    tempfile::TempDir,
+    Store,
+    ainb_hangar_daemon::events::EventSink,
+) {
     let dir = tempfile::tempdir().unwrap();
     let store = Store::open_in(dir.path()).await.unwrap();
     seed::seed_p4_fixture(store.pool()).await.unwrap();
@@ -119,16 +123,9 @@ async fn a_manual_subscriber_who_is_neither_creator_nor_assignee_gets_the_commen
         ("bob", SubscribeReason::Assignee),
         ("watcher", SubscribeReason::Manual),
     ] {
-        IssueSubscriberRepo::add(
-            store.pool(),
-            WS_ID,
-            "fanout-1",
-            &member(actor),
-            reason,
-            0,
-        )
-        .await
-        .unwrap();
+        IssueSubscriberRepo::add(store.pool(), WS_ID, "fanout-1", &member(actor), reason, 0)
+            .await
+            .unwrap();
     }
     sqlx::query(
         "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
@@ -1,0 +1,215 @@
+//! The inbox fan-out reads the REAL subscriber set (multica parity #22).
+//!
+//! Before migration 0062 `inbox_aggregator::recipients_for` approximated "who is
+//! notified" as the issue's PARTICIPANTS (creator + assignee) minus the actor,
+//! and its own doc comment said so. This file is the proof that the table is not
+//! decorative:
+//!
+//! 1. `a_manual_subscriber_who_is_neither_creator_nor_assignee_gets_the_comment_entry`
+//!    FAILS on the participant approximation — the watcher is neither endpoint,
+//!    so the old derivation could never reach them. It passes only once
+//!    `recipients_for` reads `issue_subscriber`.
+//! 2. `the_comment_author_is_not_notified_of_their_own_comment` pins the half of
+//!    the reference's rule that must SURVIVE the conversion.
+//! 3. `an_issue_with_no_subscriber_rows_still_notifies_its_participants` pins the
+//!    fallback, so no upgrade path can silence a notification.
+
+use std::time::Duration;
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::ids::{CommentId, IssueId};
+use ainb_hangar_daemon::events::EventBroker;
+use ainb_hangar_daemon::seed::{self, WS_ID};
+use ainb_hangar_proto::events::{CommentRow, HangarEvent};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
+
+fn member(id: &str) -> ActorRef {
+    ActorRef::new(ActorKind::Member, id).unwrap()
+}
+
+/// Boot a seeded store with the REAL aggregator draining a shared broker — the
+/// same wiring `boot()` uses — and hand back the emit sink.
+async fn boot() -> (tempfile::TempDir, Store, ainb_hangar_daemon::events::EventSink) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    let broker = EventBroker::new();
+    drop(ainb_hangar_daemon::inbox_aggregator::spawn(
+        store.pool().clone(),
+        broker.subscribe(),
+    ));
+    let sink = broker.sink();
+    (dir, store, sink)
+}
+
+/// Insert one issue with an explicit creator + assignee, bypassing the repo so
+/// the test controls the subscriber set exactly (the repo auto-subscribes both).
+async fn seed_issue(store: &Store, id: &str, creator: &str, assignee: Option<&str>) {
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, \
+          assignee_type, assignee_id, created_at) \
+         VALUES (?, ?, 'fanout fixture', 'open', 'member', ?, ?, ?, 0)",
+    )
+    .bind(id)
+    .bind(WS_ID)
+    .bind(creator)
+    .bind(assignee.map(|_| "member"))
+    .bind(assignee)
+    .execute(store.pool())
+    .await
+    .expect("seed issue");
+}
+
+/// Emit one `CommentAdded` for `issue_id` authored by `author`.
+fn emit_comment(
+    sink: &ainb_hangar_daemon::events::EventSink,
+    issue_id: &str,
+    comment_id: &str,
+    author: &str,
+) {
+    sink.emit(
+        WS_ID,
+        HangarEvent::CommentAdded(CommentRow {
+            id: CommentId::from_str(comment_id.to_string()).unwrap(),
+            issue_id: IssueId::from_str(issue_id.to_string()).unwrap(),
+            author: author.to_string(),
+            body: "look at this".into(),
+            created_at: 1,
+        }),
+    );
+}
+
+/// Poll until `issue_id` has at least `want` inbox entries, then return every
+/// recipient addressed for it.
+async fn recipients_for_issue(store: &Store, issue_id: &str, want: usize) -> Vec<String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT recipient_type, recipient_id FROM inbox_entry \
+             WHERE subject_id IN (SELECT id FROM comment WHERE issue_id = ?1) OR subject_id = ?1 \
+                OR subject_id LIKE ?2",
+        )
+        .bind(issue_id)
+        .bind(format!("{issue_id}%"))
+        .fetch_all(store.pool())
+        .await
+        .expect("read inbox");
+        let out: Vec<String> = rows.into_iter().map(|(k, i)| format!("{k}:{i}")).collect();
+        if out.len() >= want || std::time::Instant::now() > deadline {
+            return out;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// THE PROOF: a watcher who is neither creator nor assignee is notified.
+///
+/// The participant approximation this replaced could not reach `member:watcher`
+/// by construction, so reverting `recipients_for` to `issue_participants` fails
+/// this test.
+#[tokio::test]
+async fn a_manual_subscriber_who_is_neither_creator_nor_assignee_gets_the_comment_entry() {
+    let (_dir, store, sink) = boot().await;
+    seed_issue(&store, "fanout-1", "alice", Some("bob")).await;
+    // Everyone who exists on the issue subscribes, PLUS a third-party watcher.
+    for (actor, reason) in [
+        ("alice", SubscribeReason::Creator),
+        ("bob", SubscribeReason::Assignee),
+        ("watcher", SubscribeReason::Manual),
+    ] {
+        IssueSubscriberRepo::add(
+            store.pool(),
+            WS_ID,
+            "fanout-1",
+            &member(actor),
+            reason,
+            0,
+        )
+        .await
+        .unwrap();
+    }
+    sqlx::query(
+        "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+         VALUES ('cm-1','fanout-1','member','carol','look at this',1)",
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    emit_comment(&sink, "fanout-1", "cm-1", "member:carol");
+    let recipients = recipients_for_issue(&store, "fanout-1", 3).await;
+
+    assert!(
+        recipients.contains(&"member:watcher".to_string()),
+        "a manual subscriber must be notified: {recipients:?}"
+    );
+    assert!(recipients.contains(&"member:alice".to_string()));
+    assert!(recipients.contains(&"member:bob".to_string()));
+}
+
+/// The half of the reference's rule that must survive the conversion: you are
+/// never notified of your own action.
+#[tokio::test]
+async fn the_comment_author_is_not_notified_of_their_own_comment() {
+    let (_dir, store, sink) = boot().await;
+    seed_issue(&store, "fanout-2", "alice", None).await;
+    for actor in ["alice", "dave"] {
+        IssueSubscriberRepo::add(
+            store.pool(),
+            WS_ID,
+            "fanout-2",
+            &member(actor),
+            SubscribeReason::Manual,
+            0,
+        )
+        .await
+        .unwrap();
+    }
+    sqlx::query(
+        "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+         VALUES ('cm-2','fanout-2','member','dave','mine',1)",
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    emit_comment(&sink, "fanout-2", "cm-2", "member:dave");
+    let recipients = recipients_for_issue(&store, "fanout-2", 1).await;
+
+    assert!(recipients.contains(&"member:alice".to_string()));
+    assert!(
+        !recipients.contains(&"member:dave".to_string()),
+        "the author must not be notified of their own comment: {recipients:?}"
+    );
+}
+
+/// The upgrade-safety fallback: an issue with ZERO subscriber rows still
+/// notifies its participants, so the conversion cannot silence a notification.
+#[tokio::test]
+async fn an_issue_with_no_subscriber_rows_still_notifies_its_participants() {
+    let (_dir, store, sink) = boot().await;
+    seed_issue(&store, "fanout-3", "alice", Some("bob")).await;
+    assert_eq!(
+        IssueSubscriberRepo::count(store.pool(), "fanout-3").await.unwrap(),
+        0,
+        "the fixture deliberately has NO subscriber rows"
+    );
+    sqlx::query(
+        "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+         VALUES ('cm-3','fanout-3','member','carol','hi',1)",
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    emit_comment(&sink, "fanout-3", "cm-3", "member:carol");
+    let recipients = recipients_for_issue(&store, "fanout-3", 2).await;
+
+    assert!(
+        recipients.contains(&"member:alice".to_string())
+            && recipients.contains(&"member:bob".to_string()),
+        "the participant fallback must still fire: {recipients:?}"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -213,6 +213,9 @@ async fn wait_for_inbox_count(store: &Store, ws_id: &str, want: i64) {
 
 fn issue_event() -> HangarEvent {
     HangarEvent::IssueCreated(IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_subscribe.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_subscribe.rs
@@ -119,7 +119,9 @@ impl Client {
 async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
     let store = Store::open_in(dir).await.unwrap();
     seed::seed_p4_fixture(store.pool()).await.unwrap();
-    rpc::auth::ensure_socket_token(store.pool(), dir).await.expect("ensure socket token");
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
     let socket_path = rpc::socket_path_in(dir);
     let listener = rpc::bind(&socket_path).expect("bind socket");
     let health = DaemonHealth {
@@ -229,7 +231,10 @@ async fn re_subscribing_keeps_the_original_reason() {
             serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-2" }),
         )
         .await;
-    assert!(resp["error"].is_null(), "a redundant subscribe still acks: {resp}");
+    assert!(
+        resp["error"].is_null(),
+        "a redundant subscribe still acks: {resp}"
+    );
     assert_eq!(
         pairs(&resp),
         vec![("member:me".to_string(), "creator".to_string())],
@@ -251,7 +256,10 @@ async fn subscribe_rejects_an_unknown_issue_and_a_malformed_actor() {
             serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "no-such-issue" }),
         )
         .await;
-    assert!(!resp["error"].is_null(), "an unknown issue must fail: {resp}");
+    assert!(
+        !resp["error"].is_null(),
+        "an unknown issue must fail: {resp}"
+    );
 
     let resp = c
         .call(
@@ -263,7 +271,10 @@ async fn subscribe_rejects_an_unknown_issue_and_a_malformed_actor() {
             }),
         )
         .await;
-    assert!(!resp["error"].is_null(), "a malformed actor must fail: {resp}");
+    assert!(
+        !resp["error"].is_null(),
+        "a malformed actor must fail: {resp}"
+    );
 }
 
 /// The reference's `403`: a target that is not in this workspace is rejected.
@@ -339,7 +350,10 @@ async fn reaction_add_remove_round_trip_and_the_emoji_guard() {
         .await;
     assert!(!resp["error"].is_null(), "a blank emoji must fail: {resp}");
     assert!(
-        resp["error"]["message"].as_str().unwrap_or_default().contains("emoji is required"),
+        resp["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("emoji is required"),
         "the reference's own guard text: {resp}"
     );
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_subscribe.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_subscribe.rs
@@ -1,0 +1,345 @@
+//! Integration: issue subscribers + reactions over a real framed `UnixStream`
+//! against a real sqlite (multica parity #22).
+//!
+//! Proves the five new RPCs end to end: the mutator's OWN answer carries the
+//! refreshed collection (no read-after-write round trip), an omitted `actor`
+//! means the LOCAL HUMAN, a target outside the workspace / a malformed token /
+//! an unknown issue are all `INVALID_PARAMS` rather than silent no-ops, and a
+//! blank emoji hits the reference's "emoji is required" guard.
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// Seed one fresh issue into the fixture workspace, bypassing the repo so the
+/// subscriber set starts EMPTY (the repo auto-subscribes the creator).
+async fn seed_issue(store: &Store, id: &str) {
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, description, state, creator_type, creator_id, created_at) \
+         VALUES (?, ?, 'Subscribe fixture', 'body', 'open', 'member', 'user-1', 0)",
+    )
+    .bind(id)
+    .bind(ainb_hangar_daemon::seed::WS_ID)
+    .execute(store.pool())
+    .await
+    .expect("seed issue");
+}
+
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(22),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame_inner())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+}
+
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir).await.expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// `(actor, reason)` pairs out of a `IssueSubscribersResult` payload.
+fn pairs(resp: &serde_json::Value) -> Vec<(String, String)> {
+    resp["result"]["subscribers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .map(|r| {
+            (
+                r["actor"].as_str().unwrap_or_default().to_string(),
+                r["reason"].as_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect()
+}
+
+/// The full round trip: subscribe (defaulting to the LOCAL HUMAN), read back,
+/// unsubscribe. Every mutator answers the REFRESHED set.
+#[tokio::test]
+async fn subscribe_then_list_then_unsubscribe_over_the_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    seed_issue(&store, "sub-1").await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_SUBSCRIBE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-1" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "subscribe must ack: {resp}");
+    assert_eq!(
+        pairs(&resp),
+        vec![("member:me".to_string(), "manual".to_string())],
+        "an omitted actor defaults to the LOCAL HUMAN, reason=manual"
+    );
+
+    // At rest — the reply is not evidence of a write.
+    let at_rest: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM issue_subscriber WHERE issue_id = 'sub-1'")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(at_rest, 1);
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_SUBSCRIBERS,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-1" }),
+        )
+        .await;
+    assert_eq!(pairs(&resp).len(), 1, "the read agrees: {resp}");
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_UNSUBSCRIBE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-1" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "unsubscribe must ack: {resp}");
+    assert!(pairs(&resp).is_empty(), "the set empties: {resp}");
+}
+
+/// Re-subscribing an existing `creator` is a no-op that STILL answers
+/// "subscribed", and the original provenance survives (first reason wins).
+#[tokio::test]
+async fn re_subscribing_keeps_the_original_reason() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    seed_issue(&store, "sub-2").await;
+    ainb_hangar_store::repo::issue_subscriber::IssueSubscriberRepo::add(
+        store.pool(),
+        ainb_hangar_daemon::seed::WS_ID,
+        "sub-2",
+        &ainb_hangar_core::actor::local_member(),
+        ainb_hangar_store::repo::issue_subscriber::SubscribeReason::Creator,
+        0,
+    )
+    .await
+    .unwrap();
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_SUBSCRIBE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-2" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "a redundant subscribe still acks: {resp}");
+    assert_eq!(
+        pairs(&resp),
+        vec![("member:me".to_string(), "creator".to_string())],
+        "first reason wins: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_rejects_an_unknown_issue_and_a_malformed_actor() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    seed_issue(&store, "sub-3").await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_SUBSCRIBE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "no-such-issue" }),
+        )
+        .await;
+    assert!(!resp["error"].is_null(), "an unknown issue must fail: {resp}");
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_SUBSCRIBE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": "sub-3",
+                "actor": "nonsense",
+            }),
+        )
+        .await;
+    assert!(!resp["error"].is_null(), "a malformed actor must fail: {resp}");
+}
+
+/// The reference's `403`: a target that is not in this workspace is rejected.
+#[tokio::test]
+async fn subscribe_rejects_an_actor_outside_the_workspace() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    seed_issue(&store, "sub-4").await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_SUBSCRIBE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": "sub-4",
+                "actor": "member:stranger",
+            }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "an out-of-workspace target must be refused: {resp}"
+    );
+    let at_rest: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM issue_subscriber WHERE issue_id = 'sub-4'")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(at_rest, 0, "and nothing was written");
+}
+
+/// Reactions: add / tally / `mine` for the local human / remove / blank guard.
+#[tokio::test]
+async fn reaction_add_remove_round_trip_and_the_emoji_guard() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    seed_issue(&store, "sub-5").await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_REACTION_ADD,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-5", "emoji": "👍" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "react add must ack: {resp}");
+    let buckets = resp["result"]["reactions"].as_array().cloned().unwrap_or_default();
+    assert_eq!(buckets.len(), 1, "one bucket: {resp}");
+    assert_eq!(buckets[0]["emoji"], "👍");
+    assert_eq!(buckets[0]["count"], 1);
+    assert_eq!(buckets[0]["mine"], true, "the local human is the reactor");
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_REACTION_REMOVE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-5", "emoji": "👍" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "react remove must ack: {resp}");
+    assert!(
+        resp["result"]["reactions"].as_array().is_none_or(std::vec::Vec::is_empty),
+        "the set empties: {resp}"
+    );
+
+    let resp = c
+        .call(
+            methods::HANGAR_ISSUE_REACTION_ADD,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "sub-5", "emoji": "  " }),
+        )
+        .await;
+    assert!(!resp["error"].is_null(), "a blank emoji must fail: {resp}");
+    assert!(
+        resp["error"]["message"].as_str().unwrap_or_default().contains("emoji is required"),
+        "the reference's own guard text: {resp}"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -557,6 +557,24 @@ pub struct IssueRow {
     /// contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_dispatch_at: Option<i64>,
+    /// How many actors watch this issue (multica parity #22, migration 0062).
+    ///
+    /// DETAIL PATH ONLY — a list snapshot leaves it `0`, exactly like
+    /// [`Self::dependencies`], because filling it would need an N-query fan-out
+    /// per row. `#[serde(default)]` keeps a pre-0062 snapshot decodable.
+    #[serde(default)]
+    pub subscriber_count: u32,
+    /// Whether the LOCAL HUMAN (`member:me`) watches this issue — the viewer the
+    /// TUI renders for. The authoritative read is
+    /// [`crate::methods::HANGAR_ISSUE_SUBSCRIBERS`]; this is the convenience the
+    /// detail card's `✓ you` marker needs. Detail path only.
+    #[serde(default)]
+    pub subscribed: bool,
+    /// Aggregated emoji reactions, most-used first (multica parity #22). Detail
+    /// path only; empty ⇒ the key is not sent, so a pre-#22 daemon leaves the
+    /// card byte-identical.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reactions: Vec<ReactionRow>,
 }
 
 /// One TYPED link on an issue's detail card (multica parity #20), always stated
@@ -581,6 +599,33 @@ pub struct IssueLinkRow {
     /// the subject. Always `false` for `blocks` / `related` (neither gates).
     #[serde(default)]
     pub satisfied: bool,
+}
+
+/// One watcher on an issue's subscriber set (multica parity #22).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueSubscriberRow {
+    /// The watching actor in canonical `member:<id>` / `agent:<id>` form.
+    pub actor: String,
+    /// WHY they watch — `creator` / `assignee` / `commenter` / `mentioned` /
+    /// `manual`. PROVENANCE, not state: the FIRST reason wins, so an actor who
+    /// created the issue and later commented stays `creator`. Kept as a raw
+    /// `String` so a token from a newer daemon renders instead of failing the
+    /// decode.
+    pub reason: String,
+    /// When the subscription was created (epoch millis).
+    pub created_at: i64,
+}
+
+/// One aggregated emoji bucket on an issue (multica parity #22).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ReactionRow {
+    /// The emoji this bucket counts.
+    pub emoji: String,
+    /// How many distinct actors used it.
+    pub count: u32,
+    /// True when the LOCAL HUMAN is one of those actors (drives the `✓` pip).
+    #[serde(default)]
+    pub mine: bool,
 }
 
 /// A wire-side actor row for the agent-picker snapshot (`hangar/agents_list`).

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -1030,6 +1030,60 @@ pub const HANGAR_ISSUE_LINK_REMOVE: &str = "hangar/issue_link_remove";
 /// Read-only + workspace-scoped.
 pub const HANGAR_ISSUE_LINKS: &str = "hangar/issue_links";
 
+/// `hangar/issue_subscribe` — subscribe an actor to an issue (multica parity
+/// #22).
+///
+/// Params: [`crate::snapshots::IssueSubscribeParams`] (`{ workspace_id,
+/// issue_id, actor? }`). Result: the refreshed
+/// [`crate::snapshots::IssueSubscribersResult`]. `actor` defaults to the LOCAL
+/// HUMAN (`member:me`), mirroring the reference's "the target defaults to the
+/// caller" (`internal/handler/subscriber.go`). The write is idempotent and
+/// first-reason-wins: subscribing over an existing `creator` row is a no-op that
+/// still answers "subscribed", because the caller's intent is already satisfied.
+/// A target outside the workspace, a malformed actor token, or an unknown issue
+/// is rejected (`INVALID_PARAMS`). Mutating + workspace-scoped.
+pub const HANGAR_ISSUE_SUBSCRIBE: &str = "hangar/issue_subscribe";
+
+/// `hangar/issue_unsubscribe` — unsubscribe an actor from an issue (multica
+/// parity #22).
+///
+/// Params: [`crate::snapshots::IssueSubscribeParams`]. Result: the refreshed
+/// [`crate::snapshots::IssueSubscribersResult`]. Removing an absent subscription
+/// is an idempotent no-op. Matched to the reference, there is NO mute flag: a
+/// later auto-subscribe trigger (a fresh comment by that actor) re-adds the row.
+/// Mutating + workspace-scoped.
+pub const HANGAR_ISSUE_UNSUBSCRIBE: &str = "hangar/issue_unsubscribe";
+
+/// `hangar/issue_subscribers` — read one issue's subscriber set (multica parity
+/// #22).
+///
+/// Params: [`crate::snapshots::IssueSubscribersParams`] (`{ workspace_id,
+/// issue_id }`). Result: [`crate::snapshots::IssueSubscribersResult`] — one
+/// [`crate::events::IssueSubscriberRow`] per watcher, oldest first, each
+/// carrying the `reason` PROVENANCE token (`creator` / `assignee` / `commenter`
+/// / `mentioned` / `manual`). This set is what the inbox aggregator fans out to.
+/// Read-only + workspace-scoped.
+pub const HANGAR_ISSUE_SUBSCRIBERS: &str = "hangar/issue_subscribers";
+
+/// `hangar/issue_reaction_add` — add an emoji reaction to an issue (multica
+/// parity #22).
+///
+/// Params: [`crate::snapshots::IssueReactionParams`] (`{ workspace_id, issue_id,
+/// emoji, actor? }`). Result: the refreshed
+/// [`crate::snapshots::IssueReactionsResult`] (aggregated buckets, most-used
+/// first). `actor` defaults to the LOCAL HUMAN. A blank `emoji` is rejected
+/// (`INVALID_PARAMS`, the reference's `400 "emoji is required"`); reacting twice
+/// with the same emoji is an idempotent no-op. Mutating + workspace-scoped.
+pub const HANGAR_ISSUE_REACTION_ADD: &str = "hangar/issue_reaction_add";
+
+/// `hangar/issue_reaction_remove` — remove an emoji reaction (multica parity
+/// #22).
+///
+/// Params: [`crate::snapshots::IssueReactionParams`]. Result: the refreshed
+/// [`crate::snapshots::IssueReactionsResult`]. Removing an absent reaction is an
+/// idempotent no-op. Mutating + workspace-scoped.
+pub const HANGAR_ISSUE_REACTION_REMOVE: &str = "hangar/issue_reaction_remove";
+
 /// `hangar/board_card_set_auto_run` — flip a card's auto-run flag (tcp T4 / F7).
 ///
 /// Params: [`crate::snapshots::BoardCardAutoRunParams`] (`{ workspace_id, board_id,
@@ -1327,6 +1381,11 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_ISSUE_LINK_ADD,
     HANGAR_ISSUE_LINK_REMOVE,
     HANGAR_ISSUE_LINKS,
+    HANGAR_ISSUE_SUBSCRIBE,
+    HANGAR_ISSUE_UNSUBSCRIBE,
+    HANGAR_ISSUE_SUBSCRIBERS,
+    HANGAR_ISSUE_REACTION_ADD,
+    HANGAR_ISSUE_REACTION_REMOVE,
     // Fleet control-plane methods are appended at the wire catalogue tail.
     FLEET_SNAPSHOT,
     FLEET_SUBSCRIBE,
@@ -1564,6 +1623,11 @@ mod tests {
             HANGAR_ISSUE_LINK_ADD,
             HANGAR_ISSUE_LINK_REMOVE,
             HANGAR_ISSUE_LINKS,
+            HANGAR_ISSUE_SUBSCRIBE,
+            HANGAR_ISSUE_UNSUBSCRIBE,
+            HANGAR_ISSUE_SUBSCRIBERS,
+            HANGAR_ISSUE_REACTION_ADD,
+            HANGAR_ISSUE_REACTION_REMOVE,
             FLEET_SNAPSHOT,
             FLEET_SUBSCRIBE,
             FLEET_ACTION,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2459,6 +2459,65 @@ pub struct IssueLinksResult {
     pub links: Vec<crate::events::IssueLinkRow>,
 }
 
+/// Params for [`crate::methods::HANGAR_ISSUE_SUBSCRIBE`] /
+/// [`crate::methods::HANGAR_ISSUE_UNSUBSCRIBE`] (multica parity #22).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueSubscribeParams {
+    /// The subscribed workspace the issue belongs to (tenant guard).
+    pub workspace_id: String,
+    /// The issue to watch / stop watching.
+    pub issue_id: String,
+    /// The target actor in canonical `member:<id>` / `agent:<id>` form. Omitted
+    /// ⇒ the LOCAL HUMAN (`member:me`), mirroring the reference's "the target
+    /// defaults to the caller" — an agent caller subscribes ITSELF, not the
+    /// human behind it. Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+}
+
+/// Params for [`crate::methods::HANGAR_ISSUE_SUBSCRIBERS`] (multica parity #22).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueSubscribersParams {
+    /// The subscribed workspace the issue belongs to (tenant guard).
+    pub workspace_id: String,
+    /// The issue whose subscriber set to read.
+    pub issue_id: String,
+}
+
+/// Result of every #22 subscriber method: the issue's REFRESHED subscriber set,
+/// so a mutator needs no read-after-write round trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueSubscribersResult {
+    /// Every watcher, oldest first. Empty ⇒ nobody watches the issue.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subscribers: Vec<crate::events::IssueSubscriberRow>,
+}
+
+/// Params for [`crate::methods::HANGAR_ISSUE_REACTION_ADD`] /
+/// [`crate::methods::HANGAR_ISSUE_REACTION_REMOVE`] (multica parity #22).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueReactionParams {
+    /// The subscribed workspace the issue belongs to (tenant guard).
+    pub workspace_id: String,
+    /// The issue reacted to.
+    pub issue_id: String,
+    /// The emoji. Blank is rejected (`INVALID_PARAMS`), matching the reference's
+    /// `400 "emoji is required"`.
+    pub emoji: String,
+    /// The reacting actor. Omitted ⇒ the LOCAL HUMAN. Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+}
+
+/// Result of every #22 reaction method: the issue's REFRESHED aggregated
+/// buckets, most-used first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IssueReactionsResult {
+    /// One bucket per distinct emoji. Empty ⇒ the issue has no reactions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reactions: Vec<crate::events::ReactionRow>,
+}
+
 /// Params for [`crate::methods::HANGAR_BOARD_CARD_SET_AUTO_RUN`] (tcp T4 / F7):
 /// flip a card's auto-run flag.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -2805,6 +2864,9 @@ mod tests {
 
         let issues = IssuesListResult {
             issues: vec![IssueRow {
+                subscriber_count: 0,
+                subscribed: false,
+                reactions: Vec::new(),
                 last_dispatch_reason: None,
                 last_dispatch_detail: None,
                 last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -31,6 +31,9 @@ fn comment_id(s: &str) -> CommentId {
 
 fn sample_issue() -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,
@@ -215,6 +218,9 @@ fn presence_state_three_states_roundtrip() {
 #[test]
 fn issue_row_pr_url_is_additive() {
     let no_pr = IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         origin_type: None,
         origin_id: None,
         pr_url: None,
@@ -247,6 +253,9 @@ fn issue_row_pr_url_is_additive() {
 #[test]
 fn issue_row_priority_due_date_labels_roundtrip_and_default() {
     let row = IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         origin_type: None,
         origin_id: None,
         priority: 3,
@@ -273,6 +282,9 @@ fn issue_row_priority_due_date_labels_roundtrip_and_default() {
 #[test]
 fn issue_row_subtask_fields_roundtrip_and_default() {
     let row = IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         origin_type: None,
         origin_id: None,
         parent_id: Some("parent-issue".to_string()),
@@ -287,6 +299,9 @@ fn issue_row_subtask_fields_roundtrip_and_default() {
     // A top-level issue omits parent_id entirely (skip_serializing_if), and a zero
     // roll-up omits nothing that breaks an old reader.
     let top = IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         origin_type: None,
         origin_id: None,
         child_total: 0,

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0062_issue_subscriber_reaction.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0062_issue_subscriber_reaction.sql
@@ -1,0 +1,73 @@
+-- Hangar v1 schema, migration 0062: ISSUE SUBSCRIBERS + REACTIONS (multica
+-- parity #22).
+--
+-- Until now `inbox_aggregator::recipients_for` APPROXIMATED "who is notified"
+-- as the issue's participants (creator + assignee) minus the actor, and said so
+-- in its own doc comment: "hangar has no `issue_subscriber` table". That
+-- approximation cannot express the two cases the reference exists for: a
+-- WATCHER who is neither creator nor assignee (the human who asked an agent to
+-- do the work, multica `service/task.go:1873`), and an actor who wants OUT of a
+-- thread they created. This migration is that table
+-- (multica `015_issue_subscriber` + `016_backfill_subscribers`), plus the emoji
+-- reactions from the reference's `027_issue_reactions`.
+--
+-- DECISIONS
+-- 1. `reason` is PROVENANCE, membership is the state. PK (issue_id, actor_type,
+--    actor_id) + ON CONFLICT DO NOTHING => first reason wins, exactly as the
+--    reference (`pkg/db/queries/subscriber.sql:1-4`): an actor who created the
+--    issue and later commented stays `creator`.
+-- 2. `actor_type`/`actor_id` on BOTH tables. The reference names the subscriber
+--    columns `user_*` and the reaction columns `actor_*` (an accident of two
+--    authors two migrations apart); hangar has one polymorphic-actor convention
+--    (0003, 0060) and one Rust type (`ActorRef`).
+-- 3. CHECK on `actor_type` (as 0060), NONE on `reason` or `emoji`. SQLite cannot
+--    widen a CHECK without a table rebuild (see 0057's copy/drop/recreate); 0058
+--    set the precedent of enforcing an append-only vocabulary in Rust instead --
+--    `SubscribeReason::as_db_str` is the only writer, `::parse` the tolerant
+--    reader. `emoji` is free text by nature.
+-- 4. FK on workspace_id only; `issue_id` carries none (0058's rule). The
+--    explicit cascade in `IssueRepo::delete_cascade` reaps both tables.
+-- 5. NO `muted` flag -- matched to the reference. Unsubscribing then commenting
+--    again re-subscribes you. Divergence would be a silent behaviour fork; a
+--    `muted` column is a clean future append if we ever want one.
+
+CREATE TABLE issue_subscriber (
+    issue_id   TEXT NOT NULL,
+    actor_type TEXT NOT NULL CHECK (actor_type IN ('member','agent')),
+    actor_id   TEXT NOT NULL,
+    reason     TEXT NOT NULL,               -- SubscribeReason::as_db_str()
+    created_at INTEGER NOT NULL,            -- epoch millis
+    PRIMARY KEY (issue_id, actor_type, actor_id)
+);
+
+-- "every issue this actor watches" -- the reference's idx_issue_subscriber_user.
+CREATE INDEX idx_issue_subscriber_actor ON issue_subscriber(actor_type, actor_id);
+
+CREATE TABLE issue_reaction (
+    id           TEXT PRIMARY KEY,          -- ULID, minted by the caller's IdGen
+    issue_id     TEXT NOT NULL,
+    workspace_id TEXT NOT NULL REFERENCES workspace(id),
+    actor_type   TEXT NOT NULL CHECK (actor_type IN ('member','agent')),
+    actor_id     TEXT NOT NULL,
+    emoji        TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    UNIQUE (issue_id, actor_type, actor_id, emoji)
+);
+
+CREATE INDEX idx_issue_reaction_issue ON issue_reaction(issue_id);
+
+-- BACKFILL (the reference's 016_backfill_subscribers): an upgrading install is
+-- not born empty, so `recipients_for` reads a real subscriber set for issues
+-- that predate this migration instead of silently falling back to participants
+-- forever. Three statements, first-reason-wins ordering (creator, then assignee,
+-- then commenter), each OR IGNORE.
+INSERT OR IGNORE INTO issue_subscriber (issue_id, actor_type, actor_id, reason, created_at)
+SELECT id, creator_type, creator_id, 'creator', created_at FROM issue;
+
+INSERT OR IGNORE INTO issue_subscriber (issue_id, actor_type, actor_id, reason, created_at)
+SELECT id, assignee_type, assignee_id, 'assignee', created_at
+FROM issue WHERE assignee_type IS NOT NULL AND assignee_id IS NOT NULL;
+
+INSERT OR IGNORE INTO issue_subscriber (issue_id, actor_type, actor_id, reason, created_at)
+SELECT c.issue_id, c.author_type, c.author_id, 'commenter', MIN(c.created_at)
+FROM comment c GROUP BY c.issue_id, c.author_type, c.author_id;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -297,15 +297,8 @@ async fn auto_subscribe_on_create(pool: &SqlitePool, issue: &NewIssue) {
     ];
     for (actor, reason) in pairs {
         let Some(actor) = actor else { continue };
-        if let Err(e) = IssueSubscriberRepo::add(
-            pool,
-            &issue.workspace_id,
-            &issue.id,
-            actor,
-            reason,
-            now,
-        )
-        .await
+        if let Err(e) =
+            IssueSubscriberRepo::add(pool, &issue.workspace_id, &issue.id, actor, reason, now).await
         {
             tracing::warn!(error = %e, issue_id = %issue.id, "create auto-subscribe failed");
         }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -936,6 +936,17 @@ impl IssueRepo {
             .bind(issue_id)
             .execute(&mut *tx)
             .await?;
+        // 5b. The card's watchers and reactions (migration 0062). Neither table
+        //     carries an FK on `issue_id` (0058's rule), so the reap is explicit
+        //     here, exactly like `issue_label` / `comment` above.
+        sqlx::query("DELETE FROM issue_subscriber WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM issue_reaction WHERE issue_id = ?")
+            .bind(issue_id)
+            .execute(&mut *tx)
+            .await?;
 
         // 6. The issue row (workspace-scoped again, belt-and-braces).
         sqlx::query("DELETE FROM issue WHERE id = ? AND workspace_id = ?")

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -270,6 +270,48 @@ async fn count_dependents(
     })
 }
 
+/// Wall-clock millis for a subscription row minted as a side effect.
+///
+/// The subscription writers below are best-effort side effects, not part of the
+/// caller's logical write, so they do not thread the caller's clock through
+/// every signature. `created_at` on `issue_subscriber` is ordering metadata
+/// only — nothing branches on it.
+fn now_ms_for_subscription() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
+/// Subscribe a new issue's creator (and assignee, when set) — multica parity
+/// #22. Best effort: a failure is logged, never propagated, because the issue
+/// itself has already committed.
+async fn auto_subscribe_on_create(pool: &SqlitePool, issue: &NewIssue) {
+    use crate::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
+    let now = now_ms_for_subscription();
+    // Order matters: `creator` first, so an actor who is BOTH creator and
+    // assignee keeps `creator` (first reason wins, as the reference's backfill).
+    let pairs = [
+        (Some(&issue.creator), SubscribeReason::Creator),
+        (issue.assignee.as_ref(), SubscribeReason::Assignee),
+    ];
+    for (actor, reason) in pairs {
+        let Some(actor) = actor else { continue };
+        if let Err(e) = IssueSubscriberRepo::add(
+            pool,
+            &issue.workspace_id,
+            &issue.id,
+            actor,
+            reason,
+            now,
+        )
+        .await
+        {
+            tracing::warn!(error = %e, issue_id = %issue.id, "create auto-subscribe failed");
+        }
+    }
+}
+
 /// Stateless typed wrapper over the `issue` table.
 pub struct IssueRepo;
 
@@ -316,6 +358,14 @@ impl IssueRepo {
         .bind(issue.stage)
         .execute(pool)
         .await?;
+        // multica parity #22: the creator (and the assignee, when set) become
+        // SUBSCRIBERS of the new issue -- the reference's `016_backfill` seeds
+        // exactly this pair, and its live writer does the same at create time.
+        // Done HERE rather than in each daemon handler because `insert` is the
+        // one create seam every path shares (issue create RPC, board-card
+        // create, autopilot fire, the CLI). Best effort: a subscription is a
+        // side effect and must never fail an otherwise committed create.
+        auto_subscribe_on_create(pool, issue).await;
         Ok(())
     }
 
@@ -529,7 +579,25 @@ impl IssueRepo {
             query = query.bind(due_date);
         }
         let res = query.bind(id).bind(workspace_id).execute(pool).await?;
-        Ok(res.rows_affected() == 1)
+        let touched = res.rows_affected() == 1;
+        // multica parity #22: a NEW assignee starts watching the issue. Clearing
+        // the assignee subscribes nobody and un-subscribes nobody (the reference
+        // has no un-subscribe-on-reassign either -- membership only grows until
+        // someone explicitly opts out). Best effort, as at create.
+        if let (true, Some(Some(assignee))) = (touched, update.assignee.as_ref()) {
+            crate::repo::issue_subscriber::IssueSubscriberRepo::add(
+                pool,
+                workspace_id,
+                id,
+                assignee,
+                crate::repo::issue_subscriber::SubscribeReason::Assignee,
+                now_ms_for_subscription(),
+            )
+            .await
+            .map_err(|e| tracing::warn!(error = %e, id, "assignee auto-subscribe failed"))
+            .ok();
+        }
+        Ok(touched)
     }
 
     /// List issues in a workspace filtered by `state`, ordered by `created_at`.

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue_reaction.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue_reaction.rs
@@ -134,7 +134,10 @@ impl IssueReactionRepo {
     /// # Errors
     ///
     /// Returns a [`sqlx::Error`] if the query fails.
-    pub async fn list(pool: &SqlitePool, issue_id: &str) -> Result<Vec<IssueReaction>, sqlx::Error> {
+    pub async fn list(
+        pool: &SqlitePool,
+        issue_id: &str,
+    ) -> Result<Vec<IssueReaction>, sqlx::Error> {
         let rows = sqlx::query(
             "SELECT id, issue_id, actor_type, actor_id, emoji, created_at \
              FROM issue_reaction WHERE issue_id = ? \

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue_reaction.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue_reaction.rs
@@ -1,0 +1,189 @@
+//! Typed repository wrapper over the `issue_reaction` table (multica parity
+//! #22, migration 0062).
+//!
+//! An emoji reaction is unique per `(issue, actor, emoji)`: reacting twice is a
+//! no-op, not an error (the reference answers `201` either way,
+//! `internal/handler/issue_reaction.go`). A blank emoji is rejected at the REPO
+//! boundary so every caller — RPC, CLI, plugin — inherits the reference's
+//! "emoji is required" guard without restating it.
+//!
+//! Like [`super::issue_subscriber`], writes are workspace-scoped through the
+//! join to `issue`: a foreign tenant lands nothing and gets `Ok(false)`.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use sqlx::{Row, SqlitePool};
+
+/// Failure modes of the reaction repo.
+#[derive(Debug, thiserror::Error)]
+pub enum IssueReactionError {
+    /// The caller passed an empty (or whitespace-only) emoji — the reference's
+    /// `400 "emoji is required"`.
+    #[error("emoji is required")]
+    EmptyEmoji,
+    /// A store fault.
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
+/// One materialised `issue_reaction` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueReaction {
+    /// Primary key (ULID minted by the caller's `IdGen`).
+    pub id: String,
+    /// The issue reacted to.
+    pub issue_id: String,
+    /// The reacting actor.
+    pub actor: ActorRef,
+    /// The emoji itself (free text by nature).
+    pub emoji: String,
+    /// When the reaction landed (epoch millis).
+    pub created_at: i64,
+}
+
+/// One aggregated emoji bucket, for a wire row or a render.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReactionTally {
+    /// The emoji this bucket counts.
+    pub emoji: String,
+    /// How many distinct actors used it.
+    pub count: u32,
+    /// Those actors, so a viewer can tell whether the bucket is theirs.
+    pub actors: Vec<ActorRef>,
+}
+
+/// Stateless typed wrapper over the `issue_reaction` table.
+pub struct IssueReactionRepo;
+
+impl IssueReactionRepo {
+    /// Idempotently add one reaction. `INSERT OR IGNORE` on the UNIQUE triple,
+    /// so reacting twice lands nothing and answers `Ok(false)`.
+    ///
+    /// # Errors
+    ///
+    /// [`IssueReactionError::EmptyEmoji`] for a blank emoji;
+    /// [`IssueReactionError::Db`] on a store fault.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn add(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+        actor: &ActorRef,
+        emoji: &str,
+        id: &str,
+        now_ms: i64,
+    ) -> Result<bool, IssueReactionError> {
+        if emoji.trim().is_empty() {
+            return Err(IssueReactionError::EmptyEmoji);
+        }
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO issue_reaction \
+                 (id, issue_id, workspace_id, actor_type, actor_id, emoji, created_at) \
+             SELECT ?, ?, ?, ?, ?, ?, ? \
+             WHERE EXISTS (SELECT 1 FROM issue WHERE id = ? AND workspace_id = ?)",
+        )
+        .bind(id)
+        .bind(issue_id)
+        .bind(workspace_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(emoji)
+        .bind(now_ms)
+        .bind(issue_id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await
+        .map_err(IssueReactionError::Db)?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Remove one reaction. Removing an absent one is an idempotent
+    /// `Ok(false)`.
+    ///
+    /// # Errors
+    ///
+    /// [`IssueReactionError::EmptyEmoji`] for a blank emoji;
+    /// [`IssueReactionError::Db`] on a store fault.
+    pub async fn remove(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+        actor: &ActorRef,
+        emoji: &str,
+    ) -> Result<bool, IssueReactionError> {
+        if emoji.trim().is_empty() {
+            return Err(IssueReactionError::EmptyEmoji);
+        }
+        let res = sqlx::query(
+            "DELETE FROM issue_reaction \
+             WHERE issue_id = ? AND workspace_id = ? AND actor_type = ? \
+               AND actor_id = ? AND emoji = ?",
+        )
+        .bind(issue_id)
+        .bind(workspace_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(emoji)
+        .execute(pool)
+        .await
+        .map_err(IssueReactionError::Db)?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Every reaction on one issue, oldest first.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn list(pool: &SqlitePool, issue_id: &str) -> Result<Vec<IssueReaction>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, issue_id, actor_type, actor_id, emoji, created_at \
+             FROM issue_reaction WHERE issue_id = ? \
+             ORDER BY created_at, emoji, actor_type, actor_id",
+        )
+        .bind(issue_id)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| {
+                let kind: String = r.get("actor_type");
+                let id: String = r.get("actor_id");
+                let actor = ActorRef::new(kind.parse::<ActorKind>().ok()?, id).ok()?;
+                Some(IssueReaction {
+                    id: r.get("id"),
+                    issue_id: r.get("issue_id"),
+                    actor,
+                    emoji: r.get("emoji"),
+                    created_at: r.get("created_at"),
+                })
+            })
+            .collect())
+    }
+
+    /// Aggregated buckets, most-used first then emoji ascending — a stable
+    /// render order independent of insertion timing.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn tallies(
+        pool: &SqlitePool,
+        issue_id: &str,
+    ) -> Result<Vec<ReactionTally>, sqlx::Error> {
+        let mut buckets: Vec<ReactionTally> = Vec::new();
+        for row in Self::list(pool, issue_id).await? {
+            if let Some(b) = buckets.iter_mut().find(|b| b.emoji == row.emoji) {
+                b.count += 1;
+                b.actors.push(row.actor);
+            } else {
+                buckets.push(ReactionTally {
+                    emoji: row.emoji,
+                    count: 1,
+                    actors: vec![row.actor],
+                });
+            }
+        }
+        buckets.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.emoji.cmp(&b.emoji)));
+        Ok(buckets)
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue_subscriber.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue_subscriber.rs
@@ -1,0 +1,236 @@
+//! Typed repository wrapper over the `issue_subscriber` table (multica parity
+//! #22, migration 0062).
+//!
+//! A subscription is a SET MEMBERSHIP: `(issue, actor)` is the primary key and
+//! [`SubscribeReason`] is provenance, not state. Every add is
+//! `INSERT OR IGNORE`, so the FIRST reason wins — an actor who created an issue
+//! and later comments on it stays `creator`, exactly as the reference's
+//! `AddIssueSubscriber` (`pkg/db/queries/subscriber.sql:1-4`).
+//!
+//! # Workspace scoping without a `workspace_id` column
+//!
+//! Like [`super::comment`], the table carries no `workspace_id` — a subscription
+//! belongs to an issue, and the issue carries the workspace. Both the add and
+//! the remove are therefore **scoped through a join to `issue`**: they only land
+//! when `(issue_id, workspace_id)` resolves to a real issue in that tenant, and
+//! a foreign tenant's write returns `Ok(false)` rather than erroring.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use sqlx::{Row, SqlitePool};
+
+/// Why an actor is subscribed — PROVENANCE, not state (see migration 0062).
+///
+/// The column has no `CHECK` (SQLite cannot widen one without a table rebuild),
+/// so this enum is the vocabulary's only enforcement: [`Self::as_db_str`] is the
+/// single writer and [`Self::parse`] is a tolerant reader that yields `None` for
+/// a token written by a newer build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SubscribeReason {
+    /// The actor created the issue.
+    Creator,
+    /// The actor is (or was) the issue's assignee.
+    Assignee,
+    /// The actor commented on the issue.
+    Commenter,
+    /// The actor was `@`-mentioned in a comment.
+    Mentioned,
+    /// The actor explicitly asked to watch the issue.
+    Manual,
+}
+
+impl SubscribeReason {
+    /// The token stored in `issue_subscriber.reason`. The ONLY writer of that
+    /// column.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Creator => "creator",
+            Self::Assignee => "assignee",
+            Self::Commenter => "commenter",
+            Self::Mentioned => "mentioned",
+            Self::Manual => "manual",
+        }
+    }
+
+    /// Tolerant reader: an unknown token (a newer build's vocabulary) yields
+    /// `None` rather than failing the whole read.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "creator" => Some(Self::Creator),
+            "assignee" => Some(Self::Assignee),
+            "commenter" => Some(Self::Commenter),
+            "mentioned" => Some(Self::Mentioned),
+            "manual" => Some(Self::Manual),
+            _ => None,
+        }
+    }
+}
+
+/// One materialised `issue_subscriber` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueSubscriber {
+    /// The issue watched.
+    pub issue_id: String,
+    /// The watching actor, re-assembled from its two TEXT columns.
+    pub actor: ActorRef,
+    /// The parsed provenance, `None` for a token this build does not know.
+    pub reason: Option<SubscribeReason>,
+    /// The raw stored token, always available for rendering.
+    pub reason_raw: String,
+    /// When the subscription was created (epoch millis).
+    pub created_at: i64,
+}
+
+/// Stateless typed wrapper over the `issue_subscriber` table.
+pub struct IssueSubscriberRepo;
+
+impl IssueSubscriberRepo {
+    /// Idempotently subscribe `actor` to `issue_id`, workspace-scoped through
+    /// the join to `issue` ([`super::comment::CommentRepo::insert`]'s pattern).
+    ///
+    /// Returns `Ok(true)` when a row landed, `Ok(false)` when it did not —
+    /// either because the `(issue, workspace)` pair resolves to nothing (a
+    /// foreign tenant writes nothing rather than erroring) or because the actor
+    /// was ALREADY subscribed, in which case the existing row keeps its
+    /// ORIGINAL reason (first-reason-wins).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn add(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+        actor: &ActorRef,
+        reason: SubscribeReason,
+        now_ms: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO issue_subscriber \
+                 (issue_id, actor_type, actor_id, reason, created_at) \
+             SELECT ?, ?, ?, ?, ? \
+             WHERE EXISTS (SELECT 1 FROM issue WHERE id = ? AND workspace_id = ?)",
+        )
+        .bind(issue_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(reason.as_db_str())
+        .bind(now_ms)
+        .bind(issue_id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Unsubscribe `actor` from `issue_id`, workspace-scoped the same way.
+    ///
+    /// Removing an absent subscription is an idempotent `Ok(false)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn remove(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+        actor: &ActorRef,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "DELETE FROM issue_subscriber \
+             WHERE issue_id = ? AND actor_type = ? AND actor_id = ? \
+               AND EXISTS (SELECT 1 FROM issue WHERE id = ? AND workspace_id = ?)",
+        )
+        .bind(issue_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(issue_id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Every subscriber of one issue, oldest first.
+    ///
+    /// Ordered by `created_at`, then `actor_type`, `actor_id` — the reference's
+    /// bare `ORDER BY created_at` is non-deterministic within a millisecond.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn list(
+        pool: &SqlitePool,
+        issue_id: &str,
+    ) -> Result<Vec<IssueSubscriber>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT issue_id, actor_type, actor_id, reason, created_at \
+             FROM issue_subscriber WHERE issue_id = ? \
+             ORDER BY created_at, actor_type, actor_id",
+        )
+        .bind(issue_id)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| {
+                let kind: String = r.get("actor_type");
+                let id: String = r.get("actor_id");
+                let actor = ActorRef::new(kind.parse::<ActorKind>().ok()?, id).ok()?;
+                let reason_raw: String = r.get("reason");
+                Some(IssueSubscriber {
+                    issue_id: r.get("issue_id"),
+                    actor,
+                    reason: SubscribeReason::parse(&reason_raw),
+                    reason_raw,
+                    created_at: r.get("created_at"),
+                })
+            })
+            .collect())
+    }
+
+    /// Whether `actor` currently watches `issue_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn is_subscribed(
+        pool: &SqlitePool,
+        issue_id: &str,
+        actor: &ActorRef,
+    ) -> Result<bool, sqlx::Error> {
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM issue_subscriber \
+             WHERE issue_id = ? AND actor_type = ? AND actor_id = ?",
+        )
+        .bind(issue_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .fetch_one(pool)
+        .await?;
+        Ok(n > 0)
+    }
+
+    /// How many actors watch `issue_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn count(pool: &SqlitePool, issue_id: &str) -> Result<u32, sqlx::Error> {
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue_subscriber WHERE issue_id = ?")
+            .bind(issue_id)
+            .fetch_one(pool)
+            .await?;
+        Ok(u32::try_from(n).unwrap_or(u32::MAX))
+    }
+
+    /// The inbox aggregator's read: just the watching actors, no provenance.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn actors(pool: &SqlitePool, issue_id: &str) -> Result<Vec<ActorRef>, sqlx::Error> {
+        Ok(Self::list(pool, issue_id).await?.into_iter().map(|s| s.actor).collect())
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
@@ -26,6 +26,8 @@ pub mod event_log;
 pub mod fleet;
 pub mod inbox;
 pub mod issue;
+pub mod issue_reaction;
+pub mod issue_subscriber;
 pub mod label;
 pub mod member;
 pub mod notify_rule;

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0062_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0062_upgrade.rs
@@ -1,0 +1,170 @@
+//! Upgrade-from-populated test for migration 0062 (`issue_subscriber` +
+//! `issue_reaction` — multica parity #22).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the BACKFILL (the reference's `016_backfill_subscribers`) on a REAL
+//! populated database:
+//!
+//! 1. apply only the PRIOR migrations (0001..0061),
+//! 2. seed a workspace plus issues that already have a creator, an assignee and
+//!    comments by distinct authors,
+//! 3. apply the embedded migrations (which adds 0062),
+//! 4. assert the seeded set became subscriptions with the RIGHT provenance, and
+//!    that an actor who both created and commented keeps `reason='creator'`
+//!    (first-reason-wins through the `OR IGNORE` statement ordering).
+//!
+//! Without the backfill an upgrading install is born empty, so
+//! `inbox_aggregator::recipients_for` would fall back to the participant
+//! approximation forever on every pre-existing issue.
+
+use ainb_hangar_store::apply_migrations;
+use sqlx::Row;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test
+/// (`0062_issue_subscriber_reaction.sql`).
+const NEW_MIGRATION_VERSION: i64 = 62;
+
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let opts = SqliteConnectOptions::new()
+        .filename(dir.join("hangar.db"))
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(!migrator.migrations.is_empty());
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+/// The pre-0062 world: one issue with a creator AND an assignee plus two
+/// comments (one by a third party, one by the CREATOR), and one issue with a
+/// creator only.
+async fn seed_populated(pool: &SqlitePool) {
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO issue (id, workspace_id, title, creator_type, creator_id, \
+             assignee_type, assignee_id, created_at) \
+         VALUES ('iss-1','ws-1','With assignee','member','alice','agent','bot-7',100)",
+        "INSERT INTO issue (id, workspace_id, title, creator_type, creator_id, created_at) \
+         VALUES ('iss-2','ws-1','Solo','member','alice',200)",
+        "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+         VALUES ('c-1','iss-1','member','carol','hi',300)",
+        // The CREATOR also comments — must NOT downgrade to 'commenter'.
+        "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+         VALUES ('c-2','iss-1','member','alice','mine',400)",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+async fn table_exists(pool: &SqlitePool, name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("sqlite_master")
+        > 0
+}
+
+async fn index_exists(pool: &SqlitePool, name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("sqlite_master")
+        > 0
+}
+
+/// `(actor_type:actor_id, reason)` for one issue, sorted for a stable compare.
+async fn subs(pool: &SqlitePool, issue_id: &str) -> Vec<(String, String)> {
+    let mut v: Vec<(String, String)> = sqlx::query(
+        "SELECT actor_type, actor_id, reason FROM issue_subscriber WHERE issue_id = ?",
+    )
+    .bind(issue_id)
+    .fetch_all(pool)
+    .await
+    .expect("read subscribers")
+    .iter()
+    .map(|r| {
+        (
+            format!(
+                "{}:{}",
+                r.get::<String, _>("actor_type"),
+                r.get::<String, _>("actor_id")
+            ),
+            r.get::<String, _>("reason"),
+        )
+    })
+    .collect();
+    v.sort();
+    v
+}
+
+#[tokio::test]
+async fn migration_0062_backfills_subscribers_first_reason_wins() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+
+    assert!(
+        !table_exists(&pool, "issue_subscriber").await,
+        "issue_subscriber must not exist before 0062"
+    );
+
+    apply_migrations(&pool).await.expect("upgrade applies 0062");
+    let recorded: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?")
+            .bind(NEW_MIGRATION_VERSION)
+            .fetch_one(&pool)
+            .await
+            .expect("read migration version");
+    assert_eq!(recorded, 1, "0062 recorded as applied");
+
+    // (a) Both tables and both indexes landed.
+    assert!(table_exists(&pool, "issue_subscriber").await);
+    assert!(table_exists(&pool, "issue_reaction").await);
+    assert!(index_exists(&pool, "idx_issue_subscriber_actor").await);
+    assert!(index_exists(&pool, "idx_issue_reaction_issue").await);
+
+    // (b) The backfill: creator + assignee + the third-party commenter, and the
+    //     creator-who-also-commented keeps `creator` (first reason wins).
+    assert_eq!(
+        subs(&pool, "iss-1").await,
+        vec![
+            ("agent:bot-7".to_string(), "assignee".to_string()),
+            ("member:alice".to_string(), "creator".to_string()),
+            ("member:carol".to_string(), "commenter".to_string()),
+        ]
+    );
+    assert_eq!(
+        subs(&pool, "iss-2").await,
+        vec![("member:alice".to_string(), "creator".to_string())],
+        "an unassigned, uncommented issue backfills its creator only"
+    );
+
+    // (c) The PK really is the (issue, actor) triple.
+    let dup = sqlx::query(
+        "INSERT INTO issue_subscriber (issue_id, actor_type, actor_id, reason, created_at) \
+         VALUES ('iss-1','member','alice','manual',999)",
+    )
+    .execute(&pool)
+    .await;
+    assert!(dup.is_err(), "the (issue, actor) primary key rejects a duplicate");
+
+    // (d) Re-applying is a ledgered no-op — the backfill does not double up.
+    apply_migrations(&pool).await.expect("second apply is a no-op");
+    assert_eq!(subs(&pool, "iss-1").await.len(), 3);
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0062_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0062_upgrade.rs
@@ -90,25 +90,24 @@ async fn index_exists(pool: &SqlitePool, name: &str) -> bool {
 
 /// `(actor_type:actor_id, reason)` for one issue, sorted for a stable compare.
 async fn subs(pool: &SqlitePool, issue_id: &str) -> Vec<(String, String)> {
-    let mut v: Vec<(String, String)> = sqlx::query(
-        "SELECT actor_type, actor_id, reason FROM issue_subscriber WHERE issue_id = ?",
-    )
-    .bind(issue_id)
-    .fetch_all(pool)
-    .await
-    .expect("read subscribers")
-    .iter()
-    .map(|r| {
-        (
-            format!(
-                "{}:{}",
-                r.get::<String, _>("actor_type"),
-                r.get::<String, _>("actor_id")
-            ),
-            r.get::<String, _>("reason"),
-        )
-    })
-    .collect();
+    let mut v: Vec<(String, String)> =
+        sqlx::query("SELECT actor_type, actor_id, reason FROM issue_subscriber WHERE issue_id = ?")
+            .bind(issue_id)
+            .fetch_all(pool)
+            .await
+            .expect("read subscribers")
+            .iter()
+            .map(|r| {
+                (
+                    format!(
+                        "{}:{}",
+                        r.get::<String, _>("actor_type"),
+                        r.get::<String, _>("actor_id")
+                    ),
+                    r.get::<String, _>("reason"),
+                )
+            })
+            .collect();
     v.sort();
     v
 }
@@ -162,7 +161,10 @@ async fn migration_0062_backfills_subscribers_first_reason_wins() {
     )
     .execute(&pool)
     .await;
-    assert!(dup.is_err(), "the (issue, actor) primary key rejects a duplicate");
+    assert!(
+        dup.is_err(),
+        "the (issue, actor) primary key rejects a duplicate"
+    );
 
     // (d) Re-applying is a ledgered no-op — the backfill does not double up.
     apply_migrations(&pool).await.expect("second apply is a no-op");

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_reaction.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_reaction.rs
@@ -45,10 +45,14 @@ async fn reacting_twice_is_one_row() {
     let (_dir, store) = setup().await;
     let me = member("me");
     assert!(
-        IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "👍", "r1", 1).await.unwrap()
+        IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "👍", "r1", 1)
+            .await
+            .unwrap()
     );
     assert!(
-        !IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "👍", "r2", 2).await.unwrap(),
+        !IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "👍", "r2", 2)
+            .await
+            .unwrap(),
         "the UNIQUE triple makes a repeat a no-op, not an error"
     );
     let tallies = IssueReactionRepo::tallies(store.pool(), "iss-1").await.unwrap();
@@ -78,9 +82,19 @@ async fn two_actors_same_emoji_tally_to_two() {
 async fn remove_reaction_is_idempotent() {
     let (_dir, store) = setup().await;
     let me = member("me");
-    IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "🚀", "r1", 1).await.unwrap();
-    assert!(IssueReactionRepo::remove(store.pool(), "ws-a", "iss-1", &me, "🚀").await.unwrap());
-    assert!(!IssueReactionRepo::remove(store.pool(), "ws-a", "iss-1", &me, "🚀").await.unwrap());
+    IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "🚀", "r1", 1)
+        .await
+        .unwrap();
+    assert!(
+        IssueReactionRepo::remove(store.pool(), "ws-a", "iss-1", &me, "🚀")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !IssueReactionRepo::remove(store.pool(), "ws-a", "iss-1", &me, "🚀")
+            .await
+            .unwrap()
+    );
     assert!(IssueReactionRepo::tallies(store.pool(), "iss-1").await.unwrap().is_empty());
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_reaction.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_reaction.rs
@@ -1,0 +1,116 @@
+//! Issue emoji reactions (multica parity #22, migration 0062).
+//!
+//! Pins the reference's `AddIssueReaction` / `RemoveIssueReaction` semantics:
+//! unique per `(issue, actor, emoji)` so reacting twice is a no-op rather than
+//! an error, a required-emoji guard at the repo boundary (the reference's
+//! `400 "emoji is required"`), aggregation into per-emoji tallies, and reaping
+//! on issue delete.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::issue::IssueRepo;
+use ainb_hangar_store::repo::issue_reaction::{IssueReactionError, IssueReactionRepo};
+use sqlx::SqlitePool;
+
+fn member(id: &str) -> ActorRef {
+    ActorRef::new(ActorKind::Member, id).unwrap()
+}
+
+async fn seed_ws(pool: &SqlitePool, id: &str) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(id)
+        .bind(id)
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn setup() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_ws(store.pool(), "ws-a").await;
+    sqlx::query(
+        "INSERT INTO issue (id, workspace_id, title, creator_type, creator_id, created_at) \
+         VALUES ('iss-1','ws-a','t','member','m1',0)",
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+    (dir, store)
+}
+
+#[tokio::test]
+async fn reacting_twice_is_one_row() {
+    let (_dir, store) = setup().await;
+    let me = member("me");
+    assert!(
+        IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "👍", "r1", 1).await.unwrap()
+    );
+    assert!(
+        !IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "👍", "r2", 2).await.unwrap(),
+        "the UNIQUE triple makes a repeat a no-op, not an error"
+    );
+    let tallies = IssueReactionRepo::tallies(store.pool(), "iss-1").await.unwrap();
+    assert_eq!(tallies.len(), 1);
+    assert_eq!(tallies[0].emoji, "👍");
+    assert_eq!(tallies[0].count, 1);
+}
+
+#[tokio::test]
+async fn two_actors_same_emoji_tally_to_two() {
+    let (_dir, store) = setup().await;
+    IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &member("a"), "🎉", "r1", 1)
+        .await
+        .unwrap();
+    IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &member("b"), "🎉", "r2", 2)
+        .await
+        .unwrap();
+
+    let tallies = IssueReactionRepo::tallies(store.pool(), "iss-1").await.unwrap();
+    assert_eq!(tallies.len(), 1);
+    assert_eq!(tallies[0].count, 2);
+    assert!(tallies[0].actors.contains(&member("a")));
+    assert!(tallies[0].actors.contains(&member("b")));
+}
+
+#[tokio::test]
+async fn remove_reaction_is_idempotent() {
+    let (_dir, store) = setup().await;
+    let me = member("me");
+    IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &me, "🚀", "r1", 1).await.unwrap();
+    assert!(IssueReactionRepo::remove(store.pool(), "ws-a", "iss-1", &me, "🚀").await.unwrap());
+    assert!(!IssueReactionRepo::remove(store.pool(), "ws-a", "iss-1", &me, "🚀").await.unwrap());
+    assert!(IssueReactionRepo::tallies(store.pool(), "iss-1").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn blank_emoji_is_rejected() {
+    let (_dir, store) = setup().await;
+    let err = IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &member("me"), "  ", "r1", 1)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, IssueReactionError::EmptyEmoji));
+}
+
+#[tokio::test]
+async fn foreign_workspace_writes_nothing() {
+    let (_dir, store) = setup().await;
+    seed_ws(store.pool(), "ws-b").await;
+    assert!(
+        !IssueReactionRepo::add(store.pool(), "ws-b", "iss-1", &member("x"), "👀", "r1", 1)
+            .await
+            .unwrap()
+    );
+    assert!(IssueReactionRepo::list(store.pool(), "iss-1").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn delete_cascade_reaps_reactions() {
+    let (_dir, store) = setup().await;
+    IssueReactionRepo::add(store.pool(), "ws-a", "iss-1", &member("me"), "❤️", "r1", 1)
+        .await
+        .unwrap();
+    IssueRepo::delete_cascade(store.pool(), "ws-a", "iss-1").await.unwrap();
+    assert!(IssueReactionRepo::list(store.pool(), "iss-1").await.unwrap().is_empty());
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_subscriber.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_subscriber.rs
@@ -86,9 +86,16 @@ async fn first_reason_wins_on_repeat_subscribe() {
     let (_dir, store) = setup().await;
     let me = member("me");
     assert!(
-        IssueSubscriberRepo::add(store.pool(), "ws-a", "iss-1", &me, SubscribeReason::Creator, 1)
-            .await
-            .unwrap()
+        IssueSubscriberRepo::add(
+            store.pool(),
+            "ws-a",
+            "iss-1",
+            &me,
+            SubscribeReason::Creator,
+            1
+        )
+        .await
+        .unwrap()
     );
     assert!(
         !IssueSubscriberRepo::add(
@@ -113,9 +120,16 @@ async fn first_reason_wins_on_repeat_subscribe() {
 async fn unsubscribe_removes_and_is_idempotent() {
     let (_dir, store) = setup().await;
     let me = member("me");
-    IssueSubscriberRepo::add(store.pool(), "ws-a", "iss-1", &me, SubscribeReason::Manual, 1)
-        .await
-        .unwrap();
+    IssueSubscriberRepo::add(
+        store.pool(),
+        "ws-a",
+        "iss-1",
+        &me,
+        SubscribeReason::Manual,
+        1,
+    )
+    .await
+    .unwrap();
 
     assert!(IssueSubscriberRepo::remove(store.pool(), "ws-a", "iss-1", &me).await.unwrap());
     assert!(!IssueSubscriberRepo::is_subscribed(store.pool(), "iss-1", &me).await.unwrap());
@@ -144,7 +158,10 @@ async fn foreign_workspace_writes_nothing() {
         .await
         .unwrap()
     );
-    assert_eq!(IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(), 0);
+    assert_eq!(
+        IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(),
+        0
+    );
 }
 
 #[tokio::test]
@@ -162,7 +179,10 @@ async fn delete_cascade_reaps_subscribers() {
     .unwrap();
 
     IssueRepo::delete_cascade(store.pool(), "ws-a", "iss-1").await.unwrap();
-    assert_eq!(IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(), 0);
+    assert_eq!(
+        IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(),
+        0
+    );
 }
 
 /// A member and an agent are DISTINCT subscribers even with the same id half.
@@ -170,11 +190,21 @@ async fn delete_cascade_reaps_subscribers() {
 async fn distinct_actors_accumulate() {
     let (_dir, store) = setup().await;
     for a in [member("x"), agent("x")] {
-        IssueSubscriberRepo::add(store.pool(), "ws-a", "iss-1", &a, SubscribeReason::Manual, 1)
-            .await
-            .unwrap();
+        IssueSubscriberRepo::add(
+            store.pool(),
+            "ws-a",
+            "iss-1",
+            &a,
+            SubscribeReason::Manual,
+            1,
+        )
+        .await
+        .unwrap();
     }
-    assert_eq!(IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(), 2);
+    assert_eq!(
+        IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(),
+        2
+    );
     let actors = IssueSubscriberRepo::actors(store.pool(), "iss-1").await.unwrap();
     assert!(actors.contains(&member("x")));
     assert!(actors.contains(&agent("x")));

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_subscriber.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_issue_subscriber.rs
@@ -1,0 +1,181 @@
+//! Issue subscribers (multica parity #22, migration 0062).
+//!
+//! The acceptance sentence for #22 is *"an actor can subscribe to an issue;
+//! persists (sqlite)"*. These tests pin that at the store layer, plus the four
+//! semantics the reference's `AddIssueSubscriber` / `RemoveIssueSubscriber`
+//! carry: first-reason-wins idempotency, idempotent removal, tenant isolation
+//! through the join to `issue`, and reaping on issue delete.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::issue::IssueRepo;
+use ainb_hangar_store::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
+use sqlx::SqlitePool;
+
+fn member(id: &str) -> ActorRef {
+    ActorRef::new(ActorKind::Member, id).unwrap()
+}
+
+fn agent(id: &str) -> ActorRef {
+    ActorRef::new(ActorKind::Agent, id).unwrap()
+}
+
+async fn seed_ws(pool: &SqlitePool, id: &str) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES (?, ?, ?, 0)")
+        .bind(id)
+        .bind(id)
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn seed_issue(pool: &SqlitePool, ws: &str, id: &str) {
+    sqlx::query(
+        "INSERT INTO issue (id, workspace_id, title, creator_type, creator_id, created_at) \
+         VALUES (?, ?, ?, 'member', 'm1', 0)",
+    )
+    .bind(id)
+    .bind(ws)
+    .bind(id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn setup() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_ws(store.pool(), "ws-a").await;
+    seed_issue(store.pool(), "ws-a", "iss-1").await;
+    (dir, store)
+}
+
+/// THE ACCEPTANCE, at the unit layer: subscribe, then re-open the SAME database
+/// file from a fresh pool and read the row back.
+#[tokio::test]
+async fn subscribe_persists_and_reads_back() {
+    let (dir, store) = setup().await;
+    assert!(
+        IssueSubscriberRepo::add(
+            store.pool(),
+            "ws-a",
+            "iss-1",
+            &member("me"),
+            SubscribeReason::Manual,
+            123,
+        )
+        .await
+        .unwrap()
+    );
+    drop(store);
+
+    // A brand-new process would see exactly this.
+    let reopened = Store::open_in(dir.path()).await.unwrap();
+    let subs = IssueSubscriberRepo::list(reopened.pool(), "iss-1").await.unwrap();
+    assert_eq!(subs.len(), 1, "the subscription survives a pool reopen");
+    assert_eq!(subs[0].actor, member("me"));
+    assert_eq!(subs[0].reason, Some(SubscribeReason::Manual));
+    assert_eq!(subs[0].reason_raw, "manual");
+}
+
+/// `reason` is provenance, not state: the FIRST reason wins, exactly as the
+/// reference's `ON CONFLICT DO NOTHING`.
+#[tokio::test]
+async fn first_reason_wins_on_repeat_subscribe() {
+    let (_dir, store) = setup().await;
+    let me = member("me");
+    assert!(
+        IssueSubscriberRepo::add(store.pool(), "ws-a", "iss-1", &me, SubscribeReason::Creator, 1)
+            .await
+            .unwrap()
+    );
+    assert!(
+        !IssueSubscriberRepo::add(
+            store.pool(),
+            "ws-a",
+            "iss-1",
+            &me,
+            SubscribeReason::Commenter,
+            2
+        )
+        .await
+        .unwrap(),
+        "a repeat subscribe lands no second row"
+    );
+
+    let subs = IssueSubscriberRepo::list(store.pool(), "iss-1").await.unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0].reason, Some(SubscribeReason::Creator));
+}
+
+#[tokio::test]
+async fn unsubscribe_removes_and_is_idempotent() {
+    let (_dir, store) = setup().await;
+    let me = member("me");
+    IssueSubscriberRepo::add(store.pool(), "ws-a", "iss-1", &me, SubscribeReason::Manual, 1)
+        .await
+        .unwrap();
+
+    assert!(IssueSubscriberRepo::remove(store.pool(), "ws-a", "iss-1", &me).await.unwrap());
+    assert!(!IssueSubscriberRepo::is_subscribed(store.pool(), "iss-1", &me).await.unwrap());
+    assert!(
+        !IssueSubscriberRepo::remove(store.pool(), "ws-a", "iss-1", &me).await.unwrap(),
+        "removing an absent subscription is a no-op, not an error"
+    );
+}
+
+/// The [`CommentRepo::insert`] tenant rule: a write scoped to the WRONG
+/// workspace lands nothing and does not error.
+#[tokio::test]
+async fn foreign_workspace_writes_nothing() {
+    let (_dir, store) = setup().await;
+    seed_ws(store.pool(), "ws-b").await;
+
+    assert!(
+        !IssueSubscriberRepo::add(
+            store.pool(),
+            "ws-b",
+            "iss-1",
+            &member("intruder"),
+            SubscribeReason::Manual,
+            1,
+        )
+        .await
+        .unwrap()
+    );
+    assert_eq!(IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn delete_cascade_reaps_subscribers() {
+    let (_dir, store) = setup().await;
+    IssueSubscriberRepo::add(
+        store.pool(),
+        "ws-a",
+        "iss-1",
+        &member("me"),
+        SubscribeReason::Manual,
+        1,
+    )
+    .await
+    .unwrap();
+
+    IssueRepo::delete_cascade(store.pool(), "ws-a", "iss-1").await.unwrap();
+    assert_eq!(IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(), 0);
+}
+
+/// A member and an agent are DISTINCT subscribers even with the same id half.
+#[tokio::test]
+async fn distinct_actors_accumulate() {
+    let (_dir, store) = setup().await;
+    for a in [member("x"), agent("x")] {
+        IssueSubscriberRepo::add(store.pool(), "ws-a", "iss-1", &a, SubscribeReason::Manual, 1)
+            .await
+            .unwrap();
+    }
+    assert_eq!(IssueSubscriberRepo::count(store.pool(), "iss-1").await.unwrap(), 2);
+    let actors = IssueSubscriberRepo::actors(store.pool(), "iss-1").await.unwrap();
+    assert!(actors.contains(&member("x")));
+    assert!(actors.contains(&agent("x")));
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -4381,6 +4381,9 @@ impl HangarPlugin {
         // renders the task's title + status; the streaming transcript folds events
         // addressed to this task id, exactly as the issue board's open does.
         let issue = ainb_hangar_proto::events::IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,
@@ -5876,6 +5879,9 @@ mod tests {
         p.conn.on_dialed("s1");
         p.conn.on_subscribe_ack();
         p.screens.set_issues(vec![IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,
@@ -6037,6 +6043,9 @@ mod tests {
         // more than one column (the press must resolve the RIGHT card).
         p.screens.set_issues(vec![
             IssueRow {
+                subscriber_count: 0,
+                subscribed: false,
+                reactions: Vec::new(),
                 last_dispatch_reason: None,
                 last_dispatch_detail: None,
                 last_dispatch_at: None,
@@ -6073,6 +6082,9 @@ mod tests {
                 dependencies: Vec::new(),
             },
             IssueRow {
+                subscriber_count: 0,
+                subscribed: false,
+                reactions: Vec::new(),
                 last_dispatch_reason: None,
                 last_dispatch_detail: None,
                 last_dispatch_at: None,
@@ -6270,6 +6282,9 @@ mod tests {
 
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,
@@ -6366,6 +6381,9 @@ mod tests {
 
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,
@@ -6454,6 +6472,9 @@ mod tests {
         // Several Todo cards so a scroll offset is observable.
         let rows: Vec<IssueRow> = (0..4)
             .map(|i| IssueRow {
+                subscriber_count: 0,
+                subscribed: false,
+                reactions: Vec::new(),
                 last_dispatch_reason: None,
                 last_dispatch_detail: None,
                 last_dispatch_at: None,
@@ -6546,6 +6567,9 @@ mod tests {
         let mut p = connected_plugin_with_issue();
         p.screens.set_issues(vec![
             IssueRow {
+                subscriber_count: 0,
+                subscribed: false,
+                reactions: Vec::new(),
                 last_dispatch_reason: None,
                 last_dispatch_detail: None,
                 last_dispatch_at: None,
@@ -6582,6 +6606,9 @@ mod tests {
                 dependencies: Vec::new(),
             },
             IssueRow {
+                subscriber_count: 0,
+                subscribed: false,
+                reactions: Vec::new(),
                 last_dispatch_reason: None,
                 last_dispatch_detail: None,
                 last_dispatch_at: None,
@@ -7333,6 +7360,9 @@ mod tests {
 
         // Open the task detail for a fresh issue.
         let issue = IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/issue_list.rs
@@ -3691,6 +3691,9 @@ mod tests {
 
     fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
         IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -45,9 +45,7 @@
 
 use ainb_hangar_core::acceptance::{AcceptanceCriterion, checked_count, legacy_placeholder_id};
 use ainb_hangar_core::ids::TaskId;
-use ainb_hangar_proto::events::{
-    HangarEvent, IssueLinkRow, IssueRow, MessageKind, ReactionRow, TaskResult,
-};
+use ainb_hangar_proto::events::{HangarEvent, IssueRow, MessageKind, TaskResult};
 use ainb_hangar_proto::pr_status::{CiRollup, MergeState, Mergeable, PrStatus};
 use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
 
@@ -1538,6 +1536,8 @@ pub const fn color_for(kind: MessageKind) -> ainb_plugin_sdk::Color {
 
 #[cfg(test)]
 mod card_tests {
+    use ainb_hangar_proto::events::{IssueLinkRow, ReactionRow};
+
     use super::*;
     use ainb_hangar_core::ids::{IssueId, TaskId};
     use ainb_plugin_sdk::WireBuffer;

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -45,7 +45,9 @@
 
 use ainb_hangar_core::acceptance::{AcceptanceCriterion, checked_count, legacy_placeholder_id};
 use ainb_hangar_core::ids::TaskId;
-use ainb_hangar_proto::events::{HangarEvent, IssueLinkRow, IssueRow, MessageKind, TaskResult};
+use ainb_hangar_proto::events::{
+    HangarEvent, IssueLinkRow, IssueRow, MessageKind, ReactionRow, TaskResult,
+};
 use ainb_hangar_proto::pr_status::{CiRollup, MergeState, Mergeable, PrStatus};
 use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
 
@@ -1245,6 +1247,34 @@ fn render_detail_card(
         }
     }
 
+    // --- Subscribers + reactions (multica parity #22). Both are DETAIL-ONLY
+    //     wire fields, so a list snapshot (and any pre-#22 daemon) leaves them
+    //     at their default and the card renders byte-identically to today. ---
+    if issue.subscriber_count > 0 {
+        let count = format!("{}", issue.subscriber_count);
+        let mut cells: Vec<(&str, Color)> = vec![("Subs:  ", CARD_LABEL), (&count, CARD_VALUE)];
+        if issue.subscribed {
+            cells.push(("  ✓ you", SELECTION_GREEN));
+        }
+        card_field_row(buf, card_w, row, &cells);
+        row = row.saturating_add(1);
+    }
+    if !issue.reactions.is_empty() {
+        let buckets: Vec<String> =
+            issue.reactions.iter().map(|r| format!("{} {}  ", r.emoji, r.count)).collect();
+        let mut cells: Vec<(&str, Color)> = vec![("React: ", CARD_LABEL)];
+        for (bucket, reaction) in buckets.iter().zip(&issue.reactions) {
+            // A bucket the local human is in gets the same accent the acceptance
+            // markers use, so "mine" reads at a glance.
+            cells.push((
+                bucket.as_str(),
+                if reaction.mine { SELECTION_GREEN } else { CARD_VALUE },
+            ));
+        }
+        card_field_row(buf, card_w, row, &cells);
+        row = row.saturating_add(1);
+    }
+
     // --- divider ---
     draw_card_divider(buf, row, card_w);
     row = row.saturating_add(1);
@@ -1880,6 +1910,64 @@ mod card_tests {
         );
     }
 
+    /// multica parity #22: the watcher count (with the `✓ you` marker) and the
+    /// aggregated reaction buckets both render on the detail card.
+    #[test]
+    fn detail_card_renders_a_subs_and_react_block() {
+        let mut issue = full_issue();
+        issue.subscriber_count = 3;
+        issue.subscribed = true;
+        issue.reactions = vec![
+            ReactionRow {
+                emoji: "👍".into(),
+                count: 3,
+                mine: true,
+            },
+            ReactionRow {
+                emoji: "🎉".into(),
+                count: 1,
+                mine: false,
+            },
+        ];
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 40);
+        render_task_detail(&mut buf, 80, 0, 39, &s);
+        let squashed = painted_text(&buf).split_whitespace().collect::<Vec<_>>().join(" ");
+
+        assert!(squashed.contains("Subs: 3"), "the count: {squashed}");
+        assert!(squashed.contains("✓ you"), "the you-marker: {squashed}");
+        assert!(squashed.contains("React: 👍 3"), "the mine bucket: {squashed}");
+        assert!(squashed.contains("🎉 1"), "the other bucket: {squashed}");
+    }
+
+    /// A pre-#22 daemon sends neither field, so the card renders exactly as it
+    /// does today — no `Subs:` line and no `React:` line.
+    #[test]
+    fn detail_card_omits_subs_and_react_when_empty() {
+        let s = state_for(full_issue());
+        let mut buf = WireBuffer::new(80, 40);
+        render_task_detail(&mut buf, 80, 0, 39, &s);
+        let text = painted_text(&buf);
+        assert!(!text.contains("Subs:"), "no subscribers ⇒ no line: {text}");
+        assert!(!text.contains("React:"), "no reactions ⇒ no line: {text}");
+    }
+
+    /// A subscriber count with the LOCAL HUMAN absent renders the count but no
+    /// `✓ you` marker.
+    #[test]
+    fn detail_card_omits_the_you_marker_when_not_subscribed() {
+        let mut issue = full_issue();
+        issue.subscriber_count = 2;
+        issue.subscribed = false;
+        let s = state_for(issue);
+        let mut buf = WireBuffer::new(80, 40);
+        render_task_detail(&mut buf, 80, 0, 39, &s);
+        let squashed = painted_text(&buf).split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(squashed.contains("Subs: 2"), "the count: {squashed}");
+        assert!(!squashed.contains("✓ you"), "not subscribed: {squashed}");
+    }
+
+    /// A fresh unchecked criterion with a deterministic id.
     /// A fresh unchecked criterion with a deterministic id.
     fn crit(id: &str, text: &str) -> AcceptanceCriterion {
         AcceptanceCriterion::with_id(id, text).expect("criterion")

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1542,6 +1542,9 @@ mod card_tests {
     /// A fully-populated issue row for the card render assertions (63d).
     fn full_issue() -> IssueRow {
         IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -1268,7 +1268,11 @@ fn render_detail_card(
             // markers use, so "mine" reads at a glance.
             cells.push((
                 bucket.as_str(),
-                if reaction.mine { SELECTION_GREEN } else { CARD_VALUE },
+                if reaction.mine {
+                    SELECTION_GREEN
+                } else {
+                    CARD_VALUE
+                },
             ));
         }
         card_field_row(buf, card_w, row, &cells);
@@ -1936,7 +1940,10 @@ mod card_tests {
 
         assert!(squashed.contains("Subs: 3"), "the count: {squashed}");
         assert!(squashed.contains("✓ you"), "the you-marker: {squashed}");
-        assert!(squashed.contains("React: 👍 3"), "the mine bucket: {squashed}");
+        assert!(
+            squashed.contains("React: 👍 3"),
+            "the mine bucket: {squashed}"
+        );
         assert!(squashed.contains("🎉 1"), "the other bucket: {squashed}");
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/sidebar.rs
@@ -117,6 +117,9 @@ mod tests {
 
     fn issue(description: Option<&str>, assignee: Option<&str>) -> IssueRow {
         IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/activity_timeline_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/activity_timeline_reducer_test.rs
@@ -73,6 +73,9 @@ fn seeded() -> ActivityState {
 /// One issue row with only the fields this test cares about set.
 fn row(id: &str) -> ainb_hangar_proto::events::IssueRow {
     ainb_hangar_proto::events::IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/facet_panel_snapshot.rs
@@ -22,6 +22,9 @@ use ainb_plugin_sdk::WireBuffer;
 /// A wire row with explicit state / priority / labels for facet rendering.
 fn row(id: &str, state: &str, priority: i64, labels: &[&str]) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_board_snapshot.rs
@@ -29,6 +29,9 @@ const CLAY: Color = Color::rgb(210, 130, 90);
 /// urgency so the card anatomy (id line + priority chip) renders predictably.
 fn row(id: &str, display: &str, state: &str, priority: i64, assignee: Option<&str>) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/issue_list_reducer_test.rs
@@ -19,6 +19,9 @@ use ainb_plugin_hangar::screen::issue_list::{
 /// member/agent filter chips.
 fn row(id: &str, state: &str, assignee: Option<&str>) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_badge_snapshot.rs
@@ -23,6 +23,9 @@ use ainb_plugin_sdk::WireBuffer;
 
 fn issue_with_pr(pr_url: Option<&str>) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/pr_open_keybinding.rs
@@ -22,6 +22,9 @@ const fn key(ch: char) -> KeyEvent {
 
 fn issue(pr_url: Option<&str>) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -22,6 +22,9 @@ fn task() -> TaskId {
 
 fn issue_row() -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_render_snapshot.rs
@@ -19,6 +19,9 @@ use ainb_plugin_sdk::WireBuffer;
 
 fn issue_row() -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_acceptance_tick.rs
@@ -94,6 +94,9 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// One wire row carrying `criteria` as its structured acceptance list.
 fn row(id: &str, title: &str, criteria: Vec<AcceptanceCriterion>) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_blocked_cancelled.rs
@@ -109,6 +109,9 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// One wire row. `state` is what buckets the card into a board column.
 fn row(id: &str, title: &str, state: &str) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_issue_facets.rs
@@ -98,6 +98,9 @@ async fn read_one_raw_frame<R: tokio::io::AsyncBufRead + Unpin>(r: &mut R) -> Op
 /// `2` = P1); `state` drives the board column; `labels` drive the label facet.
 fn row(id: &str, title: &str, state: &str, priority: i64, labels: &[&str]) -> IssueRow {
     IssueRow {
+        subscriber_count: 0,
+        subscribed: false,
+        reactions: Vec::new(),
         last_dispatch_reason: None,
         last_dispatch_detail: None,
         last_dispatch_at: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -132,6 +132,9 @@ fn seeded_agents() -> serde_json::Value {
 fn seeded_issues() -> serde_json::Value {
     serde_json::to_value(IssuesListResult {
         issues: vec![IssueRow {
+            subscriber_count: 0,
+            subscribed: false,
+            reactions: Vec::new(),
             last_dispatch_reason: None,
             last_dispatch_detail: None,
             last_dispatch_at: None,

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2863,18 +2863,22 @@ Manage Hangar issues
 Usage: ainb hangar issue [OPTIONS] <COMMAND>
 
 Commands:
-  create    Create a new issue (bootstraps a default workspace on first use)
-  list      List issues in the default workspace
-  search    Search issues by title, description, or comment body (ranked)
-  show      Show one issue by id
-  update    Edit an existing issue's state, assignee, priority, or due date
-  delete    Delete an issue and all its history (dry-run without `--yes`)
-  label     Attach or detach a label on an issue
-  criteria  Inspect or tick off an issue's acceptance criteria
-  link      Add, remove, or list an issue's typed links to other issues
-  why       Explain why an issue did (or did not) dispatch — its admission history
-  timeline  Show one issue's activity timeline: state changes, assignments, comments
-  help      Print this message or the help of the given subcommand(s)
+  create       Create a new issue (bootstraps a default workspace on first use)
+  list         List issues in the default workspace
+  search       Search issues by title, description, or comment body (ranked)
+  show         Show one issue by id
+  update       Edit an existing issue's state, assignee, priority, or due date
+  delete       Delete an issue and all its history (dry-run without `--yes`)
+  label        Attach or detach a label on an issue
+  criteria     Inspect or tick off an issue's acceptance criteria
+  link         Add, remove, or list an issue's typed links to other issues
+  subscribe    Subscribe an actor to an issue's notifications (multica parity #22)
+  unsubscribe  Unsubscribe an actor from an issue's notifications. Idempotent
+  subscribers  List who watches an issue, with the reason each one was subscribed
+  react        Add, remove, or list an issue's emoji reactions
+  why          Explain why an issue did (or did not) dispatch — its admission history
+  timeline     Show one issue's activity timeline: state changes, assignments, comments
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -3147,6 +3151,86 @@ Commands:
   add     Link two issues. Re-adding a pair with a new kind replaces the kind
   remove  Remove a link between two issues. Idempotent
   list    List an issue's links (`🔒`/`✓` blocked-by, `→` blocks, `~` related)
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar issue subscribe`
+
+Subscribe an actor to an issue's notifications (multica parity #22)
+
+```console
+$ ainb hangar issue subscribe --help
+Subscribe an actor to an issue's notifications (multica parity #22)
+
+Usage: ainb hangar issue subscribe [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Issue id (ULID) to watch / stop watching
+
+Options:
+      --actor <ACTOR>          The actor, as `member:<id>` / `agent:<id>`. Defaults to the LOCAL HUMAN (`member:me`), mirroring the reference's "the target defaults to the caller"
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar issue unsubscribe`
+
+Unsubscribe an actor from an issue's notifications. Idempotent
+
+```console
+$ ainb hangar issue unsubscribe --help
+Unsubscribe an actor from an issue's notifications. Idempotent
+
+Usage: ainb hangar issue unsubscribe [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Issue id (ULID) to watch / stop watching
+
+Options:
+      --actor <ACTOR>          The actor, as `member:<id>` / `agent:<id>`. Defaults to the LOCAL HUMAN (`member:me`), mirroring the reference's "the target defaults to the caller"
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar issue subscribers`
+
+List who watches an issue, with the reason each one was subscribed
+
+```console
+$ ainb hangar issue subscribers --help
+List who watches an issue, with the reason each one was subscribed
+
+Usage: ainb hangar issue subscribers [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Issue id (ULID) whose watchers to list
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar issue react`
+
+Add, remove, or list an issue's emoji reactions
+
+```console
+$ ainb hangar issue react --help
+Add, remove, or list an issue's emoji reactions
+
+Usage: ainb hangar issue react [OPTIONS] <COMMAND>
+
+Commands:
+  add     React to an issue with an emoji. Idempotent
+  remove  Remove your reaction. Idempotent
+  list    List an issue's reactions as `<emoji> <count>` buckets
   help    Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
## multica parity #22 — issue subscribers + reactions

`main` had **zero** hits for `issue_subscriber` / `issue_reaction`, and
`inbox_aggregator::recipients_for` said so in its own doc comment: *"hangar has no
`issue_subscriber` table, so 'subscribers' is approximated by the issue's
PARTICIPANTS"*. That approximation cannot express the two cases the reference
feature exists for — a **watcher** who is neither creator nor assignee, and an
actor who wants **out** of a thread they created. This PR replaces the
approximation with the real table.

### Acceptance (the literal sentence: *an actor can subscribe to an issue; persists (sqlite)*)

Run against the real binary, no daemon and no TUI:

```
$ ainb hangar issue subscribe "$ID"
member:stevie  (creator)
member:me      (manual)

$ sqlite3 hangar.db "SELECT issue_id, actor_type, actor_id, reason FROM issue_subscriber"
01KYHAZGGZFAKR6VFMV34BQF6C|member|stevie|creator
01KYHAZGGZFAKR6VFMV34BQF6C|member|me|manual

$ ainb hangar issue show "$ID"          # a SECOND process
Subscribers: 2
  member:stevie  (creator)
  member:me  (manual)
Reactions: 👍 1
```

Pinned by `hangar_cli_integration::issue_subscribe_persists_to_sqlite_and_survives_a_new_process`.

### The table is NOT decorative

`crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs::a_manual_subscriber_who_is_neither_creator_nor_assignee_gets_the_comment_entry`
**cannot pass** on the participant approximation — the watcher is neither
endpoint, so the old derivation could never reach them. It passes only because
`recipients_for` now reads `issue_subscriber`. The participant derivation
survives as the **fallback for an issue with no subscriber rows at all**, so no
upgrade path can silence a notification (pinned by
`an_issue_with_no_subscriber_rows_still_notifies_its_participants`).

### What landed

| Layer | Change |
|---|---|
| schema | `0062_issue_subscriber_reaction.sql` — both tables, both indexes, and the reference's `016_backfill_subscribers` (creator → assignee → commenter, each `OR IGNORE`, so an upgrading install is not born empty) |
| store | `repo/issue_subscriber.rs` (`SubscribeReason`, add/remove/list/count/actors) + `repo/issue_reaction.rs` (`IssueReactionError::EmptyEmoji`, add/remove/list/tallies); both workspace-scoped through the join to `issue` (`CommentRepo::insert`'s tenant rule); reaped by `IssueRepo::delete_cascade` |
| auto-subscribe | `IssueRepo::insert` subscribes creator + assignee (the ONE create seam every path shares: issue-create RPC, board-card create, autopilot fire, CLI); `update_fields` subscribes a new assignee; `comment_add` subscribes the author; the mention fan-out subscribes each resolved agent. All best-effort — a subscription side effect never fails a committed mutation (the reference's rule at `task.go:1877`) |
| proto | 5 method consts + params/results; `IssueSubscriberRow` / `ReactionRow`; 3 append-only `IssueRow` fields (`subscriber_count`, `subscribed`, `reactions`), all `#[serde(default)]` so a pre-#22 snapshot still decodes |
| daemon | `hangar/issue_{subscribe,unsubscribe,subscribers,reaction_add,reaction_remove}`; every mutator answers the REFRESHED collection (no read-after-write race); the reference's 403 as a workspace-membership gate; blank emoji ⇒ the reference's own `emoji is required` |
| plugin | `Subs: 3  ✓ you` and `React: 👍 3  🎉 1` on the task-detail card, both DETAIL-path only and both omitted when empty, so an old daemon leaves the card byte-identical |
| CLI | `hangar issue subscribe / unsubscribe / subscribers` and `hangar issue react add\|remove\|list`, plus the `Subscribers:` / `Reactions:` blocks on `issue show` |

### Deliberate parity choices (all stated in the migration header)

1. **`reason` is provenance, membership is the state.** `PK (issue_id, actor_type, actor_id)` + `OR IGNORE` ⇒ first reason wins, exactly as the reference's `ON CONFLICT DO NOTHING`. A manual subscribe over an existing `creator` is a no-op that still answers "subscribed".
2. **One naming: `actor_type` / `actor_id` on both tables.** The reference's `user_*` on subscribers is a two-author accident; hangar has one polymorphic-actor convention and one Rust type.
3. **`CHECK` on `actor_type` only**, none on `reason` / `emoji` — SQLite cannot widen a `CHECK` without a table rebuild (0057's dance), and 0058 set the precedent of enforcing the vocabulary in Rust.
4. **No `muted` flag** — matched to the reference: unsubscribing then commenting again re-subscribes you. A divergent mute model would be a silent behaviour fork; `muted` is a clean future append.
5. **The `member:me` exemption on the workspace-membership gate is explicit.** The local human is hangar's synthetic single-user identity with no `member` row until a real signed-in identity lands; gating it would reject the default and therefore the whole single-user flow. Documented on `reject_actor_outside_workspace`.

### Not in this PR (honest scope)

The spec also sketched a board **context-menu** `Subscribe` leaf and a `React ▸`
submenu. Those are not here — the mutation surface shipped is the CLI + the five
RPCs, and the detail card is read-only. No new key binding was added, so nothing
in the keyspace guard changed.

### Gate (all run locally on this branch)

| Gate | Result |
|---|---|
| `cargo build -p ainb` | ok |
| `cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'` | 4231 tests, 4230 passed. The single failure, `components::code_review::render::tests::renders_large_diff_within_budget`, is a wall-clock budget assertion unrelated to this change; **re-run in isolation it passes** (`1 passed`) — a contention flake, attributed not hand-waved. |
| `scripts/hangar/run_all_tripwires.sh` | `ran=64 failed=0 skipped=0` |
| `scripts/hangar/run_acceptance_tests.sh` | `ran=186 failed=0 skipped=0` |
| `cargo fmt --all` | clean |

Fixture drift from the 3 new `IssueRow` fields was fixed in the same PR across
all 39 construction sites (proto / daemon / plugin, src and tests);
`migration_upgrade_full_chain` and `all_methods_covers_every_const` both stay
green unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue subscriptions, including subscribe, unsubscribe, and subscriber listing.
  * Added emoji reactions with add, remove, and list actions.
  * Issue details now display subscriber counts, subscription status, and reaction tallies.
  * Issue creators, assignees, commenters, and mentioned participants can be subscribed automatically.
  * Comment notifications now reach active issue subscribers, with participant fallback when needed.

* **Bug Fixes**
  * Added workspace validation and clearer errors for invalid issues, actors, and emojis.
  * Subscription and reaction actions are idempotent and safely cleaned up when issues are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->