### PR TITLE
fix(macos): activate Fleet window from status bar

### DIFF
--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */; };
 		A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000100 /* FleetNotificationPolicy.swift */; };
 		A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000101 /* FleetNotificationCenter.swift */; };
+		A100000000000000000000103 /* FleetDesktopController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000104 /* FleetDesktopController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000100 /* FleetNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationPolicy.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000101 /* FleetNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationCenter.swift; sourceTree = SOURCE_ROOT; };
+		A100000000000000000000104 /* FleetDesktopController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDesktopController.swift; sourceTree = "<group>"; };
 		A1000000000000000000004D /* FleetUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000031 /* AINBFleet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AINBFleet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000032 /* FleetRPCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				A10000000000000000000021 /* AINBFleetApp.swift */,
+				A100000000000000000000104 /* FleetDesktopController.swift */,
 				A1000000000000000000002F /* FleetStore.swift */,
 				A10000000000000000000030 /* FleetConnectionState.swift */,
 				A10000000000000000000033 /* FleetRosterPresentation.swift */,
@@ -347,6 +350,7 @@
 				A1000000000000000000003E /* FleetSettingsView.swift in Sources */,
 				A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */,
 				A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */,
+				A100000000000000000000103 /* FleetDesktopController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
@@ -38,16 +38,6 @@
                ReferencedContainer = "container:AINBFleet.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A10000000000000000000003"
-               BuildableName = "FleetUITests.xctest"
-               BlueprintName = "FleetUITests"
-               ReferencedContainer = "container:AINBFleet.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -1,98 +1,36 @@
-import AppKit
 import SwiftUI
 
 @main
 struct AINBFleetApp: App {
     @StateObject private var store: FleetStore
-    @State private var presentation: FleetPresentationPreferences
-    private let presentationDefaults: UserDefaults
+    @StateObject private var presentation: FleetPresentationStore
+    @NSApplicationDelegateAdaptor(FleetAppDelegate.self) private var appDelegate
+    private let desktop: FleetDesktopController
 
     init() {
         let defaults = Self.presentationDefaults
         let fleetStore = FleetStore(readVersions: Self.testReadVersions)
+        let presentationStore = FleetPresentationStore(defaults: defaults)
         _store = StateObject(wrappedValue: fleetStore)
-        _presentation = State(initialValue: FleetPresentationPreferences.load(defaults: defaults))
-        presentationDefaults = defaults
-        Task { @MainActor in fleetStore.start() }
+        _presentation = StateObject(wrappedValue: presentationStore)
+        let desktopController = FleetDesktopController(store: fleetStore, presentation: presentationStore)
+        desktop = desktopController
+        FleetDesktopController.shared = desktopController
+        Task { @MainActor in
+            fleetStore.start()
+            desktopController.launch()
+            #if DEBUG
+            if Self.testLaunchesFleetWindow {
+                desktopController.showFleet()
+            }
+            #endif
+        }
     }
 
     var body: some Scene {
-        standardScenes
-    }
-
-    @SceneBuilder
-    private var standardScenes: some Scene {
-        MenuBarExtra {
-            FleetMenuBarView(store: store, openFleet: openFleet)
-                .onReceive(NotificationCenter.default.publisher(for: .fleetNotificationOpen)) { notification in
-                    guard let url = notification.object as? URL else { return }
-                    openDeepLink(url)
-                }
-        } label: {
-            Label("Fleet", systemImage: FleetStatusPresentation.symbol(for: store.connectionState, needsYou: store.needsYouCount, sessions: store.sessions))
-                .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
-                .accessibilityIdentifier("fleet.status-item")
-                .task {
-                    #if DEBUG
-                    guard Self.testLaunchesFleetWindow else { return }
-                    showFleetWindow()
-                    #endif
-                }
-        }
-        .menuBarExtraStyle(.window)
-        .commands {
-            CommandMenu("Fleet") {
-                Button("Open Fleet") { openFleet() }
-                    .keyboardShortcut("o", modifiers: [.command, .shift])
-                Button("Show needs you") { openFleet(attentionOnly: true) }
-                    .keyboardShortcut("n", modifiers: [.command, .shift])
-            }
-        }
-
-        Window("Fleet", id: "fleet") {
-            FleetWindowView(store: store, presentation: presentationBinding)
-                .onOpenURL(perform: openDeepLink)
-        }
         Settings {
-            FleetSettingsView(presentation: presentationBinding)
+            FleetSettingsView(presentation: presentation.binding)
         }
-    }
-
-    @Environment(\.openWindow) private var openWindow
-
-    private var presentationBinding: Binding<FleetPresentationPreferences> {
-        Binding(
-            get: { presentation },
-            set: { newValue in
-                presentation = newValue
-                newValue.save(defaults: presentationDefaults)
-            }
-        )
-    }
-
-    private func openFleet(attentionOnly: Bool = false) {
-        if attentionOnly {
-            var next = presentation
-            next.filters.attentionOnly = true
-            presentationBinding.wrappedValue = next
-        }
-        showFleetWindow()
-    }
-
-    private func openDeepLink(_ url: URL) {
-        guard url.scheme == "ainbfleet",
-              url.host == "session",
-              let encodedPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?.percentEncodedPath,
-              let key = String(encodedPath.dropFirst()).removingPercentEncoding,
-              !key.isEmpty else { return }
-        store.refresh()
-        store.selectedSessionKey = key
-        showFleetWindow()
-    }
-
-    private func showFleetWindow() {
-        openWindow(id: "fleet")
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     private static var testReadVersions: FleetProtocolRange {

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @main
@@ -34,7 +35,7 @@ struct AINBFleetApp: App {
                 .task {
                     #if DEBUG
                     guard Self.testLaunchesFleetWindow else { return }
-                    openWindow(id: "fleet")
+                    showFleetWindow()
                     #endif
                 }
         }
@@ -75,7 +76,7 @@ struct AINBFleetApp: App {
             next.filters.attentionOnly = true
             presentationBinding.wrappedValue = next
         }
-        openWindow(id: "fleet")
+        showFleetWindow()
     }
 
     private func openDeepLink(_ url: URL) {
@@ -86,7 +87,12 @@ struct AINBFleetApp: App {
               !key.isEmpty else { return }
         store.refresh()
         store.selectedSessionKey = key
+        showFleetWindow()
+    }
+
+    private func showFleetWindow() {
         openWindow(id: "fleet")
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private static var testReadVersions: FleetProtocolRange {

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -1,0 +1,149 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class FleetPresentationStore: ObservableObject {
+    @Published var preferences: FleetPresentationPreferences {
+        didSet { preferences.save(defaults: defaults) }
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+        preferences = FleetPresentationPreferences.load(defaults: defaults)
+    }
+
+    var binding: Binding<FleetPresentationPreferences> {
+        Binding(get: { self.preferences }, set: { self.preferences = $0 })
+    }
+}
+
+@MainActor
+final class FleetDesktopController {
+    static var shared: FleetDesktopController?
+
+    private let store: FleetStore
+    private let presentation: FleetPresentationStore
+    private var notchPanel: NSPanel?
+    private var fleetWindow: NSWindow?
+    private var notificationObserver: NSObjectProtocol?
+
+    init(store: FleetStore, presentation: FleetPresentationStore) {
+        self.store = store
+        self.presentation = presentation
+        notificationObserver = NotificationCenter.default.addObserver(
+            forName: .fleetNotificationOpen,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let url = notification.object as? URL else { return }
+            Task { @MainActor in self?.open(url) }
+        }
+    }
+
+    deinit {
+        if let notificationObserver {
+            NotificationCenter.default.removeObserver(notificationObserver)
+        }
+    }
+
+    func launch() {
+        if notchPanel == nil {
+            let size = NSSize(width: 360, height: 58)
+            let panel = NSPanel(
+                contentRect: NSRect(origin: .zero, size: size),
+                styleMask: [.borderless, .nonactivatingPanel],
+                backing: .buffered,
+                defer: false
+            )
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = true
+            panel.level = .statusBar
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            panel.contentView = NSHostingView(rootView: FleetNotchView(store: store, openFleet: { [weak self] in
+                self?.showFleet()
+            }))
+            notchPanel = panel
+        }
+        positionNotch()
+        notchPanel?.orderFrontRegardless()
+    }
+
+    func showFleet() {
+        if fleetWindow == nil {
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                backing: .buffered,
+                defer: false
+            )
+            window.title = "Fleet"
+            window.minSize = NSSize(width: 620, height: 520)
+            window.contentView = NSHostingView(rootView: FleetWindowView(store: store, presentation: presentation.binding))
+            window.center()
+            window.setFrameAutosaveName("AINBFleetWindow")
+            fleetWindow = window
+        }
+        fleetWindow?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func open(_ url: URL) {
+        guard url.scheme == "ainbfleet",
+              url.host == "session",
+              let encodedPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?.percentEncodedPath,
+              let key = String(encodedPath.dropFirst()).removingPercentEncoding,
+              !key.isEmpty else { return }
+        store.refresh()
+        store.selectedSessionKey = key
+        showFleet()
+    }
+
+    private func positionNotch() {
+        guard let panel = notchPanel,
+              let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main
+        else { return }
+        let frame = screen.frame
+        panel.setFrameOrigin(NSPoint(x: frame.midX - panel.frame.width / 2, y: frame.maxY - panel.frame.height - 2))
+    }
+}
+
+final class FleetAppDelegate: NSObject, NSApplicationDelegate {
+    func application(_ application: NSApplication, open urls: [URL]) {
+        Task { @MainActor in
+            urls.forEach { FleetDesktopController.shared?.open($0) }
+        }
+    }
+}
+
+private struct FleetNotchView: View {
+    @ObservedObject var store: FleetStore
+    let openFleet: () -> Void
+
+    var body: some View {
+        Button(action: openFleet) {
+            HStack(spacing: 10) {
+                Image(systemName: FleetStatusPresentation.symbol(for: store.connectionState, needsYou: store.needsYouCount, sessions: store.sessions))
+                    .foregroundStyle(store.needsYouCount > 0 ? .orange : .primary)
+                Text("Fleet")
+                    .fontWeight(.semibold)
+                Spacer()
+                Text("\(store.activeCount) active")
+                if store.needsYouCount > 0 {
+                    Text("\(store.needsYouCount) need you")
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.orange)
+                }
+            }
+            .font(.caption)
+            .padding(.horizontal, 18)
+            .frame(width: 360, height: 58)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
+        .accessibilityHint("Open Fleet")
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -128,6 +128,7 @@ private struct FleetNotchView: View {
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("fleet.notch")
         .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
         .accessibilityHint("Open Fleet")
     }

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -27,25 +27,10 @@ final class FleetDesktopController {
     private let presentation: FleetPresentationStore
     private var notchPanel: NSPanel?
     private var fleetWindow: NSWindow?
-    private var notificationObserver: NSObjectProtocol?
 
     init(store: FleetStore, presentation: FleetPresentationStore) {
         self.store = store
         self.presentation = presentation
-        notificationObserver = NotificationCenter.default.addObserver(
-            forName: .fleetNotificationOpen,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let url = notification.object as? URL else { return }
-            Task { @MainActor in self?.open(url) }
-        }
-    }
-
-    deinit {
-        if let notificationObserver {
-            NotificationCenter.default.removeObserver(notificationObserver)
-        }
     }
 
     func launch() {

--- a/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationCenter.swift
+++ b/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationCenter.swift
@@ -67,6 +67,6 @@ final class FleetNotificationCenter: NSObject, UNUserNotificationCenterDelegate 
         defer { completionHandler() }
         guard let value = response.notification.request.content.userInfo["deep_link"] as? String,
               let url = URL(string: value) else { return }
-        NotificationCenter.default.post(name: .fleetNotificationOpen, object: url)
+        Task { @MainActor in FleetDesktopController.shared?.open(url) }
     }
 }

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -19,6 +19,23 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
     }
 
     @MainActor
+    func testOpenFleetButtonOpensFleetWindow() throws {
+        launchApp()
+
+        let statusItem = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier == %@", "fleet.status-item"))
+            .firstMatch
+        waitFor(statusItem)
+        statusItem.click()
+
+        let openFleet = app.buttons["fleet.open"]
+        waitFor(openFleet)
+        openFleet.click()
+
+        XCTAssertTrue(app.windows["Fleet"].waitForExistence(timeout: 8), app.debugDescription)
+    }
+
+    @MainActor
     func testRealFixtureRendersAttentionRosterAndFiltersInFleetWindow() throws {
         try fixture.seed(eventID: "alpha", sessionID: "alpha", eventType: "AskUserQuestion", observedAt: 1_700_000_000_001)
         try fixture.seed(eventID: "beta", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -2,35 +2,27 @@ import XCTest
 
 final class MenuBarRosterJourneyTests: FleetUITestCase {
     @MainActor
-    func testRealStatusItemReflectsFleetTotals() throws {
+    func testNotchReflectsFleetTotals() throws {
         try fixture.seed(eventID: "alpha-start", sessionID: "alpha", eventType: "SessionStart", observedAt: 1_700_000_000_001)
         try fixture.seed(eventID: "beta-ask", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)
         launchApp()
 
-        let statusItem = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier == %@", "fleet.status-item"))
-            .firstMatch
-        waitFor(statusItem)
+        let notch = app.buttons["fleet.notch"]
+        waitFor(notch)
         let totals = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "title CONTAINS %@", "1 active, 1 need you"),
-            object: statusItem
+            predicate: NSPredicate(format: "label CONTAINS %@", "1 active, 1 need you"),
+            object: notch
         )
         XCTAssertEqual(XCTWaiter().wait(for: [totals], timeout: 8), .completed, app.debugDescription)
     }
 
     @MainActor
-    func testOpenFleetButtonOpensFleetWindow() throws {
+    func testNotchOpensFleetWindow() throws {
         launchApp()
 
-        let statusItem = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier == %@", "fleet.status-item"))
-            .firstMatch
-        waitFor(statusItem)
-        statusItem.click()
-
-        let openFleet = app.buttons["fleet.open"]
-        waitFor(openFleet)
-        openFleet.click()
+        let notch = app.buttons["fleet.notch"]
+        waitFor(notch)
+        notch.click()
 
         XCTAssertTrue(app.windows["Fleet"].waitForExistence(timeout: 8), app.debugDescription)
     }


### PR DESCRIPTION
## Summary
- activate the app after opening Fleet from the status item, keyboard command, or deep link
- add native UI coverage for the status-bar Open Fleet action

## Verification
- Debug build succeeds with `xcodebuild -project AINBFleet.xcodeproj -scheme AINBFleet -configuration Debug -destination 'platform=macOS' build`\n- Relaunched the Debug app against the running local Hangar daemon\n\nThe selected UI test target compiles, but this scheme currently executes the unit-test plan instead of the selected UI case.