### PR TITLE
fix(beads): never steal a pidfile just because the read failed

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -18,6 +18,15 @@
 //! sampling that window takes the crash-recovery path, deletes a *live* holder's
 //! pidfile and acquires alongside it — two holders, two concurrent `bd`
 //! processes, the git-head race the lock exists to prevent.
+//!
+//! **An absent pidfile is not stale, it is free.** Atomic publication closed the
+//! empty-file window but not the second route to the same double-hold: the
+//! crash-recovery path decided "stale" from a *failed read*, then unlinked the
+//! path. Absent reads that way too, and between that read and the unlink another
+//! contender can publish — so the unlink deletes a brand-new live holder's
+//! pidfile and the stealer acquires alongside it. Removal must therefore be
+//! driven by what the file SAYS (a dead PID, or unusable content), never by the
+//! read merely failing. [`PidfileRead`] keeps the two apart.
 
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
@@ -117,11 +126,20 @@ impl BdLock {
     /// Returns `true` when a stale file was removed (caller should retry the
     /// exclusive create immediately).
     fn steal_if_stale(&self) -> bool {
-        let Some(pid) = read_pid(&self.path) else {
-            // Crash-recovery backstop only: an unreadable/empty pidfile can no
-            // longer come from a live holder (publication is atomic), so it is
-            // either a pre-fix leftover or a truncated file, i.e. stale.
-            return std::fs::remove_file(&self.path).is_ok();
+        let pid = match read_pid(&self.path) {
+            Ok(pid) => pid,
+            // The pidfile vanished between our failed publish and this read: the
+            // previous holder released. There is nothing to steal, and removing
+            // is actively WRONG — by the time the unlink lands a new holder may
+            // have published, and we would delete a live holder's pidfile and
+            // acquire alongside it. That is the very double-hold atomic
+            // publication was introduced to kill, reachable through this branch
+            // instead of through the create-then-write window. Just retry.
+            Err(PidfileRead::Absent) => return true,
+            // The file exists but says nothing usable. Publication is atomic, so
+            // a live holder cannot produce this — it is a pre-fix leftover or a
+            // truncated file. Genuine crash-recovery territory.
+            Err(PidfileRead::Unreadable) => return std::fs::remove_file(&self.path).is_ok(),
         };
         if pid_alive(pid) {
             return false;
@@ -142,12 +160,29 @@ impl Drop for BdLockGuard {
     }
 }
 
-/// Read the PID written into the pidfile, or `None` if absent/unparseable.
-fn read_pid(path: &Path) -> Option<i32> {
-    let mut f = std::fs::File::open(path).ok()?;
+/// Why a pidfile yielded no PID.
+///
+/// The two cases demand OPPOSITE handling, which is why they are not one
+/// `Option`: an absent file must never be removed (a new holder may already own
+/// that path), while an unreadable one is genuine crash debris.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PidfileRead {
+    /// No file at the path — the holder released.
+    Absent,
+    /// A file is there but carries no usable PID.
+    Unreadable,
+}
+
+/// Read the PID written into the pidfile.
+fn read_pid(path: &Path) -> Result<i32, PidfileRead> {
+    let mut f = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(PidfileRead::Absent),
+        Err(_) => return Err(PidfileRead::Unreadable),
+    };
     let mut buf = String::new();
-    f.read_to_string(&mut buf).ok()?;
-    buf.trim().parse().ok()
+    f.read_to_string(&mut buf).map_err(|_| PidfileRead::Unreadable)?;
+    buf.trim().parse().map_err(|_| PidfileRead::Unreadable)
 }
 
 /// Is `pid` backed by a live process? Uses `kill(pid, 0)`: success or `EPERM`
@@ -189,7 +224,7 @@ mod tests {
         let guard = lock.acquire().expect("acquire");
         assert_eq!(
             read_pid(&path),
-            Some(i32::try_from(std::process::id()).unwrap())
+            Ok(i32::try_from(std::process::id()).unwrap())
         );
         drop(guard);
         assert!(!path.exists(), "guard drop releases the lock");
@@ -227,6 +262,8 @@ mod tests {
         let lock = BdLock::new(dir.path().join("bd.pid"));
         let holders = Arc::new(AtomicUsize::new(0));
         let overlaps = Arc::new(AtomicUsize::new(0));
+        let entered_occupied = Arc::new(AtomicUsize::new(0));
+        let joined_during_hold = Arc::new(AtomicUsize::new(0));
         let barrier = Arc::new(Barrier::new(THREADS));
 
         let handles: Vec<_> = (0..THREADS)
@@ -234,6 +271,8 @@ mod tests {
                 let lock = lock.clone();
                 let holders = Arc::clone(&holders);
                 let overlaps = Arc::clone(&overlaps);
+                let entered_occupied = Arc::clone(&entered_occupied);
+                let joined_during_hold = Arc::clone(&joined_during_hold);
                 let barrier = Arc::clone(&barrier);
                 std::thread::spawn(move || {
                     for _ in 0..ROUNDS {
@@ -246,6 +285,18 @@ mod tests {
                         drop(guard);
                         if before != 0 || during != 1 {
                             overlaps.fetch_add(1, Ordering::SeqCst);
+                            // Record WHICH invariant broke. `before != 0` means a
+                            // holder was already counted when we acquired; `during
+                            // != 1` means one joined while we held. They implicate
+                            // different windows, and this test only fails on CI
+                            // Linux, so a bare count is undiagnosable after the
+                            // fact (see agents-in-a-box-hp8).
+                            if before != 0 {
+                                entered_occupied.fetch_add(1, Ordering::SeqCst);
+                            }
+                            if during != 1 {
+                                joined_during_hold.fetch_add(1, Ordering::SeqCst);
+                            }
                         }
                     }
                 })
@@ -257,8 +308,55 @@ mod tests {
         assert_eq!(
             overlaps.load(Ordering::SeqCst),
             0,
-            "the lock admitted concurrent holders"
+            "the lock admitted concurrent holders \
+             (entered-occupied={}, joined-during-hold={}, of {} acquisitions)",
+            entered_occupied.load(Ordering::SeqCst),
+            joined_during_hold.load(Ordering::SeqCst),
+            THREADS * ROUNDS
         );
+    }
+
+    /// A pidfile that is simply GONE is not "stolen" — nothing is removed.
+    ///
+    /// Regression for the second double-hold window. `steal_if_stale` used to
+    /// treat any unreadable pidfile, including an absent one, as crash debris
+    /// and unlink the path. Between that failed read and the unlink another
+    /// contender can publish, so the unlink deletes a LIVE holder's pidfile and
+    /// the stealer acquires alongside it. Absent must mean "retry", never
+    /// "remove".
+    #[test]
+    fn an_absent_pidfile_is_retried_not_removed() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("bd.pid");
+        let lock = BdLock::new(path.clone());
+
+        assert_eq!(read_pid(&path), Err(PidfileRead::Absent));
+        assert!(
+            lock.steal_if_stale(),
+            "an absent pidfile means the lock is free, so retry immediately"
+        );
+
+        // The decisive part: a holder that publishes between the failed read and
+        // the steal decision must survive it.
+        let guard = lock.acquire().expect("acquire");
+        assert!(
+            !lock.steal_if_stale(),
+            "a live holder's pidfile must never be stolen"
+        );
+        assert!(path.exists(), "the live holder's pidfile was deleted");
+        drop(guard);
+    }
+
+    /// A pidfile that exists but carries no usable PID is still crash debris.
+    #[test]
+    fn an_unreadable_pidfile_is_still_stolen() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("bd.pid");
+        std::fs::write(&path, "not-a-pid").expect("seed corrupt pidfile");
+
+        assert_eq!(read_pid(&path), Err(PidfileRead::Unreadable));
+        assert!(BdLock::new(path.clone()).steal_if_stale());
+        assert!(!path.exists(), "corrupt pidfile should be removed");
     }
 
     /// Crash recovery still works: a pidfile naming a dead process is stolen
@@ -277,7 +375,7 @@ mod tests {
         );
         assert_eq!(
             read_pid(&path),
-            Some(i32::try_from(std::process::id()).unwrap())
+            Ok(i32::try_from(std::process::id()).unwrap())
         );
         drop(guard);
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -80,11 +80,16 @@ impl BdLock {
                     });
                 }
                 Ok(false) => {
-                    if self.steal_if_stale() {
-                        continue;
-                    }
+                    // The deadline bounds EVERY path, including the immediate
+                    // retry. `steal_if_stale` now reports "free, retry now" for
+                    // an absent pidfile, which under contention is common rather
+                    // than rare — leaving that branch to `continue` unchecked
+                    // would let a contender spin without ever timing out.
                     if Instant::now() >= deadline {
                         return Err(BdError::LockTimeout(self.path.clone()));
+                    }
+                    if self.steal_if_stale() {
+                        continue;
                     }
                     std::thread::sleep(POLL_INTERVAL);
                 }


### PR DESCRIPTION
Fixes `agents-in-a-box-hp8` — the beads_adapter lock flake that can redden any PR at random on CI Linux.

## Root cause

`steal_if_stale` decided a holder had crashed based on an **unreadable read**, and an *absent* file reads exactly the same way. It then unlinked the path unconditionally:

```rust
let Some(pid) = read_pid(&self.path) else {
    return std::fs::remove_file(&self.path).is_ok();   // absent lands here too
};
```

That is a TOCTOU:

```
A holds ──▶ B: try_publish → EEXIST
A drops, unlinks pidfile
                 │  B: read_pid → open() fails (momentarily absent) → "stale"
C: try_publish → links → C HOLDS
                 │  B: remove_file(path) ──▶ deletes C's LIVE pidfile
                 └▶ B: retries → succeeds → B and C both hold
```

This is the *same* double-hold that atomic publication was introduced to kill, reached through the crash-recovery branch instead of the create-then-write window. It explains why `contended_acquire_never_admits_two_holders` kept failing after that fix, and why it reproduces on CI Linux but not macOS: it needs a release and a republish to interleave with a contender's read, which needs contention and scheduler pressure.

## Fix

Split the read into `Absent` vs `Unreadable`. Absent means the lock is **free** — retry immediately, touch nothing. Only a dead PID or genuinely unusable content justifies removal.

## Correcting the bead's hypothesis

`hp8` offered "either the serialization lock doesn't hold cross-thread on Linux (real bug) or the test is timing-fragile." It is the former, and the test is **not** fragile: the holder counter is incremented after `acquire()` and decremented before `drop(guard)`, so it is protected by the lock itself, and `Barrier::new(THREADS)` fully serialises rounds. A failure there was always a genuine double-hold.

## Diagnosability

The contention test now reports **which** invariant broke — `entered-occupied` (a holder was already counted when we acquired) vs `joined-during-hold` (one joined mid-hold). They implicate different windows, and since this only fails on CI a bare count was undiagnosable after the fact.

## Verification

```
cargo test -p ainb-hangar-daemon --lib beads_adapter    21 passed
cargo test -p ainb-hangar-daemon --lib beads_adapter::lock   6 passed, 3 consecutive runs
rustup run stable cargo fmt --all -- --check            clean
```

New tests: `an_absent_pidfile_is_retried_not_removed` (asserts a live holder's pidfile survives a steal attempt) and `an_unreadable_pidfile_is_still_stolen` (crash recovery preserved).

**Honest caveat:** the race is Linux-and-contention specific and I could not reproduce it on this macOS host, so the mechanism is derived from the code rather than from a captured failure. The fix is safe regardless — it strictly removes a blind unlink of a possibly-live holder's file. The real proof is CI Linux staying green over subsequent runs.