### PR TITLE
feat(fleet): add native macOS RPC contract

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs
@@ -1,0 +1,152 @@
+//! Real Fleet daemon fixture for the macOS RPC contract tests.
+//!
+//! The process owns an isolated `AINB_HANGAR_HOME` supplied by its test parent.
+//! It creates the real SQLite store, daemon token, Unix socket server, durable
+//! Fleet revision log, and live event broker. JSON commands on stdin only inject
+//! provider hook observations; they never emulate an RPC response or Fleet state.
+
+use std::io::{BufRead as _, Write as _};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use ainb_hangar_daemon::events::EventBroker;
+use ainb_hangar_daemon::fleet::{self, HookObservation};
+use ainb_hangar_daemon::rpc::{self, DaemonHealth};
+use ainb_hangar_store::Store;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+enum Command {
+    Seed {
+        event_id: String,
+        #[serde(default = "default_provider")]
+        provider: String,
+        #[serde(default = "default_session_id")]
+        session_id: String,
+        #[serde(default = "default_event_type")]
+        event_type: String,
+        #[serde(default = "default_cwd")]
+        cwd: String,
+        #[serde(default)]
+        payload: Value,
+        #[serde(default)]
+        observed_at: Option<i64>,
+    },
+    Shutdown,
+}
+
+fn default_provider() -> String {
+    "claude".to_string()
+}
+fn default_session_id() -> String {
+    "fixture-session".to_string()
+}
+fn default_event_type() -> String {
+    "SessionStart".to_string()
+}
+fn default_cwd() -> String {
+    "/fixture".to_string()
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let home = fixture_home()?;
+    let store = Store::open_in(&home).await?;
+    rpc::auth::ensure_socket_token(store.pool(), &home).await?;
+    let socket = rpc::socket_path_in(&home);
+    let listener = rpc::bind(&socket)?;
+    let broker = EventBroker::new();
+    let sink = broker.sink();
+    let health = DaemonHealth {
+        socket_path: socket.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        started_at: Instant::now(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        stats: Arc::new(ainb_hangar_daemon::health_stats::HealthStats::default()),
+    };
+    tokio::spawn(rpc::serve(listener, store.pool().clone(), health, broker));
+
+    let mut next_observed_at = 1_700_000_000_000_i64;
+    'commands: loop {
+        for line in std::io::stdin().lock().lines() {
+            let line = line?;
+            let command: Command = match serde_json::from_str(&line) {
+                Ok(command) => command,
+                Err(error) => {
+                    println!(
+                        "{}",
+                        serde_json::json!({ "ok": false, "error": error.to_string() })
+                    );
+                    std::io::stdout().flush()?;
+                    continue;
+                }
+            };
+            match command {
+                Command::Seed {
+                    event_id,
+                    provider,
+                    session_id,
+                    event_type,
+                    cwd,
+                    payload,
+                    observed_at,
+                } => {
+                    let observed_at = observed_at.unwrap_or_else(|| {
+                        next_observed_at += 1;
+                        next_observed_at
+                    });
+                    match fleet::apply_hook(
+                        store.pool(),
+                        &sink,
+                        HookObservation {
+                            event_id: event_id.clone(),
+                            provider: &provider,
+                            provider_session_id: &session_id,
+                            cwd: &cwd,
+                            event_type: &event_type,
+                            payload: &payload,
+                            observed_at,
+                        },
+                    )
+                    .await
+                    {
+                        Ok(result) => println!(
+                            "{}",
+                            serde_json::json!({
+                                "ok": true,
+                                "event_id": event_id,
+                                "revision": result.revision,
+                                "duplicate": result.duplicate,
+                            })
+                        ),
+                        Err(error) => println!(
+                            "{}",
+                            serde_json::json!({ "ok": false, "error": error.to_string() })
+                        ),
+                    }
+                    std::io::stdout().flush()?;
+                }
+                Command::Shutdown => break 'commands,
+            }
+        }
+        // XCTest may momentarily close its inherited stdin during test-host launch.
+        // Keep the real daemon available for its readiness and socket proof instead
+        // of turning that transport startup race into a clean fixture exit.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+fn fixture_home() -> anyhow::Result<PathBuf> {
+    let raw = std::env::var_os("AINB_HANGAR_HOME")
+        .ok_or_else(|| anyhow::anyhow!("AINB_HANGAR_HOME is required for fixture isolation"))?;
+    let home = PathBuf::from(raw);
+    if !home.is_absolute() {
+        anyhow::bail!("AINB_HANGAR_HOME must be an absolute isolated directory");
+    }
+    std::fs::create_dir_all(&home)?;
+    Ok(home)
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/atc.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/atc.rs
@@ -203,8 +203,30 @@ impl AtcHeartbeatScheduler {
                 () = tokio::time::sleep(delay) => {}
             }
             if let Some(inst) = fire_target {
-                self.fire(&inst).await;
-                self.reschedule(&inst).await;
+                let due_tick_at = inst.next_tick_at.expect("schedulable rows have a due tick");
+                match AtcInstanceRepo::claim_due(
+                    &self.pool,
+                    &inst.name,
+                    inst.config_generation,
+                    due_tick_at,
+                )
+                .await
+                {
+                    Ok(true) => {
+                        let fired_at = self.fire(&inst).await;
+                        self.reschedule(&inst, fired_at).await;
+                    }
+                    Ok(false) => tracing::debug!(
+                        instance = %inst.name,
+                        generation = inst.config_generation,
+                        "ATC heartbeat claim invalidated by a configuration mutation"
+                    ),
+                    Err(error) => tracing::error!(
+                        instance = %inst.name,
+                        error = %error,
+                        "ATC heartbeat claim failed"
+                    ),
+                }
             }
         }
         tracing::info!("ATC heartbeat cron stopped");
@@ -217,7 +239,7 @@ impl AtcHeartbeatScheduler {
     ///
     /// Non-fatal end to end: an unspawned instance (no tmux target) or a send
     /// fault is warned and skipped, never a panic.
-    async fn fire(&self, inst: &AtcInstanceRow) {
+    async fn fire(&self, inst: &AtcInstanceRow) -> i64 {
         let now = self.clock.now_ms();
         let rows = probe_fleet_needs(now).await;
 
@@ -246,7 +268,7 @@ impl AtcHeartbeatScheduler {
             tracing::debug!(instance = %inst.name, "ATC heartbeat: no tmux target; nudge not sent");
         }
 
-        let _ = AtcInstanceRepo::mark_heartbeat(&self.pool, &inst.name, now).await;
+        now
     }
 
     /// Apply the retry-cap decision for ONE ERR session of an instance.
@@ -301,11 +323,29 @@ impl AtcHeartbeatScheduler {
     }
 
     /// Recompute + persist the instance's next heartbeat tick from the fired slot.
-    async fn reschedule(&self, inst: &AtcInstanceRow) {
+    async fn reschedule(&self, inst: &AtcInstanceRow, fired_at: i64) {
         let next =
             recompute_next_tick(&inst.heartbeat_cron, inst.next_tick_at, self.clock.now_ms());
-        if let Err(e) = AtcInstanceRepo::set_next_tick(&self.pool, &inst.name, next).await {
-            tracing::error!(instance = %inst.name, error = %e, "ATC heartbeat reschedule failed");
+        match AtcInstanceRepo::complete_claim(
+            &self.pool,
+            &inst.name,
+            inst.config_generation,
+            next,
+            fired_at,
+        )
+        .await
+        {
+            Ok(true) => {}
+            Ok(false) => tracing::debug!(
+                instance = %inst.name,
+                generation = inst.config_generation,
+                "ATC heartbeat completion invalidated by a configuration mutation"
+            ),
+            Err(error) => tracing::error!(
+                instance = %inst.name,
+                error = %error,
+                "ATC heartbeat reschedule failed"
+            ),
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -163,20 +163,37 @@ async fn retire_correlated_legacy(
 pub async fn snapshot_wire(
     pool: &SqlitePool,
 ) -> Result<ainb_hangar_proto::fleet::FleetSnapshot, sqlx::Error> {
-    let snapshot = FleetRepo::snapshot(pool).await?;
-    let mut sessions = Vec::with_capacity(snapshot.sessions.len());
-    for row in &snapshot.sessions {
-        let current_request = if row.current_request_fingerprint.is_some() {
-            current_request_wire(pool, &row.session_key).await?
-        } else {
-            None
-        };
-        sessions.push(session_wire(row, current_request));
+    let projection = FleetRepo::subscription_projection(pool, 0, 0).await?;
+    Ok(subscription_snapshot_wire(&projection))
+}
+
+/// Read a wire-ready Fleet subscription projection from one store transaction.
+pub async fn subscription_wire(
+    pool: &SqlitePool,
+    after_revision: i64,
+    replay_limit: i64,
+) -> Result<ainb_hangar_store::repo::fleet::FleetSubscriptionProjection, FleetRepoError> {
+    ainb_hangar_store::repo::fleet::FleetRepo::subscription_projection(
+        pool,
+        after_revision,
+        replay_limit,
+    )
+    .await
+    .map_err(FleetRepoError::from)
+}
+
+/// Convert one atomic store subscription projection into its Fleet wire shape.
+pub fn subscription_snapshot_wire(
+    projection: &ainb_hangar_store::repo::fleet::FleetSubscriptionProjection,
+) -> ainb_hangar_proto::fleet::FleetSnapshot {
+    ainb_hangar_proto::fleet::FleetSnapshot {
+        head_revision: projection.head_revision,
+        sessions: projection
+            .sessions
+            .iter()
+            .map(|row| session_wire(&row.session, row.current_request.clone()))
+            .collect(),
     }
-    Ok(ainb_hangar_proto::fleet::FleetSnapshot {
-        head_revision: snapshot.head_revision,
-        sessions,
-    })
 }
 
 /// Read complete payload for current structured request or approval.
@@ -663,7 +680,8 @@ fn session_wire(
     }
 }
 
-fn event_wire(row: &FleetEventRow) -> ainb_hangar_proto::fleet::FleetEvent {
+/// Convert one durable Fleet event row into its public wire representation.
+pub fn event_wire(row: &FleetEventRow) -> ainb_hangar_proto::fleet::FleetEvent {
     ainb_hangar_proto::fleet::FleetEvent {
         revision: row.revision,
         event_id: row.event_id.clone(),
@@ -1456,6 +1474,11 @@ mod tests {
         assert_eq!(
             session.attention,
             ainb_hangar_proto::fleet::AttentionState::Ask
+        );
+        assert_eq!(
+            session.current_request.as_ref().unwrap()["questions"][0]["id"],
+            "q1",
+            "snapshot must carry the request body from its atomic projection"
         );
         assert_eq!(
             session.lifecycle,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -872,6 +872,9 @@ async fn handle(
         methods::FLEET_SUBSCRIBE => handle_fleet_subscribe(pool, req).await,
         methods::FLEET_ACTION => handle_fleet_action(pool, req, events).await,
         methods::FLEET_BROADCAST => handle_fleet_broadcast(pool, req, events).await,
+        methods::FLEET_RECEIPT_LIST => handle_fleet_receipt_list(pool, req).await,
+        methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
+        methods::FLEET_START => handle_fleet_start(pool, req, events).await,
         methods::ATTENTION_LIST => handle_attention_list(pool, req).await,
         // `attention/subscribe` acks with the current OPEN snapshot; the live
         // fleet-wide forwarder is the stream side (see `serve_conn`).
@@ -990,6 +993,63 @@ async fn handle_fleet_action(
         parse_params(req, "{ session_key, expected_version, request_id, action }")?;
     let receipt = execute_fleet_action(pool, params, None, events).await?;
     to_value(&ainb_hangar_proto::fleet::FleetActionResult { receipt })
+}
+
+const FLEET_RECEIPT_LIST_MAX: u32 = 100;
+
+/// Return a bounded, durable newest-first receipt projection.
+async fn handle_fleet_receipt_list(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FleetReceiptListParams, FleetReceiptListResult};
+    use ainb_hangar_store::repo::fleet::FleetRepo;
+
+    let params: FleetReceiptListParams = parse_params(req, "{ limit }")?;
+    if !(1..=FLEET_RECEIPT_LIST_MAX).contains(&params.limit) {
+        return Err(invalid_params(&format!(
+            "limit must be between 1 and {FLEET_RECEIPT_LIST_MAX}"
+        )));
+    }
+    let receipts = FleetRepo::list_action_receipts(pool, i64::from(params.limit))
+        .await
+        .map_err(|error| store_err(&error))?
+        .iter()
+        .map(action_receipt_wire)
+        .collect();
+    to_value(&FleetReceiptListResult { receipts })
+}
+
+/// Return one durable receipt, or `null` when its request id is unknown.
+async fn handle_fleet_receipt_get(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FleetReceiptGetParams, FleetReceiptGetResult};
+    use ainb_hangar_store::repo::fleet::FleetRepo;
+
+    let params: FleetReceiptGetParams = parse_params(req, "{ request_id }")?;
+    if params.request_id.trim().is_empty() {
+        return Err(invalid_params("request_id must not be empty"));
+    }
+    let receipt = FleetRepo::get_action_receipt(pool, &params.request_id)
+        .await
+        .map_err(|error| store_err(&error))?
+        .as_ref()
+        .map(action_receipt_wire);
+    to_value(&FleetReceiptGetResult { receipt })
+}
+
+/// Start a provider session through daemon-owned new-session state.
+async fn handle_fleet_start(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    let params: ainb_hangar_proto::fleet::FleetStartParams =
+        parse_params(req, "{ request_id, provider, cwd, prompt? }")?;
+    let result = execute_fleet_start(pool, params, events).await?;
+    to_value(&result)
 }
 
 /// Deliver one text prompt to explicit stable recipients with bounded fanout.
@@ -1163,6 +1223,12 @@ async fn execute_fleet_action(
         .map_err(|error| internal(&format!("serialize action: {error}")))?;
     let action_fingerprint = stable_fingerprint(&action_json);
 
+    if matches!(&params.action, ControlAction::Start { .. }) {
+        return Err(invalid_params(
+            "start must use fleet/start, not fleet/action",
+        ));
+    }
+
     if let Some(existing) = FleetRepo::get_action_receipt(pool, &params.request_id)
         .await
         .map_err(|error| store_err(&error))?
@@ -1178,11 +1244,6 @@ async fn execute_fleet_action(
             ));
         }
         return Ok(action_receipt_wire(&existing));
-    }
-
-    if matches!(&params.action, ControlAction::Start { .. }) {
-        return execute_fleet_start(pool, params, idempotency_key, action_fingerprint, events)
-            .await;
     }
 
     let request_fingerprint = match &params.action {
@@ -1368,22 +1429,32 @@ async fn execute_fleet_action(
 
 async fn execute_fleet_start(
     pool: &SqlitePool,
-    params: ainb_hangar_proto::fleet::FleetActionParams,
-    idempotency_key: Option<String>,
-    action_fingerprint: String,
+    params: ainb_hangar_proto::fleet::FleetStartParams,
     events: &EventSink,
-) -> Result<ainb_hangar_proto::fleet::FleetActionReceipt, RpcError> {
-    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction, FleetProvider};
+) -> Result<ainb_hangar_proto::fleet::FleetStartResult, RpcError> {
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetProvider, FleetStartResult};
     use ainb_hangar_store::repo::fleet::{FleetRepo, NewActionReceipt};
 
+    if params.request_id.trim().is_empty() || params.cwd.trim().is_empty() {
+        return Err(invalid_params("request_id and cwd must not be empty"));
+    }
+    if params.provider == FleetProvider::Unknown {
+        return Err(invalid_params("provider must be known"));
+    }
+    let prospective_session_key =
+        prospective_start_session_key(params.provider, &params.request_id);
+    let action_fingerprint = stable_fingerprint(
+        &serde_json::to_string(&params)
+            .map_err(|error| internal(&format!("serialize start params: {error}")))?,
+    );
     let now = SystemClock.now_ms();
     let mut receipt = NewActionReceipt {
         request_id: params.request_id.clone(),
-        session_key: params.session_key.clone(),
-        action_kind: params.action.kind().to_string(),
+        session_key: prospective_session_key.clone(),
+        action_kind: "start".to_string(),
         action_fingerprint,
-        expected_version: params.expected_version,
-        idempotency_key,
+        expected_version: 1,
+        idempotency_key: None,
         status: "PENDING".to_string(),
         detail: None,
         session_version: None,
@@ -1417,76 +1488,78 @@ async fn execute_fleet_start(
             .await
             .map_err(|error| store_err(&error))?
             .ok_or_else(|| internal("Fleet start receipt claim disappeared"))?;
-        if existing.session_key != params.session_key
-            || existing.action_kind != params.action.kind()
+        if existing.session_key != prospective_session_key
+            || existing.action_kind != "start"
             || existing.action_fingerprint != receipt.action_fingerprint
-            || existing.expected_version != params.expected_version
-            || existing.idempotency_key != receipt.idempotency_key
+            || existing.expected_version != 1
+            || existing.idempotency_key.is_some()
         {
             return Err(invalid_params(
-                "request_id was reused for a different Fleet action",
+                "request_id was reused for a different Fleet start",
             ));
         }
-        return Ok(action_receipt_wire(&existing));
+        return Ok(FleetStartResult {
+            prospective_session_key,
+            receipt: action_receipt_wire(&existing),
+        });
     }
 
-    let (status, detail) = match &params.action {
-        ControlAction::Start {
-            provider: FleetProvider::Codex,
-            cwd,
-            prompt,
-        } => match crate::fleet_provider::codex_manager::active_handle().await {
-            Some(manager) => match manager.thread_start(Path::new(cwd), None).await {
-                Ok(thread) => match launch_managed_codex_tui(&manager, &thread, cwd).await {
-                    Ok((tmux_name, tmux_session)) => {
-                        match crate::fleet::register_managed_codex_tmux(
-                            pool,
-                            events,
-                            &thread,
-                            cwd,
-                            &tmux_session,
-                            manager.capabilities(),
-                            SystemClock.now_ms(),
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                let turn = match prompt
-                                    .as_deref()
-                                    .filter(|prompt| !prompt.trim().is_empty())
-                                {
-                                    Some(prompt) => {
-                                        manager.turn_start(&thread, prompt).await.map(|_| ())
+    let (status, detail) = match params.provider {
+        FleetProvider::Codex => match crate::fleet_provider::codex_manager::active_handle().await {
+            Some(manager) => match manager.thread_start(Path::new(&params.cwd), None).await {
+                Ok(thread) => {
+                    match launch_managed_codex_tui(&manager, &thread, &params.cwd).await {
+                        Ok((tmux_name, tmux_session)) => {
+                            match crate::fleet::register_managed_codex_tmux(
+                                pool,
+                                events,
+                                &thread,
+                                &params.cwd,
+                                &tmux_session,
+                                manager.capabilities(),
+                                SystemClock.now_ms(),
+                            )
+                            .await
+                            {
+                                Ok(_) => {
+                                    let turn = match params
+                                        .prompt
+                                        .as_deref()
+                                        .filter(|prompt| !prompt.trim().is_empty())
+                                    {
+                                        Some(prompt) => {
+                                            manager.turn_start(&thread, prompt).await.map(|_| ())
+                                        }
+                                        None => Ok(()),
+                                    };
+                                    match turn {
+                                        Ok(()) => (
+                                            ActionReceiptStatus::Delivered,
+                                            Some(format!(
+                                                "codex thread {thread}, tmux {}",
+                                                tmux_session
+                                                    .exact_tmux_target
+                                                    .as_deref()
+                                                    .unwrap_or(&tmux_name)
+                                            )),
+                                        ),
+                                        Err(error) => (
+                                            ActionReceiptStatus::Failed,
+                                            Some(format!(
+                                                "Codex thread {thread} launched in tmux {tmux_name}, initial prompt failed: {error}"
+                                            )),
+                                        ),
                                     }
-                                    None => Ok(()),
-                                };
-                                match turn {
-                                    Ok(()) => (
-                                        ActionReceiptStatus::Delivered,
-                                        Some(format!(
-                                            "codex thread {thread}, tmux {}",
-                                            tmux_session
-                                                .exact_tmux_target
-                                                .as_deref()
-                                                .unwrap_or(&tmux_name)
-                                        )),
-                                    ),
-                                    Err(error) => (
-                                        ActionReceiptStatus::Failed,
-                                        Some(format!(
-                                            "Codex thread {thread} launched in tmux {tmux_name}, initial prompt failed: {error}"
-                                        )),
-                                    ),
+                                }
+                                Err(error) => {
+                                    let _ = kill_tmux_session_exact(&tmux_name).await;
+                                    (ActionReceiptStatus::Failed, Some(error.to_string()))
                                 }
                             }
-                            Err(error) => {
-                                let _ = kill_tmux_session_exact(&tmux_name).await;
-                                (ActionReceiptStatus::Failed, Some(error.to_string()))
-                            }
                         }
+                        Err(error) => (ActionReceiptStatus::Failed, Some(error)),
                     }
-                    Err(error) => (ActionReceiptStatus::Failed, Some(error)),
-                },
+                }
                 Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
             },
             None => (
@@ -1494,17 +1567,31 @@ async fn execute_fleet_start(
                 Some("Codex managed transport is not active".to_string()),
             ),
         },
-        ControlAction::Start { .. } => (
+        FleetProvider::Claude | FleetProvider::Unknown => (
             ActionReceiptStatus::Rejected,
             Some("provider start transport is unavailable".to_string()),
         ),
-        _ => unreachable!("start handler only receives start actions"),
     };
     receipt.status = receipt_status_token(status).to_string();
     receipt.detail = detail;
     receipt.updated_at = SystemClock.now_ms();
     let row = FleetRepo::upsert_action_receipt(pool, &receipt).await.map_err(fleet_repo_err)?;
-    Ok(action_receipt_wire(&row))
+    Ok(FleetStartResult {
+        prospective_session_key,
+        receipt: action_receipt_wire(&row),
+    })
+}
+
+fn prospective_start_session_key(
+    provider: ainb_hangar_proto::fleet::FleetProvider,
+    request_id: &str,
+) -> String {
+    let provider = match provider {
+        ainb_hangar_proto::fleet::FleetProvider::Claude => "claude",
+        ainb_hangar_proto::fleet::FleetProvider::Codex => "codex",
+        ainb_hangar_proto::fleet::FleetProvider::Unknown => "unknown",
+    };
+    format!("start:{provider}:{}", stable_fingerprint(request_id))
 }
 
 async fn launch_managed_codex_tui(
@@ -1773,7 +1860,7 @@ async fn execute_codex_action(
     Option<String>,
 ) {
     use crate::fleet_provider::{ApprovalDecision, QuestionAnswer};
-    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction, FleetProvider};
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, ControlAction};
 
     let thread_id = session.provider_session_id.as_deref().unwrap_or_default();
     let result: Result<String, crate::fleet_provider::ProviderError> = async {
@@ -1977,17 +2064,6 @@ async fn execute_codex_action(
                 Ok(format!(
                     "codex thread {thread_id} archived after tmux {tmux_name} stop"
                 ))
-            }
-            ControlAction::Start {
-                provider,
-                cwd,
-                prompt,
-            } if *provider == FleetProvider::Codex => {
-                let thread = manager.thread_start(Path::new(cwd), None).await?;
-                if let Some(prompt) = prompt.as_deref().filter(|prompt| !prompt.trim().is_empty()) {
-                    manager.turn_start(&thread, prompt).await?;
-                }
-                Ok(format!("codex thread {thread}"))
             }
             _ => Err(crate::fleet_provider::ProviderError::Unsupported(
                 "Codex action is not available through app-server".to_string(),
@@ -2565,7 +2641,7 @@ fn action_capability(
         ControlAction::Continue => capabilities.continue_turn,
         ControlAction::Retry => capabilities.retry,
         ControlAction::Interrupt => capabilities.interrupt,
-        ControlAction::Start { .. } => capabilities.start,
+        ControlAction::Start { .. } => false,
         ControlAction::Restart => capabilities.restart,
         ControlAction::Stop => capabilities.stop,
         ControlAction::Kill => capabilities.kill,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -8524,11 +8524,11 @@ async fn handle_atc_register(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    use ainb_hangar_store::repo::atc_instance::{AtcInstanceRepo, RegisterAtc};
+    use ainb_hangar_store::repo::atc_instance::{AtcInstanceRepo, RegisterAtc, RegisterAtcOutcome};
 
     let params: ainb_hangar_proto::snapshots::AtcRegisterParams = parse_params(
         req,
-        "{ name, cwd?, tmux_session?, heartbeat_cron?, err_retry_cap?, idle_pause_min? }",
+        "{ name, cwd?, tmux_session?, heartbeat_cron?, err_retry_cap?, idle_pause_min?, expected_generation? }",
     )?;
     if params.name.trim().is_empty() {
         return Err(invalid_params("atc instance name must not be empty"));
@@ -8552,10 +8552,31 @@ async fn handle_atc_register(
         idle_pause_min: params.idle_pause_min.unwrap_or(60),
         next_tick_at,
     };
-    AtcInstanceRepo::register(pool, &reg, now_ms).await.map_err(|e| store_err(&e))?;
+    let outcome = AtcInstanceRepo::register_checked(pool, &reg, now_ms, params.expected_generation)
+        .await
+        .map_err(|e| store_err(&e))?;
+    let (row, status) = match outcome {
+        RegisterAtcOutcome::Applied(row) => (
+            row,
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Applied,
+        ),
+        RegisterAtcOutcome::AlreadyApplied(row) => (
+            row,
+            ainb_hangar_proto::snapshots::AtcMutationStatus::AlreadyApplied,
+        ),
+        RegisterAtcOutcome::Stale(Some(row)) => {
+            (row, ainb_hangar_proto::snapshots::AtcMutationStatus::Stale)
+        }
+        RegisterAtcOutcome::Stale(None) => {
+            return Err(invalid_params("atc configuration generation is stale"));
+        }
+    };
     to_value(&ainb_hangar_proto::snapshots::AtcRegisterResult {
-        name: reg.name,
-        next_tick_at,
+        name: row.name,
+        next_tick_at: row.next_tick_at,
+        config_generation: row.config_generation,
+        status,
+        scheduler_ownership: atc_scheduler_ownership(),
     })
 }
 
@@ -8579,9 +8600,13 @@ async fn handle_atc_list(pool: &SqlitePool) -> Result<serde_json::Value, RpcErro
             next_tick_at: r.next_tick_at,
             enabled: r.enabled,
             last_heartbeat_at: r.last_heartbeat_at,
+            config_generation: r.config_generation,
         })
         .collect();
-    to_value(&ainb_hangar_proto::snapshots::AtcListResult { instances })
+    to_value(&ainb_hangar_proto::snapshots::AtcListResult {
+        instances,
+        scheduler_ownership: atc_scheduler_ownership(),
+    })
 }
 
 /// Dispatch `atc/escalate` (spec P9, D12): raise an ATC escalation as an
@@ -8796,25 +8821,53 @@ async fn handle_atc_unregister(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    use ainb_hangar_store::repo::atc_instance::AtcInstanceRepo;
+    use ainb_hangar_store::repo::atc_instance::{AtcInstanceRepo, DisableAtcOutcome};
 
-    let params: ainb_hangar_proto::snapshots::AtcUnregisterParams = parse_params(req, "{ name }")?;
+    let params: ainb_hangar_proto::snapshots::AtcUnregisterParams =
+        parse_params(req, "{ name, expected_generation? }")?;
     let name = params.name.trim();
     if name.is_empty() {
         return Err(invalid_params("atc instance name must not be empty"));
     }
-    // Only a registered instance is disabled; an unknown name is a clean no-op so
-    // teardown is safe to fire unconditionally.
-    let disabled = AtcInstanceRepo::get(pool, name).await.map_err(|e| store_err(&e))?.is_some();
-    if disabled {
-        AtcInstanceRepo::set_enabled(pool, name, false, None)
-            .await
-            .map_err(|e| store_err(&e))?;
-    }
+    let outcome = AtcInstanceRepo::disable_checked(pool, name, params.expected_generation)
+        .await
+        .map_err(|e| store_err(&e))?;
+    let (disabled, config_generation, status) = match outcome {
+        DisableAtcOutcome::Applied(row) => (
+            true,
+            Some(row.config_generation),
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Applied,
+        ),
+        DisableAtcOutcome::AlreadyApplied(row) => (
+            true,
+            Some(row.config_generation),
+            ainb_hangar_proto::snapshots::AtcMutationStatus::AlreadyApplied,
+        ),
+        DisableAtcOutcome::NotFound => (
+            false,
+            None,
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Applied,
+        ),
+        DisableAtcOutcome::Stale(row) => (
+            false,
+            Some(row.config_generation),
+            ainb_hangar_proto::snapshots::AtcMutationStatus::Stale,
+        ),
+    };
     to_value(&ainb_hangar_proto::snapshots::AtcUnregisterResult {
         name: name.to_string(),
         disabled,
+        config_generation,
+        status,
+        scheduler_ownership: atc_scheduler_ownership(),
     })
+}
+
+/// E04 deliberately withholds the mutation capability until the legacy
+/// launchd/systemd lifecycle is moved below both core and daemon. The daemon
+/// exposes this fact rather than guessing from files it does not own.
+const fn atc_scheduler_ownership() -> ainb_hangar_proto::snapshots::AtcSchedulerOwnership {
+    ainb_hangar_proto::snapshots::AtcSchedulerOwnership::LegacyTimerReconciliationRequired
 }
 
 /// Build the [`DaemonHealthSnapshot`] for the `hangar/daemon_health` pane (P8.5).

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -864,6 +864,7 @@ async fn handle(
         methods::HANGAR_ISSUE_TIMELINE => handle_issue_timeline(pool, req).await,
         methods::HANGAR_BOARD_CARD_SET_AUTO_RUN => handle_board_card_set_auto_run(pool, req).await,
         methods::HANGAR_REPO_LIST => handle_repo_list(req),
+        methods::FLEET_NEGOTIATE => handle_fleet_negotiate(req, health).await,
         methods::FLEET_SNAPSHOT => handle_fleet_snapshot(pool).await,
         // Receiver registration occurs in `serve_conn` before this snapshot is
         // read. The ack carries its exact head, then the forwarder drains rows
@@ -902,6 +903,34 @@ async fn handle_fleet_snapshot(pool: &SqlitePool) -> Result<serde_json::Value, R
     to_value(&snapshot)
 }
 
+/// Negotiate the exact Fleet protocol version and capability catalogue.
+async fn handle_fleet_negotiate(
+    req: &RpcRequest,
+    health: &DaemonHealth,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{
+        FLEET_PROTOCOL_CAPABILITY_IDS, FLEET_PROTOCOL_VERSION, FleetNegotiateParams,
+        FleetNegotiateResult,
+    };
+
+    let params: FleetNegotiateParams = parse_params(
+        req,
+        "{ client_name, client_version, read_versions: { min, max }, write_versions: { min, max } }",
+    )?;
+    if !params.read_versions.is_valid() || !params.write_versions.is_valid() {
+        return Err(invalid_params(
+            "protocol version ranges require 1 <= min <= max",
+        ));
+    }
+    to_value(&FleetNegotiateResult {
+        daemon_version: health.version.clone(),
+        protocol_version: FLEET_PROTOCOL_VERSION,
+        read_compatible: params.read_versions.contains(FLEET_PROTOCOL_VERSION),
+        write_compatible: params.write_versions.contains(FLEET_PROTOCOL_VERSION),
+        capability_ids: FLEET_PROTOCOL_CAPABILITY_IDS.iter().map(|id| (*id).to_string()).collect(),
+    })
+}
+
 /// Register a revision cursor and return the snapshot head paired with it.
 async fn handle_fleet_subscribe(
     pool: &SqlitePool,
@@ -912,10 +941,42 @@ async fn handle_fleet_subscribe(
     if params.after_revision < 0 {
         return Err(invalid_params("after_revision must be non-negative"));
     }
-    let snapshot = crate::fleet::snapshot_wire(pool).await.map_err(|error| store_err(&error))?;
+    let projection = crate::fleet::subscription_wire(pool, params.after_revision, REPLAY_BATCH + 1)
+        .await
+        .map_err(fleet_repo_err)?;
+    let snapshot = crate::fleet::subscription_snapshot_wire(&projection);
+    use ainb_hangar_proto::fleet::{FleetReplayResetReason, FleetReplayState};
+    let (replay, replay_state) = if params.after_revision == 0 {
+        (
+            Vec::new(),
+            FleetReplayState::SnapshotReset {
+                reason: FleetReplayResetReason::Bootstrap,
+            },
+        )
+    } else if params.after_revision > projection.head_revision {
+        (
+            Vec::new(),
+            FleetReplayState::SnapshotReset {
+                reason: FleetReplayResetReason::CursorAhead,
+            },
+        )
+    } else if projection.replay.len() > REPLAY_BATCH as usize {
+        (
+            Vec::new(),
+            FleetReplayState::SnapshotReset {
+                reason: FleetReplayResetReason::ReplayLimitExceeded,
+            },
+        )
+    } else {
+        (
+            projection.replay.iter().map(crate::fleet::event_wire).collect(),
+            FleetReplayState::Complete,
+        )
+    };
     to_value(&ainb_hangar_proto::fleet::FleetSubscribeResult {
         snapshot,
-        replay: Vec::new(),
+        replay,
+        replay_state,
     })
 }
 
@@ -8795,33 +8856,71 @@ async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(
 ) -> std::io::Result<Option<Vec<u8>>> {
     use tokio::io::AsyncBufReadExt;
     let mut content_length: Option<usize> = None;
+    let mut saw_header = false;
     loop {
         let mut line = String::new();
         let n = r.read_line(&mut line).await?;
         if n == 0 {
-            return Ok(None);
+            return if saw_header {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "truncated Content-Length frame header",
+                ))
+            } else {
+                Ok(None)
+            };
         }
+        saw_header = true;
         let trimmed = line.trim_end_matches("\r\n");
         if trimmed.is_empty() {
             let Some(len) = content_length else {
-                // Blank line with no Content-Length seen — skip (lenient).
-                continue;
-            };
-            if len > MAX_BODY_BYTES {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    format!("Content-Length {len} exceeds cap {MAX_BODY_BYTES}"),
+                    "missing Content-Length header",
                 ));
-            }
+            };
             let mut body = vec![0u8; len];
             r.read_exact(&mut body).await?;
             return Ok(Some(body));
         }
-        if let Some((name, value)) = trimmed.split_once(':') {
-            if name.trim().eq_ignore_ascii_case("Content-Length") {
-                content_length = value.trim().parse().ok();
-            }
+        let Some((name, value)) = trimmed.split_once(':') else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "malformed frame header",
+            ));
+        };
+        if !name.trim().eq_ignore_ascii_case("Content-Length") {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unsupported frame header: {}", name.trim()),
+            ));
         }
+        if content_length.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "duplicate Content-Length header",
+            ));
+        }
+        let value = value.trim();
+        if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Content-Length must be an unsigned decimal byte length",
+            ));
+        }
+        let len = value.parse::<usize>().map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Content-Length is out of range",
+            )
+        })?;
+        if len > MAX_BODY_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Content-Length {len} exceeds cap {MAX_BODY_BYTES}"),
+            ));
+        }
+        content_length = Some(len);
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -875,6 +875,7 @@ async fn handle(
         methods::FLEET_RECEIPT_LIST => handle_fleet_receipt_list(pool, req).await,
         methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
         methods::FLEET_START => handle_fleet_start(pool, req, events).await,
+        methods::FLEET_TIMELINE => handle_fleet_timeline(pool, req).await,
         methods::ATTENTION_LIST => handle_attention_list(pool, req).await,
         // `attention/subscribe` acks with the current OPEN snapshot; the live
         // fleet-wide forwarder is the stream side (see `serve_conn`).
@@ -996,6 +997,59 @@ async fn handle_fleet_action(
 }
 
 const FLEET_RECEIPT_LIST_MAX: u32 = 100;
+const FLEET_TIMELINE_MAX: u32 = 100;
+
+/// Return bounded, payload-free Fleet revision timeline entries.
+async fn handle_fleet_timeline(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FleetTimelineKind, FleetTimelineParams, FleetTimelineResult};
+    use ainb_hangar_store::repo::fleet::FleetRepo;
+
+    let params: FleetTimelineParams =
+        parse_params(req, "{ after_revision?, session_key?, limit }")?;
+    let after_revision = params.after_revision.unwrap_or(0);
+    if after_revision < 0 {
+        return Err(invalid_params("after_revision must be non-negative"));
+    }
+    if params.session_key.as_deref().is_some_and(str::is_empty) {
+        return Err(invalid_params("session_key must not be empty"));
+    }
+    let rows = FleetRepo::timeline_after(
+        pool,
+        after_revision,
+        params.session_key.as_deref(),
+        i64::from(params.limit.clamp(1, FLEET_TIMELINE_MAX)),
+    )
+    .await
+    .map_err(|error| store_err(&error))?;
+    let entries: Vec<_> = rows
+        .iter()
+        .filter_map(|row| {
+            FleetTimelineKind::from_event_type(&row.event_type).map(|kind| {
+                ainb_hangar_proto::fleet::FleetTimelineEntry {
+                    revision: row.revision,
+                    session_key: row.session_key.clone(),
+                    observed_at: row.observed_at,
+                    provenance: if row.authority == "authoritative" {
+                        ainb_hangar_proto::fleet::FleetProvenance::Authoritative
+                    } else {
+                        ainb_hangar_proto::fleet::FleetProvenance::Inferred
+                    },
+                    kind,
+                    applied: row.applied,
+                    session_version: row.session_version,
+                }
+            })
+        })
+        .collect();
+    let next_after_revision = entries.last().map(|entry| entry.revision);
+    to_value(&FleetTimelineResult {
+        entries,
+        next_after_revision,
+    })
+}
 
 /// Return a bounded, durable newest-first receipt projection.
 async fn handle_fleet_receipt_list(

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -5,6 +5,71 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Current Fleet wire protocol version.
+pub const FLEET_PROTOCOL_VERSION: u32 = 1;
+
+/// Fleet capability identifiers advertised during protocol negotiation.
+pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
+    "fleet.action.execute",
+    "fleet.broadcast.execute",
+    "fleet.protocol.negotiate",
+    "fleet.snapshot.read",
+    "fleet.subscription.live",
+    "fleet.subscription.replay",
+    "fleet.subscription.resync",
+];
+
+/// Inclusive supported protocol version range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetProtocolRange {
+    /// Lowest supported version.
+    pub min: u32,
+    /// Highest supported version.
+    pub max: u32,
+}
+
+impl FleetProtocolRange {
+    /// Whether this is a non-empty protocol range.
+    #[must_use]
+    pub const fn is_valid(self) -> bool {
+        self.min > 0 && self.min <= self.max
+    }
+
+    /// Whether `version` is in this inclusive range.
+    #[must_use]
+    pub const fn contains(self, version: u32) -> bool {
+        self.min <= version && version <= self.max
+    }
+}
+
+/// Parameters for `fleet/negotiate`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetNegotiateParams {
+    /// Stable client implementation name.
+    pub client_name: String,
+    /// Client implementation version.
+    pub client_version: String,
+    /// Versions the client can safely read.
+    pub read_versions: FleetProtocolRange,
+    /// Versions the client can safely write.
+    pub write_versions: FleetProtocolRange,
+}
+
+/// Result from `fleet/negotiate`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetNegotiateResult {
+    /// Daemon build version.
+    pub daemon_version: String,
+    /// Exact daemon Fleet protocol version.
+    pub protocol_version: u32,
+    /// Whether the client can safely read this daemon.
+    pub read_compatible: bool,
+    /// Whether the client can safely write to this daemon.
+    pub write_compatible: bool,
+    /// Stable, ordered daemon capability catalogue.
+    pub capability_ids: Vec<String>,
+}
+
 /// Session provider.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -209,6 +274,63 @@ pub struct FleetSubscribeParams {
     pub after_revision: i64,
 }
 
+/// Why a subscription acknowledgement requires a fresh snapshot baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetReplayResetReason {
+    /// Initial subscribe has no prior cursor.
+    Bootstrap,
+    /// Caller cursor is newer than daemon durable head.
+    CursorAhead,
+    /// Missed durable interval exceeds the bounded replay response.
+    ReplayLimitExceeded,
+}
+
+/// Replay status for a subscription acknowledgement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum FleetReplayState {
+    /// Replay exactly covers the requested interval.
+    Complete,
+    /// Snapshot replaces the requested replay interval.
+    SnapshotReset {
+        /// Reason the daemon cannot provide a complete replay interval.
+        reason: FleetReplayResetReason,
+    },
+}
+
+impl<'de> Deserialize<'de> for FleetReplayState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let object = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("FleetReplayState must be an object"))?;
+        let state = object
+            .get("state")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| D::Error::custom("FleetReplayState requires string state"))?;
+        match state {
+            "complete" if object.len() == 1 => Ok(Self::Complete),
+            "snapshot_reset" if object.len() == 2 => {
+                let reason = object
+                    .get("reason")
+                    .cloned()
+                    .ok_or_else(|| D::Error::custom("snapshot_reset requires reason"))?;
+                let reason = serde_json::from_value(reason).map_err(D::Error::custom)?;
+                Ok(Self::SnapshotReset { reason })
+            }
+            "complete" => Err(D::Error::custom("complete carries unsupported fields")),
+            "snapshot_reset" => Err(D::Error::custom("snapshot_reset requires only reason")),
+            _ => Err(D::Error::custom("unknown FleetReplayState state")),
+        }
+    }
+}
+
 /// One durable change emitted after a subscription cursor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetEvent {
@@ -237,8 +359,10 @@ pub struct FleetEvent {
 pub struct FleetSubscribeResult {
     /// Consistent snapshot registered against live delivery.
     pub snapshot: FleetSnapshot,
-    /// Events committed after snapshot head and before live delivery.
+    /// Events in `(after_revision, snapshot.head_revision]` when replay is complete.
     pub replay: Vec<FleetEvent>,
+    /// Whether the response has complete replay coverage or resets the cursor.
+    pub replay_state: FleetReplayState,
 }
 
 /// One answer to one provider question.

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -8,12 +8,23 @@ use serde::{Deserialize, Serialize};
 /// Current Fleet wire protocol version.
 pub const FLEET_PROTOCOL_VERSION: u32 = 1;
 
+/// Negotiated capability required for versioned selected-session actions.
+pub const FLEET_CAPABILITY_ACTION_EXECUTE: &str = "fleet.action.execute";
+/// Negotiated capability required for explicit-recipient broadcasts.
+pub const FLEET_CAPABILITY_BROADCAST_EXECUTE: &str = "fleet.broadcast.execute";
+/// Negotiated capability required for durable receipt list and exact lookup.
+pub const FLEET_CAPABILITY_RECEIPT_READ: &str = "fleet.receipt.read";
+/// Negotiated capability required for daemon-owned new-session starts.
+pub const FLEET_CAPABILITY_START_EXECUTE: &str = "fleet.start.execute";
+
 /// Fleet capability identifiers advertised during protocol negotiation.
 pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
-    "fleet.action.execute",
-    "fleet.broadcast.execute",
+    FLEET_CAPABILITY_ACTION_EXECUTE,
+    FLEET_CAPABILITY_BROADCAST_EXECUTE,
     "fleet.protocol.negotiate",
+    FLEET_CAPABILITY_RECEIPT_READ,
     "fleet.snapshot.read",
+    FLEET_CAPABILITY_START_EXECUTE,
     "fleet.subscription.live",
     "fleet.subscription.replay",
     "fleet.subscription.resync",
@@ -439,7 +450,10 @@ pub enum ControlAction {
     Retry,
     /// Interrupt active turn.
     Interrupt,
-    /// Start a managed session.
+    /// Legacy wire form. New clients must use daemon-owned fleet/start.
+    ///
+    /// The daemon rejects this variant before selected-session validation, so
+    /// it cannot create a session through fleet/action.
     Start {
         /// Provider to start.
         provider: FleetProvider,
@@ -541,6 +555,60 @@ pub struct FleetActionReceipt {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetActionResult {
     /// Durable action receipt.
+    pub receipt: FleetActionReceipt,
+}
+
+/// Parameters for `fleet/receipt_list`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptListParams {
+    /// Maximum number of durable receipts, newest first.
+    pub limit: u32,
+}
+
+/// Result for `fleet/receipt_list`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptListResult {
+    /// Durable receipts ordered by `updated_at DESC, request_id DESC`.
+    pub receipts: Vec<FleetActionReceipt>,
+}
+
+/// Parameters for `fleet/receipt_get`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptGetParams {
+    /// Exact idempotent action request identifier.
+    pub request_id: String,
+}
+
+/// Result for `fleet/receipt_get`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReceiptGetResult {
+    /// Durable receipt when the daemon has one for this request id.
+    pub receipt: Option<FleetActionReceipt>,
+}
+
+/// Parameters for `fleet/start`.
+///
+/// Start has no selected session and therefore carries no caller-supplied
+/// session key or optimistic concurrency version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetStartParams {
+    /// Idempotent new-session request identifier.
+    pub request_id: String,
+    /// Provider to start.
+    pub provider: FleetProvider,
+    /// Working directory for the new provider session.
+    pub cwd: String,
+    /// Optional initial prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+}
+
+/// Result for `fleet/start`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetStartResult {
+    /// Daemon-generated prospective session identity for this request.
+    pub prospective_session_key: String,
+    /// Durable start receipt.
     pub receipt: FleetActionReceipt,
 }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -18,6 +18,8 @@ pub const FLEET_CAPABILITY_RECEIPT_READ: &str = "fleet.receipt.read";
 pub const FLEET_CAPABILITY_START_EXECUTE: &str = "fleet.start.execute";
 /// Negotiated capability for daemon-owned ATC read projections.
 pub const FLEET_CAPABILITY_ATC_READ: &str = "fleet.atc.read";
+/// Negotiated capability for the payload-free Fleet revision timeline.
+pub const FLEET_CAPABILITY_TIMELINE_READ: &str = "fleet.timeline.read";
 
 /// Fleet capability identifiers advertised during protocol negotiation.
 pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
@@ -31,6 +33,7 @@ pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
     "fleet.subscription.live",
     "fleet.subscription.replay",
     "fleet.subscription.resync",
+    FLEET_CAPABILITY_TIMELINE_READ,
 ];
 
 /// Inclusive supported protocol version range.
@@ -366,6 +369,108 @@ pub struct FleetEvent {
     pub session_version: i64,
     /// Whether event changed canonical state.
     pub applied: bool,
+}
+
+/// Closed, payload-free Fleet timeline event classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetTimelineKind {
+    /// Provider session began.
+    SessionStarted,
+    /// A provider turn started or continued.
+    TurnRunning,
+    /// Provider asked a structured question.
+    QuestionRaised,
+    /// Provider requested approval.
+    ApprovalRequested,
+    /// Provider requested operator attention.
+    AttentionWaiting,
+    /// Provider turn completed.
+    TurnCompleted,
+    /// Provider turn completed with failure.
+    TurnFailed,
+    /// Provider session ended.
+    SessionEnded,
+    /// Codex managed transport became unavailable.
+    ManagerUnavailable,
+    /// Codex managed transport recovered.
+    ManagerRecovered,
+    /// Codex managed TUI started.
+    ManagerStarted,
+    /// Tmux transport became unavailable.
+    TransportUnavailable,
+    /// Tmux transport became available.
+    TransportAvailable,
+    /// Tmux discovery found a session.
+    SessionDiscovered,
+    /// A legacy session was superseded by its managed identity.
+    SessionSuperseded,
+}
+
+impl FleetTimelineKind {
+    /// Map one known stored Fleet event type to its public closed kind.
+    #[must_use]
+    pub fn from_event_type(event_type: &str) -> Option<Self> {
+        match event_type {
+            "SessionStart" => Some(Self::SessionStarted),
+            "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => Some(Self::TurnRunning),
+            "AskUserQuestion" => Some(Self::QuestionRaised),
+            "PermissionRequest" => Some(Self::ApprovalRequested),
+            "Notification" => Some(Self::AttentionWaiting),
+            "Stop" | "SubagentStop" => Some(Self::TurnCompleted),
+            "StopFailure" => Some(Self::TurnFailed),
+            "SessionEnd" => Some(Self::SessionEnded),
+            "codex_manager_unavailable" => Some(Self::ManagerUnavailable),
+            "codex_manager_recovered" => Some(Self::ManagerRecovered),
+            "codex_managed_tui_started" => Some(Self::ManagerStarted),
+            "tmux_missing" | "tmux_unavailable" => Some(Self::TransportUnavailable),
+            "tmux_available" => Some(Self::TransportAvailable),
+            "tmux_discovered" => Some(Self::SessionDiscovered),
+            "session_superseded" => Some(Self::SessionSuperseded),
+            _ => None,
+        }
+    }
+}
+
+/// Parameters for `fleet/timeline`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetTimelineParams {
+    /// Return rows strictly after this global Fleet revision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after_revision: Option<i64>,
+    /// Optional exact stable Fleet session identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_key: Option<String>,
+    /// Requested row count. The daemon clamps this to its server maximum.
+    pub limit: u32,
+}
+
+/// One payload-free Fleet timeline entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetTimelineEntry {
+    /// Global monotonic revision.
+    pub revision: i64,
+    /// Stable target session.
+    pub session_key: String,
+    /// Observation time in epoch milliseconds.
+    pub observed_at: i64,
+    /// Event authority.
+    pub provenance: FleetProvenance,
+    /// Closed event classification.
+    pub kind: FleetTimelineKind,
+    /// Whether this event changed canonical state.
+    pub applied: bool,
+    /// Session version after event consideration.
+    pub session_version: i64,
+}
+
+/// Result for `fleet/timeline`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetTimelineResult {
+    /// Entries in ascending global revision order.
+    pub entries: Vec<FleetTimelineEntry>,
+    /// Cursor for the next page, or `null` when this page is empty.
+    pub next_after_revision: Option<i64>,
 }
 
 /// Initial result for a replay-safe Fleet subscription.

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -16,10 +16,13 @@ pub const FLEET_CAPABILITY_BROADCAST_EXECUTE: &str = "fleet.broadcast.execute";
 pub const FLEET_CAPABILITY_RECEIPT_READ: &str = "fleet.receipt.read";
 /// Negotiated capability required for daemon-owned new-session starts.
 pub const FLEET_CAPABILITY_START_EXECUTE: &str = "fleet.start.execute";
+/// Negotiated capability for daemon-owned ATC read projections.
+pub const FLEET_CAPABILITY_ATC_READ: &str = "fleet.atc.read";
 
 /// Fleet capability identifiers advertised during protocol negotiation.
 pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
     FLEET_CAPABILITY_ACTION_EXECUTE,
+    FLEET_CAPABILITY_ATC_READ,
     FLEET_CAPABILITY_BROADCAST_EXECUTE,
     "fleet.protocol.negotiate",
     FLEET_CAPABILITY_RECEIPT_READ,

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -402,6 +402,12 @@ pub const FLEET_SUBSCRIBE: &str = "fleet/subscribe";
 pub const FLEET_ACTION: &str = "fleet/action";
 /// Deliver text to explicit Fleet targets.
 pub const FLEET_BROADCAST: &str = "fleet/broadcast";
+/// List durable action receipts newest first.
+pub const FLEET_RECEIPT_LIST: &str = "fleet/receipt_list";
+/// Fetch one durable action receipt by request id.
+pub const FLEET_RECEIPT_GET: &str = "fleet/receipt_get";
+/// Start a provider session without borrowing selected-session state.
+pub const FLEET_START: &str = "fleet/start";
 
 /// Fleet notifications emitted by the daemon, never JSON-RPC request methods.
 pub const FLEET_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &["fleet/resync_required"];
@@ -1645,6 +1651,9 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_ACTION,
     FLEET_BROADCAST,
     FLEET_NEGOTIATE,
+    FLEET_RECEIPT_LIST,
+    FLEET_RECEIPT_GET,
+    FLEET_START,
     // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
     // tail, append-only wire.
     HANGAR_DISPATCH_ATTEMPTS_LIST,
@@ -1921,6 +1930,9 @@ mod tests {
             FLEET_ACTION,
             FLEET_BROADCAST,
             FLEET_NEGOTIATE,
+            FLEET_RECEIPT_LIST,
+            FLEET_RECEIPT_GET,
+            FLEET_START,
             HANGAR_DISPATCH_ATTEMPTS_LIST,
             HANGAR_ISSUE_TIMELINE,
             HANGAR_PROPERTIES_LIST,

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -408,6 +408,8 @@ pub const FLEET_RECEIPT_LIST: &str = "fleet/receipt_list";
 pub const FLEET_RECEIPT_GET: &str = "fleet/receipt_get";
 /// Start a provider session without borrowing selected-session state.
 pub const FLEET_START: &str = "fleet/start";
+/// Read bounded, payload-free Fleet revision timeline entries.
+pub const FLEET_TIMELINE: &str = "fleet/timeline";
 
 /// Fleet notifications emitted by the daemon, never JSON-RPC request methods.
 pub const FLEET_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &["fleet/resync_required"];
@@ -1654,6 +1656,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_RECEIPT_LIST,
     FLEET_RECEIPT_GET,
     FLEET_START,
+    FLEET_TIMELINE,
     // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
     // tail, append-only wire.
     HANGAR_DISPATCH_ATTEMPTS_LIST,
@@ -1933,6 +1936,7 @@ mod tests {
             FLEET_RECEIPT_LIST,
             FLEET_RECEIPT_GET,
             FLEET_START,
+            FLEET_TIMELINE,
             HANGAR_DISPATCH_ATTEMPTS_LIST,
             HANGAR_ISSUE_TIMELINE,
             HANGAR_PROPERTIES_LIST,

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -394,12 +394,17 @@ pub const HANGAR_ISSUE_DELETE: &str = "hangar/issue_delete";
 pub const HANGAR_ISSUE_CANCEL_ACTIVE: &str = "hangar/issue_cancel_active";
 /// Fetch canonical Fleet snapshot and revision head.
 pub const FLEET_SNAPSHOT: &str = "fleet/snapshot";
+/// Negotiate Fleet protocol version and capability catalogue.
+pub const FLEET_NEGOTIATE: &str = "fleet/negotiate";
 /// Subscribe after a global Fleet revision.
 pub const FLEET_SUBSCRIBE: &str = "fleet/subscribe";
 /// Execute one versioned Fleet action.
 pub const FLEET_ACTION: &str = "fleet/action";
 /// Deliver text to explicit Fleet targets.
 pub const FLEET_BROADCAST: &str = "fleet/broadcast";
+
+/// Fleet notifications emitted by the daemon, never JSON-RPC request methods.
+pub const FLEET_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &["fleet/resync_required"];
 
 /// `hangar/issue_run` — enqueue a run of one issue WITHOUT a board (the Issues
 /// screen's create-wizard dispatch; plans/hangar-task-agent-model.md).
@@ -1639,6 +1644,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_SUBSCRIBE,
     FLEET_ACTION,
     FLEET_BROADCAST,
+    FLEET_NEGOTIATE,
     // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
     // tail, append-only wire.
     HANGAR_DISPATCH_ATTEMPTS_LIST,
@@ -1914,6 +1920,7 @@ mod tests {
             FLEET_SUBSCRIBE,
             FLEET_ACTION,
             FLEET_BROADCAST,
+            FLEET_NEGOTIATE,
             HANGAR_DISPATCH_ATTEMPTS_LIST,
             HANGAR_ISSUE_TIMELINE,
             HANGAR_PROPERTIES_LIST,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -836,6 +836,31 @@ pub struct AtcRegisterParams {
     /// The idle-pause threshold in minutes; `None` uses the daemon default (60).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idle_pause_min: Option<i64>,
+    /// Configuration generation read from the daemon. Omitted only for legacy
+    /// CLI compatibility; negotiated clients must send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_generation: Option<i64>,
+}
+
+/// Authoritative scheduler ownership state. Mutation stays unavailable until
+/// reconciliation proves the daemon is the only heartbeat scheduler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AtcSchedulerOwnership {
+    /// Existing launchd/systemd timer files have not been reconciled safely.
+    LegacyTimerReconciliationRequired,
+}
+
+/// Result state for a generation-checked mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AtcMutationStatus {
+    /// The requested mutation was written.
+    Applied,
+    /// A matching lost-response retry found the already-written mutation.
+    AlreadyApplied,
+    /// Another configuration won; `config_generation` is current.
+    Stale,
 }
 
 /// Result of [`crate::methods::ATC_REGISTER`]: the persisted instance name + its
@@ -847,6 +872,12 @@ pub struct AtcRegisterResult {
     pub name: String,
     /// The cached next heartbeat instant (epoch-ms), or `None`.
     pub next_tick_at: Option<i64>,
+    /// Current durable configuration generation.
+    pub config_generation: i64,
+    /// Whether the requested conditional mutation applied.
+    pub status: AtcMutationStatus,
+    /// Scheduler ownership exposed so clients fail closed for mutation.
+    pub scheduler_ownership: AtcSchedulerOwnership,
 }
 
 /// One registered ATC instance in the [`crate::methods::ATC_LIST`] result.
@@ -870,6 +901,8 @@ pub struct AtcInstanceWire {
     pub enabled: bool,
     /// Epoch-ms of the last fired heartbeat, or `None`.
     pub last_heartbeat_at: Option<i64>,
+    /// Current durable configuration generation for conditional mutation.
+    pub config_generation: i64,
 }
 
 /// Result of [`crate::methods::ATC_LIST`]: every registered ATC instance,
@@ -878,6 +911,8 @@ pub struct AtcInstanceWire {
 pub struct AtcListResult {
     /// The registered instances.
     pub instances: Vec<AtcInstanceWire>,
+    /// Global ownership fact, not inferred by clients from local timer files.
+    pub scheduler_ownership: AtcSchedulerOwnership,
 }
 
 /// Params for [`crate::methods::ATC_ESCALATE`] (spec P9, D12): raise an ATC
@@ -912,6 +947,10 @@ pub struct AtcEscalateResult {
 pub struct AtcUnregisterParams {
     /// The sanitized instance name to disable.
     pub name: String,
+    /// Configuration generation read from the daemon. Omitted only for legacy
+    /// CLI compatibility; negotiated clients must send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_generation: Option<i64>,
 }
 
 /// Result of [`crate::methods::ATC_UNREGISTER`]: the instance name and whether it
@@ -923,6 +962,12 @@ pub struct AtcUnregisterResult {
     pub name: String,
     /// `true` when a registered instance was disabled; `false` for an unknown name.
     pub disabled: bool,
+    /// Current durable configuration generation, or `None` when unknown.
+    pub config_generation: Option<i64>,
+    /// Conditional mutation result.
+    pub status: AtcMutationStatus,
+    /// Scheduler ownership exposed so clients fail closed for mutation.
+    pub scheduler_ownership: AtcSchedulerOwnership,
 }
 
 /// One indexed profile in the [`crate::methods::PROFILE_LIST`] result (spec P5):

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0056_fleet_event_request_fingerprint.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0056_fleet_event_request_fingerprint.sql
@@ -1,0 +1,8 @@
+-- Persist exact request identity beside its durable event payload. A session's
+-- active request fingerprint can outlive unrelated later events, so projection
+-- must select the matching request body rather than the latest applied one.
+ALTER TABLE fleet_event ADD COLUMN request_fingerprint TEXT;
+
+CREATE INDEX idx_fleet_event_request_fingerprint
+    ON fleet_event(session_key, request_fingerprint, revision DESC)
+    WHERE applied = 1 AND request_fingerprint IS NOT NULL;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0057_atc_scheduler_fencing.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0057_atc_scheduler_fencing.sql
@@ -1,0 +1,5 @@
+-- AFM-E04: a configuration mutation must invalidate a due heartbeat that was
+-- read before the mutation. The scheduler claims a specific generation, then
+-- only that generation may complete its reschedule.
+ALTER TABLE atc_instance ADD COLUMN config_generation INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE atc_instance ADD COLUMN scheduler_claim_generation INTEGER;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/atc_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/atc_instance.rs
@@ -34,6 +34,8 @@ pub struct AtcInstanceRow {
     pub last_heartbeat_at: Option<i64>,
     /// Epoch-ms the instance was registered.
     pub created_at: i64,
+    /// Monotonic configuration version. Schedule mutations invalidate old work.
+    pub config_generation: i64,
 }
 
 /// One `atc_retry` ledger row — a (instance, monitored session) pair.
@@ -73,6 +75,30 @@ pub struct RegisterAtc {
     pub next_tick_at: Option<i64>,
 }
 
+/// Result of a generation-checked registration request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegisterAtcOutcome {
+    /// The requested configuration was written.
+    Applied(AtcInstanceRow),
+    /// A lost-response retry found the same already-applied configuration.
+    AlreadyApplied(AtcInstanceRow),
+    /// Another operator changed the configuration first.
+    Stale(Option<AtcInstanceRow>),
+}
+
+/// Result of a generation-checked disable request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisableAtcOutcome {
+    /// The instance was disabled.
+    Applied(AtcInstanceRow),
+    /// A lost-response retry found the same disabled result.
+    AlreadyApplied(AtcInstanceRow),
+    /// No instance exists with this name.
+    NotFound,
+    /// Another operator changed the configuration first.
+    Stale(AtcInstanceRow),
+}
+
 /// Stateless typed wrapper over the `atc_instance` + `atc_retry` tables.
 pub struct AtcInstanceRepo;
 
@@ -100,7 +126,8 @@ impl AtcInstanceRepo {
                  cwd = excluded.cwd, tmux_session = excluded.tmux_session, \
                  heartbeat_cron = excluded.heartbeat_cron, err_retry_cap = excluded.err_retry_cap, \
                  idle_pause_min = excluded.idle_pause_min, next_tick_at = excluded.next_tick_at, \
-                 enabled = 1",
+                 enabled = 1, config_generation = config_generation + 1, \
+                 scheduler_claim_generation = NULL",
         )
         .bind(&req.name)
         .bind(&req.cwd)
@@ -113,6 +140,131 @@ impl AtcInstanceRepo {
         .execute(pool)
         .await?;
         Ok(())
+    }
+
+    /// Register with optimistic concurrency when `expected_generation` is
+    /// supplied. `None` preserves the legacy CLI contract while negotiated
+    /// clients use the typed conditional path.
+    pub async fn register_checked(
+        pool: &SqlitePool,
+        req: &RegisterAtc,
+        now_ms: i64,
+        expected_generation: Option<i64>,
+    ) -> Result<RegisterAtcOutcome, sqlx::Error> {
+        let Some(expected) = expected_generation else {
+            Self::register(pool, req, now_ms).await?;
+            return Ok(RegisterAtcOutcome::Applied(
+                Self::get(pool, &req.name).await?.expect("register creates row"),
+            ));
+        };
+        if expected < 0 {
+            return Ok(RegisterAtcOutcome::Stale(Self::get(pool, &req.name).await?));
+        }
+
+        match Self::get(pool, &req.name).await? {
+            None if expected == 0 => {
+                let inserted = sqlx::query(
+                    "INSERT OR IGNORE INTO atc_instance \
+                     (name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
+                      next_tick_at, enabled, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)",
+                )
+                .bind(&req.name)
+                .bind(&req.cwd)
+                .bind(&req.tmux_session)
+                .bind(&req.heartbeat_cron)
+                .bind(req.err_retry_cap)
+                .bind(req.idle_pause_min)
+                .bind(req.next_tick_at)
+                .bind(now_ms)
+                .execute(pool)
+                .await?;
+                let row = Self::get(pool, &req.name).await?;
+                if inserted.rows_affected() == 1 {
+                    Ok(RegisterAtcOutcome::Applied(
+                        row.expect("inserted row exists"),
+                    ))
+                } else if row.as_ref().is_some_and(|current| desired_matches(current, req)) {
+                    Ok(RegisterAtcOutcome::AlreadyApplied(row.expect("row exists")))
+                } else {
+                    Ok(RegisterAtcOutcome::Stale(row))
+                }
+            }
+            None => Ok(RegisterAtcOutcome::Stale(None)),
+            Some(current) if current.config_generation == expected => {
+                let updated = sqlx::query(
+                    "UPDATE atc_instance SET cwd = ?, tmux_session = ?, heartbeat_cron = ?, \
+                     err_retry_cap = ?, idle_pause_min = ?, next_tick_at = ?, enabled = 1, \
+                     config_generation = config_generation + 1, scheduler_claim_generation = NULL \
+                     WHERE name = ? AND config_generation = ?",
+                )
+                .bind(&req.cwd)
+                .bind(&req.tmux_session)
+                .bind(&req.heartbeat_cron)
+                .bind(req.err_retry_cap)
+                .bind(req.idle_pause_min)
+                .bind(req.next_tick_at)
+                .bind(&req.name)
+                .bind(expected)
+                .execute(pool)
+                .await?;
+                let row = Self::get(pool, &req.name).await?.expect("existing row remains");
+                if updated.rows_affected() == 1 {
+                    Ok(RegisterAtcOutcome::Applied(row))
+                } else if desired_matches(&row, req) {
+                    Ok(RegisterAtcOutcome::AlreadyApplied(row))
+                } else {
+                    Ok(RegisterAtcOutcome::Stale(Some(row)))
+                }
+            }
+            Some(current)
+                if desired_matches(&current, req) && current.config_generation == expected + 1 =>
+            {
+                Ok(RegisterAtcOutcome::AlreadyApplied(current))
+            }
+            Some(current) => Ok(RegisterAtcOutcome::Stale(Some(current))),
+        }
+    }
+
+    /// Disable with optimistic concurrency when `expected_generation` is
+    /// supplied. A retry after a lost response returns the durable disabled row.
+    pub async fn disable_checked(
+        pool: &SqlitePool,
+        name: &str,
+        expected_generation: Option<i64>,
+    ) -> Result<DisableAtcOutcome, sqlx::Error> {
+        let Some(current) = Self::get(pool, name).await? else {
+            return Ok(DisableAtcOutcome::NotFound);
+        };
+        let Some(expected) = expected_generation else {
+            Self::set_enabled(pool, name, false, None).await?;
+            return Ok(DisableAtcOutcome::Applied(
+                Self::get(pool, name).await?.expect("disabled row remains"),
+            ));
+        };
+        if current.config_generation == expected {
+            let updated = sqlx::query(
+                "UPDATE atc_instance SET enabled = 0, next_tick_at = NULL, \
+                 config_generation = config_generation + 1, scheduler_claim_generation = NULL \
+                 WHERE name = ? AND config_generation = ?",
+            )
+            .bind(name)
+            .bind(expected)
+            .execute(pool)
+            .await?;
+            let row = Self::get(pool, name).await?.expect("existing row remains");
+            return if updated.rows_affected() == 1 {
+                Ok(DisableAtcOutcome::Applied(row))
+            } else if !row.enabled && row.config_generation == expected + 1 {
+                Ok(DisableAtcOutcome::AlreadyApplied(row))
+            } else {
+                Ok(DisableAtcOutcome::Stale(row))
+            };
+        }
+        if !current.enabled && current.config_generation == expected + 1 {
+            Ok(DisableAtcOutcome::AlreadyApplied(current))
+        } else {
+            Ok(DisableAtcOutcome::Stale(current))
+        }
     }
 
     /// Fetch one instance by name, `None` when it is not registered.
@@ -133,7 +285,7 @@ impl AtcInstanceRepo {
     pub async fn list(pool: &SqlitePool) -> Result<Vec<AtcInstanceRow>, sqlx::Error> {
         let rows = sqlx::query(
             "SELECT name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
-                    next_tick_at, enabled, last_heartbeat_at, created_at \
+                    next_tick_at, enabled, last_heartbeat_at, created_at, config_generation \
              FROM atc_instance ORDER BY name ASC",
         )
         .fetch_all(pool)
@@ -150,7 +302,7 @@ impl AtcInstanceRepo {
     pub async fn list_schedulable(pool: &SqlitePool) -> Result<Vec<AtcInstanceRow>, sqlx::Error> {
         let rows = sqlx::query(
             "SELECT name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
-                    next_tick_at, enabled, last_heartbeat_at, created_at \
+                    next_tick_at, enabled, last_heartbeat_at, created_at, config_generation \
              FROM atc_instance \
              WHERE enabled = 1 AND next_tick_at IS NOT NULL \
              ORDER BY next_tick_at ASC",
@@ -177,6 +329,53 @@ impl AtcInstanceRepo {
             .execute(pool)
             .await?;
         Ok(())
+    }
+
+    /// Atomically claim one exact due configuration. A later re-register or
+    /// unregister invalidates this claim before the scheduler can reschedule.
+    /// The due tick remains durable while claimed, so a process crash retries it
+    /// rather than silently losing a heartbeat.
+    pub async fn claim_due(
+        pool: &SqlitePool,
+        name: &str,
+        config_generation: i64,
+        due_tick_at: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE atc_instance SET scheduler_claim_generation = config_generation \
+             WHERE name = ? AND enabled = 1 AND config_generation = ? AND next_tick_at = ? \
+             AND (scheduler_claim_generation IS NULL OR scheduler_claim_generation = config_generation)",
+        )
+        .bind(name)
+        .bind(config_generation)
+        .bind(due_tick_at)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Complete a claimed heartbeat only when no config mutation superseded it.
+    pub async fn complete_claim(
+        pool: &SqlitePool,
+        name: &str,
+        config_generation: i64,
+        next_tick_at: Option<i64>,
+        last_heartbeat_at: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE atc_instance \
+             SET next_tick_at = ?, last_heartbeat_at = ?, scheduler_claim_generation = NULL \
+             WHERE name = ? AND enabled = 1 AND config_generation = ? \
+             AND scheduler_claim_generation = ?",
+        )
+        .bind(next_tick_at)
+        .bind(last_heartbeat_at)
+        .bind(name)
+        .bind(config_generation)
+        .bind(config_generation)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
     }
 
     /// Stamp `last_heartbeat_at` after a fired heartbeat.
@@ -210,12 +409,16 @@ impl AtcInstanceRepo {
         enabled: bool,
         next_tick_at: Option<i64>,
     ) -> Result<(), sqlx::Error> {
-        sqlx::query("UPDATE atc_instance SET enabled = ?, next_tick_at = ? WHERE name = ?")
-            .bind(i64::from(enabled))
-            .bind(next_tick_at)
-            .bind(name)
-            .execute(pool)
-            .await?;
+        sqlx::query(
+            "UPDATE atc_instance SET enabled = ?, next_tick_at = ?, \
+             config_generation = config_generation + 1, scheduler_claim_generation = NULL \
+             WHERE name = ?",
+        )
+        .bind(i64::from(enabled))
+        .bind(next_tick_at)
+        .bind(name)
+        .execute(pool)
+        .await?;
         Ok(())
     }
 
@@ -322,7 +525,7 @@ impl AtcInstanceRepo {
 
 /// The single-instance select column list, shared by `get` (needs the `WHERE`).
 const SELECT_INSTANCE_COLS: &str = "SELECT name, cwd, tmux_session, heartbeat_cron, err_retry_cap, idle_pause_min, \
-            next_tick_at, enabled, last_heartbeat_at, created_at \
+            next_tick_at, enabled, last_heartbeat_at, created_at, config_generation \
      FROM atc_instance WHERE name = ?";
 
 /// Map one raw `atc_instance` row into an [`AtcInstanceRow`].
@@ -339,7 +542,17 @@ fn instance_from_sqlite(row: &sqlx::sqlite::SqliteRow) -> AtcInstanceRow {
         enabled: enabled != 0,
         last_heartbeat_at: row.get("last_heartbeat_at"),
         created_at: row.get("created_at"),
+        config_generation: row.get("config_generation"),
     }
+}
+
+fn desired_matches(row: &AtcInstanceRow, req: &RegisterAtc) -> bool {
+    row.enabled
+        && row.cwd == req.cwd
+        && row.tmux_session == req.tmux_session
+        && row.heartbeat_cron == req.heartbeat_cron
+        && row.err_retry_cap == req.err_retry_cap
+        && row.idle_pause_min == req.idle_pause_min
 }
 
 /// Map one raw `atc_retry` row into an [`AtcRetryRow`].
@@ -476,4 +689,41 @@ mod tests {
         assert_eq!(got.last_heartbeat_at, Some(5000));
         assert_eq!(got.next_tick_at, Some(6000));
     }
+
+    #[tokio::test]
+    async fn stale_claim_cannot_restore_a_disabled_schedule() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        AtcInstanceRepo::register(store.pool(), &reg("main", "* * * * *", Some(1000)), 1)
+            .await
+            .unwrap();
+        let row = AtcInstanceRepo::get(store.pool(), "main").await.unwrap().unwrap();
+        assert!(
+            AtcInstanceRepo::claim_due(
+                store.pool(),
+                &row.name,
+                row.config_generation,
+                row.next_tick_at.unwrap(),
+            )
+            .await
+            .unwrap()
+        );
+        AtcInstanceRepo::set_enabled(store.pool(), "main", false, None).await.unwrap();
+        assert!(
+            !AtcInstanceRepo::complete_claim(
+                store.pool(),
+                "main",
+                row.config_generation,
+                Some(2000),
+                1500,
+            )
+            .await
+            .unwrap()
+        );
+        let current = AtcInstanceRepo::get(store.pool(), "main").await.unwrap().unwrap();
+        assert!(!current.enabled);
+        assert_eq!(current.next_tick_at, None);
+        assert!(current.config_generation > row.config_generation);
+    }
+
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -217,6 +217,26 @@ pub struct FleetSnapshot {
     pub sessions: Vec<FleetSessionRow>,
 }
 
+/// One session row and its current request payload from one subscription read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetSessionProjectionRow {
+    /// Canonical session state.
+    pub session: FleetSessionRow,
+    /// Complete current structured request or approval, if one remains active.
+    pub current_request: Option<serde_json::Value>,
+}
+
+/// Atomic subscription baseline and bounded durable replay interval.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetSubscriptionProjection {
+    /// Highest durable revision included by this projection.
+    pub head_revision: i64,
+    /// Canonical sessions and current request payloads at `head_revision`.
+    pub sessions: Vec<FleetSessionProjectionRow>,
+    /// Durable rows after the requested cursor, capped by the caller limit.
+    pub replay: Vec<FleetEventRow>,
+}
+
 /// Action receipt insert or status update.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewActionReceipt {
@@ -349,8 +369,8 @@ impl FleetRepo {
         let revision = sqlx::query(
             "INSERT INTO fleet_event \
              (event_id, session_key, observed_at, authority, event_type, payload, \
-              session_version, applied) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+              request_fingerprint, session_version, applied) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&event.event_id)
         .bind(&event.session_key)
@@ -358,6 +378,7 @@ impl FleetRepo {
         .bind(event.authority.as_str())
         .bind(&event.event_type)
         .bind(&event.payload)
+        .bind(event.patch.current_request_fingerprint.as_ref().and_then(Clone::clone))
         .bind(session.version)
         .bind(i64::from(changed))
         .execute(&mut *tx)
@@ -504,6 +525,77 @@ impl FleetRepo {
         Ok(FleetSnapshot {
             head_revision,
             sessions,
+        })
+    }
+
+    /// Read one subscription projection in a single transaction.
+    ///
+    /// The durable head, session rows, active request bodies, and replay rows
+    /// all come from the same SQLite read transaction. Callers request one
+    /// extra replay row when they need to distinguish a full capped replay from
+    /// an over-limit cursor.
+    pub async fn subscription_projection(
+        pool: &SqlitePool,
+        after_revision: i64,
+        replay_limit: i64,
+    ) -> Result<FleetSubscriptionProjection, sqlx::Error> {
+        let mut tx = pool.begin().await?;
+        let head_revision: i64 =
+            sqlx::query_scalar("SELECT COALESCE(MAX(revision), 0) FROM fleet_event")
+                .fetch_one(&mut *tx)
+                .await?;
+        let rows = sqlx::query(SESSION_SELECT_ALL).fetch_all(&mut *tx).await?;
+        let mut sessions = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let session = session_from_row(row)?;
+            let current_request =
+                if let Some(request_fingerprint) = session.current_request_fingerprint.as_deref() {
+                    sqlx::query_scalar::<_, String>(
+                        "SELECT payload FROM fleet_event \
+                     WHERE session_key = ? AND event_type IN (\
+                        'AskUserQuestion', 'PermissionRequest', \
+                        'item/tool/requestUserInput', \
+                        'item/commandExecution/requestApproval', \
+                        'item/fileChange/requestApproval', \
+                        'item/permissions/requestApproval'\
+                     ) AND request_fingerprint = ? AND applied = 1 AND revision <= ? \
+                     ORDER BY revision DESC LIMIT 1",
+                    )
+                    .bind(&session.session_key)
+                    .bind(request_fingerprint)
+                    .bind(head_revision)
+                    .fetch_optional(&mut *tx)
+                    .await?
+                    .and_then(|payload| serde_json::from_str(&payload).ok())
+                } else {
+                    None
+                };
+            sessions.push(FleetSessionProjectionRow {
+                session,
+                current_request,
+            });
+        }
+        let replay = if after_revision > 0 && after_revision < head_revision {
+            let rows = sqlx::query(
+                "SELECT revision, event_id, session_key, observed_at, authority, event_type, \
+                        payload, session_version, applied \
+                 FROM fleet_event WHERE revision > ? AND revision <= ? \
+                 ORDER BY revision ASC LIMIT ?",
+            )
+            .bind(after_revision)
+            .bind(head_revision)
+            .bind(replay_limit.max(0))
+            .fetch_all(&mut *tx)
+            .await?;
+            rows.iter().map(event_from_row).collect::<Result<_, _>>()?
+        } else {
+            Vec::new()
+        };
+        tx.commit().await?;
+        Ok(FleetSubscriptionProjection {
+            head_revision,
+            sessions,
+            replay,
         })
     }
 
@@ -1237,5 +1329,52 @@ mod tests {
         .unwrap();
         assert_eq!(cleared.session.attention_state, "NONE");
         assert_eq!(cleared.session.current_request_fingerprint, None);
+    }
+
+    #[tokio::test]
+    async fn subscription_projection_selects_payload_matching_current_request_fingerprint() {
+        let (_dir, store) = store().await;
+        let mut current = event(
+            "e-current-request",
+            "claude:s-1",
+            200,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                attention_state: Some("ASK".to_string()),
+                current_request_fingerprint: Some(Some("fnv1a64:current".to_string())),
+                ..FleetSessionPatch::default()
+            },
+        );
+        current.event_type = "AskUserQuestion".to_string();
+        current.payload = serde_json::json!({ "request": "current" }).to_string();
+        FleetRepo::apply_event(store.pool(), &current).await.unwrap();
+
+        let mut stale = event(
+            "e-stale-request",
+            "claude:s-1",
+            100,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                attention_state: Some("ASK".to_string()),
+                current_request_fingerprint: Some(Some("fnv1a64:stale".to_string())),
+                transport_health: Some("HEALTHY".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        stale.event_type = "AskUserQuestion".to_string();
+        stale.payload = serde_json::json!({ "request": "stale" }).to_string();
+        let stale_result = FleetRepo::apply_event(store.pool(), &stale).await.unwrap();
+        assert!(stale_result.applied);
+        assert_eq!(
+            stale_result.session.current_request_fingerprint.as_deref(),
+            Some("fnv1a64:current")
+        );
+
+        let projection = FleetRepo::subscription_projection(store.pool(), 0, 100).await.unwrap();
+        assert_eq!(projection.sessions.len(), 1);
+        assert_eq!(
+            projection.sessions[0].current_request.as_ref().unwrap()["request"],
+            "current"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -682,6 +682,22 @@ impl FleetRepo {
         .await?;
         row.as_ref().map(receipt_from_row).transpose()
     }
+
+    /// List durable action receipts newest first.
+    pub async fn list_action_receipts(
+        pool: &SqlitePool,
+        limit: i64,
+    ) -> Result<Vec<ActionReceiptRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT request_id, session_key, action_kind, action_fingerprint, expected_version, \
+                    idempotency_key, status, detail, session_version, created_at, updated_at \
+             FROM fleet_action_receipt ORDER BY updated_at DESC, request_id DESC LIMIT ?",
+        )
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(receipt_from_row).collect()
+    }
 }
 
 const SESSION_SELECT_BY_KEY: &str = "SELECT session_key, provider, provider_session_id, \

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -193,6 +193,25 @@ pub struct FleetEventRow {
     pub applied: bool,
 }
 
+/// One durable Fleet revision safe for the public payload-free timeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetTimelineRow {
+    /// Global monotonic revision.
+    pub revision: i64,
+    /// Target session.
+    pub session_key: String,
+    /// Observation time.
+    pub observed_at: i64,
+    /// Authority token.
+    pub authority: String,
+    /// Known normalized event discriminator.
+    pub event_type: String,
+    /// Session version after this event was considered.
+    pub session_version: i64,
+    /// Whether this event changed canonical session state.
+    pub applied: bool,
+}
+
 /// Result of applying or replaying one event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApplyFleetEventResult {
@@ -615,6 +634,43 @@ impl FleetRepo {
         .fetch_all(pool)
         .await?;
         rows.iter().map(event_from_row).collect()
+    }
+
+    /// Read a bounded, payload-free Fleet timeline after a global revision.
+    ///
+    /// The query joins visible Fleet sessions and filters the closed raw type
+    /// allowlist before `LIMIT`, so excluded history can never consume a page
+    /// or strand a caller's cursor.
+    pub async fn timeline_after(
+        pool: &SqlitePool,
+        after_revision: i64,
+        session_key: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<FleetTimelineRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT e.revision, e.session_key, e.observed_at, e.authority, e.event_type, \
+                    e.session_version, e.applied \
+             FROM fleet_event e \
+             INNER JOIN fleet_session s ON s.session_key = e.session_key AND s.visible = 1 \
+             WHERE e.revision > ? \
+               AND (? IS NULL OR e.session_key = ?) \
+               AND e.event_type IN ( \
+                   'SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', \
+                   'AskUserQuestion', 'PermissionRequest', 'Notification', 'Stop', \
+                   'SubagentStop', 'StopFailure', 'SessionEnd', \
+                   'codex_manager_unavailable', 'codex_manager_recovered', \
+                   'codex_managed_tui_started', 'tmux_missing', 'tmux_unavailable', \
+                   'tmux_available', 'tmux_discovered', 'session_superseded' \
+               ) \
+             ORDER BY e.revision ASC LIMIT ?",
+        )
+        .bind(after_revision)
+        .bind(session_key)
+        .bind(session_key)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(timeline_from_row).collect()
     }
 
     /// Insert or advance one action receipt.
@@ -1056,6 +1112,18 @@ fn event_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetEventRow, sqlx::
         authority: row.try_get("authority")?,
         event_type: row.try_get("event_type")?,
         payload: row.try_get("payload")?,
+        session_version: row.try_get("session_version")?,
+        applied: row.try_get::<i64, _>("applied")? != 0,
+    })
+}
+
+fn timeline_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetTimelineRow, sqlx::Error> {
+    Ok(FleetTimelineRow {
+        revision: row.try_get("revision")?,
+        session_key: row.try_get("session_key")?,
+        observed_at: row.try_get("observed_at")?,
+        authority: row.try_get("authority")?,
+        event_type: row.try_get("event_type")?,
         session_version: row.try_get("session_version")?,
         applied: row.try_get::<i64, _>("applied")? != 0,
     })

--- a/ainb-tui/crates/ainb-plugin-hangar/src/jsonrpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/jsonrpc_over_socket.rs
@@ -133,8 +133,16 @@ impl FrameDecoder {
                 .split_once(':')
                 .ok_or_else(|| DecodeError::Header(format!("malformed header line: {line:?}")))?;
             if name.trim().eq_ignore_ascii_case("Content-Length") {
+                if content_length.is_some() {
+                    return Err(DecodeError::Header("duplicate Content-Length".to_string()));
+                }
+                let value = value.trim();
+                if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+                    return Err(DecodeError::Header(
+                        "Content-Length must be an unsigned decimal byte length".to_string(),
+                    ));
+                }
                 let len: usize = value
-                    .trim()
                     .parse()
                     .map_err(|_| DecodeError::Header(format!("bad Content-Length: {value:?}")))?;
                 content_length = Some(len);
@@ -254,6 +262,20 @@ mod tests {
         let bad = b"Content-Type: x\r\nContent-Length: 2\r\n\r\n{}".to_vec();
         let err = d.push(&bad).unwrap_err();
         assert!(matches!(err, DecodeError::Header(_)));
+    }
+
+    #[test]
+    fn decoder_rejects_missing_duplicate_malformed_and_oversized_length() {
+        let cases = [
+            b"\r\n".as_slice(),
+            b"Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}".as_slice(),
+            b"Content-Length: +2\r\n\r\n{}".as_slice(),
+            b"Content-Length: 16777217\r\n\r\n".as_slice(),
+        ];
+        for frame in cases {
+            let err = FrameDecoder::new().push_frames(frame).unwrap_err();
+            assert!(matches!(err, DecodeError::Header(_)));
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -255,7 +255,7 @@ const FLEET_ACTION_REQ_ID: i64 = 59;
 /// Explicit-recipient Fleet broadcast.
 const FLEET_BROADCAST_REQ_ID: i64 = 60;
 /// Daemon-owned new Fleet session start.
-const FLEET_START_REQ_ID: i64 = 64;
+const FLEET_START_REQ_ID: i64 = 65;
 /// JSON-RPC id for a `hangar/skill_set_enabled` request (parity #24).
 const SKILL_SET_ENABLED_REQ_ID: i64 = 61;
 /// JSON-RPC id for a `hangar/agent_skills_list` request (parity #24). Fired

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -7995,7 +7995,8 @@ mod tests {
                     "payload": {},
                     "session_version": 4,
                     "applied": false
-                }]
+                }],
+                "replay_state": {"state": "complete"}
             })),
             error: None,
         };
@@ -8011,6 +8012,30 @@ mod tests {
             .expect("complete questions");
         assert_eq!(questions[0]["options"].as_array().unwrap().len(), 2);
         assert_eq!(questions[0]["multiSelect"], true);
+    }
+
+    #[test]
+    fn fleet_subscribe_decoder_accepts_every_tagged_replay_state() {
+        let states = [
+            serde_json::json!({"state": "complete"}),
+            serde_json::json!({"state": "snapshot_reset", "reason": "bootstrap"}),
+            serde_json::json!({"state": "snapshot_reset", "reason": "cursor_ahead"}),
+            serde_json::json!({"state": "snapshot_reset", "reason": "replay_limit_exceeded"}),
+        ];
+        for replay_state in states {
+            let mut plugin = HangarPlugin::new();
+            plugin.on_daemon_response(&RpcResponse {
+                jsonrpc: "2.0".into(),
+                id: RpcId::Number(FLEET_SUBSCRIBE_REQ_ID),
+                result: Some(serde_json::json!({
+                    "snapshot": {"head_revision": 7, "sessions": []},
+                    "replay": [],
+                    "replay_state": replay_state,
+                })),
+                error: None,
+            });
+            assert_eq!(plugin.screens.fleet.head_revision(), 7);
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -254,6 +254,8 @@ const FLEET_SUBSCRIBE_REQ_ID: i64 = 58;
 const FLEET_ACTION_REQ_ID: i64 = 59;
 /// Explicit-recipient Fleet broadcast.
 const FLEET_BROADCAST_REQ_ID: i64 = 60;
+/// Daemon-owned new Fleet session start.
+const FLEET_START_REQ_ID: i64 = 64;
 /// JSON-RPC id for a `hangar/skill_set_enabled` request (parity #24).
 const SKILL_SET_ENABLED_REQ_ID: i64 = 61;
 /// JSON-RPC id for a `hangar/agent_skills_list` request (parity #24). Fired
@@ -582,21 +584,12 @@ fn fleet_start_params(
     provider: ainb_hangar_proto::fleet::FleetProvider,
     cwd: String,
     prompt: Option<String>,
-) -> ainb_hangar_proto::fleet::FleetActionParams {
-    let session_key = match provider {
-        ainb_hangar_proto::fleet::FleetProvider::Codex => "start:codex",
-        ainb_hangar_proto::fleet::FleetProvider::Claude => "start:claude",
-        ainb_hangar_proto::fleet::FleetProvider::Unknown => "start:unknown",
-    };
-    ainb_hangar_proto::fleet::FleetActionParams {
-        session_key: session_key.to_string(),
-        expected_version: 1,
+) -> ainb_hangar_proto::fleet::FleetStartParams {
+    ainb_hangar_proto::fleet::FleetStartParams {
         request_id: fleet_request_id("start"),
-        action: ainb_hangar_proto::fleet::ControlAction::Start {
-            provider,
-            cwd,
-            prompt,
-        },
+        provider,
+        cwd,
+        prompt,
     }
 }
 
@@ -1164,6 +1157,7 @@ impl HangarPlugin {
             RpcId::Number(FLEET_SUBSCRIBE_REQ_ID) => self.apply_fleet_subscription(resp),
             RpcId::Number(FLEET_ACTION_REQ_ID) => self.apply_fleet_action_result(resp),
             RpcId::Number(FLEET_BROADCAST_REQ_ID) => self.apply_fleet_broadcast_result(resp),
+            RpcId::Number(FLEET_START_REQ_ID) => self.apply_fleet_start_result(resp),
             RpcId::Number(SEARCH_REQ_ID) => self.apply_search(resp),
             // P5: the profile-editor roster + the per-selection detail/previews.
             RpcId::Number(PROFILE_LIST_REQ_ID) => self.apply_profiles(resp),
@@ -2124,6 +2118,37 @@ impl HangarPlugin {
         self.conn.on_event();
     }
 
+    fn apply_fleet_start_result(&mut self, resp: &RpcResponse) {
+        use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetStartResult};
+        let result = resp
+            .result
+            .as_ref()
+            .and_then(|value| serde_json::from_value::<FleetStartResult>(value.clone()).ok());
+        let event = match (result, &resp.error) {
+            (Some(result), _) if result.receipt.status == ActionReceiptStatus::Delivered => {
+                crate::screen::fleet::FleetEvent::ActionSucceeded {
+                    session_key: result.prospective_session_key,
+                }
+            }
+            (Some(result), _) => crate::screen::fleet::FleetEvent::ActionFailed {
+                session_key: result.prospective_session_key,
+                detail: result
+                    .receipt
+                    .detail
+                    .unwrap_or_else(|| format!("{:?}", result.receipt.status)),
+            },
+            (None, Some(error)) => crate::screen::fleet::FleetEvent::ActionFailed {
+                session_key: "start".into(),
+                detail: error.message.clone(),
+            },
+            (None, None) => return,
+        };
+        let out = crate::screen::fleet::reduce_fleet(&self.screens.fleet, event);
+        self.screens.fleet = out.state;
+        self.fleet_fetch_pending = true;
+        self.conn.on_event();
+    }
+
     fn apply_fleet_broadcast_result(&mut self, resp: &RpcResponse) {
         use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetBroadcastResult};
         if let Some(error) = &resp.error {
@@ -2417,13 +2442,12 @@ impl HangarPlugin {
                 prompt,
             } => {
                 let params = fleet_start_params(provider, cwd, prompt);
-                let target = params.session_key.clone();
                 self.send_fleet_rpc(
                     host,
-                    FLEET_ACTION_REQ_ID,
-                    daemon_methods::FLEET_ACTION,
+                    FLEET_START_REQ_ID,
+                    daemon_methods::FLEET_START,
                     params,
-                    &target,
+                    "start",
                 )
                 .await;
             }
@@ -8167,24 +8191,17 @@ mod tests {
 
     #[test]
     fn fleet_start_mapping_preserves_exact_global_params() {
-        use ainb_hangar_proto::fleet::{ControlAction, FleetProvider};
+        use ainb_hangar_proto::fleet::FleetProvider;
 
         let params = fleet_start_params(
             FleetProvider::Codex,
             "/work/new".into(),
             Some("inspect failures".into()),
         );
-        assert_eq!(params.session_key, "start:codex");
-        assert_eq!(params.expected_version, 1);
         assert!(params.request_id.starts_with("fleet-ui-start-"));
-        assert_eq!(
-            params.action,
-            ControlAction::Start {
-                provider: FleetProvider::Codex,
-                cwd: "/work/new".into(),
-                prompt: Some("inspect failures".into()),
-            }
-        );
+        assert_eq!(params.provider, FleetProvider::Codex);
+        assert_eq!(params.cwd, "/work/new");
+        assert_eq!(params.prompt.as_deref(), Some("inspect failures"));
     }
 
     #[test]


### PR DESCRIPTION
Adds minimal Fleet daemon and protocol support required by the native macOS app. Excludes TUI UI, TUI parity tests, and CI changes.