### PR TITLE
feat(fleet): add payload-free timeline

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -822,6 +822,7 @@ async fn handle(
         methods::FLEET_RECEIPT_LIST => handle_fleet_receipt_list(pool, req).await,
         methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
         methods::FLEET_START => handle_fleet_start(pool, req, events).await,
+        methods::FLEET_TIMELINE => handle_fleet_timeline(pool, req).await,
         methods::ATTENTION_LIST => handle_attention_list(pool, req).await,
         // `attention/subscribe` acks with the current OPEN snapshot; the live
         // fleet-wide forwarder is the stream side (see `serve_conn`).
@@ -943,6 +944,59 @@ async fn handle_fleet_action(
 }
 
 const FLEET_RECEIPT_LIST_MAX: u32 = 100;
+const FLEET_TIMELINE_MAX: u32 = 100;
+
+/// Return bounded, payload-free Fleet revision timeline entries.
+async fn handle_fleet_timeline(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FleetTimelineKind, FleetTimelineParams, FleetTimelineResult};
+    use ainb_hangar_store::repo::fleet::FleetRepo;
+
+    let params: FleetTimelineParams =
+        parse_params(req, "{ after_revision?, session_key?, limit }")?;
+    let after_revision = params.after_revision.unwrap_or(0);
+    if after_revision < 0 {
+        return Err(invalid_params("after_revision must be non-negative"));
+    }
+    if params.session_key.as_deref().is_some_and(str::is_empty) {
+        return Err(invalid_params("session_key must not be empty"));
+    }
+    let rows = FleetRepo::timeline_after(
+        pool,
+        after_revision,
+        params.session_key.as_deref(),
+        i64::from(params.limit.clamp(1, FLEET_TIMELINE_MAX)),
+    )
+    .await
+    .map_err(|error| store_err(&error))?;
+    let entries: Vec<_> = rows
+        .iter()
+        .filter_map(|row| {
+            FleetTimelineKind::from_event_type(&row.event_type).map(|kind| {
+                ainb_hangar_proto::fleet::FleetTimelineEntry {
+                    revision: row.revision,
+                    session_key: row.session_key.clone(),
+                    observed_at: row.observed_at,
+                    provenance: if row.authority == "authoritative" {
+                        ainb_hangar_proto::fleet::FleetProvenance::Authoritative
+                    } else {
+                        ainb_hangar_proto::fleet::FleetProvenance::Inferred
+                    },
+                    kind,
+                    applied: row.applied,
+                    session_version: row.session_version,
+                }
+            })
+        })
+        .collect();
+    let next_after_revision = entries.last().map(|entry| entry.revision);
+    to_value(&FleetTimelineResult {
+        entries,
+        next_after_revision,
+    })
+}
 
 /// Return a bounded, durable newest-first receipt projection.
 async fn handle_fleet_receipt_list(

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
@@ -849,3 +849,63 @@ async fn broadcast_returns_ordered_receipt_for_every_target() {
     assert_eq!(receipts[0]["status"], "REJECTED");
     assert_eq!(receipts[1]["status"], "REJECTED");
 }
+
+#[tokio::test]
+async fn timeline_is_payload_free_bounded_and_cursor_safe_over_the_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    let secret = serde_json::json!({ "prompt": "secret prompt must never leave store" });
+    apply_hook(
+        &store,
+        &sink,
+        "timeline-start",
+        "claude",
+        "timeline",
+        "SessionStart",
+        &secret,
+        100,
+    )
+    .await;
+    apply_hook(
+        &store,
+        &sink,
+        "timeline-turn",
+        "claude",
+        "timeline",
+        "PostToolUse",
+        &secret,
+        200,
+    )
+    .await;
+    apply_hook(
+        &store,
+        &sink,
+        "timeline-unknown",
+        "claude",
+        "timeline",
+        "InternalRaw",
+        &secret,
+        300,
+    )
+    .await;
+
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let first = client.call(methods::FLEET_TIMELINE, serde_json::json!({ "limit": 1 })).await;
+    assert!(first["error"].is_null(), "timeline must return: {first}");
+    let entries = first["result"]["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert!(entries[0].get("payload").is_none());
+    assert!(!first.to_string().contains("secret prompt"));
+    let cursor = first["result"]["next_after_revision"].as_i64().unwrap();
+
+    let second = client
+        .call(
+            methods::FLEET_TIMELINE,
+            serde_json::json!({ "after_revision": cursor, "limit": 100 }),
+        )
+        .await;
+    let entries = second["result"]["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1, "unknown raw type is omitted");
+    assert_eq!(entries[0]["kind"], "turn_running");
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -18,6 +18,8 @@ pub const FLEET_CAPABILITY_RECEIPT_READ: &str = "fleet.receipt.read";
 pub const FLEET_CAPABILITY_START_EXECUTE: &str = "fleet.start.execute";
 /// Negotiated capability for daemon-owned ATC read projections.
 pub const FLEET_CAPABILITY_ATC_READ: &str = "fleet.atc.read";
+/// Negotiated capability for the payload-free Fleet revision timeline.
+pub const FLEET_CAPABILITY_TIMELINE_READ: &str = "fleet.timeline.read";
 
 /// Fleet capability identifiers advertised during protocol negotiation.
 pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
@@ -31,6 +33,7 @@ pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
     "fleet.subscription.live",
     "fleet.subscription.replay",
     "fleet.subscription.resync",
+    FLEET_CAPABILITY_TIMELINE_READ,
 ];
 
 /// Inclusive supported protocol version range.
@@ -366,6 +369,108 @@ pub struct FleetEvent {
     pub session_version: i64,
     /// Whether event changed canonical state.
     pub applied: bool,
+}
+
+/// Closed, payload-free Fleet timeline event classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetTimelineKind {
+    /// Provider session began.
+    SessionStarted,
+    /// A provider turn started or continued.
+    TurnRunning,
+    /// Provider asked a structured question.
+    QuestionRaised,
+    /// Provider requested approval.
+    ApprovalRequested,
+    /// Provider requested operator attention.
+    AttentionWaiting,
+    /// Provider turn completed.
+    TurnCompleted,
+    /// Provider turn completed with failure.
+    TurnFailed,
+    /// Provider session ended.
+    SessionEnded,
+    /// Codex managed transport became unavailable.
+    ManagerUnavailable,
+    /// Codex managed transport recovered.
+    ManagerRecovered,
+    /// Codex managed TUI started.
+    ManagerStarted,
+    /// Tmux transport became unavailable.
+    TransportUnavailable,
+    /// Tmux transport became available.
+    TransportAvailable,
+    /// Tmux discovery found a session.
+    SessionDiscovered,
+    /// A legacy session was superseded by its managed identity.
+    SessionSuperseded,
+}
+
+impl FleetTimelineKind {
+    /// Map one known stored Fleet event type to its public closed kind.
+    #[must_use]
+    pub fn from_event_type(event_type: &str) -> Option<Self> {
+        match event_type {
+            "SessionStart" => Some(Self::SessionStarted),
+            "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => Some(Self::TurnRunning),
+            "AskUserQuestion" => Some(Self::QuestionRaised),
+            "PermissionRequest" => Some(Self::ApprovalRequested),
+            "Notification" => Some(Self::AttentionWaiting),
+            "Stop" | "SubagentStop" => Some(Self::TurnCompleted),
+            "StopFailure" => Some(Self::TurnFailed),
+            "SessionEnd" => Some(Self::SessionEnded),
+            "codex_manager_unavailable" => Some(Self::ManagerUnavailable),
+            "codex_manager_recovered" => Some(Self::ManagerRecovered),
+            "codex_managed_tui_started" => Some(Self::ManagerStarted),
+            "tmux_missing" | "tmux_unavailable" => Some(Self::TransportUnavailable),
+            "tmux_available" => Some(Self::TransportAvailable),
+            "tmux_discovered" => Some(Self::SessionDiscovered),
+            "session_superseded" => Some(Self::SessionSuperseded),
+            _ => None,
+        }
+    }
+}
+
+/// Parameters for `fleet/timeline`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetTimelineParams {
+    /// Return rows strictly after this global Fleet revision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_revision: Option<i64>,
+    /// Optional exact stable Fleet session identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_key: Option<String>,
+    /// Requested row count. The daemon clamps this to its server maximum.
+    pub limit: u32,
+}
+
+/// One payload-free Fleet timeline entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetTimelineEntry {
+    /// Global monotonic revision.
+    pub revision: i64,
+    /// Stable target session.
+    pub session_key: String,
+    /// Observation time in epoch milliseconds.
+    pub observed_at: i64,
+    /// Event authority.
+    pub provenance: FleetProvenance,
+    /// Closed event classification.
+    pub kind: FleetTimelineKind,
+    /// Whether this event changed canonical state.
+    pub applied: bool,
+    /// Session version after event consideration.
+    pub session_version: i64,
+}
+
+/// Result for `fleet/timeline`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetTimelineResult {
+    /// Entries in ascending global revision order.
+    pub entries: Vec<FleetTimelineEntry>,
+    /// Cursor for the next page, or `null` when this page is empty.
+    pub next_after_revision: Option<i64>,
 }
 
 /// Initial result for a replay-safe Fleet subscription.

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -280,6 +280,8 @@ pub const FLEET_RECEIPT_LIST: &str = "fleet/receipt_list";
 pub const FLEET_RECEIPT_GET: &str = "fleet/receipt_get";
 /// Start a provider session without borrowing selected-session state.
 pub const FLEET_START: &str = "fleet/start";
+/// Read bounded, payload-free Fleet revision timeline entries.
+pub const FLEET_TIMELINE: &str = "fleet/timeline";
 
 /// Fleet notifications emitted by the daemon, never JSON-RPC request methods.
 pub const FLEET_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &["fleet/resync_required"];
@@ -1248,6 +1250,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_RECEIPT_LIST,
     FLEET_RECEIPT_GET,
     FLEET_START,
+    FLEET_TIMELINE,
 ];
 
 #[cfg(test)]
@@ -1474,6 +1477,7 @@ mod tests {
             FLEET_RECEIPT_LIST,
             FLEET_RECEIPT_GET,
             FLEET_START,
+            FLEET_TIMELINE,
         ];
         for m in declared {
             assert!(

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -193,6 +193,25 @@ pub struct FleetEventRow {
     pub applied: bool,
 }
 
+/// One durable Fleet revision safe for the public payload-free timeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetTimelineRow {
+    /// Global monotonic revision.
+    pub revision: i64,
+    /// Target session.
+    pub session_key: String,
+    /// Observation time.
+    pub observed_at: i64,
+    /// Authority token.
+    pub authority: String,
+    /// Known normalized event discriminator.
+    pub event_type: String,
+    /// Session version after this event was considered.
+    pub session_version: i64,
+    /// Whether this event changed canonical session state.
+    pub applied: bool,
+}
+
 /// Result of applying or replaying one event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApplyFleetEventResult {
@@ -615,6 +634,43 @@ impl FleetRepo {
         .fetch_all(pool)
         .await?;
         rows.iter().map(event_from_row).collect()
+    }
+
+    /// Read a bounded, payload-free Fleet timeline after a global revision.
+    ///
+    /// The query joins visible Fleet sessions and filters the closed raw type
+    /// allowlist before `LIMIT`, so excluded history can never consume a page
+    /// or strand a caller's cursor.
+    pub async fn timeline_after(
+        pool: &SqlitePool,
+        after_revision: i64,
+        session_key: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<FleetTimelineRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT e.revision, e.session_key, e.observed_at, e.authority, e.event_type, \
+                    e.session_version, e.applied \
+             FROM fleet_event e \
+             INNER JOIN fleet_session s ON s.session_key = e.session_key AND s.visible = 1 \
+             WHERE e.revision > ? \
+               AND (? IS NULL OR e.session_key = ?) \
+               AND e.event_type IN ( \
+                   'SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', \
+                   'AskUserQuestion', 'PermissionRequest', 'Notification', 'Stop', \
+                   'SubagentStop', 'StopFailure', 'SessionEnd', \
+                   'codex_manager_unavailable', 'codex_manager_recovered', \
+                   'codex_managed_tui_started', 'tmux_missing', 'tmux_unavailable', \
+                   'tmux_available', 'tmux_discovered', 'session_superseded' \
+               ) \
+             ORDER BY e.revision ASC LIMIT ?",
+        )
+        .bind(after_revision)
+        .bind(session_key)
+        .bind(session_key)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(timeline_from_row).collect()
     }
 
     /// Insert or advance one action receipt.
@@ -1056,6 +1112,18 @@ fn event_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetEventRow, sqlx::
         authority: row.try_get("authority")?,
         event_type: row.try_get("event_type")?,
         payload: row.try_get("payload")?,
+        session_version: row.try_get("session_version")?,
+        applied: row.try_get::<i64, _>("applied")? != 0,
+    })
+}
+
+fn timeline_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetTimelineRow, sqlx::Error> {
+    Ok(FleetTimelineRow {
+        revision: row.try_get("revision")?,
+        session_key: row.try_get("session_key")?,
+        observed_at: row.try_get("observed_at")?,
+        authority: row.try_get("authority")?,
+        event_type: row.try_get("event_type")?,
         session_version: row.try_get("session_version")?,
         applied: row.try_get::<i64, _>("applied")? != 0,
     })

--- a/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-compatible.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-compatible.json
@@ -8,7 +8,8 @@
     "fleet.start.execute",
     "fleet.subscription.live",
     "fleet.subscription.replay",
-    "fleet.subscription.resync"
+    "fleet.subscription.resync",
+    "fleet.timeline.read"
   ],
   "daemon_version": "fixture-daemon-1.0.0",
   "protocol_version": 1,

--- a/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-read-only.json
+++ b/ainb-tui/fleet-parity/fixtures/v1/negotiate-result-read-only.json
@@ -8,7 +8,8 @@
     "fleet.start.execute",
     "fleet.subscription.live",
     "fleet.subscription.replay",
-    "fleet.subscription.resync"
+    "fleet.subscription.resync",
+    "fleet.timeline.read"
   ],
   "daemon_version": "fixture-daemon-1.0.0",
   "protocol_version": 1,

--- a/ainb-tui/fleet-parity/manifest.json
+++ b/ainb-tui/fleet-parity/manifest.json
@@ -289,6 +289,34 @@
         ]
       },
       "release_classification": "deferred_tui"
+    },
+    {
+      "id": "fleet.timeline.read",
+      "tier": "v1",
+      "daemon_request_method": "fleet/timeline",
+      "expected_behavior": "Daemon returns bounded payload-free Fleet revision entries for visible sessions.",
+      "daemon": {
+        "status": "pass",
+        "evidence_paths": [
+          "crates/ainb-hangar-daemon/src/rpc/mod.rs",
+          "crates/ainb-hangar-store/src/repo/fleet.rs"
+        ]
+      },
+      "tui": {
+        "status": "deferred",
+        "evidence_paths": [],
+        "rationale": "Deferred under agents-in-a-box-afm-e01.1; this does not block Swift app delivery."
+      },
+      "swift": {
+        "status": "blocked_proof",
+        "evidence_root": "workspace",
+        "evidence_paths": [
+          "apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift",
+          "apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift"
+        ],
+        "rationale": "AFM-E05 exposes a capability-gated payload-free revision timeline. Direct XCUI and isolated daemon proof remain unrun."
+      },
+      "release_classification": "deferred_tui"
     }
   ]
 }

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -68,6 +68,7 @@ final class FleetStore: ObservableObject {
     @Published private(set) var receipts: [FleetActionReceipt] = []
     @Published private(set) var atcInstances: [AtcInstance] = []
     @Published private(set) var atcSchedulerOwnership: AtcSchedulerOwnership?
+    @Published private(set) var timeline: [FleetTimelineEntry] = []
     @Published private(set) var pendingIntentID: String?
     @Published private(set) var controlNotice: String?
     @Published private(set) var lastStart: FleetStartResult?
@@ -121,6 +122,10 @@ final class FleetStore: ObservableObject {
 
     var canReadATC: Bool {
         connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.atc.read") == true
+    }
+
+    var canReadTimeline: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.timeline.read") == true
     }
 
     var canStart: Bool {
@@ -320,6 +325,21 @@ final class FleetStore: ObservableObject {
         }
     }
 
+    func refreshTimeline() {
+        guard canReadTimeline, let connection else {
+            controlNotice = "Timeline reads are unavailable for this daemon."
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                timeline = try await connection.timeline(FleetTimelineParams(afterRevision: nil, sessionKey: nil, limit: 100)).entries
+            } catch {
+                controlNotice = "Timeline refresh refused: \(String(describing: error))"
+            }
+        }
+    }
+
     private func beginConnection() {
         connectionGeneration &+= 1
         let generation = connectionGeneration
@@ -370,6 +390,11 @@ final class FleetStore: ObservableObject {
             } else {
                 atcInstances = []
                 atcSchedulerOwnership = nil
+            }
+            if result.capabilityIDs.contains("fleet.timeline.read") {
+                timeline = try await newConnection.timeline(FleetTimelineParams(afterRevision: nil, sessionKey: nil, limit: 100)).entries
+            } else {
+                timeline = []
             }
             connectionState = .live(daemonVersion: result.daemonVersion, writeCompatible: result.writeCompatible)
             established = true

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -161,6 +161,11 @@ actor FleetConnection {
         return try await request("atc/list", params: AtcListParams(), result: AtcListResult.self)
     }
 
+    func timeline(_ params: FleetTimelineParams) async throws -> FleetTimelineResult {
+        try requireReadCapability("fleet.timeline.read")
+        return try await request("fleet/timeline", params: params, result: FleetTimelineResult.self)
+    }
+
     func incoming() -> AsyncStream<FleetIncoming> {
         AsyncStream { continuation in
             let id = UUID()

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -366,6 +366,34 @@ struct FleetReceiptGetResult: Codable, Equatable {
     let receipt: FleetActionReceipt?
 }
 
+enum FleetTimelineKind: String, Codable, Equatable {
+    case sessionStarted = "session_started", turnRunning = "turn_running", questionRaised = "question_raised", approvalRequested = "approval_requested", attentionWaiting = "attention_waiting", turnCompleted = "turn_completed", turnFailed = "turn_failed", sessionEnded = "session_ended", managerUnavailable = "manager_unavailable", managerRecovered = "manager_recovered", managerStarted = "manager_started", transportUnavailable = "transport_unavailable", transportAvailable = "transport_available", sessionDiscovered = "session_discovered", sessionSuperseded = "session_superseded"
+}
+
+struct FleetTimelineParams: Codable, Equatable {
+    let afterRevision: Int64?
+    let sessionKey: String?
+    let limit: UInt32
+    private enum CodingKeys: String, CodingKey { case afterRevision = "after_revision", sessionKey = "session_key", limit }
+}
+
+struct FleetTimelineEntry: Codable, Equatable {
+    let revision: Int64
+    let sessionKey: String
+    let observedAt: Int64
+    let provenance: FleetProvenance
+    let kind: FleetTimelineKind
+    let applied: Bool
+    let sessionVersion: Int64
+    private enum CodingKeys: String, CodingKey { case revision, sessionKey = "session_key", observedAt = "observed_at", provenance, kind, applied, sessionVersion = "session_version" }
+}
+
+struct FleetTimelineResult: Codable, Equatable {
+    let entries: [FleetTimelineEntry]
+    let nextAfterRevision: Int64?
+    private enum CodingKeys: String, CodingKey { case entries, nextAfterRevision = "next_after_revision" }
+}
+
 struct FleetStartParams: Codable, Equatable {
     let requestID: String
     let provider: FleetProvider

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -9,6 +9,7 @@ struct FleetWindowView: View {
     @State private var receiptsPresented = false
     @State private var broadcastPresented = false
     @State private var atcPresented = false
+    @State private var timelinePresented = false
 
     var body: some View {
         NavigationSplitView {
@@ -44,6 +45,7 @@ struct FleetWindowView: View {
                 ToolbarItem { Button("Receipts") { receiptsPresented = true }.disabled(!store.canReadReceipts).accessibilityIdentifier("fleet.receipts.open") }
                 ToolbarItemGroup {
                     Button("ATC") { atcPresented = true }.disabled(!store.canReadATC).accessibilityIdentifier("fleet.atc.open")
+                    Button("Timeline") { timelinePresented = true }.disabled(!store.canReadTimeline).accessibilityIdentifier("fleet.timeline.open")
                     Button("Broadcast") { broadcastPresented = true }.disabled(!store.canBroadcast).accessibilityIdentifier("fleet.broadcast.open")
                 }
             }
@@ -61,8 +63,30 @@ struct FleetWindowView: View {
         .sheet(isPresented: $startPresented) { FleetStartForm(store: store, isPresented: $startPresented) }
         .sheet(isPresented: $receiptsPresented) { FleetReceiptList(store: store) }
         .sheet(isPresented: $atcPresented) { FleetATCList(store: store) }
+        .sheet(isPresented: $timelinePresented) { FleetTimelineList(store: store) }
         .sheet(isPresented: $broadcastPresented) { FleetBroadcastForm(store: store, isPresented: $broadcastPresented) }
         .frame(minWidth: 820, minHeight: 520)
+    }
+}
+
+private struct FleetTimelineList: View {
+    @ObservedObject var store: FleetStore
+
+    var body: some View {
+        List(store.timeline, id: \.revision) { entry in
+            VStack(alignment: .leading) {
+                Text(entry.kind.rawValue.replacingOccurrences(of: "_", with: " ").capitalized)
+                Text(entry.sessionKey).font(.caption).textSelection(.enabled)
+                Text(Date(timeIntervalSince1970: TimeInterval(entry.observedAt) / 1_000).formatted(date: .abbreviated, time: .shortened)).font(.caption2).foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(entry.kind.rawValue)
+            .accessibilityValue(entry.sessionKey)
+        }
+        .navigationTitle("Fleet timeline")
+        .frame(minWidth: 520, minHeight: 360)
+        .onAppear { store.refreshTimeline() }
+        .accessibilityIdentifier("fleet.timeline.list")
     }
 }
 


### PR DESCRIPTION
## Summary
- add negotiated payload-free Fleet revision timeline
- expose read-only capability-gated Swift timeline
- prove bounded cursor and payload exclusion over authenticated Unix socket

## Verification
- cargo test -p ainb-hangar-daemon --test rpc_fleet timeline_is_payload_free_bounded_and_cursor_safe_over_the_socket --quiet
- cargo test -p ainb-hangar-proto --test fleet_parity_manifest --quiet
- cargo check -p ainb-hangar-daemon --quiet
- xcodebuild build-for-testing -project apps/ainb-fleet-macos/AINBFleet.xcodeproj -scheme AINBFleet -destination 'platform=macOS,arch=arm64'