### PR TITLE
ci: gate required jobs by condition, not by workflow paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,6 @@ on:
       - ".github/workflows/ci.yml"
   pull_request:
     branches: [main, v2]
-    paths:
-      - "ainb-tui/**"
-      - "plugins/ainb-hooks/**"
-      - "ainb-tui/crates/ainb-plugin-hangar/**"
-      - "scripts/hangar/**"
-      - "Cargo.*"
-      - ".github/workflows/ci.yml"
 
 env:
   CARGO_TERM_COLOR: always
@@ -27,10 +20,45 @@ env:
 
 jobs:
   # ────────────────────────────────────────────────────────────────────────────
+  # Which paths changed?
+  #
+  # Path filtering lives HERE, on the jobs, and NOT on `on.pull_request.paths`.
+  # A workflow skipped by `on.paths` creates no check runs at all, so a required
+  # context stays "Expected" forever and the PR can never merge — that is what
+  # blocked every Swift-only and docs-only PR (bead mbl).
+  # A job skipped by an `if:` DOES report, and a skipped job satisfies a required
+  # check, so the gate stays honest while irrelevant PRs still cost no compute.
+  #
+  # `on.push` keeps its own `paths:` — push runs are not required checks, so
+  # main-branch CI cost is unchanged.
+  # ────────────────────────────────────────────────────────────────────────────
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'ainb-tui/**'
+              - 'plugins/ainb-hooks/**'
+              - 'scripts/hangar/**'
+              - 'Cargo.*'
+              - '.github/workflows/ci.yml'
+
+  # ────────────────────────────────────────────────────────────────────────────
   # Format check
   # ────────────────────────────────────────────────────────────────────────────
   fmt:
     name: Rustfmt
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +74,10 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   cli-docs:
     name: CLI reference freshness
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +103,10 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   test:
     name: Test (${{ matrix.os }})
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -149,6 +185,10 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   contracts:
     name: Contracts
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -167,6 +207,10 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   ainb-hooks:
     name: ainb-hooks (${{ matrix.os }})
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -207,6 +251,10 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   hangar-e2e:
     name: hangar-e2e (${{ matrix.os }})
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -273,6 +321,10 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   machete:
     name: Cargo Machete
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -13,9 +13,6 @@ on:
       - 'ainb-tui/**'
       - '.github/workflows/toolkit-validation.yml'
   pull_request:
-    paths:
-      - 'ainb-tui/**'
-      - '.github/workflows/toolkit-validation.yml'
 
 # The pinned ainb-toolkit ref this build of ainb consumes. Keep in lockstep
 # with release.yml's AINB_TOOLKIT_REF.
@@ -23,8 +20,40 @@ env:
   AINB_TOOLKIT_REF: v1.6.0
 
 jobs:
+  # ────────────────────────────────────────────────────────────────────────────
+  # Which paths changed?
+  #
+  # Path filtering lives HERE, on the jobs, and NOT on `on.pull_request.paths`.
+  # A workflow skipped by `on.paths` creates no check runs at all, so a required
+  # context stays "Expected" forever and the PR can never merge — that is what
+  # blocked every Swift-only and docs-only PR (bead mbl).
+  # A job skipped by an `if:` DOES report, and a skipped job satisfies a required
+  # check, so the gate stays honest while irrelevant PRs still cost no compute.
+  #
+  # `on.push` keeps its own `paths:` — push runs are not required checks, so
+  # main-branch CI cost is unchanged.
+  # ────────────────────────────────────────────────────────────────────────────
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'ainb-tui/**'
+              - '.github/workflows/toolkit-validation.yml'
+
   validate-template-skill-refs:
     name: Validate template skill refs against ainb-toolkit
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ubuntu-latest
 
     steps:
@@ -68,6 +97,10 @@ jobs:
 
   test-ainb-installations:
     name: Test ainb installations (replaces bootstrap.js parity tests)
+    needs: changes
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.relevant != 'false')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes `agents-in-a-box-mbl`. Unblocks PR #557 and every future Swift-only or docs-only change.

## The mechanism

A workflow skipped by `on.paths` creates **no check runs at all**, so a required context stays `Expected` forever and the PR can never merge. A job skipped by an `if:` conditional **does** report, and a skipped job satisfies a required check.

So the filtering moves from `on.pull_request.paths` onto the jobs. Irrelevant PRs still cost no compute (no runner spin-up), relevant PRs still run everything, and the contexts always report either way.

## Both workflows needed it

Six of the seven required contexts come from `ci.yml`. The seventh — `Test ainb installations (replaces bootstrap.js parity tests)` — comes from `toolkit-validation.yml:70`, which had its own `paths:` filter. Fixing only `ci.yml` would have left every Swift-only PR blocked on that one context.

## The gate is deliberately fail-safe

```yaml
if: >-
  always() && (github.event_name != 'pull_request' ||
  needs.changes.outputs.relevant != 'false')
```

If the `changes` job itself errors, its output is empty, which is not `'false'`, so **the full suite runs**. The obvious `== 'true'` form has the opposite failure mode: a broken detector skips every dependent job, skipped satisfies the ruleset, and a PR merges with **zero tests** — silent coverage loss, which is exactly the class this repo's CI comments warn about elsewhere.

`on.push` keeps its `paths:`, since push runs are not required checks — main-branch CI cost is unchanged.

## This PR proves itself

`.github/workflows/ci.yml` is in the `changes` filter list, so `relevant=true` here and **all 7 required contexts run for real**. A green run demonstrates the gated YAML parses and passes through correctly.

The skip leg (contexts reporting as `skipped` on an irrelevant PR) is observable by opening a throwaway PR against this branch touching only `apps/`. That "skipped satisfies a required check" is GitHub-documented behaviour.

## Verification

```
python3 -c "yaml.safe_load(...)"        both workflows parse; 7 + 2 jobs gated
cargo run -p xtask -- ci-lint           OK — hangar-e2e job satisfies the real CI contract
```

The repo's own CI linter (`xtask/src/ci_lint.rs`) asserts hangar-e2e existence, the both-OS matrix, and tmux-before-tripwires step order — none of which `needs:`/`if:` additions disturb.

## Separately, for the owner — not part of this change

Your admin role holds `bypass_mode: "always"` on ruleset `main` (`RepositoryRole` actor 5). The rule-suites ledger shows #556 (`10165efc`) landed with `result: bypass` while every other merge today shows `pass` — so that PR merged **without** its required checks ever running, silently. If you want the gate to bind you too, remove that bypass actor or narrow it to pull requests. Entirely your call; this PR does not touch repo settings.