### PR TITLE
ci: gate Fleet macOS daemon contract

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Fleet macOS consumes the Hangar daemon contract. Review these paths together.
+/apps/ainb-fleet-macos/ @stevengonsalvez
+/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs @stevengonsalvez
+/ainb-tui/crates/ainb-hangar-proto/src/methods.rs @stevengonsalvez
+/ainb-tui/crates/ainb-hangar-daemon/src/rpc/ @stevengonsalvez
+/ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs @stevengonsalvez
+/.github/workflows/fleet-macos-contract.yml @stevengonsalvez
+/docs/contracts/fleet-macos.md @stevengonsalvez

--- a/.github/workflows/fleet-macos-contract.yml
+++ b/.github/workflows/fleet-macos-contract.yml
@@ -1,0 +1,54 @@
+name: Fleet macOS contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/ainb-fleet-macos/**"
+      - "ainb-tui/crates/ainb-hangar-proto/**"
+      - "ainb-tui/crates/ainb-hangar-daemon/src/rpc/**"
+      - "ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs"
+      - "ainb-tui/crates/ainb-hangar-daemon/Cargo.toml"
+      - "ainb-tui/Cargo.lock"
+      - ".github/workflows/fleet-macos-contract.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/ainb-fleet-macos/**"
+      - "ainb-tui/crates/ainb-hangar-proto/**"
+      - "ainb-tui/crates/ainb-hangar-daemon/src/rpc/**"
+      - "ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs"
+      - "ainb-tui/crates/ainb-hangar-daemon/Cargo.toml"
+      - "ainb-tui/Cargo.lock"
+      - ".github/workflows/fleet-macos-contract.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fleet-macos-contract-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Fixture daemon and Fleet macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "ainb-tui -> target"
+      - name: Build Fleet fixture daemon
+        run: cargo build -p ainb-hangar-daemon --example fleet_fixture_daemon
+        working-directory: ainb-tui
+      - name: Run Fleet RPC contract tests
+        run: |
+          xcodebuild test \
+            -project apps/ainb-fleet-macos/AINBFleet.xcodeproj \
+            -scheme AINBFleet \
+            -destination 'platform=macOS' \
+            -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-contract" \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Build Release Fleet app
+        run: bash apps/ainb-fleet-macos/ci/check-release-diagnostics.sh "$RUNNER_TEMP/ainb-fleet-macos-release"

--- a/docs/contracts/fleet-macos.md
+++ b/docs/contracts/fleet-macos.md
@@ -1,3 +1,7 @@
+---
+title: "Fleet macOS daemon contract"
+---
+
 # Fleet macOS daemon contract
 
 Fleet macOS is a native JSON-RPC client of the Hangar daemon. It does not

--- a/docs/contracts/fleet-macos.md
+++ b/docs/contracts/fleet-macos.md
@@ -1,0 +1,37 @@
+# Fleet macOS daemon contract
+
+Fleet macOS is a native JSON-RPC client of the Hangar daemon. It does not
+depend on the TUI, CLI output, daemon database, or Rust internals.
+
+## Contract authority
+
+| Concern | Authority | Fleet macOS boundary |
+| --- | --- | --- |
+| Protocol version, capabilities, session wire types | `ainb-tui/crates/ainb-hangar-proto/src/fleet.rs` | `apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift` |
+| RPC method names and reset signal | `ainb-tui/crates/ainb-hangar-proto/src/methods.rs` | `apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift` |
+| Authentication and socket handlers | `ainb-tui/crates/ainb-hangar-daemon/src/rpc/` | `apps/ainb-fleet-macos/Sources/FleetRPC/HangarLocation.swift` and `FleetConnection.swift` |
+| Executable daemon fixture | `ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs` | `apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift` |
+
+## Change rules
+
+- Adding optional response fields is compatible until Fleet needs to display them.
+- Adding a capability or RPC method needs Fleet work only when Fleet uses it.
+- Adding a provider, lifecycle, replay-state, or other closed enum value needs
+  Fleet wire-model review before merge. Swift decoding rejects unknown values.
+- Renaming or removing required fields, changing action or revision semantics,
+  or changing daemon discovery/authentication needs Fleet implementation and
+  fixture-test updates.
+- TUI layout, keybindings, CLI formatting, and internal database migrations do
+  not require Fleet changes while the RPC contract remains identical.
+
+## Required validation
+
+Changes to a contract-authority path or `apps/ainb-fleet-macos/**` run the
+`Fleet macOS contract` GitHub Actions workflow. It:
+
+1. Builds `fleet_fixture_daemon` from current Rust sources.
+2. Runs the Fleet XCTest suite against that daemon fixture.
+3. Builds the Release app and verifies diagnostics without code signing.
+
+Protocol breaking changes must bump negotiated protocol compatibility and keep
+the Swift client read and write compatible before Fleet UI behavior changes.


### PR DESCRIPTION
## Summary
- build the real Hangar fixture daemon before Fleet XCTest
- run Fleet XCTest and Release diagnostics for app or daemon contract changes
- define shared ownership and a compact contract change checklist

## Validation
- `cargo build -p ainb-hangar-daemon --example fleet_fixture_daemon`
- `xcodebuild test -project apps/ainb-fleet-macos/AINBFleet.xcodeproj -scheme AINBFleet -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`\n- `bash apps/ainb-fleet-macos/ci/check-release-diagnostics.sh /tmp/ainb-fleet-macos-contract-release`\n- `actionlint -color -shellcheck= .github/workflows/fleet-macos-contract.yml`