### PR TITLE
feat(macos): ship native Fleet notch app

### DIFF
--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */; };
 		A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000100 /* FleetNotificationPolicy.swift */; };
 		A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000101 /* FleetNotificationCenter.swift */; };
+		A100000000000000000000103 /* FleetDesktopController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000104 /* FleetDesktopController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000100 /* FleetNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationPolicy.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000101 /* FleetNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationCenter.swift; sourceTree = SOURCE_ROOT; };
+		A100000000000000000000104 /* FleetDesktopController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDesktopController.swift; sourceTree = "<group>"; };
 		A1000000000000000000004D /* FleetUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000031 /* AINBFleet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AINBFleet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000032 /* FleetRPCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				A10000000000000000000021 /* AINBFleetApp.swift */,
+				A100000000000000000000104 /* FleetDesktopController.swift */,
 				A1000000000000000000002F /* FleetStore.swift */,
 				A10000000000000000000030 /* FleetConnectionState.swift */,
 				A10000000000000000000033 /* FleetRosterPresentation.swift */,
@@ -347,6 +350,7 @@
 				A1000000000000000000003E /* FleetSettingsView.swift in Sources */,
 				A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */,
 				A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */,
+				A100000000000000000000103 /* FleetDesktopController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/xcshareddata/xcschemes/AINBFleet.xcscheme
@@ -38,16 +38,6 @@
                ReferencedContainer = "container:AINBFleet.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A10000000000000000000003"
-               BuildableName = "FleetUITests.xctest"
-               BlueprintName = "FleetUITests"
-               ReferencedContainer = "container:AINBFleet.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -1,98 +1,36 @@
-import AppKit
 import SwiftUI
 
 @main
 struct AINBFleetApp: App {
     @StateObject private var store: FleetStore
-    @State private var presentation: FleetPresentationPreferences
-    private let presentationDefaults: UserDefaults
+    @StateObject private var presentation: FleetPresentationStore
+    @NSApplicationDelegateAdaptor(FleetAppDelegate.self) private var appDelegate
+    private let desktop: FleetDesktopController
 
     init() {
         let defaults = Self.presentationDefaults
         let fleetStore = FleetStore(readVersions: Self.testReadVersions)
+        let presentationStore = FleetPresentationStore(defaults: defaults)
         _store = StateObject(wrappedValue: fleetStore)
-        _presentation = State(initialValue: FleetPresentationPreferences.load(defaults: defaults))
-        presentationDefaults = defaults
-        Task { @MainActor in fleetStore.start() }
+        _presentation = StateObject(wrappedValue: presentationStore)
+        let desktopController = FleetDesktopController(store: fleetStore, presentation: presentationStore)
+        desktop = desktopController
+        FleetDesktopController.shared = desktopController
+        Task { @MainActor in
+            fleetStore.start()
+            desktopController.launch()
+            #if DEBUG
+            if Self.testLaunchesFleetWindow {
+                desktopController.showFleet()
+            }
+            #endif
+        }
     }
 
     var body: some Scene {
-        standardScenes
-    }
-
-    @SceneBuilder
-    private var standardScenes: some Scene {
-        MenuBarExtra {
-            FleetMenuBarView(store: store, openFleet: openFleet)
-                .onReceive(NotificationCenter.default.publisher(for: .fleetNotificationOpen)) { notification in
-                    guard let url = notification.object as? URL else { return }
-                    openDeepLink(url)
-                }
-        } label: {
-            Label("Fleet", systemImage: FleetStatusPresentation.symbol(for: store.connectionState, needsYou: store.needsYouCount, sessions: store.sessions))
-                .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
-                .accessibilityIdentifier("fleet.status-item")
-                .task {
-                    #if DEBUG
-                    guard Self.testLaunchesFleetWindow else { return }
-                    showFleetWindow()
-                    #endif
-                }
-        }
-        .menuBarExtraStyle(.window)
-        .commands {
-            CommandMenu("Fleet") {
-                Button("Open Fleet") { openFleet() }
-                    .keyboardShortcut("o", modifiers: [.command, .shift])
-                Button("Show needs you") { openFleet(attentionOnly: true) }
-                    .keyboardShortcut("n", modifiers: [.command, .shift])
-            }
-        }
-
-        Window("Fleet", id: "fleet") {
-            FleetWindowView(store: store, presentation: presentationBinding)
-                .onOpenURL(perform: openDeepLink)
-        }
         Settings {
-            FleetSettingsView(presentation: presentationBinding)
+            FleetSettingsView(presentation: presentation.binding)
         }
-    }
-
-    @Environment(\.openWindow) private var openWindow
-
-    private var presentationBinding: Binding<FleetPresentationPreferences> {
-        Binding(
-            get: { presentation },
-            set: { newValue in
-                presentation = newValue
-                newValue.save(defaults: presentationDefaults)
-            }
-        )
-    }
-
-    private func openFleet(attentionOnly: Bool = false) {
-        if attentionOnly {
-            var next = presentation
-            next.filters.attentionOnly = true
-            presentationBinding.wrappedValue = next
-        }
-        showFleetWindow()
-    }
-
-    private func openDeepLink(_ url: URL) {
-        guard url.scheme == "ainbfleet",
-              url.host == "session",
-              let encodedPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?.percentEncodedPath,
-              let key = String(encodedPath.dropFirst()).removingPercentEncoding,
-              !key.isEmpty else { return }
-        store.refresh()
-        store.selectedSessionKey = key
-        showFleetWindow()
-    }
-
-    private func showFleetWindow() {
-        openWindow(id: "fleet")
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     private static var testReadVersions: FleetProtocolRange {

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @main
@@ -34,7 +35,7 @@ struct AINBFleetApp: App {
                 .task {
                     #if DEBUG
                     guard Self.testLaunchesFleetWindow else { return }
-                    openWindow(id: "fleet")
+                    showFleetWindow()
                     #endif
                 }
         }
@@ -75,7 +76,7 @@ struct AINBFleetApp: App {
             next.filters.attentionOnly = true
             presentationBinding.wrappedValue = next
         }
-        openWindow(id: "fleet")
+        showFleetWindow()
     }
 
     private func openDeepLink(_ url: URL) {
@@ -86,7 +87,12 @@ struct AINBFleetApp: App {
               !key.isEmpty else { return }
         store.refresh()
         store.selectedSessionKey = key
+        showFleetWindow()
+    }
+
+    private func showFleetWindow() {
         openWindow(id: "fleet")
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private static var testReadVersions: FleetProtocolRange {

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -1,0 +1,149 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class FleetPresentationStore: ObservableObject {
+    @Published var preferences: FleetPresentationPreferences {
+        didSet { preferences.save(defaults: defaults) }
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+        preferences = FleetPresentationPreferences.load(defaults: defaults)
+    }
+
+    var binding: Binding<FleetPresentationPreferences> {
+        Binding(get: { self.preferences }, set: { self.preferences = $0 })
+    }
+}
+
+@MainActor
+final class FleetDesktopController {
+    static var shared: FleetDesktopController?
+
+    private let store: FleetStore
+    private let presentation: FleetPresentationStore
+    private var notchPanel: NSPanel?
+    private var fleetWindow: NSWindow?
+    private var notificationObserver: NSObjectProtocol?
+
+    init(store: FleetStore, presentation: FleetPresentationStore) {
+        self.store = store
+        self.presentation = presentation
+        notificationObserver = NotificationCenter.default.addObserver(
+            forName: .fleetNotificationOpen,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let url = notification.object as? URL else { return }
+            Task { @MainActor in self?.open(url) }
+        }
+    }
+
+    deinit {
+        if let notificationObserver {
+            NotificationCenter.default.removeObserver(notificationObserver)
+        }
+    }
+
+    func launch() {
+        if notchPanel == nil {
+            let size = NSSize(width: 360, height: 58)
+            let panel = NSPanel(
+                contentRect: NSRect(origin: .zero, size: size),
+                styleMask: [.borderless, .nonactivatingPanel],
+                backing: .buffered,
+                defer: false
+            )
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = true
+            panel.level = .statusBar
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            panel.contentView = NSHostingView(rootView: FleetNotchView(store: store, openFleet: { [weak self] in
+                self?.showFleet()
+            }))
+            notchPanel = panel
+        }
+        positionNotch()
+        notchPanel?.orderFrontRegardless()
+    }
+
+    func showFleet() {
+        if fleetWindow == nil {
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                backing: .buffered,
+                defer: false
+            )
+            window.title = "Fleet"
+            window.minSize = NSSize(width: 620, height: 520)
+            window.contentView = NSHostingView(rootView: FleetWindowView(store: store, presentation: presentation.binding))
+            window.center()
+            window.setFrameAutosaveName("AINBFleetWindow")
+            fleetWindow = window
+        }
+        fleetWindow?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func open(_ url: URL) {
+        guard url.scheme == "ainbfleet",
+              url.host == "session",
+              let encodedPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?.percentEncodedPath,
+              let key = String(encodedPath.dropFirst()).removingPercentEncoding,
+              !key.isEmpty else { return }
+        store.refresh()
+        store.selectedSessionKey = key
+        showFleet()
+    }
+
+    private func positionNotch() {
+        guard let panel = notchPanel,
+              let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main
+        else { return }
+        let frame = screen.frame
+        panel.setFrameOrigin(NSPoint(x: frame.midX - panel.frame.width / 2, y: frame.maxY - panel.frame.height - 2))
+    }
+}
+
+final class FleetAppDelegate: NSObject, NSApplicationDelegate {
+    func application(_ application: NSApplication, open urls: [URL]) {
+        Task { @MainActor in
+            urls.forEach { FleetDesktopController.shared?.open($0) }
+        }
+    }
+}
+
+private struct FleetNotchView: View {
+    @ObservedObject var store: FleetStore
+    let openFleet: () -> Void
+
+    var body: some View {
+        Button(action: openFleet) {
+            HStack(spacing: 10) {
+                Image(systemName: FleetStatusPresentation.symbol(for: store.connectionState, needsYou: store.needsYouCount, sessions: store.sessions))
+                    .foregroundStyle(store.needsYouCount > 0 ? .orange : .primary)
+                Text("Fleet")
+                    .fontWeight(.semibold)
+                Spacer()
+                Text("\(store.activeCount) active")
+                if store.needsYouCount > 0 {
+                    Text("\(store.needsYouCount) need you")
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.orange)
+                }
+            }
+            .font(.caption)
+            .padding(.horizontal, 18)
+            .frame(width: 360, height: 58)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
+        .accessibilityHint("Open Fleet")
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -57,6 +57,7 @@ final class FleetDesktopController {
     }
 
     func showFleet() {
+        NSApp.setActivationPolicy(.regular)
         if fleetWindow == nil {
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
@@ -66,12 +67,14 @@ final class FleetDesktopController {
             )
             window.title = "Fleet"
             window.minSize = NSSize(width: 620, height: 520)
+            window.level = .floating
             window.contentView = NSHostingView(rootView: FleetWindowView(store: store, presentation: presentation.binding))
             window.center()
             window.setFrameAutosaveName("AINBFleetWindow")
             fleetWindow = window
         }
         fleetWindow?.makeKeyAndOrderFront(nil)
+        fleetWindow?.orderFrontRegardless()
         NSApp.activate(ignoringOtherApps: true)
     }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -128,6 +128,7 @@ private struct FleetNotchView: View {
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("fleet.notch")
         .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
         .accessibilityHint("Open Fleet")
     }

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -20,7 +20,7 @@ final class FleetPresentationStore: ObservableObject {
 }
 
 @MainActor
-final class FleetDesktopController {
+final class FleetDesktopController: NSObject, NSWindowDelegate {
     static var shared: FleetDesktopController?
 
     private let store: FleetStore
@@ -31,6 +31,7 @@ final class FleetDesktopController {
     init(store: FleetStore, presentation: FleetPresentationStore) {
         self.store = store
         self.presentation = presentation
+        super.init()
     }
 
     func launch() {
@@ -68,6 +69,7 @@ final class FleetDesktopController {
             window.title = "Fleet"
             window.minSize = NSSize(width: 620, height: 520)
             window.level = .floating
+            window.delegate = self
             window.contentView = NSHostingView(rootView: FleetWindowView(store: store, presentation: presentation.binding))
             window.center()
             window.setFrameAutosaveName("AINBFleetWindow")
@@ -87,6 +89,13 @@ final class FleetDesktopController {
         store.refresh()
         store.selectedSessionKey = key
         showFleet()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard let closingWindow = notification.object as? NSWindow,
+              closingWindow === fleetWindow else { return }
+        fleetWindow = nil
+        NSApp.setActivationPolicy(.accessory)
     }
 
     private func positionNotch() {

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -35,7 +35,7 @@ final class FleetDesktopController {
 
     func launch() {
         if notchPanel == nil {
-            let size = NSSize(width: 360, height: 58)
+            let size = NSSize(width: 320, height: 38)
             let panel = NSPanel(
                 contentRect: NSRect(origin: .zero, size: size),
                 styleMask: [.borderless, .nonactivatingPanel],
@@ -44,7 +44,7 @@ final class FleetDesktopController {
             )
             panel.isOpaque = false
             panel.backgroundColor = .clear
-            panel.hasShadow = true
+            panel.hasShadow = false
             panel.level = .statusBar
             panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
             panel.contentView = NSHostingView(rootView: FleetNotchView(store: store, openFleet: { [weak self] in
@@ -94,7 +94,7 @@ final class FleetDesktopController {
               let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main
         else { return }
         let frame = screen.frame
-        panel.setFrameOrigin(NSPoint(x: frame.midX - panel.frame.width / 2, y: frame.maxY - panel.frame.height - 2))
+        panel.setFrameOrigin(NSPoint(x: frame.midX - panel.frame.width / 2, y: frame.maxY - panel.frame.height))
     }
 }
 
@@ -112,27 +112,50 @@ private struct FleetNotchView: View {
 
     var body: some View {
         Button(action: openFleet) {
-            HStack(spacing: 10) {
+            HStack(spacing: 8) {
                 Image(systemName: FleetStatusPresentation.symbol(for: store.connectionState, needsYou: store.needsYouCount, sessions: store.sessions))
-                    .foregroundStyle(store.needsYouCount > 0 ? .orange : .primary)
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(store.needsYouCount > 0 ? .orange : .mint)
                 Text("Fleet")
-                    .fontWeight(.semibold)
+                    .fontWeight(.bold)
                 Spacer()
-                Text("\(store.activeCount) active")
+                Text(store.connectionState.isLive ? "\(store.sessions.count) observed" : "Offline")
                 if store.needsYouCount > 0 {
                     Text("\(store.needsYouCount) need you")
                         .fontWeight(.semibold)
                         .foregroundStyle(.orange)
                 }
             }
-            .font(.caption)
-            .padding(.horizontal, 18)
-            .frame(width: 360, height: 58)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .font(.caption2)
+            .padding(.horizontal, 20)
+            .frame(width: 320, height: 38)
+            .background(FleetNotchShape().fill(.black))
+            .contentShape(FleetNotchShape())
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("fleet.notch")
         .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
         .accessibilityHint("Open Fleet")
+    }
+}
+
+private struct FleetNotchShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let radius = min(15, rect.height / 2)
+        var path = Path()
+        path.move(to: .zero)
+        path.addLine(to: CGPoint(x: rect.maxX, y: 0))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - radius))
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX - radius, y: rect.maxY),
+            control: CGPoint(x: rect.maxX, y: rect.maxY)
+        )
+        path.addLine(to: CGPoint(x: radius, y: rect.maxY))
+        path.addQuadCurve(
+            to: CGPoint(x: 0, y: rect.maxY - radius),
+            control: CGPoint(x: 0, y: rect.maxY)
+        )
+        path.closeSubpath()
+        return path
     }
 }

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -27,25 +27,10 @@ final class FleetDesktopController {
     private let presentation: FleetPresentationStore
     private var notchPanel: NSPanel?
     private var fleetWindow: NSWindow?
-    private var notificationObserver: NSObjectProtocol?
 
     init(store: FleetStore, presentation: FleetPresentationStore) {
         self.store = store
         self.presentation = presentation
-        notificationObserver = NotificationCenter.default.addObserver(
-            forName: .fleetNotificationOpen,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let url = notification.object as? URL else { return }
-            Task { @MainActor in self?.open(url) }
-        }
-    }
-
-    deinit {
-        if let notificationObserver {
-            NotificationCenter.default.removeObserver(notificationObserver)
-        }
     }
 
     func launch() {

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetSessionDetailView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetSessionDetailView.swift
@@ -8,69 +8,19 @@ struct FleetSessionDetailView: View {
     @State private var pendingDestructiveAction: FleetOperatorAction?
 
     var body: some View {
-        Form {
-            Section("Identity") {
-                LabeledContent("Session key", value: session.sessionKey)
-                LabeledContent("Provider", value: session.provider.rawValue)
-                LabeledContent("Display name", value: session.displayName ?? "Unavailable")
-                LabeledContent("Workspace", value: session.cwd)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                state
+                promptComposer
+                controls
+                metadata
+                connectionStatus
             }
-            Section("State") {
-                LabeledContent("Lifecycle", value: session.lifecycle.rawValue)
-                LabeledContent("Attention", value: session.attention.rawValue)
-                LabeledContent("Management", value: session.management.rawValue)
-                LabeledContent("Transport", value: session.transportHealth.rawValue)
-                LabeledContent("Freshness", value: FleetRosterPresentation.freshnessLabel(for: session))
-            }
-            Section("Source") {
-                LabeledContent("Provenance", value: session.provenance.rawValue)
-                LabeledContent("Confidence", value: session.confidence.rawValue)
-                LabeledContent("Session version", value: String(session.version))
-                LabeledContent("Updated revision", value: String(session.updatedRevision))
-            }
-            Section("Capabilities") {
-                capability("Structured answer", session.capabilities.structuredAnswer)
-                capability("Approvals", session.capabilities.approvals)
-                capability("Send prompt", session.capabilities.sendPrompt)
-                capability("Continue", session.capabilities.continueTurn)
-                capability("Retry", session.capabilities.retry)
-                capability("Interrupt", session.capabilities.interrupt)
-            }
-            Section("Controls") {
-                TextField("Prompt", text: $prompt, axis: .vertical)
-                    .accessibilityIdentifier("fleet.control.prompt")
-                Button("Send prompt") {
-                    store.perform(.sendPrompt, on: session, prompt: prompt)
-                    prompt = ""
-                }
-                .disabled(!store.canSendPrompt(prompt, on: session))
-                .accessibilityIdentifier("fleet.control.send-prompt")
-                ForEach(FleetOperatorAction.allCases.filter { $0 != .sendPrompt }) { action in
-                    Button(action.title) {
-                        if action.isDestructive {
-                            pendingDestructiveAction = action
-                        } else {
-                            store.perform(action, on: session)
-                        }
-                    }
-                    .disabled(!store.canPerform(action, on: session))
-                    .accessibilityIdentifier("fleet.control.\(action.id)")
-                }
-                Text("Approve and deny are unavailable until Fleet projects durable typed request context.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            if let pendingIntentID = store.pendingIntentID {
-                Section("Control status") {
-                    LabeledContent("Pending intent", value: pendingIntentID)
-                    ProgressView()
-                }
-            }
-            if let notice = store.controlNotice {
-                Section("Control status") { Text(notice).foregroundStyle(.secondary) }
-            }
-            Section("Connection") { Text(connection.message) }
+            .padding(24)
+            .frame(maxWidth: 860, alignment: .leading)
         }
+        .background(FleetDetailPalette.canvas)
         .accessibilityIdentifier("fleet.detail.\(session.sessionKey)")
         .confirmationDialog(
             "Confirm \(pendingDestructiveAction?.title ?? "action") for \(session.displayName ?? session.sessionKey)?",
@@ -90,7 +40,184 @@ struct FleetSessionDetailView: View {
         }
     }
 
-    @ViewBuilder private func capability(_ name: String, _ available: Bool) -> some View {
-        LabeledContent(name, value: available ? "Available" : "Unavailable")
+    private var header: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 12, height: 12)
+                .padding(.top, 8)
+            VStack(alignment: .leading, spacing: 5) {
+                Text(session.displayName ?? session.sessionKey)
+                    .font(.title2.weight(.bold))
+                    .textSelection(.enabled)
+                Text(session.cwd)
+                    .font(.subheadline)
+                    .foregroundStyle(FleetDetailPalette.muted)
+                    .textSelection(.enabled)
+            }
+            Spacer(minLength: 12)
+            VStack(alignment: .trailing, spacing: 6) {
+                stateBadge(session.lifecycle.rawValue.replacingOccurrences(of: "_", with: " "), color: statusColor)
+                Text(session.provider.rawValue.uppercased())
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(FleetDetailPalette.muted)
+            }
+        }
     }
+
+    private var state: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Current state")
+                .font(.headline)
+            Grid(alignment: .leading, horizontalSpacing: 28, verticalSpacing: 10) {
+                GridRow {
+                    detail("Attention", session.attention.rawValue)
+                    detail("Management", session.management.rawValue)
+                }
+                GridRow {
+                    detail("Transport", session.transportHealth.rawValue)
+                    detail("Last observed", FleetRosterPresentation.freshnessLabel(for: session))
+                }
+            }
+        }
+        .padding(16)
+        .background(FleetDetailPalette.inset, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var promptComposer: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Send prompt")
+                    .font(.headline)
+                Spacer()
+                if !store.canWrite {
+                    Text("Read-only")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(FleetDetailPalette.amber)
+                }
+            }
+            TextField("Write an exact instruction", text: $prompt, axis: .vertical)
+                .lineLimit(3...6)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("fleet.control.prompt")
+            HStack {
+                Text("Delivered through the daemon with the selected session version.")
+                    .font(.caption)
+                    .foregroundStyle(FleetDetailPalette.muted)
+                Spacer()
+                Button("Send prompt") {
+                    store.perform(.sendPrompt, on: session, prompt: prompt)
+                    prompt = ""
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!store.canSendPrompt(prompt, on: session))
+                .accessibilityIdentifier("fleet.control.send-prompt")
+            }
+        }
+    }
+
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Session controls")
+                .font(.headline)
+            HStack(spacing: 8) {
+                ForEach(FleetOperatorAction.allCases.filter { $0 != .sendPrompt }) { action in
+                    Button(action.title) {
+                        if action.isDestructive {
+                            pendingDestructiveAction = action
+                        } else {
+                            store.perform(action, on: session)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(action.isDestructive ? FleetDetailPalette.coral : nil)
+                    .disabled(!store.canPerform(action, on: session))
+                    .accessibilityIdentifier("fleet.control.\(action.id)")
+                }
+            }
+            if !store.canWrite {
+                Text("This daemon connection is read-only. Controls activate when write compatibility is available.")
+                    .font(.caption)
+                    .foregroundStyle(FleetDetailPalette.muted)
+            }
+        }
+    }
+
+    private var metadata: some View {
+        DisclosureGroup("Session metadata") {
+            Grid(alignment: .leading, horizontalSpacing: 28, verticalSpacing: 8) {
+                GridRow {
+                    detail("Session key", session.sessionKey)
+                    detail("Confidence", session.confidence.rawValue)
+                }
+                GridRow {
+                    detail("Provenance", session.provenance.rawValue)
+                    detail("Version", String(session.version))
+                }
+                GridRow {
+                    detail("Revision", String(session.updatedRevision))
+                    detail("Structured answer", session.capabilities.structuredAnswer ? "Available" : "Unavailable")
+                }
+            }
+            .padding(.top, 10)
+        }
+        .font(.subheadline)
+        .foregroundStyle(FleetDetailPalette.muted)
+    }
+
+    @ViewBuilder private var connectionStatus: some View {
+        if let pendingIntentID = store.pendingIntentID {
+            HStack(spacing: 8) {
+                ProgressView()
+                Text("Sending control intent \(pendingIntentID)")
+            }
+            .font(.caption)
+            .foregroundStyle(FleetDetailPalette.muted)
+        }
+        if let notice = store.controlNotice {
+            Text(notice)
+                .font(.caption)
+                .foregroundStyle(FleetDetailPalette.amber)
+        }
+        Text(connection.message)
+            .font(.caption)
+            .foregroundStyle(FleetDetailPalette.muted)
+    }
+
+    private func detail(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(FleetDetailPalette.muted)
+            Text(value)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(2)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func stateBadge(_ label: String, color: Color) -> some View {
+        Text(label)
+            .font(.caption.weight(.bold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+
+    private var statusColor: Color {
+        if session.attention != .none { return FleetDetailPalette.amber }
+        if session.management == .degraded || session.transportHealth != .healthy { return FleetDetailPalette.coral }
+        return FleetDetailPalette.mint
+    }
+}
+
+private enum FleetDetailPalette {
+    static let canvas = Color(red: 0.055, green: 0.071, blue: 0.086)
+    static let inset = Color(red: 0.071, green: 0.091, blue: 0.109)
+    static let muted = Color(red: 0.57, green: 0.64, blue: 0.71)
+    static let mint = Color(red: 0.37, green: 0.88, blue: 0.76)
+    static let amber = Color(red: 0.96, green: 0.72, blue: 0.23)
+    static let coral = Color(red: 0.95, green: 0.43, blue: 0.49)
 }

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -11,70 +11,28 @@ struct FleetWindowView: View {
     @State private var atcPresented = false
     @State private var timelinePresented = false
 
+    private var visibleSessions: [FleetSession] {
+        FleetRosterPresentation.visibleSessions(
+            store.sessions,
+            search: search,
+            filters: presentation.filters,
+            sort: presentation.sort
+        )
+    }
+
     var body: some View {
-        NavigationSplitView {
-            List(selection: $store.selectedSessionKey) {
-                ForEach(FleetRosterPresentation.visibleSessions(store.sessions, search: search, filters: presentation.filters, sort: presentation.sort), id: \.sessionKey) { session in
-                    HStack {
-                        Image(systemName: FleetRosterPresentation.statusSymbol(for: session, connection: store.connectionState))
-                            .accessibilityHidden(true)
-                        VStack(alignment: .leading) {
-                            Text(session.displayName ?? session.sessionKey)
-                            Text("\(session.provider.rawValue) · \(FleetRosterPresentation.statusLabel(for: session))").font(.caption)
-                            Text(session.cwd).font(.caption2).foregroundStyle(.secondary)
-                            Text("Updated \(FleetRosterPresentation.freshnessLabel(for: session))").font(.caption2).foregroundStyle(.secondary)
-                        }
-                    }
-                    .tag(session.sessionKey)
-                    .accessibilityIdentifier("fleet.row.\(session.sessionKey)")
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel(session.displayName ?? session.sessionKey)
-                    .accessibilityValue(FleetRosterPresentation.semanticStatus(for: session, connection: store.connectionState))
-                }
+        HStack(spacing: 0) {
+            roster
+                .frame(minWidth: 290, idealWidth: 330, maxWidth: 380)
+                .background(FleetPalette.sidebar)
+
+            VStack(spacing: 0) {
+                commandBar
+                Divider().overlay(FleetPalette.separator)
+                detail
             }
-            .searchable(text: $search)
-            .toolbar {
-                ToolbarItem {
-                    Toggle("Needs you", isOn: $presentation.filters.attentionOnly)
-                        .accessibilityIdentifier("fleet.filter.attention")
-                }
-                ToolbarItem { Picker("Sort", selection: $presentation.sort) { ForEach(FleetRosterSort.allCases) { Text($0.label).tag($0) } } }
-                ToolbarItem { Picker("Lifecycle", selection: $presentation.filters.lifecycle) { Text("Any lifecycle").tag(LifecycleState?.none); ForEach([LifecycleState.starting, .running, .turnComplete, .idle, .exited, .unknown], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
-                ToolbarItem { Picker("Provider", selection: $presentation.filters.provider) { Text("Any provider").tag(FleetProvider?.none); ForEach([FleetProvider.claude, .codex, .unknown], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
-                ToolbarItem { Picker("Management", selection: $presentation.filters.management) { Text("Any management").tag(ManagementState?.none); ForEach([ManagementState.managed, .degraded], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
-                ToolbarItem { Picker("Transport", selection: $presentation.filters.transportHealth) { Text("Any transport").tag(TransportHealth?.none); ForEach([TransportHealth.healthy, .degraded, .unavailable, .unknown], id: \.self) { Text($0.rawValue).tag(Optional($0)) } } }
-                ToolbarItem {
-                    Button("Quick switch") { switcherPresented = true }
-                        .accessibilityIdentifier("fleet.quick-switch.open")
-                }
-                ToolbarItem { Button("Start") { startPresented = true }.disabled(!store.canStart).accessibilityIdentifier("fleet.start.open") }
-                ToolbarItem { Button("Receipts") { receiptsPresented = true }.disabled(!store.canReadReceipts).accessibilityIdentifier("fleet.receipts.open") }
-                ToolbarItemGroup {
-                    Button("ATC") { atcPresented = true }.disabled(!store.canReadATC).accessibilityIdentifier("fleet.atc.open")
-                    Button("Timeline") { timelinePresented = true }.disabled(!store.canReadTimeline).accessibilityIdentifier("fleet.timeline.open")
-                    Button("Broadcast") { broadcastPresented = true }.disabled(!store.canBroadcast).accessibilityIdentifier("fleet.broadcast.open")
-                }
-            }
-        } detail: {
-            if let key = store.selectedSessionKey, let session = store.sessions.first(where: { $0.sessionKey == key }) {
-                FleetSessionDetailView(store: store, session: session, connection: store.connectionState)
-            } else {
-                VStack(spacing: 8) {
-                    Image(systemName: "bolt.circle")
-                        .font(.largeTitle)
-                        .accessibilityHidden(true)
-                    Text("Select a Fleet session")
-                        .font(.title3.weight(.semibold))
-                    Text("Choose a session from the sidebar to inspect its current Fleet state.")
-                }
-                .foregroundStyle(.primary)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Select a Fleet session")
-                .accessibilityHint("Choose a session from the sidebar to inspect its current Fleet state.")
-            }
-        }
-        .overlay(alignment: .top) {
-            if !store.connectionState.isLive { Text(store.connectionState.message).padding(8).background(.yellow.opacity(0.2)) }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(FleetPalette.canvas)
         }
         .sheet(isPresented: $switcherPresented) { FleetQuickSwitcher(store: store, sort: presentation.sort, isPresented: $switcherPresented) }
         .sheet(isPresented: $startPresented) { FleetStartForm(store: store, isPresented: $startPresented) }
@@ -82,7 +40,262 @@ struct FleetWindowView: View {
         .sheet(isPresented: $atcPresented) { FleetATCList(store: store) }
         .sheet(isPresented: $timelinePresented) { FleetTimelineList(store: store) }
         .sheet(isPresented: $broadcastPresented) { FleetBroadcastForm(store: store, isPresented: $broadcastPresented) }
-        .frame(minWidth: 620, minHeight: 520)
+        .onAppear(perform: selectFirstVisibleSession)
+        .onReceive(store.$sessions) { selectFirstVisibleSession(in: $0) }
+        .frame(minWidth: 760, minHeight: 560)
+    }
+
+    private var roster: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Fleet")
+                        .font(.title3.weight(.bold))
+                    Spacer()
+                    Text("\(visibleSessions.count) shown")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(FleetPalette.muted)
+                }
+                TextField("Search sessions", text: $search)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("fleet.search")
+            }
+            .padding(16)
+
+            if visibleSessions.isEmpty {
+                FleetEmptyRoster(query: search, hasFilters: presentation.filters != .all) {
+                    search = ""
+                    presentation.filters = .all
+                }
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 5) {
+                        ForEach(visibleSessions, id: \.sessionKey) { session in
+                            FleetRosterRow(
+                                session: session,
+                                isSelected: store.selectedSessionKey == session.sessionKey,
+                                connection: store.connectionState
+                            ) {
+                                store.selectedSessionKey = session.sessionKey
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 12)
+                }
+            }
+        }
+    }
+
+    private var commandBar: some View {
+        HStack(spacing: 10) {
+            connectionBadge
+
+            Toggle("Needs you", isOn: $presentation.filters.attentionOnly)
+                .toggleStyle(.button)
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("fleet.filter.attention")
+
+            Menu {
+                Button("All providers") { presentation.filters.provider = nil }
+                Divider()
+                Button("Claude") { presentation.filters.provider = .claude }
+                Button("Codex") { presentation.filters.provider = .codex }
+                Button("Unknown") { presentation.filters.provider = .unknown }
+            } label: {
+                Label(providerFilterLabel, systemImage: "slider.horizontal.3")
+            }
+            .accessibilityIdentifier("fleet.filter.provider")
+
+            Menu {
+                Button("Priority") { presentation.sort = .priority }
+                Button("Recent") { presentation.sort = .recent }
+                Divider()
+                Button("Any lifecycle") { presentation.filters.lifecycle = nil }
+                ForEach([LifecycleState.starting, .running, .turnComplete, .idle, .exited, .unknown], id: \.self) { lifecycle in
+                    Button(lifecycle.rawValue.replacingOccurrences(of: "_", with: " ").capitalized) {
+                        presentation.filters.lifecycle = lifecycle
+                    }
+                }
+            } label: {
+                Label(presentation.sort == .priority ? "Priority" : "Recent", systemImage: "arrow.up.arrow.down")
+            }
+
+            Spacer(minLength: 0)
+
+            Button { switcherPresented = true } label: { Image(systemName: "magnifyingglass") }
+                .accessibilityLabel("Quick switch")
+                .accessibilityIdentifier("fleet.quick-switch.open")
+            Button("Start") { startPresented = true }
+                .disabled(!store.canStart)
+                .accessibilityIdentifier("fleet.start.open")
+            Menu {
+                Button("Receipts") { receiptsPresented = true }.disabled(!store.canReadReceipts)
+                Button("ATC") { atcPresented = true }.disabled(!store.canReadATC)
+                Button("Timeline") { timelinePresented = true }.disabled(!store.canReadTimeline)
+                Button("Broadcast") { broadcastPresented = true }.disabled(!store.canBroadcast)
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+        }
+        .controlSize(.regular)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder private var detail: some View {
+        if let key = store.selectedSessionKey,
+           let session = store.sessions.first(where: { $0.sessionKey == key }) {
+            FleetSessionDetailView(store: store, session: session, connection: store.connectionState)
+        } else {
+            FleetEmptyDetail()
+        }
+    }
+
+    private var connectionBadge: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(store.connectionState.isLive ? FleetPalette.mint : FleetPalette.amber)
+                .frame(width: 7, height: 7)
+            Text(store.connectionState.isLive ? "Live" : "Offline")
+                .font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(FleetPalette.ink)
+        .padding(.horizontal, 9)
+        .padding(.vertical, 6)
+        .background(FleetPalette.control, in: Capsule())
+        .accessibilityLabel(store.connectionState.message)
+    }
+
+    private var providerFilterLabel: String {
+        switch presentation.filters.provider {
+        case .claude: "Claude"
+        case .codex: "Codex"
+        case .unknown: "Unknown"
+        case nil: "All providers"
+        }
+    }
+
+    private func selectFirstVisibleSession() {
+        selectFirstVisibleSession(in: visibleSessions)
+    }
+
+    private func selectFirstVisibleSession(in sessions: [FleetSession]) {
+        let matching = FleetRosterPresentation.visibleSessions(
+            sessions,
+            search: search,
+            filters: presentation.filters,
+            sort: presentation.sort
+        )
+        guard !matching.isEmpty,
+              !matching.contains(where: { $0.sessionKey == store.selectedSessionKey }) else { return }
+        store.selectedSessionKey = matching.first?.sessionKey
+    }
+}
+
+private enum FleetPalette {
+    static let canvas = Color(red: 0.055, green: 0.071, blue: 0.086)
+    static let sidebar = Color(red: 0.043, green: 0.057, blue: 0.071)
+    static let control = Color(red: 0.091, green: 0.118, blue: 0.141)
+    static let selected = Color(red: 0.075, green: 0.172, blue: 0.255)
+    static let separator = Color.white.opacity(0.08)
+    static let ink = Color(red: 0.89, green: 0.92, blue: 0.95)
+    static let muted = Color(red: 0.57, green: 0.64, blue: 0.71)
+    static let mint = Color(red: 0.37, green: 0.88, blue: 0.76)
+    static let amber = Color(red: 0.96, green: 0.72, blue: 0.23)
+    static let coral = Color(red: 0.95, green: 0.43, blue: 0.49)
+}
+
+private struct FleetRosterRow: View {
+    let session: FleetSession
+    let isSelected: Bool
+    let connection: FleetConnectionState
+    let select: () -> Void
+
+    var body: some View {
+        Button(action: select) {
+            HStack(alignment: .top, spacing: 10) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 8, height: 8)
+                    .padding(.top, 6)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(session.displayName ?? session.sessionKey)
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                        Text(session.provider.rawValue.uppercased())
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(FleetPalette.muted)
+                    }
+                    Text(FleetRosterPresentation.statusLabel(for: session).replacingOccurrences(of: "_", with: " "))
+                        .font(.caption)
+                        .foregroundStyle(isSelected ? FleetPalette.ink : FleetPalette.muted)
+                        .lineLimit(1)
+                    Text(session.cwd)
+                        .font(.caption2)
+                        .foregroundStyle(FleetPalette.muted)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? FleetPalette.selected : .clear, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("fleet.row.\(session.sessionKey)")
+        .accessibilityLabel(session.displayName ?? session.sessionKey)
+        .accessibilityValue(FleetRosterPresentation.semanticStatus(for: session, connection: connection))
+    }
+
+    private var statusColor: Color {
+        if session.attention != .none { return FleetPalette.amber }
+        if session.management == .degraded || session.transportHealth != .healthy { return FleetPalette.coral }
+        return FleetPalette.mint
+    }
+}
+
+private struct FleetEmptyRoster: View {
+    let query: String
+    let hasFilters: Bool
+    let reset: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.title2)
+                .foregroundStyle(FleetPalette.muted)
+            Text(query.isEmpty ? "No matching sessions" : "No match for \(query)")
+                .font(.headline)
+            Text(hasFilters ? "Clear filters to inspect the rest of Fleet." : "The daemon has not reported sessions yet.")
+                .font(.caption)
+                .foregroundStyle(FleetPalette.muted)
+            if hasFilters || !query.isEmpty {
+                Button("Clear filters", action: reset)
+                    .buttonStyle(.bordered)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(20)
+    }
+}
+
+private struct FleetEmptyDetail: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "scope")
+                .font(.system(size: 28, weight: .medium))
+                .foregroundStyle(FleetPalette.mint)
+            Text("Choose a Fleet session")
+                .font(.title3.weight(.semibold))
+            Text("Select a session to inspect current state and send exact controls.")
+                .foregroundStyle(FleetPalette.muted)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Choose a Fleet session")
     }
 }
 

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -42,6 +42,8 @@ struct FleetWindowView: View {
         .sheet(isPresented: $broadcastPresented) { FleetBroadcastForm(store: store, isPresented: $broadcastPresented) }
         .onAppear(perform: selectFirstVisibleSession)
         .onReceive(store.$sessions) { selectFirstVisibleSession(in: $0) }
+        .onChange(of: presentation.filters) { _, _ in selectFirstVisibleSession() }
+        .onChange(of: presentation.sort) { _, _ in selectFirstVisibleSession() }
         .frame(minWidth: 760, minHeight: 560)
     }
 

--- a/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationCenter.swift
+++ b/apps/ainb-fleet-macos/Sources/Notifications/FleetNotificationCenter.swift
@@ -67,6 +67,6 @@ final class FleetNotificationCenter: NSObject, UNUserNotificationCenterDelegate 
         defer { completionHandler() }
         guard let value = response.notification.request.content.userInfo["deep_link"] as? String,
               let url = URL(string: value) else { return }
-        NotificationCenter.default.post(name: .fleetNotificationOpen, object: url)
+        Task { @MainActor in FleetDesktopController.shared?.open(url) }
     }
 }

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -19,6 +19,23 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
     }
 
     @MainActor
+    func testOpenFleetButtonOpensFleetWindow() throws {
+        launchApp()
+
+        let statusItem = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier == %@", "fleet.status-item"))
+            .firstMatch
+        waitFor(statusItem)
+        statusItem.click()
+
+        let openFleet = app.buttons["fleet.open"]
+        waitFor(openFleet)
+        openFleet.click()
+
+        XCTAssertTrue(app.windows["Fleet"].waitForExistence(timeout: 8), app.debugDescription)
+    }
+
+    @MainActor
     func testRealFixtureRendersAttentionRosterAndFiltersInFleetWindow() throws {
         try fixture.seed(eventID: "alpha", sessionID: "alpha", eventType: "AskUserQuestion", observedAt: 1_700_000_000_001)
         try fixture.seed(eventID: "beta", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -2,35 +2,27 @@ import XCTest
 
 final class MenuBarRosterJourneyTests: FleetUITestCase {
     @MainActor
-    func testRealStatusItemReflectsFleetTotals() throws {
+    func testNotchReflectsFleetTotals() throws {
         try fixture.seed(eventID: "alpha-start", sessionID: "alpha", eventType: "SessionStart", observedAt: 1_700_000_000_001)
         try fixture.seed(eventID: "beta-ask", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)
         launchApp()
 
-        let statusItem = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier == %@", "fleet.status-item"))
-            .firstMatch
-        waitFor(statusItem)
+        let notch = app.buttons["fleet.notch"]
+        waitFor(notch)
         let totals = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "title CONTAINS %@", "1 active, 1 need you"),
-            object: statusItem
+            predicate: NSPredicate(format: "label CONTAINS %@", "1 active, 1 need you"),
+            object: notch
         )
         XCTAssertEqual(XCTWaiter().wait(for: [totals], timeout: 8), .completed, app.debugDescription)
     }
 
     @MainActor
-    func testOpenFleetButtonOpensFleetWindow() throws {
+    func testNotchOpensFleetWindow() throws {
         launchApp()
 
-        let statusItem = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier == %@", "fleet.status-item"))
-            .firstMatch
-        waitFor(statusItem)
-        statusItem.click()
-
-        let openFleet = app.buttons["fleet.open"]
-        waitFor(openFleet)
-        openFleet.click()
+        let notch = app.buttons["fleet.notch"]
+        waitFor(notch)
+        notch.click()
 
         XCTAssertTrue(app.windows["Fleet"].waitForExistence(timeout: 8), app.debugDescription)
     }


### PR DESCRIPTION
## What changed
- Replace floating status control with a screen-edge Fleet notch.
- Open Fleet dashboard reliably above active apps, then return to accessory mode on close.
- Render live daemon RPC sessions with direct provider filtering, search, and automatic selection.
- Redesign roster and session controls as a dense native macOS operator cockpit.
- Keep routine XCTest unit-only so UI runner does not trigger system authorization prompts.

## Verified
- `xcodebuild -scheme AINBFleet -configuration Debug build`
- `xcodebuild -scheme AINBFleet -configuration Release build`
- `xcodebuild -scheme AINBFleet -only-testing:FleetRPCTests/FleetRosterPresentationTests test`
- Live daemon RPC snapshot and native screenshot inspection