### PR TITLE
ci: repair toolkit-validation workflow YAML so it parses

### DIFF
--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run skill-manager unit + integration test suite
         run: |
           cd ainb-tui
-          cargo test --workspace --no-fail-fast \
+          cargo test --no-fail-fast \
             -p ainb-skill-core \
             -p ainb-fetch \
             -p ainb-adapters-source \
@@ -114,7 +114,7 @@ jobs:
               --test 'tripwire_core_skill_manager_*' \
               --test 'tripwire_core_home_tile_lists_skill_manager'
 
-      - name: Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME
+      - name: "Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME"
         run: |
           cd ainb-tui
           BIN="$PWD/target/release/ainb"


### PR DESCRIPTION
## Problem

`.github/workflows/toolkit-validation.yml` on main is invalid YAML. `yaml.safe_load` fails with:

```
mapping values are not allowed here, line 117, column 25
```

Cause: an unquoted colon in a step name scalar (`- name: Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME`). Because GitHub cannot parse the file, every run against it produces zero jobs and dies instantly, with the workflow name rendering as the raw file path in the Actions UI. This has been silently dead for an unknown period.

## Fix

Two small hunks, one file:

1. Quote the step name so the colon inside it is no longer parsed as a YAML mapping separator: `- name: "Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME"`
2. Drop `--workspace` from `cargo test --workspace --no-fail-fast -p ainb-skill-core ...`. Combining `--workspace` with `-p` flags defeats the package selection and ends up testing the entire workspace instead of the intended package list.

## Provenance

Extracted from #493 (branch `f/atc`), which contains this same fix but is 249 commits behind main and carries a separately failing gate that could not be attributed to this change. This PR isolates just the workflow YAML fix onto current main so it can land independently.

## Verification

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/toolkit-validation.yml')); print('YAML OK')"
YAML OK

$ actionlint .github/workflows/toolkit-validation.yml
(exit 0, no output)
```

Diff is exactly the two hunks above, touching only `.github/workflows/toolkit-validation.yml`.