### PR TITLE
feat(macos): add lifecycle notifications

### DIFF
--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		A10000000000000000000047 /* MenuBarRosterJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */; };
 		A1000000000000000000004F /* OfflineAndReconnectJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */; };
 		A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */; };
+		A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005F /* FleetNotificationPolicy.swift */; };
+		A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000060 /* FleetNotificationCenter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +82,8 @@
 		A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/MenuBarRosterJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift; sourceTree = SOURCE_ROOT; };
+		A1000000000000000000005F /* FleetNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationPolicy.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000060 /* FleetNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationCenter.swift; sourceTree = SOURCE_ROOT; };
 		A1000000000000000000004D /* FleetUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000031 /* AINBFleet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AINBFleet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000032 /* FleetRPCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -115,6 +119,7 @@
 			children = (
 				A10000000000000000000052 /* App */,
 				A10000000000000000000056 /* FleetRPC */,
+				A10000000000000000000061 /* Notifications */,
 				A10000000000000000000053 /* Resources */,
 				A10000000000000000000054 /* FleetRPCTests */,
 				A10000000000000000000057 /* FleetUITests */,
@@ -146,6 +151,15 @@
 			);
 			path = Resources;
 			sourceTree = "<group>";
+		};
+		A10000000000000000000061 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000005F /* FleetNotificationPolicy.swift */,
+				A10000000000000000000060 /* FleetNotificationCenter.swift */,
+			);
+			path = Sources/Notifications;
+			sourceTree = SOURCE_ROOT;
 		};
 		A10000000000000000000056 /* FleetRPC */ = {
 			isa = PBXGroup;
@@ -331,6 +345,8 @@
 				A1000000000000000000003A /* FleetSessionDetailView.swift in Sources */,
 				A1000000000000000000003C /* FleetQuickSwitcher.swift in Sources */,
 				A1000000000000000000003E /* FleetSettingsView.swift in Sources */,
+				A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */,
+				A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -37,8 +37,8 @@
 		A10000000000000000000047 /* MenuBarRosterJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */; };
 		A1000000000000000000004F /* OfflineAndReconnectJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */; };
 		A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */; };
-		A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005F /* FleetNotificationPolicy.swift */; };
-		A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000060 /* FleetNotificationCenter.swift */; };
+		A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000100 /* FleetNotificationPolicy.swift */; };
+		A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000101 /* FleetNotificationCenter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,8 +82,8 @@
 		A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/MenuBarRosterJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift; sourceTree = SOURCE_ROOT; };
-		A1000000000000000000005F /* FleetNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationPolicy.swift; sourceTree = SOURCE_ROOT; };
-		A10000000000000000000060 /* FleetNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationCenter.swift; sourceTree = SOURCE_ROOT; };
+		A100000000000000000000100 /* FleetNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationPolicy.swift; sourceTree = SOURCE_ROOT; };
+		A100000000000000000000101 /* FleetNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationCenter.swift; sourceTree = SOURCE_ROOT; };
 		A1000000000000000000004D /* FleetUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000031 /* AINBFleet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AINBFleet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000032 /* FleetRPCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -119,7 +119,7 @@
 			children = (
 				A10000000000000000000052 /* App */,
 				A10000000000000000000056 /* FleetRPC */,
-				A10000000000000000000061 /* Notifications */,
+				A100000000000000000000102 /* Notifications */,
 				A10000000000000000000053 /* Resources */,
 				A10000000000000000000054 /* FleetRPCTests */,
 				A10000000000000000000057 /* FleetUITests */,
@@ -152,11 +152,11 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		A10000000000000000000061 /* Notifications */ = {
+		A100000000000000000000102 /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
-				A1000000000000000000005F /* FleetNotificationPolicy.swift */,
-				A10000000000000000000060 /* FleetNotificationCenter.swift */,
+				A100000000000000000000100 /* FleetNotificationPolicy.swift */,
+				A100000000000000000000101 /* FleetNotificationCenter.swift */,
 			);
 			path = Sources/Notifications;
 			sourceTree = SOURCE_ROOT;

--- a/apps/ainb-fleet-macos/Resources/Info.plist
+++ b/apps/ainb-fleet-macos/Resources/Info.plist
@@ -20,9 +20,18 @@
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-    <key>LSUIElement</key>
-    <true/>
-    <key>NSPrincipalClass</key>
+	<key>LSUIElement</key>
+	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>dev.ainb.fleet.session</string>
+			<key>CFBundleURLSchemes</key>
+			<array><string>ainbfleet</string></array>
+		</dict>
+	</array>
+	<key>NSPrincipalClass</key>
     <string>NSApplication</string>
 </dict>
 </plist>

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -35,10 +35,10 @@ struct AINBFleetApp: App {
                 }
         }
         .menuBarExtraStyle(.window)
-        .onOpenURL(perform: openDeepLink)
 
         Window("Fleet", id: "fleet") {
             FleetWindowView(store: store, presentation: presentationBinding)
+                .onOpenURL(perform: openDeepLink)
         }
         Settings {
             FleetSettingsView(presentation: presentationBinding)

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -35,6 +35,7 @@ struct AINBFleetApp: App {
                 }
         }
         .menuBarExtraStyle(.window)
+        .onOpenURL(perform: openDeepLink)
 
         Window("Fleet", id: "fleet") {
             FleetWindowView(store: store, presentation: presentationBinding)
@@ -62,6 +63,12 @@ struct AINBFleetApp: App {
             next.filters.attentionOnly = true
             presentationBinding.wrappedValue = next
         }
+        openWindow(id: "fleet")
+    }
+
+    private func openDeepLink(_ url: URL) {
+        guard url.scheme == "ainbfleet", url.host == "session", let key = url.pathComponents.last else { return }
+        store.selectedSessionKey = key
         openWindow(id: "fleet")
     }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -77,6 +77,7 @@ final class FleetStore: ObservableObject {
     private let readVersions: FleetProtocolRange
     private let makeConnection: (HangarLocation) -> FleetConnection
     private let reconnectDelayNanoseconds: (Int) -> UInt64
+    private let notificationCenter = FleetNotificationCenter()
     private var connection: FleetConnection?
     private var connectionTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
@@ -86,6 +87,7 @@ final class FleetStore: ObservableObject {
     private var lastAuthoritativeRefresh: Date?
     private var reconnectAttempts = 0
     private var hasEstablishedLiveConnection = false
+    private var hasAppliedAuthoritativeSnapshot = false
     private let maximumReconnectAttempts = 3
 
     init(
@@ -474,9 +476,17 @@ final class FleetStore: ObservableObject {
     }
 
     private func apply(_ next: FleetProjection) {
+        let previousSessions = sessions
         projection = next
         sessions = next.snapshot?.sessions ?? sessions
-        if next.snapshot != nil { lastAuthoritativeRefresh = Date() }
+        if next.snapshot != nil {
+            lastAuthoritativeRefresh = Date()
+            if hasAppliedAuthoritativeSnapshot {
+                let events = FleetNotificationPolicy.events(previous: previousSessions, current: sessions)
+                Task { await notificationCenter.deliver(events) }
+            }
+            hasAppliedAuthoritativeSnapshot = true
+        }
         if let selectedSessionKey, !sessions.contains(where: { $0.sessionKey == selectedSessionKey }) {
             self.selectedSessionKey = nil
         }

--- a/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationCenter.swift
+++ b/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationCenter.swift
@@ -1,0 +1,27 @@
+import Foundation
+import UserNotifications
+
+@MainActor
+final class FleetNotificationCenter {
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    func requestAuthorization() async -> Bool {
+        (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+    }
+
+    func deliver(_ events: [FleetNotificationEvent]) async {
+        for event in events {
+            let content = UNMutableNotificationContent()
+            content.title = event.title
+            content.body = event.body
+            content.threadIdentifier = event.threadIdentifier
+            content.userInfo = ["session_key": event.sessionKey, "deep_link": event.deepLink.absoluteString]
+            let request = UNNotificationRequest(identifier: "fleet.\(event.sessionKey).\(UUID().uuidString)", content: content, trigger: nil)
+            try? await center.add(request)
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationPolicy.swift
+++ b/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationPolicy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct FleetNotificationEvent: Equatable {
+    let sessionKey: String
+    let title: String
+    let body: String
+
+    var threadIdentifier: String { "fleet.\(sessionKey)" }
+    var deepLink: URL { URL(string: "ainbfleet://session/\(sessionKey)")! }
+}
+
+enum FleetNotificationPolicy {
+    static func events(previous: [FleetSession], current: [FleetSession]) -> [FleetNotificationEvent] {
+        let previousByKey = Dictionary(uniqueKeysWithValues: previous.map { ($0.sessionKey, $0) })
+        return current.compactMap { session in
+            guard let before = previousByKey[session.sessionKey],
+                  before.lifecycle != session.lifecycle || before.attention != session.attention else { return nil }
+            let changedToAttention = before.attention == .none && session.attention != .none
+            let completed = session.lifecycle == .turnComplete || session.lifecycle == .exited
+            guard changedToAttention || completed || before.lifecycle != session.lifecycle else { return nil }
+            let name = session.displayName ?? session.sessionKey
+            return FleetNotificationEvent(
+                sessionKey: session.sessionKey,
+                title: name,
+                body: "\(session.lifecycle.rawValue.replacingOccurrences(of: "_", with: " ").capitalized) · \(session.attention.rawValue.capitalized)"
+            )
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/Settings/FleetSettingsView.swift
+++ b/apps/ainb-fleet-macos/Sources/Settings/FleetSettingsView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct FleetSettingsView: View {
     @Binding var presentation: FleetPresentationPreferences
+    @State private var notifications = FleetNotificationCenter()
+    @State private var notificationStatus = ""
 
     var body: some View {
         Form {
@@ -11,6 +13,16 @@ struct FleetSettingsView: View {
                 ForEach(FleetRosterSort.allCases) { sort in
                     Text(sort.label).tag(sort)
                 }
+            }
+            Section("Notifications") {
+                Button("Enable lifecycle notifications") {
+                    Task {
+                        notificationStatus = await notifications.requestAuthorization()
+                            ? "Lifecycle notifications enabled."
+                            : "Notifications remain disabled in macOS settings."
+                    }
+                }
+                if !notificationStatus.isEmpty { Text(notificationStatus).foregroundStyle(.secondary) }
             }
             Text("Launch at login requires a signed production app identity.").foregroundStyle(.secondary)
         }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
@@ -75,6 +75,13 @@ final class FleetRosterPresentationTests: XCTestCase {
         XCTAssertEqual(FleetStatusPresentation.symbol(for: .unavailable(message: "offline"), needsYou: 0, sessions: [value]), "exclamationmark.triangle.fill")
     }
 
+    func testLifecycleNotificationPolicyGroupsBySessionAndSkipsInitialSnapshot() {
+        let previous = session(key: "codex:alpha", lifecycle: .running, revision: 1)
+        let current = session(key: "codex:alpha", lifecycle: .turnComplete, revision: 2)
+        XCTAssertEqual(FleetNotificationPolicy.events(previous: [], current: [current]), [])
+        XCTAssertEqual(FleetNotificationPolicy.events(previous: [previous], current: [current]).first?.threadIdentifier, "fleet.codex:alpha")
+    }
+
     private func session(key: String, lifecycle: LifecycleState, attention: AttentionState = .none, management: ManagementState = .managed, transportHealth: TransportHealth = .healthy, observedAt: Int64 = 1, revision: Int64 = 1) -> FleetSession {
         FleetSession(sessionKey: key, provider: .codex, providerSessionID: nil, tmuxTarget: nil, processStartFingerprint: nil, cwd: "/workspace", displayName: key, lifecycle: lifecycle, attention: attention, currentRequestFingerprint: nil, currentRequest: nil, management: management, transportHealth: transportHealth, capabilities: FleetCapabilities(structuredAnswer: false, approvals: false, sendPrompt: false, continueTurn: false, retry: false, interrupt: false, start: false, stop: false, restart: false, kill: false, archive: false, tmuxAttach: false, tmuxText: false, verifiedPicker: false), provenance: .authoritative, confidence: .high, discoveredAt: observedAt, lastObservedAt: observedAt, lifecycleUpdatedAt: observedAt, attentionUpdatedAt: observedAt, version: 1, updatedRevision: revision)
     }


### PR DESCRIPTION
Adds native grouped lifecycle notifications, permission flow, and session deep-link routing under apps/ainb-fleet-macos. TUI surfaces and CI remain out of scope.