### PR TITLE
feat(hangar): autopilot subscriber / collaborator model (multica parity #27)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -2413,7 +2413,9 @@ async fn require_autopilot_write(
 
     let ws = WorkspaceId::from_str(workspace_id.to_string()).context("workspace id was empty")?;
     match can_write(store.pool(), &ws, id, actor).await.context("write predicate")? {
-        WriteDecision::Allowed(_) => Ok(()),
+        // No such rule here: fall through so the caller's own not-found path
+        // reports it honestly rather than as a permission refusal.
+        WriteDecision::Allowed(_) | WriteDecision::NotFound => Ok(()),
         WriteDecision::Denied => anyhow::bail!(
             "actor `{actor}` may not modify autopilot `{id}` (access_mode = restricted)"
         ),

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -2393,6 +2393,9 @@ async fn run_autopilot_edit(store: &Store, args: AutopilotEditArgs) -> Result<()
         max_concurrent_runs: args.max_concurrent_runs,
         execution_mode: args.execution_mode.map(Into::into),
         concurrency_policy: args.concurrency_policy.map(Into::into),
+        // `ainb hangar autopilot access` is the one door onto the write-access
+        // mode, so the generic edit patch deliberately leaves it alone.
+        access_mode: None,
     };
     anyhow::ensure!(
         !edit.is_empty(),
@@ -10247,6 +10250,7 @@ mod tests {
             next_tick_at: Some(1_767_258_000_000),
             enabled,
             api_trigger_enabled: false,
+            access_mode: ainb_hangar_store::repo::autopilot::AccessMode::Open,
             created_at: 0,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -276,6 +276,69 @@ pub enum AutopilotCommand {
     Webhook(AutopilotWebhookArgs),
     /// List the autopilot's recent webhook deliveries (audit log).
     Deliveries(AutopilotDeliveriesArgs),
+    /// Manage the rule's explicit WRITE-GRANT set (multica parity #27).
+    #[command(subcommand)]
+    Collaborator(AutopilotActorCommand),
+    /// Manage the rule's STANDING subscriber list — every issue the rule spawns
+    /// auto-subscribes it (multica parity #27).
+    #[command(subcommand)]
+    Subscriber(AutopilotActorCommand),
+    /// Open or restrict who may WRITE this rule (multica parity #27).
+    Access(AutopilotAccessArgs),
+}
+
+/// The add / remove / list verbs shared by `autopilot collaborator` and
+/// `autopilot subscriber` — the addressed tuple is identical, so the shape is.
+#[derive(Subcommand, Debug)]
+pub enum AutopilotActorCommand {
+    /// Add an actor to the set (idempotent; a re-add keeps the FIRST grant).
+    Add(AutopilotActorArgs),
+    /// Remove an actor from the set (idempotent).
+    Remove(AutopilotActorArgs),
+    /// List the set, oldest first.
+    List(AutopilotActorArgs),
+}
+
+/// Arguments for every `hangar autopilot collaborator|subscriber` verb.
+#[derive(Args, Debug)]
+pub struct AutopilotActorArgs {
+    /// The autopilot id (`autopilot.id`).
+    #[arg(long)]
+    pub id: String,
+    /// The target actor, `member:<id>` / `agent:<id>`. Defaults to the local
+    /// human (`member:me`).
+    #[arg(long)]
+    pub actor: Option<String>,
+    /// Collaborator ADD only: `editor` (the default) grants write, `viewer`
+    /// grants visibility only.
+    #[arg(long)]
+    pub role: Option<String>,
+    /// The ACTING human, as the write gate's subject and the grant's
+    /// attribution. Defaults to the local human.
+    #[arg(long = "as-user")]
+    pub as_user: Option<String>,
+    /// Workspace slug the autopilot belongs to. Defaults to `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Arguments for `hangar autopilot access`.
+#[derive(Args, Debug)]
+pub struct AutopilotAccessArgs {
+    /// The autopilot id (`autopilot.id`).
+    #[arg(long)]
+    pub id: String,
+    /// `open` (any actor in the workspace may write — the default and every
+    /// pre-0064 rule) or `restricted` (owner / workspace owner+admin / an
+    /// explicit `editor` collaborator only).
+    #[arg(long)]
+    pub mode: String,
+    /// The acting human (write gate subject + rule-version attribution).
+    #[arg(long = "as-user")]
+    pub as_user: Option<String>,
+    /// Workspace slug the autopilot belongs to. Defaults to `default`.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// Arguments for `hangar autopilot webhook <id>`.
@@ -2304,6 +2367,263 @@ async fn dispatch_autopilot(cmd: AutopilotCommand, format: OutputFormat) -> Resu
         AutopilotCommand::Edit(args) => run_autopilot_edit(&store, args).await,
         AutopilotCommand::Versions(args) => run_autopilot_versions(&store, args, format).await,
         AutopilotCommand::Deliveries(args) => run_autopilot_deliveries(&store, args, format).await,
+        AutopilotCommand::Collaborator(cmd) => {
+            run_autopilot_collaborator(&store, cmd, format).await
+        }
+        AutopilotCommand::Subscriber(cmd) => run_autopilot_subscriber(&store, cmd, format).await,
+        AutopilotCommand::Access(args) => run_autopilot_access(&store, args).await,
+    }
+}
+
+/// Resolve `(workspace_id, autopilot_id)` and fail LOUDLY on a foreign /
+/// unknown id — the repos' tenant join would otherwise turn a typo into a
+/// silent no-op that looks like success.
+async fn require_autopilot_in_workspace(
+    store: &Store,
+    workspace: Option<&str>,
+    id: &str,
+) -> Result<(String, ainb_hangar_core::ids::AutopilotId)> {
+    use ainb_hangar_core::ids::{AutopilotId, WorkspaceId};
+    use ainb_hangar_store::repo::autopilot::AutopilotRepo;
+
+    let workspace_id = resolve_skills_workspace(store, workspace).await?.to_string();
+    let ws = WorkspaceId::from_str(workspace_id.clone()).context("workspace id was empty")?;
+    let autopilot_id = AutopilotId::from_str(id.to_string()).context("autopilot id was empty")?;
+    if AutopilotRepo::get(store.pool(), &ws, &autopilot_id)
+        .await
+        .context("read autopilot")?
+        .is_none()
+    {
+        anyhow::bail!("no autopilot `{id}` in this workspace");
+    }
+    Ok((workspace_id, autopilot_id))
+}
+
+/// The CLI writes the sqlite file DIRECTLY, so it must apply the same
+/// restricted-mode write gate the daemon's request seam does — otherwise
+/// `ainb hangar autopilot ...` would be a trivially open back door around it.
+async fn require_autopilot_write(
+    store: &Store,
+    workspace_id: &str,
+    id: &ainb_hangar_core::ids::AutopilotId,
+    actor: &ainb_hangar_core::actor::ActorRef,
+) -> Result<()> {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::autopilot_access::{WriteDecision, can_write};
+
+    let ws = WorkspaceId::from_str(workspace_id.to_string()).context("workspace id was empty")?;
+    match can_write(store.pool(), &ws, id, actor).await.context("write predicate")? {
+        WriteDecision::Allowed(_) => Ok(()),
+        WriteDecision::Denied => anyhow::bail!(
+            "actor `{actor}` may not modify autopilot `{id}` (access_mode = restricted)"
+        ),
+    }
+}
+
+/// `hangar autopilot collaborator add|remove|list` (multica parity #27).
+async fn run_autopilot_collaborator(
+    store: &Store,
+    cmd: AutopilotActorCommand,
+    format: OutputFormat,
+) -> Result<()> {
+    use ainb_hangar_store::repo::autopilot_access::{AutopilotCollaboratorRepo, CollaboratorRole};
+
+    let (args, add) = match cmd {
+        AutopilotActorCommand::Add(a) => (a, Some(true)),
+        AutopilotActorCommand::Remove(a) => (a, Some(false)),
+        AutopilotActorCommand::List(a) => (a, None),
+    };
+    let (workspace_id, id) =
+        require_autopilot_in_workspace(store, args.workspace.as_deref(), &args.id).await?;
+
+    if let Some(add) = add {
+        let target = parse_actor_arg(args.actor.as_deref())?;
+        let acting = resolve_publisher(store, args.as_user.as_deref()).await?;
+        require_autopilot_write(store, &workspace_id, &id, &acting).await?;
+        if add {
+            // An unknown role is a caller error, not a silent downgrade to
+            // viewer — which would look exactly like the grant worked.
+            let role = match args.role.as_deref() {
+                None => CollaboratorRole::Editor,
+                Some(raw) => CollaboratorRole::parse(raw)
+                    .ok_or_else(|| anyhow::anyhow!("--role must be `editor` or `viewer`"))?,
+            };
+            let landed = AutopilotCollaboratorRepo::add(
+                store.pool(),
+                &workspace_id,
+                id.as_str(),
+                &target,
+                role,
+                Some(&acting),
+                <ainb_hangar_core::clock::SystemClock as ainb_hangar_core::clock::HangarClock>::now_ms(
+                    &ainb_hangar_core::clock::SystemClock,
+                ),
+            )
+            .await
+            .context("add collaborator")?;
+            // Set membership: a re-add keeps the FIRST grant, so an explicit
+            // role change stays explicit.
+            if !landed {
+                AutopilotCollaboratorRepo::set_role(
+                    store.pool(),
+                    &workspace_id,
+                    id.as_str(),
+                    &target,
+                    role,
+                )
+                .await
+                .context("update collaborator role")?;
+            }
+        } else {
+            AutopilotCollaboratorRepo::remove(store.pool(), &workspace_id, id.as_str(), &target)
+                .await
+                .context("remove collaborator")?;
+        }
+    }
+
+    let rows = AutopilotCollaboratorRepo::list(store.pool(), id.as_str())
+        .await
+        .context("read collaborators")?;
+    if format == OutputFormat::Json {
+        let json: Vec<_> = rows
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "actor": c.actor.to_string(),
+                    "role": c.role_raw,
+                    "created_by": c.created_by.as_ref().map(ToString::to_string),
+                    "created_at": c.created_at,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+    if rows.is_empty() {
+        println!("no collaborators");
+        return Ok(());
+    }
+    for c in rows {
+        println!("{}  {}  {}", c.actor, c.role_raw, c.created_at);
+    }
+    Ok(())
+}
+
+/// `hangar autopilot subscriber add|remove|list` (multica parity #27).
+async fn run_autopilot_subscriber(
+    store: &Store,
+    cmd: AutopilotActorCommand,
+    format: OutputFormat,
+) -> Result<()> {
+    use ainb_hangar_store::repo::autopilot_access::AutopilotSubscriberRepo;
+
+    let (args, add) = match cmd {
+        AutopilotActorCommand::Add(a) => (a, Some(true)),
+        AutopilotActorCommand::Remove(a) => (a, Some(false)),
+        AutopilotActorCommand::List(a) => (a, None),
+    };
+    let (workspace_id, id) =
+        require_autopilot_in_workspace(store, args.workspace.as_deref(), &args.id).await?;
+
+    if let Some(add) = add {
+        let target = parse_actor_arg(args.actor.as_deref())?;
+        let acting = resolve_publisher(store, args.as_user.as_deref()).await?;
+        require_autopilot_write(store, &workspace_id, &id, &acting).await?;
+        if add {
+            AutopilotSubscriberRepo::add(
+                store.pool(),
+                &workspace_id,
+                id.as_str(),
+                &target,
+                Some(&acting),
+                <ainb_hangar_core::clock::SystemClock as ainb_hangar_core::clock::HangarClock>::now_ms(
+                    &ainb_hangar_core::clock::SystemClock,
+                ),
+            )
+            .await
+            .context("add subscriber")?;
+        } else {
+            AutopilotSubscriberRepo::remove(store.pool(), &workspace_id, id.as_str(), &target)
+                .await
+                .context("remove subscriber")?;
+        }
+    }
+
+    let rows = AutopilotSubscriberRepo::list(store.pool(), id.as_str())
+        .await
+        .context("read subscribers")?;
+    if format == OutputFormat::Json {
+        let json: Vec<_> = rows
+            .iter()
+            .map(|sub| {
+                serde_json::json!({
+                    "actor": sub.actor.to_string(),
+                    "created_by": sub.created_by.as_ref().map(ToString::to_string),
+                    "created_at": sub.created_at,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+    if rows.is_empty() {
+        println!("no subscribers");
+        return Ok(());
+    }
+    for sub in rows {
+        println!("{}  {}", sub.actor, sub.created_at);
+    }
+    Ok(())
+}
+
+/// `hangar autopilot access --mode open|restricted` (multica parity #27).
+///
+/// Goes through `update_as` with the acting human so the flip mints a rule
+/// version — widening who may write a rule is exactly the kind of publish the
+/// accountability ledger exists to record.
+async fn run_autopilot_access(store: &Store, args: AutopilotAccessArgs) -> Result<()> {
+    use ainb_hangar_store::repo::autopilot::{
+        AccessMode, AutopilotEdit, AutopilotRepo, UpdateOutcome,
+    };
+
+    let mode = match args.mode.as_str() {
+        "open" => AccessMode::Open,
+        "restricted" => AccessMode::Restricted,
+        // Validated, never tolerantly coerced: a typo must not quietly leave a
+        // rule world-writable.
+        other => anyhow::bail!("--mode must be `open` or `restricted`, got `{other}`"),
+    };
+    let (workspace_id, id) =
+        require_autopilot_in_workspace(store, args.workspace.as_deref(), &args.id).await?;
+    let acting = resolve_publisher(store, args.as_user.as_deref()).await?;
+    require_autopilot_write(store, &workspace_id, &id, &acting).await?;
+
+    let ws = ainb_hangar_core::ids::WorkspaceId::from_str(workspace_id)
+        .context("workspace id was empty")?;
+    let outcome = AutopilotRepo::update_as(
+        store.pool(),
+        &ainb_hangar_core::clock::SystemClock,
+        &ws,
+        &id,
+        &AutopilotEdit {
+            access_mode: Some(mode),
+            ..AutopilotEdit::default()
+        },
+        Some(&acting),
+    )
+    .await
+    .context("set access mode")?;
+    match outcome {
+        UpdateOutcome::NotFound => anyhow::bail!("no autopilot `{}` in this workspace", id),
+        UpdateOutcome::Updated { version } => {
+            match version {
+                Some(v) => println!("access_mode = {}  (rule version v{v})", mode.as_str()),
+                // Already in that mode: the write landed, it just was not a
+                // change worth an accountability row.
+                None => println!("access_mode = {}  (unchanged)", mode.as_str()),
+            }
+            Ok(())
+        }
     }
 }
 
@@ -2377,6 +2697,9 @@ async fn run_autopilot_edit(store: &Store, args: AutopilotEditArgs) -> Result<()
     let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
     let id = AutopilotId::from_str(args.id.clone()).context("autopilot id was empty")?;
     let actor = resolve_publisher(store, args.as_user.as_deref()).await?;
+    // The CLI writes sqlite DIRECTLY, so it applies the same restricted-mode
+    // write gate the daemon's request seam does (multica parity #27).
+    require_autopilot_write(store, ws.as_str(), &id, &actor).await?;
 
     let edit = AutopilotEdit {
         name: args.name.clone(),
@@ -2516,6 +2839,9 @@ async fn run_autopilot_set_enabled(
     // Pausing / resuming is a SUBSTANTIVE publish: it changes whether the rule
     // fires unattended, so it re-stamps who is accountable (multica parity #14).
     let actor = resolve_publisher(store, args.as_user.as_deref()).await?;
+    // The CLI writes sqlite DIRECTLY, so it applies the same restricted-mode
+    // write gate the daemon's request seam does (multica parity #27).
+    require_autopilot_write(store, ws.as_str(), &id, &actor).await?;
     if enabled {
         AutopilotRepo::enable_as(store.pool(), &SystemClock, &ws, &id, Some(&actor))
             .await
@@ -2607,6 +2933,9 @@ async fn run_autopilot_api_trigger(store: &Store, args: AutopilotIdArgs) -> Resu
     let enabled = !args.disable;
 
     let actor = resolve_publisher(store, args.as_user.as_deref()).await?;
+    // The CLI writes sqlite DIRECTLY, so it applies the same restricted-mode
+    // write gate the daemon's request seam does (multica parity #27).
+    require_autopilot_write(store, ws.as_str(), &id, &actor).await?;
     let updated = AutopilotRepo::set_api_trigger_enabled_as(
         store.pool(),
         &SystemClock,
@@ -10473,5 +10802,115 @@ mod tests {
             .await
             .expect("count issues");
         assert_eq!(count, 0, "a bad origin must fail ahead of the insert");
+    }
+
+    /// End-to-end through the parsed command: `hangar autopilot collaborator add`
+    /// PERSISTS a row, read back with raw SQL after the command returns
+    /// (multica parity #27).
+    #[tokio::test]
+    async fn autopilot_collaborator_add_persists_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+        for sql in [
+            "INSERT INTO workspace (id, slug, name, created_at) \
+             VALUES ('ws-1','default','Default',0)",
+            "INSERT INTO user (id, email, created_at) VALUES ('u-amy','amy@x.io',0)",
+            "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+             VALUES ('rt-1','ws-1','d-1','claude','local')",
+            "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+             VALUES ('ag-1','ws-1','builder','rt-1','workspace','u-amy')",
+            "INSERT INTO autopilot \
+             (id, workspace_id, agent_id, name, cron_expr, max_concurrent_runs, execution_mode, \
+              concurrency_policy, next_tick_at, enabled, api_trigger_enabled, created_at) \
+             VALUES ('ap-1','ws-1','ag-1','nightly','0 3 * * *',1,'run_only','skip', \
+                     999999999999,1,0,0)",
+        ] {
+            sqlx::query(sql).execute(store.pool()).await.expect(sql);
+        }
+
+        let HangarCommand::Autopilot(AutopilotCommand::Collaborator(cmd)) = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "autopilot",
+            "collaborator",
+            "add",
+            "--id",
+            "ap-1",
+            "--actor",
+            "member:bob",
+            "--role",
+            "editor",
+        ]) else {
+            panic!("expected autopilot collaborator add");
+        };
+        run_autopilot_collaborator(&store, cmd, OutputFormat::Text)
+            .await
+            .expect("add collaborator");
+
+        let (actor_type, actor_id, role): (String, String, String) = sqlx::query_as(
+            "SELECT actor_type, actor_id, role FROM autopilot_collaborator \
+             WHERE autopilot_id = 'ap-1'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .expect("read the persisted grant");
+        assert_eq!(actor_type, "member");
+        assert_eq!(actor_id, "bob");
+        assert_eq!(role, "editor");
+    }
+
+    /// The CLI honours the restricted-mode gate too — otherwise it would be a
+    /// trivially open back door around the daemon's request seam.
+    #[tokio::test]
+    async fn autopilot_collaborator_add_is_denied_on_a_restricted_rule() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open_in(dir.path()).await.expect("open store");
+        for sql in [
+            "INSERT INTO workspace (id, slug, name, created_at) \
+             VALUES ('ws-1','default','Default',0)",
+            "INSERT INTO user (id, email, created_at) VALUES ('u-amy','amy@x.io',0)",
+            "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','u-amy','member')",
+            "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+             VALUES ('rt-1','ws-1','d-1','claude','local')",
+            "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+             VALUES ('ag-1','ws-1','builder','rt-1','workspace','u-amy')",
+            "INSERT INTO autopilot \
+             (id, workspace_id, agent_id, name, cron_expr, max_concurrent_runs, execution_mode, \
+              concurrency_policy, next_tick_at, enabled, api_trigger_enabled, access_mode, \
+              created_at) \
+             VALUES ('ap-1','ws-1','ag-1','nightly','0 3 * * *',1,'run_only','skip', \
+                     999999999999,1,0,'restricted',0)",
+        ] {
+            sqlx::query(sql).execute(store.pool()).await.expect(sql);
+        }
+
+        let HangarCommand::Autopilot(AutopilotCommand::Collaborator(cmd)) = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "autopilot",
+            "collaborator",
+            "add",
+            "--id",
+            "ap-1",
+            "--actor",
+            "member:bob",
+            "--as-user",
+            "u-amy",
+        ]) else {
+            panic!("expected autopilot collaborator add");
+        };
+        let err = run_autopilot_collaborator(&store, cmd, OutputFormat::Text)
+            .await
+            .expect_err("a plain member may not grant on a restricted rule");
+        assert!(
+            err.to_string().contains("access_mode = restricted"),
+            "got {err}"
+        );
+
+        let count: i64 = sqlx::query_scalar("SELECT count(*) FROM autopilot_collaborator")
+            .fetch_one(store.pool())
+            .await
+            .expect("count grants");
+        assert_eq!(count, 0, "a denied grant writes nothing");
     }
 }

--- a/ainb-tui/crates/ainb-hangar-core/src/autopilot/rule_version.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/autopilot/rule_version.rs
@@ -53,6 +53,10 @@ pub enum RuleChangeKind {
     /// into columns on `autopilot`, so multica's per-trigger publisher
     /// (migration 189) folds into the per-RULE version chain here.
     Trigger,
+    /// The rule's WRITE-ACCESS mode changed (`open` <-> `restricted`, migration
+    /// 0064). Opening a rule up to more writers is exactly the kind of publish
+    /// this accountability ledger exists to record.
+    Access,
 }
 
 impl RuleChangeKind {
@@ -68,6 +72,7 @@ impl RuleChangeKind {
             Self::Paused => "paused",
             Self::Resumed => "resumed",
             Self::Trigger => "trigger",
+            Self::Access => "access",
         }
     }
 
@@ -88,6 +93,7 @@ impl RuleChangeKind {
             "paused" => Self::Paused,
             "resumed" => Self::Resumed,
             "trigger" => Self::Trigger,
+            "access" => Self::Access,
             _ => return None,
         })
     }
@@ -126,6 +132,14 @@ pub struct AutopilotConfigSnapshot {
     pub enabled: bool,
     /// Whether the bare programmatic `api` trigger is armed.
     pub api_trigger_enabled: bool,
+    /// Who may WRITE the rule (`open` / `restricted`, migration 0064). Stringly
+    /// typed for the same reason as the two modes above: the typed enum lives
+    /// in the store crate, and the ledger only compares and serialises it.
+    ///
+    /// `Default` is the empty string, which every pre-0064 snapshot carries —
+    /// two empty strings compare equal, so an old ledger row never looks like
+    /// an access change.
+    pub access_mode: String,
 }
 
 impl AutopilotConfigSnapshot {
@@ -147,6 +161,7 @@ impl AutopilotConfigSnapshot {
             "concurrency_policy": self.concurrency_policy,
             "enabled": self.enabled,
             "api_trigger_enabled": self.api_trigger_enabled,
+            "access_mode": self.access_mode,
             "changed": changed,
         })
     }
@@ -189,6 +204,9 @@ pub fn changed_fields(
     if before.api_trigger_enabled != after.api_trigger_enabled {
         out.push("api_trigger_enabled");
     }
+    if before.access_mode != after.access_mode {
+        out.push("access_mode");
+    }
     out
 }
 
@@ -224,6 +242,9 @@ pub fn classify(
     }
     if before.api_trigger_enabled != after.api_trigger_enabled {
         return Some(RuleChangeKind::Trigger);
+    }
+    if before.access_mode != after.access_mode {
+        return Some(RuleChangeKind::Access);
     }
     if before.agent_id != after.agent_id {
         return Some(RuleChangeKind::Target);

--- a/ainb-tui/crates/ainb-hangar-core/src/autopilot/rule_version.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/autopilot/rule_version.rs
@@ -280,6 +280,7 @@ mod tests {
             concurrency_policy: "skip".into(),
             enabled: true,
             api_trigger_enabled: false,
+            access_mode: "open".into(),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -75,6 +75,12 @@ const METHOD_NOT_FOUND: i32 = -32601;
 const INVALID_PARAMS: i32 = -32602;
 /// JSON-RPC "internal error" code (spec-reserved) — used for store faults.
 const INTERNAL_ERROR: i32 = -32603;
+/// Application-defined "forbidden": the caller is well-formed and the target
+/// exists, but this actor may not perform the mutation (multica parity #27's
+/// restricted-mode autopilot write gate). Inside the JSON-RPC
+/// implementation-defined server-error band, deliberately distinct from
+/// `INVALID_PARAMS` so a UI can tell "you may not" from "you asked wrong".
+const PERMISSION_DENIED: i32 = -32000;
 /// Soft cap on one request body. Snapshot requests are tiny.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 
@@ -761,7 +767,14 @@ async fn handle(
         | methods::HANGAR_AUTOPILOT_TRIGGER_API
         | methods::HANGAR_AUTOPILOT_SET_API_TRIGGER
         | methods::HANGAR_AUTOPILOT_UPDATE
-        | methods::HANGAR_AUTOPILOT_VERSIONS => handle_autopilot(pool, req, events).await,
+        | methods::HANGAR_AUTOPILOT_VERSIONS
+        | methods::HANGAR_AUTOPILOT_SET_ACCESS_MODE
+        | methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD
+        | methods::HANGAR_AUTOPILOT_COLLABORATOR_REMOVE
+        | methods::HANGAR_AUTOPILOT_COLLABORATORS
+        | methods::HANGAR_AUTOPILOT_SUBSCRIBER_ADD
+        | methods::HANGAR_AUTOPILOT_SUBSCRIBER_REMOVE
+        | methods::HANGAR_AUTOPILOT_SUBSCRIBERS => handle_autopilot(pool, req, events).await,
         methods::HANGAR_TASKS_LIST => handle_tasks_list(pool, req).await,
         methods::HANGAR_TASK_TRANSITION => handle_task_transition(pool, req, events).await,
         methods::HANGAR_TASK_RETRY => handle_task_retry(pool, req, events).await,
@@ -7607,6 +7620,11 @@ async fn handle_autopilot(
                     .concurrency_policy
                     .as_deref()
                     .map(ainb_hangar_store::repo::autopilot::ConcurrencyPolicy::from_db_str),
+                // Deliberately NOT settable through the generic patch:
+                // `hangar/autopilot_set_access_mode` is the one door, so the
+                // write gate below can never be widened by the same call that
+                // it is guarding.
+                access_mode: None,
             };
 
             let result = match snapshots::autopilot_update(
@@ -7670,12 +7688,271 @@ async fn handle_autopilot(
             };
             to_value(&ainb_hangar_proto::snapshots::AutopilotVersionsResult { versions })
         }
+        methods::HANGAR_AUTOPILOT_SET_ACCESS_MODE => {
+            let params: ainb_hangar_proto::snapshots::AutopilotSetAccessModeParams =
+                parse_params(req, "{ workspace_id, autopilot_id, access_mode }")?;
+            let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+            let id = autopilot_id(&params.autopilot_id)?;
+            let actor = member_actor(params.actor_user_id.as_deref());
+            // A typo must never quietly leave a rule world-writable, so this
+            // one token is validated rather than tolerantly coerced.
+            let mode = match params.access_mode.as_str() {
+                "open" => ainb_hangar_store::repo::autopilot::AccessMode::Open,
+                "restricted" => ainb_hangar_store::repo::autopilot::AccessMode::Restricted,
+                other => {
+                    return Err(invalid_params(&format!(
+                        "access_mode must be `open` or `restricted`, got `{other}`"
+                    )));
+                }
+            };
+            autopilot_write_gate(pool, &ws, &id, actor.as_ref()).await?;
+
+            let edit = ainb_hangar_store::repo::autopilot::AutopilotEdit {
+                access_mode: Some(mode),
+                ..Default::default()
+            };
+            let result = match snapshots::autopilot_update(
+                pool,
+                &SystemClock,
+                &ws,
+                &id,
+                &edit,
+                actor.as_ref(),
+            )
+            .await
+            {
+                Ok(ainb_hangar_store::repo::autopilot::UpdateOutcome::NotFound) => {
+                    ainb_hangar_proto::snapshots::AutopilotUpdateResult {
+                        outcome: "not_found".to_string(),
+                        version: None,
+                    }
+                }
+                Ok(ainb_hangar_store::repo::autopilot::UpdateOutcome::Updated { version }) => {
+                    if let Ok(rows) = snapshots::autopilots_list(pool, &ws).await {
+                        if let Some(row) = rows.into_iter().find(|r| r.id == id.as_str()) {
+                            events.emit(
+                                ws.as_str(),
+                                ainb_hangar_proto::events::HangarEvent::AutopilotUpdated(row),
+                            );
+                        }
+                    }
+                    ainb_hangar_proto::snapshots::AutopilotUpdateResult {
+                        outcome: "updated".to_string(),
+                        version,
+                    }
+                }
+                Err(e) => return Err(autopilot_repo_err(&e)),
+            };
+            to_value(&result)
+        }
+        methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD => {
+            handle_autopilot_collaborator(pool, req, Some(true)).await
+        }
+        methods::HANGAR_AUTOPILOT_COLLABORATOR_REMOVE => {
+            handle_autopilot_collaborator(pool, req, Some(false)).await
+        }
+        methods::HANGAR_AUTOPILOT_COLLABORATORS => {
+            handle_autopilot_collaborator(pool, req, None).await
+        }
+        methods::HANGAR_AUTOPILOT_SUBSCRIBER_ADD => {
+            handle_autopilot_subscriber(pool, req, Some(true)).await
+        }
+        methods::HANGAR_AUTOPILOT_SUBSCRIBER_REMOVE => {
+            handle_autopilot_subscriber(pool, req, Some(false)).await
+        }
+        methods::HANGAR_AUTOPILOT_SUBSCRIBERS => handle_autopilot_subscriber(pool, req, None).await,
         other => Err(RpcError {
             code: METHOD_NOT_FOUND,
             message: format!("unknown autopilot method: {other}"),
             data: None,
         }),
     }
+}
+
+/// The RESTRICTED-MODE write gate (multica parity #27, migration 0064).
+///
+/// Applied at the request seam — which is where the reference puts it too — for
+/// every MUTATING autopilot method, after the tenant guard and actor
+/// resolution and before the repo seam. Deliberately NOT baked into
+/// `AutopilotRepo::update_as` and friends: that would change the meaning of
+/// every legacy `actor = None` caller and would red the #14 tests that edit as
+/// a DIFFERENT human than the creator (their rules are `access_mode = 'open'`,
+/// so this gate is a no-op for them).
+///
+/// `actor = None` (no `actor_user_id` in params) stays ALLOWED: an unattributed
+/// local caller is the daemon's own / legacy path, identical to how the #14
+/// ledger treats it.
+///
+/// `hangar/autopilot_fire_now` and `hangar/autopilot_trigger_api` are
+/// deliberately NOT gated here: firing a rule is a read-side grant, not a
+/// write, and the reference judges it through a separate agent-invocation
+/// predicate (which hangar already has as `AgentRepo::can_invoke`).
+async fn autopilot_write_gate(
+    pool: &SqlitePool,
+    workspace: &WorkspaceId,
+    id: &AutopilotId,
+    actor: Option<&ActorRef>,
+) -> Result<(), RpcError> {
+    use ainb_hangar_store::repo::autopilot_access::{WriteDecision, can_write};
+
+    let Some(actor) = actor else {
+        return Ok(());
+    };
+    match can_write(pool, workspace, id, actor).await.map_err(|e| store_err(&e))? {
+        WriteDecision::Allowed(_) => Ok(()),
+        WriteDecision::Denied => Err(RpcError {
+            code: PERMISSION_DENIED,
+            message: format!(
+                "actor `{actor}` may not modify autopilot `{id}` (access_mode = restricted)"
+            ),
+            data: None,
+        }),
+    }
+}
+
+/// Resolve the `(workspace, autopilot, target actor, acting actor)` tuple every
+/// #27 actor-set method shares, rejecting a foreign / unknown autopilot loudly
+/// rather than letting the repo's tenant join be a silent no-op.
+async fn autopilot_actor_target(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<(WorkspaceId, AutopilotId, ActorRef, Option<ActorRef>), RpcError> {
+    let params: ainb_hangar_proto::snapshots::AutopilotActorParams = parse_params(
+        req,
+        "{ workspace_id, autopilot_id, actor?, role?, actor_user_id? }",
+    )?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    let id = autopilot_id(&params.autopilot_id)?;
+    if ainb_hangar_store::repo::autopilot::AutopilotRepo::get(pool, &ws, &id)
+        .await
+        .map_err(|e| autopilot_repo_err(&e))?
+        .is_none()
+    {
+        return Err(invalid_params(&format!(
+            "no autopilot `{}` in this workspace",
+            params.autopilot_id
+        )));
+    }
+    let target = resolve_actor_param(params.actor.as_deref())?;
+    let acting = member_actor(params.actor_user_id.as_deref());
+    Ok((ws, id, target, acting))
+}
+
+/// `hangar/autopilot_collaborator_add` (`Some(true)`) / `_remove`
+/// (`Some(false)`) / `hangar/autopilot_collaborators` (`None`).
+///
+/// Both mutators go through the same write gate as any other rule mutation, so
+/// a non-collaborator cannot grant themselves collaboration. Every arm answers
+/// with the REFRESHED set, so a mutator needs no read-after-write round trip.
+async fn handle_autopilot_collaborator(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    add: Option<bool>,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::autopilot_access::{AutopilotCollaboratorRepo, CollaboratorRole};
+
+    let (ws, id, target, acting) = autopilot_actor_target(pool, req).await?;
+    if let Some(add) = add {
+        autopilot_write_gate(pool, &ws, &id, acting.as_ref()).await?;
+        let params: ainb_hangar_proto::snapshots::AutopilotActorParams =
+            parse_params(req, "{ workspace_id, autopilot_id, actor?, role? }")?;
+        if add {
+            // An unknown role token is a caller error, not a silent downgrade
+            // to viewer (which would look like the grant worked).
+            let role = match params.role.as_deref() {
+                None => CollaboratorRole::Editor,
+                Some(raw) => CollaboratorRole::parse(raw).ok_or_else(|| {
+                    invalid_params(&format!("role must be `editor` or `viewer`, got `{raw}`"))
+                })?,
+            };
+            let landed = AutopilotCollaboratorRepo::add(
+                pool,
+                ws.as_str(),
+                id.as_str(),
+                &target,
+                role,
+                acting.as_ref(),
+                SystemClock.now_ms(),
+            )
+            .await
+            .map_err(|e| store_err(&e))?;
+            // Set membership: a re-add keeps the FIRST grant, so an explicit
+            // role change is an explicit role change.
+            if !landed {
+                AutopilotCollaboratorRepo::set_role(pool, ws.as_str(), id.as_str(), &target, role)
+                    .await
+                    .map_err(|e| store_err(&e))?;
+            }
+        } else {
+            AutopilotCollaboratorRepo::remove(pool, ws.as_str(), id.as_str(), &target)
+                .await
+                .map_err(|e| store_err(&e))?;
+        }
+    }
+    autopilot_collaborators_value(pool, id.as_str()).await
+}
+
+/// `hangar/autopilot_subscriber_add` / `_remove` / `hangar/autopilot_subscribers`.
+async fn handle_autopilot_subscriber(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    add: Option<bool>,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_store::repo::autopilot_access::AutopilotSubscriberRepo;
+
+    let (ws, id, target, acting) = autopilot_actor_target(pool, req).await?;
+    if let Some(add) = add {
+        autopilot_write_gate(pool, &ws, &id, acting.as_ref()).await?;
+        if add {
+            AutopilotSubscriberRepo::add(
+                pool,
+                ws.as_str(),
+                id.as_str(),
+                &target,
+                acting.as_ref(),
+                SystemClock.now_ms(),
+            )
+            .await
+            .map_err(|e| store_err(&e))?;
+        } else {
+            AutopilotSubscriberRepo::remove(pool, ws.as_str(), id.as_str(), &target)
+                .await
+                .map_err(|e| store_err(&e))?;
+        }
+    }
+    autopilot_subscribers_value(pool, id.as_str()).await
+}
+
+/// Build the refreshed `AutopilotCollaboratorsResult` payload for one rule.
+async fn autopilot_collaborators_value(
+    pool: &SqlitePool,
+    autopilot_id: &str,
+) -> Result<serde_json::Value, RpcError> {
+    let collaborators = crate::rpc::snapshots::autopilot_collaborator_rows(pool, autopilot_id)
+        .await
+        .map_err(|e| store_err(&e))?;
+    Ok(
+        serde_json::to_value(ainb_hangar_proto::snapshots::AutopilotCollaboratorsResult {
+            collaborators,
+        })
+        .unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// Build the refreshed `AutopilotSubscribersResult` payload for one rule.
+async fn autopilot_subscribers_value(
+    pool: &SqlitePool,
+    autopilot_id: &str,
+) -> Result<serde_json::Value, RpcError> {
+    let subscribers = crate::rpc::snapshots::autopilot_subscriber_rows(pool, autopilot_id)
+        .await
+        .map_err(|e| store_err(&e))?;
+    Ok(
+        serde_json::to_value(ainb_hangar_proto::snapshots::AutopilotSubscribersResult {
+            subscribers,
+        })
+        .unwrap_or(serde_json::Value::Null),
+    )
 }
 
 /// Render an optional bare `user.id` from the wire into a canonical

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -7473,6 +7473,10 @@ async fn handle_autopilot(
             let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
             let id = autopilot_id(&params.autopilot_id)?;
             let actor = member_actor(params.actor_user_id.as_deref());
+            // multica parity #27: the restricted-mode write gate, at the
+            // request seam, after the tenant guard + actor resolution and
+            // BEFORE the repo seam.
+            autopilot_write_gate(pool, &ws, &id, actor.as_ref()).await?;
             snapshots::autopilot_set_enabled(
                 pool,
                 &SystemClock,
@@ -7564,6 +7568,10 @@ async fn handle_autopilot(
             let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
             let id = autopilot_id(&params.autopilot_id)?;
             let actor = member_actor(params.actor_user_id.as_deref());
+            // multica parity #27: the restricted-mode write gate, at the
+            // request seam, after the tenant guard + actor resolution and
+            // BEFORE the repo seam.
+            autopilot_write_gate(pool, &ws, &id, actor.as_ref()).await?;
             let updated = snapshots::autopilot_set_api_trigger(
                 pool,
                 &SystemClock,
@@ -7594,6 +7602,10 @@ async fn handle_autopilot(
             let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
             let id = autopilot_id(&params.autopilot_id)?;
             let actor = member_actor(params.actor_user_id.as_deref());
+            // multica parity #27: the restricted-mode write gate, at the
+            // request seam, after the tenant guard + actor resolution and
+            // BEFORE the repo seam.
+            autopilot_write_gate(pool, &ws, &id, actor.as_ref()).await?;
 
             // `clear_instructions` is the explicit "set to NULL" signal: JSON
             // cannot distinguish an omitted key from an explicit null in an
@@ -7800,6 +7812,10 @@ async fn autopilot_write_gate(
     };
     match can_write(pool, workspace, id, actor).await.map_err(|e| store_err(&e))? {
         WriteDecision::Allowed(_) => Ok(()),
+        // No such rule here: fall through so the repo seam reports its own
+        // honest `not_found` outcome. Every mutation is tenant-scoped anyway,
+        // so passing through writes nothing.
+        WriteDecision::NotFound => Ok(()),
         WriteDecision::Denied => Err(RpcError {
             code: PERMISSION_DENIED,
             message: format!(

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -50,6 +50,9 @@ use ainb_hangar_store::repo::attention::AttentionRepo;
 use ainb_hangar_store::repo::autopilot::{
     AutopilotEdit, AutopilotRepo, AutopilotRepoError, UpdateOutcome,
 };
+use ainb_hangar_store::repo::autopilot_access::{
+    AutopilotCollaboratorRepo, AutopilotSubscriberRepo,
+};
 use ainb_hangar_store::repo::autopilot_rule_version::AutopilotRuleVersionRepo;
 use ainb_hangar_store::repo::autopilot_run::{
     DispatchOutcome, FireError, RunAttribution, RunSource, dispatch_with_admission,
@@ -1350,6 +1353,20 @@ pub async fn autopilots_list(
     // #14) — deliberately not N+1 per autopilot. Labels are resolved from the
     // same actor-label cache the version pane uses.
     let latest_versions = AutopilotRuleVersionRepo::latest_by_autopilot(pool, workspace).await?;
+    // Two more GROUP BY reads for the #27 actor-set counts, same rule: one query
+    // per table for the whole workspace, never N+1 per row.
+    let collaborator_counts: HashMap<String, u32> =
+        AutopilotCollaboratorRepo::counts_by_autopilot(pool, workspace.as_str())
+            .await
+            .map_err(AutopilotRepoError::Db)?
+            .into_iter()
+            .collect();
+    let subscriber_counts: HashMap<String, u32> =
+        AutopilotSubscriberRepo::counts_by_autopilot(pool, workspace.as_str())
+            .await
+            .map_err(AutopilotRepoError::Db)?
+            .into_iter()
+            .collect();
     let mut publisher_labels = ActorLabelCache::default();
     let mut versions: HashMap<String, (i64, Option<String>)> = HashMap::new();
     for (autopilot_id, version, published_by) in latest_versions {
@@ -1383,6 +1400,9 @@ pub async fn autopilots_list(
             // honest to report.
             rule_version: versions.get(&id_str).map(|(v, _)| *v),
             last_published_by: versions.get(&id_str).and_then(|(_, l)| l.clone()),
+            collaborator_count: collaborator_counts.get(&id_str).copied().unwrap_or(0),
+            subscriber_count: subscriber_counts.get(&id_str).copied().unwrap_or(0),
+            access_mode: Some(ap.access_mode.as_str().to_string()),
         });
     }
     Ok(out)
@@ -2198,6 +2218,59 @@ pub async fn issue_subscriber_rows(
             created_at: s.created_at,
         })
         .collect())
+}
+
+/// One autopilot rule's write-grant set as wire rows (multica parity #27),
+/// oldest first, with the actor label resolved daemon-side.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault.
+pub async fn autopilot_collaborator_rows(
+    pool: &SqlitePool,
+    autopilot_id: &str,
+) -> Result<Vec<ainb_hangar_proto::snapshots::AutopilotCollaboratorEntry>, sqlx::Error> {
+    let rows = AutopilotCollaboratorRepo::list(pool, autopilot_id).await?;
+    let mut labels = ActorLabelCache::default();
+    let mut out = Vec::with_capacity(rows.len());
+    for c in rows {
+        let actor = c.actor.to_string();
+        let label = labels.label(pool, &actor).await;
+        out.push(ainb_hangar_proto::snapshots::AutopilotCollaboratorEntry {
+            actor,
+            label: Some(label),
+            role: c.role_raw,
+            created_by: c.created_by.map(|a| a.to_string()),
+            created_at: c.created_at,
+        });
+    }
+    Ok(out)
+}
+
+/// One autopilot rule's standing subscriber list as wire rows (multica parity
+/// #27), oldest first.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault.
+pub async fn autopilot_subscriber_rows(
+    pool: &SqlitePool,
+    autopilot_id: &str,
+) -> Result<Vec<ainb_hangar_proto::snapshots::AutopilotSubscriberEntry>, sqlx::Error> {
+    let rows = AutopilotSubscriberRepo::list(pool, autopilot_id).await?;
+    let mut labels = ActorLabelCache::default();
+    let mut out = Vec::with_capacity(rows.len());
+    for sub in rows {
+        let actor = sub.actor.to_string();
+        let label = labels.label(pool, &actor).await;
+        out.push(ainb_hangar_proto::snapshots::AutopilotSubscriberEntry {
+            actor,
+            label: Some(label),
+            created_by: sub.created_by.map(|a| a.to_string()),
+            created_at: sub.created_at,
+        });
+    }
+    Ok(out)
 }
 
 /// One issue's aggregated emoji buckets as wire rows (multica parity #22),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/scheduler.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/scheduler.rs
@@ -374,7 +374,7 @@ impl AutopilotScheduler {
         sqlx::query_as::<_, Autopilot>(
             "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
                     max_concurrent_runs, execution_mode, concurrency_policy, \
-                    next_tick_at, enabled, api_trigger_enabled, created_at \
+                    next_tick_at, enabled, api_trigger_enabled, access_mode, created_at \
              FROM autopilot \
              WHERE enabled = 1 AND next_tick_at IS NOT NULL \
              ORDER BY next_tick_at ASC",
@@ -588,6 +588,7 @@ mod tests {
             next_tick_at,
             enabled: true,
             api_trigger_enabled: false,
+            access_mode: ainb_hangar_store::repo::autopilot::AccessMode::Open,
             created_at: 0,
         }
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
@@ -210,3 +210,95 @@ async fn an_issue_with_no_subscriber_rows_still_notifies_its_participants() {
         "the participant fallback must still fire: {recipients:?}"
     );
 }
+
+/// multica parity #27: a standing AUTOPILOT subscriber ends up in the fan-out
+/// for an issue the rule SPAWNED, without ever touching that occurrence.
+///
+/// This is the end of the chain the whole item exists for: the rule's list is
+/// copied onto the spawned issue's `issue_subscriber` set at fire time, and
+/// this aggregator then reads that set. Before migration 0064 the spawned issue
+/// had NO subscriber rows at all, so `recipients_for` could only ever fall back
+/// to its participants — the agent creator alone.
+#[tokio::test]
+async fn an_autopilot_subscriber_is_notified_about_a_spawned_issue() {
+    use ainb_hangar_core::clock::FixedClock;
+    use ainb_hangar_core::ids::{AgentId, WorkspaceId};
+    use ainb_hangar_store::repo::autopilot::{
+        AutopilotRepo, ConcurrencyPolicy, ExecutionMode, NewAutopilot,
+    };
+    use ainb_hangar_store::repo::autopilot_access::AutopilotSubscriberRepo;
+    use ainb_hangar_store::repo::autopilot_run::{
+        RunAttribution, RunSource, fire_autopilot_tick_with_attribution,
+    };
+
+    let (_dir, store, sink) = boot().await;
+    let clock = FixedClock(1_767_225_600_000);
+    let ws = WorkspaceId::from_str(WS_ID).unwrap();
+
+    let ap = AutopilotRepo::create(
+        store.pool(),
+        &clock,
+        &NewAutopilot {
+            workspace_id: ws.clone(),
+            agent_id: AgentId::from_str("agent-1").unwrap(),
+            name: "nightly-fanout".to_string(),
+            instructions: Some("nightly sweep".to_string()),
+            cron_expr: "0 3 * * *".to_string(),
+            max_concurrent_runs: 4,
+            execution_mode: ExecutionMode::CreateIssue,
+            concurrency_policy: ConcurrencyPolicy::Queue,
+            api_trigger_enabled: false,
+        },
+    )
+    .await
+    .expect("create autopilot");
+
+    // A human who follows the RULE, and has nothing to do with any occurrence.
+    AutopilotSubscriberRepo::add(
+        store.pool(),
+        WS_ID,
+        ap.as_str(),
+        &member("rule-watcher"),
+        None,
+        0,
+    )
+    .await
+    .expect("subscribe to the rule");
+
+    let autopilot =
+        AutopilotRepo::get(store.pool(), &ws, &ap).await.expect("get").expect("present");
+    fire_autopilot_tick_with_attribution(
+        store.pool(),
+        &clock,
+        &autopilot,
+        RunSource::Schedule,
+        &RunAttribution::RuleOwner,
+    )
+    .await
+    .expect("tick");
+
+    let issue_id: String = sqlx::query_scalar(
+        "SELECT id FROM issue WHERE origin_type = 'autopilot' AND origin_id = ?",
+    )
+    .bind(ap.as_str())
+    .fetch_one(store.pool())
+    .await
+    .expect("the spawned issue");
+
+    sqlx::query(
+        "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
+         VALUES ('cm-ap', ?, 'member','carol','progress',1)",
+    )
+    .bind(&issue_id)
+    .execute(store.pool())
+    .await
+    .expect("comment on the spawned issue");
+
+    emit_comment(&sink, &issue_id, "cm-ap", "member:carol");
+    let recipients = recipients_for_issue(&store, &issue_id, 1).await;
+
+    assert!(
+        recipients.contains(&"member:rule-watcher".to_string()),
+        "a rule subscriber must be notified about a spawned issue: {recipients:?}"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_autopilot_collaborator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_autopilot_collaborator.rs
@@ -1,0 +1,528 @@
+//! Integration: the autopilot COLLABORATOR / SUBSCRIBER actor sets and the
+//! RESTRICTED-MODE WRITE GATE over a real framed `UnixStream` (multica parity
+//! #27, migration 0064).
+//!
+//! Drives the WHOLE path the way `boot()` wires it — the real dispatch table,
+//! the real handlers, the real store:
+//!
+//! 1. `hangar/autopilot_collaborator_add` answers with the REFRESHED set, and
+//!    an independent `hangar/autopilot_collaborators` read agrees;
+//! 2. the load-bearing one: restrict the rule as its creator, watch a STRANGER
+//!    be rejected by `hangar/autopilot_update`, grant that stranger `editor`,
+//!    and watch the IDENTICAL update succeed and mint a version;
+//! 3. an `access_mode = 'open'` rule is unchanged for a stranger — the
+//!    no-regression guard for the #14 tests that deliberately edit as a
+//!    different human than the creator;
+//! 4. `hangar/autopilots_list` carries the two counts.
+//!
+//! Mutating the gate to always-allow breaks (2). Mutating it to always-deny
+//! breaks (3).
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_ID};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(5), self.read_frame_inner())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    async fn ok(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let resp = self.call(method, params).await;
+        assert!(resp["error"].is_null(), "{method} must ack: {resp}");
+        resp["result"].clone()
+    }
+
+    async fn versions(&mut self, autopilot_id: &str) -> Vec<serde_json::Value> {
+        let r = self
+            .ok(
+                methods::HANGAR_AUTOPILOT_VERSIONS,
+                serde_json::json!({
+                    "workspace_id": WS_ID, "autopilot_id": autopilot_id, "limit": 50
+                }),
+            )
+            .await;
+        r["versions"].as_array().cloned().unwrap_or_default()
+    }
+}
+
+/// Bind + serve the real listener over a seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// Insert one autopilot bound to the fixture agent through the REAL create path
+/// (so it carries rule-version v1), published by `user-1`.
+async fn seed_autopilot(store: &Store) -> String {
+    use ainb_hangar_core::actor::{ActorKind, ActorRef};
+    use ainb_hangar_core::clock::SystemClock;
+    use ainb_hangar_core::ids::{AgentId, WorkspaceId};
+    use ainb_hangar_store::repo::autopilot::{
+        AutopilotRepo, ConcurrencyPolicy, ExecutionMode, NewAutopilot,
+    };
+
+    let id = AutopilotRepo::create_as(
+        store.pool(),
+        &SystemClock,
+        &NewAutopilot {
+            workspace_id: WorkspaceId::from_str(WS_ID).unwrap(),
+            agent_id: AgentId::from_str("agent-1").unwrap(),
+            name: "daily".to_string(),
+            instructions: Some("v1 instructions".to_string()),
+            cron_expr: "0 9 * * *".to_string(),
+            max_concurrent_runs: 4,
+            execution_mode: ExecutionMode::RunOnly,
+            concurrency_policy: ConcurrencyPolicy::Queue,
+            api_trigger_enabled: true,
+        },
+        Some(&ActorRef::new(ActorKind::Member, "user-1").unwrap()),
+    )
+    .await
+    .expect("create autopilot");
+    id.to_string()
+}
+
+/// Add a SECOND user so the edit can be attributed to somebody other than the
+/// rule's creator — the whole point of the ledger.
+async fn seed_bob(store: &Store) {
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('user-bob','bob@example.com',0)")
+        .execute(store.pool())
+        .await
+        .expect("insert bob");
+    sqlx::query("INSERT INTO member (workspace_id, user_id, role) VALUES (?, 'user-bob','member')")
+        .bind(WS_ID)
+        .execute(store.pool())
+        .await
+        .expect("member bob");
+}
+
+/// The refreshed collaborator set an add/remove/list answers with.
+async fn collaborators(c: &mut Client, ap: &str) -> Vec<serde_json::Value> {
+    let r = c
+        .ok(
+            methods::HANGAR_AUTOPILOT_COLLABORATORS,
+            serde_json::json!({ "workspace_id": WS_ID, "autopilot_id": ap }),
+        )
+        .await;
+    r["collaborators"].as_array().cloned().unwrap_or_default()
+}
+
+/// 1 — add answers with the refreshed set, and an independent read agrees.
+#[tokio::test]
+async fn collaborator_add_then_list_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    seed_bob(&store).await;
+    let ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    assert!(
+        collaborators(&mut c, &ap).await.is_empty(),
+        "no grants to start"
+    );
+
+    let r = c
+        .ok(
+            methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+            serde_json::json!({
+                "workspace_id": WS_ID,
+                "autopilot_id": ap,
+                "actor": "member:user-bob",
+                "role": "editor",
+                "actor_user_id": "user-1",
+            }),
+        )
+        .await;
+    let added = r["collaborators"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        added.len(),
+        1,
+        "the add answers with the refreshed set: {r}"
+    );
+    assert_eq!(added[0]["actor"], "member:user-bob");
+    assert_eq!(added[0]["role"], "editor");
+    assert_eq!(
+        added[0]["label"], "bob@example.com",
+        "the daemon does the user join; the plugin owns zero domain data"
+    );
+
+    // An INDEPENDENT read agrees — the add did not just echo its own input.
+    assert_eq!(collaborators(&mut c, &ap).await, added);
+
+    // Removing is idempotent and empties the set.
+    let r = c
+        .ok(
+            methods::HANGAR_AUTOPILOT_COLLABORATOR_REMOVE,
+            serde_json::json!({
+                "workspace_id": WS_ID, "autopilot_id": ap, "actor": "member:user-bob",
+            }),
+        )
+        .await;
+    assert!(
+        r["collaborators"].as_array().is_none_or(|a| a.is_empty()),
+        "{r}"
+    );
+    assert!(collaborators(&mut c, &ap).await.is_empty());
+}
+
+/// 2 — THE load-bearing test: a restricted rule denies a stranger, then admits
+/// them once they hold an `editor` grant.
+#[tokio::test]
+async fn restricted_rule_denies_a_stranger_then_admits_the_new_collaborator() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    seed_bob(&store).await;
+    let ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    // The creator restricts the rule. That flip is itself a publish.
+    let r = c
+        .ok(
+            methods::HANGAR_AUTOPILOT_SET_ACCESS_MODE,
+            serde_json::json!({
+                "workspace_id": WS_ID,
+                "autopilot_id": ap,
+                "access_mode": "restricted",
+                "actor_user_id": "user-1",
+            }),
+        )
+        .await;
+    assert_eq!(r["outcome"], "updated", "{r}");
+    assert_eq!(r["version"], 2, "restricting is a substantive publish: {r}");
+
+    let update = serde_json::json!({
+        "workspace_id": WS_ID,
+        "autopilot_id": ap,
+        "cron_expr": "0 4 * * *",
+        "actor_user_id": "user-bob",
+    });
+
+    // Bob is a plain workspace member with no grant: REJECTED.
+    let denied = c.call(methods::HANGAR_AUTOPILOT_UPDATE, update.clone()).await;
+    assert!(
+        !denied["error"].is_null(),
+        "a stranger must not edit a restricted rule: {denied}"
+    );
+    let msg = denied["error"]["message"].as_str().unwrap_or_default();
+    assert!(msg.contains("access_mode = restricted"), "got {msg}");
+    assert_eq!(
+        c.versions(&ap).await.len(),
+        2,
+        "a denied edit mints no version"
+    );
+
+    // Grant bob `editor`...
+    c.ok(
+        methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+        serde_json::json!({
+            "workspace_id": WS_ID,
+            "autopilot_id": ap,
+            "actor": "member:user-bob",
+            "role": "editor",
+            "actor_user_id": "user-1",
+        }),
+    )
+    .await;
+
+    // ...and the IDENTICAL update now succeeds and mints a version.
+    let r = c.ok(methods::HANGAR_AUTOPILOT_UPDATE, update).await;
+    assert_eq!(r["outcome"], "updated", "{r}");
+    assert_eq!(r["version"], 3, "{r}");
+    let vs = c.versions(&ap).await;
+    assert_eq!(vs[0]["published_by"], "member:user-bob");
+}
+
+/// 2b — a `viewer` grant is visibility, not permission.
+#[tokio::test]
+async fn a_viewer_grant_does_not_admit_a_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    seed_bob(&store).await;
+    let ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    c.ok(
+        methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+        serde_json::json!({
+            "workspace_id": WS_ID,
+            "autopilot_id": ap,
+            "actor": "member:user-bob",
+            "role": "viewer",
+            "actor_user_id": "user-1",
+        }),
+    )
+    .await;
+    c.ok(
+        methods::HANGAR_AUTOPILOT_SET_ACCESS_MODE,
+        serde_json::json!({
+            "workspace_id": WS_ID,
+            "autopilot_id": ap,
+            "access_mode": "restricted",
+            "actor_user_id": "user-1",
+        }),
+    )
+    .await;
+
+    let denied = c
+        .call(
+            methods::HANGAR_AUTOPILOT_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_ID,
+                "autopilot_id": ap,
+                "cron_expr": "0 5 * * *",
+                "actor_user_id": "user-bob",
+            }),
+        )
+        .await;
+    assert!(
+        !denied["error"].is_null(),
+        "a viewer may not write: {denied}"
+    );
+}
+
+/// 3 — the no-regression guard: an OPEN rule (every existing rule, and every
+/// pre-0064 one) is untouched for a stranger.
+#[tokio::test]
+async fn open_rule_is_unchanged_for_a_stranger() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    seed_bob(&store).await;
+    let ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    let r = c
+        .ok(
+            methods::HANGAR_AUTOPILOT_UPDATE,
+            serde_json::json!({
+                "workspace_id": WS_ID,
+                "autopilot_id": ap,
+                "instructions": "v2 instructions",
+                "actor_user_id": "user-bob",
+            }),
+        )
+        .await;
+    assert_eq!(
+        r["outcome"], "updated",
+        "the gate is a no-op on an open rule: {r}"
+    );
+    assert_eq!(r["version"], 2, "{r}");
+}
+
+/// 4 — the list payload carries both counts and the mode.
+#[tokio::test]
+async fn autopilots_list_carries_the_counts() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    seed_bob(&store).await;
+    let ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    let row = |list: &serde_json::Value, id: &str| -> serde_json::Value {
+        list["autopilots"]
+            .as_array()
+            .expect("autopilots array")
+            .iter()
+            .find(|r| r["id"] == id)
+            .expect("the seeded autopilot")
+            .clone()
+    };
+
+    let before = c
+        .ok(
+            methods::HANGAR_AUTOPILOTS_LIST,
+            serde_json::json!({ "workspace_id": WS_ID }),
+        )
+        .await;
+    let r = row(&before, &ap);
+    assert_eq!(r["collaborator_count"], 0);
+    assert_eq!(r["subscriber_count"], 0);
+    assert_eq!(r["access_mode"], "open", "a fresh rule is open");
+
+    c.ok(
+        methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+        serde_json::json!({
+            "workspace_id": WS_ID, "autopilot_id": ap, "actor": "member:user-bob",
+        }),
+    )
+    .await;
+    let subs = c
+        .ok(
+            methods::HANGAR_AUTOPILOT_SUBSCRIBER_ADD,
+            serde_json::json!({
+                "workspace_id": WS_ID, "autopilot_id": ap, "actor": "member:user-bob",
+            }),
+        )
+        .await;
+    assert_eq!(
+        subs["subscribers"].as_array().map(Vec::len),
+        Some(1),
+        "the subscriber add answers with the refreshed list: {subs}"
+    );
+
+    let after = c
+        .ok(
+            methods::HANGAR_AUTOPILOTS_LIST,
+            serde_json::json!({ "workspace_id": WS_ID }),
+        )
+        .await;
+    let r = row(&after, &ap);
+    assert_eq!(r["collaborator_count"], 1);
+    assert_eq!(r["subscriber_count"], 1);
+}
+
+/// A foreign / unknown autopilot id is reported LOUDLY, not silently swallowed
+/// by the repo's tenant join.
+#[tokio::test]
+async fn an_unknown_autopilot_is_rejected_not_silently_ignored() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    seed_bob(&store).await;
+    let _ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+            serde_json::json!({
+                "workspace_id": WS_ID, "autopilot_id": "ap-nope", "actor": "member:user-bob",
+            }),
+        )
+        .await;
+    assert!(!resp["error"].is_null(), "{resp}");
+    assert!(
+        resp["error"]["message"].as_str().unwrap_or_default().contains("no autopilot"),
+        "{resp}"
+    );
+}
+
+/// An unknown `access_mode` token is rejected rather than tolerantly coerced —
+/// a typo must never quietly leave a rule world-writable.
+#[tokio::test]
+async fn a_bogus_access_mode_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store) = start_server(dir.path()).await;
+    let ap = seed_autopilot(&store).await;
+    let mut c = Client::connect(&socket).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AUTOPILOT_SET_ACCESS_MODE,
+            serde_json::json!({
+                "workspace_id": WS_ID, "autopilot_id": ap, "access_mode": "wide-open",
+            }),
+        )
+        .await;
+    assert!(!resp["error"].is_null(), "{resp}");
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -833,6 +833,20 @@ pub struct AutopilotRow {
     /// plugin owns zero domain data, so the daemon does the `user` join.
     #[serde(default)]
     pub last_published_by: Option<String>,
+    /// Count of explicit write-grant rows on this rule (migration 0064,
+    /// multica parity #27). Append-only + `serde(default)`: a pre-0064
+    /// daemon's payload omits it and reads `0`.
+    #[serde(default)]
+    pub collaborator_count: u32,
+    /// Count of standing subscribers auto-subscribed to every issue this rule
+    /// SPAWNS. Append-only + `serde(default)`.
+    #[serde(default)]
+    pub subscriber_count: u32,
+    /// `"open"` | `"restricted"` (migration 0064). An OMITTED field reads as
+    /// `None`, which renders as open — the permissive legacy meaning, never an
+    /// accidental lock glyph on a rule nobody restricted.
+    #[serde(default)]
+    pub access_mode: Option<String>,
 }
 
 /// A wire-side autopilot run row for the history pane (`hangar/autopilot_runs`).

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -208,6 +208,67 @@ pub const HANGAR_AUTOPILOT_UPDATE: &str = "hangar/autopilot_update";
 /// foreign autopilot id yields an empty set.
 pub const HANGAR_AUTOPILOT_VERSIONS: &str = "hangar/autopilot_versions";
 
+/// `hangar/autopilot_collaborator_add` — grant an actor WRITE access to one
+/// autopilot rule (multica parity #27, migration 0064).
+///
+/// Params: a [`crate::snapshots::AutopilotActorParams`] (`role` omitted ⇒
+/// `editor`). Result: a [`crate::snapshots::AutopilotCollaboratorsResult`] —
+/// the REFRESHED set, so a mutator needs no read-after-write round trip.
+///
+/// A grant is set membership: re-adding an existing collaborator keeps the
+/// ORIGINAL row. Itself a rule mutation, so it goes through the same
+/// restricted-mode write gate — a non-collaborator cannot grant themselves
+/// collaboration.
+pub const HANGAR_AUTOPILOT_COLLABORATOR_ADD: &str = "hangar/autopilot_collaborator_add";
+
+/// `hangar/autopilot_collaborator_remove` — revoke an actor's write grant.
+///
+/// Params: a [`crate::snapshots::AutopilotActorParams`]. Result: a
+/// [`crate::snapshots::AutopilotCollaboratorsResult`]. Idempotent.
+pub const HANGAR_AUTOPILOT_COLLABORATOR_REMOVE: &str = "hangar/autopilot_collaborator_remove";
+
+/// `hangar/autopilot_collaborators` — read one rule's write-grant set.
+///
+/// Params: a [`crate::snapshots::AutopilotActorParams`] (`actor` / `role`
+/// ignored). Result: a [`crate::snapshots::AutopilotCollaboratorsResult`],
+/// oldest first. Workspace-scoped: a foreign id yields an empty set.
+pub const HANGAR_AUTOPILOT_COLLABORATORS: &str = "hangar/autopilot_collaborators";
+
+/// `hangar/autopilot_subscriber_add` — add an actor to a rule's STANDING
+/// subscriber list (multica parity #27).
+///
+/// Params: a [`crate::snapshots::AutopilotActorParams`]. Result: a
+/// [`crate::snapshots::AutopilotSubscribersResult`]. Every issue the rule
+/// SPAWNS thereafter auto-subscribes this set, so a human tracking a recurring
+/// automation is notified per occurrence.
+pub const HANGAR_AUTOPILOT_SUBSCRIBER_ADD: &str = "hangar/autopilot_subscriber_add";
+
+/// `hangar/autopilot_subscriber_remove` — drop an actor from the standing list.
+///
+/// Params: a [`crate::snapshots::AutopilotActorParams`]. Result: a
+/// [`crate::snapshots::AutopilotSubscribersResult`]. Idempotent. Already-spawned
+/// issues keep their own subscriber rows — a past notification is not retracted.
+pub const HANGAR_AUTOPILOT_SUBSCRIBER_REMOVE: &str = "hangar/autopilot_subscriber_remove";
+
+/// `hangar/autopilot_subscribers` — read one rule's standing subscriber list.
+///
+/// Params: a [`crate::snapshots::AutopilotActorParams`] (`actor` / `role`
+/// ignored). Result: a [`crate::snapshots::AutopilotSubscribersResult`].
+pub const HANGAR_AUTOPILOT_SUBSCRIBERS: &str = "hangar/autopilot_subscribers";
+
+/// `hangar/autopilot_set_access_mode` — open or restrict who may WRITE a rule
+/// (multica parity #27, migration 0064).
+///
+/// Params: a [`crate::snapshots::AutopilotSetAccessModeParams`]. Result: a
+/// [`crate::snapshots::AutopilotUpdateResult`] — flipping the mode is a
+/// SUBSTANTIVE publish, so it mints a rule version like any other.
+///
+/// `"open"` (the default, and every pre-0064 row) means any actor in the
+/// workspace may write, i.e. the behaviour before this method existed.
+/// `"restricted"` means the rule's owner, a workspace owner/admin, or an
+/// explicit `editor` collaborator only.
+pub const HANGAR_AUTOPILOT_SET_ACCESS_MODE: &str = "hangar/autopilot_set_access_mode";
+
 /// `hangar/tasks_list` — snapshot the task queue of a workspace for the Kanban
 /// board (P8.4).
 ///
@@ -1326,6 +1387,13 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_AUTOPILOT_SET_API_TRIGGER,
     HANGAR_AUTOPILOT_UPDATE,
     HANGAR_AUTOPILOT_VERSIONS,
+    HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+    HANGAR_AUTOPILOT_COLLABORATOR_REMOVE,
+    HANGAR_AUTOPILOT_COLLABORATORS,
+    HANGAR_AUTOPILOT_SUBSCRIBER_ADD,
+    HANGAR_AUTOPILOT_SUBSCRIBER_REMOVE,
+    HANGAR_AUTOPILOT_SUBSCRIBERS,
+    HANGAR_AUTOPILOT_SET_ACCESS_MODE,
     HANGAR_TASKS_LIST,
     HANGAR_TASK_TRANSITION,
     HANGAR_TASK_RETRY,
@@ -1525,6 +1593,13 @@ mod tests {
             HANGAR_AUTOPILOT_SET_API_TRIGGER,
             HANGAR_AUTOPILOT_UPDATE,
             HANGAR_AUTOPILOT_VERSIONS,
+            HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+            HANGAR_AUTOPILOT_COLLABORATOR_REMOVE,
+            HANGAR_AUTOPILOT_COLLABORATORS,
+            HANGAR_AUTOPILOT_SUBSCRIBER_ADD,
+            HANGAR_AUTOPILOT_SUBSCRIBER_REMOVE,
+            HANGAR_AUTOPILOT_SUBSCRIBERS,
+            HANGAR_AUTOPILOT_SET_ACCESS_MODE,
             HANGAR_TASKS_LIST,
             HANGAR_TASK_TRANSITION,
             HANGAR_TASK_RETRY,
@@ -1607,6 +1682,13 @@ mod tests {
             HANGAR_AUTOPILOT_SET_API_TRIGGER,
             HANGAR_AUTOPILOT_UPDATE,
             HANGAR_AUTOPILOT_VERSIONS,
+            HANGAR_AUTOPILOT_COLLABORATOR_ADD,
+            HANGAR_AUTOPILOT_COLLABORATOR_REMOVE,
+            HANGAR_AUTOPILOT_COLLABORATORS,
+            HANGAR_AUTOPILOT_SUBSCRIBER_ADD,
+            HANGAR_AUTOPILOT_SUBSCRIBER_REMOVE,
+            HANGAR_AUTOPILOT_SUBSCRIBERS,
+            HANGAR_AUTOPILOT_SET_ACCESS_MODE,
             HANGAR_TASKS_LIST,
             HANGAR_TASK_TRANSITION,
             HANGAR_TASK_RETRY,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -536,6 +536,105 @@ pub struct AutopilotUpdateResult {
     pub version: Option<i64>,
 }
 
+/// Params for every #27 autopilot actor-set method
+/// ([`crate::methods::HANGAR_AUTOPILOT_COLLABORATOR_ADD`] /
+/// `_REMOVE` / [`crate::methods::HANGAR_AUTOPILOT_COLLABORATORS`], and the
+/// three subscriber twins).
+///
+/// One shape for add / remove / list because the tuple they address is the
+/// same; the list reads ignore `actor` and `role`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotActorParams {
+    /// The subscribed workspace the autopilot must belong to (tenant guard).
+    pub workspace_id: String,
+    /// The autopilot whose actor set is addressed.
+    pub autopilot_id: String,
+    /// The target actor in canonical `member:<id>` / `agent:<id>` form. Omitted
+    /// ⇒ the LOCAL HUMAN (`member:me`), mirroring `IssueSubscribeParams`.
+    /// Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+    /// Collaborator ADD only: `"editor"` (the default when omitted) or
+    /// `"viewer"`. A `viewer` grant is visibility, NOT write access.
+    /// Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// The ACTING human, in canonical actor form — both the restricted-mode
+    /// write gate's subject and the `created_by` attribution. Omitted ⇒ an
+    /// unattributed local caller, which the gate admits (the daemon's own /
+    /// legacy path). Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_user_id: Option<String>,
+}
+
+/// One write-grant on an autopilot rule (multica parity #27).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotCollaboratorEntry {
+    /// The granted actor in canonical `member:<id>` / `agent:<id>` form.
+    pub actor: String,
+    /// A human-readable label for that actor (the daemon does the `user` join —
+    /// the plugin owns zero domain data), or `None` when unresolvable.
+    #[serde(default)]
+    pub label: Option<String>,
+    /// The raw stored role token. Kept as a `String` so a token from a newer
+    /// daemon renders instead of failing the decode.
+    pub role: String,
+    /// Who granted it (canonical actor form), or `None` when unattributed.
+    #[serde(default)]
+    pub created_by: Option<String>,
+    /// When the grant was created (epoch millis).
+    pub created_at: i64,
+}
+
+/// One standing subscriber on an autopilot rule (multica parity #27).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotSubscriberEntry {
+    /// The subscribing actor in canonical form.
+    pub actor: String,
+    /// A human-readable label, resolved daemon-side.
+    #[serde(default)]
+    pub label: Option<String>,
+    /// Who added them, or `None` when unattributed.
+    #[serde(default)]
+    pub created_by: Option<String>,
+    /// When the subscription was created (epoch millis).
+    pub created_at: i64,
+}
+
+/// Result of every #27 collaborator method: the rule's REFRESHED grant set, so
+/// a mutator needs no read-after-write round trip.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotCollaboratorsResult {
+    /// Every grant, oldest first. Empty ⇒ nobody holds an explicit grant.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub collaborators: Vec<AutopilotCollaboratorEntry>,
+}
+
+/// Result of every #27 subscriber method: the rule's REFRESHED standing list.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotSubscribersResult {
+    /// Every subscriber, oldest first.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subscribers: Vec<AutopilotSubscriberEntry>,
+}
+
+/// Params for [`crate::methods::HANGAR_AUTOPILOT_SET_ACCESS_MODE`]
+/// (multica parity #27).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutopilotSetAccessModeParams {
+    /// The subscribed workspace the autopilot must belong to (tenant guard).
+    pub workspace_id: String,
+    /// The autopilot to open or restrict.
+    pub autopilot_id: String,
+    /// `"open"` | `"restricted"`. Anything else is rejected with
+    /// `INVALID_PARAMS` rather than silently coerced — a typo must never
+    /// quietly leave a rule world-writable.
+    pub access_mode: String,
+    /// The acting human (gate subject + rule-version attribution). Append-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_user_id: Option<String>,
+}
+
 /// Params for [`crate::methods::HANGAR_AUTOPILOT_VERSIONS`]: the workspace
 /// (tenant guard), the autopilot, and a row cap.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3453,6 +3552,89 @@ mod tests {
             "an omitted accountable_actor is an honest unknown, not a guess"
         );
         assert_eq!(legacy_run.attribution, None);
+    }
+
+    /// The #27 autopilot collaborator / subscriber envelopes round-trip, and a
+    /// PRE-0064 payload still decodes with the permissive defaults.
+    #[test]
+    fn autopilot_actor_set_envelopes_roundtrip_and_are_append_only() {
+        let params = AutopilotActorParams {
+            workspace_id: "ws-1".into(),
+            autopilot_id: "ap-1".into(),
+            actor: Some("member:bob".into()),
+            role: Some("editor".into()),
+            actor_user_id: Some("member:amy".into()),
+        };
+        let s = serde_json::to_string(&params).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AutopilotActorParams>(&s).unwrap(),
+            params
+        );
+
+        let collaborators = AutopilotCollaboratorsResult {
+            collaborators: vec![AutopilotCollaboratorEntry {
+                actor: "member:bob".into(),
+                label: Some("bob@example.com".into()),
+                role: "editor".into(),
+                created_by: Some("member:amy".into()),
+                created_at: 1_700_000_000_000,
+            }],
+        };
+        let s = serde_json::to_string(&collaborators).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AutopilotCollaboratorsResult>(&s).unwrap(),
+            collaborators
+        );
+
+        let subscribers = AutopilotSubscribersResult {
+            subscribers: vec![AutopilotSubscriberEntry {
+                actor: "member:bob".into(),
+                label: None,
+                created_by: None,
+                created_at: 1_700_000_000_000,
+            }],
+        };
+        let s = serde_json::to_string(&subscribers).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AutopilotSubscribersResult>(&s).unwrap(),
+            subscribers
+        );
+
+        let mode = AutopilotSetAccessModeParams {
+            workspace_id: "ws-1".into(),
+            autopilot_id: "ap-1".into(),
+            access_mode: "restricted".into(),
+            actor_user_id: Some("member:amy".into()),
+        };
+        let s = serde_json::to_string(&mode).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AutopilotSetAccessModeParams>(&s).unwrap(),
+            mode
+        );
+
+        // APPEND-ONLY: a pre-0064 AutopilotRow payload, carrying none of the
+        // three new fields, still decodes — and decodes PERMISSIVELY. An
+        // omitted access_mode must never render as a lock on a rule nobody
+        // restricted.
+        let legacy: AutopilotRow = serde_json::from_str(
+            r#"{"id":"ap-1","workspace_id":"ws-1","agent_id":"a","name":"n",
+                 "cron_expr":"* * * * *","next_tick_at":null,"enabled":true,
+                 "last_run_status":null,"last_run_at":null}"#,
+        )
+        .expect("a pre-0064 AutopilotRow must still deserialise");
+        assert_eq!(legacy.collaborator_count, 0);
+        assert_eq!(legacy.subscriber_count, 0);
+        assert_eq!(
+            legacy.access_mode, None,
+            "an omitted access_mode is open, never a fabricated restriction"
+        );
+
+        // Minimal params, as an older caller would send them.
+        let legacy_params: AutopilotActorParams =
+            serde_json::from_str(r#"{"workspace_id":"ws-1","autopilot_id":"ap-1"}"#).unwrap();
+        assert_eq!(legacy_params.actor, None);
+        assert_eq!(legacy_params.role, None);
+        assert_eq!(legacy_params.actor_user_id, None);
     }
 
     /// The P8.4 Kanban task envelopes round-trip through JSON.

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0064_autopilot_subscriber_collaborator.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0064_autopilot_subscriber_collaborator.sql
@@ -1,0 +1,90 @@
+-- Hangar v1 schema, migration 0064: AUTOPILOT SUBSCRIBERS + COLLABORATORS
+-- (multica parity #27, reference migrations 120 + 128).
+--
+-- Two per-RULE actor sets, both mirroring `issue_subscriber` (0062) the way the
+-- reference does:
+--
+--   * `autopilot_subscriber`  -- the standing NOTIFY list. Every issue this
+--     autopilot SPAWNS auto-subscribes this set, so a human tracking a
+--     recurring automation is notified per occurrence without watching each
+--     spawned issue by hand.
+--   * `autopilot_collaborator` -- explicit WRITE-GRANTS on the rule itself,
+--     beyond the implicit owner / workspace-owner / workspace-admin.
+--
+-- DECISIONS
+--
+-- 1. NO FK on `autopilot_id` or on the actor columns. The reference's own rule
+--    for both tables ("no-FK, app-layer integrity"), and hangar's established
+--    one since 0058/0059/0061: tenant isolation is enforced in application SQL
+--    (every write is scoped through a join to `autopilot`), and a best-effort
+--    fan-out must never fail on a race with a concurrent delete. `workspace_id`
+--    carries the only FK, as 0062.
+--
+-- 2. CHECK on `actor_type` (the 0060/0062 convention), NONE on `role`. SQLite
+--    cannot widen a CHECK without a full table rebuild (see 0057's
+--    copy/drop/recreate), and the role vocabulary is append-only by design; it
+--    is enforced in Rust by `CollaboratorRole::as_db_str` (the only writer) and
+--    a TOLERANT `::parse` (an unknown token from a newer daemon reads back as
+--    `None` and renders raw, never poisons the read).
+--
+-- 3. PK is (autopilot_id, actor_type, actor_id) on BOTH tables -- set
+--    MEMBERSHIP, exactly as `issue_subscriber`. Every writer is
+--    `INSERT OR IGNORE`, so re-adding an existing collaborator keeps the
+--    ORIGINAL row (first-grant-wins) instead of silently re-stamping
+--    `created_at`. A ROLE CHANGE is therefore an explicit UPDATE, never an
+--    accidental side effect of a re-add.
+--
+-- 4. `access_mode` on `autopilot` DEFAULTS TO 'open', and every pre-0064 row
+--    reads back 'open'. This is the 0047 `permission_mode` precedent
+--    ('private' | 'public_to') applied to rules. Defaulting to 'restricted'
+--    would deny-by-default every autopilot that already exists on an upgrading
+--    install -- including every solo install where nobody is a collaborator of
+--    anything -- which is a silent lockout, not a security win. Collaborators
+--    MEAN something only once an owner opts the rule into 'restricted'.
+--    `ALTER TABLE ... ADD COLUMN` with a CONSTANT literal default is an O(1)
+--    catalog-only change on SQLite (0047's note); no table rewrite.
+--
+-- 5. NO BACKFILL of either table. A pre-0064 autopilot gets no subscriber and
+--    no collaborator rows. Inventing "the creator is a collaborator" would be a
+--    fabricated grant record; the creator is already implicitly authorised (the
+--    write predicate resolves it from the 0061 rule-version ledger), so the
+--    fabrication would buy nothing. Same honesty rule as 0061 decision 5 and
+--    0052's `archived_at`.
+--
+-- `created_at` is epoch MILLISECONDS (`HangarClock::now_ms`), matching every
+-- other hangar timestamp column.
+
+CREATE TABLE autopilot_subscriber (
+    autopilot_id TEXT NOT NULL,                 -- NO FK, see decision 1
+    workspace_id TEXT NOT NULL REFERENCES workspace(id),
+    actor_type   TEXT NOT NULL CHECK (actor_type IN ('member','agent')),
+    actor_id     TEXT NOT NULL,
+    created_by   TEXT,                          -- actor ref; NULL = unattributed
+    created_at   INTEGER NOT NULL,
+    PRIMARY KEY (autopilot_id, actor_type, actor_id)
+);
+
+-- "every autopilot this actor follows" -- the reference's idx_..._user.
+CREATE INDEX idx_autopilot_subscriber_actor
+    ON autopilot_subscriber(actor_type, actor_id);
+
+CREATE TABLE autopilot_collaborator (
+    autopilot_id TEXT NOT NULL,                 -- NO FK, see decision 1
+    workspace_id TEXT NOT NULL REFERENCES workspace(id),
+    actor_type   TEXT NOT NULL CHECK (actor_type IN ('member','agent')),
+    actor_id     TEXT NOT NULL,
+    role         TEXT NOT NULL,                 -- CollaboratorRole::as_db_str()
+    created_by   TEXT,                          -- actor ref; NULL = unattributed
+    created_at   INTEGER NOT NULL,
+    PRIMARY KEY (autopilot_id, actor_type, actor_id)
+);
+
+CREATE INDEX idx_autopilot_collaborator_actor
+    ON autopilot_collaborator(actor_type, actor_id);
+
+-- Who may WRITE this rule. 'open' (the default, and every pre-0064 row) = any
+-- actor in the workspace, i.e. today's behaviour, unchanged. 'restricted' =
+-- the owner / workspace owner+admin / an explicit collaborator only.
+ALTER TABLE autopilot
+    ADD COLUMN access_mode TEXT NOT NULL DEFAULT 'open'
+        CHECK (access_mode IN ('open','restricted'));

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
@@ -152,6 +152,49 @@ impl ConcurrencyPolicy {
     }
 }
 
+/// Who may WRITE this rule (the `access_mode` column, migration 0064, multica
+/// parity #27).
+///
+/// Orthogonal to [`ExecutionMode`] and [`ConcurrencyPolicy`]: this decides who
+/// may change the rule, not what it does. The predicate itself lives in
+/// [`super::autopilot_access::can_write`] — this enum is only the stored token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AccessMode {
+    /// Any actor in the workspace may write the rule. The pre-0064 behaviour,
+    /// the column DEFAULT, and what every existing row upgrades to — a
+    /// deny-by-default upgrade would silently lock an install out of its own
+    /// automations (migration 0064 decision 4).
+    #[default]
+    Open,
+    /// Only the rule's owner, a workspace owner/admin, or an explicit `editor`
+    /// collaborator may write the rule.
+    Restricted,
+}
+
+impl AccessMode {
+    /// The literal stored in the `access_mode` column.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Restricted => "restricted",
+        }
+    }
+
+    /// Parse a stored `access_mode` value. An unrecognised string falls back to
+    /// [`Open`](Self::Open) — the same forward-compatibility guard
+    /// [`ExecutionMode`] and [`ConcurrencyPolicy`] use, and the safe direction:
+    /// a token this build cannot read must never become an unexplained lockout.
+    /// The column `CHECK` already rejects junk on write.
+    #[must_use]
+    pub fn from_db_str(s: &str) -> Self {
+        match s {
+            "restricted" => Self::Restricted,
+            _ => Self::Open,
+        }
+    }
+}
+
 /// A stored, cron-scheduled autopilot (one `autopilot` row).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Autopilot {
@@ -185,6 +228,8 @@ pub struct Autopilot {
     /// directly. Defaults to `false`, mirroring `webhook_enabled`: a
     /// half-configured autopilot is never firable.
     pub api_trigger_enabled: bool,
+    /// Who may WRITE this rule (migration 0064). `Open` for every pre-0064 row.
+    pub access_mode: AccessMode,
     /// Creation time (epoch-ms).
     pub created_at: i64,
 }
@@ -278,6 +323,10 @@ pub struct AutopilotEdit {
     pub execution_mode: Option<ExecutionMode>,
     /// New concurrency policy (`Policy`).
     pub concurrency_policy: Option<ConcurrencyPolicy>,
+    /// New write-access mode (`Access`, migration 0064). Opening a rule up to
+    /// more writers is exactly the kind of publish the accountability ledger
+    /// exists to record, so this is SUBSTANTIVE, never cosmetic.
+    pub access_mode: Option<AccessMode>,
 }
 
 impl AutopilotEdit {
@@ -291,6 +340,7 @@ impl AutopilotEdit {
             && self.max_concurrent_runs.is_none()
             && self.execution_mode.is_none()
             && self.concurrency_policy.is_none()
+            && self.access_mode.is_none()
     }
 }
 
@@ -322,13 +372,14 @@ fn snapshot_of(ap: &Autopilot) -> AutopilotConfigSnapshot {
         concurrency_policy: ap.concurrency_policy.as_str().to_string(),
         enabled: ap.enabled,
         api_trigger_enabled: ap.api_trigger_enabled,
+        access_mode: ap.access_mode.as_str().to_string(),
     }
 }
 
 /// The `SELECT` column list shared by every autopilot read.
 const AUTOPILOT_COLUMNS: &str = "id, workspace_id, agent_id, name, instructions, cron_expr, \
      max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, \
-     api_trigger_enabled, created_at";
+     api_trigger_enabled, access_mode, created_at";
 
 /// Stateless typed wrapper over the autopilot tables.
 pub struct AutopilotRepo;
@@ -417,6 +468,9 @@ impl AutopilotRepo {
             concurrency_policy: req.concurrency_policy.as_str().to_string(),
             enabled: true,
             api_trigger_enabled: req.api_trigger_enabled,
+            // A rule is always born 'open' (the column default); restricting it
+            // is a deliberate, separately-ledgered publish.
+            access_mode: AccessMode::Open.as_str().to_string(),
         };
         AutopilotRuleVersionRepo::publish_in_tx(
             &mut tx,
@@ -508,6 +562,9 @@ impl AutopilotRepo {
         if let Some(policy) = edit.concurrency_policy {
             after.concurrency_policy = policy;
         }
+        if let Some(mode) = edit.access_mode {
+            after.access_mode = mode;
+        }
 
         // Cron revalidation BEFORE any write: a malformed expression must leave
         // the row and the ledger untouched.
@@ -518,7 +575,7 @@ impl AutopilotRepo {
         sqlx::query(
             "UPDATE autopilot SET name = ?, agent_id = ?, instructions = ?, cron_expr = ?, \
                     max_concurrent_runs = ?, execution_mode = ?, concurrency_policy = ?, \
-                    next_tick_at = ? \
+                    next_tick_at = ?, access_mode = ? \
              WHERE id = ? AND workspace_id = ?",
         )
         .bind(&after.name)
@@ -529,6 +586,7 @@ impl AutopilotRepo {
         .bind(after.execution_mode.as_str())
         .bind(after.concurrency_policy.as_str())
         .bind(after.next_tick_at)
+        .bind(after.access_mode.as_str())
         .bind(id.as_str())
         .bind(workspace.as_str())
         .execute(&mut *tx)
@@ -570,12 +628,9 @@ impl AutopilotRepo {
         pool: &SqlitePool,
         workspace: &WorkspaceId,
     ) -> Result<Vec<Autopilot>, AutopilotRepoError> {
-        let rows = sqlx::query_as::<_, Autopilot>(
-            "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
-                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, \
-                    api_trigger_enabled, created_at \
-             FROM autopilot WHERE workspace_id = ? ORDER BY name",
-        )
+        let rows = sqlx::query_as::<_, Autopilot>(&format!(
+            "SELECT {AUTOPILOT_COLUMNS} FROM autopilot WHERE workspace_id = ? ORDER BY name"
+        ))
         .bind(workspace.as_str())
         .fetch_all(pool)
         .await?;
@@ -592,12 +647,9 @@ impl AutopilotRepo {
         workspace: &WorkspaceId,
         id: &AutopilotId,
     ) -> Result<Option<Autopilot>, AutopilotRepoError> {
-        let row = sqlx::query_as::<_, Autopilot>(
-            "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
-                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, \
-                    api_trigger_enabled, created_at \
-             FROM autopilot WHERE id = ? AND workspace_id = ?",
-        )
+        let row = sqlx::query_as::<_, Autopilot>(&format!(
+            "SELECT {AUTOPILOT_COLUMNS} FROM autopilot WHERE id = ? AND workspace_id = ?"
+        ))
         .bind(id.as_str())
         .bind(workspace.as_str())
         .fetch_optional(pool)
@@ -619,12 +671,9 @@ impl AutopilotRepo {
         pool: &SqlitePool,
         id: &AutopilotId,
     ) -> Result<Option<Autopilot>, AutopilotRepoError> {
-        let row = sqlx::query_as::<_, Autopilot>(
-            "SELECT id, workspace_id, agent_id, name, instructions, cron_expr, \
-                    max_concurrent_runs, execution_mode, concurrency_policy, next_tick_at, enabled, \
-                    api_trigger_enabled, created_at \
-             FROM autopilot WHERE id = ?",
-        )
+        let row = sqlx::query_as::<_, Autopilot>(&format!(
+            "SELECT {AUTOPILOT_COLUMNS} FROM autopilot WHERE id = ?"
+        ))
         .bind(id.as_str())
         .fetch_optional(pool)
         .await?;
@@ -978,6 +1027,7 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Autopilot {
             // SQLite stores the boolean as INTEGER 0/1.
             enabled: row.try_get::<i64, _>("enabled")? != 0,
             api_trigger_enabled: row.try_get::<i64, _>("api_trigger_enabled")? != 0,
+            access_mode: AccessMode::from_db_str(&row.try_get::<String, _>("access_mode")?),
             created_at: row.try_get("created_at")?,
         })
     }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_access.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_access.rs
@@ -1,0 +1,579 @@
+//! Typed repositories over the `autopilot_subscriber` + `autopilot_collaborator`
+//! tables, and the ONE definition of "may this actor write this rule"
+//! (multica parity #27, migration 0064).
+//!
+//! Two per-RULE actor sets, both shaped exactly like [`super::issue_subscriber`]:
+//!
+//! * **subscribers** — the standing NOTIFY list. Every issue the autopilot
+//!   SPAWNS auto-subscribes this set (see [`super::autopilot_run`]), so a human
+//!   tracking a recurring automation is notified per occurrence without having
+//!   to watch each spawned issue by hand.
+//! * **collaborators** — explicit WRITE-GRANTS on the rule itself, beyond the
+//!   implicit owner / workspace-owner / workspace-admin.
+//!
+//! # Set membership, first-grant-wins
+//!
+//! `(autopilot, actor)` is the primary key on both tables and every add is
+//! `INSERT OR IGNORE`, so re-adding an existing collaborator keeps the ORIGINAL
+//! row (and its `created_at`). A ROLE CHANGE is therefore an explicit
+//! [`AutopilotCollaboratorRepo::set_role`], never an accidental side effect of a
+//! re-add.
+//!
+//! # Workspace scoping without trusting the caller
+//!
+//! Neither table is read by id alone on the write path: every mutation is
+//! **scoped through `WHERE EXISTS (SELECT 1 FROM autopilot WHERE id = ? AND
+//! workspace_id = ?)`**, so a foreign tenant's write returns `Ok(false)` rather
+//! than erroring or landing.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::ids::{AutopilotId, WorkspaceId};
+use sqlx::{Row, SqlitePool};
+
+use super::autopilot::AccessMode;
+use super::member::{MemberRepo, MemberRole};
+
+/// What an explicit grant lets its holder do.
+///
+/// The column carries NO `CHECK` (SQLite cannot widen one without a full table
+/// rebuild), so this enum is the vocabulary's only enforcement: [`Self::as_db_str`]
+/// is the single writer and [`Self::parse`] is a tolerant reader that yields
+/// `None` for a token written by a newer build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CollaboratorRole {
+    /// May WRITE the rule (edit / enable / disable / re-grant). The default when
+    /// a caller omits a role.
+    #[default]
+    Editor,
+    /// May be listed against the rule but grants NO write. Deliberately weaker
+    /// than "no row at all" only in that it is visible.
+    Viewer,
+}
+
+impl CollaboratorRole {
+    /// The token stored in `autopilot_collaborator.role`. The ONLY writer of
+    /// that column.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Editor => "editor",
+            Self::Viewer => "viewer",
+        }
+    }
+
+    /// Tolerant reader: an unknown token (a newer build's vocabulary) yields
+    /// `None` rather than failing the whole read — and, because only `Editor`
+    /// grants write, an unknown role can never widen access.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "editor" => Some(Self::Editor),
+            "viewer" => Some(Self::Viewer),
+            _ => None,
+        }
+    }
+}
+
+/// One materialised `autopilot_collaborator` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutopilotCollaborator {
+    /// The rule the grant is on.
+    pub autopilot_id: String,
+    /// The granted actor, re-assembled from its two TEXT columns.
+    pub actor: ActorRef,
+    /// The parsed role, `None` for a token this build does not know.
+    pub role: Option<CollaboratorRole>,
+    /// The raw stored token, always available for rendering.
+    pub role_raw: String,
+    /// Who granted it; `None` = unattributed.
+    pub created_by: Option<ActorRef>,
+    /// When the grant was created (epoch millis).
+    pub created_at: i64,
+}
+
+/// One materialised `autopilot_subscriber` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutopilotSubscriberRow {
+    /// The rule subscribed to.
+    pub autopilot_id: String,
+    /// The subscribing actor.
+    pub actor: ActorRef,
+    /// Who added them; `None` = unattributed.
+    pub created_by: Option<ActorRef>,
+    /// When the subscription was created (epoch millis).
+    pub created_at: i64,
+}
+
+fn actor_of(row: &sqlx::sqlite::SqliteRow) -> Option<ActorRef> {
+    let kind: String = row.get("actor_type");
+    let id: String = row.get("actor_id");
+    ActorRef::new(kind.parse::<ActorKind>().ok()?, id).ok()
+}
+
+fn created_by_of(row: &sqlx::sqlite::SqliteRow) -> Option<ActorRef> {
+    let raw: Option<String> = row.get("created_by");
+    raw.and_then(|s| s.parse::<ActorRef>().ok())
+}
+
+/// Stateless typed wrapper over the `autopilot_collaborator` table.
+pub struct AutopilotCollaboratorRepo;
+
+impl AutopilotCollaboratorRepo {
+    /// Idempotently grant `actor` a role on `autopilot_id`, workspace-scoped
+    /// through the join to `autopilot`.
+    ///
+    /// Returns `Ok(true)` when a row landed, `Ok(false)` when it did not —
+    /// either because `(autopilot, workspace)` resolves to nothing (a foreign
+    /// tenant writes nothing rather than erroring) or because the actor ALREADY
+    /// held a grant, in which case the existing row keeps its ORIGINAL role and
+    /// `created_at` (first-grant-wins; use [`Self::set_role`] to change one).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn add(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        autopilot_id: &str,
+        actor: &ActorRef,
+        role: CollaboratorRole,
+        created_by: Option<&ActorRef>,
+        now_ms: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO autopilot_collaborator \
+                 (autopilot_id, workspace_id, actor_type, actor_id, role, created_by, created_at) \
+             SELECT ?, ?, ?, ?, ?, ?, ? \
+             WHERE EXISTS (SELECT 1 FROM autopilot WHERE id = ? AND workspace_id = ?)",
+        )
+        .bind(autopilot_id)
+        .bind(workspace_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(role.as_db_str())
+        .bind(created_by.map(ToString::to_string))
+        .bind(now_ms)
+        .bind(autopilot_id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Change an existing grant's role. The ONLY role mutator — a re-`add` is
+    /// deliberately inert.
+    ///
+    /// Returns `Ok(false)` when no such grant exists in this workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn set_role(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        autopilot_id: &str,
+        actor: &ActorRef,
+        role: CollaboratorRole,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "UPDATE autopilot_collaborator SET role = ? \
+             WHERE autopilot_id = ? AND actor_type = ? AND actor_id = ? AND workspace_id = ?",
+        )
+        .bind(role.as_db_str())
+        .bind(autopilot_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Revoke `actor`'s grant. Removing an absent grant is an idempotent
+    /// `Ok(false)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn remove(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        autopilot_id: &str,
+        actor: &ActorRef,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "DELETE FROM autopilot_collaborator \
+             WHERE autopilot_id = ? AND actor_type = ? AND actor_id = ? AND workspace_id = ?",
+        )
+        .bind(autopilot_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Every grant on one rule, oldest first.
+    ///
+    /// Ordered by `created_at`, then `actor_type`, `actor_id` — a bare
+    /// `ORDER BY created_at` is non-deterministic within a millisecond.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn list(
+        pool: &SqlitePool,
+        autopilot_id: &str,
+    ) -> Result<Vec<AutopilotCollaborator>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT autopilot_id, actor_type, actor_id, role, created_by, created_at \
+             FROM autopilot_collaborator WHERE autopilot_id = ? \
+             ORDER BY created_at, actor_type, actor_id",
+        )
+        .bind(autopilot_id)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| {
+                let actor = actor_of(&r)?;
+                let role_raw: String = r.get("role");
+                Some(AutopilotCollaborator {
+                    autopilot_id: r.get("autopilot_id"),
+                    actor,
+                    role: CollaboratorRole::parse(&role_raw),
+                    role_raw,
+                    created_by: created_by_of(&r),
+                    created_at: r.get("created_at"),
+                })
+            })
+            .collect())
+    }
+
+    /// One grant by `(autopilot, actor)`, or `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn get(
+        pool: &SqlitePool,
+        autopilot_id: &str,
+        actor: &ActorRef,
+    ) -> Result<Option<AutopilotCollaborator>, sqlx::Error> {
+        Ok(Self::list(pool, autopilot_id).await?.into_iter().find(|c| &c.actor == actor))
+    }
+
+    /// How many grants exist on one rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn count(pool: &SqlitePool, autopilot_id: &str) -> Result<u32, sqlx::Error> {
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM autopilot_collaborator WHERE autopilot_id = ?",
+        )
+        .bind(autopilot_id)
+        .fetch_one(pool)
+        .await?;
+        Ok(u32::try_from(n).unwrap_or(u32::MAX))
+    }
+
+    /// Grant counts for EVERY rule in a workspace, as `(autopilot_id, count)`.
+    ///
+    /// One `GROUP BY` for the whole list screen — deliberately not N+1 per row.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn counts_by_autopilot(
+        pool: &SqlitePool,
+        workspace_id: &str,
+    ) -> Result<Vec<(String, u32)>, sqlx::Error> {
+        counts_by_autopilot(pool, workspace_id, "autopilot_collaborator").await
+    }
+}
+
+/// Stateless typed wrapper over the `autopilot_subscriber` table.
+pub struct AutopilotSubscriberRepo;
+
+impl AutopilotSubscriberRepo {
+    /// Idempotently subscribe `actor` to `autopilot_id`, workspace-scoped the
+    /// same way as [`AutopilotCollaboratorRepo::add`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn add(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        autopilot_id: &str,
+        actor: &ActorRef,
+        created_by: Option<&ActorRef>,
+        now_ms: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "INSERT OR IGNORE INTO autopilot_subscriber \
+                 (autopilot_id, workspace_id, actor_type, actor_id, created_by, created_at) \
+             SELECT ?, ?, ?, ?, ?, ? \
+             WHERE EXISTS (SELECT 1 FROM autopilot WHERE id = ? AND workspace_id = ?)",
+        )
+        .bind(autopilot_id)
+        .bind(workspace_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(created_by.map(ToString::to_string))
+        .bind(now_ms)
+        .bind(autopilot_id)
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Unsubscribe `actor`. Removing an absent subscription is an idempotent
+    /// `Ok(false)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement fails.
+    pub async fn remove(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        autopilot_id: &str,
+        actor: &ActorRef,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query(
+            "DELETE FROM autopilot_subscriber \
+             WHERE autopilot_id = ? AND actor_type = ? AND actor_id = ? AND workspace_id = ?",
+        )
+        .bind(autopilot_id)
+        .bind(actor.kind().as_str())
+        .bind(actor.id())
+        .bind(workspace_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Every subscriber of one rule, oldest first.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn list(
+        pool: &SqlitePool,
+        autopilot_id: &str,
+    ) -> Result<Vec<AutopilotSubscriberRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT autopilot_id, actor_type, actor_id, created_by, created_at \
+             FROM autopilot_subscriber WHERE autopilot_id = ? \
+             ORDER BY created_at, actor_type, actor_id",
+        )
+        .bind(autopilot_id)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| {
+                let actor = actor_of(&r)?;
+                Some(AutopilotSubscriberRow {
+                    autopilot_id: r.get("autopilot_id"),
+                    actor,
+                    created_by: created_by_of(&r),
+                    created_at: r.get("created_at"),
+                })
+            })
+            .collect())
+    }
+
+    /// The fan-out read: just the subscribing actors, no provenance.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn actors(
+        pool: &SqlitePool,
+        autopilot_id: &str,
+    ) -> Result<Vec<ActorRef>, sqlx::Error> {
+        Ok(Self::list(pool, autopilot_id).await?.into_iter().map(|s| s.actor).collect())
+    }
+
+    /// How many actors follow one rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn count(pool: &SqlitePool, autopilot_id: &str) -> Result<u32, sqlx::Error> {
+        let n: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM autopilot_subscriber WHERE autopilot_id = ?")
+                .bind(autopilot_id)
+                .fetch_one(pool)
+                .await?;
+        Ok(u32::try_from(n).unwrap_or(u32::MAX))
+    }
+
+    /// Subscriber counts for EVERY rule in a workspace, as
+    /// `(autopilot_id, count)`. One `GROUP BY`, not N+1.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn counts_by_autopilot(
+        pool: &SqlitePool,
+        workspace_id: &str,
+    ) -> Result<Vec<(String, u32)>, sqlx::Error> {
+        counts_by_autopilot(pool, workspace_id, "autopilot_subscriber").await
+    }
+}
+
+/// Shared `GROUP BY` for both actor-set tables. `table` is a compile-time
+/// literal supplied by the two call sites above, never caller input.
+async fn counts_by_autopilot(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    table: &'static str,
+) -> Result<Vec<(String, u32)>, sqlx::Error> {
+    let rows = sqlx::query(&format!(
+        "SELECT autopilot_id, COUNT(*) AS n FROM {table} \
+         WHERE workspace_id = ? GROUP BY autopilot_id"
+    ))
+    .bind(workspace_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| {
+            let n: i64 = r.get("n");
+            (
+                r.get::<String, _>("autopilot_id"),
+                u32::try_from(n).unwrap_or(u32::MAX),
+            )
+        })
+        .collect())
+}
+
+/// Why [`can_write`] said yes — surfaced so a caller (and a test) can tell an
+/// `access_mode = 'open'` pass from a real grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllowReason {
+    /// The rule is `access_mode = 'open'` — today's behaviour, unchanged.
+    ModeOpen,
+    /// The actor published rule version 1, i.e. created the rule.
+    Owner,
+    /// The actor is a workspace `owner` or `admin`.
+    WorkspaceAdmin,
+    /// The actor holds an explicit `editor` collaborator grant.
+    Collaborator,
+}
+
+/// The verdict of the write predicate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteDecision {
+    /// The actor may write, for this reason.
+    Allowed(AllowReason),
+    /// The actor may not write.
+    Denied,
+}
+
+impl WriteDecision {
+    /// Whether the decision permits the write.
+    #[must_use]
+    pub const fn is_allowed(self) -> bool {
+        matches!(self, Self::Allowed(_))
+    }
+}
+
+/// multica's `creator OR workspace-owner OR workspace-admin OR explicit
+/// collaborator`, plus hangar's `access_mode = 'open'` short-circuit
+/// (migration 0064 decision 4). The ONE definition of "may this actor write
+/// this rule".
+///
+/// Resolution order:
+///
+/// 1. the autopilot does not exist in this workspace → `Denied` (the caller
+///    reports not-found; the predicate never leaks a foreign rule's mode);
+/// 2. `access_mode = 'open'` → `Allowed(ModeOpen)`;
+/// 3. the actor published rule version **1** → `Allowed(Owner)`. Owner is
+///    DERIVED, not stored: an unversioned (pre-0061) or unattributed rule
+///    simply has no owner — an honest unknown, never a fabricated one;
+/// 4. the actor is a `member` with `owner`/`admin` in this workspace →
+///    `Allowed(WorkspaceAdmin)`;
+/// 5. an `editor` collaborator grant exists → `Allowed(Collaborator)`. A
+///    `viewer` grant does NOT grant write, and neither does an unparseable
+///    role token;
+/// 6. otherwise `Denied`.
+///
+/// Deliberately NOT baked into [`super::autopilot::AutopilotRepo::update_as`]
+/// and friends: authorization belongs at the request seam (which is also where
+/// the reference puts it), and burying it in the repo would silently change the
+/// meaning of every legacy `actor = None` caller.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if any of the underlying queries fail.
+pub async fn can_write(
+    pool: &SqlitePool,
+    workspace: &WorkspaceId,
+    autopilot_id: &AutopilotId,
+    actor: &ActorRef,
+) -> Result<WriteDecision, sqlx::Error> {
+    let mode: Option<String> =
+        sqlx::query_scalar("SELECT access_mode FROM autopilot WHERE id = ? AND workspace_id = ?")
+            .bind(autopilot_id.as_str())
+            .bind(workspace.as_str())
+            .fetch_optional(pool)
+            .await?;
+    let Some(mode) = mode else {
+        return Ok(WriteDecision::Denied);
+    };
+    if AccessMode::from_db_str(&mode) == AccessMode::Open {
+        return Ok(WriteDecision::Allowed(AllowReason::ModeOpen));
+    }
+
+    // The rule's OWNER: whoever published version 1.
+    let owner: Option<String> = sqlx::query_scalar(
+        "SELECT published_by FROM autopilot_rule_version \
+         WHERE autopilot_id = ? AND workspace_id = ? ORDER BY version ASC LIMIT 1",
+    )
+    .bind(autopilot_id.as_str())
+    .bind(workspace.as_str())
+    .fetch_optional(pool)
+    .await?
+    .flatten();
+    if owner.as_deref() == Some(actor.to_string().as_str()) {
+        return Ok(WriteDecision::Allowed(AllowReason::Owner));
+    }
+
+    if actor.kind() == ActorKind::Member {
+        let role = MemberRepo::role(pool, workspace, actor.id()).await?;
+        if matches!(role, Some(MemberRole::Owner | MemberRole::Admin)) {
+            return Ok(WriteDecision::Allowed(AllowReason::WorkspaceAdmin));
+        }
+    }
+
+    let grant = AutopilotCollaboratorRepo::get(pool, autopilot_id.as_str(), actor).await?;
+    if grant.is_some_and(|g| g.role == Some(CollaboratorRole::Editor)) {
+        return Ok(WriteDecision::Allowed(AllowReason::Collaborator));
+    }
+
+    Ok(WriteDecision::Denied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_tokens_round_trip_and_unknown_reads_none() {
+        for r in [CollaboratorRole::Editor, CollaboratorRole::Viewer] {
+            assert_eq!(CollaboratorRole::parse(r.as_db_str()), Some(r));
+        }
+        assert_eq!(CollaboratorRole::parse("archivist"), None);
+    }
+
+    #[test]
+    fn editor_is_the_default_role() {
+        assert_eq!(CollaboratorRole::default(), CollaboratorRole::Editor);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_access.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_access.rs
@@ -474,6 +474,13 @@ pub enum WriteDecision {
     Allowed(AllowReason),
     /// The actor may not write.
     Denied,
+    /// There is no such autopilot in this workspace, so there is nothing to
+    /// authorise. Deliberately NOT folded into [`Self::Denied`]: a caller must
+    /// report the honest "no such rule here" rather than "you may not touch
+    /// it", which would both mislead the operator and leak that some rule with
+    /// that id exists somewhere. Tenant scoping already makes the mutation a
+    /// no-op, so a caller may pass this through to its own not-found path.
+    NotFound,
 }
 
 impl WriteDecision {
@@ -481,6 +488,13 @@ impl WriteDecision {
     #[must_use]
     pub const fn is_allowed(self) -> bool {
         matches!(self, Self::Allowed(_))
+    }
+
+    /// Whether the decision is an outright refusal (as opposed to an absent
+    /// rule, which is the caller's not-found case).
+    #[must_use]
+    pub const fn is_denied(self) -> bool {
+        matches!(self, Self::Denied)
     }
 }
 
@@ -491,8 +505,9 @@ impl WriteDecision {
 ///
 /// Resolution order:
 ///
-/// 1. the autopilot does not exist in this workspace → `Denied` (the caller
-///    reports not-found; the predicate never leaks a foreign rule's mode);
+/// 1. the autopilot does not exist in this workspace → `NotFound` (the caller
+///    reports not-found; the predicate never leaks a foreign rule's mode, and
+///    never dresses an absent rule up as a permission refusal);
 /// 2. `access_mode = 'open'` → `Allowed(ModeOpen)`;
 /// 3. the actor published rule version **1** → `Allowed(Owner)`. Owner is
 ///    DERIVED, not stored: an unversioned (pre-0061) or unattributed rule
@@ -525,7 +540,7 @@ pub async fn can_write(
             .fetch_optional(pool)
             .await?;
     let Some(mode) = mode else {
-        return Ok(WriteDecision::Denied);
+        return Ok(WriteDecision::NotFound);
     };
     if AccessMode::from_db_str(&mode) == AccessMode::Open {
         return Ok(WriteDecision::Allowed(AllowReason::ModeOpen));

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
@@ -46,6 +46,7 @@ use sqlx::{Row, SqlitePool};
 
 use super::autopilot::{Autopilot, ConcurrencyPolicy, ExecutionMode};
 use super::autopilot_rule_version::AutopilotRuleVersionRepo;
+use super::issue_subscriber::SubscribeReason;
 use super::task::{NewTask, TaskRepo};
 
 /// HOW a run's accountable human is resolved — multica's attribution fork
@@ -353,6 +354,44 @@ pub async fn fire_autopilot_tick_with_attribution(
             .bind(&autopilot.id)
             .execute(&mut *tx)
             .await?;
+
+            // multica parity #27: the rule's standing subscriber list
+            // auto-subscribes every issue the rule SPAWNS. In-transaction,
+            // because a spawned issue that commits without its subscribers is
+            // the notification bug the table exists to fix.
+            //
+            // The agent creator is subscribed FIRST (first-reason-wins, so an
+            // agent that is both creator and subscriber keeps `creator`). The
+            // raw INSERT above bypasses `IssueRepo::insert`, so its
+            // `auto_subscribe_on_create` never runs on this path — without this
+            // statement a spawned issue has an EMPTY subscriber set.
+            sqlx::query(
+                "INSERT OR IGNORE INTO issue_subscriber \
+                 (issue_id, actor_type, actor_id, reason, created_at) \
+                 VALUES (?, 'agent', ?, ?, ?)",
+            )
+            .bind(&issue_id)
+            .bind(&autopilot.agent_id)
+            .bind(SubscribeReason::Creator.as_db_str())
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+
+            // Then the standing list, in ONE statement — no N+1, no round-trip
+            // per subscriber.
+            sqlx::query(
+                "INSERT OR IGNORE INTO issue_subscriber \
+                 (issue_id, actor_type, actor_id, reason, created_at) \
+                 SELECT ?, actor_type, actor_id, ?, ? \
+                 FROM autopilot_subscriber WHERE autopilot_id = ?",
+            )
+            .bind(&issue_id)
+            .bind(SubscribeReason::Autopilot.as_db_str())
+            .bind(now)
+            .bind(&autopilot.id)
+            .execute(&mut *tx)
+            .await?;
+
             Some(issue_id)
         }
     };

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue_subscriber.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue_subscriber.rs
@@ -36,6 +36,13 @@ pub enum SubscribeReason {
     Mentioned,
     /// The actor explicitly asked to watch the issue.
     Manual,
+    /// The actor is a standing SUBSCRIBER of the autopilot that SPAWNED this
+    /// issue (multica parity #27, migration 0064) — they never touched this
+    /// occurrence, they follow the recurring rule behind it.
+    ///
+    /// Appending here needs no migration precisely because 0062 decision 3 put
+    /// the vocabulary in Rust with a tolerant parser and NO SQL `CHECK`.
+    Autopilot,
 }
 
 impl SubscribeReason {
@@ -49,6 +56,7 @@ impl SubscribeReason {
             Self::Commenter => "commenter",
             Self::Mentioned => "mentioned",
             Self::Manual => "manual",
+            Self::Autopilot => "autopilot",
         }
     }
 
@@ -62,6 +70,7 @@ impl SubscribeReason {
             "commenter" => Some(Self::Commenter),
             "mentioned" => Some(Self::Mentioned),
             "manual" => Some(Self::Manual),
+            "autopilot" => Some(Self::Autopilot),
             _ => None,
         }
     }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
@@ -12,6 +12,7 @@ pub mod agent_runtime;
 pub mod atc_instance;
 pub mod attention;
 pub mod autopilot;
+pub mod autopilot_access;
 pub mod autopilot_rule_version;
 pub mod autopilot_run;
 pub mod autopilot_webhook;

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0064_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0064_upgrade.rs
@@ -1,0 +1,154 @@
+//! Upgrade-from-populated test for migration 0064 (`autopilot_subscriber` +
+//! `autopilot_collaborator` + `autopilot.access_mode` — multica parity #27).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the migration on a REAL populated database:
+//!
+//! 1. apply only the PRIOR migrations (0001..0063),
+//! 2. seed a workspace + agent + autopilot + a rule version,
+//! 3. apply the embedded migrations (which adds 0064),
+//! 4. assert the seeded autopilot survives and reads `access_mode = 'open'`,
+//!    both new tables and both indexes exist, NOTHING was backfilled into
+//!    either table, and the `access_mode` CHECK actually bites.
+
+use ainb_hangar_store::apply_migrations;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test
+/// (`0064_autopilot_subscriber_collaborator.sql`).
+const NEW_MIGRATION_VERSION: i64 = 64;
+
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let opts = SqliteConnectOptions::new()
+        .filename(dir.join("hangar.db"))
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(!migrator.migrations.is_empty());
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+/// The pre-0064 world: a workspace with an agent, an autopilot, and the v1 rule
+/// version that names its accountable human.
+async fn seed_populated(pool: &SqlitePool) {
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('u-amy','amy@x.io',10)",
+        "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','u-amy','owner')",
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','d-1','claude','local')",
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('ag-1','ws-1','builder','rt-1','workspace','u-amy')",
+        "INSERT INTO autopilot \
+         (id, workspace_id, agent_id, name, instructions, cron_expr, max_concurrent_runs, \
+          execution_mode, concurrency_policy, next_tick_at, enabled, api_trigger_enabled, \
+          created_at) \
+         VALUES ('ap-1','ws-1','ag-1','nightly','sweep','0 3 * * *',1,'run_only','skip', \
+                 999999999999,1,0,30)",
+        "INSERT INTO autopilot_rule_version \
+         (id, autopilot_id, workspace_id, version, change_kind, published_by, config_summary, \
+          created_at) \
+         VALUES ('rv-1','ap-1','ws-1',1,'created','member:u-amy','{}',30)",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+async fn object_exists(pool: &SqlitePool, kind: &str, name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM sqlite_master WHERE type = ? AND name = ?")
+        .bind(kind)
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .expect("sqlite_master")
+        > 0
+}
+
+async fn count(pool: &SqlitePool, table: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(&format!("SELECT COUNT(*) FROM {table}"))
+        .fetch_one(pool)
+        .await
+        .unwrap_or_else(|e| panic!("count {table}: {e}"))
+}
+
+#[tokio::test]
+async fn migration_0064_adds_autopilot_actor_sets_and_keeps_the_rule_open() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+
+    for t in ["autopilot_subscriber", "autopilot_collaborator"] {
+        assert!(!object_exists(&pool, "table", t).await, "{t} must not exist before 0064");
+    }
+
+    apply_migrations(&pool).await.expect("upgrade applies 0064");
+    let recorded: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?")
+            .bind(NEW_MIGRATION_VERSION)
+            .fetch_one(&pool)
+            .await
+            .expect("read migration version");
+    assert_eq!(recorded, 1, "0064 recorded as applied");
+
+    // (a) The seeded autopilot survived, and reads the PERMISSIVE default —
+    //     an upgrading install must never be silently locked out of its own
+    //     rules (migration decision 4).
+    let mode: String = sqlx::query_scalar("SELECT access_mode FROM autopilot WHERE id = 'ap-1'")
+        .fetch_one(&pool)
+        .await
+        .expect("read access_mode");
+    assert_eq!(mode, "open", "every pre-0064 autopilot upgrades to 'open'");
+
+    // (b) Both tables and both indexes landed.
+    for t in ["autopilot_subscriber", "autopilot_collaborator"] {
+        assert!(object_exists(&pool, "table", t).await, "missing table {t}");
+    }
+    for idx in ["idx_autopilot_subscriber_actor", "idx_autopilot_collaborator_actor"] {
+        assert!(object_exists(&pool, "index", idx).await, "missing index {idx}");
+    }
+
+    // (c) NOTHING was backfilled — not even "the creator is a collaborator",
+    //     which would be a fabricated grant record (decision 5).
+    assert_eq!(count(&pool, "autopilot_subscriber").await, 0);
+    assert_eq!(count(&pool, "autopilot_collaborator").await, 0);
+
+    // (d) The access_mode CHECK is engine-enforced.
+    assert!(
+        sqlx::query("UPDATE autopilot SET access_mode = 'wide-open' WHERE id = 'ap-1'")
+            .execute(&pool)
+            .await
+            .is_err(),
+        "access_mode is CHECK-constrained to the closed set"
+    );
+    assert!(
+        sqlx::query("UPDATE autopilot SET access_mode = 'restricted' WHERE id = 'ap-1'")
+            .execute(&pool)
+            .await
+            .is_ok(),
+        "'restricted' is inside the closed set"
+    );
+
+    // (e) The actor_type CHECK bites on both new tables.
+    for t in ["autopilot_subscriber", "autopilot_collaborator"] {
+        let extra = if t == "autopilot_collaborator" { ", role" } else { "" };
+        let extra_val = if t == "autopilot_collaborator" { ", 'editor'" } else { "" };
+        let sql = format!(
+            "INSERT INTO {t} (autopilot_id, workspace_id, actor_type, actor_id{extra}, created_at) \
+             VALUES ('ap-1','ws-1','robot','x'{extra_val}, 40)"
+        );
+        assert!(sqlx::query(&sql).execute(&pool).await.is_err(), "{t} actor_type CHECK");
+    }
+
+    // (f) Re-applying is a ledgered no-op.
+    apply_migrations(&pool).await.expect("second apply is a no-op");
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0064_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0064_upgrade.rs
@@ -88,7 +88,10 @@ async fn migration_0064_adds_autopilot_actor_sets_and_keeps_the_rule_open() {
     seed_populated(&pool).await;
 
     for t in ["autopilot_subscriber", "autopilot_collaborator"] {
-        assert!(!object_exists(&pool, "table", t).await, "{t} must not exist before 0064");
+        assert!(
+            !object_exists(&pool, "table", t).await,
+            "{t} must not exist before 0064"
+        );
     }
 
     apply_migrations(&pool).await.expect("upgrade applies 0064");
@@ -113,8 +116,14 @@ async fn migration_0064_adds_autopilot_actor_sets_and_keeps_the_rule_open() {
     for t in ["autopilot_subscriber", "autopilot_collaborator"] {
         assert!(object_exists(&pool, "table", t).await, "missing table {t}");
     }
-    for idx in ["idx_autopilot_subscriber_actor", "idx_autopilot_collaborator_actor"] {
-        assert!(object_exists(&pool, "index", idx).await, "missing index {idx}");
+    for idx in [
+        "idx_autopilot_subscriber_actor",
+        "idx_autopilot_collaborator_actor",
+    ] {
+        assert!(
+            object_exists(&pool, "index", idx).await,
+            "missing index {idx}"
+        );
     }
 
     // (c) NOTHING was backfilled — not even "the creator is a collaborator",
@@ -140,13 +149,24 @@ async fn migration_0064_adds_autopilot_actor_sets_and_keeps_the_rule_open() {
 
     // (e) The actor_type CHECK bites on both new tables.
     for t in ["autopilot_subscriber", "autopilot_collaborator"] {
-        let extra = if t == "autopilot_collaborator" { ", role" } else { "" };
-        let extra_val = if t == "autopilot_collaborator" { ", 'editor'" } else { "" };
+        let extra = if t == "autopilot_collaborator" {
+            ", role"
+        } else {
+            ""
+        };
+        let extra_val = if t == "autopilot_collaborator" {
+            ", 'editor'"
+        } else {
+            ""
+        };
         let sql = format!(
             "INSERT INTO {t} (autopilot_id, workspace_id, actor_type, actor_id{extra}, created_at) \
              VALUES ('ap-1','ws-1','robot','x'{extra_val}, 40)"
         );
-        assert!(sqlx::query(&sql).execute(&pool).await.is_err(), "{t} actor_type CHECK");
+        assert!(
+            sqlx::query(&sql).execute(&pool).await.is_err(),
+            "{t} actor_type CHECK"
+        );
     }
 
     // (f) Re-applying is a ledgered no-op.

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_access_predicate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_access_predicate.rs
@@ -254,7 +254,7 @@ async fn an_unversioned_restricted_rule_has_no_owner() {
 }
 
 #[tokio::test]
-async fn a_rule_in_another_workspace_is_denied_not_leaked() {
+async fn a_rule_in_another_workspace_is_not_found_not_denied() {
     let dir = tempfile::tempdir().expect("tempdir");
     let store = Store::open_in(dir.path()).await.expect("open store");
     seed_graph(&store).await;
@@ -273,7 +273,9 @@ async fn a_rule_in_another_workspace_is_denied_not_leaked() {
         )
         .await
         .expect("predicate"),
-        WriteDecision::Denied,
+        // NOT `Denied`: an absent rule must not be dressed up as a permission
+        // refusal, or the caller reports "you may not" for a plain typo.
+        WriteDecision::NotFound,
     );
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_access_predicate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_access_predicate.rs
@@ -1,0 +1,300 @@
+//! The autopilot WRITE PREDICATE (multica parity #27, migration 0064).
+//!
+//! `can_write` is the one definition of "may this actor write this rule". It
+//! mirrors the reference's `creator OR workspace-owner OR workspace-admin OR
+//! explicit collaborator`, with hangar's `access_mode = 'open'` short-circuit in
+//! front so no existing install is silently locked out.
+//!
+//! Table-driven over the whole decision surface, because the interesting cases
+//! are the NEGATIVE ones: a `viewer` grant must NOT grant write, and an
+//! unversioned rule must NOT fabricate an owner just to let somebody in.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_core::ids::{AgentId, AutopilotId, WorkspaceId};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::autopilot::{
+    AccessMode, AutopilotEdit, AutopilotRepo, ConcurrencyPolicy, ExecutionMode, NewAutopilot,
+};
+use ainb_hangar_store::repo::autopilot_access::{
+    AllowReason, AutopilotCollaboratorRepo, CollaboratorRole, WriteDecision, can_write,
+};
+
+const T0: i64 = 1_767_225_600_000;
+
+fn ws1() -> WorkspaceId {
+    WorkspaceId::from_str("ws-1").unwrap()
+}
+fn member(id: &str) -> ActorRef {
+    ActorRef::new(ActorKind::Member, id).unwrap()
+}
+
+/// `user-creator` is a plain workspace `member` so that "owner of the rule" and
+/// "owner of the workspace" are provably DIFFERENT reasons.
+async fn seed_graph(store: &Store) {
+    let pool = store.pool();
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-creator','c@x.io',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-admin','a@x.io',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-stranger','s@x.io',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-grantee','g@x.io',0)",
+        "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','user-creator','member')",
+        "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','user-admin','admin')",
+        "INSERT INTO member (workspace_id, user_id, role) \
+         VALUES ('ws-1','user-stranger','member')",
+        "INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','user-grantee','member')",
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','daemon-1','claude','local')",
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('agent-1','ws-1','Agent','rt-1','workspace','user-creator')",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+fn new_autopilot(name: &str) -> NewAutopilot {
+    NewAutopilot {
+        workspace_id: ws1(),
+        agent_id: AgentId::from_str("agent-1").unwrap(),
+        name: name.to_string(),
+        instructions: Some("sweep".to_string()),
+        cron_expr: "0 3 * * *".to_string(),
+        max_concurrent_runs: 1,
+        execution_mode: ExecutionMode::RunOnly,
+        concurrency_policy: ConcurrencyPolicy::Skip,
+        api_trigger_enabled: false,
+    }
+}
+
+/// Create a rule owned (v1-published) by `user-creator` and restrict it.
+async fn restricted_rule(store: &Store, name: &str) -> AutopilotId {
+    let clock = FixedClock(T0);
+    let id = AutopilotRepo::create_as(
+        store.pool(),
+        &clock,
+        &new_autopilot(name),
+        Some(&member("user-creator")),
+    )
+    .await
+    .expect("create");
+    AutopilotRepo::update_as(
+        store.pool(),
+        &clock,
+        &ws1(),
+        &id,
+        &AutopilotEdit {
+            access_mode: Some(AccessMode::Restricted),
+            ..AutopilotEdit::default()
+        },
+        Some(&member("user-creator")),
+    )
+    .await
+    .expect("restrict");
+    id
+}
+
+#[tokio::test]
+async fn open_mode_admits_any_actor_in_the_workspace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let id = AutopilotRepo::create_as(
+        store.pool(),
+        &FixedClock(T0),
+        &new_autopilot("nightly"),
+        Some(&member("user-creator")),
+    )
+    .await
+    .expect("create");
+
+    // The pre-0064 behaviour, unchanged: a stranger may still write.
+    assert_eq!(
+        can_write(store.pool(), &ws1(), &id, &member("user-stranger"))
+            .await
+            .expect("predicate"),
+        WriteDecision::Allowed(AllowReason::ModeOpen),
+    );
+}
+
+#[tokio::test]
+async fn restricted_mode_resolves_every_reason_and_denies_the_rest() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let id = restricted_rule(&store, "nightly").await;
+
+    // An `editor` grant, and a `viewer` grant that must NOT grant write.
+    AutopilotCollaboratorRepo::add(
+        store.pool(),
+        ws1().as_str(),
+        id.as_str(),
+        &member("user-grantee"),
+        CollaboratorRole::Editor,
+        None,
+        T0,
+    )
+    .await
+    .expect("grant editor");
+    AutopilotCollaboratorRepo::add(
+        store.pool(),
+        ws1().as_str(),
+        id.as_str(),
+        &member("user-stranger"),
+        CollaboratorRole::Viewer,
+        None,
+        T0,
+    )
+    .await
+    .expect("grant viewer");
+
+    let cases: [(&str, WriteDecision); 4] = [
+        // v1 publisher — a plain workspace member, so this can only be Owner.
+        ("user-creator", WriteDecision::Allowed(AllowReason::Owner)),
+        (
+            "user-admin",
+            WriteDecision::Allowed(AllowReason::WorkspaceAdmin),
+        ),
+        (
+            "user-grantee",
+            WriteDecision::Allowed(AllowReason::Collaborator),
+        ),
+        // A viewer grant is visibility, not permission.
+        ("user-stranger", WriteDecision::Denied),
+    ];
+    for (user, expected) in cases {
+        let got = can_write(store.pool(), &ws1(), &id, &member(user)).await.expect("predicate");
+        assert_eq!(got, expected, "actor {user}");
+    }
+}
+
+#[tokio::test]
+async fn restricted_mode_denies_an_actor_with_no_grant_at_all() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let id = restricted_rule(&store, "nightly").await;
+
+    assert_eq!(
+        can_write(store.pool(), &ws1(), &id, &member("user-stranger"))
+            .await
+            .expect("predicate"),
+        WriteDecision::Denied,
+    );
+    // Revoking a grant takes the write away again.
+    AutopilotCollaboratorRepo::add(
+        store.pool(),
+        ws1().as_str(),
+        id.as_str(),
+        &member("user-grantee"),
+        CollaboratorRole::Editor,
+        None,
+        T0,
+    )
+    .await
+    .expect("grant");
+    assert!(
+        can_write(store.pool(), &ws1(), &id, &member("user-grantee"))
+            .await
+            .expect("predicate")
+            .is_allowed()
+    );
+    AutopilotCollaboratorRepo::remove(
+        store.pool(),
+        ws1().as_str(),
+        id.as_str(),
+        &member("user-grantee"),
+    )
+    .await
+    .expect("revoke");
+    assert_eq!(
+        can_write(store.pool(), &ws1(), &id, &member("user-grantee"))
+            .await
+            .expect("predicate"),
+        WriteDecision::Denied,
+    );
+}
+
+/// An unversioned (pre-0061) or unattributed rule has NO owner. The predicate
+/// must report that honestly — never invent one to let somebody in.
+#[tokio::test]
+async fn an_unversioned_restricted_rule_has_no_owner() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+
+    // A rule as a pre-0061 install would have left it: row present, ledger empty.
+    sqlx::query(
+        "INSERT INTO autopilot \
+         (id, workspace_id, agent_id, name, cron_expr, max_concurrent_runs, execution_mode, \
+          concurrency_policy, next_tick_at, enabled, api_trigger_enabled, access_mode, created_at) \
+         VALUES ('ap-legacy','ws-1','agent-1','legacy','0 3 * * *',1,'run_only','skip', \
+                 999999999999,1,0,'restricted',0)",
+    )
+    .execute(store.pool())
+    .await
+    .expect("seed legacy autopilot");
+    let id = AutopilotId::from_str("ap-legacy").unwrap();
+
+    assert_eq!(
+        can_write(store.pool(), &ws1(), &id, &member("user-creator"))
+            .await
+            .expect("predicate"),
+        WriteDecision::Denied,
+        "no ledger row means no owner — not 'everybody is the owner'"
+    );
+    // The workspace admin is still the escape hatch, so a legacy rule is never
+    // permanently unmanageable.
+    assert_eq!(
+        can_write(store.pool(), &ws1(), &id, &member("user-admin"))
+            .await
+            .expect("predicate"),
+        WriteDecision::Allowed(AllowReason::WorkspaceAdmin),
+    );
+}
+
+#[tokio::test]
+async fn a_rule_in_another_workspace_is_denied_not_leaked() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-2','b','B',0)")
+        .execute(store.pool())
+        .await
+        .expect("second workspace");
+    let id = restricted_rule(&store, "nightly").await;
+
+    assert_eq!(
+        can_write(
+            store.pool(),
+            &WorkspaceId::from_str("ws-2").unwrap(),
+            &id,
+            &member("user-creator"),
+        )
+        .await
+        .expect("predicate"),
+        WriteDecision::Denied,
+    );
+}
+
+/// Flipping `access_mode` is a SUBSTANTIVE publish: it mints a rule version.
+#[tokio::test]
+async fn restricting_a_rule_mints_a_rule_version() {
+    use ainb_hangar_store::repo::autopilot_rule_version::AutopilotRuleVersionRepo;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let id = restricted_rule(&store, "nightly").await;
+
+    let latest = AutopilotRuleVersionRepo::latest(store.pool(), &ws1(), &id)
+        .await
+        .expect("latest")
+        .expect("a version exists");
+    assert_eq!(
+        latest.version, 2,
+        "create minted v1, the restrict minted v2"
+    );
+    assert_eq!(latest.change_kind, "access");
+    assert_eq!(latest.published_by.as_deref(), Some("member:user-creator"));
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_collaborator.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_collaborator.rs
@@ -1,0 +1,301 @@
+//! The autopilot COLLABORATOR + SUBSCRIBER sets at the store layer (multica
+//! parity #27, migration 0064).
+//!
+//! The headline test is the item's acceptance sentence, proved the only way
+//! that means anything: the grant is written, the pool is **dropped**, a NEW
+//! pool is opened on the SAME file, and the row is still there. An in-memory
+//! assert would pass even if the write never reached disk.
+//!
+//! The rest pin the contract the set-membership shape implies: a re-add is
+//! inert and keeps the FIRST grant (so `set_role` is the only role mutator), a
+//! foreign tenant's write lands nothing rather than erroring, and remove is
+//! idempotent.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_core::ids::{AgentId, WorkspaceId};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::autopilot::{
+    AutopilotRepo, ConcurrencyPolicy, ExecutionMode, NewAutopilot,
+};
+use ainb_hangar_store::repo::autopilot_access::{
+    AutopilotCollaboratorRepo, AutopilotSubscriberRepo, CollaboratorRole,
+};
+
+/// Fixed clock instant (epoch-ms, 2026-01-01T00:00:00Z).
+const T0: i64 = 1_767_225_600_000;
+
+fn ws1() -> WorkspaceId {
+    WorkspaceId::from_str("ws-1").unwrap()
+}
+fn ws2() -> WorkspaceId {
+    WorkspaceId::from_str("ws-2").unwrap()
+}
+fn bob() -> ActorRef {
+    ActorRef::new(ActorKind::Member, "user-bob").unwrap()
+}
+fn amy() -> ActorRef {
+    ActorRef::new(ActorKind::Member, "user-amy").unwrap()
+}
+
+async fn seed_graph(store: &Store) {
+    let pool = store.pool();
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-2','beta','Beta',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-amy','amy@example.com',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-bob','bob@example.com',0)",
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','daemon-1','claude','local')",
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('agent-1','ws-1','Agent','rt-1','workspace','user-amy')",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+fn new_autopilot(name: &str) -> NewAutopilot {
+    NewAutopilot {
+        workspace_id: ws1(),
+        agent_id: AgentId::from_str("agent-1").unwrap(),
+        name: name.to_string(),
+        instructions: Some("nightly sweep".to_string()),
+        cron_expr: "0 3 * * *".to_string(),
+        max_concurrent_runs: 1,
+        execution_mode: ExecutionMode::RunOnly,
+        concurrency_policy: ConcurrencyPolicy::Skip,
+        api_trigger_enabled: false,
+    }
+}
+
+/// THE ACCEPTANCE TEST: a collaborator can be added to an autopilot, and it
+/// persists to sqlite — read back by a pool that did not write it.
+#[tokio::test]
+async fn add_then_reopen_pool_still_reads_the_row() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let clock = FixedClock(T0);
+
+    let autopilot_id = {
+        let store = Store::open_in(dir.path()).await.expect("open store");
+        seed_graph(&store).await;
+        let id = AutopilotRepo::create(store.pool(), &clock, &new_autopilot("nightly"))
+            .await
+            .expect("create autopilot");
+
+        let landed = AutopilotCollaboratorRepo::add(
+            store.pool(),
+            ws1().as_str(),
+            id.as_str(),
+            &bob(),
+            CollaboratorRole::Editor,
+            Some(&amy()),
+            T0,
+        )
+        .await
+        .expect("add collaborator");
+        assert!(landed, "the grant landed");
+
+        // Drop the pool: everything below must come off DISK.
+        store.pool().close().await;
+        id
+    };
+
+    let reopened = Store::open_in(dir.path()).await.expect("reopen store");
+    let rows = AutopilotCollaboratorRepo::list(reopened.pool(), autopilot_id.as_str())
+        .await
+        .expect("list after reopen");
+    assert_eq!(rows.len(), 1, "exactly the one grant survived the reopen");
+    let row = &rows[0];
+    assert_eq!(row.actor, bob());
+    assert_eq!(row.role, Some(CollaboratorRole::Editor));
+    assert_eq!(row.role_raw, "editor");
+    assert_eq!(
+        row.created_by,
+        Some(amy()),
+        "the granting human is attributed"
+    );
+    assert_eq!(row.created_at, T0);
+}
+
+#[tokio::test]
+async fn re_add_is_idempotent_and_keeps_the_first_grant() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let clock = FixedClock(T0);
+    let id = AutopilotRepo::create(store.pool(), &clock, &new_autopilot("nightly"))
+        .await
+        .expect("create");
+
+    assert!(
+        AutopilotCollaboratorRepo::add(
+            store.pool(),
+            ws1().as_str(),
+            id.as_str(),
+            &bob(),
+            CollaboratorRole::Editor,
+            None,
+            T0,
+        )
+        .await
+        .expect("first add")
+    );
+
+    // A second add, with a DIFFERENT role and a LATER timestamp, must not
+    // silently downgrade the grant nor re-stamp created_at.
+    assert!(
+        !AutopilotCollaboratorRepo::add(
+            store.pool(),
+            ws1().as_str(),
+            id.as_str(),
+            &bob(),
+            CollaboratorRole::Viewer,
+            None,
+            T0 + 9_000,
+        )
+        .await
+        .expect("second add"),
+        "re-adding an existing collaborator reports no new row"
+    );
+
+    let row = AutopilotCollaboratorRepo::get(store.pool(), id.as_str(), &bob())
+        .await
+        .expect("get")
+        .expect("grant present");
+    assert_eq!(row.role, Some(CollaboratorRole::Editor), "first grant wins");
+    assert_eq!(row.created_at, T0, "created_at was not re-stamped");
+
+    // set_role is the ONLY role mutator.
+    assert!(
+        AutopilotCollaboratorRepo::set_role(
+            store.pool(),
+            ws1().as_str(),
+            id.as_str(),
+            &bob(),
+            CollaboratorRole::Viewer,
+        )
+        .await
+        .expect("set_role")
+    );
+    let row = AutopilotCollaboratorRepo::get(store.pool(), id.as_str(), &bob())
+        .await
+        .expect("get")
+        .expect("grant present");
+    assert_eq!(row.role, Some(CollaboratorRole::Viewer));
+    assert_eq!(row.created_at, T0, "a role change is not a new grant");
+}
+
+#[tokio::test]
+async fn foreign_workspace_add_writes_nothing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let clock = FixedClock(T0);
+    let id = AutopilotRepo::create(store.pool(), &clock, &new_autopilot("nightly"))
+        .await
+        .expect("create");
+
+    // ws-2 exists, but this autopilot is not in it.
+    assert!(
+        !AutopilotCollaboratorRepo::add(
+            store.pool(),
+            ws2().as_str(),
+            id.as_str(),
+            &bob(),
+            CollaboratorRole::Editor,
+            None,
+            T0,
+        )
+        .await
+        .expect("foreign add is not an error"),
+        "a foreign tenant's write reports no row"
+    );
+    assert_eq!(
+        AutopilotCollaboratorRepo::count(store.pool(), id.as_str())
+            .await
+            .expect("count"),
+        0,
+        "and wrote nothing"
+    );
+}
+
+#[tokio::test]
+async fn remove_is_idempotent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let clock = FixedClock(T0);
+    let id = AutopilotRepo::create(store.pool(), &clock, &new_autopilot("nightly"))
+        .await
+        .expect("create");
+
+    AutopilotCollaboratorRepo::add(
+        store.pool(),
+        ws1().as_str(),
+        id.as_str(),
+        &bob(),
+        CollaboratorRole::Editor,
+        None,
+        T0,
+    )
+    .await
+    .expect("add");
+
+    assert!(
+        AutopilotCollaboratorRepo::remove(store.pool(), ws1().as_str(), id.as_str(), &bob())
+            .await
+            .expect("first remove")
+    );
+    assert!(
+        !AutopilotCollaboratorRepo::remove(store.pool(), ws1().as_str(), id.as_str(), &bob())
+            .await
+            .expect("second remove"),
+        "removing an absent grant is an idempotent no-op"
+    );
+}
+
+#[tokio::test]
+async fn subscribers_persist_and_count_per_workspace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let clock = FixedClock(T0);
+    let a = AutopilotRepo::create(store.pool(), &clock, &new_autopilot("nightly"))
+        .await
+        .expect("create a");
+    let b = AutopilotRepo::create(store.pool(), &clock, &new_autopilot("weekly"))
+        .await
+        .expect("create b");
+
+    for (id, actor, at) in [(&a, amy(), T0), (&a, bob(), T0 + 1), (&b, bob(), T0 + 2)] {
+        assert!(
+            AutopilotSubscriberRepo::add(
+                store.pool(),
+                ws1().as_str(),
+                id.as_str(),
+                &actor,
+                None,
+                at,
+            )
+            .await
+            .expect("subscribe")
+        );
+    }
+
+    assert_eq!(
+        AutopilotSubscriberRepo::actors(store.pool(), a.as_str()).await.expect("actors"),
+        vec![amy(), bob()],
+        "oldest-first, deterministic within a millisecond"
+    );
+
+    let mut counts = AutopilotSubscriberRepo::counts_by_autopilot(store.pool(), ws1().as_str())
+        .await
+        .expect("counts");
+    counts.sort();
+    let mut expected = vec![(a.as_str().to_string(), 2), (b.as_str().to_string(), 1)];
+    expected.sort();
+    assert_eq!(
+        counts, expected,
+        "one GROUP BY covers the whole list screen"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_autopilot_subscriber_fanout.rs
@@ -1,0 +1,268 @@
+//! The autopilot SUBSCRIBER FAN-OUT onto spawned issues (multica parity #27,
+//! migration 0064).
+//!
+//! Before this item, an autopilot-spawned issue had an EMPTY `issue_subscriber`
+//! set — not even its agent creator — because the `create_issue` fire path
+//! writes the issue with a raw in-transaction `INSERT` that bypasses
+//! `IssueRepo::insert`'s `auto_subscribe_on_create`. So there was nobody to
+//! notify about a recurring automation's occurrences.
+//!
+//! These tests pin the behaviour that matters, not the wiring: after a tick,
+//! the SPAWNED issue carries the agent creator plus the rule's standing
+//! subscriber list, each tick gets its OWN full set, and a `run_only` rule
+//! spawns no issue and therefore no subscriber rows.
+
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_core::ids::{AgentId, AutopilotId, WorkspaceId};
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::autopilot::{
+    Autopilot, AutopilotRepo, ConcurrencyPolicy, ExecutionMode, NewAutopilot,
+};
+use ainb_hangar_store::repo::autopilot_access::AutopilotSubscriberRepo;
+use ainb_hangar_store::repo::autopilot_run::{
+    RunAttribution, RunSource, fire_autopilot_tick_with_attribution,
+};
+use ainb_hangar_store::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
+
+const T0: i64 = 1_767_225_600_000;
+
+fn ws1() -> WorkspaceId {
+    WorkspaceId::from_str("ws-1").unwrap()
+}
+fn member(id: &str) -> ActorRef {
+    ActorRef::new(ActorKind::Member, id).unwrap()
+}
+fn agent1() -> ActorRef {
+    ActorRef::new(ActorKind::Agent, "agent-1").unwrap()
+}
+
+async fn seed_graph(store: &Store) {
+    let pool = store.pool();
+    for sql in [
+        "INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','alpha','Alpha',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-a','a@x.io',0)",
+        "INSERT INTO user (id, email, created_at) VALUES ('user-b','b@x.io',0)",
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','daemon-1','claude','local')",
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('agent-1','ws-1','Agent','rt-1','workspace','user-a')",
+    ] {
+        sqlx::query(sql).execute(pool).await.expect(sql);
+    }
+}
+
+fn new_autopilot(name: &str, mode: ExecutionMode) -> NewAutopilot {
+    NewAutopilot {
+        workspace_id: ws1(),
+        agent_id: AgentId::from_str("agent-1").unwrap(),
+        name: name.to_string(),
+        instructions: Some("nightly sweep".to_string()),
+        cron_expr: "0 3 * * *".to_string(),
+        max_concurrent_runs: 10,
+        execution_mode: mode,
+        concurrency_policy: ConcurrencyPolicy::Queue,
+        api_trigger_enabled: false,
+    }
+}
+
+async fn load(store: &Store, id: &AutopilotId) -> Autopilot {
+    AutopilotRepo::get(store.pool(), &ws1(), id)
+        .await
+        .expect("get")
+        .expect("present")
+}
+
+/// Every issue this autopilot spawned, oldest first.
+async fn spawned_issues(store: &Store, autopilot_id: &AutopilotId) -> Vec<String> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT id FROM issue WHERE origin_type = 'autopilot' AND origin_id = ? \
+         ORDER BY created_at, id",
+    )
+    .bind(autopilot_id.as_str())
+    .fetch_all(store.pool())
+    .await
+    .expect("spawned issues")
+}
+
+/// `(actor, reason)` pairs on one issue, in the repo's stable order.
+async fn subscribers(store: &Store, issue_id: &str) -> Vec<(String, String)> {
+    IssueSubscriberRepo::list(store.pool(), issue_id)
+        .await
+        .expect("list subscribers")
+        .into_iter()
+        .map(|s| (s.actor.to_string(), s.reason_raw))
+        .collect()
+}
+
+#[tokio::test]
+async fn a_spawned_issue_carries_the_agent_creator_and_the_rules_subscribers() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let clock = FixedClock(T0);
+
+    let id = AutopilotRepo::create(
+        store.pool(),
+        &clock,
+        &new_autopilot("nightly", ExecutionMode::CreateIssue),
+    )
+    .await
+    .expect("create");
+    for (actor, at) in [(member("user-a"), T0), (member("user-b"), T0 + 1)] {
+        AutopilotSubscriberRepo::add(store.pool(), ws1().as_str(), id.as_str(), &actor, None, at)
+            .await
+            .expect("subscribe");
+    }
+
+    let autopilot = load(&store, &id).await;
+    fire_autopilot_tick_with_attribution(
+        store.pool(),
+        &clock,
+        &autopilot,
+        RunSource::Schedule,
+        &RunAttribution::RuleOwner,
+    )
+    .await
+    .expect("first tick");
+
+    let issues = spawned_issues(&store, &id).await;
+    assert_eq!(issues.len(), 1, "one tick spawned one issue");
+    let mut got = subscribers(&store, &issues[0]).await;
+    got.sort();
+    let mut expected = vec![
+        (
+            agent1().to_string(),
+            SubscribeReason::Creator.as_db_str().to_string(),
+        ),
+        (
+            member("user-a").to_string(),
+            SubscribeReason::Autopilot.as_db_str().to_string(),
+        ),
+        (
+            member("user-b").to_string(),
+            SubscribeReason::Autopilot.as_db_str().to_string(),
+        ),
+    ];
+    expected.sort();
+    assert_eq!(got, expected, "creator + the whole standing list");
+
+    // A SECOND tick gets its OWN full set — following the rule means being
+    // notified per occurrence, not once ever.
+    let autopilot = load(&store, &id).await;
+    fire_autopilot_tick_with_attribution(
+        store.pool(),
+        &clock,
+        &autopilot,
+        RunSource::Schedule,
+        &RunAttribution::RuleOwner,
+    )
+    .await
+    .expect("second tick");
+
+    let issues = spawned_issues(&store, &id).await;
+    assert_eq!(issues.len(), 2);
+    for issue in &issues {
+        assert_eq!(
+            subscribers(&store, issue).await.len(),
+            3,
+            "issue {issue} has its own full subscriber set"
+        );
+    }
+}
+
+/// An agent that is BOTH the creator and a standing subscriber keeps `creator`
+/// — first-reason-wins, which is why the creator row is written first.
+#[tokio::test]
+async fn the_creating_agent_keeps_the_creator_reason() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let clock = FixedClock(T0);
+
+    let id = AutopilotRepo::create(
+        store.pool(),
+        &clock,
+        &new_autopilot("nightly", ExecutionMode::CreateIssue),
+    )
+    .await
+    .expect("create");
+    AutopilotSubscriberRepo::add(
+        store.pool(),
+        ws1().as_str(),
+        id.as_str(),
+        &agent1(),
+        None,
+        T0,
+    )
+    .await
+    .expect("subscribe the agent to its own rule");
+
+    let autopilot = load(&store, &id).await;
+    fire_autopilot_tick_with_attribution(
+        store.pool(),
+        &clock,
+        &autopilot,
+        RunSource::Schedule,
+        &RunAttribution::RuleOwner,
+    )
+    .await
+    .expect("tick");
+
+    let issues = spawned_issues(&store, &id).await;
+    assert_eq!(
+        subscribers(&store, &issues[0]).await,
+        vec![(
+            agent1().to_string(),
+            SubscribeReason::Creator.as_db_str().to_string()
+        )],
+        "one row, and its reason is creator not autopilot"
+    );
+}
+
+#[tokio::test]
+async fn a_run_only_rule_spawns_no_issue_and_no_subscriber_rows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    seed_graph(&store).await;
+    let clock = FixedClock(T0);
+
+    let id = AutopilotRepo::create(
+        store.pool(),
+        &clock,
+        &new_autopilot("bg", ExecutionMode::RunOnly),
+    )
+    .await
+    .expect("create");
+    AutopilotSubscriberRepo::add(
+        store.pool(),
+        ws1().as_str(),
+        id.as_str(),
+        &member("user-a"),
+        None,
+        T0,
+    )
+    .await
+    .expect("subscribe");
+
+    let autopilot = load(&store, &id).await;
+    fire_autopilot_tick_with_attribution(
+        store.pool(),
+        &clock,
+        &autopilot,
+        RunSource::Schedule,
+        &RunAttribution::RuleOwner,
+    )
+    .await
+    .expect("tick");
+
+    assert!(
+        spawned_issues(&store, &id).await.is_empty(),
+        "run_only spawns no issue"
+    );
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue_subscriber")
+        .fetch_one(store.pool())
+        .await
+        .expect("count");
+    assert_eq!(total, 0, "and therefore no subscriber rows anywhere");
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/autopilots.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/autopilots.rs
@@ -122,11 +122,31 @@ impl AutopilotsState {
                 // edited since. The ledger was deliberately not backfilled, so
                 // the dash is an honest "unversioned", not a missing value.
                 let ver = ap.rule_version.map_or_else(|| "v—".to_string(), |v| format!("v{v}"));
+                // The #27 actor sets (migration 0064). Each suffix appears only
+                // when it has something to say, so an ordinary rule's card is
+                // exactly as busy as it was before this item.
+                let people = match (ap.collaborator_count, ap.subscriber_count) {
+                    (0, 0) => String::new(),
+                    (c, 0) => format!(" · 👥{c}"),
+                    (0, n) => format!(" · 🔔{n}"),
+                    (c, n) => format!(" · 👥{c} · 🔔{n}"),
+                };
+                // A lock ONLY on an explicit `restricted`. An omitted
+                // `access_mode` (a pre-0064 daemon's payload) is open, so it
+                // renders no lock — never a fabricated restriction.
+                let lock = if ap.access_mode.as_deref() == Some("restricted") {
+                    " · 🔒"
+                } else {
+                    ""
+                };
                 BoardCard {
                     not_dispatched: false,
                     issue_id: ap.id.clone(),
                     display_id: ap.name.clone(),
-                    title: format!("{} · {ver} · {state}{api} · last {last}", ap.cron_expr),
+                    title: format!(
+                        "{} · {ver} · {state}{api}{lock}{people} · last {last}",
+                        ap.cron_expr
+                    ),
                     priority: PriorityChip::from_priority(0),
                     assignee_initial: ap.name.chars().next(),
                     linked: false,
@@ -620,6 +640,54 @@ mod tests {
             cols[0].cards[1].title.contains("v\u{2014}"),
             "an unversioned rule shows a dash, not a fabricated v1: {:?}",
             cols[0].cards[1].title
+        );
+    }
+
+    /// The card carries the #27 collaborator / subscriber counts and the lock,
+    /// and a LEGACY row (no `access_mode`, both counts zero) carries none of
+    /// them — a pre-0064 payload must never render as a restricted rule.
+    #[test]
+    fn card_title_carries_the_actor_set_badges() {
+        let mut shared = autopilot("ap-1", "daily", true);
+        shared.collaborator_count = 3;
+        shared.subscriber_count = 2;
+        shared.access_mode = Some("restricted".into());
+
+        let mut open_rule = autopilot("ap-2", "nightly", true);
+        open_rule.subscriber_count = 1;
+        open_rule.access_mode = Some("open".into());
+
+        // Exactly what a pre-0064 daemon sends: the three fields absent.
+        let legacy = autopilot("ap-3", "legacy", true);
+        assert_eq!(legacy.collaborator_count, 0);
+        assert_eq!(legacy.subscriber_count, 0);
+        assert_eq!(legacy.access_mode, None);
+
+        let state = AutopilotsState::new(vec![shared, open_rule, legacy]);
+        let cards = &state.board_columns()[0].cards;
+
+        assert!(cards[0].title.contains("👥3"), "{:?}", cards[0].title);
+        assert!(cards[0].title.contains("🔔2"), "{:?}", cards[0].title);
+        assert!(cards[0].title.contains('🔒'), "{:?}", cards[0].title);
+
+        assert!(cards[1].title.contains("🔔1"), "{:?}", cards[1].title);
+        assert!(
+            !cards[1].title.contains("👥"),
+            "no grants means no grant badge: {:?}",
+            cards[1].title
+        );
+        assert!(
+            !cards[1].title.contains('🔒'),
+            "an explicitly OPEN rule carries no lock: {:?}",
+            cards[1].title
+        );
+
+        assert!(
+            !cards[2].title.contains('🔒')
+                && !cards[2].title.contains("👥")
+                && !cards[2].title.contains("🔔"),
+            "a legacy payload renders none of the #27 badges: {:?}",
+            cards[2].title
         );
     }
 

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -4585,18 +4585,21 @@ Create and control cron-scheduled autopilots
 Usage: ainb hangar autopilot [OPTIONS] <COMMAND>
 
 Commands:
-  create       Create a cron-scheduled autopilot (rejects an invalid cron expression)
-  list         List the workspace's autopilots (cron, next tick, last run, enabled)
-  disable      Disable an autopilot so the scheduler stops firing it
-  enable       Re-enable an autopilot, recomputing its next tick from now
-  edit         Edit an autopilot's config (cron / agent / instructions / policy). A substantive edit appends a rule version naming the accountable human; a rename alone is cosmetic and mints none
-  versions     Show the autopilot's rule-version ledger (who published what, when)
-  run          Fire one tick immediately, bypassing the schedule (`--source` picks the trigger recorded on the run: `manual` by default, or `api`)
-  api-trigger  Arm (or `--disable`) the bare programmatic `api` trigger
-  runs         List the autopilot's recent runs (status, trigger source, reason)
-  webhook      Configure the HTTP webhook trigger (enable/disable, rotate secret, filter)
-  deliveries   List the autopilot's recent webhook deliveries (audit log)
-  help         Print this message or the help of the given subcommand(s)
+  create        Create a cron-scheduled autopilot (rejects an invalid cron expression)
+  list          List the workspace's autopilots (cron, next tick, last run, enabled)
+  disable       Disable an autopilot so the scheduler stops firing it
+  enable        Re-enable an autopilot, recomputing its next tick from now
+  edit          Edit an autopilot's config (cron / agent / instructions / policy). A substantive edit appends a rule version naming the accountable human; a rename alone is cosmetic and mints none
+  versions      Show the autopilot's rule-version ledger (who published what, when)
+  run           Fire one tick immediately, bypassing the schedule (`--source` picks the trigger recorded on the run: `manual` by default, or `api`)
+  api-trigger   Arm (or `--disable`) the bare programmatic `api` trigger
+  runs          List the autopilot's recent runs (status, trigger source, reason)
+  webhook       Configure the HTTP webhook trigger (enable/disable, rotate secret, filter)
+  deliveries    List the autopilot's recent webhook deliveries (audit log)
+  collaborator  Manage the rule's explicit WRITE-GRANT set (multica parity #27)
+  subscriber    Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
+  access        Open or restrict who may WRITE this rule (multica parity #27)
+  help          Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -4929,6 +4932,67 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --limit <LIMIT>          Maximum number of deliveries to show (latest-first) [default: 20]
+      --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
+  -h, --help                   Print help
+```
+
+#### `ainb hangar autopilot collaborator`
+
+Manage the rule's explicit WRITE-GRANT set (multica parity #27)
+
+```console
+$ ainb hangar autopilot collaborator --help
+Manage the rule's explicit WRITE-GRANT set (multica parity #27)
+
+Usage: ainb hangar autopilot collaborator [OPTIONS] <COMMAND>
+
+Commands:
+  add     Add an actor to the set (idempotent; a re-add keeps the FIRST grant)
+  remove  Remove an actor from the set (idempotent)
+  list    List the set, oldest first
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar autopilot subscriber`
+
+Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
+
+```console
+$ ainb hangar autopilot subscriber --help
+Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
+
+Usage: ainb hangar autopilot subscriber [OPTIONS] <COMMAND>
+
+Commands:
+  add     Add an actor to the set (idempotent; a re-add keeps the FIRST grant)
+  remove  Remove an actor from the set (idempotent)
+  list    List the set, oldest first
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar autopilot access`
+
+Open or restrict who may WRITE this rule (multica parity #27)
+
+```console
+$ ainb hangar autopilot access --help
+Open or restrict who may WRITE this rule (multica parity #27)
+
+Usage: ainb hangar autopilot access [OPTIONS] --id <ID> --mode <MODE>
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --id <ID>                The autopilot id (`autopilot.id`)
+      --mode <MODE>            `open` (any actor in the workspace may write — the default and every pre-0064 rule) or `restricted` (owner / workspace owner+admin / an explicit `editor` collaborator only)
+      --as-user <AS_USER>      The acting human (write gate subject + rule-version attribution)
       --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
   -h, --help                   Print help
 ```


### PR DESCRIPTION
## Parity #27 — autopilot subscriber / collaborator model

Before this: `rg "autopilot_subscriber|autopilot_collaborator"` returned nothing.
There was no per-rule actor set, no access mode, and **no authorization check on
any autopilot mutation** — `update_as` / `enable_as` / `disable_as` /
`set_api_trigger_enabled_as` took an `actor` purely for the #14 ledger and never
checked it against anything. Separately, an autopilot-spawned issue got **zero**
`issue_subscriber` rows (not even its agent creator), because the `create_issue`
fire path writes the issue with a raw in-transaction `INSERT` that bypasses
`IssueRepo::insert`'s `auto_subscribe_on_create`.

### What landed

**Migration 0064** — `autopilot_subscriber` + `autopilot_collaborator`, both
mirroring `issue_subscriber` (no FK on `autopilot_id`, `(autopilot, actor)` PK,
`INSERT OR IGNORE` set membership), plus `autopilot.access_mode` defaulting to
`'open'`. No backfill: inventing "the creator is a collaborator" would be a
fabricated grant record, and defaulting to `'restricted'` would silently lock
every upgrading install out of its own automations.

**Store** — `repo/autopilot_access.rs`: typed repos + `can_write`, the single
definition of "may this actor write this rule". Resolution order: absent rule →
`NotFound`; `access_mode = 'open'` → allowed (today's behaviour, unchanged);
rule owner (**derived** from the v1 publisher, never stored, never fabricated);
workspace owner/admin; explicit `editor` collaborator. A `viewer` grant does
**not** grant write. `AccessMode` on the row/edit, `RuleChangeKind::Access` in
the ledger so widening who may write a rule is a recorded publish.

**Fan-out** — the rule's standing list is copied onto every spawned issue in the
SAME transaction as the issue insert, agent-creator first (first-reason-wins),
via a new `SubscribeReason::Autopilot`. No migration needed: 0062 deliberately
left the reason vocabulary in Rust with no SQL `CHECK`.

**Daemon** — 7 methods, plus the write gate at the request seam (which is where
the reference puts authorization too, and where it does not change the meaning
of every legacy `actor = None` caller). `fire_now` / `trigger_api` are
deliberately left ungated with a comment saying so — firing is a read-side
grant, judged by a separate agent-invocation predicate (#8).

**CLI + plugin** — `autopilot collaborator|subscriber add|remove|list` and
`autopilot access --mode`. Every mutating autopilot verb (including the existing
edit/enable/disable/api-trigger) applies the same gate: the CLI writes sqlite
directly, so skipping it would be an open back door around the RPC gate. Plugin
cards get `👥n` / `🔔n` / `🔒`, each only when it has something to say.

### One deviation from the spec, and why

The spec had an absent rule resolve to `WriteDecision::Denied`. That turned
`hangar/autopilot_update` against a foreign workspace into a **permission
error** where it had always reported `outcome: "not_found"` — it broke
`rpc_autopilot_rule_version.rs`'s C.4 case, misleads the operator, and leaks
that a rule with that id exists somewhere. Split out as `WriteDecision::NotFound`,
which every gate passes through to its own not-found path (tenant scoping
already makes the mutation a no-op).

### Acceptance proof

Clean tempdir, real `./target/debug/ainb`, never touching `~/.agents-in-a-box`:

```
$ export AINB_HANGAR_HOME="$(mktemp -d)"
$ ainb hangar workspace create --slug proof --name proof
created workspace proof (01KYHPQPB17FKQV7BJ63KY0ND2)
$ ainb hangar agent create --name builder --workspace proof
created agent builder
$ ainb hangar autopilot create --workspace proof --name nightly \
    --agent 01KYHPQPBS72TH2WRGS176R33S --cron "0 3 * * *" --instructions "nightly sweep"
created autopilot 01KYHPQYKJMTNZDHMMQ5BZKXB9 `nightly` (cron `0 3 * * *`) (v1 created by member:me)

# THE ACCEPTANCE ACTION
$ ainb hangar autopilot collaborator add --workspace proof --id 01KYHPQYKJMTNZDHMMQ5BZKXB9 \
    --actor member:bob --role editor
member:bob  editor  1785153195991

# 1. it persisted, read by a process that did not write it
$ sqlite3 "$AINB_HANGAR_HOME/hangar.db" \
    "SELECT autopilot_id, actor_type, actor_id, role FROM autopilot_collaborator;"
01KYHPQYKJMTNZDHMMQ5BZKXB9|member|bob|editor

# 2. it survives a fresh process (new pool, same file)
$ ainb hangar autopilot collaborator list --workspace proof --id 01KYHPQYKJMTNZDHMMQ5BZKXB9
member:bob  editor  1785153195991
```

And the grant MEANS something:

```
$ ainb hangar autopilot access --workspace proof --id 01KYHPQYKJMTNZDHMMQ5BZKXB9 --mode restricted
access_mode = restricted  (rule version v2)

$ ainb hangar autopilot edit --workspace proof --as-user carol --cron "0 4 * * *" 01KYHPQYKJMTNZDHMMQ5BZKXB9
Error: actor `member:carol` may not modify autopilot `01KYHPQYKJMTNZDHMMQ5BZKXB9` (access_mode = restricted)
exit=1

$ ainb hangar autopilot edit --workspace proof --as-user bob --cron "0 4 * * *" 01KYHPQYKJMTNZDHMMQ5BZKXB9
autopilot 01KYHPQYKJMTNZDHMMQ5BZKXB9 updated (v3 schedule by member:bob)
exit=0
```

### Local gate — all green

```
$ cargo build -p ainb
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s

$ cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'
     Summary [ 307.253s] 4260 tests run: 4260 passed (5 slow), 18 skipped

$ bash ../scripts/hangar/run_all_tripwires.sh
hangar tripwires: ran=64 failed=0 skipped=0

$ bash ../scripts/hangar/run_acceptance_tests.sh
hangar acceptance: ran=194 failed=0 skipped=0
```

Fixture drift this PR caused and fixed **in this PR**: the scheduler's
hand-written autopilot `SELECT`, three `Autopilot` struct-literal test fixtures
(scheduler, CLI render tests), one `AutopilotConfigSnapshot` fixture, and the
generated CLI reference (`docs/tui/cli.md`, which CI diffs).

Clippy note: `-D warnings` over these crates is red on `ainb-hangar-core`
(`webhook.rs` deprecated `generic-array` call, `too_long_first_doc_paragraph` /
`doc_markdown` on `agent_kind.rs`, `origin.rs`, `profile.rs`, and
`rule_version.rs:29`) — all on lines this PR does not touch, i.e. pre-existing
newer-toolchain drift, not introduced here.

### Tests

- `migration_0064_upgrade.rs` — upgrade from populated 0063: the seeded rule
  survives reading `'open'`, both tables + indexes exist, **zero** rows
  backfilled, both `CHECK`s bite.
- `repo_autopilot_collaborator.rs` — the acceptance test at the repo layer:
  add, **close the pool**, reopen a new one on the same file, the row is there.
  Plus first-grant-wins, foreign-tenant no-op, idempotent remove.
- `repo_autopilot_access_predicate.rs` — every allow reason and the load-bearing
  denials (viewer, revoked, foreign workspace, unversioned rule with no owner).
- `repo_autopilot_subscriber_fanout.rs` — the spawned issue carries
  `{agent creator, member:a, member:b}`, each tick gets its own full set, and
  `run_only` spawns neither issue nor rows.
- `rpc_autopilot_collaborator.rs` — over the real socket: restrict as creator →
  stranger REJECTED → grant editor → identical update SUCCEEDS and mints a
  version. Mutating the gate to always-allow reds this; always-deny reds
  `open_rule_is_unchanged_for_a_stranger`.
- `inbox_subscriber_fanout.rs` — extended: a rule subscriber is notified about a
  spawned issue they never touched.
- Proto append-only round trip, CLI inline persistence + denial tests, plugin
  render test asserting a legacy payload renders NO lock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manage autopilot collaborators and subscribers with add, remove, and list commands.
  * Configure autopilot access as open or restricted.
  * Restricted autopilots now support explicit editor permissions while preserving owner and administrator access.
  * Autopilot-created issues automatically subscribe configured subscribers.
  * Autopilot listings and cards now show access mode, collaborator counts, and subscriber counts.
* **Bug Fixes**
  * Prevented unauthorized autopilot changes across CLI and RPC operations.
  * Unknown autopilot targets and invalid access modes now return clear errors.
* **Documentation**
  * Updated CLI reference documentation for the new autopilot controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->