### PR TITLE
docs(fleet): record the provider-event retention decision

### DIFF
--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
@@ -1,4 +1,28 @@
 //! Durable raw provider-event ledger for Fleet projections.
+//!
+//! ## RETENTION: none. This ledger is never trimmed.
+//!
+//! Like `activity_log` (0059) and unlike `dispatch_attempt` (0058, bounded to
+//! 20/issue), this table keeps every row forever, on purpose.
+//!
+//! `raw_payload` is the verbatim provider envelope, and the whole point of
+//! keeping it is that a FUTURE reducer can replay history and re-derive Fleet
+//! state that today's reducer does not extract. Trimming would silently destroy
+//! exactly the rows that make a re-reduction possible, and it would do so
+//! oldest-first — discarding the beginning of every session's story.
+//!
+//! The growth case does not justify that risk. Measured on a heavy real profile
+//! (15-20 concurrent agent sessions): roughly 21 rows per 2 days at a ~344 byte
+//! mean `raw_payload`, i.e. on the order of 1.3 MB per YEAR, against a whole
+//! hangar database of ~4 MB. There is no horizon on which this is the thing that
+//! fills a disk.
+//!
+//! If unbounded growth ever does bite, the fix is an explicit operator-invoked
+//! export-then-delete, NOT an automatic sweep, and it must never remove a row
+//! with `projection_revision IS NULL` — that marks pending recovery work which
+//! the Codex manager replays on startup, not garbage.
+//!
+//! Revisit trigger: this table exceeding ~1M rows or ~100 MB on a real profile.
 
 use blake3::Hasher;
 use sqlx::{Row, SqlitePool};


### PR DESCRIPTION
Closes the P2 retention question on bead `agents-in-a-box-ebu`.

## The decision

**No retention. The ledger is never trimmed.** This PR records that choice next to the code rather than adding a sweeper.

## Why not build deletion

`fleet_provider_event.raw_payload` is the verbatim provider envelope, and the entire reason P1 persists it is so a *future* reducer can replay history and derive Fleet state today's reducer does not extract. Trimming destroys oldest-first — precisely the rows that make re-reduction possible, and the beginning of every session's story.

The growth case does not justify that risk. Measured on a heavy real profile (15-20 concurrent agent sessions):

| metric | value |
|---|---|
| organic rate | ~21 rows / 2 days |
| mean `raw_payload` | ~344 bytes |
| projected growth | **~1.3 MB / year** |
| whole `hangar.db` today | ~4 MB |

There is no realistic horizon on which this fills a disk. Building a sweeper, a config knob, and an export pipeline for 1.3 MB/year would be inventing a problem — and P1's contract explicitly says *"do not add silent deletion or automatic truncation."*

## Precedent

The workspace already carries both patterns, and this table belongs with the first:

- `activity_log` (0059) — deliberately **not** trimmed, because it is the narrative and trimming would silently erase the start of an issue's story. Documented in the migration.
- `dispatch_attempt` (0058) — bounded to 20/issue via trim-on-insert.

This change mirrors the `activity_log` convention: state the decision, the numbers, and the revisit trigger where the next reader will find them.

## What the doc pins down

- Retention is **none**, on purpose.
- If growth ever does bite, the fix is an explicit **operator-invoked export-then-delete**, not an automatic sweep.
- Any future sweep must never remove a row with `projection_revision IS NULL` — that marks pending recovery work the Codex manager replays on startup, not garbage.
- Revisit trigger: ~1M rows or ~100 MB on a real profile.

## Verification

Doc-only, no behaviour change.

```
cargo test -p ainb-hangar-store --lib fleet_provider_event    4 passed
rustup run stable cargo fmt --all -- --check                  clean
```