### PR TITLE
fix(hangar): pick a card's last run by rowid, not by task id

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -7716,7 +7716,7 @@ async fn handle_board_card_timeline(
     // The card's newest task (any status) — its run is the one to show.
     let task_id: Option<String> = sqlx::query_scalar(
         "SELECT id FROM agent_task_queue WHERE issue_id = ? AND workspace_id = ? \
-         ORDER BY created_at DESC, id DESC LIMIT 1",
+         ORDER BY created_at DESC, rowid DESC LIMIT 1",
     )
     .bind(&params.issue_id)
     .bind(ws.as_str())

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -249,9 +249,9 @@ async fn issue_card_fields(
     let (count, last_status, last_at): (i64, Option<String>, Option<i64>) = sqlx::query_as(
         "SELECT COUNT(*), \
          (SELECT status FROM agent_task_queue WHERE issue_id = ?1 \
-            ORDER BY created_at DESC, id DESC LIMIT 1), \
+            ORDER BY created_at DESC, rowid DESC LIMIT 1), \
          (SELECT created_at FROM agent_task_queue WHERE issue_id = ?1 \
-            ORDER BY created_at DESC, id DESC LIMIT 1) \
+            ORDER BY created_at DESC, rowid DESC LIMIT 1) \
          FROM agent_task_queue WHERE issue_id = ?1",
     )
     .bind(issue_id)
@@ -470,7 +470,7 @@ async fn latest_pr_url_for_issue(
            AND result ->> 'pr_url' IS NOT NULL \
            AND generation = (SELECT MAX(generation) FROM agent_task_queue \
                              WHERE issue_id = ?2) \
-         ORDER BY COALESCE(finished_at, created_at) DESC, id DESC \
+         ORDER BY COALESCE(finished_at, created_at) DESC, rowid DESC \
          LIMIT 1",
     )
     .bind(workspace_id)
@@ -512,7 +512,7 @@ async fn latest_branch_for_issue(
            AND branch IS NOT NULL AND branch <> '' \
            AND generation = (SELECT MAX(generation) FROM agent_task_queue \
                              WHERE issue_id = ?2) \
-         ORDER BY COALESCE(finished_at, created_at) DESC, id DESC \
+         ORDER BY COALESCE(finished_at, created_at) DESC, rowid DESC \
          LIMIT 1",
     )
     .bind(workspace_id)
@@ -797,7 +797,7 @@ async fn enrich_board_card(
     let latest: Option<(String, Option<String>)> = sqlx::query_as(
         "SELECT status, session_name FROM agent_task_queue \
          WHERE issue_id = ? AND workspace_id = ? \
-         ORDER BY created_at DESC, id DESC LIMIT 1",
+         ORDER BY created_at DESC, rowid DESC LIMIT 1",
     )
     .bind(issue_id)
     .bind(workspace_id)

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_card_last_run_same_millisecond.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_card_last_run_same_millisecond.rs
@@ -1,0 +1,68 @@
+//! A card's "last run" must be the run that actually happened last.
+//!
+//! `issue_card_fields` picks the newest `agent_task_queue` row with
+//! `ORDER BY created_at DESC, id DESC`. `created_at` is epoch MILLISECONDS, so
+//! two runs enqueued in the same millisecond tie — and the tie-break used to be
+//! the task id, which is not ordered by insertion within a millisecond. The card
+//! then rendered an ARBITRARY one of the two as `last_run_status`, i.e. a user
+//! could see `failed` on a card whose latest run was `running`, or vice versa.
+//!
+//! Sibling of the `dispatch_attempt` ordering fix (agents-in-a-box-37i); the
+//! hazard itself is already documented in
+//! `ainb-hangar-store::service::activity` — `ulid::Ulid::new()` is not monotonic
+//! within a millisecond because its low bits are random, not a counter.
+
+use ainb_hangar_daemon::rpc::snapshots::issues_list;
+use ainb_hangar_daemon::seed::{WS_ID, seed_p4_fixture};
+use ainb_hangar_store::Store;
+use sqlx::SqlitePool;
+
+/// Enqueue a task for `issue-1` at an exact millisecond.
+async fn enqueue(pool: &SqlitePool, id: &str, status: &str, created_at: i64) {
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at) \
+         VALUES (?, ?, 'runtime-1', 'agent-1', 'issue-1', ?, ?)",
+    )
+    .bind(id)
+    .bind(WS_ID)
+    .bind(status)
+    .bind(created_at)
+    .execute(pool)
+    .await
+    .expect("enqueue task");
+}
+
+async fn last_run_status(pool: &SqlitePool) -> Option<String> {
+    issues_list(pool, WS_ID)
+        .await
+        .expect("issues_list snapshot")
+        .iter()
+        .find(|i| i.id.as_str() == "issue-1")
+        .expect("issue-1 present in snapshot")
+        .last_run_status
+        .clone()
+}
+
+#[tokio::test]
+async fn the_last_run_in_a_millisecond_is_the_one_inserted_last() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_p4_fixture(store.pool()).await.unwrap();
+    let pool = store.pool();
+
+    // Both enqueued in the SAME millisecond, far enough in the future to outrank
+    // whatever the fixture seeded. The ids are chosen so a lexical tie-break
+    // disagrees with insertion order: `task-z` sorts highest but ran FIRST, so
+    // an id-ordered read reports its `failed` instead of the true latest.
+    const SAME_MS: i64 = 4_102_444_800_000; // 2100-01-01, safely newest
+    enqueue(pool, "task-z-first", "failed", SAME_MS).await;
+    enqueue(pool, "task-a-second", "running", SAME_MS).await;
+
+    assert_eq!(
+        last_run_status(pool).await.as_deref(),
+        Some("running"),
+        "the card must show the status of the run enqueued last, not the one \
+         whose id happens to sort highest"
+    );
+}


### PR DESCRIPTION
Completes `agents-in-a-box-0i3`. Sibling of #552, which fixed the same defect for `dispatch_attempt`.

## This is user-visible, and I confirmed it before changing anything

A card's run summary reads the newest `agent_task_queue` row. `created_at` is epoch **milliseconds**, so two runs enqueued in the same millisecond tie — and the task id does not order by insertion within a millisecond. The card then renders an **arbitrary** one of the two as `last_run_status`, a field the TUI shows on the card.

The new test, run against the **unfixed** code:

```
assertion `left == right` failed: the card must show the status of the run
enqueued last, not the one whose id happens to sort highest
  left:  Some("failed")
  right: Some("running")
```

A card whose latest run is `running` displayed `failed`.

## Fix

`agent_task_queue` is not `WITHOUT ROWID`, so SQLite's implicit monotonic `rowid` is the correct tie-break with **no schema change**. Applied to all six readers:

| Site | What it feeds |
|---|---|
| `snapshots.rs:252`, `:254` | card run summary (`last_run_status`, `last_run_at`) |
| `snapshots.rs:473`, `:515` | transcript/session lookups, ordered by `COALESCE(finished_at, created_at)` |
| `snapshots.rs:800` | board card enrichment |
| `rpc/mod.rs:7719` | latest-task lookup |

## Why the audit found all six on one table

`0i3` started as "~6 scattered sites". They all turned out to hit `agent_task_queue`, which made this a single coherent change rather than a scattergun.

The hazard is already documented in-tree — `ainb-hangar-store::service::activity` notes that `ulid::Ulid::new()` is not monotonic within a millisecond because its low bits are random, not a counter, and works around it by stamping `base + i` ms. Ordering by `rowid` is the better remedy where it applies, since it doesn't distort timestamps.

## Verification

```
cargo test -p ainb-hangar-daemon --test rpc_card_last_run_same_millisecond   1 passed (FAILS without the fix)
cargo test -p ainb-hangar-daemon --test issue_lifecycle_advances_on_task_fsm 5 passed
cargo test -p ainb-hangar-daemon --test rpc_dispatch_reason                  8 passed
cargo test --workspace --no-run                                             exit 0
rustup run stable cargo fmt --all -- --check                                clean
```