### PR TITLE
ci(ainb-tui): add Contracts job for phase-5 contract gates (#500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,55 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
 
   # ────────────────────────────────────────────────────────────────────────────
+  # Contracts: deterministic golden/mutation gates, own job, no rerun-to-green
+  #
+  # Runs the five contract test binaries from the contract-testing-hardening
+  # plan (issue #500, phases 1-4): argv_golden_matrix (frozen per-provider CLI
+  # invocation shape), migration_upgrade_full_chain (forward-chain replay over
+  # a populated, adversarially-seeded db), and the ainb-plugin-cts-v2 package
+  # (axes, real_plugin_axes, wire_surface_gate: 14-axis protocol conformance
+  # against real in-tree plugin binaries plus the wire-surface semver gate).
+  #
+  # Why a separate job instead of trusting `Test` to carry them: in the
+  # general `cargo test` pool a contract failure is one line among thousands
+  # and reads as noise. That is exactly how a real `BdLock` two-holder race
+  # got mistaken for a flake for days this week. These tests compare
+  # deterministic renderings to committed golden/lock files, so they cannot
+  # legitimately flake. POLICY: a red job here is NEVER rerun to green. Fix
+  # the code or delete the contract; do not re-run the workflow. See
+  # ainb-tui/CLAUDE.md for the regeneration commands when a change is
+  # intentional.
+  #
+  # DELIBERATE: `migration_upgrade_full_chain` and the `ainb-plugin-cts-v2`
+  # binaries also need `--workspace`, since this repo's `default-members`
+  # (see ainb-tui/Cargo.toml) covers only ainb-core and ainb-hangar-daemon.
+  # `ainb-hangar-store` and `ainb-plugin-cts-v2` are outside it, so `Test`'s
+  # workspace-default `cargo nextest run` does not exercise them today.
+  # `argv_golden_matrix` (ainb-hangar-daemon) IS inside default-members and
+  # genuinely double-runs in `Test`; that overlap is intentional (see below),
+  # not redundant with this job as a whole.
+  #
+  # DELIBERATE: no exclusion is added to `Test`'s `-E` filter for the overlap
+  # that does exist. The duplicate run costs a few seconds; a filter typo
+  # silently dropping coverage is the exact failure class this effort exists
+  # to prevent.
+  # ────────────────────────────────────────────────────────────────────────────
+  contracts:
+    name: Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "ainb-tui -> target"
+      - uses: taiki-e/install-action@nextest
+      - run: >
+          cargo nextest run --workspace --all-features --no-fail-fast
+          -E 'binary(argv_golden_matrix) + binary(migration_upgrade_full_chain) + package(ainb-plugin-cts-v2)'
+        working-directory: ${{ env.WORKING_DIR }}
+
+  # ────────────────────────────────────────────────────────────────────────────
   # ainb-hooks daemon + plugin integration tests
   # ────────────────────────────────────────────────────────────────────────────
   ainb-hooks:

--- a/ainb-tui/CLAUDE.md
+++ b/ainb-tui/CLAUDE.md
@@ -147,6 +147,13 @@ they cannot legitimately flake. **If one goes red, never rerun the job to
 green it.** Fix the code, or update the golden and commit the diff. A red
 contract means a frozen guarantee actually broke, not noise.
 
+A test package must be reachable by the CI command that claims to run it.
+Adding a crate to `[workspace] members` does NOT put its tests in CI while
+`default-members` is narrower: a plain `cargo nextest run` (no `--workspace`)
+silently skips every crate outside `default-members`, and it will still
+report a clean summary. Check `-p <crate>` or `--workspace` deliberately
+when wiring a new gate, rather than assuming workspace membership is enough.
+
 To regenerate a golden after an intentional change:
 - argv matrix: `UPDATE_GOLDEN=1 cargo test -p ainb-hangar-daemon --test argv_golden_matrix`
 - wire surface: bump `version` in `crates/ainb-plugin-protocol/Cargo.toml`, then `UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate`

--- a/ainb-tui/CLAUDE.md
+++ b/ainb-tui/CLAUDE.md
@@ -133,6 +133,25 @@ cargo test --features vt100-tests
 cargo test --test e2e_pty_tests
 ```
 
+### Contract Tests: never rerun to green
+
+Five test binaries are deterministic contracts, gated by their own CI job
+(`Contracts`, see `.github/workflows/ci.yml`):
+
+- `argv_golden_matrix` (`crates/ainb-hangar-daemon/tests/`): frozen per-provider CLI argv
+- `migration_upgrade_full_chain` (`crates/ainb-hangar-store/tests/`): migration replay over a populated, adversarially-seeded db
+- `axes`, `real_plugin_axes`, `wire_surface_gate` (`crates/ainb-plugin-cts-v2/tests/`): 14-axis plugin protocol conformance + wire-surface semver gate
+
+They compare a deterministic rendering to a committed golden/lock file, so
+they cannot legitimately flake. **If one goes red, never rerun the job to
+green it.** Fix the code, or update the golden and commit the diff. A red
+contract means a frozen guarantee actually broke, not noise.
+
+To regenerate a golden after an intentional change:
+- argv matrix: `UPDATE_GOLDEN=1 cargo test -p ainb-hangar-daemon --test argv_golden_matrix`
+- wire surface: bump `version` in `crates/ainb-plugin-protocol/Cargo.toml`, then `UPDATE_WIRE_SURFACE=1 cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate`
+- migration chain: extend the seed in `migration_upgrade_full_chain.rs` directly; there is no separate regen command
+
 ## Recommended tmux Configuration
 
 Claude Code generates high-frequency screen updates (4,000+ scroll events/sec) which causes flickering in tmux. See `config/tmux.conf` for recommended settings:


### PR DESCRIPTION
## Summary

Phase 5 of the contract-testing-hardening plan (#500), CI wiring only, branch
protection is explicitly out of scope for this PR (owner action, see below).

- New `Contracts` job in `.github/workflows/ci.yml` running the five
  deterministic contract test binaries from Phases 1-4 in their own job, with
  `--no-fail-fast` so every failure surfaces in one run.
- `ainb-tui/CLAUDE.md`: policy section stating a red contract is never rerun
  to green, the exact regeneration command for each golden, and a
  generalised note that workspace membership alone does not put a crate's
  tests in CI while `default-members` is narrower.

## Filter proof

`cargo nextest list --workspace --all-features -E '<filter>'` inside
`ainb-tui/`, exactly the 5 intended binaries, 54 tests, nothing else:

```
ainb-hangar-daemon::argv_golden_matrix          8 tests
ainb-hangar-store::migration_upgrade_full_chain 4 tests
ainb-plugin-cts-v2::axes                        40 tests
ainb-plugin-cts-v2::real_plugin_axes            1 test
ainb-plugin-cts-v2::wire_surface_gate           1 test
-----
5 binary ids, 54 tests total, nothing outside these five.
```

`--workspace` is required. Without it the same filter only selects
`argv_golden_matrix` (1 of 5), because this repo's `default-members` in
`ainb-tui/Cargo.toml` covers only `ainb-core` and `ainb-hangar-daemon`.
`ainb-hangar-store` and `ainb-plugin-cts-v2` are workspace members but not
default-members, so a plain `cargo nextest run` silently skips them.

## Discovered while wiring this (pre-existing, not caused by this PR)

The default-members gap above is not cosmetic. It means today's `Test` job
(`cargo nextest run --lib --tests --all-features ... -E 'not
binary(/^tripwire_/)'`, also without `--workspace`) does not run either
`ainb-hangar-store` or `ainb-plugin-cts-v2` at all. Confirmed against the
last successful `Test (ubuntu-latest)` log on `main` (run 30493043307): the
only packages that executed any tests are `ainb` and `ainb-hangar-daemon`.
`ainb-hangar-store` and `ainb-plugin-cts-v2` appear in that log only as
`Compiling` lines, zero `PASS`/`FAIL` lines for either package.

Concretely, that is roughly 75 files that have never run in CI: every
`migration_00XX_upgrade.rs`, `migration_upgrade_full_chain.rs`, every
`repo_*.rs`, `schema_drift.rs`, `workspace_data_isolation.rs`,
`partial_unique.rs`, `axes.rs`, `real_plugin_axes.rs`, `wire_surface_gate.rs`,
and the rest of `ainb-hangar-store`/`ainb-plugin-cts-v2`'s test suites. A
"4287 tests run" summary reads as comprehensive while two whole packages
contribute zero. This is also how a prior PR merged all-green while
carrying the reproducible failure documented below: CI never actually ran
that test.

This PR does **not** fix the `Test` job. Widening its filter would surface
an unknown number of never-run failures across ~75 files, which needs its
own PR and its own triage, not to be smuggled into a CI-wiring change. This
`Contracts` job is, as of this PR, the first CI job that actually executes
`ainb-hangar-store` and `ainb-plugin-cts-v2` tests.

## KNOWN RED: this PR's `Contracts` job is expected to fail on the PR run

Running the job's exact command locally
(`cargo nextest run --workspace --all-features --no-fail-fast -E '<filter
above>'`):

```
Summary [ 72.378s] 54 tests run: 53 passed (1 slow), 1 failed, 0 skipped
```

```
ainb-plugin-cts-v2::axes a16_spawn_managed_subprocess_granted_and_reaped
panicked: managed child leaked after Runtime drop (pid N still alive)
```

- **Pre-existing on `origin/main` (0bbfd40c)**, not introduced by this PR.
  This PR touches only `.github/workflows/ci.yml` and `ainb-tui/CLAUDE.md`,
  zero crate files.
- Reproduces 3/3 in isolation, not a flake.
- Diagnosis (code-level, not a guess): `Runtime::drop`/`shutdown` in
  `crates/ainb-plugin-runtime/src/runtime.rs` call
  `managed_subprocess.kill_all()` (sends the kill signal) synchronously,
  then tear the tokio runtime down via `shutdown_background()`, which per
  its own doc comment "returns immediately and joins worker threads
  off-task". The actual `waitpid()` reap of the killed child runs on a
  tokio-owned future that can be abandoned mid-teardown, leaving a zombie
  that `kill -0` keeps reporting alive past the test's 3s deadline. Only
  tested on macOS locally, but the mechanism (SIGKILL sent, runtime torn
  down before the reap future runs) is POSIX-generic, so it is expected to
  reproduce on the `ubuntu-latest` runner too.
- This is a real bug in the leak-guard reap path in `ainb-plugin-runtime`,
  and Phase 4's mutation-tested contract catching it is the contract
  working as designed, not the test being wrong.
- Per the policy this PR adds: **not** rerun to green, **not** waived,
  **not** fixed here. It must be fixed at the source. That fix is being
  routed as its own separate piece of work, out of scope for this PR.

## YAML validation

```
$ for f in .github/workflows/*.yml; do python3 -c "import yaml,sys;yaml.safe_load(open('$f'))" && echo OK: $f; done
OK: .github/workflows/actionlint.yml
OK: .github/workflows/ci.yml
OK: .github/workflows/deploy-pages.yml
OK: .github/workflows/pages-build-check.yml
OK: .github/workflows/release.yml
OK: .github/workflows/toolkit-validation.yml
```

## Out of scope (explicitly, not an oversight)

- **Branch protection**: marking `contracts` as a required check is the
  repo owner's action per the plan (`[CHECKPOINT:human-action]` in Phase 5)
  and per this task's rails. Not attempted here.
- **Widening the `Test` job** to actually cover `ainb-hangar-store` /
  `ainb-plugin-cts-v2`: needs its own PR and triage of whatever else
  surfaces, not bundled into CI wiring.
- **Fixing `a16_spawn_managed_subprocess_granted_and_reaped`**: belongs to
  whoever owns `ainb-plugin-runtime`, routed separately, not this PR.

## Test plan

- [x] `cargo nextest list --workspace --all-features -E '<filter>'` selects
      exactly the 5 intended binaries (54 tests), nothing else
- [x] Ran the job's exact command locally, 53/54 pass, 1 pre-existing
      failure documented above and NOT hidden or rerun
- [x] All workflow YAML files parse
- [ ] CI's own `Contracts` job run on this PR (expected red, see above)
- [ ] Branch protection making `contracts` required, owner action, outstanding
