### PR TITLE
ci: actionlint gate + Pages PR build check

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,8 +21,8 @@ jobs:
       # pre-existing style/quoting nits in unrelated `run:` blocks (see
       # release.yml) that would fail any PR touching workflow files for
       # reasons unrelated to workflow validity. Everything actionlint checks
-      # on top of shellcheck — YAML syntax, expression syntax, job/step
-      # schema, action input validation, reachability — stays on, which is
+      # on top of shellcheck (YAML syntax, expression syntax, job/step
+      # schema, action input validation, reachability) stays on, which is
       # what would have caught the original defect (an unquoted colon in a
       # step name breaking YAML parsing).
       - name: Download actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,35 @@
+name: Actionlint
+
+# Guards against exactly the failure mode that let toolkit-validation.yml sit
+# broken for six weeks: an unparseable workflow file produces a run with ZERO
+# jobs, which GitHub reports as neither red nor amber, so nothing here fails
+# silently again. Triggers only on pull_request for workflow-file changes so
+# it can actually block a merge (a push-only check on main cannot).
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  actionlint:
+    name: Lint workflow files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # shellcheck is intentionally disabled (-shellcheck=): it flags
+      # pre-existing style/quoting nits in unrelated `run:` blocks (see
+      # release.yml) that would fail any PR touching workflow files for
+      # reasons unrelated to workflow validity. Everything actionlint checks
+      # on top of shellcheck — YAML syntax, expression syntax, job/step
+      # schema, action input validation, reachability — stays on, which is
+      # what would have caught the original defect (an unquoted colon in a
+      # step name breaking YAML parsing).
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+        shell: bash
+
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -shellcheck=
+        shell: bash

--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -1,7 +1,7 @@
 name: Pages build check
 
 # deploy-pages.yml only triggers on push to main, so docs/site breakages were
-# never caught before merge — the first signal was a red deploy on main after
+# never caught before merge. The first signal was a red deploy on main after
 # the fact. This runs the same build on pull_request, build only, no deploy,
 # so it can actually gate a PR. It intentionally does NOT request
 # `pages: write` / `id-token: write` and does not touch the Pages deployment

--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -1,0 +1,39 @@
+name: Pages build check
+
+# deploy-pages.yml only triggers on push to main, so docs/site breakages were
+# never caught before merge — the first signal was a red deploy on main after
+# the fact. This runs the same build on pull_request, build only, no deploy,
+# so it can actually gate a PR. It intentionally does NOT request
+# `pages: write` / `id-token: write` and does not touch the Pages deployment
+# environment or its concurrency group; deployment stays exclusively on
+# deploy-pages.yml's push-to-main path.
+on:
+  pull_request:
+    paths:
+      - "website/site/**"
+      - "docs/**"
+      - ".github/workflows/pages-build-check.yml"
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website/site
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: website/site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build site
+        run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
         run: cargo run -p xtask -- gen-catalog-index --toolkit-root "${TOOLKIT_DIR}" --release-tag "${AINB_TOOLKIT_REF}" --out "${OUT_DIR}/catalog-index.json"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
           name: v${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## Why

`.github/workflows/toolkit-validation.yml` had an unquoted colon in a step
name (`- name: Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME`),
making it invalid YAML from roughly 2026-06-18 until it was repaired. GitHub
cannot schedule jobs it cannot parse, so every run on that workflow produced
zero jobs and completed instantly. A zero-job run is not a failing run, so
nobody noticed for six weeks. When the YAML was finally fixed it immediately
surfaced two genuinely broken tests that had been running against nothing.

Separately, `.github/workflows/deploy-pages.yml` only triggers on
`push: branches: [main]`, so docs/site changes could never be validated
before merge. The first signal was a red deploy on main after the fact,
which already happened once.

Governing principle: a gate that cannot fail a PR is not a gate.

## Changes

1. **`.github/workflows/actionlint.yml`**: runs actionlint on `pull_request`
   whenever `.github/workflows/**` changes. shellcheck integration is
   disabled (`-shellcheck=`) because it flags pre-existing style/quoting
   nits in `release.yml`'s `run:` blocks unrelated to workflow validity;
   actionlint's own YAML/schema/expression/action-input checks stay on,
   which is exactly what catches this class of defect (see proof below).
   Tradeoff to flag for review: with shellcheck off, quoting/globbing bugs
   inside `run:` blocks are NOT covered by this gate. That is a deliberate
   scoping decision to avoid failing PRs on pre-existing nits in unrelated
   workflows, not an oversight.

2. **`.github/workflows/pages-build-check.yml`**: new, separate workflow
   that runs the same `npm ci && npm run build` as `deploy-pages.yml`'s
   build job, but on `pull_request` for `website/site/**`, `docs/**`, or its
   own workflow file. Build only: no `pages: write` / `id-token: write`
   permissions, no deploy job, no interaction with the `github-pages`
   environment or its concurrency group. Deployment remains exclusively on
   `deploy-pages.yml`'s push-to-main path.

3. **`.github/workflows/release.yml`**: bumped `softprops/action-gh-release`
   from `@v1` to `@v2`.

   **Required to make the gate green.** actionlint v1.7.12 (the version CI
   downloads and runs) reports this as a hard error, not a suggestion:

   ```
   .github/workflows/release.yml:305:15: the runner of "softprops/action-gh-release@v1" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
      |
   305 |         uses: softprops/action-gh-release@v1
       |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ##[error]Process completed with exit code 1.
   ```

   This is actionlint's documented `action`-outdated check: `@v1` pins a
   `node16` runtime that GitHub Actions no longer supports, so this fires
   unconditionally, independent of this PR's diff. Adding actionlint to a
   repo with pre-existing violations forces a choice between fixing them
   and shipping a red gate; this makes that coupling explicit rather than
   absorbing it silently.

   Compatibility check against the three inputs this workflow step actually
   uses (`tag_name`, `name`, `files`): diffed `action.yml` between the `v1`
   and `v2` tags directly.
   - `v2.0.0`'s only change was `using: node16` -> `using: node20` (pure
     runtime bump, per the release notes: "update actions.yml declaration
     to node20 to address warnings").
   - `tag_name`, `name`, and `files` are unchanged in type, requiredness,
     and default behavior; the `files` description was clarified but its
     glob-matching semantics are the same.
   - v2 added new *optional* inputs (`preserve_order`, `working_directory`,
     `overwrite_files`, `previous_tag`, `make_latest`), all with defaults
     that preserve v1 behavior when omitted, which this workflow does.
   - The one real behavior change in the v2 line, "fail run if `files`
     contains an unmatched pattern" (added in v2.0.1), was walked back to
     opt-in only in v2.0.2 (`fail_on_unmatched_files`, default `false`).
     This workflow does not set that input, so default (non-failing)
     behavior matches v1.

   Net: no known breaking change to this step's usage. That said, this is a
   major-version bump on the workflow that shipped v1.17.0 yesterday and
   whose blast radius is published binaries + the Homebrew tap, so the next
   real release run is the first live validation of `@v2` here; nothing in
   this PR exercises the release workflow itself.

## Proof

**1. Every current workflow file parses as valid YAML and passes actionlint
   v1.7.12 (shellcheck disabled, matching CI) clean:**

```
=== full yaml parse check ===
OK: .github/workflows/actionlint.yml
OK: .github/workflows/ci.yml
OK: .github/workflows/deploy-pages.yml
OK: .github/workflows/pages-build-check.yml
OK: .github/workflows/release.yml
OK: .github/workflows/toolkit-validation.yml
=== actionlint -shellcheck= -color (v1.7.12, matches CI) ===
EXIT: 0
```

**2. Reproduction of the exact original defect** (throwaway copy in `/tmp`,
   not committed): a step named
   `- name: Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME`,
   unquoted.

```
=== yaml parse check (this is what silently produced 0 jobs) ===
yaml.scanner.ScannerError: mapping values are not allowed here
  in "/tmp/actionlint-proof/toolkit-validation.yml", line 24, column 25
YAML PARSE FAILED as expected
=== actionlint against the reproduced defect ===
.../tmp/actionlint-proof/toolkit-validation.yml:24:0: could not parse as YAML: yaml: line 24: mapping values are not allowed in this context [yaml-syntax]
   |
24 |       - name: Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME
   |
EXIT CODE: 1
```

This confirms the actionlint gate (and even a plain YAML parse) would have
failed the PR that introduced the defect, instead of silently producing a
zero-job run for six weeks.

**3. Pages build succeeds on current main** (`cd website/site && npm ci &&
   npm run build`):

```
12:25:41 Completed in 13.24s.
12:25:41 [build] Completed in 21.36s.
12:25:41 [starlight:pagefind] Building search index with Pagefind...
12:25:41 [starlight:pagefind] Found 69 HTML files.
12:25:41 [starlight:pagefind] Finished building search index in 498ms.
12:25:42 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
12:25:42 [build] 68 page(s) built in 31.39s
12:25:42 [build] Complete!
```

**4. Both new gates ran live on this PR and passed** (their paths matched
   because this PR touches `.github/workflows/**` and adds
   `pages-build-check.yml` itself, which is inside its own trigger paths):

```
Lint workflow files   pass   10s
Build site            pass   40s
```

The `actionlint` gate also caught the `action-gh-release@v1` staleness live
on this PR's first push, a real failure it found on its own, not a staged
one, which is what drove commit 3 above.

## Test plan

- [x] `python3 -c "import yaml..."` parses every workflow file cleanly
- [x] `actionlint -shellcheck=` (v1.7.12, matching CI) passes clean on the
      full `.github/workflows/` directory
- [x] Reproduced the original unquoted-colon defect in a throwaway file and
      confirmed both plain YAML parsing and actionlint fail hard on it;
      throwaway file deleted, never committed
- [x] `npm ci && npm run build` succeeds in `website/site` on current main
- [x] New `actionlint` workflow fired and passed on this PR
- [x] New `pages-build-check` workflow fired (it modifies its own trigger
      path) and passed on this PR
- [x] `actionlint` gate caught a real pre-existing issue
      (`action-gh-release@v1` staleness) live; fixed in a follow-up commit,
      with input-compatibility checked against `v1`/`v2` `action.yml`
