### PR TITLE
ci: auto-merge the release sync PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,16 @@ jobs:
           if git push origin "${BRANCH}"; then
             if gh pr create --base main --head "${BRANCH}" \
                  --title "chore(release): sync v${VERSION}" --body "${BODY}"; then
-              echo "Sync PR opened for ${BRANCH}"
+              # Auto-merge so a release needs no follow-up by hand. The PR still
+              # waits for the ruleset's required checks; this only says "merge it
+              # when they pass". If auto-merge is unavailable the PR just stays
+              # open, which is the previous behaviour, so this never blocks a
+              # release.
+              if gh pr merge "${BRANCH}" --auto --merge --delete-branch; then
+                echo "Sync PR opened for ${BRANCH} and queued to auto-merge"
+              else
+                echo "::warning::Sync PR for v${VERSION} is open but could not be queued to auto-merge. Merge ${BRANCH} to bring Cargo.toml and CHANGELOG.md back in step."
+              fi
             else
               echo "::warning::v${VERSION} is tagged and releasing, but the sync PR could not be opened. Open one from ${BRANCH} to bring Cargo.toml and CHANGELOG.md back in step."
             fi


### PR DESCRIPTION
Cutting a release left a `chore(release): sync vX.Y.Z` PR sitting open to be merged by hand, so `main` kept reporting the previous version until someone noticed. Queue it to merge itself once the required checks pass.

This does not weaken the gate. `--auto` only expresses intent: the same seven required checks still have to go green before GitHub merges anything. If auto-merge is unavailable the PR just stays open, which is the previous behaviour, so a release can never fail over it.

## Repo settings changed alongside this

Two were off and had to be turned on for the design to work unattended:

- **Actions may create pull requests.** The v1.18.0 run failed to open its sync PR with `GraphQL: GitHub Actions is not permitted to create or approve pull requests`, so #566 had to be opened by hand. The toggle also grants approval rights; that is not a new bypass here, since the ruleset requires zero approving reviews.
- **Auto-merge enabled** on the repo, which `--auto` requires.

## After this

`gh workflow run release.yml -f version=X.Y.Z` is the only human action in a release. Tag, build, publish, Homebrew tap, and the bump landing back on `main` all happen without further input.

## Verification

- `actionlint -shellcheck=` (CI's exact invocation) exits 0
- workflow parses as YAML

https://claude.ai/code/session_01LpWYDtzz2jYqj3FknDJbo2