### PR TITLE
fix(fleet): show real agent sessions with real lifecycle states

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -2261,20 +2261,36 @@ mod tests {
 
     // --- H-A1: the hook NEVER returns Err (always exit 0) --------------------
 
-    #[tokio::test]
-    async fn hook_returns_ok_even_on_unrelated_session() {
-        // The public hook() entry point must resolve to Ok(()) → process exit 0,
-        // so a global Stop hook can never wedge an unrelated host session. We
-        // build the ArgMatches the registry declares for the `hook` verb.
-        let m = clap::Command::new("hook")
-            .arg(clap::Arg::new("event").long("event"))
-            .arg(clap::Arg::new("session-id").long("session-id").default_value(""))
-            .arg(clap::Arg::new("cwd").long("cwd").default_value(""))
-            .arg(clap::Arg::new("matcher").long("matcher").default_value(""))
-            .get_matches_from(vec!["hook", "--event", "Stop", "--session-id", "unrelated"]);
+    #[test]
+    fn hook_returns_ok_even_on_unrelated_session() {
+        // A global Stop hook must never wedge an unrelated host session: the
+        // outcome the real `hook()` derives has to be exit 0 even when the home
+        // holds no ATC instance and no inbox for the session.
+        //
+        // We drive `hook_core` against a tempdir rather than calling `hook()`,
+        // because `hook_inner` resolves the process-wide `ainb_home()` — calling
+        // it here would append a synthetic Stop event and a raw-payload sidecar
+        // to the DEVELOPER'S live `~/.agents-in-a-box`, which the daemon then
+        // ingests into `fleet_provider_event`. `swallow_hook_result` is the same
+        // wrapper `hook()` applies, so the exit-0 guarantee is still the thing
+        // under test.
+        let home = TempDir::new().unwrap();
+        let result = hook_core(
+            home.path(),
+            "Stop",
+            "unrelated",
+            "",
+            None,
+            None,
+            1,
+            "{}",
+            None,
+        );
+        let (exit_ok, emitted) = swallow_hook_result(result);
+        assert!(exit_ok, "hook must always yield exit 0");
         assert!(
-            hook(&m).await.is_ok(),
-            "hook must always return Ok → exit 0"
+            emitted.is_none(),
+            "an unrelated session emits no decision JSON"
         );
     }
 

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/mod.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/mod.rs
@@ -12,4 +12,4 @@ pub use jobs::discover_from_jobs;
 pub use merge::{merge_fleet_sessions, merge_sessions};
 pub use peers::{discover_from_peers, list_broker_peers};
 pub use process_tree::ProcessTable;
-pub use tmux::discover_from_tmux;
+pub use tmux::{discover_all_tmux_panes, discover_from_tmux};

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/mod.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/mod.rs
@@ -4,10 +4,12 @@ pub mod ainb;
 pub mod jobs;
 pub mod merge;
 pub mod peers;
+pub mod process_tree;
 pub mod tmux;
 
 pub use ainb::discover_from_ainb;
 pub use jobs::discover_from_jobs;
 pub use merge::{merge_fleet_sessions, merge_sessions};
 pub use peers::{discover_from_peers, list_broker_peers};
+pub use process_tree::ProcessTable;
 pub use tmux::discover_from_tmux;

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/process_tree.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/process_tree.rs
@@ -30,11 +30,16 @@ impl ProcessTable {
     /// caller treats that as "discovery unavailable" and leaves durable state
     /// untouched, rather than concluding that no pane holds an agent.
     pub async fn snapshot() -> Result<Self> {
+        // `-ww` forces unlimited column width. macOS inherits the BSD habit of
+        // truncating to the detected terminal width even when stdout is a pipe,
+        // and `comm` is the LAST column — a truncated full path loses exactly the
+        // basename the agent match depends on, so a real agent pane would look
+        // agentless. Repeating `w` is understood by both BSD and procps.
         let output = Command::new("ps")
-            .args(["-axo", "pid=,ppid=,comm="])
+            .args(["-axww", "-o", "pid=,ppid=,comm="])
             .output()
             .await
-            .context("failed to invoke `ps -axo pid=,ppid=,comm=`")?;
+            .context("failed to invoke `ps -axww -o pid=,ppid=,comm=`")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/process_tree.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/process_tree.rs
@@ -1,0 +1,169 @@
+// ABOUTME: One `ps` snapshot of the process table so pane→agent attribution is cheap.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+/// Levels walked below a pane pid. A pane's agent sits one to three levels
+/// down (login shell → optional wrapper → agent). The cap exists to bound a
+/// pathological or self-referential table, not to describe real nesting.
+const MAX_DEPTH: usize = 8;
+
+/// A `pid → (ppid, command)` snapshot of the whole process table.
+///
+/// The tmux reconciler samples every three seconds and needs to know which
+/// panes actually hold an agent. Probing each pane separately would cost one
+/// process spawn per pane per tick, so the table is read ONCE per pass and
+/// walked in memory.
+#[derive(Debug, Default, Clone)]
+pub struct ProcessTable {
+    children: HashMap<u32, Vec<u32>>,
+    commands: HashMap<u32, String>,
+}
+
+impl ProcessTable {
+    /// Read the live process table with a single `ps` invocation.
+    ///
+    /// # Errors
+    /// Returns an error when `ps` cannot be spawned or exits non-zero. The
+    /// caller treats that as "discovery unavailable" and leaves durable state
+    /// untouched, rather than concluding that no pane holds an agent.
+    pub async fn snapshot() -> Result<Self> {
+        let output = Command::new("ps")
+            .args(["-axo", "pid=,ppid=,comm="])
+            .output()
+            .await
+            .context("failed to invoke `ps -axo pid=,ppid=,comm=`")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("ps exited non-zero: {stderr}");
+        }
+
+        Ok(Self::parse(&String::from_utf8_lossy(&output.stdout)))
+    }
+
+    /// Parse `pid ppid comm` rows.
+    ///
+    /// `comm` may contain spaces — macOS reports a full executable path, which
+    /// can read `.../Browser Helper (Renderer)` — so only the two leading
+    /// numeric columns are tokenised and the remainder is taken whole.
+    #[must_use]
+    pub fn parse(stdout: &str) -> Self {
+        let mut table = Self::default();
+        for line in stdout.lines() {
+            let Some((pid, parent, command)) = parse_row(line) else {
+                continue;
+            };
+            table.children.entry(parent).or_default().push(pid);
+            table.commands.insert(pid, command);
+        }
+        table
+    }
+
+    /// Normalised command names of `root` and every descendant, nearest first.
+    ///
+    /// Breadth-first so the shallowest match wins: a Claude session that spawns
+    /// a nested agent still reports as the outer process that owns the pane.
+    #[must_use]
+    pub fn tree_commands(&self, root: u32) -> Vec<&str> {
+        let mut seen = HashSet::from([root]);
+        let mut frontier = vec![root];
+        let mut names = Vec::new();
+
+        for _ in 0..=MAX_DEPTH {
+            if frontier.is_empty() {
+                break;
+            }
+            let mut next = Vec::new();
+            for pid in frontier.drain(..) {
+                if let Some(command) = self.commands.get(&pid) {
+                    names.push(command.as_str());
+                }
+                for child in self.children.get(&pid).into_iter().flatten() {
+                    if seen.insert(*child) {
+                        next.push(*child);
+                    }
+                }
+            }
+            frontier = next;
+        }
+
+        names
+    }
+}
+
+fn parse_row(line: &str) -> Option<(u32, u32, String)> {
+    let rest = line.trim_start();
+    let (pid, rest) = split_leading_token(rest)?;
+    let (parent, rest) = split_leading_token(rest.trim_start())?;
+    let command = rest.trim();
+    if command.is_empty() {
+        return None;
+    }
+    Some((pid.parse().ok()?, parent.parse().ok()?, normalize(command)))
+}
+
+fn split_leading_token(text: &str) -> Option<(&str, &str)> {
+    let end = text.find(char::is_whitespace)?;
+    Some((&text[..end], &text[end..]))
+}
+
+/// `comm` is a full path on macOS and a bare (15-char truncated) name on Linux.
+/// Reducing both to a lowercase file name lets callers match exact names, which
+/// keeps `/Applications/Claude.app/…/Claude` from passing as the `claude` CLI.
+fn normalize(command: &str) -> String {
+    command.rsplit('/').next().unwrap_or(command).trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = concat!(
+        "    1     0 /sbin/launchd\n",
+        "  100     1 /bin/zsh\n",
+        "  200   100 /Users/me/.local/bin/claude\n",
+        "  300   200 /usr/bin/rg\n",
+        "  400     1 /bin/zsh\n",
+        "  500     1 /Applications/Arc.app/Helpers/Browser Helper (Renderer)\n",
+    );
+
+    #[test]
+    fn walks_descendants_breadth_first_and_normalises_names() {
+        let table = ProcessTable::parse(SAMPLE);
+
+        assert_eq!(table.tree_commands(100), vec!["zsh", "claude", "rg"]);
+        assert_eq!(table.tree_commands(200), vec!["claude", "rg"]);
+    }
+
+    #[test]
+    fn a_bare_shell_tree_holds_no_agent() {
+        let table = ProcessTable::parse(SAMPLE);
+
+        // Pane 400 is a login shell with no children — the exact shape of a
+        // leftover tmux pane whose agent already exited.
+        assert_eq!(table.tree_commands(400), vec!["zsh"]);
+    }
+
+    #[test]
+    fn command_paths_containing_spaces_survive_parsing() {
+        let table = ProcessTable::parse(SAMPLE);
+
+        assert_eq!(table.tree_commands(500), vec!["browser helper (renderer)"]);
+    }
+
+    #[test]
+    fn unknown_pid_yields_no_commands() {
+        assert!(ProcessTable::parse(SAMPLE).tree_commands(9999).is_empty());
+    }
+
+    #[test]
+    fn a_self_parenting_row_cannot_loop_forever() {
+        // A malformed table must terminate rather than spin the reconciler.
+        let table = ProcessTable::parse("  7   7 /bin/loop\n");
+
+        assert_eq!(table.tree_commands(7), vec!["loop"]);
+    }
+}

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/process_tree.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/process_tree.rs
@@ -77,7 +77,7 @@ impl ProcessTable {
                 break;
             }
             let mut next = Vec::new();
-            for pid in frontier.drain(..) {
+            for pid in frontier {
                 if let Some(command) = self.commands.get(&pid) {
                     names.push(command.as_str());
                 }

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
@@ -62,7 +62,7 @@ impl TmuxPaneRow {
     /// This is an INFERRED observation, so a provider hook always outranks it
     /// (see `should_replace` in the fleet repo) — it only has to be right for
     /// sessions that emit no hooks at all, which is most of them.
-    fn lifecycle(&self, now_secs: i64) -> LifecycleState {
+    const fn lifecycle(&self, now_secs: i64) -> LifecycleState {
         if self.pane_dead {
             return LifecycleState::Exited;
         }
@@ -75,18 +75,19 @@ impl TmuxPaneRow {
         }
     }
 
-    /// Build a Fleet row, or `None` when this pane holds no agent.
+    /// Build a Fleet row for this pane.
     ///
-    /// The gate is the pane's process tree, not its command string: a running
-    /// Claude renames itself to its version (`pane_current_command` reads
-    /// `2.1.220`), while a leftover pane whose agent exited still reports a
-    /// perfectly ordinary `zsh`. Only the tree distinguishes the two.
-    fn into_agent_session(self, processes: &ProcessTable, now_secs: i64) -> Option<FleetSession> {
-        let provider = agent_provider(processes, self.pane_pid)?;
+    /// The provider comes from the pane's process tree, not its command string:
+    /// a running Claude renames itself to its version (`pane_current_command`
+    /// reads `2.1.220`), while a leftover pane whose agent exited still reports
+    /// a perfectly ordinary `zsh`. Only the tree distinguishes the two. A pane
+    /// with no agent in its tree yields `Provider::Unknown`.
+    fn into_session(self, processes: &ProcessTable, now_secs: i64) -> FleetSession {
+        let provider = agent_provider(processes, self.pane_pid).unwrap_or(Provider::Unknown);
         let exact_tmux_target = self.exact_target();
         let fingerprint = self.process_start_fingerprint();
         let lifecycle = self.lifecycle(now_secs);
-        Some(FleetSession {
+        FleetSession {
             session_key: SessionKey::legacy(provider, &exact_tmux_target, &fingerprint),
             provider,
             provider_session_id: None,
@@ -104,17 +105,36 @@ impl TmuxPaneRow {
             first_seen_ms: self.session_created.checked_mul(1000),
             last_seen_ms: None,
             version: 0,
-        })
+        }
     }
 }
 
-/// Enumerate every tmux pane that actually holds an agent. One exact pane
-/// target produces at most one Fleet row.
+/// Panes that actually hold an agent — the Fleet roster.
 ///
-/// Panes without an agent process are NOT Fleet sessions — a host accumulates
+/// Panes without an agent process are NOT Fleet sessions: a host accumulates
 /// plenty of ordinary shells, and admitting them buries the real sessions in
 /// rows that can never carry a lifecycle.
+///
+/// Use [`discover_all_tmux_panes`] instead for identity or liveness checks. A
+/// control action must not fail merely because a pane's agent is momentarily
+/// between processes.
 pub async fn discover_from_tmux() -> Result<Vec<FleetSession>> {
+    Ok(discover_all_tmux_panes()
+        .await?
+        .into_iter()
+        // The provider is derived from the very tree the gate asks about, so
+        // "has a known provider" and "holds an agent" are the same predicate.
+        .filter(|session| session.provider != Provider::Unknown)
+        .collect())
+}
+
+/// Every tmux pane, agent-bearing or not. One exact pane target produces one
+/// row.
+///
+/// This is the roster for identity and liveness checks — "is pane X with
+/// fingerprint Y still there" — which must stay true to tmux rather than to
+/// Fleet's view of what deserves a row.
+pub async fn discover_all_tmux_panes() -> Result<Vec<FleetSession>> {
     let output = Command::new("tmux")
         .args(["list-panes", "-a", "-F", LIST_FORMAT])
         .output()
@@ -140,10 +160,7 @@ pub async fn discover_from_tmux() -> Result<Vec<FleetSession>> {
     // instead of retiring every session.
     let processes = ProcessTable::snapshot().await?;
     let now_secs = chrono::Utc::now().timestamp();
-    Ok(rows
-        .into_iter()
-        .filter_map(|row| row.into_agent_session(&processes, now_secs))
-        .collect())
+    Ok(rows.into_iter().map(|row| row.into_session(&processes, now_secs)).collect())
 }
 
 fn parse_rows(stdout: &str) -> Result<Vec<TmuxPaneRow>> {
@@ -229,8 +246,7 @@ mod tests {
         .expect("parse tmux rows");
 
         let table = processes();
-        let sessions: Vec<_> =
-            rows.into_iter().filter_map(|row| row.into_agent_session(&table, NOW)).collect();
+        let sessions: Vec<_> = rows.into_iter().map(|row| row.into_session(&table, NOW)).collect();
         assert_eq!(sessions.len(), 2);
         assert_eq!(sessions[0].cwd, sessions[1].cwd);
         assert_ne!(sessions[0].session_key, sessions[1].session_key);
@@ -253,7 +269,7 @@ mod tests {
         let row = parse_row("build\t0\t0\t%1\t101\t/repo\t2.1.220\tzsh\t1700000000\t0\t1700000499")
             .expect("parse row");
 
-        let session = row.into_agent_session(&processes(), NOW).expect("claude pane is a session");
+        let session = row.into_session(&processes(), NOW);
 
         assert_eq!(session.provider, Provider::Claude);
     }
@@ -267,7 +283,10 @@ mod tests {
         )
         .expect("parse row");
 
-        assert!(row.into_agent_session(&processes(), NOW).is_none());
+        assert_eq!(
+            row.into_session(&processes(), NOW).provider,
+            Provider::Unknown
+        );
     }
 
     #[test]
@@ -275,14 +294,43 @@ mod tests {
         let row = parse_row("plain\t0\t0\t%9\t909\t/tmp\tzsh\tzsh\t1700000000\t0\t1700000499")
             .expect("parse row");
 
-        assert!(row.into_agent_session(&processes(), NOW).is_none());
+        // `Unknown` is exactly what the roster filter drops, so a bare shell is
+        // still enumerated for identity checks but never becomes a Fleet row.
+        assert_eq!(
+            row.into_session(&processes(), NOW).provider,
+            Provider::Unknown
+        );
+    }
+
+    #[test]
+    fn the_roster_filter_drops_only_the_agentless_panes() {
+        let rows = parse_rows(concat!(
+            "claude-a\t0\t0\t%1\t101\t/repo\t2.1.220\tzsh\t1700000000\t0\t1700000499\n",
+            "bare\t0\t0\t%9\t909\t/tmp\tzsh\tzsh\t1700000000\t0\t1700000499\n",
+            "codex-b\t2\t1\t%2\t202\t/repo\tcodex\tcodex\t1700000001\t0\t1700000499\n"
+        ))
+        .expect("parse tmux rows");
+        let table = processes();
+
+        let all: Vec<_> = rows.into_iter().map(|row| row.into_session(&table, NOW)).collect();
+        let roster = all.iter().filter(|session| session.provider != Provider::Unknown).count();
+
+        // Identity and liveness checks keep every pane; the Fleet roster keeps
+        // only the two that hold an agent.
+        assert_eq!(all.len(), 3);
+        assert_eq!(roster, 2);
+        assert!(
+            all.iter()
+                .any(|session| session.exact_tmux_target.as_deref() == Some("bare:0.0")),
+            "the agentless pane must still be enumerated for liveness checks"
+        );
     }
 
     #[test]
     fn tmux_rows_are_degraded_and_only_allow_safe_fallbacks() {
         let row = parse_row("plain\t0\t0\t%1\t101\t/tmp\tzsh\tclaude\t1700000000\t0\t1700000499")
             .expect("parse row");
-        let session = row.into_agent_session(&processes(), NOW).expect("claude pane is a session");
+        let session = row.into_session(&processes(), NOW);
 
         assert_eq!(session.management, ManagementState::Degraded);
         assert!(session.capabilities.contains(Capability::TextSend));
@@ -303,8 +351,7 @@ mod tests {
                 "s\t0\t0\t%1\t101\t/repo\tzsh\tclaude\t1700000000\t{dead}\t{activity}"
             ))
             .expect("parse row")
-            .into_agent_session(&processes(), NOW)
-            .expect("claude pane is a session")
+            .into_session(&processes(), NOW)
             .lifecycle
         };
 
@@ -323,7 +370,7 @@ mod tests {
         let row =
             parse_row("s\t0\t0\t%1\t101\t/repo\tzsh\tclaude\t1700000000\t0\t").expect("parse row");
 
-        let session = row.into_agent_session(&processes(), NOW).expect("claude pane is a session");
+        let session = row.into_session(&processes(), NOW);
 
         assert_eq!(session.lifecycle, LifecycleState::Unknown);
     }

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 use anyhow::{Context, Result};
 use tokio::process::Command;
 
+use crate::fleet::discover::process_tree::ProcessTable;
 use crate::fleet::types::{
     AttentionState, Capabilities, Confidence, FleetSession, LifecycleState, ManagementState,
     Provenance, Provider, SessionKey, TransportHealth,
@@ -13,8 +14,15 @@ use crate::fleet::types::{
 const LIST_FORMAT: &str = concat!(
     "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_id}\t",
     "#{pane_pid}\t#{pane_current_path}\t#{pane_current_command}\t",
-    "#{pane_start_command}\t#{session_created}"
+    "#{pane_start_command}\t#{session_created}\t#{pane_dead}\t#{window_activity}"
 );
+
+/// Silence after which a live pane counts as between turns rather than working.
+///
+/// Sized above a slow tool call (a build, a full test suite) so a quiet-but-busy
+/// agent is not mislabelled idle, and well under the multi-hour gap that
+/// separates a working session from an abandoned one.
+const IDLE_AFTER_SECS: i64 = 120;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TmuxPaneRow {
@@ -27,6 +35,11 @@ struct TmuxPaneRow {
     current_command: String,
     start_command: String,
     session_created: i64,
+    pane_dead: bool,
+    /// Epoch seconds of the last output in this pane's window. `None` when tmux
+    /// does not report it, which keeps the lifecycle honestly `Unknown` instead
+    /// of inventing an idle age from a missing value.
+    window_activity: Option<i64>,
 }
 
 impl TmuxPaneRow {
@@ -37,13 +50,6 @@ impl TmuxPaneRow {
         )
     }
 
-    fn provider(&self) -> Provider {
-        infer_provider(&format!(
-            "{} {} {}",
-            self.session_name, self.current_command, self.start_command
-        ))
-    }
-
     fn process_start_fingerprint(&self) -> String {
         format!(
             "pane={};pid={};session_started={}",
@@ -51,11 +57,36 @@ impl TmuxPaneRow {
         )
     }
 
-    fn into_fleet_session(self) -> FleetSession {
-        let provider = self.provider();
+    /// Derive lifecycle from what tmux already knows about the pane.
+    ///
+    /// This is an INFERRED observation, so a provider hook always outranks it
+    /// (see `should_replace` in the fleet repo) — it only has to be right for
+    /// sessions that emit no hooks at all, which is most of them.
+    fn lifecycle(&self, now_secs: i64) -> LifecycleState {
+        if self.pane_dead {
+            return LifecycleState::Exited;
+        }
+        match self.window_activity {
+            Some(activity) if now_secs.saturating_sub(activity) > IDLE_AFTER_SECS => {
+                LifecycleState::Idle
+            }
+            Some(_) => LifecycleState::Running,
+            None => LifecycleState::Unknown,
+        }
+    }
+
+    /// Build a Fleet row, or `None` when this pane holds no agent.
+    ///
+    /// The gate is the pane's process tree, not its command string: a running
+    /// Claude renames itself to its version (`pane_current_command` reads
+    /// `2.1.220`), while a leftover pane whose agent exited still reports a
+    /// perfectly ordinary `zsh`. Only the tree distinguishes the two.
+    fn into_agent_session(self, processes: &ProcessTable, now_secs: i64) -> Option<FleetSession> {
+        let provider = agent_provider(processes, self.pane_pid)?;
         let exact_tmux_target = self.exact_target();
         let fingerprint = self.process_start_fingerprint();
-        FleetSession {
+        let lifecycle = self.lifecycle(now_secs);
+        Some(FleetSession {
             session_key: SessionKey::legacy(provider, &exact_tmux_target, &fingerprint),
             provider,
             provider_session_id: None,
@@ -63,7 +94,7 @@ impl TmuxPaneRow {
             exact_tmux_target: Some(exact_tmux_target),
             pane_pid: Some(self.pane_pid),
             process_start_fingerprint: Some(fingerprint),
-            lifecycle: LifecycleState::Unknown,
+            lifecycle,
             attention: AttentionState::None,
             management: ManagementState::Degraded,
             capabilities: Capabilities::degraded_tmux(),
@@ -73,11 +104,16 @@ impl TmuxPaneRow {
             first_seen_ms: self.session_created.checked_mul(1000),
             last_seen_ms: None,
             version: 0,
-        }
+        })
     }
 }
 
-/// Enumerate all tmux panes. One exact pane target produces one Fleet row.
+/// Enumerate every tmux pane that actually holds an agent. One exact pane
+/// target produces at most one Fleet row.
+///
+/// Panes without an agent process are NOT Fleet sessions — a host accumulates
+/// plenty of ordinary shells, and admitting them buries the real sessions in
+/// rows that can never carry a lifecycle.
 pub async fn discover_from_tmux() -> Result<Vec<FleetSession>> {
     let output = Command::new("tmux")
         .args(["list-panes", "-a", "-F", LIST_FORMAT])
@@ -94,7 +130,20 @@ pub async fn discover_from_tmux() -> Result<Vec<FleetSession>> {
     }
 
     let stdout = String::from_utf8(output.stdout).context("tmux list-panes returned non-UTF8")?;
-    parse_rows(&stdout).map(|rows| rows.into_iter().map(TmuxPaneRow::into_fleet_session).collect())
+    let rows = parse_rows(&stdout)?;
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // A `ps` failure is discovery being unavailable, not proof that no pane
+    // holds an agent — propagate so the caller leaves durable state alone
+    // instead of retiring every session.
+    let processes = ProcessTable::snapshot().await?;
+    let now_secs = chrono::Utc::now().timestamp();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| row.into_agent_session(&processes, now_secs))
+        .collect())
 }
 
 fn parse_rows(stdout: &str) -> Result<Vec<TmuxPaneRow>> {
@@ -102,10 +151,10 @@ fn parse_rows(stdout: &str) -> Result<Vec<TmuxPaneRow>> {
 }
 
 fn parse_row(line: &str) -> Result<TmuxPaneRow> {
-    let fields: Vec<&str> = line.splitn(9, '\t').collect();
-    if fields.len() != 9 {
+    let fields: Vec<&str> = line.splitn(11, '\t').collect();
+    if fields.len() != 11 {
         anyhow::bail!(
-            "tmux list-panes row has {} fields, expected 9",
+            "tmux list-panes row has {} fields, expected 11",
             fields.len()
         );
     }
@@ -123,18 +172,29 @@ fn parse_row(line: &str) -> Result<TmuxPaneRow> {
         session_created: fields[8]
             .parse()
             .with_context(|| format!("invalid session creation time in tmux row: {line}"))?,
+        // Both activity fields degrade rather than fail the whole discovery
+        // pass: an older tmux that reports neither still yields usable rows,
+        // just with an `Unknown` lifecycle.
+        pane_dead: fields[9].trim() == "1",
+        window_activity: fields[10].trim().parse().ok(),
     })
 }
 
-fn infer_provider(command_text: &str) -> Provider {
-    let text = command_text.to_ascii_lowercase();
-    if text.contains("codex") {
-        Provider::Codex
-    } else if text.contains("claude") {
-        Provider::Claude
-    } else {
-        Provider::Unknown
-    }
+/// The agent that owns a pane, or `None` when the pane holds none.
+///
+/// Matched on exact process names rather than substrings, so neither the Claude
+/// desktop app (`…/Claude.app/Contents/MacOS/Claude`) nor a branch called
+/// `f/claude-resume` can pass as a session.
+///
+/// ponytail: copilot is deliberately absent. Fleet has no `Provider::Copilot`
+/// on the wire, so admitting one would render it `UNKNOWN` — add the name here
+/// together with the enum variant, never before it.
+fn agent_provider(processes: &ProcessTable, pane_pid: u32) -> Option<Provider> {
+    processes.tree_commands(pane_pid).into_iter().find_map(|command| match command {
+        "claude" => Some(Provider::Claude),
+        "codex" => Some(Provider::Codex),
+        _ => None,
+    })
 }
 
 fn tmux_has_no_sessions(stderr: &str) -> bool {
@@ -147,15 +207,30 @@ mod tests {
     use super::*;
     use crate::fleet::types::{Capability, ManagementState};
 
+    const NOW: i64 = 1_700_000_500;
+
+    /// Pane 101 runs claude, pane 202 runs codex, pane 909 is a bare shell.
+    fn processes() -> ProcessTable {
+        ProcessTable::parse(concat!(
+            "  101     1 /bin/zsh\n",
+            "  111   101 /Users/me/.local/bin/claude\n",
+            "  202     1 /bin/zsh\n",
+            "  222   202 /opt/homebrew/bin/codex\n",
+            "  909     1 /bin/zsh\n",
+        ))
+    }
+
     #[test]
     fn parser_preserves_same_cwd_as_distinct_exact_targets() {
         let rows = parse_rows(concat!(
-            "claude-a\t0\t0\t%1\t101\t/repo\tclaude\tclaude\t1700000000\n",
-            "codex-b\t2\t1\t%2\t202\t/repo\tcodex\tcodex\t1700000001\n"
+            "claude-a\t0\t0\t%1\t101\t/repo\t2.1.220\tclaude\t1700000000\t0\t1700000499\n",
+            "codex-b\t2\t1\t%2\t202\t/repo\tcodex\tcodex\t1700000001\t0\t1700000499\n"
         ))
         .expect("parse tmux rows");
 
-        let sessions: Vec<_> = rows.into_iter().map(TmuxPaneRow::into_fleet_session).collect();
+        let table = processes();
+        let sessions: Vec<_> =
+            rows.into_iter().filter_map(|row| row.into_agent_session(&table, NOW)).collect();
         assert_eq!(sessions.len(), 2);
         assert_eq!(sessions[0].cwd, sessions[1].cwd);
         assert_ne!(sessions[0].session_key, sessions[1].session_key);
@@ -172,9 +247,42 @@ mod tests {
     }
 
     #[test]
+    fn a_renamed_claude_process_is_still_detected_as_claude() {
+        // Claude reports its VERSION as `pane_current_command`, so the pane
+        // command string says `2.1.220` and only the process tree says claude.
+        let row = parse_row("build\t0\t0\t%1\t101\t/repo\t2.1.220\tzsh\t1700000000\t0\t1700000499")
+            .expect("parse row");
+
+        let session = row.into_agent_session(&processes(), NOW).expect("claude pane is a session");
+
+        assert_eq!(session.provider, Provider::Claude);
+    }
+
+    #[test]
+    fn a_branch_named_after_claude_is_not_a_session() {
+        // The old string heuristic matched the tmux SESSION NAME, so a branch
+        // called `f/claude-resume` minted a bogus CLAUDE row.
+        let row = parse_row(
+            "tmux_repo--f-claude-resume\t0\t0\t%9\t909\t/tmp\tzsh\tzsh\t1700000000\t0\t1700000499",
+        )
+        .expect("parse row");
+
+        assert!(row.into_agent_session(&processes(), NOW).is_none());
+    }
+
+    #[test]
+    fn a_bare_shell_pane_is_not_a_fleet_session() {
+        let row = parse_row("plain\t0\t0\t%9\t909\t/tmp\tzsh\tzsh\t1700000000\t0\t1700000499")
+            .expect("parse row");
+
+        assert!(row.into_agent_session(&processes(), NOW).is_none());
+    }
+
+    #[test]
     fn tmux_rows_are_degraded_and_only_allow_safe_fallbacks() {
-        let row = parse_row("plain\t0\t0\t%9\t909\t/tmp\tzsh\tzsh\t1700000000").expect("parse row");
-        let session = row.into_fleet_session();
+        let row = parse_row("plain\t0\t0\t%1\t101\t/tmp\tzsh\tclaude\t1700000000\t0\t1700000499")
+            .expect("parse row");
+        let session = row.into_agent_session(&processes(), NOW).expect("claude pane is a session");
 
         assert_eq!(session.management, ManagementState::Degraded);
         assert!(session.capabilities.contains(Capability::TextSend));
@@ -184,8 +292,40 @@ mod tests {
             session
                 .process_start_fingerprint
                 .as_deref()
-                .is_some_and(|value| value.contains("pid=909"))
+                .is_some_and(|value| value.contains("pid=101"))
         );
+    }
+
+    #[test]
+    fn lifecycle_follows_pane_activity_age() {
+        let live = |activity: &str, dead: &str| {
+            parse_row(&format!(
+                "s\t0\t0\t%1\t101\t/repo\tzsh\tclaude\t1700000000\t{dead}\t{activity}"
+            ))
+            .expect("parse row")
+            .into_agent_session(&processes(), NOW)
+            .expect("claude pane is a session")
+            .lifecycle
+        };
+
+        // NOW is 1_700_000_500; the threshold is 120s.
+        assert_eq!(live("1700000499", "0"), LifecycleState::Running);
+        assert_eq!(live("1700000380", "0"), LifecycleState::Running);
+        assert_eq!(live("1700000379", "0"), LifecycleState::Idle);
+        assert_eq!(live("1699990000", "0"), LifecycleState::Idle);
+        assert_eq!(live("1700000499", "1"), LifecycleState::Exited);
+    }
+
+    #[test]
+    fn a_tmux_without_activity_reporting_stays_unknown_not_idle() {
+        // Inventing an idle age from a missing field would mark a whole fleet
+        // idle on any tmux that does not report `window_activity`.
+        let row =
+            parse_row("s\t0\t0\t%1\t101\t/repo\tzsh\tclaude\t1700000000\t0\t").expect("parse row");
+
+        let session = row.into_agent_session(&processes(), NOW).expect("claude pane is a session");
+
+        assert_eq!(session.lifecycle, LifecycleState::Unknown);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
@@ -448,11 +448,22 @@ impl AttentionIngest {
                 "hook event log has no parent",
             ));
         };
-        std::fs::read_to_string(
+        let sidecar = std::fs::read_to_string(
             home.join("hangar")
                 .join("provider-events")
                 .join(format!("{}.json", line.raw_payload_ref)),
-        )
+        )?;
+        // An empty sidecar is a torn / never-filled write, not a payload. Report
+        // it as absent so the caller falls back to the durable inline envelope —
+        // storing "" would record it as the EXACT source payload and lose the
+        // real one silently.
+        if sidecar.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "empty raw payload sidecar",
+            ));
+        }
+        Ok(sidecar)
     }
 
     /// Close any OPEN ASK rows a session still carries once a later hook shows it
@@ -869,6 +880,40 @@ mod tests {
             .unwrap()
             .expect("source envelope must persist");
         assert_eq!(source.raw_payload, raw_payload);
+        assert!(source.projection_revision.is_some());
+    }
+
+    #[tokio::test]
+    async fn empty_sidecar_falls_back_to_inline_envelope_payload() {
+        // A 0-byte sidecar is a torn / never-filled write. It must NOT be stored
+        // as the exact source payload — the durable inline envelope wins, exactly
+        // as it does when the sidecar file is missing outright.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let events_jsonl = dir.path().join("events.jsonl");
+        let cursor = dir.path().join("attention_ingest.offset");
+        let event_id = "source-sidecar-empty";
+        let payload_dir = dir.path().join("hangar").join("provider-events");
+        std::fs::create_dir_all(&payload_dir).unwrap();
+        std::fs::write(payload_dir.join(format!("{event_id}.json")), "").unwrap();
+        std::fs::write(
+            &events_jsonl,
+            format!(
+                r#"{{"agent":"claude","cwd":"/w","event_id":"{event_id}","event_type":"SessionStart","matcher":null,"raw_payload_ref":"{event_id}","session_id":"sid-empty","transcript_path":null,"ts":1700000000000,"payload":{{"inline":"kept"}}}}"#,
+            ) + "\n",
+        )
+        .unwrap();
+        let ingest = ingest_for(&store, &events_jsonl, &cursor);
+
+        assert_eq!(ingest.ingest_once(5_000).await, 0);
+        let source = FleetProviderEventRepo::get(store.pool(), event_id)
+            .await
+            .unwrap()
+            .expect("source envelope must persist");
+        assert_eq!(
+            source.raw_payload, r#"{"inline":"kept"}"#,
+            "an empty sidecar must not overwrite the inline envelope payload"
+        );
         assert!(source.projection_revision.is_some());
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -1075,13 +1075,19 @@ fn tmux_missing_event(row: &FleetSessionRow, observed_at: i64) -> NewFleetEvent 
 }
 
 fn tmux_row_matches(row: &FleetSessionRow, session: &FleetSession) -> bool {
+    // A lifecycle set by a provider hook outranks this inferred tmux sample, so
+    // the repo will never apply ours over it. Comparing them anyway would report
+    // a permanent mismatch and append one no-op `fleet_event` per discovery
+    // tick, forever, for every hook-backed session.
+    let lifecycle_settled = row.lifecycle_authority == "authoritative"
+        || row.lifecycle_state == state_token(session.lifecycle);
     row.provider == session.provider.as_str()
         && row.tmux_target == session.exact_tmux_target
         && row.process_start_fingerprint == session.process_start_fingerprint
         && row.cwd == session.cwd
         && row.management_state == management_token(session.management)
         && row.confidence == confidence_token(session.confidence)
-        && row.lifecycle_state == state_token(session.lifecycle)
+        && lifecycle_settled
         && row.attention_state == attention_token(session.attention)
         && row.transport_health == transport_token(session.transport_health)
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -4,7 +4,7 @@
 //! SQLite owns canonical state and revision order. Live broadcasts only wake
 //! subscribers after the matching revision commits.
 
-use ainb_fleet_core::discover::discover_from_tmux;
+use ainb_fleet_core::discover::{discover_all_tmux_panes, discover_from_tmux};
 use ainb_fleet_core::types::{
     AttentionState, Confidence, FleetSession, LifecycleState, ManagementState, Provider,
     SessionKey, TransportHealth,
@@ -579,7 +579,9 @@ pub async fn recover_codex_manager(
     manager: &crate::fleet_provider::codex_manager::CodexManagerHandle,
     observed_at: i64,
 ) -> Result<usize, FleetRepoError> {
-    let discovered = match discover_from_tmux().await {
+    // Liveness, not roster: a managed Codex pane must not read as gone merely
+    // because its agent process is momentarily absent from the tree.
+    let discovered = match discover_all_tmux_panes().await {
         Ok(discovered) => discovered,
         Err(error) => {
             tracing::debug!(error = %error, "Codex manager recovery tmux discovery unavailable");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1860,7 +1860,7 @@ async fn launch_managed_codex_tui(
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
-        match ainb_fleet_core::discover::discover_from_tmux().await {
+        match ainb_fleet_core::discover::discover_all_tmux_panes().await {
             Ok(sessions) => {
                 if let Some(session) = sessions.into_iter().find(|session| {
                     session
@@ -2329,7 +2329,7 @@ async fn exact_live_tmux_session_name(
             "exact tmux process identity is unavailable".to_string(),
         )
     })?;
-    let discovered = ainb_fleet_core::discover::discover_from_tmux()
+    let discovered = ainb_fleet_core::discover::discover_all_tmux_panes()
         .await
         .map_err(|error| crate::fleet_provider::ProviderError::Transport(error.to_string()))?;
     if !discovered.iter().any(|candidate| {
@@ -2603,7 +2603,7 @@ async fn verified_tmux_send(
             Some("exact tmux process identity is unavailable".to_string()),
         );
     };
-    let discovered = match ainb_fleet_core::discover::discover_from_tmux().await {
+    let discovered = match ainb_fleet_core::discover::discover_all_tmux_panes().await {
         Ok(discovered) => discovered,
         Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
     };
@@ -2646,7 +2646,7 @@ async fn verified_tmux_picker(
             Some("exact tmux process identity is unavailable".to_string()),
         );
     };
-    let discovered = match ainb_fleet_core::discover::discover_from_tmux().await {
+    let discovered = match ainb_fleet_core::discover::discover_all_tmux_panes().await {
         Ok(discovered) => discovered,
         Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
     };


### PR DESCRIPTION
## Why

The Fleet screen listed 45 sessions with `Needs input 0 · Idle 0 · Running 0`. Nothing was stale — all 44 tmux panes were live — but only 13 of them actually held an agent, and every row's lifecycle was hardcoded `UNKNOWN`, so no row could reach a filter bucket.

Measured on a real profile before the change:

| | |
|---|---|
| visible non-exited `fleet_session` rows | 45 |
| rows at `lifecycle_state='UNKNOWN'` | 43 |
| rows at `provider='unknown'` | 32 |
| live tmux panes | 44 |
| panes actually holding an agent | 13 |

## What

**Discovery (`ainb-fleet-core`)**

- Admit a pane only when its process tree holds an agent. A pane with no agent is an ordinary shell, and 31 of 44 panes on the test host were exactly that — leftover login shells whose agent exited days earlier.
- Infer the provider from the real process name rather than the pane command string. A running Claude renames itself to its version, so `pane_current_command` reads `2.1.220` and the old `contains("claude")` check missed it. That same substring test also matched any tmux session named after a branch like `f/claude-resume`, minting bogus CLAUDE rows.
- Derive lifecycle from `pane_dead` and `window_activity`, idle after 120s, instead of hardcoding `Unknown`. A tmux that reports no `window_activity` leaves the lifecycle `Unknown` rather than inventing an idle age.
- Attribution reads the process table once per discovery pass (`ps -axo pid=,ppid=,comm=`) instead of once per pane, since the reconciler samples every three seconds.

The tmux sample stays `Inferred`, so a provider hook still outranks it via `should_replace`. Copilot is deliberately not in the agent set: Fleet has no `Provider::Copilot` on the wire, so admitting one would render it `UNKNOWN`. The name goes in together with the enum variant, not before.

**Reconciler churn (`ainb-hangar-daemon`)**

`tmux_row_matches` compared lifecycle even when the stored row's came from a provider hook. An inferred sample can never outrank an authoritative one, so that comparison reported a mismatch the reconciler could never resolve, appending one no-op `fleet_event` row every three seconds for every hook-backed session.

**Provider-event ledger (`ainb-core`, `ainb-hangar-daemon`)**

Two defects found while measuring ledger growth:

- `hook_returns_ok_even_on_unrelated_session` drove the public `hook()`, which resolves the process-wide `ainb_home()`. Every `cargo test` run appended a synthetic `Stop` event and a zero-byte payload sidecar to the developer's live `~/.agents-in-a-box`, which the daemon then ingested. That accounted for 20 of the 41 rows in the real ledger.
- A zero-byte sidecar read back as `Ok("")` and was stored as the exact source payload, so real payload loss would have been silent.

## Verification

```
cargo test -p ainb --lib cli::fleet::atc                      24 passed
cargo test -p ainb-hangar-daemon --lib attention_ingest       10 passed
cargo test -p ainb-hangar-daemon --lib fleet                  51 passed
cargo test -p ainb-fleet-core --lib discover                  19 passed
cargo test --workspace --no-run                               exit 0
rustup run stable cargo fmt --all                             applied
```

New behavioural coverage: a renamed Claude process is still detected, a branch named after a provider is not a session, a bare shell pane is not a session, lifecycle tracks activity age across the threshold, a tmux without activity reporting stays `Unknown`, and an empty sidecar falls back to the inline envelope.

## Not included

Existing rows are not purged. All 20 test-generated ledger rows are already projected and inert, and they are the concrete case study for the deletion boundary that retention policy (`agents-in-a-box-ebu`) still has to define. The reconciler retires the stale session rows on its own: they stop being discovered, so `tmux_missing_event` marks them `EXITED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved fleet discovery by identifying Claude and Codex sessions through their process trees.
  - Added access to all discovered terminal panes, including non-agent panes when needed.
  - Added more accurate pane lifecycle detection, including activity, exit, and unknown states.
  - Non-agent panes are excluded from the primary fleet roster.

- **Bug Fixes**
  - Empty payload sidecars now correctly fall back to inline payload data.
  - Improved session recovery when provider-reported lifecycle data differs from inferred state.
  - Improved handling of missing or incomplete session metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review round 1 — regression caught and fixed

Gating discovery on the agent process tree silently changed the answer for five callers that use `discover_from_tmux()` as a **liveness oracle** rather than a list. A pane whose agent was momentarily absent from the tree would have read as gone:

| Call site | Consequence |
|---|---|
| `rpc/mod.rs:1863` | managed Codex launch times out **and kills the tmux session it just created** |
| `rpc/mod.rs:2332` | staleness guard reports `tmux process identity changed` |
| `rpc/mod.rs:2606` | `verified_tmux_send` returns `Failed`, text never delivered |
| `rpc/mod.rs:2649` | `verified_tmux_picker` refuses the action |
| `fleet.rs:582` | Codex manager recovery treats a live session as missing |

That would have turned a display fix into a control-plane failure mode.

Fixed in `81c29ca2` by splitting the two questions:

- `discover_all_tmux_panes()` — every pane, stays true to tmux. Used by all five identity/liveness consumers.
- `discover_from_tmux()` — agent-gated, feeds only the Fleet roster (`reconcile_tmux_once`).

Both derive the provider from the process tree, so a row's stored provider still matches what a later liveness check computes. Covered by `the_roster_filter_drops_only_the_agentless_panes`.

## Live verification

Ran against the real host daemon (`hangar daemon restart` onto this build):

| | before | after |
|---|---|---|
| visible rows | 53 | 24 |
| `provider='unknown'` | 30 | 0 |
| `lifecycle='UNKNOWN'` | 43 | 0 |
| IDLE / RUNNING / TURN_COMPLETE | 0 / 0 / 10 | 13 / 1 / 10 |

No duplicate `tmux_target` rows. The 30 bare-shell rows retired themselves to `EXITED` through the existing `tmux_missing_event` path, with no manual deletion.

Follow-ups filed: `agents-in-a-box-han` (Provider::Copilot + wire variant), `agents-in-a-box-4oo` (hook-only rows never leave TURN_COMPLETE).
