### PR TITLE
ci: surface every failing tripwire instead of stopping at the first

### DIFF
--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -109,7 +109,15 @@ jobs:
           # Naming convention: `tripwire_<area>_<feature>_*` where area is
           # one of {cli, core, plugin}. `tripwire_helpers.rs` is the shared
           # module (not a test) and is excluded by the prefix scheme.
-          cargo test -p ainb --release \
+          #
+          # --no-fail-fast is deliberate: without it cargo stops at the
+          # first failing test binary, so a run reports one casualty and
+          # hides the rest. This workflow was unparseable for six weeks
+          # and several tripwires rotted meanwhile; each fix then cost a
+          # full CI cycle just to reveal the next failure. Surfacing every
+          # failure in one run is what makes the next such gap cheap to
+          # recover from.
+          cargo test -p ainb --release --no-fail-fast \
               --test 'tripwire_cli_*' \
               --test 'tripwire_core_skill_manager_*' \
               --test 'tripwire_core_home_tile_lists_skill_manager'


### PR DESCRIPTION
Adds `--no-fail-fast` to the "Run live-binary tripwires (Layer 4)" step in `toolkit-validation.yml`. The `--test` filters are unchanged.

## Why

`toolkit-validation.yml` was unparseable YAML from roughly 2026-06-18 until 2026-07-28, so GitHub produced zero jobs and the gate never ran. Several tripwires rotted in that window.

Once the workflow was repaired, cargo's default fail-fast meant each CI run reported exactly one failing test binary and hid the rest. Fixing that one revealed the next, at roughly 20 minutes per cycle (the gate's wall clock is set by `hangar-e2e` at ~16m30s). Three separate rotted tripwires were found this way, one cycle at a time, before the remainder were enumerated locally instead.

With `--no-fail-fast`, a single run surfaces every failure. That does not prevent the next gap, but it makes recovering from one cheap.

## Scope

One flag plus an explanatory comment. No `${{ }}` interpolation of event data, so no workflow-injection surface. Verified `yaml.safe_load` parses the file and the new `Actionlint` gate covers it on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation checks to run all applicable tests even when one fails, providing more complete test results in a single run.
  * Documented the test execution behavior for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->