### PR TITLE
fix(plugin-runtime): avoid blocking plugin reaper

### DIFF
--- a/ainb-tui/crates/ainb-plugin-runtime/src/managed_subprocess.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/managed_subprocess.rs
@@ -181,7 +181,7 @@ impl ManagedSubprocessRegistry {
     /// Kill every managed child owned by `plugin`. Called on plugin
     /// teardown (shutdown / crash / quarantine). Returns the number of
     /// children reaped.
-    pub fn kill_plugin(&self, plugin: &PluginId) -> usize {
+    pub async fn kill_plugin(&self, plugin: &PluginId) -> usize {
         // Remove the plugin's children under the lock, reap after
         // releasing it: `kill_child` now blocks up to `REAP_TIMEOUT` per
         // child, and holding the registry mutex across that would stall
@@ -203,8 +203,17 @@ impl ManagedSubprocessRegistry {
             drained
         };
         let n = drained.len();
-        for mut c in drained {
-            kill_child(&mut c);
+        if n == 0 {
+            return 0;
+        }
+        let result = tokio::task::spawn_blocking(move || {
+            for mut c in drained {
+                kill_child(&mut c);
+            }
+        })
+        .await;
+        if let Err(error) = result {
+            tracing::error!(?error, "managed child reaper task failed");
         }
         n
     }
@@ -384,7 +393,7 @@ mod tests {
         let reg = ManagedSubprocessRegistry::new();
         let a = reg.spawn(pid_id("p1"), "sleep", &["30".into()], &[], None).unwrap();
         let _b = reg.spawn(pid_id("p2"), "sleep", &["30".into()], &[], None).unwrap();
-        assert_eq!(reg.kill_plugin(&pid_id("p1")), 1);
+        assert_eq!(reg.kill_plugin(&pid_id("p1")).await, 1);
         assert_eq!(reg.len(), 1, "p2's child must survive");
         // p1's child must actually die within ~2s.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -1375,7 +1375,7 @@ impl PluginTask {
         // host-supervised process outlives its requester.
         self.snapshots.unsubscribe_all(&self.plugin.id);
         self.event_streams.drop_plugin(&self.plugin.id);
-        self.managed_subprocess.kill_plugin(&self.plugin.id);
+        self.managed_subprocess.kill_plugin(&self.plugin.id).await;
         self.unix_sockets.drop_plugin(&self.plugin.id);
         self.record_failure();
         if self.is_quarantine_due() {
@@ -1495,7 +1495,7 @@ impl PluginTask {
         self.event_streams.drop_plugin(&self.plugin.id);
         // Reap every managed child this plugin requested — the plugin
         // that owns their lifecycle is gone.
-        self.managed_subprocess.kill_plugin(&self.plugin.id);
+        self.managed_subprocess.kill_plugin(&self.plugin.id).await;
         // Drop every dialled socket the plugin held — the process is gone,
         // so further `socket:<id>` frames would leak to a dead subscription.
         self.unix_sockets.drop_plugin(&self.plugin.id);


### PR DESCRIPTION
## Summary
- offload per-plugin managed-child reaping to Tokio blocking workers
- await reaping during plugin teardown without blocking plugin task workers
- keep runtime-wide shutdown reaping synchronous

## Validation
- cargo fmt --check
- cargo test -p ainb-plugin-runtime managed_subprocess --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin shutdown handling to ensure managed child processes are fully terminated before teardown completes.
  * Prevented unnecessary shutdown work when no matching child processes are present.
  * Improved error reporting when process cleanup cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->