### PR TITLE
feat: ingest provider hook events

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1030,9 +1030,14 @@ fn hook_inner(matches: &clap::ArgMatches) -> Result<Option<HookEmit>> {
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
+    let agent = match std::env::var("AINB_AGENT").ok().as_deref() {
+        Some("codex") => "codex",
+        _ => "claude",
+    };
 
-    hook_core(
+    hook_core_for_agent(
         &home,
+        agent,
         &event,
         &session_id,
         &cwd,
@@ -1046,6 +1051,7 @@ fn hook_inner(matches: &clap::ArgMatches) -> Result<Option<HookEmit>> {
 
 /// Env-free core of the lifecycle hook. All filesystem state is rooted at the
 /// explicit `home`, so this is unit-testable against a tempdir.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn hook_core(
     home: &std::path::Path,
@@ -1058,11 +1064,43 @@ fn hook_core(
     payload: &str,
     matcher: Option<&str>,
 ) -> Result<Option<HookEmit>> {
+    hook_core_for_agent(
+        home,
+        "claude",
+        event,
+        session_id,
+        cwd,
+        env_parent,
+        done_summary,
+        now_ms,
+        payload,
+        matcher,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn hook_core_for_agent(
+    home: &std::path::Path,
+    agent: &str,
+    event: &str,
+    session_id: &str,
+    cwd: &str,
+    env_parent: Option<&str>,
+    done_summary: Option<String>,
+    now_ms: i64,
+    payload: &str,
+    matcher: Option<&str>,
+) -> Result<Option<HookEmit>> {
     let base_event = event.split(':').next().unwrap_or(event);
+    let matcher = matcher.map(str::to_string).or_else(|| {
+        serde_json::from_str::<serde_json::Value>(payload)
+            .ok()
+            .and_then(|value| resolve_matcher(base_event, None, Some(&value)))
+    });
     let inbox_dir = plumbing::paths::inbox_dir_in(home);
 
-    // Resolve the parent of THIS session (env first, then durable map). Used both
-    // to route our own completion up AND as one fleet-membership signal.
+    // Resolve the parent of THIS session (env first, then durable map). Used to
+    // route our own completion up and gate broker-mediated control.
     let our_parent = if session_id.is_empty() {
         None
     } else {
@@ -1074,7 +1112,7 @@ fn hook_core(
     // parent key for ATC (children are spawned `--parent <name>`, so they commit
     // to `inbox/<name>.jsonl`, NOT `inbox/<atc_session_id>.jsonl`). Resolving it
     // here lets the Stop-drain consume the SAME key the heartbeat consumes
-    // (fixes the split-brain in C-A3) and is a fleet-membership signal (H1).
+    // (fixes the split-brain in C-A3).
     // The ATC root is always `<home>/atc` (matches `atc::paths::atc_root`).
     let atc_name = if cwd.is_empty() {
         None
@@ -1097,25 +1135,24 @@ fn hook_core(
     //    hook (any error is swallowed) so a global Stop hook can't wedge any host
     //    session.
     //
-    //    GATED ON FLEET MEMBERSHIP (H1) — the CONSERVATIVE default. The hooks are
-    //    installed globally into ~/.claude/settings.json, so this verb runs on
-    //    EVERY Claude lifecycle event host-wide. To honour the host-wide-cheap
-    //    rule we append only for fleet members (a session with a resolvable
-    //    parent, a non-empty inbox, or an ATC-managed cwd); a truly unrelated host
-    //    session stays a true no-op. The appender below is trivially cheap, so if
-    //    Stevie wants broad event-sourcing coverage this gate can be dropped (or
-    //    relaxed to a lightweight lifecycle subset) by widening `is_fleet_member`
-    //    — the format + tables already accept any session.
+    //    The hooks are installed globally, so every session with a provider
+    //    session ID writes a raw envelope. Broker-mediated structured answers
+    //    and approvals remain limited to known Fleet members below.
     let is_fleet_member = our_parent.is_some() || has_self_inbox || atc_name.is_some();
-    if !session_id.is_empty() && is_fleet_member {
-        let line = build_event_line(
+    if !session_id.is_empty() {
+        let event_id = uuid::Uuid::new_v4().to_string();
+        let raw_payload_stored = persist_raw_hook_payload(home, &event_id, payload).is_ok();
+        let line = build_event_line_for_agent(
             now_ms,
+            &event_id,
+            agent,
             session_id,
             cwd,
             base_event,
-            matcher,
+            matcher.as_deref(),
             payload,
             our_parent.as_deref(),
+            raw_payload_stored,
         );
         let _ = append_event_line(home, &line);
     }
@@ -1175,8 +1212,9 @@ fn hook_core(
     // 4. PreToolUse(AskUserQuestion): block on exact structured answers and
     //    return the full original questions plus Claude's answer map. Labels
     //    never pass through generic text delivery.
-    if base_event == "PreToolUse"
-        && matcher == Some("AskUserQuestion")
+    if agent == "claude"
+        && base_event == "PreToolUse"
+        && matcher.as_deref() == Some("AskUserQuestion")
         && !session_id.is_empty()
         && is_fleet_member
     {
@@ -1214,9 +1252,13 @@ fn hook_core(
     //    on our socket. `client_await` re-dials to its deadline, so a notifyd
     //    restart mid-wait is survived; a dead socket / no answer deny-falls-back
     //    (never auto-approves).
-    if base_event == "PermissionRequest" && !session_id.is_empty() && is_fleet_member {
+    if agent == "claude"
+        && base_event == "PermissionRequest"
+        && !session_id.is_empty()
+        && is_fleet_member
+    {
         let sock = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
-        let tool = matcher.unwrap_or_default();
+        let tool = matcher.as_deref().unwrap_or_default();
         let context = extract_permission_context(payload);
         let fingerprint = ainb_plugin_notifyd::broker::permission_fingerprint(tool, &context);
         let decision = ainb_plugin_notifyd::broker::client_await_exact(
@@ -1413,7 +1455,15 @@ fn resolve_matcher(
         // the payload — without this arm the TOOL column is empty on real fires.
         "PermissionRequest" => "tool_name",
         "Notification" => "notification_type",
-        "StopFailure" => "error_type",
+        "StopFailure" => {
+            return v
+                .get("error")
+                .or_else(|| v.get("error_type"))
+                .and_then(|x| x.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+        }
         _ => return None,
     };
     v.get(key)
@@ -1458,22 +1508,52 @@ fn parse_hook_tmux_identity(row: &str) -> Option<(String, String)> {
 
 /// Build the canonical `events.jsonl` line for one hook fire. This is the exact
 /// shape the notifyd ingest tailer parses (`crate ainb-plugin-notifyd::ingest`)
-/// and the Wave 3 materializer consumes: ts, session_id, cwd, transcript_path,
-/// agent, event_type (the base event), matcher, and the bounded raw payload.
+/// and the Hangar materializer consumes: ts, session_id, cwd, transcript_path,
+/// agent, event_type, matcher, and a bounded index payload plus raw sidecar.
 /// Parent is folded into the payload so the materializer can set current_state.parent.
 ///
 /// The raw payload is parsed exactly ONCE here (host-hot-path: this runs on
-/// every Claude lifecycle event for a fleet member) and the parsed `Value` is
+/// every Claude lifecycle event) and the parsed `Value` is
 /// reused for the matcher + transcript_path fields and the embedded payload.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn build_event_line(
     now_ms: i64,
+    event_id: &str,
     session_id: &str,
     cwd: &str,
     base_event: &str,
     matcher: Option<&str>,
     payload: &str,
     parent: Option<&str>,
+    raw_payload_stored: bool,
+) -> serde_json::Value {
+    build_event_line_for_agent(
+        now_ms,
+        event_id,
+        "claude",
+        session_id,
+        cwd,
+        base_event,
+        matcher,
+        payload,
+        parent,
+        raw_payload_stored,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_event_line_for_agent(
+    now_ms: i64,
+    event_id: &str,
+    agent: &str,
+    session_id: &str,
+    cwd: &str,
+    base_event: &str,
+    matcher: Option<&str>,
+    payload: &str,
+    parent: Option<&str>,
+    raw_payload_stored: bool,
 ) -> serde_json::Value {
     // Parse the raw payload ONCE; reuse the parsed Value for every derived
     // field. Bounded by MAX_EVENT_PAYLOAD_BYTES so the whole canonical line
@@ -1499,18 +1579,36 @@ fn build_event_line(
         serde_json::json!({ "_truncated": true, "_bytes": payload.len() })
     };
     serde_json::json!({
+        "event_id": event_id,
         "ts": now_ms,
         "session_id": session_id,
         "cwd": cwd,
         "transcript_path": transcript_path,
-        "agent": "claude",
+        "agent": agent,
         "event_type": base_event,
         "matcher": matcher_val,
         "parent": parent,
         "tmux_target": tmux_target,
         "process_start_fingerprint": process_start_fingerprint,
         "payload": payload_val,
+        "raw_payload_ref": raw_payload_stored.then_some(event_id),
     })
+}
+
+/// Persist a complete hook payload before its bounded JSONL index entry. Each
+/// UUID-named file is published with rename, so concurrent global hooks cannot
+/// interleave a large envelope and daemon restart can replay it exactly.
+fn persist_raw_hook_payload(
+    home: &std::path::Path,
+    event_id: &str,
+    payload: &str,
+) -> std::io::Result<()> {
+    let dir = home.join("hangar").join("provider-events");
+    std::fs::create_dir_all(&dir)?;
+    let destination = dir.join(format!("{event_id}.json"));
+    let temporary = dir.join(format!(".{event_id}.{}.tmp", std::process::id()));
+    std::fs::write(&temporary, payload)?;
+    std::fs::rename(temporary, destination)
 }
 
 /// Append one canonical event line to `<home>/events.jsonl`. Best-effort and
@@ -1886,7 +1984,7 @@ mod tests {
         assert_eq!(hb_drained[0].child_id, "child-2");
     }
 
-    // --- H1: events.jsonl append GATED on fleet membership -------------------
+    // --- Host-wide events.jsonl capture -------------------------------------
 
     /// Read every canonical line from `<home>/events.jsonl` (empty when absent).
     fn read_event_lines(home: &std::path::Path) -> Vec<serde_json::Value> {
@@ -1903,10 +2001,10 @@ mod tests {
     }
 
     #[test]
-    fn unrelated_session_appends_no_event_line() {
+    fn unrelated_session_appends_event_without_broker_control() {
         let home = TempDir::new().unwrap();
-        // A session with NO parent, NO inbox, NOT an ATC cwd: a true no-op (H1
-        // conservative default — the appender is gated on fleet membership).
+        // A session with no Fleet relationship still contributes durable
+        // observation, but it must not block on a broker.
         let decision = hook_core(
             home.path(),
             "Stop",
@@ -1921,8 +2019,49 @@ mod tests {
         .unwrap();
         assert!(decision.is_none(), "unrelated session must not block");
         assert!(
-            !home.path().join("events.jsonl").exists(),
-            "unrelated session must append NO event line (H1)"
+            home.path().join("events.jsonl").exists(),
+            "unrelated session must append one source event"
+        );
+        let lines = read_event_lines(home.path());
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["session_id"], "random-unrelated-session");
+    }
+
+    #[test]
+    fn codex_permission_event_is_durable_without_claude_broker_control() {
+        let home = TempDir::new().unwrap();
+        let raw = r#"{"hook_event_name":"PermissionRequest","session_id":"codex-sid","cwd":"/work","tool_name":"shell_command"}"#;
+
+        let result = hook_core_for_agent(
+            home.path(),
+            "codex",
+            "PermissionRequest",
+            "codex-sid",
+            "/work",
+            None,
+            None,
+            7,
+            raw,
+            None,
+        )
+        .unwrap();
+
+        assert!(
+            result.is_none(),
+            "Codex CLI hooks must not use Claude's blocking broker"
+        );
+        let line = read_event_lines(home.path()).pop().expect("durable Codex event");
+        assert_eq!(line["agent"], "codex");
+        assert_eq!(line["event_type"], "PermissionRequest");
+        assert_eq!(line["matcher"], "shell_command");
+        let event_id = line["event_id"].as_str().expect("event id");
+        assert_eq!(
+            std::fs::read_to_string(
+                home.path().join("hangar/provider-events").join(format!("{event_id}.json")),
+            )
+            .unwrap(),
+            raw,
+            "the durable sidecar retains the exact provider payload"
         );
     }
 
@@ -1930,7 +2069,7 @@ mod tests {
     fn atc_session_appends_a_well_formed_event_line() {
         let home = TempDir::new().unwrap();
         let cwd = provision_atc(home.path(), "tower");
-        // An ATC-managed session IS a fleet member → an event line is appended.
+        // An ATC-managed session appends one event line.
         // Stamp a transcript_path + the PreToolUse matcher into the payload to
         // assert they land in the canonical line.
         let payload = r#"{"transcript_path":"/t/atc.jsonl","tool_name":"AskUserQuestion"}"#;
@@ -2001,7 +2140,7 @@ mod tests {
     #[test]
     fn child_with_parent_appends_a_line_and_routes_completion() {
         let home = TempDir::new().unwrap();
-        // A child with a live env parent IS a fleet member.
+        // A child with a live env parent writes event and routes completion.
         hook_core(
             home.path(),
             "Stop",
@@ -2046,12 +2185,14 @@ mod tests {
         assert!(big.len() > MAX_EVENT_PAYLOAD_BYTES);
         let line = build_event_line(
             1,
+            "event-oversized",
             "session-with-a-realistically-long-claude-id-0123456789abcdef",
             "/Users/someone/very/deep/nested/work/tree/path/that/is/long",
             "Stop",
             None,
             &big,
             Some("some-parent-instance-name"),
+            true,
         );
         // Over-cap payloads embed only the truncation marker (not the blob).
         assert_eq!(line["payload"]["_truncated"], true);
@@ -2073,12 +2214,14 @@ mod tests {
         assert!(payload.len() <= MAX_EVENT_PAYLOAD_BYTES);
         let line = build_event_line(
             i64::MAX,
+            "event-max",
             &"s".repeat(64),
             &"/".repeat(256),
             "PreToolUse",
             Some("AskUserQuestion"),
             &payload,
             Some(&"p".repeat(64)),
+            true,
         );
         assert!(
             line_bytes(&line) <= PIPE_BUF,
@@ -2091,7 +2234,17 @@ mod tests {
     fn small_payload_round_trips_matcher_and_transcript() {
         // The parse-once refactor must still surface matcher + transcript_path.
         let payload = r#"{"transcript_path":"/t/atc.jsonl","tool_name":"AskUserQuestion"}"#;
-        let line = build_event_line(7, "sid", "/cwd", "PreToolUse", None, payload, None);
+        let line = build_event_line(
+            7,
+            "event-small",
+            "sid",
+            "/cwd",
+            "PreToolUse",
+            None,
+            payload,
+            None,
+            true,
+        );
         assert_eq!(line["matcher"], "AskUserQuestion");
         assert_eq!(line["transcript_path"], "/t/atc.jsonl");
         assert_eq!(line["payload"]["tool_name"], "AskUserQuestion");

--- a/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
@@ -1044,6 +1044,7 @@ fn canonical_row_from_legacy(row: &StateRow) -> FleetSessionRow {
             .collect(),
         ),
         version: 1,
+        active_work_count: 0,
         cwd: row.cwd.clone(),
         repository_name: None,
         branch_name: None,

--- a/ainb-tui/crates/ainb-core/src/fleet/plumbing/hooks.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/plumbing/hooks.rs
@@ -28,21 +28,42 @@ use serde_json::{Map, Value, json};
 pub const ATC_MANAGED_KEY: &str = "_ainb_atc_managed";
 
 /// The lifecycle events ATC injects, in stable order, each paired with its
-/// matcher. Most lifecycle events use the all-matcher `""`; `PreToolUse` is
-/// scoped to the `AskUserQuestion` tool so ASK is hook-native (a PreToolUse with
-/// `""` would fire on EVERY tool call — far too hot). `StopFailure` reports an
-/// exhausted-retry API error (observational; it cannot block). Each maps to a
-/// command that invokes the canonical hook script with the matching
-/// `AINB_HOOK_EVENT` so the script forwards the right event + matcher.
+/// matcher. All documented Claude events use the all-matcher `""`, including
+/// `PreToolUse`; the hook derives `tool_name` from its raw payload. This keeps
+/// the durable source ledger complete while only `AskUserQuestion` enters the
+/// blocking structured-answer broker. Each maps to the canonical hook script
+/// with the matching `AINB_HOOK_EVENT`.
 pub const ATC_EVENTS: &[(&str, &str)] = &[
     ("SessionStart", ""),
+    ("Setup", ""),
+    ("InstructionsLoaded", ""),
     ("UserPromptSubmit", ""),
-    ("Stop", ""),
-    ("Notification", ""),
-    ("SessionEnd", ""),
-    ("PreToolUse", "AskUserQuestion"),
+    ("UserPromptExpansion", ""),
+    ("MessageDisplay", ""),
+    ("PreToolUse", ""),
     ("PermissionRequest", ""),
+    ("PostToolUse", ""),
+    ("PostToolUseFailure", ""),
+    ("PostToolBatch", ""),
+    ("PermissionDenied", ""),
+    ("Notification", ""),
+    ("SubagentStart", ""),
+    ("SubagentStop", ""),
+    ("TaskCreated", ""),
+    ("TaskCompleted", ""),
+    ("Stop", ""),
     ("StopFailure", ""),
+    ("TeammateIdle", ""),
+    ("ConfigChange", ""),
+    ("CwdChanged", ""),
+    ("FileChanged", ""),
+    ("WorktreeCreate", ""),
+    ("WorktreeRemove", ""),
+    ("PreCompact", ""),
+    ("PostCompact", ""),
+    ("SessionEnd", ""),
+    ("Elicitation", ""),
+    ("ElicitationResult", ""),
 ];
 
 /// Default per-hook timeout (seconds) Claude allows before it kills the hook.
@@ -313,17 +334,57 @@ mod tests {
                 "event {event} matcher mismatch"
             );
         }
-        // PreToolUse is scoped to AskUserQuestion (NOT the all-matcher), so it
-        // doesn't fire on every tool call.
+        // PreToolUse is an all-matcher. The hook extracts tool_name from the
+        // payload before deciding whether this is an AskUserQuestion.
         let pre = &merged["hooks"]["PreToolUse"];
         assert!(pre.is_array(), "PreToolUse installed");
         let cmd = pre[0]["hooks"][0]["command"].as_str().unwrap();
         assert!(
-            cmd.contains("AINB_HOOK_MATCHER=AskUserQuestion"),
+            cmd.contains("AINB_HOOK_MATCHER="),
             "PreToolUse forwards its matcher: {cmd}"
         );
         // StopFailure installed (observational ERR source).
         assert!(merged["hooks"]["StopFailure"].is_array());
+    }
+
+    #[test]
+    fn managed_hook_set_covers_every_documented_claude_event() {
+        let names: Vec<_> = ATC_EVENTS.iter().map(|(event, _)| *event).collect();
+        assert_eq!(
+            names,
+            vec![
+                "SessionStart",
+                "Setup",
+                "InstructionsLoaded",
+                "UserPromptSubmit",
+                "UserPromptExpansion",
+                "MessageDisplay",
+                "PreToolUse",
+                "PermissionRequest",
+                "PostToolUse",
+                "PostToolUseFailure",
+                "PostToolBatch",
+                "PermissionDenied",
+                "Notification",
+                "SubagentStart",
+                "SubagentStop",
+                "TaskCreated",
+                "TaskCompleted",
+                "Stop",
+                "StopFailure",
+                "TeammateIdle",
+                "ConfigChange",
+                "CwdChanged",
+                "FileChanged",
+                "WorktreeCreate",
+                "WorktreeRemove",
+                "PreCompact",
+                "PostCompact",
+                "SessionEnd",
+                "Elicitation",
+                "ElicitationResult",
+            ]
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
@@ -1,7 +1,7 @@
 //! The attention ingest producer (spec P2, D10) — the daemon's own tail of the
 //! durable hook event log (`events.jsonl`) into the `attention` table.
 //!
-//! The lifecycle hook (`ainb fleet atc hook`) appends one JSON line per managed
+//! The lifecycle hook (`ainb fleet atc hook`) appends one JSON line per Claude
 //! event to `~/.agents-in-a-box/events.jsonl`. notifyd already ingests that file
 //! into ITS sqlite for OS notifications; this is the SECOND, independent consumer
 //! the converged control centre needs — the one that folds every input-request
@@ -20,14 +20,13 @@
 //!
 //! ## Idempotency
 //!
-//! The attention id is keyed on the hook line's ABSOLUTE byte offset in the
-//! append-only `events.jsonl`: `att:<session>:<offset>`. The offset is a stable
-//! per-occurrence identity — a given hook line lives at one offset for the life
-//! of the file, so:
+//! The attention id uses the hook's durable event ID:
+//! `att:<session>:<event_id>`. Legacy lines fall back to their absolute byte
+//! offset. The event ID is stable across replay, so:
 //!
 //!   - A re-read of the SAME line (a crash between insert and the cursor write, a
 //!     best-effort cursor-write failure, or a corrupt/missing cursor that resets
-//!     the read to 0) hashes to the SAME id → the insert is skipped → no
+//!     the read to 0) has the SAME id → the insert is skipped → no
 //!     duplicate card. Re-reading from 0 raises each request exactly once, so the
 //!     cursor is a pure efficiency optimisation, not a correctness dependency.
 //!   - A genuinely NEW occurrence (a fresh hook line — the same question asked
@@ -35,11 +34,8 @@
 //!     NEW offset → a NEW id → a fresh row, even when its request context is
 //!     byte-for-byte identical to a prior one.
 //!
-//! Keying on the offset — rather than a blake3 of the request context — is
-//! deliberate: the context can carry TIME-DERIVED fields (e.g. `idle_minutes`),
-//! so a context hash changes when the same line is re-classified at a later
-//! wall-clock, which would mint spurious duplicate rows on any delayed re-read.
-//! The offset is invariant to when the line is read.
+//! Event IDs avoid context hashes, whose time-derived fields can change when a
+//! line is re-classified. Legacy offsets remain invariant to read time.
 //!
 //! ## Delivery semantics
 //!
@@ -54,6 +50,9 @@ use ainb_fleet_core::read::needs::{ClassifyInput, NeedsContext, classify};
 use ainb_fleet_core::types::{Session, SessionSource};
 use ainb_hangar_proto::events::HangarEvent;
 use ainb_hangar_store::repo::attention::{AttentionKind, AttentionRepo, NewAttention};
+use ainb_hangar_store::repo::fleet_provider_event::{
+    FleetProviderEventRepo, NewFleetProviderEvent,
+};
 use serde::Deserialize;
 use sqlx::SqlitePool;
 
@@ -84,6 +83,10 @@ fn is_qualifying(event_type: &str) -> bool {
 /// breaks the tail.
 #[derive(Debug, Deserialize)]
 struct HookEventLine {
+    #[serde(default, deserialize_with = "null_as_default")]
+    event_id: String,
+    #[serde(default, deserialize_with = "null_as_default")]
+    raw_payload_ref: String,
     #[serde(default, deserialize_with = "null_as_default")]
     ts: i64,
     #[serde(default, deserialize_with = "null_as_default")]
@@ -197,10 +200,9 @@ impl AttentionIngest {
 
         let mut raised = 0;
         let mut committed_end = 0usize;
-        // Track each line's absolute byte offset in the file (the stable
-        // per-occurrence identity the attention id is keyed on). `split_inclusive`
-        // keeps the delimiter, avoiding a synthetic extra byte after the final
-        // newline.
+        // Track each line's absolute byte offset for legacy event identity.
+        // `split_inclusive` keeps the delimiter, avoiding a synthetic extra byte
+        // after the final newline.
         let mut line_start = 0usize;
         for segment in buf[..end].split_inclusive(|&b| b == b'\n') {
             let offset = start + line_start as u64;
@@ -233,15 +235,57 @@ impl AttentionIngest {
         let Ok(line) = serde_json::from_str::<HookEventLine>(raw) else {
             return LineOutcome::Processed;
         };
+        let event_id = (!line.event_id.is_empty())
+            .then_some(line.event_id.clone())
+            .unwrap_or_else(|| format!("legacy-hook:{}:{offset}", line.session_id));
+        let mut payload =
+            serde_json::from_str::<serde_json::Value>(raw).unwrap_or(serde_json::Value::Null);
+        let raw_payload = match self.raw_payload(&line, &event_id, &payload) {
+            Ok(payload) => payload,
+            Err(error) => {
+                tracing::warn!(error = %error, "fleet provider event payload unavailable");
+                return LineOutcome::Retry;
+            }
+        };
+        if let Ok(raw_value) = serde_json::from_str::<serde_json::Value>(&raw_payload) {
+            if let Some(envelope) = payload.as_object_mut() {
+                envelope.insert("payload".to_string(), raw_value);
+            }
+        }
+        let provider = if line.agent.is_empty() {
+            "unknown"
+        } else {
+            line.agent.as_str()
+        };
+        let session_key =
+            (!line.session_id.is_empty()).then(|| format!("{provider}:{}", line.session_id));
+        if FleetProviderEventRepo::append(
+            &self.pool,
+            &NewFleetProviderEvent {
+                event_id: event_id.clone(),
+                provider: provider.to_string(),
+                source: "claude_hook".to_string(),
+                session_key,
+                provider_session_id: (!line.session_id.is_empty()).then(|| line.session_id.clone()),
+                observed_at: if line.ts > 0 { line.ts } else { now_ms },
+                received_at: now_ms,
+                event_type: line.event_type.clone(),
+                raw_payload,
+            },
+        )
+        .await
+        .is_err()
+        {
+            tracing::warn!("fleet provider event persistence failed");
+            return LineOutcome::Retry;
+        }
         if line.cwd.is_empty() && line.session_id.is_empty() {
             return LineOutcome::Processed;
         }
 
         // Every hook line feeds the canonical Fleet reducer, including events
-        // that do not raise an attention card. The byte offset is a replay-safe
-        // occurrence id, shared with this consumer's durable cursor semantics.
-        let payload =
-            serde_json::from_str::<serde_json::Value>(raw).unwrap_or(serde_json::Value::Null);
+        // that do not raise an attention card. The source event ID is replay-safe;
+        // legacy lines use their durable byte offset.
         let semantic_event = if line.event_type == "PreToolUse" && line.matcher == "AskUserQuestion"
         {
             "AskUserQuestion"
@@ -250,7 +294,7 @@ impl AttentionIngest {
         };
         if !line.session_id.is_empty() {
             let observation = crate::fleet::HookObservation {
-                event_id: format!("hook:{}:{offset}", line.session_id),
+                event_id: event_id.clone(),
                 provider: &line.agent,
                 provider_session_id: &line.session_id,
                 cwd: &line.cwd,
@@ -258,10 +302,19 @@ impl AttentionIngest {
                 payload: &payload,
                 observed_at: if line.ts > 0 { line.ts } else { now_ms },
             };
+            let reduced =
+                match crate::fleet::apply_hook(&self.pool, &self.events, observation).await {
+                    Ok(result) => result,
+                    Err(error) => {
+                        tracing::warn!(error = %error, "fleet hook reduce failed");
+                        return LineOutcome::Retry;
+                    }
+                };
             if let Err(error) =
-                crate::fleet::apply_hook(&self.pool, &self.events, observation).await
+                FleetProviderEventRepo::mark_projected(&self.pool, &event_id, reduced.revision)
+                    .await
             {
-                tracing::warn!(error = %error, "fleet hook reduce failed");
+                tracing::warn!(error = %error, "fleet provider event projection link failed");
                 return LineOutcome::Retry;
             }
         }
@@ -296,12 +349,10 @@ impl AttentionIngest {
             self.reconcile_stale_asks(&line.session_id, now_ms).await;
         }
 
-        // Offset-keyed id: the SAME hook line (a replay / re-read) → same offset →
-        // same id → the insert is skipped (idempotent). A NEW hook line → a new
-        // offset → a fresh row, even if its request context is identical. Keying
-        // on the offset (not a hash of the possibly time-derived context) keeps a
-        // delayed re-read from minting spurious duplicates.
-        let id = format!("att:{}:{}", line.session_id, offset);
+        // Event-keyed id: a replay keeps the same id and is skipped. New source
+        // events receive a new id even when request context is identical. Legacy
+        // records retain offset identity rather than a time-derived context hash.
+        let id = format!("att:{}:{event_id}", line.session_id);
 
         match AttentionRepo::get(&self.pool, &id).await {
             Ok(Some(_)) => return LineOutcome::Processed, // already raised
@@ -352,6 +403,44 @@ impl AttentionIngest {
             channels,
         });
         LineOutcome::Raised
+    }
+
+    /// Return the exact payload sidecar when the hook stored one. Legacy lines
+    /// have no sidecar, so their bounded inline payload remains replayable.
+    fn raw_payload(
+        &self,
+        line: &HookEventLine,
+        event_id: &str,
+        envelope: &serde_json::Value,
+    ) -> Result<String, std::io::Error> {
+        if line.raw_payload_ref.is_empty() {
+            return Ok(envelope
+                .get("payload")
+                .map(serde_json::Value::to_string)
+                .unwrap_or_else(|| envelope.to_string()));
+        }
+        if line.raw_payload_ref != event_id
+            || !line
+                .raw_payload_ref
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid raw payload reference",
+            ));
+        }
+        let Some(home) = self.events_jsonl.parent() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "hook event log has no parent",
+            ));
+        };
+        std::fs::read_to_string(
+            home.join("hangar")
+                .join("provider-events")
+                .join(format!("{}.json", line.raw_payload_ref)),
+        )
     }
 
     /// Close any OPEN ASK rows a session still carries once a later hook shows it
@@ -740,6 +829,35 @@ mod tests {
         let ingest = ingest_for(&store, &events_jsonl, &cursor);
         assert_eq!(ingest.ingest_once(5000).await, 0);
         assert!(AttentionRepo::list_fleet(store.pool()).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn raw_sidecar_reaches_source_ledger_without_jsonl_truncation() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let events_jsonl = dir.path().join("events.jsonl");
+        let cursor = dir.path().join("attention_ingest.offset");
+        let event_id = "source-sidecar-1";
+        let raw_payload = format!(r#"{{"tool_input":{{"body":"{}"}}}}"#, "x".repeat(8 * 1024));
+        let payload_dir = dir.path().join("hangar").join("provider-events");
+        std::fs::create_dir_all(&payload_dir).unwrap();
+        std::fs::write(payload_dir.join(format!("{event_id}.json")), &raw_payload).unwrap();
+        std::fs::write(
+            &events_jsonl,
+            format!(
+                r#"{{"agent":"claude","cwd":"/w","event_id":"{event_id}","event_type":"SessionStart","matcher":null,"raw_payload_ref":"{event_id}","session_id":"sid-sidecar","transcript_path":null,"ts":1700000000000,"payload":{{"_truncated":true}}}}"#,
+            ) + "\n",
+        )
+        .unwrap();
+        let ingest = ingest_for(&store, &events_jsonl, &cursor);
+
+        assert_eq!(ingest.ingest_once(5_000).await, 0);
+        let source = FleetProviderEventRepo::get(store.pool(), event_id)
+            .await
+            .unwrap()
+            .expect("source envelope must persist");
+        assert_eq!(source.raw_payload, raw_payload);
+        assert!(source.projection_revision.is_some());
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -13,11 +13,17 @@ use ainb_hangar_store::repo::fleet::{
     ApplyFleetEventResult, FleetEventRow, FleetRepo, FleetRepoError, FleetSessionPatch,
     FleetSessionRow, NewFleetEvent, ObservationAuthority,
 };
+use ainb_hangar_store::repo::fleet_provider_event::{
+    FleetProviderEventError, FleetProviderEventRepo, NewFleetProviderEvent,
+};
+use ainb_hangar_store::repo::fleet_work::{FleetWorkRepo, FleetWorkUpdate};
 use serde_json::Value;
 use sqlx::SqlitePool;
 
 use crate::events::EventSink;
-use crate::fleet_provider::codex::{CodexApprovalKind, CodexCapabilities, CodexInbound};
+use crate::fleet_provider::codex::{
+    CodexApprovalKind, CodexCapabilities, CodexInbound, CodexInboundEnvelope,
+};
 
 /// Semantic hook observation before storage normalization.
 #[derive(Debug, Clone)]
@@ -46,6 +52,7 @@ pub async fn apply_hook(
 ) -> Result<ApplyFleetEventResult, FleetRepoError> {
     let provider = parse_provider(observation.provider);
     let session_key = SessionKey::managed(provider, observation.provider_session_id);
+    let source_event_id = observation.event_id.clone();
     let tmux_target = observation
         .payload
         .get("tmux_target")
@@ -59,7 +66,8 @@ pub async fn apply_hook(
         .filter(|value| !value.is_empty())
         .map(str::to_string);
     let exact_tmux_identity = tmux_target.is_some() && process_start_fingerprint.is_some();
-    let (lifecycle_state, attention_state) = states_for_hook(observation.event_type);
+    let (lifecycle_state, attention_state) =
+        states_for_hook(observation.event_type, observation.payload);
     let request_fingerprint = match attention_state {
         Some(AttentionState::Ask | AttentionState::Approval) => {
             let fingerprint = match (provider, observation.event_type) {
@@ -85,7 +93,7 @@ pub async fn apply_hook(
         _ => None,
     };
     let event = NewFleetEvent {
-        event_id: observation.event_id,
+        event_id: source_event_id.clone(),
         session_key: session_key.to_string(),
         observed_at: observation.observed_at,
         authority: ObservationAuthority::Authoritative,
@@ -112,6 +120,9 @@ pub async fn apply_hook(
     if !result.duplicate {
         events.emit_fleet_revision(result.revision);
     }
+    if let Some(update) = hook_work_update(&observation, session_key.as_str()) {
+        apply_workload_projection(pool, events, &update).await?;
+    }
     if let (Some(target), Some(fingerprint)) =
         (tmux_target.as_deref(), process_start_fingerprint.as_deref())
     {
@@ -127,6 +138,77 @@ pub async fn apply_hook(
         .await?;
     }
     Ok(result)
+}
+
+async fn apply_workload_projection(
+    pool: &SqlitePool,
+    events: &EventSink,
+    update: &FleetWorkUpdate,
+) -> Result<ApplyFleetEventResult, FleetRepoError> {
+    let active_work_count = FleetWorkRepo::apply(pool, update).await?;
+    publish_workload_projection(pool, events, update, active_work_count).await
+}
+
+async fn publish_workload_projection(
+    pool: &SqlitePool,
+    events: &EventSink,
+    update: &FleetWorkUpdate,
+    active_work_count: i64,
+) -> Result<ApplyFleetEventResult, FleetRepoError> {
+    let workload = FleetRepo::apply_event(
+        pool,
+        &NewFleetEvent {
+            event_id: format!("workload:{}", update.event_id),
+            session_key: update.session_key.clone(),
+            observed_at: update.observed_at,
+            authority: ObservationAuthority::Authoritative,
+            event_type: "workload_changed".to_string(),
+            payload: serde_json::to_string(&serde_json::json!({
+                "kind": update.kind,
+                "workKey": update.work_key,
+                "active": update.active,
+                "activeWorkCount": active_work_count,
+            }))
+            .unwrap_or_else(|_| "{}".to_string()),
+            patch: FleetSessionPatch {
+                active_work_count: Some(active_work_count),
+                ..FleetSessionPatch::default()
+            },
+        },
+    )
+    .await?;
+    if !workload.duplicate {
+        events.emit_fleet_revision(workload.revision);
+    }
+    Ok(workload)
+}
+
+fn hook_work_update(
+    observation: &HookObservation<'_>,
+    session_key: &str,
+) -> Option<FleetWorkUpdate> {
+    let hook = observation.payload.get("payload").unwrap_or(observation.payload);
+    let (kind, active, key_names): (&str, bool, &[&str]) = match observation.event_type {
+        "SubagentStart" => ("subagent", true, &["agent_id", "agentId"]),
+        "SubagentStop" => ("subagent", false, &["agent_id", "agentId"]),
+        "TaskCreated" => ("task", true, &["task_id", "taskId"]),
+        "TaskCompleted" => ("task", false, &["task_id", "taskId"]),
+        _ => return None,
+    };
+    let work_key = key_names
+        .iter()
+        .find_map(|name| hook.get(*name).and_then(Value::as_str))
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    Some(FleetWorkUpdate {
+        provider: parse_provider(observation.provider).as_str().to_string(),
+        session_key: session_key.to_string(),
+        work_key,
+        kind: kind.to_string(),
+        active,
+        event_id: observation.event_id.clone(),
+        observed_at: observation.observed_at,
+    })
 }
 
 async fn retire_correlated_legacy(
@@ -243,6 +325,145 @@ pub async fn apply_codex_inbound(
         events.emit_fleet_revision(result.revision);
     }
     Ok(Some(result))
+}
+
+/// Error while persisting or reducing one provider source envelope.
+#[derive(Debug, thiserror::Error)]
+pub enum FleetProviderIngressError {
+    /// Raw source ledger failed.
+    #[error(transparent)]
+    ProviderEvent(#[from] FleetProviderEventError),
+    /// Fleet projection failed.
+    #[error(transparent)]
+    Fleet(#[from] FleetRepoError),
+}
+
+/// Persist one exact Codex app-server envelope before reducing it. A crash after
+/// the source write is safe: retrying the same manager sequence reuses its row,
+/// then completes the projection link.
+pub async fn ingest_codex_inbound(
+    pool: &SqlitePool,
+    events: &EventSink,
+    event_id: String,
+    envelope: CodexInboundEnvelope,
+    capabilities: &CodexCapabilities,
+    observed_at: i64,
+) -> Result<Option<ApplyFleetEventResult>, FleetProviderIngressError> {
+    let method = envelope
+        .raw
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let provider_session_id = envelope.raw.get("params").and_then(codex_thread_id);
+    let session_key = provider_session_id
+        .as_deref()
+        .map(|thread_id| SessionKey::managed(Provider::Codex, thread_id).to_string());
+    FleetProviderEventRepo::append(
+        pool,
+        &NewFleetProviderEvent {
+            event_id: event_id.clone(),
+            provider: "codex".to_string(),
+            source: "codex_app_server".to_string(),
+            session_key,
+            provider_session_id,
+            observed_at,
+            received_at: observed_at,
+            event_type: method,
+            raw_payload: serde_json::to_string(&envelope.raw).unwrap_or_default(),
+        },
+    )
+    .await?;
+    apply_codex_child_work(pool, events, &envelope.raw, &event_id, observed_at).await?;
+    let result = apply_codex_inbound(
+        pool,
+        events,
+        event_id.clone(),
+        envelope.inbound,
+        capabilities,
+        observed_at,
+    )
+    .await?;
+    if let Some(reduced) = &result {
+        FleetProviderEventRepo::mark_projected(pool, &event_id, reduced.revision).await?;
+    }
+    Ok(result)
+}
+
+async fn apply_codex_child_work(
+    pool: &SqlitePool,
+    events: &EventSink,
+    raw: &Value,
+    event_id: &str,
+    observed_at: i64,
+) -> Result<(), FleetRepoError> {
+    let method = raw.get("method").and_then(Value::as_str);
+    let params = raw.get("params").unwrap_or(&Value::Null);
+    match method {
+        Some("thread/started") => {
+            let Some(parent_thread_id) = codex_parent_thread_id(params) else {
+                return Ok(());
+            };
+            let Some(child_thread_id) = codex_thread_id(params) else {
+                return Ok(());
+            };
+            let session_key = SessionKey::managed(Provider::Codex, &parent_thread_id).to_string();
+            if FleetRepo::get_session(pool, &session_key).await?.is_none() {
+                return Ok(());
+            }
+            let update = FleetWorkUpdate {
+                provider: "codex".to_string(),
+                session_key,
+                work_key: child_thread_id,
+                kind: "child_thread".to_string(),
+                active: true,
+                event_id: event_id.to_string(),
+                observed_at,
+            };
+            apply_workload_projection(pool, events, &update).await?;
+        }
+        Some("thread/closed" | "thread/archived") => {
+            let Some(child_thread_id) = codex_thread_id(params) else {
+                return Ok(());
+            };
+            for (session_key, active_work_count) in FleetWorkRepo::complete_by_work_key(
+                pool,
+                "codex",
+                &child_thread_id,
+                event_id,
+                observed_at,
+            )
+            .await?
+            {
+                let update = FleetWorkUpdate {
+                    provider: "codex".to_string(),
+                    session_key,
+                    work_key: child_thread_id.clone(),
+                    kind: "child_thread".to_string(),
+                    active: false,
+                    event_id: event_id.to_string(),
+                    observed_at,
+                };
+                publish_workload_projection(pool, events, &update, active_work_count).await?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn codex_parent_thread_id(params: &Value) -> Option<String> {
+    params
+        .get("parentThreadId")
+        .or_else(|| params.get("parent_thread_id"))
+        .or_else(|| {
+            params.get("thread").and_then(|thread| {
+                thread.get("parentThreadId").or_else(|| thread.get("parent_thread_id"))
+            })
+        })
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 /// Downgrade managed Codex rows when app-server transport exits.
@@ -467,13 +688,10 @@ fn normalize_codex_inbound(
     capabilities: &CodexCapabilities,
     observed_at: i64,
 ) -> Option<NewFleetEvent> {
-    let _manager_sequence = event_id;
-    let event_id;
     let (thread_id, event_type, payload, lifecycle, attention, fingerprint) = match inbound {
         CodexInbound::RequestUserInput(request) => {
             let payload = serde_json::to_value(&request).ok()?;
             let fingerprint = fingerprint_value(&payload);
-            event_id = format!("codex-request:{}:{fingerprint}", request.identity.thread_id);
             (
                 request.identity.thread_id.clone(),
                 "item/tool/requestUserInput".to_string(),
@@ -505,7 +723,6 @@ fn normalize_codex_inbound(
             });
             let thread_id = payload["identity"]["threadId"].as_str()?.to_string();
             let fingerprint = fingerprint_value(&payload);
-            event_id = format!("codex-request:{thread_id}:{fingerprint}");
             (
                 thread_id,
                 event_type.to_string(),
@@ -517,11 +734,6 @@ fn normalize_codex_inbound(
         }
         CodexInbound::Notification { method, params } => {
             let thread_id = codex_thread_id(&params)?;
-            event_id = format!(
-                "codex-event:{thread_id}:{}:{}",
-                method,
-                fingerprint_value(&params)
-            );
             let (lifecycle, attention, fingerprint) = codex_notification_state(&method);
             (thread_id, method, params, lifecycle, attention, fingerprint)
         }
@@ -537,7 +749,6 @@ fn normalize_codex_inbound(
                 "params": params,
             });
             let fingerprint = fingerprint_value(&payload);
-            event_id = format!("codex-request:{thread_id}:{fingerprint}");
             (
                 thread_id,
                 method,
@@ -646,6 +857,7 @@ fn session_wire(
         cwd: row.cwd.clone(),
         display_name: row.display_name.clone(),
         lifecycle: parse_lifecycle(&row.lifecycle_state),
+        active_work_count: row.active_work_count,
         attention: parse_attention(&row.attention_state),
         current_request_fingerprint: row.current_request_fingerprint.clone(),
         current_request,
@@ -969,16 +1181,23 @@ fn parse_provider(value: &str) -> Provider {
     }
 }
 
-fn states_for_hook(event_type: &str) -> (Option<LifecycleState>, Option<AttentionState>) {
+fn states_for_hook(
+    event_type: &str,
+    payload: &Value,
+) -> (Option<LifecycleState>, Option<AttentionState>) {
     match event_type {
         "SessionStart" => (Some(LifecycleState::Starting), Some(AttentionState::None)),
-        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => {
+        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" | "PostToolUseFailure"
+        | "PostToolBatch" | "SubagentStart" | "TaskCreated" => {
             (Some(LifecycleState::Running), Some(AttentionState::None))
         }
         "AskUserQuestion" => (Some(LifecycleState::Idle), Some(AttentionState::Ask)),
         "PermissionRequest" => (Some(LifecycleState::Idle), Some(AttentionState::Approval)),
         "Notification" => (None, Some(AttentionState::Waiting)),
-        "Stop" | "SubagentStop" => (
+        "Stop" if has_active_background_work(payload) => {
+            (Some(LifecycleState::Running), Some(AttentionState::None))
+        }
+        "Stop" => (
             Some(LifecycleState::TurnComplete),
             Some(AttentionState::None),
         ),
@@ -989,6 +1208,22 @@ fn states_for_hook(event_type: &str) -> (Option<LifecycleState>, Option<Attentio
         "SessionEnd" => (Some(LifecycleState::Exited), Some(AttentionState::None)),
         _ => (None, None),
     }
+}
+
+fn has_active_background_work(payload: &Value) -> bool {
+    let hook = payload.get("payload").unwrap_or(payload);
+    [
+        "background_tasks",
+        "backgroundTasks",
+        "session_crons",
+        "sessionCrons",
+    ]
+    .iter()
+    .filter_map(|field| hook.get(*field))
+    .any(|value| {
+        value.as_array().is_some_and(|items| !items.is_empty())
+            || value.as_object().is_some_and(|items| !items.is_empty())
+    })
 }
 
 fn managed_capabilities(provider: Provider) -> String {
@@ -1153,24 +1388,45 @@ const fn transport_token(value: TransportHealth) -> &'static str {
 mod tests {
     use super::*;
     use crate::events::EventBroker;
+
+    #[test]
+    fn stop_with_background_work_remains_running() {
+        let (lifecycle, attention) = states_for_hook(
+            "Stop",
+            &serde_json::json!({ "payload": { "background_tasks": [{ "id": "task-1" }] } }),
+        );
+        assert_eq!(lifecycle, Some(LifecycleState::Running));
+        assert_eq!(attention, Some(AttentionState::None));
+    }
+
+    #[test]
+    fn subagent_stop_never_completes_parent_turn() {
+        let (lifecycle, attention) = states_for_hook("SubagentStop", &serde_json::json!({}));
+        assert_eq!(lifecycle, None);
+        assert_eq!(attention, None);
+    }
     use ainb_hangar_store::Store;
 
     #[test]
     fn lifecycle_and_attention_are_independent() {
         assert_eq!(
-            states_for_hook("AskUserQuestion"),
+            states_for_hook("AskUserQuestion", &serde_json::json!({})),
             (Some(LifecycleState::Idle), Some(AttentionState::Ask))
         );
         assert_eq!(
-            states_for_hook("PermissionRequest"),
+            states_for_hook("PermissionRequest", &serde_json::json!({})),
             (Some(LifecycleState::Idle), Some(AttentionState::Approval))
         );
         assert_eq!(
-            states_for_hook("Stop"),
+            states_for_hook("Stop", &serde_json::json!({})),
             (
                 Some(LifecycleState::TurnComplete),
                 Some(AttentionState::None)
             )
+        );
+        assert_eq!(
+            states_for_hook("SessionEnd", &serde_json::json!({})),
+            (Some(LifecycleState::Exited), Some(AttentionState::None))
         );
     }
 
@@ -1276,6 +1532,79 @@ mod tests {
         assert_eq!(codex.lifecycle_state, "IDLE");
         assert_eq!(codex.attention_state, "ASK");
         assert_eq!(codex.management_state, "DEGRADED");
+    }
+
+    #[tokio::test]
+    async fn child_work_keeps_parent_running_and_replay_safe() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let start = serde_json::json!({ "payload": { "agent_id": "agent-1" } });
+        let stop = serde_json::json!({ "payload": { "agent_id": "agent-1" } });
+
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "subagent-start-1".to_string(),
+                provider: "claude",
+                provider_session_id: "session-1",
+                cwd: "/repo",
+                event_type: "SubagentStart",
+                payload: &start,
+                observed_at: 100,
+            },
+        )
+        .await
+        .unwrap();
+        let running =
+            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
+        assert_eq!(running.lifecycle_state, "RUNNING");
+        assert_eq!(running.active_work_count, 1);
+
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "subagent-stop-1".to_string(),
+                provider: "claude",
+                provider_session_id: "session-1",
+                cwd: "/repo",
+                event_type: "SubagentStop",
+                payload: &stop,
+                observed_at: 200,
+            },
+        )
+        .await
+        .unwrap();
+        let stopped =
+            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
+        assert_eq!(stopped.lifecycle_state, "RUNNING");
+        assert_eq!(stopped.active_work_count, 0);
+
+        let replay = apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "subagent-stop-1".to_string(),
+                provider: "claude",
+                provider_session_id: "session-1",
+                cwd: "/repo",
+                event_type: "SubagentStop",
+                payload: &stop,
+                observed_at: 200,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(replay.duplicate);
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM fleet_work_item WHERE session_key = ?")
+                .bind("claude:session-1")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+        assert_eq!(count, 1);
     }
 
     #[tokio::test]
@@ -1497,7 +1826,7 @@ mod tests {
         let replay = apply_codex_inbound(
             store.pool(),
             &sink,
-            "different-manager-sequence".to_string(),
+            "codex:req:1".to_string(),
             CodexInbound::RequestUserInput(request),
             &capabilities,
             101,
@@ -1506,6 +1835,9 @@ mod tests {
         .unwrap()
         .unwrap();
         assert!(replay.duplicate);
+
+        let events = FleetRepo::events_after(store.pool(), 0, 10).await.unwrap();
+        assert_eq!(events[0].event_id, "codex:req:1");
 
         apply_codex_inbound(
             store.pool(),
@@ -1527,6 +1859,160 @@ mod tests {
         assert_eq!(row.lifecycle_state, "RUNNING");
         assert_eq!(row.attention_state, "NONE");
         assert!(row.current_request_fingerprint.is_none());
+    }
+
+    #[tokio::test]
+    async fn codex_source_ledger_preserves_unknown_raw_envelope_fields() {
+        use crate::fleet_provider::codex::{CodexCapabilities, CodexInbound, CodexInboundEnvelope};
+        use ainb_hangar_store::repo::fleet_provider_event::FleetProviderEventRepo;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let capabilities = CodexCapabilities {
+            cli_version: "codex-test".to_string(),
+            daemon_version: None,
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input: true,
+            approvals: true,
+            thread_archive: true,
+        };
+        let raw = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "turn/started",
+            "params": { "threadId": "thread-raw", "turn": { "id": "turn-1" }, "futureField": "kept" },
+            "topLevelFutureField": { "kept": true },
+        });
+        ingest_codex_inbound(
+            store.pool(),
+            &sink,
+            "codex-manager:boot:1".to_string(),
+            CodexInboundEnvelope {
+                inbound: CodexInbound::Notification {
+                    method: "turn/started".to_string(),
+                    params: raw["params"].clone(),
+                },
+                raw: raw.clone(),
+            },
+            &capabilities,
+            100,
+        )
+        .await
+        .unwrap();
+
+        let source = FleetProviderEventRepo::get(store.pool(), "codex-manager:boot:1")
+            .await
+            .unwrap()
+            .expect("source envelope persisted");
+        assert_eq!(
+            serde_json::from_str::<Value>(&source.raw_payload).unwrap(),
+            raw,
+            "raw app-server envelope must keep unknown fields"
+        );
+        assert!(source.projection_revision.is_some());
+    }
+
+    #[tokio::test]
+    async fn codex_child_thread_lifecycle_updates_only_explicit_parent_workload() {
+        use crate::fleet_provider::codex::{CodexCapabilities, CodexInbound, CodexInboundEnvelope};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let capabilities = CodexCapabilities {
+            cli_version: "codex-test".to_string(),
+            daemon_version: None,
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input: true,
+            approvals: true,
+            thread_archive: true,
+        };
+        let parent = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "thread/started",
+            "params": { "thread": { "id": "parent" } },
+        });
+        ingest_codex_inbound(
+            store.pool(),
+            &sink,
+            "manager:parent".to_string(),
+            CodexInboundEnvelope {
+                inbound: CodexInbound::Notification {
+                    method: "thread/started".to_string(),
+                    params: parent["params"].clone(),
+                },
+                raw: parent,
+            },
+            &capabilities,
+            100,
+        )
+        .await
+        .unwrap();
+        let child = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "thread/started",
+            "params": { "thread": { "id": "child", "parentThreadId": "parent" } },
+        });
+        ingest_codex_inbound(
+            store.pool(),
+            &sink,
+            "manager:child-start".to_string(),
+            CodexInboundEnvelope {
+                inbound: CodexInbound::Notification {
+                    method: "thread/started".to_string(),
+                    params: child["params"].clone(),
+                },
+                raw: child,
+            },
+            &capabilities,
+            200,
+        )
+        .await
+        .unwrap();
+        let parent_row =
+            FleetRepo::get_session(store.pool(), "codex:parent").await.unwrap().unwrap();
+        assert_eq!(parent_row.active_work_count, 1);
+
+        let closed = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "thread/closed",
+            "params": { "threadId": "child" },
+        });
+        // Simulate a crash after durable child completion but before its parent
+        // workload revision. Replaying the same source event must repair it.
+        assert_eq!(
+            FleetWorkRepo::complete_by_work_key(
+                store.pool(),
+                "codex",
+                "child",
+                "manager:child-close",
+                300,
+            )
+            .await
+            .unwrap(),
+            vec![("codex:parent".to_string(), 0)],
+        );
+        ingest_codex_inbound(
+            store.pool(),
+            &sink,
+            "manager:child-close".to_string(),
+            CodexInboundEnvelope {
+                inbound: CodexInbound::Notification {
+                    method: "thread/closed".to_string(),
+                    params: closed["params"].clone(),
+                },
+                raw: closed,
+            },
+            &capabilities,
+            300,
+        )
+        .await
+        .unwrap();
+        let parent_row =
+            FleetRepo::get_session(store.pool(), "codex:parent").await.unwrap().unwrap();
+        assert_eq!(parent_row.active_work_count, 0);
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -414,6 +414,23 @@ pub enum CodexInbound {
     },
 }
 
+/// Parsed inbound message paired with its exact JSON-RPC envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexInboundEnvelope {
+    /// Parsed action or lifecycle message.
+    pub inbound: CodexInbound,
+    /// Original app-server JSON-RPC object, including unknown fields.
+    pub raw: Value,
+}
+
+/// Parse one inbound message while retaining its complete source envelope.
+pub fn parse_inbound_envelope(message: &Value) -> Result<CodexInboundEnvelope, ProviderError> {
+    Ok(CodexInboundEnvelope {
+        inbound: parse_inbound(message)?,
+        raw: message.clone(),
+    })
+}
+
 /// Parse one app-server request or notification without discarding unknown fields.
 pub fn parse_inbound(message: &Value) -> Result<CodexInbound, ProviderError> {
     let method = message

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -26,9 +26,9 @@ use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep};
 
 use super::codex::{
-    CodexApprovalKind, CodexApprovalRequest, CodexCapabilities, CodexInbound, CodexQuestionRequest,
-    CommandSpec, RpcRequestId, app_server_command, managed_tui_command, parse_inbound, probe_codex,
-    proxy_command,
+    CodexApprovalKind, CodexApprovalRequest, CodexCapabilities, CodexInboundEnvelope,
+    CodexQuestionRequest, CommandSpec, RpcRequestId, app_server_command, managed_tui_command,
+    parse_inbound_envelope, probe_codex, proxy_command,
 };
 use super::{ApprovalDecision, ProviderError, ProviderReceipt, QuestionAnswer};
 
@@ -274,7 +274,7 @@ pub struct ManagedCodexManager {
     /// Cloneable control handle.
     pub handle: CodexManagerHandle,
     /// Ordered server requests and notifications.
-    pub events: mpsc::Receiver<CodexInbound>,
+    pub events: mpsc::Receiver<CodexInboundEnvelope>,
     task: JoinHandle<Result<(), ProviderError>>,
 }
 
@@ -340,7 +340,7 @@ pub fn spawn_service(
             while let Some(event) = inbound.recv().await {
                 sequence = sequence.wrapping_add(1);
                 let event_id = format!("codex-manager:{boot_id}:{sequence}");
-                if let Err(error) = crate::fleet::apply_codex_inbound(
+                if let Err(error) = crate::fleet::ingest_codex_inbound(
                     &pool,
                     &events,
                     event_id,
@@ -1137,7 +1137,7 @@ async fn initialize_connection<R, W>(
     reader: &mut R,
     writer: &mut W,
     client_version: &str,
-    events: &mpsc::Sender<CodexInbound>,
+    events: &mpsc::Sender<CodexInboundEnvelope>,
 ) -> Result<(), ProviderError>
 where
     R: AsyncBufRead + Unpin,
@@ -1176,7 +1176,7 @@ where
             }
             break;
         }
-        let inbound = parse_inbound(&message)?;
+        let inbound = parse_inbound_envelope(&message)?;
         events
             .send(inbound)
             .await
@@ -1194,7 +1194,7 @@ async fn run_actor<R, W>(
     mut reader: R,
     mut writer: W,
     mut commands: mpsc::Receiver<ManagerCommand>,
-    events: mpsc::Sender<CodexInbound>,
+    events: mpsc::Sender<CodexInboundEnvelope>,
 ) -> Result<(), ProviderError>
 where
     R: AsyncBufRead + Unpin,
@@ -1261,7 +1261,7 @@ where
                     }
                 }
                 events
-                    .send(parse_inbound(&message)?)
+                    .send(parse_inbound_envelope(&message)?)
                     .await
                     .map_err(|_| ProviderError::Transport("Codex event receiver closed".into()))?;
             }
@@ -1436,6 +1436,7 @@ mod tests {
     use tokio::net::UnixListener;
 
     use super::*;
+    use crate::fleet_provider::codex::CodexInbound;
     use crate::fleet_provider::{QuestionOption, StructuredQuestion};
 
     #[test]
@@ -1696,7 +1697,8 @@ mod tests {
         assert_eq!(repaired, repaired_owner);
 
         let event = manager.events.recv().await.expect("ordered event");
-        let CodexInbound::RequestUserInput(request) = event else {
+        assert_eq!(event.raw["method"], "item/tool/requestUserInput");
+        let CodexInbound::RequestUserInput(request) = event.inbound else {
             panic!("expected request-user-input");
         };
         assert_eq!(request.identity.thread_id, "thread-1");
@@ -1719,7 +1721,11 @@ mod tests {
             .await
             .expect("turn interrupt");
         let approval = manager.events.recv().await.expect("ordered approval");
-        let CodexInbound::Approval(approval) = approval else {
+        assert_eq!(
+            approval.raw["method"],
+            "item/commandExecution/requestApproval"
+        );
+        let CodexInbound::Approval(approval) = approval.inbound else {
             panic!("expected approval");
         };
         assert_eq!(approval.identity.item_id, "item-10");

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet.rs
@@ -214,6 +214,42 @@ async fn snapshot_keeps_same_cwd_authoritative_provider_sessions_distinct() {
 }
 
 #[tokio::test]
+async fn snapshot_exposes_active_claude_subagent_work() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, sink) = start_server(dir.path()).await;
+    apply_hook(
+        &store,
+        &sink,
+        "claude-session-start",
+        "claude",
+        "parent",
+        "SessionStart",
+        &serde_json::json!({}),
+        100,
+    )
+    .await;
+    apply_hook(
+        &store,
+        &sink,
+        "claude-subagent-start",
+        "claude",
+        "parent",
+        "SubagentStart",
+        &serde_json::json!({ "payload": { "agent_id": "child-1" } }),
+        200,
+    )
+    .await;
+
+    let mut client = Client::connect(&socket).await;
+    client.auth_from_file(dir.path()).await;
+    let snapshot = client.call(methods::FLEET_SNAPSHOT, serde_json::json!({})).await;
+    let session = &snapshot["result"]["sessions"][0];
+    assert_eq!(session["session_key"], "claude:parent");
+    assert_eq!(session["lifecycle"], "RUNNING");
+    assert_eq!(session["active_work_count"], 1);
+}
+
+#[tokio::test]
 async fn action_rejects_stale_or_wrong_request_and_replays_receipt() {
     let dir = tempfile::tempdir().unwrap();
     let (socket, store, sink) = start_server(dir.path()).await;

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -239,6 +239,9 @@ pub struct FleetSession {
     pub display_name: Option<String>,
     /// Independent lifecycle state.
     pub lifecycle: LifecycleState,
+    /// Number of active provider child tasks, agents, or threads.
+    #[serde(default)]
+    pub active_work_count: i64,
     /// Independent attention state.
     pub attention: AttentionState,
     /// Fingerprint of current structured request or approval.

--- a/ainb-tui/crates/ainb-hangar-store/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-store/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+blake3 = { workspace = true }
 # Injectable CSPRNG seam for token minting (P5.4). The `RngCore` trait appears
 # in the public `mint_pat` / `mint_daemon_token` signatures so callers (and
 # tests) supply their own random source; the actual hashing/encoding lives in

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0071_fleet_provider_event.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0071_fleet_provider_event.sql
@@ -1,0 +1,24 @@
+-- Durable provider-event source ledger. fleet_event remains the normalized
+-- projection timeline; this table keeps every raw provider envelope so a failed
+-- or upgraded reducer can replay without losing source fidelity.
+
+CREATE TABLE fleet_provider_event (
+    ingest_order        INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id            TEXT NOT NULL UNIQUE CHECK (length(event_id) > 0),
+    provider            TEXT NOT NULL CHECK (length(provider) > 0),
+    source              TEXT NOT NULL CHECK (length(source) > 0),
+    session_key         TEXT,
+    provider_session_id TEXT,
+    observed_at         INTEGER NOT NULL,
+    received_at         INTEGER NOT NULL,
+    event_type          TEXT NOT NULL CHECK (length(event_type) > 0),
+    raw_payload         TEXT NOT NULL,
+    raw_blake3          TEXT NOT NULL CHECK (length(raw_blake3) = 64),
+    projection_revision INTEGER REFERENCES fleet_event(revision)
+);
+
+CREATE INDEX idx_fleet_provider_event_session_order
+    ON fleet_provider_event(session_key, ingest_order);
+CREATE INDEX idx_fleet_provider_event_projection
+    ON fleet_provider_event(projection_revision)
+    WHERE projection_revision IS NULL;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0072_fleet_workload_projection.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0072_fleet_workload_projection.sql
@@ -1,0 +1,19 @@
+-- Durable child work. Parent session projection carries active_work_count.
+
+ALTER TABLE fleet_session
+    ADD COLUMN active_work_count INTEGER NOT NULL DEFAULT 0 CHECK (active_work_count >= 0);
+
+CREATE TABLE fleet_work_item (
+    provider       TEXT NOT NULL CHECK (length(provider) > 0),
+    session_key    TEXT NOT NULL CHECK (length(session_key) > 0),
+    work_key       TEXT NOT NULL CHECK (length(work_key) > 0),
+    kind           TEXT NOT NULL CHECK (kind IN ('subagent', 'task', 'child_thread')),
+    state          TEXT NOT NULL CHECK (state IN ('ACTIVE', 'COMPLETE')),
+    started_at     INTEGER NOT NULL,
+    completed_at   INTEGER,
+    last_event_id  TEXT NOT NULL UNIQUE CHECK (length(last_event_id) > 0),
+    PRIMARY KEY (provider, session_key, work_key)
+);
+
+CREATE INDEX idx_fleet_work_item_active
+    ON fleet_work_item(session_key, state);

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -70,6 +70,8 @@ pub struct FleetSessionPatch {
     pub confidence: Option<String>,
     /// Independent lifecycle state.
     pub lifecycle_state: Option<String>,
+    /// Active provider child-work count.
+    pub active_work_count: Option<i64>,
     /// Independent attention state.
     pub attention_state: Option<String>,
     /// Exact active request fingerprint. `Some(None)` explicitly clears it.
@@ -130,6 +132,8 @@ pub struct FleetSessionRow {
     pub display_name: Option<String>,
     /// Lifecycle state token.
     pub lifecycle_state: String,
+    /// Number of active provider child-work items.
+    pub active_work_count: i64,
     /// Attention state token.
     pub attention_state: String,
     /// Fingerprint of current structured request or approval.
@@ -762,7 +766,7 @@ const SESSION_SELECT_BY_KEY: &str = "SELECT session_key, provider, provider_sess
     confidence, discovered_at, last_observed_at, metadata_updated_at, \
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
-    transport_authority, version, updated_revision \
+    transport_authority, active_work_count, version, updated_revision \
     FROM fleet_session WHERE session_key = ?";
 
 const SESSION_SELECT_ALL: &str = "SELECT session_key, provider, provider_session_id, \
@@ -771,7 +775,7 @@ const SESSION_SELECT_ALL: &str = "SELECT session_key, provider, provider_session
     confidence, discovered_at, last_observed_at, metadata_updated_at, \
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
-    transport_authority, version, updated_revision \
+    transport_authority, active_work_count, version, updated_revision \
     FROM fleet_session WHERE visible = 1 ORDER BY session_key ASC";
 
 async fn session_by_key_tx(
@@ -825,6 +829,7 @@ fn new_session(event: &NewFleetEvent) -> FleetSessionRow {
             .lifecycle_state
             .clone()
             .unwrap_or_else(|| "UNKNOWN".to_string()),
+        active_work_count: event.patch.active_work_count.unwrap_or(0),
         attention_state: event.patch.attention_state.clone().unwrap_or_else(|| "NONE".to_string()),
         current_request_fingerprint: event.patch.current_request_fingerprint.clone().flatten(),
         management_state: event
@@ -900,14 +905,17 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
         changed = true;
     }
 
-    if let Some(state) = &event.patch.lifecycle_state {
+    if event.patch.lifecycle_state.is_some() || event.patch.active_work_count.is_some() {
         if should_replace(
             authority,
             event.observed_at,
             &row.lifecycle_authority,
             row.lifecycle_updated_at,
         ) {
-            row.lifecycle_state.clone_from(state);
+            assign_if_some(&mut row.lifecycle_state, &event.patch.lifecycle_state);
+            if let Some(count) = event.patch.active_work_count {
+                row.active_work_count = count;
+            }
             row.lifecycle_updated_at = event.observed_at;
             row.lifecycle_authority.clone_from(&authority_token);
             changed = true;
@@ -982,8 +990,8 @@ async fn insert_session(
             confidence, discovered_at, last_observed_at, metadata_updated_at, \
             metadata_authority, lifecycle_updated_at, lifecycle_authority, \
             attention_updated_at, attention_authority, transport_updated_at, \
-            transport_authority, version, updated_revision) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            transport_authority, active_work_count, version, updated_revision) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     );
     bind_session(query, row).execute(&mut **tx).await?;
     Ok(())
@@ -1002,7 +1010,7 @@ async fn update_session(
             discovered_at = ?, last_observed_at = ?, metadata_updated_at = ?, \
             metadata_authority = ?, lifecycle_updated_at = ?, lifecycle_authority = ?, \
             attention_updated_at = ?, attention_authority = ?, transport_updated_at = ?, \
-            transport_authority = ?, version = ?, updated_revision = ? \
+            transport_authority = ?, active_work_count = ?, version = ?, updated_revision = ? \
          WHERE session_key = ?",
     )
     .bind(&row.provider)
@@ -1029,6 +1037,7 @@ async fn update_session(
     .bind(&row.attention_authority)
     .bind(row.transport_updated_at)
     .bind(&row.transport_authority)
+    .bind(row.active_work_count)
     .bind(row.version)
     .bind(row.updated_revision)
     .bind(&row.session_key)
@@ -1067,6 +1076,7 @@ fn bind_session<'q>(
         .bind(&row.attention_authority)
         .bind(row.transport_updated_at)
         .bind(&row.transport_authority)
+        .bind(row.active_work_count)
         .bind(row.version)
         .bind(row.updated_revision)
 }
@@ -1098,6 +1108,7 @@ fn session_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetSessionRow, sq
         attention_authority: row.try_get("attention_authority")?,
         transport_updated_at: row.try_get("transport_updated_at")?,
         transport_authority: row.try_get("transport_authority")?,
+        active_work_count: row.try_get("active_work_count")?,
         version: row.try_get("version")?,
         updated_revision: row.try_get("updated_revision")?,
     })

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
@@ -1,0 +1,247 @@
+//! Durable raw provider-event ledger for Fleet projections.
+
+use blake3::Hasher;
+use sqlx::{Row, SqlitePool};
+
+/// One raw provider envelope awaiting or linked to Fleet projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewFleetProviderEvent {
+    /// Replay-safe identity minted by provider or source adapter.
+    pub event_id: String,
+    /// Provider token, for example `claude` or `codex`.
+    pub provider: String,
+    /// Source transport, for example `claude_hook` or `codex_app_server`.
+    pub source: String,
+    /// Fleet session identity when known.
+    pub session_key: Option<String>,
+    /// Provider-owned session identity when known.
+    pub provider_session_id: Option<String>,
+    /// Provider observation time in epoch milliseconds.
+    pub observed_at: i64,
+    /// Local source receipt time in epoch milliseconds.
+    pub received_at: i64,
+    /// Provider event discriminator.
+    pub event_type: String,
+    /// Exact source payload, never a normalized projection body.
+    pub raw_payload: String,
+}
+
+/// Persisted raw provider envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetProviderEventRow {
+    /// Monotonic receipt order assigned by SQLite.
+    pub ingest_order: i64,
+    /// Replay-safe event identity.
+    pub event_id: String,
+    /// Provider token.
+    pub provider: String,
+    /// Source transport.
+    pub source: String,
+    /// Fleet session identity when known.
+    pub session_key: Option<String>,
+    /// Provider session identity when known.
+    pub provider_session_id: Option<String>,
+    /// Provider observation time.
+    pub observed_at: i64,
+    /// Local receipt time.
+    pub received_at: i64,
+    /// Provider event discriminator.
+    pub event_type: String,
+    /// Exact source payload.
+    pub raw_payload: String,
+    /// Content digest of raw payload.
+    pub raw_blake3: String,
+    /// Fleet projection revision once reduced.
+    pub projection_revision: Option<i64>,
+}
+
+/// Source-ledger failures that must stop a replay cursor.
+#[derive(Debug, thiserror::Error)]
+pub enum FleetProviderEventError {
+    /// Existing ID points to a different source envelope.
+    #[error("provider event id {event_id:?} conflicts with a different envelope")]
+    EventIdCollision {
+        /// Conflicting event identity.
+        event_id: String,
+    },
+    /// SQLite failed.
+    #[error(transparent)]
+    Sql(#[from] sqlx::Error),
+}
+
+/// Typed access to the raw provider-event ledger.
+pub struct FleetProviderEventRepo;
+
+impl FleetProviderEventRepo {
+    /// Insert one source envelope. Exact replays return its original row.
+    pub async fn append(
+        pool: &SqlitePool,
+        event: &NewFleetProviderEvent,
+    ) -> Result<FleetProviderEventRow, FleetProviderEventError> {
+        let digest = digest(&event.raw_payload);
+        let result = sqlx::query(
+            "INSERT INTO fleet_provider_event (event_id, provider, source, session_key, provider_session_id, observed_at, received_at, event_type, raw_payload, raw_blake3) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(event_id) DO NOTHING",
+        )
+        .bind(&event.event_id)
+        .bind(&event.provider)
+        .bind(&event.source)
+        .bind(&event.session_key)
+        .bind(&event.provider_session_id)
+        .bind(event.observed_at)
+        .bind(event.received_at)
+        .bind(&event.event_type)
+        .bind(&event.raw_payload)
+        .bind(&digest)
+        .execute(pool)
+        .await?;
+        let row = Self::get(pool, &event.event_id)
+            .await?
+            .expect("successful insert or conflict must leave provider event row");
+        if result.rows_affected() == 0 && !matches_event(&row, event, &digest) {
+            return Err(FleetProviderEventError::EventIdCollision {
+                event_id: event.event_id.clone(),
+            });
+        }
+        Ok(row)
+    }
+
+    /// Link a source envelope to the revision that reduced it. Replays preserve
+    /// the first committed projection, but a conflicting revision is rejected.
+    pub async fn mark_projected(
+        pool: &SqlitePool,
+        event_id: &str,
+        revision: i64,
+    ) -> Result<(), FleetProviderEventError> {
+        let result = sqlx::query(
+            "UPDATE fleet_provider_event SET projection_revision = ? WHERE event_id = ? AND (projection_revision IS NULL OR projection_revision = ?)",
+        )
+        .bind(revision)
+        .bind(event_id)
+        .bind(revision)
+        .execute(pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(FleetProviderEventError::EventIdCollision {
+                event_id: event_id.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Fetch one persisted source envelope.
+    pub async fn get(
+        pool: &SqlitePool,
+        event_id: &str,
+    ) -> Result<Option<FleetProviderEventRow>, sqlx::Error> {
+        sqlx::query(
+            "SELECT ingest_order, event_id, provider, source, session_key, provider_session_id, observed_at, received_at, event_type, raw_payload, raw_blake3, projection_revision FROM fleet_provider_event WHERE event_id = ?",
+        )
+        .bind(event_id)
+        .fetch_optional(pool)
+        .await?
+        .as_ref()
+        .map(row_from)
+        .transpose()
+    }
+}
+
+fn digest(payload: &str) -> String {
+    let mut hasher = Hasher::new();
+    hasher.update(payload.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn matches_event(
+    row: &FleetProviderEventRow,
+    event: &NewFleetProviderEvent,
+    raw_blake3: &str,
+) -> bool {
+    row.provider == event.provider
+        && row.source == event.source
+        && row.session_key == event.session_key
+        && row.provider_session_id == event.provider_session_id
+        && row.observed_at == event.observed_at
+        && row.event_type == event.event_type
+        && row.raw_payload == event.raw_payload
+        && row.raw_blake3 == raw_blake3
+}
+
+fn row_from(row: &sqlx::sqlite::SqliteRow) -> Result<FleetProviderEventRow, sqlx::Error> {
+    Ok(FleetProviderEventRow {
+        ingest_order: row.try_get("ingest_order")?,
+        event_id: row.try_get("event_id")?,
+        provider: row.try_get("provider")?,
+        source: row.try_get("source")?,
+        session_key: row.try_get("session_key")?,
+        provider_session_id: row.try_get("provider_session_id")?,
+        observed_at: row.try_get("observed_at")?,
+        received_at: row.try_get("received_at")?,
+        event_type: row.try_get("event_type")?,
+        raw_payload: row.try_get("raw_payload")?,
+        raw_blake3: row.try_get("raw_blake3")?,
+        projection_revision: row.try_get("projection_revision")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    fn event(id: &str, payload: &str) -> NewFleetProviderEvent {
+        NewFleetProviderEvent {
+            event_id: id.to_string(),
+            provider: "claude".to_string(),
+            source: "claude_hook".to_string(),
+            session_key: Some("claude:session-1".to_string()),
+            provider_session_id: Some("session-1".to_string()),
+            observed_at: 100,
+            received_at: 101,
+            event_type: "PostToolUse".to_string(),
+            raw_payload: payload.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn source_event_replay_preserves_exact_raw_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let input = event("source-1", r#"{\"large\":\"payload\"}"#);
+        let first = FleetProviderEventRepo::append(store.pool(), &input).await.unwrap();
+        let replay = FleetProviderEventRepo::append(store.pool(), &input).await.unwrap();
+
+        assert_eq!(first, replay);
+        assert_eq!(first.raw_payload, input.raw_payload);
+        assert_eq!(first.ingest_order, 1);
+    }
+
+    #[tokio::test]
+    async fn source_event_replay_ignores_local_receipt_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let first = FleetProviderEventRepo::append(store.pool(), &event("source-1", "{}"))
+            .await
+            .unwrap();
+        let mut replay = event("source-1", "{}");
+        replay.received_at = 9_999;
+
+        assert_eq!(
+            FleetProviderEventRepo::append(store.pool(), &replay).await.unwrap(),
+            first,
+        );
+    }
+
+    #[tokio::test]
+    async fn source_event_id_rejects_different_raw_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        FleetProviderEventRepo::append(store.pool(), &event("source-1", "first"))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            FleetProviderEventRepo::append(store.pool(), &event("source-1", "second")).await,
+            Err(FleetProviderEventError::EventIdCollision { .. })
+        ));
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_work.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_work.rs
@@ -1,0 +1,141 @@
+//! Durable active provider child-work projection.
+
+use sqlx::SqlitePool;
+
+/// One provider child-work state transition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetWorkUpdate {
+    /// Provider token.
+    pub provider: String,
+    /// Parent Fleet session identity.
+    pub session_key: String,
+    /// Stable child identity supplied by provider.
+    pub work_key: String,
+    /// Subagent, task, or child-thread.
+    pub kind: String,
+    /// True at start, false at completion.
+    pub active: bool,
+    /// Source event identity for replay.
+    pub event_id: String,
+    /// Observation time.
+    pub observed_at: i64,
+}
+
+/// Fleet child-work repository.
+pub struct FleetWorkRepo;
+
+impl FleetWorkRepo {
+    /// Apply one transition and return parent active-work count.
+    pub async fn apply(pool: &SqlitePool, update: &FleetWorkUpdate) -> Result<i64, sqlx::Error> {
+        if update.active {
+            sqlx::query(
+                "INSERT INTO fleet_work_item (provider, session_key, work_key, kind, state, started_at, last_event_id) VALUES (?, ?, ?, ?, 'ACTIVE', ?, ?) \
+                 ON CONFLICT(provider, session_key, work_key) DO UPDATE SET kind = excluded.kind, state = 'ACTIVE', started_at = excluded.started_at, completed_at = NULL, last_event_id = excluded.last_event_id \
+                 WHERE fleet_work_item.last_event_id != excluded.last_event_id",
+            )
+            .bind(&update.provider)
+            .bind(&update.session_key)
+            .bind(&update.work_key)
+            .bind(&update.kind)
+            .bind(update.observed_at)
+            .bind(&update.event_id)
+            .execute(pool)
+            .await?;
+        } else {
+            sqlx::query(
+                "UPDATE fleet_work_item SET state = 'COMPLETE', completed_at = ?, last_event_id = ? \
+                 WHERE provider = ? AND session_key = ? AND work_key = ? AND last_event_id != ?",
+            )
+            .bind(update.observed_at)
+            .bind(&update.event_id)
+            .bind(&update.provider)
+            .bind(&update.session_key)
+            .bind(&update.work_key)
+            .bind(&update.event_id)
+            .execute(pool)
+            .await?;
+        }
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM fleet_work_item WHERE session_key = ? AND state = 'ACTIVE'",
+        )
+        .bind(&update.session_key)
+        .fetch_one(pool)
+        .await
+    }
+
+    /// Complete every active parent relationship for one provider child key.
+    /// Thread IDs are provider-global, so close events need no parent ID.
+    pub async fn complete_by_work_key(
+        pool: &SqlitePool,
+        provider: &str,
+        work_key: &str,
+        event_id: &str,
+        observed_at: i64,
+    ) -> Result<Vec<(String, i64)>, sqlx::Error> {
+        let session_keys: Vec<String> = sqlx::query_scalar(
+            "SELECT session_key FROM fleet_work_item WHERE provider = ? AND work_key = ? AND (state = 'ACTIVE' OR last_event_id = ?)",
+        )
+        .bind(provider)
+        .bind(work_key)
+        .bind(event_id)
+        .fetch_all(pool)
+        .await?;
+        let mut completed = Vec::with_capacity(session_keys.len());
+        for session_key in session_keys {
+            let count = Self::apply(
+                pool,
+                &FleetWorkUpdate {
+                    provider: provider.to_string(),
+                    session_key: session_key.clone(),
+                    work_key: work_key.to_string(),
+                    kind: "child_thread".to_string(),
+                    active: false,
+                    event_id: event_id.to_string(),
+                    observed_at,
+                },
+            )
+            .await?;
+            completed.push((session_key, count));
+        }
+        Ok(completed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    fn update(event_id: &str, active: bool) -> FleetWorkUpdate {
+        FleetWorkUpdate {
+            provider: "codex".to_string(),
+            session_key: "codex:parent".to_string(),
+            work_key: "codex:child".to_string(),
+            kind: "child_thread".to_string(),
+            active,
+            event_id: event_id.to_string(),
+            observed_at: 100,
+        }
+    }
+
+    #[tokio::test]
+    async fn child_close_without_parent_completes_active_relationship_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        assert_eq!(
+            FleetWorkRepo::apply(store.pool(), &update("start", true)).await.unwrap(),
+            1
+        );
+
+        let first =
+            FleetWorkRepo::complete_by_work_key(store.pool(), "codex", "codex:child", "close", 200)
+                .await
+                .unwrap();
+        assert_eq!(first, vec![("codex:parent".to_string(), 0)]);
+        let replay =
+            FleetWorkRepo::complete_by_work_key(store.pool(), "codex", "codex:child", "close", 200)
+                .await
+                .unwrap();
+        assert_eq!(replay, first);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/mod.rs
@@ -25,6 +25,8 @@ pub mod daemon_config;
 pub mod dispatch_attempt;
 pub mod event_log;
 pub mod fleet;
+pub mod fleet_provider_event;
+pub mod fleet_work;
 pub mod inbox;
 pub mod invitation;
 pub mod issue;

--- a/ainb-tui/crates/ainb-plugin-hangar/src/jsonrpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/jsonrpc_over_socket.rs
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn decoder_rejects_missing_duplicate_malformed_and_oversized_length() {
         let cases = [
-            b"\r\n".as_slice(),
+            b"\r\n\r\n".as_slice(),
             b"Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}".as_slice(),
             b"Content-Length: +2\r\n\r\n{}".as_slice(),
             b"Content-Length: 16777217\r\n\r\n".as_slice(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -7399,6 +7399,7 @@ mod tests {
             transport_health: "healthy".into(),
             capabilities: FleetCapabilities::List(vec!["tmux_attach".to_string()]),
             version: 7,
+            active_work_count: 0,
             cwd: "/work/claude".into(),
             tmux_target: Some("claude:ask:0.0".into()),
             display_name: Some("claude:ask".into()),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -2879,6 +2879,7 @@ mod fleet_routing_tests {
                 ("start".into(), true),
             ])),
             version: 9,
+            active_work_count: 0,
             cwd: "/work/one".into(),
             tmux_target: Some("one:0.0".into()),
             display_name: Some("one".into()),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -106,6 +106,8 @@ pub struct FleetSessionRow {
     pub current_request: Option<serde_json::Value>,
     #[serde(alias = "lifecycle")]
     pub lifecycle_state: String,
+    #[serde(default)]
+    pub active_work_count: i64,
     #[serde(alias = "attention")]
     pub attention_state: String,
     #[serde(alias = "management")]
@@ -144,6 +146,13 @@ pub struct FleetSessionRow {
 }
 
 impl FleetSessionRow {
+    /// Active Fleet roster excludes terminal history and lost transports. A
+    /// completed turn stays active while its provider or exact tmux target lives.
+    fn is_active_session(&self) -> bool {
+        !self.lifecycle_state.eq_ignore_ascii_case("EXITED")
+            && !self.transport_health.eq_ignore_ascii_case("UNAVAILABLE")
+    }
+
     fn is_actionable(&self) -> bool {
         !self.attention_state.eq_ignore_ascii_case("NONE")
     }
@@ -209,9 +218,7 @@ impl FleetSessionRow {
             "RUNNING"
         } else if self.lifecycle_state.eq_ignore_ascii_case("IDLE") {
             "IDLE"
-        } else if self.lifecycle_state.eq_ignore_ascii_case("TURN_COMPLETE")
-            || self.lifecycle_state.eq_ignore_ascii_case("EXITED")
-        {
+        } else if self.lifecycle_state.eq_ignore_ascii_case("TURN_COMPLETE") {
             "COMPLETED"
         } else {
             "UNKNOWN"
@@ -263,6 +270,7 @@ impl From<ainb_hangar_proto::fleet::FleetSession> for FleetSessionRow {
                 LifecycleState::Unknown => "UNKNOWN",
             }
             .into(),
+            active_work_count: session.active_work_count,
             attention_state: match session.attention {
                 AttentionState::None => "NONE",
                 AttentionState::Ask => "ASK",
@@ -324,13 +332,14 @@ pub enum FleetFilter {
 
 impl FleetFilter {
     fn matches(self, row: &FleetSessionRow) -> bool {
+        if !row.is_active_session() {
+            return false;
+        }
         match self {
             Self::NeedsInput => row.is_actionable(),
             Self::Idle => !row.is_actionable() && row.lifecycle_state.eq_ignore_ascii_case("IDLE"),
             Self::Completed => {
-                !row.is_actionable()
-                    && (row.lifecycle_state.eq_ignore_ascii_case("TURN_COMPLETE")
-                        || row.lifecycle_state.eq_ignore_ascii_case("EXITED"))
+                !row.is_actionable() && row.lifecycle_state.eq_ignore_ascii_case("TURN_COMPLETE")
             }
             Self::Running => {
                 !row.is_actionable()
@@ -718,16 +727,18 @@ impl FleetPaneState {
         self.roster.iter().filter(|row| self.filter.matches(row)).collect()
     }
 
-    /// Total sessions in unfiltered authoritative roster.
+    /// Total active sessions in the operator roster.
     pub fn session_count(&self) -> usize {
-        self.roster.len()
+        self.roster.iter().filter(|session| session.is_active_session()).count()
     }
 
     /// Sessions requiring operator review, independent from active lens.
     pub fn attention_count(&self) -> usize {
         self.roster
             .iter()
-            .filter(|session| !session.attention_state.eq_ignore_ascii_case("NONE"))
+            .filter(|session| {
+                session.is_active_session() && !session.attention_state.eq_ignore_ascii_case("NONE")
+            })
             .count()
     }
 
@@ -1882,8 +1893,13 @@ fn render_table_row(
     let operator_state = session.operator_state();
     let attachment = session.attachment_label();
     let age = format_age(now_ms, session.last_observed_at);
+    let workload = if session.active_work_count > 0 {
+        format!(" +{}", session.active_work_count)
+    } else {
+        String::new()
+    };
     let text = format!(
-        "{marker} {identity:<identity_width$} {provider:<8} {operator_state:<13} {attachment:<7} {age:>4}"
+        "{marker} {identity:<identity_width$} {provider:<8} {operator_state:<13}{workload:<4} {attachment:<7} {age:>4}"
     );
     put_str_styled(
         buffer,
@@ -2728,6 +2744,7 @@ mod tests {
                 .collect(),
             ),
             version: 7,
+            active_work_count: 0,
             cwd: format!("/work/{key}"),
             tmux_target: Some(format!("{key}:0.0")),
             display_name: Some(key.into()),
@@ -2840,7 +2857,7 @@ mod tests {
         let cases = [
             (FleetFilter::NeedsInput, vec!["ask", "error-done"]),
             (FleetFilter::Idle, vec!["idle"]),
-            (FleetFilter::Completed, vec!["turn-done", "exited"]),
+            (FleetFilter::Completed, vec!["turn-done"]),
             (FleetFilter::Running, vec!["starting", "running"]),
             (
                 FleetFilter::All,
@@ -2849,7 +2866,6 @@ mod tests {
                     "error-done",
                     "idle",
                     "turn-done",
-                    "exited",
                     "starting",
                     "running",
                     "unknown",
@@ -2861,6 +2877,29 @@ mod tests {
             let actual: Vec<_> =
                 filtered.visible_sessions().iter().map(|row| row.session_key.as_str()).collect();
             assert_eq!(actual, expected, "filter {filter:?}");
+        }
+    }
+
+    #[test]
+    fn terminal_history_is_excluded_from_every_operator_lens_and_counts() {
+        let mut exited = session("old-exit", "claude", "EXITED", "NONE", "degraded");
+        exited.transport_health = "UNAVAILABLE".into();
+        let mut unavailable = session("lost-turn", "codex", "TURN_COMPLETE", "NONE", "managed");
+        unavailable.transport_health = "UNAVAILABLE".into();
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![
+            session("active-turn", "claude", "TURN_COMPLETE", "NONE", "managed"),
+            exited,
+            unavailable,
+        ]);
+
+        assert_eq!(state.session_count(), 1);
+        for filter in FleetFilter::ALL {
+            let filtered = apply(&state, FleetEvent::SetFilter(filter)).state;
+            assert!(
+                filtered.visible_sessions().iter().all(|row| row.session_key == "active-turn"),
+                "terminal history leaked into {filter:?}"
+            );
         }
     }
 
@@ -3707,12 +3746,14 @@ mod tests {
             last_observed_at: 20,
             lifecycle_updated_at: 20,
             attention_updated_at: 10,
+            active_work_count: 2,
             version: 3,
             updated_revision: 4,
         });
         assert_eq!(row.provider, "codex");
         assert_eq!(row.lifecycle_state, "RUNNING");
         assert_eq!(row.management_state, "MANAGED");
+        assert_eq!(row.active_work_count, 2);
         assert!(row.capabilities.contains("interrupt"));
         assert!(row.capabilities.contains("tmux_attach"));
         let request_lines = request_detail_lines(row.current_request.as_ref().unwrap());

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -873,6 +873,84 @@ mod tests {
     }
 
     #[test]
+    fn codex_template_registers_every_documented_cli_hook() {
+        let template: serde_json::Value = serde_json::from_str(CODEX_HOOKS_TEMPLATE).unwrap();
+        let hooks = template["hooks"].as_object().expect("hooks object");
+        let events = hooks.keys().map(String::as_str).collect::<std::collections::BTreeSet<_>>();
+        let expected = [
+            "PermissionRequest",
+            "PostCompact",
+            "PostToolUse",
+            "PreCompact",
+            "PreToolUse",
+            "SessionEnd",
+            "SessionStart",
+            "Stop",
+            "SubagentStart",
+            "SubagentStop",
+            "UserPromptSubmit",
+        ]
+        .into_iter()
+        .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(events, expected);
+    }
+
+    #[test]
+    fn claude_manifest_registers_every_documented_hook() {
+        let manifest: serde_json::Value = serde_json::from_str(CLAUDE_PLUGIN_JSON).unwrap();
+        let hooks = manifest["hooks"].as_object().expect("hooks object");
+        let events = hooks.keys().map(String::as_str).collect::<std::collections::BTreeSet<_>>();
+        let expected = [
+            "SessionStart",
+            "Setup",
+            "InstructionsLoaded",
+            "UserPromptSubmit",
+            "UserPromptExpansion",
+            "MessageDisplay",
+            "PreToolUse",
+            "PermissionRequest",
+            "PostToolUse",
+            "PostToolUseFailure",
+            "PostToolBatch",
+            "PermissionDenied",
+            "Notification",
+            "SubagentStart",
+            "SubagentStop",
+            "TaskCreated",
+            "TaskCompleted",
+            "Stop",
+            "StopFailure",
+            "TeammateIdle",
+            "ConfigChange",
+            "CwdChanged",
+            "FileChanged",
+            "WorktreeCreate",
+            "WorktreeRemove",
+            "PreCompact",
+            "PostCompact",
+            "SessionEnd",
+            "Elicitation",
+            "ElicitationResult",
+        ]
+        .into_iter()
+        .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(events, expected);
+        for entries in hooks.values() {
+            assert!(
+                entries.as_array().is_some_and(|entries| entries.iter().all(|entry| {
+                    entry["hooks"].as_array().is_some_and(|hooks| {
+                        hooks.iter().all(|hook| {
+                            hook["command"]
+                                .as_str()
+                                .is_some_and(|command| command.contains("AINB_AGENT=claude"))
+                        })
+                    })
+                }))
+            );
+        }
+    }
+
+    #[test]
     fn uninstall_strips_codex_managed_block_but_keeps_user_hooks() {
         let dir = fake_home();
         let p = paths_under_home(dir.path());

--- a/docs/toolkit/plugins/ainb-hooks.md
+++ b/docs/toolkit/plugins/ainb-hooks.md
@@ -3,15 +3,15 @@ title: "ainb-hooks"
 description: "Claude Code / Codex / Copilot plugin that emits session lifecycle events to the ainb notification inbox over a Unix socket."
 ---
 
-`ainb-hooks` (v0.2.0) is a **host-agent hook plugin** — it is loaded by Claude Code, Codex CLI, or GitHub Copilot CLI, not by the `ainb` TUI. (Contrast with the ainb v2 subprocess plugins such as `burndown` and `witr`, which run inside `ainb`.) It registers lifecycle hooks on the host agent and forwards each event to the **ainb notification inbox** — the `ainb-notifyd` daemon — over a Unix socket, powering session-state badges, the Inbox screen, and optional OS notifications in `ainb-tui`. It pairs with the [Inbox & notifications](../../tui/inbox-notifications.md) daemon (`ainb-notifyd`) — host code compiled into `ainb-core`, not a plugin — which is the consumer on the other end of the socket.
+`ainb-hooks` (v0.2.0) is a **host-agent hook plugin**. Claude Code and Codex CLI events enter Hangar's durable provider log through `ainb-notifyd`; only attention events enter the notification inbox. It is not an `ainb` TUI subprocess plugin.
 
 ## How it works
 
 ![ainb-hooks — how it works](../../assets/diagrams/ainb-hooks.svg)
 
-The plugin's `.claude-plugin/plugin.json` registers only the **actionable** lifecycle events with a single command: `AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh`. Codex is registered via `codex/hooks.json` (with `AINB_AGENT=codex`), and Copilot via `copilot/hooks.json` (with `AINB_AGENT=copilot`). Each hook has a 5-second timeout so a slow delivery never stalls the agent.
+The plugin's `.claude-plugin/plugin.json` registers every documented Claude lifecycle hook with `AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh`. Codex registers every documented CLI hook via `codex/hooks.json` with `AINB_AGENT=codex`; Copilot remains `copilot/hooks.json` with `AINB_AGENT=copilot`. Each hook has a 5-second timeout so a slow delivery never stalls the agent.
 
-**Only events that need the human are hooked** — Claude/Copilot use `Notification`/`notification` for awaiting input and permission prompts, Codex uses `PermissionRequest` for approvals, and all three use `Stop`/`agentStop` for turn completion. Telemetry — `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop` — is **not** registered: `PostToolUse` alone fires dozens of times per turn and would bury the signal in the inbox. As a second line of defence, `ainb-notifyd` also drops any non-user-facing event on arrival (see `crates/ainb-plugin-notifyd/src/listener.rs`), so even a stale install never accumulates noise.
+Every observed Claude and Codex event is appended to Hangar's durable provider log, including tool and subagent activity. `ainb-notifyd` still drops non-user-facing events, so telemetry never becomes inbox noise.
 
 `hooks/notify.sh` is the universal normalizer. Claude Code pipes the hook payload as JSON on stdin; Codex passes it as `argv[1]`. The script autodetects the source, extracts the event name, session id, and cwd (via `jq`, falling back to `grep` in minimal environments), and wraps the verbatim original payload in a normalized envelope: `{protocol_version, agent, raw_event, session_id, cwd, project, ts, payload}`. The `raw_event` field preserves the original event name (e.g. `Notification:idle_prompt`) so semantic mapping happens in the consumer, not on the wire.
 
@@ -25,18 +25,16 @@ This plugin ships only hooks plus the shared `notify.sh` script — no skills, c
 
 ### Hooks
 
-Only the events that need the human are registered:
+Claude and Codex retain every documented hook in Hangar. Inbox handling remains attention-only:
 
 | Agent | Event | What fires | Why it's actionable |
 | --- | --- | --- | --- |
-| Claude Code | `Notification` | Agent notifications, incl. `Notification:idle_prompt` and permission prompts | the agent is blocked on you |
-| Claude Code | `Stop` | Agent turn / session stops | the agent finished — come back |
-| Codex CLI | `PermissionRequest` | Exec / patch / permission approval prompts | the agent is blocked on approval |
-| Codex CLI | `Stop` | Agent turn / session stops | the agent finished — come back |
+| Claude Code | all 30 documented hooks | full lifecycle and workload record | durable projection source |
+| Codex CLI | all 11 documented CLI hooks | full lifecycle and workload record | durable projection source |
 | GitHub Copilot CLI | `notification` | Agent notifications and permission prompts | the agent is blocked on you |
 | GitHub Copilot CLI | `agentStop` | Agent turn / session stops | the agent finished — come back |
 
-Deliberately **not** registered (telemetry / activity noise — would bury the signal): `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop`. `PostToolUse` alone fires once per tool call (dozens per turn). The daemon additionally drops any non-user-facing event on arrival as a safety net.
+Telemetry stays out of the inbox because the daemon drops non-user-facing events on arrival.
 
 ### Components
 
@@ -63,7 +61,7 @@ For **Claude**, the installer shells out to the `claude` plugin CLI — ensuring
 
 ## Using it
 
-- Once installed, delivery is fully automatic — every registered actionable event on the host agent (`Notification`/`notification`, `PermissionRequest`, `Stop`/`agentStop`) is forwarded to the inbox with no user action. Telemetry events are not hooked, so the inbox only ever shows things that need you.
+- Once installed, every registered Claude and Codex event is forwarded to Hangar with no user action. Only actionable events surface in the inbox.
 - `Notification:idle_prompt` and `PermissionRequest` events surface in `ainb-tui` as attention markers so you can see which sessions need you.
 - Events show up as session-state badges and in the dedicated Inbox screen in `ainb-tui`; the inbox detail view exposes the full original hook JSON (carried in `payload`) for forensics.
 - Run `ainb-notifyd status` to confirm the plugin is wired for each agent; if `ainb-notifyd` is not running, the next hook fire lazily spawns it (or buffers to the fallback file).

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -47,7 +47,7 @@ source path was placed; ignore it when reasoning about harness plugins.
 | Plugin           | Kind   | What it does                                                          | Marketplace install                          |
 |------------------|--------|----------------------------------------------------------------------|----------------------------------------------|
 | `ainb-fleet`     | skills | Teaches agents the `ainb fleet …` multi-session orchestration verbs   | `ainb-fleet@agents-in-a-box`                 |
-| `ainb-hooks`     | hooks  | Emits Stop / Notification / PermissionRequest events to the ainb inbox| `ainb-hooks@agents-in-a-box`                 |
+| `ainb-hooks`     | hooks  | Captures documented Claude and Codex events into Hangar; routes only attention to inbox | `ainb-hooks@agents-in-a-box`                 |
 | `caveman-stats`  | hooks  | Caveman token-savings statusline + compaction-survival re-inject      | `caveman-stats@agents-in-a-box`              |
 | `illustration`   | skills | Popa-mascot brand-illustration workflow (sketchnote generation)       | `illustration@agents-in-a-box`               |
 

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -1,35 +1,41 @@
 {
   "name": "ainb-hooks",
   "version": "0.3.0",
-  "description": "Emit actionable Claude Code lifecycle events (awaiting-input / permission via Notification, plus Stop) to the ainb notification inbox (ainb-notifyd via Unix socket). The same notify.sh also powers the event-driven ATC plumbing when installed under ATC management (AINB_MANAGED=atc): it writes per-session status files, commits child completions to the parent's durable inbox, and runs the synchronous Stop-drain. Those ATC lifecycle hooks are installed into ~/.claude/settings.json by `ainb fleet atc setup` (read-preserve-modify-write — reflect/notifyd hooks are preserved), NOT by this marketplace manifest.",
+  "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc.",
   "author": {
     "name": "Agents-in-a-Box"
   },
-  "//": "Only the events that need the human are registered. Claude Code surfaces both idle/awaiting-input AND permission prompts through the Notification hook, so Notification + Stop cover every actionable case. Telemetry (SessionStart / UserPromptSubmit / PostToolUse / PreCompact) is intentionally NOT hooked — PostToolUse alone fires dozens of times per turn and would bury the signal. The daemon also drops any non-user-facing event defensively (see crates/ainb-plugin-notifyd/src/listener.rs).",
+  "//": "All documented Claude Code hook events are registered for Hangar's durable provider log. ainb-notifyd independently drops non-user-facing events, so activity telemetry never pollutes the operator inbox.",
   "hooks": {
-    "Notification": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
+    "SessionStart": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "Setup": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "InstructionsLoaded": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "UserPromptSubmit": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "UserPromptExpansion": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "MessageDisplay": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PreToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PostToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PostToolUseFailure": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PostToolBatch": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PermissionDenied": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "Notification": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "SubagentStart": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "SubagentStop": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "TaskCreated": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "TaskCompleted": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "Stop": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "StopFailure": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "TeammateIdle": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "ConfigChange": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "CwdChanged": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "FileChanged": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "WorktreeCreate": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "WorktreeRemove": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PreCompact": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PostCompact": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "Elicitation": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "ElicitationResult": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }]
   }
 }

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -82,18 +82,18 @@ The CLI:
 
 ## Hook events
 
-Claude and Codex both use PascalCase event names, but Codex now exposes a
-separate `PermissionRequest` hook instead of a `Notification` hook. The
-human-facing registrations are:
+Claude and Codex both use PascalCase event names. Every documented event is
+registered and retained by Hangar. The notification inbox independently keeps
+only human-facing events:
 
 | Agent | Hooks registered | Meaning |
 | --- | --- | --- |
-| Claude Code | `Notification`, `Stop` | awaiting input / permission prompt, turn finished |
-| Codex CLI | `PermissionRequest`, `Stop` | approval prompt, turn finished |
+| Claude Code | all 30 documented hooks | lifecycle, tool, task, worktree, compact, and attention state |
+| Codex CLI | all 11 documented CLI hooks | lifecycle, tool, compact, subagent, approval, and session-end state |
 | GitHub Copilot CLI | `notification`, `agentStop` | awaiting input / permission prompt, turn finished |
 
-Only the user-facing events are hooked on every agent; telemetry events are
-intentionally left out so they don't bury the signal.
+Telemetry reaches the durable provider log, never the operator inbox. This
+keeps lifecycle projections accurate without burying attention signal.
 
 The matcher `Notification:idle_prompt` (Claude) and `PermissionRequest`
 (Codex) carry different raw names but the same user-facing shape: the agent
@@ -120,12 +120,9 @@ inbox detail view can show full forensics.
 
 ## ATC plumbing (event-driven orchestration)
 
-The same `notify.sh` doubles as the shell shim for the **event-driven ATC
-plumbing**. It is dormant by default and activates only when the hook was
-installed under ATC management — i.e. the command carries `AINB_MANAGED=atc`
-(set by the lifecycle-hook block that `ainb fleet atc setup` merges into
-`~/.claude/settings.json`). A plain notifyd-only install never sets it, so the
-plumbing block is skipped and leaf sessions pay nothing.
+The same `notify.sh` sends Claude and Codex hook payloads into Hangar's durable
+provider log. `AINB_MANAGED=atc` adds ATC-only structured control: completion
+routing and synchronous Claude answer or permission brokerage.
 
 When active, after delivering the notifyd envelope the script forwards the parsed
 event to the Rust side:
@@ -151,10 +148,8 @@ replaces reliance on the claude-peers broker's lossy delivery path. Full design,
 formats, and the consecutive-block budget are documented in
 [`docs/atc-plumbing.md`](../../docs/atc-plumbing.md).
 
-> The lifecycle hooks are installed into `~/.claude/settings.json` by
-> `ainb fleet atc setup` via a read-preserve-modify-write merge that keeps the
-> reflect plugin's and notifyd's hooks intact — they are **not** part of this
-> marketplace manifest (which stays notifyd-only: `Notification` + `Stop`).
+> `ainb fleet atc setup` merges the same Claude lifecycle registrations into
+> `~/.claude/settings.json` for managed sessions while preserving other hooks.
 
 ## See also
 

--- a/plugins/ainb-hooks/codex/hooks.json
+++ b/plugins/ainb-hooks/codex/hooks.json
@@ -1,6 +1,18 @@
 {
-  "//": "ainb-hooks managed block, merged into ~/.codex/hooks.json by `ainb-notifyd install --codex`. Do not edit by hand. Only the events that need the human are registered (PermissionRequest = approval prompt, Stop = turn finished). Telemetry (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / PreCompact / PostCompact / SubagentStart / SubagentStop) is intentionally NOT hooked because it would bury the signal. The daemon also drops any non-user-facing event defensively.",
+  "//": "ainb-hooks managed block, merged into ~/.codex/hooks.json by `ainb-notifyd install --codex`. Do not edit by hand. Every Codex CLI lifecycle hook is captured into Hangar's durable provider log. The notification daemon still routes only user-facing events to OS surfaces.",
   "hooks": {
+    "SessionStart": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
+    "SessionEnd": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
+    "UserPromptSubmit": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
+    "PreToolUse": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
     "PermissionRequest": [
       {
         "matcher": "",
@@ -12,6 +24,21 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
+    "PreCompact": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
+    "PostCompact": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
+    "SubagentStart": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+    ],
+    "SubagentStop": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
     ],
     "Stop": [
       {

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -232,7 +232,8 @@ fi
 # parent inbox commit, and — on Stop — the synchronous drain that prints
 # {"decision":"block",...}). The shell only forwards what it already parsed and
 # relays the command's stdout verbatim so Claude Code sees the block JSON.
-if [ "${AINB_MANAGED:-}" = "atc" ] && command -v ainb >/dev/null 2>&1; then
+if { [ "${AINB_MANAGED:-}" = "atc" ] || [ "${AINB_AGENT:-}" = "claude" ] || [ "${AINB_AGENT:-}" = "codex" ]; } \
+  && command -v ainb >/dev/null 2>&1; then
   AINB_HOOK_EVENT="${AINB_HOOK_EVENT:-${AINB_RAW_EVENT}}"
   # Resolve the matcher to forward: the managed command sets AINB_HOOK_MATCHER
   # (e.g. AskUserQuestion for the PreToolUse hook); otherwise fall back to the


### PR DESCRIPTION
## Summary
- persist raw Claude and Codex provider events in Hangar
- reduce lifecycle, attention, and active subagent work into Fleet
- capture all documented Claude and Codex hooks, including Codex SessionEnd
- expose active workload state in Fleet CLI and TUI

## Verification
- cargo test --workspace --no-run
- cargo test -p ainb-hangar-store --lib
- cargo test -p ainb-hangar-daemon --test rpc_fleet
- cargo test -p ainb-plugin-hangar --lib
- cargo test -p ainb --test tripwire_fleet_panel_opens_and_answers -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Claude and Codex lifecycle event capture, with durable storage of complete provider payloads.
  * Added active-work tracking for subagents, tasks, and child sessions.
  * Fleet views now display workload counts and exclude exited or unavailable sessions from active views.
  * Improved event replay, deduplication, and recovery of captured payloads.
* **Bug Fixes**
  * Preserved background work as active when sessions stop.
  * Improved handling of stop-failure details and Codex event processing.
* **Documentation**
  * Updated hook documentation to describe expanded event coverage and inbox behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->