### PR TITLE
chore(justfile): regenerate and verify the CLI reference in just check

### DIFF
--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -137,10 +137,21 @@ lint:
 lint-fix:
     cargo clippy --fix --allow-dirty --allow-staged
 
+# Regenerate docs/tui/cli.md from the ainb binary (source of truth)
+gen-cli-ref:
+    cargo build -p ainb
+    AINB_BIN=target/debug/ainb bash scripts/gen-cli-reference.sh
+
+# Fail if docs/tui/cli.md has drifted from the binary
+# (docs/tui/ lives at the repo root, one level up from this justfile)
+check-cli-ref: gen-cli-ref
+    git diff --exit-code -- ../docs/tui/cli.md
+
 # Check everything (format, lint, test)
 check:
     just fmt-check
     just lint
+    just check-cli-ref
     just test
 
 # Fix formatting and linting issues


### PR DESCRIPTION
Phase 1 of `plans/contract-testing-hardening.md`. Tracking issue #500.

## Problem

`docs/tui/cli.md` is generated from the `ainb` binary. CI job `cli-docs` ("CLI reference freshness") verifies it, but only *after* the work is pushed, so a clap change means a red CI run plus a follow-up commit. That tax was paid on #496, #497 and #499.

## Change

Two justfile recipes, and `check-cli-ref` wired into `just check` after `lint` and before `test` so it fails fast:

```
gen-cli-ref:
    cargo build -p ainb
    AINB_BIN=target/debug/ainb bash scripts/gen-cli-reference.sh

check-cli-ref: gen-cli-ref
    git diff --exit-code -- ../docs/tui/cli.md
```

CI is untouched and stays the backstop.

## Proof the gate bites

Per the plan's meta-rule, the acceptance criterion is not that the check passes, it is that breaking the contract turns it red. Note that appending junk to `docs/tui/cli.md` and re-running is NOT a valid test: `gen-cli-ref` overwrites the file before the diff, so it always passes. The real contract is "committed file matches binary output", so the mutation has to be a committed drift.

Committed a deliberate drift, then ran `just check-cli-ref`:

```
AINB_BIN=target/debug/ainb bash scripts/gen-cli-reference.sh
[gen-cli-reference] wrote .../docs/tui/cli.md
git diff --exit-code -- ../docs/tui/cli.md
diff --git a/docs/tui/cli.md b/docs/tui/cli.md
index 0a48a7d3..49caf190 100644
--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -4988,5 +4988,3 @@ ainb recover list --format json && ainb recover cleanup
 # Search the knowledge base headlessly
 ainb learnings search "redis connection pooling" --format json
 ```
-
-<!-- deliberate drift for gate proof -->
error: recipe `check-cli-ref` failed on line 148 with exit code 1
```

The drift commit was then reset, and `just check-cli-ref` exits 0 on a clean tree. `gen-cli-ref` leaves no spurious diff on unmodified main.
