### PR TITLE
test(tripwire): pin AINB_HOME in the drift-glyph live tripwire

### DIFF
--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_drift_glyph_live.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_drift_glyph_live.rs
@@ -230,10 +230,28 @@ fn pressing_m_renders_drift_warning_glyph_against_real_local_bare() {
         .expect("tmux new-session");
     assert!(status.success(), "tmux new-session failed");
 
+    // Pin `AINB_HOME` explicitly alongside `HOME` rather than relying
+    // on `default_ainb_home()`'s `HOME`-only fallback — every sibling
+    // live tripwire (`SandboxLayout::env_vars()` in
+    // ainb-skill-core::fixtures) does the same for exactly this
+    // reason: `default_ainb_home()` prefers `$AINB_HOME`, then
+    // `$XDG_CONFIG_HOME/agents-in-a-box`, and only falls back to
+    // `$HOME/.agents-in-a-box` last. On a CI runner where either of
+    // those higher-precedence vars is set in the job's ambient
+    // environment, a bare `HOME=...` override silently loses the race
+    // and the app reads an empty/real ainb home instead of the one we
+    // just seeded — Sources/Units render empty and the ⚠ glyph never
+    // appears, which is exactly the failure this test is guarding
+    // against, just misattributed to the product instead of the
+    // launch line. Also set `GIT_TERMINAL_PROMPT`/`GIT_ASKPASS`
+    // belt-and-braces (matches `SandboxLayout::env_vars()`) so a
+    // credential prompt can never freeze the pane.
+    let ainb_home = home_tmp.path().join(".agents-in-a-box");
     let cmd = format!(
-        "HOME={} exec {} 2>&1",
-        home_tmp.path().display(),
-        bin.display()
+        "HOME={home} AINB_HOME={ainb_home} GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/true exec {bin} 2>&1",
+        home = home_tmp.path().display(),
+        ainb_home = ainb_home.display(),
+        bin = bin.display(),
     );
     Command::new("tmux")
         .args(["send-keys", "-t", &session, &cmd, "Enter"])

--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_drift_glyph_live.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_drift_glyph_live.rs
@@ -231,7 +231,7 @@ fn pressing_m_renders_drift_warning_glyph_against_real_local_bare() {
     assert!(status.success(), "tmux new-session failed");
 
     // Pin `AINB_HOME` explicitly alongside `HOME` rather than relying
-    // on `default_ainb_home()`'s `HOME`-only fallback — every sibling
+    // on `default_ainb_home()`'s `HOME`-only fallback. Every sibling
     // live tripwire (`SandboxLayout::env_vars()` in
     // ainb-skill-core::fixtures) does the same for exactly this
     // reason: `default_ainb_home()` prefers `$AINB_HOME`, then
@@ -240,7 +240,7 @@ fn pressing_m_renders_drift_warning_glyph_against_real_local_bare() {
     // those higher-precedence vars is set in the job's ambient
     // environment, a bare `HOME=...` override silently loses the race
     // and the app reads an empty/real ainb home instead of the one we
-    // just seeded — Sources/Units render empty and the ⚠ glyph never
+    // just seeded, so Sources/Units render empty and the glyph never
     // appears, which is exactly the failure this test is guarding
     // against, just misattributed to the product instead of the
     // launch line. Also set `GIT_TERMINAL_PROMPT`/`GIT_ASKPASS`


### PR DESCRIPTION
## Summary

`tripwire_core_skill_manager_drift_glyph_live.rs` was failing in the
now-repaired `toolkit-validation.yml` gate. Panic:

```
SkillManager Units panel never rendered the ⚠ drift glyph against the
real local bare repo (file:///tmp/.tmpKDi1Rd/seed-bare.git, tip=...).
last capture:
(no sources configured) / No units installed yet
```

## Discriminator evidence

The test seeds `manifest.yaml` + `lock.yaml` directly at
`$HOME/.agents-in-a-box/` and launches the real `ainb` binary with
only `HOME=<tmp> exec ainb` set, relying on
`ainb_skill_core::default_ainb_home()`'s fallback chain
(`AINB_HOME` -> `XDG_CONFIG_HOME/agents-in-a-box` -> `HOME/.agents-in-a-box`)
to land on the seeded files.

I manually reproduced the test's exact setup (real bare repo, real
manifest/lockfile, real tmux-driven `ainb` binary) against the actual
product code and confirmed: when `AINB_HOME` is pinned explicitly, the
SkillManager screen loads the seeded source and unit and renders the
⚠ Outdated glyph correctly, every time (3 runs, debug and release).
So the config **does** land at a path the product reads by default —
this is not a product regression.

The gap is that every sibling live tripwire in this file family
(`tripwire_core_skill_manager_check_live.rs`,
`browse_curated_live.rs`, `keys_wired.rs`, etc.) launches via
`ainb_skill_core::fixtures::SandboxLayout::env_vars()`, which pins
`AINB_HOME` explicitly (and `GIT_TERMINAL_PROMPT`/`GIT_ASKPASS`
belt-and-braces) precisely because relying on `HOME`-only fallthrough
is fragile against whatever else is in a CI runner's ambient
environment. `tripwire_core_skill_manager_drift_glyph_live.rs`
predates that shared helper and does its own bespoke seeding, but
never got the same explicit-env treatment — the same class of drift
as the sibling `doctor_exits_nonzero_on_missing_deployed_file` fix
(stale assumption about what the harness needs to pin down).

**Verdict: test/harness drift, not a product regression.**

## Fix

Pin `AINB_HOME` explicitly to the same path the test already seeds
(`home.join(".agents-in-a-box")`), and add
`GIT_TERMINAL_PROMPT=0` / `GIT_ASKPASS=/bin/true` to match the
sibling pattern. No assertion was weakened, no sleep/retry was added,
and the test still drives the real binary against a real local bare
git repo end-to-end.

## Test plan

Run from `ainb-tui/`:

```
cargo test -p ainb --test tripwire_core_skill_manager_drift_glyph_live -- --nocapture
cargo test -p ainb --test tripwire_cli_doctor_exit_codes -- --nocapture
```

Both run twice locally (debug build) after the fix:

- `tripwire_core_skill_manager_drift_glyph_live`: `ok` (2x, ~4s each)
- `tripwire_cli_doctor_exit_codes` (sibling, no regression): `ok` (0.1-0.2s)