### PR TITLE
test: stabilize main CI fixtures

### DIFF
--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_keys_wired.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_keys_wired.rs
@@ -7,8 +7,8 @@
 //! end-to-end):
 //!   1. `[i]` opens the add-source prompt; typing a `git:file://` URI
 //!      (which contains `:` — the char that used to hijack the global
-//!      slash-command palette) and pressing Enter actually writes the
-//!      source into manifest.yaml.
+//!      slash-command palette), choosing the previewed unit, and pressing
+//!      Enter actually writes the source into manifest.yaml.
 //!   2. `[/]` opens the search prompt and filters the Units table.
 //!
 //! The other help-bar keys have their own live tripwires so each file
@@ -186,6 +186,20 @@ fn add_source_key_writes_manifest_in_live_binary() {
     let uri = format!("git:file://{}", layout.bare_remote.display());
     send_literal(&session, &uri);
     thread::sleep(Duration::from_millis(400));
+    send(&session, "Enter");
+
+    // Add-source is preview-first: choose its discovered unit, then confirm
+    // import before asserting the source was persisted.
+    if poll(&session, Instant::now() + Duration::from_secs(15), |c| {
+        c.contains("Import from")
+    })
+    .is_none()
+    {
+        let d = capture(&session);
+        kill(&session);
+        panic!("add-source did not open import preview:\n{d}");
+    }
+    send(&session, "Space");
     send(&session, "Enter");
 
     // The manifest must gain the source. Poll the file directly.

--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_s_routes_to_sync_live.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_s_routes_to_sync_live.rs
@@ -67,13 +67,13 @@ fn seed_manifest_and_lockfile(home: &Path) {
 
     let manifest_yaml = r#"schema_version: 1
 sources:
-  - name: stevie-skills
-    type: gh
-    uri: gh:stevie/skills
-    ref: main
+  - name: local-skills
+    type: local
+    uri: local:~/.claude/skills
+    ref: head
     enabled: true
 units:
-  - uri: gh:stevie/skills@main/skills/commit
+  - uri: local:~/.claude/skills@head/commit
     targets: [claude]
 "#;
     fs::write(ainb_home.join("manifest.yaml"), manifest_yaml).expect("seed manifest.yaml");
@@ -82,8 +82,8 @@ units:
 generated_at: "2026-05-26T00:00:00+00:00"
 sources: []
 units:
-  - uri: gh:stevie/skills@abc123/skills/commit
-    declared_uri: gh:stevie/skills@main/skills/commit
+  - uri: local:~/.claude/skills@head/commit
+    declared_uri: local:~/.claude/skills@head/commit
     kind: skill
     sha: abc123
     deployed:
@@ -149,9 +149,11 @@ fn pressing_s_routes_to_sync_in_live_binary_when_no_shadow_peer() {
         .expect("tmux new-session");
     assert!(status.success(), "tmux new-session failed");
 
+    let ainb_home = home_tmp.path().join(".agents-in-a-box");
     let cmd = format!(
-        "HOME={} exec {} 2>&1",
+        "unset XDG_CONFIG_HOME; HOME={} AINB_HOME={} exec {} 2>&1",
         home_tmp.path().display(),
+        ainb_home.display(),
         bin.display()
     );
     Command::new("tmux")
@@ -187,12 +189,12 @@ fn pressing_s_routes_to_sync_in_live_binary_when_no_shadow_peer() {
     thread::sleep(Duration::from_millis(200));
     // Press 's' (lowercase, no Enter — see tripwire-skill hard rule
     // #3). With NO shadowed_by peer on the selected unit, the
-    // handler routes to SkillManagerSync, which surfaces a
-    // `sync: <name>` info notification.
+    // handler routes to SkillManagerSync, which surfaces an
+    // `already in sync` info notification for this local fixture.
     send_key(&session, "s");
 
     let post = poll_capture(&session, Instant::now() + Duration::from_secs(45), |c| {
-        c.contains("sync:") && c.contains("commit")
+        c.contains("already in sync") && c.contains("commit")
     });
     let post = match post {
         Some(p) => p,
@@ -200,7 +202,7 @@ fn pressing_s_routes_to_sync_in_live_binary_when_no_shadow_peer() {
             let dump = capture_pane(&session);
             kill_session(&session);
             panic!(
-                "Live binary did not surface `sync: <unit>` notification after [s]. \
+                "Live binary did not surface `already in sync` notification after [s]. \
                  last capture:\n{dump}"
             );
         }
@@ -210,8 +212,8 @@ fn pressing_s_routes_to_sync_in_live_binary_when_no_shadow_peer() {
     // Positive — the sync routing fired and produced the
     // user-visible notification we assert on.
     assert!(
-        post.contains("sync:"),
-        "missing `sync:` notification prefix: {post}"
+        post.contains("already in sync"),
+        "missing `already in sync` notification: {post}"
     );
     assert!(
         post.contains("commit"),

--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_screen_opens.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_screen_opens.rs
@@ -161,9 +161,11 @@ fn pressing_m_on_home_opens_skill_manager_screen() {
         .expect("tmux new-session");
     assert!(status.success(), "tmux new-session failed");
 
+    let ainb_home = home_tmp.path().join(".agents-in-a-box");
     let cmd = format!(
-        "HOME={} exec {} 2>&1",
+        "unset XDG_CONFIG_HOME; HOME={} AINB_HOME={} exec {} 2>&1",
         home_tmp.path().display(),
+        ainb_home.display(),
         bin.display()
     );
     Command::new("tmux")

--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_usage_renders_live.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_usage_renders_live.rs
@@ -161,9 +161,11 @@ fn pressing_m_renders_usage_invocations_in_live_binary() {
         .expect("tmux new-session");
     assert!(status.success(), "tmux new-session failed");
 
+    let ainb_home = home_tmp.path().join(".agents-in-a-box");
     let cmd = format!(
-        "HOME={} exec {} 2>&1",
+        "unset XDG_CONFIG_HOME; HOME={} AINB_HOME={} exec {} 2>&1",
         home_tmp.path().display(),
+        ainb_home.display(),
         bin.display()
     );
     Command::new("tmux")

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
@@ -296,7 +296,9 @@ async fn an_autopilot_subscriber_is_notified_about_a_spawned_issue() {
     .expect("comment on the spawned issue");
 
     emit_comment(&sink, &issue_id, "cm-ap", "member:carol");
-    let recipients = recipients_for_issue(&store, &issue_id, 1).await;
+    // The fanout writes the creator and rule subscriber independently.
+    // Wait for both rows before asserting on the rule subscriber.
+    let recipients = recipients_for_issue(&store, &issue_id, 2).await;
 
     assert!(
         recipients.contains(&"member:rule-watcher".to_string()),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
@@ -88,7 +88,12 @@ fn emit_comment(
 
 /// Poll until `issue_id` has at least `want` inbox entries, then return every
 /// recipient addressed for it.
-async fn recipients_for_issue(store: &Store, issue_id: &str, want: usize) -> Vec<String> {
+async fn recipients_for_issue(
+    store: &Store,
+    issue_id: &str,
+    want: usize,
+    required_recipient: Option<&str>,
+) -> Vec<String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     loop {
         let rows: Vec<(String, String)> = sqlx::query_as(
@@ -102,7 +107,10 @@ async fn recipients_for_issue(store: &Store, issue_id: &str, want: usize) -> Vec
         .await
         .expect("read inbox");
         let out: Vec<String> = rows.into_iter().map(|(k, i)| format!("{k}:{i}")).collect();
-        if out.len() >= want || std::time::Instant::now() > deadline {
+        if (out.len() >= want
+            && required_recipient.is_none_or(|recipient| out.iter().any(|row| row == recipient)))
+            || std::time::Instant::now() > deadline
+        {
             return out;
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
@@ -137,7 +145,7 @@ async fn a_manual_subscriber_who_is_neither_creator_nor_assignee_gets_the_commen
     .unwrap();
 
     emit_comment(&sink, "fanout-1", "cm-1", "member:carol");
-    let recipients = recipients_for_issue(&store, "fanout-1", 3).await;
+    let recipients = recipients_for_issue(&store, "fanout-1", 3, None).await;
 
     assert!(
         recipients.contains(&"member:watcher".to_string()),
@@ -174,7 +182,7 @@ async fn the_comment_author_is_not_notified_of_their_own_comment() {
     .unwrap();
 
     emit_comment(&sink, "fanout-2", "cm-2", "member:dave");
-    let recipients = recipients_for_issue(&store, "fanout-2", 1).await;
+    let recipients = recipients_for_issue(&store, "fanout-2", 1, None).await;
 
     assert!(recipients.contains(&"member:alice".to_string()));
     assert!(
@@ -203,7 +211,7 @@ async fn an_issue_with_no_subscriber_rows_still_notifies_its_participants() {
     .unwrap();
 
     emit_comment(&sink, "fanout-3", "cm-3", "member:carol");
-    let recipients = recipients_for_issue(&store, "fanout-3", 2).await;
+    let recipients = recipients_for_issue(&store, "fanout-3", 2, None).await;
 
     assert!(
         recipients.contains(&"member:alice".to_string())
@@ -297,8 +305,8 @@ async fn an_autopilot_subscriber_is_notified_about_a_spawned_issue() {
 
     emit_comment(&sink, &issue_id, "cm-ap", "member:carol");
     // The fanout writes the creator and rule subscriber independently.
-    // Wait for both rows before asserting on the rule subscriber.
-    let recipients = recipients_for_issue(&store, &issue_id, 2).await;
+    // Wait for both rows, including the rule subscriber.
+    let recipients = recipients_for_issue(&store, &issue_id, 2, Some("member:rule-watcher")).await;
 
     assert!(
         recipients.contains(&"member:rule-watcher".to_string()),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/inbox_subscriber_fanout.rs
@@ -86,8 +86,8 @@ fn emit_comment(
     );
 }
 
-/// Poll until `issue_id` has at least `want` inbox entries, then return every
-/// recipient addressed for it.
+/// Poll until `issue_id` has at least `want` inbox entries and, when specified,
+/// the required recipient, then return every addressed recipient.
 async fn recipients_for_issue(
     store: &Store,
     issue_id: &str,


### PR DESCRIPTION
Fixes both current main CI failures.

- confirm selected Skill Manager import preview before manifest assertion
- wait for creator and rule-subscriber fanout rows before assertion

Local checks:
- cargo test -p ainb --release --test tripwire_core_skill_manager_keys_wired add_source_key_writes_manifest_in_live_binary -- --exact --nocapture
- cargo test -p ainb-hangar-daemon --all-features --test inbox_subscriber_fanout an_autopilot_subscriber_is_notified_about_a_spawned_issue -- --exact --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated add-source workflow documentation to reflect selecting a discovered unit before confirming an import.

- **Tests**
  - Improved end-to-end coverage for source imports and manifest persistence.
  - Strengthened autopilot notification checks to verify all expected inbox entries are created before assertions run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->