### PR TITLE
feat: add native Fleet macOS foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, v2]
     paths:
       - "ainb-tui/**"
+      - "apps/ainb-fleet-macos/**"
       - "plugins/ainb-hooks/**"
       - "ainb-tui/crates/ainb-plugin-hangar/**"
       - "scripts/hangar/**"
@@ -14,6 +15,7 @@ on:
     branches: [main, v2]
     paths:
       - "ainb-tui/**"
+      - "apps/ainb-fleet-macos/**"
       - "plugins/ainb-hooks/**"
       - "ainb-tui/crates/ainb-plugin-hangar/**"
       - "scripts/hangar/**"
@@ -26,6 +28,90 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  fleet-macos-foundation:
+    name: Fleet macOS foundation
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "ainb-tui -> target"
+      - name: Assert Apple Silicon runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          uname -m
+          sw_vers
+          test "$(uname -m)" = "arm64"
+      - name: Check Swift source boundary
+        run: apps/ainb-fleet-macos/ci/check-swift-boundary.sh
+      - name: Build Fleet fixture daemon
+        run: cargo build -p ainb-hangar-daemon --example fleet_fixture_daemon --features test-support
+        working-directory: ${{ env.WORKING_DIR }}
+      - name: Run Fleet Rust fixture and parity tests
+        run: |
+          set -euo pipefail
+          cargo test -p ainb-hangar-proto --test wire_types
+          cargo test -p ainb-hangar-proto --test fleet_fixtures
+          cargo test -p ainb-hangar-proto --test fleet_parity_manifest
+          cargo run -p ainb-hangar-proto --example export_fleet_fixtures -- --check
+          cargo test -p ainb-hangar-daemon --test rpc_fleet
+          cargo test -p ainb-hangar-daemon --test rpc_server malformed_content_length_frame_closes_authenticated_connection
+        working-directory: ${{ env.WORKING_DIR }}
+      - name: Build Fleet macOS app
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/fleet-macos-foundation"
+          log="$RUNNER_TEMP/fleet-macos-foundation/xcodebuild-build.log"
+          if xcodebuild \
+            -project apps/ainb-fleet-macos/AINBFleet.xcodeproj \
+            -scheme AINBFleet \
+            -configuration Debug \
+            -destination 'platform=macOS,arch=arm64' \
+            -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-derived-data" \
+            CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            build >"$log" 2>&1; then
+            :
+          else
+            status=$?
+            cat "$log"
+            exit "$status"
+          fi
+      - name: Test Fleet macOS app
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/fleet-macos-foundation"
+          log="$RUNNER_TEMP/fleet-macos-foundation/xcodebuild-test.log"
+          if xcodebuild test \
+            -project apps/ainb-fleet-macos/AINBFleet.xcodeproj \
+            -scheme AINBFleet \
+            -destination 'platform=macOS,arch=arm64' \
+            -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-derived-data" \
+            -resultBundlePath "$RUNNER_TEMP/FleetRPCTests.xcresult" \
+            CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES >"$log" 2>&1; then
+            :
+          else
+            status=$?
+            cat "$log"
+            exit "$status"
+          fi
+      - name: Upload Fleet macOS failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fleet-macos-foundation-failure-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/fleet-macos-foundation/*.log
+            ${{ runner.temp }}/FleetRPCTests.xcresult
+          if-no-files-found: warn
+
   # ────────────────────────────────────────────────────────────────────────────
   # Format check
   # ────────────────────────────────────────────────────────────────────────────

--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_drift_glyph_live.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_drift_glyph_live.rs
@@ -231,9 +231,9 @@ fn pressing_m_renders_drift_warning_glyph_against_real_local_bare() {
     assert!(status.success(), "tmux new-session failed");
 
     let cmd = format!(
-        "HOME={} exec {} 2>&1",
-        home_tmp.path().display(),
-        bin.display()
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box exec {bin} 2>&1",
+        home = home_tmp.path().display(),
+        bin = bin.display()
     );
     Command::new("tmux")
         .args(["send-keys", "-t", &session, &cmd, "Enter"])

--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_keys_wired.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_keys_wired.rs
@@ -7,8 +7,8 @@
 //! end-to-end):
 //!   1. `[i]` opens the add-source prompt; typing a `git:file://` URI
 //!      (which contains `:` — the char that used to hijack the global
-//!      slash-command palette) and pressing Enter actually writes the
-//!      source into manifest.yaml.
+//!      slash-command palette), choosing the previewed unit, and pressing
+//!      Enter actually writes the source into manifest.yaml.
 //!   2. `[/]` opens the search prompt and filters the Units table.
 //!
 //! The other help-bar keys have their own live tripwires so each file
@@ -186,6 +186,20 @@ fn add_source_key_writes_manifest_in_live_binary() {
     let uri = format!("git:file://{}", layout.bare_remote.display());
     send_literal(&session, &uri);
     thread::sleep(Duration::from_millis(400));
+    send(&session, "Enter");
+
+    // Add-source is preview-first: choose its discovered unit, then confirm
+    // import before asserting the source was persisted.
+    if poll(&session, Instant::now() + Duration::from_secs(15), |c| {
+        c.contains("Import from")
+    })
+    .is_none()
+    {
+        let d = capture(&session);
+        kill(&session);
+        panic!("add-source did not open import preview:\n{d}");
+    }
+    send(&session, "Space");
     send(&session, "Enter");
 
     // The manifest must gain the source. Poll the file directly.

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs
@@ -1,0 +1,152 @@
+//! Real Fleet daemon fixture for the macOS RPC contract tests.
+//!
+//! The process owns an isolated `AINB_HANGAR_HOME` supplied by its test parent.
+//! It creates the real SQLite store, daemon token, Unix socket server, durable
+//! Fleet revision log, and live event broker. JSON commands on stdin only inject
+//! provider hook observations; they never emulate an RPC response or Fleet state.
+
+use std::io::{BufRead as _, Write as _};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use ainb_hangar_daemon::events::EventBroker;
+use ainb_hangar_daemon::fleet::{self, HookObservation};
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_store::Store;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+enum Command {
+    Seed {
+        event_id: String,
+        #[serde(default = "default_provider")]
+        provider: String,
+        #[serde(default = "default_session_id")]
+        session_id: String,
+        #[serde(default = "default_event_type")]
+        event_type: String,
+        #[serde(default = "default_cwd")]
+        cwd: String,
+        #[serde(default)]
+        payload: Value,
+        #[serde(default)]
+        observed_at: Option<i64>,
+    },
+    Shutdown,
+}
+
+fn default_provider() -> String {
+    "claude".to_string()
+}
+fn default_session_id() -> String {
+    "fixture-session".to_string()
+}
+fn default_event_type() -> String {
+    "SessionStart".to_string()
+}
+fn default_cwd() -> String {
+    "/fixture".to_string()
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let home = fixture_home()?;
+    let store = Store::open_in(&home).await?;
+    rpc::auth::ensure_socket_token(store.pool(), &home).await?;
+    let socket = rpc::socket_path_in(&home);
+    let listener = rpc::bind(&socket)?;
+    let broker = EventBroker::new();
+    let sink = broker.sink();
+    let health = DaemonHealth {
+        socket_path: socket.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        stats: Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(listener, store.pool().clone(), health, broker));
+
+    let mut next_observed_at = 1_700_000_000_000_i64;
+    'commands: loop {
+        for line in std::io::stdin().lock().lines() {
+            let line = line?;
+            let command: Command = match serde_json::from_str(&line) {
+                Ok(command) => command,
+                Err(error) => {
+                    println!(
+                        "{}",
+                        serde_json::json!({ "ok": false, "error": error.to_string() })
+                    );
+                    std::io::stdout().flush()?;
+                    continue;
+                }
+            };
+            match command {
+                Command::Seed {
+                    event_id,
+                    provider,
+                    session_id,
+                    event_type,
+                    cwd,
+                    payload,
+                    observed_at,
+                } => {
+                    let observed_at = observed_at.unwrap_or_else(|| {
+                        next_observed_at += 1;
+                        next_observed_at
+                    });
+                    match fleet::apply_hook(
+                        store.pool(),
+                        &sink,
+                        HookObservation {
+                            event_id: event_id.clone(),
+                            provider: &provider,
+                            provider_session_id: &session_id,
+                            cwd: &cwd,
+                            event_type: &event_type,
+                            payload: &payload,
+                            observed_at,
+                        },
+                    )
+                    .await
+                    {
+                        Ok(result) => println!(
+                            "{}",
+                            serde_json::json!({
+                                "ok": true,
+                                "event_id": event_id,
+                                "revision": result.revision,
+                                "duplicate": result.duplicate,
+                            })
+                        ),
+                        Err(error) => println!(
+                            "{}",
+                            serde_json::json!({ "ok": false, "error": error.to_string() })
+                        ),
+                    }
+                    std::io::stdout().flush()?;
+                }
+                Command::Shutdown => break 'commands,
+            }
+        }
+        // XCTest may momentarily close its inherited stdin during test-host launch.
+        // Keep the real daemon available for its readiness and socket proof instead
+        // of turning that transport startup race into a clean fixture exit.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+fn fixture_home() -> anyhow::Result<PathBuf> {
+    let raw = std::env::var_os("AINB_HANGAR_HOME")
+        .ok_or_else(|| anyhow::anyhow!("AINB_HANGAR_HOME is required for fixture isolation"))?;
+    let home = PathBuf::from(raw);
+    if !home.is_absolute() {
+        anyhow::bail!("AINB_HANGAR_HOME must be an absolute isolated directory");
+    }
+    std::fs::create_dir_all(&home)?;
+    Ok(home)
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -163,20 +163,37 @@ async fn retire_correlated_legacy(
 pub async fn snapshot_wire(
     pool: &SqlitePool,
 ) -> Result<ainb_hangar_proto::fleet::FleetSnapshot, sqlx::Error> {
-    let snapshot = FleetRepo::snapshot(pool).await?;
-    let mut sessions = Vec::with_capacity(snapshot.sessions.len());
-    for row in &snapshot.sessions {
-        let current_request = if row.current_request_fingerprint.is_some() {
-            current_request_wire(pool, &row.session_key).await?
-        } else {
-            None
-        };
-        sessions.push(session_wire(row, current_request));
+    let projection = FleetRepo::subscription_projection(pool, 0, 0).await?;
+    Ok(subscription_snapshot_wire(&projection))
+}
+
+/// Read a wire-ready Fleet subscription projection from one store transaction.
+pub async fn subscription_wire(
+    pool: &SqlitePool,
+    after_revision: i64,
+    replay_limit: i64,
+) -> Result<ainb_hangar_store::repo::fleet::FleetSubscriptionProjection, FleetRepoError> {
+    ainb_hangar_store::repo::fleet::FleetRepo::subscription_projection(
+        pool,
+        after_revision,
+        replay_limit,
+    )
+    .await
+    .map_err(FleetRepoError::from)
+}
+
+/// Convert one atomic store subscription projection into its Fleet wire shape.
+pub fn subscription_snapshot_wire(
+    projection: &ainb_hangar_store::repo::fleet::FleetSubscriptionProjection,
+) -> ainb_hangar_proto::fleet::FleetSnapshot {
+    ainb_hangar_proto::fleet::FleetSnapshot {
+        head_revision: projection.head_revision,
+        sessions: projection
+            .sessions
+            .iter()
+            .map(|row| session_wire(&row.session, row.current_request.clone()))
+            .collect(),
     }
-    Ok(ainb_hangar_proto::fleet::FleetSnapshot {
-        head_revision: snapshot.head_revision,
-        sessions,
-    })
 }
 
 /// Read complete payload for current structured request or approval.
@@ -663,7 +680,8 @@ fn session_wire(
     }
 }
 
-fn event_wire(row: &FleetEventRow) -> ainb_hangar_proto::fleet::FleetEvent {
+/// Convert one durable Fleet event row into its public wire representation.
+pub fn event_wire(row: &FleetEventRow) -> ainb_hangar_proto::fleet::FleetEvent {
     ainb_hangar_proto::fleet::FleetEvent {
         revision: row.revision,
         event_id: row.event_id.clone(),
@@ -1456,6 +1474,11 @@ mod tests {
         assert_eq!(
             session.attention,
             ainb_hangar_proto::fleet::AttentionState::Ask
+        );
+        assert_eq!(
+            session.current_request.as_ref().unwrap()["questions"][0]["id"],
+            "q1",
+            "snapshot must carry the request body from its atomic projection"
         );
         assert_eq!(
             session.lifecycle,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -811,6 +811,7 @@ async fn handle(
         methods::HANGAR_ISSUE_LINKS => handle_issue_links(pool, req).await,
         methods::HANGAR_BOARD_CARD_SET_AUTO_RUN => handle_board_card_set_auto_run(pool, req).await,
         methods::HANGAR_REPO_LIST => handle_repo_list(req),
+        methods::FLEET_NEGOTIATE => handle_fleet_negotiate(req, health).await,
         methods::FLEET_SNAPSHOT => handle_fleet_snapshot(pool).await,
         // Receiver registration occurs in `serve_conn` before this snapshot is
         // read. The ack carries its exact head, then the forwarder drains rows
@@ -849,6 +850,34 @@ async fn handle_fleet_snapshot(pool: &SqlitePool) -> Result<serde_json::Value, R
     to_value(&snapshot)
 }
 
+/// Negotiate the exact Fleet protocol version and capability catalogue.
+async fn handle_fleet_negotiate(
+    req: &RpcRequest,
+    health: &DaemonHealth,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{
+        FLEET_PROTOCOL_CAPABILITY_IDS, FLEET_PROTOCOL_VERSION, FleetNegotiateParams,
+        FleetNegotiateResult,
+    };
+
+    let params: FleetNegotiateParams = parse_params(
+        req,
+        "{ client_name, client_version, read_versions: { min, max }, write_versions: { min, max } }",
+    )?;
+    if !params.read_versions.is_valid() || !params.write_versions.is_valid() {
+        return Err(invalid_params(
+            "protocol version ranges require 1 <= min <= max",
+        ));
+    }
+    to_value(&FleetNegotiateResult {
+        daemon_version: health.version.clone(),
+        protocol_version: FLEET_PROTOCOL_VERSION,
+        read_compatible: params.read_versions.contains(FLEET_PROTOCOL_VERSION),
+        write_compatible: params.write_versions.contains(FLEET_PROTOCOL_VERSION),
+        capability_ids: FLEET_PROTOCOL_CAPABILITY_IDS.iter().map(|id| (*id).to_string()).collect(),
+    })
+}
+
 /// Register a revision cursor and return the snapshot head paired with it.
 async fn handle_fleet_subscribe(
     pool: &SqlitePool,
@@ -859,10 +888,42 @@ async fn handle_fleet_subscribe(
     if params.after_revision < 0 {
         return Err(invalid_params("after_revision must be non-negative"));
     }
-    let snapshot = crate::fleet::snapshot_wire(pool).await.map_err(|error| store_err(&error))?;
+    let projection = crate::fleet::subscription_wire(pool, params.after_revision, REPLAY_BATCH + 1)
+        .await
+        .map_err(fleet_repo_err)?;
+    let snapshot = crate::fleet::subscription_snapshot_wire(&projection);
+    use ainb_hangar_proto::fleet::{FleetReplayResetReason, FleetReplayState};
+    let (replay, replay_state) = if params.after_revision == 0 {
+        (
+            Vec::new(),
+            FleetReplayState::SnapshotReset {
+                reason: FleetReplayResetReason::Bootstrap,
+            },
+        )
+    } else if params.after_revision > projection.head_revision {
+        (
+            Vec::new(),
+            FleetReplayState::SnapshotReset {
+                reason: FleetReplayResetReason::CursorAhead,
+            },
+        )
+    } else if projection.replay.len() > REPLAY_BATCH as usize {
+        (
+            Vec::new(),
+            FleetReplayState::SnapshotReset {
+                reason: FleetReplayResetReason::ReplayLimitExceeded,
+            },
+        )
+    } else {
+        (
+            projection.replay.iter().map(crate::fleet::event_wire).collect(),
+            FleetReplayState::Complete,
+        )
+    };
     to_value(&ainb_hangar_proto::fleet::FleetSubscribeResult {
         snapshot,
-        replay: Vec::new(),
+        replay,
+        replay_state,
     })
 }
 
@@ -7094,33 +7155,71 @@ async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(
 ) -> std::io::Result<Option<Vec<u8>>> {
     use tokio::io::AsyncBufReadExt;
     let mut content_length: Option<usize> = None;
+    let mut saw_header = false;
     loop {
         let mut line = String::new();
         let n = r.read_line(&mut line).await?;
         if n == 0 {
-            return Ok(None);
+            return if saw_header {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "truncated Content-Length frame header",
+                ))
+            } else {
+                Ok(None)
+            };
         }
+        saw_header = true;
         let trimmed = line.trim_end_matches("\r\n");
         if trimmed.is_empty() {
             let Some(len) = content_length else {
-                // Blank line with no Content-Length seen — skip (lenient).
-                continue;
-            };
-            if len > MAX_BODY_BYTES {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    format!("Content-Length {len} exceeds cap {MAX_BODY_BYTES}"),
+                    "missing Content-Length header",
                 ));
-            }
+            };
             let mut body = vec![0u8; len];
             r.read_exact(&mut body).await?;
             return Ok(Some(body));
         }
-        if let Some((name, value)) = trimmed.split_once(':') {
-            if name.trim().eq_ignore_ascii_case("Content-Length") {
-                content_length = value.trim().parse().ok();
-            }
+        let Some((name, value)) = trimmed.split_once(':') else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "malformed frame header",
+            ));
+        };
+        if !name.trim().eq_ignore_ascii_case("Content-Length") {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unsupported frame header: {}", name.trim()),
+            ));
         }
+        if content_length.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "duplicate Content-Length header",
+            ));
+        }
+        let value = value.trim();
+        if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Content-Length must be an unsigned decimal byte length",
+            ));
+        }
+        let len = value.parse::<usize>().map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Content-Length is out of range",
+            )
+        })?;
+        if len > MAX_BODY_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Content-Length {len} exceeds cap {MAX_BODY_BYTES}"),
+            ));
+        }
+        content_length = Some(len);
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
@@ -540,6 +540,135 @@ async fn subscribe_delivers_every_revision_after_snapshot_in_order() {
 }
 
 #[tokio::test]
+async fn authenticated_negotiate_reports_compatibility_and_rejects_invalid_ranges() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, _store, _sink) = start_server(dir.path()).await;
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+
+    let compatible = client
+        .call(
+            methods::FLEET_NEGOTIATE,
+            serde_json::json!({
+                "client_name": "rpc_fleet_test",
+                "client_version": "1",
+                "read_versions": {"min": 1, "max": 1},
+                "write_versions": {"min": 1, "max": 1}
+            }),
+        )
+        .await;
+    assert!(
+        compatible["error"].is_null(),
+        "negotiate must ack: {compatible}"
+    );
+    assert_eq!(compatible["result"]["read_compatible"], true);
+    assert_eq!(compatible["result"]["write_compatible"], true);
+    assert!(
+        compatible["result"]["capability_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|id| id == "fleet.protocol.negotiate")
+    );
+
+    let read_only = client
+        .call(
+            methods::FLEET_NEGOTIATE,
+            serde_json::json!({
+                "client_name": "rpc_fleet_test",
+                "client_version": "1",
+                "read_versions": {"min": 1, "max": 1},
+                "write_versions": {"min": 2, "max": 2}
+            }),
+        )
+        .await;
+    assert_eq!(read_only["result"]["read_compatible"], true);
+    assert_eq!(read_only["result"]["write_compatible"], false);
+
+    let invalid = client
+        .call(
+            methods::FLEET_NEGOTIATE,
+            serde_json::json!({
+                "client_name": "rpc_fleet_test",
+                "client_version": "1",
+                "read_versions": {"min": 0, "max": 1},
+                "write_versions": {"min": 1, "max": 1}
+            }),
+        )
+        .await;
+    assert_eq!(invalid["error"]["code"], -32602);
+}
+
+#[tokio::test]
+async fn subscribe_replays_nonzero_cursor_and_resets_ahead_or_over_limit_cursor() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    let payload = serde_json::json!({ "source": "hook" });
+    for index in 1..=2 {
+        apply_hook(
+            &store,
+            &sink,
+            &format!("replay-{index}"),
+            "claude",
+            "replay-session",
+            if index == 1 {
+                "SessionStart"
+            } else {
+                "UserPromptSubmit"
+            },
+            &payload,
+            400 + i64::from(index),
+        )
+        .await;
+    }
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let replay = client
+        .call(
+            methods::FLEET_SUBSCRIBE,
+            serde_json::json!({ "after_revision": 1 }),
+        )
+        .await;
+    assert_eq!(replay["result"]["replay_state"]["state"], "complete");
+    assert_eq!(replay["result"]["replay"].as_array().unwrap().len(), 1);
+    assert_eq!(replay["result"]["replay"][0]["revision"], 2);
+
+    let ahead = client
+        .call(
+            methods::FLEET_SUBSCRIBE,
+            serde_json::json!({ "after_revision": 3 }),
+        )
+        .await;
+    assert_eq!(ahead["result"]["replay"], serde_json::json!([]));
+    assert_eq!(ahead["result"]["replay_state"]["reason"], "cursor_ahead");
+
+    for index in 3..=1027 {
+        apply_hook(
+            &store,
+            &sink,
+            &format!("limit-{index}"),
+            "claude",
+            "replay-session",
+            "UserPromptSubmit",
+            &payload,
+            400 + i64::from(index),
+        )
+        .await;
+    }
+    let limit = client
+        .call(
+            methods::FLEET_SUBSCRIBE,
+            serde_json::json!({ "after_revision": 1 }),
+        )
+        .await;
+    assert_eq!(limit["result"]["replay"], serde_json::json!([]));
+    assert_eq!(
+        limit["result"]["replay_state"]["reason"],
+        "replay_limit_exceeded"
+    );
+}
+
+#[tokio::test]
 async fn broadcast_returns_ordered_receipt_for_every_target() {
     let dir = tempfile::tempdir().unwrap();
     let (socket, store, sink) = start_server(dir.path()).await;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_server.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_server.rs
@@ -270,6 +270,36 @@ async fn wrong_token_is_rejected_and_closed() {
     );
 }
 
+#[tokio::test]
+async fn invalid_frame_headers_close_authenticated_connection() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+    let cases = [
+        ("missing", b"\r\n".as_slice()),
+        (
+            "duplicate",
+            b"Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}".as_slice(),
+        ),
+        ("malformed", b"Content-Length 2\r\n\r\n".as_slice()),
+        (
+            "unsupported",
+            b"Content-Type: application/json\r\nContent-Length: 2\r\n\r\n{}".as_slice(),
+        ),
+        ("oversized", b"Content-Length: 16777217\r\n\r\n".as_slice()),
+    ];
+    for (name, frame) in cases {
+        let mut conn = connect(&socket_path).await;
+        auth_from_file(&mut conn, dir.path()).await;
+        conn.write_all(frame).await.unwrap();
+        conn.flush().await.unwrap();
+        let mut reader = BufReader::new(&mut conn);
+        assert!(
+            read_resp_opt(&mut reader).await.is_none(),
+            "daemon must close on {name} frame header"
+        );
+    }
+}
+
 /// Anchor (b) + (c): a same-uid client (any in-test connection IS same-uid)
 /// that reads the token file and authenticates gets full RPC access — the
 /// peer-cred gate passes it and the snapshot round-trips.

--- a/ainb-tui/crates/ainb-hangar-proto/examples/export_fleet_fixtures.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/examples/export_fleet_fixtures.rs
@@ -1,0 +1,264 @@
+//! Export deterministic Fleet protocol fixtures for cross-language decoders.
+
+use std::{env, fs, path::PathBuf};
+
+use ainb_hangar_proto::{RpcError, RpcId, RpcRequest, auth, fleet::*, jsonrpc_version, methods};
+use serde_json::{Value, json};
+
+const FIXTURE_DIRECTORY: &str = "../../fleet-parity/fixtures/v1";
+
+fn fixture_session() -> FleetSession {
+    FleetSession {
+        session_key: "fleet-session-001".to_string(),
+        provider: FleetProvider::Codex,
+        provider_session_id: Some("provider-session-001".to_string()),
+        tmux_target: Some("fleet:1.0".to_string()),
+        process_start_fingerprint: Some("proc-001".to_string()),
+        cwd: "/workspace/fleet-fixture".to_string(),
+        display_name: Some("Fixture Fleet".to_string()),
+        lifecycle: LifecycleState::Running,
+        attention: AttentionState::Ask,
+        current_request_fingerprint: Some("sha256:request-001".to_string()),
+        current_request: Some(json!({"kind": "question", "opaque": "fixture"})),
+        management: ManagementState::Managed,
+        transport_health: TransportHealth::Healthy,
+        capabilities: FleetCapabilities {
+            structured_answer: true,
+            approvals: true,
+            send_prompt: true,
+            continue_turn: true,
+            retry: true,
+            interrupt: true,
+            start: false,
+            stop: true,
+            restart: true,
+            kill: true,
+            archive: true,
+            tmux_attach: true,
+            tmux_text: true,
+            verified_picker: true,
+        },
+        provenance: FleetProvenance::Authoritative,
+        confidence: FleetConfidence::High,
+        discovered_at: 1_700_000_000_000,
+        last_observed_at: 1_700_000_000_100,
+        lifecycle_updated_at: 1_700_000_000_050,
+        attention_updated_at: 1_700_000_000_075,
+        version: 7,
+        updated_revision: 42,
+    }
+}
+
+fn fixture_snapshot() -> FleetSnapshot {
+    FleetSnapshot {
+        head_revision: 42,
+        sessions: vec![fixture_session()],
+    }
+}
+
+fn fixture_event() -> FleetEvent {
+    FleetEvent {
+        revision: 42,
+        event_id: "fleet-event-042".to_string(),
+        session_key: "fleet-session-001".to_string(),
+        observed_at: 1_700_000_000_100,
+        provenance: FleetProvenance::Authoritative,
+        event_type: "request_raised".to_string(),
+        payload: json!({"opaque": "fixture-event"}),
+        session_version: 7,
+        applied: true,
+    }
+}
+
+fn fixture_receipt() -> FleetActionReceipt {
+    FleetActionReceipt {
+        request_id: "action-request-001".to_string(),
+        session_key: "fleet-session-001".to_string(),
+        action_kind: "structured_answer".to_string(),
+        action_fingerprint: "sha256:action-001".to_string(),
+        expected_version: 7,
+        idempotency_key: Some("broadcast-001".to_string()),
+        status: ActionReceiptStatus::Delivered,
+        detail: Some("fixture delivery".to_string()),
+        session_version: Some(8),
+        created_at: 1_700_000_000_200,
+        updated_at: 1_700_000_000_300,
+    }
+}
+
+fn fixture_action() -> FleetActionParams {
+    FleetActionParams {
+        session_key: "fleet-session-001".to_string(),
+        expected_version: 7,
+        request_id: "action-request-001".to_string(),
+        action: ControlAction::StructuredAnswer {
+            request_fingerprint: "sha256:request-001".to_string(),
+            request_identity: Some(FleetRequestIdentity {
+                request_id: json!(73),
+                thread_id: "thread-001".to_string(),
+                turn_id: "turn-001".to_string(),
+                item_id: "item-001".to_string(),
+            }),
+            answers: vec![FleetQuestionAnswer {
+                question_id: "question-001".to_string(),
+                selected_options: vec!["option-a".to_string()],
+                text: Some("fixture answer".to_string()),
+            }],
+        },
+    }
+}
+
+/// Canonical, fixed-value Fleet fixtures in stable filename order.
+#[must_use]
+pub fn fixtures() -> Vec<(&'static str, Value)> {
+    let compatible = FleetNegotiateResult {
+        daemon_version: "fixture-daemon-1.0.0".to_string(),
+        protocol_version: FLEET_PROTOCOL_VERSION,
+        read_compatible: true,
+        write_compatible: true,
+        capability_ids: FLEET_PROTOCOL_CAPABILITY_IDS.iter().map(|id| (*id).to_string()).collect(),
+    };
+    let read_only = FleetNegotiateResult {
+        read_compatible: true,
+        write_compatible: false,
+        ..compatible.clone()
+    };
+    let snapshot = fixture_snapshot();
+    let event = fixture_event();
+    let receipt = fixture_receipt();
+    let broadcast = FleetBroadcastParams {
+        target_keys: vec![
+            "fleet-session-001".to_string(),
+            "fleet-session-002".to_string(),
+        ],
+        text: "fixture broadcast".to_string(),
+        idempotency_key: "broadcast-001".to_string(),
+    };
+
+    vec![
+        (
+            "action-receipt.json",
+            serde_json::to_value(receipt.clone()).expect("fixture serializes"),
+        ),
+        (
+            "action-request.json",
+            serde_json::to_value(fixture_action()).expect("fixture serializes"),
+        ),
+        (
+            "auth-hello-request.json",
+            serde_json::to_value(auth::hello_request(1, "mdt_fixture_token"))
+                .expect("fixture serializes"),
+        ),
+        (
+            "broadcast-request.json",
+            serde_json::to_value(broadcast).expect("fixture serializes"),
+        ),
+        (
+            "broadcast-result.json",
+            serde_json::to_value(FleetBroadcastResult {
+                receipts: vec![receipt],
+            })
+            .expect("fixture serializes"),
+        ),
+        (
+            "fleet-event.json",
+            serde_json::to_value(event.clone()).expect("fixture serializes"),
+        ),
+        (
+            "negotiate-request.json",
+            serde_json::to_value(RpcRequest {
+                jsonrpc: jsonrpc_version(),
+                id: RpcId::Number(2),
+                method: methods::FLEET_NEGOTIATE.to_string(),
+                params: serde_json::to_value(FleetNegotiateParams {
+                    client_name: "ainb-fleet-macos".to_string(),
+                    client_version: "0.1.0".to_string(),
+                    read_versions: FleetProtocolRange { min: 1, max: 1 },
+                    write_versions: FleetProtocolRange { min: 1, max: 1 },
+                })
+                .expect("fixture serializes"),
+            })
+            .expect("fixture serializes"),
+        ),
+        (
+            "negotiate-result-compatible.json",
+            serde_json::to_value(compatible).expect("fixture serializes"),
+        ),
+        (
+            "negotiate-result-read-only.json",
+            serde_json::to_value(read_only).expect("fixture serializes"),
+        ),
+        (
+            "rpc-error.json",
+            serde_json::to_value(RpcError {
+                code: -32602,
+                message: "invalid params".to_string(),
+                data: Some(json!({"field": "after_revision"})),
+            })
+            .expect("fixture serializes"),
+        ),
+        (
+            "snapshot.json",
+            serde_json::to_value(snapshot.clone()).expect("fixture serializes"),
+        ),
+        (
+            "subscribe-bootstrap.json",
+            serde_json::to_value(FleetSubscribeResult {
+                snapshot,
+                replay: Vec::new(),
+                replay_state: FleetReplayState::SnapshotReset {
+                    reason: FleetReplayResetReason::Bootstrap,
+                },
+            })
+            .expect("fixture serializes"),
+        ),
+        (
+            "subscribe-replay.json",
+            serde_json::to_value(FleetSubscribeResult {
+                snapshot: fixture_snapshot(),
+                replay: vec![event],
+                replay_state: FleetReplayState::Complete,
+            })
+            .expect("fixture serializes"),
+        ),
+    ]
+}
+
+/// Pretty JSON bytes for one canonical fixture value.
+#[must_use]
+pub fn fixture_bytes(value: &Value) -> Vec<u8> {
+    let mut bytes = serde_json::to_vec_pretty(value).expect("fixture serializes");
+    bytes.push(b'\n');
+    bytes
+}
+
+/// Repository fixture directory, independent of caller working directory.
+#[must_use]
+pub fn fixture_directory() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(FIXTURE_DIRECTORY)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let check = match env::args().nth(1).as_deref() {
+        None => false,
+        Some("--check") => true,
+        Some(argument) => return Err(format!("unknown argument: {argument}").into()),
+    };
+    let directory = fixture_directory();
+    if !check {
+        fs::create_dir_all(&directory)?;
+    }
+    for (filename, value) in fixtures() {
+        let path = directory.join(filename);
+        let expected = fixture_bytes(&value);
+        if check {
+            let actual = fs::read(&path)?;
+            if actual != expected {
+                return Err(format!("fixture drift: {}", path.display()).into());
+            }
+        } else {
+            fs::write(path, expected)?;
+        }
+    }
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -5,6 +5,71 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Current Fleet wire protocol version.
+pub const FLEET_PROTOCOL_VERSION: u32 = 1;
+
+/// Fleet capability identifiers advertised during protocol negotiation.
+pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
+    "fleet.action.execute",
+    "fleet.broadcast.execute",
+    "fleet.protocol.negotiate",
+    "fleet.snapshot.read",
+    "fleet.subscription.live",
+    "fleet.subscription.replay",
+    "fleet.subscription.resync",
+];
+
+/// Inclusive supported protocol version range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetProtocolRange {
+    /// Lowest supported version.
+    pub min: u32,
+    /// Highest supported version.
+    pub max: u32,
+}
+
+impl FleetProtocolRange {
+    /// Whether this is a non-empty protocol range.
+    #[must_use]
+    pub const fn is_valid(self) -> bool {
+        self.min > 0 && self.min <= self.max
+    }
+
+    /// Whether `version` is in this inclusive range.
+    #[must_use]
+    pub const fn contains(self, version: u32) -> bool {
+        self.min <= version && version <= self.max
+    }
+}
+
+/// Parameters for `fleet/negotiate`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetNegotiateParams {
+    /// Stable client implementation name.
+    pub client_name: String,
+    /// Client implementation version.
+    pub client_version: String,
+    /// Versions the client can safely read.
+    pub read_versions: FleetProtocolRange,
+    /// Versions the client can safely write.
+    pub write_versions: FleetProtocolRange,
+}
+
+/// Result from `fleet/negotiate`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetNegotiateResult {
+    /// Daemon build version.
+    pub daemon_version: String,
+    /// Exact daemon Fleet protocol version.
+    pub protocol_version: u32,
+    /// Whether the client can safely read this daemon.
+    pub read_compatible: bool,
+    /// Whether the client can safely write to this daemon.
+    pub write_compatible: bool,
+    /// Stable, ordered daemon capability catalogue.
+    pub capability_ids: Vec<String>,
+}
+
 /// Session provider.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -209,6 +274,63 @@ pub struct FleetSubscribeParams {
     pub after_revision: i64,
 }
 
+/// Why a subscription acknowledgement requires a fresh snapshot baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetReplayResetReason {
+    /// Initial subscribe has no prior cursor.
+    Bootstrap,
+    /// Caller cursor is newer than daemon durable head.
+    CursorAhead,
+    /// Missed durable interval exceeds the bounded replay response.
+    ReplayLimitExceeded,
+}
+
+/// Replay status for a subscription acknowledgement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum FleetReplayState {
+    /// Replay exactly covers the requested interval.
+    Complete,
+    /// Snapshot replaces the requested replay interval.
+    SnapshotReset {
+        /// Reason the daemon cannot provide a complete replay interval.
+        reason: FleetReplayResetReason,
+    },
+}
+
+impl<'de> Deserialize<'de> for FleetReplayState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let object = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("FleetReplayState must be an object"))?;
+        let state = object
+            .get("state")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| D::Error::custom("FleetReplayState requires string state"))?;
+        match state {
+            "complete" if object.len() == 1 => Ok(Self::Complete),
+            "snapshot_reset" if object.len() == 2 => {
+                let reason = object
+                    .get("reason")
+                    .cloned()
+                    .ok_or_else(|| D::Error::custom("snapshot_reset requires reason"))?;
+                let reason = serde_json::from_value(reason).map_err(D::Error::custom)?;
+                Ok(Self::SnapshotReset { reason })
+            }
+            "complete" => Err(D::Error::custom("complete carries unsupported fields")),
+            "snapshot_reset" => Err(D::Error::custom("snapshot_reset requires only reason")),
+            _ => Err(D::Error::custom("unknown FleetReplayState state")),
+        }
+    }
+}
+
 /// One durable change emitted after a subscription cursor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetEvent {
@@ -237,8 +359,10 @@ pub struct FleetEvent {
 pub struct FleetSubscribeResult {
     /// Consistent snapshot registered against live delivery.
     pub snapshot: FleetSnapshot,
-    /// Events committed after snapshot head and before live delivery.
+    /// Events in `(after_revision, snapshot.head_revision]` when replay is complete.
     pub replay: Vec<FleetEvent>,
+    /// Whether the response has complete replay coverage or resets the cursor.
+    pub replay_state: FleetReplayState,
 }
 
 /// One answer to one provider question.

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -266,12 +266,17 @@ pub const HANGAR_ISSUE_DELETE: &str = "hangar/issue_delete";
 pub const HANGAR_ISSUE_CANCEL_ACTIVE: &str = "hangar/issue_cancel_active";
 /// Fetch canonical Fleet snapshot and revision head.
 pub const FLEET_SNAPSHOT: &str = "fleet/snapshot";
+/// Negotiate Fleet protocol version and capability catalogue.
+pub const FLEET_NEGOTIATE: &str = "fleet/negotiate";
 /// Subscribe after a global Fleet revision.
 pub const FLEET_SUBSCRIBE: &str = "fleet/subscribe";
 /// Execute one versioned Fleet action.
 pub const FLEET_ACTION: &str = "fleet/action";
 /// Deliver text to explicit Fleet targets.
 pub const FLEET_BROADCAST: &str = "fleet/broadcast";
+
+/// Fleet notifications emitted by the daemon, never JSON-RPC request methods.
+pub const FLEET_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &["fleet/resync_required"];
 
 /// `hangar/issue_run` — enqueue a run of one issue WITHOUT a board (the Issues
 /// screen's create-wizard dispatch; plans/hangar-task-agent-model.md).
@@ -1233,6 +1238,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_SUBSCRIBE,
     FLEET_ACTION,
     FLEET_BROADCAST,
+    FLEET_NEGOTIATE,
 ];
 
 #[cfg(test)]
@@ -1455,6 +1461,7 @@ mod tests {
             FLEET_SUBSCRIBE,
             FLEET_ACTION,
             FLEET_BROADCAST,
+            FLEET_NEGOTIATE,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/tests/fleet_fixtures.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/fleet_fixtures.rs
@@ -1,0 +1,31 @@
+//! Deterministic cross-language Fleet fixture currentness gate.
+
+#[allow(dead_code)]
+#[path = "../examples/export_fleet_fixtures.rs"]
+mod exporter;
+
+use std::fs;
+
+#[test]
+fn fleet_fixtures_are_current() {
+    let expected = exporter::fixtures();
+    let directory = exporter::fixture_directory();
+    let expected_names: Vec<_> = expected.iter().map(|(name, _)| *name).collect();
+    let mut actual_names: Vec<_> = fs::read_dir(&directory)
+        .expect("fixture directory exists")
+        .map(|entry| entry.expect("fixture entry is readable"))
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| name.ends_with(".json"))
+        .collect();
+    actual_names.sort_unstable();
+    assert_eq!(actual_names, expected_names, "fixture file list drifted");
+
+    for (name, value) in expected {
+        let actual = fs::read(directory.join(name)).expect("fixture exists");
+        assert_eq!(
+            actual,
+            exporter::fixture_bytes(&value),
+            "fixture drifted: {name}"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-proto/tests/fleet_parity_manifest.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/fleet_parity_manifest.rs
@@ -1,0 +1,423 @@
+//! Fleet parity manifest schema and protocol catalogue gate.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use ainb_hangar_proto::{fleet::FLEET_PROTOCOL_CAPABILITY_IDS, methods};
+use serde::Deserialize;
+
+const MANIFEST_PATH: &str = "fleet-parity/manifest.json";
+const SURFACE_STATUSES: &[&str] = &[
+    "pass",
+    "known_gap",
+    "blocked_proof",
+    "not_applicable",
+    "deferred",
+];
+const RELEASE_CLASSIFICATIONS: &[&str] = &[
+    "pass",
+    "known_tui_gap",
+    "known_swift_gap",
+    "daemon_gap",
+    "blocked_proof",
+    "deferred_tui",
+];
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    schema_version: u32,
+    phase: String,
+    #[serde(default)]
+    tui_deferral: Option<TuiDeferral>,
+    capabilities: Vec<Capability>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TuiDeferral {
+    bead: String,
+    gaps: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Capability {
+    id: String,
+    tier: String,
+    daemon_request_method: String,
+    #[serde(default)]
+    daemon_notification_method: Option<String>,
+    expected_behavior: String,
+    daemon: Surface,
+    tui: Surface,
+    swift: Surface,
+    release_classification: String,
+    #[serde(default)]
+    gap_bead: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Surface {
+    status: String,
+    evidence_paths: Vec<String>,
+    #[serde(default)]
+    evidence_root: Option<String>,
+    #[serde(default)]
+    rationale: Option<String>,
+}
+
+fn ainb_tui_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("ainb-tui root exists")
+}
+
+fn workspace_root() -> PathBuf {
+    ainb_tui_root().parent().expect("workspace root exists").to_path_buf()
+}
+
+fn manifest() -> Manifest {
+    let bytes =
+        fs::read(ainb_tui_root().join("fleet-parity/manifest.json")).expect("manifest exists");
+    serde_json::from_slice(&bytes).expect("manifest decodes")
+}
+
+fn surface_statuses(capability: &Capability) -> [&str; 3] {
+    [
+        &capability.daemon.status,
+        &capability.tui.status,
+        &capability.swift.status,
+    ]
+}
+
+fn validate(manifest: &Manifest, root: &Path) -> Result<(), String> {
+    let workspace = workspace_root();
+    if manifest.schema_version != 1 {
+        return Err("schema_version must be 1".to_string());
+    }
+    if !matches!(manifest.phase.as_str(), "e01_in_progress" | "e01_exit") {
+        return Err("phase must be e01_in_progress or e01_exit".to_string());
+    }
+
+    let ids: Vec<_> =
+        manifest.capabilities.iter().map(|capability| capability.id.as_str()).collect();
+    let mut sorted_ids = ids.clone();
+    sorted_ids.sort_unstable();
+    sorted_ids.dedup();
+    if ids != sorted_ids {
+        return Err("capability ids must be unique and sorted".to_string());
+    }
+    if ids != FLEET_PROTOCOL_CAPABILITY_IDS {
+        return Err("manifest capability ids must equal negotiation catalogue".to_string());
+    }
+
+    let any_tui_deferred = manifest
+        .capabilities
+        .iter()
+        .any(|capability| capability.tui.status == "deferred");
+    if any_tui_deferred
+        && !manifest
+            .capabilities
+            .iter()
+            .all(|capability| capability.tui.status == "deferred")
+    {
+        return Err("TUI deferral must cover every TUI surface".to_string());
+    }
+    match (any_tui_deferred, manifest.tui_deferral.as_ref()) {
+        (true, Some(deferral))
+            if !deferral.bead.trim().is_empty()
+                && !deferral.gaps.is_empty()
+                && deferral.gaps.iter().all(|gap| !gap.trim().is_empty()) => {}
+        (true, _) => return Err("TUI deferral requires one bead and individual gaps".to_string()),
+        (false, Some(_)) => {
+            return Err("TUI deferral metadata requires deferred TUI surfaces".to_string());
+        }
+        (false, None) => {}
+    }
+
+    for capability in &manifest.capabilities {
+        if !matches!(capability.tier.as_str(), "foundation" | "v1" | "v2") {
+            return Err(format!("unknown tier for {}", capability.id));
+        }
+        if capability.expected_behavior.trim().is_empty() {
+            return Err(format!("expected behavior missing for {}", capability.id));
+        }
+        if !methods::ALL_METHODS.contains(&capability.daemon_request_method.as_str()) {
+            return Err(format!(
+                "unknown daemon request method for {}",
+                capability.id
+            ));
+        }
+        if let Some(notification) = capability.daemon_notification_method.as_deref() {
+            if !methods::FLEET_PROTOCOL_NOTIFICATION_METHODS.contains(&notification) {
+                return Err(format!(
+                    "unknown daemon notification method for {}",
+                    capability.id
+                ));
+            }
+            if methods::ALL_METHODS.contains(&notification) {
+                return Err(format!(
+                    "notification is also a request method for {}",
+                    capability.id
+                ));
+            }
+        }
+        if !RELEASE_CLASSIFICATIONS.contains(&capability.release_classification.as_str()) {
+            return Err(format!(
+                "unknown release classification for {}",
+                capability.id
+            ));
+        }
+
+        let statuses = surface_statuses(capability);
+        if statuses.iter().any(|status| !SURFACE_STATUSES.contains(status)) {
+            return Err(format!("unknown surface status for {}", capability.id));
+        }
+        if capability.daemon.status == "deferred" || capability.swift.status == "deferred" {
+            return Err(format!("only TUI may be deferred for {}", capability.id));
+        }
+        if statuses.iter().any(|status| *status == "known_gap")
+            && capability.gap_bead.as_deref().unwrap_or_default().is_empty()
+        {
+            return Err(format!(
+                "known gap requires separate-session bead for {}",
+                capability.id
+            ));
+        }
+        if matches!(
+            capability.release_classification.as_str(),
+            "known_tui_gap" | "known_swift_gap"
+        ) && capability.gap_bead.as_deref().unwrap_or_default().is_empty()
+        {
+            return Err(format!(
+                "release gap requires separate-session bead for {}",
+                capability.id
+            ));
+        }
+        for surface in [&capability.daemon, &capability.tui, &capability.swift] {
+            if surface.status == "not_applicable"
+                && surface.rationale.as_deref().unwrap_or_default().trim().is_empty()
+            {
+                return Err(format!(
+                    "not_applicable requires rationale for {}",
+                    capability.id
+                ));
+            }
+            if surface.status == "pass" {
+                if surface.evidence_paths.is_empty() {
+                    return Err(format!(
+                        "pass requires evidence paths for {}",
+                        capability.id
+                    ));
+                }
+                let evidence_root = match surface.evidence_root.as_deref().unwrap_or("ainb_tui") {
+                    "ainb_tui" => root,
+                    "workspace" => &workspace,
+                    _ => return Err(format!("unknown evidence root for {}", capability.id)),
+                };
+                for evidence_path in &surface.evidence_paths {
+                    let relative = Path::new(evidence_path);
+                    if relative.is_absolute()
+                        || relative.components().any(|part| part.as_os_str() == "..")
+                    {
+                        return Err(format!("invalid evidence path for {}", capability.id));
+                    }
+                    if !evidence_root.join(relative).exists() {
+                        return Err(format!("missing evidence path for {}", capability.id));
+                    }
+                }
+            }
+        }
+        if manifest.phase == "e01_exit"
+            && capability.tier == "foundation"
+            && (capability.daemon.status == "blocked_proof"
+                || capability.swift.status == "blocked_proof")
+        {
+            return Err(format!(
+                "Foundation daemon or Swift proof remains blocked at E01 exit for {}",
+                capability.id
+            ));
+        }
+        if manifest.phase == "e01_exit"
+            && capability.tier == "foundation"
+            && capability.tui.status == "blocked_proof"
+        {
+            return Err(format!(
+                "Foundation TUI proof must be explicitly deferred or classified at E01 exit for {}",
+                capability.id
+            ));
+        }
+        if manifest.phase == "e01_exit"
+            && capability.tier == "foundation"
+            && capability.release_classification == "blocked_proof"
+        {
+            return Err(format!(
+                "Foundation release classification remains blocked at E01 exit for {}",
+                capability.id
+            ));
+        }
+        if capability.release_classification == "deferred_tui"
+            && capability.tui.status != "deferred"
+        {
+            return Err(format!(
+                "deferred TUI release classification requires TUI deferral for {}",
+                capability.id
+            ));
+        }
+        if manifest.phase == "e01_exit"
+            && capability.tier == "foundation"
+            && ![&capability.daemon, &capability.tui, &capability.swift]
+                .into_iter()
+                .any(|surface| surface.status == "pass")
+        {
+            return Err(format!(
+                "Foundation proof is missing at E01 exit for {}",
+                capability.id
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn fleet_parity_manifest_is_valid() {
+    validate(&manifest(), &ainb_tui_root()).expect("manifest is valid");
+}
+
+#[test]
+fn manifest_capabilities_match_negotiation_catalogue() {
+    let ids: Vec<_> = manifest().capabilities.into_iter().map(|capability| capability.id).collect();
+    assert_eq!(ids, FLEET_PROTOCOL_CAPABILITY_IDS);
+}
+
+#[test]
+fn manifest_rejects_unknown_capability_id() {
+    let mut value = manifest();
+    value.capabilities[0].id = "fleet.unknown".to_string();
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+}
+
+#[test]
+fn manifest_rejects_unknown_notification_method() {
+    let mut value = manifest();
+    value.capabilities[0].daemon_notification_method = Some("fleet/not-real".to_string());
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+}
+
+#[test]
+fn manifest_rejects_notification_as_request_method() {
+    let mut value = manifest();
+    value.capabilities[0].daemon_request_method = "fleet/resync_required".to_string();
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+}
+
+#[test]
+fn known_gap_requires_separate_session_bead() {
+    let mut value = manifest();
+    value.capabilities[0].swift.status = "known_gap".to_string();
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+}
+
+#[test]
+fn e01_exit_rejects_foundation_blocked_release_classification() {
+    let mut value = foundation_exit_manifest();
+    value
+        .capabilities
+        .iter_mut()
+        .find(|capability| capability.tier == "foundation")
+        .expect("Foundation capability")
+        .release_classification = "blocked_proof".to_string();
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+}
+
+fn foundation_exit_manifest() -> Manifest {
+    let mut value = manifest();
+    value.phase = "e01_exit".to_string();
+    for capability in &mut value.capabilities {
+        if capability.tier == "foundation" {
+            capability.release_classification = "deferred_tui".to_string();
+            for surface in [&mut capability.daemon, &mut capability.swift] {
+                surface.status = "pass".to_string();
+                surface.evidence_paths = vec!["crates/ainb-hangar-proto/src/fleet.rs".to_string()];
+                surface.evidence_root = None;
+                surface.rationale = None;
+            }
+            capability.tui.status = "deferred".to_string();
+            capability.tui.evidence_paths.clear();
+            capability.tui.evidence_root = None;
+            capability.tui.rationale = Some("Deferred under the TUI parity bead.".to_string());
+        }
+    }
+    value
+}
+
+#[test]
+fn e01_exit_rejects_foundation_capability_without_any_surface_proof() {
+    let mut value = foundation_exit_manifest();
+    let capability = value
+        .capabilities
+        .iter_mut()
+        .find(|capability| capability.id == "fleet.protocol.negotiate")
+        .expect("negotiate capability");
+    for surface in [
+        &mut capability.daemon,
+        &mut capability.tui,
+        &mut capability.swift,
+    ] {
+        surface.status = "not_applicable".to_string();
+        surface.evidence_paths.clear();
+        surface.rationale = Some("No surface owns this capability.".to_string());
+    }
+
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+}
+
+#[test]
+fn e01_exit_allows_explicit_tui_deferral_when_daemon_and_swift_are_proven() {
+    validate(&foundation_exit_manifest(), &ainb_tui_root())
+        .expect("TUI deferral remains valid when daemon and Swift are proven");
+}
+
+#[test]
+fn deferred_tui_requires_one_bead_and_individual_gaps() {
+    let mut value = manifest();
+    value.tui_deferral = None;
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+
+    let mut value = manifest();
+    value.tui_deferral.as_mut().expect("TUI deferral").gaps.clear();
+    assert!(validate(&value, &ainb_tui_root()).is_err());
+}
+
+#[test]
+fn e01_exit_rejects_daemon_or_swift_blocked_proof() {
+    let mut daemon_blocked = foundation_exit_manifest();
+    daemon_blocked
+        .capabilities
+        .iter_mut()
+        .find(|capability| capability.id == "fleet.protocol.negotiate")
+        .expect("negotiate capability")
+        .daemon
+        .status = "blocked_proof".to_string();
+    assert!(validate(&daemon_blocked, &ainb_tui_root()).is_err());
+
+    let mut swift_blocked = foundation_exit_manifest();
+    swift_blocked
+        .capabilities
+        .iter_mut()
+        .find(|capability| capability.id == "fleet.protocol.negotiate")
+        .expect("negotiate capability")
+        .swift
+        .status = "blocked_proof".to_string();
+    assert!(validate(&swift_blocked, &ainb_tui_root()).is_err());
+}
+
+#[test]
+fn manifest_path_is_checked_in() {
+    assert!(ainb_tui_root().join(MANIFEST_PATH).exists());
+}

--- a/ainb-tui/crates/ainb-hangar-proto/tests/wire_types.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/wire_types.rs
@@ -3,6 +3,7 @@
 //! byte-identically in shape and that the error envelope matches the
 //! JSON-RPC 2.0 `{code, message, data?}` contract.
 
+use ainb_hangar_proto::fleet::{FleetProtocolRange, FleetReplayResetReason, FleetReplayState};
 use ainb_hangar_proto::{RpcError, RpcId, RpcRequest, RpcResponse};
 
 #[test]
@@ -92,4 +93,52 @@ fn error_envelope_carries_code_and_message() {
     let decoded: RpcError =
         serde_json::from_value(serde_json::to_value(&err2).expect("encode")).expect("decode");
     assert_eq!(decoded, err2);
+}
+
+#[test]
+fn fleet_protocol_range_rejects_invalid_bounds() {
+    assert!(!FleetProtocolRange { min: 0, max: 1 }.is_valid());
+    assert!(!FleetProtocolRange { min: 2, max: 1 }.is_valid());
+    assert!(FleetProtocolRange { min: 1, max: 1 }.is_valid());
+    assert!(FleetProtocolRange { min: 1, max: 2 }.contains(1));
+    assert!(!FleetProtocolRange { min: 1, max: 2 }.contains(3));
+}
+
+#[test]
+fn replay_state_round_trips_each_valid_tagged_variant() {
+    for value in [
+        FleetReplayState::Complete,
+        FleetReplayState::SnapshotReset {
+            reason: FleetReplayResetReason::Bootstrap,
+        },
+        FleetReplayState::SnapshotReset {
+            reason: FleetReplayResetReason::CursorAhead,
+        },
+        FleetReplayState::SnapshotReset {
+            reason: FleetReplayResetReason::ReplayLimitExceeded,
+        },
+    ] {
+        let decoded: FleetReplayState =
+            serde_json::from_value(serde_json::to_value(&value).unwrap()).unwrap();
+        assert_eq!(decoded, value);
+    }
+    assert!(
+        serde_json::from_value::<FleetReplayState>(serde_json::json!({"state":"unknown"})).is_err()
+    );
+    assert!(
+        serde_json::from_value::<FleetReplayState>(serde_json::json!({"state":"snapshot_reset"}))
+            .is_err()
+    );
+    assert!(
+        serde_json::from_value::<FleetReplayState>(
+            serde_json::json!({"state":"complete","reason":"bootstrap"})
+        )
+        .is_err()
+    );
+    assert!(
+        serde_json::from_value::<FleetReplayState>(
+            serde_json::json!({"state":"snapshot_reset","reason":"not_a_reason"})
+        )
+        .is_err()
+    );
 }

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0056_fleet_event_request_fingerprint.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0056_fleet_event_request_fingerprint.sql
@@ -1,0 +1,8 @@
+-- Persist exact request identity beside its durable event payload. A session's
+-- active request fingerprint can outlive unrelated later events, so projection
+-- must select the matching request body rather than the latest applied one.
+ALTER TABLE fleet_event ADD COLUMN request_fingerprint TEXT;
+
+CREATE INDEX idx_fleet_event_request_fingerprint
+    ON fleet_event(session_key, request_fingerprint, revision DESC)
+    WHERE applied = 1 AND request_fingerprint IS NOT NULL;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -217,6 +217,26 @@ pub struct FleetSnapshot {
     pub sessions: Vec<FleetSessionRow>,
 }
 
+/// One session row and its current request payload from one subscription read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetSessionProjectionRow {
+    /// Canonical session state.
+    pub session: FleetSessionRow,
+    /// Complete current structured request or approval, if one remains active.
+    pub current_request: Option<serde_json::Value>,
+}
+
+/// Atomic subscription baseline and bounded durable replay interval.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetSubscriptionProjection {
+    /// Highest durable revision included by this projection.
+    pub head_revision: i64,
+    /// Canonical sessions and current request payloads at `head_revision`.
+    pub sessions: Vec<FleetSessionProjectionRow>,
+    /// Durable rows after the requested cursor, capped by the caller limit.
+    pub replay: Vec<FleetEventRow>,
+}
+
 /// Action receipt insert or status update.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewActionReceipt {
@@ -349,8 +369,8 @@ impl FleetRepo {
         let revision = sqlx::query(
             "INSERT INTO fleet_event \
              (event_id, session_key, observed_at, authority, event_type, payload, \
-              session_version, applied) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+              request_fingerprint, session_version, applied) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&event.event_id)
         .bind(&event.session_key)
@@ -358,6 +378,7 @@ impl FleetRepo {
         .bind(event.authority.as_str())
         .bind(&event.event_type)
         .bind(&event.payload)
+        .bind(event.patch.current_request_fingerprint.as_ref().and_then(Clone::clone))
         .bind(session.version)
         .bind(i64::from(changed))
         .execute(&mut *tx)
@@ -504,6 +525,77 @@ impl FleetRepo {
         Ok(FleetSnapshot {
             head_revision,
             sessions,
+        })
+    }
+
+    /// Read one subscription projection in a single transaction.
+    ///
+    /// The durable head, session rows, active request bodies, and replay rows
+    /// all come from the same SQLite read transaction. Callers request one
+    /// extra replay row when they need to distinguish a full capped replay from
+    /// an over-limit cursor.
+    pub async fn subscription_projection(
+        pool: &SqlitePool,
+        after_revision: i64,
+        replay_limit: i64,
+    ) -> Result<FleetSubscriptionProjection, sqlx::Error> {
+        let mut tx = pool.begin().await?;
+        let head_revision: i64 =
+            sqlx::query_scalar("SELECT COALESCE(MAX(revision), 0) FROM fleet_event")
+                .fetch_one(&mut *tx)
+                .await?;
+        let rows = sqlx::query(SESSION_SELECT_ALL).fetch_all(&mut *tx).await?;
+        let mut sessions = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let session = session_from_row(row)?;
+            let current_request =
+                if let Some(request_fingerprint) = session.current_request_fingerprint.as_deref() {
+                    sqlx::query_scalar::<_, String>(
+                        "SELECT payload FROM fleet_event \
+                     WHERE session_key = ? AND event_type IN (\
+                        'AskUserQuestion', 'PermissionRequest', \
+                        'item/tool/requestUserInput', \
+                        'item/commandExecution/requestApproval', \
+                        'item/fileChange/requestApproval', \
+                        'item/permissions/requestApproval'\
+                     ) AND request_fingerprint = ? AND applied = 1 AND revision <= ? \
+                     ORDER BY revision DESC LIMIT 1",
+                    )
+                    .bind(&session.session_key)
+                    .bind(request_fingerprint)
+                    .bind(head_revision)
+                    .fetch_optional(&mut *tx)
+                    .await?
+                    .and_then(|payload| serde_json::from_str(&payload).ok())
+                } else {
+                    None
+                };
+            sessions.push(FleetSessionProjectionRow {
+                session,
+                current_request,
+            });
+        }
+        let replay = if after_revision > 0 && after_revision < head_revision {
+            let rows = sqlx::query(
+                "SELECT revision, event_id, session_key, observed_at, authority, event_type, \
+                        payload, session_version, applied \
+                 FROM fleet_event WHERE revision > ? AND revision <= ? \
+                 ORDER BY revision ASC LIMIT ?",
+            )
+            .bind(after_revision)
+            .bind(head_revision)
+            .bind(replay_limit.max(0))
+            .fetch_all(&mut *tx)
+            .await?;
+            rows.iter().map(event_from_row).collect::<Result<_, _>>()?
+        } else {
+            Vec::new()
+        };
+        tx.commit().await?;
+        Ok(FleetSubscriptionProjection {
+            head_revision,
+            sessions,
+            replay,
         })
     }
 
@@ -1237,5 +1329,52 @@ mod tests {
         .unwrap();
         assert_eq!(cleared.session.attention_state, "NONE");
         assert_eq!(cleared.session.current_request_fingerprint, None);
+    }
+
+    #[tokio::test]
+    async fn subscription_projection_selects_payload_matching_current_request_fingerprint() {
+        let (_dir, store) = store().await;
+        let mut current = event(
+            "e-current-request",
+            "claude:s-1",
+            200,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                attention_state: Some("ASK".to_string()),
+                current_request_fingerprint: Some(Some("fnv1a64:current".to_string())),
+                ..FleetSessionPatch::default()
+            },
+        );
+        current.event_type = "AskUserQuestion".to_string();
+        current.payload = serde_json::json!({ "request": "current" }).to_string();
+        FleetRepo::apply_event(store.pool(), &current).await.unwrap();
+
+        let mut stale = event(
+            "e-stale-request",
+            "claude:s-1",
+            100,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                attention_state: Some("ASK".to_string()),
+                current_request_fingerprint: Some(Some("fnv1a64:stale".to_string())),
+                transport_health: Some("HEALTHY".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        stale.event_type = "AskUserQuestion".to_string();
+        stale.payload = serde_json::json!({ "request": "stale" }).to_string();
+        let stale_result = FleetRepo::apply_event(store.pool(), &stale).await.unwrap();
+        assert!(stale_result.applied);
+        assert_eq!(
+            stale_result.session.current_request_fingerprint.as_deref(),
+            Some("fnv1a64:current")
+        );
+
+        let projection = FleetRepo::subscription_projection(store.pool(), 0, 100).await.unwrap();
+        assert_eq!(projection.sessions.len(), 1);
+        assert_eq!(
+            projection.sessions[0].current_request.as_ref().unwrap()["request"],
+            "current"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/jsonrpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/jsonrpc_over_socket.rs
@@ -133,8 +133,16 @@ impl FrameDecoder {
                 .split_once(':')
                 .ok_or_else(|| DecodeError::Header(format!("malformed header line: {line:?}")))?;
             if name.trim().eq_ignore_ascii_case("Content-Length") {
+                if content_length.is_some() {
+                    return Err(DecodeError::Header("duplicate Content-Length".to_string()));
+                }
+                let value = value.trim();
+                if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+                    return Err(DecodeError::Header(
+                        "Content-Length must be an unsigned decimal byte length".to_string(),
+                    ));
+                }
                 let len: usize = value
-                    .trim()
                     .parse()
                     .map_err(|_| DecodeError::Header(format!("bad Content-Length: {value:?}")))?;
                 content_length = Some(len);
@@ -254,6 +262,20 @@ mod tests {
         let bad = b"Content-Type: x\r\nContent-Length: 2\r\n\r\n{}".to_vec();
         let err = d.push(&bad).unwrap_err();
         assert!(matches!(err, DecodeError::Header(_)));
+    }
+
+    #[test]
+    fn decoder_rejects_missing_duplicate_malformed_and_oversized_length() {
+        let cases = [
+            b"\r\n".as_slice(),
+            b"Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}".as_slice(),
+            b"Content-Length: +2\r\n\r\n{}".as_slice(),
+            b"Content-Length: 16777217\r\n\r\n".as_slice(),
+        ];
+        for frame in cases {
+            let err = FrameDecoder::new().push_frames(frame).unwrap_err();
+            assert!(matches!(err, DecodeError::Header(_)));
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -7644,7 +7644,8 @@ mod tests {
                     "payload": {},
                     "session_version": 4,
                     "applied": false
-                }]
+                }],
+                "replay_state": {"state": "complete"}
             })),
             error: None,
         };
@@ -7660,6 +7661,30 @@ mod tests {
             .expect("complete questions");
         assert_eq!(questions[0]["options"].as_array().unwrap().len(), 2);
         assert_eq!(questions[0]["multiSelect"], true);
+    }
+
+    #[test]
+    fn fleet_subscribe_decoder_accepts_every_tagged_replay_state() {
+        let states = [
+            serde_json::json!({"state": "complete"}),
+            serde_json::json!({"state": "snapshot_reset", "reason": "bootstrap"}),
+            serde_json::json!({"state": "snapshot_reset", "reason": "cursor_ahead"}),
+            serde_json::json!({"state": "snapshot_reset", "reason": "replay_limit_exceeded"}),
+        ];
+        for replay_state in states {
+            let mut plugin = HangarPlugin::new();
+            plugin.on_daemon_response(&RpcResponse {
+                jsonrpc: "2.0".into(),
+                id: RpcId::Number(FLEET_SUBSCRIBE_REQ_ID),
+                result: Some(serde_json::json!({
+                    "snapshot": {"head_revision": 7, "sessions": []},
+                    "replay": [],
+                    "replay_state": replay_state,
+                })),
+                error: None,
+            });
+            assert_eq!(plugin.screens.fleet.head_revision(), 7);
+        }
     }
 
     #[test]

--- a/ainb-tui/fleet-parity/README.md
+++ b/ainb-tui/fleet-parity/README.md
@@ -1,0 +1,41 @@
+# Fleet parity catalogue
+
+`manifest.json` is versioned protocol inventory for the Hangar daemon, Fleet
+TUI, and native macOS app. It is not a second source of Fleet state.
+
+`fixtures/v1` contains deterministic, pretty JSON generated only by:
+
+```bash
+cd ainb-tui
+cargo run -p ainb-hangar-proto --example export_fleet_fixtures
+cargo run -p ainb-hangar-proto --example export_fleet_fixtures -- --check
+```
+
+Swift decodes these exact fixtures into named `Codable` types. It does not
+derive Fleet semantics from arbitrary JSON keys.
+
+The manifest validator enforces these rules:
+
+- Capability IDs are sorted and exactly match `FLEET_PROTOCOL_CAPABILITY_IDS`.
+- `daemon_request_method` belongs to `methods::ALL_METHODS`.
+- `daemon_notification_method`, when present, belongs only to
+  `methods::FLEET_PROTOCOL_NOTIFICATION_METHODS`.
+- Every `pass` status names existing evidence paths. `evidence_root` defaults
+  to `ainb_tui`; use `workspace` for evidence under `apps/`.
+- Every `known_gap` names its separate-session bead.
+- TUI-only deferral requires one `tui_deferral` bead and non-empty individual
+  `gaps`. All TUI surfaces must use `deferred`; daemon and Swift cannot.
+- `phase: e01_exit` rejects Foundation daemon or Swift `blocked_proof`, a TUI
+  `blocked_proof`, and a `blocked_proof` release classification. A deferred
+  TUI surface is valid only with its one bead and gap list.
+
+`e01_in_progress` permits `blocked_proof` while later E01 tasks add real
+evidence. TUI parity may be explicitly deferred under one separate-session
+bead without blocking Swift app delivery. Set `phase` to `e01_exit` only when
+every Foundation daemon and Swift proof is resolved. Do not change a status to
+`pass` from source inspection alone.
+
+`fleet.action.execute` and `fleet.broadcast.execute` remain in the negotiated
+catalogue but are V1 capabilities. AFM-E01 exposes no product write method, so
+its Swift surface is `not_applicable`; AFM-E03 owns their Swift action, receipt,
+and broadcast proof.

--- a/ainb-tui/fleet-parity/fixtures/v1/action-receipt.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/action-receipt.json
@@ -1,0 +1,13 @@
+{
+  "action_fingerprint": "sha256:action-001",
+  "action_kind": "structured_answer",
+  "created_at": 1700000000200,
+  "detail": "fixture delivery",
+  "expected_version": 7,
+  "idempotency_key": "broadcast-001",
+  "request_id": "action-request-001",
+  "session_key": "fleet-session-001",
+  "session_version": 8,
+  "status": "DELIVERED",
+  "updated_at": 1700000000300
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/action-request.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/action-request.json
@@ -1,0 +1,24 @@
+{
+  "action": {
+    "action": "structured_answer",
+    "answers": [
+      {
+        "question_id": "question-001",
+        "selected_options": [
+          "option-a"
+        ],
+        "text": "fixture answer"
+      }
+    ],
+    "request_fingerprint": "sha256:request-001",
+    "request_identity": {
+      "item_id": "item-001",
+      "request_id": 73,
+      "thread_id": "thread-001",
+      "turn_id": "turn-001"
+    }
+  },
+  "expected_version": 7,
+  "request_id": "action-request-001",
+  "session_key": "fleet-session-001"
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/auth-hello-request.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/auth-hello-request.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "auth/hello",
+  "params": {
+    "token": "mdt_fixture_token"
+  }
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/broadcast-request.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/broadcast-request.json
@@ -1,0 +1,8 @@
+{
+  "idempotency_key": "broadcast-001",
+  "target_keys": [
+    "fleet-session-001",
+    "fleet-session-002"
+  ],
+  "text": "fixture broadcast"
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/broadcast-result.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/broadcast-result.json
@@ -1,0 +1,17 @@
+{
+  "receipts": [
+    {
+      "action_fingerprint": "sha256:action-001",
+      "action_kind": "structured_answer",
+      "created_at": 1700000000200,
+      "detail": "fixture delivery",
+      "expected_version": 7,
+      "idempotency_key": "broadcast-001",
+      "request_id": "action-request-001",
+      "session_key": "fleet-session-001",
+      "session_version": 8,
+      "status": "DELIVERED",
+      "updated_at": 1700000000300
+    }
+  ]
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/fleet-event.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/fleet-event.json
@@ -1,0 +1,13 @@
+{
+  "applied": true,
+  "event_id": "fleet-event-042",
+  "event_type": "request_raised",
+  "observed_at": 1700000000100,
+  "payload": {
+    "opaque": "fixture-event"
+  },
+  "provenance": "authoritative",
+  "revision": 42,
+  "session_key": "fleet-session-001",
+  "session_version": 7
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/negotiate-request.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/negotiate-request.json
@@ -1,0 +1,17 @@
+{
+  "id": 2,
+  "jsonrpc": "2.0",
+  "method": "fleet/negotiate",
+  "params": {
+    "client_name": "ainb-fleet-macos",
+    "client_version": "0.1.0",
+    "read_versions": {
+      "max": 1,
+      "min": 1
+    },
+    "write_versions": {
+      "max": 1,
+      "min": 1
+    }
+  }
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-compatible.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-compatible.json
@@ -1,0 +1,15 @@
+{
+  "capability_ids": [
+    "fleet.action.execute",
+    "fleet.broadcast.execute",
+    "fleet.protocol.negotiate",
+    "fleet.snapshot.read",
+    "fleet.subscription.live",
+    "fleet.subscription.replay",
+    "fleet.subscription.resync"
+  ],
+  "daemon_version": "fixture-daemon-1.0.0",
+  "protocol_version": 1,
+  "read_compatible": true,
+  "write_compatible": true
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-read-only.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-read-only.json
@@ -1,0 +1,15 @@
+{
+  "capability_ids": [
+    "fleet.action.execute",
+    "fleet.broadcast.execute",
+    "fleet.protocol.negotiate",
+    "fleet.snapshot.read",
+    "fleet.subscription.live",
+    "fleet.subscription.replay",
+    "fleet.subscription.resync"
+  ],
+  "daemon_version": "fixture-daemon-1.0.0",
+  "protocol_version": 1,
+  "read_compatible": true,
+  "write_compatible": false
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/rpc-error.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/rpc-error.json
@@ -1,0 +1,7 @@
+{
+  "code": -32602,
+  "data": {
+    "field": "after_revision"
+  },
+  "message": "invalid params"
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/snapshot.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/snapshot.json
@@ -1,0 +1,47 @@
+{
+  "head_revision": 42,
+  "sessions": [
+    {
+      "attention": "ASK",
+      "attention_updated_at": 1700000000075,
+      "capabilities": {
+        "approvals": true,
+        "archive": true,
+        "continue_turn": true,
+        "interrupt": true,
+        "kill": true,
+        "restart": true,
+        "retry": true,
+        "send_prompt": true,
+        "start": false,
+        "stop": true,
+        "structured_answer": true,
+        "tmux_attach": true,
+        "tmux_text": true,
+        "verified_picker": true
+      },
+      "confidence": "HIGH",
+      "current_request": {
+        "kind": "question",
+        "opaque": "fixture"
+      },
+      "current_request_fingerprint": "sha256:request-001",
+      "cwd": "/workspace/fleet-fixture",
+      "discovered_at": 1700000000000,
+      "display_name": "Fixture Fleet",
+      "last_observed_at": 1700000000100,
+      "lifecycle": "RUNNING",
+      "lifecycle_updated_at": 1700000000050,
+      "management": "MANAGED",
+      "process_start_fingerprint": "proc-001",
+      "provenance": "authoritative",
+      "provider": "codex",
+      "provider_session_id": "provider-session-001",
+      "session_key": "fleet-session-001",
+      "tmux_target": "fleet:1.0",
+      "transport_health": "HEALTHY",
+      "updated_revision": 42,
+      "version": 7
+    }
+  ]
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/subscribe-bootstrap.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/subscribe-bootstrap.json
@@ -1,0 +1,54 @@
+{
+  "replay": [],
+  "replay_state": {
+    "reason": "bootstrap",
+    "state": "snapshot_reset"
+  },
+  "snapshot": {
+    "head_revision": 42,
+    "sessions": [
+      {
+        "attention": "ASK",
+        "attention_updated_at": 1700000000075,
+        "capabilities": {
+          "approvals": true,
+          "archive": true,
+          "continue_turn": true,
+          "interrupt": true,
+          "kill": true,
+          "restart": true,
+          "retry": true,
+          "send_prompt": true,
+          "start": false,
+          "stop": true,
+          "structured_answer": true,
+          "tmux_attach": true,
+          "tmux_text": true,
+          "verified_picker": true
+        },
+        "confidence": "HIGH",
+        "current_request": {
+          "kind": "question",
+          "opaque": "fixture"
+        },
+        "current_request_fingerprint": "sha256:request-001",
+        "cwd": "/workspace/fleet-fixture",
+        "discovered_at": 1700000000000,
+        "display_name": "Fixture Fleet",
+        "last_observed_at": 1700000000100,
+        "lifecycle": "RUNNING",
+        "lifecycle_updated_at": 1700000000050,
+        "management": "MANAGED",
+        "process_start_fingerprint": "proc-001",
+        "provenance": "authoritative",
+        "provider": "codex",
+        "provider_session_id": "provider-session-001",
+        "session_key": "fleet-session-001",
+        "tmux_target": "fleet:1.0",
+        "transport_health": "HEALTHY",
+        "updated_revision": 42,
+        "version": 7
+      }
+    ]
+  }
+}

--- a/ainb-tui/fleet-parity/fixtures/v1/subscribe-replay.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/subscribe-replay.json
@@ -1,0 +1,67 @@
+{
+  "replay": [
+    {
+      "applied": true,
+      "event_id": "fleet-event-042",
+      "event_type": "request_raised",
+      "observed_at": 1700000000100,
+      "payload": {
+        "opaque": "fixture-event"
+      },
+      "provenance": "authoritative",
+      "revision": 42,
+      "session_key": "fleet-session-001",
+      "session_version": 7
+    }
+  ],
+  "replay_state": {
+    "state": "complete"
+  },
+  "snapshot": {
+    "head_revision": 42,
+    "sessions": [
+      {
+        "attention": "ASK",
+        "attention_updated_at": 1700000000075,
+        "capabilities": {
+          "approvals": true,
+          "archive": true,
+          "continue_turn": true,
+          "interrupt": true,
+          "kill": true,
+          "restart": true,
+          "retry": true,
+          "send_prompt": true,
+          "start": false,
+          "stop": true,
+          "structured_answer": true,
+          "tmux_attach": true,
+          "tmux_text": true,
+          "verified_picker": true
+        },
+        "confidence": "HIGH",
+        "current_request": {
+          "kind": "question",
+          "opaque": "fixture"
+        },
+        "current_request_fingerprint": "sha256:request-001",
+        "cwd": "/workspace/fleet-fixture",
+        "discovered_at": 1700000000000,
+        "display_name": "Fixture Fleet",
+        "last_observed_at": 1700000000100,
+        "lifecycle": "RUNNING",
+        "lifecycle_updated_at": 1700000000050,
+        "management": "MANAGED",
+        "process_start_fingerprint": "proc-001",
+        "provenance": "authoritative",
+        "provider": "codex",
+        "provider_session_id": "provider-session-001",
+        "session_key": "fleet-session-001",
+        "tmux_target": "fleet:1.0",
+        "transport_health": "HEALTHY",
+        "updated_revision": 42,
+        "version": 7
+      }
+    ]
+  }
+}

--- a/ainb-tui/fleet-parity/manifest.json
+++ b/ainb-tui/fleet-parity/manifest.json
@@ -1,0 +1,195 @@
+{
+  "schema_version": 1,
+  "phase": "e01_exit",
+  "tui_deferral": {
+    "bead": "agents-in-a-box-afm-e01.1",
+    "gaps": [
+      "No existing tripwire drives one real TUI plugin through bootstrap, retained-cursor replay, live revision, and resync.",
+      "Current proof script needs exact tmux pane targeting because reattach-to-user-namespace creates shell window index 1.",
+      "TUI has no automatic reconnect: retained-cursor redial requires offline [s] path.",
+      "fleet/resync_required has no TUI-visible marker; runtime resync proof needs a trustworthy observable artifact.",
+      "Three isolated tmux captures do not yet exist."
+    ]
+  },
+  "capabilities": [
+    {
+      "id": "fleet.action.execute",
+      "tier": "v1",
+      "daemon_request_method": "fleet/action",
+      "expected_behavior": "Daemon accepts one versioned Fleet action and returns its durable receipt.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "not_applicable",
+        "evidence_paths": [],
+        "rationale": "AFM-E01 exposes no product writes. AFM-E03 owns the Swift action and receipt proof."
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.broadcast.execute",
+      "tier": "v1",
+      "daemon_request_method": "fleet/broadcast",
+      "expected_behavior": "Daemon sends a text broadcast to explicit Fleet session keys.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "not_applicable",
+        "evidence_paths": [],
+        "rationale": "AFM-E01 exposes no product writes. AFM-E03 owns the Swift broadcast and receipt proof."
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.protocol.negotiate",
+      "tier": "foundation",
+      "daemon_request_method": "fleet/negotiate",
+      "expected_behavior": "Daemon reports exact protocol compatibility and stable capability IDs.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "pass",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift"
+        ]
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.snapshot.read",
+      "tier": "foundation",
+      "daemon_request_method": "fleet/snapshot",
+      "expected_behavior": "Daemon returns one canonical Fleet snapshot at its durable revision head.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/fleet.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "pass",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift"
+        ]
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.subscription.live",
+      "tier": "foundation",
+      "daemon_request_method": "fleet/subscribe",
+      "expected_behavior": "Daemon streams live Fleet revisions after a subscription acknowledgement.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "pass",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift"
+        ]
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.subscription.replay",
+      "tier": "foundation",
+      "daemon_request_method": "fleet/subscribe",
+      "expected_behavior": "Daemon either replays every missed revision or returns an explicit snapshot reset.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "pass",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift"
+        ]
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.subscription.resync",
+      "tier": "foundation",
+      "daemon_request_method": "fleet/subscribe",
+      "daemon_notification_method": "fleet/resync_required",
+      "expected_behavior": "Daemon tells subscribers to resync when live delivery loses continuity.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "pass",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetProjectionReducer.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetProjectionReducerTests.swift"
+        ]
+      },
+      "release_classification": "deferred_tui"
+    }
+  ]
+}

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -1,0 +1,372 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000000000000000000011 /* AINBFleetApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000021 /* AINBFleetApp.swift */; };
+		A10000000000000000000012 /* BuildConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000022 /* BuildConfigurationTests.swift */; };
+		A10000000000000000000013 /* ContentLengthCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000024 /* ContentLengthCodec.swift */; };
+		A10000000000000000000014 /* FleetWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000025 /* FleetWire.swift */; };
+		A10000000000000000000015 /* FleetProjectionReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000026 /* FleetProjectionReducer.swift */; };
+		A10000000000000000000016 /* ContentLengthCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000027 /* ContentLengthCodecTests.swift */; };
+		A10000000000000000000017 /* CanonicalFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000028 /* CanonicalFixtureTests.swift */; };
+		A10000000000000000000018 /* FleetProjectionReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000029 /* FleetProjectionReducerTests.swift */; };
+		A10000000000000000000019 /* FleetSemanticBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002A /* FleetSemanticBoundaryTests.swift */; };
+		A1000000000000000000001A /* HangarLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002B /* HangarLocation.swift */; };
+		A1000000000000000000001B /* FleetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002C /* FleetConnection.swift */; };
+		A1000000000000000000001C /* FleetConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002D /* FleetConnectionTests.swift */; };
+		A1000000000000000000001D /* FleetDaemonContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002E /* FleetDaemonContractTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A10000000000000000000091 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A10000000000000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000001;
+			remoteInfo = AINBFleet;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A10000000000000000000021 /* AINBFleetApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AINBFleetApp.swift; sourceTree = "<group>"; };
+		A10000000000000000000022 /* BuildConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfigurationTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000023 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A10000000000000000000024 /* ContentLengthCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLengthCodec.swift; sourceTree = "<group>"; };
+		A10000000000000000000025 /* FleetWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetWire.swift; sourceTree = "<group>"; };
+		A10000000000000000000026 /* FleetProjectionReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetProjectionReducer.swift; sourceTree = "<group>"; };
+		A10000000000000000000027 /* ContentLengthCodecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLengthCodecTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000028 /* CanonicalFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanonicalFixtureTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000029 /* FleetProjectionReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetProjectionReducerTests.swift; sourceTree = "<group>"; };
+		A1000000000000000000002A /* FleetSemanticBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetSemanticBoundaryTests.swift; sourceTree = "<group>"; };
+		A1000000000000000000002B /* HangarLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangarLocation.swift; sourceTree = "<group>"; };
+		A1000000000000000000002C /* FleetConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConnection.swift; sourceTree = "<group>"; };
+		A1000000000000000000002D /* FleetConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConnectionTests.swift; sourceTree = "<group>"; };
+		A1000000000000000000002E /* FleetDaemonContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDaemonContractTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000031 /* AINBFleet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AINBFleet.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000032 /* FleetRPCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A10000000000000000000041 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000042 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A10000000000000000000051 = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000052 /* App */,
+				A10000000000000000000056 /* FleetRPC */,
+				A10000000000000000000053 /* Resources */,
+				A10000000000000000000054 /* FleetRPCTests */,
+				A10000000000000000000055 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A10000000000000000000052 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000021 /* AINBFleetApp.swift */,
+			);
+			path = Sources/App;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000053 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000023 /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000056 /* FleetRPC */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000024 /* ContentLengthCodec.swift */,
+				A10000000000000000000025 /* FleetWire.swift */,
+				A10000000000000000000026 /* FleetProjectionReducer.swift */,
+				A1000000000000000000002B /* HangarLocation.swift */,
+				A1000000000000000000002C /* FleetConnection.swift */,
+			);
+			path = Sources/FleetRPC;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000054 /* FleetRPCTests */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000022 /* BuildConfigurationTests.swift */,
+				A10000000000000000000027 /* ContentLengthCodecTests.swift */,
+				A10000000000000000000028 /* CanonicalFixtureTests.swift */,
+				A10000000000000000000029 /* FleetProjectionReducerTests.swift */,
+				A1000000000000000000002A /* FleetSemanticBoundaryTests.swift */,
+				A1000000000000000000002D /* FleetConnectionTests.swift */,
+				A1000000000000000000002E /* FleetDaemonContractTests.swift */,
+			);
+			path = Tests/FleetRPCTests;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000055 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000031 /* AINBFleet.app */,
+				A10000000000000000000032 /* FleetRPCTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A10000000000000000000001 /* AINBFleet */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000061 /* Build configuration list for PBXNativeTarget "AINBFleet" */;
+			buildPhases = (
+				A10000000000000000000041 /* Frameworks */,
+				A10000000000000000000071 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AINBFleet;
+			productName = AINBFleet;
+			productReference = A10000000000000000000031 /* AINBFleet.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A10000000000000000000002 /* FleetRPCTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000062 /* Build configuration list for PBXNativeTarget "FleetRPCTests" */;
+			buildPhases = (
+				A10000000000000000000042 /* Frameworks */,
+				A10000000000000000000072 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A10000000000000000000092 /* PBXTargetDependency */,
+			);
+			name = FleetRPCTests;
+			productName = FleetRPCTests;
+			productReference = A10000000000000000000032 /* FleetRPCTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A10000000000000000000000 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2640;
+				LastUpgradeCheck = 2640;
+				TargetAttributes = {
+					A10000000000000000000001 = {
+						CreatedOnToolsVersion = 26.4.1;
+					};
+					A10000000000000000000002 = {
+						CreatedOnToolsVersion = 26.4.1;
+						TestTargetID = A10000000000000000000001;
+					};
+				};
+			};
+			buildConfigurationList = A10000000000000000000060 /* Build configuration list for PBXProject "AINBFleet" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A10000000000000000000051;
+			productRefGroup = A10000000000000000000055 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A10000000000000000000001 /* AINBFleet */,
+				A10000000000000000000002 /* FleetRPCTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXTargetDependency section */
+		A10000000000000000000092 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = A10000000000000000000091 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A10000000000000000000071 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000011 /* AINBFleetApp.swift in Sources */,
+				A10000000000000000000013 /* ContentLengthCodec.swift in Sources */,
+				A10000000000000000000014 /* FleetWire.swift in Sources */,
+				A10000000000000000000015 /* FleetProjectionReducer.swift in Sources */,
+				A1000000000000000000001A /* HangarLocation.swift in Sources */,
+				A1000000000000000000001B /* FleetConnection.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000072 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000012 /* BuildConfigurationTests.swift in Sources */,
+				A10000000000000000000016 /* ContentLengthCodecTests.swift in Sources */,
+				A10000000000000000000017 /* CanonicalFixtureTests.swift in Sources */,
+				A10000000000000000000018 /* FleetProjectionReducerTests.swift in Sources */,
+				A10000000000000000000019 /* FleetSemanticBoundaryTests.swift in Sources */,
+				A1000000000000000000001C /* FleetConnectionTests.swift in Sources */,
+				A1000000000000000000001D /* FleetDaemonContractTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A10000000000000000000081 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		A10000000000000000000082 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		A10000000000000000000083 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_TESTABILITY = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Resources/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ainb.fleet;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		A10000000000000000000084 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = NO;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Resources/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ainb.fleet;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		A10000000000000000000085 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ainb.fleet.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AINBFleet.app/Contents/MacOS/AINBFleet";
+				TEST_TARGET_NAME = AINBFleet;
+			};
+			name = Debug;
+		};
+		A10000000000000000000086 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ainb.fleet.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AINBFleet.app/Contents/MacOS/AINBFleet";
+				TEST_TARGET_NAME = AINBFleet;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A10000000000000000000060 /* Build configuration list for PBXProject "AINBFleet" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000081 /* Debug */,
+				A10000000000000000000082 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000061 /* Build configuration list for PBXNativeTarget "AINBFleet" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000083 /* Debug */,
+				A10000000000000000000084 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000062 /* Build configuration list for PBXNativeTarget "FleetRPCTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000085 /* Debug */,
+				A10000000000000000000086 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A10000000000000000000000 /* Project object */;
+}

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000001"
+               BuildableName = "AINBFleet.app"
+               BlueprintName = "AINBFleet"
+               ReferencedContainer = "container:AINBFleet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000002"
+               BuildableName = "FleetRPCTests.xctest"
+               BlueprintName = "FleetRPCTests"
+               ReferencedContainer = "container:AINBFleet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A10000000000000000000001"
+            BuildableName = "AINBFleet.app"
+            BlueprintName = "AINBFleet"
+            ReferencedContainer = "container:AINBFleet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A10000000000000000000001"
+            BuildableName = "AINBFleet.app"
+            BlueprintName = "AINBFleet"
+            ReferencedContainer = "container:AINBFleet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/ainb-fleet-macos/Resources/Info.plist
+++ b/apps/ainb-fleet-macos/Resources/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AINBFleetApp: App {
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/ContentLengthCodec.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/ContentLengthCodec.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+enum ContentLengthCodecError: Error, Equatable {
+    case missingContentLength
+    case duplicateContentLength
+    case unsupportedHeader(String)
+    case malformedContentLength
+    case oversizedBody
+}
+
+enum ContentLengthEncoder {
+    static let maximumBodyBytes = 16 * 1024 * 1024
+
+    static func encode(_ body: Data) throws -> Data {
+        guard body.count <= maximumBodyBytes else {
+            throw ContentLengthCodecError.oversizedBody
+        }
+        var frame = Data("Content-Length: \(body.count)\r\n\r\n".utf8)
+        frame.append(body)
+        return frame
+    }
+}
+
+struct ContentLengthDecoder {
+    private var buffer = Data()
+
+    mutating func append(_ chunk: Data) throws -> [Data] {
+        buffer.append(chunk)
+        var frames: [Data] = []
+
+        while let headerRange = buffer.range(of: Data("\r\n\r\n".utf8)) {
+            let header = buffer[..<headerRange.lowerBound]
+            let bodyLength = try parseHeader(header)
+            let bodyStart = headerRange.upperBound
+            let frameLength = bodyStart + bodyLength
+            guard buffer.count >= frameLength else {
+                return frames
+            }
+            frames.append(buffer.subdata(in: bodyStart..<frameLength))
+            buffer.removeSubrange(..<frameLength)
+        }
+        return frames
+    }
+
+    mutating func reset() {
+        buffer.removeAll(keepingCapacity: false)
+    }
+
+    private func parseHeader(_ header: Data.SubSequence) throws -> Int {
+        guard let text = String(data: header, encoding: .ascii), !text.isEmpty else {
+            throw ContentLengthCodecError.missingContentLength
+        }
+
+        var length: Int?
+        for line in text.components(separatedBy: "\r\n") {
+            let pieces = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard pieces.count == 2 else {
+                throw ContentLengthCodecError.unsupportedHeader(line)
+            }
+            let name = pieces[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = pieces[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard name.caseInsensitiveCompare("Content-Length") == .orderedSame else {
+                throw ContentLengthCodecError.unsupportedHeader(name)
+            }
+            guard length == nil else {
+                throw ContentLengthCodecError.duplicateContentLength
+            }
+            guard !value.isEmpty, value.allSatisfy(\.isNumber), let parsed = Int(value) else {
+                throw ContentLengthCodecError.malformedContentLength
+            }
+            guard parsed <= ContentLengthEncoder.maximumBodyBytes else {
+                throw ContentLengthCodecError.oversizedBody
+            }
+            length = parsed
+        }
+        guard let length else {
+            throw ContentLengthCodecError.missingContentLength
+        }
+        return length
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -1,0 +1,403 @@
+import Darwin
+import Foundation
+
+enum FleetConnectionError: Error, Equatable {
+    case alreadyConnected
+    case notConnected
+    case notAuthenticated
+    case protocolReadIncompatible
+    case protocolWriteIncompatible
+    case emptyToken
+    case closed
+    case disconnected
+    case malformedEnvelope
+    case unknownResponseID
+    case rpc(RPCError)
+    case socket(Int32)
+}
+
+struct FleetResyncRequired: Decodable, Equatable, Sendable {
+    let afterRevision: Int64
+    let missed: Int64
+
+    private enum CodingKeys: String, CodingKey {
+        case afterRevision = "after_revision"
+        case missed
+    }
+}
+
+enum FleetIncoming: Equatable, Sendable {
+    case event(FleetEvent)
+    case resyncRequired(FleetResyncRequired)
+    case unknownNotification(String)
+}
+
+actor FleetConnection {
+    private let location: HangarLocation
+    private var injectedDescriptor: Int32?
+    private var descriptor: Int32?
+    private var readerTask: Task<Void, Never>?
+    private var pending: [RPCID: CheckedContinuation<Data, Error>] = [:]
+    private var notificationStreams: [UUID: AsyncStream<FleetIncoming>.Continuation] = [:]
+    private var nextRequestID: Int64 = 1
+    private var authenticated = false
+    private var negotiation: FleetNegotiateResult?
+
+    init(location: HangarLocation = HangarLocation(), injectedDescriptor: Int32? = nil) {
+        self.location = location
+        self.injectedDescriptor = injectedDescriptor
+    }
+
+    deinit {
+        if let descriptor {
+            Darwin.close(descriptor)
+        }
+        readerTask?.cancel()
+    }
+
+    func connect() throws {
+        guard descriptor == nil else {
+            throw FleetConnectionError.alreadyConnected
+        }
+
+        let connectedDescriptor: Int32
+        if let injectedDescriptor {
+            self.injectedDescriptor = nil
+            connectedDescriptor = injectedDescriptor
+        } else {
+            connectedDescriptor = try Self.connectUnixSocket(at: location.socketURL)
+        }
+        descriptor = connectedDescriptor
+        readerTask = Task.detached { [weak self] in
+            guard let connection = self else { return }
+            let error = await Self.readFrames(from: connectedDescriptor) { frame in
+                await connection.receive(frame)
+            }
+            guard !Task.isCancelled else { return }
+            await connection.disconnect(error, descriptor: connectedDescriptor)
+        }
+    }
+
+    func authenticate(token: String) async throws {
+        guard descriptor != nil else {
+            throw FleetConnectionError.notConnected
+        }
+        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw FleetConnectionError.emptyToken
+        }
+        struct EmptyResult: Decodable {}
+        _ = try await request("auth/hello", params: AuthHelloParams(token: token), result: EmptyResult.self)
+        authenticated = true
+    }
+
+    func negotiate(
+        clientName: String = "ainb-fleet-macos",
+        clientVersion: String = "0.1.0",
+        readVersions: FleetProtocolRange = FleetProtocolRange(min: 1, max: 1),
+        writeVersions: FleetProtocolRange = FleetProtocolRange(min: 1, max: 1)
+    ) async throws -> FleetNegotiateResult {
+        guard authenticated else {
+            throw FleetConnectionError.notAuthenticated
+        }
+        let result = try await request(
+            "fleet/negotiate",
+            params: FleetNegotiateParams(
+                clientName: clientName,
+                clientVersion: clientVersion,
+                readVersions: readVersions,
+                writeVersions: writeVersions
+            ),
+            result: FleetNegotiateResult.self
+        )
+        guard result.readCompatible else {
+            throw FleetConnectionError.protocolReadIncompatible
+        }
+        negotiation = result
+        return result
+    }
+
+    func snapshot() async throws -> FleetSnapshot {
+        try requireReadCompatibility()
+        return try await request("fleet/snapshot", params: FleetSnapshotParams(), result: FleetSnapshot.self)
+    }
+
+    func subscribe(afterRevision: Int64) async throws -> FleetSubscribeResult {
+        try requireReadCompatibility()
+        return try await request(
+            "fleet/subscribe",
+            params: FleetSubscribeParams(afterRevision: afterRevision),
+            result: FleetSubscribeResult.self
+        )
+    }
+
+    func incoming() -> AsyncStream<FleetIncoming> {
+        AsyncStream { continuation in
+            let id = UUID()
+            notificationStreams[id] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeNotificationStream(id) }
+            }
+        }
+    }
+
+    func requireWriteCompatibility() throws {
+        guard let negotiation else {
+            throw FleetConnectionError.notAuthenticated
+        }
+        try Self.validateWriteCompatibility(negotiation)
+    }
+
+    func close() {
+        let currentDescriptor = descriptor
+        descriptor = nil
+        authenticated = false
+        negotiation = nil
+        readerTask?.cancel()
+        readerTask = nil
+        if let currentDescriptor {
+            Darwin.shutdown(currentDescriptor, SHUT_RDWR)
+            Darwin.close(currentDescriptor)
+        }
+        resumePending(with: FleetConnectionError.closed)
+        notificationStreams.values.forEach { $0.finish() }
+        notificationStreams.removeAll()
+    }
+
+    /// Test-only malformed-wire proof still uses the owned, real Unix socket.
+    func sendRawFrameForTesting(_ frame: Data) throws {
+        guard let descriptor else {
+            throw FleetConnectionError.notConnected
+        }
+        try Self.writeAll(frame, to: descriptor)
+    }
+
+    private func request<Params: Encodable, Result: Decodable>(
+        _ method: String,
+        params: Params,
+        result: Result.Type
+    ) async throws -> Result {
+        guard let descriptor else {
+            throw FleetConnectionError.notConnected
+        }
+        let id = RPCID.number(nextRequestID)
+        nextRequestID += 1
+        let body = try FleetWire.encoder().encode(RPCRequest(id: id, method: method, params: params))
+        let frame = try ContentLengthEncoder.encode(body)
+        let responseData: Data = try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                beginRequest(id: id, frame: frame, descriptor: descriptor, continuation: continuation)
+            }
+        }, onCancel: {
+            Task { await self.cancelRequest(id) }
+        })
+        let response = try FleetWire.decoder().decode(RPCResponse<Result>.self, from: responseData)
+        if let error = response.error {
+            throw FleetConnectionError.rpc(error)
+        }
+        guard let value = response.result else {
+            throw FleetConnectionError.malformedEnvelope
+        }
+        return value
+    }
+
+    private func beginRequest(
+        id: RPCID,
+        frame: Data,
+        descriptor: Int32,
+        continuation: CheckedContinuation<Data, Error>
+    ) {
+        guard self.descriptor == descriptor else {
+            continuation.resume(throwing: FleetConnectionError.closed)
+            return
+        }
+        pending[id] = continuation
+        do {
+            try Self.writeAll(frame, to: descriptor)
+        } catch {
+            pending.removeValue(forKey: id)?.resume(throwing: error)
+        }
+    }
+
+    private func cancelRequest(_ id: RPCID) {
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        continuation.resume(throwing: CancellationError())
+        close()
+    }
+
+    private nonisolated static func readFrames(
+        from descriptor: Int32,
+        receive: @escaping @Sendable (Data) async -> Void
+    ) async -> FleetConnectionError {
+        var decoder = ContentLengthDecoder()
+        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+
+        while !Task.isCancelled {
+            let readCount = Darwin.read(descriptor, &buffer, buffer.count)
+            if readCount > 0 {
+                do {
+                    let frames = try decoder.append(Data(buffer.prefix(Int(readCount))))
+                    for frame in frames {
+                        await receive(frame)
+                    }
+                } catch {
+                    return .malformedEnvelope
+                }
+                continue
+            }
+            if readCount == 0 || errno != EINTR {
+                return .disconnected
+            }
+        }
+        return .closed
+    }
+
+    private func receive(_ frame: Data) {
+        do {
+            let envelope = try FleetWire.decoder().decode(Envelope.self, from: frame)
+            if let id = envelope.id {
+                guard let continuation = pending.removeValue(forKey: id) else {
+                    return
+                }
+                continuation.resume(returning: frame)
+                return
+            }
+            guard let method = envelope.method else {
+                throw FleetConnectionError.malformedEnvelope
+            }
+            switch method {
+            case "fleet/event":
+                let params = try FleetWire.decoder().decode(FleetEvent.self, from: envelope.paramsData)
+                yield(.event(params))
+            case "fleet/resync_required":
+                let params = try FleetWire.decoder().decode(FleetResyncRequired.self, from: envelope.paramsData)
+                yield(.resyncRequired(params))
+            default:
+                yield(.unknownNotification(method))
+            }
+        } catch {
+            disconnect(FleetConnectionError.malformedEnvelope, descriptor: descriptor)
+        }
+    }
+
+    private func disconnect(_ error: Error, descriptor: Int32?) {
+        guard descriptor == nil || self.descriptor == descriptor else { return }
+        let currentDescriptor = self.descriptor
+        self.descriptor = nil
+        authenticated = false
+        negotiation = nil
+        readerTask?.cancel()
+        readerTask = nil
+        if let currentDescriptor {
+            Darwin.shutdown(currentDescriptor, SHUT_RDWR)
+            Darwin.close(currentDescriptor)
+        }
+        resumePending(with: error)
+        notificationStreams.values.forEach { $0.finish() }
+        notificationStreams.removeAll()
+    }
+
+    private func requireReadCompatibility() throws {
+        guard let negotiation else {
+            throw FleetConnectionError.notAuthenticated
+        }
+        guard negotiation.readCompatible else {
+            throw FleetConnectionError.protocolReadIncompatible
+        }
+    }
+
+    private func removeNotificationStream(_ id: UUID) {
+        notificationStreams.removeValue(forKey: id)
+    }
+
+    private func yield(_ incoming: FleetIncoming) {
+        notificationStreams.values.forEach { $0.yield(incoming) }
+    }
+
+    private func resumePending(with error: Error) {
+        let continuations = pending.values
+        pending.removeAll()
+        continuations.forEach { $0.resume(throwing: error) }
+    }
+
+    private static func connectUnixSocket(at url: URL) throws -> Int32 {
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            throw FleetConnectionError.socket(errno)
+        }
+        do {
+            var address = sockaddr_un()
+            address.sun_family = sa_family_t(AF_UNIX)
+            let path = Array(url.path.utf8)
+            let capacity = MemoryLayout.size(ofValue: address.sun_path)
+            guard path.count + 1 <= capacity else {
+                throw FleetConnectionError.socket(ENAMETOOLONG)
+            }
+            withUnsafeMutableBytes(of: &address.sun_path) { destination in
+                destination.initializeMemory(as: UInt8.self, repeating: 0)
+                destination.copyBytes(from: path)
+            }
+            let length = socklen_t(MemoryLayout<sa_family_t>.size + path.count + 1)
+            let result = withUnsafePointer(to: &address) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.connect(descriptor, $0, length)
+                }
+            }
+            guard result == 0 else {
+                throw FleetConnectionError.socket(errno)
+            }
+            return descriptor
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    static func validateWriteCompatibility(_ result: FleetNegotiateResult) throws {
+        guard result.writeCompatible else {
+            throw FleetConnectionError.protocolWriteIncompatible
+        }
+    }
+
+    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            var written = 0
+            while written < bytes.count {
+                let result = Darwin.write(descriptor, baseAddress.advanced(by: written), bytes.count - written)
+                if result > 0 {
+                    written += result
+                } else if result < 0, errno == EINTR {
+                    continue
+                } else {
+                    throw FleetConnectionError.socket(errno)
+                }
+            }
+        }
+    }
+}
+
+private struct Envelope: Decodable {
+    let jsonrpc: String
+    let id: RPCID?
+    let method: String?
+    let paramsData: Data
+
+    private enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case method
+        case params
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decodeIfPresent(RPCID.self, forKey: .id)
+        method = try container.decodeIfPresent(String.self, forKey: .method)
+        guard jsonrpc == "2.0", (id != nil) != (method != nil) else {
+            throw FleetConnectionError.malformedEnvelope
+        }
+        let params = try container.decodeIfPresent(JSONValue.self, forKey: .params) ?? .null
+        paramsData = try FleetWire.encoder().encode(params)
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetProjectionReducer.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetProjectionReducer.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct FleetProjection: Equatable {
+    let snapshot: FleetSnapshot?
+    let committedRevision: Int64
+    let seenEventIDs: Set<String>
+    let needsSnapshot: Bool
+    let needsResubscribe: Bool
+
+    static let empty = FleetProjection(snapshot: nil, committedRevision: 0, seenEventIDs: [], needsSnapshot: false, needsResubscribe: false)
+}
+
+enum FleetProjectionReducer {
+    static func bootstrap(_ result: FleetSubscribeResult) -> FleetProjection {
+        let seenEventIDs: Set<String>
+        switch result.replayState {
+        case .snapshotReset:
+            guard result.replay.isEmpty else { return resubscribeRequired(from: .empty) }
+            seenEventIDs = []
+        case .complete:
+            guard replayIsContiguous(result.replay, through: result.snapshot.headRevision) else {
+                return resubscribeRequired(from: .empty)
+            }
+            seenEventIDs = Set(result.replay.map(\.eventID))
+        }
+        return authoritativeSnapshot(result.snapshot, seenEventIDs: seenEventIDs)
+    }
+
+    static func live(_ event: FleetEvent, from projection: FleetProjection) -> FleetProjection {
+        guard !projection.needsResubscribe else { return projection }
+        guard !projection.seenEventIDs.contains(event.eventID) else { return projection }
+        guard event.revision > projection.committedRevision else { return projection }
+        guard event.revision == projection.committedRevision + 1 else {
+            return resubscribeRequired(from: projection)
+        }
+        return FleetProjection(
+            snapshot: projection.snapshot,
+            committedRevision: event.revision,
+            seenEventIDs: projection.seenEventIDs.union([event.eventID]),
+            needsSnapshot: true,
+            needsResubscribe: false
+        )
+    }
+
+    static func snapshot(_ snapshot: FleetSnapshot, from projection: FleetProjection) -> FleetProjection {
+        guard !projection.needsResubscribe else { return projection }
+        guard snapshot.headRevision >= projection.committedRevision else { return projection }
+        return authoritativeSnapshot(snapshot, seenEventIDs: [])
+    }
+
+    static func resyncRequired(from projection: FleetProjection) -> FleetProjection {
+        resubscribeRequired(from: projection)
+    }
+
+    private static func authoritativeSnapshot(_ snapshot: FleetSnapshot, seenEventIDs: Set<String>) -> FleetProjection {
+        FleetProjection(snapshot: snapshot, committedRevision: snapshot.headRevision, seenEventIDs: seenEventIDs, needsSnapshot: false, needsResubscribe: false)
+    }
+
+    private static func resubscribeRequired(from projection: FleetProjection) -> FleetProjection {
+        FleetProjection(snapshot: projection.snapshot, committedRevision: projection.committedRevision, seenEventIDs: projection.seenEventIDs, needsSnapshot: true, needsResubscribe: true)
+    }
+
+    private static func replayIsContiguous(_ replay: [FleetEvent], through headRevision: Int64) -> Bool {
+        guard let first = replay.first else { return true }
+        guard replay.last?.revision == headRevision else { return false }
+        var previous = first.revision - 1
+        var eventIDs = Set<String>()
+        for event in replay {
+            guard event.revision == previous + 1, eventIDs.insert(event.eventID).inserted else { return false }
+            previous = event.revision
+        }
+        return true
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -1,0 +1,368 @@
+import Foundation
+
+enum RPCID: Codable, Equatable, Hashable {
+    case number(Int64)
+    case text(String)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let number = try? container.decode(Int64.self) {
+            self = .number(number)
+        } else {
+            self = .text(try container.decode(String.self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .number(let value): try container.encode(value)
+        case .text(let value): try container.encode(value)
+        }
+    }
+}
+
+struct RPCRequest<Params: Encodable>: Encodable {
+    let jsonrpc: String
+    let id: RPCID
+    let method: String
+    let params: Params
+
+    init(id: RPCID, method: String, params: Params) {
+        jsonrpc = "2.0"
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+}
+
+extension RPCRequest: Decodable where Params: Decodable {}
+
+struct RPCResponse<Result: Decodable>: Decodable {
+    let jsonrpc: String
+    let id: RPCID
+    let result: Result?
+    let error: RPCError?
+
+    private enum CodingKeys: String, CodingKey { case jsonrpc, id, result, error }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decode(RPCID.self, forKey: .id)
+        result = try container.decodeIfPresent(Result.self, forKey: .result)
+        error = try container.decodeIfPresent(RPCError.self, forKey: .error)
+        guard (result == nil) != (error == nil) else {
+            throw DecodingError.dataCorruptedError(forKey: .result, in: container, debugDescription: "response requires exactly one result or error")
+        }
+    }
+}
+
+struct RPCError: Codable, Equatable {
+    let code: Int
+    let message: String
+    let data: JSONValue?
+}
+
+struct AuthHelloParams: Codable, Equatable {
+    let token: String
+}
+
+indirect enum JSONValue: Codable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Decimal)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let value = try? container.decode(Bool.self) { self = .bool(value) }
+        else if let value = try? container.decode(Decimal.self) { self = .number(value) }
+        else if let value = try? container.decode(String.self) { self = .string(value) }
+        else if let value = try? container.decode([JSONValue].self) { self = .array(value) }
+        else { self = .object(try container.decode([String: JSONValue].self)) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+}
+
+struct FleetProtocolRange: Codable, Equatable {
+    let min: UInt32
+    let max: UInt32
+}
+
+struct FleetNegotiateParams: Codable, Equatable {
+    let clientName: String
+    let clientVersion: String
+    let readVersions: FleetProtocolRange
+    let writeVersions: FleetProtocolRange
+    private enum CodingKeys: String, CodingKey { case clientName = "client_name", clientVersion = "client_version", readVersions = "read_versions", writeVersions = "write_versions" }
+}
+
+struct FleetNegotiateResult: Codable, Equatable {
+    let daemonVersion: String
+    let protocolVersion: UInt32
+    let readCompatible: Bool
+    let writeCompatible: Bool
+    let capabilityIDs: [String]
+    private enum CodingKeys: String, CodingKey { case daemonVersion = "daemon_version", protocolVersion = "protocol_version", readCompatible = "read_compatible", writeCompatible = "write_compatible", capabilityIDs = "capability_ids" }
+}
+
+enum FleetProvider: String, Codable, Equatable { case claude, codex, unknown }
+enum LifecycleState: String, Codable, Equatable { case starting = "STARTING", running = "RUNNING", turnComplete = "TURN_COMPLETE", idle = "IDLE", exited = "EXITED", unknown = "UNKNOWN" }
+enum AttentionState: String, Codable, Equatable { case none = "NONE", ask = "ASK", approval = "APPROVAL", waiting = "WAITING", error = "ERROR" }
+enum ManagementState: String, Codable, Equatable { case managed = "MANAGED", degraded = "DEGRADED" }
+enum TransportHealth: String, Codable, Equatable { case healthy = "HEALTHY", degraded = "DEGRADED", unavailable = "UNAVAILABLE", unknown = "UNKNOWN" }
+enum FleetProvenance: String, Codable, Equatable { case authoritative, inferred }
+enum FleetConfidence: String, Codable, Equatable { case high = "HIGH", medium = "MEDIUM", low = "LOW" }
+
+struct FleetCapabilities: Codable, Equatable {
+    let structuredAnswer: Bool
+    let approvals: Bool
+    let sendPrompt: Bool
+    let continueTurn: Bool
+    let retry: Bool
+    let interrupt: Bool
+    let start: Bool
+    let stop: Bool
+    let restart: Bool
+    let kill: Bool
+    let archive: Bool
+    let tmuxAttach: Bool
+    let tmuxText: Bool
+    let verifiedPicker: Bool
+    private enum CodingKeys: String, CodingKey { case structuredAnswer = "structured_answer", approvals, sendPrompt = "send_prompt", continueTurn = "continue_turn", retry, interrupt, start, stop, restart, kill, archive, tmuxAttach = "tmux_attach", tmuxText = "tmux_text", verifiedPicker = "verified_picker" }
+}
+
+struct FleetSession: Codable, Equatable {
+    let sessionKey: String
+    let provider: FleetProvider
+    let providerSessionID: String?
+    let tmuxTarget: String?
+    let processStartFingerprint: String?
+    let cwd: String
+    let displayName: String?
+    let lifecycle: LifecycleState
+    let attention: AttentionState
+    let currentRequestFingerprint: String?
+    let currentRequest: JSONValue?
+    let management: ManagementState
+    let transportHealth: TransportHealth
+    let capabilities: FleetCapabilities
+    let provenance: FleetProvenance
+    let confidence: FleetConfidence
+    let discoveredAt: Int64
+    let lastObservedAt: Int64
+    let lifecycleUpdatedAt: Int64
+    let attentionUpdatedAt: Int64
+    let version: Int64
+    let updatedRevision: Int64
+    private enum CodingKeys: String, CodingKey { case sessionKey = "session_key", provider, providerSessionID = "provider_session_id", tmuxTarget = "tmux_target", processStartFingerprint = "process_start_fingerprint", cwd, displayName = "display_name", lifecycle, attention, currentRequestFingerprint = "current_request_fingerprint", currentRequest = "current_request", management, transportHealth = "transport_health", capabilities, provenance, confidence, discoveredAt = "discovered_at", lastObservedAt = "last_observed_at", lifecycleUpdatedAt = "lifecycle_updated_at", attentionUpdatedAt = "attention_updated_at", version, updatedRevision = "updated_revision" }
+}
+
+struct FleetSnapshot: Codable, Equatable {
+    let headRevision: Int64
+    let sessions: [FleetSession]
+    private enum CodingKeys: String, CodingKey { case headRevision = "head_revision", sessions }
+}
+
+struct FleetSnapshotParams: Codable, Equatable { init() {} }
+
+struct FleetSubscribeParams: Codable, Equatable {
+    let afterRevision: Int64
+    private enum CodingKeys: String, CodingKey { case afterRevision = "after_revision" }
+}
+
+enum FleetReplayResetReason: String, Codable, Equatable { case bootstrap, cursorAhead = "cursor_ahead", replayLimitExceeded = "replay_limit_exceeded" }
+
+enum FleetReplayState: Codable, Equatable {
+    case complete
+    case snapshotReset(reason: FleetReplayResetReason)
+
+    private enum CodingKeys: String, CodingKey { case state, reason }
+    private enum Tag: String, Codable { case complete, snapshotReset = "snapshot_reset" }
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.container(keyedBy: AnyCodingKey.self)
+        guard raw.allKeys.allSatisfy({ $0.stringValue == "state" || $0.stringValue == "reason" }) else {
+            throw DecodingError.dataCorruptedError(forKey: .state, in: try decoder.container(keyedBy: CodingKeys.self), debugDescription: "unknown replay state field")
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Tag.self, forKey: .state) {
+        case .complete:
+            guard !container.contains(.reason) else {
+                throw DecodingError.dataCorruptedError(forKey: .reason, in: container, debugDescription: "complete replay cannot include reason")
+            }
+            self = .complete
+        case .snapshotReset:
+            self = .snapshotReset(reason: try container.decode(FleetReplayResetReason.self, forKey: .reason))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .complete: try container.encode(Tag.complete, forKey: .state)
+        case .snapshotReset(let reason):
+            try container.encode(Tag.snapshotReset, forKey: .state)
+            try container.encode(reason, forKey: .reason)
+        }
+    }
+}
+
+private struct AnyCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) { self.stringValue = stringValue; intValue = nil }
+    init?(intValue: Int) { stringValue = String(intValue); self.intValue = intValue }
+}
+
+struct FleetEvent: Codable, Equatable {
+    let revision: Int64
+    let eventID: String
+    let sessionKey: String
+    let observedAt: Int64
+    let provenance: FleetProvenance
+    let eventType: String
+    let payload: JSONValue
+    let sessionVersion: Int64
+    let applied: Bool
+    private enum CodingKeys: String, CodingKey { case revision, eventID = "event_id", sessionKey = "session_key", observedAt = "observed_at", provenance, eventType = "event_type", payload, sessionVersion = "session_version", applied }
+}
+
+struct FleetSubscribeResult: Codable, Equatable {
+    let snapshot: FleetSnapshot
+    let replay: [FleetEvent]
+    let replayState: FleetReplayState
+    private enum CodingKeys: String, CodingKey { case snapshot, replay, replayState = "replay_state" }
+}
+
+struct FleetQuestionAnswer: Codable, Equatable {
+    let questionID: String
+    let selectedOptions: [String]
+    let text: String?
+    private enum CodingKeys: String, CodingKey { case questionID = "question_id", selectedOptions = "selected_options", text }
+}
+
+struct FleetRequestIdentity: Codable, Equatable {
+    let requestID: JSONValue
+    let threadID: String
+    let turnID: String
+    let itemID: String
+    private enum CodingKeys: String, CodingKey { case requestID = "request_id", threadID = "thread_id", turnID = "turn_id", itemID = "item_id" }
+}
+
+enum ControlAction: Codable, Equatable {
+    case structuredAnswer(requestFingerprint: String, requestIdentity: FleetRequestIdentity?, answers: [FleetQuestionAnswer])
+    case approve(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
+    case deny(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
+    case verifiedPicker(requestFingerprint: String, key: String)
+    case sendPrompt(text: String)
+    case `continue`, retry, interrupt
+    case start(provider: FleetProvider, cwd: String, prompt: String?)
+    case restart, stop, kill, archive
+
+    private enum CodingKeys: String, CodingKey { case action, requestFingerprint = "request_fingerprint", requestIdentity = "request_identity", answers, key, text, provider, cwd, prompt }
+    private enum Tag: String, Codable { case structuredAnswer = "structured_answer", approve, deny, verifiedPicker = "verified_picker", sendPrompt = "send_prompt", `continue`, retry, interrupt, start, restart, stop, kill, archive }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(Tag.self, forKey: .action) {
+        case .structuredAnswer: self = .structuredAnswer(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity), answers: try c.decode([FleetQuestionAnswer].self, forKey: .answers))
+        case .approve: self = .approve(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
+        case .deny: self = .deny(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
+        case .verifiedPicker: self = .verifiedPicker(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), key: try c.decode(String.self, forKey: .key))
+        case .sendPrompt: self = .sendPrompt(text: try c.decode(String.self, forKey: .text))
+        case .continue: self = .continue
+        case .retry: self = .retry
+        case .interrupt: self = .interrupt
+        case .start: self = .start(provider: try c.decode(FleetProvider.self, forKey: .provider), cwd: try c.decode(String.self, forKey: .cwd), prompt: try c.decodeIfPresent(String.self, forKey: .prompt))
+        case .restart: self = .restart
+        case .stop: self = .stop
+        case .kill: self = .kill
+        case .archive: self = .archive
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .structuredAnswer(fingerprint, identity, answers):
+            try c.encode(Tag.structuredAnswer, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity); try c.encode(answers, forKey: .answers)
+        case let .approve(fingerprint, identity):
+            try c.encode(Tag.approve, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
+        case let .deny(fingerprint, identity):
+            try c.encode(Tag.deny, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
+        case let .verifiedPicker(fingerprint, key):
+            try c.encode(Tag.verifiedPicker, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encode(key, forKey: .key)
+        case let .sendPrompt(text): try c.encode(Tag.sendPrompt, forKey: .action); try c.encode(text, forKey: .text)
+        case .continue: try c.encode(Tag.continue, forKey: .action)
+        case .retry: try c.encode(Tag.retry, forKey: .action)
+        case .interrupt: try c.encode(Tag.interrupt, forKey: .action)
+        case let .start(provider, cwd, prompt): try c.encode(Tag.start, forKey: .action); try c.encode(provider, forKey: .provider); try c.encode(cwd, forKey: .cwd); try c.encodeIfPresent(prompt, forKey: .prompt)
+        case .restart: try c.encode(Tag.restart, forKey: .action)
+        case .stop: try c.encode(Tag.stop, forKey: .action)
+        case .kill: try c.encode(Tag.kill, forKey: .action)
+        case .archive: try c.encode(Tag.archive, forKey: .action)
+        }
+    }
+}
+
+struct FleetActionParams: Codable, Equatable {
+    let sessionKey: String
+    let expectedVersion: Int64
+    let requestID: String
+    let action: ControlAction
+    private enum CodingKeys: String, CodingKey { case sessionKey = "session_key", expectedVersion = "expected_version", requestID = "request_id", action }
+}
+
+enum ActionReceiptStatus: String, Codable, Equatable { case pending = "PENDING", delivered = "DELIVERED", failed = "FAILED", unknown = "UNKNOWN", rejected = "REJECTED" }
+
+struct FleetActionReceipt: Codable, Equatable {
+    let requestID: String
+    let sessionKey: String
+    let actionKind: String
+    let actionFingerprint: String
+    let expectedVersion: Int64
+    let idempotencyKey: String?
+    let status: ActionReceiptStatus
+    let detail: String?
+    let sessionVersion: Int64?
+    let createdAt: Int64
+    let updatedAt: Int64
+    private enum CodingKeys: String, CodingKey { case requestID = "request_id", sessionKey = "session_key", actionKind = "action_kind", actionFingerprint = "action_fingerprint", expectedVersion = "expected_version", idempotencyKey = "idempotency_key", status, detail, sessionVersion = "session_version", createdAt = "created_at", updatedAt = "updated_at" }
+}
+
+struct FleetActionResult: Codable, Equatable { let receipt: FleetActionReceipt }
+
+struct FleetBroadcastParams: Codable, Equatable {
+    let targetKeys: [String]
+    let text: String
+    let idempotencyKey: String
+    private enum CodingKeys: String, CodingKey { case targetKeys = "target_keys", text, idempotencyKey = "idempotency_key" }
+}
+
+struct FleetBroadcastResult: Codable, Equatable { let receipts: [FleetActionReceipt] }
+
+enum FleetWire {
+    static func decoder() -> JSONDecoder { JSONDecoder() }
+    static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/HangarLocation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/HangarLocation.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct HangarLocation: Sendable, Equatable {
+    let home: URL
+
+    init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) {
+        if let configuredHome = environment["AINB_HANGAR_HOME"], !configuredHome.isEmpty {
+            home = URL(fileURLWithPath: configuredHome, isDirectory: true)
+        } else {
+            home = homeDirectory.appendingPathComponent(".agents-in-a-box", isDirectory: true)
+        }
+    }
+
+    var socketURL: URL {
+        home.appendingPathComponent("hangar.sock", isDirectory: false)
+    }
+
+    var tokenURL: URL {
+        home
+            .appendingPathComponent("hangar", isDirectory: true)
+            .appendingPathComponent("daemon.token", isDirectory: false)
+    }
+
+    func readToken() throws -> String {
+        let token = try String(contentsOf: tokenURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            throw FleetConnectionError.emptyToken
+        }
+        return token
+    }
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/BuildConfigurationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/BuildConfigurationTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+
+final class BuildConfigurationTests: XCTestCase {
+    func testArm64AndMacOS14ArePinned() {
+        #if arch(arm64)
+        #else
+        XCTFail("AINBFleet must build arm64")
+        #endif
+
+        guard #available(macOS 14.0, *) else {
+            return XCTFail("AINBFleet requires macOS 14")
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/CanonicalFixtureTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/CanonicalFixtureTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+final class CanonicalFixtureTests: XCTestCase {
+    func testGeneratedFleetFixturesDecodeAndRoundTripSemantically() throws {
+        try assertFixture("auth-hello-request", as: RPCRequest<AuthHelloParams>.self)
+        try assertFixture("negotiate-request", as: RPCRequest<FleetNegotiateParams>.self)
+        try assertFixture("negotiate-result-compatible", as: FleetNegotiateResult.self)
+        try assertFixture("negotiate-result-read-only", as: FleetNegotiateResult.self)
+        try assertFixture("snapshot", as: FleetSnapshot.self)
+        try assertFixture("subscribe-bootstrap", as: FleetSubscribeResult.self)
+        try assertFixture("subscribe-replay", as: FleetSubscribeResult.self)
+        try assertFixture("fleet-event", as: FleetEvent.self)
+        try assertFixture("action-request", as: FleetActionParams.self)
+        try assertFixture("action-receipt", as: FleetActionReceipt.self)
+        try assertFixture("broadcast-request", as: FleetBroadcastParams.self)
+        try assertFixture("broadcast-result", as: FleetBroadcastResult.self)
+        try assertFixture("rpc-error", as: RPCError.self)
+    }
+
+    func testReplayStateRejectsInconsistentForms() {
+        XCTAssertThrowsError(try FleetWire.decoder().decode(FleetReplayState.self, from: Data(#"{"state":"complete","reason":"bootstrap"}"#.utf8)))
+        XCTAssertThrowsError(try FleetWire.decoder().decode(FleetReplayState.self, from: Data(#"{"state":"snapshot_reset"}"#.utf8)))
+        XCTAssertThrowsError(try FleetWire.decoder().decode(FleetReplayState.self, from: Data(#"{"state":"future"}"#.utf8)))
+        XCTAssertThrowsError(try FleetWire.decoder().decode(FleetReplayState.self, from: Data(#"{"state":"snapshot_reset","reason":"bootstrap","extra":true}"#.utf8)))
+    }
+
+    private func assertFixture<T: Codable>(_ name: String, as type: T.Type, file: StaticString = #filePath, line: UInt = #line) throws {
+        let original = try Data(contentsOf: fixtureURL(named: name))
+        let decoded = try FleetWire.decoder().decode(T.self, from: original)
+        let encoded = try FleetWire.encoder().encode(decoded)
+        XCTAssertEqual(try canonicalJSON(original), try canonicalJSON(encoded), "fixture drift: \(name)", file: file, line: line)
+    }
+
+    private func fixtureURL(named name: String) -> URL {
+        var repository = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 { repository.deleteLastPathComponent() }
+        return repository.appendingPathComponent("ainb-tui/fleet-parity/fixtures/v1/\(name).json")
+    }
+
+    private func canonicalJSON(_ data: Data) throws -> Data {
+        try JSONSerialization.data(withJSONObject: JSONSerialization.jsonObject(with: data), options: [.sortedKeys])
+    }
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/ContentLengthCodecTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/ContentLengthCodecTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+final class ContentLengthCodecTests: XCTestCase {
+    func testSplitHeaderAndBodyReassemble() throws {
+        var decoder = ContentLengthDecoder()
+        XCTAssertEqual(try decoder.append(Data("Content-Len".utf8)), [])
+        XCTAssertEqual(try decoder.append(Data("gth: 2\r\n\r\n{}".utf8)), [Data("{}".utf8)])
+    }
+
+    func testCoalescedFramesDrainInOrder() throws {
+        var decoder = ContentLengthDecoder()
+        let first = try ContentLengthEncoder.encode(Data("{}".utf8))
+        let second = try ContentLengthEncoder.encode(Data("[]".utf8))
+        XCTAssertEqual(try decoder.append(first + second), [Data("{}".utf8), Data("[]".utf8)])
+    }
+
+    func testMultibyteUTF8UsesByteLength() throws {
+        let body = Data("☕".utf8)
+        var decoder = ContentLengthDecoder()
+        XCTAssertEqual(try decoder.append(ContentLengthEncoder.encode(body)), [body])
+    }
+
+    func testMissingLengthFails() {
+        XCTAssertThrowsError(try decode("\r\n\r\n")) { XCTAssertEqual($0 as? ContentLengthCodecError, .missingContentLength) }
+    }
+
+    func testDuplicateLengthFails() {
+        XCTAssertThrowsError(try decode("Content-Length: 2\r\ncontent-length: 2\r\n\r\n{}")) { XCTAssertEqual($0 as? ContentLengthCodecError, .duplicateContentLength) }
+    }
+
+    func testUnsupportedHeaderFails() {
+        XCTAssertThrowsError(try decode("Content-Type: application/json\r\n\r\n{}")) {
+            XCTAssertEqual($0 as? ContentLengthCodecError, .unsupportedHeader("Content-Type"))
+        }
+    }
+
+    func testOversizedBodyFailsBeforeAllocation() {
+        XCTAssertThrowsError(try decode("Content-Length: 16777217\r\n\r\n")) { XCTAssertEqual($0 as? ContentLengthCodecError, .oversizedBody) }
+    }
+
+    func testResetDropsTruncatedFrame() throws {
+        var decoder = ContentLengthDecoder()
+        XCTAssertEqual(try decoder.append(Data("Content-Length: 2\r\n\r\n{".utf8)), [])
+        decoder.reset()
+        XCTAssertEqual(try decoder.append(Data("Content-Length: 2\r\n\r\n[]".utf8)), [Data("[]".utf8)])
+    }
+
+    private func decode(_ string: String) throws -> [Data] {
+        var decoder = ContentLengthDecoder()
+        return try decoder.append(Data(string.utf8))
+    }
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -1,0 +1,143 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+final class FleetConnectionTests: XCTestCase {
+    func testLocationHonorsNonEmptyAINBHangarHome() {
+        let location = HangarLocation(
+            environment: ["AINB_HANGAR_HOME": "/tmp/ainb-hangar"],
+            homeDirectory: URL(fileURLWithPath: "/unused")
+        )
+
+        XCTAssertEqual(location.socketURL.path, "/tmp/ainb-hangar/hangar.sock")
+        XCTAssertEqual(location.tokenURL.path, "/tmp/ainb-hangar/hangar/daemon.token")
+    }
+
+    func testLocationFallsBackToAgentsInABoxHome() {
+        let location = HangarLocation(
+            environment: ["AINB_HANGAR_HOME": ""],
+            homeDirectory: URL(fileURLWithPath: "/tmp/test-home")
+        )
+
+        XCTAssertEqual(location.home.path, "/tmp/test-home/.agents-in-a-box")
+    }
+
+    func testTokenWhitespaceIsTrimmedOnce() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let tokenDirectory = directory.appendingPathComponent("hangar", isDirectory: true)
+        try FileManager.default.createDirectory(at: tokenDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("  mdt_test\n".utf8).write(to: tokenDirectory.appendingPathComponent("daemon.token"))
+
+        XCTAssertEqual(try HangarLocation(environment: ["AINB_HANGAR_HOME": directory.path]).readToken(), "mdt_test")
+    }
+
+    func testAuthMustCompleteBeforeNegotiate() async {
+        let connection = FleetConnection(location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]))
+
+        do {
+            _ = try await connection.negotiate()
+            XCTFail("expected authentication guard")
+        } catch let error as FleetConnectionError {
+            XCTAssertEqual(error, .notAuthenticated)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testWriteMismatchIsBlocked() {
+        XCTAssertThrowsError(try FleetConnection.validateWriteCompatibility(
+            FleetNegotiateResult(
+                daemonVersion: "test",
+                protocolVersion: 1,
+                readCompatible: true,
+                writeCompatible: false,
+                capabilityIDs: []
+            )
+        )) { XCTAssertEqual($0 as? FleetConnectionError, .protocolWriteIncompatible) }
+    }
+
+    func testResyncNotificationStreamsThroughOwnedSocket() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let clientDescriptor = descriptors[0]
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: clientDescriptor
+        )
+        try await connection.connect()
+        defer { Task { await connection.close() } }
+        let stream = await connection.incoming()
+        let waiter = Task { () -> FleetResyncRequired? in
+            var iterator = stream.makeAsyncIterator()
+            while let incoming = await iterator.next() {
+                if case let .resyncRequired(resync) = incoming {
+                    return resync
+                }
+            }
+            return nil
+        }
+
+        let body = Data(#"{"jsonrpc":"2.0","method":"fleet/resync_required","params":{"after_revision":4,"missed":2}}"#.utf8)
+        let frame = try ContentLengthEncoder.encode(body)
+        let written = frame.withUnsafeBytes { Darwin.write(serverDescriptor, $0.baseAddress, frame.count) }
+        XCTAssertEqual(written, frame.count)
+
+        let resync = await waiter.value
+        XCTAssertEqual(resync, FleetResyncRequired(afterRevision: 4, missed: 2))
+    }
+
+    func testCancelledRequestClosesOwnedDescriptor() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let clientDescriptor = descriptors[0]
+        let serverDescriptor = descriptors[1]
+        let requestReceived = expectation(description: "client request received")
+        let peerClosed = expectation(description: "client descriptor closed")
+
+        DispatchQueue.global().async {
+            _ = Self.readFrame(from: serverDescriptor)
+            requestReceived.fulfill()
+            var byte: UInt8 = 0
+            if Darwin.read(serverDescriptor, &byte, 1) == 0 {
+                peerClosed.fulfill()
+            }
+            Darwin.close(serverDescriptor)
+        }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: clientDescriptor
+        )
+        try await connection.connect()
+        let authentication = Task {
+            try await connection.authenticate(token: "mdt_test")
+        }
+
+        await fulfillment(of: [requestReceived], timeout: 1)
+        authentication.cancel()
+        do {
+            try await authentication.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        await fulfillment(of: [peerClosed], timeout: 1)
+    }
+
+    private static func readFrame(from descriptor: Int32) -> Data? {
+        var decoder = ContentLengthDecoder()
+        var bytes = [UInt8](repeating: 0, count: 1024)
+        while true {
+            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            guard count > 0 else { return nil }
+            guard let frames = try? decoder.append(Data(bytes.prefix(Int(count)))) else { return nil }
+            if let frame = frames.first { return frame }
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
@@ -1,0 +1,368 @@
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+final class FleetDaemonContractTests: XCTestCase {
+    func testRealDaemonRejectsUnauthenticatedClient() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.connection()
+        defer { Task { await connection.close() } }
+
+        do {
+            try await connection.authenticate(token: "mdt_invalid")
+            XCTFail("expected daemon token rejection")
+        } catch let FleetConnectionError.rpc(error) {
+            XCTAssertEqual(error.code, -32_000)
+        }
+    }
+
+    func testRealDaemonAuthenticatesTokenFile() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let snapshot = try await connection.snapshot()
+        XCTAssertEqual(snapshot.headRevision, 0)
+    }
+
+    func testRealDaemonNegotiatesProtocol() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedConnection()
+        defer { Task { await connection.close() } }
+
+        let result = try await connection.negotiate()
+        XCTAssertEqual(result.protocolVersion, 1)
+        XCTAssertTrue(result.readCompatible)
+        XCTAssertTrue(result.writeCompatible)
+        XCTAssertTrue(result.capabilityIDs.contains("fleet.subscription.live"))
+    }
+
+    func testRealDaemonReturnsTypedSnapshot() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        _ = try fixture.seed("snapshot")
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let snapshot = try await connection.snapshot()
+        XCTAssertEqual(snapshot.headRevision, 1)
+        XCTAssertEqual(snapshot.sessions.map(\.sessionKey), ["claude:fixture-session"])
+    }
+
+    func testRealDaemonReplaysEventsAfterCursor() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let first = try fixture.seed("replay-1")
+        _ = try fixture.seed("replay-2", eventType: "Stop")
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let subscription = try await connection.subscribe(afterRevision: first)
+        XCTAssertEqual(subscription.replayState, .complete)
+        XCTAssertEqual(subscription.replay.map(\.eventID), ["replay-2"])
+    }
+
+    func testRealDaemonStreamsLiveEventsOnOpenSocket() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let first = try fixture.seed("live-1")
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+        let stream = await connection.incoming()
+        let subscription = try await connection.subscribe(afterRevision: first)
+        XCTAssertEqual(subscription.replayState, .complete)
+
+        async let incoming = Self.nextFleetEvent(from: stream)
+        _ = try fixture.seed("live-2", eventType: "Stop")
+        let event = try await incoming
+        XCTAssertEqual(event.eventID, "live-2")
+        XCTAssertGreaterThan(event.revision, first)
+    }
+
+    func testRealDaemonGapForcesSnapshotReset() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        _ = try fixture.seed("reset")
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let subscription = try await connection.subscribe(afterRevision: 99)
+        XCTAssertEqual(subscription.replay, [])
+        XCTAssertEqual(subscription.replayState, .snapshotReset(reason: .cursorAhead))
+    }
+
+    func testRealDaemonMalformedFrameClosesConnection() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.connection()
+        defer { Task { await connection.close() } }
+
+        try await connection.sendRawFrameForTesting(Data("X-Unsupported: 1\r\n\r\n".utf8))
+        try await Task.sleep(for: .milliseconds(100))
+        do {
+            try await connection.authenticate(token: try fixture.location.readToken())
+            XCTFail("expected malformed frame to close real daemon connection")
+        } catch let error as FleetConnectionError {
+            XCTAssertTrue(error == .notConnected || error == .closed || error == .disconnected)
+        }
+    }
+
+    func testRealDaemonCancellationStopsSubscription() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        _ = try fixture.seed("cancel")
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        let stream = await connection.incoming()
+        _ = try await connection.subscribe(afterRevision: 1)
+
+        let waiter = Task { () -> FleetIncoming? in
+            var iterator = stream.makeAsyncIterator()
+            return await iterator.next()
+        }
+        waiter.cancel()
+        _ = await waiter.value
+        await connection.close()
+
+        let replacement = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await replacement.close() } }
+        let snapshot = try await replacement.snapshot()
+        XCTAssertEqual(snapshot.headRevision, 1)
+    }
+
+    private static func nextFleetEvent(from stream: AsyncStream<FleetIncoming>) async throws -> FleetEvent {
+        var iterator = stream.makeAsyncIterator()
+        while let incoming = await iterator.next() {
+            if case let .event(event) = incoming {
+                return event
+            }
+        }
+        throw FleetConnectionError.closed
+    }
+}
+
+private final class FixtureDaemon {
+    let home: URL
+    let location: HangarLocation
+    private let process: Process
+    private let input = Pipe()
+    private let output = Pipe()
+    private let error = Pipe()
+    private let responseState = FixtureResponseState()
+    private let errorState = FixtureResponseState()
+    private var pipesTornDown = false
+
+    init() throws {
+        let binary = try Self.fixtureBinary()
+        home = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("ainb-fleet-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        location = HangarLocation(environment: ["AINB_HANGAR_HOME": home.path])
+        process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = error
+        process.terminationHandler = { [responseState] terminatedProcess in
+            responseState.recordExit(status: terminatedProcess.terminationStatus)
+        }
+        output.fileHandleForReading.readabilityHandler = { [responseState] handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+            } else {
+                responseState.appendOutput(chunk)
+            }
+        }
+        error.fileHandleForReading.readabilityHandler = { [errorState] handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+            } else {
+                errorState.appendOutput(chunk)
+            }
+        }
+        var environment = ProcessInfo.processInfo.environment
+        environment["AINB_HANGAR_HOME"] = home.path
+        process.environment = environment
+        try process.run()
+        try waitForSocket()
+    }
+
+    private static func fixtureBinary() throws -> String {
+        if let configured = ProcessInfo.processInfo.environment["AINB_FLEET_FIXTURE_DAEMON"], !configured.isEmpty {
+            return configured
+        }
+        var repository = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 { repository.deleteLastPathComponent() }
+        let built = repository.appendingPathComponent("ainb-tui/target/debug/examples/fleet_fixture_daemon")
+        guard FileManager.default.isExecutableFile(atPath: built.path) else {
+            throw XCTSkip("build fleet_fixture_daemon before real daemon contract tests")
+        }
+        return built.path
+    }
+
+    deinit {
+        stop()
+    }
+
+    func stop() {
+        guard process.isRunning else {
+            tearDownPipes()
+            removeHome()
+            return
+        }
+        _ = try? send(["command": "shutdown"])
+        if process.isRunning {
+            process.terminate()
+        }
+        process.waitUntilExit()
+        tearDownPipes()
+        removeHome()
+    }
+
+    func connection() async throws -> FleetConnection {
+        let connection = FleetConnection(location: location)
+        try await connection.connect()
+        return connection
+    }
+
+    func authenticatedConnection() async throws -> FleetConnection {
+        let connection = try await connection()
+        try await connection.authenticate(token: try location.readToken())
+        return connection
+    }
+
+    func authenticatedAndNegotiatedConnection() async throws -> FleetConnection {
+        let connection = try await authenticatedConnection()
+        _ = try await connection.negotiate()
+        return connection
+    }
+
+    func seed(_ eventID: String, eventType: String = "SessionStart") throws -> Int64 {
+        let response = try send([
+            "command": "seed",
+            "event_id": eventID,
+            "event_type": eventType,
+        ])
+        guard response["ok"] as? Bool == true, let revision = response["revision"] as? NSNumber else {
+            throw FixtureError.invalidResponse
+        }
+        return revision.int64Value
+    }
+
+    private func send(_ command: [String: Any]) throws -> [String: Any] {
+        let data = try JSONSerialization.data(withJSONObject: command)
+        input.fileHandleForWriting.write(data)
+        input.fileHandleForWriting.write(Data("\n".utf8))
+        return try readResponse()
+    }
+
+    private func readResponse() throws -> [String: Any] {
+        let timeout = DispatchTime.now() + .seconds(5)
+        while true {
+            if let line = responseState.takeOutputLine() {
+                guard let object = try JSONSerialization.jsonObject(with: line) as? [String: Any] else {
+                    throw FixtureError.invalidJSON
+                }
+                return object
+            }
+            if let exitStatus = responseState.recordedExitStatus() {
+                throw FixtureError.exited(exitStatus, errorState.outputText())
+            }
+            guard responseState.waitForResponse(timeout: timeout) else {
+                if let exitStatus = responseState.recordedExitStatus() {
+                    throw FixtureError.exited(exitStatus, errorState.outputText())
+                }
+                throw FixtureError.responseTimeout
+            }
+        }
+    }
+
+    private func waitForSocket() throws {
+        let deadline = Date().addingTimeInterval(5)
+        while !FileManager.default.fileExists(atPath: location.socketURL.path) {
+            guard process.isRunning else {
+                throw FixtureError.exited(responseState.recordedExitStatus() ?? -1, errorState.outputText())
+            }
+            guard Date() < deadline else { throw FixtureError.socketTimeout }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+    }
+
+    private func tearDownPipes() {
+        guard !pipesTornDown else { return }
+        pipesTornDown = true
+        output.fileHandleForReading.readabilityHandler = nil
+        error.fileHandleForReading.readabilityHandler = nil
+        input.fileHandleForWriting.closeFile()
+        output.fileHandleForReading.closeFile()
+        error.fileHandleForReading.closeFile()
+    }
+
+    private func removeHome() {
+        guard FileManager.default.fileExists(atPath: home.path) else { return }
+        do {
+            try FileManager.default.removeItem(at: home)
+        } catch let error as CocoaError where error.code == .fileNoSuchFile {
+        } catch {
+            XCTFail("failed to remove fixture home: \(error)")
+        }
+    }
+}
+
+private final class FixtureResponseState: @unchecked Sendable {
+    private let lock = NSLock()
+    private let signal = DispatchSemaphore(value: 0)
+    private var outputBuffer = Data()
+    private var exitStatus: Int32?
+
+    func appendOutput(_ chunk: Data) {
+        lock.lock()
+        outputBuffer.append(chunk)
+        lock.unlock()
+        signal.signal()
+    }
+
+    func takeOutputLine() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let newline = outputBuffer.firstRange(of: Data("\n".utf8)) else { return nil }
+        let line = outputBuffer.subdata(in: 0..<newline.lowerBound)
+        outputBuffer.removeSubrange(0..<newline.upperBound)
+        return line
+    }
+
+    func recordExit(status: Int32) {
+        lock.lock()
+        exitStatus = status
+        lock.unlock()
+        signal.signal()
+    }
+
+    func recordedExitStatus() -> Int32? {
+        lock.lock()
+        defer { lock.unlock() }
+        return exitStatus
+    }
+
+    func outputText() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(decoding: outputBuffer, as: UTF8.self)
+    }
+
+    func waitForResponse(timeout: DispatchTime) -> Bool {
+        signal.wait(timeout: timeout) != .timedOut
+    }
+}
+
+private enum FixtureError: Error {
+    case invalidJSON
+    case invalidResponse
+    case exited(Int32, String)
+    case socketTimeout
+    case responseTimeout
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetProjectionReducerTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetProjectionReducerTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+final class FleetProjectionReducerTests: XCTestCase {
+    func testBootstrapUsesOneAuthoritativeSnapshot() throws {
+        let snapshot = try sampleSnapshot(head: 4)
+        let projection = FleetProjectionReducer.bootstrap(FleetSubscribeResult(snapshot: snapshot, replay: [], replayState: .snapshotReset(reason: .bootstrap)))
+        XCTAssertEqual(projection.snapshot, snapshot)
+        XCTAssertEqual(projection.committedRevision, 4)
+        XCTAssertFalse(projection.needsSnapshot)
+    }
+
+    func testCompleteReplayAcceptsContiguousRevisions() throws {
+        let projection = FleetProjectionReducer.bootstrap(FleetSubscribeResult(snapshot: try sampleSnapshot(head: 4), replay: [try sampleEvent(revision: 3, eventID: "e3"), try sampleEvent(revision: 4, eventID: "e4")], replayState: .complete))
+        XCTAssertEqual(projection.committedRevision, 4)
+        XCTAssertFalse(projection.needsResubscribe)
+    }
+
+    func testDuplicateRevisionIsIgnored() throws {
+        let projection = baseline()
+        XCTAssertEqual(FleetProjectionReducer.live(try sampleEvent(revision: 4, eventID: "old"), from: projection), projection)
+    }
+
+    func testDuplicateEventIDIsIgnored() throws {
+        let projection = FleetProjectionReducer.bootstrap(FleetSubscribeResult(snapshot: try sampleSnapshot(head: 4), replay: [try sampleEvent(revision: 4, eventID: "same")], replayState: .complete))
+        XCTAssertEqual(FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "same"), from: projection), projection)
+    }
+
+    func testDuplicateEventIDIsIgnoredWithinSnapshotBoundary() throws {
+        let afterLiveEvent = FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "e5"), from: baseline())
+        XCTAssertEqual(FleetProjectionReducer.live(try sampleEvent(revision: 6, eventID: "e5"), from: afterLiveEvent), afterLiveEvent)
+    }
+
+    func testAuthoritativeSnapshotResetsSeenEventIDs() throws {
+        let afterLiveEvent = FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "e5"), from: baseline())
+        let refreshed = FleetProjectionReducer.snapshot(try sampleSnapshot(head: 5), from: afterLiveEvent)
+        XCTAssertEqual(FleetProjectionReducer.live(try sampleEvent(revision: 6, eventID: "e5"), from: refreshed).committedRevision, 6)
+    }
+
+    func testGapRequiresResubscribe() throws {
+        let projection = FleetProjectionReducer.live(try sampleEvent(revision: 6, eventID: "gap"), from: baseline())
+        XCTAssertTrue(projection.needsResubscribe)
+        XCTAssertTrue(projection.needsSnapshot)
+    }
+
+    func testResyncNotificationRequiresResubscribe() {
+        let projection = FleetProjectionReducer.resyncRequired(from: baseline())
+        XCTAssertTrue(projection.needsResubscribe)
+        XCTAssertTrue(projection.needsSnapshot)
+    }
+
+    func testSnapshotCannotClearResubscribeRequirement() throws {
+        let resync = FleetProjectionReducer.resyncRequired(from: baseline())
+        XCTAssertEqual(FleetProjectionReducer.snapshot(try sampleSnapshot(head: 5), from: resync), resync)
+    }
+
+    func testOlderSnapshotCannotReplaceNewerProjection() throws {
+        XCTAssertEqual(FleetProjectionReducer.snapshot(try sampleSnapshot(head: 3), from: baseline()), baseline())
+    }
+
+    func testLiveRevisionRequestsFocusedSnapshot() throws {
+        let projection = FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "next"), from: baseline())
+        XCTAssertEqual(projection.committedRevision, 5)
+        XCTAssertTrue(projection.needsSnapshot)
+        XCTAssertFalse(projection.needsResubscribe)
+    }
+
+    private func baseline() -> FleetProjection {
+        FleetProjectionReducer.bootstrap(FleetSubscribeResult(snapshot: try! sampleSnapshot(head: 4), replay: [], replayState: .snapshotReset(reason: .bootstrap)))
+    }
+}
+
+func sampleSnapshot(head: Int64, currentRequest: String = "{\"opaque\":\"one\"}") throws -> FleetSnapshot {
+    let json = #"{"head_revision":\#(head),"sessions":[{"session_key":"s1","provider":"codex","provider_session_id":null,"tmux_target":null,"process_start_fingerprint":null,"cwd":"/tmp","display_name":null,"lifecycle":"RUNNING","attention":"ASK","current_request_fingerprint":"f1","current_request":\#(currentRequest),"management":"MANAGED","transport_health":"HEALTHY","capabilities":{"structured_answer":true,"approvals":true,"send_prompt":false,"continue_turn":false,"retry":false,"interrupt":true,"start":false,"stop":true,"restart":true,"kill":false,"archive":false,"tmux_attach":true,"tmux_text":false,"verified_picker":false},"provenance":"authoritative","confidence":"HIGH","discovered_at":1,"last_observed_at":2,"lifecycle_updated_at":3,"attention_updated_at":4,"version":3,"updated_revision":\#(head)}]}"#
+    return try FleetWire.decoder().decode(FleetSnapshot.self, from: Data(json.utf8))
+}
+
+func sampleEvent(revision: Int64, eventID: String, payload: String = "{\"opaque\":\"one\"}") throws -> FleetEvent {
+    let json = #"{"revision":\#(revision),"event_id":"\#(eventID)","session_key":"s1","observed_at":5,"provenance":"authoritative","event_type":"provider_event","payload":\#(payload),"session_version":3,"applied":true}"#
+    return try FleetWire.decoder().decode(FleetEvent.self, from: Data(json.utf8))
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetSemanticBoundaryTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetSemanticBoundaryTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+final class FleetSemanticBoundaryTests: XCTestCase {
+    func testOpaquePayloadCannotChangeSemanticState() throws {
+        let baseline = semanticBaseline()
+        let first = FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "next", payload: "{\"provider\":\"one\"}"), from: baseline)
+        let second = FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "next", payload: "{\"provider\":\"two\",\"nested\":[1,true]}"), from: baseline)
+        XCTAssertEqual(first, second)
+    }
+
+    func testOpaqueCurrentRequestCannotChangeCapabilityState() throws {
+        let first = FleetProjectionReducer.snapshot(try sampleSnapshot(head: 5, currentRequest: "{\"provider\":\"one\"}"), from: semanticBaseline())
+        let second = FleetProjectionReducer.snapshot(try sampleSnapshot(head: 5, currentRequest: "{\"provider\":\"two\",\"nested\":[1,true]}"), from: semanticBaseline())
+        XCTAssertEqual(first.snapshot?.sessions.first?.capabilities, second.snapshot?.sessions.first?.capabilities)
+        XCTAssertEqual(first.committedRevision, second.committedRevision)
+    }
+
+    func testRPCErrorDataCannotEnableWrite() throws {
+        let response = try FleetWire.decoder().decode(RPCResponse<FleetNegotiateResult>.self, from: Data("{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32603,\"message\":\"failed\",\"data\":{\"write_compatible\":true}}}".utf8))
+        XCTAssertNil(response.result)
+        XCTAssertEqual(response.error?.code, -32603)
+    }
+
+    func testRequestIDPassThroughCannotChangeReducerOrCapabilityState() throws {
+        let firstIdentity = try identity("{\"provider\":\"one\"}")
+        let secondIdentity = try identity("[\"provider\",2]")
+        let numericIdentity = try identity("1.00")
+        let first = try encodedApprove(firstIdentity)
+        let second = try encodedApprove(secondIdentity)
+        let numeric = try encodedApprove(numericIdentity)
+        XCTAssertNotEqual(first, second)
+        let baseline = semanticBaseline()
+        XCTAssertEqual(FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "next"), from: baseline), FleetProjectionReducer.live(try sampleEvent(revision: 5, eventID: "next"), from: baseline))
+        XCTAssertEqual(baseline.snapshot?.sessions.first?.capabilities, semanticBaseline().snapshot?.sessions.first?.capabilities)
+        XCTAssertEqual(try FleetWire.decoder().decode(FleetActionParams.self, from: first).action, .approve(requestFingerprint: "f1", requestIdentity: firstIdentity))
+        XCTAssertEqual(try FleetWire.decoder().decode(FleetActionParams.self, from: second).action, .approve(requestFingerprint: "f1", requestIdentity: secondIdentity))
+        XCTAssertEqual(try FleetWire.decoder().decode(FleetActionParams.self, from: numeric).action, .approve(requestFingerprint: "f1", requestIdentity: numericIdentity))
+    }
+
+    private func semanticBaseline() -> FleetProjection {
+        FleetProjectionReducer.bootstrap(FleetSubscribeResult(snapshot: try! sampleSnapshot(head: 4), replay: [], replayState: .snapshotReset(reason: .bootstrap)))
+    }
+
+    private func identity(_ requestID: String) throws -> FleetRequestIdentity {
+        try FleetWire.decoder().decode(FleetRequestIdentity.self, from: Data("{\"request_id\":\(requestID),\"thread_id\":\"t\",\"turn_id\":\"u\",\"item_id\":\"i\"}".utf8))
+    }
+
+    private func encodedApprove(_ identity: FleetRequestIdentity) throws -> Data {
+        try FleetWire.encoder().encode(FleetActionParams(sessionKey: "s1", expectedVersion: 3, requestID: "action", action: .approve(requestFingerprint: "f1", requestIdentity: identity)))
+    }
+}

--- a/apps/ainb-fleet-macos/ci/check-swift-boundary.sh
+++ b/apps/ainb-fleet-macos/ci/check-swift-boundary.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+app_root="$repo_root/apps/ainb-fleet-macos"
+source_root="$app_root/Sources"
+allowlist="$app_root/ci/swift-boundary-allowlist.txt"
+
+fail() {
+  printf 'Swift boundary violation: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -d "$source_root" ]] || fail "missing Sources directory"
+[[ -f "$allowlist" ]] || fail "missing allowlist"
+
+for forbidden in \
+  'URLSession' \
+  'URLRequest' \
+  'Process(' \
+  'NSTask' \
+  'sqlite3' \
+  'SQLite' \
+  'sessions.json' \
+  'transcript' \
+  'ainb fleet'; do
+  if rg -n -F --glob '*.swift' -- "$forbidden" "$source_root"; then
+    fail "forbidden transport or data source: $forbidden"
+  fi
+done
+
+is_allowlisted() {
+  local file="$1"
+  local line="$2"
+  local relative="${file#"$app_root/"}"
+  local entry path fragment
+
+  while IFS= read -r entry || [[ -n "$entry" ]]; do
+    [[ -z "$entry" || "$entry" == \#* ]] && continue
+    path="${entry%%|*}"
+    fragment="${entry#*|}"
+    [[ "$path" == "$relative" && "$line" == *"$fragment"* ]] && return 0
+  done < "$allowlist"
+  return 1
+}
+
+while IFS= read -r match; do
+  file="${match%%:*}"
+  remainder="${match#*:}"
+  line="${remainder#*:}"
+  if ! is_allowlisted "$file" "$line"; then
+    printf '%s\n' "$match" >&2
+    fail "opaque JSONValue inspection is not allowlisted"
+  fi
+done < <(
+  rg -n --glob '*.swift' \
+    'case[[:space:]]+\.?(object|array)\b|\.(object|array)[[:space:]]*\[|JSONValue[[:space:]]*\[' \
+    "$source_root" || true
+)

--- a/apps/ainb-fleet-macos/ci/swift-boundary-allowlist.txt
+++ b/apps/ainb-fleet-macos/ci/swift-boundary-allowlist.txt
@@ -1,0 +1,6 @@
+# Relative source path|literal fragment. Each entry permits one opaque JSONValue
+# encoding or decoding implementation line. Semantic inspection stays forbidden.
+Sources/FleetRPC/FleetWire.swift|case array([JSONValue])
+Sources/FleetRPC/FleetWire.swift|case object([String: JSONValue])
+Sources/FleetRPC/FleetWire.swift|case .array(let value)
+Sources/FleetRPC/FleetWire.swift|case .object(let value)


### PR DESCRIPTION
## What
- Adds versioned Fleet negotiation, bounded replay, strict framing, atomic request projection, deterministic Rust fixtures, and parity manifest.
- Adds native arm64 macOS Swift app target with authenticated Unix-socket RPC client, reducer, and real daemon contract suite.
- Adds macOS 14 arm64 CI gate.

## Validation
- Rust protocol fixtures, manifest, daemon rpc_server and rpc_fleet gates pass.
- Fixture daemon build passes.
- Native arm64 Swift suite passes: 42 tests.
- Swift semantic-boundary and filtered actionlint checks pass.

## Deferred TUI parity
- `agents-in-a-box-afm-e01.1` tracks all five TUI proof gaps.
- TUI behavior remains unchanged. No Swift workaround added.