### PR TITLE
feat(fleet): add read-only ATC panel

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -245,6 +245,7 @@ heartbeat falls back to the local timer"
         heartbeat_cron: Some(heartbeat_cron_for_interval(meta.heartbeat_interval_min)),
         err_retry_cap: None,
         idle_pause_min: Some(i64::from(meta.idle_pause_min)),
+        expected_generation: None,
     };
     match client.atc_register(params).await {
         Ok(_) => true,
@@ -282,6 +283,7 @@ the instance row is left as-is"
     match client
         .atc_unregister(AtcUnregisterParams {
             name: name.to_string(),
+            expected_generation: None,
         })
         .await
     {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/atc.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/atc.rs
@@ -203,8 +203,30 @@ impl AtcHeartbeatScheduler {
                 () = tokio::time::sleep(delay) => {}
             }
             if let Some(inst) = fire_target {
-                self.fire(&inst).await;
-                self.reschedule(&inst).await;
+                let due_tick_at = inst.next_tick_at.expect("schedulable rows have a due tick");
+                match AtcInstanceRepo::claim_due(
+                    &self.pool,
+                    &inst.name,
+                    inst.config_generation,
+                    due_tick_at,
+                )
+                .await
+                {
+                    Ok(true) => {
+                        let fired_at = self.fire(&inst).await;
+                        self.reschedule(&inst, fired_at).await;
+                    }
+                    Ok(false) => tracing::debug!(
+                        instance = %inst.name,
+                        generation = inst.config_generation,
+                        "ATC heartbeat claim invalidated by a configuration mutation"
+                    ),
+                    Err(error) => tracing::error!(
+                        instance = %inst.name,
+                        error = %error,
+                        "ATC heartbeat claim failed"
+                    ),
+                }
             }
         }
         tracing::info!("ATC heartbeat cron stopped");
@@ -217,7 +239,7 @@ impl AtcHeartbeatScheduler {
     ///
     /// Non-fatal end to end: an unspawned instance (no tmux target) or a send
     /// fault is warned and skipped, never a panic.
-    async fn fire(&self, inst: &AtcInstanceRow) {
+    async fn fire(&self, inst: &AtcInstanceRow) -> i64 {
         let now = self.clock.now_ms();
         let rows = probe_fleet_needs(now).await;
 
@@ -246,7 +268,7 @@ impl AtcHeartbeatScheduler {
             tracing::debug!(instance = %inst.name, "ATC heartbeat: no tmux target; nudge not sent");
         }
 
-        let _ = AtcInstanceRepo::mark_heartbeat(&self.pool, &inst.name, now).await;
+        now
     }
 
     /// Apply the retry-cap decision for ONE ERR session of an instance.
@@ -301,11 +323,29 @@ impl AtcHeartbeatScheduler {
     }
 
     /// Recompute + persist the instance's next heartbeat tick from the fired slot.
-    async fn reschedule(&self, inst: &AtcInstanceRow) {
+    async fn reschedule(&self, inst: &AtcInstanceRow, fired_at: i64) {
         let next =
             recompute_next_tick(&inst.heartbeat_cron, inst.next_tick_at, self.clock.now_ms());
-        if let Err(e) = AtcInstanceRepo::set_next_tick(&self.pool, &inst.name, next).await {
-            tracing::error!(instance = %inst.name, error = %e, "ATC heartbeat reschedule failed");
+        match AtcInstanceRepo::complete_claim(
+            &self.pool,
+            &inst.name,
+            inst.config_generation,
+            next,
+            fired_at,
+        )
+        .await
+        {
+            Ok(true) => {}
+            Ok(false) => tracing::debug!(
+                instance = %inst.name,
+                generation = inst.config_generation,
+                "ATC heartbeat completion invalidated by a configuration mutation"
+            ),
+            Err(error) => tracing::error!(
+                instance = %inst.name,
+                error = %error,
+                "ATC heartbeat reschedule failed"
+            ),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -6823,11 +6823,11 @@ async fn handle_atc_register(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    use ainb_hangar_store::repo::atc_instance::{AtcInstanceRepo, RegisterAtc};
+    use ainb_hangar_store::repo::atc_instance::{AtcInstanceRepo, RegisterAtc, RegisterAtcOutcome};
 
     let params: ainb_hangar_proto::snapshots::AtcRegisterParams = parse_params(
         req,
-        "{ name, cwd?, tmux_session?, heartbeat_cron?, err_retry_cap?, idle_pause_min? }",
+        "{ name, cwd?, tmux_session?, heartbeat_cron?, err_retry_cap?, idle_pause_min?, expected_generation? }",
     )?;
     if params.name.trim().is_empty() {
         return Err(invalid_params("atc instance name must not be empty"));
@@ -6851,10 +6851,31 @@ async fn handle_atc_register(
         idle_pause_min: params.idle_pause_min.unwrap_or(60),
         next_tick_at,
     };
-    AtcInstanceRepo::register(pool, &reg, now_ms).await.map_err(|e| store_err(&e))?;
+    let outcome = AtcInstanceRepo::register_checked(pool, &reg, now_ms, params.expected_generation)
+        .await
+        .map_err(|e| store_err(&e))?;
+    let (row, status) = match outcome {
+        RegisterAtcOutcome::Applied(row) => (
+            row,
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Applied,
+        ),
+        RegisterAtcOutcome::AlreadyApplied(row) => (
+            row,
+            ainb_hangar_proto::snapshots::AtcMutationStatus::AlreadyApplied,
+        ),
+        RegisterAtcOutcome::Stale(Some(row)) => {
+            (row, ainb_hangar_proto::snapshots::AtcMutationStatus::Stale)
+        }
+        RegisterAtcOutcome::Stale(None) => {
+            return Err(invalid_params("atc configuration generation is stale"));
+        }
+    };
     to_value(&ainb_hangar_proto::snapshots::AtcRegisterResult {
-        name: reg.name,
-        next_tick_at,
+        name: row.name,
+        next_tick_at: row.next_tick_at,
+        config_generation: row.config_generation,
+        status,
+        scheduler_ownership: atc_scheduler_ownership(),
     })
 }
 
@@ -6878,9 +6899,13 @@ async fn handle_atc_list(pool: &SqlitePool) -> Result<serde_json::Value, RpcErro
             next_tick_at: r.next_tick_at,
             enabled: r.enabled,
             last_heartbeat_at: r.last_heartbeat_at,
+            config_generation: r.config_generation,
         })
         .collect();
-    to_value(&ainb_hangar_proto::snapshots::AtcListResult { instances })
+    to_value(&ainb_hangar_proto::snapshots::AtcListResult {
+        instances,
+        scheduler_ownership: atc_scheduler_ownership(),
+    })
 }
 
 /// Dispatch `atc/escalate` (spec P9, D12): raise an ATC escalation as an
@@ -7095,25 +7120,53 @@ async fn handle_atc_unregister(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    use ainb_hangar_store::repo::atc_instance::AtcInstanceRepo;
+    use ainb_hangar_store::repo::atc_instance::{AtcInstanceRepo, DisableAtcOutcome};
 
-    let params: ainb_hangar_proto::snapshots::AtcUnregisterParams = parse_params(req, "{ name }")?;
+    let params: ainb_hangar_proto::snapshots::AtcUnregisterParams =
+        parse_params(req, "{ name, expected_generation? }")?;
     let name = params.name.trim();
     if name.is_empty() {
         return Err(invalid_params("atc instance name must not be empty"));
     }
-    // Only a registered instance is disabled; an unknown name is a clean no-op so
-    // teardown is safe to fire unconditionally.
-    let disabled = AtcInstanceRepo::get(pool, name).await.map_err(|e| store_err(&e))?.is_some();
-    if disabled {
-        AtcInstanceRepo::set_enabled(pool, name, false, None)
-            .await
-            .map_err(|e| store_err(&e))?;
-    }
+    let outcome = AtcInstanceRepo::disable_checked(pool, name, params.expected_generation)
+        .await
+        .map_err(|e| store_err(&e))?;
+    let (disabled, config_generation, status) = match outcome {
+        DisableAtcOutcome::Applied(row) => (
+            true,
+            Some(row.config_generation),
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Applied,
+        ),
+        DisableAtcOutcome::AlreadyApplied(row) => (
+            true,
+            Some(row.config_generation),
+            ainb_hangar_proto::snapshots::AtcMutationStatus::AlreadyApplied,
+        ),
+        DisableAtcOutcome::NotFound => (
+            false,
+            None,
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Applied,
+        ),
+        DisableAtcOutcome::Stale(row) => (
+            false,
+            Some(row.config_generation),
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Stale,
+        ),
+    };
     to_value(&ainb_hangar_proto::snapshots::AtcUnregisterResult {
         name: name.to_string(),
         disabled,
+        config_generation,
+        status,
+        scheduler_ownership: atc_scheduler_ownership(),
     })
+}
+
+/// E04 deliberately withholds the mutation capability until the legacy
+/// launchd/systemd lifecycle is moved below both core and daemon. The daemon
+/// exposes this fact rather than guessing from files it does not own.
+const fn atc_scheduler_ownership() -> ainb_hangar_proto::snapshots::AtcSchedulerOwnership {
+    ainb_hangar_proto::snapshots::AtcSchedulerOwnership::LegacyTimerReconciliationRequired
 }
 
 /// Build the [`DaemonHealthSnapshot`] for the `hangar/daemon_health` pane (P8.5).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_atc.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_atc.rs
@@ -323,3 +323,65 @@ async fn atc_register_rejects_an_invalid_cron() {
         "an unparseable heartbeat cron is a client error: {resp}"
     );
 }
+
+#[tokio::test]
+async fn atc_generation_retry_is_idempotent_and_conflicts_are_typed() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, _store) = start_server(dir.path()).await;
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+
+    let created = client
+        .call(
+            methods::ATC_REGISTER,
+            serde_json::json!({ "name": "main", "expected_generation": 0 }),
+        )
+        .await;
+    assert_eq!(created["result"]["status"], "applied");
+    assert_eq!(created["result"]["config_generation"], 1);
+
+    let changed = client
+        .call(
+            methods::ATC_REGISTER,
+            serde_json::json!({
+                "name": "main",
+                "heartbeat_cron": "*/5 * * * *",
+                "expected_generation": 1
+            }),
+        )
+        .await;
+    assert_eq!(changed["result"]["status"], "applied");
+    assert_eq!(changed["result"]["config_generation"], 2);
+
+    let retry = client
+        .call(
+            methods::ATC_REGISTER,
+            serde_json::json!({
+                "name": "main",
+                "heartbeat_cron": "*/5 * * * *",
+                "expected_generation": 1
+            }),
+        )
+        .await;
+    assert_eq!(retry["result"]["status"], "already_applied");
+    assert_eq!(retry["result"]["config_generation"], 2);
+
+    let conflict = client
+        .call(
+            methods::ATC_REGISTER,
+            serde_json::json!({
+                "name": "main",
+                "heartbeat_cron": "*/10 * * * *",
+                "expected_generation": 1
+            }),
+        )
+        .await;
+    assert_eq!(conflict["result"]["status"], "stale");
+    assert_eq!(conflict["result"]["config_generation"], 2);
+
+    let list = client.call(methods::ATC_LIST, serde_json::json!({})).await;
+    assert_eq!(
+        list["result"]["scheduler_ownership"],
+        "legacy_timer_reconciliation_required"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -16,10 +16,13 @@ pub const FLEET_CAPABILITY_BROADCAST_EXECUTE: &str = "fleet.broadcast.execute";
 pub const FLEET_CAPABILITY_RECEIPT_READ: &str = "fleet.receipt.read";
 /// Negotiated capability required for daemon-owned new-session starts.
 pub const FLEET_CAPABILITY_START_EXECUTE: &str = "fleet.start.execute";
+/// Negotiated capability for daemon-owned ATC read projections.
+pub const FLEET_CAPABILITY_ATC_READ: &str = "fleet.atc.read";
 
 /// Fleet capability identifiers advertised during protocol negotiation.
 pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
     FLEET_CAPABILITY_ACTION_EXECUTE,
+    FLEET_CAPABILITY_ATC_READ,
     FLEET_CAPABILITY_BROADCAST_EXECUTE,
     "fleet.protocol.negotiate",
     FLEET_CAPABILITY_RECEIPT_READ,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -550,6 +550,31 @@ pub struct AtcRegisterParams {
     /// The idle-pause threshold in minutes; `None` uses the daemon default (60).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idle_pause_min: Option<i64>,
+    /// Configuration generation read from the daemon. Omitted only for legacy
+    /// CLI compatibility; negotiated clients must send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_generation: Option<i64>,
+}
+
+/// Authoritative scheduler ownership state. Mutation stays unavailable until
+/// reconciliation proves the daemon is the only heartbeat scheduler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AtcSchedulerOwnership {
+    /// Existing launchd/systemd timer files have not been reconciled safely.
+    LegacyTimerReconciliationRequired,
+}
+
+/// Result state for a generation-checked mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AtcMutationStatus {
+    /// The requested mutation was written.
+    Applied,
+    /// A matching lost-response retry found the already-written mutation.
+    AlreadyApplied,
+    /// Another configuration won; `config_generation` is current.
+    Stale,
 }
 
 /// Result of [`crate::methods::ATC_REGISTER`]: the persisted instance name + its
@@ -561,6 +586,12 @@ pub struct AtcRegisterResult {
     pub name: String,
     /// The cached next heartbeat instant (epoch-ms), or `None`.
     pub next_tick_at: Option<i64>,
+    /// Current durable configuration generation.
+    pub config_generation: i64,
+    /// Whether the requested conditional mutation applied.
+    pub status: AtcMutationStatus,
+    /// Scheduler ownership exposed so clients fail closed for mutation.
+    pub scheduler_ownership: AtcSchedulerOwnership,
 }
 
 /// One registered ATC instance in the [`crate::methods::ATC_LIST`] result.
@@ -584,6 +615,8 @@ pub struct AtcInstanceWire {
     pub enabled: bool,
     /// Epoch-ms of the last fired heartbeat, or `None`.
     pub last_heartbeat_at: Option<i64>,
+    /// Current durable configuration generation for conditional mutation.
+    pub config_generation: i64,
 }
 
 /// Result of [`crate::methods::ATC_LIST`]: every registered ATC instance,
@@ -592,6 +625,8 @@ pub struct AtcInstanceWire {
 pub struct AtcListResult {
     /// The registered instances.
     pub instances: Vec<AtcInstanceWire>,
+    /// Global ownership fact, not inferred by clients from local timer files.
+    pub scheduler_ownership: AtcSchedulerOwnership,
 }
 
 /// Params for [`crate::methods::ATC_ESCALATE`] (spec P9, D12): raise an ATC
@@ -626,6 +661,10 @@ pub struct AtcEscalateResult {
 pub struct AtcUnregisterParams {
     /// The sanitized instance name to disable.
     pub name: String,
+    /// Configuration generation read from the daemon. Omitted only for legacy
+    /// CLI compatibility; negotiated clients must send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_generation: Option<i64>,
 }
 
 /// Result of [`crate::methods::ATC_UNREGISTER`]: the instance name and whether it
@@ -637,6 +676,12 @@ pub struct AtcUnregisterResult {
     pub name: String,
     /// `true` when a registered instance was disabled; `false` for an unknown name.
     pub disabled: bool,
+    /// Current durable configuration generation, or `None` when unknown.
+    pub config_generation: Option<i64>,
+    /// Conditional mutation result.
+    pub status: AtcMutationStatus,
+    /// Scheduler ownership exposed so clients fail closed for mutation.
+    pub scheduler_ownership: AtcSchedulerOwnership,
 }
 
 /// One indexed profile in the [`crate::methods::PROFILE_LIST`] result (spec P5):

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0057_atc_scheduler_fencing.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0057_atc_scheduler_fencing.sql
@@ -1,0 +1,5 @@
+-- AFM-E04: a configuration mutation must invalidate a due heartbeat that was
+-- read before the mutation. The scheduler claims a specific generation, then
+-- only that generation may complete its reschedule.
+ALTER TABLE atc_instance ADD COLUMN config_generation INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE atc_instance ADD COLUMN scheduler_claim_generation INTEGER;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/atc_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/atc_instance.rs
@@ -34,6 +34,8 @@ pub struct AtcInstanceRow {
     pub last_heartbeat_at: Option<i64>,
     /// Epoch-ms the instance was registered.
     pub created_at: i64,
+    /// Monotonic configuration version. Schedule mutations invalidate old work.
+    pub config_generation: i64,
 }
 
 /// One `atc_retry` ledger row — a (instance, monitored session) pair.
@@ -73,6 +75,30 @@ pub struct RegisterAtc {
     pub next_tick_at: Option<i64>,
 }
 
+/// Result of a generation-checked registration request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegisterAtcOutcome {
+    /// The requested configuration was written.
+    Applied(AtcInstanceRow),
+    /// A lost-response retry found the same already-applied configuration.
+    AlreadyApplied(AtcInstanceRow),
+    /// Another operator changed the configuration first.
+    Stale(Option<AtcInstanceRow>),
+}
+
+/// Result of a generation-checked disable request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisableAtcOutcome {
+    /// The instance was disabled.
+    Applied(AtcInstanceRow),
+    /// A lost-response retry found the same disabled result.
+    AlreadyApplied(AtcInstanceRow),
+    /// No instance exists with this name.
+    NotFound,
+    /// Another operator changed the configuration first.
+    Stale(AtcInstanceRow),
+}
+
 /// Stateless typed wrapper over the `atc_instance` + `atc_retry` tables.
 pub struct AtcInstanceRepo;
 
@@ -100,7 +126,8 @@ impl AtcInstanceRepo {
                  cwd = excluded.cwd, tmux_session = excluded.tmux_session, \
                  heartbeat_cron = excluded.heartbeat_cron, err_retry_cap = excluded.err_retry_cap, \
                  idle_pause_min = excluded.idle_pause_min, next_tick_at = excluded.next_tick_at, \
-                 enabled = 1",
+                 enabled = 1, config_generation = config_generation + 1, \
+                 scheduler_claim_generation = NULL",
         )
         .bind(&req.name)
         .bind(&req.cwd)
@@ -113,6 +140,131 @@ impl AtcInstanceRepo {
         .execute(pool)
         .await?;
         Ok(())
+    }
+
+    /// Register with optimistic concurrency when `expected_generation` is
+    /// supplied. `None` preserves the legacy CLI contract while negotiated
+    /// clients use the typed conditional path.
+    pub async fn register_checked(
+        pool: &SqlitePool,
+        req: &RegisterAtc,
+        now_ms: i64,
+        expected_generation: Option<i64>,
+    ) -> Result<RegisterAtcOutcome, sqlx::Error> {
+        let Some(expected) = expected_generation else {
+            Self::register(pool, req, now_ms).await?;
+            return Ok(RegisterAtcOutcome::Applied(
+                Self::get(pool, &req.name).await?.expect("register creates row"),
+            ));
+        };
+        if expected < 0 {
+            return Ok(RegisterAtcOutcome::Stale(Self::get(pool, &req.name).await?));
+        }
+
+        match Self::get(pool, &req.name).await? {
+            None if expected == 0 => {
+                let inserted = sqlx::query(
+                    "INSERT OR IGNORE INTO atc_instance \
+                     (name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
+                      next_tick_at, enabled, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)",
+                )
+                .bind(&req.name)
+                .bind(&req.cwd)
+                .bind(&req.tmux_session)
+                .bind(&req.heartbeat_cron)
+                .bind(req.err_retry_cap)
+                .bind(req.idle_pause_min)
+                .bind(req.next_tick_at)
+                .bind(now_ms)
+                .execute(pool)
+                .await?;
+                let row = Self::get(pool, &req.name).await?;
+                if inserted.rows_affected() == 1 {
+                    Ok(RegisterAtcOutcome::Applied(
+                        row.expect("inserted row exists"),
+                    ))
+                } else if row.as_ref().is_some_and(|current| desired_matches(current, req)) {
+                    Ok(RegisterAtcOutcome::AlreadyApplied(row.expect("row exists")))
+                } else {
+                    Ok(RegisterAtcOutcome::Stale(row))
+                }
+            }
+            None => Ok(RegisterAtcOutcome::Stale(None)),
+            Some(current) if current.config_generation == expected => {
+                let updated = sqlx::query(
+                    "UPDATE atc_instance SET cwd = ?, tmux_session = ?, heartbeat_cron = ?, \
+                     err_retry_cap = ?, idle_pause_min = ?, next_tick_at = ?, enabled = 1, \
+                     config_generation = config_generation + 1, scheduler_claim_generation = NULL \
+                     WHERE name = ? AND config_generation = ?",
+                )
+                .bind(&req.cwd)
+                .bind(&req.tmux_session)
+                .bind(&req.heartbeat_cron)
+                .bind(req.err_retry_cap)
+                .bind(req.idle_pause_min)
+                .bind(req.next_tick_at)
+                .bind(&req.name)
+                .bind(expected)
+                .execute(pool)
+                .await?;
+                let row = Self::get(pool, &req.name).await?.expect("existing row remains");
+                if updated.rows_affected() == 1 {
+                    Ok(RegisterAtcOutcome::Applied(row))
+                } else if desired_matches(&row, req) {
+                    Ok(RegisterAtcOutcome::AlreadyApplied(row))
+                } else {
+                    Ok(RegisterAtcOutcome::Stale(Some(row)))
+                }
+            }
+            Some(current)
+                if desired_matches(&current, req) && current.config_generation == expected + 1 =>
+            {
+                Ok(RegisterAtcOutcome::AlreadyApplied(current))
+            }
+            Some(current) => Ok(RegisterAtcOutcome::Stale(Some(current))),
+        }
+    }
+
+    /// Disable with optimistic concurrency when `expected_generation` is
+    /// supplied. A retry after a lost response returns the durable disabled row.
+    pub async fn disable_checked(
+        pool: &SqlitePool,
+        name: &str,
+        expected_generation: Option<i64>,
+    ) -> Result<DisableAtcOutcome, sqlx::Error> {
+        let Some(current) = Self::get(pool, name).await? else {
+            return Ok(DisableAtcOutcome::NotFound);
+        };
+        let Some(expected) = expected_generation else {
+            Self::set_enabled(pool, name, false, None).await?;
+            return Ok(DisableAtcOutcome::Applied(
+                Self::get(pool, name).await?.expect("disabled row remains"),
+            ));
+        };
+        if current.config_generation == expected {
+            let updated = sqlx::query(
+                "UPDATE atc_instance SET enabled = 0, next_tick_at = NULL, \
+                 config_generation = config_generation + 1, scheduler_claim_generation = NULL \
+                 WHERE name = ? AND config_generation = ?",
+            )
+            .bind(name)
+            .bind(expected)
+            .execute(pool)
+            .await?;
+            let row = Self::get(pool, name).await?.expect("existing row remains");
+            return if updated.rows_affected() == 1 {
+                Ok(DisableAtcOutcome::Applied(row))
+            } else if !row.enabled && row.config_generation == expected + 1 {
+                Ok(DisableAtcOutcome::AlreadyApplied(row))
+            } else {
+                Ok(DisableAtcOutcome::Stale(row))
+            };
+        }
+        if !current.enabled && current.config_generation == expected + 1 {
+            Ok(DisableAtcOutcome::AlreadyApplied(current))
+        } else {
+            Ok(DisableAtcOutcome::Stale(current))
+        }
     }
 
     /// Fetch one instance by name, `None` when it is not registered.
@@ -133,7 +285,7 @@ impl AtcInstanceRepo {
     pub async fn list(pool: &SqlitePool) -> Result<Vec<AtcInstanceRow>, sqlx::Error> {
         let rows = sqlx::query(
             "SELECT name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
-                    next_tick_at, enabled, last_heartbeat_at, created_at \
+                    next_tick_at, enabled, last_heartbeat_at, created_at, config_generation \
              FROM atc_instance ORDER BY name ASC",
         )
         .fetch_all(pool)
@@ -150,7 +302,7 @@ impl AtcInstanceRepo {
     pub async fn list_schedulable(pool: &SqlitePool) -> Result<Vec<AtcInstanceRow>, sqlx::Error> {
         let rows = sqlx::query(
             "SELECT name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
-                    next_tick_at, enabled, last_heartbeat_at, created_at \
+                    next_tick_at, enabled, last_heartbeat_at, created_at, config_generation \
              FROM atc_instance \
              WHERE enabled = 1 AND next_tick_at IS NOT NULL \
              ORDER BY next_tick_at ASC",
@@ -177,6 +329,53 @@ impl AtcInstanceRepo {
             .execute(pool)
             .await?;
         Ok(())
+    }
+
+    /// Atomically claim one exact due configuration. A later re-register or
+    /// unregister invalidates this claim before the scheduler can reschedule.
+    /// The due tick remains durable while claimed, so a process crash retries it
+    /// rather than silently losing a heartbeat.
+    pub async fn claim_due(
+        pool: &SqlitePool,
+        name: &str,
+        config_generation: i64,
+        due_tick_at: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE atc_instance SET scheduler_claim_generation = config_generation \
+             WHERE name = ? AND enabled = 1 AND config_generation = ? AND next_tick_at = ? \
+             AND (scheduler_claim_generation IS NULL OR scheduler_claim_generation = config_generation)",
+        )
+        .bind(name)
+        .bind(config_generation)
+        .bind(due_tick_at)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Complete a claimed heartbeat only when no config mutation superseded it.
+    pub async fn complete_claim(
+        pool: &SqlitePool,
+        name: &str,
+        config_generation: i64,
+        next_tick_at: Option<i64>,
+        last_heartbeat_at: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE atc_instance \
+             SET next_tick_at = ?, last_heartbeat_at = ?, scheduler_claim_generation = NULL \
+             WHERE name = ? AND enabled = 1 AND config_generation = ? \
+             AND scheduler_claim_generation = ?",
+        )
+        .bind(next_tick_at)
+        .bind(last_heartbeat_at)
+        .bind(name)
+        .bind(config_generation)
+        .bind(config_generation)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
     }
 
     /// Stamp `last_heartbeat_at` after a fired heartbeat.
@@ -210,12 +409,16 @@ impl AtcInstanceRepo {
         enabled: bool,
         next_tick_at: Option<i64>,
     ) -> Result<(), sqlx::Error> {
-        sqlx::query("UPDATE atc_instance SET enabled = ?, next_tick_at = ? WHERE name = ?")
-            .bind(i64::from(enabled))
-            .bind(next_tick_at)
-            .bind(name)
-            .execute(pool)
-            .await?;
+        sqlx::query(
+            "UPDATE atc_instance SET enabled = ?, next_tick_at = ?, \
+             config_generation = config_generation + 1, scheduler_claim_generation = NULL \
+             WHERE name = ?",
+        )
+        .bind(i64::from(enabled))
+        .bind(next_tick_at)
+        .bind(name)
+        .execute(pool)
+        .await?;
         Ok(())
     }
 
@@ -322,7 +525,7 @@ impl AtcInstanceRepo {
 
 /// The single-instance select column list, shared by `get` (needs the `WHERE`).
 const SELECT_INSTANCE_COLS: &str = "SELECT name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
-            next_tick_at, enabled, last_heartbeat_at, created_at \
+            next_tick_at, enabled, last_heartbeat_at, created_at, config_generation \
      FROM atc_instance WHERE name = ?";
 
 /// Map one raw `atc_instance` row into an [`AtcInstanceRow`].
@@ -339,7 +542,17 @@ fn instance_from_sqlite(row: &sqlx::sqlite::SqliteRow) -> AtcInstanceRow {
         enabled: enabled != 0,
         last_heartbeat_at: row.get("last_heartbeat_at"),
         created_at: row.get("created_at"),
+        config_generation: row.get("config_generation"),
     }
+}
+
+fn desired_matches(row: &AtcInstanceRow, req: &RegisterAtc) -> bool {
+    row.enabled
+        && row.cwd == req.cwd
+        && row.tmux_session == req.tmux_session
+        && row.heartbeat_cron == req.heartbeat_cron
+        && row.err_retry_cap == req.err_retry_cap
+        && row.idle_pause_min == req.idle_pause_min
 }
 
 /// Map one raw `atc_retry` row into an [`AtcRetryRow`].
@@ -476,4 +689,41 @@ mod tests {
         assert_eq!(got.last_heartbeat_at, Some(5000));
         assert_eq!(got.next_tick_at, Some(6000));
     }
+
+    #[tokio::test]
+    async fn stale_claim_cannot_restore_a_disabled_schedule() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        AtcInstanceRepo::register(store.pool(), &reg("main", "* * * * *", Some(1000)), 1)
+            .await
+            .unwrap();
+        let row = AtcInstanceRepo::get(store.pool(), "main").await.unwrap().unwrap();
+        assert!(
+            AtcInstanceRepo::claim_due(
+                store.pool(),
+                &row.name,
+                row.config_generation,
+                row.next_tick_at.unwrap(),
+            )
+            .await
+            .unwrap()
+        );
+        AtcInstanceRepo::set_enabled(store.pool(), "main", false, None).await.unwrap();
+        assert!(
+            !AtcInstanceRepo::complete_claim(
+                store.pool(),
+                "main",
+                row.config_generation,
+                Some(2000),
+                1500,
+            )
+            .await
+            .unwrap()
+        );
+        let current = AtcInstanceRepo::get(store.pool(), "main").await.unwrap().unwrap();
+        assert!(!current.enabled);
+        assert_eq!(current.next_tick_at, None);
+        assert!(current.config_generation > row.config_generation);
+    }
+
 }

--- a/ainb-tui/fleet-parity/manifest.json
+++ b/ainb-tui/fleet-parity/manifest.json
@@ -42,6 +42,35 @@
       "release_classification": "deferred_tui"
     },
     {
+      "id": "fleet.atc.read",
+      "tier": "v1",
+      "daemon_request_method": "atc/list",
+      "expected_behavior": "Daemon returns typed ATC schedule facts and explicit scheduler ownership state.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs",
+          "crates/ainb-hangar-daemon/tests/rpc_atc.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; legacy CLI scheduler migration needs separate parity proof."
+      },
+      "swift": {
+        "status": "blocked_proof",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift",
+          "apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift"
+        ],
+        "rationale": "AFM-E04 exposes read-only typed schedule facts. Direct XCUI and isolated booted-daemon proof remain unrun."
+      },
+      "release_classification": "deferred_tui"
+    },
+    {
       "id": "fleet.broadcast.execute",
       "tier": "v1",
       "daemon_request_method": "fleet/broadcast",

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -66,6 +66,8 @@ final class FleetStore: ObservableObject {
     @Published private(set) var connectionState: FleetConnectionState = .connecting
     @Published var selectedSessionKey: String?
     @Published private(set) var receipts: [FleetActionReceipt] = []
+    @Published private(set) var atcInstances: [AtcInstance] = []
+    @Published private(set) var atcSchedulerOwnership: AtcSchedulerOwnership?
     @Published private(set) var pendingIntentID: String?
     @Published private(set) var controlNotice: String?
     @Published private(set) var lastStart: FleetStartResult?
@@ -115,6 +117,10 @@ final class FleetStore: ObservableObject {
 
     var canReadReceipts: Bool {
         connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.receipt.read") == true
+    }
+
+    var canReadATC: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.atc.read") == true
     }
 
     var canStart: Bool {
@@ -297,6 +303,23 @@ final class FleetStore: ObservableObject {
         }
     }
 
+    func refreshATC() {
+        guard canReadATC, let connection else {
+            controlNotice = "ATC reads are unavailable for this daemon."
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let result = try await connection.atcList()
+                atcInstances = result.instances
+                atcSchedulerOwnership = result.schedulerOwnership
+            } catch {
+                controlNotice = "ATC refresh refused: \(String(describing: error))"
+            }
+        }
+    }
+
     private func beginConnection() {
         connectionGeneration &+= 1
         let generation = connectionGeneration
@@ -339,6 +362,14 @@ final class FleetStore: ObservableObject {
             apply(bootstrapped)
             if result.capabilityIDs.contains("fleet.receipt.read") {
                 receipts = try await newConnection.receiptList(FleetReceiptListParams(limit: 50)).receipts
+            }
+            if result.capabilityIDs.contains("fleet.atc.read") {
+                let atc = try await newConnection.atcList()
+                atcInstances = atc.instances
+                atcSchedulerOwnership = atc.schedulerOwnership
+            } else {
+                atcInstances = []
+                atcSchedulerOwnership = nil
             }
             connectionState = .live(daemonVersion: result.daemonVersion, writeCompatible: result.writeCompatible)
             established = true

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -156,6 +156,11 @@ actor FleetConnection {
         return try await request("fleet/receipt_get", params: params, result: FleetReceiptGetResult.self)
     }
 
+    func atcList() async throws -> AtcListResult {
+        try requireReadCapability("fleet.atc.read")
+        return try await request("atc/list", params: AtcListParams(), result: AtcListResult.self)
+    }
+
     func incoming() -> AsyncStream<FleetIncoming> {
         AsyncStream { continuation in
             let id = UUID()

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -389,6 +389,46 @@ struct FleetBroadcastParams: Codable, Equatable {
 
 struct FleetBroadcastResult: Codable, Equatable { let receipts: [FleetActionReceipt] }
 
+enum AtcSchedulerOwnership: String, Codable, Equatable {
+    case legacyTimerReconciliationRequired = "legacy_timer_reconciliation_required"
+}
+
+struct AtcListParams: Codable, Equatable { init() {} }
+
+struct AtcInstance: Codable, Equatable {
+    let name: String
+    let cwd: String
+    let tmuxSession: String?
+    let heartbeatCron: String
+    let errRetryCap: Int64
+    let idlePauseMin: Int64
+    let nextTickAt: Int64?
+    let enabled: Bool
+    let lastHeartbeatAt: Int64?
+    let configGeneration: Int64
+
+    private enum CodingKeys: String, CodingKey {
+        case name, cwd, enabled
+        case tmuxSession = "tmux_session"
+        case heartbeatCron = "heartbeat_cron"
+        case errRetryCap = "err_retry_cap"
+        case idlePauseMin = "idle_pause_min"
+        case nextTickAt = "next_tick_at"
+        case lastHeartbeatAt = "last_heartbeat_at"
+        case configGeneration = "config_generation"
+    }
+}
+
+struct AtcListResult: Codable, Equatable {
+    let instances: [AtcInstance]
+    let schedulerOwnership: AtcSchedulerOwnership
+
+    private enum CodingKeys: String, CodingKey {
+        case instances
+        case schedulerOwnership = "scheduler_ownership"
+    }
+}
+
 enum FleetWire {
     static func decoder() -> JSONDecoder { JSONDecoder() }
     static func encoder() -> JSONEncoder {

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -8,6 +8,7 @@ struct FleetWindowView: View {
     @State private var startPresented = false
     @State private var receiptsPresented = false
     @State private var broadcastPresented = false
+    @State private var atcPresented = false
 
     var body: some View {
         NavigationSplitView {
@@ -41,7 +42,10 @@ struct FleetWindowView: View {
                 ToolbarItem { Button("Quick switch") { switcherPresented = true } }
                 ToolbarItem { Button("Start") { startPresented = true }.disabled(!store.canStart).accessibilityIdentifier("fleet.start.open") }
                 ToolbarItem { Button("Receipts") { receiptsPresented = true }.disabled(!store.canReadReceipts).accessibilityIdentifier("fleet.receipts.open") }
-                ToolbarItem { Button("Broadcast") { broadcastPresented = true }.disabled(!store.canBroadcast).accessibilityIdentifier("fleet.broadcast.open") }
+                ToolbarItemGroup {
+                    Button("ATC") { atcPresented = true }.disabled(!store.canReadATC).accessibilityIdentifier("fleet.atc.open")
+                    Button("Broadcast") { broadcastPresented = true }.disabled(!store.canBroadcast).accessibilityIdentifier("fleet.broadcast.open")
+                }
             }
         } detail: {
             if let key = store.selectedSessionKey, let session = store.sessions.first(where: { $0.sessionKey == key }) {
@@ -56,8 +60,60 @@ struct FleetWindowView: View {
         .sheet(isPresented: $switcherPresented) { FleetQuickSwitcher(store: store, sort: presentation.sort, isPresented: $switcherPresented) }
         .sheet(isPresented: $startPresented) { FleetStartForm(store: store, isPresented: $startPresented) }
         .sheet(isPresented: $receiptsPresented) { FleetReceiptList(store: store) }
+        .sheet(isPresented: $atcPresented) { FleetATCList(store: store) }
         .sheet(isPresented: $broadcastPresented) { FleetBroadcastForm(store: store, isPresented: $broadcastPresented) }
         .frame(minWidth: 820, minHeight: 520)
+    }
+}
+
+private struct FleetATCList: View {
+    @ObservedObject var store: FleetStore
+
+    var body: some View {
+        List(store.atcInstances, id: \.name) { instance in
+            VStack(alignment: .leading) {
+                Text(instance.name)
+                Text(instance.enabled ? "Enabled" : "Disabled")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("Cron \(instance.heartbeatCron) · retry cap \(instance.errRetryCap)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("Next \(timestamp(instance.nextTickAt)) · last \(timestamp(instance.lastHeartbeatAt))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(instance.name)
+            .accessibilityValue(instance.enabled ? "Enabled" : "Disabled")
+        }
+        .navigationTitle("ATC")
+        .safeAreaInset(edge: .bottom) {
+            VStack(alignment: .leading, spacing: 4) {
+                if let ownership = store.atcSchedulerOwnership {
+                    Text(ownershipLabel(ownership)).font(.caption).foregroundStyle(.secondary)
+                }
+                Text("Schedule edits remain disabled until daemon scheduler ownership is proven.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+        }
+        .frame(minWidth: 520, minHeight: 360)
+        .onAppear { store.refreshATC() }
+        .accessibilityIdentifier("fleet.atc.list")
+    }
+
+    private func timestamp(_ value: Int64?) -> String {
+        guard let value else { return "not scheduled" }
+        return Date(timeIntervalSince1970: TimeInterval(value) / 1_000).formatted(date: .abbreviated, time: .shortened)
+    }
+
+    private func ownershipLabel(_ ownership: AtcSchedulerOwnership) -> String {
+        switch ownership {
+        case .legacyTimerReconciliationRequired: "Legacy timer reconciliation required"
+        }
     }
 }
 

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -89,6 +89,16 @@ final class FleetConnectionTests: XCTestCase {
         }
     }
 
+    func testATCReadProjectionDecodesOwnershipAndScheduleFacts() throws {
+        let result = try FleetWire.decoder().decode(AtcListResult.self, from: Data(#"""
+        {"instances":[{"name":"main","cwd":"/tmp","tmux_session":"atc-main","heartbeat_cron":"*/2 * * * *","err_retry_cap":3,"idle_pause_min":60,"next_tick_at":2000,"enabled":true,"last_heartbeat_at":1000,"config_generation":4}],"scheduler_ownership":"legacy_timer_reconciliation_required"}
+        """#.utf8))
+
+        XCTAssertEqual(result.instances.map(\.name), ["main"])
+        XCTAssertEqual(result.instances.first?.configGeneration, 4)
+        XCTAssertEqual(result.schedulerOwnership, .legacyTimerReconciliationRequired)
+    }
+
     func testOldCatalogueRefusesReceiptAndStartBeforeWireIO() async throws {
         var descriptors = [Int32](repeating: 0, count: 2)
         XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)


### PR DESCRIPTION
## AFM-E04 safe read-only slice

Adds negotiated `fleet.atc.read`, typed ATC schedule projection, and native macOS ATC panel.

Validation:
- `cargo test -p ainb-hangar-daemon --test rpc_atc` 6/6
- `cargo test -p ainb-hangar-store stale_claim_cannot_restore_a_disabled_schedule`
- `cargo test -p ainb-hangar-proto --test fleet_parity_manifest` 12/12
- `xcodebuild build-for-testing -project apps/ainb-fleet-macos/AINBFleet.xcodeproj -scheme AINBFleet -destination platform=macOS,arch=arm64`

ATC mutations are deliberately not advertised. Daemon reports `legacy_timer_reconciliation_required`; follow-up `agents-in-a-box-afm-e04.1` owns legacy scheduler reconciliation and booted runtime proof. Direct XCUI remains UNVERIFIABLE on this host.