### PR TITLE
test(cts-v2): run the conformance axes per in-tree plugin + gate the protocol wire surface

### DIFF
--- a/ainb-tui/crates/ainb-plugin-cts-v2/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/Cargo.toml
@@ -29,6 +29,11 @@ toml = { workspace = true }
 bytes = { version = "1.6", features = ["serde"] }
 async-trait = "0.1"
 base64 = "0.22"
+# `wire_surface` renders ainb-plugin-protocol's public surface from source so
+# the semver gate is a plain `cargo test` on stable (no rustdoc JSON, no
+# nightly, no crates.io baseline: the protocol crate is a path dependency).
+syn = { version = "2.0", features = ["full", "parsing", "printing", "extra-traits"] }
+quote = "1.0"
 
 [dev-dependencies]
 ainb-plugin-protocol = { path = "../ainb-plugin-protocol" }

--- a/ainb-tui/crates/ainb-plugin-cts-v2/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/src/lib.rs
@@ -11,3 +11,4 @@
 //! - A host-side `#[test]` in `tests/axes.rs`
 
 pub mod harness;
+pub mod wire_surface;

--- a/ainb-tui/crates/ainb-plugin-cts-v2/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/src/lib.rs
@@ -11,4 +11,5 @@
 //! - A host-side `#[test]` in `tests/axes.rs`
 
 pub mod harness;
+pub mod real_plugin;
 pub mod wire_surface;

--- a/ainb-tui/crates/ainb-plugin-cts-v2/src/real_plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/src/real_plugin.rs
@@ -1,0 +1,412 @@
+//! Run the conformance axes against the REAL in-tree plugin binaries.
+//!
+//! The canary suite in `tests/axes.rs` proves the RUNTIME is conformant: it
+//! builds a synthetic plugin per axis and drives it. It has never proved that
+//! the plugins we actually ship satisfy the protocol they claim. This module
+//! supplies the missing half:
+//!
+//! - [`IN_TREE_PLUGINS`]: the descriptors, one per shipped ABI-v2 plugin.
+//! - [`resolve_binary`] : builds the plugin's `[[bin]]` and returns its path,
+//!   so the axes run against the same artifact a user installs.
+//! - [`RawPlugin`]      : a direct Content-Length/JSON-RPC stdio client, for
+//!   the axes whose observable side effect (a `-32601` reply, a process exit
+//!   status) is not reachable through `RuntimeHandle`.
+//!
+//! The host-side axes live in `tests/real_plugin_axes.rs`.
+
+use std::io::{BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ainb_plugin_protocol::framing;
+use serde_json::Value;
+
+/// One shipped ABI-v2 subprocess plugin.
+///
+/// Membership rule: the crate depends on `ainb-plugin-sdk-rust` and ships a
+/// manifest describing an `abi_version = 2` plugin. That excludes the
+/// libraries (`-protocol`, `-runtime`, `-sdk-rust`, `-types-sessions`), the
+/// test harnesses (`-testkit`, `-cts-v2`), and `-notifyd`, which is a
+/// standalone notification daemon with no manifest and no SDK dependency;
+/// it does not speak the plugin ABI at all.
+#[derive(Debug, Clone, Copy)]
+pub struct PluginUnderTest {
+    /// Row label in the matrix; matches `[plugin].name` in the manifest.
+    pub name: &'static str,
+    /// Cargo package to build.
+    pub package: &'static str,
+    /// `[[bin]]` target inside that package.
+    pub bin: &'static str,
+    /// Manifest file, relative to the package directory.
+    pub manifest_file: &'static str,
+}
+
+/// Every in-tree plugin the axes run against.
+pub const IN_TREE_PLUGINS: &[PluginUnderTest] = &[
+    PluginUnderTest {
+        name: "hangar-tui",
+        package: "ainb-plugin-hangar",
+        bin: "ainb-plugin-hangar",
+        manifest_file: "manifest.toml",
+    },
+    PluginUnderTest {
+        name: "burndown",
+        package: "ainb-plugin-burndown",
+        bin: "ainb-plugin-burndown",
+        manifest_file: "plugin.toml",
+    },
+    PluginUnderTest {
+        name: "session-reader",
+        package: "ainb-plugin-session-reader",
+        bin: "ainb-plugin-session-reader",
+        manifest_file: "manifest.toml",
+    },
+    PluginUnderTest {
+        name: "witr",
+        package: "ainb-plugin-witr",
+        bin: "ainb-plugin-witr",
+        manifest_file: "manifest.toml",
+    },
+    PluginUnderTest {
+        name: "learnings",
+        package: "ainb-plugin-learnings",
+        bin: "ainb-plugin-learnings",
+        manifest_file: "manifest.toml",
+    },
+    PluginUnderTest {
+        name: "abtop",
+        package: "ainb-plugin-abtop",
+        bin: "ainb-plugin-abtop",
+        manifest_file: "manifest.toml",
+    },
+];
+
+impl PluginUnderTest {
+    /// Directory holding this plugin's `Cargo.toml`.
+    pub fn crate_dir(&self) -> PathBuf {
+        crates_dir().join(self.package)
+    }
+
+    /// Absolute path to this plugin's manifest file.
+    pub fn manifest_path(&self) -> PathBuf {
+        self.crate_dir().join(self.manifest_file)
+    }
+}
+
+/// `<workspace>/crates`, derived from this crate's own manifest dir.
+fn crates_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ainb-plugin-cts-v2 lives under crates/")
+        .to_path_buf()
+}
+
+/// Cargo workspace root (`ainb-tui/`).
+pub fn workspace_root() -> PathBuf {
+    crates_dir()
+        .parent()
+        .expect("crates/ lives under the workspace root")
+        .to_path_buf()
+}
+
+/// Build `plugin`'s binary and return its path.
+///
+/// `CARGO_BIN_EXE_<name>` only covers targets in the *same* package, so the
+/// axes have to build the plugin themselves. Cargo releases the build lock
+/// before it executes test binaries, so this nested build is safe and, on a
+/// warm target dir, near-instant. A failure is loud: a plugin whose binary
+/// will not build cannot be silently dropped from the matrix.
+pub fn resolve_binary(plugin: &PluginUnderTest) -> Result<PathBuf, String> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(workspace_root())
+        .args([
+            "build",
+            "--package",
+            plugin.package,
+            "--bin",
+            plugin.bin,
+            "--message-format=json-render-diagnostics",
+        ])
+        // Cargo sets these for the test process; leaking them into the nested
+        // build makes cargo think it is being invoked from a build script.
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("CARGO_MAKEFLAGS")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    if is_release_profile() {
+        cmd.arg("--release");
+    }
+
+    let out = cmd
+        .output()
+        .map_err(|e| format!("spawn cargo build for {}: {e}", plugin.package))?;
+    if !out.status.success() {
+        return Err(format!(
+            "cargo build --package {} --bin {} failed with {}",
+            plugin.package, plugin.bin, out.status
+        ));
+    }
+
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|v| v.get("reason").and_then(Value::as_str) == Some("compiler-artifact"))
+        .filter(|v| {
+            v.pointer("/target/name").and_then(Value::as_str) == Some(plugin.bin)
+                && v.pointer("/target/kind/0").and_then(Value::as_str) == Some("bin")
+        })
+        .filter_map(|v| v.get("executable").and_then(Value::as_str).map(PathBuf::from))
+        .next_back()
+        .ok_or_else(|| {
+            format!(
+                "cargo build emitted no executable artifact for {}::{}",
+                plugin.package, plugin.bin
+            )
+        })
+}
+
+/// Whether the test binary itself was built in the release profile, so the
+/// nested build produces artifacts alongside it rather than a second copy.
+fn is_release_profile() -> bool {
+    std::env::current_exe()
+        .is_ok_and(|p| p.components().any(|c| c.as_os_str().eq_ignore_ascii_case("release")))
+}
+
+// =====================================================================
+// Raw stdio client
+// =====================================================================
+
+/// A direct Content-Length/JSON-RPC client bolted onto a plugin's stdio.
+///
+/// Used for the axes whose observable side effect is not reachable through
+/// `RuntimeHandle`: the `-32601` reply to an unknown method, the
+/// `plugin/init` name/version echo, and the child's EXIT STATUS after a
+/// graceful shutdown.
+///
+/// A background reader thread answers any host-bound request the plugin makes
+/// (see [`stub_host_reply`]) so a plugin that calls the host during `on_init`
+/// or `on_shutdown` never blocks the axis waiting for a host that is not
+/// there.
+pub struct RawPlugin {
+    child: Child,
+    stdin: Arc<Mutex<Option<std::process::ChildStdin>>>,
+    replies: Receiver<Value>,
+    next_id: i64,
+}
+
+impl RawPlugin {
+    /// Spawn `bin` with piped stdio and start the reader thread.
+    pub fn spawn(bin: &Path) -> Result<Self, String> {
+        let mut child = Command::new(bin)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // Not piped: nothing drains it, and a full stderr pipe would
+            // wedge the plugin mid-axis.
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("spawn {}: {e}", bin.display()))?;
+
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stdin = Arc::new(Mutex::new(Some(child.stdin.take().expect("piped stdin"))));
+        let (tx, replies) = channel();
+        let writer = Arc::clone(&stdin);
+
+        std::thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            while let Ok(Some(frame)) = framing::read_frame(&mut reader) {
+                let Ok(value) = serde_json::from_slice::<Value>(&frame) else {
+                    continue;
+                };
+                match (
+                    value.get("method").and_then(Value::as_str),
+                    value.get("id").cloned(),
+                ) {
+                    // Host-bound request: answer it so the plugin proceeds.
+                    (Some(method), Some(id)) => {
+                        let mut ack = serde_json::json!({"jsonrpc": "2.0", "id": id});
+                        match stub_host_reply(method) {
+                            Ok(result) => ack["result"] = result,
+                            Err((code, message)) => {
+                                ack["error"] = serde_json::json!({
+                                    "code": code, "message": message
+                                });
+                            }
+                        }
+                        write_frame(&writer, &ack);
+                    }
+                    // Reply to one of our requests.
+                    (None, Some(_)) => {
+                        if tx.send(value).is_err() {
+                            break;
+                        }
+                    }
+                    // Host-bound notification (host/log, ...), or a frame with
+                    // neither a method nor an id: nothing to answer.
+                    (Some(_) | None, _) => {}
+                }
+            }
+        });
+
+        Ok(Self {
+            child,
+            stdin,
+            replies,
+            next_id: 1,
+        })
+    }
+
+    /// Send a request and wait for its reply.
+    ///
+    /// Returns `Ok(result)` on success and `Err((code, message))` for a
+    /// JSON-RPC error reply.
+    pub fn request(
+        &mut self,
+        method: &str,
+        params: &Value,
+        timeout: Duration,
+    ) -> Result<Result<Value, (i64, String)>, String> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let frame = serde_json::json!({
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params
+        });
+        write_frame(&self.stdin, &frame);
+
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let reply = match self.replies.recv_timeout(remaining) {
+                Ok(v) => v,
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(format!("no reply to {method} within {timeout:?}"));
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(format!("plugin closed stdout before replying to {method}"));
+                }
+            };
+            if reply.get("id").and_then(Value::as_i64) != Some(id) {
+                continue;
+            }
+            if let Some(err) = reply.get("error") {
+                let code = err.get("code").and_then(Value::as_i64).unwrap_or(0);
+                let message =
+                    err.get("message").and_then(Value::as_str).unwrap_or_default().to_owned();
+                return Ok(Err((code, message)));
+            }
+            return Ok(Ok(reply.get("result").cloned().unwrap_or(Value::Null)));
+        }
+    }
+
+    /// Close the plugin's stdin, which is how the host signals "no more
+    /// frames"; a conformant plugin then drains and exits.
+    pub fn close_stdin(&self) {
+        drop(self.stdin.lock().expect("stdin mutex").take());
+    }
+
+    /// Wait for the child to exit, returning its exit code.
+    pub fn wait_exit(&mut self, timeout: Duration) -> Result<Option<i32>, String> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => return Ok(status.code()),
+                Ok(None) => {}
+                Err(e) => return Err(format!("try_wait: {e}")),
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!("plugin still running after {timeout:?}"));
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+impl Drop for RawPlugin {
+    fn drop(&mut self) {
+        self.close_stdin();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// The capability keys a manifest actually asks for.
+///
+/// A key counts as asked-for when its grant is bool-true or a non-empty list.
+/// Used as `plugin/init`'s `granted_capabilities`, so the raw probe hands the
+/// plugin the same set a permissive host would.
+pub fn declared_capability_keys(manifest: &ainb_plugin_protocol::Manifest) -> Vec<String> {
+    let Ok(Value::Object(map)) = serde_json::to_value(&manifest.capabilities) else {
+        return Vec::new();
+    };
+    map.into_iter()
+        .filter(|(_, v)| match v {
+            Value::Bool(b) => *b,
+            Value::Array(a) => !a.is_empty(),
+            _ => false,
+        })
+        .map(|(k, _)| k)
+        .collect()
+}
+
+/// What the stub host answers for a plugin-initiated request.
+///
+/// The raw probe is a MINIMAL host. It answers the pure bookkeeping calls a
+/// plugin makes while coming up (snapshot get/subscribe, stream subscribe,
+/// workspace reads) with the default-shaped result those methods return, and
+/// denies the calls that would require the host to actually DO something it
+/// cannot here (spawn a child, dial a socket, read the user's filesystem,
+/// open the keychain). A plugin must survive a denial on those: a real host
+/// denies them too whenever the capability is not granted.
+///
+/// Anything unlisted gets `-32601`, which is the honest answer from a host
+/// that does not implement the method.
+fn stub_host_reply(method: &str) -> Result<Value, (i32, String)> {
+    use ainb_plugin_protocol::{errors, methods};
+    match method {
+        methods::HOST_SNAPSHOT_GET => {
+            Ok(serde_json::json!({ "payload": Value::Null, "version": 0 }))
+        }
+        methods::HOST_SNAPSHOT_SUBSCRIBE
+        | methods::HOST_WORKSPACE_GET_ACTIVE
+        | methods::HOST_WORKSPACE_SET_ACTIVE
+        | methods::HOST_WORKSPACE_SET_DEFAULT => Ok(serde_json::json!({})),
+        methods::HOST_EVENT_STREAM_SUBSCRIBE => {
+            Ok(serde_json::json!({ "stream_id": "cts-stub-stream", "version": 0 }))
+        }
+        methods::HOST_WORKSPACE_LIST => Ok(serde_json::json!({ "workspaces": [] })),
+        methods::HOST_SPAWN_MANAGED_SUBPROCESS
+        | methods::HOST_UNIX_SOCKET_DIAL
+        | methods::HOST_UNIX_SOCKET_SEND
+        | methods::HOST_FS_READ_FILE
+        | methods::HOST_FS_READ_DIR
+        | methods::HOST_NETWORK_FETCH
+        | methods::HOST_SECRET_STORE_GET
+        | methods::HOST_ACTION_INVOKE
+        | methods::HOST_WORKSPACE_CREATE
+        | methods::HOST_WORKSPACE_DELETE => Err((
+            errors::CAPABILITY_DENIED,
+            format!("{method} is not available from the CTS stub host"),
+        )),
+        other => Err((
+            errors::METHOD_NOT_FOUND,
+            format!("CTS stub host does not implement {other}"),
+        )),
+    }
+}
+
+/// Write one Content-Length framed JSON value, ignoring a closed pipe.
+fn write_frame(stdin: &Arc<Mutex<Option<std::process::ChildStdin>>>, value: &Value) {
+    let Ok(mut guard) = stdin.lock() else {
+        return;
+    };
+    let Some(w) = guard.as_mut() else {
+        return;
+    };
+    let body = serde_json::to_vec(value).expect("serialize frame");
+    if framing::write_frame(w, &body).is_ok() {
+        let _ = w.flush();
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-cts-v2/src/wire_surface.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/src/wire_surface.rs
@@ -1,0 +1,245 @@
+//! Source-derived snapshot of `ainb-plugin-protocol`'s public wire surface.
+//!
+//! Ten crates depend on `ainb-plugin-protocol`. Nothing used to detect a
+//! wire-type change landing without a version bump, so this module renders
+//! the crate's public surface (method-name constants, error codes, serde
+//! types with their field names / types / serde attributes, type aliases and
+//! public function signatures) into a stable text document. The rendered
+//! document is committed as `crates/ainb-plugin-protocol/wire-surface.lock`
+//! and compared by `tests/wire_surface_gate.rs`.
+//!
+//! Rendering is done with `syn` over the crate sources rather than rustdoc
+//! JSON so the gate is a plain `cargo test` on stable: no external binary, no
+//! nightly, no published baseline (the crate is a path dependency and has
+//! never been on crates.io).
+//!
+//! Deliberately covers the WHOLE public API of the crate, not just the
+//! `#[derive(Serialize)]` types: a `pub const PLUGIN_RENDER: &str` IS the
+//! wire, and a changed `pub fn decode_frame` signature breaks the SDK and the
+//! runtime just as hard as a renamed struct field.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use quote::ToTokens;
+
+/// Modules of `ainb-plugin-protocol` whose public items form the wire
+/// surface, in the order they are rendered. `lib.rs` is included so a change
+/// to the crate's re-exports is caught too.
+pub const SURFACE_MODULES: &[&str] = &[
+    "lib",
+    "errors",
+    "framing",
+    "manifest",
+    "methods",
+    "params",
+    "topics",
+    "wire_buffer",
+];
+
+/// Header line of the rendered document; carries the crate version the
+/// surface was last regenerated at.
+const VERSION_KEY: &str = "protocol_version = ";
+
+/// Errors from rendering or reading the surface.
+#[derive(Debug)]
+pub enum SurfaceError {
+    /// A source file could not be read.
+    Io(std::path::PathBuf, std::io::Error),
+    /// A source file could not be parsed as Rust.
+    Parse(std::path::PathBuf, syn::Error),
+    /// The committed lock file has no `protocol_version = "..."` header.
+    MissingVersionHeader,
+}
+
+impl std::fmt::Display for SurfaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(p, e) => write!(f, "read {}: {e}", p.display()),
+            Self::Parse(p, e) => write!(f, "parse {}: {e}", p.display()),
+            Self::MissingVersionHeader => {
+                f.write_str("lock file is missing its `protocol_version = \"...\"` header")
+            }
+        }
+    }
+}
+
+/// Render the public wire surface of the protocol crate rooted at
+/// `crate_dir` (the directory holding its `Cargo.toml`), stamped with
+/// `version`.
+///
+/// The output is deterministic: items are emitted in source order within a
+/// module and modules in [`SURFACE_MODULES`] order, all token streams are
+/// normalised through `syn`, and doc comments / `#[cfg(test)]` modules are
+/// dropped so prose edits never move the gate.
+pub fn render(crate_dir: &Path, version: &str) -> Result<String, SurfaceError> {
+    let mut out = String::new();
+    out.push_str("# ainb-plugin-protocol public wire surface\n");
+    out.push_str("#\n");
+    out.push_str("# GENERATED. Do not hand-edit. Regenerate with:\n");
+    out.push_str(
+        "#   UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate\n",
+    );
+    out.push_str("#\n");
+    out.push_str("# The regenerator REFUSES to write while the surface has changed but\n");
+    out.push_str("# ainb-plugin-protocol's version has not. Bump the version first.\n");
+    let _ = writeln!(out, "{VERSION_KEY}\"{version}\"");
+
+    for module in SURFACE_MODULES {
+        let path = crate_dir.join("src").join(format!("{module}.rs"));
+        let src = std::fs::read_to_string(&path).map_err(|e| SurfaceError::Io(path.clone(), e))?;
+        let file = syn::parse_file(&src).map_err(|e| SurfaceError::Parse(path.clone(), e))?;
+
+        let _ = writeln!(out, "\n[{module}]");
+        for item in &file.items {
+            render_item(&mut out, item);
+        }
+    }
+    Ok(out)
+}
+
+/// Read the `protocol_version` recorded in a rendered surface document.
+pub fn recorded_version(document: &str) -> Result<&str, SurfaceError> {
+    document
+        .lines()
+        .find_map(|l| l.strip_prefix(VERSION_KEY))
+        .map(|v| v.trim().trim_matches('"'))
+        .ok_or(SurfaceError::MissingVersionHeader)
+}
+
+/// Strip the version header line so two documents can be compared on their
+/// surface content alone.
+pub fn surface_only(document: &str) -> String {
+    document
+        .lines()
+        .filter(|l| !l.starts_with(VERSION_KEY))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Emit one top-level item if it is public and wire-relevant.
+fn render_item(out: &mut String, item: &syn::Item) {
+    match item {
+        syn::Item::Const(c) if is_public(&c.vis) => {
+            let _ = writeln!(
+                out,
+                "const {}: {} = {}",
+                c.ident,
+                tokens(&c.ty),
+                tokens(&c.expr)
+            );
+        }
+        syn::Item::Type(t) if is_public(&t.vis) => {
+            let _ = writeln!(out, "type {} = {}", t.ident, tokens(&t.ty));
+        }
+        syn::Item::Use(u) if is_public(&u.vis) => {
+            let _ = writeln!(out, "reexport {}", tokens(&u.tree));
+        }
+        syn::Item::Struct(s) if is_public(&s.vis) => {
+            let _ = writeln!(out, "struct {}{}", s.ident, attrs(&s.attrs));
+            for field in &s.fields {
+                if !is_public(&field.vis) {
+                    continue;
+                }
+                let name = field.ident.as_ref().map_or_else(|| "_".to_owned(), ToString::to_string);
+                let _ = writeln!(
+                    out,
+                    "  field {name}: {}{}",
+                    tokens(&field.ty),
+                    attrs(&field.attrs)
+                );
+            }
+        }
+        syn::Item::Enum(e) if is_public(&e.vis) => {
+            let _ = writeln!(out, "enum {}{}", e.ident, attrs(&e.attrs));
+            for variant in &e.variants {
+                let _ = writeln!(
+                    out,
+                    "  variant {}{}{}",
+                    variant.ident,
+                    variant_shape(&variant.fields),
+                    attrs(&variant.attrs)
+                );
+            }
+        }
+        syn::Item::Fn(f) if is_public(&f.vis) => {
+            let _ = writeln!(out, "{}", tokens(&f.sig));
+        }
+        syn::Item::Impl(i) => render_impl(out, i),
+        _ => {}
+    }
+}
+
+/// Emit the public associated functions of an inherent impl block. Inherent
+/// constructors like `RpcError::method_not_found` are part of the contract
+/// the SDK and runtime code against.
+fn render_impl(out: &mut String, item: &syn::ItemImpl) {
+    if item.trait_.is_some() {
+        return;
+    }
+    let ty = tokens(&item.self_ty);
+    for sub in &item.items {
+        if let syn::ImplItem::Fn(f) = sub {
+            if is_public(&f.vis) {
+                let _ = writeln!(out, "{ty}::{}", tokens(&f.sig));
+            }
+        }
+    }
+}
+
+/// Render the shape of an enum variant's payload.
+fn variant_shape(fields: &syn::Fields) -> String {
+    match fields {
+        syn::Fields::Unit => String::new(),
+        syn::Fields::Unnamed(u) => {
+            let inner = u.unnamed.iter().map(|f| tokens(&f.ty)).collect::<Vec<_>>().join(", ");
+            format!("({inner})")
+        }
+        syn::Fields::Named(n) => {
+            let inner = n
+                .named
+                .iter()
+                .map(|f| {
+                    let name = f.ident.as_ref().map_or_else(|| "_".to_owned(), ToString::to_string);
+                    format!("{name}: {}{}", tokens(&f.ty), attrs(&f.attrs))
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" {{ {inner} }}")
+        }
+    }
+}
+
+/// Render the wire-relevant attributes of an item: `#[serde(...)]` (field
+/// renames, tagging, defaults) and `#[derive(...)]` (which tells us whether
+/// the type is serialised at all). Doc comments and everything else are
+/// dropped so prose edits never move the gate.
+fn attrs(attrs: &[syn::Attribute]) -> String {
+    let mut kept: Vec<String> = Vec::new();
+    for a in attrs {
+        if a.path().is_ident("serde") {
+            kept.push(tokens(a));
+        } else if a.path().is_ident("derive") {
+            let derived = tokens(a);
+            // Only the (de)serialisation derives change the wire.
+            if derived.contains("Serialize") || derived.contains("Deserialize") {
+                kept.push(derived);
+            }
+        }
+    }
+    if kept.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", kept.join(" "))
+    }
+}
+
+const fn is_public(vis: &syn::Visibility) -> bool {
+    matches!(vis, syn::Visibility::Public(_))
+}
+
+/// Normalise any syn node to a single-line token string so formatting
+/// changes in the source never move the gate.
+fn tokens<T: ToTokens>(node: &T) -> String {
+    node.to_token_stream().to_string()
+}

--- a/ainb-tui/crates/ainb-plugin-cts-v2/tests/axes.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/tests/axes.rs
@@ -482,7 +482,7 @@ fn run_tmp(tag: &str) -> PathBuf {
     base
 }
 
-/// Register the read_paths/[config] canary with a custom `read_paths`
+/// Register the `read_paths`/`[config]` canary with a custom `read_paths`
 /// allow-list, a `[config]` schema, and a stamped resolved config table.
 fn register_read_paths_canary(
     rt: &Runtime,

--- a/ainb-tui/crates/ainb-plugin-cts-v2/tests/real_plugin_axes.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/tests/real_plugin_axes.rs
@@ -1,0 +1,697 @@
+//! Conformance axes run against the REAL in-tree plugin binaries.
+//!
+//! `tests/axes.rs` drives a synthetic canary per axis; that proves the
+//! RUNTIME is conformant and says nothing about the plugins we ship. This
+//! suite runs the axes that are obligations of EVERY ABI-v2 plugin against
+//! the actual binaries (the same artifacts a user installs) and prints a
+//! plugin x axis matrix.
+//!
+//! One command:
+//!
+//! ```text
+//! cargo test -p ainb-plugin-cts-v2 --test real_plugin_axes -- --nocapture
+//! ```
+//!
+//! Axis selection rule: an axis belongs here only if it is a protocol
+//! obligation of any conformant plugin AND is observable from outside the
+//! plugin (a wire reply, a buffer's dimensions, a process exit status, a
+//! lifecycle state). Axes that probe a canary's scripted behaviour
+//! (`a04_capability_denied` expects the plugin to answer a CLI probe with
+//! `-32001`; `a06`/`a07` expect a specific snapshot payload) are not
+//! obligations of a real plugin and stay in `tests/axes.rs`.
+//!
+//! No `#[ignore]`, no silent skips: every cell is `PASS`, `n/a` with a reason
+//! derived from the plugin's own manifest, or a named entry in [`WAIVERS`].
+//!
+//! ## Disk / process safety
+//!
+//! `$AINB_HANGAR_HOME` is redirected under `CARGO_TARGET_TMPDIR` before any
+//! plugin spawns, so the hangar plugin dials a scratch socket path instead of
+//! the user's live `~/.agents-in-a-box/hangar.sock`.
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ainb_plugin_cts_v2::real_plugin::{
+    IN_TREE_PLUGINS, PluginUnderTest, RawPlugin, declared_capability_keys, resolve_binary,
+};
+use ainb_plugin_protocol::manifest::Manifest;
+use ainb_plugin_runtime::registry::RegisteredPlugin;
+use ainb_plugin_runtime::types::{
+    CliOutcome, LifecycleState, PluginId, RenderOutcome, RuntimeConfig,
+};
+use ainb_plugin_runtime::{Runtime, RuntimeHandle, Viewport};
+
+// =====================================================================
+// Axis catalogue
+// =====================================================================
+
+/// Result of one plugin x axis cell.
+#[derive(Debug, Clone)]
+enum Outcome {
+    Pass,
+    Fail(String),
+    /// The axis does not apply, with the manifest fact that says so.
+    NotApplicable(String),
+}
+
+/// A named, reviewable exemption for one cell.
+///
+/// Empty is the goal. An entry here is a claim that the failure is
+/// acceptable for that plugin, and a reviewer has to be able to judge it from
+/// the reason alone.
+struct Waiver {
+    plugin: &'static str,
+    axis: &'static str,
+    reason: &'static str,
+}
+
+const WAIVERS: &[Waiver] = &[Waiver {
+    plugin: "hangar-tui",
+    axis: "A14.cli_dispatch",
+    // Found by this suite's first run. hangar's manifest advertises
+    // `cli_namespaces = ["hangar"]`, but `Plugin::cli_dispatch` in
+    // ainb-plugin-hangar/src/plugin.rs is an unconditional
+    // `RpcError::not_implemented` for every namespace and every argv, so the
+    // declaration is an over-claim. It is inert rather than user-visible:
+    // `ainb hangar ...` is served natively by the clap subtree in
+    // ainb-core/src/cli/hangar/, which never reaches the plugin. Resolving it
+    // means either dropping the line from the manifest or implementing the
+    // plugin-side dispatch, and both are product calls for the hangar owner,
+    // not a change to make inside a test-hardening PR.
+    reason: "manifest declares cli_namespaces = [\"hangar\"] but cli_dispatch is an \
+             unconditional -32005 stub; `ainb hangar` is served natively by ainb-core's \
+             clap subtree, so the declaration is a stale over-claim, not a user-visible break",
+}];
+
+/// One matrix column: its label and the function that measures it.
+type Axis = (&'static str, fn(&Subject) -> Outcome);
+
+/// Every axis, in matrix-column order.
+const AXES: &[Axis] = &[
+    ("A01.manifest", axis_manifest_round_trip),
+    ("A01.identity", axis_init_identity),
+    ("A02.framing", axis_render_framing),
+    ("A02.viewport", axis_render_viewport),
+    ("A03.unknown_method", axis_unknown_method),
+    ("A05.determinism", axis_render_determinism),
+    ("A11.shutdown", axis_graceful_shutdown),
+    ("A12.crash_recovery", axis_crash_recovery),
+    ("A13.quarantine", axis_quarantine),
+    ("A14.cli_dispatch", axis_cli_dispatch),
+];
+
+/// One plugin, resolved and ready to drive.
+struct Subject {
+    plugin: PluginUnderTest,
+    binary: PathBuf,
+    manifest: Manifest,
+    manifest_src: String,
+}
+
+// =====================================================================
+// The matrix
+// =====================================================================
+
+#[test]
+fn in_tree_plugins_satisfy_the_protocol_they_claim() {
+    isolate_hangar_home();
+
+    let subjects: Vec<Subject> = IN_TREE_PLUGINS.iter().map(resolve_subject).collect();
+
+    let mut rows: Vec<(&str, Vec<Outcome>)> = Vec::new();
+    for subject in &subjects {
+        let cells = AXES
+            .iter()
+            .map(|(name, run)| {
+                let outcome = run(subject);
+                eprintln!(
+                    "  {:<16} {:<20} {}",
+                    subject.plugin.name,
+                    name,
+                    short(&outcome)
+                );
+                outcome
+            })
+            .collect();
+        rows.push((subject.plugin.name, cells));
+    }
+
+    eprintln!("\n{}", render_matrix(&rows));
+
+    let mut unwaived: Vec<String> = Vec::new();
+    let mut stale_waivers: Vec<String> = Vec::new();
+    for (plugin, cells) in &rows {
+        for ((axis, _), outcome) in AXES.iter().zip(cells) {
+            let waived = WAIVERS.iter().find(|w| w.plugin == *plugin && w.axis == *axis);
+            match (outcome, waived) {
+                (Outcome::Fail(why), None) => {
+                    unwaived.push(format!("{plugin} / {axis}: {why}"));
+                }
+                (Outcome::Pass | Outcome::NotApplicable(_), Some(w)) => {
+                    stale_waivers.push(format!(
+                        "{plugin} / {axis} is waived (\"{}\") but no longer fails; delete the waiver",
+                        w.reason
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    assert!(
+        unwaived.is_empty() && stale_waivers.is_empty(),
+        "real-plugin conformance failed\n\nunwaived failures:\n{}\n\nstale waivers:\n{}",
+        if unwaived.is_empty() {
+            "  (none)".to_owned()
+        } else {
+            unwaived.join("\n")
+        },
+        if stale_waivers.is_empty() {
+            "  (none)".to_owned()
+        } else {
+            stale_waivers.join("\n")
+        }
+    );
+}
+
+/// Point `$AINB_HANGAR_HOME` at a repo-local scratch dir so the hangar
+/// plugin's `unix_socket_dial` resolves to a socket that does not exist
+/// instead of the user's live daemon.
+fn isolate_hangar_home() {
+    let home = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("real-plugin-axes-hangar-home");
+    std::fs::create_dir_all(&home).expect("create scratch hangar home");
+    let live = dirs_home().join(".agents-in-a-box");
+    assert!(
+        !home.starts_with(&live),
+        "scratch hangar home {} must not be inside the live hangar home {}",
+        home.display(),
+        live.display()
+    );
+    // The matrix runs as a single test, so nothing races this write.
+    std::env::set_var("AINB_HANGAR_HOME", &home);
+}
+
+fn dirs_home() -> PathBuf {
+    std::env::var_os("HOME").map_or_else(|| PathBuf::from("/nonexistent"), PathBuf::from)
+}
+
+fn resolve_subject(plugin: &PluginUnderTest) -> Subject {
+    let binary = resolve_binary(plugin).unwrap_or_else(|e| panic!("{}: {e}", plugin.name));
+    let path = plugin.manifest_path();
+    let manifest_src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: read {}: {e}", plugin.name, path.display()));
+    let manifest: Manifest = toml::from_str(&manifest_src)
+        .unwrap_or_else(|e| panic!("{}: parse {}: {e}", plugin.name, path.display()));
+    Subject {
+        plugin: *plugin,
+        binary,
+        manifest,
+        manifest_src,
+    }
+}
+
+// =====================================================================
+// Rendering
+// =====================================================================
+
+fn short(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Pass => "PASS".to_owned(),
+        Outcome::NotApplicable(why) => format!("n/a  ({why})"),
+        Outcome::Fail(why) => format!("FAIL  {why}"),
+    }
+}
+
+const fn cell(outcome: &Outcome, waived: bool) -> &'static str {
+    match outcome {
+        Outcome::Pass => "PASS",
+        Outcome::NotApplicable(_) => "n/a",
+        Outcome::Fail(_) if waived => "WAIV",
+        Outcome::Fail(_) => "FAIL",
+    }
+}
+
+fn render_matrix(rows: &[(&str, Vec<Outcome>)]) -> String {
+    let label_width = rows.iter().map(|(p, _)| p.len()).max().unwrap_or(6).max(6);
+    let widths: Vec<usize> = AXES.iter().map(|(a, _)| a.len().max(4)).collect();
+
+    let mut out = String::from("CTS v2 conformance: in-tree plugin binaries\n\n");
+    let _ = write!(out, "{:<label_width$}", "plugin");
+    for ((axis, _), w) in AXES.iter().zip(&widths) {
+        let _ = write!(out, " | {axis:<w$}");
+    }
+    out.push('\n');
+    out.push_str(&"-".repeat(label_width));
+    for w in &widths {
+        let _ = write!(out, "-+-{}", "-".repeat(*w));
+    }
+    out.push('\n');
+
+    for (plugin, cells) in rows {
+        let _ = write!(out, "{plugin:<label_width$}");
+        for (((axis, _), w), outcome) in AXES.iter().zip(&widths).zip(cells) {
+            let waived = WAIVERS.iter().any(|wv| wv.plugin == *plugin && wv.axis == *axis);
+            let _ = write!(out, " | {:<w$}", cell(outcome, waived));
+        }
+        out.push('\n');
+    }
+
+    out.push_str(
+        "\nlegend: PASS = axis satisfied, n/a = axis does not apply per the plugin's \
+                  own manifest,\n        WAIV = failing under a named waiver, FAIL = unwaived \
+                  failure\n",
+    );
+
+    let mut notes: Vec<String> = Vec::new();
+    for (plugin, cells) in rows {
+        for ((axis, _), outcome) in AXES.iter().zip(cells) {
+            match outcome {
+                Outcome::NotApplicable(why) => notes.push(format!("  {plugin} / {axis}: {why}")),
+                Outcome::Fail(why) => notes.push(format!("  {plugin} / {axis}: FAILED: {why}")),
+                Outcome::Pass => {}
+            }
+        }
+    }
+    if !notes.is_empty() {
+        out.push_str("\nnotes:\n");
+        out.push_str(&notes.join("\n"));
+        out.push('\n');
+    }
+    out
+}
+
+// =====================================================================
+// Runtime plumbing
+// =====================================================================
+
+fn build_runtime() -> (Runtime, RuntimeHandle) {
+    let cfg = RuntimeConfig {
+        respawn_backoff: [
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            Duration::from_millis(150),
+        ],
+        failure_window: Duration::from_secs(60),
+        ..RuntimeConfig::default()
+    };
+    Runtime::with_config(cfg).expect("build runtime")
+}
+
+/// Register the real binary with its real manifest, so the runtime enforces
+/// exactly the capabilities the plugin ships with.
+fn register(rt: &Runtime, subject: &Subject) -> PluginId {
+    let plugin = RegisteredPlugin::new(
+        subject.manifest.clone(),
+        subject.binary.clone(),
+        subject.plugin.manifest_path(),
+    );
+    let id = plugin.id.clone();
+    rt.register(plugin);
+    id
+}
+
+/// First render also pays for spawn + `plugin/init`, hence the generous
+/// budget: this axis asserts conformance, not latency.
+const RENDER_TIMEOUT: Duration = Duration::from_secs(20);
+
+fn block_render(
+    rt: &Runtime,
+    handle: &RuntimeHandle,
+    id: &PluginId,
+    w: u16,
+    h: u16,
+) -> Result<RenderOutcome, String> {
+    let rx = handle.render(id, Viewport::new(w, h), 0);
+    rt.tokio_handle().block_on(async {
+        match tokio::time::timeout(RENDER_TIMEOUT, rx).await {
+            Ok(Ok(outcome)) => Ok(outcome),
+            Ok(Err(_)) => Err("render channel closed".to_owned()),
+            Err(_) => Err(format!("no plugin/render reply within {RENDER_TIMEOUT:?}")),
+        }
+    })
+}
+
+fn wait_running(handle: &RuntimeHandle, id: &PluginId) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if matches!(handle.lifecycle_state(id), Some(LifecycleState::Running)) {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    Err(format!(
+        "never reached Running; state = {:?}",
+        handle.lifecycle_state(id)
+    ))
+}
+
+/// Bring a plugin up and return its runtime, handle and id.
+fn spawned(subject: &Subject) -> Result<(Runtime, RuntimeHandle, PluginId), String> {
+    let (rt, handle) = build_runtime();
+    let id = register(&rt, subject);
+    block_render(&rt, &handle, &id, 1, 1)?;
+    wait_running(&handle, &id)?;
+    Ok((rt, handle, id))
+}
+
+fn fail<T>(msg: impl Into<String>) -> Result<T, String> {
+    Err(msg.into())
+}
+
+/// Adapt a `Result`-returning axis body into an [`Outcome`].
+fn outcome(body: impl FnOnce() -> Result<(), String>) -> Outcome {
+    body().map_or_else(Outcome::Fail, |()| Outcome::Pass)
+}
+
+// =====================================================================
+// Axes
+// =====================================================================
+
+/// A01: the shipped manifest parses as a v2 `Manifest`, survives a TOML
+/// round-trip unchanged, declares `abi_version = 2`, and its `[plugin].name`
+/// is the name the host will key it by.
+fn axis_manifest_round_trip(subject: &Subject) -> Outcome {
+    outcome(|| {
+        if subject.manifest.plugin.abi_version != 2 {
+            return fail(format!(
+                "abi_version is {} not 2",
+                subject.manifest.plugin.abi_version
+            ));
+        }
+        if subject.manifest.plugin.name != subject.plugin.name {
+            return fail(format!(
+                "[plugin].name is {:?}, matrix row says {:?}",
+                subject.manifest.plugin.name, subject.plugin.name
+            ));
+        }
+        if subject.manifest.plugin.version.is_empty() {
+            return fail("[plugin].version is empty");
+        }
+        let re_encoded =
+            toml::to_string(&subject.manifest).map_err(|e| format!("re-encode manifest: {e}"))?;
+        let back: Manifest = toml::from_str(&re_encoded)
+            .map_err(|e| format!("re-parse round-tripped manifest: {e}"))?;
+        if back != subject.manifest {
+            return fail("manifest does not survive a TOML round-trip");
+        }
+        // Guard against a manifest that parses only because every field it
+        // declares was silently ignored.
+        if subject.manifest_src.trim().is_empty() {
+            return fail("manifest file is empty");
+        }
+        Ok(())
+    })
+}
+
+/// A01: `plugin/init` must echo the name and version the manifest declares
+/// (`PluginInitResult`'s documented contract), so the host can detect a
+/// binary/manifest mismatch at spawn.
+fn axis_init_identity(subject: &Subject) -> Outcome {
+    outcome(|| {
+        let mut raw = RawPlugin::spawn(&subject.binary)?;
+        let params = serde_json::json!({
+            "manifest_path": subject.plugin.manifest_path().to_string_lossy(),
+            "granted_capabilities": declared_capability_keys(&subject.manifest),
+            "abi_version": 2,
+            "config": serde_json::Value::Null,
+        });
+        match raw.request("plugin/init", &params, Duration::from_secs(15))? {
+            Ok(result) => {
+                let name = result.get("name").and_then(serde_json::Value::as_str);
+                let version = result.get("version").and_then(serde_json::Value::as_str);
+                if name != Some(subject.manifest.plugin.name.as_str()) {
+                    return fail(format!(
+                        "plugin/init echoed name {name:?}, manifest says {:?}",
+                        subject.manifest.plugin.name
+                    ));
+                }
+                if version != Some(subject.manifest.plugin.version.as_str()) {
+                    return fail(format!(
+                        "plugin/init echoed version {version:?}, manifest says {:?}",
+                        subject.manifest.plugin.version
+                    ));
+                }
+                Ok(())
+            }
+            Err((code, message)) => fail(format!("plugin/init returned {code}: {message}")),
+        }
+    })
+}
+
+/// A02: Content-Length framing. A `plugin/render` at 80x24 must come back as
+/// a decodable `RenderResult`, and every cell in the (sparse) `WireBuffer`
+/// must land inside the buffer the plugin declared. An out-of-bounds cell is
+/// a paint the host would silently drop.
+fn axis_render_framing(subject: &Subject) -> Outcome {
+    outcome(|| {
+        let (rt, handle) = build_runtime();
+        let id = register(&rt, subject);
+        match block_render(&rt, &handle, &id, 80, 24)? {
+            RenderOutcome::Ok(buf) => {
+                if let Some((coord, _)) =
+                    buf.cells.iter().find(|(c, _)| c.x >= buf.width || c.y >= buf.height)
+                {
+                    return fail(format!(
+                        "cell at ({}, {}) is outside the plugin's own {}x{} buffer",
+                        coord.x, coord.y, buf.width, buf.height
+                    ));
+                }
+                Ok(())
+            }
+            other => fail(format!("render did not return Ok: {other:?}")),
+        }
+    })
+}
+
+/// A02: the render contract's other half. A plugin that advertises a screen
+/// must paint the viewport it was handed: the buffer it returns has exactly
+/// the requested dimensions, so the host's damage tracking and the plugin's
+/// idea of the frame agree. `WireBuffer` is SPARSE, so this asserts the
+/// declared dimensions, not a full `width * height` cell count.
+fn axis_render_viewport(subject: &Subject) -> Outcome {
+    if subject.manifest.provides.screens.is_empty() {
+        return Outcome::NotApplicable("manifest declares no [provides].screens".to_owned());
+    }
+    outcome(|| {
+        let (rt, handle) = build_runtime();
+        let id = register(&rt, subject);
+        match block_render(&rt, &handle, &id, 80, 24)? {
+            RenderOutcome::Ok(buf) => {
+                if buf.width != 80 || buf.height != 24 {
+                    return fail(format!("asked for 80x24, got {}x{}", buf.width, buf.height));
+                }
+                Ok(())
+            }
+            other => fail(format!("render did not return Ok: {other:?}")),
+        }
+    })
+}
+
+/// A03: an unknown method must come back as JSON-RPC `-32601`, not a hang,
+/// a crash, or a success. Probed on the raw wire before `plugin/init` so
+/// nothing else is in flight.
+fn axis_unknown_method(subject: &Subject) -> Outcome {
+    outcome(|| {
+        let mut raw = RawPlugin::spawn(&subject.binary)?;
+        match raw.request(
+            "cts/definitely_not_a_method",
+            &serde_json::json!({}),
+            Duration::from_secs(10),
+        )? {
+            Ok(v) => fail(format!("unknown method succeeded with {v}")),
+            Err((code, _)) if code == i64::from(ainb_plugin_protocol::errors::METHOD_NOT_FOUND) => {
+                Ok(())
+            }
+            Err((code, message)) => fail(format!(
+                "unknown method returned {code} ({message}), expected {}",
+                ainb_plugin_protocol::errors::METHOD_NOT_FOUND
+            )),
+        }
+    })
+}
+
+/// A05: once a plugin has SETTLED, repeated renders of an unchanged viewport
+/// must be byte-identical.
+///
+/// The canary version of this axis renders a stateless plugin five times and
+/// demands five identical buffers. A real plugin legitimately transitions
+/// while it comes up (`checking witr…` becomes the detection result, hangar
+/// connects to its daemon), so demanding determinism from frame 0 measures
+/// startup, not conformance. This axis instead renders until two consecutive
+/// frames agree (the settle point), then requires the next
+/// [`STEADY_FRAMES`] to be byte-identical. A plugin that paints a clock or a
+/// spinner never settles and fails, which is the finding the axis exists for:
+/// the host treats an unchanged buffer as a no-op frame.
+const SETTLE_BUDGET: usize = 20;
+const STEADY_FRAMES: usize = 3;
+
+fn axis_render_determinism(subject: &Subject) -> Outcome {
+    outcome(|| {
+        let (rt, handle) = build_runtime();
+        let id = register(&rt, subject);
+        let frame = |n: usize| -> Result<Vec<u8>, String> {
+            match block_render(&rt, &handle, &id, 40, 12)? {
+                RenderOutcome::Ok(buf) => {
+                    serde_json::to_vec(&buf).map_err(|e| format!("serialize render {n}: {e}"))
+                }
+                other => Err(format!("render {n} did not return Ok: {other:?}")),
+            }
+        };
+
+        let mut previous = frame(0)?;
+        let mut settled_at = None;
+        for n in 1..SETTLE_BUDGET {
+            let current = frame(n)?;
+            if current == previous {
+                settled_at = Some(n);
+                break;
+            }
+            previous = current;
+        }
+        let Some(settled_at) = settled_at else {
+            return fail(format!(
+                "no two consecutive renders agreed within {SETTLE_BUDGET} frames; \
+                 the plugin never reaches a steady state"
+            ));
+        };
+
+        for n in 0..STEADY_FRAMES {
+            let current = frame(settled_at + 1 + n)?;
+            if current != previous {
+                return fail(format!(
+                    "settled at frame {settled_at}, then frame {} differed byte-for-byte",
+                    settled_at + 1 + n
+                ));
+            }
+        }
+        Ok(())
+    })
+}
+
+/// A11: `plugin/shutdown` must be acknowledged, and the process must then
+/// exit 0 once stdin closes. The observable side effect is the EXIT STATUS,
+/// not "the host did not hang".
+fn axis_graceful_shutdown(subject: &Subject) -> Outcome {
+    outcome(|| {
+        let mut raw = RawPlugin::spawn(&subject.binary)?;
+        let init = serde_json::json!({
+            "manifest_path": subject.plugin.manifest_path().to_string_lossy(),
+            "granted_capabilities": declared_capability_keys(&subject.manifest),
+            "abi_version": 2,
+            "config": serde_json::Value::Null,
+        });
+        raw.request("plugin/init", &init, Duration::from_secs(15))?
+            .map_err(|(c, m)| format!("plugin/init returned {c}: {m}"))?;
+
+        raw.request(
+            "plugin/shutdown",
+            &serde_json::json!({}),
+            Duration::from_secs(5),
+        )?
+        .map_err(|(c, m)| format!("plugin/shutdown returned {c}: {m}"))?;
+
+        raw.close_stdin();
+        match raw.wait_exit(Duration::from_secs(5))? {
+            Some(0) => Ok(()),
+            Some(code) => fail(format!("exited {code} after a graceful shutdown")),
+            None => fail("terminated by a signal after a graceful shutdown"),
+        }
+    })
+}
+
+/// A12: a killed plugin must be respawned and serve renders again.
+fn axis_crash_recovery(subject: &Subject) -> Outcome {
+    outcome(|| {
+        let (rt, handle, id) = spawned(subject)?;
+        handle.inject_kill(&id).map_err(|e| format!("inject_kill: {e}"))?;
+        std::thread::sleep(Duration::from_millis(300));
+
+        drop(handle.render(&id, Viewport::new(1, 1), 1));
+        std::thread::sleep(Duration::from_millis(500));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        while std::time::Instant::now() < deadline {
+            if matches!(block_render(&rt, &handle, &id, 1, 1)?, RenderOutcome::Ok(_)) {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(150));
+        }
+        fail("render never succeeded again after the plugin was killed")
+    })
+}
+
+/// A13: three crashes inside the failure window must quarantine the plugin,
+/// and an explicit reload must clear the quarantine.
+fn axis_quarantine(subject: &Subject) -> Outcome {
+    outcome(|| {
+        let (_rt, handle, id) = spawned(subject)?;
+        for _ in 0..3 {
+            handle.inject_kill(&id).map_err(|e| format!("inject_kill: {e}"))?;
+            std::thread::sleep(Duration::from_millis(300));
+            drop(handle.render(&id, Viewport::new(1, 1), 0));
+            std::thread::sleep(Duration::from_millis(300));
+        }
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let mut quarantined = false;
+        while std::time::Instant::now() < deadline {
+            if matches!(
+                handle.lifecycle_state(&id),
+                Some(LifecycleState::Quarantined)
+            ) {
+                quarantined = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        if !quarantined {
+            return fail(format!(
+                "3 crashes did not quarantine; state = {:?}",
+                handle.lifecycle_state(&id)
+            ));
+        }
+
+        handle.reload(&id).map_err(|e| format!("reload: {e}"))?;
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if matches!(handle.lifecycle_state(&id), Some(LifecycleState::Idle)) {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        fail(format!(
+            "reload did not clear quarantine; state = {:?}",
+            handle.lifecycle_state(&id)
+        ))
+    })
+}
+
+/// A14: a plugin that advertises a CLI namespace must answer
+/// `plugin/cli_dispatch` on it with a well-formed result. The exit code is
+/// the plugin's business; producing a decodable `CliDispatchResult` instead
+/// of an error or a hang is the protocol obligation.
+fn axis_cli_dispatch(subject: &Subject) -> Outcome {
+    let Some(namespace) = subject.manifest.provides.cli_namespaces.first().cloned() else {
+        return Outcome::NotApplicable("manifest declares no [provides].cli_namespaces".to_owned());
+    };
+    outcome(|| {
+        let (rt, handle, id) = spawned(subject)?;
+        let rx = handle.dispatch_cli(&id, &namespace, vec!["--help".to_owned()]);
+        let out = rt.tokio_handle().block_on(async {
+            match tokio::time::timeout(Duration::from_secs(20), rx).await {
+                Ok(Ok(outcome)) => Ok(outcome),
+                Ok(Err(_)) => Err("cli channel closed".to_owned()),
+                Err(_) => Err("no plugin/cli_dispatch reply within 20s".to_owned()),
+            }
+        })?;
+        match out {
+            CliOutcome::Ok(_) => Ok(()),
+            other => fail(format!(
+                "cli_dispatch on the declared namespace {namespace:?} did not return a \
+                 well-formed result: {other:?}"
+            )),
+        }
+    })
+}

--- a/ainb-tui/crates/ainb-plugin-cts-v2/tests/wire_surface_gate.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/tests/wire_surface_gate.rs
@@ -1,0 +1,181 @@
+//! Semver gate for `ainb-plugin-protocol`'s public wire surface.
+//!
+//! Ten crates depend on the protocol crate and nothing detected a wire-type
+//! change landing without a version bump. This test renders the crate's
+//! public surface from source (see `ainb_plugin_cts_v2::wire_surface`) and
+//! compares it byte-for-byte with the committed
+//! `crates/ainb-plugin-protocol/wire-surface.lock`.
+//!
+//! Break it deliberately to see it bite: rename a field on any `pub struct`
+//! in `ainb-plugin-protocol/src/params.rs` and run this test.
+//!
+//! Regenerate after an INTENTIONAL wire change:
+//!
+//! ```text
+//! # 1. bump `version` in crates/ainb-plugin-protocol/Cargo.toml
+//! # 2. UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate
+//! ```
+//!
+//! Step 1 is not advisory: the regenerator refuses to stamp a changed
+//! surface while the version is unchanged, which is what makes this a semver
+//! gate rather than a golden file.
+//!
+//! ## Why not `cargo-semver-checks`
+//!
+//! It was evaluated, not dismissed. `cargo-semver-checks 0.49.0` installs and
+//! runs against this crate in about 13s:
+//!
+//! ```text
+//! cargo semver-checks --manifest-path crates/ainb-plugin-protocol/Cargo.toml \
+//!     --baseline-rev origin/main
+//! ```
+//!
+//! Two things rule it out as THE gate here:
+//!
+//! 1. It checks the Rust API, not the wire. Renaming a serde key, for example
+//!    `#[serde(rename = "secrets:read")]` to `"secrets_read"`, breaks every
+//!    shipped plugin manifest and does not touch the Rust API at all.
+//!    cargo-semver-checks reports `196 checks: 196 pass` and
+//!    `no semver update required`; this gate reports the changed line.
+//! 2. It needs a baseline revision, so it cannot run as part of `cargo test`
+//!    and is meaningless on `main` itself, where the baseline is HEAD.
+//!
+//! The two are complements, not alternatives. Wiring cargo-semver-checks into
+//! CI with a merge-base baseline belongs to Phase 5, which owns the workflow
+//! changes; this gate is what a plain `cargo test` can enforce today.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use ainb_plugin_cts_v2::wire_surface;
+
+/// Directory of the `ainb-plugin-protocol` crate.
+fn protocol_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/ dir")
+        .join("ainb-plugin-protocol")
+}
+
+/// The `[package] version` declared by `ainb-plugin-protocol`.
+fn protocol_version(dir: &Path) -> String {
+    let manifest =
+        std::fs::read_to_string(dir.join("Cargo.toml")).expect("read protocol Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&manifest).expect("parse protocol Cargo.toml");
+    parsed
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(toml::Value::as_str)
+        .expect("ainb-plugin-protocol must declare a literal [package] version")
+        .to_owned()
+}
+
+fn lock_path(dir: &Path) -> PathBuf {
+    dir.join("wire-surface.lock")
+}
+
+/// Parse `major.minor.patch` for an ordering comparison without pulling in a
+/// semver dependency.
+fn version_triple(v: &str) -> (u64, u64, u64) {
+    let mut parts = v.split(['.', '-', '+']).map(|p| p.parse::<u64>().unwrap_or(0));
+    (
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+    )
+}
+
+/// First-difference report between two surface documents.
+fn diff(committed: &str, rendered: &str) -> String {
+    let old: Vec<&str> = committed.lines().collect();
+    let new: Vec<&str> = rendered.lines().collect();
+    let mut out = String::new();
+    let first = (0..old.len().max(new.len())).find(|&i| old.get(i) != new.get(i)).unwrap_or(0);
+    let _ = writeln!(out, "first divergence at surface line {}", first + 1);
+    for i in first.saturating_sub(2)..(first + 6).min(old.len().max(new.len())) {
+        match (old.get(i), new.get(i)) {
+            (Some(o), Some(n)) if o == n => {
+                let _ = writeln!(out, "  {o}");
+            }
+            (o, n) => {
+                if let Some(o) = o {
+                    let _ = writeln!(out, "- {o}");
+                }
+                if let Some(n) = n {
+                    let _ = writeln!(out, "+ {n}");
+                }
+            }
+        }
+    }
+    let removed = old.iter().filter(|l| !new.contains(*l)).count();
+    let added = new.iter().filter(|l| !old.contains(*l)).count();
+    let _ = writeln!(
+        out,
+        "\n{removed} line(s) only in the committed lock, {added} line(s) only in the current source"
+    );
+    out
+}
+
+#[test]
+fn protocol_wire_surface_matches_committed_lock() {
+    let dir = protocol_dir();
+    let version = protocol_version(&dir);
+    let rendered = wire_surface::render(&dir, &version).expect("render wire surface");
+    let lock = lock_path(&dir);
+
+    if std::env::var_os("UPDATE_WIRE_SURFACE").is_some() {
+        regenerate(&lock, &rendered, &version);
+        return;
+    }
+
+    let committed = std::fs::read_to_string(&lock).unwrap_or_else(|e| {
+        panic!(
+            "missing wire-surface lock at {}: {e}\n\
+             Generate it with: UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate",
+            lock.display()
+        )
+    });
+
+    let committed_surface = wire_surface::surface_only(&committed);
+    let rendered_surface = wire_surface::surface_only(&rendered);
+    assert!(
+        committed_surface == rendered_surface,
+        "ainb-plugin-protocol's public wire surface changed but {} was not regenerated.\n\
+         Ten crates depend on this surface. Bump `version` in {}/Cargo.toml, then run:\n  \
+         UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate\n\n{}",
+        lock.display(),
+        dir.display(),
+        diff(&committed_surface, &rendered_surface)
+    );
+
+    // The lock records the version the surface was last stamped at. The
+    // crate may move ahead of it (a release with no wire change), but never
+    // behind it.
+    let recorded = wire_surface::recorded_version(&committed).expect("lock version header");
+    assert!(
+        version_triple(&version) >= version_triple(recorded),
+        "ainb-plugin-protocol version {version} is BEHIND the version recorded in \
+         {} ({recorded}); a wire surface cannot un-ship",
+        lock.display()
+    );
+}
+
+/// Write a new lock, refusing while the surface has changed and the version
+/// has not. This refusal is the semver half of the gate: without it, an
+/// author could silence a wire change by regenerating.
+fn regenerate(lock: &Path, rendered: &str, version: &str) {
+    if let Ok(committed) = std::fs::read_to_string(lock) {
+        let changed =
+            wire_surface::surface_only(&committed) != wire_surface::surface_only(rendered);
+        let recorded = wire_surface::recorded_version(&committed).expect("lock version header");
+        assert!(
+            !(changed && recorded == version),
+            "REFUSING to regenerate {}: the wire surface changed but \
+             ainb-plugin-protocol is still at version {version}.\n\
+             Ten crates consume this surface. Bump the version first, then re-run.",
+            lock.display()
+        );
+    }
+    std::fs::write(lock, rendered).expect("write wire-surface lock");
+    eprintln!("wrote {} at protocol version {version}", lock.display());
+}

--- a/ainb-tui/crates/ainb-plugin-protocol/wire-surface.lock
+++ b/ainb-tui/crates/ainb-plugin-protocol/wire-surface.lock
@@ -1,0 +1,373 @@
+# ainb-plugin-protocol public wire surface
+#
+# GENERATED. Do not hand-edit. Regenerate with:
+#   UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate
+#
+# The regenerator REFUSES to write while the surface has changed but
+# ainb-plugin-protocol's version has not. Bump the version first.
+protocol_version = "0.1.0"
+
+[lib]
+reexport errors :: { ProtocolError , RpcError }
+reexport manifest :: Manifest
+reexport wire_buffer :: { Cell , Color , Coord , WireBuffer }
+
+[errors]
+const METHOD_NOT_FOUND: i32 = - 32601
+const INVALID_PARAMS: i32 = - 32602
+const INTERNAL_ERROR: i32 = - 32603
+const CAPABILITY_DENIED: i32 = - 32001
+const ACTION_TIMEOUT: i32 = - 32002
+const MANIFEST_VALIDATION: i32 = - 32003
+const SECRET_NOT_FOUND: i32 = - 32004
+const NOT_IMPLEMENTED: i32 = - 32005
+const SECRET_BACKEND_LOCKED: i32 = - 32006
+const SECRET_ACCESS_DENIED: i32 = - 32007
+const WORKSPACE_CREATION_DISABLED: i32 = - 32008
+struct RpcError [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field code: i32
+  field message: String
+  field data: Option < serde_json :: Value > [# [serde (skip_serializing_if = "Option::is_none")]]
+RpcError::fn new (code : i32 , message : impl Into < String >) -> Self
+RpcError::fn with_data (mut self , data : serde_json :: Value) -> Self
+RpcError::fn method_not_found (method : impl Into < String >) -> Self
+RpcError::fn capability_denied (cap : impl Into < String >) -> Self
+RpcError::fn action_timeout (action : impl Into < String >) -> Self
+RpcError::fn manifest_validation (reason : impl Into < String >) -> Self
+RpcError::fn invalid_params (reason : impl Into < String >) -> Self
+RpcError::fn internal (reason : impl Into < String >) -> Self
+RpcError::fn secret_not_found (scope : impl Into < String > , key : impl Into < String >) -> Self
+RpcError::fn secret_backend_locked (scope : impl Into < String > , key : impl Into < String >) -> Self
+RpcError::fn secret_access_denied (scope : impl Into < String > , key : impl Into < String >) -> Self
+RpcError::fn not_implemented (reason : impl Into < String >) -> Self
+RpcError::fn workspace_creation_disabled () -> Self
+enum ProtocolError
+  variant Transport(std :: io :: Error)
+  variant Decode(String)
+  variant Server { code: i32, message: String }
+
+[framing]
+const MAX_BODY_BYTES: usize = 16 * 1024 * 1024
+fn encode (body : & [u8]) -> Vec < u8 >
+fn encode_json (body : & serde_json :: Value) -> Result < Vec < u8 > , ProtocolError >
+fn write_frame < W : Write > (w : & mut W , body : & [u8]) -> Result < () , ProtocolError >
+fn read_frame < R : BufRead > (r : & mut R) -> Result < Option < Vec < u8 > > , ProtocolError >
+
+[manifest]
+struct Manifest [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field plugin: PluginMeta
+  field capabilities: Capabilities [# [serde (default)]]
+  field provides: Provides [# [serde (default)]]
+  field subscribes: Subscribes [# [serde (default)]]
+  field lifecycle: Lifecycle [# [serde (default)]]
+  field config: Vec < ConfigField > [# [serde (default)]]
+enum ConfigKind [# [derive (Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize)] # [serde (rename_all = "lowercase")]]
+  variant Path
+  variant String
+  variant Bool
+  variant Enum
+  variant Int
+struct ConfigField [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field key: String
+  field kind: ConfigKind
+  field label: String
+  field default: String [# [serde (default)]]
+  field choices: Vec < String > [# [serde (default)]]
+struct PluginMeta [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field name: String
+  field version: String
+  field abi_version: u32
+  field description: String [# [serde (default)]]
+enum CapabilityGrant [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)] # [serde (untagged)]]
+  variant Bool(bool)
+  variant List(Vec < String >)
+CapabilityGrant::const fn is_granted (& self) -> bool
+CapabilityGrant::fn allow_list (& self) -> Option < & [String] >
+struct Capabilities [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field read_sessions: CapabilityGrant [# [serde (default)]]
+  field write_plugin_data: CapabilityGrant [# [serde (default)]]
+  field event_bus: CapabilityGrant [# [serde (default)]]
+  field network: CapabilityGrant [# [serde (default)]]
+  field spawn_subprocess: CapabilityGrant [# [serde (default)]]
+  field read_claude_logs: CapabilityGrant [# [serde (default)]]
+  field read_codex_logs: CapabilityGrant [# [serde (default)]]
+  field read_paths: CapabilityGrant [# [serde (default)]]
+  field event_stream_subscribe: CapabilityGrant [# [serde (default)]]
+  field spawn_managed_subprocess: CapabilityGrant [# [serde (default)]]
+  field unix_socket_dial: CapabilityGrant [# [serde (default)]]
+  field secrets_read: CapabilityGrant [# [serde (rename = "secrets:read" , default)]]
+  field workspace_write: CapabilityGrant [# [serde (rename = "workspace:write" , default)]]
+struct Provides [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field screens: Vec < String > [# [serde (default)]]
+  field commands: Vec < String > [# [serde (default)]]
+  field cli_namespaces: Vec < String > [# [serde (default)]]
+  field snapshots: Vec < String > [# [serde (default)]]
+struct Subscribes [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field snapshots: Vec < String > [# [serde (default)]]
+enum SpawnMode [# [derive (Debug , Clone , Copy , Default , PartialEq , Eq , Serialize , Deserialize)] # [serde (rename_all = "lowercase")]]
+  variant Eager
+  variant Lazy
+struct Lifecycle [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field spawn: SpawnMode [# [serde (default)]]
+  field idle_reap_secs: u32 [# [serde (default = "default_idle_reap_secs")]]
+
+[methods]
+const PLUGIN_INIT: & str = "plugin/init"
+const PLUGIN_SHUTDOWN: & str = "plugin/shutdown"
+const PLUGIN_RENDER: & str = "plugin/render"
+const PLUGIN_HANDLE_EVENT: & str = "plugin/handle_event"
+const PLUGIN_HANDLE_KEY: & str = "plugin/handle_key"
+const PLUGIN_HANDLE_MOUSE: & str = "plugin/handle_mouse"
+const PLUGIN_CLI_DISPATCH: & str = "plugin/cli_dispatch"
+const HOST_SNAPSHOT_GET: & str = "host/snapshot/get"
+const HOST_SNAPSHOT_PUBLISH: & str = "host/snapshot/publish"
+const HOST_SNAPSHOT_SUBSCRIBE: & str = "host/snapshot/subscribe"
+const HOST_ACTION_INVOKE: & str = "host/action/invoke"
+const HOST_LOG: & str = "host/log"
+const HOST_FS_READ_DIR: & str = "host/fs/read_dir"
+const HOST_FS_READ_FILE: & str = "host/fs/read_file"
+const HOST_NETWORK_FETCH: & str = "host/network/fetch"
+const HOST_EVENT_STREAM_SUBSCRIBE: & str = "host/event_stream_subscribe"
+const HOST_EVENT_STREAM_CANCEL: & str = "host/event_stream_cancel"
+const HOST_SPAWN_MANAGED_SUBPROCESS: & str = "host/spawn_managed_subprocess"
+const HOST_UNIX_SOCKET_DIAL: & str = "host/unix_socket_dial"
+const HOST_UNIX_SOCKET_SEND: & str = "host/unix_socket_send"
+const HOST_UNIX_SOCKET_CLOSE: & str = "host/unix_socket_close"
+const HOST_SECRET_STORE_GET: & str = "host/secret_store_get"
+const HOST_WORKSPACE_LIST: & str = "host/workspace_list"
+const HOST_WORKSPACE_GET_ACTIVE: & str = "host/workspace_get_active"
+const HOST_WORKSPACE_SET_ACTIVE: & str = "host/workspace_set_active"
+const HOST_WORKSPACE_SET_DEFAULT: & str = "host/workspace_set_default"
+const HOST_WORKSPACE_CREATE: & str = "host/workspace_create"
+const HOST_WORKSPACE_DELETE: & str = "host/workspace_delete"
+const ALL_METHODS: & [& str] = & [PLUGIN_INIT , PLUGIN_SHUTDOWN , PLUGIN_RENDER , PLUGIN_HANDLE_EVENT , PLUGIN_HANDLE_KEY , PLUGIN_HANDLE_MOUSE , PLUGIN_CLI_DISPATCH , HOST_SNAPSHOT_GET , HOST_SNAPSHOT_PUBLISH , HOST_SNAPSHOT_SUBSCRIBE , HOST_ACTION_INVOKE , HOST_LOG , HOST_FS_READ_DIR , HOST_FS_READ_FILE , HOST_NETWORK_FETCH , HOST_EVENT_STREAM_SUBSCRIBE , HOST_EVENT_STREAM_CANCEL , HOST_SPAWN_MANAGED_SUBPROCESS , HOST_UNIX_SOCKET_DIAL , HOST_UNIX_SOCKET_SEND , HOST_UNIX_SOCKET_CLOSE , HOST_SECRET_STORE_GET , HOST_WORKSPACE_LIST , HOST_WORKSPACE_GET_ACTIVE , HOST_WORKSPACE_SET_ACTIVE , HOST_WORKSPACE_SET_DEFAULT , HOST_WORKSPACE_CREATE , HOST_WORKSPACE_DELETE ,]
+
+[params]
+struct PluginInitParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field manifest_path: String
+  field granted_capabilities: Vec < String >
+  field abi_version: u32
+  field config: serde_json :: Value [# [serde (default)]]
+struct PluginInitResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field name: String
+  field version: String
+struct PluginShutdownParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+struct PluginShutdownResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+struct Viewport [# [derive (Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize)]]
+  field width: u16
+  field height: u16
+Viewport::const fn new (width : u16 , height : u16) -> Self
+struct RenderParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field viewport: Viewport
+  field generation: u64 [# [serde (default)]]
+struct RenderResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field buffer: WireBuffer
+  field redraw: bool [# [serde (default)]]
+  field captures_text: bool [# [serde (default)]]
+struct HandleEventParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field topic: String
+  field payload: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+struct KeyEvent [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field code: KeyCode
+  field mods: u8 [# [serde (default)]]
+  field kind: KeyKind [# [serde (default)]]
+enum KeyCode [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)] # [serde (tag = "type" , rename_all = "snake_case")]]
+  variant Char { ch: char }
+  variant Enter
+  variant Tab
+  variant BackTab
+  variant Esc
+  variant Backspace
+  variant Delete
+  variant Up
+  variant Down
+  variant Left
+  variant Right
+  variant Home
+  variant End
+  variant PageUp
+  variant PageDown
+  variant F { n: u8 }
+enum KeyKind [# [derive (Debug , Clone , Copy , PartialEq , Eq , Default , Serialize , Deserialize)] # [serde (rename_all = "snake_case")]]
+  variant Press
+  variant Repeat
+  variant Release
+const KEY_MOD_SHIFT: u8 = 0b0001
+const KEY_MOD_CTRL: u8 = 0b0010
+const KEY_MOD_ALT: u8 = 0b0100
+const KEY_MOD_SUPER: u8 = 0b1000
+struct HandleKeyParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field screen_id: String
+  field key: KeyEvent
+  field generation: u64
+enum MouseButton [# [derive (Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize)] # [serde (tag = "type" , rename_all = "snake_case")]]
+  variant Left
+  variant Right
+  variant Middle
+enum MouseKind [# [derive (Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize)] # [serde (tag = "type" , rename_all = "snake_case")]]
+  variant Down { button: MouseButton }
+  variant Up { button: MouseButton }
+  variant Drag { button: MouseButton }
+  variant Moved
+  variant ScrollUp
+  variant ScrollDown
+  variant ScrollLeft
+  variant ScrollRight
+struct MouseEvent [# [derive (Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize)]]
+  field kind: MouseKind
+  field col: u16
+  field row: u16
+  field mods: u8 [# [serde (default)]]
+struct HandleMouseParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field screen_id: String
+  field mouse: MouseEvent
+  field generation: u64
+struct CliDispatchParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field namespace: String
+  field argv: Vec < String >
+struct CliDispatchResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field stdout: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+  field stderr: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+  field exit_code: i32
+struct SnapshotGetParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field topic: String
+struct SnapshotGetResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field payload: Option < bytes :: Bytes > [# [serde (default , with = "opt_bytes_serde")]]
+  field version: u64 [# [serde (default)]]
+struct SnapshotPublishParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field topic: String
+  field payload: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+struct SnapshotSubscribeParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field topic: String
+struct SnapshotSubscribeResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+struct ActionInvokeParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field action: String
+  field payload: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+  field timeout_ms: u64 [# [serde (default)]]
+struct ActionInvokeResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field payload: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+enum LogLevel [# [derive (Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize)] # [serde (rename_all = "lowercase")]]
+  variant Trace
+  variant Debug
+  variant Info
+  variant Warn
+  variant Error
+struct LogParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field level: LogLevel
+  field message: String
+  field fields: Option < serde_json :: Value > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+struct FsReadDirParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field path: String
+struct FsDirEntry [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field name: String
+  field is_dir: bool
+  field size: u64 [# [serde (default)]]
+struct FsReadDirResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field entries: Vec < FsDirEntry >
+struct FsReadFileParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field path: String
+struct FsReadFileResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field bytes: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+struct NetworkFetchParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field url: String
+  field method: String [# [serde (default)]]
+  field body: Option < bytes :: Bytes > [# [serde (default , with = "opt_bytes_serde")]]
+  field headers: Vec < (String , String) > [# [serde (default)]]
+struct NetworkFetchResult [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field status: u16
+  field headers: Vec < (String , String) >
+  field body: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+struct EventStreamSubscribeParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field topic: String
+  field since_version: Option < u64 > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+struct EventStreamSubscribeResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field stream_id: String
+  field version: u64 [# [serde (default)]]
+struct EventStreamCancelParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field stream_id: String
+struct SpawnManagedSubprocessParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field bin: String
+  field argv: Vec < String > [# [serde (default)]]
+  field env_allowlist: Vec < String > [# [serde (default)]]
+  field cwd: Option < String > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+struct SpawnManagedSubprocessResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field handle: String
+  field pid: u32
+struct UnixSocketDialParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field path: String
+struct UnixSocketDialResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field stream_id: String
+struct UnixSocketSendParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field stream_id: String
+  field bytes: bytes :: Bytes [# [serde (with = "bytes_serde")]]
+struct UnixSocketCloseParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field stream_id: String
+enum UnixSocketEventKind [# [derive (Debug , Clone , Copy , PartialEq , Eq , Serialize , Deserialize)] # [serde (rename_all = "lowercase")]]
+  variant Data
+  variant Eof
+  variant Error
+struct UnixSocketEvent [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field kind: UnixSocketEventKind
+  field bytes: Option < bytes :: Bytes > [# [serde (default , skip_serializing_if = "Option::is_none" , with = "opt_bytes_serde")]]
+  field error: Option < String > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+struct SecretStoreGetParams [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field scope: String
+  field workspace_id: Option < String > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+  field key: String
+struct SecretStoreGetResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field value: String
+struct WorkspaceEntry [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field id: String
+  field slug: String
+  field name: String
+  field active: bool
+  field default: bool
+struct WorkspaceListParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+struct WorkspaceListResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field workspaces: Vec < WorkspaceEntry >
+  field creation_disabled: bool [# [serde (default , skip_serializing_if = "std::ops::Not::not")]]
+struct WorkspaceGetActiveParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+struct WorkspaceGetActiveResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field workspace_id: Option < String > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+struct WorkspaceSetActiveParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field workspace_id: String
+struct WorkspaceSetActiveResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+struct WorkspaceSetDefaultParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field workspace_id: String
+struct WorkspaceSetDefaultResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+struct WorkspaceCreateParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field slug: String
+  field name: String
+struct WorkspaceCreateResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field workspace: WorkspaceEntry
+struct WorkspaceDeleteParams [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+  field workspace_id: String
+struct WorkspaceDeleteResult [# [derive (Debug , Clone , Default , PartialEq , Eq , Serialize , Deserialize)]]
+
+[topics]
+const UI_CLOSE_REQUEST: & str = "ui.close_request"
+struct UiCloseRequest [# [derive (Debug , Clone , PartialEq , Eq , serde :: Serialize , serde :: Deserialize)]]
+  field screen_id: String
+
+[wire_buffer]
+struct Coord [# [derive (Debug , Clone , Copy , PartialEq , Eq , Hash , Serialize , Deserialize)]]
+  field x: u16
+  field y: u16
+Coord::const fn new (x : u16 , y : u16) -> Self
+struct Color [# [derive (Debug , Clone , Copy , PartialEq , Eq , Hash , Serialize , Deserialize)]]
+  field r: u8
+  field g: u8
+  field b: u8
+Color::const fn rgb (r : u8 , g : u8 , b : u8) -> Self
+struct Cell [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field symbol: String
+  field fg: Option < Color > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+  field bg: Option < Color > [# [serde (default , skip_serializing_if = "Option::is_none")]]
+  field modifier: u16 [# [serde (default)]]
+Cell::fn new (symbol : impl Into < String >) -> Self
+struct WireBuffer [# [derive (Debug , Clone , PartialEq , Eq , Serialize , Deserialize)]]
+  field width: u16
+  field height: u16
+  field cells: Vec < (Coord , Cell) >
+WireBuffer::const fn new (width : u16 , height : u16) -> Self
+WireBuffer::fn push (& mut self , coord : Coord , cell : Cell)

--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -147,6 +147,18 @@ gen-cli-ref:
 check-cli-ref: gen-cli-ref
     git diff --exit-code -- ../docs/tui/cli.md
 
+# Run the v2 conformance axes against every in-tree plugin BINARY and print
+# the plugin x axis matrix. The synthetic-canary suite in
+# crates/ainb-plugin-cts-v2/tests/axes.rs proves the runtime is conformant;
+# this proves the plugins we actually ship are.
+cts-matrix:
+    cargo test -p ainb-plugin-cts-v2 --test real_plugin_axes -- --nocapture
+
+# Every plugin contract in one shot: the synthetic axes, the per-plugin
+# matrix, and the ainb-plugin-protocol wire-surface semver gate.
+cts-contracts:
+    cargo test -p ainb-plugin-cts-v2 -- --nocapture
+
 # Check everything (format, lint, test)
 check:
     just fmt-check


### PR DESCRIPTION
Phase 4 of `ainb-tui/plans/contract-testing-hardening.md`. Tracking issue #500.

The 18-axis conformance suite in `crates/ainb-plugin-cts-v2` builds a synthetic
canary per axis. That proves the RUNTIME is conformant and has never said
anything about the plugins we actually ship. `ainb-plugin-protocol` sits at
0.1.0 with ten dependent crates and nothing gating a wire-type change.

This PR adds the missing halves: the axes now run against the real in-tree
plugin BINARIES, and the protocol's public wire surface is pinned by a
committed lock.

## What runs

```
just cts-matrix       # axes for every in-tree plugin, prints the matrix
just cts-contracts    # synthetic axes + per-plugin matrix + wire-surface gate
```

## Reality as first measured

Recorded before fixing anything, against `origin/main` plugin sources.

```
plugin         | A01.manifest | A01.identity | A02.framing | A03.unknown_method | A05.determinism | A11.shutdown | A12.crash_recovery | A13.quarantine | A14.cli_dispatch
---------------+--------------+--------------+-------------+--------------------+-----------------+--------------+--------------------+----------------+-----------------
hangar-tui     | PASS         | PASS         | FAIL        | PASS               | FAIL            | PASS         | PASS               | PASS           | FAIL
burndown       | PASS         | PASS         | PASS        | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
session-reader | PASS         | FAIL         | FAIL        | PASS               | PASS            | FAIL         | PASS               | PASS           | n/a
witr           | PASS         | PASS         | FAIL        | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
learnings      | PASS         | PASS         | FAIL        | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
abtop          | PASS         | PASS         | FAIL        | PASS               | FAIL            | PASS         | PASS               | PASS           | PASS
```

Nine of those ten failures were MY AXES BEING WRONG, not the plugins. Being
explicit about which is which, because a matrix that blames plugins for a
harness bug is worse than no matrix:

| First-run failure | Verdict | What changed |
|---|---|---|
| `A02.framing` on 5 plugins ("80x24 buffer carries 126 cells, expected 1920") | axis wrong | `WireBuffer` is documented as SPARSE (`Vec<(Coord, Cell)>`; cells the plugin does not write are left untouched host-side). Asserting a full `width * height` grid was a category error. The axis now asserts every cell lands inside the buffer the plugin declared, and a separate `A02.viewport` asserts the declared dimensions equal the requested viewport. |
| `session-reader / A02` ("asked for 80x24, got 0x0") | axis wrong | session-reader is a pure data plane and declares no `[provides].screens`. `A02.viewport` is now `n/a` for a plugin that provides no screen, derived from its own manifest. |
| `session-reader / A01.identity` and `/ A11.shutdown` (`-32602 ... expected struct SnapshotSubscribeResult`) | axis wrong | The raw stdio probe answered every host-bound request with `result: null`. session-reader calls `host/snapshot/subscribe` during `on_init`, and a real host returns `SnapshotSubscribeResult`, not null. The probe now has an explicit per-method stub table. |
| `hangar-tui / A05` and `abtop / A05` | axis wrong | Both were mid-transition, not nondeterministic (abtop paints `checking abtop...` until detection lands; hangar until it connects). Demanding determinism from frame 0 measures startup, not conformance. The axis now renders until two consecutive frames agree, then requires the next 3 to be byte-identical. A plugin painting a clock or a spinner still never settles and still fails. |
| `hangar-tui / A14.cli_dispatch` (`-32005 not implemented`) | **real** | See below. |

## Reality after correcting the axes

```
plugin         | A01.manifest | A01.identity | A02.framing | A02.viewport | A03.unknown_method | A05.determinism | A11.shutdown | A12.crash_recovery | A13.quarantine | A14.cli_dispatch
---------------+--------------+--------------+-------------+--------------+--------------------+-----------------+--------------+--------------------+----------------+-----------------
hangar-tui     | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | WAIV
burndown       | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
session-reader | PASS         | PASS         | PASS        | n/a          | PASS               | PASS            | PASS         | PASS               | PASS           | n/a
witr           | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
learnings      | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
abtop          | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS

legend: PASS = axis satisfied, n/a = axis does not apply per the plugin's own manifest,
        WAIV = failing under a named waiver, FAIL = unwaived failure
```

**Fixed: nothing in the plugins.** After correcting the axes, five of the six
plugins are clean on every applicable axis. No plugin source was touched.

**Waived: one cell, `hangar-tui / A14.cli_dispatch`.**
hangar's `manifest.toml` advertises `cli_namespaces = ["hangar"]`, but
`Plugin::cli_dispatch` at `crates/ainb-plugin-hangar/src/plugin.rs:5437` is an
unconditional `RpcError::not_implemented` for every namespace and every argv.
That is a genuine over-claim, and it is the finding this suite exists to
surface. It is inert rather than user-visible: `ainb hangar ...` is served
natively by the clap subtree in `crates/ainb-core/src/cli/hangar/`, which never
reaches the plugin. Resolving it means either dropping the line from the
manifest or implementing the plugin-side dispatch, and both are calls for the
hangar owner rather than something to change inside a test-hardening PR. The
waiver is a `const` entry carrying that reason, and a waived cell that starts
passing fails the suite as a stale waiver, so it cannot rot silently.

`n/a` is never a skip: it is derived from the plugin's own manifest
(`session-reader` declares no `[provides].screens` and no
`[provides].cli_namespaces`) and is printed with that reason.

## Semver gate: committed wire-surface lock

Chosen mechanism: `crates/ainb-plugin-protocol/wire-surface.lock`, rendered
from source with `syn` and compared by `cargo test`. It covers the crate's
whole public surface: method-name constants, error codes, serde types with
their field names, types and serde attributes, type aliases, re-exports, and
public function signatures.

`cargo-semver-checks` was evaluated, not dismissed. 0.49.0 installs and runs
here in about 13s with `--baseline-rev origin/main`. Two things rule it out as
THE gate:

1. **It checks the Rust API, not the wire.** Proof below: renaming the serde
   key `secrets:read` to `secrets_read` breaks every shipped plugin manifest,
   and cargo-semver-checks reports `196 checks: 196 pass` /
   `no semver update required`.
2. **It needs a baseline revision**, so it cannot run inside `cargo test` and
   is meaningless on `main`, where the baseline is HEAD.

They are complements. Wiring cargo-semver-checks into CI with a merge-base
baseline belongs to Phase 5, which owns the workflow changes; this gate is what
a plain `cargo test` can enforce today. The exact command is recorded in the
test's doc comment.

## Mutation proof 1: one broken axis in one plugin turns exactly that cell red

Perturbation (scratch, reverted): `crates/ainb-plugin-witr/src/plugin.rs:93`,
`WireBuffer::new(w, h)` becomes `WireBuffer::new(w, h + 1)`.

```
$ cargo test -p ainb-plugin-cts-v2 --test real_plugin_axes -- --nocapture

plugin         | A01.manifest | A01.identity | A02.framing | A02.viewport | A03.unknown_method | A05.determinism | A11.shutdown | A12.crash_recovery | A13.quarantine | A14.cli_dispatch
---------------+--------------+--------------+-------------+--------------+--------------------+-----------------+--------------+--------------------+----------------+-----------------
hangar-tui     | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | WAIV
burndown       | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
session-reader | PASS         | PASS         | PASS        | n/a          | PASS               | PASS            | PASS         | PASS               | PASS           | n/a
witr           | PASS         | PASS         | PASS        | FAIL         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
learnings      | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS
abtop          | PASS         | PASS         | PASS        | PASS         | PASS               | PASS            | PASS         | PASS               | PASS           | PASS

notes:
  witr / A02.viewport: FAILED: asked for 80x24, got 80x25

unwaived failures:
witr / A02.viewport: asked for 80x24, got 80x25

test result: FAILED. 0 passed; 1 failed
```

Exactly one cell flipped. Every other cell is byte-identical to the unmutated
run. Reverted; `git status` clean.

## Mutation proof 2: a wire change without a version bump turns the gate red

Perturbation (scratch, reverted):
`crates/ainb-plugin-protocol/src/manifest.rs`,
`#[serde(rename = "secrets:read", default)]` becomes
`#[serde(rename = "secrets_read", default)]`. It compiles everywhere, and it
changes the manifest key every shipped plugin writes. `version` left at 0.1.0.

```
$ cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate
test protocol_wire_surface_matches_committed_lock ... FAILED

ainb-plugin-protocol's public wire surface changed but
.../crates/ainb-plugin-protocol/wire-surface.lock was not regenerated.
Ten crates depend on this surface. Bump `version` in
.../crates/ainb-plugin-protocol/Cargo.toml, then run:
  UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate

first divergence at surface line 97
    field spawn_managed_subprocess: CapabilityGrant [# [serde (default)]]
    field unix_socket_dial: CapabilityGrant [# [serde (default)]]
-   field secrets_read: CapabilityGrant [# [serde (rename = "secrets:read" , default)]]
+   field secrets_read: CapabilityGrant [# [serde (rename = "secrets_read" , default)]]
    field workspace_write: CapabilityGrant [# [serde (rename = "workspace:write" , default)]]

1 line(s) only in the committed lock, 1 line(s) only in the current source

test result: FAILED. 0 passed; 1 failed
```

The same mutation, through the established tool:

```
$ cargo semver-checks --manifest-path crates/ainb-plugin-protocol/Cargo.toml \
      --baseline-rev origin/main
    Checking ainb-plugin-protocol v0.1.0 -> v0.1.0 (no change; assume minor)
     Checked [   0.023s] 196 checks: 196 pass, 57 skip
     Summary no semver update required
    Finished [   2.226s] ainb-plugin-protocol
$ echo $?
0
```

That contrast is the reason for the choice.

Silencing the gate by regenerating is also blocked, which is the semver half:

```
$ UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate
REFUSING to regenerate .../wire-surface.lock: the wire surface changed but
ainb-plugin-protocol is still at version 0.1.0.
Ten crates consume this surface. Bump the version first, then re-run.

test result: FAILED. 0 passed; 1 failed
```

Reverted; `git status` clean. `ainb-plugin-protocol`'s version is unchanged at
0.1.0 in this PR, because no wire type was changed.

## Verification

```
$ cargo test -p ainb-plugin-cts-v2      # run 1
40 passed (synthetic axes) / 1 passed (real-plugin matrix, 28.5s) / 1 passed (wire gate)
$ cargo test -p ainb-plugin-cts-v2      # run 2
40 passed / 1 passed (18.8s) / 1 passed

$ cargo fmt          # clean
$ cargo clippy -p ainb-plugin-cts-v2 --no-deps --all-targets -- -D warnings   # clean
```

Note on the clippy invocation: `cargo clippy -p ainb-plugin-cts-v2 -- -D warnings`
without `--no-deps` is ALREADY red on `origin/main`, because `-D warnings`
reaches the workspace path dependencies and `ainb-hangar-core` (32 errors) and
`ainb-plugin-protocol` (2) carry pre-existing lint debt. Verified by stashing
this branch's changes and re-running: identical failures. `--no-deps` scopes it
to the crate this PR touches, and that is clean.

## Safety

`$AINB_HANGAR_HOME` is redirected under `CARGO_TARGET_TMPDIR` before any plugin
spawns, with an assertion that it is not inside the live hangar home, so the
hangar plugin resolves `${AINB_HANGAR_HOME}/hangar.sock` and never dials the
user's running daemon.

## Not in this PR

No `.github/workflows` changes. Making these a required `contracts` job needs
branch protection and is Phase 5, the owner's call.
