### PR TITLE
feat(macos): add keyboard Fleet commands

### DIFF
--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -43,6 +43,12 @@ struct AINBFleetApp: App {
         Settings {
             FleetSettingsView(presentation: presentationBinding)
         }
+        CommandMenu("Fleet") {
+            Button("Open Fleet") { openFleet() }
+                .keyboardShortcut("o", modifiers: [.command, .shift])
+            Button("Show needs you") { openFleet(attentionOnly: true) }
+                .keyboardShortcut("n", modifiers: [.command, .shift])
+        }
     }
 
     @Environment(\.openWindow) private var openWindow

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -35,6 +35,14 @@ struct AINBFleetApp: App {
                 }
         }
         .menuBarExtraStyle(.window)
+        .commands {
+            CommandMenu("Fleet") {
+                Button("Open Fleet") { openFleet() }
+                    .keyboardShortcut("o", modifiers: [.command, .shift])
+                Button("Show needs you") { openFleet(attentionOnly: true) }
+                    .keyboardShortcut("n", modifiers: [.command, .shift])
+            }
+        }
 
         Window("Fleet", id: "fleet") {
             FleetWindowView(store: store, presentation: presentationBinding)
@@ -42,12 +50,6 @@ struct AINBFleetApp: App {
         }
         Settings {
             FleetSettingsView(presentation: presentationBinding)
-        }
-        CommandMenu("Fleet") {
-            Button("Open Fleet") { openFleet() }
-                .keyboardShortcut("o", modifiers: [.command, .shift])
-            Button("Show needs you") { openFleet(attentionOnly: true) }
-                .keyboardShortcut("n", modifiers: [.command, .shift])
         }
     }
 


### PR DESCRIPTION
Adds keyboard access for opening Fleet and attention-filtered Fleet views. Only apps/ainb-fleet-macos changed.