### PR TITLE
fix(plugin-runtime): waitpid killed managed children before runtime teardown

### DIFF
--- a/ainb-tui/crates/ainb-plugin-runtime/src/managed_subprocess.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/managed_subprocess.rs
@@ -31,6 +31,7 @@ use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use tokio::process::{Child as TokioChild, Command};
@@ -199,6 +200,10 @@ impl ManagedSubprocessRegistry {
     /// Kill every managed child regardless of owner. Called on
     /// [`crate::Runtime`] drop so no managed process outlives the host.
     /// Returns the number of children reaped.
+    ///
+    /// Blocks until each child has actually been `waitpid`-ed, so the
+    /// caller may tear the tokio runtime down immediately afterwards
+    /// without leaving zombies behind. See [`reap_child`].
     pub fn kill_all(&self) -> usize {
         let mut map = self.inner.lock();
         let n = map.len();
@@ -228,8 +233,9 @@ impl ManagedSubprocessRegistry {
 }
 
 /// Reap a single managed child: SIGTERM the whole process group (so any
-/// descendants the child forked die too), then `start_kill` the child
-/// itself as a backstop.
+/// descendants the child forked die too), `start_kill` the child itself
+/// as a backstop, then **block until the child has actually been
+/// `waitpid`-ed** (see [`reap_child`]).
 fn kill_child(c: &mut ManagedChild) {
     // `setpgid(0, 0)` in the leak guard makes the child a process-group
     // leader equal to its pid, so `kill(-pid, SIGTERM)` reaches every
@@ -238,6 +244,61 @@ fn kill_child(c: &mut ManagedChild) {
         let _ = signal_pgrp(c.pid.cast_signed(), SIGTERM);
     }
     let _ = c.child.start_kill();
+    reap_child(c);
+}
+
+/// Longest [`reap_child`] will block waiting for a signalled child to
+/// become reapable. A SIGKILL-ed child is normally reapable within a
+/// millisecond or two; the bound only exists so a pathological child
+/// (uninterruptible sleep in a syscall) can't wedge host shutdown.
+const REAP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Poll interval for the [`reap_child`] `waitpid` loop.
+const REAP_POLL: Duration = Duration::from_millis(2);
+
+/// Block until `c`'s child has been reaped, bounded by [`REAP_TIMEOUT`].
+///
+/// ## Why this has to be synchronous
+///
+/// `start_kill` only *delivers* SIGKILL; it does not `waitpid`. Tokio
+/// performs the actual reap on a SIGCHLD-driven future owned by the
+/// tokio runtime. Every caller of [`kill_child`] is a teardown path
+/// ([`ManagedSubprocessRegistry::kill_all`] from `Runtime::shutdown` /
+/// `Drop`, [`ManagedSubprocessRegistry::kill_plugin`] from plugin
+/// teardown), and `Runtime` tears the tokio runtime down with
+/// `shutdown_background()`, which by contract returns immediately. That
+/// abandons the reaping future, so the child dies but is never
+/// `waitpid`-ed: it becomes a **zombie**, and a zombie still answers
+/// `kill(pid, 0)`, i.e. every liveness probe (ours, the CTS suite's, an
+/// operator's `kill -0`) reports the "reaped" child as still alive for
+/// the remaining life of the host process.
+///
+/// Reaping here, before the caller returns, makes the kill observably
+/// complete. We own the [`TokioChild`] exclusively (it is never polled
+/// as a task), so `try_wait` is the authoritative `waitpid` for it and
+/// needs no reactor, so it is safe to call while the runtime is being
+/// torn down.
+/// It also cannot re-trip the "cannot drop a runtime in a context where
+/// blocking is not allowed" panic guarded at `runtime.rs`: this blocks
+/// on a `waitpid` syscall, it does not drop or `block_on` a runtime.
+fn reap_child(c: &mut ManagedChild) {
+    let deadline = Instant::now() + REAP_TIMEOUT;
+    loop {
+        match c.child.try_wait() {
+            // Reaped. `Err` means the pid is not ours to wait on any
+            // more (ECHILD): already reaped, equally done.
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) => {}
+        }
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                pid = c.pid,
+                "managed child still unreaped after {REAP_TIMEOUT:?}; leaving it to the OS"
+            );
+            return;
+        }
+        std::thread::sleep(REAP_POLL);
+    }
 }
 
 /// The delivery topic a managed child's stdout stream arrives under:
@@ -358,6 +419,34 @@ mod tests {
         std::env::remove_var("CTS_MANAGED_KEEP");
         std::env::remove_var("CTS_MANAGED_DROP");
         let _ = reg.kill_all();
+    }
+
+    /// Regression lock for the zombie leak: `kill_all` must complete the
+    /// `waitpid`, not merely deliver the signal. Deliberately NOT a
+    /// `#[tokio::test]`: the bug only shows once the tokio runtime that
+    /// owns the SIGCHLD reaper is gone, which is exactly what
+    /// `Runtime::shutdown` / `Drop` do via `shutdown_background()`.
+    /// Before the fix the child ended up `Z (defunct)`, and `kill(pid, 0)`
+    /// still reported it alive for the rest of the process's life.
+    #[test]
+    fn kill_all_reaps_before_tokio_runtime_teardown() {
+        let tokio_rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let reg = ManagedSubprocessRegistry::new();
+        let s = tokio_rt.block_on(async {
+            reg.spawn(pid_id("p"), "sleep", &["30".into()], &[], None).expect("spawn sleep")
+        });
+        assert!(process_alive(s.pid), "child not alive after spawn");
+
+        // Mirror `Runtime::shutdown` exactly: drain the registry, then
+        // hand the tokio runtime off to a non-blocking teardown.
+        assert_eq!(reg.kill_all(), 1);
+        tokio_rt.shutdown_background();
+
+        // No polling grace: `kill_all` returning is the guarantee.
+        assert!(
+            !process_alive(s.pid),
+            "managed child left unreaped (zombie) after kill_all + shutdown_background"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-runtime/src/managed_subprocess.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/managed_subprocess.rs
@@ -182,17 +182,29 @@ impl ManagedSubprocessRegistry {
     /// teardown (shutdown / crash / quarantine). Returns the number of
     /// children reaped.
     pub fn kill_plugin(&self, plugin: &PluginId) -> usize {
-        let mut map = self.inner.lock();
-        let to_kill: Vec<ManagedHandle> = map
-            .iter()
-            .filter(|(_, c)| &c.plugin == plugin)
-            .map(|(h, _)| h.clone())
-            .collect();
-        let n = to_kill.len();
-        for h in to_kill {
-            if let Some(mut c) = map.remove(&h) {
-                kill_child(&mut c);
+        // Remove the plugin's children under the lock, reap after
+        // releasing it: `kill_child` now blocks up to `REAP_TIMEOUT` per
+        // child, and holding the registry mutex across that would stall
+        // every other caller (`spawn`, `len`, `kill_all`, ...) during
+        // teardown.
+        let drained: Vec<ManagedChild> = {
+            let mut map = self.inner.lock();
+            let to_kill: Vec<ManagedHandle> = map
+                .iter()
+                .filter(|(_, c)| &c.plugin == plugin)
+                .map(|(h, _)| h.clone())
+                .collect();
+            let mut drained = Vec::with_capacity(to_kill.len());
+            for h in to_kill {
+                if let Some(c) = map.remove(&h) {
+                    drained.push(c);
+                }
             }
+            drained
+        };
+        let n = drained.len();
+        for mut c in drained {
+            kill_child(&mut c);
         }
         n
     }
@@ -205,9 +217,16 @@ impl ManagedSubprocessRegistry {
     /// caller may tear the tokio runtime down immediately afterwards
     /// without leaving zombies behind. See [`reap_child`].
     pub fn kill_all(&self) -> usize {
-        let mut map = self.inner.lock();
-        let n = map.len();
-        for (_, mut c) in map.drain() {
+        // Drain under the lock, reap after releasing it: `kill_child` now
+        // blocks up to `REAP_TIMEOUT` per child, and holding the registry
+        // mutex across that would stall every other caller during
+        // teardown.
+        let drained: Vec<ManagedChild> = {
+            let mut map = self.inner.lock();
+            map.drain().map(|(_, c)| c).collect()
+        };
+        let n = drained.len();
+        for mut c in drained {
             kill_child(&mut c);
         }
         n


### PR DESCRIPTION
## The bug

`ainb-plugin-cts-v2::axes a16_spawn_managed_subprocess_granted_and_reaped` fails on
both macOS and ubuntu-latest CI:

```
panicked at crates/ainb-plugin-cts-v2/tests/axes.rs:875:
  managed child leaked after Runtime drop (pid N still alive)
```

It has never run in CI before: `ainb-plugin-cts-v2` is not in `ainb-tui/Cargo.toml`'s
`default-members`, so every `cargo test` / `cargo nextest run` without `--workspace`
silently skips the whole package. This is a long-standing bug, not a new regression.

## Zombie, not still running

Direct evidence. A standalone reproduction (create a tokio runtime, spawn a managed
child through `ManagedSubprocessRegistry`, then `kill_all()` + `shutdown_background()`
exactly as `Runtime::shutdown` does) with `ps -o pid,stat,command` around it:

Before the fix:

```
--- ps after spawn:
  PID STAT COMMAND
34532 S    sleep 30

--- ps after kill_all + shutdown_background + 3s poll:
  PID STAT COMMAND
34532 Z    <defunct>

kill -0 says alive = true
```

After the fix:

```
--- ps after spawn:
  PID STAT COMMAND
42543 S    sleep 30

--- ps after kill_all + shutdown_background + 3s poll:
  PID STAT COMMAND
(empty, ps exits 1: no such process)

kill -0 says alive = false
```

`STAT = Z` / `<defunct>`. The child was **dead but unreaped**. The kill worked; the
`waitpid` never happened.

## Root cause

`ManagedSubprocessRegistry::kill_child` signalled and returned:

```rust
let _ = signal_pgrp(c.pid.cast_signed(), SIGTERM);
let _ = c.child.start_kill();
```

`start_kill` only *delivers* SIGKILL. The actual `waitpid` runs on a SIGCHLD-driven
future owned by the tokio runtime. `Runtime::shutdown` and `impl Drop for Runtime`
both call `TokioRuntime::shutdown_background()`, which by its own contract returns
immediately, abandoning that reaping future.

So the child died and was never waited on: it became a zombie. A zombie still answers
`kill(pid, 0)`, so every liveness probe (the CTS suite's `kill -0`, ours, an
operator's) reports the "reaped" child as alive for the remaining life of the host
process.

Why the existing unit tests missed it: `kill_all_drains_registry` is a
`#[tokio::test]`, so the tokio runtime is still alive while it polls and tokio's own
reaper collects the child. The bug only appears once that runtime is gone, which is
precisely what `Runtime::shutdown` / `Drop` do.

## The fix (in the runtime, not the test)

`crates/ainb-plugin-runtime/src/managed_subprocess.rs`: `kill_child` now finishes the
job by blocking on a bounded `try_wait` loop (`reap_child`) before returning.

- The registry owns the `tokio::process::Child` exclusively (it is never polled as a
  task), so `try_wait` is the authoritative `waitpid` for it and needs no reactor.
  Safe to call while the runtime is being torn down.
- Bounded at 2s with a 2ms poll so a pathological child cannot wedge host shutdown.
  A SIGKILL-ed child is reapable in a millisecond or two in practice.
- `Err` (ECHILD) is treated as done: already reaped.
- This does **not** reintroduce the "cannot drop a runtime in a context where blocking
  is not allowed" panic guarded at `runtime.rs:56`. That guard is about dropping or
  `block_on`-ing a tokio runtime inside an async context; this blocks on a `waitpid`
  syscall, which is a different thing entirely. The `shutdown_background()` calls are
  untouched.

The test was not changed. It asserts a real guarantee (dropping the `Runtime` must not
leak managed children) and that guarantee is correct; the production code was simply
not honouring it. Fixing the test would have deleted the guarantee instead of
delivering it.

Also added `kill_all_reaps_before_tokio_runtime_teardown` in the runtime crate, a
deliberately non-`#[tokio::test]` regression lock that shuts the tokio runtime down
the same way `Runtime` does and asserts liveness with no polling grace, so the
guarantee is covered at crate level and not only in the (non-default-member) CTS
package.

## Verification

- Baseline on unmodified `origin/main`: `42 tests run: 41 passed, 1 failed`
  (`a16_spawn_managed_subprocess_granted_and_reaped`).
- `cargo nextest run --workspace -E 'package(ainb-plugin-cts-v2)'` green, run three
  times consecutively (the bug is timing-sensitive; one green run proves little).
- Full contract set as CI runs it:
  `cargo nextest run --workspace --all-features --no-fail-fast -E 'binary(argv_golden_matrix) + binary(migration_upgrade_full_chain) + package(ainb-plugin-cts-v2)'`
  green.
- No regression: `cargo nextest run --workspace -p ainb-plugin-runtime` green, and the
  default-members subset CI runs today,
  `cargo nextest run --lib --tests --all-features -E 'not binary(/^tripwire_/)'`, green.
- `cargo fmt --check` clean. `cargo clippy -p ainb-plugin-runtime -- -D warnings`
  reports zero findings in `ainb-plugin-runtime`; the errors it surfaces are all
  pre-existing ones in `ainb-hangar-core` and `ainb-plugin-protocol`, neither of which
  this PR touches.

## Why now

This unblocks the `Contracts` job on #538, which is the first thing to actually run
this package in CI.
