### PR TITLE
fix(hangar): order dispatch attempts by rowid, not by ULID

### DIFF
--- a/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
@@ -8,6 +8,17 @@
 //! running", which before 0058 existed only as an ephemeral RPC error string or
 //! a debug log line.
 //!
+//! # Newest-first is ordered by `rowid`, not by `id`
+//!
+//! `created_at` is epoch MILLISECONDS, and a burst of admission decisions for
+//! one card lands inside a single millisecond routinely. The tie-break must
+//! therefore carry the real insertion order. `id` cannot: it is a ULID, whose
+//! low 80 bits are random within a millisecond, so `ORDER BY created_at DESC,
+//! id DESC` scrambled same-millisecond rows and made "newest first" a lie —
+//! both for the trim (which decides what to KEEP) and for every reader.
+//! SQLite's implicit `rowid` is monotonic per insert and the table is not
+//! `WITHOUT ROWID`, so it is the tie-break with no schema change.
+//!
 //! # Bounded by construction
 //!
 //! [`DispatchAttemptRepo::record`] trims the issue's history to the newest
@@ -168,7 +179,7 @@ impl DispatchAttemptRepo {
                    AND id NOT IN ( \
                        SELECT id FROM dispatch_attempt \
                        WHERE issue_id = ? \
-                       ORDER BY created_at DESC, id DESC \
+                       ORDER BY created_at DESC, rowid DESC \
                        LIMIT ? \
                    )",
             )
@@ -190,7 +201,7 @@ impl DispatchAttemptRepo {
     ) -> Result<Option<DispatchAttempt>, sqlx::Error> {
         let row = sqlx::query(&format!(
             "SELECT {SELECT_COLS} FROM dispatch_attempt \
-             WHERE issue_id = ? ORDER BY created_at DESC, id DESC LIMIT 1"
+             WHERE issue_id = ? ORDER BY created_at DESC, rowid DESC LIMIT 1"
         ))
         .bind(issue_id)
         .fetch_optional(pool)
@@ -206,7 +217,7 @@ impl DispatchAttemptRepo {
     ) -> Result<Vec<DispatchAttempt>, sqlx::Error> {
         let rows = sqlx::query(&format!(
             "SELECT {SELECT_COLS} FROM dispatch_attempt \
-             WHERE issue_id = ? ORDER BY created_at DESC, id DESC LIMIT ?"
+             WHERE issue_id = ? ORDER BY created_at DESC, rowid DESC LIMIT ?"
         ))
         .bind(issue_id)
         .bind(limit.max(0))
@@ -224,7 +235,7 @@ impl DispatchAttemptRepo {
     ) -> Result<Vec<DispatchAttempt>, sqlx::Error> {
         let rows = sqlx::query(&format!(
             "SELECT {SELECT_COLS} FROM dispatch_attempt \
-             WHERE workspace_id = ? ORDER BY created_at DESC, id DESC LIMIT ?"
+             WHERE workspace_id = ? ORDER BY created_at DESC, rowid DESC LIMIT ?"
         ))
         .bind(workspace_id)
         .bind(limit.max(0))

--- a/ainb-tui/crates/ainb-hangar-store/tests/repo_dispatch_attempt.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/repo_dispatch_attempt.rs
@@ -131,6 +131,52 @@ async fn newest_first_and_queued_reads_as_dispatched() {
     assert_eq!(latest.id, "att-new");
 }
 
+/// Same-millisecond attempts still read back in insertion order.
+///
+/// `created_at` is epoch milliseconds and a burst of admission decisions for one
+/// card lands inside a single millisecond routinely. The old tie-break was
+/// `id DESC`, and `id` is a ULID whose low bits are RANDOM within a
+/// millisecond — so this ordering was decided by chance, which is what made
+/// `dispatch_attempts_list_is_newest_first_limited_and_tenant_scoped` fail on
+/// CI at random. The ids here are deliberately chosen so a lexical tie-break
+/// would disagree with insertion order.
+#[tokio::test]
+async fn attempts_in_one_millisecond_keep_insertion_order() {
+    let (_dir, store) = open().await;
+    const SAME_MS: i64 = 5_000;
+
+    // Insertion order is z, a, m. A ULID-style `id DESC` tie-break would return
+    // z, m, a; only a monotonic tie-break returns the true reverse insertion.
+    for id in ["att-z", "att-a", "att-m"] {
+        record(
+            &store,
+            id,
+            "ws-1",
+            Some("iss-1"),
+            DispatchReason::AlreadyActive,
+            None,
+            SAME_MS,
+        )
+        .await;
+    }
+
+    let rows = DispatchAttemptRepo::list_for_issue(store.pool(), "iss-1", 10)
+        .await
+        .expect("list");
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        ["att-m", "att-a", "att-z"],
+        "same-millisecond rows must read newest-inserted first"
+    );
+
+    let latest = DispatchAttemptRepo::latest_for_issue(store.pool(), "iss-1")
+        .await
+        .expect("query")
+        .expect("present");
+    assert_eq!(latest.id, "att-m", "latest must be the last one inserted");
+}
+
 /// Bounded by construction: 25 records leave exactly the newest 20, so a hot
 /// auto-run cascade cannot grow the table without bound (migration decision 3).
 #[tokio::test]


### PR DESCRIPTION
Fixes `agents-in-a-box-37i` — the ordering flake that failed `hangar-e2e (macos-latest)` on PR #550 while that PR touched only `beads_adapter/lock.rs`.

## Root cause

`created_at` is epoch **milliseconds**, and a burst of admission decisions for one card lands inside a single millisecond routinely. The tie-break was `id DESC` — and `id` is a **ULID**, whose low 80 bits are random within a millisecond. So same-millisecond rows came back in an arbitrary order:

```
left:  ["already_active", "queued", "already_active"]
right: ["already_active", "already_active", "queued"]
```

## This was not only a test problem

The same ordering drives the **trim** that bounds the table to the newest 20 per issue:

```sql
DELETE FROM dispatch_attempt WHERE issue_id = ?
  AND id NOT IN (SELECT id ... ORDER BY created_at DESC, id DESC LIMIT ?)
```

With a random tie-break, a hot auto-run cascade could discard a **newer** attempt and keep an older one. "Newest first" was a lie for every reader and for retention.

## Fix

SQLite's implicit `rowid` is monotonic per insert, and this table is not `WITHOUT ROWID` — so it is the correct tie-break with **no schema change**. Applied to all four queries (list-by-issue, latest-by-issue, list-by-workspace, and the trim).

## The test is a real tripwire

`attempts_in_one_millisecond_keep_insertion_order` picks ids so a lexical tie-break disagrees with insertion order — insert `z, a, m`, expect `m, a, z`. Verified against the old ordering:

```
$ # with ORDER BY created_at DESC, id DESC
left:  ["att-z", "att-m", "att-a"]     <-- lexical, FAILS
right: ["att-m", "att-a", "att-z"]
```

## Not fixed here, filed as `agents-in-a-box-0i3`

The same `ORDER BY created_at DESC, id DESC` shape appears at ~6 other production sites (`rpc/snapshots.rs` 252/254/473/515/800, `rpc/mod.rs:7719`) on **different tables**. Each needs checking for whether its id is random and whether the table is `WITHOUT ROWID`. Changing ordering across tables I have not verified would trade a rare flake for a wrong result, so it gets its own pass with the site list recorded.

The index in `0058` still declares `id DESC`; harmless, now merely inconsistent with the query, noted for a future migration.

## Verification

```
cargo test -p ainb-hangar-store --test repo_dispatch_attempt    8 passed
cargo test -p ainb-hangar-daemon --test rpc_dispatch_reason     8 passed, 3 consecutive runs
cargo test --workspace --no-run                                 exit 0
rustup run stable cargo fmt --all -- --check                    clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the ordering of dispatch attempts created within the same millisecond.
  - The newest attempt is now consistently identified by insertion order, regardless of its ID value.

- **Tests**
  - Added coverage to verify reverse insertion ordering for same-millisecond dispatch attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->