### PR TITLE
fix(fleet): make AINB_TMUX_BIN actually work across the fleet control plane

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1475,7 +1475,7 @@ fn resolve_matcher(
 
 fn current_tmux_identity() -> Option<(String, String)> {
     let pane = std::env::var_os("TMUX_PANE").filter(|value| !value.is_empty())?;
-    let tmux = std::env::var_os("AINB_TMUX_BIN").unwrap_or_else(|| "tmux".into());
+    let tmux = ainb_fleet_core::fleet::tmux_bin();
     let output = std::process::Command::new(tmux)
         .args([
             std::ffi::OsStr::new("display-message"),

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
@@ -135,7 +135,7 @@ pub async fn discover_from_tmux() -> Result<Vec<FleetSession>> {
 /// fingerprint Y still there" — which must stay true to tmux rather than to
 /// Fleet's view of what deserves a row.
 pub async fn discover_all_tmux_panes() -> Result<Vec<FleetSession>> {
-    let output = Command::new("tmux")
+    let output = Command::new(crate::fleet::tmux_bin())
         .args(["list-panes", "-a", "-F", LIST_FORMAT])
         .output()
         .await

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/mod.rs
@@ -23,3 +23,51 @@ pub use types::{
     FleetSession, LifecycleState, Liveness, ManagementState, Provenance, Provider, SendOutcome,
     Session, SessionKey, SessionSource, SessionState, Signal, TransportHealth,
 };
+
+/// The tmux binary this process drives, honouring `AINB_TMUX_BIN`.
+///
+/// Launch, discovery, liveness validation and send MUST resolve tmux the same
+/// way. The managed-Codex launch path already reads `AINB_TMUX_BIN`; when the
+/// fleet paths hardcoded `tmux` instead, a custom binary meant sessions were
+/// launched against one tmux server and then looked up against another — so
+/// they were created successfully and were immediately invisible to discovery
+/// and unreachable by send.
+#[must_use]
+pub fn tmux_bin() -> std::ffi::OsString {
+    resolve_tmux_bin(std::env::var_os("AINB_TMUX_BIN"))
+}
+
+/// Env-free core of [`tmux_bin`], so the contract is testable without mutating
+/// process-global state (this crate forbids `unsafe`, so tests cannot call
+/// `set_var`, and env-mutating tests race under a parallel runner anyway).
+///
+/// An EMPTY override falls back rather than spawning `""`. `var_os` returns
+/// `Some("")` for `AINB_TMUX_BIN=`, which an `unwrap_or_else` alone would
+/// happily pass to `Command::new`, turning an unset-looking variable into a
+/// spawn failure on every tmux call.
+fn resolve_tmux_bin(configured: Option<std::ffi::OsString>) -> std::ffi::OsString {
+    configured.filter(|value| !value.is_empty()).unwrap_or_else(|| "tmux".into())
+}
+
+#[cfg(test)]
+mod tmux_bin_tests {
+    use super::resolve_tmux_bin;
+
+    #[test]
+    fn unset_falls_back_to_path_tmux() {
+        assert_eq!(resolve_tmux_bin(None), "tmux");
+    }
+
+    #[test]
+    fn a_configured_binary_wins() {
+        assert_eq!(
+            resolve_tmux_bin(Some("/opt/custom/bin/tmux".into())),
+            "/opt/custom/bin/tmux"
+        );
+    }
+
+    #[test]
+    fn an_empty_override_falls_back_instead_of_spawning_nothing() {
+        assert_eq!(resolve_tmux_bin(Some(String::new().into())), "tmux");
+    }
+}

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/read/tmux_pane.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/read/tmux_pane.rs
@@ -7,7 +7,7 @@ use crate::fleet::types::Signal;
 
 pub async fn capture_pane(tmux_session: &str, lines: u32) -> Result<String> {
     let scroll_arg = format!("-{lines}");
-    let output = Command::new("tmux")
+    let output = Command::new(crate::fleet::tmux_bin())
         .args([
             "capture-pane",
             "-t",

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/send/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/send/tmux.rs
@@ -70,7 +70,7 @@ fn picker_key_args<'a>(tmux_session: &'a str, key: &'a str) -> Option<[&'a str; 
 }
 
 pub async fn tmux_send(tmux_session: &str, text: &str) -> Result<()> {
-    let status = Command::new("tmux")
+    let status = Command::new(crate::fleet::tmux_bin())
         .args(send_keys_literal_args(tmux_session, text))
         .status()
         .await
@@ -107,7 +107,7 @@ pub async fn tmux_send(tmux_session: &str, text: &str) -> Result<()> {
 /// Press Enter in the target session (used both to submit a send and to flush
 /// a previously-parked paste).
 pub async fn tmux_press_enter(tmux_session: &str) -> Result<()> {
-    let enter = Command::new("tmux")
+    let enter = Command::new(crate::fleet::tmux_bin())
         .args(["send-keys", "-t", tmux_session, "Enter"])
         .status()
         .await
@@ -122,7 +122,7 @@ pub async fn tmux_press_enter(tmux_session: &str) -> Result<()> {
 pub async fn tmux_send_picker_key(tmux_session: &str, key: &str) -> Result<()> {
     let args = picker_key_args(tmux_session, key)
         .ok_or_else(|| anyhow::anyhow!("unsupported verified picker key: {key}"))?;
-    let status = Command::new("tmux")
+    let status = Command::new(crate::fleet::tmux_bin())
         .args(args)
         .status()
         .await
@@ -171,7 +171,7 @@ fn composer_pending(pane: &str) -> bool {
 }
 
 pub async fn tmux_session_exists(name: &str) -> bool {
-    Command::new("tmux")
+    Command::new(crate::fleet::tmux_bin())
         .args(["has-session", "-t", name])
         .status()
         .await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1836,7 +1836,7 @@ async fn launch_managed_codex_tui(
 ) -> Result<(String, ainb_fleet_core::types::FleetSession), String> {
     let tmux_name = managed_codex_tmux_name(thread_id, SystemClock.now_ms());
     let codex_binary = std::env::var_os("AINB_CODEX_BIN").unwrap_or_else(|| "codex".into());
-    let tmux_binary = std::env::var_os("AINB_TMUX_BIN").unwrap_or_else(|| "tmux".into());
+    let tmux_binary = ainb_fleet_core::fleet::tmux_bin();
     let command = manager.managed_tui_command(
         &codex_binary,
         [
@@ -1913,7 +1913,7 @@ fn managed_codex_tmux_name(thread_id: &str, now_ms: i64) -> String {
 }
 
 async fn kill_tmux_session_exact(session_name: &str) -> Result<(), String> {
-    let tmux_binary = std::env::var_os("AINB_TMUX_BIN").unwrap_or_else(|| "tmux".into());
+    let tmux_binary = ainb_fleet_core::fleet::tmux_bin();
     let output = tokio::process::Command::new(tmux_binary)
         .args(["kill-session", "-t", session_name])
         .output()


### PR DESCRIPTION
Addresses `agents-in-a-box-f5b`, raised by CodeRabbit on #546.

## The finding was wider than reported

`AINB_TMUX_BIN` was read in exactly **three** places, with **zero** tests, docs, or scripts setting it, while ~104 production sites hardcoded `Command::new("tmux")`.

Because discovery, send and liveness validation never honoured it, a custom tmux meant a managed session was **launched against one tmux server and then looked up against another** — created successfully, then instantly invisible to discovery and unreachable by send. The knob never worked end to end.

## What this changes

One reader, nine consumers:

| Path | Before | After |
|---|---|---|
| managed Codex launch (`rpc/mod.rs` 1839, 1916) | read the env var | `tmux_bin()` |
| `ainb-core` ATC hook (`atc.rs:1478`) | read the env var | `tmux_bin()` |
| discovery (`discover/tmux.rs`) | hardcoded `tmux` | `tmux_bin()` |
| send (`send/tmux.rs` ×4) | hardcoded `tmux` | `tmux_bin()` |
| pane read (`read/tmux_pane.rs`) | hardcoded `tmux` | `tmux_bin()` |

`resolve_tmux_bin()` is an env-free core so the contract is unit-testable — this crate forbids `unsafe`, so tests cannot call `set_var`, and env-mutating tests race under a parallel runner anyway.

## Bug found while doing it

All three original readers shared this:

```rust
std::env::var_os("AINB_TMUX_BIN").unwrap_or_else(|| "tmux".into())
```

`var_os` returns `Some("")` for `AINB_TMUX_BIN=`, so an empty-looking variable was passed straight to `Command::new` — a spawn failure on **every** tmux call rather than the obvious fallback. `resolve_tmux_bin` filters empty and falls back.

## Deliberately NOT in scope

98 sites outside the fleet control plane still hardcode `tmux`: `ainb-core` 94 (TUI/CLI session management, attach, recovery, status, embed), `ainb-hangar-daemon` 3 (`interactive.rs`), `ainb-plugin-hangar` 1.

So the fleet plane is now self-consistent, but with `AINB_TMUX_BIN` set, `ainb attach` and TUI session management would still drive PATH `tmux`. That is a real remaining gap, recorded on `f5b` with a decision to make: route all 98 through `tmux_bin()`, or delete the variable and require a custom tmux on PATH. The latter is arguably honest for a knob nothing sets, tests, or documents — but it removes a user-facing escape hatch, so it is not mine to decide unilaterally.

## Verification

```
cargo test -p ainb-fleet-core --lib          95 passed
cargo test --workspace --no-run              exit 0
rustup run stable cargo fmt --all --check    clean
```

New tests: `unset_falls_back_to_path_tmux`, `a_configured_binary_wins`, `an_empty_override_falls_back_instead_of_spawning_nothing`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the tmux executable through `AINB_TMUX_BIN`.
  * Automatically falls back to the default tmux command when the setting is empty or unavailable.

* **Bug Fixes**
  * Applied the configured tmux executable consistently across pane discovery, capture, command sending, session checks, and managed launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->