### PR TITLE
fix(fleet): stop EXITED orphan rows churning fleet_event every 3 seconds

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -1163,7 +1163,19 @@ async fn restore_tmux_transport(
             session.exact_tmux_target.as_deref() == Some(target)
                 && session.process_start_fingerprint == row.process_start_fingerprint
         });
-        if !live || row.transport_health == "HEALTHY" {
+        // An EXITED row is never restored, even when a pane still matches its
+        // target and fingerprint. Matching here is by (target, fingerprint) —
+        // deliberately, so a MANAGED row whose key is provider-qualified is still
+        // reachable — while the missing-sweep matches by session_key. When those
+        // two disagree the row flip-flops: this loop restores it to HEALTHY, the
+        // sweep's skip (which needs EXITED *and* UNAVAILABLE) then misses, and it
+        // is marked UNAVAILABLE again, one applied event each per tick forever.
+        //
+        // They disagree whenever a pane's session_key changes but the pane does
+        // not — which is exactly what happens when provider detection improves,
+        // since the provider is part of `SessionKey::legacy`. The old row is
+        // orphaned, stays EXITED, and still matches by target+fingerprint.
+        if !live || row.transport_health == "HEALTHY" || row.lifecycle_state == "EXITED" {
             continue;
         }
         let event = NewFleetEvent {
@@ -1449,6 +1461,99 @@ const fn transport_token(value: TransportHealth) -> &'static str {
 mod tests {
     use super::*;
     use crate::events::EventBroker;
+
+    /// An orphaned row must not flip-flop with the missing-sweep, forever.
+    ///
+    /// `restore_tmux_transport` matches by (target, fingerprint) so a MANAGED
+    /// row with a provider-qualified key stays reachable; the missing-sweep
+    /// matches by `session_key`. When a pane's key changes but the pane does
+    /// not — which is what happens when provider detection improves, since the
+    /// provider is part of `SessionKey::legacy` — the old row is orphaned yet
+    /// still matches by target+fingerprint. Restore then set it HEALTHY, the
+    /// sweep's skip (which needs EXITED *and* UNAVAILABLE) missed, and it was
+    /// marked UNAVAILABLE again: two applied events per row per tick, forever.
+    /// Observed live at ~57,600 rows/day for two panes before this guard.
+    #[tokio::test]
+    async fn an_exited_orphan_row_stops_churning_against_a_live_pane() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let pool = store.pool();
+
+        // A pane that IS live, and an EXITED orphan row pointing at the very
+        // same target+fingerprint (the shape a provider re-detection leaves).
+        let target = "tmux_demo:1.1";
+        let fingerprint = "pane=%1;pid=101;session_started=1700000000";
+        let discovered = vec![FleetSession {
+            session_key: SessionKey::legacy(Provider::Claude, target, fingerprint),
+            provider: Provider::Claude,
+            provider_session_id: None,
+            cwd: "/repo".to_string(),
+            exact_tmux_target: Some(target.to_string()),
+            pane_pid: Some(101),
+            process_start_fingerprint: Some(fingerprint.to_string()),
+            lifecycle: LifecycleState::Running,
+            attention: AttentionState::None,
+            management: ManagementState::Degraded,
+            capabilities: ainb_fleet_core::types::Capabilities::degraded_tmux(),
+            provenance: std::collections::BTreeSet::from([
+                ainb_fleet_core::types::Provenance::Tmux,
+            ]),
+            confidence: ainb_fleet_core::types::Confidence::Inferred,
+            transport_health: ainb_fleet_core::types::TransportHealth::Healthy,
+            first_seen_ms: Some(1_700_000_000_000),
+            last_seen_ms: None,
+            version: 0,
+        }];
+
+        let orphan_key = SessionKey::legacy(Provider::Unknown, target, fingerprint).to_string();
+        FleetRepo::apply_event(
+            pool,
+            &NewFleetEvent {
+                event_id: "seed:orphan".to_string(),
+                session_key: orphan_key.clone(),
+                observed_at: 1,
+                authority: ObservationAuthority::Authoritative,
+                event_type: "seed".to_string(),
+                payload: "{}".to_string(),
+                patch: FleetSessionPatch {
+                    tmux_target: Some(target.to_string()),
+                    process_start_fingerprint: Some(fingerprint.to_string()),
+                    lifecycle_state: Some("EXITED".to_string()),
+                    transport_health: Some("UNAVAILABLE".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            },
+        )
+        .await
+        .expect("seed orphan");
+
+        let before = FleetRepo::get_session(pool, &orphan_key)
+            .await
+            .expect("get")
+            .expect("orphan present")
+            .version;
+
+        // Two passes of the restore half, exactly as the 3s loop runs it.
+        for tick in 0..2 {
+            restore_tmux_transport(pool, &sink, &discovered, 1_000 + tick)
+                .await
+                .expect("restore");
+        }
+
+        let after = FleetRepo::get_session(pool, &orphan_key)
+            .await
+            .expect("get")
+            .expect("orphan present");
+        assert_eq!(
+            after.version, before,
+            "an EXITED orphan must not be restored, or it flip-flops with the sweep forever"
+        );
+        assert_eq!(
+            after.transport_health, "UNAVAILABLE",
+            "the orphan must stay UNAVAILABLE so the missing-sweep keeps skipping it"
+        );
+    }
 
     #[test]
     fn stop_with_background_work_remains_running() {


### PR DESCRIPTION
**P0, and it is a regression from #546.** Filed as `agents-in-a-box-dw9`.

## Observed live, not theoretical

On the author's machine, confirmed still running at time of writing:

| | |
|---|---|
| `fleet_event` rows | **41,200** |
| `tmux_missing` | 19,269 — **all** `applied=1` |
| `tmux_available` | 18,254 — **all** `applied=1` |
| worst single session | 6,878 events, 07:36 → 13:19 |
| row `version` counters | past 13,000 |

5h44m ÷ 3s = 6,880 ticks. Exactly one event per tick per orphan, times two event types. A 120-second sample showed 88 + 88 — still going.

## Mechanism

`restore_tmux_transport` matches rows by `(tmux_target, process_start_fingerprint)` — deliberately, so a MANAGED row whose `session_key` is provider-qualified stays reachable. The missing-sweep in `reconcile_tmux_once` matches by `session_key`. When those two disagree, the row flip-flops forever:

```
restore   matches by (target, fingerprint) ─▶ orphan looks LIVE ─▶ transport = HEALTHY
sweep     matches by session_key           ─▶ orphan not found  ─▶ transport = UNAVAILABLE
   └───────────── skip needs EXITED *and* UNAVAILABLE, so it never fires ─────────────┘
```

## Why #546 triggered it

`SessionKey::legacy(provider, target, fingerprint)` embeds the **provider**. #546 improved provider detection, so every pane whose provider was re-detected got a *new* row while the old one was orphaned — yet the orphan still matches by target+fingerprint. Confirmed: every churning target had exactly two rows with different providers.

| tmux target | rows | providers | states |
|---|---|---|---|
| `tmux_ainb-reflect-memory--fix-dr` | 2 | `unknown`, `claude` | EXITED, IDLE |
| `tmux_fix-codex-appserver-leak` | 2 | `codex`, `claude` | EXITED, IDLE |

It stayed invisible because the events are `applied=1` — they look like legitimate state transitions — and nothing surfaces `fleet_event` growth.

## Fix

An EXITED row has nothing to restore. Skipping it means:
- managed live rows are unaffected (they are not EXITED),
- the orphan stays UNAVAILABLE, so the sweep's skip keeps matching and it goes quiet permanently.

## The test is a real tripwire

`an_exited_orphan_row_stops_churning_against_a_live_pane` runs the restore half twice against a live pane plus an EXITED orphan sharing its target+fingerprint, and asserts the row `version` does not move. Against the unguarded code:

```
assertion `left == right` failed: an EXITED orphan must not be restored,
or it flip-flops with the sweep forever
  left: 2      <-- one applied event per pass
  right: 1
```

This is the reconcile-idempotency check that was missing; it would have caught this before #546 merged.

## Not in scope, filed on `dw9`

- The 41k existing `fleet_event` rows are not pruned by this fix.
- A `session_key` change should retire its predecessor rather than orphan it (cf. `retire_correlated_legacy`).
- Nothing bounds or alarms on `fleet_event` growth, which is why this ran for hours unnoticed. Note #548 carefully documented retention for `fleet_provider_event` at ~1.3 MB/year while *this* table was leaking ~29k rows/day/session.

## Verification

```
cargo test -p ainb-hangar-daemon --lib fleet     52 passed
cargo test --workspace --no-run                  exit 0
rustup run stable cargo fmt --all -- --check     clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exited sessions from incorrectly regaining tmux availability during repeated reconciliation.
  * Prevented orphaned session entries from oscillating between healthy and unavailable states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->