### PR TITLE
fix(fleet): remove duplicate migration versions

### DIFF
--- a/ainb-tui/crates/ainb-hangar-store/migrations/0068_fleet_event_request_fingerprint.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0068_fleet_event_request_fingerprint.sql
@@ -1,4 +1,4 @@
--- Persist exact request identity beside its durable event payload. A session's
+-- Migration 0068. Persist exact request identity beside its durable event payload. A session's
 -- active request fingerprint can outlive unrelated later events, so projection
 -- must select the matching request body rather than the latest applied one.
 ALTER TABLE fleet_event ADD COLUMN request_fingerprint TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0069_atc_scheduler_fencing.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0069_atc_scheduler_fencing.sql
@@ -1,4 +1,4 @@
--- AFM-E04: a configuration mutation must invalidate a due heartbeat that was
+-- Migration 0069. A configuration mutation must invalidate a due heartbeat that was
 -- read before the mutation. The scheduler claims a specific generation, then
 -- only that generation may complete its reschedule.
 ALTER TABLE atc_instance ADD COLUMN config_generation INTEGER NOT NULL DEFAULT 1;


### PR DESCRIPTION
Fixes isolated Fleet daemon startup for native macOS app acceptance. Renames only duplicate SQL migration versions; no TUI UI work.