### PR TITLE
docs(site): replace per-file glob exclusions with directory conventions

### DIFF
--- a/docs/atc-plumbing.md
+++ b/docs/atc-plumbing.md
@@ -1,3 +1,7 @@
+---
+title: "ATC plumbing — event-driven orchestration"
+---
+
 # ATC plumbing — event-driven orchestration
 
 The ATC plumbing upgrades **Air Traffic Control** from *poll-mode* (act on the

--- a/docs/fleet-bridge.md
+++ b/docs/fleet-bridge.md
@@ -1,3 +1,7 @@
+---
+title: "`ainb fleet bridge` — native phone bridge (Telegram + Slack + Discord)"
+---
+
 # `ainb fleet bridge` — native phone bridge (Telegram + Slack + Discord)
 
 A single-binary Rust daemon, built into `ainb`, that relays messages **two-way**

--- a/website/site/src/content.config.ts
+++ b/website/site/src/content.config.ts
@@ -12,16 +12,26 @@ export const collections = {
       pattern: [
         '**/*.{md,mdx}',
         '!assets/**',
-        // Internal Hangar build artifacts (no Starlight frontmatter) — keep
-        // them in-repo but out of the published docsite. Only hangar/architecture.md
-        // is a real site page.
-        '!hangar/research/**',
-        '!hangar/phases/**',
-        '!hangar/build-plan.md',
-        '!hangar/README.md',
-        '!hangar/tui-keybindings.md',
-        '!hangar/verify-hangar-goal.md',
-        '!hangar/execute-hangar-parity-goal.md',
+        // Published docs are human-authored and review-gated. Automation may
+        // only write under these excluded directories: explorations/ (research
+        // notes, gap matrices, progress ledgers), hangar/ (internal build
+        // artifacts, goals, specs, proofs), and solutions/ (reflect-generated
+        // machine-written knowledge notes). None of these carry Starlight
+        // frontmatter, so excluding the whole directory (rather than naming
+        // files one at a time as they're added) keeps the site build from
+        // breaking every time automation drops a new file in one of them.
+        '!explorations/**',
+        '!solutions/**',
+        // hangar/architecture.md is the one exception: a real, human-authored
+        // site page (see astro.config.mjs sidebar entry for slug
+        // 'hangar/architecture'). A plain '!hangar/**' plus a later
+        // re-include pattern does NOT work here: tinyglobby/fdir prunes
+        // excluded directories from traversal entirely, so nothing under
+        // hangar/ is even visited once '!hangar/**' is applied, and a later
+        // positive pattern can't un-prune it. The extglob form below excludes
+        // every hangar/ entry except architecture.md while still letting the
+        // walker descend into hangar/ to find it.
+        '!hangar/!(architecture.md)',
       ],
     }),
     schema: docsSchema(),

--- a/website/site/src/content.config.ts
+++ b/website/site/src/content.config.ts
@@ -31,6 +31,12 @@ export const collections = {
         // positive pattern can't un-prune it. The extglob form below excludes
         // every hangar/ entry except architecture.md while still letting the
         // walker descend into hangar/ to find it.
+        //
+        // architecture.md is the ONLY public page under hangar/. Anything
+        // else that becomes public must MOVE out of hangar/ rather than
+        // being added here. A second name in this pattern means the
+        // directory-exclusion convention has been abandoned, which is the
+        // exact per-file-exception drift this change was meant to end.
         '!hangar/!(architecture.md)',
       ],
     }),


### PR DESCRIPTION
## Summary

- Deploy site build was RED: Starlight's docsSchema() requires `title` frontmatter and 23 of 101 docs lack it. Build reports only the first offender, so fixing files one at a time just moves the error.
- Replace the hand-maintained per-file exclusion list in `website/site/src/content.config.ts` with directory-level conventions: exclude `explorations/**`, `hangar/**`, `solutions/**` wholesale (all machine-written or internal, none carry frontmatter), with one explicit re-include for `hangar/architecture.md` (the sole published page under hangar/, referenced by `astro.config.mjs` sidebar slug `hangar/architecture`).
- Note on the re-include: a plain `!hangar/**` plus a later positive pattern does NOT work with tinyglobby, since excluded directories are pruned from traversal entirely before later patterns are applied. Used the extglob form `!hangar/!(architecture.md)` instead, which excludes every hangar entry except architecture.md while still letting the walker descend into the directory. Verified directly against tinyglobby before relying on it.
- Added missing Starlight `title` frontmatter to the two genuinely public docs that lacked it: `docs/fleet-bridge.md` and `docs/atc-plumbing.md`. Title text copied verbatim from each file's existing H1, no other content changes.
- Updated the exclusion-list comment to state the underlying principle: published docs are human-authored and review-gated; automation may only write under `explorations/`, `hangar/`, or `solutions/`.

## Test plan

- [x] `cd website/site && npm ci && npm run build` completes successfully (see build tail below)
- [x] `find dist -path "*hangar/architecture*"` shows the route was emitted at `dist/hangar/architecture`
- [x] `find dist -path "*explorations*"` and `find dist -path "*solutions*"` both emit nothing
- [x] `find dist -path "*fleet-bridge*"` and `find dist -path "*atc-plumbing*"` both emit their pages

### Build output tail

```
12:00:18 ✓ Completed in 5.63s.

12:00:18 [build] ✓ Completed in 7.92s.
12:00:18 [starlight:pagefind] Building search index with Pagefind...
12:00:18 [starlight:pagefind] Found 69 HTML files.
12:00:18 [starlight:pagefind] Finished building search index in 220ms.
12:00:18 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
12:00:18 [build] 68 page(s) built in 10.17s
12:00:18 [build] Complete!
```

### Route verification

```
$ find dist -iname "*architecture*" -path "*hangar*"
dist/hangar/architecture

$ find dist -path "*explorations*"
(no output)

$ find dist -path "*solutions*"
(no output)

$ find dist -path "*fleet-bridge*"
dist/fleet-bridge
dist/fleet-bridge/index.html

$ find dist -path "*atc-plumbing*"
dist/atc-plumbing
dist/atc-plumbing/index.html
```