### PR TITLE
fix: harden Fleet provider event recovery

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
@@ -242,6 +242,13 @@ impl AttentionIngest {
             serde_json::from_str::<serde_json::Value>(raw).unwrap_or(serde_json::Value::Null);
         let raw_payload = match self.raw_payload(&line, &event_id, &payload) {
             Ok(payload) => payload,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!(error = %error, event_id, "fleet provider event sidecar missing; using envelope payload");
+                payload
+                    .get("payload")
+                    .map(serde_json::Value::to_string)
+                    .unwrap_or_else(|| payload.to_string())
+            }
             Err(error) => {
                 tracing::warn!(error = %error, "fleet provider event payload unavailable");
                 return LineOutcome::Retry;
@@ -264,7 +271,12 @@ impl AttentionIngest {
             &NewFleetProviderEvent {
                 event_id: event_id.clone(),
                 provider: provider.to_string(),
-                source: "claude_hook".to_string(),
+                source: match provider {
+                    "claude" => "claude_hook",
+                    "codex" => "codex_hook",
+                    _ => "hook",
+                }
+                .to_string(),
                 session_key,
                 provider_session_id: (!line.session_id.is_empty()).then(|| line.session_id.clone()),
                 observed_at: if line.ts > 0 { line.ts } else { now_ms },

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -22,8 +22,8 @@ use sqlx::SqlitePool;
 
 use crate::events::EventSink;
 use crate::fleet_provider::codex::{
-    parse_inbound_envelope, CodexApprovalKind, CodexCapabilities, CodexInbound,
-    CodexInboundEnvelope,
+    CodexApprovalKind, CodexCapabilities, CodexInbound, CodexInboundEnvelope,
+    parse_inbound_envelope,
 };
 
 /// Semantic hook observation before storage normalization.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -22,7 +22,8 @@ use sqlx::SqlitePool;
 
 use crate::events::EventSink;
 use crate::fleet_provider::codex::{
-    CodexApprovalKind, CodexCapabilities, CodexInbound, CodexInboundEnvelope,
+    parse_inbound_envelope, CodexApprovalKind, CodexCapabilities, CodexInbound,
+    CodexInboundEnvelope,
 };
 
 /// Semantic hook observation before storage normalization.
@@ -374,20 +375,72 @@ pub async fn ingest_codex_inbound(
         },
     )
     .await?;
-    apply_codex_child_work(pool, events, &envelope.raw, &event_id, observed_at).await?;
+    reduce_codex_source_event(pool, events, &event_id, envelope, capabilities, observed_at).await
+}
+
+async fn reduce_codex_source_event(
+    pool: &SqlitePool,
+    events: &EventSink,
+    event_id: &str,
+    envelope: CodexInboundEnvelope,
+    capabilities: &CodexCapabilities,
+    observed_at: i64,
+) -> Result<Option<ApplyFleetEventResult>, FleetProviderIngressError> {
+    apply_codex_child_work(pool, events, &envelope.raw, event_id, observed_at).await?;
     let result = apply_codex_inbound(
         pool,
         events,
-        event_id.clone(),
+        event_id.to_string(),
         envelope.inbound,
         capabilities,
         observed_at,
     )
     .await?;
     if let Some(reduced) = &result {
-        FleetProviderEventRepo::mark_projected(pool, &event_id, reduced.revision).await?;
+        FleetProviderEventRepo::mark_projected(pool, event_id, reduced.revision).await?;
     }
     Ok(result)
+}
+
+/// Replay Codex source envelopes that committed before their Fleet projection.
+/// Each source row keeps its original event ID and observation time, so replay
+/// is idempotent and cannot manufacture a newer state.
+pub async fn replay_unprojected_codex_events(
+    pool: &SqlitePool,
+    events: &EventSink,
+    capabilities: &CodexCapabilities,
+) -> Result<usize, FleetProviderIngressError> {
+    let rows = FleetProviderEventRepo::unprojected(pool, "codex", "codex_app_server", 1_000)
+        .await
+        .map_err(FleetProviderEventError::from)?;
+    let mut replayed = 0;
+    for row in rows {
+        let raw: Value = match serde_json::from_str(&row.raw_payload) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::warn!(event_id = %row.event_id, error = %error, "Codex source replay skipped invalid raw envelope");
+                continue;
+            }
+        };
+        let envelope = match parse_inbound_envelope(&raw) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                tracing::warn!(event_id = %row.event_id, error = %error, "Codex source replay skipped unsupported envelope");
+                continue;
+            }
+        };
+        reduce_codex_source_event(
+            pool,
+            events,
+            &row.event_id,
+            envelope,
+            capabilities,
+            row.observed_at,
+        )
+        .await?;
+        replayed += 1;
+    }
+    Ok(replayed)
 }
 
 async fn apply_codex_child_work(

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -335,7 +335,8 @@ pub fn spawn_service(
                 tracing::warn!(error = %error, "Codex Fleet recovery sweep failed");
             }
             if let Err(error) =
-                crate::fleet::replay_unprojected_codex_events(&pool, &events, handle.capabilities()).await
+                crate::fleet::replay_unprojected_codex_events(&pool, &events, handle.capabilities())
+                    .await
             {
                 tracing::warn!(error = %error, "Codex Fleet source replay failed");
             }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -334,6 +334,11 @@ pub fn spawn_service(
             {
                 tracing::warn!(error = %error, "Codex Fleet recovery sweep failed");
             }
+            if let Err(error) =
+                crate::fleet::replay_unprojected_codex_events(&pool, &events, handle.capabilities()).await
+            {
+                tracing::warn!(error = %error, "Codex Fleet source replay failed");
+            }
 
             let boot_id = epoch_millis();
             let mut sequence = 0_u64;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0073_fleet_workload_ordering.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0073_fleet_workload_ordering.sql
@@ -1,0 +1,28 @@
+-- Workload projections advance independently from lifecycle observations.
+-- A provider child-work update must not overwrite a newer lifecycle state.
+
+ALTER TABLE fleet_session
+    ADD COLUMN workload_updated_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE fleet_session
+    ADD COLUMN workload_authority TEXT NOT NULL DEFAULT 'inferred'
+        CHECK (workload_authority IN ('authoritative', 'inferred'));
+
+-- One source event can change multiple parent relationships. SQLite cannot drop
+-- the table-level UNIQUE constraint in place, so rebuild only this projection.
+CREATE TABLE fleet_work_item_next (
+    provider       TEXT NOT NULL CHECK (length(provider) > 0),
+    session_key    TEXT NOT NULL CHECK (length(session_key) > 0),
+    work_key       TEXT NOT NULL CHECK (length(work_key) > 0),
+    kind           TEXT NOT NULL CHECK (kind IN ('subagent', 'task', 'child_thread')),
+    state          TEXT NOT NULL CHECK (state IN ('ACTIVE', 'COMPLETE')),
+    started_at     INTEGER NOT NULL,
+    completed_at   INTEGER,
+    last_event_id  TEXT NOT NULL CHECK (length(last_event_id) > 0),
+    PRIMARY KEY (provider, session_key, work_key)
+);
+INSERT INTO fleet_work_item_next
+    SELECT provider, session_key, work_key, kind, state, started_at, completed_at, last_event_id
+    FROM fleet_work_item;
+DROP TABLE fleet_work_item;
+ALTER TABLE fleet_work_item_next RENAME TO fleet_work_item;
+CREATE INDEX idx_fleet_work_item_active ON fleet_work_item(session_key, state);

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -134,6 +134,10 @@ pub struct FleetSessionRow {
     pub lifecycle_state: String,
     /// Number of active provider child-work items.
     pub active_work_count: i64,
+    /// Workload group timestamp.
+    pub workload_updated_at: i64,
+    /// Workload group authority.
+    pub workload_authority: String,
     /// Attention state token.
     pub attention_state: String,
     /// Fingerprint of current structured request or approval.
@@ -766,7 +770,7 @@ const SESSION_SELECT_BY_KEY: &str = "SELECT session_key, provider, provider_sess
     confidence, discovered_at, last_observed_at, metadata_updated_at, \
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
-    transport_authority, active_work_count, version, updated_revision \
+    transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision \
     FROM fleet_session WHERE session_key = ?";
 
 const SESSION_SELECT_ALL: &str = "SELECT session_key, provider, provider_session_id, \
@@ -775,7 +779,7 @@ const SESSION_SELECT_ALL: &str = "SELECT session_key, provider, provider_session
     confidence, discovered_at, last_observed_at, metadata_updated_at, \
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
-    transport_authority, active_work_count, version, updated_revision \
+    transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision \
     FROM fleet_session WHERE visible = 1 ORDER BY session_key ASC";
 
 async fn session_by_key_tx(
@@ -816,6 +820,7 @@ fn new_session(event: &NewFleetEvent) -> FleetSessionRow {
         0
     };
     let transport_at = event.patch.transport_health.as_ref().map_or(0, |_| event.observed_at);
+    let workload_at = event.patch.active_work_count.map_or(0, |_| event.observed_at);
     FleetSessionRow {
         session_key: event.session_key.clone(),
         provider: event.patch.provider.clone().unwrap_or_else(|| "unknown".to_string()),
@@ -830,6 +835,12 @@ fn new_session(event: &NewFleetEvent) -> FleetSessionRow {
             .clone()
             .unwrap_or_else(|| "UNKNOWN".to_string()),
         active_work_count: event.patch.active_work_count.unwrap_or(0),
+        workload_updated_at: workload_at,
+        workload_authority: if workload_at == 0 {
+            "inferred".to_string()
+        } else {
+            authority.clone()
+        },
         attention_state: event.patch.attention_state.clone().unwrap_or_else(|| "NONE".to_string()),
         current_request_fingerprint: event.patch.current_request_fingerprint.clone().flatten(),
         management_state: event
@@ -905,7 +916,7 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
         changed = true;
     }
 
-    if event.patch.lifecycle_state.is_some() || event.patch.active_work_count.is_some() {
+    if event.patch.lifecycle_state.is_some() {
         if should_replace(
             authority,
             event.observed_at,
@@ -913,11 +924,22 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
             row.lifecycle_updated_at,
         ) {
             assign_if_some(&mut row.lifecycle_state, &event.patch.lifecycle_state);
-            if let Some(count) = event.patch.active_work_count {
-                row.active_work_count = count;
-            }
             row.lifecycle_updated_at = event.observed_at;
             row.lifecycle_authority.clone_from(&authority_token);
+            changed = true;
+        }
+    }
+
+    if let Some(count) = event.patch.active_work_count {
+        if should_replace(
+            authority,
+            event.observed_at,
+            &row.workload_authority,
+            row.workload_updated_at,
+        ) {
+            row.active_work_count = count;
+            row.workload_updated_at = event.observed_at;
+            row.workload_authority.clone_from(&authority_token);
             changed = true;
         }
     }
@@ -990,8 +1012,8 @@ async fn insert_session(
             confidence, discovered_at, last_observed_at, metadata_updated_at, \
             metadata_authority, lifecycle_updated_at, lifecycle_authority, \
             attention_updated_at, attention_authority, transport_updated_at, \
-            transport_authority, active_work_count, version, updated_revision) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     );
     bind_session(query, row).execute(&mut **tx).await?;
     Ok(())
@@ -1010,7 +1032,7 @@ async fn update_session(
             discovered_at = ?, last_observed_at = ?, metadata_updated_at = ?, \
             metadata_authority = ?, lifecycle_updated_at = ?, lifecycle_authority = ?, \
             attention_updated_at = ?, attention_authority = ?, transport_updated_at = ?, \
-            transport_authority = ?, active_work_count = ?, version = ?, updated_revision = ? \
+            transport_authority = ?, active_work_count = ?, workload_updated_at = ?, workload_authority = ?, version = ?, updated_revision = ? \
          WHERE session_key = ?",
     )
     .bind(&row.provider)
@@ -1038,6 +1060,8 @@ async fn update_session(
     .bind(row.transport_updated_at)
     .bind(&row.transport_authority)
     .bind(row.active_work_count)
+    .bind(row.workload_updated_at)
+    .bind(&row.workload_authority)
     .bind(row.version)
     .bind(row.updated_revision)
     .bind(&row.session_key)
@@ -1077,6 +1101,8 @@ fn bind_session<'q>(
         .bind(row.transport_updated_at)
         .bind(&row.transport_authority)
         .bind(row.active_work_count)
+        .bind(row.workload_updated_at)
+        .bind(&row.workload_authority)
         .bind(row.version)
         .bind(row.updated_revision)
 }
@@ -1109,6 +1135,8 @@ fn session_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetSessionRow, sq
         transport_updated_at: row.try_get("transport_updated_at")?,
         transport_authority: row.try_get("transport_authority")?,
         active_work_count: row.try_get("active_work_count")?,
+        workload_updated_at: row.try_get("workload_updated_at")?,
+        workload_authority: row.try_get("workload_authority")?,
         version: row.try_get("version")?,
         updated_revision: row.try_get("updated_revision")?,
     })

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -1282,6 +1282,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workload_update_does_not_replace_newer_lifecycle_state() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-running",
+                "codex:s-1",
+                200,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    lifecycle_state: Some("RUNNING".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+        let result = FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-workload",
+                "codex:s-1",
+                100,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    active_work_count: Some(1),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.session.lifecycle_state, "RUNNING");
+        assert_eq!(result.session.lifecycle_updated_at, 200);
+        assert_eq!(result.session.active_work_count, 1);
+        assert_eq!(result.session.workload_updated_at, 100);
+    }
+
+    #[tokio::test]
     async fn inferred_event_never_overwrites_authoritative_group() {
         let (_dir, store) = store().await;
         FleetRepo::apply_event(

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
@@ -64,6 +64,12 @@ pub enum FleetProviderEventError {
         /// Conflicting event identity.
         event_id: String,
     },
+    /// The requested source event is absent from the durable ledger.
+    #[error("provider event {event_id:?} was not found")]
+    EventNotFound {
+        /// Missing event identity.
+        event_id: String,
+    },
     /// SQLite failed.
     #[error(transparent)]
     Sql(#[from] sqlx::Error),
@@ -96,7 +102,9 @@ impl FleetProviderEventRepo {
         .await?;
         let row = Self::get(pool, &event.event_id)
             .await?
-            .expect("successful insert or conflict must leave provider event row");
+            .ok_or_else(|| FleetProviderEventError::EventNotFound {
+                event_id: event.event_id.clone(),
+            })?;
         if result.rows_affected() == 0 && !matches_event(&row, event, &digest) {
             return Err(FleetProviderEventError::EventIdCollision {
                 event_id: event.event_id.clone(),
@@ -121,6 +129,11 @@ impl FleetProviderEventRepo {
         .execute(pool)
         .await?;
         if result.rows_affected() == 0 {
+            if Self::get(pool, event_id).await?.is_none() {
+                return Err(FleetProviderEventError::EventNotFound {
+                    event_id: event_id.to_string(),
+                });
+            }
             return Err(FleetProviderEventError::EventIdCollision {
                 event_id: event_id.to_string(),
             });
@@ -142,6 +155,26 @@ impl FleetProviderEventRepo {
         .as_ref()
         .map(row_from)
         .transpose()
+    }
+
+    /// List source envelopes that still require projection, oldest receipt first.
+    pub async fn unprojected(
+        pool: &SqlitePool,
+        provider: &str,
+        source: &str,
+        limit: i64,
+    ) -> Result<Vec<FleetProviderEventRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT ingest_order, event_id, provider, source, session_key, provider_session_id, observed_at, received_at, event_type, raw_payload, raw_blake3, projection_revision \
+             FROM fleet_provider_event WHERE provider = ? AND source = ? AND projection_revision IS NULL \
+             ORDER BY ingest_order ASC LIMIT ?",
+        )
+        .bind(provider)
+        .bind(source)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(row_from).collect()
     }
 }
 
@@ -242,6 +275,16 @@ mod tests {
         assert!(matches!(
             FleetProviderEventRepo::append(store.pool(), &event("source-1", "second")).await,
             Err(FleetProviderEventError::EventIdCollision { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn unknown_projection_event_is_not_a_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        assert!(matches!(
+            FleetProviderEventRepo::mark_projected(store.pool(), "missing", 1).await,
+            Err(FleetProviderEventError::EventNotFound { .. })
         ));
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
@@ -100,11 +100,11 @@ impl FleetProviderEventRepo {
         .bind(&digest)
         .execute(pool)
         .await?;
-        let row = Self::get(pool, &event.event_id)
-            .await?
-            .ok_or_else(|| FleetProviderEventError::EventNotFound {
+        let row = Self::get(pool, &event.event_id).await?.ok_or_else(|| {
+            FleetProviderEventError::EventNotFound {
                 event_id: event.event_id.clone(),
-            })?;
+            }
+        })?;
         if result.rows_affected() == 0 && !matches_event(&row, event, &digest) {
             return Err(FleetProviderEventError::EventIdCollision {
                 event_id: event.event_id.clone(),

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_work.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_work.rs
@@ -27,6 +27,7 @@ pub struct FleetWorkRepo;
 impl FleetWorkRepo {
     /// Apply one transition and return parent active-work count.
     pub async fn apply(pool: &SqlitePool, update: &FleetWorkUpdate) -> Result<i64, sqlx::Error> {
+        let mut tx = pool.begin().await?;
         if update.active {
             sqlx::query(
                 "INSERT INTO fleet_work_item (provider, session_key, work_key, kind, state, started_at, last_event_id) VALUES (?, ?, ?, ?, 'ACTIVE', ?, ?) \
@@ -39,7 +40,7 @@ impl FleetWorkRepo {
             .bind(&update.kind)
             .bind(update.observed_at)
             .bind(&update.event_id)
-            .execute(pool)
+            .execute(&mut *tx)
             .await?;
         } else {
             sqlx::query(
@@ -52,15 +53,17 @@ impl FleetWorkRepo {
             .bind(&update.session_key)
             .bind(&update.work_key)
             .bind(&update.event_id)
-            .execute(pool)
+            .execute(&mut *tx)
             .await?;
         }
-        sqlx::query_scalar(
+        let count = sqlx::query_scalar(
             "SELECT COUNT(*) FROM fleet_work_item WHERE session_key = ? AND state = 'ACTIVE'",
         )
         .bind(&update.session_key)
-        .fetch_one(pool)
-        .await
+        .fetch_one(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(count)
     }
 
     /// Complete every active parent relationship for one provider child key.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -736,9 +736,7 @@ impl FleetPaneState {
     pub fn attention_count(&self) -> usize {
         self.roster
             .iter()
-            .filter(|session| {
-                session.is_active_session() && !session.attention_state.eq_ignore_ascii_case("NONE")
-            })
+            .filter(|session| session.is_actionable())
             .count()
     }
 
@@ -2911,6 +2909,7 @@ mod tests {
         state.set_sessions(vec![blocked]);
 
         assert_eq!(state.session_count(), 0);
+        assert_eq!(state.attention_count(), 1);
         let keys: Vec<_> =
             state.visible_sessions().iter().map(|row| row.session_key.as_str()).collect();
         assert_eq!(keys, ["lost-ask"]);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -2904,6 +2904,19 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_session_with_open_attention_stays_in_needs_input() {
+        let mut blocked = session("lost-ask", "codex", "IDLE", "ASK", "managed");
+        blocked.transport_health = "UNAVAILABLE".into();
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![blocked]);
+
+        assert_eq!(state.session_count(), 0);
+        let keys: Vec<_> =
+            state.visible_sessions().iter().map(|row| row.session_key.as_str()).collect();
+        assert_eq!(keys, ["lost-ask"]);
+    }
+
+    #[test]
     fn successful_action_advances_to_next_needs_input_row() {
         let state = state_with_roster();
         assert_eq!(state.selected_key(), Some("claude:ask"));

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -734,10 +734,7 @@ impl FleetPaneState {
 
     /// Sessions requiring operator review, independent from active lens.
     pub fn attention_count(&self) -> usize {
-        self.roster
-            .iter()
-            .filter(|session| session.is_actionable())
-            .count()
+        self.roster.iter().filter(|session| session.is_actionable()).count()
     }
 
     pub fn feedback(&self) -> Option<&str> {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -332,7 +332,7 @@ pub enum FleetFilter {
 
 impl FleetFilter {
     fn matches(self, row: &FleetSessionRow) -> bool {
-        if !row.is_active_session() {
+        if !row.is_active_session() && !row.is_actionable() {
             return false;
         }
         match self {


### PR DESCRIPTION
## Summary\n- make raw provider-ledger lookup failures explicit and recover missing hook sidecars from durable envelope data\n- order workload projection independently from lifecycle state and allow one source event to close multiple parent work items\n- replay unprojected Codex app-server envelopes after manager restart and retain actionable unavailable rows in Needs input\n\n## Verification\n- cargo test -p ainb-hangar-store --lib fleet_provider_event\n- cargo test -p ainb-hangar-store --lib fleet_work\n- cargo test -p ainb-hangar-daemon --lib fleet::tests\n- cargo test -p ainb-plugin-hangar --lib screen::fleet\n\nFollow-up tracked: agents-in-a-box-ebu defines raw-event retention policy without silently changing durable capture semantics.