### PR TITLE
fix(hangar-store): rebuild on migration file changes

### DIFF
--- a/ainb-tui/crates/ainb-hangar-store/build.rs
+++ b/ainb-tui/crates/ainb-hangar-store/build.rs
@@ -1,0 +1,24 @@
+//! Forces a rebuild whenever anything under `migrations/` changes.
+//!
+//! `sqlx::migrate!("./migrations")` (see `src/lib.rs`) embeds the migration
+//! set at COMPILE time, but on stable Rust the macro has no way to register
+//! that directory as a build dependency. Without this file, cargo has no
+//! signal that `migrations/` affects the crate, so adding, editing, or
+//! deleting a `.sql` file leaves the compiled binary caching the OLD
+//! migration set even though `cargo build` reports success.
+//!
+//! The failure this caused in practice: a migration was present on disk and
+//! already applied in the database, but the stale binary had never embedded
+//! it, so the daemon refused to boot with `migration N was previously
+//! applied but is missing in the resolved migrations` (an error that
+//! points at the database when the database is fine and the binary is
+//! stale). The only prior workaround was `cargo clean -p ainb-hangar-store`.
+//!
+//! `cargo:rerun-if-changed=<dir>` tracks file creation, edits, and deletion
+//! within that directory (verified empirically, not just per Cargo docs),
+//! so this one line is sufficient, no per-file entries needed. Do not
+//! delete this thinking it is a no-op: without it, migration changes are
+//! silently invisible to the build.
+fn main() {
+    println!("cargo:rerun-if-changed=migrations");
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -9,9 +9,13 @@
 //! Migrations live in `migrations/` and follow the frozen naming convention
 //! `NNNN_<terse_slug>.sql` (4-digit zero-padded ordinal, `snake_case` slug, no
 //! `_up`/`_down` suffix — `SQLite` migrations are forward-only here). They are
-//! embedded at compile time by [`sqlx::migrate!`], so a migration edit that is
-//! not picked up usually means a stale build cache — run
-//! `cargo clean -p ainb-hangar-store` and rebuild.
+//! embedded at compile time by [`sqlx::migrate!`], which on stable Rust
+//! cannot register `migrations/` as a build dependency on its own; `build.rs`
+//! emits `cargo:rerun-if-changed=migrations` so cargo rebuilds this crate
+//! whenever a `.sql` file is added, edited, or removed. If a migration edit
+//! is somehow still not picked up, that is a `build.rs` regression, not
+//! expected behavior (`cargo clean -p ainb-hangar-store` remains the escape
+//! hatch, but should not be needed).
 //!
 //! ## An applied migration file is IMMUTABLE — including its comments
 //!


### PR DESCRIPTION
## Summary

`sqlx::migrate!(\"./migrations\")` in `ainb-tui/crates/ainb-hangar-store/src/lib.rs:93` embeds the migration set at COMPILE time. On stable Rust the macro cannot register that directory as a build dependency, so cargo has no signal that `migrations/` affects the crate. Adding or editing a `.sql` file leaves cargo reusing a cached `ainb-hangar-store` build that embeds the OLD migration set, even though `cargo build`/`just dev` report success.

The consequence hit three times in one session: a migration was present on disk and already applied in the database with a matching description, but the stale binary had never embedded it, so the daemon refused to boot with:

```
Error: run hangar daemon (foreground)
Caused by: migration N was previously applied but is missing in the resolved migrations
```

That message blames the database. The database was fine; the binary was stale. The only prior workaround was `cargo clean -p ainb-hangar-store`.

## Fix

- Add `crates/ainb-hangar-store/build.rs` emitting `cargo:rerun-if-changed=migrations`, so cargo rebuilds the crate on any change under that directory.
- No `build = "build.rs"` key needed in `Cargo.toml`, cargo auto-detects `build.rs` at the package root; confirmed no existing build script was clobbered (there was none).
- Updated the related comment in `lib.rs` (previously described the `cargo clean` workaround) to describe the fix instead, keeping it consistent with `build.rs`'s own comment.

## Empirical proof

1. `cargo build -p ainb-hangar-store` (cold): builds normally, ~46s.
2. Immediate rebuild: no-op, confirms nothing spuriously recompiles.
   ```
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.71s
   ```
3. Added throwaway `migrations/9999_rerun_probe.sql` (`SELECT 1;`), rebuilt:
   ```
   Compiling ainb-hangar-store v0.1.0 (.../ainb-hangar-store)
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.26s
   ```
   Confirms addition triggers a rebuild.
4. Deleted the probe file, rebuilt again:
   ```
   Compiling ainb-hangar-store v0.1.0 (.../ainb-hangar-store)
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.19s
   ```
   Confirms deletion also triggers a rebuild (directory-level `rerun-if-changed` does track creation/deletion in this cargo version, verified empirically rather than assumed). Probe file confirmed removed and absent from `git status` before committing.
5. End-to-end: `cargo build -p ainb --bin ainb -p ainb-hangar-daemon`, then booted the daemon against an isolated `AINB_HANGAR_HOME` (never the live DB):
   ```
   hangar rpc listening socket=.../.hangar-home/hangar.sock
   ainb-hangar-daemon ready idle=true idle=true
   ```
   No migration error.

## Test plan

- [x] `cargo build -p ainb-hangar-store` cold build succeeds
- [x] Repeat build is a no-op
- [x] Adding a migration file triggers a rebuild of `ainb-hangar-store`
- [x] Deleting a migration file also triggers a rebuild
- [x] No throwaway migration file left in the tree or in `git status`
- [x] `cargo build -p ainb --bin ainb -p ainb-hangar-daemon` succeeds
- [x] Daemon boots cleanly against an isolated `AINB_HANGAR_HOME` with no migration error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured database migration updates are detected reliably when migration files are added, edited, or removed.
  * Prevented builds from using stale embedded migration data.

* **Documentation**
  * Updated migration guidance to explain how changes are detected and incorporated during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->