### PR TITLE
feat: add native Fleet roster app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   fleet-macos-foundation:
-    name: Fleet macOS foundation
+    name: Fleet macOS app acceptance
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -81,18 +81,23 @@ jobs:
             cat "$log"
             exit "$status"
           fi
+      - name: Verify Fleet Release excludes DEBUG diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash apps/ainb-fleet-macos/ci/check-release-diagnostics.sh "$RUNNER_TEMP/ainb-fleet-macos-release-derived-data"
       - name: Test Fleet macOS app
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/fleet-macos-foundation"
           log="$RUNNER_TEMP/fleet-macos-foundation/xcodebuild-test.log"
-          if xcodebuild test \
+          if AINB_FLEET_FIXTURE_DAEMON="$GITHUB_WORKSPACE/ainb-tui/target/debug/examples/fleet_fixture_daemon" xcodebuild test \
             -project apps/ainb-fleet-macos/AINBFleet.xcodeproj \
             -scheme AINBFleet \
             -destination 'platform=macOS,arch=arm64' \
             -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-derived-data" \
-            -resultBundlePath "$RUNNER_TEMP/FleetRPCTests.xcresult" \
+            -resultBundlePath "$RUNNER_TEMP/FleetMacOSAcceptance.xcresult" \
             CODE_SIGNING_ALLOWED=NO \
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES >"$log" 2>&1; then
@@ -109,7 +114,8 @@ jobs:
           name: fleet-macos-foundation-failure-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/fleet-macos-foundation/*.log
-            ${{ runner.temp }}/FleetRPCTests.xcresult
+            ${{ runner.temp }}/FleetMacOSAcceptance.xcresult
+            ${{ runner.temp }}/ainb-fleet-macos-derived-data/Logs/Test/**/*.png
           if-no-files-found: warn
 
   # ────────────────────────────────────────────────────────────────────────────

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -20,6 +20,24 @@
 		A1000000000000000000001B /* FleetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002C /* FleetConnection.swift */; };
 		A1000000000000000000001C /* FleetConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002D /* FleetConnectionTests.swift */; };
 		A1000000000000000000001D /* FleetDaemonContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002E /* FleetDaemonContractTests.swift */; };
+		A1000000000000000000001E /* FleetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002F /* FleetStore.swift */; };
+		A1000000000000000000001F /* FleetConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000030 /* FleetConnectionState.swift */; };
+		A10000000000000000000020 /* FleetRosterPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000033 /* FleetRosterPresentation.swift */; };
+		A10000000000000000000034 /* FleetStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000035 /* FleetStatusPresentation.swift */; };
+		A10000000000000000000036 /* FleetMenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000037 /* FleetMenuBarView.swift */; };
+		A10000000000000000000038 /* FleetWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* FleetWindowView.swift */; };
+		A1000000000000000000003A /* FleetSessionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003B /* FleetSessionDetailView.swift */; };
+		A1000000000000000000003C /* FleetQuickSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003D /* FleetQuickSwitcher.swift */; };
+		A1000000000000000000003E /* FleetSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003F /* FleetSettingsView.swift */; };
+		A10000000000000000000040 /* FleetRosterPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000043 /* FleetRosterPresentationTests.swift */; };
+		A10000000000000000000045 /* FleetFixtureDaemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000049 /* FleetFixtureDaemon.swift */; };
+		A1000000000000000000005A /* FleetFixtureDaemonFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005B /* FleetFixtureDaemonFallbackTests.swift */; };
+		A1000000000000000000005C /* FleetFixtureDaemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000049 /* FleetFixtureDaemon.swift */; };
+		A10000000000000000000046 /* FleetUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000004A /* FleetUITestCase.swift */; };
+		A10000000000000000000047 /* MenuBarRosterJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */; };
+		A10000000000000000000048 /* WindowAndSwitcherJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000004C /* WindowAndSwitcherJourneyTests.swift */; };
+		A1000000000000000000004F /* OfflineAndReconnectJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */; };
+		A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +65,24 @@
 		A1000000000000000000002C /* FleetConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConnection.swift; sourceTree = "<group>"; };
 		A1000000000000000000002D /* FleetConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConnectionTests.swift; sourceTree = "<group>"; };
 		A1000000000000000000002E /* FleetDaemonContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDaemonContractTests.swift; sourceTree = "<group>"; };
+		A1000000000000000000002F /* FleetStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetStore.swift; sourceTree = "<group>"; };
+		A10000000000000000000030 /* FleetConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConnectionState.swift; sourceTree = "<group>"; };
+		A10000000000000000000033 /* FleetRosterPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetRoster/FleetRosterPresentation.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000035 /* FleetStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/MenuBar/FleetStatusPresentation.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000037 /* FleetMenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/MenuBar/FleetMenuBarView.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000039 /* FleetWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetRoster/FleetWindowView.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000003B /* FleetSessionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetRoster/FleetSessionDetailView.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000003D /* FleetQuickSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetRoster/FleetQuickSwitcher.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000003F /* FleetSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Settings/FleetSettingsView.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000043 /* FleetRosterPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetRosterPresentationTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000049 /* FleetFixtureDaemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/Support/FleetFixtureDaemon.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000005B /* FleetFixtureDaemonFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests/FleetRPCTests/FleetFixtureDaemonFallbackTests.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000004A /* FleetUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/Support/FleetUITestCase.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/MenuBarRosterJourneyTests.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000004C /* WindowAndSwitcherJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/WindowAndSwitcherJourneyTests.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000004D /* FleetUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000031 /* AINBFleet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AINBFleet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000032 /* FleetRPCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -66,6 +102,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A1000000000000000000004E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -76,6 +119,7 @@
 				A10000000000000000000056 /* FleetRPC */,
 				A10000000000000000000053 /* Resources */,
 				A10000000000000000000054 /* FleetRPCTests */,
+				A10000000000000000000057 /* FleetUITests */,
 				A10000000000000000000055 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -84,6 +128,15 @@
 			isa = PBXGroup;
 			children = (
 				A10000000000000000000021 /* AINBFleetApp.swift */,
+				A1000000000000000000002F /* FleetStore.swift */,
+				A10000000000000000000030 /* FleetConnectionState.swift */,
+				A10000000000000000000033 /* FleetRosterPresentation.swift */,
+				A10000000000000000000035 /* FleetStatusPresentation.swift */,
+				A10000000000000000000037 /* FleetMenuBarView.swift */,
+				A10000000000000000000039 /* FleetWindowView.swift */,
+				A1000000000000000000003B /* FleetSessionDetailView.swift */,
+				A1000000000000000000003D /* FleetQuickSwitcher.swift */,
+				A1000000000000000000003F /* FleetSettingsView.swift */,
 			);
 			path = Sources/App;
 			sourceTree = "<group>";
@@ -118,6 +171,8 @@
 				A1000000000000000000002A /* FleetSemanticBoundaryTests.swift */,
 				A1000000000000000000002D /* FleetConnectionTests.swift */,
 				A1000000000000000000002E /* FleetDaemonContractTests.swift */,
+				A10000000000000000000043 /* FleetRosterPresentationTests.swift */,
+				A1000000000000000000005B /* FleetFixtureDaemonFallbackTests.swift */,
 			);
 			path = Tests/FleetRPCTests;
 			sourceTree = "<group>";
@@ -127,8 +182,22 @@
 			children = (
 				A10000000000000000000031 /* AINBFleet.app */,
 				A10000000000000000000032 /* FleetRPCTests.xctest */,
+				A1000000000000000000004D /* FleetUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000057 /* FleetUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000049 /* FleetFixtureDaemon.swift */,
+				A1000000000000000000004A /* FleetUITestCase.swift */,
+				A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */,
+				A1000000000000000000004C /* WindowAndSwitcherJourneyTests.swift */,
+				A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */,
+				A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */,
+			);
+			path = UITests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -167,6 +236,23 @@
 			productReference = A10000000000000000000032 /* FleetRPCTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		A10000000000000000000003 /* FleetUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000063 /* Build configuration list for PBXNativeTarget "FleetUITests" */;
+			buildPhases = (
+				A1000000000000000000004E /* Frameworks */,
+				A10000000000000000000073 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A10000000000000000000094 /* PBXTargetDependency */,
+			);
+			name = FleetUITests;
+			productName = FleetUITests;
+			productReference = A1000000000000000000004D /* FleetUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -182,6 +268,10 @@
 					};
 					A10000000000000000000002 = {
 						CreatedOnToolsVersion = 26.4.1;
+						TestTargetID = A10000000000000000000001;
+					};
+					A10000000000000000000003 = {
+						CreatedOnToolsVersion = 2640;
 						TestTargetID = A10000000000000000000001;
 					};
 				};
@@ -201,6 +291,7 @@
 			targets = (
 				A10000000000000000000001 /* AINBFleet */,
 				A10000000000000000000002 /* FleetRPCTests */,
+				A10000000000000000000003 /* FleetUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -209,6 +300,17 @@
 		A10000000000000000000092 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			targetProxy = A10000000000000000000091 /* PBXContainerItemProxy */;
+		};
+		A10000000000000000000093 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A10000000000000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000001;
+			remoteInfo = AINBFleet;
+		};
+		A10000000000000000000094 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = A10000000000000000000093 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -223,6 +325,15 @@
 				A10000000000000000000015 /* FleetProjectionReducer.swift in Sources */,
 				A1000000000000000000001A /* HangarLocation.swift in Sources */,
 				A1000000000000000000001B /* FleetConnection.swift in Sources */,
+				A1000000000000000000001E /* FleetStore.swift in Sources */,
+				A1000000000000000000001F /* FleetConnectionState.swift in Sources */,
+				A10000000000000000000020 /* FleetRosterPresentation.swift in Sources */,
+				A10000000000000000000034 /* FleetStatusPresentation.swift in Sources */,
+				A10000000000000000000036 /* FleetMenuBarView.swift in Sources */,
+				A10000000000000000000038 /* FleetWindowView.swift in Sources */,
+				A1000000000000000000003A /* FleetSessionDetailView.swift in Sources */,
+				A1000000000000000000003C /* FleetQuickSwitcher.swift in Sources */,
+				A1000000000000000000003E /* FleetSettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,6 +348,22 @@
 				A10000000000000000000019 /* FleetSemanticBoundaryTests.swift in Sources */,
 				A1000000000000000000001C /* FleetConnectionTests.swift in Sources */,
 				A1000000000000000000001D /* FleetDaemonContractTests.swift in Sources */,
+				A10000000000000000000040 /* FleetRosterPresentationTests.swift in Sources */,
+				A1000000000000000000005C /* FleetFixtureDaemon.swift in Sources */,
+				A1000000000000000000005A /* FleetFixtureDaemonFallbackTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000000000000000000073 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000045 /* FleetFixtureDaemon.swift in Sources */,
+				A10000000000000000000046 /* FleetUITestCase.swift in Sources */,
+				A10000000000000000000047 /* MenuBarRosterJourneyTests.swift in Sources */,
+				A10000000000000000000048 /* WindowAndSwitcherJourneyTests.swift in Sources */,
+				A1000000000000000000004F /* OfflineAndReconnectJourneyTests.swift in Sources */,
+				A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -279,6 +406,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
@@ -336,6 +464,36 @@
 			};
 			name = Release;
 		};
+		A10000000000000000000087 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ainb.fleet.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = AINBFleet;
+			};
+			name = Debug;
+		};
+		A10000000000000000000088 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ainb.fleet.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = AINBFleet;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -362,6 +520,15 @@
 			buildConfigurations = (
 				A10000000000000000000085 /* Debug */,
 				A10000000000000000000086 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000000000000000000063 /* Build configuration list for PBXNativeTarget "FleetUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000087 /* Debug */,
+				A10000000000000000000088 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:AINBFleet.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000000000000000000003"
+               BuildableName = "FleetUITests.xctest"
+               BlueprintName = "FleetUITests"
+               ReferencedContainer = "container:AINBFleet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ainb-fleet-macos/Resources/Info.plist
+++ b/apps/ainb-fleet-macos/Resources/Info.plist
@@ -20,6 +20,8 @@
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>LSUIElement</key>
+    <true/>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
 </dict>

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -2,9 +2,95 @@ import SwiftUI
 
 @main
 struct AINBFleetApp: App {
+    @StateObject private var store: FleetStore
+    @State private var presentation: FleetPresentationPreferences
+    private let presentationDefaults: UserDefaults
+
+    init() {
+        let defaults = Self.presentationDefaults
+        let fleetStore = FleetStore(readVersions: Self.testReadVersions)
+        _store = StateObject(wrappedValue: fleetStore)
+        _presentation = State(initialValue: FleetPresentationPreferences.load(defaults: defaults))
+        presentationDefaults = defaults
+        Task { @MainActor in fleetStore.start() }
+    }
+
     var body: some Scene {
+        standardScenes
+    }
+
+    @SceneBuilder
+    private var standardScenes: some Scene {
+        MenuBarExtra {
+            FleetMenuBarView(store: store, openFleet: openFleet)
+        } label: {
+            Label("Fleet", systemImage: FleetStatusPresentation.symbol(for: store.connectionState, needsYou: store.needsYouCount, sessions: store.sessions))
+                .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
+                .accessibilityIdentifier("fleet.status-item")
+                .task {
+                    #if DEBUG
+                    guard Self.testLaunchesFleetWindow else { return }
+                    openWindow(id: "fleet")
+                    #endif
+                }
+        }
+        .menuBarExtraStyle(.window)
+
+        Window("Fleet", id: "fleet") {
+            FleetWindowView(store: store, presentation: presentationBinding)
+        }
         Settings {
-            EmptyView()
+            FleetSettingsView(presentation: presentationBinding)
         }
     }
+
+    @Environment(\.openWindow) private var openWindow
+
+    private var presentationBinding: Binding<FleetPresentationPreferences> {
+        Binding(
+            get: { presentation },
+            set: { newValue in
+                presentation = newValue
+                newValue.save(defaults: presentationDefaults)
+            }
+        )
+    }
+
+    private func openFleet(attentionOnly: Bool = false) {
+        if attentionOnly {
+            var next = presentation
+            next.filters.attentionOnly = true
+            presentationBinding.wrappedValue = next
+        }
+        openWindow(id: "fleet")
+    }
+
+    private static var testReadVersions: FleetProtocolRange {
+        #if DEBUG
+        if CommandLine.arguments.contains("--fleet-test-read-range=2...2")
+            || ProcessInfo.processInfo.environment["AINB_FLEET_TEST_READ_RANGE"] == "2...2" {
+            return FleetProtocolRange(min: 2, max: 2)
+        }
+        #endif
+        return FleetProtocolRange(min: 1, max: 1)
+    }
+
+    private static var presentationDefaults: UserDefaults {
+        #if DEBUG
+        guard testLaunchesFleetWindow else { return .standard }
+        let suite = "dev.ainb.fleet.xcui"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+        #else
+        return .standard
+        #endif
+    }
+
+    #if DEBUG
+    private static var testLaunchesFleetWindow: Bool {
+        CommandLine.arguments.contains("--fleet-test-open-window")
+            || ProcessInfo.processInfo.environment["AINB_FLEET_TEST_OPEN_WINDOW"] == "1"
+    }
+    #endif
 }

--- a/apps/ainb-fleet-macos/Sources/App/FleetConnectionState.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetConnectionState.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum FleetConnectionState: Equatable {
+    case connecting
+    case live(daemonVersion: String, writeCompatible: Bool)
+    case stale(lastUpdated: Date, reason: String)
+    case unavailable(message: String)
+    case readIncompatible(daemonVersion: String, protocolVersion: UInt32)
+
+    var isLive: Bool {
+        if case .live = self { return true }
+        return false
+    }
+
+    var message: String {
+        switch self {
+        case .connecting: return "Connecting to local Fleet daemon"
+        case let .live(daemonVersion, _): return "Live, daemon \(daemonVersion)"
+        case let .stale(lastUpdated, reason):
+            return "Stale since \(lastUpdated.formatted(date: .omitted, time: .shortened)): \(reason)"
+        case let .unavailable(message): return message
+        case let .readIncompatible(daemonVersion, protocolVersion):
+            return "Daemon \(daemonVersion) uses Fleet protocol \(protocolVersion), which this app cannot read"
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -1,0 +1,271 @@
+import Combine
+import Foundation
+
+@MainActor
+final class FleetStore: ObservableObject {
+    @Published private(set) var sessions: [FleetSession] = []
+    @Published private(set) var connectionState: FleetConnectionState = .connecting
+    @Published var selectedSessionKey: String?
+
+    private let location: HangarLocation
+    private let readVersions: FleetProtocolRange
+    private let makeConnection: (HangarLocation) -> FleetConnection
+    private let reconnectDelayNanoseconds: (Int) -> UInt64
+    private var connection: FleetConnection?
+    private var connectionTask: Task<Void, Never>?
+    private var reconnectTask: Task<Void, Never>?
+    private var connectionGeneration: UInt = 0
+    private var projection = FleetProjection.empty
+    private var negotiation: FleetNegotiateResult?
+    private var lastAuthoritativeRefresh: Date?
+    private var reconnectAttempts = 0
+    private var hasEstablishedLiveConnection = false
+    private let maximumReconnectAttempts = 3
+
+    init(
+        location: HangarLocation = HangarLocation(),
+        readVersions: FleetProtocolRange = FleetProtocolRange(min: 1, max: 1),
+        makeConnection: @escaping (HangarLocation) -> FleetConnection = { FleetConnection(location: $0) },
+        reconnectDelayNanoseconds: @escaping (Int) -> UInt64 = { UInt64($0) * 500_000_000 }
+    ) {
+        self.location = location
+        self.readVersions = readVersions
+        self.makeConnection = makeConnection
+        self.reconnectDelayNanoseconds = reconnectDelayNanoseconds
+    }
+
+    deinit {
+        connectionTask?.cancel()
+        reconnectTask?.cancel()
+    }
+
+    var activeCount: Int {
+        sessions.filter { $0.lifecycle == .starting || $0.lifecycle == .running }.count
+    }
+
+    var needsYouCount: Int { sessions.filter { $0.attention != .none }.count }
+
+    var canWrite: Bool {
+        guard case let .live(_, writeCompatible) = connectionState else { return false }
+        return writeCompatible && negotiation?.readCompatible == true
+    }
+
+    #if DEBUG
+    var debugConnectionTaskCount: Int {
+        [connectionTask, reconnectTask].compactMap { $0 }.count
+    }
+    #endif
+
+    var needsResubscribe: Bool { projection.needsResubscribe }
+
+    func start() {
+        guard connectionTask == nil, reconnectTask == nil else { return }
+        connectionState = .connecting
+        beginConnection()
+    }
+
+    func retry() {
+        reconnectAttempts = 0
+        hasEstablishedLiveConnection = false
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        connectionState = .connecting
+        beginConnection()
+    }
+
+    func stop() {
+        connectionGeneration &+= 1
+        hasEstablishedLiveConnection = false
+        connectionTask?.cancel()
+        connectionTask = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        let currentConnection = connection
+        connection = nil
+        Task { await currentConnection?.close() }
+    }
+
+    private func beginConnection() {
+        connectionGeneration &+= 1
+        let generation = connectionGeneration
+        let currentConnection = connection
+        connection = nil
+        connectionTask?.cancel()
+        connectionTask = Task { [weak self] in
+            await currentConnection?.close()
+            guard !Task.isCancelled else { return }
+            await self?.connectAndConsume(generation: generation)
+        }
+    }
+
+    private func connectAndConsume(generation: UInt) async {
+        defer {
+            if connectionGeneration == generation {
+                connectionTask = nil
+            }
+        }
+        let newConnection = makeConnection(location)
+        connection = newConnection
+        var established = false
+        do {
+            try await newConnection.connect()
+            try await newConnection.authenticate(token: location.readToken())
+            let result = try await newConnection.negotiate(readVersions: readVersions)
+            negotiation = result
+            let stream = await newConnection.incoming()
+            let subscription = try await newConnection.subscribe(afterRevision: projection.committedRevision)
+            let bootstrapped = FleetProjectionReducer.bootstrap(subscription)
+            guard !bootstrapped.needsResubscribe else {
+                projection = bootstrapped
+                await reconnectOrBecomeUnavailable(
+                    reason: "Fleet subscription requires resubscription",
+                    connection: newConnection,
+                    generation: generation
+                )
+                return
+            }
+            apply(bootstrapped)
+            connectionState = .live(daemonVersion: result.daemonVersion, writeCompatible: result.writeCompatible)
+            established = true
+            if reconnectAttempts > 0 {
+                reconnectAttempts = 0
+            }
+            hasEstablishedLiveConnection = true
+
+            for await incoming in stream {
+                if Task.isCancelled || connectionGeneration != generation { return }
+                if try await handle(incoming, on: newConnection, generation: generation) == false { return }
+            }
+            if !Task.isCancelled, connectionGeneration == generation {
+                await reconnectOrBecomeUnavailable(
+                    reason: "Fleet daemon connection closed",
+                    connection: newConnection,
+                    generation: generation
+                )
+            }
+        } catch let error as FleetConnectionError {
+            if case .protocolReadIncompatible = error {
+                handle(error)
+                await close(newConnection, ifCurrentGeneration: generation)
+            } else if established || hasEstablishedLiveConnection {
+                await reconnectOrBecomeUnavailable(
+                    reason: error.localizedDescription,
+                    connection: newConnection,
+                    generation: generation
+                )
+            } else {
+                handle(error)
+                await close(newConnection, ifCurrentGeneration: generation)
+            }
+        } catch is CancellationError {
+        } catch {
+            if established || hasEstablishedLiveConnection {
+                await reconnectOrBecomeUnavailable(
+                    reason: error.localizedDescription,
+                    connection: newConnection,
+                    generation: generation
+                )
+            } else {
+                handle(error)
+                await close(newConnection, ifCurrentGeneration: generation)
+            }
+        }
+    }
+
+    private func handle(_ incoming: FleetIncoming, on connection: FleetConnection, generation: UInt) async throws -> Bool {
+        switch incoming {
+        case let .event(event):
+            let next = FleetProjectionReducer.live(event, from: projection)
+            if next.needsResubscribe {
+                await reconnectOrBecomeUnavailable(
+                    reason: "Fleet stream needs resubscription",
+                    connection: connection,
+                    generation: generation
+                )
+                return false
+            }
+            apply(next)
+            if next.needsSnapshot {
+                apply(FleetProjectionReducer.snapshot(try await connection.snapshot(), from: next))
+            }
+        case .resyncRequired:
+            projection = FleetProjectionReducer.resyncRequired(from: projection)
+            await reconnectOrBecomeUnavailable(
+                reason: "Fleet daemon requested resync",
+                connection: connection,
+                generation: generation
+            )
+            return false
+        case .unknownNotification:
+            break
+        }
+        return true
+    }
+
+    private func apply(_ next: FleetProjection) {
+        projection = next
+        sessions = next.snapshot?.sessions ?? sessions
+        if next.snapshot != nil { lastAuthoritativeRefresh = Date() }
+        if let selectedSessionKey, !sessions.contains(where: { $0.sessionKey == selectedSessionKey }) {
+            self.selectedSessionKey = nil
+        }
+    }
+
+    private func becomeStale(reason: String) {
+        if sessions.isEmpty {
+            connectionState = .unavailable(message: reason)
+        } else {
+            connectionState = .stale(lastUpdated: lastAuthoritativeRefresh ?? Date(), reason: reason)
+        }
+        negotiation = nil
+    }
+
+    private func reconnectOrBecomeUnavailable(
+        reason: String,
+        connection: FleetConnection,
+        generation: UInt
+    ) async {
+        guard connectionGeneration == generation else { return }
+        becomeStale(reason: reason)
+        await close(connection, ifCurrentGeneration: generation)
+        guard connectionGeneration == generation,
+              reconnectAttempts < maximumReconnectAttempts,
+              !Task.isCancelled else { return }
+        reconnectAttempts += 1
+        let delay = reconnectDelayNanoseconds(reconnectAttempts)
+        reconnectTask?.cancel()
+        reconnectTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: delay)
+            } catch {
+                return
+            }
+            guard let self,
+                  !Task.isCancelled,
+                  self.connectionGeneration == generation else { return }
+            self.reconnectTask = nil
+            self.connectionState = .connecting
+            self.beginConnection()
+        }
+    }
+
+    private func close(_ connection: FleetConnection, ifCurrentGeneration generation: UInt) async {
+        await connection.close()
+        guard connectionGeneration == generation, self.connection === connection else { return }
+        self.connection = nil
+    }
+
+    private func handle(_ error: FleetConnectionError) {
+        switch error {
+        case let .protocolReadIncompatible(result):
+            negotiation = result
+            connectionState = .readIncompatible(daemonVersion: result.daemonVersion, protocolVersion: result.protocolVersion)
+        default:
+            becomeStale(reason: error.localizedDescription)
+        }
+    }
+
+    private func handle(_ error: Error) {
+        becomeStale(reason: error.localizedDescription)
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -5,7 +5,7 @@ enum FleetConnectionError: Error, Equatable {
     case alreadyConnected
     case notConnected
     case notAuthenticated
-    case protocolReadIncompatible
+    case protocolReadIncompatible(FleetNegotiateResult)
     case protocolWriteIncompatible
     case emptyToken
     case closed
@@ -110,7 +110,7 @@ actor FleetConnection {
             result: FleetNegotiateResult.self
         )
         guard result.readCompatible else {
-            throw FleetConnectionError.protocolReadIncompatible
+            throw FleetConnectionError.protocolReadIncompatible(result)
         }
         negotiation = result
         return result
@@ -301,7 +301,7 @@ actor FleetConnection {
             throw FleetConnectionError.notAuthenticated
         }
         guard negotiation.readCompatible else {
-            throw FleetConnectionError.protocolReadIncompatible
+            throw FleetConnectionError.protocolReadIncompatible(negotiation)
         }
     }
 

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetQuickSwitcher.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetQuickSwitcher.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct FleetQuickSwitcher: View {
+    @ObservedObject var store: FleetStore
+    let sort: FleetRosterSort
+    @Binding var isPresented: Bool
+    @State private var search = ""
+
+    var body: some View {
+        NavigationStack {
+            List(FleetRosterPresentation.visibleSessions(store.sessions, search: search, filters: .all, sort: sort), id: \.sessionKey) { session in
+                Button(session.displayName ?? session.sessionKey) {
+                    store.selectedSessionKey = session.sessionKey
+                    isPresented = false
+                }
+                .accessibilityIdentifier("fleet.switch.\(session.sessionKey)")
+            }
+            .searchable(text: $search)
+            .navigationTitle("Switch Fleet session")
+        }
+        .frame(minWidth: 420, minHeight: 360)
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+struct FleetRosterFilters: Codable, Equatable {
+    var attentionOnly = false
+    var lifecycle: LifecycleState?
+    var provider: FleetProvider?
+    var management: ManagementState?
+    var transportHealth: TransportHealth?
+
+    static let all = FleetRosterFilters()
+    static let attentionOnly = FleetRosterFilters(attentionOnly: true)
+}
+
+enum FleetRosterSort: String, Codable, CaseIterable, Identifiable {
+    case priority
+    case recent
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .priority: "Attention and lifecycle"
+        case .recent: "Most recently updated"
+        }
+    }
+}
+
+struct FleetPresentationPreferences: Codable, Equatable {
+    static let currentVersion = 2
+    private static let defaultsKey = "ainb.fleet.presentation.v2"
+
+    var version = currentVersion
+    var filters = FleetRosterFilters.all
+    var sort = FleetRosterSort.priority
+
+    static func load(defaults: UserDefaults = .standard) -> Self {
+        guard let data = defaults.data(forKey: defaultsKey),
+              let decoded = try? JSONDecoder().decode(Self.self, from: data),
+              decoded.version == currentVersion
+        else { return Self() }
+        return decoded
+    }
+
+    func save(defaults: UserDefaults = .standard) {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+}
+
+enum FleetRosterPresentation {
+    static func visibleSessions(
+        _ sessions: [FleetSession],
+        search: String,
+        filters: FleetRosterFilters,
+        sort: FleetRosterSort = .priority
+    ) -> [FleetSession] {
+        sessions
+            .filter { matches($0, search: search, filters: filters) }
+            .sorted { orderedBefore($0, $1, sort: sort) }
+    }
+
+    static func statusLabel(for session: FleetSession) -> String {
+        "\(session.lifecycle.rawValue.replacingOccurrences(of: "_", with: " ")) · \(session.attention.rawValue)"
+    }
+
+    static func statusSymbol(for session: FleetSession, connection: FleetConnectionState) -> String {
+        guard connection.isLive else { return "exclamationmark.triangle" }
+        if session.management == .degraded || session.transportHealth != .healthy { return "exclamationmark.circle" }
+        if session.attention != .none { return "bell.badge" }
+        return "checkmark.circle"
+    }
+
+    static func semanticStatus(for session: FleetSession, connection: FleetConnectionState) -> String {
+        guard connection.isLive else { return connection.message }
+        if session.management == .degraded || session.transportHealth != .healthy {
+            return "Degraded: \(statusLabel(for: session)), \(session.management.rawValue), \(session.transportHealth.rawValue)"
+        }
+        return statusLabel(for: session)
+    }
+
+    static func freshnessLabel(for session: FleetSession) -> String {
+        ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(session.lastObservedAt) / 1_000))
+    }
+
+    static func matches(_ session: FleetSession, search: String, filters: FleetRosterFilters) -> Bool {
+        let query = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let searchable = [session.sessionKey, session.displayName ?? "", session.cwd, session.provider.rawValue]
+        return (query.isEmpty || searchable.contains { $0.lowercased().contains(query) })
+            && (!filters.attentionOnly || session.attention != .none)
+            && (filters.lifecycle == nil || session.lifecycle == filters.lifecycle)
+            && (filters.provider == nil || session.provider == filters.provider)
+            && (filters.management == nil || session.management == filters.management)
+            && (filters.transportHealth == nil || session.transportHealth == filters.transportHealth)
+    }
+
+    private static func orderedBefore(_ lhs: FleetSession, _ rhs: FleetSession, sort: FleetRosterSort) -> Bool {
+        switch sort {
+        case .priority:
+            let left = (lhs.attention == .none ? 0 : 1, lifecyclePriority(lhs.lifecycle), lhs.updatedRevision)
+            let right = (rhs.attention == .none ? 0 : 1, lifecyclePriority(rhs.lifecycle), rhs.updatedRevision)
+            if left.0 != right.0 { return left.0 > right.0 }
+            if left.1 != right.1 { return left.1 > right.1 }
+            if left.2 != right.2 { return left.2 > right.2 }
+        case .recent:
+            if lhs.updatedRevision != rhs.updatedRevision { return lhs.updatedRevision > rhs.updatedRevision }
+        }
+        return lhs.sessionKey < rhs.sessionKey
+    }
+
+    private static func lifecyclePriority(_ value: LifecycleState) -> Int {
+        switch value {
+        case .starting: return 6
+        case .running: return 5
+        case .turnComplete: return 4
+        case .idle: return 3
+        case .exited: return 2
+        case .unknown: return 1
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetSessionDetailView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetSessionDetailView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct FleetSessionDetailView: View {
+    let session: FleetSession
+    let connection: FleetConnectionState
+
+    var body: some View {
+        Form {
+            Section("Identity") {
+                LabeledContent("Session key", value: session.sessionKey)
+                LabeledContent("Provider", value: session.provider.rawValue)
+                LabeledContent("Display name", value: session.displayName ?? "Unavailable")
+                LabeledContent("Workspace", value: session.cwd)
+            }
+            Section("State") {
+                LabeledContent("Lifecycle", value: session.lifecycle.rawValue)
+                LabeledContent("Attention", value: session.attention.rawValue)
+                LabeledContent("Management", value: session.management.rawValue)
+                LabeledContent("Transport", value: session.transportHealth.rawValue)
+                LabeledContent("Freshness", value: FleetRosterPresentation.freshnessLabel(for: session))
+            }
+            Section("Source") {
+                LabeledContent("Provenance", value: session.provenance.rawValue)
+                LabeledContent("Confidence", value: session.confidence.rawValue)
+                LabeledContent("Session version", value: String(session.version))
+                LabeledContent("Updated revision", value: String(session.updatedRevision))
+            }
+            Section("Capabilities") {
+                capability("Structured answer", session.capabilities.structuredAnswer)
+                capability("Approvals", session.capabilities.approvals)
+                capability("Send prompt", session.capabilities.sendPrompt)
+                capability("Continue", session.capabilities.continueTurn)
+                capability("Retry", session.capabilities.retry)
+                capability("Interrupt", session.capabilities.interrupt)
+            }
+            Section("Connection") { Text(connection.message) }
+        }
+        .accessibilityIdentifier("fleet.detail.\(session.sessionKey)")
+    }
+
+    @ViewBuilder private func capability(_ name: String, _ available: Bool) -> some View {
+        LabeledContent(name, value: available ? "Available" : "Unavailable")
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct FleetWindowView: View {
+    @ObservedObject var store: FleetStore
+    @Binding var presentation: FleetPresentationPreferences
+    @State private var search = ""
+    @State private var switcherPresented = false
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $store.selectedSessionKey) {
+                ForEach(FleetRosterPresentation.visibleSessions(store.sessions, search: search, filters: presentation.filters, sort: presentation.sort), id: \.sessionKey) { session in
+                    HStack {
+                        Image(systemName: FleetRosterPresentation.statusSymbol(for: session, connection: store.connectionState))
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading) {
+                            Text(session.displayName ?? session.sessionKey)
+                            Text("\(session.provider.rawValue) · \(FleetRosterPresentation.statusLabel(for: session))").font(.caption)
+                            Text(session.cwd).font(.caption2).foregroundStyle(.secondary)
+                            Text("Updated \(FleetRosterPresentation.freshnessLabel(for: session))").font(.caption2).foregroundStyle(.secondary)
+                        }
+                    }
+                    .tag(session.sessionKey)
+                    .accessibilityIdentifier("fleet.row.\(session.sessionKey)")
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(session.displayName ?? session.sessionKey)
+                    .accessibilityValue(FleetRosterPresentation.semanticStatus(for: session, connection: store.connectionState))
+                }
+            }
+            .searchable(text: $search)
+            .toolbar {
+                ToolbarItem { Toggle("Needs you", isOn: $presentation.filters.attentionOnly) }
+                ToolbarItem { Picker("Sort", selection: $presentation.sort) { ForEach(FleetRosterSort.allCases) { Text($0.label).tag($0) } } }
+                ToolbarItem { Picker("Lifecycle", selection: $presentation.filters.lifecycle) { Text("Any lifecycle").tag(LifecycleState?.none); ForEach([LifecycleState.starting, .running, .turnComplete, .idle, .exited, .unknown], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
+                ToolbarItem { Picker("Provider", selection: $presentation.filters.provider) { Text("Any provider").tag(FleetProvider?.none); ForEach([FleetProvider.claude, .codex, .unknown], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
+                ToolbarItem { Picker("Management", selection: $presentation.filters.management) { Text("Any management").tag(ManagementState?.none); ForEach([ManagementState.managed, .degraded], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
+                ToolbarItem { Picker("Transport", selection: $presentation.filters.transportHealth) { Text("Any transport").tag(TransportHealth?.none); ForEach([TransportHealth.healthy, .degraded, .unavailable, .unknown], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
+                ToolbarItem { Button("Quick switch") { switcherPresented = true } }
+            }
+        } detail: {
+            if let key = store.selectedSessionKey, let session = store.sessions.first(where: { $0.sessionKey == key }) {
+                FleetSessionDetailView(session: session, connection: store.connectionState)
+            } else {
+                ContentUnavailableView("Select a Fleet session", systemImage: "bolt.circle")
+            }
+        }
+        .overlay(alignment: .top) {
+            if !store.connectionState.isLive { Text(store.connectionState.message).padding(8).background(.yellow.opacity(0.2)) }
+        }
+        .sheet(isPresented: $switcherPresented) { FleetQuickSwitcher(store: store, sort: presentation.sort, isPresented: $switcherPresented) }
+        .frame(minWidth: 820, minHeight: 520)
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/MenuBar/FleetMenuBarView.swift
+++ b/apps/ainb-fleet-macos/Sources/MenuBar/FleetMenuBarView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct FleetMenuBarView: View {
+    @ObservedObject var store: FleetStore
+    let openFleet: (Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
+                .accessibilityIdentifier("fleet.status")
+            Text("\(store.activeCount) active · \(store.needsYouCount) need you")
+                .font(.caption)
+            #if DEBUG
+            Text("Diagnostics: canWrite \(store.canWrite), connection tasks \(store.debugConnectionTaskCount)")
+                .accessibilityIdentifier("fleet.debug.connection")
+            #endif
+            Divider()
+            ForEach(Array(FleetRosterPresentation.visibleSessions(store.sessions, search: "", filters: .attentionOnly).prefix(3)), id: \.sessionKey) { session in
+                VStack(alignment: .leading) {
+                    Text(session.displayName ?? session.sessionKey)
+                    Text(FleetRosterPresentation.statusLabel(for: session)).font(.caption)
+                }
+                .accessibilityIdentifier("fleet.popover.\(session.sessionKey)")
+            }
+            if store.needsYouCount > 3 {
+                Button("Overflow") { openFleet(true) }
+                    .accessibilityIdentifier("fleet.overflow")
+            }
+            if !store.connectionState.isLive {
+                Button("Retry") { store.retry() }.accessibilityIdentifier("fleet.retry")
+            }
+            Button("Open Fleet") { openFleet(false) }.accessibilityIdentifier("fleet.open")
+        }
+        .padding()
+        .frame(width: 320)
+        .task { store.start() }
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/MenuBar/FleetStatusPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/MenuBar/FleetStatusPresentation.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum FleetStatusPresentation {
+    static func label(active: Int, needsYou: Int, state: FleetConnectionState, sessions: [FleetSession] = []) -> String {
+        "Fleet: \(active) active, \(needsYou) need you. \(semanticState(for: state, sessions: sessions))"
+    }
+
+    static func symbol(for state: FleetConnectionState, needsYou: Int, sessions: [FleetSession] = []) -> String {
+        guard state.isLive else { return "exclamationmark.triangle.fill" }
+        if sessions.contains(where: isDegraded) { return "exclamationmark.circle.fill" }
+        return needsYou > 0 ? "bell.badge.fill" : "bolt.circle.fill"
+    }
+
+    private static func semanticState(for state: FleetConnectionState, sessions: [FleetSession]) -> String {
+        guard state.isLive else { return state.message }
+        return sessions.contains(where: isDegraded) ? "Degraded Fleet session health" : state.message
+    }
+
+    private static func isDegraded(_ session: FleetSession) -> Bool {
+        session.management == .degraded || session.transportHealth != .healthy
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/Settings/FleetSettingsView.swift
+++ b/apps/ainb-fleet-macos/Sources/Settings/FleetSettingsView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct FleetSettingsView: View {
+    @Binding var presentation: FleetPresentationPreferences
+
+    var body: some View {
+        Form {
+            Text("Fleet presentation preferences remain local to this Mac.")
+            Toggle("Needs you filter", isOn: $presentation.filters.attentionOnly)
+            Picker("Roster sort", selection: $presentation.sort) {
+                ForEach(FleetRosterSort.allCases) { sort in
+                    Text(sort.label).tag(sort)
+                }
+            }
+            Text("Launch at login requires a signed production app identity.").foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(width: 420)
+    }
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -58,6 +58,20 @@ final class FleetConnectionTests: XCTestCase {
         )) { XCTAssertEqual($0 as? FleetConnectionError, .protocolWriteIncompatible) }
     }
 
+    func testReadMismatchCarriesDaemonAndProtocolVersions() {
+        let result = FleetNegotiateResult(
+            daemonVersion: "fixture-daemon",
+            protocolVersion: 7,
+            readCompatible: false,
+            writeCompatible: false,
+            capabilityIDs: []
+        )
+        XCTAssertEqual(
+            FleetConnectionError.protocolReadIncompatible(result),
+            .protocolReadIncompatible(result)
+        )
+    }
+
     func testResyncNotificationStreamsThroughOwnedSocket() async throws {
         var descriptors = [Int32](repeating: 0, count: 2)
         XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
@@ -130,6 +144,211 @@ final class FleetConnectionTests: XCTestCase {
         await fulfillment(of: [peerClosed], timeout: 1)
     }
 
+    func testStoreBuffersEventArrivingBeforeSubscribeResponse() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let clientDescriptor = descriptors[0]
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let connection = FleetConnection(location: location, injectedDescriptor: clientDescriptor)
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: { _ in connection },
+                reconnectDelayNanoseconds: { _ in 0 }
+            )
+        }
+        let serverDone = expectation(description: "store bootstrap server finished")
+        let serverResult = SocketServerResult()
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: serverDescriptor,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 0, sessions: []),
+                    eventBeforeSubscriptionResponse: true,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 1, sessions: [try Self.sampleSessionObject(head: 1)])
+                )
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        await MainActor.run { store.start() }
+        await fulfillment(of: [serverDone], timeout: 2)
+        try serverResult.throwIfRecorded()
+        let receivedSnapshot = await Self.waitUntil {
+            await MainActor.run { store.sessions.map(\.sessionKey) == ["s1"] }
+        }
+        await MainActor.run { store.stop() }
+
+        XCTAssertTrue(receivedSnapshot, "event delivered before subscribe response must trigger an authoritative snapshot")
+    }
+
+    func testStoreReconnectsAfterLiveSnapshotFailure() async throws {
+        var first = [Int32](repeating: 0, count: 2)
+        var second = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &first), 0)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &second), 0)
+        let firstServer = first[1]
+        let secondServer = second[1]
+        defer {
+            Darwin.close(firstServer)
+            Darwin.close(secondServer)
+        }
+
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let factory = TestConnectionFactory(
+            descriptors: [first[0], second[0]],
+            location: location
+        )
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: factory.make,
+                reconnectDelayNanoseconds: { _ in 0 }
+            )
+        }
+        let firstServerDone = expectation(description: "first store server finished")
+        let firstServerResult = SocketServerResult()
+        DispatchQueue.global().async {
+            defer { firstServerDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: firstServer,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 0, sessions: [try Self.sampleSessionObject(head: 0)]),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: nil
+                )
+                Darwin.shutdown(firstServer, SHUT_RDWR)
+            } catch {
+                firstServerResult.record(error)
+            }
+        }
+        await MainActor.run { store.start() }
+        await fulfillment(of: [firstServerDone], timeout: 2)
+        try firstServerResult.throwIfRecorded()
+        let reconnected = await Self.waitUntil {
+            factory.count == 2
+        }
+        await MainActor.run { store.stop() }
+
+        XCTAssertTrue(reconnected, "snapshot failure after a live subscription must start exactly one bounded reconnect attempt")
+    }
+
+    func testStoreReconnectsWhenBootstrapRequiresResubscribeBeforeLive() async throws {
+        var first = [Int32](repeating: 0, count: 2)
+        var second = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &first), 0)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &second), 0)
+        let firstServer = first[1]
+        let secondServer = second[1]
+        defer {
+            Darwin.close(firstServer)
+            Darwin.close(secondServer)
+        }
+
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let factory = TestConnectionFactory(descriptors: [first[0], second[0]], location: location)
+        let store = await MainActor.run {
+            FleetStore(location: location, makeConnection: factory.make, reconnectDelayNanoseconds: { _ in 0 })
+        }
+        let firstServerDone = expectation(description: "invalid bootstrap server finished")
+        let secondServerReady = expectation(description: "reconnected bootstrap server ready")
+        let releaseSecondServer = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global().async {
+            defer { firstServerDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: firstServer,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 0, sessions: []),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 0, sessions: []),
+                    subscriptionReplay: [try Self.eventObject(revision: 1)],
+                    replayState: ["state": "snapshot_reset", "reason": "bootstrap"]
+                )
+                Darwin.shutdown(firstServer, SHUT_RDWR)
+            } catch {}
+        }
+        DispatchQueue.global().async {
+            defer { Darwin.shutdown(secondServer, SHUT_RDWR) }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: secondServer,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 0, sessions: [try Self.sampleSessionObject(head: 0)]),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 0, sessions: [try Self.sampleSessionObject(head: 0)])
+                )
+                secondServerReady.fulfill()
+                _ = releaseSecondServer.wait(timeout: .now() + 2)
+            } catch {
+                secondServerReady.fulfill()
+            }
+        }
+
+        await MainActor.run { store.start() }
+        await fulfillment(of: [firstServerDone, secondServerReady], timeout: 2)
+        let reconnectedBeforeLive = await Self.waitUntil {
+            await MainActor.run {
+                guard case .live = store.connectionState else { return false }
+                return factory.count == 2
+            }
+        }
+        await MainActor.run { store.stop() }
+        releaseSecondServer.signal()
+
+        XCTAssertTrue(reconnectedBeforeLive, "invalid bootstrap replay must reconnect before Fleet becomes live")
+    }
+
+    func testStoreMarksProjectionForResubscribeBeforeResyncReconnect() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: { _ in FleetConnection(location: location, injectedDescriptor: descriptors[0]) },
+                reconnectDelayNanoseconds: { _ in 10_000_000_000 }
+            )
+        }
+        let serverDone = expectation(description: "resync notification sent")
+        let serverResult = SocketServerResult()
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: serverDescriptor,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 0, sessions: [try Self.sampleSessionObject(head: 0)]),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 0, sessions: []),
+                    resyncAfterSubscription: true
+                )
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        await MainActor.run { store.start() }
+        await fulfillment(of: [serverDone], timeout: 2)
+        try serverResult.throwIfRecorded()
+        let reducerApplied = await Self.waitUntil {
+            await MainActor.run { store.needsResubscribe }
+        }
+        await MainActor.run { store.stop() }
+
+        XCTAssertTrue(reducerApplied, "resync notification must mark projection before reconnect scheduling")
+    }
+
     private static func readFrame(from descriptor: Int32) -> Data? {
         var decoder = ContentLengthDecoder()
         var bytes = [UInt8](repeating: 0, count: 1024)
@@ -139,5 +358,152 @@ final class FleetConnectionTests: XCTestCase {
             guard let frames = try? decoder.append(Data(bytes.prefix(Int(count)))) else { return nil }
             if let frame = frames.first { return frame }
         }
+    }
+
+    private static func testLocation() throws -> HangarLocation {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let tokenDirectory = home.appendingPathComponent("hangar", isDirectory: true)
+        try FileManager.default.createDirectory(at: tokenDirectory, withIntermediateDirectories: true)
+        try Data("mdt_test".utf8).write(to: tokenDirectory.appendingPathComponent("daemon.token"))
+        return HangarLocation(environment: ["AINB_HANGAR_HOME": home.path])
+    }
+
+    private static func serveStoreBootstrap(
+        descriptor: Int32,
+        subscriptionSnapshot: Any,
+        eventBeforeSubscriptionResponse: Bool,
+        snapshotAfterEvent: Any?,
+        subscriptionReplay: [Any] = [],
+        replayState: [String: Any] = ["state": "complete"],
+        resyncAfterSubscription: Bool = false
+    ) throws {
+        let authentication = try readRequest(from: descriptor)
+        try writeResponse(to: descriptor, request: authentication, result: [:])
+
+        let negotiation = try readRequest(from: descriptor)
+        try writeResponse(to: descriptor, request: negotiation, result: [
+            "daemon_version": "fixture-daemon",
+            "protocol_version": 1,
+            "read_compatible": true,
+            "write_compatible": true,
+            "capability_ids": [],
+        ])
+
+        let subscription = try readRequest(from: descriptor)
+        let event = try eventObject(revision: 1)
+        if eventBeforeSubscriptionResponse {
+            try writeNotification(to: descriptor, method: "fleet/event", params: event)
+        }
+        try writeResponse(to: descriptor, request: subscription, result: [
+            "snapshot": subscriptionSnapshot,
+            "replay": subscriptionReplay,
+            "replay_state": replayState,
+        ])
+        if resyncAfterSubscription {
+            try writeNotification(
+                to: descriptor,
+                method: "fleet/resync_required",
+                params: ["after_revision": 0, "missed": 1]
+            )
+        }
+        if eventBeforeSubscriptionResponse {
+            let snapshot = try readRequest(from: descriptor)
+            XCTAssertEqual(snapshot["method"] as? String, "fleet/snapshot")
+            try writeResponse(to: descriptor, request: snapshot, result: snapshotAfterEvent ?? subscriptionSnapshot)
+        } else if snapshotAfterEvent == nil {
+            try writeNotification(to: descriptor, method: "fleet/event", params: event)
+            _ = try readRequest(from: descriptor)
+        }
+    }
+
+    private static func readRequest(from descriptor: Int32) throws -> [String: Any] {
+        guard let frame = readFrame(from: descriptor),
+              let request = try JSONSerialization.jsonObject(with: frame) as? [String: Any] else {
+            throw StoreServerError.closed
+        }
+        return request
+    }
+
+    private static func writeResponse(to descriptor: Int32, request: [String: Any], result: Any) throws {
+        try writeJSONObject(["jsonrpc": "2.0", "id": request["id"] as Any, "result": result], to: descriptor)
+    }
+
+    private static func writeNotification(to descriptor: Int32, method: String, params: Any) throws {
+        try writeJSONObject(["jsonrpc": "2.0", "method": method, "params": params], to: descriptor)
+    }
+
+    private static func writeJSONObject(_ object: [String: Any], to descriptor: Int32) throws {
+        let frame = try ContentLengthEncoder.encode(JSONSerialization.data(withJSONObject: object))
+        let written = frame.withUnsafeBytes { Darwin.write(descriptor, $0.baseAddress, frame.count) }
+        guard written == frame.count else { throw StoreServerError.closed }
+    }
+
+    private static func snapshotObject(head: Int64, sessions: [Any]) throws -> Any {
+        ["head_revision": head, "sessions": sessions]
+    }
+
+    private static func sampleSessionObject(head: Int64) throws -> Any {
+        let object = try JSONSerialization.jsonObject(with: FleetWire.encoder().encode(sampleSnapshot(head: head)))
+        guard let snapshot = object as? [String: Any], let session = (snapshot["sessions"] as? [Any])?.first else {
+            throw StoreServerError.closed
+        }
+        return session
+    }
+
+    private static func eventObject(revision: Int64) throws -> Any {
+        try JSONSerialization.jsonObject(with: FleetWire.encoder().encode(sampleEvent(revision: revision, eventID: "event-\(revision)")))
+    }
+
+    private static func waitUntil(_ condition: @escaping () async -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return false
+    }
+}
+
+private final class TestConnectionFactory: @unchecked Sendable {
+    private let lock = NSLock()
+    private var descriptors: [Int32]
+    private let location: HangarLocation
+
+    init(descriptors: [Int32], location: HangarLocation) {
+        self.descriptors = descriptors
+        self.location = location
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return descriptors.count == 2 ? 0 : 2 - descriptors.count
+    }
+
+    func make(_: HangarLocation) -> FleetConnection {
+        lock.lock()
+        defer { lock.unlock() }
+        return FleetConnection(location: location, injectedDescriptor: descriptors.removeFirst())
+    }
+}
+
+private enum StoreServerError: Error {
+    case closed
+}
+
+private final class SocketServerResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var error: Error?
+
+    func record(_ error: Error) {
+        lock.lock()
+        self.error = error
+        lock.unlock()
+    }
+
+    func throwIfRecorded() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let error { throw error }
     }
 }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetFixtureDaemonFallbackTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetFixtureDaemonFallbackTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+final class FleetFixtureDaemonFallbackTests: XCTestCase {
+    func testLocalFallbackResolvesFixtureWithoutEnvironmentOverride() throws {
+        let executable = FleetFixtureDaemon.fixtureExecutableURL(sourceFilePath: #filePath, environment: [:])
+
+        XCTAssertTrue(executable.path.hasSuffix("ainb-tui/target/debug/examples/fleet_fixture_daemon"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: executable.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().path))
+    }
+}

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import AINBFleet
+
+final class FleetRosterPresentationTests: XCTestCase {
+    func testAttentionThenLifecycleThenRevisionThenKeyOrder() {
+        let sessions = [
+            session(key: "idle", lifecycle: .idle),
+            session(key: "running-old", lifecycle: .running, revision: 2),
+            session(key: "running-new", lifecycle: .running, revision: 3),
+            session(key: "attention", lifecycle: .exited, attention: .ask),
+        ]
+        XCTAssertEqual(FleetRosterPresentation.visibleSessions(sessions, search: "", filters: .all).map(\.sessionKey), ["attention", "running-new", "running-old", "idle"])
+    }
+
+    func testOnlyCanonicalFieldsParticipateInSearchAndFilters() {
+        let value = session(key: "codex-1", lifecycle: .running, attention: .approval)
+        XCTAssertTrue(FleetRosterPresentation.matches(value, search: "codex", filters: .attentionOnly))
+        XCTAssertTrue(FleetRosterPresentation.matches(value, search: "/workspace", filters: .all))
+        XCTAssertFalse(FleetRosterPresentation.matches(value, search: "request", filters: .all))
+    }
+
+    func testCanonicalLifecycleProviderManagementAndTransportFilters() {
+        let value = session(key: "codex-1", lifecycle: .running, attention: .approval)
+        XCTAssertTrue(FleetRosterPresentation.matches(value, search: "", filters: FleetRosterFilters(lifecycle: .running, provider: .codex, management: .managed, transportHealth: .healthy)))
+        XCTAssertFalse(FleetRosterPresentation.matches(value, search: "", filters: FleetRosterFilters(lifecycle: .idle)))
+        XCTAssertFalse(FleetRosterPresentation.matches(value, search: "", filters: FleetRosterFilters(provider: .claude)))
+    }
+
+    func testVersionedPresentationPreferencesRestoreOnlyCurrentSchema() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        var preferences = FleetPresentationPreferences()
+        preferences.filters.provider = .codex
+        preferences.sort = .recent
+        preferences.save(defaults: defaults)
+        let restored = FleetPresentationPreferences.load(defaults: defaults)
+        XCTAssertEqual(restored.filters.provider, .codex)
+        XCTAssertEqual(restored.sort, .recent)
+
+        preferences.version = 0
+        preferences.save(defaults: defaults)
+        XCTAssertEqual(FleetPresentationPreferences.load(defaults: defaults), FleetPresentationPreferences())
+    }
+
+    func testRecentSortUsesRevisionThenSessionKey() {
+        let sessions = [
+            session(key: "bravo", lifecycle: .idle, revision: 4),
+            session(key: "alpha", lifecycle: .running, revision: 4),
+            session(key: "newest", lifecycle: .idle, revision: 5),
+        ]
+        XCTAssertEqual(
+            FleetRosterPresentation.visibleSessions(sessions, search: "", filters: .all, sort: .recent).map(\.sessionKey),
+            ["newest", "alpha", "bravo"]
+        )
+    }
+
+    func testFreshnessUsesDaemonMilliseconds() {
+        let value = session(key: "fresh", lifecycle: .idle, observedAt: 1_700_000_000_000)
+        XCTAssertEqual(FleetRosterPresentation.freshnessLabel(for: value), "2023-11-14T22:13:20Z")
+    }
+
+    func testStatusIconPrefersDegradedSessionOverAttention() {
+        let value = session(key: "degraded", lifecycle: .running, attention: .ask, management: .degraded)
+        XCTAssertEqual(FleetStatusPresentation.symbol(for: .live(daemonVersion: "test", writeCompatible: true), needsYou: 1, sessions: [value]), "exclamationmark.circle.fill")
+        XCTAssertEqual(FleetStatusPresentation.label(active: 1, needsYou: 1, state: .live(daemonVersion: "test", writeCompatible: true), sessions: [value]), "Fleet: 1 active, 1 need you. Degraded Fleet session health")
+    }
+
+    func testStatusIconTreatsNonHealthyTransportAsDegraded() {
+        let value = session(key: "transport", lifecycle: .running, attention: .ask, transportHealth: .unknown)
+        XCTAssertEqual(FleetStatusPresentation.symbol(for: .live(daemonVersion: "test", writeCompatible: true), needsYou: 1, sessions: [value]), "exclamationmark.circle.fill")
+    }
+
+    func testStatusIconPrefersUnavailableConnectionOverDegradedSession() {
+        let value = session(key: "degraded", lifecycle: .running, management: .degraded)
+        XCTAssertEqual(FleetStatusPresentation.symbol(for: .unavailable(message: "offline"), needsYou: 0, sessions: [value]), "exclamationmark.triangle.fill")
+    }
+
+    private func session(key: String, lifecycle: LifecycleState, attention: AttentionState = .none, management: ManagementState = .managed, transportHealth: TransportHealth = .healthy, observedAt: Int64 = 1, revision: Int64 = 1) -> FleetSession {
+        FleetSession(sessionKey: key, provider: .codex, providerSessionID: nil, tmuxTarget: nil, processStartFingerprint: nil, cwd: "/workspace", displayName: key, lifecycle: lifecycle, attention: attention, currentRequestFingerprint: nil, currentRequest: nil, management: management, transportHealth: transportHealth, capabilities: FleetCapabilities(structuredAnswer: false, approvals: false, sendPrompt: false, continueTurn: false, retry: false, interrupt: false, start: false, stop: false, restart: false, kill: false, archive: false, tmuxAttach: false, tmuxText: false, verifiedPicker: false), provenance: .authoritative, confidence: .high, discoveredAt: observedAt, lastObservedAt: observedAt, lifecycleUpdatedAt: observedAt, attentionUpdatedAt: observedAt, version: 1, updatedRevision: revision)
+    }
+}

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+final class MenuBarRosterJourneyTests: FleetUITestCase {
+    @MainActor
+    func testRealStatusItemReflectsFleetTotals() throws {
+        try fixture.seed(eventID: "alpha-start", sessionID: "alpha", eventType: "SessionStart", observedAt: 1_700_000_000_001)
+        try fixture.seed(eventID: "beta-ask", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)
+        launchApp()
+
+        let statusItem = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier == %@", "fleet.status-item"))
+            .firstMatch
+        waitFor(statusItem)
+        let totals = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "title CONTAINS %@", "1 active, 1 need you"),
+            object: statusItem
+        )
+        XCTAssertEqual(XCTWaiter().wait(for: [totals], timeout: 8), .completed, app.debugDescription)
+    }
+
+    @MainActor
+    func testRealFixtureRendersAttentionRosterAndFiltersInFleetWindow() throws {
+        try fixture.seed(eventID: "alpha", sessionID: "alpha", eventType: "AskUserQuestion", observedAt: 1_700_000_000_001)
+        try fixture.seed(eventID: "beta", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)
+        try fixture.seed(eventID: "gamma", provider: "unknown", sessionID: "gamma", eventType: "AskUserQuestion", observedAt: 1_700_000_000_003)
+        try fixture.seed(eventID: "running", sessionID: "running", eventType: "UserPromptSubmit", observedAt: 1_700_000_000_004)
+        launchFleetWindow()
+
+        waitFor(fleetRow("claude:alpha"))
+        waitFor(fleetRow("codex:beta"))
+        waitFor(fleetRow("unknown:gamma"))
+        waitFor(fleetRow("claude:running"))
+
+        selectToolbarItem("Needs you")
+        XCTAssertFalse(fleetRow("claude:running").waitForExistence(timeout: 1))
+    }
+}

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+final class OfflineAndReconnectJourneyTests: FleetUITestCase {
+    @MainActor
+    func testRealFixtureDisconnectShowsRetryWithoutLaunchingDaemon() throws {
+        try fixture.seed(eventID: "alpha-running", sessionID: "alpha", eventType: "UserPromptSubmit", observedAt: 1_700_000_000_001)
+        launchFleetWindow()
+        waitFor(fleetRow("claude:alpha"))
+
+        fixture.stop(removeHome: false)
+        let stale = textValue(beginningWith: "Stale since")
+        waitFor(stale)
+        XCTAssertTrue(fleetRow("claude:alpha").exists, "stale mode must retain authoritative roster")
+    }
+}

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+final class ProtocolCompatibilityJourneyTests: FleetUITestCase {
+    @MainActor
+    func testRealFixtureReportsReadIncompatibleDaemonProtocol() throws {
+        try fixture.seed(eventID: "alpha", sessionID: "alpha", eventType: "SessionStart", observedAt: 1_700_000_000_001)
+        launchFleetWindow(arguments: ["--fleet-test-read-range=2...2"])
+
+        let incompatibility = textValue(beginningWith: "Daemon")
+        waitFor(incompatibility)
+        XCTAssertTrue((incompatibility.value as? String)?.contains("Fleet protocol 1") == true)
+    }
+}

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/WindowAndSwitcherJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/WindowAndSwitcherJourneyTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+final class WindowAndSwitcherJourneyTests: FleetUITestCase {
+    @MainActor
+    func testRealFixtureWindowAndSwitcherSelectStableSessionKey() throws {
+        try fixture.seed(eventID: "alpha-start", sessionID: "alpha", eventType: "SessionStart", observedAt: 1_700_000_000_001)
+        try fixture.seed(eventID: "beta-ask", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)
+        launchFleetWindow()
+        let betaRow = fleetRow("codex:beta")
+        waitFor(betaRow)
+        selectToolbarItem("Quick switch")
+        let beta = app.buttons["fleet.switch.codex:beta"]
+        waitFor(beta)
+        beta.click()
+        waitFor(fleetDetail("codex:beta"))
+    }
+
+    @MainActor
+    func testRealFixtureRetainsSelectedSessionAcrossReorderedLiveSnapshot() throws {
+        try fixture.seed(eventID: "alpha-start", sessionID: "alpha", eventType: "SessionStart", observedAt: 1_700_000_000_001)
+        try fixture.seed(eventID: "beta-start", provider: "codex", sessionID: "beta", eventType: "SessionStart", observedAt: 1_700_000_000_002)
+        launchFleetWindow()
+        let betaRow = fleetRow("codex:beta")
+        waitFor(betaRow)
+        betaRow.click()
+        waitFor(fleetDetail("codex:beta"))
+
+        try fixture.seed(eventID: "alpha-attention", sessionID: "alpha", eventType: "AskUserQuestion", observedAt: 1_700_000_000_003)
+        waitFor(fleetRow("claude:alpha"))
+        XCTAssertTrue(fleetDetail("codex:beta").exists, "live reorder must retain selection by session key")
+    }
+}

--- a/apps/ainb-fleet-macos/UITests/Support/FleetFixtureDaemon.swift
+++ b/apps/ainb-fleet-macos/UITests/Support/FleetFixtureDaemon.swift
@@ -1,0 +1,212 @@
+import Foundation
+import XCTest
+
+/// XCTest-owned process wrapper for the real Rust Fleet daemon fixture.
+/// Swift only supplies hook observations on stdin. The daemon owns SQLite,
+/// token, Unix socket, revisions, snapshots, and subscription notifications.
+final class FleetFixtureDaemon: @unchecked Sendable {
+    private(set) var home: URL
+    private var process: Process?
+    private var input: Pipe?
+    private var output: Pipe?
+    private var standardError: Pipe?
+    private var responseBuffer = Data()
+    private var outputTranscript = Data()
+    private var errorTranscript = Data()
+    private var responseError: String?
+    private var responseWaiter: DispatchSemaphore?
+    private let responseLock = NSLock()
+
+    init() throws {
+        // Unix-domain sockets have a short path limit. XCTest's temporary root is
+        // often already long enough to make `hangar.sock` fail to bind.
+        home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("f\(UUID().uuidString.prefix(4))", isDirectory: true)
+        try launch()
+    }
+
+    deinit { stop(removeHome: true) }
+
+    func seed(
+        eventID: String,
+        provider: String = "claude",
+        sessionID: String,
+        eventType: String,
+        cwd: String = "/fixture/workspace",
+        payload: [String: Any] = [:],
+        observedAt: Int64
+    ) throws {
+        let command: [String: Any] = [
+            "command": "seed",
+            "event_id": eventID,
+            "provider": provider,
+            "session_id": sessionID,
+            "event_type": eventType,
+            "cwd": cwd,
+            "payload": payload,
+            "observed_at": observedAt,
+        ]
+        responseLock.lock()
+        responseWaiter = DispatchSemaphore(value: 0)
+        responseError = nil
+        let waiter = responseWaiter
+        responseLock.unlock()
+        let body = try JSONSerialization.data(withJSONObject: command)
+        guard process?.isRunning == true, let input else {
+            throw FixtureError.notRunning(diagnostics())
+        }
+        input.fileHandleForWriting.write(body + Data([0x0A]))
+        guard waiter?.wait(timeout: .now() + 5) == .success else {
+            throw FixtureError.timedOutWaitingForSeed(diagnostics())
+        }
+        responseLock.lock()
+        let error = responseError
+        responseLock.unlock()
+        if let error { throw FixtureError.commandRejected(error, diagnostics()) }
+    }
+
+    func stop(removeHome: Bool = false) {
+        guard let process else { return }
+        if process.isRunning {
+            let shutdown = #"{"command":"shutdown"}"# + "\n"
+            input?.fileHandleForWriting.write(Data(shutdown.utf8))
+            process.terminate()
+        }
+        process.waitUntilExit()
+        self.process = nil
+        input = nil
+        output = nil
+        if removeHome { try? FileManager.default.removeItem(at: home) }
+    }
+
+    func restart() throws {
+        stop(removeHome: false)
+        try launch()
+    }
+
+    private func launch() throws {
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        let executable = try Self.fixtureExecutable()
+        let input = Pipe()
+        let output = Pipe()
+        let standardError = Pipe()
+        let process = Process()
+        process.executableURL = executable
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = standardError
+        process.environment = ["AINB_HANGAR_HOME": home.path]
+        output.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            self?.consume(handle.availableData)
+        }
+        standardError.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            self?.consumeStandardError(handle.availableData)
+        }
+        try process.run()
+        self.process = process
+        self.input = input
+        self.output = output
+        self.standardError = standardError
+        try waitForDaemonFiles()
+    }
+
+    static func fixtureExecutable(
+        sourceFilePath: String = #filePath,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> URL {
+        let executable = fixtureExecutableURL(sourceFilePath: sourceFilePath, environment: environment)
+        guard FileManager.default.isExecutableFile(atPath: executable.path) else {
+            throw FixtureError.missingExecutable(executable.path)
+        }
+        return executable
+    }
+
+    static func fixtureExecutableURL(
+        sourceFilePath: String,
+        environment: [String: String]
+    ) -> URL {
+        if let path = environment["AINB_FLEET_FIXTURE_DAEMON"] {
+            return URL(fileURLWithPath: path)
+        }
+        var root = URL(fileURLWithPath: sourceFilePath).deletingLastPathComponent()
+        while root.path != "/" {
+            let daemonWorkspace = root.appendingPathComponent("ainb-tui", isDirectory: true)
+            if FileManager.default.fileExists(atPath: daemonWorkspace.path) {
+                return daemonWorkspace.appendingPathComponent("target/debug/examples/fleet_fixture_daemon")
+            }
+            root.deleteLastPathComponent()
+        }
+        return URL(fileURLWithPath: sourceFilePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("ainb-tui/target/debug/examples/fleet_fixture_daemon")
+    }
+
+    private func waitForDaemonFiles() throws {
+        let socket = home.appendingPathComponent("hangar.sock").path
+        let token = home.appendingPathComponent("hangar/daemon.token").path
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: socket), FileManager.default.fileExists(atPath: token) { return }
+            if process?.isRunning == false { throw FixtureError.exited(process?.terminationStatus ?? -1, diagnostics()) }
+            Thread.sleep(forTimeInterval: 0.025)
+        }
+        throw FixtureError.timedOutWaitingForDaemon(home.path, diagnostics())
+    }
+
+    private func consume(_ data: Data) {
+        guard !data.isEmpty else { return }
+        responseLock.lock()
+        responseBuffer.append(data)
+        outputTranscript.append(data)
+        var signals = 0
+        while let newline = responseBuffer.firstIndex(of: 0x0A) {
+            let line = responseBuffer.prefix(upTo: newline)
+            responseBuffer.removeSubrange(...newline)
+            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any] else { continue }
+            if object["ok"] as? Bool != true {
+                responseError = object["error"] as? String ?? String(data: line, encoding: .utf8) ?? "fixture command failed"
+            }
+            signals += 1
+        }
+        let waiter = responseWaiter
+        responseLock.unlock()
+        for _ in 0..<signals { waiter?.signal() }
+    }
+
+    private func consumeStandardError(_ data: Data) {
+        guard !data.isEmpty else { return }
+        responseLock.lock()
+        errorTranscript.append(data)
+        responseLock.unlock()
+    }
+
+    private func diagnostics() -> String {
+        responseLock.lock()
+        defer { responseLock.unlock() }
+        let output = String(data: outputTranscript, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let error = String(data: errorTranscript, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let printedOutput = output.isEmpty ? "<empty>" : output
+        let printedError = error.isEmpty ? "<empty>" : error
+        return "stdout: \(printedOutput); stderr: \(printedError)"
+    }
+
+    enum FixtureError: LocalizedError {
+        case missingExecutable(String)
+        case timedOutWaitingForDaemon(String, String)
+        case timedOutWaitingForSeed(String)
+        case commandRejected(String, String)
+        case notRunning(String)
+        case exited(Int32, String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .missingExecutable(path): return "Fleet fixture daemon is missing at \(path)"
+            case let .timedOutWaitingForDaemon(path, diagnostics): return "Fleet fixture daemon did not create socket and token in \(path). \(diagnostics)"
+            case let .timedOutWaitingForSeed(diagnostics): return "Fleet fixture daemon did not acknowledge seed. \(diagnostics)"
+            case let .commandRejected(message, diagnostics): return "Fleet fixture daemon rejected command: \(message). \(diagnostics)"
+            case let .notRunning(diagnostics): return "Fleet fixture daemon is not running. \(diagnostics)"
+            case let .exited(status, diagnostics): return "Fleet fixture daemon exited with status \(status). \(diagnostics)"
+            }
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/UITests/Support/FleetUITestCase.swift
+++ b/apps/ainb-fleet-macos/UITests/Support/FleetUITestCase.swift
@@ -1,0 +1,88 @@
+import XCTest
+
+class FleetUITestCase: XCTestCase {
+    var fixture: FleetFixtureDaemon!
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        fixture = try FleetFixtureDaemon()
+        app = XCUIApplication()
+    }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        fixture?.stop(removeHome: true)
+    }
+
+    @MainActor
+    func launchApp(arguments: [String] = []) {
+        if app.state != .notRunning {
+            app.terminate()
+        }
+        app.launchEnvironment["AINB_HANGAR_HOME"] = fixture.home.path
+        if arguments.contains("--fleet-test-open-window") {
+            app.launchEnvironment["AINB_FLEET_TEST_OPEN_WINDOW"] = "1"
+        }
+        if arguments.contains("--fleet-test-read-range=2...2") {
+            app.launchEnvironment["AINB_FLEET_TEST_READ_RANGE"] = "2...2"
+        }
+        app.launchArguments = arguments
+        app.launch()
+    }
+
+    @MainActor
+    func launchFleetWindow(
+        arguments: [String] = [],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        launchApp(arguments: ["--fleet-test-open-window"] + arguments)
+        let fleetWindow = app.windows["Fleet"]
+        XCTAssertTrue(
+            fleetWindow.waitForExistence(timeout: 8),
+            "Fleet window missing after normal app launch. \(app.debugDescription)",
+            file: file,
+            line: line
+        )
+    }
+
+    @MainActor
+    func waitFor(_ element: XCUIElement, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(
+            element.waitForExistence(timeout: 8),
+            "Missing \(element). \(app.debugDescription)",
+            file: file,
+            line: line
+        )
+    }
+
+    @MainActor
+    func fleetRow(_ sessionKey: String) -> XCUIElement {
+        app.staticTexts
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "fleet.row.\(sessionKey)"))
+            .firstMatch
+    }
+
+    @MainActor
+    func fleetDetail(_ sessionKey: String) -> XCUIElement {
+        app.staticTexts["fleet.detail.\(sessionKey)"]
+    }
+
+    @MainActor
+    func textValue(beginningWith value: String) -> XCUIElement {
+        app.staticTexts
+            .matching(NSPredicate(format: "value BEGINSWITH %@", value))
+            .firstMatch
+    }
+
+    @MainActor
+    func selectToolbarItem(_ title: String) {
+        let overflow = app.popUpButtons["more toolbar items"]
+        waitFor(overflow)
+        overflow.click()
+        let item = app.menuItems[title]
+        waitFor(item)
+        item.click()
+    }
+}

--- a/apps/ainb-fleet-macos/ci/check-release-diagnostics.sh
+++ b/apps/ainb-fleet-macos/ci/check-release-diagnostics.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+derived_data="${1:-/tmp/ainb-fleet-macos-e02-release-derived-data}"
+binary="$derived_data/Build/Products/Release/AINBFleet.app/Contents/MacOS/AINBFleet"
+
+xcodebuild build \
+  -project "$repo_root/apps/ainb-fleet-macos/AINBFleet.xcodeproj" \
+  -scheme AINBFleet \
+  -configuration Release \
+  -destination 'platform=macOS,arch=arm64' \
+  -derivedDataPath "$derived_data" \
+  CODE_SIGNING_ALLOWED=NO ARCHS=arm64 ONLY_ACTIVE_ARCH=YES
+
+test -x "$binary"
+! strings "$binary" | rg -F -- '--fleet-test-read-range'
+! strings "$binary" | rg -F -- '--fleet-test-open-window'


### PR DESCRIPTION
## Summary
- Add standalone SwiftUI Fleet status bar and roster app.
- Use real Fleet daemon JSON-RPC with reconnect, revision replay, and stale-state handling.
- Add isolated Rust fixture daemon plus Swift, RPC, and XCUI acceptance coverage.

## Verification
- `cargo build -p ainb-hangar-daemon --example fleet_fixture_daemon --features test-support`
- 57 Swift/RPC tests and 6 XCUI journeys passed.
- Apple Silicon Release diagnostic check passed.

## Verification limitation
SystemUIServer accessibility on this host prevents direct popover-click and card-route automation. Actual status-item totals have direct XCUI proof. Popover route is marked UNVERIFIABLE, not passed.