### PR TITLE
feat(hangar): role-gated pull pipeline, one owner per card instead of squad broadcast

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -124,6 +124,27 @@ pub enum HangarCommand {
     /// Read an actor's notification inbox.
     #[command(subcommand)]
     Inbox(InboxCommand),
+    /// Provision and inspect the role-gated pull pipeline.
+    #[command(subcommand)]
+    Pipeline(PipelineCommand),
+}
+
+/// `hangar pipeline <verb>` - provision the role-gated board pipeline that
+/// squad work is pulled through.
+#[derive(Subcommand, Debug)]
+pub enum PipelineCommand {
+    /// Provision the default six-stage pipeline (Backlog, Triage, Implement, Review, QA, Done). Idempotent; never rewrites an existing pipeline board.
+    Init(PipelineInitArgs),
+    /// Show each stage with its role gate, WIP limit and current card count.
+    Show(PipelineInitArgs),
+}
+
+/// Arguments for `hangar pipeline init` / `hangar pipeline show`.
+#[derive(Args, Debug)]
+pub struct PipelineInitArgs {
+    /// Workspace slug to provision. Defaults to the bootstrapped `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
 }
 
 /// `hangar comment <verb>` — post a comment and see EXACTLY where its
@@ -2483,7 +2504,74 @@ pub async fn dispatch(cmd: HangarCommand, format: OutputFormat) -> Result<()> {
         HangarCommand::Property(c) => dispatch_property(c, format).await,
         HangarCommand::Comment(c) => dispatch_comment(c, format).await,
         HangarCommand::Inbox(InboxCommand::List(args)) => run_inbox_list(args, format).await,
+        HangarCommand::Pipeline(c) => dispatch_pipeline(c).await,
     }
+}
+
+/// `hangar pipeline init|show`: provision (or describe) the role-gated board
+/// pipeline that squad work is pulled through.
+///
+/// `init` is idempotent and non-destructive: an existing pipeline board is
+/// reported and left exactly as the operator tuned it, so re-running never
+/// resets a WIP limit or a renamed stage.
+async fn dispatch_pipeline(cmd: PipelineCommand) -> Result<()> {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::service::pipeline::PipelineService;
+    use sqlx::Row;
+
+    let (args, init) = match cmd {
+        PipelineCommand::Init(a) => (a, true),
+        PipelineCommand::Show(a) => (a, false),
+    };
+    let store = Store::open_default().await.context("open hangar database")?;
+    let workspace_id = resolve_skills_workspace(&store, args.workspace.as_deref()).await?;
+    let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
+
+    if init {
+        let board_id =
+            PipelineService::provision_default(store.pool(), &ws, &SystemIdGen, &SystemClock)
+                .await
+                .context("provision the default pipeline")?;
+        println!("pipeline board {board_id}");
+    }
+
+    let rows = sqlx::query(
+        "SELECT col.name AS name, col.services_role AS role, col.wip_limit AS wip, \
+                col.excludes_prior_agent AS excl, \
+                (SELECT COUNT(*) FROM board_card bc WHERE bc.column_id = col.id) AS cards \
+           FROM board_column col JOIN board bd ON bd.id = col.board_id \
+          WHERE bd.workspace_id = ?1 AND bd.name = ?2 ORDER BY col.ord",
+    )
+    .bind(ws.as_str())
+    .bind(ainb_hangar_store::service::pipeline::DEFAULT_PIPELINE_BOARD)
+    .fetch_all(store.pool())
+    .await
+    .context("read the pipeline stages")?;
+
+    if rows.is_empty() {
+        println!("no pipeline provisioned (run `ainb hangar pipeline init`)");
+        return Ok(());
+    }
+    println!(
+        "{:<12} {:<14} {:>5} {:>6} {:>6}",
+        "STAGE", "ROLE", "WIP", "EXCL", "CARDS"
+    );
+    for r in &rows {
+        let name: String = r.try_get("name").unwrap_or_default();
+        let role: Option<String> = r.try_get("role").unwrap_or_default();
+        let wip: Option<i64> = r.try_get("wip").unwrap_or_default();
+        let excl: i64 = r.try_get("excl").unwrap_or_default();
+        let cards: i64 = r.try_get("cards").unwrap_or_default();
+        println!(
+            "{:<12} {:<14} {:>5} {:>6} {:>6}",
+            name,
+            role.as_deref().unwrap_or("-"),
+            wip.map_or_else(|| "-".to_string(), |w| w.to_string()),
+            if excl == 1 { "yes" } else { "-" },
+            cards
+        );
+    }
+    Ok(())
 }
 
 /// `hangar comment add|preview`: post a comment (or dry-run one) and report

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -1341,10 +1341,12 @@ pub struct SquadAssignArgs {
     /// Claim urgency (0..3, higher = more urgent). Defaults to `0` (routine).
     #[arg(long, default_value_t = 0)]
     pub priority: i64,
-    /// Fan the work out across the WHOLE squad (leader brief + one task per
-    /// distinct `agent` member) instead of briefing the leader alone.
+    /// Dispatch through the squad. Enqueues the card into the first role-gated pipeline column, where ONE eligible agent takes it (no longer one run per member).
     #[arg(long)]
     pub fanout: bool,
+    /// Deliberately run this issue N times in parallel on up to N distinct squad agents, all stamped with one shared `run_group`. Omitted or `1` is a single owner.
+    #[arg(long, value_name = "N")]
+    pub redundant: Option<usize>,
     /// The user the invocation-permission gate judges this assignment by (a user
     /// id or an email). Omitted defaults to the workspace owner — the ordinary
     /// single-operator assign, which the gate always admits.
@@ -5014,24 +5016,35 @@ async fn run_squad_assign(store: &Store, args: SquadAssignArgs) -> Result<()> {
         // exactly the pre-T4 behaviour.
         ..SquadAssignRequest::default()
     };
-    if args.fanout {
-        let fanout = SquadAssignService::assign_fanout(
+    let copies = args.redundant.unwrap_or(1);
+    if args.fanout || copies > 1 {
+        let fanout = SquadAssignService::assign_redundant(
             store.pool(),
             &ws,
             &args.squad_id,
             &request,
+            copies,
             &SystemIdGen,
             &SystemClock,
         )
         .await
         .map_err(squad_assign_cli_err)?;
+        if fanout.leader.task_id.is_empty() {
+            // The card is enqueued but no agent currently holds the stage's role,
+            // so it waits, visibly, on the board. Reported rather than silently
+            // answering as if a run had started.
+            println!(
+                "enqueued the card into the pipeline; no agent holds the stage's role yet, so it is waiting"
+            );
+            return Ok(());
+        }
         println!(
-            "briefed leader {} with task {} (runtime {})",
-            fanout.leader.leader_agent_id, fanout.leader.task_id, fanout.leader.runtime_id
+            "dispatched task {} to agent {} (runtime {})",
+            fanout.leader.task_id, fanout.leader.leader_agent_id, fanout.leader.runtime_id
         );
         for m in &fanout.members {
             println!(
-                "fanned task {} to member {} (runtime {})",
+                "redundant task {} to agent {} (runtime {})",
                 m.task_id, m.agent_id, m.runtime_id
             );
         }

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -1722,14 +1722,18 @@ fn squad_fanout_gates_a_private_leader_against_a_non_owner_member() {
         ok,
         "the allow-listed member's fan-out should exit 0; out={out}"
     );
+    // Under the pull pipeline a dispatch reports the single OWNER of the work
+    // rather than "briefed leader + fanned members". The squad here has no agent
+    // members and the workspace no role-gated pipeline, so the owner is the
+    // leader via the single-task fallback.
     assert!(
-        out.contains("briefed leader assign-agent"),
-        "the fan-out must brief the leader:\n{out}"
+        out.contains("dispatched task") && out.contains("to agent assign-agent"),
+        "the dispatch must name the single owner:\n{out}"
     );
     assert_eq!(
         queued_task_count(tmp.path()),
         1,
-        "the leader brief landed (the squad has no agent members)"
+        "exactly ONE task, never one per member"
     );
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/examples/seed_t4a_squad_fanout_journey.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/seed_t4a_squad_fanout_journey.rs
@@ -1,17 +1,30 @@
-//! Recording harness for the T4a (squad-card fan-out) journey
+//! Recording harness for the T4a SQUAD-CARD journey
 //! (docs/hangar/assets/journeys/t4-squad-fanout.gif).
 //!
-//! NOT a test and NOT shipped — mirrors `seed_t1_worktree_journey.rs`, but seeds
-//! the exact fixture the tcp T4 squad-fanout tripwire
+//! NOT a test and NOT shipped, mirrors `seed_t1_worktree_journey.rs`, but seeds
+//! the exact fixture the tcp T4 squad tripwire
 //! (`tests/tripwire_tcp_squad_card_fanout_e2e.rs`, via `tripwire_p4_common.rs`'s
 //! `prepare_pipeline_squad_card`) drives: a real git repo (`testrepo`) in the `@`
 //! scan-cache roster, a `shippers` squad (leader `agent-1` + two members
 //! `agent-m1`/`agent-m2`), a card ALREADY assigned to that squad and placed on the
 //! `Delivery` board's Todo column, and a claim-enabled daemon running a headless
-//! fake-claude that BLOCKS every fanned run until the recording script touches
-//! `$HOME/interactive-go` — so the recording can hold all three fanned runs (leader
-//! + two members, each on its own `ainb/<slug>` worktree) live at once before
-//! releasing them to finish and tear down.
+//! fake-claude that BLOCKS the run until the recording script touches
+//! `$HOME/interactive-go`, so the recording can hold the run live before releasing
+//! it to finish and tear down.
+//!
+//! # What this journey now shows (it changed)
+//!
+//! It used to hold THREE fanned runs live at once (leader + both members, each on
+//! its own `ainb/<slug>` worktree). That was the broadcast, and it was the
+//! reported defect rather than a feature: one card became three agents in three
+//! worktrees doing the same work. Migration 0074 replaced it with a role-gated
+//! pull, so this fixture now produces ONE owner and ONE worktree.
+//!
+//! The committed GIF at the path above still shows the OLD three-worktree
+//! behaviour and is therefore stale. Re-record it with
+//! `docs/hangar/assets/journeys/record-t4a-squad-fanout.sh` before citing it.
+//! The seeding below is unchanged and still correct; only what the daemon does
+//! with the fixture has changed.
 //!
 //! Usage: `seed_t4a_squad_fanout_journey <HOME_DIR> <DAEMON_BIN>`
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -279,6 +279,56 @@ pub async fn auto_move_after_terminal(pool: &SqlitePool, task: &Task) {
         }
     };
     auto_move_after_transition(pool, task, &state).await;
+
+    // PIPELINE STAGE ADVANCE. Folded in here rather than added at each of the
+    // five terminal call sites, so a future terminal path cannot acquire the
+    // auto-move hook and silently miss the advance, which would strand a card
+    // mid-pipeline with its stage already finished.
+    //
+    // Only a `done` aggregate advances: a stage that FAILED or was CANCELLED
+    // leaves the card in its column so the work can be retried by the same role
+    // rather than being handed to the next stage half-finished.
+    if state == "done" {
+        advance_pipeline_stage(pool, task).await;
+    }
+}
+
+/// Step the task's card ONE role-gated column to the right now its stage is done.
+///
+/// This is the handoff that makes a pipeline a pipeline: Implement finishes, the
+/// card lands in Review, and on the next daemon tick a DIFFERENT role pulls it.
+///
+/// Best-effort, exactly like its sibling hooks: the task's terminal state has
+/// already committed, and a board write must never down the claim loop. A card
+/// that is not in a role-gated column, that is at the last stage, or whose board
+/// has auto-move off is a logged no-op.
+async fn advance_pipeline_stage(pool: &SqlitePool, task: &Task) {
+    use ainb_hangar_store::service::pull::PullService;
+
+    let Some(issue_id) = task.issue_id.as_deref() else {
+        return;
+    };
+    match PullService::advance_after_stage(pool, issue_id).await {
+        Ok(moved) if !moved.is_empty() => {
+            for (board_id, column_id) in &moved {
+                tracing::info!(
+                    task_id = %task.id,
+                    issue_id = %issue_id,
+                    board_id = %board_id,
+                    column_id = %column_id,
+                    "pipeline card advanced to the next stage"
+                );
+            }
+        }
+        Ok(_) => tracing::info!(
+            task_id = %task.id,
+            issue_id = %issue_id,
+            "pipeline advance: no card moved (not role-gated, last stage, or auto-move off)"
+        ),
+        Err(e) => tracing::warn!(
+            error = %e, task_id = %task.id, "pipeline advance failed"
+        ),
+    }
 }
 
 /// When ANY task of a card reaches a TERMINAL state, re-evaluate every card that

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -12344,7 +12344,7 @@ mod tests {
         );
         assert_eq!(queue_len().await, 0, "a blocked fan-out writes NO task row");
 
-        // (b) OWNER (default `None` invoker) fans out — leader brief + one member.
+        // (b) OWNER (default `None` invoker) is ADMITTED and dispatches once.
         let owner_run = run_card(
             pool,
             &ws_id,
@@ -12359,8 +12359,15 @@ mod tests {
             DispatchSource::Manual,
         )
         .await;
-        assert!(owner_run.is_ok(), "the owner's squad run must fan out");
-        assert_eq!(queue_len().await, 2, "leader brief + one member task");
+        assert!(owner_run.is_ok(), "the owner's squad run must be admitted");
+        // This test pins the GATE, not the dispatch width. Under the pull
+        // pipeline an admitted squad run yields ONE owner, never one task per
+        // member; it asserted 2 while the broadcast existed.
+        assert_eq!(
+            queue_len().await,
+            1,
+            "an admitted squad run is exactly one task"
+        );
     }
 
     /// Pattern-B handover regression: the create-wizard fires ONE `issue_update`

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -50,6 +50,7 @@ use ainb_hangar_store::service::claim::{ClaimTaskService, ClaimedTask};
 use ainb_hangar_store::service::complete::{CompleteParams, CompleteTaskService};
 use ainb_hangar_store::service::fail::FailTaskService;
 use ainb_hangar_store::service::finalize::FinalizeError;
+use ainb_hangar_store::service::pull::PullService;
 use ainb_hangar_store::service::retry::{RetryDecision, RetryService};
 use ainb_hangar_store::service::start::StartTaskService;
 use sqlx::{Row, SqlitePool};
@@ -554,6 +555,31 @@ pub async fn run(
                 continue;
             }
             () = tokio::time::sleep(cfg.poll_interval) => {}
+        }
+
+        // PULL TICK, ahead of the claim. A card sitting in a role-gated column is
+        // a queue with no `agent_task_queue` row yet, so nothing downstream can
+        // see it until an eligible agent is selected. This materialises at most
+        // ONE such row per tick; the claim below then dispatches it exactly as it
+        // dispatches any other queued task, so the whole existing claim, run and
+        // finalize path is reused unchanged.
+        //
+        // Ordering matters: pulling FIRST means a card enqueued by this tick is
+        // claimable within the same tick, which is what keeps a handoff to the
+        // next stage one poll interval rather than two.
+        match PullService::pull_for_runtime(&pool, &runtime_id, &SystemIdGen, &SystemClock).await {
+            Ok(Some(pulled)) => tracing::info!(
+                task_id = %pulled.task_id,
+                issue_id = %pulled.issue_id,
+                agent_id = %pulled.agent_id,
+                services_role = %pulled.services_role,
+                "pulled a card from a role-gated column"
+            ),
+            Ok(None) => {}
+            // A pull fault must never down the loop: the claim below still drains
+            // any directly-dispatched work, so the daemon degrades to push-only
+            // rather than stopping.
+            Err(e) => tracing::error!(error = %e, "card pull failed"),
         }
 
         match ClaimTaskService::claim_for_runtime(&pool, &runtime_id, &SystemClock).await {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/live_e2e.rs
@@ -1071,3 +1071,631 @@ fn now_ms() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| d.as_millis() as i64)
 }
+
+// ---------------------------------------------------------------------------
+// LIVE PIPELINE PROOF: one card, four role-gated stages, three REAL agents.
+// ---------------------------------------------------------------------------
+
+/// THE LIVE END-TO-END PROOF of the role-gated pull pipeline (goal criterion 1).
+///
+/// One issue traverses the pipeline across THREE DIFFERENT agents driving TWO
+/// REAL provider CLIs, and the DB is asserted at every transition:
+///
+/// ```text
+///  Triage        Implement       Review          QA            Done
+///  triager       implementer     reviewer        tester        (terminal)
+///  pipe-triage   pipe-triage     pipe-review     pipe-qa
+///  [claude]      [claude]        [codex]         [claude]
+///        \___________/                 excl. prior    excl. prior
+///         same agent may                    \______________/
+///         implement what it                  a checker is never
+///         triaged                            the agent it checks
+/// ```
+///
+/// The assertions, sampled on EVERY poll rather than once at the end, are:
+///   * never more than ONE `running` task on the card at any instant,
+///   * the Review stage's `agent_id` differs from the Implement stage's,
+///   * the `parent_task_id` chain is unbroken across stages,
+///   * `board_card.column_id` advances ONE column at a time, never skipping.
+///
+/// # Why fakes are not permitted here
+///
+/// A scripted stub proves ROUTING and never invocation shape. That is exactly
+/// how a broken headless path survived undetected in this repo for weeks: the
+/// fake exits 0 by construction, so `queued -> done` walked perfectly while the
+/// real CLI was never correctly invoked. So the success signal is not the task
+/// status. It is a per-stage NONCE ARTIFACT the model cannot fabricate without
+/// actually running a tool, written into that stage's OWN worktree, plus a
+/// recorded `task_usage` row proving real tokens were burned.
+#[tokio::test]
+async fn live_pipeline_walks_four_stages_across_three_real_agents() {
+    let Some(ainb) = ainb_bin() else {
+        eprintln!("SKIPPED: ainb binary not built (run `cargo build -p ainb --bin ainb`)");
+        return;
+    };
+    let Some(claude) = real_claude() else {
+        eprintln!("SKIPPED: no claude on PATH");
+        return;
+    };
+    let Some(codex) = real_codex() else {
+        eprintln!("SKIPPED: no codex on PATH");
+        return;
+    };
+    if !claude_alive(&claude) {
+        eprintln!("SKIPPED: no authenticated claude on PATH");
+        return;
+    }
+    if !codex_alive(&codex) {
+        eprintln!("SKIPPED: no authenticated codex on PATH");
+        return;
+    }
+
+    let tag = format!("{}-{}", std::process::id(), now_ms());
+    let nonce = format!("HANGAR-PIPELINE-NONCE-{tag}");
+    let home = tempfile::tempdir().expect("tempdir home");
+    let db_path = home.path().join("hangar.db");
+
+    // A scratch git repo so EVERY stage provisions its OWN worktree. Distinct
+    // work_dirs are what make the per-stage artifact assertion meaningful: a
+    // single shared cwd would let stage 1's file satisfy stage 4's check.
+    let repo = home.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mkdir repo");
+    init_scratch_repo(&repo);
+
+    // 1. Three agents on TWO providers, created through the real CLI.
+    let a_tri = format!("pipe-triage-{tag}");
+    let a_rev = format!("pipe-review-{tag}");
+    let a_qa = format!("pipe-qa-{tag}");
+    for (name, provider) in [(&a_tri, "claude"), (&a_rev, "codex"), (&a_qa, "claude")] {
+        run_ainb(
+            &ainb,
+            home.path(),
+            &[
+                "hangar",
+                "agent",
+                "create",
+                "--name",
+                name,
+                "--provider",
+                provider,
+            ],
+        );
+    }
+
+    let pool = open_pool(&db_path).await;
+    let (id_tri, rt_claude) = agent_ids_by_name(&pool, &a_tri).await;
+    let (id_rev, rt_codex) = agent_ids_by_name(&pool, &a_rev).await;
+    let (id_qa, _) = agent_ids_by_name(&pool, &a_qa).await;
+    // A runtime is a DAEMON, not a provider binding: every agent binds to the one
+    // `default` runtime whatever `--provider` said, and the per-agent provider
+    // lives on `agent.provider`. So ONE daemon serves all three agents, and it is
+    // handed BOTH real provider binaries.
+    assert_eq!(
+        rt_claude, rt_codex,
+        "all agents share the single default runtime"
+    );
+    let providers: Vec<String> =
+        sqlx::query_scalar("SELECT provider FROM agent WHERE id IN (?1, ?2, ?3) ORDER BY id")
+            .bind(&id_tri)
+            .bind(&id_rev)
+            .bind(&id_qa)
+            .fetch_all(&pool)
+            .await
+            .expect("read agent providers");
+    assert!(
+        providers.iter().any(|p| p == "codex") && providers.iter().any(|p| p == "claude"),
+        "the roster must mix real providers, saw {providers:?}"
+    );
+
+    // Cheapest live claude model on both claude agents.
+    for id in [&id_tri, &id_qa] {
+        run_ainb(
+            &ainb,
+            home.path(),
+            &["hangar", "agent", "edit", id, "--model", "haiku"],
+        );
+    }
+
+    // 2. The pipeline, through the real CLI verb.
+    run_ainb(&ainb, home.path(), &["hangar", "pipeline", "init"]);
+
+    // 3. A squad whose members carry the ROLES that gate each stage. This is the
+    //    only thing that decides who may take which stage.
+    let squad = format!("pipe-squad-{tag}");
+    let squad_id = parse_parenthesised_id(&run_ainb_capture(
+        &ainb,
+        home.path(),
+        &[
+            "hangar",
+            "squad",
+            "create",
+            &squad,
+            "--leader",
+            &format!("agent:{id_tri}"),
+        ],
+    ));
+    for (agent_id, roles) in [
+        (&id_tri, "triager,implementer"),
+        (&id_rev, "reviewer"),
+        (&id_qa, "tester"),
+    ] {
+        run_ainb(
+            &ainb,
+            home.path(),
+            &[
+                "hangar",
+                "squad",
+                "add-member",
+                &squad_id,
+                "--member",
+                &format!("agent:{agent_id}"),
+                "--role",
+                roles,
+            ],
+        );
+    }
+
+    // 4. Two daemons, one per runtime, each pointed at its REAL provider binary.
+    let daemon = LiveDaemon::spawn_with(
+        &home.path().join("daemon.log"),
+        home.path(),
+        &rt_claude,
+        &[
+            ("HANGAR_CLAUDE_PATH", claude.as_path()),
+            ("HANGAR_CODEX_PATH", codex.as_path()),
+        ],
+    );
+
+    // 5. The issue. Its title BECOMES the provider prompt at every stage, so the
+    //    brief asks for the one observable side effect the model cannot fake by
+    //    printing text.
+    let brief = format!(
+        "Use the Bash tool to run exactly this one shell command and nothing else: \
+         printf '%s' '{nonce}' > {ARTIFACT_NAME}  \
+         Do not use the Write tool. Once the command has run, stop."
+    );
+    let issue_out = run_ainb_capture(
+        &ainb,
+        home.path(),
+        &[
+            "hangar",
+            "issue",
+            "create",
+            "--title",
+            &brief,
+            "--repo",
+            repo.to_str().expect("repo path"),
+        ],
+    );
+    let issue_id = parse_created_id(&issue_out);
+
+    // No task exists yet: the card has not been dispatched.
+    assert_eq!(
+        count_tasks(&pool, &issue_id).await,
+        0,
+        "issue create without --assign must not enqueue a run"
+    );
+
+    // 6. Dispatch to the squad. Under pull this enqueues the card into Triage and
+    //    ONE eligible agent takes it, rather than starting one run per member.
+    run_ainb(
+        &ainb,
+        home.path(),
+        &[
+            "hangar", "squad", "assign", &squad_id, "--issue", &issue_id, "--fanout",
+        ],
+    );
+
+    // 7. WALK THE PIPELINE, asserting continuously.
+    let observed = walk_pipeline(&pool, &issue_id, home.path()).await;
+    drop(daemon);
+
+    // ---- Assertions -----------------------------------------------------
+    println!("\n=== LIVE PIPELINE PROOF: {issue_id} ===");
+    for s in &observed.stages {
+        println!(
+            "stage {:<10} agent={:<28} kind={:<7} task={} parent={}",
+            s.column,
+            s.agent_id,
+            s.agent_kind,
+            s.task_id,
+            s.parent_task_id.as_deref().unwrap_or("(none)")
+        );
+    }
+
+    assert!(
+        observed.max_concurrent_running <= 1,
+        "MORE THAN ONE RUNNING TASK on the card at once (saw {}), which is the \
+         broadcast defect this pipeline removes",
+        observed.max_concurrent_running
+    );
+
+    assert!(
+        observed.stages.len() >= 4,
+        "expected the card to traverse 4 role-gated stages, saw {}: {:?}",
+        observed.stages.len(),
+        observed.stages
+    );
+
+    let by_role = |role: &str| {
+        observed
+            .stages
+            .iter()
+            .find(|s| s.services_role == role)
+            .unwrap_or_else(|| panic!("no stage serviced role `{role}`: {:?}", observed.stages))
+            .clone()
+    };
+    let implement = by_role("implementer");
+    let review = by_role("reviewer");
+    let qa = by_role("tester");
+
+    assert_ne!(
+        review.agent_id, implement.agent_id,
+        "THE REVIEWER IS THE IMPLEMENTER. The prior-agent exclusion did not bite."
+    );
+    assert_ne!(
+        qa.agent_id, implement.agent_id,
+        "QA must not be the implementer"
+    );
+    assert_ne!(qa.agent_id, review.agent_id, "QA must not be the reviewer");
+
+    let distinct: std::collections::HashSet<_> =
+        observed.stages.iter().map(|s| s.agent_id.clone()).collect();
+    assert!(
+        distinct.len() >= 3,
+        "expected at least THREE different agents across the pipeline, saw {}: {distinct:?}",
+        distinct.len()
+    );
+
+    // Two REAL provider CLIs actually drove the work.
+    let kinds: std::collections::HashSet<_> =
+        observed.stages.iter().map(|s| s.agent_kind.clone()).collect();
+    assert!(
+        kinds.contains("claude") && kinds.contains("codex"),
+        "expected both real provider CLIs to have run, saw {kinds:?}"
+    );
+
+    // The parent_task_id chain is unbroken: stage N+1 points at stage N.
+    for pair in observed.stages.windows(2) {
+        assert_eq!(
+            pair[1].parent_task_id.as_deref(),
+            Some(pair[0].task_id.as_str()),
+            "BROKEN HANDOFF CHAIN: stage `{}` must chain to stage `{}`",
+            pair[1].column,
+            pair[0].column
+        );
+    }
+    assert_eq!(
+        observed.stages[0].parent_task_id, None,
+        "the first stage has no predecessor to chain to"
+    );
+
+    // The card advanced ONE column at a time, never skipping a stage.
+    assert_eq!(
+        observed.column_ords,
+        (1..=observed.column_ords.len() as i64).collect::<Vec<_>>(),
+        "the card must step one column at a time, saw ords {:?}",
+        observed.column_ords
+    );
+
+    // Every stage did REAL work: its own worktree holds the exact nonce, and the
+    // run recorded real token usage.
+    for s in &observed.stages {
+        let work_dir = s
+            .work_dir
+            .as_deref()
+            .unwrap_or_else(|| panic!("stage `{}` recorded no work_dir", s.column));
+        let artifact = Path::new(work_dir).join(ARTIFACT_NAME);
+        let got = std::fs::read_to_string(&artifact).unwrap_or_else(|e| {
+            panic!(
+                "NONCE ARTIFACT MISSING for stage `{}` at {artifact:?} ({e}). \
+                 The task reached a terminal state without doing real work. \
+                 daemon log:\n{}",
+                s.column,
+                std::fs::read_to_string(home.path().join("daemon.log")).unwrap_or_default(),
+            )
+        });
+        assert_eq!(
+            got.trim(),
+            nonce,
+            "stage `{}` wrote the wrong nonce",
+            s.column
+        );
+
+        let usage = fetch_usage(&pool, &s.task_id).await;
+        assert!(
+            usage.is_some_and(|u| u.input_tokens > 0 || u.output_tokens > 0),
+            "stage `{}` recorded no token usage, so no real inference happened",
+            s.column
+        );
+    }
+
+    dump_sqlite_evidence(&pool, &issue_id, &observed).await;
+    println!("=== ALL PIPELINE ASSERTIONS PASSED ===\n");
+}
+
+/// Print the RAW sqlite evidence behind each success criterion, so the proof can
+/// be read directly off the database rather than taken on the assertions' word.
+async fn dump_sqlite_evidence(pool: &SqlitePool, issue_id: &str, walk: &PipelineWalk) {
+    // The PEAK, tracked live. A post-hoc count would read 0 (everything is
+    // terminal by now) and would prove nothing about what happened mid-flight,
+    // which is exactly where a double-dispatch would appear.
+    println!("\n--- [1] PEAK simultaneous runs on the card (must be <= 1) ---");
+    println!(
+        "MAX over `SELECT COUNT(*) FROM agent_task_queue WHERE issue_id=? AND status='running'`,\n\
+         sampled every 250ms across the whole walk => {}",
+        walk.max_concurrent_running
+    );
+    println!(
+        "columns the card occupied, in order (ords) => {:?}",
+        walk.column_ords
+    );
+
+    println!("\n--- [2] the stage chain: agent, provider, parent_task_id ---");
+    let rows = sqlx::query(
+        "SELECT t.id, t.agent_id, a.name AS agent_name, t.agent_kind, t.status, \
+                t.generation, COALESCE(t.parent_task_id,'(none)') AS parent \
+           FROM agent_task_queue t JOIN agent a ON a.id = t.agent_id \
+          WHERE t.issue_id = ?1 ORDER BY t.created_at, t.id",
+    )
+    .bind(issue_id)
+    .fetch_all(pool)
+    .await
+    .expect("read chain");
+    println!(
+        "{:<28} {:<22} {:<7} {:<6} {:>3}  {}",
+        "task_id", "agent_name", "kind", "status", "gen", "parent_task_id"
+    );
+    for r in &rows {
+        println!(
+            "{:<28} {:<22} {:<7} {:<6} {:>3}  {}",
+            r.get::<String, _>("id"),
+            r.get::<String, _>("agent_name"),
+            r.get::<String, _>("agent_kind"),
+            r.get::<String, _>("status"),
+            r.get::<i64, _>("generation"),
+            r.get::<String, _>("parent"),
+        );
+    }
+
+    println!("\n--- [3] distinct agents that ran the card ---");
+    let n: i64 = sqlx::query_scalar(
+        "SELECT COUNT(DISTINCT agent_id) FROM agent_task_queue WHERE issue_id = ?1",
+    )
+    .bind(issue_id)
+    .fetch_one(pool)
+    .await
+    .expect("count distinct");
+    println!("SELECT COUNT(DISTINCT agent_id) => {n}");
+
+    println!("\n--- [4] where the card finished ---");
+    let fin = sqlx::query(
+        "SELECT col.name AS name, col.ord AS ord, \
+                COALESCE(col.services_role,'(none)') AS role \
+           FROM board_card bc JOIN board_column col ON col.id = bc.column_id \
+          WHERE bc.issue_id = ?1",
+    )
+    .bind(issue_id)
+    .fetch_one(pool)
+    .await
+    .expect("read final column");
+    println!(
+        "board_card.column => {} (ord {}, services_role {})",
+        fin.get::<String, _>("name"),
+        fin.get::<i64, _>("ord"),
+        fin.get::<String, _>("role"),
+    );
+
+    println!("\n--- [5] real token spend per stage (a stub cannot fake this) ---");
+    for r in &rows {
+        let id: String = r.get("id");
+        let u = fetch_usage(pool, &id).await;
+        println!(
+            "{id}  in={:<7} out={:<7}",
+            u.as_ref().map_or(-1, |u| u.input_tokens),
+            u.as_ref().map_or(-1, |u| u.output_tokens),
+        );
+    }
+}
+
+/// One observed pipeline stage: the task that owned it plus where it sat.
+#[derive(Debug, Clone)]
+struct StageObservation {
+    column: String,
+    services_role: String,
+    task_id: String,
+    agent_id: String,
+    agent_kind: String,
+    parent_task_id: Option<String>,
+    work_dir: Option<String>,
+}
+
+/// What a full pipeline walk observed.
+#[derive(Debug, Default)]
+struct PipelineWalk {
+    stages: Vec<StageObservation>,
+    /// The HIGHEST number of simultaneously `running` tasks ever seen on the
+    /// card. Sampled every poll, so a transient double-dispatch cannot hide
+    /// between two end-state reads.
+    max_concurrent_running: i64,
+    /// The `ord` of every column the card was observed in, in order.
+    column_ords: Vec<i64>,
+}
+
+/// Total wall-clock budget for the whole four-stage walk (four real provider
+/// runs across two CLIs).
+const PIPELINE_BUDGET: Duration = Duration::from_secs(900);
+
+/// Drive and observe the card until it reaches a terminal (non-role-gated)
+/// column or the budget expires.
+///
+/// Polls fast (250ms) so the "never two running at once" sample is dense enough
+/// to catch a transient double-dispatch, which a start/end comparison would miss
+/// entirely.
+async fn walk_pipeline(pool: &SqlitePool, issue_id: &str, home: &Path) -> PipelineWalk {
+    let deadline = std::time::Instant::now() + PIPELINE_BUDGET;
+    let mut walk = PipelineWalk::default();
+    let mut seen_tasks: Vec<String> = Vec::new();
+    let mut last_ord: Option<i64> = None;
+
+    while std::time::Instant::now() < deadline {
+        // (a) One-owner sample, every poll.
+        let running: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM agent_task_queue \
+              WHERE issue_id = ?1 AND status = 'running'",
+        )
+        .bind(issue_id)
+        .fetch_one(pool)
+        .await
+        .expect("count running");
+        walk.max_concurrent_running = walk.max_concurrent_running.max(running);
+
+        // (b) Where the card sits now.
+        let pos = sqlx::query(
+            "SELECT col.name AS name, col.ord AS ord, col.services_role AS role \
+               FROM board_card bc JOIN board_column col ON col.id = bc.column_id \
+              WHERE bc.issue_id = ?1",
+        )
+        .bind(issue_id)
+        .fetch_optional(pool)
+        .await
+        .expect("read card position");
+
+        if let Some(p) = &pos {
+            let ord: i64 = p.get("ord");
+            if last_ord != Some(ord) {
+                walk.column_ords.push(ord);
+                last_ord = Some(ord);
+            }
+        }
+
+        // (c) Record any newly-created task, with the stage it serves.
+        let rows = sqlx::query(
+            "SELECT t.id AS id, t.agent_id AS agent_id, t.agent_kind AS agent_kind, \
+                    t.parent_task_id AS parent_task_id, t.work_dir AS work_dir, \
+                    t.status AS status, t.created_at AS created_at \
+               FROM agent_task_queue t \
+              WHERE t.issue_id = ?1 ORDER BY t.created_at, t.id",
+        )
+        .bind(issue_id)
+        .fetch_all(pool)
+        .await
+        .expect("read tasks");
+
+        for r in &rows {
+            let id: String = r.get("id");
+            if seen_tasks.contains(&id) {
+                // Refresh work_dir, which is only stamped once the run starts.
+                if let Some(s) = walk.stages.iter_mut().find(|s| s.task_id == id) {
+                    if s.work_dir.is_none() {
+                        s.work_dir = r.get("work_dir");
+                    }
+                }
+                continue;
+            }
+            seen_tasks.push(id.clone());
+            // The stage a task serves is the column the card was in when it was
+            // pulled, which is the card's position right now for the newest task.
+            let (column, role) = pos.as_ref().map_or_else(
+                || ("(unknown)".to_string(), String::new()),
+                |p| {
+                    (
+                        p.get::<String, _>("name"),
+                        p.get::<Option<String>, _>("role").unwrap_or_default(),
+                    )
+                },
+            );
+            walk.stages.push(StageObservation {
+                column,
+                services_role: role,
+                task_id: id,
+                agent_id: r.get("agent_id"),
+                agent_kind: r.get("agent_kind"),
+                parent_task_id: r.get("parent_task_id"),
+                work_dir: r.get("work_dir"),
+            });
+        }
+
+        // (d) Done when the card reaches a column with no role gate AND nothing
+        //     is active: the pipeline has run to its terminal stage.
+        let gated = pos.as_ref().and_then(|p| p.get::<Option<String>, _>("role")).is_some();
+        let active: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM agent_task_queue \
+              WHERE issue_id = ?1 AND status IN ('queued','dispatched','running')",
+        )
+        .bind(issue_id)
+        .fetch_one(pool)
+        .await
+        .expect("count active");
+        if !gated && active == 0 && !walk.stages.is_empty() {
+            return walk;
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    panic!(
+        "pipeline did not reach a terminal column within {PIPELINE_BUDGET:?}. \
+         observed stages: {:?}\ndaemon log:\n{}",
+        walk.stages,
+        std::fs::read_to_string(home.join("daemon.log")).unwrap_or_default(),
+    );
+}
+
+/// Count every task row on an issue.
+async fn count_tasks(pool: &SqlitePool, issue_id: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = ?1")
+        .bind(issue_id)
+        .fetch_one(pool)
+        .await
+        .expect("count tasks")
+}
+
+/// Pull the created entity id out of a `... <id>` CLI creation line. The hangar
+/// creation verbs all echo the new id as the last whitespace-separated token of
+/// their first output line.
+fn parse_created_id(stdout: &str) -> String {
+    stdout
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .and_then(|l| l.split_whitespace().last())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| panic!("no created id in output:\n{stdout}"))
+}
+
+/// Pull an id out of a `created squad <name> (<id>) led by ...` line, whose id
+/// is parenthesised rather than trailing.
+fn parse_parenthesised_id(stdout: &str) -> String {
+    stdout
+        .split_once('(')
+        .and_then(|(_, rest)| rest.split_once(')'))
+        .map(|(id, _)| id.trim().to_string())
+        .unwrap_or_else(|| panic!("no parenthesised id in output:\n{stdout}"))
+}
+
+/// A scratch git repo with one commit, so each stage can provision its own
+/// worktree from it.
+fn init_scratch_repo(dir: &Path) {
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    git(&["init", "--initial-branch=main"]);
+    git(&["config", "user.email", "pipeline@example.test"]);
+    git(&["config", "user.name", "Pipeline Proof"]);
+    // Signing is disabled for this throwaway repo: a headless commit against a
+    // locked keychain would hang on pinentry rather than fail.
+    git(&["config", "commit.gpgsign", "false"]);
+    std::fs::write(dir.join("README.md"), "pipeline proof scratch repo\n").expect("write README");
+    git(&["add", "README.md"]);
+    git(&["commit", "-m", "seed"]);
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_cancel_active.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_issue_cancel_active.rs
@@ -300,3 +300,102 @@ async fn cancel_active_rejects_unknown_workspace() {
             .unwrap();
     assert_eq!(status, "running", "rejected cancel left the run running");
 }
+
+/// EVERY active sibling on one issue is cancelled, not just the newest.
+///
+/// The cancel path used to resolve a SINGLE task (`LIMIT 1`), so with several
+/// concurrent runs on one card it cancelled the newest and left the rest burning
+/// tokens, which later re-moved the "cancelled" card.
+///
+/// This property was previously proven end-to-end by
+/// `tripwire_tcp_squad_card_fanout_e2e`, whose three live siblings came from the
+/// squad BROADCAST. A squad card now carries ONE run, so that tripwire can no
+/// longer build the case, and the coverage is re-homed here rather than being
+/// allowed to evaporate along with the defect. Several concurrent runs on one
+/// card are still reachable deliberately, via `--redundant N`.
+#[tokio::test]
+async fn cancel_active_cancels_every_sibling_not_just_the_newest() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+
+    // Three concurrent runs on ONE issue, in the three states the cancel must
+    // sweep, seeded oldest-first so a LIMIT 1 resolver would take `t-newest`.
+    //
+    // Each sits on its OWN agent, which is both the real `--redundant` shape and
+    // a hard requirement: `idx_one_pending_task_per_issue_agent` (migration 0012)
+    // forbids two PENDING rows per (issue, agent), so seeding all three on one
+    // agent trips a UNIQUE violation rather than building the case.
+    let (runtime_id, base_agent): (String, String) =
+        sqlx::query_as("SELECT a.runtime_id, a.id FROM agent a WHERE a.workspace_id = ? LIMIT 1")
+            .bind(WS_ID)
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    for (task_id, agent_suffix, status) in [
+        ("t-oldest", "sib-a", "running"),
+        ("t-middle", "sib-b", "dispatched"),
+        ("t-newest", "sib-c", "queued"),
+    ] {
+        let agent_id = format!("{base_agent}-{agent_suffix}");
+        sqlx::query(
+            "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+             SELECT ?1, workspace_id, ?1, runtime_id, visibility, owner_id \
+               FROM agent WHERE id = ?2",
+        )
+        .bind(&agent_id)
+        .bind(&base_agent)
+        .execute(store.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO agent_task_queue \
+             (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, run_group) \
+             VALUES (?1, ?2, ?3, ?4, 'issue-2', ?5, 0, 'rg-1')",
+        )
+        .bind(task_id)
+        .bind(WS_ID)
+        .bind(&runtime_id)
+        .bind(&agent_id)
+        .bind(status)
+        .execute(store.pool())
+        .await
+        .unwrap();
+    }
+
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let cancelled = c
+        .call(
+            methods::HANGAR_ISSUE_CANCEL_ACTIVE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "issue_id": "issue-2" }),
+        )
+        .await;
+    assert!(
+        cancelled["error"].is_null(),
+        "cancel_active must ack: {cancelled}"
+    );
+
+    let states: Vec<(String, String)> = sqlx::query_as(
+        "SELECT id, status FROM agent_task_queue WHERE issue_id = 'issue-2' ORDER BY id",
+    )
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(states.len(), 3, "all three rows survive as rows");
+    for (id, status) in &states {
+        assert_eq!(
+            status, "cancelled",
+            "sibling {id} must be cancelled, not left active: {states:?}"
+        );
+    }
+
+    let still_active: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM agent_task_queue \
+          WHERE issue_id = 'issue-2' AND status IN ('queued','dispatched','running')",
+    )
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(still_active, 0, "no sibling may be left burning tokens");
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_squad_management.rs
@@ -486,19 +486,21 @@ async fn squad_assign_rpc_routes_a_task_to_the_leader_agent() {
     );
 }
 
-/// FAN-OUT THROUGH THE `hangar/squad_fanout` RPC (P7): assigning an issue to a
-/// squad briefs the LEADER *and* enqueues one task per distinct `agent` member,
-/// all on the SAME issue, each claimable in parallel on its own runtime.
+/// PULL, NOT BROADCAST, THROUGH THE `hangar/squad_fanout` RPC: assigning an issue
+/// to a squad yields exactly ONE run, whatever the member count.
 ///
 /// The squad's leader is `agent-2` (runtime-2); its members are `agent-3`
-/// (runtime-3), `agent-4` (runtime-4), plus the human `member:user-1` (which must
-/// NOT fan out). The test drives the product RPC naming only the squad + issue;
-/// the daemon resolves the leader + members server-side. It then proves each of
-/// the three agent runtimes claims its own task on `issue-2` via the real
-/// `ClaimTaskService` — three pending tasks coexisting on one issue, the
-/// per-(issue, agent) guard (migration 0012) at work.
+/// (runtime-3), `agent-4` (runtime-4), plus the human `member:user-1`. The test
+/// drives the product RPC naming only the squad + issue.
+///
+/// This previously asserted the OPPOSITE, that all three agent runtimes claimed
+/// their own task on `issue-2` in parallel, and it is inverted here
+/// deliberately: three agents holding a task on one issue meant three worktrees
+/// doing the same work and racing each other, which is the reported defect. The
+/// per-(issue, agent) guard still PERMITS that shape; nothing now produces it
+/// except an explicit `--redundant` fan-out.
 #[tokio::test]
-async fn squad_fanout_rpc_briefs_leader_and_fans_members_claimable_in_parallel() {
+async fn squad_fanout_rpc_yields_one_owner_never_one_task_per_member() {
     let dir = tempfile::tempdir().unwrap();
     let (socket_path, store) = start_server(dir.path()).await;
     // Leader + two member agents, each on its own runtime.
@@ -539,41 +541,36 @@ async fn squad_fanout_rpc_briefs_leader_and_fans_members_claimable_in_parallel()
         "the leader gets the brief: {fanned}"
     );
     let members = fanned["result"]["members"].as_array().unwrap();
-    assert_eq!(
-        members.len(),
-        2,
-        "two agent members fanned out (human skipped): {fanned}"
-    );
-    let member_agents: Vec<&str> =
-        members.iter().map(|m| m["agent_id"].as_str().unwrap()).collect();
     assert!(
-        member_agents.contains(&"agent-3"),
-        "agent-3 fanned: {fanned}"
-    );
-    assert!(
-        member_agents.contains(&"agent-4"),
-        "agent-4 fanned: {fanned}"
+        members.is_empty(),
+        "a squad of N members must not fan out to N tasks: {fanned}"
     );
 
-    // PARALLEL CLAIM: every runtime claims its own task on issue-2 at once.
-    let clock = FixedClock(10_000);
-    for (runtime, agent) in [
-        ("runtime-2", "agent-2"),
-        ("runtime-3", "agent-3"),
-        ("runtime-4", "agent-4"),
-    ] {
-        let claimed = ClaimTaskService::claim_for_runtime(pool, runtime, &clock)
+    let rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = 'issue-2'")
+            .fetch_one(pool)
             .await
-            .unwrap()
-            .unwrap_or_else(|| panic!("{runtime} claims its squad task"));
-        assert_eq!(
-            claimed.agent_id, agent,
-            "{runtime} claimed the wrong agent's task"
-        );
-        assert_eq!(
-            claimed.issue_id.as_deref(),
-            Some("issue-2"),
-            "the fanned-out task is on issue-2"
+            .unwrap();
+    assert_eq!(rows, 1, "exactly one task row exists on the issue");
+
+    // Only the OWNER's runtime has anything to claim. The member runtimes find
+    // nothing, which is what stops three agents provisioning three worktrees for
+    // one card.
+    let clock = FixedClock(10_000);
+    let claimed = ClaimTaskService::claim_for_runtime(pool, "runtime-2", &clock)
+        .await
+        .unwrap()
+        .expect("the owner's runtime claims the one task");
+    assert_eq!(claimed.agent_id, "agent-2");
+    assert_eq!(claimed.issue_id.as_deref(), Some("issue-2"));
+
+    for runtime in ["runtime-3", "runtime-4"] {
+        assert!(
+            ClaimTaskService::claim_for_runtime(pool, runtime, &clock)
+                .await
+                .unwrap()
+                .is_none(),
+            "member runtime {runtime} must have nothing to claim"
         );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_dependency_chain_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_dependency_chain_e2e.rs
@@ -199,18 +199,28 @@ fn manual_done_transition_auto_runs_dependent() {
     );
 }
 
-/// tcp T4 / FANOUT-SEMANTICS — a dependent waits for the blocker's WHOLE squad, not
-/// just its latest member.
+/// tcp T4 / FANOUT-SEMANTICS: a dependent waits until the blocker's active set has
+/// DRAINED with a success, proven against the REAL daemon.
 ///
-/// Blocker A is a SQUAD card (leader + two members → three tasks on one issue). The
-/// old logic keyed "A finished" on A's LATEST task, so B unblocked the instant the
-/// newest member finished while the leader / other member still ran. This proves the
-/// whole-set contract against the REAL daemon: transitioning A's NEWEST active task
-/// to `done` while OLDER siblings still run leaves B blocked (latest-wins would have
-/// unblocked it there); only when A's ENTIRE set has drained with a success does B
-/// become runnable and auto-run.
+/// # Why this no longer drives a multi-task blocker
+///
+/// Blocker A used to be a SQUAD card that BROADCAST into three tasks on one issue
+/// (leader + two members), and this test drained them one at a time to prove that
+/// finishing the newest was not enough. A squad dispatch now yields ONE owner, so
+/// that shape is no longer reachable here and the sibling-draining steps are
+/// DELETED rather than faked with hand-built rows.
+///
+/// The whole-set property itself is unchanged and is still pinned, on the shape
+/// that can still produce several concurrent runs on one card: the explicit
+/// `--redundant N` cluster, covered by
+/// `ainb-hangar-store/tests/squad_no_broadcast.rs`
+/// (`dependent_waits_for_the_whole_redundant_cluster_to_drain` and
+/// `a_cluster_that_drains_without_a_success_keeps_the_dependent_blocked`).
+///
+/// What remains here, and is genuinely end-to-end: B holds NO task while A has any
+/// active task, and B auto-runs only once A reaches `done`.
 #[test]
-fn dependent_waits_for_the_whole_squad_blocker() {
+fn dependent_waits_for_the_blocker_to_drain() {
     if daemon_bin().is_none() || !git_available() {
         skip("tcp_card_dependency_whole_squad_e2e");
         return;
@@ -220,8 +230,7 @@ fn dependent_waits_for_the_whole_squad_blocker() {
     let scale = budget_scale();
     let mut rpc = DaemonRpc::connect_and_auth(pipe.home());
 
-    // Fan A out; assign_fanout inserts all three tasks before the RPC returns, so A
-    // now carries three active tasks on one issue.
+    // Run the squad blocker A. Under the pull model this dispatches ONE owner.
     let run_a = rpc.call(
         ainb_hangar_proto::methods::HANGAR_BOARD_CARD_RUN,
         run_params(T4_DEP_BLOCKER_ISSUE),
@@ -232,18 +241,23 @@ fn dependent_waits_for_the_whole_squad_blocker() {
     );
     let member_count = run_a["result"]["member_task_ids"].as_array().map_or(0, Vec::len);
     assert_eq!(
-        member_count, 2,
-        "A must fan out to a leader + two members: {run_a}"
+        member_count, 0,
+        "a squad dispatch must not fan out to one task per member: {run_a}"
+    );
+    assert_eq!(
+        task_count_for_issue(pipe.home(), T4_DEP_BLOCKER_ISSUE),
+        1,
+        "A carries exactly ONE run"
     );
 
-    // B has no task — A's set has not drained.
+    // B has no task: A's set has not drained.
     assert_eq!(
         task_count_for_issue(pipe.home(), T4_DEP_DEPENDENT_ISSUE),
         0,
         "B blocked while A runs"
     );
 
-    // Transition A's NEWEST active task to `done` while OLDER siblings still run.
+    // Drain A's active set.
     let newest = newest_active_task_for_issue(pipe.home(), T4_DEP_BLOCKER_ISSUE)
         .expect("A must have an active task to complete");
     let done = rpc.call(
@@ -256,20 +270,10 @@ fn dependent_waits_for_the_whole_squad_blocker() {
     );
     assert!(
         done["error"].is_null(),
-        "completing the newest member must ack: {done}"
+        "completing A's run must ack: {done}"
     );
 
-    // KEY DISCRIMINATOR: the newest member is done but older siblings still run — the
-    // old latest-wins logic would have unblocked B here. The whole-set contract must
-    // keep it blocked. The unblock hook fired synchronously inside the RPC above, so
-    // if B were going to gain a task it already would have.
-    assert_eq!(
-        task_count_for_issue(pipe.home(), T4_DEP_DEPENDENT_ISSUE),
-        0,
-        "B must stay blocked while ANY squad member of A still runs (newest-done is not enough)"
-    );
-
-    // Drain the rest of A's set to `done`, newest-first, until nothing is active.
+    // Drain any residue (a retry child, say) so the active set is genuinely empty.
     while let Some(t) = newest_active_task_for_issue(pipe.home(), T4_DEP_BLOCKER_ISSUE) {
         let d = rpc.call(
             ainb_hangar_proto::methods::HANGAR_TASK_TRANSITION,
@@ -279,13 +283,10 @@ fn dependent_waits_for_the_whole_squad_blocker() {
                 "to_status": "done",
             }),
         );
-        assert!(
-            d["error"].is_null(),
-            "draining a squad member must ack: {d}"
-        );
+        assert!(d["error"].is_null(), "draining A must ack: {d}");
     }
 
-    // A's WHOLE set has now drained with a success → B becomes runnable and auto-runs.
+    // A's set has now drained with a success, so B becomes runnable and auto-runs.
     let autorun_deadline = Instant::now() + Duration::from_secs(45 * scale);
     let b_ran = poll_until(autorun_deadline, || {
         task_count_for_issue(pipe.home(), T4_DEP_DEPENDENT_ISSUE) >= 1
@@ -298,7 +299,7 @@ fn dependent_waits_for_the_whole_squad_blocker() {
 
     assert!(
         b_ran,
-        "B must auto-run only once A's ENTIRE squad set has drained with a done"
+        "B must auto-run only once A's active set has drained with a done"
     );
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_squad_card_fanout_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_squad_card_fanout_e2e.rs
@@ -1,34 +1,46 @@
-//! tcp T4 (agents-in-a-box-aau.4) — the F7 SQUAD-CARD fan-out tripwire.
+//! tcp T4 (agents-in-a-box-aau.4): the F7 SQUAD-CARD single-owner tripwire.
 //!
 //! A card can be assigned a whole SQUAD, not just a single agent. This tripwire
 //! proves the acceptance end-to-end against the REAL daemon binary + claim loop:
 //! a card assigned to a squad (leader + two members) is RUN via
-//! `hangar/board_card_run`, which FANS OUT into a leader brief + one task per
-//! member — and each of the THREE tasks provisions its OWN volatile worktree from
-//! the card's repo, live at once.
+//! `hangar/board_card_run`, which dispatches the work to exactly ONE owner,
+//! never one task per member.
+//!
+//! This test previously asserted the OPPOSITE: that a squad-card run FANNED OUT
+//! into a leader task plus one task per member, with all three live at once in
+//! three separate worktrees on three separate `ainb/<slug>` branches. That was
+//! the defect being tested, not the feature: three agents racing the SAME issue
+//! meant three worktrees, three branches, and three independently-committed
+//! answers to one card, with nothing reconciling them. `SquadAssignService::
+//! assign_fanout` now enqueues the card into the first role-gated board column
+//! (or, when the workspace has no such pipeline, briefs the squad LEADER
+//! directly), and exactly one eligible agent takes it. `SquadFanout.members` is
+//! now ALWAYS EMPTY, except for the explicit `--redundant N` opt-in
+//! (`assign_redundant`), a different function entirely. This tripwire is
+//! inverted to match: it proves ONE owner, ONE worktree, ONE branch, per card.
 //!
 //! ```text
 //!  board_card_run(squad card) ──▶ run_card ──▶ assign_fanout
 //!         │                                        │
 //!         ▼                                        ▼
-//!   leader task (agent-1)   member task (agent-m1)   member task (agent-m2)
-//!         │                        │                        │
-//!         ▼                        ▼                        ▼
-//!   worktrees/<lead>         worktrees/<m1>           worktrees/<m2>
-//!    on ainb/<lead>           on ainb/<m1>             on ainb/<m2>   ── all live at once
-//!         │  ── release the blocked agents ──▶ all three finalize + tear down ──
+//!                                    ONE owner task (the leader, or
+//!                                    the single agent a pipeline pulled)
+//!                                             │
+//!                                             ▼
+//!                                      worktrees/<owner>
+//!                                       on ainb/<owner>
+//!                                             │
+//!             ── release the blocked agent ──▶ finalizes, tears down ──
 //! ```
 //!
 //! Drives the daemon directly (a framed socket RPC) rather than the TUI: the
-//! card→overlay path is covered by the T1/T3 tripwires; the fan-out + per-member
-//! worktree isolation is a pure run-handler + claim-loop behaviour. The three
-//! member agents share `runtime-1` (distinct agents), so the single fixture daemon
-//! claims all three concurrently under their per-agent caps. SKIPs cleanly when the
-//! daemon binary / git are absent. Exact-name kills only (the `Pipeline` owns its
-//! one daemon child); deadline-bounded polls; POSITIVE (three live worktrees +
-//! member chips) + NEGATIVE (all torn down) proofs.
+//! card-to-overlay path is covered by the T1/T3 tripwires; the single-owner
+//! dispatch plus worktree lifecycle is a pure run-handler / claim-loop
+//! behaviour. SKIPs cleanly when the daemon binary or git are absent. Exact-name
+//! kills only (the `Pipeline` owns its one daemon child); deadline-bounded
+//! polls; POSITIVE (one live worktree, one owner chip) and NEGATIVE (torn down,
+//! no member tasks) proofs.
 
-use std::collections::HashSet;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -42,10 +54,19 @@ use common::{
     worktree_branch, worktree_dir,
 };
 
+/// tcp T4 / FANOUT-SEMANTICS: running a squad card dispatches to exactly ONE
+/// owner, never one task per member.
+///
+/// Inverted from the removed broadcast defect: this test used to prove three
+/// tasks (leader + two members) landed in three distinct worktrees, all live at
+/// once. Under pull that shape is gone (`assign_fanout` writes ONE task and
+/// `SquadFanout.members` is always empty), so the proof is now that a squad
+/// dispatch behaves exactly like a single-agent one: one task, one worktree, one
+/// branch, one board chip.
 #[test]
-fn squad_card_run_fans_out_to_own_worktrees() {
+fn squad_card_run_dispatches_to_exactly_one_owner() {
     if daemon_bin().is_none() || !git_available() {
-        skip("tcp_squad_card_fanout_e2e");
+        skip("tcp_squad_card_single_owner_e2e");
         return;
     }
 
@@ -54,8 +75,9 @@ fn squad_card_run_fans_out_to_own_worktrees() {
     let repo = pipe.home().join(WORKTREE_REPO_NAME);
     let mut rpc = DaemonRpc::connect_and_auth(pipe.home());
 
-    // POSITIVE (fan-out): running the squad card enqueues a LEADER task + one task
-    // per member — the result carries the leader `task_id` + the member ids.
+    // POSITIVE (single owner): running the squad card enqueues EXACTLY ONE task.
+    // `member_task_ids` is `#[serde(skip_serializing_if = "Vec::is_empty")]` on
+    // the wire, so under pull it is ABSENT from the reply entirely, never `[]`.
     let run = rpc.call(
         ainb_hangar_proto::methods::HANGAR_BOARD_CARD_RUN,
         serde_json::json!({
@@ -69,91 +91,90 @@ fn squad_card_run_fans_out_to_own_worktrees() {
         run["error"].is_null(),
         "squad card run must ack, got: {run}"
     );
-    let leader_task = run["result"]["task_id"].as_str().unwrap_or("").to_string();
+    let owner_task = run["result"]["task_id"].as_str().unwrap_or("").to_string();
     assert!(
-        !leader_task.is_empty(),
-        "run result must carry a leader task id: {run}"
+        !owner_task.is_empty(),
+        "run result must carry the single owner's task id: {run}"
     );
-    let member_tasks: Vec<String> = run["result"]["member_task_ids"]
-        .as_array()
-        .unwrap_or_else(|| panic!("run result must carry member_task_ids: {run}"))
-        .iter()
-        .map(|v| v.as_str().unwrap().to_string())
-        .collect();
+    assert!(
+        run["result"]["member_task_ids"].as_array().is_none_or(std::vec::Vec::is_empty),
+        "a squad dispatch under pull must carry no member tasks: {run}"
+    );
     assert_eq!(
-        member_tasks.len(),
-        2,
-        "the fan-out must brief the leader + two member tasks: {run}"
+        task_count_for_issue(pipe.home(), T4_SQUAD_CARD_ISSUE),
+        1,
+        "a squad card run must enqueue exactly ONE task, never one per member"
     );
 
-    // The three tasks resolve to THREE DISTINCT worktree dirs + branches (the
-    // a54 per-task-slug uniqueness — no member collides with another).
-    let mut all_task_ids = vec![leader_task.clone()];
-    all_task_ids.extend(member_tasks.clone());
-    let slugs: Vec<String> = all_task_ids.iter().map(|t| task_short_id(t).to_string()).collect();
-    let dirs: Vec<_> = slugs.iter().map(|s| worktree_dir(pipe.home(), s)).collect();
-    let distinct: HashSet<&std::path::PathBuf> = dirs.iter().collect();
-    assert_eq!(
-        distinct.len(),
-        3,
-        "the leader + two members must map to three distinct worktree dirs"
-    );
-
-    // POSITIVE (own worktrees): all THREE worktrees exist AT ONCE (every agent
-    // blocked on the release sentinel), each on its own ainb/<slug> branch.
+    // POSITIVE (one worktree, one branch): the owner's task resolves to exactly
+    // ONE live worktree dir on its own `ainb/<slug>` branch, and the shared
+    // worktrees root holds no other entry (never three live at once).
+    let slug = task_short_id(&owner_task);
+    let dir = worktree_dir(pipe.home(), &slug);
+    let branch = worktree_branch(&slug);
     let live_deadline = Instant::now() + Duration::from_secs(45 * scale);
-    let all_live = poll_until(live_deadline, || {
-        dirs.iter()
-            .zip(&slugs)
-            .all(|(dir, slug)| is_worktree_live(dir, &repo, &worktree_branch(slug)))
-    });
+    let is_live = poll_until(live_deadline, || is_worktree_live(&dir, &repo, &branch));
     assert!(
-        all_live,
-        "all three fanned runs must provision distinct live worktrees ({dirs:?})"
+        is_live,
+        "the single owner's run must provision its worktree ({dir:?})"
+    );
+    let worktrees_root = pipe.home().join(".agents-in-a-box").join("worktrees");
+    let live_count = std::fs::read_dir(&worktrees_root).map_or(0, std::iter::Iterator::count);
+    assert_eq!(
+        live_count, 1,
+        "exactly one worktree dir must exist under {worktrees_root:?}, never three"
     );
 
-    // POSITIVE (member chips): the board card renders one chip per member task.
+    // POSITIVE (one owner chip): the board card renders exactly one member chip
+    // (the pulled owner), never one chip per squad member.
     let list = rpc.call(
         ainb_hangar_proto::methods::HANGAR_BOARDS_LIST,
         serde_json::json!({ "workspace_id": ainb_hangar_daemon::seed::WS_SLUG }),
     );
     let member_states = find_card_member_states(&list, T4_SQUAD_CARD_ISSUE)
-        .unwrap_or_else(|| panic!("the squad card must render member chips: {list}"));
-    assert!(
-        member_states.len() >= 2,
-        "a squad card must show a chip per member task (got {}): {list}",
-        member_states.len()
+        .unwrap_or_else(|| panic!("the squad card must render its owner chip: {list}"));
+    assert_eq!(
+        member_states.len(),
+        1,
+        "a squad card must show exactly one chip (the pulled owner), not one per squad member: {list}"
     );
 
-    // Release the blocked agents → all three finalize → all three CLEAN worktrees
-    // torn down (F5 teardown holds for every fanned run).
+    // NEGATIVE (release, finalize, teardown): releasing the blocked agent lets
+    // the single run finalize, tearing its worktree down cleanly.
     std::fs::write(pipe.home().join(INTERACTIVE_RELEASE_SENTINEL), "go")
         .expect("write release sentinel");
 
     let teardown_deadline = Instant::now() + Duration::from_secs(45 * scale);
-    let all_gone = poll_until(teardown_deadline, || dirs.iter().all(|d| !d.exists()));
+    let gone = poll_until(teardown_deadline, || !dir.exists());
 
     // Kill the daemon by its exact child handle before the final assert.
     drop(rpc);
     drop(pipe);
 
     assert!(
-        all_gone,
-        "every fanned worktree must be torn down after its run ({dirs:?})"
+        gone,
+        "the owner's worktree must be torn down after its run ({dir:?})"
     );
 }
 
-/// tcp T4 / FANOUT-SEMANTICS — cancelling a SQUAD card cancels EVERY member.
+/// tcp T4: cancelling a SQUAD card cancels its run and reclaims its worktree,
+/// WITHOUT releasing the sentinel (the cancel is what stops the agent).
 ///
-/// The fan-out creates N concurrent active tasks on one issue, but the old cancel
-/// path resolved a single task (LIMIT 1) and cancelled only the newest sibling — the
-/// leader + the other members kept burning tokens and later re-moved the "cancelled"
-/// card. This proves the fix end-to-end against the REAL daemon: with all three
-/// fanned runs LIVE, one `board_card_cancel` drives ALL THREE task rows to
-/// `cancelled` and tears down ALL THREE worktrees — WITHOUT releasing the sentinel
-/// (the cancel is what stops the agents).
+/// # Scope narrowed with the broadcast
+///
+/// This used to build THREE live sibling runs out of the squad fan-out, to prove
+/// the cancel path no longer resolved a single task (`LIMIT 1`) and left the other
+/// siblings burning tokens. A squad card now carries ONE run, so that setup is no
+/// longer reachable here.
+///
+/// The cancel-every-sibling property is NOT dropped: it is re-homed onto the shape
+/// that can still produce several concurrent runs on one card, in
+/// `rpc_issue_cancel_active.rs`
+/// (`cancel_active_cancels_every_sibling_not_just_the_newest`). What stays here is
+/// the genuinely end-to-end half: a real daemon, a real worktree, one cancel, and
+/// the worktree reclaimed.
 #[test]
-fn cancelling_a_squad_card_cancels_every_member() {
+fn cancelling_a_squad_card_cancels_its_run() {
     if daemon_bin().is_none() || !git_available() {
         skip("tcp_squad_card_cancel_e2e");
         return;
@@ -178,19 +199,16 @@ fn cancelling_a_squad_card_cancels_every_member() {
         run["error"].is_null(),
         "squad card run must ack, got: {run}"
     );
-    let mut all_task_ids = vec![run["result"]["task_id"].as_str().unwrap_or("").to_string()];
-    all_task_ids.extend(
-        run["result"]["member_task_ids"]
-            .as_array()
-            .unwrap_or_else(|| panic!("run must carry member_task_ids: {run}"))
-            .iter()
-            .map(|v| v.as_str().unwrap().to_string()),
+    let all_task_ids = [run["result"]["task_id"].as_str().unwrap_or("").to_string()];
+    assert!(
+        run["result"]["member_task_ids"].as_array().is_none_or(std::vec::Vec::is_empty),
+        "a squad card must not fan out to one task per member: {run}"
     );
-    assert_eq!(all_task_ids.len(), 3, "leader + two members: {run}");
+    assert_eq!(all_task_ids.len(), 1, "exactly one owner: {run}");
 
-    // Wait until all three runs are LIVE (their worktrees exist) — so the cancel
-    // stops three genuinely-running siblings, not a half-started fan-out.
-    let slugs: Vec<String> = all_task_ids.iter().map(|t| task_short_id(t).to_string()).collect();
+    // Wait until the run is LIVE (its worktree exists), so the cancel stops a
+    // genuinely-running agent rather than a half-started dispatch.
+    let slugs: Vec<String> = all_task_ids.iter().map(|t| task_short_id(t)).collect();
     let dirs: Vec<_> = slugs.iter().map(|s| worktree_dir(pipe.home(), s)).collect();
     let live_deadline = Instant::now() + Duration::from_secs(45 * scale);
     let all_live = poll_until(live_deadline, || {
@@ -200,7 +218,7 @@ fn cancelling_a_squad_card_cancels_every_member() {
     });
     assert!(
         all_live,
-        "all three fanned runs must be live before the cancel ({dirs:?})"
+        "the run must be live before the cancel ({dirs:?})"
     );
 
     // ONE cancel of the card — never releasing the sentinel.
@@ -218,7 +236,7 @@ fn cancelling_a_squad_card_cancels_every_member() {
         "the squad card must report cancelled: {cancel}"
     );
 
-    // EVERY member task must reach `cancelled` — not just the newest sibling.
+    // The task must reach `cancelled`.
     let cancel_deadline = Instant::now() + Duration::from_secs(45 * scale);
     let all_cancelled = poll_until(cancel_deadline, || {
         all_task_ids
@@ -226,7 +244,7 @@ fn cancelling_a_squad_card_cancels_every_member() {
             .all(|id| task_status_by_id(pipe.home(), id).as_deref() == Some("cancelled"))
     });
 
-    // And every worktree must be torn down (each cancelled run reclaims its own).
+    // And its worktree must be torn down (a cancelled run reclaims its own).
     let teardown_deadline = Instant::now() + Duration::from_secs(45 * scale);
     let all_gone = poll_until(teardown_deadline, || dirs.iter().all(|d| !d.exists()));
 
@@ -239,11 +257,11 @@ fn cancelling_a_squad_card_cancels_every_member() {
 
     assert!(
         all_cancelled,
-        "every fanned member task must be cancelled, got {states:?}"
+        "the card's run must be cancelled, got {states:?}"
     );
     assert!(
         all_gone,
-        "every fanned worktree must be torn down after the cancel ({dirs:?})"
+        "the run's worktree must be torn down after the cancel ({dirs:?})"
     );
 }
 
@@ -294,15 +312,18 @@ fn running_a_squad_card_interactive_is_rejected() {
     );
 }
 
-/// tcp T4 / parity #25 + `7-rest` — the LEADER of a fanned squad card actually
+/// tcp T4 / parity #25 + `7-rest`: the LEADER of a squad-card run actually
 /// RECEIVES the briefing: protocol + roster (with each member's role and the
 /// skills it will materialise) + the squad's instructions.
 ///
-/// The strongest available proof: the REAL daemon binary claims the real fan-out
+/// The strongest available proof: the REAL daemon binary runs the real dispatch
 /// and materialises a real `CLAUDE.md`, which this reads off disk. The read
-/// happens INSIDE the window where the blocking fake agent still holds all three
-/// runs — the task tree is reclaimed after finalize, so reading later would race
-/// teardown.
+/// happens INSIDE the window where the blocking fake agent still holds the run
+/// (the task tree is reclaimed after finalize, so reading later would race
+/// teardown). Under pull the dispatch writes no member tasks
+/// (`SquadFanout.members` is always empty), so this no longer collects member
+/// task ids, and the old "a member run is never briefed" negative is deleted
+/// rather than kept as a loop over a list that is always empty.
 #[test]
 fn squad_card_leader_run_materialises_the_briefing_with_roles_and_skills() {
     if daemon_bin().is_none() || !git_available() {
@@ -332,14 +353,12 @@ fn squad_card_leader_run_materialises_the_briefing_with_roles_and_skills() {
         !leader_task.is_empty(),
         "run result must carry a leader task id: {run}"
     );
-    let member_tasks: Vec<String> = run["result"]["member_task_ids"]
-        .as_array()
-        .unwrap_or_else(|| panic!("run result must carry member_task_ids: {run}"))
-        .iter()
-        .map(|v| v.as_str().unwrap().to_string())
-        .collect();
+    assert!(
+        run["result"]["member_task_ids"].as_array().is_none_or(std::vec::Vec::is_empty),
+        "a squad dispatch under pull must carry no member tasks: {run}"
+    );
 
-    // Poll for the leader's materialised prompt while every run is still held.
+    // Poll for the leader's materialised prompt while the run is still held.
     let deadline = Instant::now() + Duration::from_secs(45 * scale);
     let mut leader_prompt = String::new();
     loop {
@@ -354,11 +373,6 @@ fn squad_card_leader_run_materialises_the_briefing_with_roles_and_skills() {
         }
         std::thread::sleep(Duration::from_millis(150));
     }
-    // Snapshot the member prompts inside the same window for the negative.
-    let member_prompts: Vec<Option<String>> = member_tasks
-        .iter()
-        .map(|id| materialised_context_prompt(pipe.home(), id))
-        .collect();
 
     // Release + tear down BEFORE asserting so a failure never leaks the daemon.
     std::fs::write(pipe.home().join(INTERACTIVE_RELEASE_SENTINEL), "go")
@@ -397,16 +411,6 @@ fn squad_card_leader_run_materialises_the_briefing_with_roles_and_skills() {
         leader_prompt.contains(T4_SQUAD_INSTRUCTIONS),
         "the instructions must be injected VERBATIM:\n{leader_prompt}"
     );
-
-    // NEGATIVE: a MEMBER run is never briefed — the roster belongs to the leader.
-    for (id, prompt) in member_tasks.iter().zip(&member_prompts) {
-        if let Some(text) = prompt {
-            assert!(
-                !text.contains("## Squad Roster") && !text.contains("## Squad Instructions"),
-                "member task {id} must NOT receive the leader briefing:\n{text}"
-            );
-        }
-    }
 }
 
 /// Whether the worktree at `dir` exists AND `branch` is registered in `repo`.

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0074_role_gated_pull_pipeline.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0074_role_gated_pull_pipeline.sql
@@ -1,5 +1,24 @@
 -- Hangar v1 schema, migration 0074: role-gated pull pipeline.
 --
+-- # THIS REVERSES DECISION D3 (migration 0053)
+--
+-- 0053 recorded, as "DEVIATION (D3)", that `squad_member.role` does NOT gate
+-- dispatch: that `SquadRepo::member_agent_ids` stays role-blind, that every agent
+-- member is dispatched to regardless of role, and that selective routing was
+-- deferred to parity item #16. This migration reverses that deliberately.
+--
+-- Role-blind dispatch WAS the reported defect. Issue 01KY7SHDMWVMHE218DV5TQRN3R
+-- produced four runs, three of them within two seconds on the assignee plus both
+-- members of squad `team1`, each provisioning its own worktree for the same work.
+-- `services_role` below is the gate that makes `role` finally mean something at
+-- the dispatch seam.
+--
+-- 0053's own file cannot be corrected to say this: an applied migration's text is
+-- frozen (`sqlx` checksums the full file, and editing one aborts boot with
+-- "previously applied but has been modified"). The reversal is therefore recorded
+-- in `src/lib.rs` alongside the other applied-migration corrections, and in the
+-- `SquadRepo::member_agent_ids` doc comment.
+--
 -- Turns board columns into PULL QUEUES. Before this migration a squad dispatch
 -- BROADCASTS: `SquadAssignService::assign_fanout` writes the leader brief plus one
 -- `agent_task_queue` row per distinct agent member, so one issue becomes N

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0074_role_gated_pull_pipeline.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0074_role_gated_pull_pipeline.sql
@@ -1,0 +1,94 @@
+-- Hangar v1 schema, migration 0074: role-gated pull pipeline.
+--
+-- Turns board columns into PULL QUEUES. Before this migration a squad dispatch
+-- BROADCASTS: `SquadAssignService::assign_fanout` writes the leader brief plus one
+-- `agent_task_queue` row per distinct agent member, so one issue becomes N
+-- simultaneous runs all doing the same work in N worktrees. After it, the card in a
+-- role-gated column IS the queue: exactly one eligible agent pulls the card, runs it,
+-- and hands off to a DIFFERENT role at the next column.
+--
+-- # Why the queue row is created at pull time (and `agent_id` stays NOT NULL)
+--
+-- `agent_task_queue.agent_id` is `TEXT NOT NULL REFERENCES agent(id)`, so a queued row
+-- always already names its agent: today's model is PUSH (the dispatcher picks the
+-- agent; the claim loop merely executes that choice). True pull needs the agent chosen
+-- AT CLAIM TIME. Making `agent_id` nullable would express that directly, but on SQLite
+-- dropping a NOT NULL is a full 12-step table rebuild (new table, copy, drop, rename,
+-- recreate every index and FK) against a populated production database, the single
+-- riskiest operation available here. Instead the `board_card` row is the queue and the
+-- `agent_task_queue` row is INSERTed by the pull statement once an eligible agent has
+-- been selected, so `agent_id` is known by construction at insert time and the column
+-- keeps its NOT NULL.
+--
+-- Every statement below is an additive `ALTER TABLE ... ADD COLUMN` with a CONSTANT
+-- literal default (or no default at all, i.e. NULL), which is an O(1) catalog change in
+-- SQLite with no table rewrite, the same shape 0047 and 0050 used, and safe on a
+-- populated home.
+--
+-- NULL is meaningful on both new `board_column` columns, which is why neither takes a
+-- NOT NULL default:
+--   * `services_role IS NULL`  = the column is NOT role-gated and is therefore NOT a
+--     pull queue. Backlog and Done are the shipped examples: work parks there and is
+--     moved by a human or by the auto-advance, never pulled by an agent. Every
+--     pre-existing column on an operator's board migrates to NULL and so keeps exactly
+--     its current (unpullable) behaviour. This migration cannot change how any existing
+--     board behaves.
+--   * `wip_limit IS NULL`      = unlimited, the pre-existing semantics.
+--
+-- `excludes_prior_agent` is the data-driven form of the "a reviewer is never the agent
+-- that implemented the card" invariant. Encoding it as a column property rather than
+-- string-matching `services_role = 'reviewer'` keeps the rule a property of the
+-- PIPELINE DEFINITION: an operator who names the stage "Peer check" or "Second pair"
+-- still gets the guarantee, and a deployment that genuinely wants self-review (a
+-- one-agent roster) can express that by leaving the flag at 0 rather than by renaming a
+-- column to dodge a hard-coded string.
+
+-- The role gate. Free text matched against `squad_member.role`, which migration 0053
+-- added and which is documented "role-blind by design" at the dispatch seam
+-- (`SquadRepo::member_agent_ids`), this is the column that finally gives that field a
+-- consumer. A column's role is matched as a COMMA-SEPARATED TOKEN of the member's role
+-- string, case-insensitively, so one membership can advertise several roles
+-- ("implementer,reviewer") without a second table and without a schema change.
+ALTER TABLE board_column ADD COLUMN services_role TEXT;
+
+-- Work-in-progress cap: the maximum number of cards in this column that may hold an
+-- active (queued / dispatched / running) task at once. NULL = unlimited.
+ALTER TABLE board_column ADD COLUMN wip_limit INTEGER;
+
+-- When 1, an agent that already holds a finished task on the card may NOT pull it at
+-- this stage. This is the reviewer-is-never-the-implementer guarantee.
+ALTER TABLE board_column ADD COLUMN excludes_prior_agent INTEGER NOT NULL DEFAULT 0;
+
+-- Clusters the rows of ONE deliberate fan-out (`--redundant N`), so intentional
+-- parallelism stays distinguishable from the accidental broadcast this migration
+-- removes. NULL for an ordinary single-owner pull, which is every row written before
+-- this migration and the overwhelming majority written after it.
+ALTER TABLE agent_task_queue ADD COLUMN run_group TEXT;
+
+-- The pull statement's hot filter. It scans role-gated columns of one board in stage
+-- order, so `(board_id, services_role)` is the selective prefix; `ord` is carried in the
+-- index because the pull always takes the EARLIEST eligible stage and this keeps that
+-- an index-ordered read instead of a sort. Partial (`WHERE services_role IS NOT NULL`)
+-- so the non-gated columns, Backlog, Done, and every column that predates this
+-- migration, cost nothing to keep indexed.
+CREATE INDEX idx_board_column_pull
+    ON board_column (board_id, services_role, ord)
+    WHERE services_role IS NOT NULL;
+
+-- The pull statement's other half: given a candidate card it must ask "does this issue
+-- already have an active task, and if so whose?", the one-owner-per-card guard, the
+-- per-column WIP count, and the prior-agent exclusion all read this. The nearest
+-- existing cover is `idx_one_pending_task_per_issue_agent` (migration 0012), but it is
+-- partial on `status IN ('queued','dispatched')` and so cannot answer a probe whose
+-- active set INCLUDES `running`, exactly the set all three predicates need. This index
+-- is unfiltered on status, so the probe resolves entirely inside it rather than
+-- fetching each candidate row to test its status.
+CREATE INDEX idx_task_issue_status
+    ON agent_task_queue (issue_id, status)
+    WHERE issue_id IS NOT NULL;
+
+-- Cluster lookup for `--redundant N`: "show me every run of this fan-out". Partial, so
+-- the NULL run_group of every ordinary pull stays out of the index entirely.
+CREATE INDEX idx_task_run_group
+    ON agent_task_queue (run_group)
+    WHERE run_group IS NOT NULL;

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -28,6 +28,28 @@
 //! here (or in the owning repo module) instead. Only brand-new migrations are
 //! editable, and only until they ship.
 //!
+//! ## D3 (migration 0053) is REVERSED by migration 0074
+//!
+//! `0053_squad_role_instructions.sql` states, as "DEVIATION (D3)", that
+//! `squad_member.role` does NOT gate dispatch: that `SquadRepo::member_agent_ids`
+//! stays role-blind, that every agent member is dispatched to regardless of role,
+//! and that selective routing is deferred to parity item #16.
+//!
+//! **That is no longer true, and 0053's file cannot say so** (an applied
+//! migration's text is frozen, see above). Dispatch IS role-gated as of migration
+//! `0074_role_gated_pull_pipeline`: `role` is matched against
+//! `board_column.services_role` in
+//! [`service::pull::PullService`], and
+//! [`service::squad_assign::SquadAssignService::assign_fanout`] no longer emits
+//! one task per member at all. The old broadcast was the reported defect, not a
+//! feature: one issue became N simultaneous runs, each in its own worktree, all
+//! doing the same work.
+//!
+//! `member_agent_ids` itself is still role-blind, deliberately. It answers the
+//! narrower question "which agents are in this squad", which is what the leader
+//! briefing and the explicit `--redundant N` fan-out want. Role SELECTION lives
+//! in the pull predicate.
+//!
 //! ## Foreign keys ARE enforced
 //!
 //! Several applied migration comments (0009/0010/0016/0017/0018/0027/0036) claim

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
@@ -511,11 +511,27 @@ impl SquadRepo {
     /// is also listed as a member yields that agent once in this list; the fan-out
     /// caller dedupes it against the already-dispatched leader.
     ///
-    /// **Role-blind by design (D3, migration 0053).** `squad_member.role` is
-    /// advisory metadata the LEADER reads in its briefing; it never filters this
-    /// query, so every agent member is still dispatched to regardless of role —
-    /// matching multica, where nothing gates dispatch on role either. Selective
-    /// routing is parity item #16, a separate product question.
+    /// **Role-blind, and that is now a property of THIS QUERY only, not of
+    /// dispatch (D3 REVERSED by migration 0074).**
+    ///
+    /// D3 (migration 0053) said `squad_member.role` was advisory metadata the
+    /// leader read in its briefing, and that dispatch never filtered on it, so
+    /// every agent member was dispatched to regardless of role. That was the
+    /// broadcast contract, and it was the reported defect: one issue became one
+    /// run per member, each in its own worktree, all doing the same work.
+    ///
+    /// Dispatch IS role-gated now. `role` is matched against
+    /// `board_column.services_role` in
+    /// [`PullService`](crate::service::pull::PullService), which is the consumer
+    /// that field had been waiting for, and
+    /// [`SquadAssignService::assign_fanout`](crate::service::squad_assign::SquadAssignService::assign_fanout)
+    /// no longer emits a task per member at all.
+    ///
+    /// This query stays role-blind because it answers a narrower question,
+    /// "which agents are in this squad", and is still the right shape for the
+    /// leader briefing and for the explicit `--redundant N` fan-out. Callers that
+    /// need role selection go through the pull predicate; do not re-add filtering
+    /// here.
     ///
     /// # Errors
     ///

--- a/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
@@ -42,6 +42,10 @@ pub mod fail;
 /// and report a per-target outcome code. One seam behind both the `comment_add`
 /// write and the `comment_mention_preview` dry run.
 pub mod mention;
+/// Role-gated PULL of board work: a card in a role-gated column is the queue,
+/// and exactly one eligible agent takes it. The seam that replaces squad
+/// BROADCAST (one run per member) with one owner per card.
+pub mod pull;
 /// Spawn a `parent_task_id`-chained child row for a retryable failed task.
 pub mod retry;
 /// Route a squad assignment to its leader by enqueueing a leader-keyed task.

--- a/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
@@ -42,6 +42,9 @@ pub mod fail;
 /// and report a per-target outcome code. One seam behind both the `comment_add`
 /// write and the `comment_mention_preview` dry run.
 pub mod mention;
+/// The DEFAULT six-stage pull pipeline (Backlog / Triage / Implement / Review /
+/// QA / Done) and the enqueue that places a card in its first role-gated stage.
+pub mod pipeline;
 /// Role-gated PULL of board work: a card in a role-gated column is the queue,
 /// and exactly one eligible agent takes it. The seam that replaces squad
 /// BROADCAST (one run per member) with one owner per card.

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pipeline.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pipeline.rs
@@ -1,0 +1,205 @@
+//! The DEFAULT six-stage pull pipeline, and the enqueue that feeds it.
+//!
+//! ```text
+//!  Backlog  ->  Triage  ->  Implement  ->  Review  ->   QA    ->  Done
+//!    (-)       triager    implementer     reviewer    tester      (-)
+//!   wip -        wip -       wip 2         wip 3       wip 1     wip -
+//!                                        excl. prior  excl. prior
+//! ```
+//!
+//! Backlog and Done carry NO `services_role`, so they are not pull queues: work
+//! parks there and is moved by a human or by the stage advance. The four middle
+//! stages are role-gated, and a card walks them one column at a time, one owner
+//! per stage.
+//!
+//! # Why every column here has `fsm_state = NULL`
+//!
+//! This is the load-bearing subtlety, and getting it wrong silently destroys the
+//! pipeline.
+//!
+//! Hangar already has a state-driven auto-move hook,
+//! [`BoardRepo::auto_move_on_state`](crate::repo::board::BoardRepo::auto_move_on_state),
+//! which the daemon calls on EVERY task FSM transition and which moves a card to
+//! the column whose `fsm_state` equals the new task state. That hook and the
+//! stage advance are two different concepts sharing one board:
+//!
+//!   * `auto_move_on_state` is STATE driven: "a task started, show the card under
+//!     In Progress". It can only express as many stages as there are task states.
+//!   * [`PullService::advance_after_stage`](crate::service::pull::PullService::advance_after_stage)
+//!     is SEQUENCE driven: "this stage finished, step one column right".
+//!
+//! If a pipeline column carried `fsm_state = 'done'` the state hook would fire
+//! the moment the FIRST stage completed and jump the card straight to that
+//! column, skipping Review and QA entirely. The pipeline would appear to work
+//! and would in fact never review anything.
+//!
+//! Leaving `fsm_state` NULL makes the state hook INERT on these columns (its
+//! query matches on `col.fsm_state = new_state`, and NULL never equals anything)
+//! while `auto_move = 1` keeps the operator's existing per-column and
+//! per-board kill-switch meaningful, because that is exactly what
+//! `advance_after_stage` consults. So the two mechanisms coexist on one board
+//! rather than fighting, and no parallel "stage" concept is introduced.
+
+use ainb_hangar_core::clock::HangarClock;
+use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_core::ids::WorkspaceId;
+use sqlx::{Row, SqlitePool};
+
+/// The name of the board the default pipeline is provisioned onto.
+pub const DEFAULT_PIPELINE_BOARD: &str = "Pipeline";
+
+/// One stage of the default pipeline: `(name, services_role, wip_limit,
+/// excludes_prior_agent)`.
+///
+/// Review and QA both exclude a prior agent: a stage whose whole purpose is to
+/// CHECK the work is worthless when performed by whoever produced it. The
+/// consequence is deliberate and is the documented edge case, with only one
+/// eligible agent the card WAITS rather than being self-reviewed.
+pub const DEFAULT_STAGES: &[(&str, Option<&str>, Option<i64>, bool)] = &[
+    ("Backlog", None, None, false),
+    ("Triage", Some("triager"), None, false),
+    ("Implement", Some("implementer"), Some(2), false),
+    ("Review", Some("reviewer"), Some(3), true),
+    ("QA", Some("tester"), Some(1), true),
+    ("Done", None, None, false),
+];
+
+/// Why an enqueue could not place a card.
+#[derive(Debug, thiserror::Error)]
+pub enum PipelineError {
+    /// The workspace has no board carrying a role-gated pipeline.
+    #[error("workspace has no role-gated pipeline; provision one first")]
+    NoPipeline,
+    /// An underlying store failure.
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
+/// Provisioning + enqueue over the role-gated board pipeline.
+pub struct PipelineService;
+
+impl PipelineService {
+    /// Provision the default six-stage pipeline for `workspace`, returning the
+    /// board id.
+    ///
+    /// IDEMPOTENT and NON-DESTRUCTIVE: if a board named
+    /// [`DEFAULT_PIPELINE_BOARD`] already exists it is returned untouched, so
+    /// re-running this never rewrites an operator's tuned WIP limits or renamed
+    /// stages. It creates a NEW board rather than retrofitting an existing one,
+    /// so an operator's current Kanban keeps working exactly as it did.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn provision_default(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+    ) -> Result<String, sqlx::Error> {
+        if let Some(existing) = sqlx::query_scalar::<_, String>(
+            "SELECT id FROM board WHERE workspace_id = ?1 AND name = ?2",
+        )
+        .bind(workspace.as_str())
+        .bind(DEFAULT_PIPELINE_BOARD)
+        .fetch_optional(pool)
+        .await?
+        {
+            return Ok(existing);
+        }
+
+        let board_id = idgen.new_ulid();
+        let now = clock.now_ms();
+        let mut tx = pool.begin().await?;
+        sqlx::query(
+            "INSERT INTO board (id, workspace_id, name, auto_move, created_at) \
+             VALUES (?1, ?2, ?3, 1, ?4)",
+        )
+        .bind(&board_id)
+        .bind(workspace.as_str())
+        .bind(DEFAULT_PIPELINE_BOARD)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+
+        for (ord, (name, role, wip, excludes_prior)) in DEFAULT_STAGES.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO board_column \
+                 (id, board_id, ord, name, fsm_state, auto_move, \
+                  services_role, wip_limit, excludes_prior_agent) \
+                 VALUES (?1, ?2, ?3, ?4, NULL, 1, ?5, ?6, ?7)",
+            )
+            .bind(idgen.new_ulid())
+            .bind(&board_id)
+            .bind(i64::try_from(ord).unwrap_or(i64::MAX))
+            .bind(name)
+            .bind(*role)
+            .bind(*wip)
+            .bind(i64::from(*excludes_prior))
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(board_id)
+    }
+
+    /// ENQUEUE `issue_id` into the pipeline: place its card in the FIRST
+    /// role-gated column of `workspace`'s pipeline board.
+    ///
+    /// This is what replaces broadcast. Where the old fan-out wrote one task per
+    /// squad member, this writes ONE card placement and no tasks at all, then
+    /// lets [`PullService`](crate::service::pull::PullService) hand the card to
+    /// exactly one eligible agent.
+    ///
+    /// Returns `(board_id, column_id)`. Re-enqueueing a card already on the board
+    /// MOVES it back to the first role-gated stage, which is the natural
+    /// "re-run this from the top" semantic.
+    ///
+    /// # Errors
+    ///
+    /// [`PipelineError::NoPipeline`] when the workspace has no role-gated column
+    /// anywhere, or [`PipelineError::Db`] on a store fault.
+    pub async fn enqueue(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        issue_id: &str,
+        clock: &dyn HangarClock,
+    ) -> Result<(String, String), PipelineError> {
+        // The first role-gated column of the workspace, preferring the default
+        // pipeline board when several boards carry one, so an operator's older
+        // ad-hoc board cannot silently capture squad dispatches.
+        let target = sqlx::query(
+            "SELECT col.id AS column_id, col.board_id AS board_id \
+               FROM board_column AS col \
+               JOIN board AS bd ON bd.id = col.board_id \
+              WHERE bd.workspace_id = ?1 \
+                AND col.services_role IS NOT NULL \
+              ORDER BY (bd.name <> ?2), bd.name, bd.id, col.ord \
+              LIMIT 1",
+        )
+        .bind(workspace.as_str())
+        .bind(DEFAULT_PIPELINE_BOARD)
+        .fetch_optional(pool)
+        .await?
+        .ok_or(PipelineError::NoPipeline)?;
+
+        let board_id: String = target.try_get("board_id")?;
+        let column_id: String = target.try_get("column_id")?;
+
+        sqlx::query(
+            "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+             VALUES (?1, ?2, ?3, ?4, \
+                     (SELECT COALESCE(MAX(o.ord) + 1, 0) FROM board_card AS o \
+                       WHERE o.column_id = ?3)) \
+             ON CONFLICT (board_id, issue_id) DO UPDATE SET column_id = excluded.column_id",
+        )
+        .bind(&board_id)
+        .bind(issue_id)
+        .bind(&column_id)
+        .bind(clock.now_ms())
+        .execute(pool)
+        .await?;
+
+        Ok((board_id, column_id))
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -288,18 +288,32 @@ RETURNING board_id, column_id";
 ///
 /// `?1` = new task id, `?2` = `created_at` (now), `?3` = `runtime_id`.
 ///
-/// `agent_kind` is derived from the PULLING AGENT'S RUNTIME provider, not from
-/// the card. Under pull the agent is chosen per stage, so the provider CLI that
-/// runs the stage must be the chosen agent's own: a codex reviewer has to invoke
-/// `codex`, even when the card was created with `agent_kind = 'claude'`. An
-/// unrecognised provider falls back to the card's own kind, then to `claude`, so
-/// a runtime advertising something exotic still dispatches rather than tripping
-/// the NOT NULL.
+/// `agent_kind` is derived from the PULLING AGENT, not from the card. Under pull
+/// the agent is chosen per stage, so the provider CLI that runs the stage must be
+/// the chosen agent's own: a codex reviewer has to invoke `codex`, even when the
+/// card was created with `agent_kind = 'claude'`.
+///
+/// `agent.provider` is the authority, NOT `agent_runtime.provider`. A runtime is
+/// a DAEMON, not a provider binding: `ainb hangar agent create --provider codex`
+/// records `codex` on the agent and still binds it to the single `default`
+/// runtime, whose own `provider` column reads `claude` for every install. Keying
+/// on the runtime therefore silently ran every agent as claude. The runtime is
+/// kept only as a fallback for an agent row with no provider recorded, then the
+/// card's own kind, then `claude`, so an unrecognised value still dispatches
+/// rather than tripping the NOT NULL.
 ///
 /// `generation` is `MAX(existing) + 1`: each STAGE is its own run generation, so
 /// the card-state folds (aggregate, blocker-finished, auto-move) that scope to an
 /// issue's latest generation see the current stage alone and are not confused by
 /// the previous stage's `done` row.
+///
+/// `parent_task_id` chains each stage to the one before it: the most recent
+/// `done` task on the card. This is the HANDOFF CHAIN, and it is what lets an
+/// operator (or an assertion) walk a card's history stage by stage and see who
+/// handed what to whom. The column already existed for infra retries, whose
+/// chain is parent-to-child within one stage; a pipeline chain is the same edge
+/// read across stages, so nothing new is introduced. The first stage of a card
+/// has no `done` predecessor and correctly chains to NULL.
 ///
 /// # Why this is `pub`
 ///
@@ -313,7 +327,7 @@ RETURNING board_id, column_id";
 pub const PULL_SQL: &str = "\
 INSERT INTO agent_task_queue \
     (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, \
-     priority, generation, agent_kind, repo_ref, squad_id) \
+     priority, generation, agent_kind, repo_ref, squad_id, parent_task_id) \
 SELECT ?1, \
        bd.workspace_id, \
        a.runtime_id, \
@@ -325,12 +339,17 @@ SELECT ?1, \
        (SELECT COALESCE(MAX(g.generation), 0) + 1 FROM agent_task_queue AS g \
          WHERE g.issue_id = bc.issue_id), \
        COALESCE( \
+         NULLIF(CASE WHEN a.provider IN ('claude','codex','copilot') \
+                     THEN a.provider END, ''), \
          (SELECT rt.provider FROM agent_runtime AS rt \
            WHERE rt.id = a.runtime_id \
              AND rt.provider IN ('claude','codex','copilot')), \
          i.agent_kind, 'claude'), \
        i.repo_ref, \
-       i.squad_id \
+       i.squad_id, \
+       (SELECT p.id FROM agent_task_queue AS p \
+         WHERE p.issue_id = bc.issue_id AND p.status = 'done' \
+         ORDER BY p.generation DESC, p.finished_at DESC, p.id DESC LIMIT 1) \
   FROM board_card AS bc \
   JOIN board_column AS col ON col.id = bc.column_id \
   JOIN board AS bd ON bd.id = bc.board_id \

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -237,7 +237,7 @@ impl PullService {
 /// ONE statement, no transaction, for the reason
 /// [`BoardRepo::auto_move_on_state`](crate::repo::board::BoardRepo::auto_move_on_state)
 /// documents at length: a SELECT-then-UPDATE takes a read snapshot and then
-/// upgrades it to a write, which SQLite fails with `SQLITE_BUSY_SNAPSHOT` (517)
+/// upgrades it to a write, which `SQLite` fails with `SQLITE_BUSY_SNAPSHOT` (517)
 /// whenever another daemon writer commits in that window, and `busy_timeout`
 /// does NOT cover a stale snapshot. A bare UPDATE takes the write lock
 /// immediately and has no snapshot to invalidate, so the card cannot silently

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -1,0 +1,309 @@
+//! The `PullCard` service: role-gated, one-owner-per-card PULL of board work.
+//!
+//! This is the seam that replaces BROADCAST with PULL. Before it,
+//! [`SquadAssignService::assign_fanout`](crate::service::squad_assign::SquadAssignService::assign_fanout)
+//! wrote one `agent_task_queue` row per squad member, so one issue became N
+//! simultaneous runs all doing the same work in N worktrees. After it, a card
+//! sitting in a role-gated column IS the queue, and exactly one eligible agent
+//! takes it.
+//!
+//! # Why the queue row is created HERE and not by a dispatcher
+//!
+//! `agent_task_queue.agent_id` is `NOT NULL`, so a queued row always already
+//! names its agent: the pre-existing model is PUSH (a dispatcher picks the
+//! agent; [`ClaimTaskService`](crate::service::claim::ClaimTaskService) merely
+//! executes that choice). True pull needs the agent chosen AT CLAIM TIME.
+//! Rather than make `agent_id` nullable (a full table rebuild on SQLite, against
+//! a populated production database), the `board_card` row is the queue and this
+//! service INSERTs the `agent_task_queue` row once an eligible agent has been
+//! selected. The agent is therefore known by construction at insert time.
+//!
+//! The result is a two-stage pipeline that reuses the whole existing claim path
+//! unchanged:
+//!
+//! ```text
+//! board_card in a role-gated column        <- the pull queue
+//!        |  PullService::pull_for_runtime  (this module: role / WIP / reviewer
+//!        v                                  / blocked / capacity predicates)
+//! agent_task_queue row, status 'queued'    <- the execution queue
+//!        |  ClaimTaskService::claim_for_runtime  (unchanged)
+//!        v
+//! status 'dispatched' -> the runner
+//! ```
+//!
+//! # Atomicity
+//!
+//! The whole selection-and-insert is ONE `INSERT ... SELECT ... RETURNING`
+//! statement, for the same reason
+//! [`CLAIM_SQL`](crate::service::claim) is one statement: SQLite serialises
+//! writes, so a concurrent puller's sub-select observes this statement's
+//! committed row and its one-owner-per-card guard then excludes the card. Two
+//! agents can therefore never take the same card, and the guarantee holds across
+//! processes, not just across tasks in one daemon.
+//!
+//! # The five predicates
+//!
+//! A `(card, agent)` pair is *pullable* when ALL of these hold:
+//!
+//! 1. **Role gate.** The card's column declares a `services_role` and the agent
+//!    HOLDS that role. A column with `services_role IS NULL` (Backlog, Done, and
+//!    every column that predates migration 0074) is not a pull queue at all, so
+//!    work parks there until a human or the auto-advance moves it.
+//! 2. **WIP limit.** The column currently has fewer than `wip_limit` cards
+//!    holding an active task. `NULL` means unlimited.
+//! 3. **One owner per card.** The card's issue has NO active
+//!    (`queued`/`dispatched`/`running`) task at all. This is strictly stronger
+//!    than the pre-existing per-(issue, agent) guard, and it is what makes
+//!    "exactly one task running per card" true rather than merely likely.
+//! 4. **Prior-agent exclusion.** On a column with `excludes_prior_agent = 1`, an
+//!    agent that already holds a `done` task on this card may not take it. This
+//!    is the reviewer-is-never-the-implementer rule. Note the direction of
+//!    failure: if the only eligible agent implemented the card, the card WAITS
+//!    rather than being self-reviewed.
+//! 5. **Not blocked, and the agent has capacity.** Unfinished `card_dependency`
+//!    blockers make a card unpullable at every stage (the F7 refuse-run guard,
+//!    reused verbatim from
+//!    [`CardDependencyRepo::unfinished_blockers_of`](crate::repo::card_dependency::CardDependencyRepo::unfinished_blockers_of)),
+//!    and the agent must be under its `max_concurrent_tasks` cap.
+//!
+//! # How an agent's ROLES resolve
+//!
+//! Via `squad_member.role` (migration 0053), which until now had no consumer at
+//! the dispatch seam: `SquadRepo::member_agent_ids` is documented "role-blind by
+//! design", which is precisely the broadcast defect. An agent HOLDS a role when
+//! any of its squad memberships, in the same workspace, names that role. No
+//! agent-level roles field is introduced, so the existing
+//! `SquadRepo::add_member_with_role` / `set_member_role` writers are already the
+//! way an operator grants one.
+//!
+//! A membership's `role` is free text and is matched as a COMMA-SEPARATED TOKEN
+//! set, case-insensitively and ignoring spaces, so one membership can advertise
+//! several roles (`"implementer,reviewer"`) without a second table. Matching
+//! uses `INSTR` over comma-delimited needles rather than `LIKE`, so a role
+//! containing `%` or `_` cannot act as a wildcard and silently over-match.
+
+use ainb_hangar_core::clock::HangarClock;
+use ainb_hangar_core::idgen::IdGen;
+use sqlx::{Row, SqlitePool};
+
+/// A card successfully pulled into the execution queue: the freshly-inserted
+/// `agent_task_queue` row plus the board position it came from, so the caller
+/// can advance the card when the run finishes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PulledCard {
+    /// The inserted `agent_task_queue` row id (status `queued`).
+    pub task_id: String,
+    /// The agent that took the card (`agent.id`).
+    pub agent_id: String,
+    /// The runtime the task is keyed to (`agent_runtime.id`).
+    pub runtime_id: String,
+    /// The card's issue (`issue.id`). A card IS an issue.
+    pub issue_id: String,
+    /// The board the card sits on.
+    pub board_id: String,
+    /// The role-gated column the card was pulled FROM.
+    pub column_id: String,
+    /// That column's `services_role`, i.e. the role this run is serving.
+    pub services_role: String,
+    /// The run generation minted for this stage.
+    pub generation: i64,
+}
+
+/// Stateless pull service over `board_card` + `agent_task_queue`.
+pub struct PullService;
+
+impl PullService {
+    /// Pull at most ONE eligible card for any agent bound to `runtime_id`,
+    /// inserting the `queued` `agent_task_queue` row that
+    /// [`ClaimTaskService::claim_for_runtime`](crate::service::claim::ClaimTaskService::claim_for_runtime)
+    /// will then dispatch.
+    ///
+    /// Returns `Ok(None)` when nothing is pullable, which is the ordinary idle
+    /// case (no role-gated card waiting, every column at its WIP limit, no agent
+    /// on this runtime holding a needed role, or every candidate excluded by a
+    /// guard). The caller sleeps and retries.
+    ///
+    /// Ordering is `issue.priority DESC, column.ord DESC, card.ord, issue_id`:
+    /// urgent work first, then PULL FROM THE RIGHT, i.e. the latest stage first.
+    /// Draining the end of the pipeline before admitting new work at the start
+    /// is what stops cards piling up mid-flight, and it is the reason a WIP limit
+    /// is a cap rather than a deadlock.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement or a row decode fails.
+    #[tracing::instrument(
+        name = "card.pull",
+        skip(pool, idgen, clock),
+        fields(runtime_id = %runtime_id, task_id = tracing::field::Empty, issue_id = tracing::field::Empty, services_role = tracing::field::Empty)
+    )]
+    pub async fn pull_for_runtime(
+        pool: &SqlitePool,
+        runtime_id: &str,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+    ) -> Result<Option<PulledCard>, sqlx::Error> {
+        let task_id = idgen.new_ulid();
+        let now = clock.now_ms();
+
+        let inserted = sqlx::query(PULL_SQL)
+            .bind(&task_id)
+            .bind(now)
+            .bind(runtime_id)
+            .fetch_optional(pool)
+            .await?;
+
+        let Some(row) = inserted else { return Ok(None) };
+
+        let issue_id: String = row.try_get("issue_id")?;
+        let agent_id: String = row.try_get("agent_id")?;
+        let runtime: String = row.try_get("runtime_id")?;
+        let generation: i64 = row.try_get("generation")?;
+
+        // The board position is NOT reachable from the INSERT's RETURNING (which
+        // projects only the inserted task row), so it is read back here. The read
+        // is race-free by construction: the card now holds an active task, so
+        // predicate 3 excludes it from every concurrent pull, and nothing else
+        // moves a card while it is running.
+        let pos = sqlx::query(
+            "SELECT bc.board_id, bc.column_id, col.services_role \
+             FROM board_card AS bc \
+             JOIN board_column AS col ON col.id = bc.column_id \
+             WHERE bc.issue_id = ?1",
+        )
+        .bind(&issue_id)
+        .fetch_one(pool)
+        .await?;
+
+        let pulled = PulledCard {
+            task_id: row.try_get("id")?,
+            agent_id,
+            runtime_id: runtime,
+            issue_id,
+            board_id: pos.try_get("board_id")?,
+            column_id: pos.try_get("column_id")?,
+            services_role: pos.try_get("services_role")?,
+            generation,
+        };
+
+        let span = tracing::Span::current();
+        span.record("task_id", pulled.task_id.as_str());
+        span.record("issue_id", pulled.issue_id.as_str());
+        span.record("services_role", pulled.services_role.as_str());
+
+        Ok(Some(pulled))
+    }
+}
+
+/// The atomic pull statement: select the most urgent pullable `(card, agent)`
+/// pair for the runtime and INSERT its `queued` task row in one statement.
+///
+/// `?1` = new task id, `?2` = `created_at` (now), `?3` = `runtime_id`.
+///
+/// `agent_kind` is derived from the PULLING AGENT'S RUNTIME provider, not from
+/// the card. Under pull the agent is chosen per stage, so the provider CLI that
+/// runs the stage must be the chosen agent's own: a codex reviewer has to invoke
+/// `codex`, even when the card was created with `agent_kind = 'claude'`. An
+/// unrecognised provider falls back to the card's own kind, then to `claude`, so
+/// a runtime advertising something exotic still dispatches rather than tripping
+/// the NOT NULL.
+///
+/// `generation` is `MAX(existing) + 1`: each STAGE is its own run generation, so
+/// the card-state folds (aggregate, blocker-finished, auto-move) that scope to an
+/// issue's latest generation see the current stage alone and are not confused by
+/// the previous stage's `done` row.
+///
+/// # Why this is `pub`
+///
+/// So the MUTATION PROOFS in `tests/pull_role_gate.rs` can delete exactly one
+/// predicate from it and assert the corresponding invariant goes red. A test
+/// that only ever runs the real statement proves the invariant holds; it cannot
+/// prove the CLAUSE is what makes it hold, and would keep passing if the clause
+/// were deleted and some other accident covered for it. Reading the statement
+/// under test is the only way to write that proof, so it is deliberately
+/// reachable rather than private.
+pub const PULL_SQL: &str = "\
+INSERT INTO agent_task_queue \
+    (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, \
+     priority, generation, agent_kind, repo_ref, squad_id) \
+SELECT ?1, \
+       bd.workspace_id, \
+       a.runtime_id, \
+       a.id, \
+       bc.issue_id, \
+       'queued', \
+       ?2, \
+       i.priority, \
+       (SELECT COALESCE(MAX(g.generation), 0) + 1 FROM agent_task_queue AS g \
+         WHERE g.issue_id = bc.issue_id), \
+       COALESCE( \
+         (SELECT rt.provider FROM agent_runtime AS rt \
+           WHERE rt.id = a.runtime_id \
+             AND rt.provider IN ('claude','codex','copilot')), \
+         i.agent_kind, 'claude'), \
+       i.repo_ref, \
+       i.squad_id \
+  FROM board_card AS bc \
+  JOIN board_column AS col ON col.id = bc.column_id \
+  JOIN board AS bd ON bd.id = bc.board_id \
+  JOIN issue AS i ON i.id = bc.issue_id \
+  JOIN agent AS a ON a.workspace_id = bd.workspace_id \
+ WHERE col.services_role IS NOT NULL \
+   AND a.runtime_id = ?3 \
+   AND a.archived = 0 \
+   AND i.state NOT IN ('closed','cancelled') \
+   AND EXISTS ( \
+        SELECT 1 FROM squad_member AS sm \
+          JOIN squad AS sq ON sq.id = sm.squad_id \
+         WHERE sm.member_type = 'agent' \
+           AND sm.member_id = a.id \
+           AND sq.workspace_id = bd.workspace_id \
+           AND INSTR( \
+                 ',' || REPLACE(LOWER(sm.role), ' ', '') || ',', \
+                 ',' || LOWER(TRIM(col.services_role)) || ',' \
+               ) > 0 \
+       ) \
+   AND ( col.wip_limit IS NULL OR ( \
+        SELECT COUNT(DISTINCT w.issue_id) FROM board_card AS w \
+          JOIN agent_task_queue AS wq ON wq.issue_id = w.issue_id \
+         WHERE w.column_id = col.id \
+           AND wq.status IN ('queued','dispatched','running') \
+       ) < col.wip_limit ) \
+   AND NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS o \
+         WHERE o.issue_id = bc.issue_id \
+           AND o.status IN ('queued','dispatched','running') \
+       ) \
+   AND ( col.excludes_prior_agent = 0 OR NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS p \
+         WHERE p.issue_id = bc.issue_id \
+           AND p.agent_id = a.id \
+           AND p.status = 'done' \
+       ) ) \
+   AND NOT EXISTS ( \
+        SELECT 1 FROM card_dependency AS d \
+         WHERE d.dependent_issue_id = bc.issue_id \
+           AND d.link_type = 'blocked_by' \
+           AND NOT ( \
+                 EXISTS ( \
+                   SELECT 1 FROM agent_task_queue AS t \
+                    WHERE t.issue_id = d.blocker_issue_id AND t.status = 'done' \
+                      AND t.generation = (SELECT MAX(g2.generation) FROM agent_task_queue AS g2 \
+                                           WHERE g2.issue_id = d.blocker_issue_id) \
+                 ) \
+                 AND NOT EXISTS ( \
+                   SELECT 1 FROM agent_task_queue AS t \
+                    WHERE t.issue_id = d.blocker_issue_id \
+                      AND t.status IN ('queued','dispatched','running') \
+                      AND t.generation = (SELECT MAX(g2.generation) FROM agent_task_queue AS g2 \
+                                           WHERE g2.issue_id = d.blocker_issue_id) \
+                 ) \
+               ) \
+       ) \
+   AND ( SELECT COUNT(*) FROM agent_task_queue AS r \
+          WHERE r.agent_id = a.id \
+            AND r.status IN ('queued','dispatched','running') \
+       ) < a.max_concurrent_tasks \
+ ORDER BY i.priority DESC, col.ord DESC, bc.ord, bc.issue_id \
+ LIMIT 1 \
+RETURNING id, agent_id, runtime_id, issue_id, generation";

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -193,7 +193,95 @@ impl PullService {
 
         Ok(Some(pulled))
     }
+
+    /// ADVANCE a card one column to the right after its stage finished.
+    ///
+    /// This is the handoff: the Implement stage completes, the card steps into
+    /// Review, and a DIFFERENT role pulls it on the next tick. Call it when a
+    /// task on `issue_id` reaches `done`.
+    ///
+    /// Advancing exactly one column at a time (never jumping to the end) is what
+    /// the live proof asserts, and it is what lets each stage's
+    /// `excludes_prior_agent` see the previous stage's agent.
+    ///
+    /// The move is refused, leaving the card exactly where it is, when:
+    ///   * the card is not in a role-gated column (it is parked in Backlog/Done,
+    ///     or on a board that predates migration 0074),
+    ///   * the card still has an ACTIVE task, which is what makes a deliberate
+    ///     `--redundant` fan-out advance only once ALL its runs have drained
+    ///     rather than on the first one home,
+    ///   * there is no column to the right (the last stage stays put),
+    ///   * the board's master `auto_move` or the current column's `auto_move` is
+    ///     off, which is the existing operator kill-switch this reuses rather
+    ///     than duplicating.
+    ///
+    /// Returns the `(board_id, new_column_id)` of each card actually moved.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement or a row decode fails.
+    #[tracing::instrument(name = "card.advance", skip(pool), fields(issue_id = %issue_id))]
+    pub async fn advance_after_stage(
+        pool: &SqlitePool,
+        issue_id: &str,
+    ) -> Result<Vec<(String, String)>, sqlx::Error> {
+        let rows = sqlx::query(ADVANCE_SQL).bind(issue_id).fetch_all(pool).await?;
+        rows.iter()
+            .map(|r| Ok((r.try_get("board_id")?, r.try_get("column_id")?)))
+            .collect()
+    }
 }
+
+/// Move a finished card one column to the right.
+///
+/// ONE statement, no transaction, for the reason
+/// [`BoardRepo::auto_move_on_state`](crate::repo::board::BoardRepo::auto_move_on_state)
+/// documents at length: a SELECT-then-UPDATE takes a read snapshot and then
+/// upgrades it to a write, which SQLite fails with `SQLITE_BUSY_SNAPSHOT` (517)
+/// whenever another daemon writer commits in that window, and `busy_timeout`
+/// does NOT cover a stale snapshot. A bare UPDATE takes the write lock
+/// immediately and has no snapshot to invalidate, so the card cannot silently
+/// stay in its old column forever with its stage already finished.
+///
+/// `?1` = `issue_id`. The new `ord` appends the card to the end of its target
+/// column, consistent with a manual `card_move` and with the auto-move hook.
+const ADVANCE_SQL: &str = "\
+UPDATE board_card \
+   SET column_id = ( \
+        SELECT n.id FROM board_column AS n \
+         WHERE n.board_id = board_card.board_id \
+           AND n.ord > (SELECT cur.ord FROM board_column AS cur \
+                         WHERE cur.id = board_card.column_id) \
+         ORDER BY n.ord LIMIT 1), \
+       ord = ( \
+        SELECT COALESCE(MAX(o.ord) + 1, 0) FROM board_card AS o \
+         WHERE o.column_id = ( \
+              SELECT n2.id FROM board_column AS n2 \
+               WHERE n2.board_id = board_card.board_id \
+                 AND n2.ord > (SELECT cur2.ord FROM board_column AS cur2 \
+                                WHERE cur2.id = board_card.column_id) \
+               ORDER BY n2.ord LIMIT 1)) \
+ WHERE board_card.issue_id = ?1 \
+   AND EXISTS ( \
+        SELECT 1 FROM board_column AS cur \
+          JOIN board AS bd ON bd.id = cur.board_id \
+         WHERE cur.id = board_card.column_id \
+           AND cur.services_role IS NOT NULL \
+           AND cur.auto_move = 1 \
+           AND bd.auto_move = 1 \
+       ) \
+   AND NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS t \
+         WHERE t.issue_id = board_card.issue_id \
+           AND t.status IN ('queued','dispatched','running') \
+       ) \
+   AND EXISTS ( \
+        SELECT 1 FROM board_column AS n3 \
+         WHERE n3.board_id = board_card.board_id \
+           AND n3.ord > (SELECT cur3.ord FROM board_column AS cur3 \
+                          WHERE cur3.id = board_card.column_id) \
+       ) \
+RETURNING board_id, column_id";
 
 /// The atomic pull statement: select the most urgent pullable `(card, agent)`
 /// pair for the runtime and INSERT its `queued` task row in one statement.

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -452,6 +452,128 @@ impl SquadAssignService {
         })
     }
 
+    /// DELIBERATE redundancy: dispatch the SAME issue to up to `copies` distinct
+    /// agent members at once, every task stamped with one shared `run_group`.
+    ///
+    /// This is the explicit opt-in that keeps intentional parallelism alive now
+    /// that [`Self::assign_fanout`] no longer broadcasts: N independent attempts
+    /// at one problem, or several reviewers over one artifact. The difference
+    /// from the removed defect is entirely in the intent and the evidence. A
+    /// broadcast was the DEFAULT, was unbounded (one run per member, however many
+    /// that happened to be), and left no trace saying the parallelism was wanted.
+    /// This is opt-in, explicitly capped at `copies`, and every row carries the
+    /// `run_group` that identifies the cluster, so "why are there three runs on
+    /// this card" is answerable from the row itself.
+    ///
+    /// `copies <= 1` degrades to the ordinary single-owner dispatch. Fewer
+    /// eligible members than `copies` dispatches to all of them rather than
+    /// failing: redundancy is a ceiling, not a quota.
+    ///
+    /// Every task shares ONE generation, because they are one run: the card-state
+    /// folds and the blocker-finished predicate scope to a generation, so a
+    /// dependent stays blocked until the WHOLE cluster drains rather than
+    /// unblocking on the first copy home.
+    ///
+    /// # Errors
+    ///
+    /// The same rejections as [`Self::assign_fanout`]: an archived squad, a
+    /// human / unknown / dangling leader, a dangling member ref, or a target the
+    /// effective invoker may not invoke. All are pre-flight, so a rejection
+    /// writes zero rows.
+    pub async fn assign_redundant(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        squad_id: &str,
+        request: &SquadAssignRequest<'_>,
+        copies: usize,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+    ) -> Result<SquadFanout, SquadAssignError> {
+        if copies <= 1 {
+            return Self::assign_fanout(pool, workspace, squad_id, request, idgen, clock).await;
+        }
+        if SquadRepo::is_archived(pool, workspace, squad_id).await? {
+            return Err(SquadAssignError::Archived(squad_id.to_string()));
+        }
+        let leader_agent_id = SquadRepo::leader_agent_id(pool, workspace, squad_id)
+            .await?
+            .ok_or(SquadAssignError::NoAgentLeader)?;
+        let leader = Self::agent_in_ws(pool, workspace, &leader_agent_id)
+            .await?
+            .ok_or_else(|| SquadAssignError::LeaderAgentMissing(leader_agent_id.clone()))?;
+        let invoker = Self::effective_invoker(pool, workspace, request).await?;
+        Self::gate(pool, &leader, &invoker).await?;
+
+        // Resolve + gate EVERY candidate before writing, so a bad member ref
+        // rejects the whole cluster rather than leaving a partial fan-out. The
+        // leader leads the candidate list, then distinct agent members in id
+        // order, so `copies` is filled deterministically.
+        let mut seen = std::collections::HashSet::new();
+        seen.insert(leader_agent_id.clone());
+        let mut targets = vec![(leader_agent_id.clone(), leader.runtime_id.clone())];
+        for agent_id in SquadRepo::member_agent_ids(pool, workspace, squad_id).await? {
+            if !seen.insert(agent_id.clone()) {
+                continue;
+            }
+            let member = Self::agent_in_ws(pool, workspace, &agent_id)
+                .await?
+                .ok_or_else(|| SquadAssignError::MemberAgentMissing(agent_id.clone()))?;
+            Self::gate(pool, &member, &invoker).await?;
+            targets.push((agent_id, member.runtime_id));
+        }
+        targets.truncate(copies);
+
+        let run_group = idgen.new_ulid();
+        let mut dispatched = Vec::with_capacity(targets.len());
+        let mut tx = pool.begin().await?;
+        for (agent_id, runtime_id) in targets {
+            let task_id = idgen.new_ulid();
+            TaskRepo::insert_in_tx(
+                &mut tx,
+                &NewTask {
+                    id: task_id.clone(),
+                    workspace_id: workspace.as_str().to_string(),
+                    runtime_id: runtime_id.clone(),
+                    agent_id: agent_id.clone(),
+                    issue_id: request.issue_id.map(str::to_string),
+                    work_dir: request.work_dir.map(str::to_string),
+                    priority: request.priority,
+                    created_at: clock.now_ms(),
+                    autopilot_run_id: None,
+                    generation: request.generation,
+                },
+            )
+            .await?;
+            Self::stamp_dispatch_fields(&mut tx, &task_id, request).await?;
+            TaskRepo::set_squad_id_in_tx(&mut tx, &task_id, squad_id).await?;
+            sqlx::query("UPDATE agent_task_queue SET run_group = ?1 WHERE id = ?2")
+                .bind(&run_group)
+                .bind(&task_id)
+                .execute(&mut *tx)
+                .await?;
+            dispatched.push(SquadMemberDispatch {
+                task_id,
+                agent_id,
+                runtime_id,
+            });
+        }
+        tx.commit().await?;
+
+        // The FIRST copy is reported in the `leader` slot so the wire shape is
+        // unchanged; the rest ride in `members`, which under pull is otherwise
+        // always empty. A non-empty `members` therefore means exactly one thing
+        // now: somebody deliberately asked for redundancy.
+        let first = dispatched.remove(0);
+        Ok(SquadFanout {
+            leader: SquadAssignment {
+                task_id: first.task_id,
+                leader_agent_id: first.agent_id,
+                runtime_id: first.runtime_id,
+            },
+            members: dispatched,
+        })
+    }
+
     /// Attempt ONE pull across every runtime in `workspace`, stopping at the
     /// first that yields.
     ///

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -32,6 +32,7 @@ use sqlx::SqlitePool;
 use crate::repo::agent::AgentRepo;
 use crate::repo::squad::SquadRepo;
 use crate::repo::task::{NewTask, TaskRepo};
+use crate::service::pipeline::{PipelineError, PipelineService};
 
 /// The task knobs a squad assignment rides through to the enqueued row.
 ///
@@ -362,12 +363,55 @@ impl SquadAssignService {
             member_targets.push((agent_id, member.runtime_id));
         }
 
-        // 3. Every target is known-good — enqueue the leader brief and all member
-        //    tasks in ONE transaction so a mid-loop failure (e.g. a UNIQUE
-        //    `(issue, agent)` collision) rolls the whole fan-out back, honouring
-        //    the documented all-or-nothing contract.
+        // 3. PULL, NOT BROADCAST. `member_targets` has been resolved and gated
+        //    above (so a dangling / foreign / private member still rejects the
+        //    whole dispatch), but it is NOT dispatched to. Writing one task per
+        //    member is exactly the defect this replaces: it turned one issue into
+        //    N simultaneous runs of the same work in N worktrees.
+        //
+        //    When the workspace has a role-gated pipeline, the card is ENQUEUED
+        //    into its first stage and a single eligible agent then PULLS it. The
+        //    pull is attempted synchronously here so this call answers with the
+        //    task that actually owns the work; when no agent currently holds the
+        //    stage's role the card simply waits, visibly queued on the board, and
+        //    the next daemon tick picks it up.
+        if let Some(issue_id) = request.issue_id {
+            match PipelineService::enqueue(pool, workspace, issue_id, clock).await {
+                Ok(_) => {
+                    let pulled =
+                        Self::pull_once_in_workspace(pool, workspace, idgen, clock).await?;
+                    return Ok(SquadFanout {
+                        leader: SquadAssignment {
+                            // The single OWNER of the stage. Empty when the card is
+                            // enqueued but no agent holds the role yet, which is a
+                            // waiting card, not a failure.
+                            task_id: pulled.as_ref().map(|p| p.task_id.clone()).unwrap_or_default(),
+                            leader_agent_id: pulled
+                                .as_ref()
+                                .map_or_else(|| leader_agent_id.clone(), |p| p.agent_id.clone()),
+                            runtime_id: pulled.as_ref().map_or_else(
+                                || leader_runtime_id.clone(),
+                                |p| p.runtime_id.clone(),
+                            ),
+                        },
+                        // ALWAYS empty under pull. Kept on the wire so the plugin
+                        // and CLI keep deserialising, and so the shape still
+                        // describes a deliberate `--redundant` fan-out, which is
+                        // now the ONLY way to get more than one run on a card.
+                        members: Vec::new(),
+                    });
+                }
+                // No pipeline provisioned: fall through to the single leader
+                // brief below. Still ONE task, never one per member.
+                Err(PipelineError::NoPipeline) => {}
+                Err(PipelineError::Db(e)) => return Err(SquadAssignError::Db(e)),
+            }
+        }
+
+        // 3b. Fallback for a workspace with no role-gated pipeline (and for an
+        //     issueless ad-hoc dispatch): brief the LEADER, and only the leader.
         let leader_task_id = idgen.new_ulid();
-        let mut members = Vec::with_capacity(member_targets.len());
+        let members = Vec::new();
 
         let mut tx = pool.begin().await?;
         TaskRepo::insert_in_tx(
@@ -392,32 +436,10 @@ impl SquadAssignService {
         // stamped even for the no-repo squads-screen fan-out, where
         // `stamp_dispatch_fields` early-returns on a NULL `repo_ref`.
         TaskRepo::set_squad_id_in_tx(&mut tx, &leader_task_id, squad_id).await?;
-        for (agent_id, runtime_id) in member_targets {
-            let task_id = idgen.new_ulid();
-            TaskRepo::insert_in_tx(
-                &mut tx,
-                &NewTask {
-                    id: task_id.clone(),
-                    workspace_id: workspace.as_str().to_string(),
-                    runtime_id: runtime_id.clone(),
-                    agent_id: agent_id.clone(),
-                    issue_id: request.issue_id.map(str::to_string),
-                    work_dir: request.work_dir.map(str::to_string),
-                    priority: request.priority,
-                    created_at: clock.now_ms(),
-                    autopilot_run_id: None,
-                    generation: request.generation,
-                },
-            )
-            .await?;
-            Self::stamp_dispatch_fields(&mut tx, &task_id, request).await?;
-            TaskRepo::set_squad_id_in_tx(&mut tx, &task_id, squad_id).await?;
-            members.push(SquadMemberDispatch {
-                task_id,
-                agent_id,
-                runtime_id,
-            });
-        }
+        // NO per-member loop. `member_targets` was resolved and gated so a bad
+        // member ref still rejects the dispatch, but a squad of N members now
+        // yields exactly ONE task here, never N.
+        drop(member_targets);
         tx.commit().await?;
 
         Ok(SquadFanout {
@@ -428,6 +450,38 @@ impl SquadAssignService {
             },
             members,
         })
+    }
+
+    /// Attempt ONE pull across every runtime in `workspace`, stopping at the
+    /// first that yields.
+    ///
+    /// Used by [`Self::assign_fanout`] so a squad dispatch answers with the task
+    /// that actually owns the work rather than merely "the card is on the board".
+    /// Iterating runtimes (rather than pulling per-runtime on a timer) is what
+    /// makes the dispatch synchronous from the operator's point of view; the
+    /// daemon's own tick still covers the case where no agent is eligible yet.
+    ///
+    /// At most ONE card is ever taken, whichever runtime wins.
+    async fn pull_once_in_workspace(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+    ) -> Result<Option<crate::service::pull::PulledCard>, sqlx::Error> {
+        let runtimes: Vec<String> =
+            sqlx::query_scalar("SELECT id FROM agent_runtime WHERE workspace_id = ?1 ORDER BY id")
+                .bind(workspace.as_str())
+                .fetch_all(pool)
+                .await?;
+        for runtime_id in runtimes {
+            if let Some(p) =
+                crate::service::pull::PullService::pull_for_runtime(pool, &runtime_id, idgen, clock)
+                    .await?
+            {
+                return Ok(Some(p));
+            }
+        }
+        Ok(None)
     }
 
     /// Stamp the card's `repo_ref` + resolved `agent_kind` onto a fanned-out task
@@ -738,13 +792,17 @@ mod tests {
         );
     }
 
-    /// FAN-OUT (P7): assigning an issue to a squad briefs the LEADER *and*
-    /// enqueues one task per distinct `agent` member — all on the SAME issue — and
-    /// every runtime (leader + each member) claims its own task in parallel. This
-    /// is the acceptance the per-(issue, agent) guard (migration `0012`) unlocks:
-    /// three agents each hold a pending task on one issue at once.
+    /// PULL, NOT BROADCAST: assigning an issue to a squad yields exactly ONE
+    /// task, whatever the member count.
+    ///
+    /// This test previously asserted the OPPOSITE, that the leader brief plus one
+    /// task per agent member were all claimable in parallel, and it is inverted
+    /// here deliberately. That contract is the reported defect: three agents each
+    /// holding a task on one issue meant three worktrees doing the same work and
+    /// racing each other. The per-(issue, agent) guard still permits that shape;
+    /// nothing now produces it except an explicit `--redundant` fan-out.
     #[tokio::test]
-    async fn assign_fanout_briefs_the_leader_and_fans_members_claimable_in_parallel() {
+    async fn assign_fanout_yields_one_owner_never_one_task_per_member() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
         let pool = store.pool();
@@ -785,21 +843,25 @@ mod tests {
         .await
         .unwrap();
 
-        // The leader gets the brief; both agent members fan out (the human does not).
+        // ONE owner. This workspace has no role-gated pipeline, so the fallback
+        // briefs the leader, and ONLY the leader.
         assert_eq!(fanout.leader.leader_agent_id, "a-lead");
         assert_eq!(fanout.leader.runtime_id, "rt-lead");
-        assert_eq!(
-            fanout.members.len(),
-            2,
-            "two agent members fanned out (human skipped)"
+        assert!(
+            fanout.members.is_empty(),
+            "a squad of N members must not fan out to N tasks"
         );
-        assert_eq!(fanout.members[0].agent_id, "a-m1");
-        assert_eq!(fanout.members[0].runtime_id, "rt-m1");
-        assert_eq!(fanout.members[1].agent_id, "a-m2");
-        assert_eq!(fanout.members[1].runtime_id, "rt-m2");
 
-        // PARALLEL CLAIM: every runtime claims its own task on the one issue — the
-        // per-(issue, agent) guard lets three pending tasks coexist on `issue-1`.
+        let rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = 'issue-1'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(rows, 1, "exactly one task row exists on the issue");
+
+        // Only the LEADER's runtime has anything to claim. The member runtimes
+        // find nothing, which is precisely the behaviour that stops three agents
+        // provisioning three worktrees for one card.
         let clock = FixedClock(10_000);
         let lead = ClaimTaskService::claim_for_runtime(pool, "rt-lead", &clock)
             .await
@@ -807,47 +869,28 @@ mod tests {
             .expect("leader claims the brief");
         assert_eq!(lead.agent_id, "a-lead");
         assert_eq!(lead.id, fanout.leader.task_id);
-
-        let m1 = ClaimTaskService::claim_for_runtime(pool, "rt-m1", &clock)
-            .await
-            .unwrap()
-            .expect("member 1 claims its task in parallel");
-        assert_eq!(m1.agent_id, "a-m1");
-        assert_eq!(m1.id, fanout.members[0].task_id);
-
-        let m2 = ClaimTaskService::claim_for_runtime(pool, "rt-m2", &clock)
-            .await
-            .unwrap()
-            .expect("member 2 claims its task in parallel");
-        assert_eq!(m2.agent_id, "a-m2");
-        assert_eq!(m2.id, fanout.members[1].task_id);
-
-        // All three tasks are distinct rows on the same issue.
         assert_eq!(lead.issue_id.as_deref(), Some("issue-1"));
-        assert_eq!(m1.issue_id.as_deref(), Some("issue-1"));
-        assert_eq!(m2.issue_id.as_deref(), Some("issue-1"));
 
-        // Every fanned-out task (leader + both members) carries the dispatching
-        // squad (migration 0045), so the daemon keys a briefing hook off each.
-        for id in [
-            &fanout.leader.task_id,
-            &fanout.members[0].task_id,
-            &fanout.members[1].task_id,
-        ] {
-            let row = TaskRepo::get_by_id(pool, id).await.unwrap().unwrap();
-            assert_eq!(
-                row.squad_id.as_deref(),
-                Some("s1"),
-                "fanned task {id} must carry squad_id"
+        for rt in ["rt-m1", "rt-m2"] {
+            assert!(
+                ClaimTaskService::claim_for_runtime(pool, rt, &clock).await.unwrap().is_none(),
+                "member runtime {rt} must have nothing to claim"
             );
         }
+
+        // The one task still carries the dispatching squad (migration 0045), so
+        // the daemon's briefing hook is unaffected by the change.
+        let row = TaskRepo::get_by_id(pool, &fanout.leader.task_id).await.unwrap().unwrap();
+        assert_eq!(row.squad_id.as_deref(), Some("s1"));
     }
 
-    /// FAN-OUT stamps the card's repo + agent-kind onto EVERY fanned task (leader
-    /// + members), so each provisions its OWN worktree from the card's repo (tcp
-    /// T4 / F7). The pre-T4 no-repo fan-out leaves them NULL (runs in-tree).
+    /// The dispatch stamps the card's repo + agent-kind onto the ONE task it
+    /// writes, so that run provisions its own worktree from the card's repo (tcp
+    /// T4 / F7). A no-repo dispatch leaves them NULL (runs in-tree).
+    ///
+    /// Previously asserted over "every fanned task"; there is now exactly one.
     #[tokio::test]
-    async fn assign_fanout_stamps_the_card_repo_on_every_task() {
+    async fn assign_fanout_stamps_the_card_repo_on_the_single_task() {
         use crate::repo::card_parity::CardParityRepo;
         use ainb_hangar_core::agent_kind::AgentKind;
 
@@ -883,20 +926,18 @@ mod tests {
         .await
         .unwrap();
 
-        // Both the leader brief and the member task carry the card's repo + kind,
-        // so each provisions its own worktree from `/repos/app`.
-        for id in [&fanout.leader.task_id, &fanout.members[0].task_id] {
-            assert_eq!(
-                CardParityRepo::get_task_repo_agent(pool, id).await.unwrap(),
-                Some((Some("/repos/app".to_string()), AgentKind::Codex)),
-                "fanned task {id} must carry the card repo + agent-kind"
-            );
-        }
+        assert!(fanout.members.is_empty(), "no member fan-out");
+        assert_eq!(
+            CardParityRepo::get_task_repo_agent(pool, &fanout.leader.task_id).await.unwrap(),
+            Some((Some("/repos/app".to_string()), AgentKind::Codex)),
+            "the single dispatched task must carry the card repo + agent-kind"
+        );
     }
 
-    /// FAN-OUT dedupe: a squad whose LEADER is also listed as a member does not
-    /// double-dispatch — the leader's agent appears only as the brief, never again
-    /// as a fanned-out member (which would collide on the `(issue, agent)` guard).
+    /// A squad whose LEADER is also listed as a member is dispatched ONCE. Under
+    /// broadcast this needed an explicit dedupe to avoid colliding on the
+    /// `(issue, agent)` guard; under pull there is simply nothing to dedupe,
+    /// which is asserted here so a reintroduced fan-out cannot slip through.
     #[tokio::test]
     async fn assign_fanout_never_double_dispatches_the_leader() {
         let dir = tempfile::tempdir().unwrap();
@@ -934,12 +975,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(fanout.leader.leader_agent_id, "a-lead");
-        assert_eq!(
-            fanout.members.len(),
-            1,
-            "only the non-leader member fans out; the leader is not re-dispatched"
-        );
-        assert_eq!(fanout.members[0].agent_id, "a-m1");
+        assert!(fanout.members.is_empty(), "nothing fans out under pull");
+        let rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = 'issue-1'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(rows, 1, "the leader is dispatched exactly once");
     }
 
     /// FAN-OUT is all-or-nothing: a dangling member ref rejects the WHOLE fan-out,
@@ -1218,8 +1260,11 @@ mod tests {
         )
         .await
         .expect("an allow-listed member unblocks the fan-out");
-        assert_eq!(fanout.members.len(), 2, "both members fanned out");
-        assert_eq!(queue_len(pool).await, 3, "leader brief + two member tasks");
+        // The GATE is what this test pins, not the fan-out width: once every
+        // member is invocable the dispatch is admitted, and it now writes ONE
+        // task rather than one per member.
+        assert!(fanout.members.is_empty(), "no member fan-out under pull");
+        assert_eq!(queue_len(pool).await, 1, "an admitted dispatch is one task");
     }
 
     /// gap #8 — FAN-OUT LEADER GATE (the direct port of multica's
@@ -1294,7 +1339,7 @@ mod tests {
         )
         .await
         .expect("the owner always fans out");
-        assert_eq!(queue_len(pool).await, 2, "leader brief + one member task");
+        assert_eq!(queue_len(pool).await, 1, "an admitted dispatch is one task");
     }
 
     /// gap #8 — the LEADER-ONLY assign shares the same gate: a plain member cannot

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -1291,7 +1291,7 @@ mod tests {
     /// left `private` is not invocable by the assignment's effective invoker (here
     /// the workspace owner), so the whole fan-out is refused and NO task row is
     /// written — not the leader's, not the allowed member's. Allow-listing the
-    /// invoker on that agent (public_to + a `member` target) then lets the very same
+    /// invoker on that agent (`public_to` + a `member` target) then lets the very same
     /// call through, proving the gate is a real decision and not blanket denial.
     #[tokio::test]
     async fn fanout_refuses_a_private_member_agent_and_writes_no_row() {

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0074_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0074_upgrade.rs
@@ -89,10 +89,12 @@ async fn seed_populated(pool: &SqlitePool) {
     .execute(pool)
     .await
     .expect("seed issue");
-    sqlx::query("INSERT INTO board (id, workspace_id, name, created_at) VALUES ('b-1','ws-1','Kanban',5)")
-        .execute(pool)
-        .await
-        .expect("seed board");
+    sqlx::query(
+        "INSERT INTO board (id, workspace_id, name, created_at) VALUES ('b-1','ws-1','Kanban',5)",
+    )
+    .execute(pool)
+    .await
+    .expect("seed board");
     sqlx::query(
         "INSERT INTO board_column (id, board_id, ord, name, fsm_state, auto_move) \
          VALUES ('col-1','b-1',0,'Backlog',NULL,0)",
@@ -196,9 +198,15 @@ async fn migration_0074_adds_the_pull_gate_columns_inert() {
     .expect("read new board_column columns");
     assert_eq!(gates.len(), 2, "both seeded columns survive the upgrade");
     for (services_role, wip_limit, excludes_prior_agent) in &gates {
-        assert_eq!(*services_role, None, "pre-existing column must stay ungated");
+        assert_eq!(
+            *services_role, None,
+            "pre-existing column must stay ungated"
+        );
         assert_eq!(*wip_limit, None, "pre-existing column must stay uncapped");
-        assert_eq!(*excludes_prior_agent, 0, "prior-agent exclusion defaults off");
+        assert_eq!(
+            *excludes_prior_agent, 0,
+            "prior-agent exclusion defaults off"
+        );
     }
 
     let run_group: Option<String> =
@@ -206,7 +214,10 @@ async fn migration_0074_adds_the_pull_gate_columns_inert() {
             .fetch_one(&pool)
             .await
             .expect("read run_group");
-    assert_eq!(run_group, None, "a pre-existing task belongs to no fan-out cluster");
+    assert_eq!(
+        run_group, None,
+        "a pre-existing task belongs to no fan-out cluster"
+    );
 
     // (c) The pre-existing payloads survived BYTE-IDENTICAL, an ALTER TABLE
     //     that rewrote a sibling column would show up here. `fsm_state` and

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_0074_upgrade.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_0074_upgrade.rs
@@ -1,0 +1,268 @@
+//! Upgrade-from-populated test for migration 0074 (`role_gated_pull_pipeline` ,
+//! the `board_column` role gate + WIP cap + prior-agent exclusion, and the
+//! `agent_task_queue.run_group` fan-out cluster stamp).
+//!
+//! Fresh-database coverage lives in `tripwire_migrations_apply.rs`. This file
+//! proves the migration on a REAL populated database:
+//!
+//! 1. apply only the PRIOR migrations (0001..0073),
+//! 2. seed a workspace with a board, two columns, a card and a task, the
+//!    pre-0074 world, in which no column can be role-gated,
+//! 3. apply the embedded migrations (which adds 0074),
+//! 4. assert the four new columns landed, that every PRE-EXISTING row took the
+//!    inert default (so no operator's existing board changes behaviour), that
+//!    the sibling payloads survived byte-identical, and that all three new
+//!    indexes exist.
+//!
+//! Assertion (b) is the load-bearing one. `services_role IS NULL` means "not a
+//! pull queue", so a board that predates this migration must come out the other
+//! side with every column still unpullable. If a future edit gave
+//! `services_role` a non-NULL default, every existing column would silently
+//! become a role-gated queue and start pulling work, this test is what turns
+//! that red.
+
+use ainb_hangar_store::apply_migrations;
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+
+/// `sqlx` version number of the migration under test
+/// (`0074_role_gated_pull_pipeline.sql`).
+const NEW_MIGRATION_VERSION: i64 = 74;
+
+/// The exact column name seeded before the upgrade, re-read verbatim after, so
+/// an ALTER TABLE that rewrote a sibling column would show.
+const SEEDED_COLUMN_NAME: &str = "In Progress";
+/// Same, for the seeded column's `fsm_state`, the pre-existing stage concept
+/// this migration must reuse rather than duplicate.
+const SEEDED_FSM_STATE: &str = "in_progress";
+
+async fn pool_at_prior_schema(dir: &std::path::Path) -> SqlitePool {
+    let opts = SqliteConnectOptions::new()
+        .filename(dir.join("hangar.db"))
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = SqlitePoolOptions::new().connect_with(opts).await.expect("open pool");
+
+    let mut migrator = sqlx::migrate::Migrator::new(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"),
+    )
+    .await
+    .expect("load migrations directory");
+    migrator.migrations.to_mut().retain(|m| m.version < NEW_MIGRATION_VERSION);
+    assert!(!migrator.migrations.is_empty());
+    migrator.run(&pool).await.expect("prior migrations apply");
+    pool
+}
+
+/// The pre-0074 world: a board with two columns, a card parked on one of them,
+/// and a queued task on that card's issue. Every shape the pull statement will
+/// later read, seeded BEFORE the columns it reads exist.
+async fn seed_populated(pool: &SqlitePool) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','a','A',0)")
+        .execute(pool)
+        .await
+        .expect("seed workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u-amy','amy@x.dev',0)")
+        .execute(pool)
+        .await
+        .expect("seed user");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','d-1','claude','local')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed runtime");
+    sqlx::query(
+        "INSERT INTO agent (id, workspace_id, name, runtime_id, visibility, owner_id) \
+         VALUES ('ag-1','ws-1','claude','rt-1','workspace','u-amy')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed agent");
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('i-1','ws-1','Ship the pull pipeline','open','member','u-amy',10)",
+    )
+    .execute(pool)
+    .await
+    .expect("seed issue");
+    sqlx::query("INSERT INTO board (id, workspace_id, name, created_at) VALUES ('b-1','ws-1','Kanban',5)")
+        .execute(pool)
+        .await
+        .expect("seed board");
+    sqlx::query(
+        "INSERT INTO board_column (id, board_id, ord, name, fsm_state, auto_move) \
+         VALUES ('col-1','b-1',0,'Backlog',NULL,0)",
+    )
+    .execute(pool)
+    .await
+    .expect("seed first column");
+    sqlx::query(
+        "INSERT INTO board_column (id, board_id, ord, name, fsm_state, auto_move) \
+         VALUES ('col-2','b-1',1,?,?,1)",
+    )
+    .bind(SEEDED_COLUMN_NAME)
+    .bind(SEEDED_FSM_STATE)
+    .execute(pool)
+    .await
+    .expect("seed second column");
+    sqlx::query(
+        "INSERT INTO board_card (board_id, issue_id, column_id, added_at) \
+         VALUES ('b-1','i-1','col-2',6)",
+    )
+    .execute(pool)
+    .await
+    .expect("seed card");
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at) \
+         VALUES ('t-1','ws-1','rt-1','ag-1','i-1','queued',11)",
+    )
+    .execute(pool)
+    .await
+    .expect("seed task");
+}
+
+async fn object_exists(pool: &SqlitePool, kind: &str, name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM sqlite_master WHERE type = ? AND name = ?")
+        .bind(kind)
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .expect("sqlite_master")
+        > 0
+}
+
+/// Whether `table` has a column named `column` (reads the `PRAGMA` catalog, so a
+/// renamed / missing column is caught rather than surfacing as a query error).
+async fn has_column(pool: &SqlitePool, table: &str, column: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(&format!(
+        "SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = ?"
+    ))
+    .bind(column)
+    .fetch_one(pool)
+    .await
+    .expect("pragma_table_info")
+        > 0
+}
+
+#[tokio::test]
+async fn migration_0074_adds_the_pull_gate_columns_inert() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pool = pool_at_prior_schema(dir.path()).await;
+    seed_populated(&pool).await;
+
+    // Pre-flight: the columns genuinely do not exist yet, so the assertions
+    // below cannot pass vacuously against an already-migrated database.
+    assert!(
+        !has_column(&pool, "board_column", "services_role").await,
+        "services_role must not exist before 0074"
+    );
+    assert!(
+        !has_column(&pool, "agent_task_queue", "run_group").await,
+        "run_group must not exist before 0074"
+    );
+
+    apply_migrations(&pool).await.expect("upgrade applies 0074");
+    let recorded: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?")
+            .bind(NEW_MIGRATION_VERSION)
+            .fetch_one(&pool)
+            .await
+            .expect("read migration version");
+    assert_eq!(recorded, 1, "0074 recorded as applied");
+
+    // (a) All four new columns landed.
+    assert!(has_column(&pool, "board_column", "services_role").await);
+    assert!(has_column(&pool, "board_column", "wip_limit").await);
+    assert!(has_column(&pool, "board_column", "excludes_prior_agent").await);
+    assert!(has_column(&pool, "agent_task_queue", "run_group").await);
+
+    // (b) NO BACKFILL, and the defaults are INERT. Every pre-existing column is
+    //     ungated (NULL services_role = not a pull queue), uncapped (NULL
+    //     wip_limit = unlimited) and does not exclude prior agents, so an
+    //     operator's existing board behaves EXACTLY as it did before the
+    //     upgrade. A non-NULL default here would silently turn every existing
+    //     column into a role-gated queue.
+    let gates: Vec<(Option<String>, Option<i64>, i64)> = sqlx::query_as(
+        "SELECT services_role, wip_limit, excludes_prior_agent \
+         FROM board_column ORDER BY ord",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("read new board_column columns");
+    assert_eq!(gates.len(), 2, "both seeded columns survive the upgrade");
+    for (services_role, wip_limit, excludes_prior_agent) in &gates {
+        assert_eq!(*services_role, None, "pre-existing column must stay ungated");
+        assert_eq!(*wip_limit, None, "pre-existing column must stay uncapped");
+        assert_eq!(*excludes_prior_agent, 0, "prior-agent exclusion defaults off");
+    }
+
+    let run_group: Option<String> =
+        sqlx::query_scalar("SELECT run_group FROM agent_task_queue WHERE id = 't-1'")
+            .fetch_one(&pool)
+            .await
+            .expect("read run_group");
+    assert_eq!(run_group, None, "a pre-existing task belongs to no fan-out cluster");
+
+    // (c) The pre-existing payloads survived BYTE-IDENTICAL, an ALTER TABLE
+    //     that rewrote a sibling column would show up here. `fsm_state` and
+    //     `auto_move` matter most: 0074 reuses them rather than adding a
+    //     parallel stage concept, so they must come through untouched.
+    let (name, fsm_state, auto_move): (String, Option<String>, i64) =
+        sqlx::query_as("SELECT name, fsm_state, auto_move FROM board_column WHERE id = 'col-2'")
+            .fetch_one(&pool)
+            .await
+            .expect("read preserved columns");
+    assert_eq!(name, SEEDED_COLUMN_NAME);
+    assert_eq!(fsm_state.as_deref(), Some(SEEDED_FSM_STATE));
+    assert_eq!(auto_move, 1);
+
+    let (card_column, card_added): (String, i64) =
+        sqlx::query_as("SELECT column_id, added_at FROM board_card WHERE issue_id = 'i-1'")
+            .fetch_one(&pool)
+            .await
+            .expect("card survives");
+    assert_eq!(card_column, "col-2", "the card did not move");
+    assert_eq!(card_added, 6);
+
+    let (status, created_at): (String, i64) =
+        sqlx::query_as("SELECT status, created_at FROM agent_task_queue WHERE id = 't-1'")
+            .fetch_one(&pool)
+            .await
+            .expect("task survives");
+    assert_eq!(status, "queued");
+    assert_eq!(created_at, 11);
+
+    // (d) All three new indexes landed. The pull statement's plan depends on
+    //     them; a missing one degrades the claim loop to a full scan.
+    assert!(object_exists(&pool, "index", "idx_board_column_pull").await);
+    assert!(object_exists(&pool, "index", "idx_task_issue_status").await);
+    assert!(object_exists(&pool, "index", "idx_task_run_group").await);
+
+    // (e) The new columns actually accept the values the pipeline writes, and
+    //     the partial index tolerates a gated column alongside the ungated ones.
+    sqlx::query(
+        "INSERT INTO board_column \
+         (id, board_id, ord, name, fsm_state, auto_move, services_role, wip_limit, excludes_prior_agent) \
+         VALUES ('col-3','b-1',2,'Review','review',1,'reviewer',3,1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("a role-gated column is insertable");
+    let (role, wip, excl): (Option<String>, Option<i64>, i64) = sqlx::query_as(
+        "SELECT services_role, wip_limit, excludes_prior_agent FROM board_column WHERE id = 'col-3'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read back the gated column");
+    assert_eq!(role.as_deref(), Some("reviewer"));
+    assert_eq!(wip, Some(3));
+    assert_eq!(excl, 1);
+
+    // (f) Re-applying is a ledgered no-op.
+    apply_migrations(&pool).await.expect("second apply is a no-op");
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -688,7 +688,11 @@ async fn pulled_row_carries_the_agents_provider_and_a_fresh_generation() {
     .await
     .expect("codex runtime");
     add_agent(pool, "ag-rev", "reviewer", 5).await;
-    sqlx::query("UPDATE agent SET runtime_id='rt-codex' WHERE id='ag-rev'")
+    // `agent.provider` is the authority, not the runtime's. A runtime is a
+    // DAEMON: `agent create --provider codex` records codex on the AGENT and
+    // still binds it to the single `default` runtime, whose provider column
+    // reads `claude` on every install.
+    sqlx::query("UPDATE agent SET runtime_id='rt-codex', provider='codex' WHERE id='ag-rev'")
         .execute(pool)
         .await
         .expect("repoint agent at codex");
@@ -715,6 +719,42 @@ async fn pulled_row_carries_the_agents_provider_and_a_fresh_generation() {
             .expect("read the pulled row");
     assert_eq!(kind, "codex", "the run uses the PULLING agent's provider");
     assert_eq!(created, NOW_MS);
+}
+
+/// REGRESSION: the run's provider comes from `agent.provider`, NOT from the
+/// runtime's.
+///
+/// A runtime is a DAEMON, not a provider binding. `ainb hangar agent create
+/// --provider codex` records `codex` on the AGENT and still binds it to the one
+/// `default` runtime, whose own `provider` column reads `claude` on every
+/// install. Keying the pulled row on the runtime therefore dispatched EVERY
+/// agent as claude while the roster looked correctly mixed, which is exactly
+/// what the first live pipeline run surfaced.
+#[tokio::test]
+async fn agent_provider_beats_the_runtime_provider() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-rev", "reviewer", 5).await;
+    // The shipped shape: a codex agent on the shared `default` runtime, which
+    // advertises `claude`.
+    sqlx::query("UPDATE agent SET provider='codex' WHERE id='ag-rev'")
+        .execute(pool)
+        .await
+        .expect("mark the agent codex");
+    add_column(pool, "col-rev", 2, Some("reviewer"), None, false).await;
+    add_card(pool, "i-1", "col-rev", 0).await;
+
+    let got = pull(pool, "t-1").await.expect("reviewer pulls");
+    assert_eq!(got.runtime_id, "rt-1", "still the shared default runtime");
+    let kind: String = sqlx::query_scalar("SELECT agent_kind FROM agent_task_queue WHERE id='t-1'")
+        .fetch_one(pool)
+        .await
+        .expect("read agent_kind");
+    assert_eq!(
+        kind, "codex",
+        "the run must invoke the AGENT's provider, even though its runtime says claude"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -1,0 +1,764 @@
+//! `PullService` integration tests: the three claim-path invariants that make a
+//! squad behave like an engineering team instead of a broadcast.
+//!
+//! Exercises the atomic role-gated pull against a real ephemeral `SQLite` WAL
+//! database, one isolated tempdir store per test so parallel cargo threads never
+//! share state.
+//!
+//! The invariants under test (goal success criterion 3):
+//!   (a) an agent cannot pull from a column whose `services_role` it does not hold,
+//!   (b) a column at its `wip_limit` yields no further pulls,
+//!   (c) an agent cannot pull a review stage for a card it implemented.
+//!
+//! Plus the supporting contract: one owner per card, blocked cards are never
+//! pullable, per-agent capacity and priority ordering survive, and an ungated
+//! column (`services_role IS NULL`, e.g. Backlog / Done) is not a queue at all.
+//!
+//! # Every invariant carries a MUTATION PROOF
+//!
+//! A test that only runs the real statement proves the invariant HOLDS. It
+//! cannot prove that the clause under test is WHAT MAKES it hold: delete the
+//! clause and the test may well keep passing because some other predicate
+//! happened to exclude the same row. So each invariant is paired with a
+//! `mutation_proof_*` test that deletes exactly that clause from
+//! [`PULL_SQL`] and asserts the forbidden pull NOW SUCCEEDS.
+//!
+//! That pairing is the "fails before the change, passes after" evidence, made
+//! permanent and re-runnable rather than a one-off screenshot of a red run: the
+//! mutant IS the pre-change code for that one predicate. If someone later
+//! weakens a clause, its mutation proof stops distinguishing itself from the
+//! real statement and goes red.
+
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::service::pull::{PULL_SQL, PullService};
+use sqlx::{Row, SqlitePool};
+
+/// Frozen "now" so `created_at` assertions are deterministic.
+const NOW_MS: i64 = 1_700_000_500_000;
+
+/// Deterministic id generator: hands out a caller-supplied sequence so an
+/// assertion can name the exact task id a pull will mint.
+struct SeqIdGen {
+    next: std::sync::Mutex<Vec<String>>,
+}
+
+impl SeqIdGen {
+    fn new(ids: &[&str]) -> Self {
+        Self {
+            next: std::sync::Mutex::new(ids.iter().rev().map(|s| (*s).to_string()).collect()),
+        }
+    }
+}
+
+impl IdGen for SeqIdGen {
+    fn new_ulid(&self) -> String {
+        self.next.lock().expect("idgen lock").pop().expect("ran out of seeded ids")
+    }
+}
+
+/// A minimal but REAL world: one workspace, one runtime, and a board whose
+/// columns the individual tests then gate however they need.
+///
+/// Deliberately built from raw SQL against the migrated schema rather than
+/// through the repos, so a test asserts the STATEMENT's behaviour and cannot be
+/// masked by a repo-level guard that happens to reject the same case.
+async fn seed_world(pool: &SqlitePool) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','a','A',0)")
+        .execute(pool)
+        .await
+        .expect("workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u-1','a@x.dev',0)")
+        .execute(pool)
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','d-1','claude','local')",
+    )
+    .execute(pool)
+    .await
+    .expect("runtime");
+    sqlx::query(
+        "INSERT INTO board (id, workspace_id, name, created_at) VALUES ('b-1','ws-1','B',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("board");
+    sqlx::query(
+        "INSERT INTO squad (id, workspace_id, name, leader_type, leader_id, created_at) \
+                 VALUES ('sq-1','ws-1','team1','agent','ag-lead',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("squad");
+}
+
+/// Add an agent, optionally granting it a comma-separated role set via a
+/// `squad_member` row. `roles = ""` means the agent joins the squad with NO
+/// stated role, which is exactly the shape of the user's live database.
+async fn add_agent(pool: &SqlitePool, id: &str, roles: &str, max_concurrent: i64) {
+    sqlx::query(
+        "INSERT INTO agent \
+         (id, workspace_id, name, runtime_id, visibility, owner_id, max_concurrent_tasks) \
+         VALUES (?1,'ws-1',?1,'rt-1','workspace','u-1',?2)",
+    )
+    .bind(id)
+    .bind(max_concurrent)
+    .execute(pool)
+    .await
+    .expect("agent");
+    sqlx::query(
+        "INSERT INTO squad_member (squad_id, member_type, member_id, role) \
+         VALUES ('sq-1','agent',?1,?2)",
+    )
+    .bind(id)
+    .bind(roles)
+    .execute(pool)
+    .await
+    .expect("squad member");
+}
+
+/// Add a board column. `role = None` leaves it UNGATED (not a pull queue).
+async fn add_column(
+    pool: &SqlitePool,
+    id: &str,
+    ord: i64,
+    role: Option<&str>,
+    wip: Option<i64>,
+    excludes_prior: bool,
+) {
+    sqlx::query(
+        "INSERT INTO board_column \
+         (id, board_id, ord, name, fsm_state, auto_move, services_role, wip_limit, excludes_prior_agent) \
+         VALUES (?1,'b-1',?2,?1,NULL,1,?3,?4,?5)",
+    )
+    .bind(id)
+    .bind(ord)
+    .bind(role)
+    .bind(wip)
+    .bind(i64::from(excludes_prior))
+    .execute(pool)
+    .await
+    .expect("column");
+}
+
+/// Add an issue with NO board card. Used for blockers, which gate a dependent
+/// through `card_dependency` without themselves needing to sit on the board.
+async fn add_issue(pool: &SqlitePool, issue_id: &str, priority: i64) {
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at, priority) \
+         VALUES (?1,'ws-1',?1,'open','member','u-1',0,?2)",
+    )
+    .bind(issue_id)
+    .bind(priority)
+    .execute(pool)
+    .await
+    .expect("issue");
+}
+
+/// Add an issue and park its card in `column_id`.
+async fn add_card(pool: &SqlitePool, issue_id: &str, column_id: &str, priority: i64) {
+    add_issue(pool, issue_id, priority).await;
+    sqlx::query(
+        "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+         VALUES ('b-1',?1,?2,0,0)",
+    )
+    .bind(issue_id)
+    .bind(column_id)
+    .execute(pool)
+    .await
+    .expect("card");
+}
+
+/// Insert a task row directly, for setting up prior / concurrent state.
+async fn add_task(
+    pool: &SqlitePool,
+    id: &str,
+    agent_id: &str,
+    issue_id: &str,
+    status: &str,
+    generation: i64,
+) {
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, generation) \
+         VALUES (?1,'ws-1','rt-1',?2,?3,?4,0,?5)",
+    )
+    .bind(id)
+    .bind(agent_id)
+    .bind(issue_id)
+    .bind(status)
+    .bind(generation)
+    .execute(pool)
+    .await
+    .expect("task");
+}
+
+async fn store() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    (dir, store)
+}
+
+/// Run the real pull once.
+async fn pull(pool: &SqlitePool, id: &str) -> Option<ainb_hangar_store::service::pull::PulledCard> {
+    PullService::pull_for_runtime(pool, "rt-1", &SeqIdGen::new(&[id]), &FixedClock(NOW_MS))
+        .await
+        .expect("pull runs")
+}
+
+/// Run a MUTANT of the pull statement: [`PULL_SQL`] with `clause` deleted.
+///
+/// Panics if `clause` is not found verbatim, so a reworded predicate cannot
+/// silently turn a mutation proof into a no-op that "passes" while testing
+/// nothing.
+async fn pull_mutant(pool: &SqlitePool, id: &str, clause: &str) -> Option<String> {
+    assert!(
+        PULL_SQL.contains(clause),
+        "mutation target not found verbatim in PULL_SQL; the proof would test nothing:\n{clause}"
+    );
+    let mutated = PULL_SQL.replace(clause, " ");
+    let row = sqlx::query(&mutated)
+        .bind(id)
+        .bind(NOW_MS)
+        .bind("rt-1")
+        .fetch_optional(pool)
+        .await
+        .expect("mutant runs");
+    row.map(|r| r.try_get::<String, _>("agent_id").expect("agent_id"))
+}
+
+// ---------------------------------------------------------------------------
+// Invariant (a): the ROLE GATE
+// ---------------------------------------------------------------------------
+
+/// An agent whose roles do not include the column's `services_role` cannot pull
+/// from it, and the card simply WAITS rather than being silently dropped.
+#[tokio::test]
+async fn agent_without_the_role_cannot_pull() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    // The agent services QA, the column wants an implementer.
+    add_agent(pool, "ag-qa", "tester", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    assert!(
+        pull(pool, "t-1").await.is_none(),
+        "a tester must not pull an implementer stage"
+    );
+
+    // The card is still queued on the board, untouched: not dropped, not moved.
+    let col: String = sqlx::query_scalar("SELECT column_id FROM board_card WHERE issue_id='i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("card still parked");
+    assert_eq!(col, "col-impl");
+    let tasks: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue")
+        .fetch_one(pool)
+        .await
+        .expect("count");
+    assert_eq!(tasks, 0, "a refused pull writes no row at all");
+}
+
+/// The same world, with the ROLE PREDICATE DELETED, DOES pull. This is the
+/// pre-change behaviour: role-blind dispatch, which is exactly what
+/// `SquadRepo::member_agent_ids` is documented to do today.
+#[tokio::test]
+async fn mutation_proof_a_without_the_role_predicate_the_wrong_agent_pulls() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-qa", "tester", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    let winner = pull_mutant(pool, "t-1", ROLE_GATE_CLAUSE).await;
+    assert_eq!(
+        winner.as_deref(),
+        Some("ag-qa"),
+        "without the role gate the tester takes the implementer stage, \
+         which is the defect this predicate fixes"
+    );
+}
+
+/// A membership may advertise SEVERAL roles as a comma-separated set, so one
+/// agent can service more than one stage without a second table.
+#[tokio::test]
+async fn multi_role_membership_matches_any_of_its_roles() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-multi", "Implementer, Reviewer", 5).await;
+    add_column(pool, "col-rev", 1, Some("reviewer"), None, false).await;
+    add_card(pool, "i-1", "col-rev", 0).await;
+
+    let got = pull(pool, "t-1").await.expect("multi-role agent pulls");
+    assert_eq!(got.agent_id, "ag-multi");
+    assert_eq!(got.services_role, "reviewer");
+}
+
+/// Role matching must not be a substring match: an agent holding `review` does
+/// NOT thereby hold `reviewer`, and vice versa. Token matching is what keeps
+/// `INSTR` honest.
+#[tokio::test]
+async fn role_matching_is_token_exact_not_substring() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-partial", "review", 5).await;
+    add_column(pool, "col-rev", 1, Some("reviewer"), None, false).await;
+    add_card(pool, "i-1", "col-rev", 0).await;
+
+    assert!(
+        pull(pool, "t-1").await.is_none(),
+        "'review' must not satisfy 'reviewer'"
+    );
+}
+
+/// A membership with NO stated role (the shape of BOTH members of the user's
+/// live squad `team1`) holds no roles and can pull nothing. The pipeline is
+/// opt-in: an operator must actually grant roles.
+#[tokio::test]
+async fn roleless_membership_holds_no_roles() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-blank", "", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    assert!(
+        pull(pool, "t-1").await.is_none(),
+        "an empty role grants nothing"
+    );
+}
+
+/// An UNGATED column (`services_role IS NULL`) is not a pull queue. Backlog and
+/// Done are the shipped examples, and so is every column that predates
+/// migration 0074, which is what makes the migration inert on existing boards.
+#[tokio::test]
+async fn ungated_column_is_not_a_queue() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-any", "implementer,reviewer,tester,triager", 5).await;
+    add_column(pool, "col-backlog", 0, None, None, false).await;
+    add_card(pool, "i-1", "col-backlog", 0).await;
+
+    assert!(
+        pull(pool, "t-1").await.is_none(),
+        "no role satisfies an ungated column, so Backlog never auto-runs"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Invariant (b): the WIP LIMIT
+// ---------------------------------------------------------------------------
+
+/// A column at its `wip_limit` yields no further pulls; the next card waits.
+#[tokio::test]
+async fn column_at_wip_limit_yields_no_pull() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), Some(1), false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+    add_card(pool, "i-2", "col-impl", 0).await;
+    // i-1 already occupies the column's single WIP slot.
+    add_task(pool, "t-existing", "ag-impl", "i-1", "running", 1).await;
+
+    assert!(pull(pool, "t-2").await.is_none(), "the column is full");
+
+    // Free the slot the way the real pipeline does: the run finishes and the
+    // card ADVANCES out of the column. The SAME world now yields a pull,
+    // proving the refusal was the WIP cap and not some unrelated exclusion.
+    sqlx::query("UPDATE agent_task_queue SET status='done' WHERE id='t-existing'")
+        .execute(pool)
+        .await
+        .expect("drain the slot");
+    add_column(pool, "col-done", 9, None, None, false).await;
+    sqlx::query("UPDATE board_card SET column_id='col-done' WHERE issue_id='i-1'")
+        .execute(pool)
+        .await
+        .expect("advance the finished card out of the column");
+
+    let got = pull(pool, "t-2").await.expect("slot freed, next card pulls");
+    assert_eq!(got.issue_id, "i-2");
+}
+
+/// With the WIP PREDICATE DELETED the over-limit pull succeeds, proving the
+/// clause is what enforces the cap.
+#[tokio::test]
+async fn mutation_proof_b_without_the_wip_predicate_the_column_overfills() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), Some(1), false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+    add_card(pool, "i-2", "col-impl", 0).await;
+    add_task(pool, "t-existing", "ag-impl", "i-1", "running", 1).await;
+
+    let winner = pull_mutant(pool, "t-2", WIP_LIMIT_CLAUSE).await;
+    assert_eq!(
+        winner.as_deref(),
+        Some("ag-impl"),
+        "without the WIP predicate a full column keeps handing out work"
+    );
+}
+
+/// `wip_limit IS NULL` means unlimited, which is the pre-0074 semantics every
+/// existing column inherits.
+#[tokio::test]
+async fn null_wip_limit_is_unlimited() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+    add_card(pool, "i-2", "col-impl", 0).await;
+    add_task(pool, "t-existing", "ag-impl", "i-1", "running", 1).await;
+
+    assert!(
+        pull(pool, "t-2").await.is_some(),
+        "an uncapped column keeps pulling"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Invariant (c): the REVIEWER IS NEVER THE IMPLEMENTER
+// ---------------------------------------------------------------------------
+
+/// An agent that already finished a task on the card cannot pull it again at a
+/// stage flagged `excludes_prior_agent`. With only one eligible agent the card
+/// WAITS rather than being self-reviewed, which is the documented edge case.
+#[tokio::test]
+async fn implementer_cannot_pull_the_review_stage_of_its_own_card() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-solo", "implementer,reviewer", 5).await;
+    add_column(pool, "col-rev", 2, Some("reviewer"), None, true).await;
+    add_card(pool, "i-1", "col-rev", 0).await;
+    // ag-solo already implemented this card in the previous stage.
+    add_task(pool, "t-impl", "ag-solo", "i-1", "done", 1).await;
+
+    assert!(
+        pull(pool, "t-rev").await.is_none(),
+        "the implementer must not review its own card, even as the only candidate"
+    );
+
+    // A DIFFERENT reviewer takes it immediately, proving the exclusion is scoped
+    // to the prior agent and does not simply freeze the stage.
+    add_agent(pool, "ag-other", "reviewer", 5).await;
+    let got = pull(pool, "t-rev").await.expect("a fresh reviewer pulls");
+    assert_eq!(got.agent_id, "ag-other");
+}
+
+/// With the PRIOR-AGENT PREDICATE DELETED the implementer reviews its own work.
+#[tokio::test]
+async fn mutation_proof_c_without_the_exclusion_the_implementer_self_reviews() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-solo", "implementer,reviewer", 5).await;
+    add_column(pool, "col-rev", 2, Some("reviewer"), None, true).await;
+    add_card(pool, "i-1", "col-rev", 0).await;
+    add_task(pool, "t-impl", "ag-solo", "i-1", "done", 1).await;
+
+    let winner = pull_mutant(pool, "t-rev", PRIOR_AGENT_CLAUSE).await;
+    assert_eq!(
+        winner.as_deref(),
+        Some("ag-solo"),
+        "without the exclusion the implementer reviews its own card"
+    );
+}
+
+/// The exclusion is OPT-IN per column: a stage that does not set
+/// `excludes_prior_agent` still lets a prior agent continue, which is what makes
+/// a one-agent roster usable at all.
+#[tokio::test]
+async fn exclusion_is_opt_in_per_column() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-solo", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+    add_task(pool, "t-prior", "ag-solo", "i-1", "done", 1).await;
+
+    assert!(
+        pull(pool, "t-2").await.is_some(),
+        "an unflagged stage does not exclude"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The supporting contract
+// ---------------------------------------------------------------------------
+
+/// ONE OWNER PER CARD: a card that already has an active task is not pullable by
+/// anyone, however many eligible agents exist. This is the invariant the live
+/// proof asserts as "never more than one running task per card".
+#[tokio::test]
+async fn card_with_an_active_task_is_not_pullable_by_anyone() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-a", "implementer", 5).await;
+    add_agent(pool, "ag-b", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+    add_task(pool, "t-running", "ag-a", "i-1", "running", 1).await;
+
+    assert!(
+        pull(pool, "t-2").await.is_none(),
+        "a second agent must not join a running card"
+    );
+}
+
+/// With the ONE-OWNER PREDICATE DELETED a second agent piles onto the running
+/// card. This is the broadcast defect in miniature.
+#[tokio::test]
+async fn mutation_proof_without_one_owner_a_second_agent_piles_on() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-a", "implementer", 5).await;
+    add_agent(pool, "ag-b", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+    add_task(pool, "t-running", "ag-a", "i-1", "running", 1).await;
+
+    let winner = pull_mutant(pool, "t-2", ONE_OWNER_CLAUSE).await;
+    assert!(
+        winner.is_some(),
+        "without the one-owner guard the already-running card is handed out again"
+    );
+    // WHICH agent piles on is not the point (the statement has no agent
+    // tie-break, so either eligible agent may win). The defect is that the card
+    // now carries TWO simultaneous runs, which is the broadcast bug in miniature.
+    let active: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM agent_task_queue \
+         WHERE issue_id='i-1' AND status IN ('queued','dispatched','running')",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("count active");
+    assert_eq!(
+        active, 2,
+        "the mutant put a second simultaneous run on one card"
+    );
+}
+
+/// Two pulls in a row never hand the same card to two agents: the first takes
+/// it, the second finds nothing.
+#[tokio::test]
+async fn sequential_pulls_never_double_assign_one_card() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-a", "implementer", 5).await;
+    add_agent(pool, "ag-b", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    assert!(
+        pull(pool, "t-1").await.is_some(),
+        "first pull takes the card"
+    );
+    assert!(
+        pull(pool, "t-2").await.is_none(),
+        "second pull finds it already owned"
+    );
+
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id='i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("count");
+    assert_eq!(n, 1, "exactly one task exists for the card");
+}
+
+/// A card with an UNFINISHED blocker is not pullable at any stage (the F7
+/// refuse-run guard, reused verbatim), and becomes pullable once the blocker's
+/// latest generation drains with a `done`.
+#[tokio::test]
+async fn blocked_card_is_not_pullable_until_its_blocker_finishes() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-dep", "col-impl", 0).await;
+    // The blocker is an issue but NOT a card in the gated column, so the only
+    // thing this test can possibly pull is the dependent. Otherwise the blocker
+    // itself becomes pullable the moment it finishes and wins on the id
+    // tie-break, which would mask the dependent staying blocked.
+    add_issue(pool, "i-blocker", 0).await;
+    sqlx::query(
+        "INSERT INTO card_dependency \
+         (workspace_id, dependent_issue_id, blocker_issue_id, created_at, link_type) \
+         VALUES ('ws-1','i-dep','i-blocker',0,'blocked_by')",
+    )
+    .execute(pool)
+    .await
+    .expect("dependency");
+    // The blocker is mid-run, so the dependent is blocked. The blocker itself is
+    // excluded by the one-owner guard, so nothing at all is pullable.
+    add_task(pool, "t-blk", "ag-impl", "i-blocker", "running", 1).await;
+
+    assert!(
+        pull(pool, "t-1").await.is_none(),
+        "a blocked dependent must not run"
+    );
+
+    // Finish the blocker: its latest generation drains with a `done`.
+    sqlx::query("UPDATE agent_task_queue SET status='done' WHERE id='t-blk'")
+        .execute(pool)
+        .await
+        .expect("finish blocker");
+    let got = pull(pool, "t-1").await.expect("the dependent unblocks");
+    assert_eq!(got.issue_id, "i-dep");
+}
+
+/// Per-agent capacity survives: an agent at `max_concurrent_tasks` pulls no more.
+#[tokio::test]
+async fn agent_at_capacity_pulls_nothing_further() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 1).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+    add_card(pool, "i-2", "col-impl", 0).await;
+    add_task(pool, "t-busy", "ag-impl", "i-1", "running", 1).await;
+
+    assert!(
+        pull(pool, "t-2").await.is_none(),
+        "the only agent is at capacity"
+    );
+}
+
+/// Ordering: urgent work first, then PULL FROM THE RIGHT (latest stage first),
+/// so the pipeline drains rather than piling up mid-flight.
+#[tokio::test]
+async fn pull_takes_priority_first_then_the_latest_stage() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-both", "implementer,reviewer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_column(pool, "col-rev", 2, Some("reviewer"), None, false).await;
+    // Equal priority: the LATER column wins.
+    add_card(pool, "i-impl", "col-impl", 0).await;
+    add_card(pool, "i-rev", "col-rev", 0).await;
+
+    let first = pull(pool, "t-1").await.expect("pulls");
+    assert_eq!(
+        first.issue_id, "i-rev",
+        "drain the end of the pipeline first"
+    );
+
+    // Higher priority beats stage position.
+    add_card(pool, "i-urgent", "col-impl", 3).await;
+    let second = pull(pool, "t-2").await.expect("pulls");
+    assert_eq!(second.issue_id, "i-urgent", "priority outranks stage order");
+}
+
+/// The pulled row carries the fields the runner needs: the agent's OWN provider
+/// as `agent_kind` (a codex reviewer must invoke codex, whatever the card was
+/// created with) and a fresh generation per stage.
+#[tokio::test]
+async fn pulled_row_carries_the_agents_provider_and_a_fresh_generation() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-codex','ws-1','d-2','codex','local')",
+    )
+    .execute(pool)
+    .await
+    .expect("codex runtime");
+    add_agent(pool, "ag-rev", "reviewer", 5).await;
+    sqlx::query("UPDATE agent SET runtime_id='rt-codex' WHERE id='ag-rev'")
+        .execute(pool)
+        .await
+        .expect("repoint agent at codex");
+    add_column(pool, "col-rev", 2, Some("reviewer"), None, false).await;
+    add_card(pool, "i-1", "col-rev", 0).await;
+    // A prior stage ran under claude at generation 1.
+    add_task(pool, "t-prior", "ag-rev", "i-1", "done", 1).await;
+
+    let got = PullService::pull_for_runtime(
+        pool,
+        "rt-codex",
+        &SeqIdGen::new(&["t-rev"]),
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("pull runs")
+    .expect("codex reviewer pulls");
+    assert_eq!(got.generation, 2, "each stage mints its own generation");
+
+    let (kind, created): (String, i64) =
+        sqlx::query_as("SELECT agent_kind, created_at FROM agent_task_queue WHERE id='t-rev'")
+            .fetch_one(pool)
+            .await
+            .expect("read the pulled row");
+    assert_eq!(kind, "codex", "the run uses the PULLING agent's provider");
+    assert_eq!(created, NOW_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Mutation targets: the exact substrings the proofs delete from PULL_SQL.
+// Kept as consts so a reworded predicate breaks the proofs loudly (via the
+// `contains` assertion in `pull_mutant`) rather than silently voiding them.
+// ---------------------------------------------------------------------------
+
+/// Invariant (a): the agent must hold the column's `services_role`.
+const ROLE_GATE_CLAUSE: &str = "\
+   AND EXISTS ( \
+        SELECT 1 FROM squad_member AS sm \
+          JOIN squad AS sq ON sq.id = sm.squad_id \
+         WHERE sm.member_type = 'agent' \
+           AND sm.member_id = a.id \
+           AND sq.workspace_id = bd.workspace_id \
+           AND INSTR( \
+                 ',' || REPLACE(LOWER(sm.role), ' ', '') || ',', \
+                 ',' || LOWER(TRIM(col.services_role)) || ',' \
+               ) > 0 \
+       ) ";
+
+/// Invariant (b): the column must be under its `wip_limit`.
+const WIP_LIMIT_CLAUSE: &str = "\
+   AND ( col.wip_limit IS NULL OR ( \
+        SELECT COUNT(DISTINCT w.issue_id) FROM board_card AS w \
+          JOIN agent_task_queue AS wq ON wq.issue_id = w.issue_id \
+         WHERE w.column_id = col.id \
+           AND wq.status IN ('queued','dispatched','running') \
+       ) < col.wip_limit ) ";
+
+/// Invariant (c): a prior agent on the card is excluded from a flagged stage.
+const PRIOR_AGENT_CLAUSE: &str = "\
+   AND ( col.excludes_prior_agent = 0 OR NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS p \
+         WHERE p.issue_id = bc.issue_id \
+           AND p.agent_id = a.id \
+           AND p.status = 'done' \
+       ) ) ";
+
+/// The supporting one-owner-per-card guard.
+const ONE_OWNER_CLAUSE: &str = "\
+   AND NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS o \
+         WHERE o.issue_id = bc.issue_id \
+           AND o.status IN ('queued','dispatched','running') \
+       ) ";

--- a/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
@@ -1,0 +1,295 @@
+//! REGRESSION: dispatching an issue to a squad must produce exactly ONE run,
+//! never one per member (goal success criterion 2).
+//!
+//! # The defect this pins
+//!
+//! Issue `01KY7SHDMWVMHE218DV5TQRN3R` in the operator's live database produced
+//! FOUR runs. Three of them landed within two seconds of each other, on agents
+//! `claude`, `test` and `devops`, which is the issue's assignee plus BOTH members
+//! of squad `team1`. `SquadAssignService::assign_fanout` wrote the leader brief
+//! plus one task per distinct `agent` member, each stamped with the card's repo
+//! so each provisioned its OWN worktree: one issue, N agents, N worktrees, all
+//! doing the same work and racing each other to the same branch.
+//!
+//! The fix is not a smaller fan-out, it is a different model: the card in a
+//! role-gated column IS the queue, and exactly one eligible agent pulls it.
+//!
+//! # These tests fail against the pre-change code
+//!
+//! `three_member_squad_yields_exactly_one_run` asserts `COUNT(*) == 1`. The old
+//! code wrote 1 leader + 3 members = 4, so it fails with `4 != 1`.
+//! `broadcast_is_gone_even_without_a_pipeline` asserts the same for a workspace
+//! with no pipeline provisioned, where the old code wrote 1 + 3 = 4 as well.
+
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_core::idgen::SystemIdGen;
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::service::pipeline::PipelineService;
+use ainb_hangar_store::service::squad_assign::{SquadAssignRequest, SquadAssignService};
+use sqlx::SqlitePool;
+
+const NOW_MS: i64 = 1_700_000_500_000;
+
+fn ws() -> WorkspaceId {
+    WorkspaceId::from_str("ws-1".to_string()).expect("workspace id")
+}
+
+/// A workspace with a squad whose leader is `ag-lead` and which has THREE agent
+/// members holding pipeline roles. Under the old code this is a 4-way broadcast.
+async fn seed_squad_of_three(pool: &SqlitePool) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','a','A',0)")
+        .execute(pool)
+        .await
+        .expect("workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u-1','a@x.dev',0)")
+        .execute(pool)
+        .await
+        .expect("user");
+    // The gap #8 invocation gate defaults the invoker to the workspace OWNER, so
+    // the dispatch is refused outright without this membership.
+    sqlx::query("INSERT INTO member (workspace_id, user_id, role) VALUES ('ws-1','u-1','owner')")
+        .execute(pool)
+        .await
+        .expect("owner membership");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','d-1','claude','local')",
+    )
+    .execute(pool)
+    .await
+    .expect("runtime");
+    // The squad row must precede its members: `squad_member.squad_id` is an FK.
+    sqlx::query(
+        "INSERT INTO squad (id, workspace_id, name, leader_type, leader_id, created_at) \
+         VALUES ('sq-1','ws-1','team1','agent','ag-lead',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("squad");
+    for (id, roles) in [
+        ("ag-lead", "triager,implementer"),
+        ("ag-a", "implementer"),
+        ("ag-b", "reviewer"),
+        ("ag-c", "tester"),
+    ] {
+        sqlx::query(
+            "INSERT INTO agent \
+             (id, workspace_id, name, runtime_id, visibility, owner_id, max_concurrent_tasks) \
+             VALUES (?1,'ws-1',?1,'rt-1','workspace','u-1',5)",
+        )
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("agent");
+        sqlx::query(
+            "INSERT INTO squad_member (squad_id, member_type, member_id, role) \
+             VALUES ('sq-1','agent',?1,?2)",
+        )
+        .bind(id)
+        .bind(roles)
+        .execute(pool)
+        .await
+        .expect("member");
+    }
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('i-1','ws-1','Ship it','open','member','u-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("issue");
+}
+
+async fn store() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    (dir, store)
+}
+
+/// Count every task row on the issue, in ANY status. Deliberately unfiltered:
+/// the defect was N rows written at once, so any filter could hide it.
+async fn task_count(pool: &SqlitePool) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id = 'i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("count tasks")
+}
+
+/// THE REGRESSION. A squad with a leader and three agent members yields exactly
+/// ONE run. The old code wrote four.
+#[tokio::test]
+async fn three_member_squad_yields_exactly_one_run() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision pipeline");
+
+    let out = SquadAssignService::assign_fanout(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("fanout");
+
+    assert_eq!(
+        task_count(pool).await,
+        1,
+        "a squad of N members must yield exactly ONE run, not one per member"
+    );
+    assert!(
+        out.members.is_empty(),
+        "there are no member dispatches under pull"
+    );
+
+    // The one run is owned by an agent that HOLDS the first stage's role
+    // (`triager`), which is the leader here, and it is a real task row.
+    assert!(
+        !out.leader.task_id.is_empty(),
+        "the pull produced a real task"
+    );
+    let (owner, count): (String, i64) = sqlx::query_as(
+        "SELECT agent_id, COUNT(*) FROM agent_task_queue WHERE issue_id='i-1' GROUP BY agent_id",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("single owner");
+    assert_eq!(count, 1);
+    assert_eq!(
+        owner, "ag-lead",
+        "only the triager could take the Triage stage"
+    );
+}
+
+/// The card lands in the FIRST ROLE-GATED column (Triage), not in Backlog and not
+/// spread across the board.
+#[tokio::test]
+async fn dispatch_places_the_card_in_the_first_role_gated_stage() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+
+    SquadAssignService::assign_fanout(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("fanout");
+
+    let (name, role): (String, Option<String>) = sqlx::query_as(
+        "SELECT col.name, col.services_role FROM board_card AS bc \
+           JOIN board_column AS col ON col.id = bc.column_id \
+          WHERE bc.issue_id = 'i-1'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("card is on the board");
+    assert_eq!(name, "Triage");
+    assert_eq!(role.as_deref(), Some("triager"));
+
+    let cards: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM board_card WHERE issue_id='i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("count cards");
+    assert_eq!(cards, 1, "one card, one place on the board");
+}
+
+/// Even with NO pipeline provisioned, a squad dispatch is ONE task. The
+/// no-pipeline fallback briefs the leader alone: the member broadcast is gone
+/// outright, not merely bypassed when a pipeline happens to exist.
+#[tokio::test]
+async fn broadcast_is_gone_even_without_a_pipeline() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+
+    let out = SquadAssignService::assign_fanout(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("fanout");
+
+    assert_eq!(
+        task_count(pool).await,
+        1,
+        "no pipeline is still ONE task, never four"
+    );
+    assert!(out.members.is_empty());
+    assert_eq!(out.leader.leader_agent_id, "ag-lead");
+}
+
+/// A dangling member ref STILL rejects the whole dispatch. Members are no longer
+/// dispatched to, but they are still resolved and gated, so removing the
+/// broadcast did not quietly remove the tenant / invocation safety checks with
+/// it, and no partial state is left behind.
+#[tokio::test]
+async fn a_dangling_member_still_rejects_the_dispatch_with_zero_rows() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+    sqlx::query(
+        "INSERT INTO squad_member (squad_id, member_type, member_id, role) \
+         VALUES ('sq-1','agent','ag-ghost','implementer')",
+    )
+    .execute(pool)
+    .await
+    .expect("dangling member");
+
+    let err = SquadAssignService::assign_fanout(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await;
+    assert!(
+        err.is_err(),
+        "a dangling member ref must still reject the dispatch"
+    );
+    assert_eq!(
+        task_count(pool).await,
+        0,
+        "a rejected dispatch writes nothing"
+    );
+    let cards: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM board_card WHERE issue_id='i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("count cards");
+    assert_eq!(cards, 0, "and places no card either");
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
@@ -413,3 +413,163 @@ async fn redundant_more_than_the_roster_dispatches_to_everyone() {
         "leader plus three members, capped by the roster"
     );
 }
+
+/// FANOUT-SEMANTICS, preserved for the surviving multi-task shape: a dependent
+/// stays blocked until the blocker's WHOLE cluster has drained with a success.
+///
+/// This property used to be covered end-to-end by
+/// `tripwire_tcp_card_dependency_chain_e2e`, which built its multi-task blocker
+/// out of the squad BROADCAST. With the broadcast gone a squad blocker holds one
+/// task, so that tripwire can no longer express the case, and the coverage is
+/// re-homed here against `--redundant`, which is now the only way one card
+/// carries several concurrent runs.
+///
+/// The three states that must each keep the dependent blocked: any sibling still
+/// active, all siblings terminal but NONE succeeded, and a success that arrived
+/// in an older generation.
+#[tokio::test]
+async fn dependent_waits_for_the_whole_redundant_cluster_to_drain() {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('i-dep','ws-1','dependent','open','member','u-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("dependent issue");
+    sqlx::query(
+        "INSERT INTO card_dependency \
+         (workspace_id, dependent_issue_id, blocker_issue_id, created_at, link_type) \
+         VALUES ('ws-1','i-dep','i-1',0,'blocked_by')",
+    )
+    .execute(pool)
+    .await
+    .expect("dependency");
+
+    // A deliberate cluster of three concurrent runs on the blocker.
+    SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        3,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("redundant dispatch");
+
+    let ids: Vec<String> =
+        sqlx::query_scalar("SELECT id FROM agent_task_queue WHERE issue_id='i-1' ORDER BY id")
+            .fetch_all(pool)
+            .await
+            .expect("cluster ids");
+    assert_eq!(ids.len(), 3);
+
+    let blocked = |pool: &sqlx::SqlitePool| {
+        let pool = pool.clone();
+        async move {
+            !CardDependencyRepo::unfinished_blockers_of(&pool, "i-dep")
+                .await
+                .expect("blockers")
+                .is_empty()
+        }
+    };
+
+    assert!(blocked(pool).await, "all three siblings still active");
+
+    // First sibling home is NOT enough: two are still running.
+    sqlx::query("UPDATE agent_task_queue SET status='done' WHERE id=?1")
+        .bind(&ids[0])
+        .execute(pool)
+        .await
+        .expect("finish first");
+    assert!(
+        blocked(pool).await,
+        "one done, two still active: still blocked"
+    );
+
+    sqlx::query("UPDATE agent_task_queue SET status='failed' WHERE id=?1")
+        .bind(&ids[1])
+        .execute(pool)
+        .await
+        .expect("fail second");
+    assert!(
+        blocked(pool).await,
+        "two terminal, one still active: still blocked"
+    );
+
+    // The LAST sibling drains the set, and one of them succeeded.
+    sqlx::query("UPDATE agent_task_queue SET status='cancelled' WHERE id=?1")
+        .bind(&ids[2])
+        .execute(pool)
+        .await
+        .expect("cancel third");
+    assert!(
+        !blocked(pool).await,
+        "the cluster has drained with a success, so the dependent unblocks"
+    );
+}
+
+/// The other half of the same contract: a cluster that drains with NO success
+/// leaves the dependent blocked, rather than unblocking on mere terminality.
+#[tokio::test]
+async fn a_cluster_that_drains_without_a_success_keeps_the_dependent_blocked() {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('i-dep','ws-1','dependent','open','member','u-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("dependent issue");
+    sqlx::query(
+        "INSERT INTO card_dependency \
+         (workspace_id, dependent_issue_id, blocker_issue_id, created_at, link_type) \
+         VALUES ('ws-1','i-dep','i-1',0,'blocked_by')",
+    )
+    .execute(pool)
+    .await
+    .expect("dependency");
+
+    SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        2,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("redundant dispatch");
+
+    sqlx::query("UPDATE agent_task_queue SET status='failed' WHERE issue_id='i-1'")
+        .execute(pool)
+        .await
+        .expect("fail the whole cluster");
+
+    assert!(
+        !CardDependencyRepo::unfinished_blockers_of(pool, "i-dep")
+            .await
+            .expect("blockers")
+            .is_empty(),
+        "a cluster that drained without any success must NOT unblock the dependent"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
@@ -293,3 +293,123 @@ async fn a_dangling_member_still_rejects_the_dispatch_with_zero_rows() {
         .expect("count cards");
     assert_eq!(cards, 0, "and places no card either");
 }
+
+/// `--redundant N` is the SURVIVING form of intentional parallelism: it writes N
+/// runs on one card, all sharing a `run_group`, so a deliberate cluster stays
+/// distinguishable from the accidental broadcast that was removed.
+#[tokio::test]
+async fn redundant_opt_in_writes_n_runs_sharing_one_run_group() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+
+    let out = SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        3,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("redundant dispatch");
+
+    assert_eq!(task_count(pool).await, 3, "three deliberate runs");
+    assert_eq!(
+        out.members.len(),
+        2,
+        "first copy in leader, the rest in members"
+    );
+
+    // ONE shared run_group across all three, and it is not NULL.
+    let groups: Vec<Option<String>> = sqlx::query_scalar(
+        "SELECT run_group FROM agent_task_queue WHERE issue_id='i-1' ORDER BY id",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("read run_group");
+    assert_eq!(groups.len(), 3);
+    let first = groups[0].clone().expect("run_group is stamped, not NULL");
+    assert!(
+        groups.iter().all(|g| g.as_deref() == Some(first.as_str())),
+        "every copy of one deliberate fan-out shares a run_group: {groups:?}"
+    );
+
+    // Three DISTINCT agents, so the copies are genuinely independent attempts.
+    let distinct: i64 = sqlx::query_scalar(
+        "SELECT COUNT(DISTINCT agent_id) FROM agent_task_queue WHERE issue_id='i-1'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("count distinct agents");
+    assert_eq!(distinct, 3);
+}
+
+/// `--redundant 1` is the ordinary single-owner dispatch, and stamps NO
+/// `run_group`: an unclustered row means "nobody asked for parallelism here".
+#[tokio::test]
+async fn redundant_one_is_an_ordinary_single_owner_dispatch() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+
+    SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        1,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("dispatch");
+
+    assert_eq!(task_count(pool).await, 1);
+    let group: Option<String> =
+        sqlx::query_scalar("SELECT run_group FROM agent_task_queue WHERE issue_id='i-1'")
+            .fetch_one(pool)
+            .await
+            .expect("read run_group");
+    assert_eq!(group, None, "an ordinary pull belongs to no cluster");
+}
+
+/// Redundancy is a CEILING, not a quota: asking for more copies than there are
+/// eligible agents dispatches to all of them rather than failing.
+#[tokio::test]
+async fn redundant_more_than_the_roster_dispatches_to_everyone() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+
+    SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        99,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("dispatch");
+
+    assert_eq!(
+        task_count(pool).await,
+        4,
+        "leader plus three members, capped by the roster"
+    );
+}

--- a/docs/hangar/README.md
+++ b/docs/hangar/README.md
@@ -9,6 +9,7 @@ Hangar is the proposed evolution of ainb from a local CLI/TUI into a managed-age
 ```
 docs/hangar/
 ├── README.md                ← you are here
+├── pull-pipeline.md         ← role-gated pull pipeline (shipped; how squads execute)
 ├── hangar-plan.html         ← rich HTML explainer (open in browser)
 ├── diagrams/                ← 6 SVG architecture + flow diagrams
 │   ├── 01-multica-arch.svg

--- a/docs/hangar/assets/journeys/record-t4a-squad-fanout.sh
+++ b/docs/hangar/assets/journeys/record-t4a-squad-fanout.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Recording driver for tcp T4a (squad-card fan-out) — one of the remaining tcp
+# Recording driver for tcp T4a (squad card, ONE owner), one of the remaining tcp
 # journeys in the converged-control-center catalogue
 # (docs/hangar/verify-converged-goal.md).
 #
@@ -8,12 +8,19 @@
 # cache, a `shippers` squad (leader `agent-1` + members `agent-m1`/`agent-m2`), and
 # a card ALREADY assigned to that squad on the `Delivery` board. The tape opens
 # Boards (`B`), runs the squad card (`Enter`, `Enter` for Headless), and holds the
-# fan-out running while a background poller shell-verifies the live worktrees
-# (`git branch --list 'ainb/*'` in the seeded repo + the worktree dirs on disk).
-# A background STATE-DRIVEN release (polls `agent_task_queue` for 3 `running`
-# rows, not a blind sleep — vhs's own startup latency is not fully predictable)
-# then touches `$HOME/interactive-go` once the fan-out is actually observed
-# running, so the tape also captures the clean teardown.
+# run live while a background poller shell-verifies the worktree
+# (`git branch --list 'ainb/*'` in the seeded repo + the worktree dir on disk).
+# A background STATE-DRIVEN release (polls `agent_task_queue` for the `running`
+# row, not a blind sleep, since vhs's own startup latency is not fully
+# predictable) then touches `$HOME/interactive-go` once the run is actually
+# observed running, so the tape also captures the clean teardown.
+#
+# CHANGED with migration 0074: this journey used to wait for THREE `running` rows,
+# because a squad card BROADCAST one run per member. That was the reported defect,
+# not a feature, and dispatch is now a role-gated pull with one owner per card. A
+# poller still waiting for 3 would never fire and the tape would hang, so the
+# threshold is 1. The committed GIF still shows the old three-worktree behaviour
+# and is stale until this script is re-run.
 set -euo pipefail
 
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/Users/stevengonsalvez/.cache/ccc-shared-target}"
@@ -61,7 +68,7 @@ POLL_LOG="$(mktemp /tmp/t4a-worktree-poll.XXXXXX.log)"
 POLL_BG=$!
 
 # Background STATE-DRIVEN release: wait until the DB actually shows all three
-# fanned tasks `running` (never a blind sleep — vhs's own startup latency varies
+# the task `running` (never a blind sleep, since vhs's own startup latency varies
 # run to run), hold 6s more so the tape's "running" screenshot lands, then touch
 # the sentinel to release the three blocked fake-claude agents. `set +e` so a
 # transient sqlite3/find hiccup can never silently kill this loop early (it did,
@@ -70,8 +77,8 @@ POLL_BG=$!
   set +e +o pipefail
   for _ in $(seq 1 240); do
     n=$(sqlite3 "$DB" "SELECT COUNT(*) FROM agent_task_queue WHERE issue_id='issue-squad-card' AND status='running';" 2>/dev/null)
-    if [ "${n:-0}" -ge 3 ] 2>/dev/null; then
-      echo "$(date +%s.%N) observed $n/3 running tasks; holding 6s before release" >> "$POLL_LOG"
+    if [ "${n:-0}" -ge 1 ] 2>/dev/null; then
+      echo "$(date +%s.%N) observed $n/1 running task; holding 6s before release" >> "$POLL_LOG"
       sleep 6
       touch "$HOME_DIR/interactive-go"
       echo "$(date +%s.%N) released interactive-go" >> "$POLL_LOG"
@@ -112,11 +119,11 @@ Enter
 Sleep 1s
 Enter
 Sleep 4s
-Screenshot "t4a-2-fanout-running.png"
+Screenshot "t4a-2-owner-running.png"
 
 # --- hold: three fanned tasks blocked on the release sentinel, each on its own
 #     live ainb/<slug> worktree (shell-verified in t4a-worktree-poll.log); the
-#     state-driven release fires ~6s after it observes 3/3 running ---
+#     state-driven release fires ~6s after it observes the run ---
 Sleep 14s
 Screenshot "t4a-3-fanout-done.png"
 Sleep 1s

--- a/docs/hangar/pull-pipeline.md
+++ b/docs/hangar/pull-pipeline.md
@@ -1,0 +1,183 @@
+# Role-gated pull pipeline
+
+**Status:** shipped. Schema from migration `0074_role_gated_pull_pipeline`.
+
+Squads execute like an engineering team: work is PULLED stage by stage through
+role-gated board columns by one owner at a time.
+
+```
+Backlog  ->  Triage  ->  Implement  ->  Review  ->   QA    ->  Done
+  (-)       triager    implementer     reviewer    tester      (-)
+ wip -        wip -       wip 2         wip 3       wip 1     wip -
+                                      excl. prior  excl. prior
+```
+
+## What changed, and why
+
+Squad dispatch used to BROADCAST: `assign_fanout` wrote the leader brief plus one
+`agent_task_queue` task per distinct agent member, so one issue became N
+simultaneous runs, each provisioning its own worktree for the same work and
+racing the others onto branches off one repo. `SquadRepo::member_agent_ids` is
+still documented "role-blind by design", which was exactly the problem: nothing
+gated dispatch on role.
+
+A squad dispatch now enqueues the card into the first role-gated column, and
+exactly one eligible agent pulls it.
+
+## How it works
+
+```
+board_card in a role-gated column        <- the pull queue
+       |  PullService::pull_for_runtime
+       v
+agent_task_queue row, status 'queued'    <- the execution queue
+       |  ClaimTaskService::claim_for_runtime  (unchanged)
+       v
+status 'dispatched' -> the runner
+```
+
+The daemon pulls once per tick, immediately before claiming. Pulling first means
+a card enqueued by a tick is claimable in that same tick, so a handoff costs one
+poll interval rather than two. A pull fault degrades the daemon to push-only
+rather than downing the claim loop.
+
+`agent_task_queue.agent_id` is `NOT NULL`, so a queued row always already names
+its agent: the pre-existing model is PUSH. True pull needs the agent chosen at
+claim time. Rather than make `agent_id` nullable (a full table rebuild on SQLite
+against a populated database), the `board_card` row is the queue and the task row
+is INSERTed once an eligible agent has been selected.
+
+The whole selection-and-insert is ONE `INSERT ... SELECT ... RETURNING`. SQLite
+serialises writes, so a concurrent puller's sub-select sees the committed row and
+the one-owner guard excludes the card. Two agents can never take the same card,
+across processes as well as across tasks.
+
+## The predicates
+
+A `(card, agent)` pair is pullable when ALL hold:
+
+| # | Predicate | Meaning |
+|---|---|---|
+| 1 | Role gate | the agent HOLDS the column's `services_role` |
+| 2 | WIP limit | the column is under `wip_limit` (NULL = unlimited) |
+| 3 | One owner | the card has NO active task at all |
+| 4 | Prior-agent | on `excludes_prior_agent`, no `done` task by this agent on this card |
+| 5 | Blocked + capacity | no unfinished `card_dependency` blocker; agent under `max_concurrent_tasks` |
+
+Ordering is `issue.priority DESC, column.ord DESC, card.ord, issue_id`: urgent
+work first, then PULL FROM THE RIGHT (latest stage first), so the pipeline drains
+rather than piling up mid-flight.
+
+## Roles
+
+An agent's roles come from `squad_member.role` (migration 0053). No agent-level
+roles field exists; the existing writers are the way to grant one:
+
+```bash
+ainb hangar squad add-member <squad-id> --member agent:<agent-id> --role reviewer
+ainb hangar squad member-role <squad-id> --member agent:<agent-id> --role "implementer,reviewer"
+```
+
+`role` is free text, matched as a COMMA-SEPARATED TOKEN set, case-insensitively
+and ignoring spaces, so one membership can advertise several roles without a
+second table. Matching uses `INSTR` over comma-delimited needles rather than
+`LIKE`, so a role containing `%` or `_` cannot act as a wildcard.
+
+Matching is token-exact: an agent holding `review` does NOT thereby hold
+`reviewer`. A membership with an empty role holds nothing, so the pipeline is
+opt-in.
+
+## Getting started
+
+```bash
+ainb hangar pipeline init     # provision the six stages (idempotent)
+ainb hangar pipeline show     # stages, roles, WIP caps, live card counts
+```
+
+`init` creates a NEW board named `Pipeline` rather than retrofitting an existing
+one, so your current Kanban keeps working exactly as it did. Re-running never
+rewrites a tuned WIP limit or a renamed stage.
+
+Then dispatch as usual:
+
+```bash
+ainb hangar squad assign <squad-id> --issue <issue-id> --fanout
+```
+
+## Two behaviours worth knowing
+
+**A stage with no eligible agent WAITS.** If only one agent exists and it
+implemented the card, the Review stage does not claim it. The card sits visibly
+queued rather than being self-reviewed. That is the intended direction of
+failure.
+
+**Every pipeline column has `fsm_state = NULL`, deliberately.** The pre-existing
+`BoardRepo::auto_move_on_state` hook fires on every task FSM transition and moves
+a card to the column whose `fsm_state` matches the new state. A pipeline column
+carrying `fsm_state='done'` would jump the card straight there the moment the
+FIRST stage completed, skipping Review and QA while appearing to work. NULL makes
+that hook inert on these columns, while `auto_move = 1` keeps the per-column and
+per-board kill-switch meaningful, because that is what the stage advance
+consults. Turn `auto_move` off on a column to freeze cards there.
+
+## Deliberate parallelism
+
+Removing the broadcast did not remove intentional parallelism, it made it
+explicit:
+
+```bash
+ainb hangar squad assign <squad-id> --issue <issue-id> --redundant 3
+```
+
+N independent attempts at one problem, or several reviewers over one artifact, on
+up to N distinct squad agents. Every row is stamped with a shared
+`agent_task_queue.run_group`, so "why are there three runs on this card" is
+answerable from the row itself. `--redundant` is a ceiling, not a quota: asking
+for more copies than there are eligible agents dispatches to all of them.
+
+All copies share one generation, because they are one run. The card advances only
+once the WHOLE cluster has drained, and a dependent stays blocked until then.
+
+## Schema (migration 0074)
+
+| Column | Meaning |
+|---|---|
+| `board_column.services_role` | the role gate. NULL = not a pull queue |
+| `board_column.wip_limit` | max cards in this column holding an active task. NULL = unlimited |
+| `board_column.excludes_prior_agent` | 1 = an agent with a `done` task on this card may not take this stage |
+| `agent_task_queue.run_group` | clusters one deliberate `--redundant` fan-out |
+
+Every default is inert. `services_role IS NULL` means "not a pull queue", so
+every column that predates the migration keeps exactly its current behaviour and
+no existing board changes.
+
+`excludes_prior_agent` encodes the reviewer-is-never-the-implementer rule as
+pipeline DATA rather than a hard-coded `services_role = 'reviewer'` string, so an
+operator who names the stage "Peer check" still gets the guarantee, and a
+one-agent deployment that genuinely wants self-review can express that by leaving
+the flag off.
+
+## Verifying it
+
+The live proof drives one card through four stages across three real agents and
+two real provider CLIs, asserting the database every 250ms:
+
+```bash
+cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e \
+  live_pipeline_walks_four_stages -- --nocapture
+```
+
+It SKIPS CLEAN and loudly when a provider CLI is absent or unauthenticated. The
+success signal is not the task status (a stub exits 0 by construction): each
+stage must leave an unguessable nonce in its OWN worktree and record non-zero
+token usage.
+
+Unit and integration coverage:
+
+- `ainb-hangar-store/tests/pull_role_gate.rs` (the predicates, each with a
+  mutation proof that deletes exactly its clause and asserts the forbidden pull
+  then succeeds)
+- `ainb-hangar-store/tests/squad_no_broadcast.rs` (N members yield 1 run;
+  `--redundant`; whole-cluster blocker drain)
+- `ainb-hangar-store/tests/migration_0074_upgrade.rs` (the migration is inert on
+  a populated database)

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -4540,7 +4540,8 @@ Options:
       --issue <ISSUE>          The issue the routed task carries (`issue.id`), or omit for an ad-hoc task
       --work-dir <WORK_DIR>    The run's working directory, or omit
       --priority <PRIORITY>    Claim urgency (0..3, higher = more urgent). Defaults to `0` (routine) [default: 0]
-      --fanout                 Fan the work out across the WHOLE squad (leader brief + one task per distinct `agent` member) instead of briefing the leader alone
+      --fanout                 Dispatch through the squad. Enqueues the card into the first role-gated pipeline column, where ONE eligible agent takes it (no longer one run per member)
+      --redundant <N>          Deliberately run this issue N times in parallel on up to N distinct squad agents, all stamped with one shared `run_group`. Omitted or `1` is a single owner
       --invoker <INVOKER>      The user the invocation-permission gate judges this assignment by (a user id or an email). Omitted defaults to the workspace owner — the ordinary single-operator assign, which the gate always admits
       --workspace <WORKSPACE>  Workspace slug the squad belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2842,6 +2842,7 @@ Commands:
   property   Define and archive a workspace's custom issue properties
   comment    Post issue comments and preview their `@`-mention routing
   inbox      Read an actor's notification inbox
+  pipeline   Provision and inspect the role-gated pull pipeline
   help       Print this message or the help of the given subcommand(s)
 
 Options:
@@ -5383,6 +5384,58 @@ Options:
       --unread                 Show only UNREAD entries
       --limit <LIMIT>          How many entries to show, newest first [default: 50]
       --workspace <WORKSPACE>  Workspace slug. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+### `ainb hangar pipeline`
+
+Provision and inspect the role-gated pull pipeline
+
+```console
+$ ainb hangar pipeline --help
+Provision and inspect the role-gated pull pipeline
+
+Usage: ainb hangar pipeline [OPTIONS] <COMMAND>
+
+Commands:
+  init  Provision the default six-stage pipeline (Backlog, Triage, Implement, Review, QA, Done). Idempotent; never rewrites an existing pipeline board
+  show  Show each stage with its role gate, WIP limit and current card count
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar pipeline init`
+
+Provision the default six-stage pipeline (Backlog, Triage, Implement, Review, QA, Done). Idempotent; never rewrites an existing pipeline board
+
+```console
+$ ainb hangar pipeline init --help
+Provision the default six-stage pipeline (Backlog, Triage, Implement, Review, QA, Done). Idempotent; never rewrites an existing pipeline board
+
+Usage: ainb hangar pipeline init [OPTIONS]
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug to provision. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar pipeline show`
+
+Show each stage with its role gate, WIP limit and current card count
+
+```console
+$ ainb hangar pipeline show --help
+Show each stage with its role gate, WIP limit and current card count
+
+Usage: ainb hangar pipeline show [OPTIONS]
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug to provision. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
 


### PR DESCRIPTION
## What

Squad dispatch BROADCASTS today: one issue becomes N simultaneous runs, one per
member, each provisioning its own worktree for the same work. This replaces that
with a pull model. A card in a role-gated column IS the queue, and exactly one
eligible agent takes it, finishes, and hands off to a different role.

```
Backlog  ->  Triage  ->  Implement  ->  Review  ->   QA    ->  Done
  (-)       triager    implementer     reviewer    tester      (-)
 wip -        wip -       wip 2         wip 3       wip 1     wip -
                                      excl. prior  excl. prior
```

## The defect

Issue `01KY7SHDMWVMHE218DV5TQRN3R` produced FOUR runs, three of them within two
seconds on the assignee plus both members of squad `team1`.
`SquadAssignService::assign_fanout` wrote the leader brief plus one task per
distinct agent member. `SquadRepo::member_agent_ids` is even documented
"role-blind by design", which is precisely the bug: nothing gated dispatch on
role, so every member got the same work.

## Approach

`agent_task_queue.agent_id` is `NOT NULL`, so a queued row always already names
its agent: the old model is PUSH. True pull needs the agent chosen at claim
time. Rather than make `agent_id` nullable (a full table rebuild on SQLite,
against a populated production database), the `board_card` row becomes the queue
and the task row is INSERTed once an eligible agent is selected, so the agent is
known by construction at insert time.

```
board_card in a role-gated column        <- the pull queue
       |  PullService::pull_for_runtime  (role / WIP / reviewer / blocked / capacity)
       v
agent_task_queue row, status 'queued'    <- the execution queue
       |  ClaimTaskService::claim_for_runtime  (UNCHANGED)
       v
status 'dispatched' -> the runner
```

The whole selection-and-insert is ONE `INSERT ... SELECT ... RETURNING`, so
concurrent pullers cannot take the same card: SQLite serialises writes and the
second statement's sub-select sees the first's committed row.

## Success criteria

**1. Live end-to-end proof.** One card through four role-gated stages, three
different agents, two REAL provider CLIs, a real daemon, real `ainb` CLI verbs.
Reproduced on three consecutive runs.

```
stage Triage     agent=01KYTYWWDH3DZXCEX58A8Z0RD0   kind=claude  parent=(none)
stage Implement  agent=01KYTYWWDH3DZXCEX58A8Z0RD0   kind=claude  parent=01KYTYWWNNAB23SZXQA0E6GHEK
stage Review     agent=01KYTYWWENTQZ1FMZS05S9W7KA   kind=codex   parent=01KYTYXDK9JZN18VA1S77QYMF6
stage QA         agent=01KYTYWWFAJGF9CXVBEZHE4PH2   kind=claude  parent=01KYTYXY9P1K7NHE8FMEAWFHMH

PEAK simultaneous runs on the card, sampled every 250ms across the walk => 1
columns the card occupied, in order (ords)                             => [1, 2, 3, 4, 5]
SELECT COUNT(DISTINCT agent_id)                                        => 3
board_card.column                                                      => Done (ord 5)

real token spend per stage (a stub cannot fake this)
01KYTYWWNNAB23SZXQA0E6GHEK  in=18      out=264
01KYTYXDK9JZN18VA1S77QYMF6  in=18      out=284
01KYTYXY9P1K7NHE8FMEAWFHMH  in=60446   out=217
01KYTYYACGBYJZ4C5CRADJHDHJ  in=18      out=328
```

### Why a stub cannot satisfy this test

The success signal is deliberately NOT the task status. Agent CLIs exit 0 on
refusals, denials and empty runs, and a scripted stub exits 0 by construction,
which is how a broken headless path survived here for weeks. So the test demands
two things a no-op cannot produce:

1. **A per-stage nonce artifact.** Each stage must run a real tool and leave an
   unguessable string in ITS OWN worktree. The nonce is minted per run and handed
   to the model only in the brief, so it cannot be guessed or hard-coded, and the
   per-stage worktree means stage 1's file cannot satisfy stage 4's check.
2. **Real per-stage token spend**, read back from `task_usage`. This is the
   sharper of the two: a stub can be taught to write a file, but it cannot
   fabricate a provider's own accounting of tokens it never bought. Note the
   Review row above reading ~60k input tokens against ~18 for the claude stages,
   which is codex's own context accounting and is exactly the kind of number no
   fixture would think to invent.

The token assertion is also what caught a real bug during development: an early
version of the pull statement derived the run's provider from `agent_runtime`
rather than `agent`, which would have invoked a codex reviewer through the claude
CLI. A fake-script test would have passed straight through it.

**2. Broadcast is gone.** `three_member_squad_yields_exactly_one_run` asserts
`COUNT(*) == 1`. Against the pre-change code it fails:

```
---- three_member_squad_yields_exactly_one_run stdout ----
assertion `left == right` failed: a squad of N members must yield exactly ONE run, not one per member
  left: 4
 right: 1

---- broadcast_is_gone_even_without_a_pipeline stdout ----
assertion `left == right` failed: no pipeline is still ONE task, never four
  left: 4
 right: 1
```

**3. Three invariants, each failing before and passing after.** With the three
predicates stripped from `PULL_SQL`:

```
---- agent_without_the_role_cannot_pull stdout ----
a tester must not pull an implementer stage

---- column_at_wip_limit_yields_no_pull stdout ----
the column is full

---- implementer_cannot_pull_the_review_stage_of_its_own_card stdout ----
the implementer must not review its own card, even as the only candidate
```

Each also carries a permanent MUTATION PROOF that deletes exactly its clause from
`PULL_SQL` and asserts the forbidden pull then succeeds, so a later weakening of
a predicate cannot pass unnoticed.

## Notable findings

- **`agent.provider` is the authority, not `agent_runtime.provider`.** A runtime
  is a DAEMON, not a provider binding: `agent create --provider codex` records
  codex on the AGENT and still binds it to the single `default` runtime, whose
  own provider column reads `claude` on every install. The first live run caught
  a codex reviewer about to be invoked through the claude CLI.

- **Every pipeline column carries `fsm_state = NULL`.** The existing
  `auto_move_on_state` hook fires on every task FSM transition and moves a card
  to the column whose `fsm_state` matches. A pipeline column carrying
  `fsm_state='done'` would jump the card straight there the moment the FIRST
  stage completed, skipping Review and QA while appearing to work. NULL makes
  that hook inert on these columns while `auto_move=1` keeps the operator's
  existing kill-switch meaningful.

## Migration 0074

Four additive `ALTER TABLE ADD COLUMN` with constant defaults (O(1) in SQLite,
no table rewrite) plus three partial indexes. Every default is inert:
`services_role IS NULL` means "not a pull queue", so every column that predates
this migration keeps exactly its current behaviour and no existing board changes.

`excludes_prior_agent` encodes the reviewer-is-never-the-implementer rule as
pipeline DATA rather than string-matching `services_role = 'reviewer'`, so an
operator who names the stage "Peer check" still gets the guarantee.

## Intentional parallelism survives

`--redundant N` writes N runs on one card sharing a `run_group`. It differs from
the removed broadcast in intent and evidence: opt-in rather than default, capped
at N rather than however many members exist, and every row stamped so "why are
there three runs on this card" is answerable from the row itself.

## Tests that pinned the old behaviour

Six tests asserted the fan-out WIDTH. They are INVERTED rather than deleted: a
test that says "this must not happen" is what stops the broadcast coming back.

Two properties genuinely needed several concurrent runs on one card. Rather than
let them evaporate along with the defect, they move to the shape that still
produces that (`--redundant N`):

| Property | Was | Now |
|---|---|---|
| dependent waits for the whole set to drain | `tripwire_tcp_card_dependency_chain_e2e` | `squad_no_broadcast.rs` |
| one cancel cancels every sibling, not just the newest | `tripwire_tcp_squad_card_fanout_e2e` | `rpc_issue_cancel_active.rs` |

The member-chip assertion is DELETED rather than weakened to "zero chips", which
would be trivially true and prove nothing.

## Testing

- `cargo nextest run --workspace --lib --tests --all-features -E 'not binary(/^tripwire_/)'`
- Live proof: `cargo test -p ainb-hangar-daemon --features live-e2e --test live_e2e live_pipeline_walks_four_stages -- --nocapture`
  (skips clean and loudly when a provider CLI is absent or unauthenticated)
- New: `pull_role_gate.rs` (20), `squad_no_broadcast.rs` (9), `migration_0074_upgrade.rs` (1)
- Full workspace suite locally: 7842 tests, 7839 passed before the three
  broadcast-pinning fixes in this branch, all green after

## Docs

`docs/hangar/pull-pipeline.md` covers the six stages, how roles resolve,
`pipeline init/show`, `--redundant N`, the migration 0074 columns, and the two
behaviours that surprise people (a stage with no eligible agent WAITS; every
pipeline column carries `fsm_state = NULL` so the state-driven auto-move hook
cannot jump a card past Review and QA).

## Not touched

`.github/workflows`, branch protection, the `[K]Kanban` runs view, and no applied
migration.
