### PR TITLE
f/atc 4

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7904,7 +7904,10 @@ async fn run_daemon_reproject_claude_interview(
         )
         .await
         .context("reproject Claude interview")?;
-    print!("{}", render_daemon_reproject_claude_interview(&args.session_key, &result, format)?);
+    print!(
+        "{}",
+        render_daemon_reproject_claude_interview(&args.session_key, &result, format)?
+    );
     Ok(())
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -2403,6 +2403,8 @@ pub enum DaemonCommand {
     Restart,
     /// One-command bring-up: ensure the store + socket-auth token, then `start`.
     Setup,
+    /// Rebuild one stale Claude structured interview from durable hook history.
+    ReprojectClaudeInterview(ReprojectClaudeInterviewArgs),
     /// View + edit the daemon's user-config knobs (`list`/`get`/`set`).
     #[command(subcommand)]
     Config(DaemonConfigCommand),
@@ -2410,6 +2412,20 @@ pub enum DaemonCommand {
     /// into confined headless runs (`status`/`set`/`clear`).
     #[command(subcommand)]
     Cred(DaemonCredCommand),
+}
+
+/// Arguments for one controlled Claude interview reprojection.
+#[derive(Args, Debug)]
+pub struct ReprojectClaudeInterviewArgs {
+    /// Exact Fleet session key, for example `claude:<provider-session-id>`.
+    #[arg(long)]
+    pub session_key: String,
+    /// Exact version observed before this mutation. Rejects stale inspection.
+    #[arg(long)]
+    pub expected_version: i64,
+    /// Required acknowledgement that this appends a recovery projection.
+    #[arg(long)]
+    pub apply: bool,
 }
 
 /// `hangar daemon cred <verb>` — the daemon-level claude credential.
@@ -7861,9 +7877,35 @@ async fn dispatch_daemon(cmd: DaemonCommand, format: OutputFormat) -> Result<()>
         DaemonCommand::Stop => run_daemon_stop(),
         DaemonCommand::Restart => run_daemon_restart(),
         DaemonCommand::Setup => run_daemon_setup().await,
+        DaemonCommand::ReprojectClaudeInterview(args) => {
+            run_daemon_reproject_claude_interview(args).await
+        }
         DaemonCommand::Config(c) => dispatch_daemon_config(c, format).await,
         DaemonCommand::Cred(c) => dispatch_daemon_cred(c).await,
     }
+}
+
+/// Rebuild a stale Claude interview without talking to Claude or the broker.
+async fn run_daemon_reproject_claude_interview(args: ReprojectClaudeInterviewArgs) -> Result<()> {
+    if !args.apply {
+        anyhow::bail!("refusing recovery mutation: rerun with --apply");
+    }
+    let store = Store::open_default().await.context("open hangar database")?;
+    let broker = ainb_hangar_daemon::events::EventBroker::new();
+    let result = ainb_hangar_daemon::fleet::reproject_claude_interview(
+        store.pool(),
+        &broker.sink(),
+        &args.session_key,
+        args.expected_version,
+        chrono::Utc::now().timestamp_millis(),
+    )
+    .await
+    .context("reproject Claude interview")?;
+    println!(
+        "reprojected Claude interview: session={} revision={} version={}",
+        args.session_key, result.revision, result.session_version
+    );
+    Ok(())
 }
 
 /// Dispatch the `hangar daemon cred` verbs against the platform secret store.
@@ -10784,6 +10826,27 @@ mod tests {
     fn parses_daemon_status() {
         let cmd = parse_hangar(&["ainb", "hangar", "daemon", "status"]);
         assert!(matches!(cmd, HangarCommand::Daemon(DaemonCommand::Status)));
+    }
+
+    #[test]
+    fn parses_daemon_reproject_claude_interview() {
+        let cmd = parse_hangar(&[
+            "ainb",
+            "hangar",
+            "daemon",
+            "reproject-claude-interview",
+            "--session-key",
+            "claude:session-1",
+            "--expected-version",
+            "13",
+            "--apply",
+        ]);
+        let HangarCommand::Daemon(DaemonCommand::ReprojectClaudeInterview(args)) = cmd else {
+            panic!("expected Claude interview reprojection command");
+        };
+        assert_eq!(args.session_key, "claude:session-1");
+        assert_eq!(args.expected_version, 13);
+        assert!(args.apply);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7878,7 +7878,7 @@ async fn dispatch_daemon(cmd: DaemonCommand, format: OutputFormat) -> Result<()>
         DaemonCommand::Restart => run_daemon_restart(),
         DaemonCommand::Setup => run_daemon_setup().await,
         DaemonCommand::ReprojectClaudeInterview(args) => {
-            run_daemon_reproject_claude_interview(args).await
+            run_daemon_reproject_claude_interview(args, format).await
         }
         DaemonCommand::Config(c) => dispatch_daemon_config(c, format).await,
         DaemonCommand::Cred(c) => dispatch_daemon_cred(c).await,
@@ -7886,7 +7886,10 @@ async fn dispatch_daemon(cmd: DaemonCommand, format: OutputFormat) -> Result<()>
 }
 
 /// Rebuild a stale Claude interview through the live daemon broker.
-async fn run_daemon_reproject_claude_interview(args: ReprojectClaudeInterviewArgs) -> Result<()> {
+async fn run_daemon_reproject_claude_interview(
+    args: ReprojectClaudeInterviewArgs,
+    format: OutputFormat,
+) -> Result<()> {
     if !args.apply {
         anyhow::bail!("refusing recovery mutation: rerun with --apply");
     }
@@ -7901,11 +7904,31 @@ async fn run_daemon_reproject_claude_interview(args: ReprojectClaudeInterviewArg
         )
         .await
         .context("reproject Claude interview")?;
-    println!(
-        "reprojected Claude interview: session={} revision={} version={}",
-        args.session_key, result.revision, result.session_version
-    );
+    print!("{}", render_daemon_reproject_claude_interview(&args.session_key, &result, format)?);
     Ok(())
+}
+
+fn render_daemon_reproject_claude_interview(
+    session_key: &str,
+    result: &ainb_hangar_proto::fleet::FleetReprojectClaudeInterviewResult,
+    format: OutputFormat,
+) -> Result<String> {
+    if format == OutputFormat::Json {
+        return Ok(format!(
+            "{}\n",
+            serde_json::to_string(&serde_json::json!({
+                "session_key": session_key,
+                "revision": result.revision,
+                "session_version": result.session_version,
+                "applied": result.applied,
+                "duplicate": result.duplicate,
+            }))?
+        ));
+    }
+    Ok(format!(
+        "reprojected Claude interview: session={session_key} revision={} version={} applied={} duplicate={}\n",
+        result.revision, result.session_version, result.applied, result.duplicate
+    ))
 }
 
 /// Dispatch the `hangar daemon cred` verbs against the platform secret store.
@@ -10847,6 +10870,34 @@ mod tests {
         assert_eq!(args.session_key, "claude:session-1");
         assert_eq!(args.expected_version, 13);
         assert!(args.apply);
+    }
+
+    #[test]
+    fn reproject_output_reports_mutation_and_honors_json() {
+        let result = ainb_hangar_proto::fleet::FleetReprojectClaudeInterviewResult {
+            revision: 23,
+            session_version: 7,
+            applied: true,
+            duplicate: false,
+        };
+        let text = render_daemon_reproject_claude_interview(
+            "claude:session-1",
+            &result,
+            OutputFormat::Text,
+        )
+        .unwrap();
+        assert!(text.contains("applied=true duplicate=false"));
+
+        let json = render_daemon_reproject_claude_interview(
+            "claude:session-1",
+            &result,
+            OutputFormat::Json,
+        )
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["session_key"], "claude:session-1");
+        assert_eq!(parsed["applied"], true);
+        assert_eq!(parsed["duplicate"], false);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7885,22 +7885,22 @@ async fn dispatch_daemon(cmd: DaemonCommand, format: OutputFormat) -> Result<()>
     }
 }
 
-/// Rebuild a stale Claude interview without talking to Claude or the broker.
+/// Rebuild a stale Claude interview through the live daemon broker.
 async fn run_daemon_reproject_claude_interview(args: ReprojectClaudeInterviewArgs) -> Result<()> {
     if !args.apply {
         anyhow::bail!("refusing recovery mutation: rerun with --apply");
     }
-    let store = Store::open_default().await.context("open hangar database")?;
-    let broker = ainb_hangar_daemon::events::EventBroker::new();
-    let result = ainb_hangar_daemon::fleet::reproject_claude_interview(
-        store.pool(),
-        &broker.sink(),
-        &args.session_key,
-        args.expected_version,
-        chrono::Utc::now().timestamp_millis(),
-    )
-    .await
-    .context("reproject Claude interview")?;
+    let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+        .context("connect to live hangar daemon")?;
+    let result = client
+        .fleet_reproject_claude_interview(
+            ainb_hangar_proto::fleet::FleetReprojectClaudeInterviewParams {
+                session_key: args.session_key.clone(),
+                expected_version: args.expected_version,
+            },
+        )
+        .await
+        .context("reproject Claude interview")?;
     println!(
         "reprojected Claude interview: session={} revision={} version={}",
         args.session_key, result.revision, result.session_version

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/daemon.rs
@@ -219,6 +219,17 @@ impl DaemonClient {
         Ok(result.receipt)
     }
 
+    /// Rebuild one stale Claude interview through the live daemon.
+    pub async fn fleet_reproject_claude_interview(
+        &self,
+        params: ainb_hangar_proto::fleet::FleetReprojectClaudeInterviewParams,
+    ) -> Result<ainb_hangar_proto::fleet::FleetReprojectClaudeInterviewResult, DaemonError> {
+        let value =
+            serde_json::to_value(params).expect("FleetReprojectClaudeInterviewParams serializes");
+        let result = self.call(methods::FLEET_REPROJECT_CLAUDE_INTERVIEW, value).await?;
+        serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))
+    }
+
     /// Broadcast text to explicit stable Fleet targets.
     pub async fn fleet_broadcast(
         &self,

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -188,6 +188,60 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         }),
         4_000_000_000_300,
     );
+    // Claude emits both of these around AskUserQuestion. They must not
+    // downgrade the active structured interview to WAITING.
+    hangar.apply_hook(
+        "fleet-panel-ask-permission",
+        "fleet-panel-ask-1",
+        &home_tmp.path().join("fleet-tripwire-project"),
+        "PermissionRequest",
+        serde_json::json!({
+            "matcher": "AskUserQuestion",
+            "payload": {
+                "tool_input": {
+                    "questions": [
+                        {
+                            "id": "scope",
+                            "question": "What release scope should Fleet use?",
+                            "header": "Scope",
+                            "options": [
+                                {"label": "Focused", "description": "ship only verified Fleet work"},
+                                {"label": "Broad", "description": "include adjacent changes"}
+                            ]
+                        },
+                        {
+                            "id": "validation",
+                            "question": "Which proof should gate launch?",
+                            "header": "Validation",
+                            "multiSelect": true,
+                            "options": [
+                                {"label": "Tests", "description": "run targeted Rust coverage"},
+                                {"label": "Tripwire", "description": "capture live terminal truth"}
+                            ]
+                        },
+                        {
+                            "id": "rollout",
+                            "question": "When should the release launch?",
+                            "header": "Rollout",
+                            "options": [
+                                {"label": "Now", "description": "start after proof completes"},
+                                {"label": "Later", "description": "hold for a manual window"}
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+        4_000_000_000_301,
+    );
+    hangar.apply_hook(
+        "fleet-panel-ask-notification",
+        "fleet-panel-ask-1",
+        &home_tmp.path().join("fleet-tripwire-project"),
+        "Notification",
+        serde_json::json!({ "payload": { "notification_type": "permission_prompt" } }),
+        4_000_000_000_302,
+    );
     hangar.apply_hook(
         "fleet-panel-wait",
         "fleet-panel-wait-1",

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -1663,13 +1663,7 @@ fn claude_questions(payload: &Value) -> Option<&Vec<Value>> {
 
 fn claude_permission_identity(payload: &Value) -> Option<(String, String)> {
     let hook = payload.get("payload").unwrap_or(payload);
-    let tool = payload
-        .get("matcher")
-        .or_else(|| hook.get("tool_name"))
-        .or_else(|| hook.get("tool"))
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
+    let tool = claude_hook_tool_name(payload).unwrap_or_default().to_string();
     let context = hook
         .get("tool_input")
         .or_else(|| hook.get("input"))

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -54,6 +54,16 @@ pub async fn apply_hook(
     let provider = parse_provider(observation.provider);
     let session_key = SessionKey::managed(provider, observation.provider_session_id);
     let source_event_id = observation.event_id.clone();
+    // Claude emits a PermissionRequest and then a generic notification around an
+    // AskUserQuestion. They describe the same picker, not two operator actions.
+    let event_type = canonical_hook_event_type(observation.event_type, observation.payload);
+    let preserve_active_request = observation.event_type == "Notification"
+        && FleetRepo::get_session(pool, session_key.as_str())
+            .await?
+            .is_some_and(|session| {
+                matches!(session.attention_state.as_str(), "ASK" | "APPROVAL")
+                    && session.current_request_fingerprint.is_some()
+            });
     let tmux_target = observation
         .payload
         .get("tmux_target")
@@ -67,11 +77,14 @@ pub async fn apply_hook(
         .filter(|value| !value.is_empty())
         .map(str::to_string);
     let exact_tmux_identity = tmux_target.is_some() && process_start_fingerprint.is_some();
-    let (lifecycle_state, attention_state) =
-        states_for_hook(observation.event_type, observation.payload);
+    let (lifecycle_state, attention_state) = if preserve_active_request {
+        (None, None)
+    } else {
+        states_for_hook(event_type, observation.payload)
+    };
     let request_fingerprint = match attention_state {
         Some(AttentionState::Ask | AttentionState::Approval) => {
-            let fingerprint = match (provider, observation.event_type) {
+            let fingerprint = match (provider, event_type) {
                 (Provider::Claude, "AskUserQuestion") => {
                     claude_request_identity(observation.payload).map_or_else(
                         || fingerprint_value(observation.payload),
@@ -98,7 +111,7 @@ pub async fn apply_hook(
         session_key: session_key.to_string(),
         observed_at: observation.observed_at,
         authority: ObservationAuthority::Authoritative,
-        event_type: observation.event_type.to_string(),
+        event_type: event_type.to_string(),
         payload: serde_json::to_string(observation.payload).unwrap_or_else(|_| "{}".to_string()),
         patch: FleetSessionPatch {
             provider: Some(provider.as_str().to_string()),
@@ -1386,6 +1399,25 @@ fn states_for_hook(
     }
 }
 
+fn canonical_hook_event_type<'a>(event_type: &'a str, payload: &Value) -> &'a str {
+    if event_type == "PermissionRequest"
+        && claude_hook_tool_name(payload) == Some("AskUserQuestion")
+    {
+        "AskUserQuestion"
+    } else {
+        event_type
+    }
+}
+
+fn claude_hook_tool_name(payload: &Value) -> Option<&str> {
+    let hook = payload.get("payload").unwrap_or(payload);
+    payload
+        .get("matcher")
+        .or_else(|| hook.get("tool_name"))
+        .or_else(|| hook.get("tool"))
+        .and_then(Value::as_str)
+}
+
 fn has_active_background_work(payload: &Value) -> bool {
     let hook = payload.get("payload").unwrap_or(payload);
     [
@@ -1826,6 +1858,74 @@ mod tests {
             states_for_hook("SessionEnd", &serde_json::json!({})),
             (Some(LifecycleState::Exited), Some(AttentionState::None))
         );
+    }
+
+    #[tokio::test]
+    async fn claude_interview_stays_answerable_through_permission_notification() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let question = serde_json::json!({
+            "questions": [{
+                "question": "When?",
+                "options": [{"label": "August"}]
+            }]
+        });
+        let ask = serde_json::json!({ "payload": { "tool_input": question.clone() } });
+
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "ask".into(),
+                provider: "claude",
+                provider_session_id: "session-1",
+                cwd: "/repo",
+                event_type: "AskUserQuestion",
+                payload: &ask,
+                observed_at: 1,
+            },
+        )
+        .await
+        .unwrap();
+        let expected = FleetRepo::get_session(store.pool(), "claude:session-1")
+            .await
+            .unwrap()
+            .unwrap()
+            .current_request_fingerprint;
+
+        let permission = serde_json::json!({
+            "matcher": "AskUserQuestion",
+            "payload": { "tool_input": question.clone() }
+        });
+        let notification = serde_json::json!({
+            "payload": { "notification_type": "permission_prompt" }
+        });
+        for (event_id, event_type, payload, observed_at) in [
+            ("permission", "PermissionRequest", &permission, 2),
+            ("notification", "Notification", &notification, 3),
+        ] {
+            apply_hook(
+                store.pool(),
+                &sink,
+                HookObservation {
+                    event_id: event_id.into(),
+                    provider: "claude",
+                    provider_session_id: "session-1",
+                    cwd: "/repo",
+                    event_type,
+                    payload,
+                    observed_at,
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        let session =
+            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
+        assert_eq!(session.attention_state, "ASK");
+        assert_eq!(session.current_request_fingerprint, expected);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -93,7 +93,9 @@ pub async fn reproject_claude_interview(
         .await?
         .ok_or_else(|| FleetReprojectError::SessionNotFound(session_key.to_string()))?;
     if session.provider != "claude" || session.management_state != "MANAGED" {
-        return Err(FleetReprojectError::NotManagedClaude(session_key.to_string()));
+        return Err(FleetReprojectError::NotManagedClaude(
+            session_key.to_string(),
+        ));
     }
     if session.version != expected_version {
         return Err(FleetReprojectError::StaleVersion {
@@ -131,12 +133,14 @@ pub async fn reproject_claude_interview(
         }
     }
     let Some((source_event_id, payload)) = active_request else {
-        return Err(FleetReprojectError::NoRecoverableInterview(session_key.to_string()));
+        return Err(FleetReprojectError::NoRecoverableInterview(
+            session_key.to_string(),
+        ));
     };
     let fingerprint = claude_request_identity(&payload)
         .map(|identity| ainb_plugin_notifyd::broker::request_fingerprint(&identity))
         .ok_or_else(|| FleetReprojectError::NoRecoverableInterview(session_key.to_string()))?;
-    let result = FleetRepo::apply_event(
+    let result = FleetRepo::apply_event_if_version(
         pool,
         &NewFleetEvent {
             event_id: format!("fleet-reproject:{session_key}:{source_event_id}"),
@@ -152,8 +156,20 @@ pub async fn reproject_claude_interview(
                 ..FleetSessionPatch::default()
             },
         },
+        expected_version,
     )
-    .await?;
+    .await
+    .map_err(|error| match error {
+        FleetRepoError::StaleVersion { actual, .. } => FleetReprojectError::StaleVersion {
+            session_key: session_key.to_string(),
+            expected: expected_version,
+            actual,
+        },
+        FleetRepoError::SessionNotFound { .. } => {
+            FleetReprojectError::SessionNotFound(session_key.to_string())
+        }
+        error => FleetReprojectError::Store(error),
+    })?;
     if !result.duplicate {
         events.emit_fleet_revision(result.revision);
     }
@@ -2056,7 +2072,8 @@ mod tests {
     async fn reproject_claude_interview_recovers_old_waiting_projection() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
-        let sink = EventBroker::new().sink();
+        let broker = EventBroker::new();
+        let sink = broker.sink();
         let question = serde_json::json!({
             "questions": [{
                 "question": "When?",
@@ -2122,28 +2139,24 @@ mod tests {
             .await
             .unwrap();
         }
-        let stale = FleetRepo::get_session(store.pool(), "claude:session-1")
-            .await
-            .unwrap()
-            .unwrap();
+        let stale =
+            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
         assert_eq!(stale.attention_state, "WAITING");
+        let mut revisions = broker.subscribe_fleet();
 
-        let result = reproject_claude_interview(
-            store.pool(),
-            &sink,
-            "claude:session-1",
-            stale.version,
-            4,
-        )
-        .await
-        .unwrap();
+        let result =
+            reproject_claude_interview(store.pool(), &sink, "claude:session-1", stale.version, 4)
+                .await
+                .unwrap();
         assert!(!result.duplicate);
-        let projection = FleetRepo::subscription_projection(store.pool(), 0, 100)
-            .await
-            .unwrap();
+        assert_eq!(revisions.recv().await.unwrap(), result.revision);
+        let projection = FleetRepo::subscription_projection(store.pool(), 0, 100).await.unwrap();
         let restored = &projection.sessions[0];
         assert_eq!(restored.session.attention_state, "ASK");
-        assert_eq!(restored.current_request.as_ref().unwrap()["payload"]["tool_input"]["questions"][0]["question"], "When?");
+        assert_eq!(
+            restored.current_request.as_ref().unwrap()["payload"]["tool_input"]["questions"][0]["question"],
+            "When?"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -45,6 +45,121 @@ pub struct HookObservation<'a> {
     pub observed_at: i64,
 }
 
+/// Reprojecting an old Claude interview failed its explicit safety gate.
+#[derive(Debug, thiserror::Error)]
+pub enum FleetReprojectError {
+    /// Session was absent.
+    #[error("Fleet session {0:?} was not found")]
+    SessionNotFound(String),
+    /// Recovery only accepts managed Claude sessions.
+    #[error("Fleet session {0:?} is not a managed Claude session")]
+    NotManagedClaude(String),
+    /// Caller must pin the version inspected before mutation.
+    #[error("Fleet session {session_key:?} version is {actual}, expected {expected}")]
+    StaleVersion {
+        /// Target session.
+        session_key: String,
+        /// Version supplied by caller.
+        expected: i64,
+        /// Current version.
+        actual: i64,
+    },
+    /// Only a stale waiting projection may be recovered.
+    #[error("Fleet session {0:?} is not waiting for recovery")]
+    NotWaiting(String),
+    /// Durable history has no unresolved structured interview.
+    #[error("Fleet session {0:?} has no recoverable Claude interview")]
+    NoRecoverableInterview(String),
+    /// Store failure.
+    #[error(transparent)]
+    Store(#[from] FleetRepoError),
+    /// Query failure.
+    #[error(transparent)]
+    Sql(#[from] sqlx::Error),
+}
+
+/// Rebuild one stale Claude interview from its durable hook history.
+///
+/// This only appends a canonical recovery event. It never calls the broker,
+/// writes to tmux, or sends a provider response.
+pub async fn reproject_claude_interview(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session_key: &str,
+    expected_version: i64,
+    observed_at: i64,
+) -> Result<ApplyFleetEventResult, FleetReprojectError> {
+    let session = FleetRepo::get_session(pool, session_key)
+        .await?
+        .ok_or_else(|| FleetReprojectError::SessionNotFound(session_key.to_string()))?;
+    if session.provider != "claude" || session.management_state != "MANAGED" {
+        return Err(FleetReprojectError::NotManagedClaude(session_key.to_string()));
+    }
+    if session.version != expected_version {
+        return Err(FleetReprojectError::StaleVersion {
+            session_key: session_key.to_string(),
+            expected: expected_version,
+            actual: session.version,
+        });
+    }
+    if session.attention_state != "WAITING" {
+        return Err(FleetReprojectError::NotWaiting(session_key.to_string()));
+    }
+
+    let mut active_request = None;
+    for event in FleetRepo::events_for_session(pool, session_key).await? {
+        if event.event_id.starts_with("fleet-reproject:") {
+            continue;
+        }
+        let Ok(payload) = serde_json::from_str::<Value>(&event.payload) else {
+            continue;
+        };
+        let event_type = canonical_hook_event_type(&event.event_type, &payload);
+        let (_, attention) = states_for_hook(event_type, &payload);
+        match attention {
+            Some(AttentionState::Ask)
+                if claude_request_identity(&payload).is_some()
+                    && claude_questions(&payload).is_some() =>
+            {
+                active_request = Some((event.event_id, payload));
+            }
+            // A generic notification caused the original lost projection. It
+            // carries no provider completion signal, so it cannot invalidate
+            // an earlier unresolved interview.
+            Some(AttentionState::Waiting) | None => {}
+            Some(_) => active_request = None,
+        }
+    }
+    let Some((source_event_id, payload)) = active_request else {
+        return Err(FleetReprojectError::NoRecoverableInterview(session_key.to_string()));
+    };
+    let fingerprint = claude_request_identity(&payload)
+        .map(|identity| ainb_plugin_notifyd::broker::request_fingerprint(&identity))
+        .ok_or_else(|| FleetReprojectError::NoRecoverableInterview(session_key.to_string()))?;
+    let result = FleetRepo::apply_event(
+        pool,
+        &NewFleetEvent {
+            event_id: format!("fleet-reproject:{session_key}:{source_event_id}"),
+            session_key: session_key.to_string(),
+            observed_at,
+            authority: ObservationAuthority::Authoritative,
+            event_type: "AskUserQuestion".to_string(),
+            payload: serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string()),
+            patch: FleetSessionPatch {
+                lifecycle_state: Some(state_token(LifecycleState::Idle)),
+                attention_state: Some(attention_token(AttentionState::Ask)),
+                current_request_fingerprint: Some(Some(fingerprint)),
+                ..FleetSessionPatch::default()
+            },
+        },
+    )
+    .await?;
+    if !result.duplicate {
+        events.emit_fleet_revision(result.revision);
+    }
+    Ok(result)
+}
+
 /// Apply one exact provider hook and wake revision subscribers after commit.
 pub async fn apply_hook(
     pool: &SqlitePool,
@@ -1521,6 +1636,15 @@ fn claude_request_identity(payload: &Value) -> Option<Value> {
     }))
 }
 
+fn claude_questions(payload: &Value) -> Option<&Vec<Value>> {
+    let hook = payload.get("payload").unwrap_or(payload);
+    hook.get("tool_input")
+        .or_else(|| hook.get("input"))?
+        .get("questions")?
+        .as_array()
+        .filter(|questions| !questions.is_empty())
+}
+
 fn claude_permission_identity(payload: &Value) -> Option<(String, String)> {
     let hook = payload.get("payload").unwrap_or(payload);
     let tool = payload
@@ -1926,6 +2050,100 @@ mod tests {
             FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
         assert_eq!(session.attention_state, "ASK");
         assert_eq!(session.current_request_fingerprint, expected);
+    }
+
+    #[tokio::test]
+    async fn reproject_claude_interview_recovers_old_waiting_projection() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let question = serde_json::json!({
+            "questions": [{
+                "question": "When?",
+                "options": [{"label": "August"}]
+            }]
+        });
+        let ask = serde_json::json!({ "payload": { "tool_input": question.clone() } });
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "ask".into(),
+                provider: "claude",
+                provider_session_id: "session-1",
+                cwd: "/repo",
+                event_type: "AskUserQuestion",
+                payload: &ask,
+                observed_at: 1,
+            },
+        )
+        .await
+        .unwrap();
+
+        let permission = serde_json::json!({
+            "matcher": "AskUserQuestion",
+            "payload": { "tool_input": question.clone() }
+        });
+        for (event_id, event_type, payload, patch, observed_at) in [
+            (
+                "old-permission",
+                "PermissionRequest",
+                permission,
+                FleetSessionPatch {
+                    attention_state: Some("APPROVAL".to_string()),
+                    current_request_fingerprint: Some(Some("fnv1a64:old".to_string())),
+                    ..FleetSessionPatch::default()
+                },
+                2,
+            ),
+            (
+                "old-notification",
+                "Notification",
+                serde_json::json!({ "payload": { "notification_type": "permission_prompt" } }),
+                FleetSessionPatch {
+                    attention_state: Some("WAITING".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+                3,
+            ),
+        ] {
+            FleetRepo::apply_event(
+                store.pool(),
+                &NewFleetEvent {
+                    event_id: event_id.to_string(),
+                    session_key: "claude:session-1".to_string(),
+                    observed_at,
+                    authority: ObservationAuthority::Authoritative,
+                    event_type: event_type.to_string(),
+                    payload: serde_json::to_string(&payload).unwrap(),
+                    patch,
+                },
+            )
+            .await
+            .unwrap();
+        }
+        let stale = FleetRepo::get_session(store.pool(), "claude:session-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stale.attention_state, "WAITING");
+
+        let result = reproject_claude_interview(
+            store.pool(),
+            &sink,
+            "claude:session-1",
+            stale.version,
+            4,
+        )
+        .await
+        .unwrap();
+        assert!(!result.duplicate);
+        let projection = FleetRepo::subscription_projection(store.pool(), 0, 100)
+            .await
+            .unwrap();
+        let restored = &projection.sessions[0];
+        assert_eq!(restored.session.attention_state, "ASK");
+        assert_eq!(restored.current_request.as_ref().unwrap()["payload"]["tool_input"]["questions"][0]["question"], "When?");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -929,6 +929,9 @@ async fn handle(
         methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
         methods::FLEET_START => handle_fleet_start(pool, req, events).await,
         methods::FLEET_TIMELINE => handle_fleet_timeline(pool, req).await,
+        methods::FLEET_REPROJECT_CLAUDE_INTERVIEW => {
+            handle_fleet_reproject_claude_interview(pool, req, events).await
+        }
         methods::ATTENTION_LIST => handle_attention_list(pool, req).await,
         // `attention/subscribe` acks with the current OPEN snapshot; the live
         // fleet-wide forwarder is the stream side (see `serve_conn`).
@@ -1047,6 +1050,41 @@ async fn handle_fleet_action(
         parse_params(req, "{ session_key, expected_version, request_id, action }")?;
     let receipt = execute_fleet_action(pool, params, None, events).await?;
     to_value(&ainb_hangar_proto::fleet::FleetActionResult { receipt })
+}
+
+/// Rebuild one stale Claude interview and publish its committed revision.
+async fn handle_fleet_reproject_claude_interview(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+    events: &EventSink,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{
+        FleetReprojectClaudeInterviewParams, FleetReprojectClaudeInterviewResult,
+    };
+
+    let params: FleetReprojectClaudeInterviewParams =
+        parse_params(req, "{ session_key, expected_version }")?;
+    if params.session_key.trim().is_empty() {
+        return Err(invalid_params("session_key must not be empty"));
+    }
+    if params.expected_version < 0 {
+        return Err(invalid_params("expected_version must be non-negative"));
+    }
+    let result = crate::fleet::reproject_claude_interview(
+        pool,
+        events,
+        &params.session_key,
+        params.expected_version,
+        SystemClock.now_ms(),
+    )
+    .await
+    .map_err(fleet_reproject_err)?;
+    to_value(&FleetReprojectClaudeInterviewResult {
+        revision: result.revision,
+        session_version: result.session_version,
+        applied: result.applied,
+        duplicate: result.duplicate,
+    })
 }
 
 const FLEET_RECEIPT_LIST_MAX: u32 = 100;
@@ -2943,6 +2981,14 @@ fn fleet_repo_err(error: ainb_hangar_store::repo::fleet::FleetRepoError) -> RpcE
         | FleetRepoError::RequestFingerprintMismatch { .. }
         | FleetRepoError::ReceiptCollision { .. }
         | FleetRepoError::EventIdCollision { .. } => invalid_params(&error.to_string()),
+    }
+}
+
+fn fleet_reproject_err(error: crate::fleet::FleetReprojectError) -> RpcError {
+    match error {
+        crate::fleet::FleetReprojectError::Sql(error) => store_err(&error),
+        crate::fleet::FleetReprojectError::Store(error) => fleet_repo_err(error),
+        error => invalid_params(&error.to_string()),
     }
 }
 
@@ -9313,6 +9359,58 @@ mod tests {
             method: method.into(),
             params,
         }
+    }
+
+    #[tokio::test]
+    async fn fleet_reproject_uses_daemon_broker_for_live_revision() {
+        use ainb_hangar_proto::fleet::{
+            FleetReprojectClaudeInterviewParams, FleetReprojectClaudeInterviewResult,
+        };
+        use ainb_hangar_store::repo::fleet::{
+            FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let source = NewFleetEvent {
+            event_id: "ask".to_string(),
+            session_key: "claude:session-1".to_string(),
+            observed_at: 1,
+            authority: ObservationAuthority::Authoritative,
+            event_type: "AskUserQuestion".to_string(),
+            payload: serde_json::json!({
+                "payload": { "tool_input": { "questions": [{ "question": "When?" }] } }
+            })
+            .to_string(),
+            patch: FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                management_state: Some("MANAGED".to_string()),
+                attention_state: Some("WAITING".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        };
+        let stale = FleetRepo::apply_event(store.pool(), &source).await.unwrap();
+        let broker = EventBroker::new();
+        let mut revisions = broker.subscribe_fleet();
+        let response = dispatch(
+            store.pool(),
+            &req(
+                methods::FLEET_REPROJECT_CLAUDE_INTERVIEW,
+                serde_json::to_value(FleetReprojectClaudeInterviewParams {
+                    session_key: "claude:session-1".to_string(),
+                    expected_version: stale.session_version,
+                })
+                .unwrap(),
+            ),
+            &health(),
+            &broker.sink(),
+        )
+        .await;
+
+        assert!(response.error.is_none(), "{response:?}");
+        let result: FleetReprojectClaudeInterviewResult =
+            serde_json::from_value(response.result.unwrap()).unwrap();
+        assert_eq!(revisions.recv().await.unwrap(), result.revision);
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -671,6 +671,28 @@ pub struct FleetActionResult {
     pub receipt: FleetActionReceipt,
 }
 
+/// Parameters for `fleet/reproject_claude_interview`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReprojectClaudeInterviewParams {
+    /// Exact managed Claude session to recover.
+    pub session_key: String,
+    /// Version observed before requesting recovery.
+    pub expected_version: i64,
+}
+
+/// Result for `fleet/reproject_claude_interview`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReprojectClaudeInterviewResult {
+    /// Durable Fleet revision of the recovery event.
+    pub revision: i64,
+    /// Session version after recovery.
+    pub session_version: i64,
+    /// Whether recovery changed canonical state.
+    pub applied: bool,
+    /// Whether this request reused a prior recovery event.
+    pub duplicate: bool,
+}
+
 /// Parameters for `fleet/receipt_list`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetReceiptListParams {

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -410,6 +410,8 @@ pub const FLEET_RECEIPT_GET: &str = "fleet/receipt_get";
 pub const FLEET_START: &str = "fleet/start";
 /// Read bounded, payload-free Fleet revision timeline entries.
 pub const FLEET_TIMELINE: &str = "fleet/timeline";
+/// Rebuild one stale Claude interview through the live daemon broker.
+pub const FLEET_REPROJECT_CLAUDE_INTERVIEW: &str = "fleet/reproject_claude_interview";
 
 /// Fleet notifications emitted by the daemon, never JSON-RPC request methods.
 pub const FLEET_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &["fleet/resync_required"];
@@ -1657,6 +1659,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_RECEIPT_GET,
     FLEET_START,
     FLEET_TIMELINE,
+    FLEET_REPROJECT_CLAUDE_INTERVIEW,
     // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
     // tail, append-only wire.
     HANGAR_DISPATCH_ATTEMPTS_LIST,
@@ -1937,6 +1940,7 @@ mod tests {
             FLEET_RECEIPT_GET,
             FLEET_START,
             FLEET_TIMELINE,
+            FLEET_REPROJECT_CLAUDE_INTERVIEW,
             HANGAR_DISPATCH_ATTEMPTS_LIST,
             HANGAR_ISSUE_TIMELINE,
             HANGAR_PROPERTIES_LIST,

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -644,6 +644,22 @@ impl FleetRepo {
         rows.iter().map(event_from_row).collect()
     }
 
+    /// Read one session's durable event history in projection order.
+    pub async fn events_for_session(
+        pool: &SqlitePool,
+        session_key: &str,
+    ) -> Result<Vec<FleetEventRow>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT revision, event_id, session_key, observed_at, authority, event_type, \
+                    payload, session_version, applied \
+             FROM fleet_event WHERE session_key = ? ORDER BY revision ASC",
+        )
+        .bind(session_key)
+        .fetch_all(pool)
+        .await?;
+        rows.iter().map(event_from_row).collect()
+    }
+
     /// Read a bounded, payload-free Fleet timeline after a global revision.
     ///
     /// The query joins visible Fleet sessions and filters the closed raw type

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -352,6 +352,27 @@ impl FleetRepo {
         pool: &SqlitePool,
         event: &NewFleetEvent,
     ) -> Result<ApplyFleetEventResult, FleetRepoError> {
+        Self::apply_event_at_version(pool, event, None).await
+    }
+
+    /// Apply one normalized event only if the existing session has `expected_version`.
+    ///
+    /// Duplicate event ids remain idempotent and return before the version gate.
+    /// This is for recovery mutations that must not overwrite a newer provider
+    /// observation between inspection and commit.
+    pub async fn apply_event_if_version(
+        pool: &SqlitePool,
+        event: &NewFleetEvent,
+        expected_version: i64,
+    ) -> Result<ApplyFleetEventResult, FleetRepoError> {
+        Self::apply_event_at_version(pool, event, Some(expected_version)).await
+    }
+
+    async fn apply_event_at_version(
+        pool: &SqlitePool,
+        event: &NewFleetEvent,
+        expected_version: Option<i64>,
+    ) -> Result<ApplyFleetEventResult, FleetRepoError> {
         let mut tx = pool.begin().await?;
 
         if let Some(prior) = event_by_id(&mut tx, &event.event_id).await? {
@@ -375,6 +396,21 @@ impl FleetRepo {
         }
 
         let prior = session_by_key_tx(&mut tx, &event.session_key).await?;
+        if let Some(expected) = expected_version {
+            let actual = prior
+                .as_ref()
+                .ok_or_else(|| FleetRepoError::SessionNotFound {
+                    session_key: event.session_key.clone(),
+                })?
+                .version;
+            if actual != expected {
+                return Err(FleetRepoError::StaleVersion {
+                    session_key: event.session_key.clone(),
+                    expected,
+                    actual,
+                });
+            }
+        }
         let is_new = prior.is_none();
         let (mut session, changed) = match prior {
             Some(mut row) => {
@@ -1254,6 +1290,51 @@ mod tests {
         assert_eq!(
             FleetRepo::events_after(store.pool(), 0, 100).await.unwrap().len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn version_guard_rejects_recovery_after_newer_observation() {
+        let (_dir, store) = store().await;
+        let created = FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-created",
+                "claude:s-1",
+                100,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    attention_state: Some("WAITING".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+        let recovery = event(
+            "e-recovery",
+            "claude:s-1",
+            200,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                attention_state: Some("ASK".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+
+        assert!(matches!(
+            FleetRepo::apply_event_if_version(
+                store.pool(),
+                &recovery,
+                created.session_version + 1,
+            )
+            .await,
+            Err(FleetRepoError::StaleVersion { .. })
+        ));
+        assert_eq!(
+            FleetRepo::events_after(store.pool(), 0, 100).await.unwrap().len(),
+            1,
+            "stale recovery must append no event"
         );
     }
 

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -3478,15 +3478,16 @@ Inspect the Hangar control-plane daemon
 Usage: ainb hangar daemon [OPTIONS] <COMMAND>
 
 Commands:
-  status   Report whether the daemon is running (PID file + socket) and the database is reachable
-  run      Run the daemon in the FOREGROUND (boot + claim loop until interrupted)
-  start    Start the daemon as a BACKGROUND child, recording its PID
-  stop     Stop the running daemon: signal the exact recorded PID, then remove the PID file
-  restart  Restart the daemon: `stop` (if running) then `start`
-  setup    One-command bring-up: ensure the store + socket-auth token, then `start`
-  config   View + edit the daemon's user-config knobs (`list`/`get`/`set`)
-  cred     Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
-  help     Print this message or the help of the given subcommand(s)
+  status                      Report whether the daemon is running (PID file + socket) and the database is reachable
+  run                         Run the daemon in the FOREGROUND (boot + claim loop until interrupted)
+  start                       Start the daemon as a BACKGROUND child, recording its PID
+  stop                        Stop the running daemon: signal the exact recorded PID, then remove the PID file
+  restart                     Restart the daemon: `stop` (if running) then `start`
+  setup                       One-command bring-up: ensure the store + socket-auth token, then `start`
+  reproject-claude-interview  Rebuild one stale Claude structured interview from durable hook history
+  config                      View + edit the daemon's user-config knobs (`list`/`get`/`set`)
+  cred                        Manage the one-time, host-wide `claude` credential the daemon injects into confined headless runs (`status`/`set`/`clear`)
+  help                        Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -3597,6 +3598,29 @@ Usage: ainb hangar daemon setup [OPTIONS]
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
   -h, --help             Print help
+```
+
+#### `ainb hangar daemon reproject-claude-interview`
+
+Rebuild one stale Claude structured interview from durable hook history
+
+```console
+$ ainb hangar daemon reproject-claude-interview --help
+Rebuild one stale Claude structured interview from durable hook history
+
+Usage: ainb hangar daemon reproject-claude-interview [OPTIONS] --session-key <SESSION_KEY> --expected-version <EXPECTED_VERSION>
+
+Options:
+      --format <format>
+          Output format [default: text] [possible values: text, json, csv, markdown]
+      --session-key <SESSION_KEY>
+          Exact Fleet session key, for example `claude:<provider-session-id>`
+      --expected-version <EXPECTED_VERSION>
+          Exact version observed before this mutation. Rejects stale inspection
+      --apply
+          Required acknowledgement that this appends a recovery projection
+  -h, --help
+          Print help
 ```
 
 #### `ainb hangar daemon config`


### PR DESCRIPTION
- **fix: preserve Claude interview state**
- **test: cover Claude interview hook order**
- **fix: add Claude interview reprojection**
- **fix: route Claude recovery live**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to recover and reproject stale Claude interviews through the live daemon.
  * Recovery reports the resulting revision and session version, with safeguards against unintended changes.
  * Claude interview questions are now preserved and restored from durable event history when needed.

* **Bug Fixes**
  * Improved handling of Claude permission requests and related notifications.
  * Prevented stale recovery operations from creating duplicate or conflicting events.

* **Tests**
  * Added coverage for command parsing, recovery flows, event publication, and question preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->