### PR TITLE
feat(hangar): mention routing layer with per-target outcomes (parity 2-rest)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -118,6 +118,74 @@ pub enum HangarCommand {
     /// Define and archive a workspace's custom issue properties.
     #[command(subcommand)]
     Property(PropertyCommand),
+    /// Post issue comments and preview their `@`-mention routing.
+    #[command(subcommand)]
+    Comment(CommentCommand),
+    /// Read an actor's notification inbox.
+    #[command(subcommand)]
+    Inbox(InboxCommand),
+}
+
+/// `hangar comment <verb>` — post a comment and see EXACTLY where its
+/// `@`-mentions went (multica parity #2-rest).
+///
+/// Store-direct, like `issue timeline`: no daemon required, which is what makes
+/// the routing behaviour provable against a bare SQLite file.
+#[derive(Subcommand, Debug)]
+pub enum CommentCommand {
+    /// Post a comment on an issue and print one row per routed `@`-mention.
+    Add(CommentAddArgs),
+    /// DRY-RUN the mention router over a draft body: identical resolution and
+    /// identical gates, zero writes.
+    Preview(CommentAddArgs),
+}
+
+/// `hangar inbox <verb>` — the read surface that proves a mention of a human
+/// actually landed on that human.
+#[derive(Subcommand, Debug)]
+pub enum InboxCommand {
+    /// List one actor's inbox entries, newest first.
+    List(InboxListArgs),
+}
+
+/// Arguments shared by `hangar comment add` and `hangar comment preview`.
+#[derive(Args, Debug)]
+pub struct CommentAddArgs {
+    /// Issue id (ULID) to comment on.
+    #[arg(long)]
+    pub issue: String,
+    /// The comment body. `@handle` and `[@Label](mention://type/id)` both route.
+    #[arg(long)]
+    pub body: String,
+    /// The author as a canonical actor-ref. `member:me` is the local operator,
+    /// which the invocation gate resolves to the workspace owner.
+    #[arg(long, default_value = "member:me")]
+    pub author: String,
+    /// The comment this one replies to — drives the reply-parent fallback and
+    /// multica's parent-mention inheritance.
+    #[arg(long)]
+    pub parent: Option<String>,
+    /// Workspace slug the issue belongs to. Defaults to the bootstrapped
+    /// `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+}
+
+/// Arguments for `hangar inbox list`.
+#[derive(Args, Debug)]
+pub struct InboxListArgs {
+    /// Whose inbox to read, as `member:<user-id>` / `agent:<agent-id>`.
+    #[arg(long, default_value = "member:me")]
+    pub recipient: String,
+    /// Show only UNREAD entries.
+    #[arg(long)]
+    pub unread: bool,
+    /// How many entries to show, newest first.
+    #[arg(long, default_value_t = 50)]
+    pub limit: i64,
+    /// Workspace slug. Defaults to the bootstrapped `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// `hangar property <verb>` — the per-workspace CUSTOM PROPERTY catalog
@@ -2411,7 +2479,264 @@ pub async fn dispatch(cmd: HangarCommand, format: OutputFormat) -> Result<()> {
         HangarCommand::Workspace(c) => dispatch_workspace(c, format).await,
         HangarCommand::Logs(LogsCommand::Tail(args)) => run_logs_tail(args).await,
         HangarCommand::Property(c) => dispatch_property(c, format).await,
+        HangarCommand::Comment(c) => dispatch_comment(c, format).await,
+        HangarCommand::Inbox(InboxCommand::List(args)) => run_inbox_list(args, format).await,
     }
+}
+
+/// `hangar comment add|preview`: post a comment (or dry-run one) and report
+/// where every `@`-mention went (multica parity #2-rest).
+///
+/// Both verbs drive the SAME `service::mention::route` the daemon drives, with
+/// `dry_run` flipped — the shared path is the contract, so the preview applies
+/// the identical invocation gate and can never disagree with the write.
+async fn dispatch_comment(cmd: CommentCommand, format: OutputFormat) -> Result<()> {
+    use ainb_hangar_core::actor::ActorRef;
+    use ainb_hangar_core::clock::{HangarClock as _, SystemClock};
+    use ainb_hangar_core::idgen::{IdGen as _, SystemIdGen};
+    use ainb_hangar_store::repo::comment::{CommentRepo, NewComment};
+    use ainb_hangar_store::service::mention::{MentionRouteRequest, route};
+    use std::str::FromStr as _;
+
+    let (args, dry_run) = match cmd {
+        CommentCommand::Add(a) => (a, false),
+        CommentCommand::Preview(a) => (a, true),
+    };
+    if args.body.trim().is_empty() {
+        anyhow::bail!("comment body must not be empty");
+    }
+    let author = ActorRef::from_str(&args.author)
+        .map_err(|e| anyhow::anyhow!("author must be `agent:<id>` or `member:<id>`: {e}"))?;
+
+    let store = Store::open_default().await.context("open hangar database")?;
+    // A typo'd workspace is an ERROR, never a silently empty routing report.
+    let workspace_id = resolve_skills_workspace(&store, args.workspace.as_deref()).await?;
+
+    // The write happens FIRST and separately, exactly as the daemon does it: a
+    // routing fault can then never lose the comment.
+    let comment_id = if dry_run {
+        None
+    } else {
+        let id = SystemIdGen.new_ulid();
+        let landed = CommentRepo::insert(
+            store.pool(),
+            &workspace_id,
+            &NewComment {
+                id: id.clone(),
+                issue_id: args.issue.clone(),
+                author: author.clone(),
+                body: args.body.clone(),
+                created_at: SystemClock.now_ms(),
+                parent_id: args.parent.clone(),
+            },
+        )
+        .await
+        .context("write comment")?;
+        anyhow::ensure!(
+            landed,
+            "no issue `{}` in this workspace (nothing was written)",
+            args.issue
+        );
+        Some(id)
+    };
+
+    let rows = route(
+        store.pool(),
+        &SystemIdGen,
+        &SystemClock,
+        &MentionRouteRequest {
+            workspace_id: &workspace_id,
+            issue_id: &args.issue,
+            comment_id: comment_id.as_deref(),
+            parent_comment_id: args.parent.as_deref(),
+            author: &author,
+            body: &args.body,
+            dry_run,
+        },
+    )
+    .await
+    .context("route comment mentions")?;
+
+    print_mention_rows(&rows, format, dry_run);
+    Ok(())
+}
+
+/// Render the routing rows in the requested output format.
+fn print_mention_rows(
+    rows: &[ainb_hangar_store::service::mention::MentionRouteRow],
+    format: OutputFormat,
+    dry_run: bool,
+) {
+    let reason = |r: &ainb_hangar_store::service::mention::MentionRouteRow| {
+        r.reason.map(|d| d.as_db_str()).unwrap_or_default()
+    };
+    match format {
+        OutputFormat::Json => {
+            let wire: Vec<serde_json::Value> = rows
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "target_type": r.target_type,
+                        "target_id": r.target_id,
+                        "handle": r.handle,
+                        "outcome": r.outcome.as_str(),
+                        "reason": reason(r),
+                        "task_id": r.task_id,
+                        "source": r.source.as_str(),
+                    })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string(&wire).unwrap_or_else(|_| "[]".to_string())
+            );
+        }
+        OutputFormat::Csv => {
+            println!("target_type,target_id,handle,outcome,reason,source,task_id");
+            for r in rows {
+                println!(
+                    "{},{},{},{},{},{},{}",
+                    r.target_type,
+                    csv_field(&r.target_id),
+                    csv_field(&r.handle),
+                    r.outcome.as_str(),
+                    reason(r),
+                    r.source.as_str(),
+                    r.task_id.as_deref().unwrap_or_default()
+                );
+            }
+        }
+        OutputFormat::Markdown => {
+            println!("| target | handle | outcome | reason | source |");
+            println!("|---|---|---|---|---|");
+            for r in rows {
+                println!(
+                    "| {}:{} | @{} | {} | {} | {} |",
+                    r.target_type,
+                    r.target_id,
+                    r.handle,
+                    r.outcome.as_str(),
+                    reason(r),
+                    r.source.as_str()
+                );
+            }
+        }
+        OutputFormat::Text => {
+            if rows.is_empty() {
+                println!("no mentions routed");
+                return;
+            }
+            for r in rows {
+                let why = if reason(r).is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({})", reason(r))
+                };
+                println!(
+                    "{:<8} @{:<20} {}{}  [{}]",
+                    r.target_type,
+                    r.handle,
+                    r.outcome.as_str(),
+                    why,
+                    r.source.as_str()
+                );
+            }
+            if dry_run {
+                println!("(preview — nothing was written)");
+            }
+        }
+    }
+}
+
+/// `hangar inbox list`: one actor's notification entries, newest first.
+///
+/// The read surface that proves an `@`-mention of a HUMAN actually landed on
+/// that human (migration 0060 made `inbox_entry` actor-polymorphic).
+async fn run_inbox_list(args: InboxListArgs, format: OutputFormat) -> Result<()> {
+    use ainb_hangar_core::actor::ActorRef;
+    use ainb_hangar_store::repo::inbox::InboxRepo;
+    use std::str::FromStr as _;
+
+    let recipient = ActorRef::from_str(&args.recipient)
+        .map_err(|e| anyhow::anyhow!("recipient must be `agent:<id>` or `member:<id>`: {e}"))?;
+    let store = Store::open_default().await.context("open hangar database")?;
+    let workspace_id = resolve_skills_workspace(&store, args.workspace.as_deref()).await?;
+    let mut entries = InboxRepo::list(store.pool(), &workspace_id, &recipient, args.limit.max(1))
+        .await
+        .context("read inbox")?;
+    // `--unread` filters HERE rather than in SQL: the repo's list is the shared
+    // read the TUI also drives, and the unread model is a single nullable
+    // column, so a post-filter cannot drift from `unread_count`'s definition.
+    if args.unread {
+        entries.retain(|e| e.read_at.is_none());
+    }
+
+    match format {
+        OutputFormat::Json => {
+            let wire: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|e| {
+                    serde_json::json!({
+                        "id": e.id,
+                        "kind": e.kind.as_str(),
+                        "event": e.event,
+                        "subject_id": e.subject_id,
+                        "summary": e.summary,
+                        "created_at": e.created_at,
+                        "read_at": e.read_at,
+                    })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string(&wire).unwrap_or_else(|_| "[]".to_string())
+            );
+        }
+        OutputFormat::Csv => {
+            println!("kind,event,subject_id,summary,created_at,read");
+            for e in &entries {
+                println!(
+                    "{},{},{},{},{},{}",
+                    e.kind.as_str(),
+                    csv_field(&e.event),
+                    csv_field(&e.subject_id),
+                    csv_field(&e.summary),
+                    e.created_at,
+                    e.read_at.is_some()
+                );
+            }
+        }
+        OutputFormat::Markdown => {
+            println!("| when | event | subject | summary |");
+            println!("|---|---|---|---|");
+            for e in &entries {
+                println!(
+                    "| {} | {} | {} | {} |",
+                    fmt_epoch_ms_utc(e.created_at),
+                    e.event,
+                    e.subject_id,
+                    md_cell(&e.summary)
+                );
+            }
+        }
+        OutputFormat::Text => {
+            if entries.is_empty() {
+                println!("inbox empty for {}", args.recipient);
+                return Ok(());
+            }
+            for e in &entries {
+                println!(
+                    "{}  {}  {:<14} {:<28} {}",
+                    fmt_epoch_ms_utc(e.created_at),
+                    if e.read_at.is_some() { " " } else { "*" },
+                    e.event,
+                    e.subject_id,
+                    e.summary
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// `hangar logs tail`: pretty-print the daemon's structured-log events.

--- a/ainb-tui/crates/ainb-core/tests/hangar_mention_routing_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_mention_routing_cli.rs
@@ -1,0 +1,319 @@
+//! ACCEPTANCE (CLI half): `ainb hangar comment add|preview` reports where every
+//! `@`-mention went, and `ainb hangar inbox list` proves a human mention landed
+//! on that human (multica parity #2-rest).
+//!
+//! Drives the REAL `ainb` binary against an isolated `AINB_HANGAR_HOME`, with
+//! no daemon and no network — nothing but sqlite + the CLI. That is the point:
+//! the routing behaviour is provable against a bare database file, so the
+//! acceptance proof does not depend on a running control plane.
+//!
+//! The three legs, each asserting BOTH the side effect and the surfaced code:
+//!
+//! 1. mentioning a HUMAN notifies them and spawns nothing;
+//! 2. re-mentioning an agent reports `coalesced` rather than failing silently;
+//! 3. a preview reports the identical codes and writes nothing.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+/// Run one `ainb hangar …` invocation inside the isolated home, returning stdout.
+fn ainb(home: &std::path::Path, args: &[&str]) -> String {
+    let out = Command::new(ainb_bin())
+        .args(args)
+        .env("AINB_HANGAR_HOME", home)
+        .env("HOME", home)
+        .output()
+        .expect("run ainb");
+    assert!(
+        out.status.success(),
+        "`ainb {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// The `created issue <ULID>` ack's id.
+fn created_id(ack: &str) -> String {
+    ack.split_whitespace()
+        .last()
+        .unwrap_or_else(|| panic!("no id in ack {ack:?}"))
+        .to_string()
+}
+
+/// Parse the JSON row array a `comment add|preview` invocation prints.
+fn rows(json: &str) -> Vec<serde_json::Value> {
+    serde_json::from_str(json).unwrap_or_else(|e| panic!("bad routing json {json:?}: {e}"))
+}
+
+fn field<'a>(row: &'a serde_json::Value, key: &str) -> &'a str {
+    row.get(key).and_then(serde_json::Value::as_str).unwrap_or("")
+}
+
+/// **ACCEPTANCE 1** — `@`-mentioning a HUMAN routes to that human: a `notified`
+/// outcome, an inbox entry addressed to them, and NO task.
+#[test]
+fn mentioning_a_human_notifies_them_and_never_spawns_a_run() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+
+    let issue = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "routing demo"],
+    ));
+    // A second human, so the mention target is unambiguous and is not the
+    // bootstrapped owner.
+    ainb(
+        h,
+        &["hangar", "member", "add", "--email", "bob@example.com"],
+    );
+
+    let out = ainb(
+        h,
+        &[
+            "hangar",
+            "comment",
+            "add",
+            "--issue",
+            &issue,
+            "--body",
+            "@bob can you look?",
+            "--format",
+            "json",
+        ],
+    );
+    let routed = rows(&out);
+    assert_eq!(routed.len(), 1, "one row per target: {out}");
+    assert_eq!(field(&routed[0], "target_type"), "member", "{out}");
+    assert_eq!(field(&routed[0], "outcome"), "notified", "{out}");
+    let user_id = field(&routed[0], "target_id").to_string();
+    assert!(
+        !user_id.is_empty(),
+        "the human resolved to a user id: {out}"
+    );
+
+    // The mention landed in THAT human's inbox.
+    let inbox = ainb(
+        h,
+        &[
+            "hangar",
+            "inbox",
+            "list",
+            "--recipient",
+            &format!("member:{user_id}"),
+            "--format",
+            "json",
+        ],
+    );
+    let entries = rows(&inbox);
+    assert_eq!(entries.len(), 1, "exactly one inbox entry: {inbox}");
+    assert_eq!(field(&entries[0], "event"), "mention", "{inbox}");
+    assert_eq!(field(&entries[0], "subject_id"), issue, "{inbox}");
+
+    // Nobody else's inbox saw it (the entry is addressed, not broadcast).
+    let other = ainb(
+        h,
+        &[
+            "hangar",
+            "inbox",
+            "list",
+            "--recipient",
+            "member:nobody",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        rows(&other).is_empty(),
+        "an addressed entry is not a broadcast: {other}"
+    );
+}
+
+/// **ACCEPTANCE 2** — a repeat mention SURFACES as `coalesced` instead of
+/// disappearing into a swallowed unique-constraint violation.
+#[test]
+fn re_mentioning_a_pending_agent_reports_coalesced() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+
+    ainb(h, &["hangar", "agent", "create", "--name", "builder"]);
+    let issue = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "coalesce demo"],
+    ));
+
+    let first = rows(&ainb(
+        h,
+        &[
+            "hangar",
+            "comment",
+            "add",
+            "--issue",
+            &issue,
+            "--body",
+            "@builder go",
+            "--format",
+            "json",
+        ],
+    ));
+    assert_eq!(first.len(), 1, "{first:?}");
+    assert_eq!(field(&first[0], "outcome"), "queued", "{first:?}");
+    assert_eq!(field(&first[0], "target_type"), "agent");
+
+    let second = rows(&ainb(
+        h,
+        &[
+            "hangar",
+            "comment",
+            "add",
+            "--issue",
+            &issue,
+            "--body",
+            "@builder again",
+            "--format",
+            "json",
+        ],
+    ));
+    assert_eq!(second.len(), 1, "{second:?}");
+    assert_eq!(
+        field(&second[0], "outcome"),
+        "coalesced",
+        "a repeat mention is reported, not swallowed: {second:?}"
+    );
+    assert_eq!(field(&second[0], "reason"), "coalesced", "{second:?}");
+}
+
+/// The preview reports the identical codes the write then produces, and writes
+/// nothing — proven by running the preview TWICE and then the write, and
+/// checking the agent still ends up with exactly one queued task.
+#[test]
+fn a_preview_reports_the_same_codes_and_writes_nothing() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+
+    ainb(h, &["hangar", "agent", "create", "--name", "builder"]);
+    let issue = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "preview demo"],
+    ));
+
+    let preview_args = [
+        "hangar",
+        "comment",
+        "preview",
+        "--issue",
+        &issue,
+        "--body",
+        "@builder go",
+        "--format",
+        "json",
+    ];
+    let first_preview = rows(&ainb(h, &preview_args));
+    assert_eq!(first_preview.len(), 1, "{first_preview:?}");
+    assert_eq!(field(&first_preview[0], "outcome"), "queued");
+
+    // A preview writes nothing, so running it again reports the SAME thing
+    // rather than degrading to `coalesced` (which is what a write would do).
+    let second_preview = rows(&ainb(h, &preview_args));
+    assert_eq!(
+        field(&second_preview[0], "outcome"),
+        "queued",
+        "a preview that had written would now report coalesced: {second_preview:?}"
+    );
+
+    // And nothing landed in the timeline either — the comment was never written.
+    let timeline = ainb(
+        h,
+        &["hangar", "issue", "timeline", &issue, "--format", "json"],
+    );
+    assert!(
+        !timeline.contains("@builder go"),
+        "a preview must not write the comment: {timeline}"
+    );
+
+    // The real write then produces the code the preview promised.
+    let written = rows(&ainb(
+        h,
+        &[
+            "hangar",
+            "comment",
+            "add",
+            "--issue",
+            &issue,
+            "--body",
+            "@builder go",
+            "--format",
+            "json",
+        ],
+    ));
+    assert_eq!(field(&written[0], "outcome"), "queued", "{written:?}");
+}
+
+/// A mention that resolves to nothing is REPORTED as `ignored`, not silently
+/// dropped — the whole point of the outcome vocabulary.
+#[test]
+fn an_unresolvable_handle_is_reported_as_ignored() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+
+    let issue = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "ignored demo"],
+    ));
+    let out = ainb(
+        h,
+        &[
+            "hangar",
+            "comment",
+            "add",
+            "--issue",
+            &issue,
+            "--body",
+            "@nobody-at-all hello",
+            "--format",
+            "json",
+        ],
+    );
+    let routed = rows(&out);
+    assert_eq!(routed.len(), 1, "{out}");
+    assert_eq!(field(&routed[0], "outcome"), "ignored", "{out}");
+    assert_eq!(field(&routed[0], "handle"), "nobody-at-all", "{out}");
+}
+
+/// A typo'd `--workspace` is an ERROR, never a silently empty routing report a
+/// caller would read as "this comment mentions nobody".
+#[test]
+fn a_mistyped_workspace_is_rejected_rather_than_reporting_nothing() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let h = home.path();
+    let issue = created_id(&ainb(
+        h,
+        &["hangar", "issue", "create", "--title", "ws demo"],
+    ));
+
+    let out = Command::new(ainb_bin())
+        .args([
+            "hangar",
+            "comment",
+            "preview",
+            "--issue",
+            &issue,
+            "--body",
+            "@builder go",
+            "--workspace",
+            "not-a-workspace",
+        ])
+        .env("AINB_HANGAR_HOME", h)
+        .env("HOME", h)
+        .output()
+        .expect("run ainb");
+    assert!(
+        !out.status.success(),
+        "a typo'd workspace must fail: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/dispatch_reason.rs
@@ -35,13 +35,20 @@
 //!
 //! # Reserved variants
 //!
-//! [`DispatchReason::Coalesced`], [`DispatchReason::AttributionBlocked`] and
-//! [`DispatchReason::SelfTriggerSuppressed`] ship with **no producer** at this
+//! [`DispatchReason::AttributionBlocked`] ships with **no producer** at this
 //! stage. That is deliberate, not an oversight: the vocabulary is a *wire
 //! contract*, so a reader must already accept codes a future writer will emit.
-//! Those three belong to the mention-routing layer, which is unstarted. The
-//! [`DispatchReason::RESERVED`] list pins the set — a future change that adds a
-//! producer has to remove its variant from that list deliberately.
+//! It belongs with the `originator_user_id` attribution chain (multica 184/185),
+//! which hangar has not started.
+//!
+//! [`DispatchReason::Coalesced`] and [`DispatchReason::SelfTriggerSuppressed`]
+//! WERE reserved alongside it until the mention-routing layer (multica parity
+//! #2-rest) shipped their producers:
+//! `ainb_hangar_store::service::mention::route` emits `Coalesced` when a mention
+//! folds into a pending task and `SelfTriggerSuppressed` when an agent's own
+//! comment would have re-triggered itself. The
+//! [`DispatchReason::RESERVED`] list pins the remaining set — a future change
+//! that adds a producer has to remove its variant from that list deliberately.
 
 use serde::{Deserialize, Serialize};
 
@@ -63,7 +70,8 @@ pub enum DispatchReason {
     Queued,
     /// Folded into an existing pending task rather than creating a second one.
     ///
-    /// **Reserved** — no producer yet (see the module docs).
+    /// Produced by the mention router when the mentioned agent already holds a
+    /// `queued`/`dispatched` task on the issue (multica's merge-into-pending).
     Coalesced,
     /// Admitted but parked: a later event promotes it. hangar's producer is a
     /// card blocked by unfinished dependencies, which `board::auto_run_dependent`
@@ -94,7 +102,8 @@ pub enum DispatchReason {
     /// The trigger was produced by the same agent it would have targeted, and
     /// was suppressed to stop a self-driving loop.
     ///
-    /// **Reserved** — no producer yet (see the module docs).
+    /// Produced by the mention router when a comment's agent author mentions
+    /// itself (multica `comment.go`'s `authorType == "agent" && authorID == m.ID`).
     SelfTriggerSuppressed,
     /// The admission path itself faulted (e.g. a database error).
     InternalError,
@@ -120,11 +129,7 @@ impl DispatchReason {
     /// Variants that ship in the vocabulary with **no producer** in this
     /// codebase (see the module docs). Pinned by a test so adding a producer is
     /// a deliberate edit here, and so the list can never quietly grow.
-    pub const RESERVED: [Self; 3] = [
-        Self::Coalesced,
-        Self::AttributionBlocked,
-        Self::SelfTriggerSuppressed,
-    ];
+    pub const RESERVED: [Self; 1] = [Self::AttributionBlocked];
 
     /// The `snake_case` token persisted to `dispatch_attempt.reason` and put on
     /// the wire.
@@ -300,11 +305,10 @@ mod tests {
         // the variant from `RESERVED` here.
         assert_eq!(
             DispatchReason::RESERVED,
-            [
-                DispatchReason::Coalesced,
-                DispatchReason::AttributionBlocked,
-                DispatchReason::SelfTriggerSuppressed,
-            ]
+            [DispatchReason::AttributionBlocked],
+            "the mention router (parity #2-rest) ships the Coalesced and \
+             SelfTriggerSuppressed producers, so only the attribution-chain \
+             code stays reserved"
         );
         for r in DispatchReason::RESERVED {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/lib.rs
@@ -56,6 +56,10 @@ pub mod ids;
 /// Structured-log line model + `daemon.<date>` reader shared by the
 /// `ainb hangar logs tail` CLI verb and the TUI `LogsScreen` (P8.6).
 pub mod logs;
+/// Comment `@mention` grammar (`mention://` links + bare `@handle`) and the
+/// per-target routing outcome vocabulary (multica parity #2-rest). The pure
+/// half; resolution + writes live in `ainb_hangar_store::service::mention`.
+pub mod mention;
 /// Issue / task ORIGIN PROVENANCE: the validated `(origin_type, origin_id)`
 /// pair over the closed `{autopilot, comment_mention, manual}` allow-list
 /// (multica parity #21, migration 0056).

--- a/ainb-tui/crates/ainb-hangar-core/src/mention.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/mention.rs
@@ -1,0 +1,487 @@
+//! **Mention grammar + routing outcome vocabulary** (multica parity #2-rest).
+//!
+//! This module is the pure half of the mention-routing layer: it turns a comment
+//! body into the ordered set of things the author addressed, and it names the
+//! per-target outcomes the router reports back. Resolution (matching a target to
+//! a real agent / member / squad) and the writes live in
+//! `ainb_hangar_store::service::mention`, which is the single seam both the
+//! daemon RPC and the CLI drive.
+//!
+//! # Two markup forms
+//!
+//! 1. **Link form** — multica's `util.MentionRe`
+//!    (`server/internal/util/mention.go:17`):
+//!    `` [@Label](mention://<type>/<id>) `` with `type` in
+//!    `member | agent | squad | issue | all`. This is the exact, unambiguous
+//!    address: the id is carried verbatim so two agents sharing a display label
+//!    can never be confused. The label is matched NON-GREEDILY because a label
+//!    may itself contain `[` / `]` (the upstream comment says the same).
+//!
+//!    One deliberate widening: multica's id class is UUID hex
+//!    (`[0-9a-fA-F-]+`), hangar ids are ULIDs and its slugs are kebab-case, so
+//!    the class here is `[A-Za-z0-9_-]+` (plus the literal `all`).
+//!
+//! 2. **Bare form** — `@handle`, the grammar hangar has shipped since e38.7.
+//!    [`parse_handles`] is that implementation moved here VERBATIM (it was
+//!    `ainb_hangar_daemon::mentions::parse_mentions`) together with its
+//!    regression tests, because the daemon must keep resolving today's bare
+//!    mentions exactly as it does now.
+//!
+//! Both forms are collected in ONE pass over the body, first-seen order
+//! preserved. A bare `@handle` that appears INSIDE a link's label is not a
+//! second mention: link spans are blanked out before the bare scan, so
+//! `[@alice](mention://member/u1)` yields exactly one target.
+//!
+//! # Dedup
+//!
+//! Multica's dedup key is `type + ":" + id` (`mention.go:29`). This module uses
+//! the same key for links — `(kind, token)` — and the bare `token` alone for
+//! bare handles (a bare handle has no type until the router resolves it).
+
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+
+/// The entity family a `mention://` link addresses.
+///
+/// `member | agent | issue | all` are multica's original four (`mention.go:17`);
+/// `squad` is the newer revision's addition and is the form that routes to the
+/// squad's leader (multica step 6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MentionTargetKind {
+    /// A human workspace member — a NOTIFICATION target, never a trigger.
+    Member,
+    /// An agent — the trigger target.
+    Agent,
+    /// A squad — routes to the squad's leader.
+    Squad,
+    /// A cross-reference to another issue. Never a trigger.
+    Issue,
+    /// The `mention://all/all` broadcast marker. Never a trigger.
+    All,
+}
+
+impl MentionTargetKind {
+    /// The wire / link token for this kind.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Member => "member",
+            Self::Agent => "agent",
+            Self::Squad => "squad",
+            Self::Issue => "issue",
+            Self::All => "all",
+        }
+    }
+
+    /// Parse a link type token, returning `None` outside the closed set.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "member" => Some(Self::Member),
+            "agent" => Some(Self::Agent),
+            "squad" => Some(Self::Squad),
+            "issue" => Some(Self::Issue),
+            "all" => Some(Self::All),
+            _ => None,
+        }
+    }
+}
+
+/// Which markup produced a [`ParsedMention`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MentionForm {
+    /// `[@Label](mention://type/id)` — typed and exact.
+    Link,
+    /// `@handle` — untyped; the router resolves it (agent first, then member).
+    Bare,
+}
+
+/// One addressed target lifted out of a comment body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedMention {
+    /// The link's declared type, or `None` for a bare handle (whose type is only
+    /// known once the router has resolved it).
+    pub kind: Option<MentionTargetKind>,
+    /// The id for a link, the handle for a bare mention — verbatim as typed.
+    pub token: String,
+    /// The display label from the link, or the handle itself for a bare mention.
+    pub label: String,
+    /// Which markup this came from.
+    pub form: MentionForm,
+}
+
+/// Where a routed target came from: an explicit mention in the body, or one of
+/// the three implicit fallbacks multica walks when the body mentions nobody
+/// (`comment.go` step 4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MentionSource {
+    /// Named in the comment body (or inherited from the parent, which multica
+    /// also treats as explicit).
+    Explicit,
+    /// The author of the comment this one replies to.
+    ReplyParent,
+    /// The author of the thread's root comment.
+    ThreadRoot,
+    /// The issue's assignee.
+    Assignee,
+}
+
+impl MentionSource {
+    /// The wire token for this source.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::ReplyParent => "reply_parent",
+            Self::ThreadRoot => "thread_root",
+            Self::Assignee => "assignee",
+        }
+    }
+}
+
+/// What the router DID about one addressed target.
+///
+/// `Queued | Coalesced | Deferred | Blocked` are multica's four
+/// `CommentTriggerOutcome` values verbatim (MUL-4525 §2).
+///
+/// # Hangar divergence
+///
+/// `Notified` and `Ignored` are **hangar-additive**. Multica's outcome array
+/// only ever describes AGENT triggers: a member mention and an unresolvable
+/// handle simply do not appear in it. Hangar reports them because reporting
+/// every target — including "this went to a human, not a run" and "this handle
+/// matched nothing" — is the entire point of this layer; silently dropping the
+/// non-trigger cases is exactly the failure mode it replaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MentionOutcome {
+    /// A task row was written for this agent.
+    Queued,
+    /// Folded into a task this agent already had pending on the issue.
+    Coalesced,
+    /// Admitted but parked behind unfinished blockers; promoted later.
+    Deferred,
+    /// Refused. The paired `DispatchReason` says why.
+    Blocked,
+    /// A human was notified (inbox + subscription). Never a run.
+    Notified,
+    /// Nothing to do: the handle resolved to nothing, or the link was an
+    /// `issue` / `all` cross-reference.
+    Ignored,
+}
+
+impl MentionOutcome {
+    /// Every variant, in declaration order.
+    pub const ALL: [Self; 6] = [
+        Self::Queued,
+        Self::Coalesced,
+        Self::Deferred,
+        Self::Blocked,
+        Self::Notified,
+        Self::Ignored,
+    ];
+
+    /// The wire token for this outcome (matches the `serde` rename).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Coalesced => "coalesced",
+            Self::Deferred => "deferred",
+            Self::Blocked => "blocked",
+            Self::Notified => "notified",
+            Self::Ignored => "ignored",
+        }
+    }
+
+    /// Parse an outcome token, returning `None` outside the closed set.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|o| o.as_str() == raw)
+    }
+}
+
+/// multica `util.MentionRe` (`mention.go:17`), with the id class widened from
+/// UUID hex to the ULID / slug characters hangar ids actually use.
+static LINK_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"\[@?(.+?)\]\(mention://(member|agent|squad|issue|all)/([A-Za-z0-9_-]+)\)")
+        .expect("mention link regex is a compile-time constant")
+});
+
+/// Scan `body` for every addressed target, link form and bare form, in
+/// first-seen order.
+///
+/// Links are scanned first and their spans blanked out, so a bare `@handle`
+/// inside a link's label is counted ONCE (as the link), never twice. Dedup is by
+/// `(kind, token)` for links (multica's `type:id` key) and by `token` for bare
+/// handles.
+#[must_use]
+pub fn parse(body: &str) -> Vec<ParsedMention> {
+    let mut out: Vec<ParsedMention> = Vec::new();
+    // Blank out the link spans byte-for-byte (spaces keep the byte offsets of
+    // the surrounding text intact, so the bare scan sees the same boundaries).
+    let mut residue: Vec<u8> = body.as_bytes().to_vec();
+    for caps in LINK_RE.captures_iter(body) {
+        let whole = caps.get(0).expect("group 0 always matches");
+        let label = caps.get(1).map_or("", |m| m.as_str()).to_string();
+        let kind = MentionTargetKind::parse(caps.get(2).map_or("", |m| m.as_str()));
+        let token = caps.get(3).map_or("", |m| m.as_str()).to_string();
+        for b in &mut residue[whole.start()..whole.end()] {
+            *b = b' ';
+        }
+        if !out
+            .iter()
+            .any(|m| m.form == MentionForm::Link && m.kind == kind && m.token == token)
+        {
+            out.push(ParsedMention {
+                kind,
+                token,
+                label,
+                form: MentionForm::Link,
+            });
+        }
+    }
+    // The residue is still valid UTF-8: only whole ASCII-delimited link spans
+    // were overwritten with ASCII spaces.
+    let residue = String::from_utf8(residue).unwrap_or_else(|_| body.to_string());
+    for handle in parse_handles(&residue) {
+        if !out
+            .iter()
+            .any(|m| m.form == MentionForm::Bare && m.token == handle)
+        {
+            out.push(ParsedMention {
+                kind: None,
+                label: handle.clone(),
+                token: handle,
+                form: MentionForm::Bare,
+            });
+        }
+    }
+    out
+}
+
+/// The handle characters that may follow `@` in a mention: ASCII alphanumerics
+/// plus `-` and `_` (agent names like `claude-agent` are valid handles).
+const fn is_handle_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_'
+}
+
+/// Scan `body` for bare `@handle` mentions, returning the distinct handles in
+/// first-seen order (case preserved — the resolver decides case sensitivity).
+///
+/// A mention is an `@` at a token boundary (body start, or after a non-handle
+/// char such as whitespace) followed by ≥1 [handle char](is_handle_char). The
+/// leading `@` and the handle are case-preserved verbatim. Duplicates collapse
+/// to their first occurrence so `"@bot @bot"` yields one handle, mirroring the
+/// resolver's idempotent per-agent enqueue.
+///
+/// An `@` embedded mid-token (e.g. inside `user@host`) is not a boundary mention
+/// and is skipped, so email-shaped text never spawns a phantom mention.
+///
+/// This is `ainb_hangar_daemon::mentions::parse_mentions` moved here unchanged;
+/// the daemon re-exports it so today's call sites and tests are untouched.
+#[must_use]
+pub fn parse_handles(body: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let chars: Vec<char> = body.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        // A mention's `@` must sit at a token boundary: either the body start or
+        // immediately after a character that cannot itself be part of a handle.
+        // This stops `user@host` (the `@` follows the handle char `r`) from being
+        // read as an `@host` mention.
+        let at_boundary = i == 0 || !is_handle_char(chars[i - 1]);
+        if chars[i] == '@' && at_boundary {
+            let start = i + 1;
+            let mut j = start;
+            while j < chars.len() && is_handle_char(chars[j]) {
+                j += 1;
+            }
+            // Require at least one handle char after `@`; a bare `@` is ignored.
+            if j > start {
+                let handle: String = chars[start..j].iter().collect();
+                if !out.contains(&handle) {
+                    out.push(handle);
+                }
+            }
+            i = j.max(start);
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse, parse_handles, MentionForm, MentionOutcome, MentionTargetKind};
+
+    // --- bare grammar: the 9 regression tests moved verbatim from the daemon ---
+
+    #[test]
+    fn extracts_a_single_hyphenated_handle() {
+        assert_eq!(
+            parse_handles("@claude-agent please do X"),
+            vec!["claude-agent".to_string()]
+        );
+    }
+
+    #[test]
+    fn extracts_multiple_handles_in_first_seen_order() {
+        assert_eq!(
+            parse_handles("ping @alpha and @beta then @gamma"),
+            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]
+        );
+    }
+
+    #[test]
+    fn collapses_duplicate_handles_to_first_occurrence() {
+        assert_eq!(
+            parse_handles("@bot @bot @bot"),
+            vec!["bot".to_string()],
+            "a repeated mention yields one handle (resolver is idempotent)"
+        );
+    }
+
+    #[test]
+    fn a_plain_comment_yields_no_handles() {
+        assert!(parse_handles("just a normal comment, no pings").is_empty());
+    }
+
+    #[test]
+    fn an_email_address_is_not_a_mention() {
+        assert!(
+            parse_handles("mail me at alice@example.com").is_empty(),
+            "the @ in an email follows a handle char, not a boundary"
+        );
+    }
+
+    #[test]
+    fn a_bare_at_sign_is_ignored() {
+        assert!(parse_handles("just an @ here and @ there").is_empty());
+    }
+
+    #[test]
+    fn punctuation_terminates_a_handle() {
+        assert_eq!(
+            parse_handles("hey @claude-agent, ship it!"),
+            vec!["claude-agent".to_string()],
+            "the comma is not a handle char so it ends the handle"
+        );
+    }
+
+    #[test]
+    fn underscores_and_digits_are_handle_chars() {
+        assert_eq!(parse_handles("@agent_7 go"), vec!["agent_7".to_string()]);
+    }
+
+    #[test]
+    fn mention_at_body_start_with_no_leading_space() {
+        assert_eq!(parse_handles("@solo"), vec!["solo".to_string()]);
+    }
+
+    // --- link grammar ---
+
+    #[test]
+    fn parses_a_link_form_agent_mention() {
+        let got = parse("[@Builder](mention://agent/agent-1) please ship");
+        assert_eq!(got.len(), 1, "one target: {got:?}");
+        assert_eq!(got[0].kind, Some(MentionTargetKind::Agent));
+        assert_eq!(got[0].token, "agent-1");
+        assert_eq!(got[0].label, "Builder");
+        assert_eq!(got[0].form, MentionForm::Link);
+    }
+
+    #[test]
+    fn a_bare_handle_inside_a_link_label_is_counted_once() {
+        let got = parse("[@alice](mention://member/user-1) can you look?");
+        assert_eq!(
+            got.len(),
+            1,
+            "the label's `@alice` must not double-count as a bare mention: {got:?}"
+        );
+        assert_eq!(got[0].kind, Some(MentionTargetKind::Member));
+        assert_eq!(got[0].token, "user-1");
+    }
+
+    #[test]
+    fn dedups_links_by_type_and_id() {
+        let got = parse(
+            "[@A](mention://agent/a1) then [@A again](mention://agent/a1) \
+             and [@A](mention://member/a1)",
+        );
+        assert_eq!(
+            got.len(),
+            2,
+            "same (type,id) collapses; a different type does not: {got:?}"
+        );
+        assert_eq!(got[0].kind, Some(MentionTargetKind::Agent));
+        assert_eq!(got[1].kind, Some(MentionTargetKind::Member));
+    }
+
+    #[test]
+    fn a_label_may_contain_brackets() {
+        let got = parse("[@Team [core]](mention://squad/sq-1) heads up");
+        assert_eq!(got.len(), 1, "{got:?}");
+        assert_eq!(got[0].kind, Some(MentionTargetKind::Squad));
+        assert_eq!(got[0].token, "sq-1");
+    }
+
+    #[test]
+    fn issue_and_all_links_parse_as_their_own_kinds() {
+        let got = parse("see [#12](mention://issue/issue-12) and [@all](mention://all/all)");
+        assert_eq!(got.len(), 2, "{got:?}");
+        assert_eq!(got[0].kind, Some(MentionTargetKind::Issue));
+        assert_eq!(got[1].kind, Some(MentionTargetKind::All));
+    }
+
+    #[test]
+    fn links_and_bare_handles_mix_in_first_seen_order() {
+        let got = parse("[@Builder](mention://agent/a1) and @claude-agent");
+        assert_eq!(got.len(), 2, "{got:?}");
+        assert_eq!(got[0].form, MentionForm::Link);
+        assert_eq!(got[1].form, MentionForm::Bare);
+        assert_eq!(got[1].token, "claude-agent");
+    }
+
+    #[test]
+    fn an_unknown_link_type_is_not_a_link_mention() {
+        let got = parse("[@x](mention://robot/r1)");
+        assert!(
+            got.iter().all(|m| m.form == MentionForm::Bare),
+            "only the closed type set yields a LINK target: {got:?}"
+        );
+        // The label's `@x` is still a bare handle — that is today's shipped
+        // behaviour and the link scan must not silently take it away.
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].token, "x");
+    }
+
+    #[test]
+    fn a_plain_markdown_link_is_not_a_mention() {
+        assert!(parse("see [the docs](https://example.com/x)").is_empty());
+    }
+
+    // --- outcome vocabulary ---
+
+    #[test]
+    fn outcome_tokens_round_trip() {
+        for o in MentionOutcome::ALL {
+            assert_eq!(MentionOutcome::parse(o.as_str()), Some(o));
+            let json = serde_json::to_string(&o).unwrap();
+            assert_eq!(json, format!("\"{}\"", o.as_str()), "serde matches as_str");
+        }
+    }
+
+    #[test]
+    fn multicas_four_outcome_tokens_are_present_verbatim() {
+        for token in ["queued", "coalesced", "deferred", "blocked"] {
+            assert!(
+                MentionOutcome::parse(token).is_some(),
+                "multica CommentTriggerOutcome `{token}` must exist verbatim"
+            );
+        }
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-core/src/mention.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/mention.rs
@@ -247,10 +247,7 @@ pub fn parse(body: &str) -> Vec<ParsedMention> {
     // were overwritten with ASCII spaces.
     let residue = String::from_utf8(residue).unwrap_or_else(|_| body.to_string());
     for handle in parse_handles(&residue) {
-        if !out
-            .iter()
-            .any(|m| m.form == MentionForm::Bare && m.token == handle)
-        {
+        if !out.iter().any(|m| m.form == MentionForm::Bare && m.token == handle) {
             out.push(ParsedMention {
                 kind: None,
                 label: handle.clone(),
@@ -316,7 +313,7 @@ pub fn parse_handles(body: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse, parse_handles, MentionForm, MentionOutcome, MentionTargetKind};
+    use super::{MentionForm, MentionOutcome, MentionTargetKind, parse, parse_handles};
 
     // --- bare grammar: the 9 regression tests moved verbatim from the daemon ---
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -542,6 +542,7 @@ pub async fn deliver_cascade(
                 ),
                 body: cascade.comment_body.clone(),
                 created_at: now_ms,
+                parent_id: None,
             }),
         );
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -253,6 +253,7 @@ mod tests {
                 author: "member:u1".into(),
                 body: "lgtm".into(),
                 created_at: 0,
+                parent_id: None,
             }),
             HangarEvent::AgentPresence {
                 agent_id: AgentId::from_str("a1").unwrap(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/inbox_aggregator.rs
@@ -419,6 +419,7 @@ mod tests {
             author: "member:u1".into(),
             body: "lgtm".into(),
             created_at: 0,
+            parent_id: None,
         };
         let f = entry_for_event(&HangarEvent::CommentAdded(row)).expect("comment aggregates");
         assert_eq!(f.kind, InboxKind::Comment);
@@ -478,6 +479,7 @@ mod tests {
             author: author.into(),
             body: "lgtm".into(),
             created_at: 0,
+            parent_id: None,
         })
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/mentions.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/mentions.rs
@@ -1,140 +1,16 @@
-//! `@handle` mention parsing over a comment body (e38.7).
+//! `@`-mention parsing over a comment body — a re-export shim.
 //!
-//! The reference's collaboration loop lets a user `@`-mention an agent in a comment to
-//! trigger a task for that agent (`docs/hangar/research/01-codebase-archaeology.md`:
-//! "`@agent_name` mention in a comment triggers a new task run"). This module is
-//! the parser half: a pure scan over a comment body that extracts the distinct
-//! `@handle` tokens, preserving first-seen order. The *resolution* half (matching
-//! a handle to a real agent in the comment's workspace and enqueuing its task)
-//! lives in [`crate::rpc::snapshots`], driven from the `comment_add` handler
+//! The grammar moved to [`ainb_hangar_core::mention`] (multica parity #2-rest)
+//! so the CLI's store-direct path and the daemon's RPC path parse a body with
+//! ONE implementation. The move was verbatim: [`parse_mentions`] is
+//! [`ainb_hangar_core::mention::parse_handles`] under its historical name, and
+//! the nine bare-grammar regression tests moved with it.
+//!
+//! [`parse`] is the newer, fuller scan: it also lifts multica's
+//! `[@Label](mention://type/id)` link form out of the body. The *resolution*
+//! half (matching a target to a real agent / member / squad in the comment's
+//! workspace, gating it, and enqueuing) lives in
+//! `ainb_hangar_store::service::mention`, driven from the `comment_add` handler
 //! after the comment commits.
-//!
-//! # Handle grammar
-//!
-//! A mention is an `@` immediately followed by one or more handle characters:
-//! ASCII letters, digits, `-`, or `_`. Agent names like `claude-agent` therefore
-//! parse whole. The `@` must start a token boundary (start of the body or after
-//! whitespace / a non-handle char), so an email address (`a@b.com`) or a literal
-//! `foo@bar` does NOT yield a `bar` mention — the `@` there is preceded by a
-//! handle char, not a boundary. A bare `@` with no following handle char is
-//! ignored.
-//!
-//! Parsing is deliberately permissive: it does not validate a handle against the
-//! agent roster (the caller does, workspace-scoped), so an unknown `@nobody` is
-//! returned here and silently dropped by the resolver — never an error.
 
-/// The handle characters that may follow `@` in a mention: ASCII alphanumerics
-/// plus `-` and `_` (agent names like `claude-agent` are valid handles).
-const fn is_handle_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '-' || c == '_'
-}
-
-/// Scan `body` for `@handle` mentions, returning the distinct handles in
-/// first-seen order (case preserved — the resolver decides case sensitivity).
-///
-/// A mention is an `@` at a token boundary (body start, or after a non-handle
-/// char such as whitespace) followed by ≥1 [handle char](is_handle_char). The
-/// leading `@` and the handle are case-preserved verbatim. Duplicates collapse
-/// to their first occurrence so `"@bot @bot"` yields one handle, mirroring the
-/// resolver's idempotent per-agent enqueue.
-///
-/// An `@` embedded mid-token (e.g. inside `user@host`) is not a boundary mention
-/// and is skipped, so email-shaped text never spawns a phantom mention.
-#[must_use]
-pub fn parse_mentions(body: &str) -> Vec<String> {
-    let mut out: Vec<String> = Vec::new();
-    let chars: Vec<char> = body.chars().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        // A mention's `@` must sit at a token boundary: either the body start or
-        // immediately after a character that cannot itself be part of a handle.
-        // This stops `user@host` (the `@` follows the handle char `r`) from being
-        // read as an `@host` mention.
-        let at_boundary = i == 0 || !is_handle_char(chars[i - 1]);
-        if chars[i] == '@' && at_boundary {
-            let start = i + 1;
-            let mut j = start;
-            while j < chars.len() && is_handle_char(chars[j]) {
-                j += 1;
-            }
-            // Require at least one handle char after `@`; a bare `@` is ignored.
-            if j > start {
-                let handle: String = chars[start..j].iter().collect();
-                if !out.contains(&handle) {
-                    out.push(handle);
-                }
-            }
-            i = j.max(start);
-            continue;
-        }
-        i += 1;
-    }
-    out
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_mentions;
-
-    #[test]
-    fn extracts_a_single_hyphenated_handle() {
-        assert_eq!(
-            parse_mentions("@claude-agent please do X"),
-            vec!["claude-agent".to_string()]
-        );
-    }
-
-    #[test]
-    fn extracts_multiple_handles_in_first_seen_order() {
-        assert_eq!(
-            parse_mentions("ping @alpha and @beta then @gamma"),
-            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]
-        );
-    }
-
-    #[test]
-    fn collapses_duplicate_handles_to_first_occurrence() {
-        assert_eq!(
-            parse_mentions("@bot @bot @bot"),
-            vec!["bot".to_string()],
-            "a repeated mention yields one handle (resolver is idempotent)"
-        );
-    }
-
-    #[test]
-    fn a_plain_comment_yields_no_handles() {
-        assert!(parse_mentions("just a normal comment, no pings").is_empty());
-    }
-
-    #[test]
-    fn an_email_address_is_not_a_mention() {
-        assert!(
-            parse_mentions("mail me at alice@example.com").is_empty(),
-            "the @ in an email follows a handle char, not a boundary"
-        );
-    }
-
-    #[test]
-    fn a_bare_at_sign_is_ignored() {
-        assert!(parse_mentions("just an @ here and @ there").is_empty());
-    }
-
-    #[test]
-    fn punctuation_terminates_a_handle() {
-        assert_eq!(
-            parse_mentions("hey @claude-agent, ship it!"),
-            vec!["claude-agent".to_string()],
-            "the comma is not a handle char so it ends the handle"
-        );
-    }
-
-    #[test]
-    fn underscores_and_digits_are_handle_chars() {
-        assert_eq!(parse_mentions("@agent_7 go"), vec!["agent_7".to_string()]);
-    }
-
-    #[test]
-    fn mention_at_body_start_with_no_leading_space() {
-        assert_eq!(parse_mentions("@solo"), vec!["solo".to_string()]);
-    }
-}
+pub use ainb_hangar_core::mention::{parse, parse_handles as parse_mentions};

--- a/ainb-tui/crates/ainb-hangar-daemon/src/progress_comment.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/progress_comment.rs
@@ -131,6 +131,7 @@ pub async fn emit_checkpoint(
         author,
         body: checkpoint.body(),
         created_at: clock.now_ms(),
+        parent_id: None,
     };
 
     match CommentRepo::insert(pool, &task.workspace_id, &comment).await {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4099,6 +4099,7 @@ async fn handle_comment_add(
         &params.issue_id,
         &author,
         &params.body,
+        params.parent_id.as_deref(),
     )
     .await
     .map_err(|e| store_err(&e))?;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -804,6 +804,7 @@ async fn handle(
             handle_issue_metadata(pool, req, events, MetaOp::Delete).await
         }
         methods::HANGAR_COMMENT_ADD => handle_comment_add(pool, req, events).await,
+        methods::HANGAR_COMMENT_MENTION_PREVIEW => handle_comment_mention_preview(pool, req).await,
         methods::HANGAR_AGENT_CREATE => handle_agent_create(pool, req).await,
         methods::HANGAR_AGENT_DELETE => handle_agent_delete(pool, req).await,
         methods::HANGAR_AGENT_UPDATE => handle_agent_update(pool, req).await,
@@ -4111,7 +4112,10 @@ async fn handle_comment_add(
             params.issue_id
         )));
     };
-    // A committed insert announces the new comment to subscribers.
+    // A committed insert announces the new comment to subscribers. The event
+    // carries the COMMENT only: the per-target mention outcomes ride the RPC
+    // result back to the caller that wrote it, never the broadcast, so the
+    // invocation gate's refusals are not fanned out to the whole workspace.
     events.emit(ws.as_str(), HangarEvent::CommentAdded(row.clone()));
     // e38.7 — the collaboration trigger: now that the comment has committed,
     // parse its @-mentions and enqueue a task for every agent that resolves in
@@ -4121,7 +4125,7 @@ async fn handle_comment_add(
     // failed trigger must not turn a successful comment into an RPC error. The
     // AUTHOR rides through as the gap #8 effective invoker: a mention of an agent
     // the author may not invoke spawns nothing (the comment still lands).
-    if let Err(e) = snapshots::spawn_mention_tasks(
+    let mention_outcomes = match snapshots::route_comment_mentions(
         pool,
         &SystemIdGen,
         &SystemClock,
@@ -4129,15 +4133,88 @@ async fn handle_comment_add(
         row.issue_id.as_str(),
         // 0056: the COMMITTED comment's id is this run's provenance
         // (`('comment_mention', <comment.id>)`).
-        row.id.as_str(),
+        Some(row.id.as_str()),
+        params.parent_id.as_deref(),
         &author,
         &params.body,
+        false,
     )
     .await
     {
-        tracing::warn!(error = %e, "comment mention task spawn failed");
+        Ok(rows) => rows,
+        // The comment already committed, so a routing fault must not turn a
+        // successful comment into an RPC error. It is no longer SILENT either:
+        // the caller gets one `blocked` / `internal_error` row, so "nothing
+        // happened" and "the router fell over" are distinguishable.
+        Err(e) => {
+            tracing::warn!(error = %e, "comment mention routing failed");
+            vec![ainb_hangar_proto::snapshots::MentionOutcomeRow {
+                target_type: "agent".to_string(),
+                target_id: String::new(),
+                handle: String::new(),
+                outcome: "blocked".to_string(),
+                reason: ainb_hangar_core::dispatch_reason::DispatchReason::InternalError
+                    .as_db_str()
+                    .to_string(),
+                task_id: None,
+                detail: "mention routing failed".to_string(),
+                source: String::new(),
+            }]
+        }
+    };
+    to_value(&ainb_hangar_proto::snapshots::CommentAddResult {
+        comment: row,
+        mention_outcomes,
+    })
+}
+
+/// Dispatch `hangar/comment_mention_preview` (multica parity #2-rest): report
+/// what the mention router WOULD do for a draft comment, writing nothing.
+///
+/// Drives the SAME `service::mention::route` the write drives, with `dry_run`
+/// set — that shared path is the contract. It therefore applies the identical
+/// visibility / invocation gate, so a preview can never leak a private agent's
+/// readiness, and can never disagree with the write it previews.
+///
+/// Read-only, but workspace-scoped like the mutating handlers: a mistyped
+/// workspace is `INVALID_PARAMS`, never a silently empty preview that a caller
+/// would read as "this mentions nobody".
+async fn handle_comment_mention_preview(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_core::actor::ActorRef;
+    use ainb_hangar_core::idgen::SystemIdGen;
+    use std::str::FromStr as _;
+
+    let params: ainb_hangar_proto::snapshots::CommentMentionPreviewParams =
+        parse_params(req, "{ workspace_id, issue_id, author, body, parent_id? }")?;
+    let ws = resolve_wire_or_reject(pool, &params.workspace_id).await?;
+    if params.body.trim().is_empty() {
+        return Err(invalid_params("comment body must not be empty"));
     }
-    to_value(&row)
+    let author = ActorRef::from_str(&params.author).map_err(|e| {
+        invalid_params(&format!(
+            "author must be `agent:<id>` or `member:<id>`: {e}"
+        ))
+    })?;
+    let mention_outcomes = snapshots::route_comment_mentions(
+        pool,
+        &SystemIdGen,
+        &SystemClock,
+        ws.as_str(),
+        &params.issue_id,
+        // No comment exists yet, which is also the interlock that makes the run
+        // unconditionally dry inside the router.
+        None,
+        params.parent_id.as_deref(),
+        &author,
+        &params.body,
+        true,
+    )
+    .await
+    .map_err(|e| store_err(&e))?;
+    to_value(&ainb_hangar_proto::snapshots::CommentMentionPreviewResult { mention_outcomes })
 }
 
 /// Dispatch `hangar/agent_update` (e38.15): edit one agent's config knobs and

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -42,7 +42,7 @@ use ainb_hangar_proto::events::{
     CommentRow, InboxEntryRow, IssueRow, PresenceState, SkillFile, SkillRow, TaskCardRow, Workload,
 };
 use ainb_hangar_proto::snapshots::{
-    AgentSkillsListResult, SkillDetail, SkillsSyncResult, TimelineEntryRow,
+    AgentSkillsListResult, MentionOutcomeRow, SkillDetail, SkillsSyncResult, TimelineEntryRow,
 };
 use ainb_hangar_store::repo::agent::AgentRepo;
 use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
@@ -2945,6 +2945,17 @@ pub async fn auto_subscribe(
     }
 }
 
+/// Write one comment on an issue, workspace-scoped, and return its wire row.
+///
+/// Returns `None` when `(issue_id, workspace_id)` matched no issue — an unknown
+/// id or a foreign tenant's — so the caller can reject rather than ack a write
+/// that never happened. `parent_id` threads the comment under an existing one
+/// (migration 0067); a malformed id is dropped from the WIRE row rather than
+/// failing the write.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on a store fault.
 pub async fn comment_add(
     pool: &SqlitePool,
     idgen: &dyn IdGen,
@@ -3007,47 +3018,76 @@ pub async fn comment_add(
     }))
 }
 
-/// Resolve the `@handle` mentions in a just-committed comment to agents in
-/// `workspace_id`, and enqueue an issue task for each that matches (e38.7).
+/// Route the `@`-mentions of a just-committed comment and return one wire row
+/// per addressed target (multica parity #2-rest).
 ///
-/// This is the comment-triggered task-spawn path: the `comment_add` handler
-/// calls it AFTER the comment commits, so a user `@`-mentioning an agent in a
-/// comment spawns that agent's task on the comment's issue. The trigger fires
-/// after the write so a spawn-side failure can never roll back (or lose) the
-/// comment — matching the bead's "fires from inside `comment_add` after the
-/// comment commits" contract and side-stepping the reference's mid-write expansion race.
-///
-/// Every resolved target is GATED (gap #8, multica
-/// `resolveMentionedAgentCommentTriggers`): the comment's `author` is mapped to an
-/// effective invoker ([`effective_mention_invoker`]) and an agent that invoker may
-/// not invoke is skipped exactly like an unresolvable handle — no task row, and no
-/// error. The gate runs BEFORE any other per-agent state is consulted, so a caller
-/// who cannot invoke an agent learns nothing about it from the trigger; and it is a
-/// per-target skip, so a denied `@handle` never suppresses the others in the same
-/// comment.
-///
-/// Resolution is by agent **name**, **workspace-scoped**: the candidate set is
-/// [`AgentRepo::list_by_workspace`] for the comment's workspace, so a foreign
-/// tenant's agent sharing the handle never gets a task. An unknown handle resolves
-/// to no agent and is silently ignored — never an error. Each matched agent is
-/// enqueued through the ordinary [`TaskRepo::insert`] path (no claim/dispatch
-/// logic is duplicated), bound to the comment's `issue_id` with the agent's
-/// `runtime_id` (`NOT NULL` + FK-enforced, so a resolved agent always has one).
-/// A duplicate enqueue while the agent still holds a *pending* (`queued` /
-/// `dispatched`) task on this issue — the per-`(issue, agent)` unique index — is
-/// coalesced, not an error, so re-mentioning is idempotent. Once that task has
-/// advanced to `running` the index no longer guards it, so a fresh mention
-/// enqueues a new task (intended: a follow-up mention after work started is a
-/// new request).
-///
-/// Returns the agent ids that actually got a task enqueued (for the caller's
-/// logging / future event push), empty when no mention resolved.
+/// A thin adapter: every decision lives in
+/// [`ainb_hangar_store::service::mention::route`], which is also what the
+/// `comment_mention_preview` dry run drives, so a preview can never disagree
+/// with the write it previews.
 ///
 /// # Errors
 ///
-/// Returns a [`sqlx::Error`] only on an unexpected store fault — the expected
-/// duplicate-pending-task case is coalesced inline by the unique index, not
-/// surfaced, so a single repeated mention never poisons the whole comment.
+/// Returns a [`sqlx::Error`] only on a store fault that is not attributable to
+/// one target — a per-target fault is reported as that target's
+/// `blocked` / `internal_error` row and the other targets still route.
+pub async fn route_comment_mentions(
+    pool: &SqlitePool,
+    idgen: &dyn IdGen,
+    clock: &dyn HangarClock,
+    workspace_id: &str,
+    issue_id: &str,
+    comment_id: Option<&str>,
+    parent_comment_id: Option<&str>,
+    author: &ainb_hangar_core::actor::ActorRef,
+    body: &str,
+    dry_run: bool,
+) -> Result<Vec<MentionOutcomeRow>, sqlx::Error> {
+    use ainb_hangar_store::service::mention::{MentionRouteRequest, route};
+
+    let rows = route(
+        pool,
+        idgen,
+        clock,
+        &MentionRouteRequest {
+            workspace_id,
+            issue_id,
+            comment_id,
+            parent_comment_id,
+            author,
+            body,
+            dry_run,
+        },
+    )
+    .await?;
+    Ok(rows.into_iter().map(to_wire).collect())
+}
+
+/// Map one store routing row onto the wire row.
+fn to_wire(row: ainb_hangar_store::service::mention::MentionRouteRow) -> MentionOutcomeRow {
+    MentionOutcomeRow {
+        target_type: row.target_type,
+        target_id: row.target_id,
+        handle: row.handle,
+        outcome: row.outcome.as_str().to_string(),
+        reason: row.reason.map(|r| r.as_db_str().to_string()).unwrap_or_default(),
+        task_id: row.task_id,
+        detail: row.detail.unwrap_or_default(),
+        source: row.source.as_str().to_string(),
+    }
+}
+
+/// The agent ids a comment's mentions actually ENQUEUED a task for (e38.7).
+///
+/// Kept as the historical name + shape over
+/// [`route_comment_mentions`] so the existing call sites and the in-source
+/// regression tests below — which are the mention tests the `--lib` job runs —
+/// keep exercising the same contract they always did. New callers that need the
+/// per-target outcome codes should use [`route_comment_mentions`] directly.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] on an unexpected store fault.
 pub async fn spawn_mention_tasks(
     pool: &SqlitePool,
     idgen: &dyn IdGen,
@@ -3058,153 +3098,24 @@ pub async fn spawn_mention_tasks(
     author: &ainb_hangar_core::actor::ActorRef,
     body: &str,
 ) -> Result<Vec<String>, sqlx::Error> {
-    use crate::mentions::parse_mentions;
-    use ainb_hangar_store::repo::agent::AgentRepo;
-    use ainb_hangar_store::repo::task::NewTask;
-
-    let handles = parse_mentions(body);
-    if handles.is_empty() {
-        return Ok(Vec::new());
-    }
-    // gap #8 — the EFFECTIVE invoker the invocation gate judges each mention target
-    // by (multica `resolveMentionedAgentCommentTriggers`, `comment.go:2323`/`:2365`).
-    let (invoker_kind, invoker_id) = effective_mention_invoker(pool, workspace_id, author).await?;
-    // The workspace's agents are the only resolution candidates: a foreign
-    // tenant's agent sharing a handle is never in this list, so it cannot be
-    // mention-triggered here.
-    let agents = AgentRepo::list_by_workspace(pool, workspace_id).await?;
-    let now = clock.now_ms();
-    // One mention event is one run GENERATION (migration 0039, tcp 8ln): every agent
-    // fanned out from this comment shares it, and it scopes the card-state folds to
-    // this run so a prior run's terminal rows on the issue do not poison it. Minted
-    // once, before the fan-out loop, exactly like the squad fan-out.
-    let generation = TaskRepo::next_generation_for_issue(pool, issue_id).await?;
-    // 0056 ORIGIN PROVENANCE: every task this comment spawns is stamped
-    // `('comment_mention', <comment.id>)` — hangar's structural analogue of
-    // multica's `quick_create` provenance. The dispatcher hands it to the agent
-    // child, so an issue the agent creates mid-run is attributable back to the
-    // comment that asked for it.
-    let mention_origin = IssueOrigin::comment_mention(comment_id).map_err(|e| {
-        sqlx::Error::Protocol(format!(
-            "comment {comment_id} is unusable as an origin id: {e}"
-        ))
-    })?;
-    let mut spawned = Vec::new();
-    for handle in &handles {
-        // Resolve by name; an unknown handle simply matches no agent (ignored).
-        let Some(agent) = agents.iter().find(|a| &a.name == handle) else {
-            continue;
-        };
-        // gap #8 — the invocation gate, FIRST: multica checks invocability before
-        // any other per-agent state is read, so a caller who cannot invoke an agent
-        // never learns its archived / runtime state from the trigger's behaviour
-        // (`comment.go:2364`, enumeration-safety). A refusal is a per-target
-        // `continue`, never an early return: one denied `@handle` must not suppress
-        // the other mentions in the same comment. Denied ⇒ NO task row.
-        if !AgentRepo::can_invoke(pool, agent, invoker_kind, invoker_id.as_deref()).await? {
-            tracing::debug!(
-                agent = %agent.id,
-                handle = %handle,
-                "mention dispatch refused: invocation not allowed"
-            );
-            continue;
-        }
-        let task = NewTask {
-            id: idgen.new_ulid(),
-            workspace_id: workspace_id.to_string(),
-            runtime_id: agent.runtime_id.clone(),
-            agent_id: agent.id.clone(),
-            issue_id: Some(issue_id.to_string()),
-            work_dir: None,
-            // A mention is a direct, user-initiated ask: default urgency (P3),
-            // drained FIFO among equals — the same default the autopilot path uses.
-            priority: 0,
-            created_at: now,
-            autopilot_run_id: None,
-            generation,
-        };
-        match TaskRepo::insert(pool, &task).await {
-            Ok(_) => {
-                // Stamped per spawned task, INSIDE the per-handle loop and AFTER
-                // the invocation gate: a refused mention writes no row and
-                // therefore no provenance.
-                TaskRepo::set_origin(pool, &task.id, &mention_origin).await?;
-                // multica parity #22: being @-mentioned subscribes you.
-                if let Ok(actor) =
-                    ainb_hangar_core::actor::ActorRef::new(ActorKind::Agent, agent.id.clone())
-                {
-                    auto_subscribe(
-                        pool,
-                        workspace_id,
-                        issue_id,
-                        &actor,
-                        SubscribeReason::Mentioned,
-                        now,
-                    )
-                    .await;
-                }
-                spawned.push(agent.id.clone());
-            }
-            // The agent already has a pending task on this issue (the per-(issue,
-            // agent) unique index): coalesce, don't error. The trigger is
-            // idempotent — re-mentioning an already-queued agent is a no-op.
-            Err(e) if is_unique_violation(&e) => {}
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(spawned)
-}
-
-/// The actor id the local TUI stamps on everything it authors (`member:me`).
-///
-/// It is a PLACEHOLDER, not a `user.id`: the plugin has no identity of its own and
-/// the daemon socket is the local operator's. `handle_issue_create` mints the same
-/// ref for wizard-created issues.
-pub(crate) const LOCAL_OPERATOR_MEMBER_ID: &str = "me";
-
-/// Resolve a comment author to the EFFECTIVE invoking identity the gap #8
-/// invocation gate judges its `@`-mention targets by.
-///
-/// - a `member` author naming a REAL user id → that user (the multi-user case the
-///   allow-list exists for);
-/// - the local-operator placeholder [`LOCAL_OPERATOR_MEMBER_ID`] → the workspace
-///   OWNER, exactly like `run_card`'s "no explicit invoker ⇒ owner" default. The
-///   local TUI stamps `member:me` on every comment it composes, so without this the
-///   gate would deny the single operator access to their own private agents — a
-///   regression with no security gain, since that socket IS the operator's. An
-///   owner-less workspace resolves to `""`, which matches no `owner_id` and fails
-///   closed, the same shape `run_card` has;
-/// - an `agent` author → `(Agent, None)`: hangar has no `originator_user_id`
-///   column (multica 184/185 is a separate gap), so an agent-authored mention is
-///   the UNATTRIBUTED A2A case — it fails closed for `private` and `member`-target
-///   agents and admits only a `public_to workspace` target (`workspaceBroad`).
-async fn effective_mention_invoker(
-    pool: &SqlitePool,
-    workspace_id: &str,
-    author: &ainb_hangar_core::actor::ActorRef,
-) -> Result<(ainb_hangar_core::actor::ActorKind, Option<String>), sqlx::Error> {
-    use ainb_hangar_core::actor::ActorKind;
-    use ainb_hangar_core::ids::WorkspaceId;
-
-    if author.kind() != ActorKind::Member {
-        return Ok((ActorKind::Agent, None));
-    }
-    if author.id() != LOCAL_OPERATOR_MEMBER_ID {
-        return Ok((ActorKind::Member, Some(author.id().to_string())));
-    }
-    let owner = match WorkspaceId::from_str(workspace_id.to_string()) {
-        Ok(ws) => ainb_hangar_store::repo::workspace::WorkspaceRepo::owner_id(pool, &ws)
-            .await?
-            .unwrap_or_default(),
-        Err(_) => String::new(),
-    };
-    Ok((ActorKind::Member, Some(owner)))
-}
-
-/// Whether a `sqlx` error is a UNIQUE-constraint violation (the per-`(issue,
-/// agent)` pending-task index coalescing a duplicate mention enqueue).
-fn is_unique_violation(e: &sqlx::Error) -> bool {
-    matches!(e, sqlx::Error::Database(db) if db.is_unique_violation())
+    let rows = route_comment_mentions(
+        pool,
+        idgen,
+        clock,
+        workspace_id,
+        issue_id,
+        Some(comment_id),
+        None,
+        author,
+        body,
+        false,
+    )
+    .await?;
+    Ok(rows
+        .into_iter()
+        .filter(|r| r.target_type == "agent" && r.outcome == "queued")
+        .map(|r| r.target_id)
+        .collect())
 }
 
 /// Snapshot the registered runtimes of `workspace` for the daemon-health pane.
@@ -3297,7 +3208,7 @@ mod issue_states_contract_tests {
 
 #[cfg(test)]
 mod mention_spawn_tests {
-    use super::spawn_mention_tasks;
+    use super::{route_comment_mentions, spawn_mention_tasks};
     use ainb_hangar_core::actor::{ActorKind, ActorRef};
     use ainb_hangar_core::clock::SystemClock;
     use ainb_hangar_core::idgen::SystemIdGen;
@@ -3663,7 +3574,11 @@ mod mention_spawn_tests {
         let store = Store::open_in(dir.path()).await.unwrap();
         crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
 
-        let me = ActorRef::new(ActorKind::Member, super::LOCAL_OPERATOR_MEMBER_ID).unwrap();
+        let me = ActorRef::new(
+            ActorKind::Member,
+            ainb_hangar_store::service::mention::LOCAL_OPERATOR_MEMBER_ID,
+        )
+        .unwrap();
         let spawned = spawn_mention_tasks(
             store.pool(),
             &SystemIdGen,
@@ -3679,6 +3594,372 @@ mod mention_spawn_tests {
 
         assert_eq!(spawned, vec!["agent-1".to_string()]);
         assert_eq!(count_for_issue3(&store).await, 1);
+    }
+
+    /// Route helper with the defaults the daemon's `comment_add` uses.
+    async fn route_for(
+        store: &Store,
+        author: &ActorRef,
+        body: &str,
+    ) -> Vec<ainb_hangar_proto::snapshots::MentionOutcomeRow> {
+        route_comment_mentions(
+            store.pool(),
+            &SystemIdGen,
+            &SystemClock,
+            crate::seed::WS_ID,
+            "issue-3",
+            Some("c-1"),
+            None,
+            author,
+            body,
+            false,
+        )
+        .await
+        .unwrap()
+    }
+
+    /// **2-rest** — the router reports a per-target OUTCOME, not just the ids it
+    /// spawned. A plain resolved mention is `queued`.
+    #[tokio::test]
+    async fn a_resolved_mention_reports_queued() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let rows = route_for(&store, &owner(), "@claude-agent please do X").await;
+        assert_eq!(rows.len(), 1, "one row per target: {rows:?}");
+        assert_eq!(rows[0].outcome, "queued");
+        assert_eq!(rows[0].reason, "queued");
+        assert_eq!(rows[0].target_type, "agent");
+        assert_eq!(rows[0].target_id, "agent-1");
+        assert_eq!(rows[0].source, "explicit");
+        assert!(rows[0].task_id.is_some(), "the queued row names its task");
+    }
+
+    /// **2-rest** — a REPEAT mention against a still-pending task is reported as
+    /// `coalesced` instead of vanishing into a swallowed unique violation, and
+    /// the pending task is re-pointed at the NEWER comment.
+    #[tokio::test]
+    async fn a_repeat_mention_reports_coalesced_and_repoints_the_trigger() {
+        use ainb_hangar_store::repo::task::TaskRepo;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let first = route_for(&store, &owner(), "@claude-agent do X").await;
+        assert_eq!(first[0].outcome, "queued");
+        let task_id = first[0].task_id.clone().unwrap();
+        assert_eq!(
+            TaskRepo::trigger_comment_id(store.pool(), &task_id).await.unwrap(),
+            Some("c-1".to_string()),
+            "the queued task records the comment that summoned it"
+        );
+
+        let second = route_comment_mentions(
+            store.pool(),
+            &SystemIdGen,
+            &SystemClock,
+            crate::seed::WS_ID,
+            "issue-3",
+            Some("c-2"),
+            None,
+            &owner(),
+            "@claude-agent again",
+            false,
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.len(), 1, "{second:?}");
+        assert_eq!(second[0].outcome, "coalesced");
+        assert_eq!(second[0].reason, "coalesced");
+        assert_eq!(count_for_issue3(&store).await, 1, "still one task");
+        assert_eq!(
+            TaskRepo::trigger_comment_id(store.pool(), &task_id).await.unwrap(),
+            Some("c-2".to_string()),
+            "merge-into-pending re-points the task at the NEWER comment"
+        );
+    }
+
+    /// **2-rest** — a refusal now carries a CODE. Before this item the same call
+    /// returned an empty spawn list with no way to tell "denied" from "nobody
+    /// was mentioned".
+    #[tokio::test]
+    async fn a_refused_mention_reports_blocked_invocation_not_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+        seed_plain_member(&store, "bob").await;
+
+        let bob = ActorRef::new(ActorKind::Member, "bob").unwrap();
+        let rows = route_for(&store, &bob, "@claude-agent please do X").await;
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].outcome, "blocked");
+        assert_eq!(rows[0].reason, "invocation_not_allowed");
+        assert_eq!(count_for_issue3(&store).await, 0, "no task row is written");
+    }
+
+    /// **2-rest** — an agent's own comment never re-triggers itself
+    /// (multica's self-loop guard), and says so.
+    #[tokio::test]
+    async fn an_agent_mentioning_itself_is_suppressed_with_a_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let itself = ActorRef::new(ActorKind::Agent, "agent-1").unwrap();
+        let rows = route_for(&store, &itself, "@claude-agent keep going").await;
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].outcome, "blocked");
+        assert_eq!(rows[0].reason, "self_trigger_suppressed");
+        assert_eq!(count_for_issue3(&store).await, 0);
+    }
+
+    /// **2-rest** — one denied handle produces its OWN row rather than
+    /// suppressing the allowed one: two rows, one task.
+    #[tokio::test]
+    async fn one_denied_handle_never_suppresses_the_others() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+        seed_plain_member(&store, "bob").await;
+        seed_second_agent(&store, "agent-priv", "private-bot").await;
+        allow_member(&store, "agent-1", "bob").await;
+
+        let bob = ActorRef::new(ActorKind::Member, "bob").unwrap();
+        let rows = route_for(&store, &bob, "@private-bot and @claude-agent do X").await;
+        assert_eq!(rows.len(), 2, "one row per target: {rows:?}");
+        assert_eq!(rows[0].outcome, "blocked", "{rows:?}");
+        assert_eq!(rows[0].reason, "invocation_not_allowed");
+        assert_eq!(rows[1].outcome, "queued", "{rows:?}");
+        assert_eq!(count_for_issue3(&store).await, 1);
+    }
+
+    /// **2-rest** — the LINK form addresses the same agent by id and produces the
+    /// same task the bare form does.
+    #[tokio::test]
+    async fn the_link_form_spawns_the_same_task_the_bare_form_does() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let rows = route_for(
+            &store,
+            &owner(),
+            "[@Claude](mention://agent/agent-1) ship it",
+        )
+        .await;
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].outcome, "queued");
+        assert_eq!(rows[0].target_id, "agent-1");
+        assert_eq!(count_for_issue3(&store).await, 1);
+    }
+
+    /// **2-rest** — mentioning a HUMAN routes to that human: zero tasks, one
+    /// inbox entry addressed to them, and a `notified` outcome. This is the leg
+    /// that did not exist at all before this item.
+    #[tokio::test]
+    async fn mentioning_a_human_notifies_them_and_spawns_no_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+        // A member who is NOT the issue creator, so the subscription reason this
+        // asserts on is the mention's own and not a pre-existing `creator` row
+        // (the subscriber repo is first-reason-wins).
+        seed_plain_member(&store, "bob").await;
+
+        let rows = route_for(
+            &store,
+            &owner(),
+            "[@Bob](mention://member/bob) can you look?",
+        )
+        .await;
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].outcome, "notified");
+        assert_eq!(rows[0].target_type, "member");
+        assert_eq!(rows[0].target_id, "bob");
+        assert_eq!(
+            count_for_issue3(&store).await,
+            0,
+            "a human mention is not a run"
+        );
+
+        let inbox: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM inbox_entry \
+             WHERE recipient_type = 'member' AND recipient_id = 'bob' \
+               AND event = 'mention' AND subject_id = 'issue-3'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(inbox, 1, "the mention landed in that human's inbox");
+
+        let subscribed: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM issue_subscriber \
+             WHERE issue_id = 'issue-3' AND actor_type = 'member' \
+               AND actor_id = 'bob' AND reason = 'mentioned'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(subscribed, 1, "being @-mentioned subscribes you");
+    }
+
+    /// **2-rest** — the bare-handle form finds the human too (`@alice` is the
+    /// email local part), since hangar has no `handle` column.
+    #[tokio::test]
+    async fn a_bare_handle_resolves_to_a_human_when_no_agent_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let rows = route_for(&store, &owner(), "@alice thoughts?").await;
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].outcome, "notified");
+        assert_eq!(rows[0].target_id, "user-1");
+    }
+
+    /// **2-rest** — an `issue` cross-reference is understood and reported as
+    /// `ignored`, never treated as a trigger.
+    #[tokio::test]
+    async fn an_issue_cross_reference_is_ignored_not_triggered() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        let rows = route_for(&store, &owner(), "see [#1](mention://issue/issue-1)").await;
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].outcome, "ignored");
+        assert_eq!(rows[0].target_type, "issue");
+        assert_eq!(count_for_issue3(&store).await, 0);
+    }
+
+    /// **2-rest** — a mention-less comment on an AGENT-ASSIGNED issue falls back
+    /// to the assignee (multica's implicit chain), tagged `assignee`.
+    #[tokio::test]
+    async fn a_mentionless_comment_falls_back_to_the_agent_assignee() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+
+        // issue-1 is the fixture's agent-assigned card; issue-3 is unassigned.
+        let rows = route_comment_mentions(
+            store.pool(),
+            &SystemIdGen,
+            &SystemClock,
+            crate::seed::WS_ID,
+            "issue-1",
+            Some("c-1"),
+            None,
+            &owner(),
+            "any update?",
+            false,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].source, "assignee");
+        assert_eq!(rows[0].target_id, "agent-1");
+
+        // The unassigned issue has nowhere to fall back to: zero rows.
+        let none = route_for(&store, &owner(), "any update?").await;
+        assert!(
+            none.is_empty(),
+            "no parent, no assignee ⇒ nothing: {none:?}"
+        );
+    }
+
+    /// **2-rest** — the DRY RUN reports the identical outcome codes the write
+    /// then produces, and writes nothing at all.
+    #[tokio::test]
+    async fn a_dry_run_matches_the_write_and_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+        seed_plain_member(&store, "bob").await;
+
+        async fn counts(store: &Store) -> (i64, i64, i64) {
+            let t: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+            let i: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM inbox_entry")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+            let s: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM issue_subscriber")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+            (t, i, s)
+        }
+
+        let body = "[@Alice](mention://member/user-1) and @claude-agent go";
+        let before = counts(&store).await;
+        let preview = route_comment_mentions(
+            store.pool(),
+            &SystemIdGen,
+            &SystemClock,
+            crate::seed::WS_ID,
+            "issue-3",
+            None,
+            None,
+            &owner(),
+            body,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(counts(&store).await, before, "a preview writes NOTHING");
+
+        let written = route_for(&store, &owner(), body).await;
+        let codes = |rows: &[ainb_hangar_proto::snapshots::MentionOutcomeRow]| {
+            rows.iter()
+                .map(|r| {
+                    (
+                        r.target_type.clone(),
+                        r.target_id.clone(),
+                        r.outcome.clone(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            codes(&preview),
+            codes(&written),
+            "the preview must report exactly what the write then does"
+        );
+        assert_ne!(counts(&store).await, before, "the write DOES write");
+    }
+
+    /// **2-rest** — the private-agent gate is IDENTICAL on the preview path, so
+    /// a preview can never leak an agent's readiness to someone who may not
+    /// invoke it.
+    #[tokio::test]
+    async fn the_preview_applies_the_private_gate_identically() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        crate::seed::seed_p4_fixture(store.pool()).await.unwrap();
+        seed_plain_member(&store, "bob").await;
+
+        let bob = ActorRef::new(ActorKind::Member, "bob").unwrap();
+        let preview = route_comment_mentions(
+            store.pool(),
+            &SystemIdGen,
+            &SystemClock,
+            crate::seed::WS_ID,
+            "issue-3",
+            None,
+            None,
+            &bob,
+            "@claude-agent go",
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(preview.len(), 1, "{preview:?}");
+        assert_eq!(preview[0].outcome, "blocked");
+        assert_eq!(preview[0].reason, "invocation_not_allowed");
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -2993,12 +2993,17 @@ pub async fn comment_add(
         index: "issue_id".to_string(),
         source: format!("malformed issue id {issue_id:?}: {e}").into(),
     })?;
+    // A malformed parent id is dropped from the WIRE row rather than failing the
+    // write: the comment landed with the pointer the caller gave, and a row the
+    // client cannot decode would be a worse outcome than a missing optional.
+    let parent = parent_id.and_then(|p| CommentId::from_str(p.to_string()).ok());
     Ok(Some(CommentRow {
         id: comment_id,
         issue_id: issue,
         author: format!("{}:{}", author.kind().as_str(), author.id()),
         body: body.to_string(),
         created_at,
+        parent_id: parent,
     }))
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -2953,6 +2953,7 @@ pub async fn comment_add(
     issue_id: &str,
     author: &ActorRef,
     body: &str,
+    parent_id: Option<&str>,
 ) -> Result<Option<CommentRow>, sqlx::Error> {
     let id = idgen.new_ulid();
     let created_at = clock.now_ms();
@@ -2965,6 +2966,7 @@ pub async fn comment_add(
             author: author.clone(),
             body: body.to_string(),
             created_at,
+            parent_id: parent_id.map(str::to_string),
         },
     )
     .await?;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
@@ -81,6 +81,7 @@ fn emit_comment(
             author: author.to_string(),
             body: "look at this".into(),
             created_at: 1,
+            parent_id: None,
         }),
     );
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_comment_add.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_comment_add.rs
@@ -28,6 +28,15 @@ use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 struct Client {
     reader: BufReader<OwnedReadHalf>,
     writer: OwnedWriteHalf,
+    /// Event pushes seen while draining frames for an RPC RESPONSE.
+    ///
+    /// The daemon emits `comment_added` BEFORE it writes the `comment_add`
+    /// reply, so whether the push or the reply reaches this socket first is a
+    /// race on how much work the handler does after the emit. Buffering the
+    /// pushes `call` walks past makes `next_event` deterministic either way —
+    /// without it, a handler that grows slower silently starts eating the very
+    /// event the test is asserting on.
+    pending_events: std::collections::VecDeque<serde_json::Value>,
 }
 
 impl Client {
@@ -46,6 +55,7 @@ impl Client {
         Self {
             reader: BufReader::new(read_half),
             writer,
+            pending_events: std::collections::VecDeque::new(),
         }
     }
 
@@ -98,10 +108,16 @@ impl Client {
             if frame.get("id").is_some() {
                 return frame;
             }
+            if frame["method"] == EVENT_METHOD {
+                self.pending_events.push_back(frame["params"].clone());
+            }
         }
     }
 
     async fn next_event(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        if let Some(buffered) = self.pending_events.pop_front() {
+            return Some(buffered);
+        }
         let deadline = Instant::now() + timeout;
         loop {
             let remaining = deadline.checked_duration_since(Instant::now())?;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_comment_mention_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_comment_mention_routing.rs
@@ -1,0 +1,570 @@
+//! Integration: the `comment_add` RPC now REPORTS what happened to every
+//! `@`-mention, and `comment_mention_preview` reports the same thing without
+//! writing (multica parity #2-rest), over a real framed `UnixStream`.
+//!
+//! The sibling `rpc_comment_mention_spawn.rs` pins the pre-2-rest behaviour (a
+//! mention spawns a task; a denied one spawns nothing). This file pins the part
+//! that did not exist before: the per-target OUTCOME CODES on the wire.
+//!
+//! Each test asserts BOTH the side effect and the surfaced code, because
+//! either one alone can pass while the feature is broken — the campaign's
+//! recurring failure mode.
+//!
+//! RED against `main`: every assertion here reads `result.mention_outcomes`,
+//! a key `main`'s `comment_add` reply does not contain at all.
+
+#![allow(clippy::too_many_lines)]
+
+use std::time::{Duration, Instant};
+
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_daemon::seed::{self, WS_ID, WS_SLUG};
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::Store;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// One test client connection: a persistent buffered reader + writer half.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &std::path::Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => panic!("never connected: {e}"),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    async fn read_frame(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        tokio::time::timeout(timeout, self.read_frame_inner()).await.ok()
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    /// Send `method`, then drain frames until the response (id-bearing) lands,
+    /// ignoring any interleaved event pushes.
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(5))
+                .await
+                .unwrap_or_else(|| panic!("no response to {method} within 5s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &std::path::Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let token = std::fs::read_to_string(&token_path).expect("read daemon.token");
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    async fn subscribe(&mut self, workspace_id: &str) {
+        let resp = self
+            .call(
+                methods::WORKSPACE_SUBSCRIBE,
+                serde_json::json!({ "workspace_id": workspace_id }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "subscribe must ack: {resp}");
+    }
+
+    async fn comment(&mut self, issue_id: &str, body: &str) -> serde_json::Value {
+        self.comment_as("member:user-1", issue_id, body).await
+    }
+
+    /// Post a comment under an explicit AUTHOR ref — the gap #8 effective invoker
+    /// the mention gate judges each `@`-target by.
+    async fn comment_as(&mut self, author: &str, issue_id: &str, body: &str) -> serde_json::Value {
+        let resp = self
+            .call(
+                methods::HANGAR_COMMENT_ADD,
+                serde_json::json!({
+                    "workspace_id": WS_SLUG,
+                    "issue_id": issue_id,
+                    "author": author,
+                    "body": body,
+                }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "comment_add must ack: {resp}");
+        resp
+    }
+}
+
+/// Bind + serve the real listener over the seeded store (mirrors `boot()`).
+async fn start_server(dir: &std::path::Path) -> (std::path::PathBuf, Store) {
+    let store = Store::open_in(dir).await.unwrap();
+    seed::seed_p4_fixture(store.pool()).await.unwrap();
+    rpc::auth::ensure_socket_token(store.pool(), dir)
+        .await
+        .expect("ensure socket token");
+    let socket_path = rpc::socket_path_in(dir);
+    let listener = rpc::bind(&socket_path).expect("bind socket");
+    let health = DaemonHealth {
+        socket_path: socket_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: "0.1.0".into(),
+        stats: std::sync::Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(
+        listener,
+        store.pool().clone(),
+        health,
+        ainb_hangar_daemon::events::EventBroker::new(),
+    ));
+    (socket_path, store)
+}
+
+/// Count the tasks enqueued for `agent_id` on `issue_id` in the seeded workspace.
+async fn task_count(store: &Store, agent_id: &str, issue_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM agent_task_queue \
+         WHERE workspace_id = ?1 AND agent_id = ?2 AND issue_id = ?3",
+    )
+    .bind(WS_ID)
+    .bind(agent_id)
+    .bind(issue_id)
+    .fetch_one(store.pool())
+    .await
+    .unwrap()
+}
+
+/// Add `user_id` to the fixture workspace as a plain (non-owner) member.
+async fn seed_plain_member(store: &Store, user_id: &str) {
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES (?, ?, 0)")
+        .bind(user_id)
+        .bind(format!("{user_id}@example.com"))
+        .execute(store.pool())
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO member (workspace_id, user_id, role) VALUES (?, ?, 'member')")
+        .bind(WS_ID)
+        .bind(user_id)
+        .execute(store.pool())
+        .await
+        .unwrap();
+}
+
+/// The `mention_outcomes` array off a `comment_add` / preview reply.
+fn outcomes(resp: &serde_json::Value) -> &Vec<serde_json::Value> {
+    resp["result"]["mention_outcomes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no mention_outcomes on the reply: {resp}"))
+}
+
+/// **ACCEPTANCE 1** — `@`-mentioning a HUMAN routes to that human: zero tasks,
+/// one inbox entry addressed to them, and a `notified` outcome on the wire.
+#[tokio::test]
+async fn mentioning_a_human_routes_to_that_human_not_an_agent() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    seed_plain_member(&store, "bob").await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let resp = c.comment("issue-3", "[@Bob](mention://member/bob) can you look?").await;
+    // The comment itself still acks exactly as before (the result FLATTENS the
+    // comment row, so an old client's parse is unaffected).
+    assert_eq!(resp["result"]["issue_id"], "issue-3");
+
+    let rows = outcomes(&resp);
+    assert_eq!(rows.len(), 1, "one row per target: {resp}");
+    assert_eq!(rows[0]["target_type"], "member");
+    assert_eq!(rows[0]["target_id"], "bob");
+    assert_eq!(rows[0]["outcome"], "notified");
+
+    // A human mention is NEVER a run.
+    let tasks: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = ?")
+        .bind("issue-3")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(tasks, 0, "a human mention spawns no task");
+
+    let inbox: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM inbox_entry \
+         WHERE recipient_type = 'member' AND recipient_id = 'bob' \
+           AND event = 'mention' AND subject_id = 'issue-3'",
+    )
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(inbox, 1, "the mention landed in that human's inbox");
+
+    let subscribed: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM issue_subscriber \
+         WHERE issue_id = 'issue-3' AND actor_type = 'member' \
+           AND actor_id = 'bob' AND reason = 'mentioned'",
+    )
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(subscribed, 1, "being @-mentioned subscribes you");
+}
+
+/// **ACCEPTANCE 2** — a re-mention reports `coalesced` rather than failing
+/// silently, and the pending task is re-pointed at the NEWER comment.
+#[tokio::test]
+async fn re_mentioning_a_pending_agent_reports_coalesced_and_repoints_the_trigger() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let first = c.comment("issue-3", "@claude-agent go").await;
+    assert_eq!(outcomes(&first)[0]["outcome"], "queued", "{first}");
+    let task_id = outcomes(&first)[0]["task_id"].as_str().unwrap().to_string();
+
+    let second = c.comment("issue-3", "@claude-agent again").await;
+    assert_eq!(outcomes(&second)[0]["outcome"], "coalesced", "{second}");
+    assert_eq!(outcomes(&second)[0]["reason"], "coalesced");
+    assert_eq!(
+        task_count(&store, "agent-1", "issue-3").await,
+        1,
+        "the second mention folded into the pending task"
+    );
+
+    let second_comment_id = second["result"]["id"].as_str().unwrap();
+    let trigger: Option<String> =
+        sqlx::query_scalar("SELECT trigger_comment_id FROM agent_task_queue WHERE id = ?")
+            .bind(&task_id)
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(
+        trigger.as_deref(),
+        Some(second_comment_id),
+        "merge-into-pending re-points the task at the newer comment"
+    );
+}
+
+/// **ACCEPTANCE 3** — a private, non-allowed agent is refused WITH A CODE.
+/// Against `main` the identical call answers with no `mention_outcomes` at all.
+#[tokio::test]
+async fn a_private_non_allowed_agent_is_refused_with_a_code() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    seed_plain_member(&store, "bob").await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let resp = c.comment_as("member:bob", "issue-3", "@claude-agent go").await;
+    let rows = outcomes(&resp);
+    assert_eq!(rows.len(), 1, "{resp}");
+    assert_eq!(rows[0]["outcome"], "blocked");
+    assert_eq!(rows[0]["reason"], "invocation_not_allowed");
+    assert_eq!(
+        task_count(&store, "agent-1", "issue-3").await,
+        0,
+        "a refused mention writes no task"
+    );
+}
+
+/// The preview reports the SAME codes the write then produces, and writes
+/// NOTHING — asserted by snapshotting every table the router can touch.
+#[tokio::test]
+async fn the_preview_matches_the_write_and_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    seed_plain_member(&store, "bob").await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    async fn snapshot(store: &Store) -> Vec<(&'static str, i64)> {
+        let mut out = Vec::new();
+        for table in [
+            "comment",
+            "agent_task_queue",
+            "inbox_entry",
+            "issue_subscriber",
+            "dispatch_attempt",
+        ] {
+            let n: i64 = sqlx::query_scalar(&format!("SELECT COUNT(*) FROM {table}"))
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+            out.push((table, n));
+        }
+        out
+    }
+
+    let body = "[@Bob](mention://member/bob) and @claude-agent go";
+    let before = snapshot(&store).await;
+    let preview = c
+        .call(
+            methods::HANGAR_COMMENT_MENTION_PREVIEW,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": "issue-3",
+                "author": "member:user-1",
+                "body": body,
+            }),
+        )
+        .await;
+    assert!(preview["error"].is_null(), "preview must ack: {preview}");
+    assert_eq!(
+        snapshot(&store).await,
+        before,
+        "a preview writes NOTHING, in any table"
+    );
+
+    let written = c.comment("issue-3", body).await;
+    let codes = |resp: &serde_json::Value| {
+        outcomes(resp)
+            .iter()
+            .map(|r| {
+                (
+                    r["target_type"].as_str().unwrap_or("").to_string(),
+                    r["target_id"].as_str().unwrap_or("").to_string(),
+                    r["outcome"].as_str().unwrap_or("").to_string(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        codes(&preview),
+        codes(&written),
+        "preview {preview} must match write {written}"
+    );
+}
+
+/// The preview applies the private-agent gate IDENTICALLY, so it can never leak
+/// a private agent's readiness to a caller who may not invoke it.
+#[tokio::test]
+async fn the_preview_applies_the_private_gate_identically() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    seed_plain_member(&store, "bob").await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let preview = c
+        .call(
+            methods::HANGAR_COMMENT_MENTION_PREVIEW,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": "issue-3",
+                "author": "member:bob",
+                "body": "@claude-agent go",
+            }),
+        )
+        .await;
+    let rows = outcomes(&preview);
+    assert_eq!(rows.len(), 1, "{preview}");
+    assert_eq!(rows[0]["outcome"], "blocked");
+    assert_eq!(rows[0]["reason"], "invocation_not_allowed");
+}
+
+/// A mistyped workspace is `INVALID_PARAMS` on the preview too — never a
+/// silently empty preview a caller would read as "this mentions nobody".
+#[tokio::test]
+async fn a_mistyped_workspace_rejects_rather_than_previewing_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_COMMENT_MENTION_PREVIEW,
+            serde_json::json!({
+                "workspace_id": "not-a-workspace",
+                "issue_id": "issue-3",
+                "author": "member:user-1",
+                "body": "@claude-agent go",
+            }),
+        )
+        .await;
+    assert!(
+        !resp["error"].is_null(),
+        "a typo'd workspace must be rejected, not silently empty: {resp}"
+    );
+}
+
+/// A comment that mentions NOBODY on an unassigned issue reports no outcomes at
+/// all, and the reply is byte-shaped exactly as it was pre-2-rest (the array is
+/// omitted, not present-and-empty).
+#[tokio::test]
+async fn a_comment_with_no_mentions_reports_no_outcomes_and_keeps_the_old_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, _store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    // issue-3 is unassigned, so there is nothing to fall back to either.
+    let resp = c.comment("issue-3", "just a plain remark").await;
+    assert!(
+        resp["result"].get("mention_outcomes").is_none(),
+        "an empty outcome set is OMITTED, keeping the wire byte-identical: {resp}"
+    );
+    assert_eq!(resp["result"]["body"], "just a plain remark");
+}
+
+/// One denied handle produces its own row and never suppresses the allowed one:
+/// two outcome rows, exactly one task.
+#[tokio::test]
+async fn one_denied_handle_never_suppresses_the_others() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    seed_plain_member(&store, "bob").await;
+    // A second agent bob may NOT invoke, alongside claude-agent which he may.
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('agent-priv', ?, 'private-bot', 'runtime-1', 'workspace', 'user-1')",
+    )
+    .bind(WS_ID)
+    .execute(store.pool())
+    .await
+    .unwrap();
+    {
+        use ainb_hangar_core::clock::SystemClock;
+        use ainb_hangar_core::idgen::SystemIdGen;
+        use ainb_hangar_store::repo::agent::AgentRepo;
+        use ainb_hangar_store::repo::agent_invocation_target::AgentInvocationTargetRepo;
+        AgentRepo::set_permission_mode(store.pool(), "agent-1", "public_to")
+            .await
+            .unwrap();
+        AgentInvocationTargetRepo::add(
+            store.pool(),
+            &SystemIdGen,
+            &SystemClock,
+            "agent-1",
+            "member",
+            "bob",
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    let resp = c.comment_as("member:bob", "issue-3", "@private-bot and @claude-agent go").await;
+    let rows = outcomes(&resp);
+    assert_eq!(rows.len(), 2, "one row per target: {resp}");
+    assert_eq!(rows[0]["outcome"], "blocked", "{resp}");
+    assert_eq!(rows[1]["outcome"], "queued", "{resp}");
+    assert_eq!(task_count(&store, "agent-1", "issue-3").await, 1);
+    assert_eq!(task_count(&store, "agent-priv", "issue-3").await, 0);
+}
+
+/// A reply whose parent was authored by an AGENT and which mentions nobody
+/// falls back to that agent (multica's reply-parent leg), tagged `reply_parent`.
+#[tokio::test]
+async fn a_mentionless_reply_falls_back_to_the_parents_agent_author() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+    c.subscribe(WS_SLUG).await;
+
+    // The agent posts first...
+    let parent = c.comment_as("agent:agent-1", "issue-3", "here is what I found").await;
+    let parent_id = parent["result"]["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        task_count(&store, "agent-1", "issue-3").await,
+        0,
+        "an agent's own comment never triggers itself"
+    );
+
+    // ...and a human replies with no mention at all.
+    let reply = c
+        .call(
+            methods::HANGAR_COMMENT_ADD,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "issue_id": "issue-3",
+                "author": "member:user-1",
+                "body": "thanks, please continue",
+                "parent_id": parent_id,
+            }),
+        )
+        .await;
+    assert!(reply["error"].is_null(), "reply must ack: {reply}");
+    assert_eq!(
+        reply["result"]["parent_id"], parent_id,
+        "the reply threads under its parent: {reply}"
+    );
+    let rows = outcomes(&reply);
+    assert_eq!(rows.len(), 1, "{reply}");
+    assert_eq!(rows[0]["source"], "reply_parent");
+    assert_eq!(rows[0]["target_id"], "agent-1");
+    assert_eq!(rows[0]["outcome"], "queued");
+    assert_eq!(task_count(&store, "agent-1", "issue-3").await, 1);
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_inbox.rs
@@ -262,6 +262,7 @@ fn comment_event() -> HangarEvent {
         author: "member:user-1".into(),
         body: "lgtm".into(),
         created_at: 2_000,
+        parent_id: None,
     })
 }
 
@@ -456,6 +457,7 @@ fn comment_on_i1(id: &str, author: &str) -> HangarEvent {
         author: author.into(),
         body: "over to you".into(),
         created_at: 2_000,
+        parent_id: None,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/events.rs
@@ -1132,6 +1132,13 @@ pub struct CommentRow {
     pub body: String,
     /// Creation timestamp (epoch milliseconds).
     pub created_at: i64,
+    /// The comment this one REPLIES to, or `None` at the top level
+    /// (migration 0067, multica parity #2-rest).
+    ///
+    /// **Append-only**: absent on the wire when unset, so a pre-2-rest snapshot
+    /// still decodes and the bytes an old client sees are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<CommentId>,
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -605,6 +605,23 @@ pub const HANGAR_ISSUE_CRITERION_SET: &str = "hangar/issue_criterion_set";
 /// subscribed task-detail screen re-renders the new comment.
 pub const HANGAR_COMMENT_ADD: &str = "hangar/comment_add";
 
+/// `hangar/comment_mention_preview` — dry-run the mention router over a comment
+/// body WITHOUT writing anything (multica `PreviewCommentTriggers`, parity
+/// #2-rest).
+///
+/// Params: [`crate::snapshots::CommentMentionPreviewParams`]
+/// (`{ workspace_id, issue_id, author, body, parent_id? }`). Result:
+/// [`crate::snapshots::CommentMentionPreviewResult`] — the SAME
+/// [`crate::snapshots::MentionOutcomeRow`] vector
+/// [`HANGAR_COMMENT_ADD`] returns, produced by the same code path with
+/// `dry_run` set. That shared path is the contract: the preview runs the
+/// identical visibility / invocation gate, so it can never leak a private
+/// agent's readiness, and it can never disagree with the write it previews.
+///
+/// Read-only but workspace-scoped like the mutating handlers: a mistyped
+/// workspace is `INVALID_PARAMS`, never a silently empty preview.
+pub const HANGAR_COMMENT_MENTION_PREVIEW: &str = "hangar/comment_mention_preview";
+
 /// `hangar/agent_update` — edit one agent's config knobs (e38.15).
 ///
 /// Params: [`crate::snapshots::AgentUpdateParams`]
@@ -1510,6 +1527,7 @@ pub const ALL_METHODS: &[&str] = &[
     HANGAR_ISSUE_LABEL_DETACH,
     HANGAR_ISSUE_CRITERION_SET,
     HANGAR_COMMENT_ADD,
+    HANGAR_COMMENT_MENTION_PREVIEW,
     HANGAR_AGENT_UPDATE,
     HANGAR_AGENT_ARCHIVE,
     HANGAR_MEMBERS_LIST,
@@ -1906,6 +1924,7 @@ mod tests {
             HANGAR_ISSUE_METADATA_GET,
             HANGAR_ISSUE_METADATA_SET,
             HANGAR_ISSUE_METADATA_DELETE,
+            HANGAR_COMMENT_MENTION_PREVIEW,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1666,6 +1666,15 @@ pub struct CommentAddParams {
     pub author: String,
     /// The comment body text.
     pub body: String,
+    /// The comment this one REPLIES to (`comment.id`), or `None` for a
+    /// top-level comment (migration 0067, multica parity #2-rest).
+    ///
+    /// **Append-only**: `#[serde(default)]` means a pre-2-rest client that omits
+    /// the key still decodes, and the field is skipped on the wire when unset so
+    /// the serialized shape is byte-identical to what old clients send today.
+    /// The mention router walks it for the reply-to-parent-author fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
 }
 
 /// One workspace member for the settings Members pane

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1677,6 +1677,91 @@ pub struct CommentAddParams {
     pub parent_id: Option<String>,
 }
 
+/// One routed `@mention` target and what the router DID about it
+/// (multica `CommentTriggerOutcome`, MUL-4525 §2; parity #2-rest).
+///
+/// Rides the `comment_add` RPC **result** and the
+/// [`crate::methods::HANGAR_COMMENT_MENTION_PREVIEW`] result only — deliberately
+/// NOT on [`crate::events::CommentRow`]. `CommentRow` is the `CommentAdded`
+/// event payload broadcast to every workspace subscriber, and broadcasting
+/// per-target refusal reasons there would leak the invocation gate's decisions
+/// to people who were not the ones asking. The outcomes go back to the caller
+/// that wrote the comment, and nobody else.
+///
+/// Every optional field is `#[serde(default)]` + skipped when empty, so this row
+/// stays append-only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MentionOutcomeRow {
+    /// `agent` | `member` | `squad` | `issue` | `all`.
+    pub target_type: String,
+    /// The resolved id, `""` when nothing resolved.
+    pub target_id: String,
+    /// The token exactly as typed.
+    pub handle: String,
+    /// `queued` | `coalesced` | `deferred` | `blocked` | `notified` | `ignored`
+    /// (`ainb_hangar_core::mention::MentionOutcome`).
+    pub outcome: String,
+    /// The `DispatchReason` token, `""` when the outcome carries none.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reason: String,
+    /// The task written or coalesced into, when there is one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    /// Free-form human detail. Never an existence oracle.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub detail: String,
+    /// `explicit` | `reply_parent` | `thread_root` | `assignee`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub source: String,
+}
+
+/// The result of [`crate::methods::HANGAR_COMMENT_ADD`] (parity #2-rest).
+///
+/// `#[serde(flatten)]` over the comment keeps the wire **byte-compatible** with
+/// the bare [`crate::events::CommentRow`] every existing client parses: with no
+/// mentions the payload is exactly what it was before this item, and a client
+/// that only knows about `CommentRow` decodes the richer payload unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommentAddResult {
+    /// The comment that was written.
+    #[serde(flatten)]
+    pub comment: crate::events::CommentRow,
+    /// One row per addressed target. Empty — and omitted from the wire — when
+    /// the comment mentioned nobody.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mention_outcomes: Vec<MentionOutcomeRow>,
+}
+
+/// Params for [`crate::methods::HANGAR_COMMENT_MENTION_PREVIEW`].
+///
+/// The same inputs `comment_add` takes, minus the write. `parent_id` matters:
+/// the fallback chain and the parent-mention inheritance both key off it, so a
+/// preview that omitted it would preview a different comment than the one the
+/// user is about to send.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CommentMentionPreviewParams {
+    /// The subscribed workspace the issue must belong to (tenant guard).
+    pub workspace_id: String,
+    /// The issue the comment would be posted on.
+    pub issue_id: String,
+    /// The prospective author in canonical `member:<id>` / `agent:<id>` form.
+    pub author: String,
+    /// The draft comment body.
+    pub body: String,
+    /// The comment this draft would reply to, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+}
+
+/// The result of [`crate::methods::HANGAR_COMMENT_MENTION_PREVIEW`]: exactly the
+/// rows the real write would produce, with nothing written.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CommentMentionPreviewResult {
+    /// One row per addressed target, in the same order `comment_add` returns.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mention_outcomes: Vec<MentionOutcomeRow>,
+}
+
 /// One workspace member for the settings Members pane
 /// ([`crate::methods::HANGAR_MEMBERS_LIST`], e38.11).
 ///
@@ -3996,12 +4081,93 @@ mod tests {
             issue_id: "issue-1".into(),
             author: "member:alice".into(),
             body: "looks good to me".into(),
+            parent_id: None,
         };
         let s = serde_json::to_string(&params).unwrap();
         assert_eq!(
             serde_json::from_str::<CommentAddParams>(&s).unwrap(),
             params
         );
+    }
+
+    /// **2-rest** — `parent_id` is APPEND-ONLY: a pre-2-rest client's payload
+    /// (no `parent_id` key at all) still decodes, and an unset `parent_id` is
+    /// OMITTED from the wire so the serialized shape an old daemon sees is
+    /// byte-identical to today's.
+    #[test]
+    fn comment_add_params_parent_id_is_append_only() {
+        let legacy = r#"{"workspace_id":"ws-1","issue_id":"i-1","author":"member:a","body":"hi"}"#;
+        let decoded: CommentAddParams = serde_json::from_str(legacy).unwrap();
+        assert_eq!(decoded.parent_id, None, "an absent key decodes to None");
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            legacy,
+            "an unset parent_id is omitted, so the wire shape is unchanged"
+        );
+
+        let reply = CommentAddParams {
+            parent_id: Some("c-1".into()),
+            ..decoded
+        };
+        let encoded = serde_json::to_string(&reply).unwrap();
+        assert!(encoded.contains(r#""parent_id":"c-1""#), "{encoded}");
+        assert_eq!(
+            serde_json::from_str::<CommentAddParams>(&encoded).unwrap(),
+            reply
+        );
+    }
+
+    /// **2-rest** — `CommentAddResult` is `#[serde(flatten)]`ed over
+    /// `CommentRow`, so a pre-2-rest client that parses the result as a bare
+    /// `CommentRow` still succeeds, and a result with no outcomes is
+    /// BYTE-IDENTICAL to the bare row it used to be.
+    #[test]
+    fn comment_add_result_stays_wire_compatible_with_a_bare_comment_row() {
+        use crate::events::CommentRow;
+        use ainb_hangar_core::ids::{CommentId, IssueId};
+
+        let comment = CommentRow {
+            id: CommentId::from_str("c-1".to_string()).unwrap(),
+            issue_id: IssueId::from_str("i-1").unwrap(),
+            author: "member:alice".into(),
+            body: "ship it".into(),
+            created_at: 7,
+            parent_id: None,
+        };
+        let bare = serde_json::to_string(&comment).unwrap();
+        let empty = CommentAddResult {
+            comment: comment.clone(),
+            mention_outcomes: Vec::new(),
+        };
+        assert_eq!(
+            serde_json::to_string(&empty).unwrap(),
+            bare,
+            "no outcomes ⇒ the exact bytes an old client already parses"
+        );
+
+        let with_outcomes = CommentAddResult {
+            comment,
+            mention_outcomes: vec![MentionOutcomeRow {
+                target_type: "agent".into(),
+                target_id: "a-1".into(),
+                handle: "builder".into(),
+                outcome: "queued".into(),
+                reason: "queued".into(),
+                task_id: Some("t-1".into()),
+                detail: String::new(),
+                source: "explicit".into(),
+            }],
+        };
+        let encoded = serde_json::to_string(&with_outcomes).unwrap();
+        // An OLD client still gets its comment out of the richer payload.
+        let as_row: CommentRow = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(as_row.body, "ship it");
+        assert_eq!(
+            serde_json::from_str::<CommentAddResult>(&encoded).unwrap(),
+            with_outcomes
+        );
+        // Empty optional fields never hit the wire.
+        assert!(!encoded.contains("\"detail\""), "{encoded}");
     }
 
     /// `AgentUpdateParams` round-trips, and the three-state nullable wrapper keeps

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -80,8 +80,8 @@ fn sample_comment() -> CommentRow {
         author: "member:alice".to_string(),
         body: "looks good".to_string(),
         created_at: 1_700_000_001_000,
-    },
-    parent_id: None,
+        parent_id: None,
+    }
 }
 
 fn all_variants() -> Vec<HangarEvent> {

--- a/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/event_roundtrip_test.rs
@@ -80,7 +80,8 @@ fn sample_comment() -> CommentRow {
         author: "member:alice".to_string(),
         body: "looks good".to_string(),
         created_at: 1_700_000_001_000,
-    }
+    },
+    parent_id: None,
 }
 
 fn all_variants() -> Vec<HangarEvent> {

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0067_comment_thread_and_trigger.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0067_comment_thread_and_trigger.sql
@@ -1,0 +1,62 @@
+-- 0067: COMMENT THREADING + TASK TRIGGER PROVENANCE (multica parity #2-rest).
+--
+-- The mention-routing layer needs two facts the schema could not express:
+--
+-- 1. WHICH comment a reply answers, so the router can walk multica's implicit
+--    fallback chain (reply-to-parent-author -> thread-root owner -> assignee,
+--    `server/internal/handler/comment.go` step 4) when a comment mentions
+--    nobody. multica carries this as `comment.parent_id`
+--    (`001_init.up.sql:97`); hangar's `comment` table (0003) had no such column,
+--    so hangar had no comment threads at all.
+--
+-- 2. WHICH comment summoned a task, so the spawned agent reads the actual ask
+--    and its reply threads under that comment (multica
+--    `agent_task_queue.trigger_comment_id`, `server/internal/service/task.go:443`).
+--
+-- Both are plain `ADD COLUMN` with an implicit NULL default plus an index: O(1)
+-- catalog changes in SQLite, safe on a populated database, no table rewrite and
+-- no backfill. Every pre-0067 comment is a top-level comment (`parent_id IS
+-- NULL`) and every pre-0067 task has no recorded trigger, which is the honest
+-- reading of "we never stored this" -- neither is given a fabricated value.
+--
+-- Re-applying is a no-op via the version ledger: sqlx records the applied
+-- version, so this file runs exactly once per database. It must therefore never
+-- be edited after it has been applied anywhere (a byte-changed applied
+-- migration stops the daemon booting with "previously applied but has been
+-- modified"); a correction goes in a NEW numbered file.
+
+-- Comment threading. Nullable with no default, so the ADD COLUMN may legally
+-- carry the self-referencing FK in SQLite (a NOT NULL / non-constant default
+-- could not).
+--
+-- ON DELETE SET NULL, deliberately, and NOT the omitted-clause default:
+--   * omitting it means NO ACTION, which BLOCKS a parent delete while a reply
+--     points at it. `IssueRepo::delete` and the workspace purge both run one
+--     bulk `DELETE FROM comment WHERE issue_id = ?`, and SQLite enforces FKs
+--     row-by-row inside a statement, so a thread whose parent happened to be
+--     deleted first would fail the whole issue delete. That is a regression
+--     0067 must not introduce.
+--   * CASCADE would let deleting one comment silently take a subtree of
+--     unrelated replies with it.
+-- SET NULL detaches the reply instead: it becomes a top-level comment, still
+-- readable, and the thread walk simply stops there. Same spirit as 0065's rule
+-- that a delete never reaches into another table's ledger.
+ALTER TABLE comment ADD COLUMN parent_id TEXT
+    REFERENCES comment(id) ON DELETE SET NULL;
+
+-- The reply lookup the fallback chain performs is "who authored the parent of
+-- this comment", plus "list the replies under X" for the thread walk; both key
+-- on parent_id.
+CREATE INDEX IF NOT EXISTS idx_comment_parent ON comment(parent_id);
+
+-- The comment that summoned this task. NO foreign key, deliberately: deleting
+-- the comment must neither cascade the task away (the run happened; its history
+-- is not the comment's to erase) nor block the delete. A stale id simply reads
+-- back as "no trigger", the same tolerant-reader rule the origin provenance
+-- columns (0056) use.
+ALTER TABLE agent_task_queue ADD COLUMN trigger_comment_id TEXT;
+
+-- Answers "which tasks did this comment spawn" for the audit / `issue why`
+-- surfaces without a scan of the queue.
+CREATE INDEX IF NOT EXISTS idx_task_trigger_comment
+    ON agent_task_queue(trigger_comment_id);

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/comment.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/comment.rs
@@ -36,6 +36,10 @@ pub struct NewComment {
     pub body: String,
     /// Creation timestamp (epoch milliseconds).
     pub created_at: i64,
+    /// The comment this one REPLIES to (`comment.id`), or `None` for a
+    /// top-level comment (migration 0067, multica `comment.parent_id`). The
+    /// mention router walks it to find the reply's parent author.
+    pub parent_id: Option<String>,
 }
 
 /// A fully-materialised `comment` row read back from the database.
@@ -53,6 +57,9 @@ pub struct Comment {
     pub body: String,
     /// Creation timestamp (epoch milliseconds).
     pub created_at: i64,
+    /// The comment this one replies to, or `None` at the top level
+    /// (migration 0067).
+    pub parent_id: Option<String>,
 }
 
 /// Stateless typed wrapper over the `comment` table.
@@ -105,8 +112,9 @@ impl CommentRepo {
         // target issue does not belong to `workspace_id`: a foreign-tenant (or
         // unknown) issue id matches no row in the sub-select, so zero rows insert.
         let res = sqlx::query(
-            "INSERT INTO comment (id, issue_id, author_type, author_id, body, created_at) \
-             SELECT ?, ?, ?, ?, ?, ? \
+            "INSERT INTO comment \
+             (id, issue_id, author_type, author_id, body, created_at, parent_id) \
+             SELECT ?, ?, ?, ?, ?, ?, ? \
              WHERE EXISTS (SELECT 1 FROM issue WHERE id = ? AND workspace_id = ?)",
         )
         .bind(&comment.id)
@@ -115,6 +123,7 @@ impl CommentRepo {
         .bind(author_id)
         .bind(&comment.body)
         .bind(comment.created_at)
+        .bind(&comment.parent_id)
         .bind(&comment.issue_id)
         .bind(workspace_id)
         .execute(exec)
@@ -141,7 +150,8 @@ impl CommentRepo {
         issue_id: &str,
     ) -> Result<Vec<Comment>, sqlx::Error> {
         let rows = sqlx::query(
-            "SELECT c.id, c.issue_id, c.author_type, c.author_id, c.body, c.created_at \
+            "SELECT c.id, c.issue_id, c.author_type, c.author_id, c.body, c.created_at, \
+                    c.parent_id \
              FROM comment c \
              JOIN issue i ON i.id = c.issue_id \
              WHERE c.issue_id = ? AND i.workspace_id = ? \
@@ -153,7 +163,80 @@ impl CommentRepo {
         .await?;
         rows.iter().map(comment_from_row).collect()
     }
+
+    /// Read one comment by id, **workspace-scoped through the join to `issue`**.
+    ///
+    /// A comment id from another tenant resolves to `None` — the same tenant
+    /// guard [`list_by_issue`](Self::list_by_issue) enforces, so a caller
+    /// probing ids learns nothing about a foreign workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails or the stored author pair is
+    /// malformed.
+    pub async fn get(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        comment_id: &str,
+    ) -> Result<Option<Comment>, sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT c.id, c.issue_id, c.author_type, c.author_id, c.body, c.created_at, \
+                    c.parent_id \
+             FROM comment c \
+             JOIN issue i ON i.id = c.issue_id \
+             WHERE c.id = ? AND i.workspace_id = ?",
+        )
+        .bind(comment_id)
+        .bind(workspace_id)
+        .fetch_optional(pool)
+        .await?;
+        row.as_ref().map(comment_from_row).transpose()
+    }
+
+    /// Walk `parent_id` up from `comment_id` and return the THREAD ROOT — the
+    /// topmost ancestor that itself has no parent (multica's thread-root owner
+    /// leg of the mention fallback chain).
+    ///
+    /// Returns `None` when `comment_id` resolves to no comment in this
+    /// workspace. A comment with no parent is its own root.
+    ///
+    /// The walk is **hard-capped at [`THREAD_WALK_MAX_HOPS`] hops**. 0067's
+    /// self-FK has no cycle check (SQLite cannot express one), so a corrupt or
+    /// externally-tampered chain could otherwise spin forever inside a request
+    /// handler; the cap turns that into "the deepest ancestor we reached",
+    /// which is a strictly better failure mode than a hung daemon.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if a lookup fails.
+    pub async fn thread_root(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        comment_id: &str,
+    ) -> Result<Option<Comment>, sqlx::Error> {
+        let Some(mut current) = Self::get(pool, workspace_id, comment_id).await? else {
+            return Ok(None);
+        };
+        for _ in 0..THREAD_WALK_MAX_HOPS {
+            let Some(parent_id) = current.parent_id.clone() else {
+                break;
+            };
+            // A dangling parent pointer (0067 deliberately has no ON DELETE)
+            // stops the walk at the deepest ancestor that still exists.
+            let Some(parent) = Self::get(pool, workspace_id, &parent_id).await? else {
+                break;
+            };
+            current = parent;
+        }
+        Ok(Some(current))
+    }
 }
+
+/// The hop ceiling [`CommentRepo::thread_root`] walks before giving up.
+///
+/// Threads in practice are a handful deep; the cap exists purely so a cyclic or
+/// corrupt `parent_id` chain cannot hang a request handler.
+pub const THREAD_WALK_MAX_HOPS: usize = 32;
 
 /// Re-assemble an [`ActorRef`] from a non-null `(type, id)` author pair.
 ///
@@ -184,6 +267,7 @@ fn comment_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Comment, sqlx::Erro
         author,
         body: row.try_get("body")?,
         created_at: row.try_get("created_at")?,
+        parent_id: row.try_get("parent_id")?,
     })
 }
 
@@ -233,6 +317,7 @@ mod tests {
                 author: author(),
                 body: "first comment".into(),
                 created_at: 1234,
+                parent_id: None,
             },
         )
         .await
@@ -262,6 +347,7 @@ mod tests {
                     author: author(),
                     body: body.into(),
                     created_at: ts,
+                    parent_id: None,
                 },
             )
             .await
@@ -300,6 +386,7 @@ mod tests {
                 author: author(),
                 body: "cross-tenant".into(),
                 created_at: 1234,
+                parent_id: None,
             },
         )
         .await
@@ -310,6 +397,151 @@ mod tests {
         assert!(
             comments.is_empty(),
             "no comment leaked into the real tenant"
+        );
+    }
+
+    /// 0067 threading: a reply carries its `parent_id` through insert → read,
+    /// and `thread_root` walks a chain back to the topmost comment.
+    #[tokio::test]
+    async fn parent_id_round_trips_and_thread_root_walks_to_the_top() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_issue(store.pool(), "ws-a", "issue-a").await;
+        for (id, parent) in [("c1", None), ("c2", Some("c1")), ("c3", Some("c2"))] {
+            CommentRepo::insert(
+                store.pool(),
+                "ws-a",
+                &NewComment {
+                    id: id.into(),
+                    issue_id: "issue-a".into(),
+                    author: author(),
+                    body: id.into(),
+                    created_at: 1000,
+                    parent_id: parent.map(str::to_string),
+                },
+            )
+            .await
+            .unwrap();
+        }
+        let c3 = CommentRepo::get(store.pool(), "ws-a", "c3").await.unwrap().unwrap();
+        assert_eq!(c3.parent_id.as_deref(), Some("c2"), "parent_id round-trips");
+
+        let root = CommentRepo::thread_root(store.pool(), "ws-a", "c3")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(root.id, "c1", "the walk reaches the parentless root");
+        assert!(root.parent_id.is_none());
+
+        // A top-level comment is its own root.
+        let self_root = CommentRepo::thread_root(store.pool(), "ws-a", "c1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(self_root.id, "c1");
+    }
+
+    /// A CYCLIC `parent_id` chain (which the self-FK cannot forbid) terminates
+    /// instead of hanging the caller: the hop cap is the whole point.
+    #[tokio::test]
+    async fn thread_root_terminates_on_a_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_issue(store.pool(), "ws-a", "issue-a").await;
+        for id in ["c1", "c2"] {
+            CommentRepo::insert(
+                store.pool(),
+                "ws-a",
+                &NewComment {
+                    id: id.into(),
+                    issue_id: "issue-a".into(),
+                    author: author(),
+                    body: id.into(),
+                    created_at: 1000,
+                    parent_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        }
+        // c1 -> c2 -> c1. Both FKs are satisfied, so nothing at the schema level
+        // stops this; only the hop cap does.
+        sqlx::query("UPDATE comment SET parent_id = 'c2' WHERE id = 'c1'")
+            .execute(store.pool())
+            .await
+            .unwrap();
+        sqlx::query("UPDATE comment SET parent_id = 'c1' WHERE id = 'c2'")
+            .execute(store.pool())
+            .await
+            .unwrap();
+        let root = CommentRepo::thread_root(store.pool(), "ws-a", "c1")
+            .await
+            .unwrap();
+        assert!(root.is_some(), "the walk returns rather than spinning forever");
+    }
+
+    /// Deleting a parent DETACHES its reply (0067 `ON DELETE SET NULL`) rather
+    /// than blocking the delete or cascading the reply away. This is what keeps
+    /// the bulk `DELETE FROM comment WHERE issue_id = ?` in `IssueRepo::delete`
+    /// working on a threaded issue.
+    #[tokio::test]
+    async fn deleting_a_parent_detaches_its_reply() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_issue(store.pool(), "ws-a", "issue-a").await;
+        for (id, parent) in [("c1", None), ("c2", Some("c1"))] {
+            CommentRepo::insert(
+                store.pool(),
+                "ws-a",
+                &NewComment {
+                    id: id.into(),
+                    issue_id: "issue-a".into(),
+                    author: author(),
+                    body: id.into(),
+                    created_at: 1000,
+                    parent_id: parent.map(str::to_string),
+                },
+            )
+            .await
+            .unwrap();
+        }
+        sqlx::query("DELETE FROM comment WHERE id = 'c1'")
+            .execute(store.pool())
+            .await
+            .expect("deleting a parent must not be blocked by its reply");
+        let c2 = CommentRepo::get(store.pool(), "ws-a", "c2").await.unwrap();
+        let c2 = c2.expect("the reply survives its parent");
+        assert!(c2.parent_id.is_none(), "the reply is detached, not deleted");
+    }
+
+    /// `get` is workspace-scoped: a foreign tenant cannot read the comment.
+    #[tokio::test]
+    async fn get_is_workspace_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_issue(store.pool(), "ws-a", "issue-a").await;
+        sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-b','b','b',1)")
+            .execute(store.pool())
+            .await
+            .unwrap();
+        CommentRepo::insert(
+            store.pool(),
+            "ws-a",
+            &NewComment {
+                id: "c1".into(),
+                issue_id: "issue-a".into(),
+                author: author(),
+                body: "owner".into(),
+                created_at: 1,
+                parent_id: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(CommentRepo::get(store.pool(), "ws-a", "c1").await.unwrap().is_some());
+        assert!(
+            CommentRepo::get(store.pool(), "ws-b", "c1").await.unwrap().is_none(),
+            "a foreign tenant reads nothing"
         );
     }
 
@@ -335,6 +567,7 @@ mod tests {
                 author: author(),
                 body: "owner".into(),
                 created_at: 1234,
+                parent_id: None,
             },
         )
         .await

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/comment.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/comment.rs
@@ -426,18 +426,13 @@ mod tests {
         let c3 = CommentRepo::get(store.pool(), "ws-a", "c3").await.unwrap().unwrap();
         assert_eq!(c3.parent_id.as_deref(), Some("c2"), "parent_id round-trips");
 
-        let root = CommentRepo::thread_root(store.pool(), "ws-a", "c3")
-            .await
-            .unwrap()
-            .unwrap();
+        let root = CommentRepo::thread_root(store.pool(), "ws-a", "c3").await.unwrap().unwrap();
         assert_eq!(root.id, "c1", "the walk reaches the parentless root");
         assert!(root.parent_id.is_none());
 
         // A top-level comment is its own root.
-        let self_root = CommentRepo::thread_root(store.pool(), "ws-a", "c1")
-            .await
-            .unwrap()
-            .unwrap();
+        let self_root =
+            CommentRepo::thread_root(store.pool(), "ws-a", "c1").await.unwrap().unwrap();
         assert_eq!(self_root.id, "c1");
     }
 
@@ -474,10 +469,11 @@ mod tests {
             .execute(store.pool())
             .await
             .unwrap();
-        let root = CommentRepo::thread_root(store.pool(), "ws-a", "c1")
-            .await
-            .unwrap();
-        assert!(root.is_some(), "the walk returns rather than spinning forever");
+        let root = CommentRepo::thread_root(store.pool(), "ws-a", "c1").await.unwrap();
+        assert!(
+            root.is_some(),
+            "the walk returns rather than spinning forever"
+        );
     }
 
     /// Deleting a parent DETACHES its reply (0067 `ON DELETE SET NULL`) rather

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
@@ -256,6 +256,75 @@ impl MemberRepo {
             .collect()
     }
 
+    /// Resolve a human `@handle` from a comment body to a workspace member.
+    ///
+    /// hangar has **no `handle` column on `user`** — the identity it stores is
+    /// the email — so the email's LOCAL PART is the human handle:
+    /// `alice@example.com` is `@alice`. Matching is attempted in this order,
+    /// first hit wins, all workspace-scoped and all case-insensitive except the
+    /// exact id:
+    ///
+    /// 1. exact `user.id` (so a roster that pastes the raw id works);
+    /// 2. the email local part (`substr(email, 1, instr(email,'@') - 1)`);
+    /// 3. the full email.
+    ///
+    /// A handle that matches more than one member (two tenants' users sharing a
+    /// local part, e.g. `alice@a.com` and `alice@b.com` both in this workspace)
+    /// is genuinely ambiguous; the lowest `user.id` wins deterministically
+    /// rather than the query returning an arbitrary row. The unambiguous address
+    /// is the link form `[@Alice](mention://member/<user_id>)`, which never goes
+    /// through this resolver at all — every generated roster prefers it.
+    ///
+    /// Returns `None` for an unknown handle: an unresolvable mention is an
+    /// `ignored` outcome, never an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn resolve_handle(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        handle: &str,
+    ) -> Result<Option<Member>, sqlx::Error> {
+        use sqlx::Row;
+        let handle = handle.trim();
+        if handle.is_empty() {
+            return Ok(None);
+        }
+        // One query, three ranked predicates: SQLite has no NULLS-ordered CASE
+        // shortcut, so the rank is computed and ordered on. `instr` returns 0
+        // for an email with no `@`, and `substr(x, 1, -1)` is empty, so such a
+        // row can only ever match rule 1 or 3 — never a phantom local part.
+        let rows = sqlx::query(
+            "SELECT m.user_id AS user_id, u.email AS email, m.role AS role, \
+                    CASE WHEN m.user_id = ?1 THEN 0 \
+                         WHEN instr(u.email, '@') > 1 \
+                              AND lower(substr(u.email, 1, instr(u.email, '@') - 1)) \
+                                  = lower(?1) THEN 1 \
+                         ELSE 2 END AS rank \
+             FROM member m JOIN user u ON u.id = m.user_id \
+             WHERE m.workspace_id = ?2 \
+               AND ( m.user_id = ?1 \
+                     OR lower(u.email) = lower(?1) \
+                     OR ( instr(u.email, '@') > 1 \
+                          AND lower(substr(u.email, 1, instr(u.email, '@') - 1)) \
+                              = lower(?1) ) ) \
+             ORDER BY rank, m.user_id LIMIT 1",
+        )
+        .bind(handle)
+        .bind(workspace.as_str())
+        .fetch_optional(pool)
+        .await?;
+        rows.map(|r| {
+            Ok(Member {
+                user_id: r.try_get("user_id")?,
+                email: r.try_get("email")?,
+                role: r.try_get("role")?,
+            })
+        })
+        .transpose()
+    }
+
     /// Set `user_id`'s role within `workspace` to `role`, guarding the last owner.
     ///
     /// Workspace-scoped: a `(workspace, user)` pair that matches no member row is

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -708,6 +708,90 @@ impl TaskRepo {
             .await?;
         Ok(res.rows_affected() == 1)
     }
+
+    /// The PENDING (`queued` / `dispatched`) task this agent already holds on
+    /// `issue_id`, if any — the row the per-`(issue, agent)` partial unique
+    /// index (migration 0012) guards.
+    ///
+    /// This is the mention router's COALESCE probe. Before 2-rest a repeat
+    /// mention hit the unique index and the resulting violation was swallowed,
+    /// so "already pending" was indistinguishable from "enqueued": detecting it
+    /// up front is what lets the router report multica's `coalesced` outcome
+    /// instead of silently doing nothing.
+    ///
+    /// Workspace-scoped, so a foreign tenant's pending task never satisfies the
+    /// probe. Deterministic when (impossibly, given the index) two rows match:
+    /// the oldest wins.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn pending_for_issue_agent(
+        pool: &SqlitePool,
+        workspace_id: &str,
+        issue_id: &str,
+        agent_id: &str,
+    ) -> Result<Option<Task>, sqlx::Error> {
+        let sql = format!(
+            "SELECT {COLUMNS} FROM agent_task_queue \
+             WHERE workspace_id = ? AND issue_id = ? AND agent_id = ? \
+               AND status IN ('queued', 'dispatched') \
+             ORDER BY created_at, id LIMIT 1"
+        );
+        let row = sqlx::query(&sql)
+            .bind(workspace_id)
+            .bind(issue_id)
+            .bind(agent_id)
+            .fetch_optional(pool)
+            .await?;
+        row.as_ref().map(task_from_row).transpose()
+    }
+
+    /// Re-point a task at the comment that (re-)summoned it (migration 0067).
+    ///
+    /// multica's merge-into-pending: when a second mention coalesces into a task
+    /// the agent has not claimed yet, the task is re-pointed at the NEWER
+    /// comment so the agent reads the latest ask rather than the stale first
+    /// one. Returns `true` when exactly one row was updated (`false` for an
+    /// unknown task id — never an error).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the update fails.
+    pub async fn set_trigger_comment(
+        pool: &SqlitePool,
+        task_id: &str,
+        comment_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query("UPDATE agent_task_queue SET trigger_comment_id = ? WHERE id = ?")
+            .bind(comment_id)
+            .bind(task_id)
+            .execute(pool)
+            .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// The comment that summoned `task_id`, or `None` when the task was not
+    /// mention-triggered (or predates migration 0067).
+    ///
+    /// A dangling id — 0067 deliberately carries no FK, so deleting a comment
+    /// neither cascades the task away nor is blocked by it — still reads back
+    /// here; the caller decides whether the comment still exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn trigger_comment_id(
+        pool: &SqlitePool,
+        task_id: &str,
+    ) -> Result<Option<String>, sqlx::Error> {
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT trigger_comment_id FROM agent_task_queue WHERE id = ?")
+                .bind(task_id)
+                .fetch_optional(pool)
+                .await?;
+        Ok(row.and_then(|(v,)| v))
+    }
 }
 
 /// The full `agent_task_queue` column list, in the order [`task_from_row`]

--- a/ainb-tui/crates/ainb-hangar-store/src/service/child_done.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/child_done.rs
@@ -294,6 +294,9 @@ pub async fn cascade_children_done(
                 author: author.clone(),
                 body: body.clone(),
                 created_at: now_ms,
+                // The cascade roll-up is a top-level comment on the parent, not
+                // a reply: it summarises a stage, it does not answer anyone.
+                parent_id: None,
             },
         )
         .await?;

--- a/ainb-tui/crates/ainb-hangar-store/src/service/mention.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/mention.rs
@@ -248,7 +248,9 @@ pub async fn route(
                     );
                 }
                 Resolved::Member(user_id) => {
-                    rows.push(notify_member(pool, idgen, req, &user_id, &m.token, now, dry_run).await);
+                    rows.push(
+                        notify_member(pool, idgen, req, &user_id, &m.token, now, dry_run).await,
+                    );
                 }
                 Resolved::Row(row) => rows.push(row),
             }
@@ -384,7 +386,8 @@ async fn fallback_target(
     if let Some(parent_id) = req.parent_comment_id {
         if let Some(parent) = CommentRepo::get(pool, req.workspace_id, parent_id).await? {
             if parent.author.kind() == ActorKind::Agent {
-                if let Some(agent) = agent_in_workspace(pool, req.workspace_id, parent.author.id()).await?
+                if let Some(agent) =
+                    agent_in_workspace(pool, req.workspace_id, parent.author.id()).await?
                 {
                     return Ok(Some((agent, MentionSource::ReplyParent)));
                 }
@@ -392,7 +395,8 @@ async fn fallback_target(
         }
         if let Some(root) = CommentRepo::thread_root(pool, req.workspace_id, parent_id).await? {
             if root.author.kind() == ActorKind::Agent {
-                if let Some(agent) = agent_in_workspace(pool, req.workspace_id, root.author.id()).await?
+                if let Some(agent) =
+                    agent_in_workspace(pool, req.workspace_id, root.author.id()).await?
                 {
                     return Ok(Some((agent, MentionSource::ThreadRoot)));
                 }
@@ -422,9 +426,7 @@ async fn agent_in_workspace(
     workspace_id: &str,
     agent_id: &str,
 ) -> Result<Option<Agent>, sqlx::Error> {
-    Ok(AgentRepo::get(pool, agent_id)
-        .await?
-        .filter(|a| a.workspace_id == workspace_id))
+    Ok(AgentRepo::get(pool, agent_id).await?.filter(|a| a.workspace_id == workspace_id))
 }
 
 /// Gate and (unless dry) act on ONE agent target, always producing exactly one

--- a/ainb-tui/crates/ainb-hangar-store/src/service/mention.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/mention.rs
@@ -1,0 +1,707 @@
+//! **Comment `@mention` routing** (multica parity #2-rest).
+//!
+//! One function, [`route`], answers "who did this comment address, and what did
+//! we do about each of them". It is the single seam behind BOTH the daemon's
+//! `hangar/comment_add` write and its `hangar/comment_mention_preview` dry run —
+//! and behind the CLI's store-direct equivalents — precisely so a preview can
+//! never disagree with the write it previews (multica step 10, and the
+//! visibility-gate-identical-on-both requirement of step 7).
+//!
+//! # What changed relative to the pre-2-rest path
+//!
+//! The old `spawn_mention_tasks` returned only the agent ids it managed to
+//! enqueue. A refused target was a silent `continue`, a repeat mention was a
+//! swallowed unique-constraint violation, and a human `@handle` matched no agent
+//! and vanished. Every one of those is now a REPORTED [`MentionRouteRow`] with a
+//! [`MentionOutcome`] and, where one applies, a [`DispatchReason`].
+//!
+//! # The algorithm (each step cites the multica step it mirrors)
+//!
+//! 1. Parse the body ([`ainb_hangar_core::mention::parse`]). A reply that
+//!    mentions nobody INHERITS its parent's mentions, under multica's three
+//!    narrowing conditions (`shouldInheritParentMentions`, `comment.go:389`):
+//!    the reply has no mentions of its own, its author is not an agent, and the
+//!    parent's author is a member.
+//! 2. Resolve every parsed target, workspace-scoped.
+//! 3. **Explicit beats implicit** (multica step 2): if anything resolved, the
+//!    fallback chain is skipped entirely.
+//! 4. Otherwise walk the fallback chain, first hit wins (multica step 4):
+//!    reply-parent author → thread-root author → issue assignee, each only when
+//!    it is an AGENT.
+//! 5. Act per target, one row each, never an early return, so one refused handle
+//!    can never suppress the others.
+//!
+//! # Divergences from multica, deliberate
+//!
+//! * **Members and unresolvable handles are reported.** multica's outcome array
+//!   only ever describes agent triggers. See [`MentionOutcome`]'s own docs.
+//! * **No `mentioned` activity row.** hangar's `activity_log.action` is a closed
+//!   CHECK-constrained set with no mention verb; adding one is a schema change
+//!   this item does not need, since the inbox entry + subscription already make
+//!   the human-routing leg observable. Left for the activity-vocabulary item.
+//! * **An explicit mention bypasses the blocker gate**, matching multica's "no
+//!   status gate here — an `@`mention is an explicit action" (`comment.go:~410`).
+//!   Only a FALLBACK target is deferred behind unfinished blockers, because
+//!   nobody asked for it by name.
+
+use crate::repo::agent::{Agent, AgentRepo};
+use crate::repo::card_dependency::CardDependencyRepo;
+use crate::repo::comment::CommentRepo;
+use crate::repo::inbox::{InboxKind, InboxRepo, NewInboxEntry};
+use crate::repo::issue::IssueRepo;
+use crate::repo::issue_subscriber::{IssueSubscriberRepo, SubscribeReason};
+use crate::repo::member::MemberRepo;
+use crate::repo::squad::SquadRepo;
+use crate::repo::task::{NewTask, TaskRepo};
+use crate::repo::workspace::WorkspaceRepo;
+use ainb_hangar_core::actor::{ActorKind, ActorRef};
+use ainb_hangar_core::clock::HangarClock;
+use ainb_hangar_core::dispatch_reason::DispatchReason;
+use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_core::mention::{
+    self, MentionForm, MentionOutcome, MentionSource, MentionTargetKind, ParsedMention,
+};
+use ainb_hangar_core::origin::IssueOrigin;
+use sqlx::SqlitePool;
+
+/// The actor id the local TUI stamps on everything it authors (`member:me`).
+///
+/// It is a PLACEHOLDER, not a `user.id`: the plugin has no identity of its own
+/// and the daemon socket is the local operator's.
+pub const LOCAL_OPERATOR_MEMBER_ID: &str = "me";
+
+/// How many characters of the comment body ride along in the inbox summary.
+const SUMMARY_CHARS: usize = 120;
+
+/// One routing request: everything [`route`] needs to decide and (optionally) act.
+#[derive(Debug, Clone)]
+pub struct MentionRouteRequest<'a> {
+    /// The resolved workspace row id (never a slug).
+    pub workspace_id: &'a str,
+    /// The issue the comment belongs to.
+    pub issue_id: &'a str,
+    /// The COMMITTED comment's id. `None` means there is no comment yet, which
+    /// is the preview case; [`route`] then behaves as a dry run regardless of
+    /// [`dry_run`](Self::dry_run), because there is nothing to attribute a write
+    /// to.
+    pub comment_id: Option<&'a str>,
+    /// The comment being replied to, if any (drives inheritance + the
+    /// reply-parent fallback).
+    pub parent_comment_id: Option<&'a str>,
+    /// Who wrote the comment.
+    pub author: &'a ActorRef,
+    /// The comment body.
+    pub body: &'a str,
+    /// `true` ⇒ resolve and gate identically but write NOTHING.
+    pub dry_run: bool,
+}
+
+/// What happened to ONE addressed target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionRouteRow {
+    /// `agent` | `member` | `squad` | `issue` — the family of the target.
+    pub target_type: String,
+    /// The resolved id, or `""` when nothing resolved.
+    pub target_id: String,
+    /// The token exactly as typed (a bare handle, or the link's id).
+    pub handle: String,
+    /// The bucket.
+    pub outcome: MentionOutcome,
+    /// The precise reason, when the bucket has one.
+    pub reason: Option<DispatchReason>,
+    /// The task that was written or coalesced into.
+    pub task_id: Option<String>,
+    /// Free-form human detail. Never an existence oracle (see
+    /// [`DispatchReason::InvocationNotAllowed`]).
+    pub detail: Option<String>,
+    /// Explicit, or which fallback leg produced this target.
+    pub source: MentionSource,
+}
+
+impl MentionRouteRow {
+    /// A `blocked` row with a reason and no target-specific ids.
+    fn blocked(
+        target_type: &str,
+        target_id: &str,
+        handle: &str,
+        reason: DispatchReason,
+        source: MentionSource,
+    ) -> Self {
+        Self {
+            target_type: target_type.to_string(),
+            target_id: target_id.to_string(),
+            handle: handle.to_string(),
+            outcome: MentionOutcome::Blocked,
+            reason: Some(reason),
+            task_id: None,
+            detail: None,
+            source,
+        }
+    }
+
+    /// An `ignored` row: nothing resolved, or a non-actor cross-reference.
+    fn ignored(target_type: &str, handle: &str) -> Self {
+        Self {
+            target_type: target_type.to_string(),
+            target_id: String::new(),
+            handle: handle.to_string(),
+            outcome: MentionOutcome::Ignored,
+            reason: None,
+            task_id: None,
+            detail: None,
+            source: MentionSource::Explicit,
+        }
+    }
+}
+
+/// What one parsed mention resolved to.
+enum Resolved {
+    /// A real agent in this workspace (possibly via a squad's leader).
+    Agent(Box<Agent>),
+    /// A human member of this workspace, carrying their `user.id`.
+    Member(String),
+    /// Nothing to act on — the row is emitted verbatim.
+    Row(MentionRouteRow),
+}
+
+/// Resolve every mention in `req.body`, decide what to do with each, and — when
+/// this is not a dry run — do it.
+///
+/// Returns one [`MentionRouteRow`] per addressed target, in first-seen mention
+/// order (fallback rows, which only exist when nothing was mentioned, last).
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] only on a store fault that is not attributable to a
+/// single target. A per-target fault degrades that target's row to
+/// `blocked` / [`DispatchReason::InternalError`] and the rest of the targets are
+/// still routed.
+#[allow(clippy::too_many_lines)]
+pub async fn route(
+    pool: &SqlitePool,
+    idgen: &dyn IdGen,
+    clock: &dyn HangarClock,
+    req: &MentionRouteRequest<'_>,
+) -> Result<Vec<MentionRouteRow>, sqlx::Error> {
+    // No committed comment ⇒ nothing a write could be attributed to, so the run
+    // is forced dry. This is a safety interlock, not a convenience: it makes
+    // "preview writes nothing" impossible to get wrong at a call site.
+    let dry_run = req.dry_run || req.comment_id.is_none();
+    let now = clock.now_ms();
+
+    let mut parsed = mention::parse(req.body);
+    // Step 1 — multica `shouldInheritParentMentions` (`comment.go:389`), with
+    // all three of its narrowing conditions: this reply mentions nobody, its
+    // author is not an agent, and the parent's author is a member. A human
+    // saying "yes please" under a comment that pinged an agent means the ping.
+    if parsed.is_empty() && req.author.kind() == ActorKind::Member {
+        if let Some(parent_id) = req.parent_comment_id {
+            if let Some(parent) = CommentRepo::get(pool, req.workspace_id, parent_id).await? {
+                if parent.author.kind() == ActorKind::Member {
+                    parsed = mention::parse(&parent.body);
+                }
+            }
+        }
+    }
+
+    // Step 2 — resolve, workspace-scoped.
+    let mut targets: Vec<(ParsedMention, Resolved)> = Vec::new();
+    for m in parsed {
+        let resolved = resolve_one(pool, req.workspace_id, &m).await?;
+        targets.push((m, resolved));
+    }
+
+    // Step 3 — explicit beats implicit (multica step 2). "Resolved" means an
+    // actual actor: an `issue`/`all` cross-reference or an unknown handle does
+    // NOT suppress the fallback, because the author addressed nobody.
+    let any_actor = targets
+        .iter()
+        .any(|(_, r)| matches!(r, Resolved::Agent(_) | Resolved::Member(_)));
+
+    let mut rows: Vec<MentionRouteRow> = Vec::new();
+
+    if any_actor {
+        // A single generation for the whole fan-out (migration 0039): every
+        // agent this ONE comment triggers belongs to the same run. Minted once,
+        // before the loop, exactly like the squad fan-out. Read-only, so it is
+        // safe on the dry-run path too.
+        let generation = TaskRepo::next_generation_for_issue(pool, req.issue_id).await?;
+        let invoker = effective_invoker(pool, req.workspace_id, req.author).await?;
+        for (m, resolved) in targets {
+            match resolved {
+                Resolved::Agent(agent) => {
+                    rows.push(
+                        route_agent(
+                            pool,
+                            idgen,
+                            req,
+                            &agent,
+                            &m.token,
+                            MentionSource::Explicit,
+                            &invoker,
+                            generation,
+                            now,
+                            dry_run,
+                        )
+                        .await,
+                    );
+                }
+                Resolved::Member(user_id) => {
+                    rows.push(notify_member(pool, idgen, req, &user_id, &m.token, now, dry_run).await);
+                }
+                Resolved::Row(row) => rows.push(row),
+            }
+        }
+        return Ok(rows);
+    }
+
+    // Anything that parsed but resolved to nothing is still reported.
+    for (_, resolved) in targets {
+        if let Resolved::Row(row) = resolved {
+            rows.push(row);
+        }
+    }
+
+    // Step 4 — the fallback chain, first hit wins (multica step 4).
+    let Some((agent, source)) = fallback_target(pool, req).await? else {
+        return Ok(rows);
+    };
+    let generation = TaskRepo::next_generation_for_issue(pool, req.issue_id).await?;
+    let invoker = effective_invoker(pool, req.workspace_id, req.author).await?;
+    let handle = agent.name.clone();
+    rows.push(
+        route_agent(
+            pool, idgen, req, &agent, &handle, source, &invoker, generation, now, dry_run,
+        )
+        .await,
+    );
+    Ok(rows)
+}
+
+/// Resolve one parsed mention to an actor in `workspace_id`.
+async fn resolve_one(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    m: &ParsedMention,
+) -> Result<Resolved, sqlx::Error> {
+    match (m.form, m.kind) {
+        // `mention://issue/...` and `mention://all/all` are CROSS-REFERENCES,
+        // never triggers — multica filters them out of the trigger set
+        // (`comment.go:293`). hangar reports them as `ignored` rather than
+        // dropping them, so the caller can see they were understood.
+        (MentionForm::Link, Some(MentionTargetKind::Issue)) => {
+            Ok(Resolved::Row(MentionRouteRow::ignored("issue", &m.token)))
+        }
+        (MentionForm::Link, Some(MentionTargetKind::All)) => {
+            Ok(Resolved::Row(MentionRouteRow::ignored("all", &m.token)))
+        }
+        (MentionForm::Link, Some(MentionTargetKind::Agent)) => {
+            match AgentRepo::get(pool, &m.token).await? {
+                // The workspace check is what stops a foreign tenant's agent id
+                // being addressable by pasting it into a link.
+                Some(a) if a.workspace_id == workspace_id => Ok(Resolved::Agent(Box::new(a))),
+                _ => Ok(Resolved::Row(MentionRouteRow::ignored("agent", &m.token))),
+            }
+        }
+        (MentionForm::Link, Some(MentionTargetKind::Member)) => {
+            resolve_member(pool, workspace_id, &m.token).await
+        }
+        (MentionForm::Link, Some(MentionTargetKind::Squad)) => {
+            resolve_squad(pool, workspace_id, &m.token).await
+        }
+        // A bare handle is UNTYPED: agent first (that is today's shipped
+        // behaviour and every existing bare-mention test depends on it), then
+        // member, then nothing.
+        _ => {
+            let agents = AgentRepo::list_by_workspace(pool, workspace_id).await?;
+            if let Some(agent) = agents.into_iter().find(|a| a.name == m.token) {
+                return Ok(Resolved::Agent(Box::new(agent)));
+            }
+            resolve_member(pool, workspace_id, &m.token).await
+        }
+    }
+}
+
+/// Resolve a member handle / id, or report it ignored.
+async fn resolve_member(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    token: &str,
+) -> Result<Resolved, sqlx::Error> {
+    let Ok(ws) = WorkspaceId::from_str(workspace_id.to_string()) else {
+        return Ok(Resolved::Row(MentionRouteRow::ignored("member", token)));
+    };
+    match MemberRepo::resolve_handle(pool, &ws, token).await? {
+        Some(member) => Ok(Resolved::Member(member.user_id)),
+        None => Ok(Resolved::Row(MentionRouteRow::ignored("member", token))),
+    }
+}
+
+/// Resolve a squad to its LEADER agent (multica step 6).
+///
+/// A squad whose leader is a human — or which has no leader at all — has nothing
+/// to dispatch to, so it is `blocked` / [`DispatchReason::TargetUnavailable`]
+/// rather than silently ignored: the author DID address someone.
+async fn resolve_squad(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    token: &str,
+) -> Result<Resolved, sqlx::Error> {
+    let Ok(ws) = WorkspaceId::from_str(workspace_id.to_string()) else {
+        return Ok(Resolved::Row(MentionRouteRow::ignored("squad", token)));
+    };
+    let leader = SquadRepo::leader_agent_id(pool, &ws, token).await?;
+    let Some(leader_id) = leader else {
+        return Ok(Resolved::Row(MentionRouteRow::blocked(
+            "squad",
+            token,
+            token,
+            DispatchReason::TargetUnavailable,
+            MentionSource::Explicit,
+        )));
+    };
+    match AgentRepo::get(pool, &leader_id).await? {
+        Some(a) if a.workspace_id == workspace_id => Ok(Resolved::Agent(Box::new(a))),
+        _ => Ok(Resolved::Row(MentionRouteRow::blocked(
+            "squad",
+            token,
+            token,
+            DispatchReason::TargetUnavailable,
+            MentionSource::Explicit,
+        ))),
+    }
+}
+
+/// Walk multica's implicit fallback chain and return the first AGENT it hits.
+///
+/// reply-parent author → thread-root author → issue assignee. Only an agent
+/// counts: falling back onto a human would notify somebody nobody addressed.
+async fn fallback_target(
+    pool: &SqlitePool,
+    req: &MentionRouteRequest<'_>,
+) -> Result<Option<(Agent, MentionSource)>, sqlx::Error> {
+    if let Some(parent_id) = req.parent_comment_id {
+        if let Some(parent) = CommentRepo::get(pool, req.workspace_id, parent_id).await? {
+            if parent.author.kind() == ActorKind::Agent {
+                if let Some(agent) = agent_in_workspace(pool, req.workspace_id, parent.author.id()).await?
+                {
+                    return Ok(Some((agent, MentionSource::ReplyParent)));
+                }
+            }
+        }
+        if let Some(root) = CommentRepo::thread_root(pool, req.workspace_id, parent_id).await? {
+            if root.author.kind() == ActorKind::Agent {
+                if let Some(agent) = agent_in_workspace(pool, req.workspace_id, root.author.id()).await?
+                {
+                    return Ok(Some((agent, MentionSource::ThreadRoot)));
+                }
+            }
+        }
+    }
+    let Some(issue) = IssueRepo::get_by_id(pool, req.issue_id).await? else {
+        return Ok(None);
+    };
+    if issue.workspace_id != req.workspace_id {
+        return Ok(None);
+    }
+    let Some(assignee) = issue.assignee else {
+        return Ok(None);
+    };
+    if assignee.kind() != ActorKind::Agent {
+        return Ok(None);
+    }
+    Ok(agent_in_workspace(pool, req.workspace_id, assignee.id())
+        .await?
+        .map(|a| (a, MentionSource::Assignee)))
+}
+
+/// An agent by id, but only when it belongs to `workspace_id`.
+async fn agent_in_workspace(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    agent_id: &str,
+) -> Result<Option<Agent>, sqlx::Error> {
+    Ok(AgentRepo::get(pool, agent_id)
+        .await?
+        .filter(|a| a.workspace_id == workspace_id))
+}
+
+/// Gate and (unless dry) act on ONE agent target, always producing exactly one
+/// row. Gates run in multica's order — the self-loop skip and then the
+/// invocation gate BEFORE any agent state is read, so a caller who may not
+/// invoke an agent never learns its archived / runtime state from the trigger's
+/// behaviour.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn route_agent(
+    pool: &SqlitePool,
+    idgen: &dyn IdGen,
+    req: &MentionRouteRequest<'_>,
+    agent: &Agent,
+    handle: &str,
+    source: MentionSource,
+    invoker: &(ActorKind, Option<String>),
+    generation: i64,
+    now: i64,
+    dry_run: bool,
+) -> MentionRouteRow {
+    let blocked = |reason| MentionRouteRow::blocked("agent", &agent.id, handle, reason, source);
+
+    // 1. Self-loop (multica step 8). First, because it reads no agent state and
+    //    therefore leaks nothing.
+    if req.author.kind() == ActorKind::Agent && req.author.id() == agent.id {
+        return blocked(DispatchReason::SelfTriggerSuppressed);
+    }
+
+    // 2. The invocation gate, IDENTICAL on preview and on write (multica step 7)
+    //    so a preview can never leak a private agent's readiness.
+    match AgentRepo::can_invoke(pool, agent, invoker.0, invoker.1.as_deref()).await {
+        Ok(true) => {}
+        Ok(false) => return blocked(DispatchReason::InvocationNotAllowed),
+        Err(_) => return blocked(DispatchReason::InternalError),
+    }
+
+    // 3. Nothing to dispatch to.
+    if agent.archived || agent.runtime_id.is_empty() {
+        return blocked(DispatchReason::TargetUnavailable);
+    }
+
+    // 4. Blockers, FALLBACK targets only. An explicit mention is a deliberate
+    //    human act and bypasses this (multica `comment.go:~410`); an implicit
+    //    fallback is parked until `board::auto_run_dependent` promotes it.
+    if source != MentionSource::Explicit {
+        match CardDependencyRepo::unfinished_blockers_of(pool, req.issue_id).await {
+            Ok(b) if !b.is_empty() => {
+                return MentionRouteRow {
+                    outcome: MentionOutcome::Deferred,
+                    reason: Some(DispatchReason::Deferred),
+                    ..blocked(DispatchReason::Deferred)
+                };
+            }
+            Ok(_) => {}
+            Err(_) => return blocked(DispatchReason::InternalError),
+        }
+    }
+
+    // 5. Merge-into-pending (multica step 9). Detecting it up front is what
+    //    turns a swallowed unique-constraint violation into a REPORTED outcome.
+    match TaskRepo::pending_for_issue_agent(pool, req.workspace_id, req.issue_id, &agent.id).await {
+        Ok(Some(pending)) => {
+            if !dry_run {
+                if let Some(comment_id) = req.comment_id {
+                    // Re-point the pending task at the NEWER comment so the
+                    // agent reads the latest ask when it claims.
+                    let _ = TaskRepo::set_trigger_comment(pool, &pending.id, comment_id).await;
+                }
+            }
+            return MentionRouteRow {
+                target_type: "agent".into(),
+                target_id: agent.id.clone(),
+                handle: handle.to_string(),
+                outcome: MentionOutcome::Coalesced,
+                reason: Some(DispatchReason::Coalesced),
+                task_id: Some(pending.id),
+                detail: None,
+                source,
+            };
+        }
+        Ok(None) => {}
+        Err(_) => return blocked(DispatchReason::InternalError),
+    }
+
+    if dry_run {
+        // The preview reports what the write WOULD do, having run every gate.
+        return MentionRouteRow {
+            target_type: "agent".into(),
+            target_id: agent.id.clone(),
+            handle: handle.to_string(),
+            outcome: MentionOutcome::Queued,
+            reason: Some(DispatchReason::Queued),
+            task_id: None,
+            detail: None,
+            source,
+        };
+    }
+
+    // 6. Enqueue.
+    let task = NewTask {
+        id: idgen.new_ulid(),
+        workspace_id: req.workspace_id.to_string(),
+        runtime_id: agent.runtime_id.clone(),
+        agent_id: agent.id.clone(),
+        issue_id: Some(req.issue_id.to_string()),
+        work_dir: None,
+        // A mention is a direct, user-initiated ask: default urgency (P3),
+        // drained FIFO among equals.
+        priority: 0,
+        created_at: now,
+        autopilot_run_id: None,
+        generation,
+    };
+    match TaskRepo::insert(pool, &task).await {
+        Ok(_) => {}
+        // A racing enqueue lost to the per-(issue, agent) unique index: that is
+        // exactly the coalesce case, reported as such rather than errored.
+        Err(e) if is_unique_violation(&e) => {
+            return MentionRouteRow {
+                target_type: "agent".into(),
+                target_id: agent.id.clone(),
+                handle: handle.to_string(),
+                outcome: MentionOutcome::Coalesced,
+                reason: Some(DispatchReason::Coalesced),
+                task_id: None,
+                detail: None,
+                source,
+            };
+        }
+        Err(_) => return blocked(DispatchReason::InternalError),
+    }
+
+    if let Some(comment_id) = req.comment_id {
+        // 0056 ORIGIN PROVENANCE, stamped only on a task that actually landed.
+        if let Ok(origin) = IssueOrigin::comment_mention(comment_id) {
+            let _ = TaskRepo::set_origin(pool, &task.id, &origin).await;
+        }
+        // 0067: the comment that summoned this run, so the agent reads the
+        // actual ask and threads its reply under it (multica task.go:443).
+        let _ = TaskRepo::set_trigger_comment(pool, &task.id, comment_id).await;
+    }
+    // multica parity #22: being @-mentioned subscribes you.
+    if let Ok(actor) = ActorRef::new(ActorKind::Agent, agent.id.clone()) {
+        let _ = IssueSubscriberRepo::add(
+            pool,
+            req.workspace_id,
+            req.issue_id,
+            &actor,
+            SubscribeReason::Mentioned,
+            now,
+        )
+        .await;
+    }
+
+    MentionRouteRow {
+        target_type: "agent".into(),
+        target_id: agent.id.clone(),
+        handle: handle.to_string(),
+        outcome: MentionOutcome::Queued,
+        reason: Some(DispatchReason::Queued),
+        task_id: Some(task.id),
+        detail: None,
+        source,
+    }
+}
+
+/// A member mention NOTIFIES, it never triggers (multica step 3).
+///
+/// On a write that is an inbox entry addressed to the human plus a `mentioned`
+/// subscription, which together are what make "@mentioning a person routes to
+/// that person" observable. 0060 already made `inbox_entry` actor-polymorphic,
+/// so no schema work was needed for this leg.
+async fn notify_member(
+    pool: &SqlitePool,
+    idgen: &dyn IdGen,
+    req: &MentionRouteRequest<'_>,
+    user_id: &str,
+    handle: &str,
+    now: i64,
+    dry_run: bool,
+) -> MentionRouteRow {
+    let row = MentionRouteRow {
+        target_type: "member".into(),
+        target_id: user_id.to_string(),
+        handle: handle.to_string(),
+        outcome: MentionOutcome::Notified,
+        reason: None,
+        task_id: None,
+        detail: None,
+        source: MentionSource::Explicit,
+    };
+    if dry_run {
+        return row;
+    }
+    let Ok(recipient) = ActorRef::new(ActorKind::Member, user_id.to_string()) else {
+        return MentionRouteRow::blocked(
+            "member",
+            user_id,
+            handle,
+            DispatchReason::InternalError,
+            MentionSource::Explicit,
+        );
+    };
+    let entry = NewInboxEntry {
+        id: idgen.new_ulid(),
+        workspace_id: req.workspace_id.to_string(),
+        recipient: recipient.clone(),
+        kind: InboxKind::Issue,
+        event: "mention".to_string(),
+        subject_id: req.issue_id.to_string(),
+        summary: summarise(req.body),
+        created_at: now,
+    };
+    if InboxRepo::insert(pool, &entry).await.is_err() {
+        return MentionRouteRow::blocked(
+            "member",
+            user_id,
+            handle,
+            DispatchReason::InternalError,
+            MentionSource::Explicit,
+        );
+    }
+    let _ = IssueSubscriberRepo::add(
+        pool,
+        req.workspace_id,
+        req.issue_id,
+        &recipient,
+        SubscribeReason::Mentioned,
+        now,
+    )
+    .await;
+    row
+}
+
+/// The first [`SUMMARY_CHARS`] CHARACTERS (not bytes) of the body, so a
+/// multi-byte body can never be sliced mid-character.
+fn summarise(body: &str) -> String {
+    body.chars().take(SUMMARY_CHARS).collect()
+}
+
+/// Resolve a comment author to the EFFECTIVE invoking identity the invocation
+/// gate judges its targets by.
+///
+/// - a `member` author naming a REAL user id → that user;
+/// - the local-operator placeholder [`LOCAL_OPERATOR_MEMBER_ID`] → the workspace
+///   OWNER, exactly like `run_card`'s "no explicit invoker ⇒ owner" default. The
+///   local TUI stamps `member:me` on every comment it composes, so without this
+///   the gate would deny the single operator access to their own private agents
+///   — a regression with no security gain, since that socket IS the operator's.
+///   An owner-less workspace resolves to `""`, which matches no `owner_id` and
+///   fails closed;
+/// - an `agent` author → `(Agent, None)`: hangar has no `originator_user_id`
+///   column, so an agent-authored mention is the UNATTRIBUTED A2A case — it
+///   fails closed for `private` and `member`-target agents.
+///
+/// Moved verbatim from `ainb_hangar_daemon::rpc::snapshots` so the CLI's
+/// store-direct path applies the identical rule.
+async fn effective_invoker(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    author: &ActorRef,
+) -> Result<(ActorKind, Option<String>), sqlx::Error> {
+    if author.kind() != ActorKind::Member {
+        return Ok((ActorKind::Agent, None));
+    }
+    if author.id() != LOCAL_OPERATOR_MEMBER_ID {
+        return Ok((ActorKind::Member, Some(author.id().to_string())));
+    }
+    let owner = match WorkspaceId::from_str(workspace_id.to_string()) {
+        Ok(ws) => WorkspaceRepo::owner_id(pool, &ws).await?.unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+    Ok((ActorKind::Member, Some(owner)))
+}
+
+/// Whether a `sqlx` error is a UNIQUE-constraint violation (the per-`(issue,
+/// agent)` pending-task index coalescing a racing enqueue).
+fn is_unique_violation(e: &sqlx::Error) -> bool {
+    matches!(e, sqlx::Error::Database(db) if db.is_unique_violation())
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
@@ -37,6 +37,11 @@ pub mod child_done;
 pub mod complete;
 /// `{running|queued} -> failed` with a typed [`fail::FailureReason`].
 pub mod fail;
+/// Comment `@mention` ROUTING (multica parity #2-rest): resolve every mention
+/// in a comment body to an agent / member / squad-leader, gate it, act on it,
+/// and report a per-target outcome code. One seam behind both the `comment_add`
+/// write and the `comment_mention_preview` dry run.
+pub mod mention;
 /// Spawn a `parent_task_id`-chained child row for a retryable failed task.
 pub mod retry;
 /// Route a squad assignment to its leader by enqueueing a leader-keyed task.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -283,6 +283,47 @@ const SELF_AUTHOR_REF: &str = "member:me";
 /// the request names [`SELF_AUTHOR_REF`] as the recipient, and the daemon
 /// returns / sweeps only that actor's rows. When a real signed-in identity
 /// lands, only that constant changes.
+/// Render the `@`-mention routing outcomes of one `comment_add` reply as a
+/// single transcript line, or `None` when there is nothing to say
+/// (multica parity #2-rest).
+///
+/// Shape: `↪ @alice notified · @builder queued · @bot blocked (invocation not allowed)`.
+/// A `blocked` / `deferred` row carries the DispatchReason's human label in
+/// parentheses — that parenthetical IS the feature: before this item a refused
+/// mention was indistinguishable from one that ran.
+///
+/// An EMPTY outcome set renders nothing, so a comment with no mentions looks
+/// exactly as it did before.
+fn render_mention_outcomes(
+    rows: &[ainb_hangar_proto::snapshots::MentionOutcomeRow],
+) -> Option<String> {
+    use ainb_hangar_core::dispatch_reason::DispatchReason;
+
+    if rows.is_empty() {
+        return None;
+    }
+    let parts: Vec<String> = rows
+        .iter()
+        .map(|r| {
+            let who = if r.handle.is_empty() {
+                "(unknown)".to_string()
+            } else {
+                format!("@{}", r.handle)
+            };
+            // Only a refusal / deferral needs the WHY; `queued` and `notified`
+            // already say everything.
+            let why = match r.outcome.as_str() {
+                "blocked" | "deferred" => DispatchReason::parse(&r.reason)
+                    .map(|d| format!(" ({})", d.label()))
+                    .unwrap_or_default(),
+                _ => String::new(),
+            };
+            format!("{who} {}{why}", r.outcome)
+        })
+        .collect();
+    Some(format!("↪ {}", parts.join(" · ")))
+}
+
 fn inbox_params(ws: &str) -> serde_json::Value {
     serde_json::json!({ "workspace_id": ws, "recipient": SELF_AUTHOR_REF })
 }
@@ -1040,6 +1081,11 @@ impl HangarPlugin {
                 }
                 self.conn.on_event();
             }
+            // multica parity #2-rest: the `comment_add` reply now carries one
+            // outcome row per `@`-mention. Before this the reply was dropped on
+            // the floor, so a refused or coalesced mention looked exactly like
+            // one that ran.
+            RpcId::Number(COMMENT_ADD_REQ_ID) => self.apply_comment_mention_outcomes(resp),
             RpcId::Number(SQUAD_FANOUT_REQ_ID) => self.apply_squad_fanout(resp),
             RpcId::Number(DAEMON_HEALTH_REQ_ID) => self.apply_daemon_health(resp),
             RpcId::Number(USAGE_ROLLUP_REQ_ID) => self.apply_usage(resp),
@@ -1466,6 +1512,28 @@ impl HangarPlugin {
         }
         self.fetch_pending = true;
         self.conn.on_event();
+    }
+
+    /// Fold the `@`-mention routing outcomes off a `comment_add` reply into the
+    /// open task-detail transcript (multica parity #2-rest).
+    ///
+    /// Renders ONE line, e.g.
+    /// `↪ @alice notified · @builder queued · @secret-bot blocked (invocation not allowed)`.
+    /// A comment that mentioned nobody produces an empty vector and therefore
+    /// renders NOTHING, so a plain comment looks exactly as it did before.
+    fn apply_comment_mention_outcomes(&mut self, resp: &RpcResponse) {
+        let Some(result) = resp.result.as_ref() else {
+            return;
+        };
+        let Ok(parsed) = serde_json::from_value::<ainb_hangar_proto::snapshots::CommentAddResult>(
+            result.clone(),
+        ) else {
+            return;
+        };
+        if let Some(line) = render_mention_outcomes(&parsed.mention_outcomes) {
+            self.screens.push_task_detail_system_line(line);
+            self.conn.on_event();
+        }
     }
 
     /// Surface a `hangar/board_card_cancel` reply (tcp T3 / F6): a transient note
@@ -7374,6 +7442,68 @@ mod tests {
     /// into the draft, not routed to the control-center tab-switch. Before the
     /// text-capture guard the routing layer swallowed `C`/`U`/`I` first,
     /// navigating away and abandoning the compose draft.
+    /// **2-rest** — a comment that mentioned NOBODY renders nothing, so a plain
+    /// comment's transcript is byte-identical to what it was before this item.
+    #[test]
+    fn no_mentions_renders_no_transcript_line() {
+        assert_eq!(super::render_mention_outcomes(&[]), None);
+    }
+
+    /// **2-rest** — every outcome is named, and a REFUSAL carries the reason's
+    /// human label in parentheses. Asserted on the exact phrase, not a
+    /// substring-OR: the parenthetical is the whole point of the item.
+    #[test]
+    fn outcomes_render_with_the_refusal_reason_spelled_out() {
+        use ainb_hangar_proto::snapshots::MentionOutcomeRow;
+
+        let row = |handle: &str, outcome: &str, reason: &str| MentionOutcomeRow {
+            target_type: "agent".into(),
+            target_id: "x".into(),
+            handle: handle.into(),
+            outcome: outcome.into(),
+            reason: reason.into(),
+            task_id: None,
+            detail: String::new(),
+            source: "explicit".into(),
+        };
+        let line = super::render_mention_outcomes(&[
+            row("alice", "notified", ""),
+            row("builder", "queued", "queued"),
+            row("secret-bot", "blocked", "invocation_not_allowed"),
+        ])
+        .expect("a non-empty outcome set renders a line");
+        assert_eq!(
+            line,
+            "↪ @alice notified · @builder queued · @secret-bot blocked (invocation not allowed)"
+        );
+    }
+
+    /// **2-rest** — a `coalesced` row says so without a parenthetical (the
+    /// bucket already carries the meaning), and a `deferred` row explains why.
+    #[test]
+    fn coalesced_is_bare_and_deferred_explains_itself() {
+        use ainb_hangar_proto::snapshots::MentionOutcomeRow;
+
+        let row = |outcome: &str, reason: &str| MentionOutcomeRow {
+            target_type: "agent".into(),
+            target_id: "x".into(),
+            handle: "bot".into(),
+            outcome: outcome.into(),
+            reason: reason.into(),
+            task_id: None,
+            detail: String::new(),
+            source: "explicit".into(),
+        };
+        assert_eq!(
+            super::render_mention_outcomes(&[row("coalesced", "coalesced")]).unwrap(),
+            "↪ @bot coalesced"
+        );
+        assert_eq!(
+            super::render_mention_outcomes(&[row("deferred", "deferred")]).unwrap(),
+            "↪ @bot deferred (waiting on blockers)"
+        );
+    }
+
     #[test]
     fn uppercase_c_types_into_task_detail_compose_not_tab_switch() {
         use ainb_hangar_proto::events::IssueRow;

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -1264,6 +1264,15 @@ impl ScreenStates {
             td.set_pr_status(status);
         }
     }
+
+    /// Fold a system transcript line into the OPEN task-detail screen, if one is
+    /// open. A no-op otherwise — the mention outcomes are informational and must
+    /// never resurrect a closed screen.
+    pub fn push_task_detail_system_line(&mut self, body: String) {
+        if let Some(td) = self.task_detail.as_mut() {
+            td.push_system_line(body);
+        }
+    }
 }
 
 /// A cross-screen navigation the key router surfaces to the plugin glue, which

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/task_detail.rs
@@ -330,6 +330,24 @@ impl TaskDetailState {
         self.pr_status = status;
     }
 
+    /// Append a SYSTEM line to the transcript in the tool-result lane
+    /// (`is_comment: false`, so it is not styled as somebody's comment).
+    ///
+    /// Used to surface the `@`-mention routing outcomes the daemon returns from
+    /// `comment_add` (multica parity #2-rest). Before this, the reply was
+    /// dropped on the floor, so a mention that was refused or coalesced looked
+    /// exactly like one that ran.
+    pub fn push_system_line(&mut self, body: String) {
+        push_entry(
+            self,
+            TranscriptEntry {
+                kind: MessageKind::ToolResult,
+                body,
+                is_comment: false,
+            },
+        );
+    }
+
     /// The current lifecycle.
     #[must_use]
     pub const fn lifecycle(&self) -> TaskLifecycle {

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/transcript_reducer_test.rs
@@ -342,6 +342,7 @@ fn comments_interleave_with_transcript_in_arrival_order() {
             author: "member:alice".into(),
             body: "a comment".into(),
             created_at: 5,
+            parent_id: None,
         })),
     )
     .state;

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2840,6 +2840,8 @@ Commands:
   workspace  View + set per-workspace config (context prompt, issue prefix, repo whitelist)
   logs       Read the daemon's structured logs
   property   Define and archive a workspace's custom issue properties
+  comment    Post issue comments and preview their `@`-mention routing
+  inbox      Read an actor's notification inbox
   help       Print this message or the help of the given subcommand(s)
 
 Options:
@@ -5281,6 +5283,104 @@ Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --key <KEY>              The definition's stable slug
       --unarchive              Un-archive instead: bring the definition (and its values) back
+      --workspace <WORKSPACE>  Workspace slug. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+### `ainb hangar comment`
+
+Post issue comments and preview their `@`-mention routing
+
+```console
+$ ainb hangar comment --help
+Post issue comments and preview their `@`-mention routing
+
+Usage: ainb hangar comment [OPTIONS] <COMMAND>
+
+Commands:
+  add      Post a comment on an issue and print one row per routed `@`-mention
+  preview  DRY-RUN the mention router over a draft body: identical resolution and identical gates, zero writes
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar comment add`
+
+Post a comment on an issue and print one row per routed `@`-mention
+
+```console
+$ ainb hangar comment add --help
+Post a comment on an issue and print one row per routed `@`-mention
+
+Usage: ainb hangar comment add [OPTIONS] --issue <ISSUE> --body <BODY>
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --issue <ISSUE>          Issue id (ULID) to comment on
+      --body <BODY>            The comment body. `@handle` and `[@Label](mention://type/id)` both route
+      --author <AUTHOR>        The author as a canonical actor-ref. `member:me` is the local operator, which the invocation gate resolves to the workspace owner [default: member:me]
+      --parent <PARENT>        The comment this one replies to — drives the reply-parent fallback and multica's parent-mention inheritance
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar comment preview`
+
+DRY-RUN the mention router over a draft body: identical resolution and identical gates, zero writes
+
+```console
+$ ainb hangar comment preview --help
+DRY-RUN the mention router over a draft body: identical resolution and identical gates, zero writes
+
+Usage: ainb hangar comment preview [OPTIONS] --issue <ISSUE> --body <BODY>
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --issue <ISSUE>          Issue id (ULID) to comment on
+      --body <BODY>            The comment body. `@handle` and `[@Label](mention://type/id)` both route
+      --author <AUTHOR>        The author as a canonical actor-ref. `member:me` is the local operator, which the invocation gate resolves to the workspace owner [default: member:me]
+      --parent <PARENT>        The comment this one replies to — drives the reply-parent fallback and multica's parent-mention inheritance
+      --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+### `ainb hangar inbox`
+
+Read an actor's notification inbox
+
+```console
+$ ainb hangar inbox --help
+Read an actor's notification inbox
+
+Usage: ainb hangar inbox [OPTIONS] <COMMAND>
+
+Commands:
+  list  List one actor's inbox entries, newest first
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar inbox list`
+
+List one actor's inbox entries, newest first
+
+```console
+$ ainb hangar inbox list --help
+List one actor's inbox entries, newest first
+
+Usage: ainb hangar inbox list [OPTIONS]
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --recipient <RECIPIENT>  Whose inbox to read, as `member:<user-id>` / `agent:<agent-id>` [default: member:me]
+      --unread                 Show only UNREAD entries
+      --limit <LIMIT>          How many entries to show, newest first [default: 50]
       --workspace <WORKSPACE>  Workspace slug. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```


### PR DESCRIPTION
Implements parity item **2-rest — the mention routing layer**.

Before this, `@`-mentions in a hangar comment could only resolve a bare `@handle`
to an agent. A refused target was a silent `continue`, a repeat mention was a
swallowed unique-constraint violation, and a handle naming a human matched no
agent and simply vanished. The caller could not tell "nobody was mentioned" from
"the one agent you mentioned was refused".

## What lands

| multica behaviour | how |
|---|---|
| `[@Label](mention://type/id)` link form | `ainb_hangar_core::mention::parse`, `util.MentionRe` shape with the id class widened to ULID/slug |
| MEMBER (human) mentions | resolve via `MemberRepo::resolve_handle`; inbox entry + `mentioned` subscription, never a run |
| reply-parent / thread-root routing | migration 0067 `comment.parent_id`; `CommentRepo::thread_root` |
| assignee fallback | `service::mention::route` step 4, first hit wins |
| per-target outcome codes | `MentionOutcome` — multica's `queued\|coalesced\|deferred\|blocked` verbatim, plus hangar-additive `notified\|ignored` |
| preview endpoint | `hangar/comment_mention_preview`, same `route()` with `dry_run` |
| self-loop suppression | author-vs-target check, before any agent state is read |
| squad → leader | `SquadRepo::leader_agent_id` |
| merge-into-pending | `TaskRepo::pending_for_issue_agent` + `set_trigger_comment` re-points the pending task at the newer comment |
| trigger provenance | migration 0067 `agent_task_queue.trigger_comment_id` |
| `can_invoke` gate | kept, and now applied identically on preview so a dry run cannot leak a private agent's readiness |

`DispatchReason::RESERVED` shrinks to `[AttributionBlocked]` — this item ships the
`Coalesced` and `SelfTriggerSuppressed` producers.

## Deliberate divergences (all documented in-source)

- **`notified` / `ignored` are hangar-additive.** multica's outcome array only ever
  describes agent triggers; hangar reports the human-routing and no-op cases too,
  which is the point of the item.
- **No `mentioned` activity row.** `activity_log.action` is a closed CHECK set with no
  mention verb. The inbox entry + subscription already make the human leg observable,
  so this item does not widen that vocabulary.
- **`NewTask` did not gain a field.** `trigger_comment_id` is written by a setter
  (like `set_origin` already is), which keeps ~40 struct-literal fixtures across the
  workspace from drifting for no behavioural gain.
- **0067's `comment.parent_id` is `ON DELETE SET NULL`, not the omitted default.**
  `NO ACTION` would BLOCK the bulk `DELETE FROM comment WHERE issue_id = ?` that
  `IssueRepo::delete` runs, since SQLite enforces FKs row-by-row inside a statement.
  SET NULL detaches the reply instead. There is a test for it.
- **An explicit mention bypasses the blocker gate**, matching multica's "no status
  gate here". Only a fallback target is `deferred`.

## Behaviour change worth calling out

The assignee fallback means a mention-less comment on an **agent-assigned** issue now
enqueues that agent, tagged `source: "assignee"`. That is multica's documented chain
and is what makes "reply to the agent" work, but it is new behaviour on hangar.

## Wire compatibility

`comment_add` now answers with `CommentAddResult`, which `#[serde(flatten)]`s the
`CommentRow`. With no mentions the payload is **byte-identical** to what it was, and a
client that only knows `CommentRow` still decodes the richer payload. There is a proto
test pinning both. Outcomes deliberately do NOT ride `CommentRow` — that is the
`CommentAdded` event broadcast to every workspace subscriber, and per-target refusal
reasons belong only to the caller that wrote the comment.

## Tests (fail-before / pass-after)

- `ainb-hangar-core::mention` — 9 moved bare-grammar regressions verbatim + 8 link-form
  tests (dedup by `(type,id)`, bracketed labels, a bare handle inside a label counted once).
- `rpc/snapshots.rs` in-source — the 9 existing mention tests unchanged, plus 12 new
  outcome-vector tests.
- `crates/ainb-hangar-daemon/tests/rpc_comment_mention_routing.rs` — 9 framed-`UnixStream`
  tests. Red against `main`: every one reads `result.mention_outcomes`, a key `main`'s
  reply does not contain.
- `crates/ainb-core/tests/hangar_mention_routing_cli.rs` — 5 store-direct acceptance
  tests driving the real binary against a bare sqlite file, no daemon.
- Preview-writes-nothing is asserted by snapshotting row counts on all five tables the
  router can touch.

Also fixes a **pre-existing latency race** in `rpc_comment_add.rs`: `comment_added` is
emitted before the reply is written, and the frame walk silently ate the push once the
handler got slower. It now buffers pushes it steps over.

## Local gate

```
cargo build -p ainb                                        ok
cargo nextest run --lib --tests --all-features ...   4290/4290 passed, 0 failed
scripts/hangar/run_all_tripwires.sh                  ran=65   failed=0
scripts/hangar/run_acceptance_tests.sh               ran=205  failed=0
just gen-cli-ref                                     docs/tui/cli.md regenerated + committed
```

The acceptance suite caught one fixture the filtered nextest run never built
(`event_roundtrip_test`); it is repaired in this PR.

## Not in scope

The optional `p`-key preview in the compose modal (spec marks it P2) and a tmux
tripwire for the transcript line. The transcript renderer is covered by three unit
tests asserting the exact rendered phrase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hangar comment add` and `comment preview` for posting comments and safely previewing mention routing.
  * Added `hangar inbox list` with unread filtering and JSON, CSV, Markdown, and text output.
  * Added threaded comment replies with optional parent comments.
  * Mention routing now notifies members, queues agent work, coalesces repeats, and reports outcomes.
  * The interface displays mention-routing results in task details.

* **Documentation**
  * Added CLI reference documentation for comment and inbox commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->