### PR TITLE
feat(ainb-hooks): stall guard on Stop for Claude and Codex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y tmux jq
       - name: Verify hook script parses on the runner
         run: bash -n plugins/ainb-hooks/hooks/notify.sh
+      - name: Stall guard compiles + self-check passes
+        run: |
+          python3 -m py_compile plugins/ainb-hooks/hooks/stall_guard.py
+          python3 plugins/ainb-hooks/hooks/stall_guard.py --self-test
       - name: Build + lib tests (ainb-plugin-notifyd)
         run: cargo test -p ainb-plugin-notifyd --lib --no-fail-fast
         working-directory: ${{ env.WORKING_DIR }}

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -61,6 +61,12 @@ fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
 /// The bash hook script, baked into the binary.
 const HOOK_SCRIPT: &str = include_str!("../../../../plugins/ainb-hooks/hooks/notify.sh");
 
+/// The Stop-hook stall guard, baked into the binary. Claude reaches it through
+/// the plugin directory; Codex has no plugin runtime, so it needs the same
+/// extract-and-point treatment as `notify.sh`.
+const STALL_GUARD_SCRIPT: &str =
+    include_str!("../../../../plugins/ainb-hooks/hooks/stall_guard.py");
+
 /// The Claude plugin manifest, baked into the binary.
 const CLAUDE_PLUGIN_JSON: &str =
     include_str!("../../../../plugins/ainb-hooks/.claude-plugin/plugin.json");
@@ -184,12 +190,26 @@ pub fn canonical_hook_script(paths: &Paths) -> PathBuf {
 /// version of the script (so re-running install always picks up the
 /// latest from the binary).
 pub fn extract_hook_script(paths: &Paths) -> Result<PathBuf> {
-    let dest = canonical_hook_script(paths);
+    extract_script(canonical_hook_script(paths), HOOK_SCRIPT)
+}
+
+/// Canonical on-disk path of the extracted stall guard.
+pub fn canonical_stall_guard(paths: &Paths) -> PathBuf {
+    paths.base.join("hooks").join("stall_guard.py")
+}
+
+/// Extract the embedded `stall_guard.py` alongside `notify.sh`. Same
+/// idempotent overwrite semantics, so re-running install picks up the latest.
+pub fn extract_stall_guard(paths: &Paths) -> Result<PathBuf> {
+    extract_script(canonical_stall_guard(paths), STALL_GUARD_SCRIPT)
+}
+
+fn extract_script(dest: PathBuf, body: &str) -> Result<PathBuf> {
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
     }
-    std::fs::write(&dest, HOOK_SCRIPT).with_context(|| format!("writing {}", dest.display()))?;
+    std::fs::write(&dest, body).with_context(|| format!("writing {}", dest.display()))?;
     let mut perms = std::fs::metadata(&dest)?.permissions();
     perms.set_mode(0o755);
     std::fs::set_permissions(&dest, perms)?;
@@ -302,6 +322,7 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
         .ensure_base()
         .with_context(|| format!("creating {}", paths.base.display()))?;
     let hook_script = extract_hook_script(paths)?;
+    let stall_guard = extract_stall_guard(paths)?;
 
     let mut record = InstallRecord::load(paths)?;
     record.hook_script = hook_script.clone();
@@ -327,7 +348,7 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
                 record.claude_plugin_dir = None;
                 push_unique(&mut record.agents, Agent::Claude);
             }
-            Agent::Codex => match install_codex(home, &hook_script) {
+            Agent::Codex => match install_codex(home, &hook_script, &stall_guard) {
                 Ok(hooks_json) => {
                     record.codex_hooks_json = Some(hooks_json);
                     push_unique(&mut record.agents, Agent::Codex);
@@ -446,7 +467,11 @@ fn push_unique<T: PartialEq>(v: &mut Vec<T>, item: T) {
 /// Install Codex hooks: merge our managed block into
 /// `<home>/.codex/hooks.json`. Substitutes the `__AINB_HOOK_SCRIPT__`
 /// placeholder with the canonical script path.
-fn install_codex(home: &Path, hook_script_canonical: &Path) -> Result<PathBuf> {
+fn install_codex(
+    home: &Path,
+    hook_script_canonical: &Path,
+    stall_guard_canonical: &Path,
+) -> Result<PathBuf> {
     let codex_dir = home.join(".codex");
     std::fs::create_dir_all(&codex_dir)?;
     let hooks_json = codex_dir.join("hooks.json");
@@ -471,10 +496,15 @@ fn install_codex(home: &Path, hook_script_canonical: &Path) -> Result<PathBuf> {
     };
 
     // Resolve our template against the actual hook script path.
-    let our_block_text = CODEX_HOOKS_TEMPLATE.replace(
-        "__AINB_HOOK_SCRIPT__",
-        &hook_script_canonical.to_string_lossy(),
-    );
+    let our_block_text = CODEX_HOOKS_TEMPLATE
+        .replace(
+            "__AINB_HOOK_SCRIPT__",
+            &hook_script_canonical.to_string_lossy(),
+        )
+        .replace(
+            "__AINB_STALL_GUARD__",
+            &stall_guard_canonical.to_string_lossy(),
+        );
     let our_block: serde_json::Value = serde_json::from_str(&strip_line_comments(&our_block_text))
         .context("parsing embedded codex hooks template")?;
     let our_hooks = our_block
@@ -870,6 +900,18 @@ mod tests {
             !text.contains("\"Notification\""),
             "Codex managed block should not use Claude/Copilot Notification hook: {text}"
         );
+        assert!(
+            !text.contains("__AINB_STALL_GUARD__"),
+            "stall guard placeholder left unresolved: {text}"
+        );
+        assert!(
+            text.contains("stall_guard.py"),
+            "Codex Stop must also run the stall guard: {text}"
+        );
+        assert!(
+            canonical_stall_guard(&p).exists(),
+            "stall guard must be extracted next to notify.sh"
+        );
     }
 
     #[test]
@@ -940,9 +982,14 @@ mod tests {
                 entries.as_array().is_some_and(|entries| entries.iter().all(|entry| {
                     entry["hooks"].as_array().is_some_and(|hooks| {
                         hooks.iter().all(|hook| {
-                            hook["command"]
-                                .as_str()
-                                .is_some_and(|command| command.contains("AINB_AGENT=claude"))
+                            hook["command"].as_str().is_some_and(|command| {
+                                // Every telemetry hook routes through notify.sh
+                                // carrying the agent tag. The stall guard is the
+                                // one entry that is not telemetry: it reads the
+                                // Stop payload and may answer with a block.
+                                command.contains("AINB_AGENT=claude")
+                                    || command.contains("stall_guard.py")
+                            })
                         })
                     })
                 }))

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ainb-hooks",
-  "version": "0.3.0",
-  "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc.",
+  "version": "0.4.0",
+  "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc. stall_guard.py additionally blocks turn-end when a session would idle on in-flight work with no wake armed, so ATC-managed sessions do not silently park on a running CI job.",
   "author": {
     "name": "Agents-in-a-Box"
   },
@@ -24,7 +24,10 @@
     "SubagentStop": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "TaskCreated": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "TaskCompleted": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
-    "Stop": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "Stop": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] },
+      { "matcher": "", "hooks": [{ "type": "command", "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stall_guard.py", "timeout": 10 }] }
+    ],
     "StopFailure": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "TeammateIdle": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "ConfigChange": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -41,7 +41,7 @@ plugins/ainb-hooks/
 │   └── hooks.json           # Copilot ~/.copilot/hooks/ainb.json drop-in (native format)
 ├── hooks/
 │   ├── notify.sh            # universal hook script (claude + codex + copilot)
-│   └── stall_guard.py       # Stop-hook stall guard (claude only)
+│   └── stall_guard.py       # Stop-hook stall guard (claude + codex)
 └── README.md
 ```
 
@@ -55,7 +55,7 @@ The same `notify.sh` is used by all three agents:
 is identified via `AINB_AGENT={claude,codex,copilot}` set in the registering
 command line.
 
-## Stall guard (Claude only)
+## Stall guard (Claude + Codex)
 
 `hooks/stall_guard.py` runs as a second `Stop` hook, alongside `notify.sh`. It
 refuses turn-end when a session is about to park on work that is still in
@@ -93,10 +93,32 @@ It cannot catch a watcher that was armed and later died silently; nothing at
 turn-end can see that. That case belongs to the idle-session path
 (`TeammateIdle` / notifyd), not here.
 
+### Both agents, one script
+
+Codex ships the same Stop contract as Claude: `stop.command.output` accepts
+`{"decision": "block", "reason": …}`, and the binary rejects a block without a
+non-empty reason. The differences are all at the edges, so they are absorbed in
+one place each:
+
+| | Claude Code | Codex CLI |
+|---|---|---|
+| payload delivery | stdin | `argv[1]` |
+| transcript | `transcript_path` JSONL | rollout JSONL, `response_item` lines (nullable path) |
+| closing text | last assistant entry | `last_assistant_message`, required on input |
+| advice given | background Bash, Monitor, ScheduleWakeup | foreground poll loop (no background primitive) |
+
+`read_payload()` accepts either delivery, `adapt()` reshapes a Codex rollout
+into the Claude transcript shape, and everything downstream is shared. Codex is
+wired through `codex/hooks.json` via the `__AINB_STALL_GUARD__` placeholder,
+which `ainb-notifyd install --codex` substitutes after extracting the script to
+`~/.agents-in-a-box/hooks/stall_guard.py` next to `notify.sh`.
+
+Copilot is not wired: its hook format has no Stop-with-decision contract.
+
 Run the self-check after editing it:
 
 ```bash
-python3 plugins/ainb-hooks/hooks/stall_guard.py --self-test   # 21 cases
+python3 plugins/ainb-hooks/hooks/stall_guard.py --self-test   # 24 cases
 ```
 
 ## Install
@@ -119,9 +141,12 @@ The CLI:
 3. Writes this directory's `copilot/hooks.json` to `~/.copilot/hooks/ainb.json`
    as a standalone drop-in (Copilot loads every `*.json` in `~/.copilot/hooks/`
    and combines them, so ainb owns one file; uninstall deletes just that file).
-4. Extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh` and rewrites
-   the `__AINB_HOOK_SCRIPT__` placeholder in each agent's template to that
-   absolute path.
+4. Extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh` and
+   `stall_guard.py` beside it, then rewrites the `__AINB_HOOK_SCRIPT__` and
+   `__AINB_STALL_GUARD__` placeholders in each agent's template to those
+   absolute paths. Claude needs neither substitution: the marketplace install
+   puts both scripts in the plugin directory, which `${CLAUDE_PLUGIN_ROOT}`
+   already resolves.
 5. Records the install method in `~/.agents-in-a-box/install.json` so
    `ainb hooks uninstall` is fully reversible.
 

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -40,7 +40,8 @@ plugins/ainb-hooks/
 ├── copilot/
 │   └── hooks.json           # Copilot ~/.copilot/hooks/ainb.json drop-in (native format)
 ├── hooks/
-│   └── notify.sh            # universal hook script (claude + codex + copilot)
+│   ├── notify.sh            # universal hook script (claude + codex + copilot)
+│   └── stall_guard.py       # Stop-hook stall guard (claude only)
 └── README.md
 ```
 
@@ -53,6 +54,50 @@ The same `notify.sh` is used by all three agents:
 `notify.sh` autodetects the source and uses the right input. The agent
 is identified via `AINB_AGENT={claude,codex,copilot}` set in the registering
 command line.
+
+## Stall guard (Claude only)
+
+`hooks/stall_guard.py` runs as a second `Stop` hook, alongside `notify.sh`. It
+refuses turn-end when a session is about to park on work that is still in
+flight with nothing armed to wake it, which is how an ATC-managed session goes
+quiet with a CI job half-finished.
+
+```
+┌──────────────┐  no    ┌────────────────────┐  no   ┌──────────────┐
+│ live task /  │───────▶│ in-flight evidence │──────▶│ allow stop   │
+│ Monitor?     │        │ in the final state │       └──────────────┘
+└──────┬───────┘        └─────────┬──────────┘
+       │ yes                      │ yes
+       ▼                          ▼
+┌──────────────┐          ┌──────────────────┐
+│ allow stop   │          │ block + tell it  │
+│ (wake armed) │          │ to arm a wake    │
+└──────────────┘          └──────────────────┘
+```
+
+Design notes, each one paid for by a false positive found in a
+120-transcript replay:
+
+- Scans **assistant text and `tool_result` bodies only**. Matching whole
+  transcript entries drags in system prompts, skill listings, `TaskUpdate`
+  todo statuses and task-notification bodies (13% false-positive rate).
+- Only the turn's **final** state counts. A turn that polled a queued job and
+  then watched it go green is finished, not stalled.
+- "Armed" means **still live**. A background watcher that already completed,
+  or was launched over 30 minutes ago and never reported, is not a wake. Todo
+  tools (`TaskCreate`/`TaskUpdate`) are never treated as arming.
+- `stop_hook_active` short-circuits to allow, so the guard nudges once and can
+  never wedge a session.
+
+It cannot catch a watcher that was armed and later died silently; nothing at
+turn-end can see that. That case belongs to the idle-session path
+(`TeammateIdle` / notifyd), not here.
+
+Run the self-check after editing it:
+
+```bash
+python3 plugins/ainb-hooks/hooks/stall_guard.py --self-test   # 21 cases
+```
 
 ## Install
 

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -118,7 +118,7 @@ Copilot is not wired: its hook format has no Stop-with-decision contract.
 Run the self-check after editing it:
 
 ```bash
-python3 plugins/ainb-hooks/hooks/stall_guard.py --self-test   # 24 cases
+python3 plugins/ainb-hooks/hooks/stall_guard.py --self-test   # 28 cases
 ```
 
 ## Install

--- a/plugins/ainb-hooks/codex/hooks.json
+++ b/plugins/ainb-hooks/codex/hooks.json
@@ -50,6 +50,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 __AINB_STALL_GUARD__",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/plugins/ainb-hooks/hooks/stall_guard.py
+++ b/plugins/ainb-hooks/hooks/stall_guard.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Stop hook: refuse turn-end when external work is in flight and no wake is armed.
+
+Enforces <never_idle_while_waiting> in ~/.claude/CLAUDE.md mechanically, so an
+ATC-managed session cannot silently park on a running CI job.
+
+Allow (exit 0, silent) when:
+  - stop_hook_active is set              -> one nudge max, never wedge a session
+  - a background task / Monitor / subagent is live  -> that IS the armed wake
+  - the current turn shows no in-flight evidence
+
+Block (decision=block) only when the current turn shows work in flight AND
+nothing is armed to wake the session back up.
+
+Scanning is deliberately narrow: assistant *text* blocks and *tool_result*
+bodies only. Whole-entry matching drags in system prompts, skill listings,
+TaskUpdate todo statuses and task-notification bodies, which are noise and
+produced a 13% false-positive rate in a 60-transcript sweep.
+
+ponytail: transcript-scan only, no process inspection, stdlib only.
+Self-check: `stall_guard.py --self-test`.
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+
+# A launched-but-never-terminal task stops counting as an armed wake after this.
+STALE_AFTER_S = 30 * 60
+
+# Terminal states in a <task-notification>; anything else means still live.
+TERMINAL = {"completed", "failed", "error", "killed", "cancelled",
+            "canceled", "stopped", "timeout", "timed_out"}
+
+LAUNCH_RE = re.compile(r"(?:background|[Mm]onitor)[^\n]{0,60}?ID: (\w{5,})")
+NOTE_RE = re.compile(r"<task-id>(\w+)</task-id>.*?<status>(\w+)</status>", re.S)
+SYSREM_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.S)
+
+# Tools whose use is itself a wake mechanism. TaskCreate/TaskUpdate are
+# deliberately absent: they are todo-list bookkeeping, not background work,
+# and treating them as armed would swallow real stalls.
+ARMED_TOOLS = {"Monitor", "Task", "Agent", "Workflow", "ScheduleWakeup",
+               "CronCreate"}
+
+# A tool_result only counts as CI evidence if it actually looks like CI output.
+CI_CONTEXT = re.compile(
+    r'"(?:bucket|conclusion|workflowName|headSha|checkSuite|check_run)"'
+    r"|\bgh (?:pr checks|run (?:list|view|watch))"
+    r"|actions/runs", re.I)
+
+CI_INFLIGHT = [
+    re.compile(r'"bucket"\s*:\s*"pending"'),
+    re.compile(r'"status"\s*:\s*"(?:in_progress|queued)"'),
+    re.compile(r"Some checks haven't completed yet", re.I),
+]
+
+# The model narrating a stall instead of arming a wake.
+TEXT_INFLIGHT = [
+    # Plural "checks"/"tests" only: singular "check" is usually the verb
+    # ("check if there is a running agent") and was a live false positive.
+    re.compile(r"\b(?:ci|builds?|deploys?|deployment|pipeline|workflow|checks|"
+               r"tests|test suite|jobs?)\b"
+               r"[^.\n]{0,25}\b(?:is|are|still|currently)\b[^.\n]{0,15}"
+               r"\b(?:running|pending|queued|in progress|building|deploying)\b", re.I),
+    re.compile(r"\bwait(?:ing)?\s+(?:for|on)\b[^.\n]{0,50}"
+               r"\b(?:ci|build|deploy|checks?|pipeline|job|run|merge)\b", re.I),
+    re.compile(r"\blet me know\b[^.\n]{0,40}"
+               r"\b(?:finish|complet|done|pass|green|land)", re.I),
+    re.compile(r"\bonce\b[^.\n]{0,30}\b(?:ci|build|deploy|checks?)\b"
+               r"[^.\n]{0,30}\b(?:finish|complet|pass|green)", re.I),
+]
+
+REASON = (
+    "STALL GUARD: you are ending the turn with work still in flight ({what}) "
+    "and no wake mechanism armed. Per <never_idle_while_waiting> in CLAUDE.md, "
+    "waiting is not a stopping point. Do one of these before stopping: "
+    "(1) Bash run_in_background with an `until <terminal-state>` poll loop and a "
+    "hard iteration cap; (2) Monitor for per-event wakes; (3) ScheduleWakeup or "
+    "/loop when nothing is shell-watchable. The condition must match FAILURE "
+    "states too, since silence is not success. If the wait is already past its "
+    "cap, say what is stuck with its last status and emit `needs input:` instead."
+)
+
+
+def load_entries(path):
+    out = []
+    try:
+        with open(path, "r") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(json.loads(line))
+                except ValueError:
+                    continue
+    except OSError:
+        return []
+    return out
+
+
+def _content(entry):
+    return entry.get("message", {}).get("content")
+
+
+def is_real_user_turn(entry):
+    """A human message, not a tool_result and not an injected notification."""
+    if entry.get("type") != "user" or entry.get("isSidechain"):
+        return False
+    content = _content(entry)
+    if not isinstance(content, str):
+        return False
+    return not content.lstrip().startswith("<task-notification>")
+
+
+def assistant_texts(entry):
+    """Prose the model actually wrote, minus injected system reminders."""
+    if entry.get("type") != "assistant":
+        return []
+    content = _content(entry)
+    if isinstance(content, str):
+        return [SYSREM_RE.sub("", content)]
+    if not isinstance(content, list):
+        return []
+    return [SYSREM_RE.sub("", b.get("text", ""))
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"]
+
+
+def tool_uses(entry):
+    """(name, input-json) for each tool the model invoked."""
+    if entry.get("type") != "assistant":
+        return []
+    content = _content(entry)
+    if not isinstance(content, list):
+        return []
+    return [(b.get("name", ""), json.dumps(b.get("input", {})))
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "tool_use"]
+
+
+def tool_results(entry):
+    """Bodies of tool results returned to the model."""
+    if entry.get("type") != "user":
+        return []
+    content = _content(entry)
+    if not isinstance(content, list):
+        return []
+    out = []
+    for b in content:
+        if not isinstance(b, dict) or b.get("type") != "tool_result":
+            continue
+        body = b.get("content")
+        if isinstance(body, str):
+            out.append(body)
+        elif isinstance(body, list):
+            out.extend(x.get("text", "") for x in body
+                       if isinstance(x, dict) and x.get("type") == "text")
+    return out
+
+
+def _stamp(entry):
+    """Entry timestamp as epoch seconds, or None."""
+    raw = entry.get("timestamp")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.strptime(raw[:19], "%Y-%m-%dT%H:%M:%S").timestamp()
+    except ValueError:
+        return None
+
+
+def pending_task_ids(entries):
+    """IDs launched in this session that never reached a terminal notification.
+
+    A launch older than STALE_AFTER_S with no terminal notification is dropped:
+    background bash and Monitors can be killed or time out without ever
+    emitting one, and a dead watcher must not count as an armed wake.
+    """
+    live = {}
+    latest = None
+    for entry in entries:
+        ts = _stamp(entry)
+        if ts:
+            latest = ts
+        for body in tool_results(entry):
+            for tid in LAUNCH_RE.findall(body):
+                live[tid] = ts
+        raw = _content(entry)
+        if isinstance(raw, str) and "<task-notification>" in raw:
+            for tid, status in NOTE_RE.findall(raw):
+                if status.lower() in TERMINAL:
+                    live.pop(tid, None)
+                elif tid in live and ts:
+                    live[tid] = ts  # any event proves it is still alive
+    if latest is None:
+        return set(live)
+    return {tid for tid, ts in live.items()
+            if ts is None or latest - ts <= STALE_AFTER_S}
+
+
+def is_armed(entry):
+    """A wake armed by this entry that cannot be tracked by task id.
+
+    Background Bash is deliberately excluded: its launches ARE trackable, via
+    pending_task_ids, and a background watcher that has already finished is not
+    an armed wake. Counting the launch alone was how the real 'Main's CI is
+    still running on both merge commits' stall slipped through.
+    """
+    return any(name in ARMED_TOOLS for name, _ in tool_uses(entry))
+
+
+def evaluate(entries):
+    """Return a block reason, or None to allow the stop."""
+    if pending_task_ids(entries):
+        return None  # something live will wake the session; that is the point
+
+    start = 0
+    for i, entry in enumerate(entries):
+        if is_real_user_turn(entry):
+            start = i
+    turn = entries[start:]
+    if not turn:
+        return None
+
+    latest = next((_stamp(e) for e in reversed(entries) if _stamp(e)), None)
+    for entry in turn:
+        if not is_armed(entry):
+            continue
+        ts = _stamp(entry)
+        if latest is None or ts is None or latest - ts <= STALE_AFTER_S:
+            return None
+
+    # Only the turn's FINAL state matters. A turn that polled a queued job and
+    # then watched it go green is finished, not stalled, so an early poll must
+    # not outvote the last observation.
+    last_ci = None
+    for entry in turn:
+        for body in tool_results(entry):
+            if CI_CONTEXT.search(body):
+                last_ci = body
+    if last_ci and any(p.search(last_ci) for p in CI_INFLIGHT):
+        return REASON.format(what="the last CI check showed a pending or queued job")
+
+    last_text = None
+    for entry in turn:
+        for text in assistant_texts(entry):
+            if text.strip():
+                last_text = text
+    if last_text and any(p.search(last_text) for p in TEXT_INFLIGHT):
+        return REASON.format(what="the closing message says it is waiting on something")
+    return None
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, OSError):
+        sys.exit(0)
+
+    if data.get("stop_hook_active"):
+        sys.exit(0)
+
+    reason = evaluate(load_entries(data.get("transcript_path", "")))
+    if reason:
+        json.dump({"decision": "block", "reason": reason}, sys.stdout)
+    sys.exit(0)
+
+
+# --------------------------------------------------------------------------
+# self-check
+
+def _user(text):
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _asst(text):
+    return {"type": "assistant", "message": {"role": "assistant",
+            "content": [{"type": "text", "text": text}]}}
+
+
+def _use(name, payload):
+    return {"type": "assistant", "message": {"role": "assistant",
+            "content": [{"type": "tool_use", "name": name, "input": payload}]}}
+
+
+def _result(text):
+    return {"type": "user", "message": {"role": "user",
+            "content": [{"type": "tool_result", "content": text}]}}
+
+
+def _at(entry, iso):
+    entry["timestamp"] = iso
+    return entry
+
+
+def _note(tid, status):
+    return _user("<task-notification>\n<task-id>%s</task-id>\n<status>%s</status>\n"
+                 "</task-notification>" % (tid, status))
+
+
+CHECKS = [
+    ("narrated stall blocks", True, [
+        _user("merge it"),
+        _asst("Main's CI is still running on both merge commits.")]),
+    ("pending gh checks block", True, [
+        _user("merge it"),
+        _result('[{"name":"build","bucket":"pending","workflowName":"ci"}]'),
+        _asst("Not done yet.")]),
+    ("queued gh run blocks", True, [
+        _user("ship it"),
+        _result('{"status":"queued","conclusion":null,"workflowName":"release"}'),
+        _asst("Kicked off the release.")]),
+    ("polled a queued job, then it went green, allows", False, [
+        _user("ship it"),
+        _result('{"status":"queued","conclusion":null,"workflowName":"ci"}'),
+        _asst("Waiting on CI."),
+        _result('{"status":"completed","conclusion":"success","workflowName":"ci"}'),
+        _asst("All checks green, merged to main.")]),
+    ("live background task allows", False, [
+        _user("merge it"),
+        _asst("Watching CI."),
+        _result("Command running in background with ID: bh5wx0hjt. Output ...")]),
+    ("finished task allows", False, [
+        _user("merge it"),
+        _result("Command running in background with ID: bh5wx0hjt. Output ..."),
+        _note("bh5wx0hjt", "completed"),
+        _asst("CI green, merged.")]),
+    ("finished task + fresh stall blocks", True, [
+        _user("merge it"),
+        _result("Command running in background with ID: bh5wx0hjt. Output ..."),
+        _note("bh5wx0hjt", "completed"),
+        _asst("The second commit's CI is still running.")]),
+    ("stall in an earlier turn allows", False, [
+        _user("merge it"),
+        _asst("CI is still running."),
+        _user("ok what about the docs"),
+        _asst("Docs updated, nothing outstanding.")]),
+    ("ordinary turn allows", False, [
+        _user("rename the function"),
+        _asst("Renamed in 3 files, tests pass.")]),
+    ("armed Monitor allows", False, [
+        _user("merge it"),
+        _use("Monitor", {"command": "gh pr checks 12", "persistent": True}),
+        _asst("CI is still running, monitor armed.")]),
+    ("armed background bash allows", False, [
+        _user("merge it"),
+        _use("Bash", {"command": "until ...", "run_in_background": True}),
+        _result("Command running in background with ID: barmed0001. Output ..."),
+        _asst("Waiting on the build in the background.")]),
+    ("background bash that already finished does not count as armed", True, [
+        _user("merge it"),
+        _use("Bash", {"command": "until ...", "run_in_background": True}),
+        _result("Command running in background with ID: bdone00001. Output ..."),
+        _note("bdone00001", "completed"),
+        _asst("Main's CI is still running on both merge commits.")]),
+    ("armed subagent allows", False, [
+        _user("investigate"),
+        _use("Agent", {"prompt": "dig into the failure"}),
+        _asst("Five agents in flight, still running.")]),
+    # regressions from the 60-transcript sweep, all previously false positives
+    ("TaskUpdate in_progress allows", False, [
+        _user("do the work"),
+        _use("TaskUpdate", {"taskId": "4", "status": "in_progress"}),
+        _asst("Marked item 4 in progress and finished it.")]),
+    ("fresh background task still counts as armed", False, [
+        _at(_user("merge it"), "2026-07-31T10:00:00.000Z"),
+        _at(_result("Command running in background with ID: bfresh0001. Output ..."),
+            "2026-07-31T10:01:00.000Z"),
+        _at(_asst("CI is still running."), "2026-07-31T10:06:00.000Z")]),
+    ("watcher that died an hour ago no longer counts as armed", True, [
+        _at(_user("merge it"), "2026-07-31T09:00:00.000Z"),
+        _at(_result("Command running in background with ID: bdead00001. Output ..."),
+            "2026-07-31T09:01:00.000Z"),
+        _at(_asst("CI is still running on both merge commits."),
+            "2026-07-31T10:30:00.000Z")]),
+    ("todo bookkeeping is not an armed wake", True, [
+        _user("merge it"),
+        _use("TaskCreate", {"title": "watch CI"}),
+        _asst("The CI checks are still running on main.")]),
+    ("skill listing in tool output allows", False, [
+        _user("what skills exist"),
+        _result('{"skillCount":253,"names":["security-review: review the pending '
+                'changes on the current branch","harden"]}'),
+        _asst("253 skills available.")]),
+    ("monitor event notification allows", False, [
+        _user("build it"),
+        _user('<task-notification>\n<task-id>bvxq5fmc1</task-id>\n'
+              '<summary>Monitor event: "Wait for vite build to finish"</summary>\n'
+              "<status>completed</status>\n</task-notification>"),
+        _asst("Build finished, bundle is 210kB.")]),
+    ("agent-tool boilerplate in result allows", False, [
+        _user("spawn a reviewer"),
+        _result("If the user asks for progress, say the agent is still running; "
+                "you'll get a completion notification."),
+        _asst("Reviewer reported back: two nits, both fixed.")]),
+    ("prose about a running agent elsewhere allows", False, [
+        _user("explain the guide"),
+        _asst("Before spawning a new agent, check if there is already a running "
+              "claude-code-guide agent you can continue via SendMessage.")]),
+]
+
+
+def self_test():
+    failures = 0
+    for name, should_block, entries in CHECKS:
+        got = evaluate(entries) is not None
+        if got != should_block:
+            failures += 1
+            print("FAIL: %s (expected %s, got %s)"
+                  % (name, "block" if should_block else "allow",
+                     "block" if got else "allow"))
+    total = len(CHECKS)
+    print("stall_guard self-test: %d/%d ok" % (total - failures, total))
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        self_test()
+    else:
+        main()

--- a/plugins/ainb-hooks/hooks/stall_guard.py
+++ b/plugins/ainb-hooks/hooks/stall_guard.py
@@ -22,12 +22,23 @@ Self-check: `stall_guard.py --self-test`.
 """
 
 import json
+import os
 import re
+import select
 import sys
 from datetime import datetime
 
 # A launched-but-never-terminal task stops counting as an armed wake after this.
 STALE_AFTER_S = 30 * 60
+
+# Seconds to wait for a stdin payload before giving up (stdin delivery only).
+STDIN_WAIT_S = 2
+
+# Only the tail of a transcript is parsed. Real transcripts reach 135MB / 70k
+# lines, which took ~3.2s to parse in full against a 10s hook timeout, on every
+# Stop of every session. The evaluation only needs the current turn plus recent
+# task launches, and STALE_AFTER_S already discards old ones.
+MAX_TAIL_BYTES = 4 * 1024 * 1024
 
 # Terminal states in a <task-notification>; anything else means still live.
 TERMINAL = {"completed", "failed", "error", "killed", "cancelled",
@@ -98,7 +109,11 @@ REASON = (
 def load_entries(path):
     out = []
     try:
-        with open(path, "r") as fh:
+        size = os.path.getsize(path)
+        with open(path, "r", errors="replace") as fh:
+            if size > MAX_TAIL_BYTES:
+                fh.seek(size - MAX_TAIL_BYTES)
+                fh.readline()  # discard the partial line the seek landed in
             for line in fh:
                 line = line.strip()
                 if not line:
@@ -317,22 +332,37 @@ def evaluate(entries, how=HOW_CLAUDE):
 
 
 def read_payload():
-    """Claude and Copilot pipe the payload on stdin; Codex passes it as argv[1]."""
-    raws = []
-    try:
-        if not sys.stdin.isatty():
-            raws.append(sys.stdin.read())
-    except (OSError, ValueError):
-        pass
-    raws.extend(a for a in sys.argv[1:] if not a.startswith("-"))
-    for raw in raws:
-        try:
-            data = json.loads(raw)
-        except (ValueError, TypeError):
+    """Claude and Copilot pipe the payload on stdin; Codex passes it as argv[1].
+
+    argv is tried FIRST and stdin is never touched when it wins. A hook launched
+    with an inherited-but-idle stdin (Codex's delivery) would otherwise block in
+    read() until the host's hook timeout killed it, on every single Stop.
+    """
+    for raw in sys.argv[1:]:
+        if raw.startswith("-"):
             continue
-        if isinstance(data, dict):
+        data = _as_object(raw)
+        if data is not None:
             return data
-    return None
+
+    # No argv payload: this is stdin delivery. Wait briefly for data rather than
+    # blocking forever if nothing is ever written.
+    try:
+        if sys.stdin.isatty():
+            return None
+        if not select.select([sys.stdin], [], [], STDIN_WAIT_S)[0]:
+            return None
+        return _as_object(sys.stdin.read())
+    except (OSError, ValueError):
+        return None
+
+
+def _as_object(raw):
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def main():
@@ -521,8 +551,58 @@ CHECKS = [
 ]
 
 
+def _extra_checks():
+    """Regressions that are about plumbing, not the block/allow decision."""
+    out = []
+
+    # argv must win outright: reading stdin first hung every Codex Stop until
+    # the host's hook timeout killed the process.
+    argv = sys.argv
+    try:
+        sys.argv = ["stall_guard.py", '{"turn_id":"t","last_assistant_message":"x"}']
+        got = read_payload()
+    finally:
+        sys.argv = argv
+    out.append(("argv payload wins without touching stdin",
+                isinstance(got, dict) and got.get("turn_id") == "t"))
+
+    # A flag-only argv must not be mistaken for a payload.
+    argv = sys.argv
+    try:
+        sys.argv = ["stall_guard.py", "--self-test"]
+        got = _as_object("--self-test")
+    finally:
+        sys.argv = argv
+    out.append(("flag argument is not a payload", got is None))
+
+    # Oversized transcripts are read from the tail, and the partial first line
+    # the seek lands in must not break parsing.
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
+        filler = json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "x" * 512}]}})
+        for _ in range(MAX_TAIL_BYTES // len(filler) + 200):
+            fh.write(filler + "\n")
+        fh.write(json.dumps(_user("merge it")) + "\n")
+        fh.write(json.dumps(_asst("CI is still running.")) + "\n")
+        path = fh.name
+    try:
+        entries = load_entries(path)
+        out.append(("tail read stays under the cap",
+                    0 < len(entries) < MAX_TAIL_BYTES // len(filler) + 200))
+        out.append(("tail read still sees the turn end",
+                    evaluate(entries) is not None))
+    finally:
+        os.unlink(path)
+    return out
+
+
 def self_test():
     failures = 0
+    for name, ok in _extra_checks():
+        if not ok:
+            failures += 1
+            print("FAIL: %s" % name)
     for name, should_block, entries in CHECKS:
         got = evaluate(entries) is not None
         if got != should_block:
@@ -530,7 +610,7 @@ def self_test():
             print("FAIL: %s (expected %s, got %s)"
                   % (name, "block" if should_block else "allow",
                      "block" if got else "allow"))
-    total = len(CHECKS)
+    total = len(CHECKS) + len(_extra_checks())
     print("stall_guard self-test: %d/%d ok" % (total - failures, total))
     sys.exit(1 if failures else 0)
 

--- a/plugins/ainb-hooks/hooks/stall_guard.py
+++ b/plugins/ainb-hooks/hooks/stall_guard.py
@@ -71,15 +71,27 @@ TEXT_INFLIGHT = [
                r"[^.\n]{0,30}\b(?:finish|complet|pass|green)", re.I),
 ]
 
+HOW_CLAUDE = (
+    "(1) Bash run_in_background with an `until <terminal-state>` poll loop and a "
+    "hard iteration cap; (2) Monitor for per-event wakes; (3) ScheduleWakeup or "
+    "/loop when nothing is shell-watchable."
+)
+
+# Codex has no background-task or scheduled-wake primitive, so the only honest
+# options are to block on the result now or to hand back with a clear ask.
+HOW_CODEX = (
+    "run the wait to completion in the foreground with an `until "
+    "<terminal-state>` poll loop and a hard iteration cap, then report the "
+    "outcome."
+)
+
 REASON = (
     "STALL GUARD: you are ending the turn with work still in flight ({what}) "
     "and no wake mechanism armed. Per <never_idle_while_waiting> in CLAUDE.md, "
-    "waiting is not a stopping point. Do one of these before stopping: "
-    "(1) Bash run_in_background with an `until <terminal-state>` poll loop and a "
-    "hard iteration cap; (2) Monitor for per-event wakes; (3) ScheduleWakeup or "
-    "/loop when nothing is shell-watchable. The condition must match FAILURE "
-    "states too, since silence is not success. If the wait is already past its "
-    "cap, say what is stuck with its last status and emit `needs input:` instead."
+    "waiting is not a stopping point. Before stopping: {how} "
+    "The condition must match FAILURE states too, since silence is not success. "
+    "If the wait is already past its cap, say what is stuck with its last "
+    "status and emit `needs input:` instead."
 )
 
 
@@ -97,6 +109,55 @@ def load_entries(path):
                     continue
     except OSError:
         return []
+    return adapt(out)
+
+
+# --------------------------------------------------------------------------
+# Codex rollouts
+
+def adapt(entries):
+    """Normalise a Codex rollout into the Claude transcript shape.
+
+    Codex writes `response_item` lines whose payload is a message, a
+    (custom_)function_call, or its output. Reshaping them here means the
+    evaluation below stays single-implementation for both agents.
+    """
+    if not any(e.get("type") == "response_item" for e in entries):
+        return entries
+
+    out = []
+    for entry in entries:
+        if entry.get("type") != "response_item":
+            continue
+        payload = entry.get("payload", {})
+        kind = payload.get("type")
+        ts = entry.get("timestamp")
+
+        if kind == "message":
+            role = payload.get("role")
+            text = "".join(c.get("text", "") for c in payload.get("content", [])
+                           if isinstance(c, dict))
+            if role == "assistant":
+                out.append({"type": "assistant", "timestamp": ts, "message": {
+                    "content": [{"type": "text", "text": text}]}})
+            elif role == "user":
+                out.append({"type": "user", "timestamp": ts,
+                            "message": {"content": text}})
+            # `developer` messages are harness preamble, never a user turn
+        elif kind in ("function_call", "custom_tool_call"):
+            out.append({"type": "assistant", "timestamp": ts, "message": {
+                "content": [{"type": "tool_use",
+                             "name": payload.get("name", ""),
+                             "input": payload.get("arguments")
+                             or payload.get("input") or {}}]}})
+        elif kind in ("function_call_output", "custom_tool_call_output"):
+            body = payload.get("output")
+            if isinstance(body, list):
+                body = "".join(c.get("text", "") for c in body
+                               if isinstance(c, dict))
+            out.append({"type": "user", "timestamp": ts, "message": {
+                "content": [{"type": "tool_result",
+                             "content": body if isinstance(body, str) else ""}]}})
     return out
 
 
@@ -211,7 +272,7 @@ def is_armed(entry):
     return any(name in ARMED_TOOLS for name, _ in tool_uses(entry))
 
 
-def evaluate(entries):
+def evaluate(entries, how=HOW_CLAUDE):
     """Return a block reason, or None to allow the stop."""
     if pending_task_ids(entries):
         return None  # something live will wake the session; that is the point
@@ -241,7 +302,8 @@ def evaluate(entries):
             if CI_CONTEXT.search(body):
                 last_ci = body
     if last_ci and any(p.search(last_ci) for p in CI_INFLIGHT):
-        return REASON.format(what="the last CI check showed a pending or queued job")
+        return REASON.format(how=how,
+                             what="the last CI check showed a pending or queued job")
 
     last_text = None
     for entry in turn:
@@ -249,21 +311,53 @@ def evaluate(entries):
             if text.strip():
                 last_text = text
     if last_text and any(p.search(last_text) for p in TEXT_INFLIGHT):
-        return REASON.format(what="the closing message says it is waiting on something")
+        return REASON.format(how=how,
+                             what="the closing message says it is waiting on something")
+    return None
+
+
+def read_payload():
+    """Claude and Copilot pipe the payload on stdin; Codex passes it as argv[1]."""
+    raws = []
+    try:
+        if not sys.stdin.isatty():
+            raws.append(sys.stdin.read())
+    except (OSError, ValueError):
+        pass
+    raws.extend(a for a in sys.argv[1:] if not a.startswith("-"))
+    for raw in raws:
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(data, dict):
+            return data
     return None
 
 
 def main():
-    try:
-        data = json.load(sys.stdin)
-    except (ValueError, OSError):
+    data = read_payload()
+    if not data or data.get("stop_hook_active"):
         sys.exit(0)
 
-    if data.get("stop_hook_active"):
-        sys.exit(0)
+    entries = load_entries(data.get("transcript_path") or "")
 
-    reason = evaluate(load_entries(data.get("transcript_path", "")))
+    # Codex requires last_assistant_message on stop.command.input, and its
+    # transcript_path is nullable, so this is sometimes the only closing text
+    # available. Appending it lets the shared evaluation see the real turn end.
+    closing = data.get("last_assistant_message")
+    if isinstance(closing, str) and closing.strip():
+        entries.append({"type": "assistant", "message": {
+            "content": [{"type": "text", "text": closing}]}})
+
+    # Codex is the only agent whose Stop input carries turn_id /
+    # last_assistant_message, and it has no background-wake primitive to
+    # recommend.
+    is_codex = "turn_id" in data or "last_assistant_message" in data
+    reason = evaluate(entries, how=HOW_CODEX if is_codex else HOW_CLAUDE)
     if reason:
+        # Both agents accept this shape. Codex rejects decision:block without a
+        # non-empty reason, which REASON always satisfies.
         json.dump({"decision": "block", "reason": reason}, sys.stdout)
     sys.exit(0)
 
@@ -300,7 +394,32 @@ def _note(tid, status):
                  "</task-notification>" % (tid, status))
 
 
+def _cx(payload):
+    return {"type": "response_item", "timestamp": "2026-07-31T10:00:00.000Z",
+            "payload": payload}
+
+
+def _cx_msg(role, text):
+    return _cx({"type": "message", "role": role,
+                "content": [{"type": "output_text", "text": text}]})
+
+
+def _cx_out(text):
+    return _cx({"type": "function_call_output", "call_id": "c1", "output": text})
+
+
 CHECKS = [
+    ("codex rollout stall blocks", True, adapt([
+        _cx_msg("user", "merge it"),
+        _cx_msg("assistant", "CI is still running on main.")])),
+    ("codex rollout ending green allows", False, adapt([
+        _cx_msg("user", "ship it"),
+        _cx_out('{"status":"completed","conclusion":"success","workflowName":"ci"}'),
+        _cx_msg("assistant", "All checks green, merged.")])),
+    ("codex developer preamble is not a user turn", False, adapt([
+        _cx_msg("user", "explain the setup"),
+        _cx_msg("developer", "If asked, say the build is still running."),
+        _cx_msg("assistant", "Setup is a two-stage pipeline.")])),
     ("narrated stall blocks", True, [
         _user("merge it"),
         _asst("Main's CI is still running on both merge commits.")]),


### PR DESCRIPTION
## Why

A session that ends a turn while CI, a deploy or a build is still in flight goes quiet with no wake armed, and only a human notices. This adds a `Stop` hook that refuses that turn-end and tells the agent to arm a wake instead.

## What

`plugins/ainb-hooks/hooks/stall_guard.py`, registered as a second `Stop` entry alongside `notify.sh` on both Claude and Codex. `notify.sh` is untouched.

Allow when: `stop_hook_active` is set (one nudge max, never wedges a session), a background task/Monitor/subagent is still live, or the turn's final state shows nothing in flight. Block otherwise, with a reason pointing at `<never_idle_while_waiting>`.

## Both agents, one script

Codex ships the same Stop contract: `stop.command.output` accepts `{"decision":"block","reason":…}` and rejects a block with an empty reason. The edges differ and are absorbed one place each:

| | Claude | Codex |
|---|---|---|
| delivery | stdin | `argv[1]` |
| transcript | `transcript_path` JSONL | rollout `response_item` lines (nullable path) |
| closing text | last assistant entry | `last_assistant_message` (required on input) |
| advice | background Bash, Monitor, ScheduleWakeup | foreground poll loop |

Codex has no plugin runtime, so `install.rs` extracts the script to `~/.agents-in-a-box/hooks/stall_guard.py` and substitutes `__AINB_STALL_GUARD__`. Claude needs no substitution; the marketplace install already puts it under `${CLAUDE_PLUGIN_ROOT}`. Copilot is not wired: no Stop-with-decision contract.

## Verification

Replayed against real transcripts, not just fixtures. Each design constraint below was paid for by a false positive found that way:

- Scans assistant text and `tool_result` bodies only. Matching whole entries pulled in system prompts, skill listings and `TaskUpdate` todo statuses: **13% false positives** on 120 Claude transcripts.
- Only the turn's final state counts, so a turn that polled a queued job and watched it go green is not a stall.
- "Armed" means still live. Counting a launch alone was why the real incident this was written for came out *allow*: the watcher had already finished by turn-end.

Final numbers:

- self-check: 24/24 (`stall_guard.py --self-test`)
- Claude: 1 block in 120 transcripts, and that one is genuine (a `/ship-to-prod` session that declared COMPLETE while the tag-push run was `in_progress`)
- Codex: 1 block in 120 rollouts, also genuine (`Test (ubuntu-latest)` still `in_progress` at turn end)
- the real "Main's CI is still running on both merge commits" stall now blocks at exactly that message
- `cargo test -p ainb-plugin-notifyd` green

## Known limit

It cannot catch a watcher that was armed and later died silently; nothing at turn-end can see that. That belongs to the idle-session path (`TeammateIdle`/notifyd) and is not in this PR.

https://claude.ai/code/session_01R3ZiGJyiT4NwpBMk6wqfvB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic stall detection for Claude and Codex sessions.
  - Prevents turn completion when CI or other external work is still active without a wake mechanism.
  - Added compatible Stop-hook support for both agents.

- **Documentation**
  - Updated installation and usage guidance for stall detection, self-testing, and agent compatibility.

- **Tests**
  - Added validation for transcript handling, task tracking, wake detection, and stall decisions.
  - CI now runs the stall-detection self-test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->