### PR TITLE
fix(ainb-hooks): Codex was never running the stall guard (hook trust)

### DIFF
--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -352,6 +352,17 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
                 Ok(hooks_json) => {
                     record.codex_hooks_json = Some(hooks_json);
                     push_unique(&mut record.agents, Agent::Codex);
+                    // Writing hooks.json is only half a Codex install. Codex
+                    // pins every hook in config.toml by `trusted_hash` and
+                    // SILENTLY skips any entry it has not trusted — no error,
+                    // no log line, the hook simply never runs. Say so, or the
+                    // install looks complete while doing nothing.
+                    eprintln!(
+                        "note: Codex only runs hooks it has trusted. Start `codex` once and \
+                         approve the startup hooks review, otherwise the ainb hooks (including \
+                         the stall guard) are skipped silently. Non-interactive automation can \
+                         pass --dangerously-bypass-hook-trust instead."
+                    );
                 }
                 Err(e) => failures.push((Agent::Codex, e)),
             },

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -102,7 +102,7 @@ one place each:
 
 | | Claude Code | Codex CLI |
 |---|---|---|
-| payload delivery | stdin | `argv[1]` |
+| payload delivery | stdin | stdin (Stop; probed live as `argc=0`) |
 | transcript | `transcript_path` JSONL | rollout JSONL, `response_item` lines (nullable path) |
 | closing text | last assistant entry | `last_assistant_message`, required on input |
 | advice given | background Bash, Monitor, ScheduleWakeup | foreground poll loop (no background primitive) |
@@ -114,6 +114,37 @@ which `ainb-notifyd install --codex` substitutes after extracting the script to
 `~/.agents-in-a-box/hooks/stall_guard.py` next to `notify.sh`.
 
 Copilot is not wired: its hook format has no Stop-with-decision contract.
+
+### Codex hook trust (required, or the guard never runs)
+
+Codex will not run a hook it has not trusted. Every hook is pinned in
+`~/.codex/config.toml` under `[hooks.state]`, keyed by
+`<hooks.json path>:<event>:<group index>:<hook index>`, with a `trusted_hash`:
+
+```toml
+[hooks.state."/Users/you/.codex/hooks.json:stop:3:0"]
+trusted_hash = "sha256:…"
+```
+
+An untrusted or changed entry is **skipped silently** — no error, no log line,
+no hook output. Writing `hooks.json` therefore installs the hook without
+enabling it, and everything looks fine until you notice turns are not being
+blocked. This was diagnosed by wiring a probe wrapper in place of the guard and
+watching it never get invoked while three sibling `Stop` hooks ran.
+
+After `ainb-notifyd install --codex`, start `codex` once and approve the
+startup hooks review (`tui/src/startup_hooks_review.rs`, shown when "hooks are
+new or changed"). That writes the `trusted_hash` entries.
+
+For non-interactive automation, `codex exec --dangerously-bypass-hook-trust`
+runs enabled hooks without persisted trust. That is how the end-to-end
+verification below was done; it is not a substitute for trusting the hook.
+
+Verified end to end on Codex with trust bypassed: a turn closing with "The CI
+checks are still running on main." produced
+`{"decision":"block",…}` on the first Stop (`stop_hook_active: false`) and
+silence on the second (`stop_hook_active: true`), and the turn was re-run —
+exactly the one-nudge design.
 
 Run the self-check after editing it:
 

--- a/plugins/ainb-hooks/hooks/stall_guard.py
+++ b/plugins/ainb-hooks/hooks/stall_guard.py
@@ -332,11 +332,14 @@ def evaluate(entries, how=HOW_CLAUDE):
 
 
 def read_payload():
-    """Claude and Copilot pipe the payload on stdin; Codex passes it as argv[1].
+    """Read the hook payload from wherever the host put it.
 
-    argv is tried FIRST and stdin is never touched when it wins. A hook launched
-    with an inherited-but-idle stdin (Codex's delivery) would otherwise block in
-    read() until the host's hook timeout killed it, on every single Stop.
+    Measured, not assumed: Codex delivers the Stop payload on stdin with an
+    empty argv (probed live — `argc=0`), and Claude pipes it on stdin too.
+    argv is still tried first because other Codex hook events are documented to
+    pass JSON in argv[1], and because reading stdin first would block forever
+    against a host that leaves stdin open and idle. The bounded select() below
+    is what actually guarantees this never hangs a turn.
     """
     for raw in sys.argv[1:]:
         if raw.startswith("-"):


### PR DESCRIPTION
## The bug

#551 shipped the stall guard for Codex and it never ran once. Direct invocation of the script worked, so it looked fine; driving a real `codex exec` turn showed the stall sentence passing straight through unblocked.

## Root cause

Codex will not run a hook it has not trusted. Every hook is pinned in `~/.codex/config.toml`:

```toml
[hooks.state."/Users/you/.codex/hooks.json:stop:3:0"]
trusted_hash = "sha256:…"
```

An untrusted or changed entry is **skipped silently** — no error, no log line, no output. Writing `hooks.json` installs a hook without enabling it. Three already-trusted sibling `Stop` hooks kept running the whole time, so nothing looked broken.

Diagnosed by swapping a probe wrapper in for the guard (never invoked), then finding `[hooks.state]` and the TUI startup hooks review, which reported `Stop: 6 installed, 3 active, 3 needing review`.

## What changed

- `install.rs` now tells the user that Codex only runs trusted hooks, and how to trust them
- README documents the gate, the `[hooks.state]` shape, and the bypass flag for automation
- corrected a factual error: Codex delivers the Stop payload on **stdin** with `argc=0`, not `argv[1]`. argv is still tried first (other events do use it, and the bounded `select()` is the real anti-hang), but the rationale now matches reality

No behavioural change to the guard itself.

## Verification

End-to-end against real `codex exec`, after trusting the hook from the startup review — **no bypass flag**:

| | Stop-hook invocations | assistant turns | result |
|---|---|---|---|
| "The deploy is still running." | 8 | 2 | **blocked, turn re-run** |
| "Renamed the function in three files and the tests pass." | 4 | 1 | untouched |

Before the fix the stall case was 3 invocations / 1 turn / no block.

Probe also captured the guard's own behaviour on the real payload: `{"decision":"block",…}` on the first Stop (`stop_hook_active: false`) and silence on the second (`stop_hook_active: true`) — the one-nudge design working exactly as intended.

`stall_guard.py --self-test` 28/28, `cargo test -p ainb-plugin-notifyd` green.

https://claude.ai/code/session_01R3ZiGJyiT4NwpBMk6wqfvB