### PR TITLE
feat(fleet): add Provider::Copilot

### DIFF
--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
@@ -203,9 +203,10 @@ fn parse_row(line: &str) -> Result<TmuxPaneRow> {
 /// desktop app (`…/Claude.app/Contents/MacOS/Claude`) nor a branch called
 /// `f/claude-resume` can pass as a session.
 ///
-/// ponytail: copilot is deliberately absent. Fleet has no `Provider::Copilot`
-/// on the wire, so admitting one would render it `UNKNOWN` — add the name here
-/// together with the enum variant, never before it.
+/// Copilot is admitted now that `Provider::Copilot` exists on the wire AND the
+/// Swift client decodes unknown enum values tolerantly. Emitting a provider token
+/// an older client has never seen used to fail its whole snapshot decode, so this
+/// name could not land before those two.
 fn agent_provider(processes: &ProcessTable, pane_pid: u32) -> Option<Provider> {
     processes.tree_commands(pane_pid).into_iter().find_map(|command| match command {
         "claude" => Some(Provider::Claude),

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/types.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/types.rs
@@ -25,6 +25,7 @@ pub enum SessionSource {
 pub enum Provider {
     Claude,
     Codex,
+    Copilot,
     Unknown,
 }
 
@@ -34,6 +35,7 @@ impl Provider {
         match self {
             Self::Claude => "claude",
             Self::Codex => "codex",
+            Self::Copilot => "copilot",
             Self::Unknown => "unknown",
         }
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -904,6 +904,7 @@ fn session_wire(
         provider: match row.provider.as_str() {
             "claude" => wire::FleetProvider::Claude,
             "codex" => wire::FleetProvider::Codex,
+            "copilot" => wire::FleetProvider::Copilot,
             _ => wire::FleetProvider::Unknown,
         },
         provider_session_id: row.provider_session_id.clone(),
@@ -1351,6 +1352,7 @@ fn parse_provider(value: &str) -> Provider {
     match value.to_ascii_lowercase().as_str() {
         "claude" => Provider::Claude,
         "codex" => Provider::Codex,
+        "copilot" => Provider::Copilot,
         _ => Provider::Unknown,
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1802,7 +1802,11 @@ async fn execute_fleet_start(
                 Some("Codex managed transport is not active".to_string()),
             ),
         },
-        FleetProvider::Claude | FleetProvider::Unknown => (
+        // Codex is the only provider with a managed start transport. Copilot
+        // sits with Claude here: Fleet can SEE a copilot pane, but it cannot
+        // launch one, so a start request is honestly rejected rather than
+        // silently accepted.
+        FleetProvider::Claude | FleetProvider::Copilot | FleetProvider::Unknown => (
             ActionReceiptStatus::Rejected,
             Some("provider start transport is unavailable".to_string()),
         ),
@@ -1824,6 +1828,7 @@ fn prospective_start_session_key(
     let provider = match provider {
         ainb_hangar_proto::fleet::FleetProvider::Claude => "claude",
         ainb_hangar_proto::fleet::FleetProvider::Codex => "codex",
+        ainb_hangar_proto::fleet::FleetProvider::Copilot => "copilot",
         ainb_hangar_proto::fleet::FleetProvider::Unknown => "unknown",
     };
     format!("start:{provider}:{}", stable_fingerprint(request_id))

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -95,6 +95,8 @@ pub enum FleetProvider {
     Claude,
     /// OpenAI Codex.
     Codex,
+    /// GitHub Copilot CLI.
+    Copilot,
     /// Provider could not be determined.
     #[default]
     Unknown,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -255,6 +255,7 @@ impl From<ainb_hangar_proto::fleet::FleetSession> for FleetSessionRow {
             provider: match session.provider {
                 FleetProvider::Claude => "claude",
                 FleetProvider::Codex => "codex",
+                FleetProvider::Copilot => "copilot",
                 FleetProvider::Unknown => "unknown",
             }
             .into(),

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -146,7 +146,7 @@ extension TolerantWireEnum {
     }
 }
 
-enum FleetProvider: String, Encodable, Equatable { case claude, codex, unknown }
+enum FleetProvider: String, Encodable, Equatable { case claude, codex, copilot, unknown }
 enum LifecycleState: String, Encodable, Equatable { case starting = "STARTING", running = "RUNNING", turnComplete = "TURN_COMPLETE", idle = "IDLE", exited = "EXITED", unknown = "UNKNOWN" }
 enum AttentionState: String, Encodable, Equatable { case none = "NONE", ask = "ASK", approval = "APPROVAL", waiting = "WAITING", error = "ERROR" }
 enum ManagementState: String, Encodable, Equatable { case managed = "MANAGED", degraded = "DEGRADED" }

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -173,6 +173,7 @@ struct FleetWindowView: View {
         switch presentation.filters.provider {
         case .claude: "Claude"
         case .codex: "Codex"
+        case .copilot: "Copilot"
         case .unknown: "Unknown"
         case nil: "All providers"
         }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
@@ -16,8 +16,10 @@ final class FleetWireForwardCompatibilityTests: XCTestCase {
     }
 
     func testUnknownProviderDecodesAsUnknownRatherThanThrowing() throws {
-        XCTAssertEqual(try decode(FleetProvider.self, "copilot"), .unknown)
+        XCTAssertEqual(try decode(FleetProvider.self, "gemini"), .unknown)
         XCTAssertEqual(try decode(FleetProvider.self, "claude"), .claude)
+        // copilot is a KNOWN provider now, so it must decode as itself.
+        XCTAssertEqual(try decode(FleetProvider.self, "copilot"), .copilot)
     }
 
     func testUnknownLifecycleDecodesAsUnknown() throws {
@@ -50,7 +52,7 @@ final class FleetWireForwardCompatibilityTests: XCTestCase {
     func testAnUnknownProviderDoesNotFailTheWholeSnapshot() throws {
         let json = """
         {"head_revision":7,"sessions":[
-          {"session_key":"legacy:copilot:pane","provider":"copilot","provider_session_id":null,
+          {"session_key":"legacy:gemini:pane","provider":"gemini","provider_session_id":null,
            "tmux_target":"demo:1.1","process_start_fingerprint":"pane=%1;pid=1;session_started=1",
            "cwd":"/repo","display_name":null,"lifecycle":"RUNNING","attention":"NONE",
            "current_request_fingerprint":null,"current_request":null,"management":"DEGRADED",


### PR DESCRIPTION
Closes `agents-in-a-box-han`, the last open bead from this batch.

## Why it was blocked until now

Copilot was already first-class in the daemon **run** path (`materialise.rs:102`, `run_loop.rs:196`) but absent from the Fleet provider enums. After the discovery gate landed in #546, a copilot pane was excluded from Fleet **entirely** — strictly worse than the UNKNOWN row it replaced.

It could not be fixed directly, because emitting a provider token an older Swift client had never seen failed that client's **whole snapshot** decode, not one row. #557 made the client tolerant; this PR is the follow-through.

## What changed

| layer | change |
|---|---|
| `ainb-fleet-core` `Provider` | `+ Copilot`, token `"copilot"` |
| wire `FleetProvider` | `+ Copilot` |
| discovery agent gate | admits `copilot` in the process tree |
| daemon token mappings | `"copilot"` → `Provider::Copilot` / `FleetProvider::Copilot` |
| plugin display | renders `copilot` |
| Swift client | `+ case copilot`, provider-filter label |

## Two places needed a decision, not a mechanical arm

The compiler surfaced three exhaustive matches — two Rust, one Swift — which is exactly the variant-propagation break to expect.

The interesting one is the **start** path. Codex is the only provider with a managed start transport, so Copilot joins Claude in **rejecting** a start request honestly: Fleet can *see* a copilot pane, but it cannot *launch* one. Silently accepting would have been worse than the error.

## The Swift half is load-bearing

Tolerant decoding alone would map `"copilot"` → `.unknown`, so the app would still display **UNKNOWN** — the precise thing this bead exists to fix. The case had to be added too.

The forward-compatibility test moves off `"copilot"` as its unknown-token fixture (it is known now) onto `"gemini"`, and gains an assertion that `"copilot"` decodes as itself.

## Verification

```
cargo test -p ainb-fleet-core --lib                92 passed
cargo test -p ainb-hangar-daemon --lib            403 passed
cargo test -p ainb-plugin-cts-v2 --test wire_surface_gate    1 passed (no protocol bump needed)
cargo test --workspace --no-run                   exit 0
xcodebuild test -only-testing:FleetRPCTests        78 passed, TEST SUCCEEDED
rustup run stable cargo fmt --all -- --check       clean
```

**One local-only failure, disclosed:** `real_plugin_axes::in_tree_plugins_satisfy_the_protocol_they_claim` refuses to run here because this worktree lives under `~/.agents-in-a-box`, so its scratch hangar home would sit inside the live one. That guard depends only on the worktree path, not on this diff — CI checks out elsewhere and runs it.