### PR TITLE
fix(fleet-macos): decode unknown wire enum values instead of throwing

### DIFF
--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A10000000000000000000017 /* CanonicalFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000028 /* CanonicalFixtureTests.swift */; };
 		A10000000000000000000018 /* FleetProjectionReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000029 /* FleetProjectionReducerTests.swift */; };
 		A10000000000000000000019 /* FleetSemanticBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002A /* FleetSemanticBoundaryTests.swift */; };
+		A10000000000000000000095 /* FleetWireForwardCompatibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000096 /* FleetWireForwardCompatibilityTests.swift */; };
 		A1000000000000000000001A /* HangarLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002B /* HangarLocation.swift */; };
 		A1000000000000000000001B /* FleetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002C /* FleetConnection.swift */; };
 		A1000000000000000000001C /* FleetConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002D /* FleetConnectionTests.swift */; };
@@ -63,6 +64,7 @@
 		A10000000000000000000028 /* CanonicalFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanonicalFixtureTests.swift; sourceTree = "<group>"; };
 		A10000000000000000000029 /* FleetProjectionReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetProjectionReducerTests.swift; sourceTree = "<group>"; };
 		A1000000000000000000002A /* FleetSemanticBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetSemanticBoundaryTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000096 /* FleetWireForwardCompatibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetWireForwardCompatibilityTests.swift; sourceTree = "<group>"; };
 		A1000000000000000000002B /* HangarLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangarLocation.swift; sourceTree = "<group>"; };
 		A1000000000000000000002C /* FleetConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConnection.swift; sourceTree = "<group>"; };
 		A1000000000000000000002D /* FleetConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConnectionTests.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				A10000000000000000000028 /* CanonicalFixtureTests.swift */,
 				A10000000000000000000029 /* FleetProjectionReducerTests.swift */,
 				A1000000000000000000002A /* FleetSemanticBoundaryTests.swift */,
+				A10000000000000000000096 /* FleetWireForwardCompatibilityTests.swift */,
 				A1000000000000000000002D /* FleetConnectionTests.swift */,
 				A1000000000000000000002E /* FleetDaemonContractTests.swift */,
 				A10000000000000000000043 /* FleetRosterPresentationTests.swift */,
@@ -363,6 +366,7 @@
 				A10000000000000000000017 /* CanonicalFixtureTests.swift in Sources */,
 				A10000000000000000000018 /* FleetProjectionReducerTests.swift in Sources */,
 				A10000000000000000000019 /* FleetSemanticBoundaryTests.swift in Sources */,
+				A10000000000000000000095 /* FleetWireForwardCompatibilityTests.swift in Sources */,
 				A1000000000000000000001C /* FleetConnectionTests.swift in Sources */,
 				A1000000000000000000001D /* FleetDaemonContractTests.swift in Sources */,
 				A10000000000000000000040 /* FleetRosterPresentationTests.swift in Sources */,

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -121,13 +121,51 @@ struct FleetNegotiateResult: Codable, Equatable {
     private enum CodingKeys: String, CodingKey { case daemonVersion = "daemon_version", protocolVersion = "protocol_version", readCompatible = "read_compatible", writeCompatible = "write_compatible", capabilityIDs = "capability_ids" }
 }
 
-enum FleetProvider: String, Codable, Equatable { case claude, codex, unknown }
-enum LifecycleState: String, Codable, Equatable { case starting = "STARTING", running = "RUNNING", turnComplete = "TURN_COMPLETE", idle = "IDLE", exited = "EXITED", unknown = "UNKNOWN" }
-enum AttentionState: String, Codable, Equatable { case none = "NONE", ask = "ASK", approval = "APPROVAL", waiting = "WAITING", error = "ERROR" }
-enum ManagementState: String, Codable, Equatable { case managed = "MANAGED", degraded = "DEGRADED" }
-enum TransportHealth: String, Codable, Equatable { case healthy = "HEALTHY", degraded = "DEGRADED", unavailable = "UNAVAILABLE", unknown = "UNKNOWN" }
-enum FleetProvenance: String, Codable, Equatable { case authoritative, inferred }
-enum FleetConfidence: String, Codable, Equatable { case high = "HIGH", medium = "MEDIUM", low = "LOW" }
+/// A wire enum that survives a value this client has never heard of.
+///
+/// The daemon may add enum values — a new provider, a new lifecycle — and that
+/// is NOT a protocol version bump today, so version negotiation does not catch
+/// it. Swift's synthesized `Codable` throws `DecodingError.dataCorrupted` on an
+/// unrecognised raw value, and because `FleetSnapshot` decodes `sessions` as an
+/// ARRAY, one unknown value fails the ENTIRE snapshot: the client goes blank
+/// rather than degrading. Falling back is strictly better than failing.
+///
+/// Each `wireFallback` is chosen for FAIL-SAFETY, not convenience: where the
+/// choice affects whether an operator sees a session, it errs toward showing it.
+/// These types declare `Encodable` only, so the synthesized `init(from:)` does
+/// not shadow the tolerant one below.
+protocol TolerantWireEnum: RawRepresentable, Decodable where RawValue == String {
+    /// Used when the daemon sends a value this build does not know.
+    static var wireFallback: Self { get }
+}
+
+extension TolerantWireEnum {
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: raw) ?? Self.wireFallback
+    }
+}
+
+enum FleetProvider: String, Encodable, Equatable { case claude, codex, unknown }
+enum LifecycleState: String, Encodable, Equatable { case starting = "STARTING", running = "RUNNING", turnComplete = "TURN_COMPLETE", idle = "IDLE", exited = "EXITED", unknown = "UNKNOWN" }
+enum AttentionState: String, Encodable, Equatable { case none = "NONE", ask = "ASK", approval = "APPROVAL", waiting = "WAITING", error = "ERROR" }
+enum ManagementState: String, Encodable, Equatable { case managed = "MANAGED", degraded = "DEGRADED" }
+enum TransportHealth: String, Encodable, Equatable { case healthy = "HEALTHY", degraded = "DEGRADED", unavailable = "UNAVAILABLE", unknown = "UNKNOWN" }
+enum FleetProvenance: String, Encodable, Equatable { case authoritative, inferred }
+enum FleetConfidence: String, Encodable, Equatable { case high = "HIGH", medium = "MEDIUM", low = "LOW" }
+
+// An unrecognised PROVIDER or LIFECYCLE is simply unknown — both already model it.
+extension FleetProvider: TolerantWireEnum { static var wireFallback: Self { .unknown } }
+extension LifecycleState: TolerantWireEnum { static var wireFallback: Self { .unknown } }
+// An unrecognised ATTENTION means the daemon is signalling something we cannot
+// name. Falling back to `.none` would DROP it out of the Needs-input tab and the
+// operator would never learn a session wanted them; `.waiting` keeps it visible.
+extension AttentionState: TolerantWireEnum { static var wireFallback: Self { .waiting } }
+// Unrecognised capability/quality signals degrade rather than over-promise.
+extension ManagementState: TolerantWireEnum { static var wireFallback: Self { .degraded } }
+extension TransportHealth: TolerantWireEnum { static var wireFallback: Self { .unknown } }
+extension FleetProvenance: TolerantWireEnum { static var wireFallback: Self { .inferred } }
+extension FleetConfidence: TolerantWireEnum { static var wireFallback: Self { .low } }
 
 struct FleetCapabilities: Codable, Equatable {
     let structuredAnswer: Bool

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+/// The daemon may grow enum values without a protocol version bump, so this
+/// client must degrade rather than fail when it meets one.
+///
+/// Before this, every wire enum used synthesized `Codable`, which throws
+/// `DecodingError.dataCorrupted` on an unrecognised raw value. Because a
+/// snapshot decodes `sessions` as an ARRAY, a single unknown value failed the
+/// WHOLE snapshot and the app went blank. Adding `Provider::Copilot` daemon-side
+/// would have done exactly that to every un-updated client.
+final class FleetWireForwardCompatibilityTests: XCTestCase {
+    private func decode<T: Decodable>(_ type: T.Type, _ raw: String) throws -> T {
+        try JSONDecoder().decode(type, from: Data("\"\(raw)\"".utf8))
+    }
+
+    func testUnknownProviderDecodesAsUnknownRatherThanThrowing() throws {
+        XCTAssertEqual(try decode(FleetProvider.self, "copilot"), .unknown)
+        XCTAssertEqual(try decode(FleetProvider.self, "claude"), .claude)
+    }
+
+    func testUnknownLifecycleDecodesAsUnknown() throws {
+        XCTAssertEqual(try decode(LifecycleState.self, "HIBERNATING"), .unknown)
+        XCTAssertEqual(try decode(LifecycleState.self, "RUNNING"), .running)
+    }
+
+    /// Fail-safe direction: an attention state we cannot name still reaches the
+    /// operator. Falling back to `.none` would silently drop the session out of
+    /// the Needs-input tab, which is the one failure the tab exists to prevent.
+    func testUnknownAttentionStaysActionable() throws {
+        XCTAssertEqual(try decode(AttentionState.self, "ELICITATION"), .waiting)
+        XCTAssertEqual(try decode(AttentionState.self, "NONE"), .none)
+    }
+
+    func testUnknownCapabilitySignalsDegradeRatherThanOverPromise() throws {
+        XCTAssertEqual(try decode(ManagementState.self, "SUPERVISED"), .degraded)
+        XCTAssertEqual(try decode(TransportHealth.self, "FLAKY"), .unknown)
+        XCTAssertEqual(try decode(FleetProvenance.self, "measured"), .inferred)
+        XCTAssertEqual(try decode(FleetConfidence.self, "CERTAIN"), .low)
+    }
+
+    func testKnownValuesStillRoundTripThroughEncoding() throws {
+        let encoded = try JSONEncoder().encode(FleetProvider.codex)
+        XCTAssertEqual(String(decoding: encoded, as: UTF8.self), "\"codex\"")
+    }
+
+    /// The regression that matters: one unknown value inside a session row must
+    /// not take down the whole snapshot.
+    func testAnUnknownProviderDoesNotFailTheWholeSnapshot() throws {
+        let json = """
+        {"head_revision":7,"sessions":[
+          {"session_key":"legacy:copilot:pane","provider":"copilot","provider_session_id":null,
+           "tmux_target":"demo:1.1","process_start_fingerprint":"pane=%1;pid=1;session_started=1",
+           "cwd":"/repo","display_name":null,"lifecycle":"RUNNING","attention":"NONE",
+           "current_request_fingerprint":null,"current_request":null,"management":"DEGRADED",
+           "transport_health":"HEALTHY","capabilities":{"structured_answer":false,"approvals":false,"send_prompt":false,"continue_turn":false,"retry":false,"interrupt":false,"start":false,"stop":false,"restart":false,"kill":false,"archive":false,"tmux_attach":true,"tmux_text":true,"verified_picker":false},"provenance":"inferred","confidence":"LOW",
+           "discovered_at":1,"last_observed_at":2,"lifecycle_updated_at":2,"attention_updated_at":2,
+           "version":1,"updated_revision":7}
+        ]}
+        """
+        let snapshot = try JSONDecoder().decode(FleetSnapshot.self, from: Data(json.utf8))
+        XCTAssertEqual(snapshot.sessions.count, 1, "the row must survive an unknown provider")
+        XCTAssertEqual(snapshot.sessions.first?.provider, .unknown)
+        XCTAssertEqual(snapshot.sessions.first?.lifecycle, .running)
+    }
+}


### PR DESCRIPTION
Fixes `agents-in-a-box-3ou`, and **unblocks `han`** (Provider::Copilot).

## The problem

Every wire enum in `FleetWire.swift` used synthesized `Codable`, which **throws** `DecodingError.dataCorrupted` on an unrecognised raw value. A snapshot decodes `sessions` as an **array**, so one unknown value failed the *whole* snapshot — the app goes blank rather than degrading.

The daemon can add enum values without a protocol version bump, so negotiation (pinned `min:1 max:1`) does not catch it. **Adding `Provider::Copilot` daemon-side would have blanked every un-updated client.** That turned a cosmetic gap into a client outage, which is why `han` was more expensive than it looked.

## Fallbacks are chosen for fail-safety, not convenience

| enum | fallback | why |
|---|---|---|
| `FleetProvider` | `.unknown` | already models it |
| `LifecycleState` | `.unknown` | already models it |
| **`AttentionState`** | **`.waiting`** | `.none` would DROP the session out of Needs-input and the operator would never learn it wanted them |
| `ManagementState` | `.degraded` | never over-promise capability |
| `TransportHealth` | `.unknown` | already models it |
| `FleetProvenance` | `.inferred` | assume the weaker claim |
| `FleetConfidence` | `.low` | assume the weaker claim |

The `AttentionState` choice is the one that matters: the Needs-input tab exists precisely to stop a waiting session being missed, so an attention value we cannot name must stay visible.

## Implementation note

The enums now declare `Encodable` only. Swift's synthesized `init(from:)` would otherwise **shadow** the tolerant one supplied by the protocol extension, silently keeping the throwing behaviour. Encoding is unchanged.

## Verification, run locally against Xcode 26.4.1

```
xcodebuild test -only-testing:FleetRPCTests/FleetWireForwardCompatibilityTests   6 passed
xcodebuild test -only-testing:FleetRPCTests                                     78 passed, TEST SUCCEEDED
cargo build -p ainb-hangar-daemon --example fleet_fixture_daemon                 exit 0
```

The full existing contract suite passes unchanged, so tolerance was added without loosening anything the contract already pinned.

The decisive new test decodes a snapshot whose single session carries `"provider":"copilot"` — a value this build has never heard of — and asserts the row survives as `.unknown` with its other fields intact, instead of the array failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer fleet service values by safely handling unknown status and metadata values.
  * Prevented unrecognized provider values from invalidating an entire fleet snapshot.

* **Tests**
  * Added coverage for unknown values across fleet status, health, provenance, and confidence data.
  * Verified that known values continue to encode correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->