### PR TITLE
feat: add native Fleet action controls

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3258,7 +3258,7 @@ impl EventHandler {
 
     fn dispatch_fleet_intent(state: &mut AppState, intent: FleetIntent) {
         use ainb_hangar_proto::fleet::{
-            ActionReceiptStatus, ControlAction, FleetActionParams, FleetBroadcastParams,
+            ActionReceiptStatus, FleetActionParams, FleetBroadcastParams, FleetStartParams,
         };
 
         match intent {
@@ -3358,31 +3358,28 @@ impl EventHandler {
                     );
                     return;
                 }
-                let session_key = "start:codex".to_string();
-                let params = FleetActionParams {
-                    session_key: session_key.clone(),
-                    expected_version: 1,
+                let params = FleetStartParams {
                     request_id: format!("fleet-host-start-{}", uuid::Uuid::new_v4()),
-                    action: ControlAction::Start {
-                        provider,
-                        cwd,
-                        prompt,
-                    },
+                    provider,
+                    cwd,
+                    prompt,
                 };
                 let sink = state.fleet_panel_state.canonical_update_sink();
                 std::thread::spawn(move || {
-                    let event = match crate::fleet::control::execute_fleet_action_blocking(params) {
-                        Ok(receipt) if receipt.status == ActionReceiptStatus::Delivered => {
-                            FleetEvent::ActionSucceeded { session_key }
+                    let event = match crate::fleet::control::execute_fleet_start_blocking(params) {
+                        Ok(result) if result.receipt.status == ActionReceiptStatus::Delivered => {
+                            FleetEvent::ActionSucceeded {
+                                session_key: result.prospective_session_key,
+                            }
                         }
-                        Ok(receipt) => FleetEvent::ActionFailed {
-                            session_key,
-                            detail: receipt
-                                .detail
-                                .unwrap_or_else(|| format!("delivery status {:?}", receipt.status)),
+                        Ok(result) => FleetEvent::ActionFailed {
+                            session_key: result.prospective_session_key,
+                            detail: result.receipt.detail.unwrap_or_else(|| {
+                                format!("delivery status {:?}", result.receipt.status)
+                            }),
                         },
                         Err(detail) => FleetEvent::ActionFailed {
-                            session_key,
+                            session_key: "start".to_string(),
                             detail,
                         },
                     };

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/daemon.rs
@@ -219,6 +219,16 @@ impl DaemonClient {
         Ok(result.receipt)
     }
 
+    /// Start one provider session through daemon-owned new-session state.
+    pub async fn fleet_start(
+        &self,
+        params: ainb_hangar_proto::fleet::FleetStartParams,
+    ) -> Result<ainb_hangar_proto::fleet::FleetStartResult, DaemonError> {
+        let value = serde_json::to_value(params).expect("FleetStartParams serializes");
+        let result = self.call(methods::FLEET_START, value).await?;
+        serde_json::from_value(result).map_err(|error| DaemonError::Decode(error.to_string()))
+    }
+
     /// Broadcast text to explicit stable Fleet targets.
     pub async fn fleet_broadcast(
         &self,

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -213,6 +213,21 @@ pub fn execute_fleet_action_blocking(
     })
 }
 
+/// Start one provider session through daemon-owned new-session state.
+pub fn execute_fleet_start_blocking(
+    params: ainb_hangar_proto::fleet::FleetStartParams,
+) -> Result<ainb_hangar_proto::fleet::FleetStartResult, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| error.to_string())?;
+    runtime.block_on(async {
+        let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+            .map_err(|error| error.to_string())?;
+        client.fleet_start(params).await.map_err(|error| error.to_string())
+    })
+}
+
 /// Dispatch a send to the session described by `(session_id, cwd)`, off the UI
 /// thread. Resolves the row to a live `Session` (for its tmux name) via the
 /// same discovery the CLI uses, then sends `text` through `fleet::send::send`.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -819,6 +819,9 @@ async fn handle(
         methods::FLEET_SUBSCRIBE => handle_fleet_subscribe(pool, req).await,
         methods::FLEET_ACTION => handle_fleet_action(pool, req, events).await,
         methods::FLEET_BROADCAST => handle_fleet_broadcast(pool, req, events).await,
+        methods::FLEET_RECEIPT_LIST => handle_fleet_receipt_list(pool, req).await,
+        methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
+        methods::FLEET_START => handle_fleet_start(pool, req, events).await,
         methods::ATTENTION_LIST => handle_attention_list(pool, req).await,
         // `attention/subscribe` acks with the current OPEN snapshot; the live
         // fleet-wide forwarder is the stream side (see `serve_conn`).
@@ -937,6 +940,63 @@ async fn handle_fleet_action(
         parse_params(req, "{ session_key, expected_version, request_id, action }")?;
     let receipt = execute_fleet_action(pool, params, None, events).await?;
     to_value(&ainb_hangar_proto::fleet::FleetActionResult { receipt })
+}
+
+const FLEET_RECEIPT_LIST_MAX: u32 = 100;
+
+/// Return a bounded, durable newest-first receipt projection.
+async fn handle_fleet_receipt_list(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FleetReceiptListParams, FleetReceiptListResult};
+    use ainb_hangar_store::repo::fleet::FleetRepo;
+
+    let params: FleetReceiptListParams = parse_params(req, "{ limit }")?;
+    if !(1..=FLEET_RECEIPT_LIST_MAX).contains(&params.limit) {
+        return Err(invalid_params(&format!(
+            "limit must be between 1 and {FLEET_RECEIPT_LIST_MAX}"
+        )));
+    }
+    let receipts = FleetRepo::list_action_receipts(pool, i64::from(params.limit))
+        .await
+        .map_err(|error| store_err(&error))?
+        .iter()
+        .map(action_receipt_wire)
+        .collect();
+    to_value(&FleetReceiptListResult { receipts })
+}
+
+/// Return one durable receipt, or `null` when its request id is unknown.
+async fn handle_fleet_receipt_get(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FleetReceiptGetParams, FleetReceiptGetResult};
+    use ainb_hangar_store::repo::fleet::FleetRepo;
+
+    let params: FleetReceiptGetParams = parse_params(req, "{ request_id }")?;
+    if params.request_id.trim().is_empty() {
+        return Err(invalid_params("request_id must not be empty"));
+    }
+    let receipt = FleetRepo::get_action_receipt(pool, &params.request_id)
+        .await
+        .map_err(|error| store_err(&error))?
+        .as_ref()
+        .map(action_receipt_wire);
+    to_value(&FleetReceiptGetResult { receipt })
+}
+
+/// Start a provider session through daemon-owned new-session state.
+async fn handle_fleet_start(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::fleet::FleetStartParams =
+        parse_params(req, "{ request_id, provider, cwd, prompt? }")?;
+    let result = execute_fleet_start(pool, params, events).await?;
+    to_value(&result)
 }
 
 /// Deliver one text prompt to explicit stable recipients with bounded fanout.
@@ -1110,6 +1170,12 @@ async fn execute_fleet_action(
         .map_err(|error| internal(&format!("serialize action: {error}")))?;
     let action_fingerprint = stable_fingerprint(&action_json);
 
+    if matches!(&params.action, ControlAction::Start { .. }) {
+        return Err(invalid_params(
+            "start must use fleet/start, not fleet/action",
+        ));
+    }
+
     if let Some(existing) = FleetRepo::get_action_receipt(pool, &params.request_id)
         .await
         .map_err(|error| store_err(&error))?
@@ -1125,11 +1191,6 @@ async fn execute_fleet_action(
             ));
         }
         return Ok(action_receipt_wire(&existing));
-    }
-
-    if matches!(&params.action, ControlAction::Start { .. }) {
-        return execute_fleet_start(pool, params, idempotency_key, action_fingerprint, events)
-            .await;
     }
 
     let request_fingerprint = match &params.action {
@@ -1315,22 +1376,32 @@ async fn execute_fleet_action(
 
 async fn execute_fleet_start(
     pool: &SqlitePool,
-    params: ainb_hangar_proto::fleet::FleetActionParams,
-    idempotency_key: Option<String>,
-    action_fingerprint: String,
+    params: ainb_hangar_proto::fleet::FleetStartParams,
     events: &EventSink,
-) -> Result<ainb_hangar_proto::fleet::FleetActionReceipt, RpcError> {
-    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction, FleetProvider};
+) -> Result<ainb_hangar_proto::fleet::FleetStartResult, RpcError> {
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetProvider, FleetStartResult};
     use ainb_hangar_store::repo::fleet::{FleetRepo, NewActionReceipt};
 
+    if params.request_id.trim().is_empty() || params.cwd.trim().is_empty() {
+        return Err(invalid_params("request_id and cwd must not be empty"));
+    }
+    if params.provider == FleetProvider::Unknown {
+        return Err(invalid_params("provider must be known"));
+    }
+    let prospective_session_key =
+        prospective_start_session_key(params.provider, &params.request_id);
+    let action_fingerprint = stable_fingerprint(
+        &serde_json::to_string(&params)
+            .map_err(|error| internal(&format!("serialize start params: {error}")))?,
+    );
     let now = SystemClock.now_ms();
     let mut receipt = NewActionReceipt {
         request_id: params.request_id.clone(),
-        session_key: params.session_key.clone(),
-        action_kind: params.action.kind().to_string(),
+        session_key: prospective_session_key.clone(),
+        action_kind: "start".to_string(),
         action_fingerprint,
-        expected_version: params.expected_version,
-        idempotency_key,
+        expected_version: 1,
+        idempotency_key: None,
         status: "PENDING".to_string(),
         detail: None,
         session_version: None,
@@ -1364,76 +1435,78 @@ async fn execute_fleet_start(
             .await
             .map_err(|error| store_err(&error))?
             .ok_or_else(|| internal("Fleet start receipt claim disappeared"))?;
-        if existing.session_key != params.session_key
-            || existing.action_kind != params.action.kind()
+        if existing.session_key != prospective_session_key
+            || existing.action_kind != "start"
             || existing.action_fingerprint != receipt.action_fingerprint
-            || existing.expected_version != params.expected_version
-            || existing.idempotency_key != receipt.idempotency_key
+            || existing.expected_version != 1
+            || existing.idempotency_key.is_some()
         {
             return Err(invalid_params(
-                "request_id was reused for a different Fleet action",
+                "request_id was reused for a different Fleet start",
             ));
         }
-        return Ok(action_receipt_wire(&existing));
+        return Ok(FleetStartResult {
+            prospective_session_key,
+            receipt: action_receipt_wire(&existing),
+        });
     }
 
-    let (status, detail) = match &params.action {
-        ControlAction::Start {
-            provider: FleetProvider::Codex,
-            cwd,
-            prompt,
-        } => match crate::fleet_provider::codex_manager::active_handle().await {
-            Some(manager) => match manager.thread_start(Path::new(cwd), None).await {
-                Ok(thread) => match launch_managed_codex_tui(&manager, &thread, cwd).await {
-                    Ok((tmux_name, tmux_session)) => {
-                        match crate::fleet::register_managed_codex_tmux(
-                            pool,
-                            events,
-                            &thread,
-                            cwd,
-                            &tmux_session,
-                            manager.capabilities(),
-                            SystemClock.now_ms(),
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                let turn = match prompt
-                                    .as_deref()
-                                    .filter(|prompt| !prompt.trim().is_empty())
-                                {
-                                    Some(prompt) => {
-                                        manager.turn_start(&thread, prompt).await.map(|_| ())
+    let (status, detail) = match params.provider {
+        FleetProvider::Codex => match crate::fleet_provider::codex_manager::active_handle().await {
+            Some(manager) => match manager.thread_start(Path::new(&params.cwd), None).await {
+                Ok(thread) => {
+                    match launch_managed_codex_tui(&manager, &thread, &params.cwd).await {
+                        Ok((tmux_name, tmux_session)) => {
+                            match crate::fleet::register_managed_codex_tmux(
+                                pool,
+                                events,
+                                &thread,
+                                &params.cwd,
+                                &tmux_session,
+                                manager.capabilities(),
+                                SystemClock.now_ms(),
+                            )
+                            .await
+                            {
+                                Ok(_) => {
+                                    let turn = match params
+                                        .prompt
+                                        .as_deref()
+                                        .filter(|prompt| !prompt.trim().is_empty())
+                                    {
+                                        Some(prompt) => {
+                                            manager.turn_start(&thread, prompt).await.map(|_| ())
+                                        }
+                                        None => Ok(()),
+                                    };
+                                    match turn {
+                                        Ok(()) => (
+                                            ActionReceiptStatus::Delivered,
+                                            Some(format!(
+                                                "codex thread {thread}, tmux {}",
+                                                tmux_session
+                                                    .exact_tmux_target
+                                                    .as_deref()
+                                                    .unwrap_or(&tmux_name)
+                                            )),
+                                        ),
+                                        Err(error) => (
+                                            ActionReceiptStatus::Failed,
+                                            Some(format!(
+                                                "Codex thread {thread} launched in tmux {tmux_name}, initial prompt failed: {error}"
+                                            )),
+                                        ),
                                     }
-                                    None => Ok(()),
-                                };
-                                match turn {
-                                    Ok(()) => (
-                                        ActionReceiptStatus::Delivered,
-                                        Some(format!(
-                                            "codex thread {thread}, tmux {}",
-                                            tmux_session
-                                                .exact_tmux_target
-                                                .as_deref()
-                                                .unwrap_or(&tmux_name)
-                                        )),
-                                    ),
-                                    Err(error) => (
-                                        ActionReceiptStatus::Failed,
-                                        Some(format!(
-                                            "Codex thread {thread} launched in tmux {tmux_name}, initial prompt failed: {error}"
-                                        )),
-                                    ),
+                                }
+                                Err(error) => {
+                                    let _ = kill_tmux_session_exact(&tmux_name).await;
+                                    (ActionReceiptStatus::Failed, Some(error.to_string()))
                                 }
                             }
-                            Err(error) => {
-                                let _ = kill_tmux_session_exact(&tmux_name).await;
-                                (ActionReceiptStatus::Failed, Some(error.to_string()))
-                            }
                         }
+                        Err(error) => (ActionReceiptStatus::Failed, Some(error)),
                     }
-                    Err(error) => (ActionReceiptStatus::Failed, Some(error)),
-                },
+                }
                 Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
             },
             None => (
@@ -1441,17 +1514,31 @@ async fn execute_fleet_start(
                 Some("Codex managed transport is not active".to_string()),
             ),
         },
-        ControlAction::Start { .. } => (
+        FleetProvider::Claude | FleetProvider::Unknown => (
             ActionReceiptStatus::Rejected,
             Some("provider start transport is unavailable".to_string()),
         ),
-        _ => unreachable!("start handler only receives start actions"),
     };
     receipt.status = receipt_status_token(status).to_string();
     receipt.detail = detail;
     receipt.updated_at = SystemClock.now_ms();
     let row = FleetRepo::upsert_action_receipt(pool, &receipt).await.map_err(fleet_repo_err)?;
-    Ok(action_receipt_wire(&row))
+    Ok(FleetStartResult {
+        prospective_session_key,
+        receipt: action_receipt_wire(&row),
+    })
+}
+
+fn prospective_start_session_key(
+    provider: ainb_hangar_proto::fleet::FleetProvider,
+    request_id: &str,
+) -> String {
+    let provider = match provider {
+        ainb_hangar_proto::fleet::FleetProvider::Claude => "claude",
+        ainb_hangar_proto::fleet::FleetProvider::Codex => "codex",
+        ainb_hangar_proto::fleet::FleetProvider::Unknown => "unknown",
+    };
+    format!("start:{provider}:{}", stable_fingerprint(request_id))
 }
 
 async fn launch_managed_codex_tui(
@@ -1720,7 +1807,7 @@ async fn execute_codex_action(
     Option<String>,
 ) {
     use crate::fleet_provider::{ApprovalDecision, QuestionAnswer};
-    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction, FleetProvider};
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction};
 
     let thread_id = session.provider_session_id.as_deref().unwrap_or_default();
     let result: Result<String, crate::fleet_provider::ProviderError> = async {
@@ -1924,17 +2011,6 @@ async fn execute_codex_action(
                 Ok(format!(
                     "codex thread {thread_id} archived after tmux {tmux_name} stop"
                 ))
-            }
-            ControlAction::Start {
-                provider,
-                cwd,
-                prompt,
-            } if *provider == FleetProvider::Codex => {
-                let thread = manager.thread_start(Path::new(cwd), None).await?;
-                if let Some(prompt) = prompt.as_deref().filter(|prompt| !prompt.trim().is_empty()) {
-                    manager.turn_start(&thread, prompt).await?;
-                }
-                Ok(format!("codex thread {thread}"))
             }
             _ => Err(crate::fleet_provider::ProviderError::Unsupported(
                 "Codex action is not available through app-server".to_string(),
@@ -2512,7 +2588,7 @@ fn action_capability(
         ControlAction::Continue => capabilities.continue_turn,
         ControlAction::Retry => capabilities.retry,
         ControlAction::Interrupt => capabilities.interrupt,
-        ControlAction::Start { .. } => capabilities.start,
+        ControlAction::Start { .. } => false,
         ControlAction::Restart => capabilities.restart,
         ControlAction::Stop => capabilities.stop,
         ControlAction::Kill => capabilities.kill,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
@@ -356,6 +356,139 @@ async fn action_rejects_stale_or_wrong_request_and_replays_receipt() {
 }
 
 #[tokio::test]
+async fn receipt_queries_are_bounded_newest_first_and_start_owns_session_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    let payload = serde_json::json!({ "source": "hook" });
+    apply_hook(
+        &store,
+        &sink,
+        "receipt-session-start",
+        "claude",
+        "receipt-session",
+        "SessionStart",
+        &payload,
+        200,
+    )
+    .await;
+
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let snapshot = client.call(methods::FLEET_SNAPSHOT, serde_json::json!({})).await;
+    let version = snapshot["result"]["sessions"][0]["version"].as_i64().unwrap();
+    for request_id in ["receipt-a", "receipt-z"] {
+        let response = client
+            .call(
+                methods::FLEET_ACTION,
+                serde_json::json!({
+                    "session_key": "claude:receipt-session",
+                    "expected_version": version,
+                    "request_id": request_id,
+                    "action": { "action": "send_prompt", "text": "hello" }
+                }),
+            )
+            .await;
+        assert!(
+            response["error"].is_null(),
+            "action must persist receipt: {response}"
+        );
+    }
+
+    let list = client
+        .call(
+            methods::FLEET_RECEIPT_LIST,
+            serde_json::json!({ "limit": 1 }),
+        )
+        .await;
+    assert!(list["error"].is_null(), "receipt list must ack: {list}");
+    assert_eq!(list["result"]["receipts"].as_array().unwrap().len(), 1);
+    assert_eq!(list["result"]["receipts"][0]["request_id"], "receipt-z");
+    let get = client
+        .call(
+            methods::FLEET_RECEIPT_GET,
+            serde_json::json!({ "request_id": "receipt-z" }),
+        )
+        .await;
+    assert_eq!(get["result"]["receipt"]["request_id"], "receipt-z");
+    let miss = client
+        .call(
+            methods::FLEET_RECEIPT_GET,
+            serde_json::json!({ "request_id": "receipt-missing" }),
+        )
+        .await;
+    assert!(miss["result"]["receipt"].is_null());
+    let oversized = client
+        .call(
+            methods::FLEET_RECEIPT_LIST,
+            serde_json::json!({ "limit": 101 }),
+        )
+        .await;
+    assert!(
+        oversized["error"].is_object(),
+        "server must bound receipt list"
+    );
+
+    let start = serde_json::json!({
+        "request_id": "start-request",
+        "provider": "codex",
+        "cwd": "/work/new",
+        "prompt": "inspect failures"
+    });
+    let first = client.call(methods::FLEET_START, start.clone()).await;
+    assert!(
+        first["error"].is_null(),
+        "start must persist a receipt: {first}"
+    );
+    assert!(
+        first["result"]["prospective_session_key"]
+            .as_str()
+            .is_some_and(|key| key.starts_with("start:codex:"))
+    );
+    assert_eq!(
+        first["result"]["receipt"]["session_key"],
+        first["result"]["prospective_session_key"]
+    );
+    let replay = client.call(methods::FLEET_START, start).await;
+    assert_eq!(replay["result"], first["result"]);
+    let changed = client
+        .call(
+            methods::FLEET_START,
+            serde_json::json!({
+                "request_id": "start-request",
+                "provider": "codex",
+                "cwd": "/work/other"
+            }),
+        )
+        .await;
+    assert!(
+        changed["error"].is_object(),
+        "changed start payload must reject"
+    );
+
+    let legacy_start = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": "claude:receipt-session",
+                "expected_version": version,
+                "request_id": "legacy-start",
+                "action": {
+                    "action": "start",
+                    "provider": "codex",
+                    "cwd": "/work/new"
+                }
+            }),
+        )
+        .await;
+    assert!(
+        legacy_start["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("fleet/start")),
+        "legacy action start must refuse the selected-session route: {legacy_start}"
+    );
+}
+
+#[tokio::test]
 async fn claude_structured_action_delivers_exact_complete_answer_once() {
     use ainb_plugin_notifyd::broker::{
         BrokerState, StructuredResolution, client_await_structured, client_list,
@@ -570,6 +703,16 @@ async fn authenticated_negotiate_reports_compatibility_and_rejects_invalid_range
             .iter()
             .any(|id| id == "fleet.protocol.negotiate")
     );
+    for capability in ["fleet.receipt.read", "fleet.start.execute"] {
+        assert!(
+            compatible["result"]["capability_ids"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|id| id == capability),
+            "negotiate must advertise {capability}: {compatible}"
+        );
+    }
 
     let read_only = client
         .call(

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -8,12 +8,23 @@ use serde::{Deserialize, Serialize};
 /// Current Fleet wire protocol version.
 pub const FLEET_PROTOCOL_VERSION: u32 = 1;
 
+/// Negotiated capability required for versioned selected-session actions.
+pub const FLEET_CAPABILITY_ACTION_EXECUTE: &str = "fleet.action.execute";
+/// Negotiated capability required for explicit-recipient broadcasts.
+pub const FLEET_CAPABILITY_BROADCAST_EXECUTE: &str = "fleet.broadcast.execute";
+/// Negotiated capability required for durable receipt list and exact lookup.
+pub const FLEET_CAPABILITY_RECEIPT_READ: &str = "fleet.receipt.read";
+/// Negotiated capability required for daemon-owned new-session starts.
+pub const FLEET_CAPABILITY_START_EXECUTE: &str = "fleet.start.execute";
+
 /// Fleet capability identifiers advertised during protocol negotiation.
 pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
-    "fleet.action.execute",
-    "fleet.broadcast.execute",
+    FLEET_CAPABILITY_ACTION_EXECUTE,
+    FLEET_CAPABILITY_BROADCAST_EXECUTE,
     "fleet.protocol.negotiate",
+    FLEET_CAPABILITY_RECEIPT_READ,
     "fleet.snapshot.read",
+    FLEET_CAPABILITY_START_EXECUTE,
     "fleet.subscription.live",
     "fleet.subscription.replay",
     "fleet.subscription.resync",
@@ -439,7 +450,10 @@ pub enum ControlAction {
     Retry,
     /// Interrupt active turn.
     Interrupt,
-    /// Start a managed session.
+    /// Legacy wire form. New clients must use daemon-owned fleet/start.
+    ///
+    /// The daemon rejects this variant before selected-session validation, so
+    /// it cannot create a session through fleet/action.
     Start {
         /// Provider to start.
         provider: FleetProvider,
@@ -541,6 +555,60 @@ pub struct FleetActionReceipt {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetActionResult {
     /// Durable action receipt.
+    pub receipt: FleetActionReceipt,
+}
+
+/// Parameters for `fleet/receipt_list`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptListParams {
+    /// Maximum number of durable receipts, newest first.
+    pub limit: u32,
+}
+
+/// Result for `fleet/receipt_list`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptListResult {
+    /// Durable receipts ordered by `updated_at DESC, request_id DESC`.
+    pub receipts: Vec<FleetActionReceipt>,
+}
+
+/// Parameters for `fleet/receipt_get`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptGetParams {
+    /// Exact idempotent action request identifier.
+    pub request_id: String,
+}
+
+/// Result for `fleet/receipt_get`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptGetResult {
+    /// Durable receipt when the daemon has one for this request id.
+    pub receipt: Option<FleetActionReceipt>,
+}
+
+/// Parameters for `fleet/start`.
+///
+/// Start has no selected session and therefore carries no caller-supplied
+/// session key or optimistic concurrency version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetStartParams {
+    /// Idempotent new-session request identifier.
+    pub request_id: String,
+    /// Provider to start.
+    pub provider: FleetProvider,
+    /// Working directory for the new provider session.
+    pub cwd: String,
+    /// Optional initial prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+}
+
+/// Result for `fleet/start`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetStartResult {
+    /// Daemon-generated prospective session identity for this request.
+    pub prospective_session_key: String,
+    /// Durable start receipt.
     pub receipt: FleetActionReceipt,
 }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -274,6 +274,12 @@ pub const FLEET_SUBSCRIBE: &str = "fleet/subscribe";
 pub const FLEET_ACTION: &str = "fleet/action";
 /// Deliver text to explicit Fleet targets.
 pub const FLEET_BROADCAST: &str = "fleet/broadcast";
+/// List durable action receipts newest first.
+pub const FLEET_RECEIPT_LIST: &str = "fleet/receipt_list";
+/// Fetch one durable action receipt by request id.
+pub const FLEET_RECEIPT_GET: &str = "fleet/receipt_get";
+/// Start a provider session without borrowing selected-session state.
+pub const FLEET_START: &str = "fleet/start";
 
 /// Fleet notifications emitted by the daemon, never JSON-RPC request methods.
 pub const FLEET_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &["fleet/resync_required"];
@@ -1239,6 +1245,9 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_ACTION,
     FLEET_BROADCAST,
     FLEET_NEGOTIATE,
+    FLEET_RECEIPT_LIST,
+    FLEET_RECEIPT_GET,
+    FLEET_START,
 ];
 
 #[cfg(test)]
@@ -1462,6 +1471,9 @@ mod tests {
             FLEET_ACTION,
             FLEET_BROADCAST,
             FLEET_NEGOTIATE,
+            FLEET_RECEIPT_LIST,
+            FLEET_RECEIPT_GET,
+            FLEET_START,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -682,6 +682,22 @@ impl FleetRepo {
         .await?;
         row.as_ref().map(receipt_from_row).transpose()
     }
+
+    /// List durable action receipts newest first.
+    pub async fn list_action_receipts(
+        pool: &SqlitePool,
+        limit: i64,
+    ) -> Result<Vec<ActionReceiptRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT request_id, session_key, action_kind, action_fingerprint, expected_version, \
+                    idempotency_key, status, detail, session_version, created_at, updated_at \
+             FROM fleet_action_receipt ORDER BY updated_at DESC, request_id DESC LIMIT ?",
+        )
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(receipt_from_row).collect()
+    }
 }
 
 const SESSION_SELECT_BY_KEY: &str = "SELECT session_key, provider, provider_session_id, \

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -254,6 +254,8 @@ const FLEET_SUBSCRIBE_REQ_ID: i64 = 58;
 const FLEET_ACTION_REQ_ID: i64 = 59;
 /// Explicit-recipient Fleet broadcast.
 const FLEET_BROADCAST_REQ_ID: i64 = 60;
+/// Daemon-owned new Fleet session start.
+const FLEET_START_REQ_ID: i64 = 64;
 /// JSON-RPC id for a `hangar/skill_set_enabled` request (parity #24).
 const SKILL_SET_ENABLED_REQ_ID: i64 = 61;
 /// JSON-RPC id for a `hangar/agent_skills_list` request (parity #24). Fired
@@ -526,21 +528,12 @@ fn fleet_start_params(
     provider: ainb_hangar_proto::fleet::FleetProvider,
     cwd: String,
     prompt: Option<String>,
-) -> ainb_hangar_proto::fleet::FleetActionParams {
-    let session_key = match provider {
-        ainb_hangar_proto::fleet::FleetProvider::Codex => "start:codex",
-        ainb_hangar_proto::fleet::FleetProvider::Claude => "start:claude",
-        ainb_hangar_proto::fleet::FleetProvider::Unknown => "start:unknown",
-    };
-    ainb_hangar_proto::fleet::FleetActionParams {
-        session_key: session_key.to_string(),
-        expected_version: 1,
+) -> ainb_hangar_proto::fleet::FleetStartParams {
+    ainb_hangar_proto::fleet::FleetStartParams {
         request_id: fleet_request_id("start"),
-        action: ainb_hangar_proto::fleet::ControlAction::Start {
-            provider,
-            cwd,
-            prompt,
-        },
+        provider,
+        cwd,
+        prompt,
     }
 }
 
@@ -1102,6 +1095,7 @@ impl HangarPlugin {
             RpcId::Number(FLEET_SUBSCRIBE_REQ_ID) => self.apply_fleet_subscription(resp),
             RpcId::Number(FLEET_ACTION_REQ_ID) => self.apply_fleet_action_result(resp),
             RpcId::Number(FLEET_BROADCAST_REQ_ID) => self.apply_fleet_broadcast_result(resp),
+            RpcId::Number(FLEET_START_REQ_ID) => self.apply_fleet_start_result(resp),
             RpcId::Number(SEARCH_REQ_ID) => self.apply_search(resp),
             // P5: the profile-editor roster + the per-selection detail/previews.
             RpcId::Number(PROFILE_LIST_REQ_ID) => self.apply_profiles(resp),
@@ -2034,6 +2028,37 @@ impl HangarPlugin {
         self.conn.on_event();
     }
 
+    fn apply_fleet_start_result(&mut self, resp: &RpcResponse) {
+        use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetStartResult};
+        let result = resp
+            .result
+            .as_ref()
+            .and_then(|value| serde_json::from_value::<FleetStartResult>(value.clone()).ok());
+        let event = match (result, &resp.error) {
+            (Some(result), _) if result.receipt.status == ActionReceiptStatus::Delivered => {
+                crate::screen::fleet::FleetEvent::ActionSucceeded {
+                    session_key: result.prospective_session_key,
+                }
+            }
+            (Some(result), _) => crate::screen::fleet::FleetEvent::ActionFailed {
+                session_key: result.prospective_session_key,
+                detail: result
+                    .receipt
+                    .detail
+                    .unwrap_or_else(|| format!("{:?}", result.receipt.status)),
+            },
+            (None, Some(error)) => crate::screen::fleet::FleetEvent::ActionFailed {
+                session_key: "start".into(),
+                detail: error.message.clone(),
+            },
+            (None, None) => return,
+        };
+        let out = crate::screen::fleet::reduce_fleet(&self.screens.fleet, event);
+        self.screens.fleet = out.state;
+        self.fleet_fetch_pending = true;
+        self.conn.on_event();
+    }
+
     fn apply_fleet_broadcast_result(&mut self, resp: &RpcResponse) {
         use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetBroadcastResult};
         if let Some(error) = &resp.error {
@@ -2323,13 +2348,12 @@ impl HangarPlugin {
                 prompt,
             } => {
                 let params = fleet_start_params(provider, cwd, prompt);
-                let target = params.session_key.clone();
                 self.send_fleet_rpc(
                     host,
-                    FLEET_ACTION_REQ_ID,
-                    daemon_methods::FLEET_ACTION,
+                    FLEET_START_REQ_ID,
+                    daemon_methods::FLEET_START,
                     params,
-                    &target,
+                    "start",
                 )
                 .await;
             }
@@ -7816,24 +7840,17 @@ mod tests {
 
     #[test]
     fn fleet_start_mapping_preserves_exact_global_params() {
-        use ainb_hangar_proto::fleet::{ControlAction, FleetProvider};
+        use ainb_hangar_proto::fleet::FleetProvider;
 
         let params = fleet_start_params(
             FleetProvider::Codex,
             "/work/new".into(),
             Some("inspect failures".into()),
         );
-        assert_eq!(params.session_key, "start:codex");
-        assert_eq!(params.expected_version, 1);
         assert!(params.request_id.starts_with("fleet-ui-start-"));
-        assert_eq!(
-            params.action,
-            ControlAction::Start {
-                provider: FleetProvider::Codex,
-                cwd: "/work/new".into(),
-                prompt: Some("inspect failures".into()),
-            }
-        );
+        assert_eq!(params.provider, FleetProvider::Codex);
+        assert_eq!(params.cwd, "/work/new");
+        assert_eq!(params.prompt.as_deref(), Some("inspect failures"));
     }
 
     #[test]

--- a/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-compatible.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-compatible.json
@@ -3,7 +3,9 @@
     "fleet.action.execute",
     "fleet.broadcast.execute",
     "fleet.protocol.negotiate",
+    "fleet.receipt.read",
     "fleet.snapshot.read",
+    "fleet.start.execute",
     "fleet.subscription.live",
     "fleet.subscription.replay",
     "fleet.subscription.resync"

--- a/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-read-only.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-read-only.json
@@ -3,7 +3,9 @@
     "fleet.action.execute",
     "fleet.broadcast.execute",
     "fleet.protocol.negotiate",
+    "fleet.receipt.read",
     "fleet.snapshot.read",
+    "fleet.start.execute",
     "fleet.subscription.live",
     "fleet.subscription.replay",
     "fleet.subscription.resync"

--- a/ainb-tui/fleet-parity/manifest.json
+++ b/ainb-tui/fleet-parity/manifest.json
@@ -8,7 +8,8 @@
       "Current proof script needs exact tmux pane targeting because reattach-to-user-namespace creates shell window index 1.",
       "TUI has no automatic reconnect: retained-cursor redial requires offline [s] path.",
       "fleet/resync_required has no TUI-visible marker; runtime resync proof needs a trustworthy observable artifact.",
-      "Three isolated tmux captures do not yet exist."
+      "Three isolated tmux captures do not yet exist.",
+      "No TUI tripwire proves daemon-owned fleet/start or receipt list/get behavior."
     ]
   },
   "capabilities": [
@@ -29,9 +30,14 @@
         "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
       },
       "swift": {
-        "status": "not_applicable",
-        "evidence_paths": [],
-        "rationale": "AFM-E01 exposes no product writes. AFM-E03 owns the Swift action and receipt proof."
+        "status": "blocked_proof",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/App/FleetStore.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift"
+        ],
+        "rationale": "AFM-E03 Swift action client and old-catalogue refusal proof exist. XCUI and isolated daemon delivery proof remain unrun."
       },
       "release_classification": "deferred_tui"
     },
@@ -52,9 +58,13 @@
         "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
       },
       "swift": {
-        "status": "not_applicable",
-        "evidence_paths": [],
-        "rationale": "AFM-E01 exposes no product writes. AFM-E03 owns the Swift broadcast and receipt proof."
+        "status": "blocked_proof",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/App/FleetStore.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift"
+        ],
+        "rationale": "AFM-E03 Swift broadcast UI preserves explicit target and daemon receipt ordering. XCUI and isolated daemon mixed-outcome proof remain unrun."
       },
       "release_classification": "deferred_tui"
     },
@@ -85,6 +95,36 @@
       "release_classification": "deferred_tui"
     },
     {
+      "id": "fleet.receipt.read",
+      "tier": "v1",
+      "daemon_request_method": "fleet/receipt_list",
+      "expected_behavior": "Daemon returns bounded newest-first durable receipts and exact request-id lookup.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs",
+          "crates/ainb-hangar-store/src/repo/fleet.rs",
+          "crates/ainb-hangar-daemon/tests/rpc_fleet.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "blocked_proof",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift"
+        ],
+        "rationale": "AFM-E03 typed receipt read and old-catalogue refusal proof exist. Receipt-center XCUI and isolated daemon proof remain unrun."
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
       "id": "fleet.snapshot.read",
       "tier": "foundation",
       "daemon_request_method": "fleet/snapshot",
@@ -107,6 +147,36 @@
           "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
           "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift"
         ]
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.start.execute",
+      "tier": "v1",
+      "daemon_request_method": "fleet/start",
+      "expected_behavior": "Daemon starts a provider session from daemon-owned new-session parameters and returns a durable receipt.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs",
+          "crates/ainb-hangar-daemon/tests/rpc_fleet.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "blocked_proof",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/App/FleetStore.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift"
+        ],
+        "rationale": "AFM-E03 typed daemon-owned Start client and local cwd preflight exist. Start XCUI and isolated daemon delivery proof remain unrun."
       },
       "release_classification": "deferred_tui"
     },

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -1,11 +1,74 @@
 import Combine
 import Foundation
 
+enum FleetOperatorAction: CaseIterable, Identifiable, Equatable {
+    case sendPrompt, continueTurn, retry, interrupt, restart, stop, kill, archive
+
+    var id: String { title }
+
+    var title: String {
+        switch self {
+        case .sendPrompt: "Send prompt"
+        case .continueTurn: "Continue"
+        case .retry: "Retry"
+        case .interrupt: "Interrupt"
+        case .restart: "Restart"
+        case .stop: "Stop"
+        case .kill: "Kill"
+        case .archive: "Archive"
+        }
+    }
+
+    var isDestructive: Bool {
+        switch self {
+        case .interrupt, .stop, .kill, .archive: true
+        default: false
+        }
+    }
+
+    func isAvailable(in capabilities: FleetCapabilities) -> Bool {
+        switch self {
+        case .sendPrompt: capabilities.sendPrompt || capabilities.tmuxText
+        case .continueTurn: capabilities.continueTurn
+        case .retry: capabilities.retry
+        case .interrupt: capabilities.interrupt
+        case .restart: capabilities.restart
+        case .stop: capabilities.stop
+        case .kill: capabilities.kill
+        case .archive: capabilities.archive
+        }
+    }
+
+    func wireAction(prompt: String = "") -> ControlAction {
+        switch self {
+        case .sendPrompt: .sendPrompt(text: prompt)
+        case .continueTurn: .continue
+        case .retry: .retry
+        case .interrupt: .interrupt
+        case .restart: .restart
+        case .stop: .stop
+        case .kill: .kill
+        case .archive: .archive
+        }
+    }
+}
+
+enum FleetStartPreflight {
+    static func isExistingDirectory(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+}
+
 @MainActor
 final class FleetStore: ObservableObject {
     @Published private(set) var sessions: [FleetSession] = []
     @Published private(set) var connectionState: FleetConnectionState = .connecting
     @Published var selectedSessionKey: String?
+    @Published private(set) var receipts: [FleetActionReceipt] = []
+    @Published private(set) var pendingIntentID: String?
+    @Published private(set) var controlNotice: String?
+    @Published private(set) var lastStart: FleetStartResult?
 
     private let location: HangarLocation
     private let readVersions: FleetProtocolRange
@@ -50,6 +113,18 @@ final class FleetStore: ObservableObject {
         return writeCompatible && negotiation?.readCompatible == true
     }
 
+    var canReadReceipts: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.receipt.read") == true
+    }
+
+    var canStart: Bool {
+        canWrite && negotiation?.capabilityIDs.contains("fleet.start.execute") == true && pendingIntentID == nil
+    }
+
+    var canBroadcast: Bool {
+        canWrite && negotiation?.capabilityIDs.contains("fleet.broadcast.execute") == true && pendingIntentID == nil
+    }
+
     #if DEBUG
     var debugConnectionTaskCount: Int {
         [connectionTask, reconnectTask].compactMap { $0 }.count
@@ -82,7 +157,144 @@ final class FleetStore: ObservableObject {
         reconnectTask = nil
         let currentConnection = connection
         connection = nil
+        negotiation = nil
         Task { await currentConnection?.close() }
+    }
+
+    func canPerform(_ action: FleetOperatorAction, on session: FleetSession) -> Bool {
+        canWrite
+            && pendingIntentID == nil
+            && negotiation?.capabilityIDs.contains("fleet.action.execute") == true
+            && selectedSessionKey == session.sessionKey
+            && !session.sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && session.version > 0
+            && action.isAvailable(in: session.capabilities)
+    }
+
+    func canSendPrompt(_ prompt: String, on session: FleetSession) -> Bool {
+        canPerform(.sendPrompt, on: session)
+            && !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func perform(_ action: FleetOperatorAction, on session: FleetSession, prompt: String = "") {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowed = action == .sendPrompt
+            ? canSendPrompt(trimmedPrompt, on: session)
+            : canPerform(action, on: session)
+        guard allowed else {
+            controlNotice = "Action is unavailable or incomplete."
+            return
+        }
+        guard selectedSessionKey == session.sessionKey,
+              let current = sessions.first(where: { $0.sessionKey == session.sessionKey }),
+              current.version == session.version else {
+            controlNotice = "Fleet state changed. Review the current session before sending."
+            return
+        }
+        guard let connection else {
+            controlNotice = "Fleet connection is unavailable."
+            return
+        }
+        let requestID = UUID().uuidString
+        pendingIntentID = requestID
+        controlNotice = nil
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.pendingIntentID = nil }
+            do {
+                let result = try await connection.action(FleetActionParams(
+                    sessionKey: current.sessionKey,
+                    expectedVersion: current.version,
+                    requestID: requestID,
+                    action: action.wireAction(prompt: trimmedPrompt)
+                ))
+                self.record(result.receipt)
+                await self.refreshAuthoritativeState(using: connection)
+            } catch {
+                self.controlNotice = "Action refused: \(String(describing: error))"
+            }
+        }
+    }
+
+    func start(provider: FleetProvider, cwd: String, prompt: String?) {
+        let trimmedCWD = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canStart,
+              provider != .unknown,
+              !trimmedCWD.isEmpty,
+              FleetStartPreflight.isExistingDirectory(trimmedCWD),
+              let connection else {
+            controlNotice = "Start is unavailable or incomplete."
+            return
+        }
+        let requestID = UUID().uuidString
+        pendingIntentID = requestID
+        controlNotice = nil
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.pendingIntentID = nil }
+            do {
+                let result = try await connection.start(FleetStartParams(
+                    requestID: requestID,
+                    provider: provider,
+                    cwd: trimmedCWD,
+                    prompt: prompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+                ))
+                self.lastStart = result
+                self.record(result.receipt)
+                await self.refreshAuthoritativeState(using: connection)
+            } catch {
+                self.controlNotice = "Start refused: \(String(describing: error))"
+            }
+        }
+    }
+
+    func broadcast(targetKeys: [String], text: String) {
+        var seen = Set<String>()
+        let orderedTargets = targetKeys.filter { seen.insert($0).inserted }
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canBroadcast,
+              !orderedTargets.isEmpty,
+              !trimmedText.isEmpty,
+              let connection,
+              orderedTargets.allSatisfy({ key in
+                  sessions.contains { $0.sessionKey == key && $0.version > 0 && ($0.capabilities.sendPrompt || $0.capabilities.tmuxText) }
+              }) else {
+            controlNotice = "Broadcast is unavailable or incomplete."
+            return
+        }
+        let intentID = UUID().uuidString
+        pendingIntentID = intentID
+        controlNotice = nil
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.pendingIntentID = nil }
+            do {
+                let result = try await connection.broadcast(FleetBroadcastParams(
+                    targetKeys: orderedTargets,
+                    text: trimmedText,
+                    idempotencyKey: intentID
+                ))
+                self.record(result.receipts)
+                await self.refreshAuthoritativeState(using: connection)
+            } catch {
+                self.controlNotice = "Broadcast refused: \(String(describing: error))"
+            }
+        }
+    }
+
+    func refreshReceipts() {
+        guard canReadReceipts, let connection else {
+            controlNotice = "Receipt reads are unavailable for this daemon."
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                self.receipts = try await connection.receiptList(FleetReceiptListParams(limit: 50)).receipts
+            } catch {
+                self.controlNotice = "Receipt refresh refused: \(String(describing: error))"
+            }
+        }
     }
 
     private func beginConnection() {
@@ -125,6 +337,9 @@ final class FleetStore: ObservableObject {
                 return
             }
             apply(bootstrapped)
+            if result.capabilityIDs.contains("fleet.receipt.read") {
+                receipts = try await newConnection.receiptList(FleetReceiptListParams(limit: 50)).receipts
+            }
             connectionState = .live(daemonVersion: result.daemonVersion, writeCompatible: result.writeCompatible)
             established = true
             if reconnectAttempts > 0 {
@@ -267,5 +482,33 @@ final class FleetStore: ObservableObject {
 
     private func handle(_ error: Error) {
         becomeStale(reason: error.localizedDescription)
+    }
+
+    private func record(_ receipt: FleetActionReceipt) {
+        record([receipt])
+    }
+
+    private func record(_ incoming: [FleetActionReceipt]) {
+        receipts = Self.mergedReceipts(incoming, existing: receipts)
+    }
+
+    static func mergedReceipts(_ incoming: [FleetActionReceipt], existing: [FleetActionReceipt]) -> [FleetActionReceipt] {
+        let incomingIDs = Set(incoming.map(\.requestID))
+        return incoming + existing.filter { !incomingIDs.contains($0.requestID) }
+    }
+
+    private func refreshAuthoritativeState(using connection: FleetConnection) async {
+        do {
+            let snapshot = try await connection.snapshot()
+            apply(FleetProjectionReducer.snapshot(snapshot, from: projection))
+        } catch {
+            controlNotice = "Fleet refresh refused: \(String(describing: error))"
+        }
+        guard canReadReceipts else { return }
+        do {
+            receipts = try await connection.receiptList(FleetReceiptListParams(limit: 50)).receipts
+        } catch {
+            controlNotice = "Receipt refresh refused: \(String(describing: error))"
+        }
     }
 }

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -7,6 +7,7 @@ enum FleetConnectionError: Error, Equatable {
     case notAuthenticated
     case protocolReadIncompatible(FleetNegotiateResult)
     case protocolWriteIncompatible
+    case missingNegotiatedCapability(String)
     case emptyToken
     case closed
     case disconnected
@@ -128,6 +129,31 @@ actor FleetConnection {
             params: FleetSubscribeParams(afterRevision: afterRevision),
             result: FleetSubscribeResult.self
         )
+    }
+
+    func action(_ params: FleetActionParams) async throws -> FleetActionResult {
+        try requireWriteCapability("fleet.action.execute")
+        return try await request("fleet/action", params: params, result: FleetActionResult.self)
+    }
+
+    func start(_ params: FleetStartParams) async throws -> FleetStartResult {
+        try requireWriteCapability("fleet.start.execute")
+        return try await request("fleet/start", params: params, result: FleetStartResult.self)
+    }
+
+    func broadcast(_ params: FleetBroadcastParams) async throws -> FleetBroadcastResult {
+        try requireWriteCapability("fleet.broadcast.execute")
+        return try await request("fleet/broadcast", params: params, result: FleetBroadcastResult.self)
+    }
+
+    func receiptList(_ params: FleetReceiptListParams) async throws -> FleetReceiptListResult {
+        try requireReadCapability("fleet.receipt.read")
+        return try await request("fleet/receipt_list", params: params, result: FleetReceiptListResult.self)
+    }
+
+    func receiptGet(_ params: FleetReceiptGetParams) async throws -> FleetReceiptGetResult {
+        try requireReadCapability("fleet.receipt.read")
+        return try await request("fleet/receipt_get", params: params, result: FleetReceiptGetResult.self)
     }
 
     func incoming() -> AsyncStream<FleetIncoming> {
@@ -356,6 +382,28 @@ actor FleetConnection {
         guard result.writeCompatible else {
             throw FleetConnectionError.protocolWriteIncompatible
         }
+    }
+
+    static func validateCapability(_ capabilityID: String, in result: FleetNegotiateResult) throws {
+        guard result.capabilityIDs.contains(capabilityID) else {
+            throw FleetConnectionError.missingNegotiatedCapability(capabilityID)
+        }
+    }
+
+    private func requireWriteCapability(_ capabilityID: String) throws {
+        try requireWriteCompatibility()
+        guard let negotiation else {
+            throw FleetConnectionError.notAuthenticated
+        }
+        try Self.validateCapability(capabilityID, in: negotiation)
+    }
+
+    private func requireReadCapability(_ capabilityID: String) throws {
+        try requireReadCompatibility()
+        guard let negotiation else {
+            throw FleetConnectionError.notAuthenticated
+        }
+        try Self.validateCapability(capabilityID, in: negotiation)
     }
 
     private static func writeAll(_ data: Data, to descriptor: Int32) throws {

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -349,6 +349,37 @@ struct FleetActionReceipt: Codable, Equatable {
 
 struct FleetActionResult: Codable, Equatable { let receipt: FleetActionReceipt }
 
+struct FleetReceiptListParams: Codable, Equatable {
+    let limit: UInt32
+}
+
+struct FleetReceiptListResult: Codable, Equatable {
+    let receipts: [FleetActionReceipt]
+}
+
+struct FleetReceiptGetParams: Codable, Equatable {
+    let requestID: String
+    private enum CodingKeys: String, CodingKey { case requestID = "request_id" }
+}
+
+struct FleetReceiptGetResult: Codable, Equatable {
+    let receipt: FleetActionReceipt?
+}
+
+struct FleetStartParams: Codable, Equatable {
+    let requestID: String
+    let provider: FleetProvider
+    let cwd: String
+    let prompt: String?
+    private enum CodingKeys: String, CodingKey { case requestID = "request_id", provider, cwd, prompt }
+}
+
+struct FleetStartResult: Codable, Equatable {
+    let prospectiveSessionKey: String
+    let receipt: FleetActionReceipt
+    private enum CodingKeys: String, CodingKey { case prospectiveSessionKey = "prospective_session_key", receipt }
+}
+
 struct FleetBroadcastParams: Codable, Equatable {
     let targetKeys: [String]
     let text: String

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetSessionDetailView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetSessionDetailView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 
 struct FleetSessionDetailView: View {
+    @ObservedObject var store: FleetStore
     let session: FleetSession
     let connection: FleetConnectionState
+    @State private var prompt = ""
+    @State private var pendingDestructiveAction: FleetOperatorAction?
 
     var body: some View {
         Form {
@@ -33,9 +36,58 @@ struct FleetSessionDetailView: View {
                 capability("Retry", session.capabilities.retry)
                 capability("Interrupt", session.capabilities.interrupt)
             }
+            Section("Controls") {
+                TextField("Prompt", text: $prompt, axis: .vertical)
+                    .accessibilityIdentifier("fleet.control.prompt")
+                Button("Send prompt") {
+                    store.perform(.sendPrompt, on: session, prompt: prompt)
+                    prompt = ""
+                }
+                .disabled(!store.canSendPrompt(prompt, on: session))
+                .accessibilityIdentifier("fleet.control.send-prompt")
+                ForEach(FleetOperatorAction.allCases.filter { $0 != .sendPrompt }) { action in
+                    Button(action.title) {
+                        if action.isDestructive {
+                            pendingDestructiveAction = action
+                        } else {
+                            store.perform(action, on: session)
+                        }
+                    }
+                    .disabled(!store.canPerform(action, on: session))
+                    .accessibilityIdentifier("fleet.control.\(action.id)")
+                }
+                Text("Approve and deny are unavailable until Fleet projects durable typed request context.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let pendingIntentID = store.pendingIntentID {
+                Section("Control status") {
+                    LabeledContent("Pending intent", value: pendingIntentID)
+                    ProgressView()
+                }
+            }
+            if let notice = store.controlNotice {
+                Section("Control status") { Text(notice).foregroundStyle(.secondary) }
+            }
             Section("Connection") { Text(connection.message) }
         }
         .accessibilityIdentifier("fleet.detail.\(session.sessionKey)")
+        .confirmationDialog(
+            "Confirm \(pendingDestructiveAction?.title ?? "action") for \(session.displayName ?? session.sessionKey)?",
+            isPresented: Binding(
+                get: { pendingDestructiveAction != nil },
+                set: { if !$0 { pendingDestructiveAction = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let action = pendingDestructiveAction {
+                Button(action.title, role: .destructive) {
+                    pendingDestructiveAction = nil
+                    store.perform(action, on: session)
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingDestructiveAction = nil }
+        }
     }
 
     @ViewBuilder private func capability(_ name: String, _ available: Bool) -> some View {

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -5,6 +5,9 @@ struct FleetWindowView: View {
     @Binding var presentation: FleetPresentationPreferences
     @State private var search = ""
     @State private var switcherPresented = false
+    @State private var startPresented = false
+    @State private var receiptsPresented = false
+    @State private var broadcastPresented = false
 
     var body: some View {
         NavigationSplitView {
@@ -36,10 +39,13 @@ struct FleetWindowView: View {
                 ToolbarItem { Picker("Management", selection: $presentation.filters.management) { Text("Any management").tag(ManagementState?.none); ForEach([ManagementState.managed, .degraded], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
                 ToolbarItem { Picker("Transport", selection: $presentation.filters.transportHealth) { Text("Any transport").tag(TransportHealth?.none); ForEach([TransportHealth.healthy, .degraded, .unavailable, .unknown], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
                 ToolbarItem { Button("Quick switch") { switcherPresented = true } }
+                ToolbarItem { Button("Start") { startPresented = true }.disabled(!store.canStart).accessibilityIdentifier("fleet.start.open") }
+                ToolbarItem { Button("Receipts") { receiptsPresented = true }.disabled(!store.canReadReceipts).accessibilityIdentifier("fleet.receipts.open") }
+                ToolbarItem { Button("Broadcast") { broadcastPresented = true }.disabled(!store.canBroadcast).accessibilityIdentifier("fleet.broadcast.open") }
             }
         } detail: {
             if let key = store.selectedSessionKey, let session = store.sessions.first(where: { $0.sessionKey == key }) {
-                FleetSessionDetailView(session: session, connection: store.connectionState)
+                FleetSessionDetailView(store: store, session: session, connection: store.connectionState)
             } else {
                 ContentUnavailableView("Select a Fleet session", systemImage: "bolt.circle")
             }
@@ -48,6 +54,120 @@ struct FleetWindowView: View {
             if !store.connectionState.isLive { Text(store.connectionState.message).padding(8).background(.yellow.opacity(0.2)) }
         }
         .sheet(isPresented: $switcherPresented) { FleetQuickSwitcher(store: store, sort: presentation.sort, isPresented: $switcherPresented) }
+        .sheet(isPresented: $startPresented) { FleetStartForm(store: store, isPresented: $startPresented) }
+        .sheet(isPresented: $receiptsPresented) { FleetReceiptList(store: store) }
+        .sheet(isPresented: $broadcastPresented) { FleetBroadcastForm(store: store, isPresented: $broadcastPresented) }
         .frame(minWidth: 820, minHeight: 520)
+    }
+}
+
+private struct FleetStartForm: View {
+    @ObservedObject var store: FleetStore
+    @Binding var isPresented: Bool
+    @State private var provider: FleetProvider = .codex
+    @State private var cwd = FileManager.default.currentDirectoryPath
+    @State private var prompt = ""
+
+    var body: some View {
+        Form {
+            Picker("Provider", selection: $provider) {
+                Text("Codex").tag(FleetProvider.codex)
+                Text("Claude").tag(FleetProvider.claude)
+            }
+            TextField("Working directory", text: $cwd)
+            TextField("Initial prompt", text: $prompt, axis: .vertical)
+            if let start = store.lastStart {
+                LabeledContent("Prospective session", value: start.prospectiveSessionKey)
+                LabeledContent("Receipt", value: start.receipt.status.rawValue)
+            }
+            if let notice = store.controlNotice { Text(notice).foregroundStyle(.secondary) }
+            HStack {
+                Button("Cancel") { isPresented = false }
+                Spacer()
+                Button("Start") {
+                    store.start(provider: provider, cwd: cwd, prompt: prompt)
+                }
+                .disabled(!store.canStart || !FleetStartPreflight.isExistingDirectory(cwd.trimmingCharacters(in: .whitespacesAndNewlines)))
+                .accessibilityIdentifier("fleet.start.submit")
+            }
+        }
+        .padding()
+        .frame(minWidth: 440)
+        .accessibilityIdentifier("fleet.start.form")
+    }
+}
+
+private struct FleetReceiptList: View {
+    @ObservedObject var store: FleetStore
+
+    var body: some View {
+        List(store.receipts, id: \.requestID) { receipt in
+            VStack(alignment: .leading) {
+                Text(receipt.actionKind)
+                Text(receipt.status.rawValue).font(.caption).foregroundStyle(.secondary)
+                Text(receipt.detail ?? "No daemon detail").font(.caption).foregroundStyle(.secondary)
+                Text(receipt.requestID).font(.caption2).textSelection(.enabled)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(receipt.actionKind), \(receipt.status.rawValue)")
+            .accessibilityValue(receipt.detail ?? "No daemon detail")
+        }
+        .navigationTitle("Receipts")
+        .frame(minWidth: 520, minHeight: 360)
+        .onAppear { store.refreshReceipts() }
+        .accessibilityIdentifier("fleet.receipts.list")
+    }
+}
+
+private struct FleetBroadcastForm: View {
+    @ObservedObject var store: FleetStore
+    @Binding var isPresented: Bool
+    @State private var text = ""
+    @State private var selected = Set<String>()
+    @State private var confirming = false
+
+    private var targets: [FleetSession] {
+        store.sessions.filter { $0.version > 0 && ($0.capabilities.sendPrompt || $0.capabilities.tmuxText) }
+    }
+
+    private var orderedTargets: [String] {
+        targets.map(\.sessionKey).filter(selected.contains)
+    }
+
+    var body: some View {
+        Form {
+            TextField("Message", text: $text, axis: .vertical)
+            Section("Recipients") {
+                ForEach(targets, id: \.sessionKey) { session in
+                    Toggle(session.displayName ?? session.sessionKey, isOn: Binding(
+                        get: { selected.contains(session.sessionKey) },
+                        set: { enabled in
+                            if enabled { selected.insert(session.sessionKey) }
+                            else { selected.remove(session.sessionKey) }
+                        }
+                    ))
+                }
+            }
+            Text("Targets: \(orderedTargets.joined(separator: ", "))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if let notice = store.controlNotice { Text(notice).foregroundStyle(.secondary) }
+            HStack {
+                Button("Cancel") { isPresented = false }
+                Spacer()
+                Button("Review broadcast") { confirming = true }
+                    .disabled(!store.canBroadcast || orderedTargets.isEmpty || text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding()
+        .frame(minWidth: 480)
+        .confirmationDialog("Send to \(orderedTargets.count) explicit recipients?", isPresented: $confirming, titleVisibility: .visible) {
+            Button("Send") {
+                store.broadcast(targetKeys: orderedTargets, text: text)
+                isPresented = false
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .accessibilityIdentifier("fleet.broadcast.form")
     }
 }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -72,6 +72,247 @@ final class FleetConnectionTests: XCTestCase {
         )
     }
 
+    func testOldCatalogueRefusesReceiptReadsAndStart() {
+        let oldCatalogue = FleetNegotiateResult(
+            daemonVersion: "fixture-daemon-0.9.0",
+            protocolVersion: 1,
+            readCompatible: true,
+            writeCompatible: true,
+            capabilityIDs: ["fleet.snapshot.read", "fleet.action.execute"]
+        )
+
+        XCTAssertThrowsError(try FleetConnection.validateCapability("fleet.receipt.read", in: oldCatalogue)) {
+            XCTAssertEqual($0 as? FleetConnectionError, .missingNegotiatedCapability("fleet.receipt.read"))
+        }
+        XCTAssertThrowsError(try FleetConnection.validateCapability("fleet.start.execute", in: oldCatalogue)) {
+            XCTAssertEqual($0 as? FleetConnectionError, .missingNegotiatedCapability("fleet.start.execute"))
+        }
+    }
+
+    func testOldCatalogueRefusesReceiptAndStartBeforeWireIO() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let clientDescriptor = descriptors[0]
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+        let serverDone = expectation(description: "old catalogue server finished")
+        let serverResult = SocketServerResult()
+
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                let authentication = try Self.readRequest(from: serverDescriptor)
+                try Self.writeResponse(to: serverDescriptor, request: authentication, result: [:])
+                let negotiation = try Self.readRequest(from: serverDescriptor)
+                try Self.writeResponse(to: serverDescriptor, request: negotiation, result: [
+                    "daemon_version": "old-daemon",
+                    "protocol_version": 1,
+                    "read_compatible": true,
+                    "write_compatible": true,
+                    "capability_ids": ["fleet.snapshot.read"],
+                ])
+                var pollDescriptor = pollfd(fd: serverDescriptor, events: Int16(POLLIN), revents: 0)
+                if Darwin.poll(&pollDescriptor, 1, 200) > 0 {
+                    throw StoreServerError.closed
+                }
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: clientDescriptor
+        )
+        try await connection.connect()
+        defer { Task { await connection.close() } }
+        try await connection.authenticate(token: "mdt_test")
+        _ = try await connection.negotiate()
+
+        do {
+            _ = try await connection.receiptList(FleetReceiptListParams(limit: 1))
+            XCTFail("old catalogue must refuse receipt reads")
+        } catch let error as FleetConnectionError {
+            XCTAssertEqual(error, .missingNegotiatedCapability("fleet.receipt.read"))
+        }
+        do {
+            _ = try await connection.start(FleetStartParams(requestID: "request", provider: .codex, cwd: "/tmp", prompt: nil))
+            XCTFail("old catalogue must refuse fleet/start")
+        } catch let error as FleetConnectionError {
+            XCTAssertEqual(error, .missingNegotiatedCapability("fleet.start.execute"))
+        }
+        await fulfillment(of: [serverDone], timeout: 1)
+        try serverResult.throwIfRecorded()
+    }
+
+    func testTmuxTextCapabilityAllowsPromptAndBroadcastTarget() {
+        let capabilities = FleetCapabilities(
+            structuredAnswer: false, approvals: false, sendPrompt: false, continueTurn: false,
+            retry: false, interrupt: false, start: false, stop: false, restart: false,
+            kill: false, archive: false, tmuxAttach: false, tmuxText: true, verifiedPicker: false
+        )
+
+        XCTAssertTrue(FleetOperatorAction.sendPrompt.isAvailable(in: capabilities))
+    }
+
+    @MainActor
+    func testBroadcastReceiptMergePreservesDaemonInputOrder() {
+        let existing = [receipt("old")]
+        let daemonOrder = [receipt("first"), receipt("second")]
+
+        XCTAssertEqual(FleetStore.mergedReceipts(daemonOrder, existing: existing).map(\.requestID), ["first", "second", "old"])
+    }
+
+    func testStartCWDPreflightRequiresExistingDirectory() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let file = root.appendingPathComponent("file")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data().write(to: file)
+
+        XCTAssertTrue(FleetStartPreflight.isExistingDirectory(root.path))
+        XCTAssertFalse(FleetStartPreflight.isExistingDirectory(file.path))
+        XCTAssertFalse(FleetStartPreflight.isExistingDirectory(root.appendingPathComponent("missing").path))
+    }
+
+    func testUnavailablePromptNeverWritesActionWire() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let releasePoll = DispatchSemaphore(value: 0)
+        let serverDone = expectation(description: "prompt refusal server finished")
+        let serverResult = SocketServerResult()
+
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                let authentication = try Self.readRequest(from: serverDescriptor)
+                try Self.writeResponse(to: serverDescriptor, request: authentication, result: [:])
+                let negotiation = try Self.readRequest(from: serverDescriptor)
+                try Self.writeResponse(to: serverDescriptor, request: negotiation, result: [
+                    "daemon_version": "fixture-daemon",
+                    "protocol_version": 1,
+                    "read_compatible": true,
+                    "write_compatible": true,
+                    "capability_ids": ["fleet.action.execute"],
+                ])
+                let subscription = try Self.readRequest(from: serverDescriptor)
+                try Self.writeResponse(to: serverDescriptor, request: subscription, result: [
+                    "snapshot": try Self.snapshotObject(head: 1, sessions: [try Self.sampleSessionObject(head: 1)]),
+                    "replay": [],
+                    "replay_state": ["state": "complete"],
+                ])
+                _ = releasePoll.wait(timeout: .now() + 1)
+                var pollDescriptor = pollfd(fd: serverDescriptor, events: Int16(POLLIN), revents: 0)
+                if Darwin.poll(&pollDescriptor, 1, 200) > 0 {
+                    throw StoreServerError.closed
+                }
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: { _ in FleetConnection(location: location, injectedDescriptor: descriptors[0]) },
+                reconnectDelayNanoseconds: { _ in 10_000_000_000 }
+            )
+        }
+        await MainActor.run { store.start() }
+        let live = await Self.waitUntil {
+            await MainActor.run {
+                guard case .live = store.connectionState else { return false }
+                return store.sessions.count == 1
+            }
+        }
+        XCTAssertTrue(live)
+        await MainActor.run {
+            let session = store.sessions[0]
+            store.selectedSessionKey = session.sessionKey
+            XCTAssertFalse(store.canSendPrompt("hello", on: session))
+            store.perform(.sendPrompt, on: session, prompt: "hello")
+        }
+        releasePoll.signal()
+        await fulfillment(of: [serverDone], timeout: 1)
+        try serverResult.throwIfRecorded()
+        await MainActor.run { store.stop() }
+    }
+
+    func testReconnectReloadsReceiptsBeforeReturningLive() async throws {
+        var first = [Int32](repeating: 0, count: 2)
+        var second = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &first), 0)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &second), 0)
+        let firstServer = first[1]
+        let secondServer = second[1]
+        defer {
+            Darwin.close(firstServer)
+            Darwin.close(secondServer)
+        }
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let factory = TestConnectionFactory(descriptors: [first[0], second[0]], location: location)
+        let store = await MainActor.run {
+            FleetStore(location: location, makeConnection: factory.make, reconnectDelayNanoseconds: { _ in 0 })
+        }
+        let firstDone = expectation(description: "first receipt server finished")
+        let secondReady = expectation(description: "second receipt server ready")
+        let releaseSecond = DispatchSemaphore(value: 0)
+        let serverResult = SocketServerResult()
+
+        DispatchQueue.global().async {
+            defer { firstDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: firstServer,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 1, sessions: [try Self.sampleSessionObject(head: 1)]),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 1, sessions: [try Self.sampleSessionObject(head: 1)]),
+                    capabilityIDs: ["fleet.receipt.read"],
+                    receiptList: [try Self.receiptObject(requestID: "first")]
+                )
+                Darwin.shutdown(firstServer, SHUT_RDWR)
+            } catch {
+                serverResult.record(error)
+            }
+        }
+        DispatchQueue.global().async {
+            defer { Darwin.shutdown(secondServer, SHUT_RDWR) }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: secondServer,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 1, sessions: [try Self.sampleSessionObject(head: 1)]),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 1, sessions: [try Self.sampleSessionObject(head: 1)]),
+                    capabilityIDs: ["fleet.receipt.read"],
+                    receiptList: [try Self.receiptObject(requestID: "second")]
+                )
+                secondReady.fulfill()
+                _ = releaseSecond.wait(timeout: .now() + 2)
+            } catch {
+                serverResult.record(error)
+                secondReady.fulfill()
+            }
+        }
+
+        await MainActor.run { store.start() }
+        await fulfillment(of: [firstDone, secondReady], timeout: 2)
+        let reloaded = await Self.waitUntil {
+            await MainActor.run {
+                guard case .live = store.connectionState else { return false }
+                return factory.count == 2 && store.receipts.map(\.requestID) == ["second"]
+            }
+        }
+        await MainActor.run { store.stop() }
+        releaseSecond.signal()
+        try serverResult.throwIfRecorded()
+        XCTAssertTrue(reloaded, "reconnect must reload durable receipts before Fleet becomes live")
+    }
+
     func testResyncNotificationStreamsThroughOwnedSocket() async throws {
         var descriptors = [Int32](repeating: 0, count: 2)
         XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
@@ -360,6 +601,22 @@ final class FleetConnectionTests: XCTestCase {
         }
     }
 
+    private func receipt(_ requestID: String) -> FleetActionReceipt {
+        FleetActionReceipt(
+            requestID: requestID,
+            sessionKey: "session-\(requestID)",
+            actionKind: "send_prompt",
+            actionFingerprint: "fingerprint-\(requestID)",
+            expectedVersion: 1,
+            idempotencyKey: nil,
+            status: .pending,
+            detail: nil,
+            sessionVersion: nil,
+            createdAt: 1,
+            updatedAt: 1
+        )
+    }
+
     private static func testLocation() throws -> HangarLocation {
         let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let tokenDirectory = home.appendingPathComponent("hangar", isDirectory: true)
@@ -375,7 +632,9 @@ final class FleetConnectionTests: XCTestCase {
         snapshotAfterEvent: Any?,
         subscriptionReplay: [Any] = [],
         replayState: [String: Any] = ["state": "complete"],
-        resyncAfterSubscription: Bool = false
+        resyncAfterSubscription: Bool = false,
+        capabilityIDs: [String] = [],
+        receiptList: [Any] = []
     ) throws {
         let authentication = try readRequest(from: descriptor)
         try writeResponse(to: descriptor, request: authentication, result: [:])
@@ -386,7 +645,7 @@ final class FleetConnectionTests: XCTestCase {
             "protocol_version": 1,
             "read_compatible": true,
             "write_compatible": true,
-            "capability_ids": [],
+            "capability_ids": capabilityIDs,
         ])
 
         let subscription = try readRequest(from: descriptor)
@@ -399,6 +658,11 @@ final class FleetConnectionTests: XCTestCase {
             "replay": subscriptionReplay,
             "replay_state": replayState,
         ])
+        if capabilityIDs.contains("fleet.receipt.read") {
+            let receiptRequest = try readRequest(from: descriptor)
+            XCTAssertEqual(receiptRequest["method"] as? String, "fleet/receipt_list")
+            try writeResponse(to: descriptor, request: receiptRequest, result: ["receipts": receiptList])
+        }
         if resyncAfterSubscription {
             try writeNotification(
                 to: descriptor,
@@ -448,6 +712,23 @@ final class FleetConnectionTests: XCTestCase {
             throw StoreServerError.closed
         }
         return session
+    }
+
+    private static func receiptObject(requestID: String) throws -> Any {
+        let receipt = FleetActionReceipt(
+            requestID: requestID,
+            sessionKey: "s1",
+            actionKind: "send_prompt",
+            actionFingerprint: "fingerprint-\(requestID)",
+            expectedVersion: 3,
+            idempotencyKey: nil,
+            status: .pending,
+            detail: nil,
+            sessionVersion: nil,
+            createdAt: 1,
+            updatedAt: 1
+        )
+        return try JSONSerialization.jsonObject(with: FleetWire.encoder().encode(receipt))
     }
 
     private static func eventObject(revision: Int64) throws -> Any {

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/WindowAndSwitcherJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/WindowAndSwitcherJourneyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 
 final class WindowAndSwitcherJourneyTests: FleetUITestCase {
@@ -28,5 +29,169 @@ final class WindowAndSwitcherJourneyTests: FleetUITestCase {
         try fixture.seed(eventID: "alpha-attention", sessionID: "alpha", eventType: "AskUserQuestion", observedAt: 1_700_000_000_003)
         waitFor(fleetRow("claude:alpha"))
         XCTAssertTrue(fleetDetail("codex:beta").exists, "live reorder must retain selection by session key")
+    }
+
+    @MainActor
+    func testRealDaemonDeliversOnePromptThroughExactTmuxAndShowsReceipt() throws {
+        let target = try FleetExactTmuxSession()
+        defer { target.stop() }
+        try fixture.seed(
+            eventID: "live-session",
+            sessionID: "live-session",
+            eventType: "SessionStart",
+            payload: target.hookPayload,
+            observedAt: 1_700_000_000_001
+        )
+        launchFleetWindow()
+
+        let row = fleetRow("claude:live-session")
+        waitFor(row)
+        row.click()
+        waitFor(fleetDetail("claude:live-session"))
+
+        let prompt = app.textFields["fleet.control.prompt"]
+        waitFor(prompt)
+        prompt.click()
+        prompt.typeText("AFM-E03-ONE-DELIVERY")
+        let send = app.buttons["fleet.control.Send prompt"]
+        waitFor(send)
+        send.click()
+        send.click()
+
+        XCTAssertTrue(target.waitForText("AFM-E03-ONE-DELIVERY", count: 1), target.capture())
+
+        selectToolbarItem("Receipts")
+        let receipts = app.staticTexts["fleet.receipts.list"]
+        waitFor(receipts)
+        let delivered = app.staticTexts.matching(NSPredicate(format: "value CONTAINS %@", "tmux (")).firstMatch
+        waitFor(delivered)
+        XCTAssertTrue((delivered.label as String).contains("send_prompt"), app.debugDescription)
+    }
+
+    @MainActor
+    func testRealDaemonStartAndBroadcastPreserveDaemonReceiptTruth() throws {
+        let delivered = try FleetExactTmuxSession()
+        defer { delivered.stop() }
+        try fixture.seed(
+            eventID: "broadcast-delivered",
+            sessionID: "broadcast-delivered",
+            eventType: "SessionStart",
+            payload: delivered.hookPayload,
+            observedAt: 1_700_000_000_001
+        )
+        try fixture.seed(
+            eventID: "broadcast-stale",
+            sessionID: "broadcast-stale",
+            eventType: "SessionStart",
+            payload: [
+                "tmux_target": "afm-e03-stale:0.0",
+                "process_start_fingerprint": "pane=%999;pid=999;session_started=1",
+            ],
+            observedAt: 1_700_000_000_002
+        )
+        launchFleetWindow()
+        waitFor(fleetRow("claude:broadcast-delivered"))
+        waitFor(fleetRow("claude:broadcast-stale"))
+
+        selectToolbarItem("Start")
+        let start = app.otherElements["fleet.start.form"]
+        waitFor(start)
+        let cwd = app.textFields["Working directory"]
+        waitFor(cwd)
+        cwd.click()
+        cwd.typeKey("a", modifierFlags: .command)
+        cwd.typeText("/definitely/not/a/directory")
+        XCTAssertFalse(app.buttons["fleet.start.submit"].isEnabled)
+        cwd.click()
+        cwd.typeKey("a", modifierFlags: .command)
+        cwd.typeText(FileManager.default.temporaryDirectory.path)
+        app.buttons["fleet.start.submit"].click()
+        let prospective = app.staticTexts.matching(NSPredicate(format: "value BEGINSWITH %@", "start:codex:")).firstMatch
+        waitFor(prospective)
+        XCTAssertTrue(app.staticTexts["UNKNOWN"].exists, app.debugDescription)
+        app.buttons["Cancel"].click()
+
+        selectToolbarItem("Broadcast")
+        let broadcast = app.otherElements["fleet.broadcast.form"]
+        waitFor(broadcast)
+        let message = app.textFields["Message"]
+        waitFor(message)
+        message.click()
+        message.typeText("AFM-E03-BROADCAST")
+        for key in ["claude:broadcast-delivered", "claude:broadcast-stale"] {
+            let recipient = app.checkBoxes[key]
+            waitFor(recipient)
+            recipient.click()
+        }
+        app.buttons["Review broadcast"].click()
+        let send = app.buttons["Send"]
+        waitFor(send)
+        send.click()
+        XCTAssertTrue(delivered.waitForText("AFM-E03-BROADCAST", count: 1), delivered.capture())
+
+        selectToolbarItem("Receipts")
+        let receipts = app.staticTexts["fleet.receipts.list"]
+        waitFor(receipts)
+        let received = app.staticTexts.matching(NSPredicate(format: "value CONTAINS %@", "tmux (")).firstMatch
+        waitFor(received)
+        let failed = app.staticTexts.matching(NSPredicate(format: "value CONTAINS %@", "identity changed")).firstMatch
+        waitFor(failed)
+    }
+}
+
+private final class FleetExactTmuxSession {
+    private let session = "afm-e03-claude-\(UUID().uuidString.prefix(8).lowercased())"
+
+    init() throws {
+        try run("new-session", "-d", "-s", session, "-c", FileManager.default.temporaryDirectory.path, "--", "/bin/sh", "-c", "printf 'AFM-E03-READY\\n'; while IFS= read -r line; do printf 'AFM-E03-RECEIVED:%s\\n' \"$line\"; done")
+        _ = capture()
+    }
+
+    deinit { stop() }
+
+    var hookPayload: [String: Any] {
+        let fields = try! run("list-panes", "-t", session, "-F", "#{session_name}:#{window_index}.#{pane_index}\\t#{pane_id}\\t#{pane_pid}\\t#{session_created}")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\\t", omittingEmptySubsequences: false)
+        precondition(fields.count == 4, "unexpected tmux identity")
+        return [
+            "tmux_target": String(fields[0]),
+            "process_start_fingerprint": "pane=\(fields[1]);pid=\(fields[2]);session_started=\(fields[3])",
+        ]
+    }
+
+    func capture() -> String {
+        (try? run("capture-pane", "-p", "-t", "\(session):0.0")) ?? "unable to capture \(session)"
+    }
+
+    func waitForText(_ text: String, count: Int) -> Bool {
+        let deadline = Date().addingTimeInterval(8)
+        while Date() < deadline {
+            if capture().components(separatedBy: text).count - 1 == count { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return false
+    }
+
+    func stop() {
+        _ = try? run("kill-session", "-t", session)
+    }
+
+    @discardableResult
+    private func run(_ arguments: String...) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tmux")
+        process.arguments = arguments
+        let output = Pipe()
+        let error = Pipe()
+        process.standardOutput = output
+        process.standardError = error
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let message = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "tmux failed"
+            throw NSError(domain: "FleetExactTmuxSession", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        return String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
     }
 }


### PR DESCRIPTION
## Summary
- Add negotiated receipt reads and daemon-owned session start.
- Add safe native action, broadcast, receipt, and Start controls.
- Preserve daemon authority, typed capability gates, idempotency, and exact receipt truth.

## Verification
- `cargo test -p ainb-hangar-daemon --test rpc_fleet`: 8 passed.
- Swift RPC suite: 62 passed.
- Exact disposable tmux delivery probe: 3 of 3 passed.
- `xcodebuild build-for-testing` passed.

## Verification limitation
macOS denied XCTest automation mode before any UI test body ran. Direct XCUI action/control proof is marked UNVERIFIABLE, not passed. Parity ledger records blocked proof honestly.