### PR TITLE
ci: run the whole workspace, and fix the plugin init/render race it caught

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,15 @@ jobs:
       # `+01:00` wall clock for a range anchored at LOCAL midnight. They now
       # drive a stub on a controlled `$PATH` and derive their boundaries from
       # the host's own zone, so nothing needs muting.
-      - run: "cargo nextest run --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'"
+      #
+      # `--workspace` is load-bearing. Without it nextest honours the
+      # `default-members` in ainb-tui/Cargo.toml (ainb-core and
+      # ainb-hangar-daemon), so this job tested 2 of 29 crates and silently
+      # skipped 27, roughly 160 test files. Everything in ainb-hangar-store
+      # (the database layer, 74 files) and ainb-plugin-hangar (46) had never
+      # run here. `--lib --tests` widened WHICH targets are built; this
+      # widens WHICH crates they are built from.
+      - run: "cargo nextest run --workspace --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'"
         working-directory: ${{ env.WORKING_DIR }}
 
   # ────────────────────────────────────────────────────────────────────────────
@@ -127,18 +135,17 @@ jobs:
   # intentional.
   #
   # DELIBERATE: `migration_upgrade_full_chain` and the `ainb-plugin-cts-v2`
-  # binaries also need `--workspace`, since this repo's `default-members`
-  # (see ainb-tui/Cargo.toml) covers only ainb-core and ainb-hangar-daemon.
-  # `ainb-hangar-store` and `ainb-plugin-cts-v2` are outside it, so `Test`'s
-  # workspace-default `cargo nextest run` does not exercise them today.
-  # `argv_golden_matrix` (ainb-hangar-daemon) IS inside default-members and
-  # genuinely double-runs in `Test`; that overlap is intentional (see below),
-  # not redundant with this job as a whole.
+  # binaries need `--workspace`, since this repo's `default-members` (see
+  # ainb-tui/Cargo.toml) covers only ainb-core and ainb-hangar-daemon and
+  # both live outside it. `Test` now passes `--workspace` too, so all three
+  # of these binaries double-run: once here, once there.
   #
-  # DELIBERATE: no exclusion is added to `Test`'s `-E` filter for the overlap
-  # that does exist. The duplicate run costs a few seconds; a filter typo
-  # silently dropping coverage is the exact failure class this effort exists
-  # to prevent.
+  # DELIBERATE: that overlap is kept, and no exclusion is added to `Test`'s
+  # `-E` filter to remove it. This job exists for the SIGNAL: a contract
+  # failure gets its own red check and its own no-rerun policy instead of
+  # being one line among thousands. Running the same binary twice costs
+  # seconds; a filter typo silently dropping coverage is the exact failure
+  # class this effort exists to prevent.
   # ────────────────────────────────────────────────────────────────────────────
   contracts:
     name: Contracts

--- a/ainb-tui/crates/ainb-plugin-abtop/src/main.rs
+++ b/ainb-tui/crates/ainb-plugin-abtop/src/main.rs
@@ -22,6 +22,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .compact()
         .init();
 
-    Server::new(AbtopPlugin::default()).run_stdio().await?;
+    // Detect BEFORE the stdio server reads its first frame: the host does
+    // not wait for `plugin/init` to be answered before it sends
+    // `plugin/render`, so a plugin that resolves its lifecycle in
+    // `on_init` can be asked to paint while it is still Unknown. See
+    // `AbtopPlugin::detected`.
+    Server::new(AbtopPlugin::detected().await).run_stdio().await?;
     Ok(())
 }

--- a/ainb-tui/crates/ainb-plugin-abtop/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-abtop/src/plugin.rs
@@ -53,16 +53,10 @@ impl Plugin for AbtopPlugin {
     }
 
     async fn on_init(&mut self, _host: &HostClient, _ctx: InitContext<'_>) -> Result<()> {
-        let result = detect_abtop().await;
-        match &result {
-            crate::detect::DetectResult::Ready { path } => {
-                self.abtop_path = Some(path.clone());
-            }
-            crate::detect::DetectResult::Missing(_) => {
-                self.abtop_path = None;
-            }
-        }
-        self.lifecycle = Lifecycle::from_detect(result);
+        // Idempotent. The binary already detected in `AbtopPlugin::detected`
+        // before the stdio server started, so this normally re-affirms the
+        // same answer; it matters only for a plugin built via `Default`.
+        self.refresh_detect().await;
         Ok(())
     }
 
@@ -102,16 +96,7 @@ impl Plugin for AbtopPlugin {
         // actually transitions to Ready when abtop appears on PATH.
         let r_pressed = matches!(params.key.code, KeyCode::Char { ch: 'r' });
         if r_pressed && !was_ready && matches!(self.lifecycle, Lifecycle::Unknown) {
-            let result = detect_abtop().await;
-            match &result {
-                crate::detect::DetectResult::Ready { path } => {
-                    self.abtop_path = Some(path.clone());
-                }
-                crate::detect::DetectResult::Missing(_) => {
-                    self.abtop_path = None;
-                }
-            }
-            self.lifecycle = Lifecycle::from_detect(result);
+            self.refresh_detect().await;
         }
 
         Ok(())
@@ -135,6 +120,43 @@ impl Plugin for AbtopPlugin {
 }
 
 impl AbtopPlugin {
+    /// Build a plugin that has ALREADY resolved whether abtop is on
+    /// PATH, so [`Lifecycle::Unknown`] never reaches the wire.
+    ///
+    /// The host does not wait for `plugin/init` to be answered before it
+    /// sends `plugin/render` (`ainb-plugin-runtime`'s `send_init` writes
+    /// the request and returns; `spawn_and_init` marks the plugin Running
+    /// immediately), and the SDK serves `plugin/init` and `plugin/render`
+    /// on independent tasks. A render can therefore be answered before
+    /// `on_init` has run. Every other plugin needs that window because its
+    /// startup work is genuinely slow (a subprocess exec, a socket dial)
+    /// and the transient IS the wanted UI. abtop's is a single `which`
+    /// lookup with no blocking call in it, so paying for a "checking
+    /// abtop…" flash buys nothing: resolve it here, before the stdio
+    /// server reads its first frame, and the screen is correct from frame
+    /// zero.
+    pub async fn detected() -> Self {
+        let mut plugin = Self::default();
+        plugin.refresh_detect().await;
+        plugin
+    }
+
+    /// Run detection and apply it to lifecycle + the cached binary path.
+    /// The single place that maps a [`crate::detect::DetectResult`] onto
+    /// state, shared by construction, `on_init`, and the `r` re-detect.
+    async fn refresh_detect(&mut self) {
+        let result = detect_abtop().await;
+        match &result {
+            crate::detect::DetectResult::Ready { path } => {
+                self.abtop_path = Some(path.clone());
+            }
+            crate::detect::DetectResult::Missing(_) => {
+                self.abtop_path = None;
+            }
+        }
+        self.lifecycle = Lifecycle::from_detect(result);
+    }
+
     /// Host-free body of [`Plugin::cli_dispatch`]. Public (doc-hidden)
     /// so integration tests can exercise the full `ainb abtop` surface
     /// against a stub binary without constructing a [`HostClient`].
@@ -355,6 +377,21 @@ mod tests {
         assert_eq!(p.lifecycle, Lifecycle::Unknown);
         let buf = render_test(&mut p, vp(40, 6));
         assert!(buffer_contains(&buf, "checking abtop"));
+    }
+
+    /// The invariant that keeps abtop's frames deterministic: the binary
+    /// hands `Server` an already-detected plugin, so the host can never be
+    /// answered with the `Unknown` placeholder no matter how the init and
+    /// render tasks interleave. Holds whether or not abtop is installed on
+    /// the machine running the test.
+    #[tokio::test]
+    async fn detected_plugin_is_never_unknown() {
+        let p = AbtopPlugin::detected().await;
+        assert_ne!(
+            p.lifecycle_for_test(),
+            &Lifecycle::Unknown,
+            "detected() must resolve lifecycle before the server loop starts"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-abtop/tests/stdio_smoke.rs
+++ b/ainb-tui/crates/ainb-plugin-abtop/tests/stdio_smoke.rs
@@ -62,6 +62,95 @@ fn read_frame<R: BufRead>(r: &mut R) -> Option<Value> {
     }
 }
 
+/// Flatten a `WireBuffer`'s cells into the text it paints.
+fn buffer_text(buffer: &Value) -> String {
+    buffer["cells"]
+        .as_array()
+        .expect("cells array")
+        .iter()
+        .filter_map(|pair| pair.get(1))
+        .filter_map(|cell| cell.get("symbol"))
+        .filter_map(Value::as_str)
+        .collect()
+}
+
+/// The host does NOT wait for `plugin/init` to be answered before it asks
+/// for a frame: `ainb-plugin-runtime`'s `send_init` writes the init request
+/// and returns, `spawn_and_init` marks the plugin Running straight after,
+/// and the SDK serves `plugin/init` and `plugin/render` on independent
+/// tasks, so which one takes the plugin mutex first is a scheduler race.
+///
+/// abtop must therefore be correct from its FIRST frame: it resolves
+/// detection in `AbtopPlugin::detected` before the stdio server reads
+/// anything, so `Lifecycle::Unknown` (the "checking abtop…" placeholder)
+/// can never reach the wire.
+///
+/// Regression: while detection lived only in `on_init`, a render that won
+/// the race painted the placeholder. Two such frames in a row read as a
+/// settled screen to CTS v2's A05 determinism axis, which then failed on
+/// the next (real) frame: a load-sensitive flake rather than an honest
+/// signal.
+#[test]
+fn render_racing_init_never_paints_the_pre_init_placeholder() {
+    // The window is a scheduler race, so a single round trip proves little.
+    for attempt in 0..5 {
+        let mut child = Command::new(binary_path())
+            .env("RUST_LOG", "off")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn abtop plugin");
+
+        let mut stdin = child.stdin.take().expect("stdin handle");
+        let mut stdout = BufReader::new(child.stdout.take().expect("stdout handle"));
+
+        // Back to back, exactly like the runtime: no wait for the init reply.
+        write_frame(
+            &mut stdin,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "plugin/init",
+                "params": {
+                    "manifest_path": "/tmp/abtop/manifest.toml",
+                    "granted_capabilities": ["spawn_subprocess"],
+                    "abi_version": 2
+                }
+            }),
+        );
+        write_frame(
+            &mut stdin,
+            &json!({
+                "jsonrpc": "2.0", "id": 2, "method": "plugin/render",
+                "params": {
+                    "viewport": { "width": 60_u16, "height": 12_u16 },
+                    "generation": 0_u64
+                }
+            }),
+        );
+
+        // Independent tasks answer these, so replies may arrive in either
+        // order. Take them by id.
+        let mut render: Option<Value> = None;
+        for _ in 0..2 {
+            let resp = read_frame(&mut stdout).expect("a response");
+            if resp["id"] == 2 {
+                render = Some(resp);
+            }
+        }
+        let resp = render.expect("render response");
+        let buffer = resp["result"].get("buffer").expect("render buffer");
+        let text = buffer_text(buffer);
+        assert!(
+            !text.contains("checking abtop"),
+            "attempt {attempt}: first frame painted the pre-init placeholder \
+             ({text:?}); detection must be resolved before the server loop"
+        );
+
+        drop(stdin);
+        let _ = child.wait();
+    }
+}
+
 #[test]
 fn init_render_cli_dispatch_shutdown_round_trip() {
     let mut child = Command::new(binary_path())

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -3459,6 +3459,7 @@ pub fn format_tokens_commas(n: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDateTime;
     use std::fs;
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -3467,6 +3468,24 @@ mod tests {
     // same process don't read each other's env. Defined here rather
     // than via lazy_static so the lock has no init-order surprises.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Stamp a wall clock with the host's own UTC offset.
+    ///
+    /// Period bounds anchor at LOCAL midnight (`start_of_day` /
+    /// `end_of_day`) and daily buckets key off the local calendar date, so
+    /// any fixture that means "this instant is on day D" has to be written
+    /// in the host's zone. A hardcoded offset (`+01:00`, `Z`) silently
+    /// means a different calendar day on a machine at a different offset,
+    /// which is how these tests passed at +01:00 and failed at UTC.
+    fn local_rfc3339(naive: NaiveDateTime) -> String {
+        Local
+            .from_local_datetime(&naive)
+            .single()
+            // Same DST fallback the production boundary helpers use for a
+            // wall clock a transition skips or repeats.
+            .unwrap_or_else(|| Local.from_utc_datetime(&naive))
+            .to_rfc3339()
+    }
 
     #[test]
     fn last_day_of_month_handles_leap_years() {
@@ -3745,14 +3764,23 @@ mod tests {
         let temp = tempdir().unwrap();
         let claude_projects = temp.path().join(".claude/projects");
         let project_dir = claude_projects.join("proj");
-        write_file(
-            &project_dir.join("session.jsonl"),
-            r#"{"type":"user","timestamp":"2026-04-09T23:59:00Z","sessionId":"s1","message":{"role":"user","content":"late ask"}}
-{"type":"assistant","timestamp":"2026-04-10T00:00:05Z","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":2}}}
-"#,
-        );
 
         let day = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        // The user ask lands the day before, its assistant reply just after
+        // local midnight, so the pair only counts if the filter keys off
+        // the assistant timestamp. The literal `Z` this used to hardcode
+        // put the reply on the previous local day at any negative offset.
+        let ask = local_rfc3339(day.pred_opt().unwrap().and_hms_opt(23, 59, 0).unwrap());
+        let reply = local_rfc3339(day.and_hms_opt(0, 0, 5).unwrap());
+        write_file(
+            &project_dir.join("session.jsonl"),
+            &format!(
+                r#"{{"type":"user","timestamp":"{ask}","sessionId":"s1","message":{{"role":"user","content":"late ask"}}}}
+{{"type":"assistant","timestamp":"{reply}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":1,"output_tokens":2}}}}}}
+"#
+            ),
+        );
+
         let data = parse_usage_for_with_roots(
             UsageQuery {
                 provider_filter: UsageProviderFilter::Claude,
@@ -3773,14 +3801,23 @@ mod tests {
         let temp = tempdir().unwrap();
         let claude_projects = temp.path().join(".claude/projects");
         let project_dir = claude_projects.join("proj");
-        write_file(
-            &project_dir.join("session.jsonl"),
-            r#"{"type":"assistant","timestamp":"2026-04-10T23:59:59+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":1,"output_tokens":1}}}
-{"type":"assistant","timestamp":"2026-04-11T00:00:00+01:00","sessionId":"s1","message":{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":10,"output_tokens":10}}}
-"#,
-        );
 
         let day = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        // Two events either side of the local midnight that ends `day`:
+        // the first is the last instant the range covers, the second the
+        // first instant past it.
+        let inside = local_rfc3339(day.and_hms_opt(23, 59, 59).unwrap());
+        let outside = local_rfc3339(day.succ_opt().unwrap().and_hms_opt(0, 0, 0).unwrap());
+
+        write_file(
+            &project_dir.join("session.jsonl"),
+            &format!(
+                r#"{{"type":"assistant","timestamp":"{inside}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":1,"output_tokens":1}}}}}}
+{{"type":"assistant","timestamp":"{outside}","sessionId":"s1","message":{{"role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{{"input_tokens":10,"output_tokens":10}}}}}}
+"#
+            ),
+        );
+
         let data = parse_usage_for_with_roots(
             UsageQuery {
                 provider_filter: UsageProviderFilter::Claude,
@@ -4277,7 +4314,16 @@ mod tests {
         // so the override is unambiguously responsible for the answer.
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let prev = std::env::var("AINB_NOW").ok();
-        std::env::set_var("AINB_NOW", "2026-05-11T00:00:00Z");
+        // AINB_NOW names an INSTANT, which `local_now` reads in the host's
+        // zone; the anchor asserted below is a local calendar date. Pin the
+        // instant by local midday so it names 2026-05-11 at every offset.
+        // The literal `2026-05-11T00:00:00Z` this used to hardcode anchored
+        // on 2026-05-10 anywhere west of Greenwich.
+        let anchor = NaiveDate::from_ymd_opt(2026, 5, 11).unwrap();
+        std::env::set_var(
+            "AINB_NOW",
+            local_rfc3339(anchor.and_hms_opt(12, 0, 0).unwrap()),
+        );
 
         let (today_start, today_end) =
             date_range_for_period(&UsagePeriod::Today).expect("today range");

--- a/ainb-tui/crates/ainb-plugin-cts-v2/tests/real_plugin_axes.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/tests/real_plugin_axes.rs
@@ -519,13 +519,24 @@ fn axis_unknown_method(subject: &Subject) -> Outcome {
 /// demands five identical buffers. A real plugin legitimately transitions
 /// while it comes up (`checking witr…` becomes the detection result, hangar
 /// connects to its daemon), so demanding determinism from frame 0 measures
-/// startup, not conformance. This axis instead renders until two consecutive
-/// frames agree (the settle point), then requires the next
-/// [`STEADY_FRAMES`] to be byte-identical. A plugin that paints a clock or a
-/// spinner never settles and fails, which is the finding the axis exists for:
-/// the host treats an unchanged buffer as a no-op frame.
-const SETTLE_BUDGET: usize = 20;
-const STEADY_FRAMES: usize = 3;
+/// startup, not conformance. This axis instead asks for a run of
+/// [`STEADY_RUN`] consecutive byte-identical frames somewhere inside
+/// [`SETTLE_BUDGET`] frames. A plugin that paints a clock or a spinner never
+/// produces that run and fails, which is the finding the axis exists for: the
+/// host treats an unchanged buffer as a no-op frame.
+///
+/// The run is deliberately NOT anchored to the first pair of agreeing frames.
+/// The host does not wait for `plugin/init` to be answered before it asks for
+/// a frame, so a startup transient can be painted for several frames running
+/// and two identical transients are not a steady state. Anchoring on the
+/// first agreement read that as "settled", then failed on the next frame when
+/// the real screen finally arrived. That made the axis load-sensitive: it
+/// passed on an idle machine and failed under a saturated one, for plugins
+/// that were behaving correctly. Requiring a longer unanchored run is a
+/// strictly stronger stability demand ([`STEADY_RUN`] identical frames versus
+/// the five the anchored form asked for) without the false signal.
+const SETTLE_BUDGET: usize = 24;
+const STEADY_RUN: usize = 6;
 
 fn axis_render_determinism(subject: &Subject) -> Outcome {
     outcome(|| {
@@ -540,33 +551,33 @@ fn axis_render_determinism(subject: &Subject) -> Outcome {
             }
         };
 
-        let mut previous = frame(0)?;
-        let mut settled_at = None;
-        for n in 1..SETTLE_BUDGET {
+        let mut previous: Option<Vec<u8>> = None;
+        let mut run = 0_usize;
+        let mut longest_run = 0_usize;
+        let mut transitions = 0_usize;
+        for n in 0..SETTLE_BUDGET {
             let current = frame(n)?;
-            if current == previous {
-                settled_at = Some(n);
-                break;
+            if previous.as_ref() == Some(&current) {
+                run += 1;
+            } else {
+                if previous.is_some() {
+                    transitions += 1;
+                }
+                run = 1;
             }
-            previous = current;
+            longest_run = longest_run.max(run);
+            if run >= STEADY_RUN {
+                return Ok(());
+            }
+            previous = Some(current);
         }
-        let Some(settled_at) = settled_at else {
-            return fail(format!(
-                "no two consecutive renders agreed within {SETTLE_BUDGET} frames; \
-                 the plugin never reaches a steady state"
-            ));
-        };
 
-        for n in 0..STEADY_FRAMES {
-            let current = frame(settled_at + 1 + n)?;
-            if current != previous {
-                return fail(format!(
-                    "settled at frame {settled_at}, then frame {} differed byte-for-byte",
-                    settled_at + 1 + n
-                ));
-            }
-        }
-        Ok(())
+        fail(format!(
+            "never produced {STEADY_RUN} consecutive byte-identical frames within \
+             {SETTLE_BUDGET} renders of an unchanged viewport (longest identical run was \
+             {longest_run}, across {transitions} buffer changes); the plugin does not \
+             reach a steady state"
+        ))
     })
 }
 


### PR DESCRIPTION
Two changes: a real plugin-protocol bug found by the CTS determinism axis, and the CI widening that made it findable.

## 1. abtop rendered before it had resolved its own state

The host does not wait for `plugin/init` to be answered before sending `plugin/render` (`ainb-plugin-runtime`'s `send_init` writes the request and returns; `spawn_and_init` marks the plugin Running immediately), and the SDK read loop serves `plugin/init` and `plugin/render` on independent tokio tasks (`ainb-plugin-sdk-rust/src/server.rs`, the non-key/mouse/event arm). Which of the two takes the plugin mutex first is a scheduler race, so a render can be answered before `on_init` has run.

abtop resolved its lifecycle in `on_init`, so a render that won that race painted the `Lifecycle::Unknown` placeholder, "checking abtop...".

**Mechanism confirmed, not inferred.** Delaying only the spawned `plugin/init` dispatch task by 2ms (a throwaway patch, reverted) reproduces the reported failure verbatim:

```
frame 0: "checking abtop..."
frame 1: "checking abtop..."
frame 2: "abtop is installed  open it from the menu (press t) ..."
-> settled at frame 1, then frame 2 differed byte-for-byte
```

That is the exact string the A05 axis reported. abtop's render is a pure function of `Lifecycle`: it is one of three fully static screens, and `abtop --once` is exec'd only in `cli_dispatch`, never in `render`. No live system state can reach a frame, so this was a real bug and not a case for a waiver.

Fix: resolve detection in `AbtopPlugin::detected` before `Server::run_stdio`, so `Unknown` can never reach the wire. Detection is a single `which` lookup with no blocking call in it, so the placeholder was buying nothing. `on_init` stays idempotent for a plugin built via `Default`, and the three open-coded copies of the detect-to-state mapping collapse into one `refresh_detect`.

**This hazard is not abtop-specific.** Any plugin resolving state in `on_init` can be rendered before that resolution lands. For witr, hangar and session-reader the transient is legitimate and wanted (a subprocess exec, a socket dial), so they are deliberately left alone; abtop's was gratuitous.

## 2. A05 mis-measured a repeated transient as a settled state

The axis declared a plugin "settled" at the first pair of agreeing frames, then demanded the next 3 match. A startup transient painted twice in a row satisfies that test and then fails on the next frame when the real screen arrives. That is what made this a latent flake rather than an honest signal: it passed on an idle machine and failed on a saturated one, for plugins that were behaving correctly.

It now asks for 6 consecutive byte-identical frames anywhere within a 24-frame budget. That is strictly more stability than the old rule demanded (which bottomed out at 5 identical frames) and drops only the incorrect anchoring. A plugin painting a clock or a spinner still never produces the run, and the failure message now reports the longest run seen and the number of buffer changes.

## 3. A burndown test that only passed at +01:00

The first CI run of the widened job failed one test on BOTH runners:
`ainb-plugin-burndown data::usage::tests::custom_ranges_are_inclusive`, expecting 1 call and getting 2.

Its fixture hardcoded `+01:00` on both events. A Custom range is anchored at LOCAL midnight, so "one event inside the range, one just outside" only held on a host that was itself at +01:00. At UTC (which is what both runners are) the two events land on the same local day and the range returns both. Fixed by stamping the fixture from the host's own offset, using the same DST fallback the production boundary helpers use. Verified under Europe/London, UTC, America/Los_Angeles, Pacific/Auckland and Asia/Kolkata.

Note what this says about the gap: `ainb-tui/CLAUDE.md`'s CI comment already claimed this test had been fixed to "derive their boundaries from the host's own zone". It had not, and nothing noticed, because the crate was never built.

## 4. The Test job covered 2 of 29 crates

`ainb-tui/Cargo.toml` sets `default-members = ["crates/ainb-core", "crates/ainb-hangar-daemon"]`. Without `--workspace`, nextest honours that, so the `Test` job silently skipped 27 crates and roughly 160 test files, including:

- all of `ainb-hangar-store` (74 files: every `migration_00XX_upgrade.rs`, `schema_drift.rs`, `workspace_data_isolation.rs`), which is the database layer
- all of `ainb-plugin-hangar` (46 files)
- `ainb-plugin-runtime` (4 files), where this week's zombie-reap bug lived

Test count goes from 4287 to 7813. `4287 tests run` looked thorough and was two crates' worth.

## Evidence

`cargo nextest run --workspace --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'`, run three times: twice in the host zone, once forced to UTC to match the runners.

```
Summary [ 158.027s] 7813 tests run: 7813 passed, 22 skipped
Summary [ 155.513s] 7813 tests run: 7813 passed, 22 skipped
Summary [ 184.215s] 7813 tests run: 7813 passed, 22 skipped   (TZ=UTC)
```

An earlier run of the same command on the same tree reported 9 failures (code-review render budget, sessions double-click, a13_quarantine, three hangar socket tests, learnings search, witr smoke) and took 831s. That was measured on a box carrying 190 stray CPU-spinner processes left over from the reproduction work above, with a load average of 698 on 10 cores. Every one of those tests is wall-clock bounded (a 4000ms render budget, a double-click window, socket timeouts). With the spinners cleared the same command runs in ~156s and is completely green. No test was changed to make that happen; the only test behaviour changed in this PR is the burndown fixture in section 3.

Worth watching regardless: `--workspace` lengthens the run, so a noisy runner has more opportunity to trip `renders_large_diff_within_budget` (4000ms for 20 frames of a 2000-row diff) and `sessions_mouse_double_click_attaches_selected_session_row`. Both live in `ainb`, which is already inside `default-members` and already runs in CI today. If they start flaking, the answer is to raise the budgets or make the tests load-independent, not to rerun the job.

## Note on overlap

`Test` and `Contracts` now both run `argv_golden_matrix`, `migration_upgrade_full_chain` and the cts-v2 binaries. That duplication is deliberate and left in place: `Contracts` exists for the signal (its own red check, its own no-rerun policy) rather than for exclusivity, and a filter typo that silently drops coverage is the exact failure class this work exists to prevent.