### PR TITLE
feat: add Fleet interview answer queue

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3279,6 +3279,7 @@ impl EventHandler {
                 }
                 let action_label = match &action {
                     FleetAction::StructuredAnswer { .. } => "answered ask",
+                    FleetAction::DismissStructured { .. } => "rejected interview",
                     FleetAction::Approve { .. } => "approved request",
                     FleetAction::Deny { .. } => "denied request",
                     FleetAction::SendText { .. } => "sent prompt",

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -492,23 +492,23 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     send_key(&session, "Down");
     send_key(&session, "Space");
     demo_pause();
-    send_key(&session, "Tab");
+    send_key(&session, "Right");
     let tabbed = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
         c.contains("Rollout") && c.contains("When should the release launch?")
     });
     assert!(
         tabbed.is_some(),
-        "Tab did not move to Rollout:\n{}",
+        "Right arrow did not move to Rollout:\n{}",
         capture_pane(&session)
     );
     demo_pause();
     send_key(&session, "Enter");
     let answered = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
-        c.contains("answered ask: Delivered") && c.contains("claude structured hook broker")
+        c.contains("waiting for Fleet snapshot confirmation") && c.contains("STRUCTURED INTERVIEW")
     });
     let Some(answer_cap) = answered else {
         let last = capture_pane(&session);
-        panic!("Fleet answer dispatch feedback never rendered; last capture:\n---\n{last}\n---");
+        panic!("Fleet answer confirmation never rendered; last capture:\n---\n{last}\n---");
     };
     assert!(
         !answer_cap.contains("no live session matched"),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -1569,6 +1569,7 @@ fn managed_capabilities(provider: Provider) -> String {
     let broker = provider == Provider::Claude;
     serde_json::to_string(&ainb_hangar_proto::fleet::FleetCapabilities {
         structured_answer: broker,
+        structured_dismiss: broker,
         approvals: broker,
         send_prompt: false,
         continue_turn: false,
@@ -1601,6 +1602,7 @@ fn claude_managed_capabilities(exact_tmux_identity: bool) -> String {
 fn codex_managed_capabilities(capabilities: &CodexCapabilities) -> String {
     serde_json::to_string(&ainb_hangar_proto::fleet::FleetCapabilities {
         structured_answer: capabilities.request_user_input,
+        structured_dismiss: false,
         approvals: capabilities.approvals,
         send_prompt: true,
         continue_turn: true,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1497,6 +1497,10 @@ async fn execute_fleet_action(
             request_fingerprint,
             ..
         }
+        | ControlAction::DismissStructured {
+            request_fingerprint,
+            ..
+        }
         | ControlAction::Approve {
             request_fingerprint,
             ..
@@ -1622,6 +1626,12 @@ async fn execute_fleet_action(
                 } if session.provider == "claude" => {
                     execute_claude_structured(pool, &session, request_fingerprint, answers).await
                 }
+                ControlAction::DismissStructured {
+                    request_fingerprint,
+                    ..
+                } if session.provider == "claude" => {
+                    execute_claude_structured_dismiss(&session, request_fingerprint).await
+                }
                 ControlAction::Approve {
                     request_fingerprint,
                     ..
@@ -1650,6 +1660,7 @@ async fn execute_fleet_action(
                     }
                 }
                 ControlAction::StructuredAnswer { .. }
+                | ControlAction::DismissStructured { .. }
                 | ControlAction::Approve { .. }
                 | ControlAction::Deny { .. } => (
                     ActionReceiptStatus::Unknown,
@@ -2611,6 +2622,47 @@ async fn execute_claude_structured(
     }
 }
 
+async fn execute_claude_structured_dismiss(
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    request_fingerprint: &str,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    let session_id = session.provider_session_id.clone().unwrap_or_default();
+    let fingerprint = request_fingerprint.to_string();
+    let socket = match approve_socket_path() {
+        Ok(socket) => socket,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    match tokio::task::spawn_blocking(move || {
+        ainb_plugin_notifyd::broker::client_dismiss_structured(
+            &socket,
+            &session_id,
+            &fingerprint,
+            "rejected from Fleet",
+        )
+    })
+    .await
+    {
+        Ok(Ok(ack)) if ack.matched => (
+            ActionReceiptStatus::Delivered,
+            Some("claude structured rejection broker".to_string()),
+        ),
+        Ok(Ok(ack)) if ack.stale => (
+            ActionReceiptStatus::Failed,
+            Some("Claude structured request is stale".to_string()),
+        ),
+        Ok(Ok(ack)) => (
+            ActionReceiptStatus::Failed,
+            ack.error.or_else(|| Some("Claude request no longer waiting".to_string())),
+        ),
+        Ok(Err(error)) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+    }
+}
+
 fn approve_socket_path() -> std::io::Result<PathBuf> {
     #[cfg(any(test, feature = "test-support"))]
     if let Some(path) = APPROVE_SOCKET_OVERRIDE
@@ -2913,6 +2965,7 @@ fn action_capability(
     use ainb_hangar_proto::fleet::ControlAction;
     match action {
         ControlAction::StructuredAnswer { .. } => capabilities.structured_answer,
+        ControlAction::DismissStructured { .. } => capabilities.structured_dismiss,
         ControlAction::Approve { .. } | ControlAction::Deny { .. } => capabilities.approvals,
         ControlAction::VerifiedPicker { .. } => capabilities.verified_picker,
         ControlAction::SendPrompt { .. } => capabilities.send_prompt || capabilities.tmux_text,

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -194,6 +194,8 @@ pub enum FleetConfidence {
 pub struct FleetCapabilities {
     /// Answer exact structured provider requests.
     pub structured_answer: bool,
+    /// Reject an exact structured request without fabricating an answer.
+    pub structured_dismiss: bool,
     /// Approve or deny exact provider requests.
     pub approvals: bool,
     /// Send generic prompt text.
@@ -529,6 +531,14 @@ pub enum ControlAction {
         /// Complete ordered answers for all questions.
         answers: Vec<FleetQuestionAnswer>,
     },
+    /// Reject exact structured request when provider exposes a safe rejection route.
+    DismissStructured {
+        /// Provider request fingerprint verified against current state.
+        request_fingerprint: String,
+        /// Exact provider routing identity when provider protocol requires it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_identity: Option<FleetRequestIdentity>,
+    },
     /// Approve exact provider request.
     Approve {
         /// Provider request fingerprint verified against current state.
@@ -592,6 +602,7 @@ impl ControlAction {
     pub const fn kind(&self) -> &'static str {
         match self {
             Self::StructuredAnswer { .. } => "structured_answer",
+            Self::DismissStructured { .. } => "dismiss_structured",
             Self::Approve { .. } => "approve",
             Self::Deny { .. } => "deny",
             Self::VerifiedPicker { .. } => "verified_picker",
@@ -801,6 +812,24 @@ mod tests {
         assert_eq!(encoded["request_identity"]["request_id"], 41);
         assert_eq!(encoded["answers"][0]["question_id"], "q-1");
         assert_eq!(action.kind(), "structured_answer");
+    }
+
+    #[test]
+    fn structured_dismiss_preserves_exact_request_identity() {
+        let action = ControlAction::DismissStructured {
+            request_fingerprint: "sha256:request".to_string(),
+            request_identity: Some(FleetRequestIdentity {
+                request_id: serde_json::json!(41),
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-2".to_string(),
+                item_id: "item-3".to_string(),
+            }),
+        };
+        let encoded = serde_json::to_value(&action).unwrap();
+        assert_eq!(action.kind(), "dismiss_structured");
+        assert_eq!(encoded["action"], "dismiss_structured");
+        assert_eq!(encoded["request_fingerprint"], "sha256:request");
+        assert_eq!(encoded["request_identity"]["request_id"], 41);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -404,6 +404,10 @@ pub enum FleetAction {
         request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
         answers: Vec<ainb_hangar_proto::fleet::FleetQuestionAnswer>,
     },
+    DismissStructured {
+        request_fingerprint: String,
+        request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
+    },
     Approve {
         request_fingerprint: String,
         request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
@@ -442,6 +446,13 @@ impl FleetAction {
                 request_identity,
                 answers,
             },
+            Self::DismissStructured {
+                request_fingerprint,
+                request_identity,
+            } => ControlAction::DismissStructured {
+                request_fingerprint,
+                request_identity,
+            },
             Self::Approve {
                 request_fingerprint,
                 request_identity,
@@ -477,6 +488,7 @@ impl FleetAction {
     fn is_supported_by(&self, capabilities: &FleetCapabilities) -> bool {
         match self {
             Self::StructuredAnswer { .. } => capabilities.contains("structured_answer"),
+            Self::DismissStructured { .. } => capabilities.contains("structured_dismiss"),
             Self::Approve { .. } | Self::Deny { .. } => capabilities.contains("approvals"),
             Self::SendText { .. } => {
                 capabilities.contains("send_prompt") || capabilities.contains("tmux_text")
@@ -495,6 +507,7 @@ impl FleetAction {
     fn capability_label(&self) -> &'static str {
         match self {
             Self::StructuredAnswer { .. } => "structured_answer",
+            Self::DismissStructured { .. } => "structured_dismiss",
             Self::Approve { .. } | Self::Deny { .. } => "approvals",
             Self::SendText { .. } => "send_prompt or tmux_text",
             Self::VerifiedPicker { .. } => "verified_picker",
@@ -511,7 +524,10 @@ impl FleetAction {
     fn is_structured(&self) -> bool {
         matches!(
             self,
-            Self::StructuredAnswer { .. } | Self::Approve { .. } | Self::Deny { .. }
+            Self::StructuredAnswer { .. }
+                | Self::DismissStructured { .. }
+                | Self::Approve { .. }
+                | Self::Deny { .. }
         )
     }
 
@@ -585,6 +601,7 @@ impl Default for BroadcastState {
 enum FleetMode {
     Browse,
     Answer(AnswerState),
+    AnswerDismissConfirm(AnswerState),
     Start(StartState),
     Prompt {
         text: String,
@@ -629,6 +646,13 @@ struct AnswerState {
     selections: Vec<BTreeSet<usize>>,
     texts: Vec<String>,
     editing_text: bool,
+    delivery: AnswerDelivery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnswerDelivery {
+    Ready,
+    Confirming,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -758,8 +782,9 @@ impl FleetPaneState {
     }
 
     fn discard_stale_answer(&mut self) {
-        let FleetMode::Answer(answer) = &self.mode else {
-            return;
+        let answer = match &self.mode {
+            FleetMode::Answer(answer) | FleetMode::AnswerDismissConfirm(answer) => answer,
+            _ => return,
         };
         let fresh = self
             .roster
@@ -846,6 +871,17 @@ pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction
         FleetEvent::Key(key) => reduce_key(&mut next, key),
         FleetEvent::RequestAction(action) => request_action(&mut next, action),
         FleetEvent::ActionSucceeded { session_key } => {
+            if let FleetMode::Answer(answer) = &next.mode {
+                if answer.session_key == session_key
+                    && answer.delivery == AnswerDelivery::Confirming
+                {
+                    next.feedback = Some("delivered, confirming authoritative Fleet state".into());
+                    return FleetReduction {
+                        state: next,
+                        intent: None,
+                    };
+                }
+            }
             next.feedback = Some(format!("action succeeded: {session_key}"));
             select_next_needs_input(&mut next, &session_key);
             None
@@ -854,6 +890,11 @@ pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction
             session_key,
             detail,
         } => {
+            if let FleetMode::Answer(answer) = &mut next.mode {
+                if answer.session_key == session_key {
+                    answer.delivery = AnswerDelivery::Ready;
+                }
+            }
             next.feedback = Some(format!("action failed: {session_key}: {detail}"));
             None
         }
@@ -884,6 +925,7 @@ fn reduce_key(state: &mut FleetPaneState, key: FleetKey) -> Option<FleetIntent> 
     match state.mode.clone() {
         FleetMode::Browse => reduce_browse_key(state, key),
         FleetMode::Answer(answer) => reduce_answer_key(state, answer, key),
+        FleetMode::AnswerDismissConfirm(answer) => reduce_answer_dismiss_key(state, answer, key),
         FleetMode::Start(start) => reduce_start_key(state, start, key),
         FleetMode::Prompt { text } => reduce_prompt_key(state, text, key),
         FleetMode::Broadcast(broadcast) => reduce_broadcast_key(state, broadcast, key),
@@ -975,6 +1017,7 @@ fn begin_structured_answer(state: &mut FleetPaneState) {
         selections,
         texts,
         editing_text,
+        delivery: AnswerDelivery::Ready,
     });
 }
 
@@ -1075,20 +1118,39 @@ fn reduce_answer_key(
         state.mode = FleetMode::Browse;
         return None;
     }
+    if answer.delivery == AnswerDelivery::Confirming {
+        state.feedback = Some("waiting for authoritative Fleet state".into());
+        state.mode = FleetMode::Answer(answer);
+        return None;
+    }
+    if key == FleetKey::Char('x') {
+        let can_dismiss = state
+            .roster
+            .iter()
+            .find(|row| row.session_key == answer.session_key)
+            .is_some_and(|row| row.capabilities.contains("structured_dismiss"));
+        if can_dismiss {
+            state.mode = FleetMode::AnswerDismissConfirm(answer);
+        } else {
+            state.feedback = Some("provider does not expose safe interview dismissal".into());
+            state.mode = FleetMode::Answer(answer);
+        }
+        return None;
+    }
     let Some(question) = answer.questions.get(answer.question_index) else {
         state.mode = FleetMode::Browse;
         state.feedback = Some("structured question changed before answer".into());
         return None;
     };
     match key {
-        FleetKey::Tab => {
+        FleetKey::Tab | FleetKey::Right => {
             answer.question_index = (answer.question_index + 1) % answer.questions.len();
             answer.option_cursor = 0;
             answer.editing_text = answer.questions[answer.question_index].options.is_empty();
             state.mode = FleetMode::Answer(answer);
             return None;
         }
-        FleetKey::BackTab => {
+        FleetKey::BackTab | FleetKey::Left => {
             answer.question_index = answer
                 .question_index
                 .checked_sub(1)
@@ -1155,6 +1217,36 @@ fn reduce_answer_key(
     None
 }
 
+fn reduce_answer_dismiss_key(
+    state: &mut FleetPaneState,
+    mut answer: AnswerState,
+    key: FleetKey,
+) -> Option<FleetIntent> {
+    match key {
+        FleetKey::Esc => {
+            state.mode = FleetMode::Answer(answer);
+            None
+        }
+        FleetKey::Enter => {
+            answer.delivery = AnswerDelivery::Confirming;
+            let intent = FleetIntent::Execute {
+                session_key: answer.session_key.clone(),
+                expected_version: answer.expected_version,
+                action: FleetAction::DismissStructured {
+                    request_fingerprint: answer.request_fingerprint.clone(),
+                    request_identity: answer.request_identity.clone(),
+                },
+            };
+            state.mode = FleetMode::Answer(answer);
+            Some(intent)
+        }
+        _ => {
+            state.mode = FleetMode::AnswerDismissConfirm(answer);
+            None
+        }
+    }
+}
+
 fn advance_or_submit_answer(
     state: &mut FleetPaneState,
     mut answer: AnswerState,
@@ -1203,7 +1295,8 @@ fn advance_or_submit_answer(
             }
         })
         .collect();
-    state.mode = FleetMode::Browse;
+    answer.delivery = AnswerDelivery::Confirming;
+    state.mode = FleetMode::Answer(answer.clone());
     Some(FleetIntent::Execute {
         session_key: answer.session_key,
         expected_version: answer.expected_version,
@@ -2279,6 +2372,18 @@ fn render_mode(
     match &state.mode {
         FleetMode::Browse => {}
         FleetMode::Answer(answer) => render_interview(buffer, area_width, top, bottom, answer),
+        FleetMode::AnswerDismissConfirm(answer) => render_modal(
+            buffer,
+            area_width,
+            top,
+            bottom,
+            "Reject structured interview",
+            &[
+                format!("session: {}", answer.session_key),
+                "This returns a rejected result to Claude.".into(),
+                "Enter rejects, Esc returns to draft".into(),
+            ],
+        ),
         FleetMode::Start(start) => render_modal(
             buffer,
             area_width,
@@ -2364,7 +2469,14 @@ fn render_interview(
     let left = 2;
     let right = area_width.saturating_sub(2);
     let title_y = top.saturating_add(1);
-    put_str(buffer, left, title_y, "STRUCTURED INTERVIEW", GOLD, right);
+    put_str(
+        buffer,
+        left,
+        title_y,
+        "ANSWER QUEUE  ·  STRUCTURED INTERVIEW",
+        GOLD,
+        right,
+    );
     let answered = answer
         .questions
         .iter()
@@ -2434,7 +2546,16 @@ fn render_interview(
         y = y.saturating_add(1);
     }
     y = y.saturating_add(1);
-    if answer.editing_text {
+    if answer.delivery == AnswerDelivery::Confirming {
+        put_str(
+            buffer,
+            left,
+            y,
+            "● delivered, waiting for Fleet snapshot confirmation",
+            GOLD,
+            right,
+        );
+    } else if answer.editing_text {
         put_str(
             buffer,
             left,
@@ -2490,12 +2611,14 @@ fn render_interview(
     for x in left..right {
         put_char(buffer, x, bottom.saturating_sub(2), '─', BLUE);
     }
-    let help = if answer.editing_text {
-        "Type answer  Enter next  Tab question  Esc cancel"
+    let help = if answer.delivery == AnswerDelivery::Confirming {
+        "Refreshing authoritative state, Esc leaves queue"
+    } else if answer.editing_text {
+        "Type answer  Enter next  ←→ card  x reject  Esc leave"
     } else if question.multi_select {
-        "Up/Down move  Space toggle  Enter next  Tab question  Esc cancel"
+        "↑↓ move  Space toggle  Enter next  ←→ card  x reject  Esc leave"
     } else {
-        "Up/Down move  Enter next  o Other text  Tab question  Esc cancel"
+        "↑↓ move  Enter next  o Other text  ←→ card  x reject  Esc leave"
     };
     put_str(buffer, left, bottom.saturating_sub(1), help, MUTED, right);
 }
@@ -3085,16 +3208,16 @@ mod tests {
         state.set_sessions(vec![row]);
 
         state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
-        state = apply(&state, FleetEvent::Key(FleetKey::Tab)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Left)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Right)).state;
         state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
-        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
-        assert!(matches!(state.mode, FleetMode::Answer(_)));
-        assert_eq!(
-            state.feedback(),
-            Some("complete every interview question before submit")
-        );
-
-        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let FleetMode::Answer(answer) = &state.mode else {
+            panic!("arrow navigation must keep interview open");
+        };
+        assert_eq!(answer.question_index, 1);
+        assert_eq!(answer.selections[0], BTreeSet::from([0]));
+        assert_eq!(answer.selections[1], BTreeSet::from([0]));
         let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
         let Some(FleetIntent::Execute {
             action: FleetAction::StructuredAnswer { answers, .. },
@@ -3106,6 +3229,86 @@ mod tests {
         assert_eq!(answers.len(), 2);
         assert_eq!(answers[0].selected_options, ["Focused"]);
         assert_eq!(answers[1].selected_options, ["Tests"]);
+    }
+
+    #[test]
+    fn delivered_interview_stays_open_until_authoritative_snapshot_changes() {
+        let mut row = session("claude:confirm", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("before".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Continue?", "options": ["Yes"]}]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row.clone()]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+        let FleetMode::Answer(answer) = &submitted.state.mode else {
+            panic!("delivered interview must remain visible");
+        };
+        assert_eq!(answer.delivery, AnswerDelivery::Confirming);
+
+        let delivered = apply(
+            &submitted.state,
+            FleetEvent::ActionSucceeded {
+                session_key: "claude:confirm".into(),
+            },
+        )
+        .state;
+        assert!(matches!(delivered.mode, FleetMode::Answer(_)));
+        assert_eq!(
+            delivered.feedback(),
+            Some("delivered, confirming authoritative Fleet state")
+        );
+
+        row.current_request_fingerprint = Some("after".into());
+        row.version += 1;
+        let closed = apply(&delivered, FleetEvent::Snapshot(vec![row])).state;
+        assert!(matches!(closed.mode, FleetMode::Browse));
+    }
+
+    #[test]
+    fn claude_can_confirm_rejection_but_codex_cannot_fabricate_one() {
+        let mut claude = session("claude:reject", "claude", "IDLE", "ASK", "managed");
+        claude.current_request_fingerprint = Some("request".into());
+        claude.current_request = Some(serde_json::json!({
+            "tool_use_id": "tool-1",
+            "questions": [{"id": "q", "question": "Continue?", "options": ["Yes"]}]
+        }));
+        claude.capabilities = FleetCapabilities::List(
+            ["structured_answer", "structured_dismiss"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        );
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![claude]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let confirm = apply(&state, FleetEvent::Key(FleetKey::Char('x'))).state;
+        assert!(matches!(confirm.mode, FleetMode::AnswerDismissConfirm(_)));
+        let submitted = apply(&confirm, FleetEvent::Key(FleetKey::Enter));
+        assert!(matches!(
+            submitted.intent,
+            Some(FleetIntent::Execute {
+                action: FleetAction::DismissStructured { .. },
+                ..
+            })
+        ));
+
+        let mut codex = session("codex:reject", "codex", "IDLE", "ASK", "managed");
+        codex.current_request_fingerprint = Some("request".into());
+        codex.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Continue?", "options": ["Yes"]}]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![codex]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let refused = apply(&state, FleetEvent::Key(FleetKey::Char('x'))).state;
+        assert!(matches!(refused.mode, FleetMode::Answer(_)));
+        assert_eq!(
+            refused.feedback(),
+            Some("provider does not expose safe interview dismissal")
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -543,6 +543,47 @@ impl BrokerState {
             _ => StructuredAnswerAck::unmatched(),
         }
     }
+
+    /// Reject only the exact current structured request. This is deliberately
+    /// separate from answer validation: rejection must never fabricate values.
+    fn dismiss_structured(
+        &self,
+        session_id: &str,
+        request_fingerprint: &str,
+        reason: String,
+    ) -> StructuredAnswerAck {
+        let taken = {
+            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            let Some(pending) = map.get(session_id) else {
+                return StructuredAnswerAck::unmatched();
+            };
+            let PendingKind::Structured {
+                request_fingerprint: current,
+                ..
+            } = &pending.kind
+            else {
+                return StructuredAnswerAck::stale();
+            };
+            if current != request_fingerprint {
+                return StructuredAnswerAck::stale();
+            }
+            map.remove(session_id)
+        };
+
+        match taken {
+            Some(Pending {
+                kind: PendingKind::Structured { tx, .. },
+                ..
+            }) => {
+                if tx.send(StructuredResolution::Rejected { reason }).is_ok() {
+                    StructuredAnswerAck::matched()
+                } else {
+                    StructuredAnswerAck::unmatched()
+                }
+            }
+            _ => StructuredAnswerAck::unmatched(),
+        }
+    }
 }
 
 impl Default for BrokerState {
@@ -587,6 +628,13 @@ enum Request {
         session_id: String,
         request_fingerprint: String,
         answers: Vec<StructuredQuestionAnswer>,
+    },
+    /// Human rejects an exact current AskUserQuestion request.
+    #[serde(rename = "dismiss_structured")]
+    DismissStructured {
+        session_id: String,
+        request_fingerprint: String,
+        reason: String,
     },
     /// Dump the pending session ids.
     List,
@@ -699,6 +747,14 @@ async fn handle_connection(stream: UnixStream, state: BrokerState) -> Result<()>
             answers,
         } => {
             let ack = state.answer_structured(&session_id, &request_fingerprint, answers);
+            write_line(reader.get_mut(), &ack).await?;
+        }
+        Request::DismissStructured {
+            session_id,
+            request_fingerprint,
+            reason,
+        } => {
+            let ack = state.dismiss_structured(&session_id, &request_fingerprint, reason);
             write_line(reader.get_mut(), &ack).await?;
         }
         Request::List => {
@@ -888,6 +944,26 @@ pub fn client_answer_structured(
             "session_id": session_id,
             "request_fingerprint": request_fingerprint,
             "answers": answers,
+        }),
+    )?;
+    serde_json::from_value(response)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+/// Reject the current exact structured request without supplying an answer.
+pub fn client_dismiss_structured(
+    sock: &Path,
+    session_id: &str,
+    request_fingerprint: &str,
+    reason: &str,
+) -> std::io::Result<StructuredAnswerAck> {
+    let response = client_round_trip(
+        sock,
+        &serde_json::json!({
+            "op": "dismiss_structured",
+            "session_id": session_id,
+            "request_fingerprint": request_fingerprint,
+            "reason": reason,
         }),
     )?;
     serde_json::from_value(response)
@@ -1139,6 +1215,56 @@ mod tests {
             serde_json::from_str(round_trip(&sock, &answer_line).await.trim()).unwrap();
         assert!(!second.matched, "first structured answer must win");
         assert!(!second.stale);
+
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn structured_dismiss_rejects_only_the_exact_pending_request() {
+        let (sock, _state, handle) = spawn_broker(Duration::from_secs(30)).await;
+        let request = serde_json::json!({
+            "op": "await_structured",
+            "session_id": "ask-dismiss",
+            "request_fingerprint": "fnv1a64:current",
+            "questions": [{"question": "Continue?", "options": ["Yes"]}],
+        });
+        let waiter_sock = sock.clone();
+        let waiter = tokio::spawn(async move {
+            round_trip(&waiter_sock, &serde_json::to_string(&request).unwrap()).await
+        });
+        wait_for_pending(&sock, "ask-dismiss").await;
+
+        let stale: StructuredAnswerAck = serde_json::from_str(
+            round_trip(
+                &sock,
+                r#"{"op":"dismiss_structured","session_id":"ask-dismiss","request_fingerprint":"fnv1a64:stale","reason":"operator rejected"}"#,
+            )
+            .await
+            .trim(),
+        )
+        .unwrap();
+        assert!(stale.stale);
+
+        let accepted: StructuredAnswerAck = serde_json::from_str(
+            round_trip(
+                &sock,
+                r#"{"op":"dismiss_structured","session_id":"ask-dismiss","request_fingerprint":"fnv1a64:current","reason":"operator rejected"}"#,
+            )
+            .await
+            .trim(),
+        )
+        .unwrap();
+        assert!(accepted.matched);
+
+        let resolution: StructuredResolution =
+            serde_json::from_str(waiter.await.unwrap().trim()).unwrap();
+        assert_eq!(
+            resolution,
+            StructuredResolution::Rejected {
+                reason: "operator rejected".into()
+            }
+        );
 
         handle.abort();
         let _ = std::fs::remove_file(&sock);

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -245,6 +245,82 @@ final class FleetStore: ObservableObject {
         }
     }
 
+    func submitStructuredAnswers(_ answers: [FleetQuestionAnswer], on session: FleetSession) {
+        guard !answers.isEmpty else {
+            controlNotice = "Complete every interview question before submit."
+            return
+        }
+        performStructured(
+            .structuredAnswer(
+                requestFingerprint: session.currentRequestFingerprint ?? "",
+                requestIdentity: FleetRequestIdentity.from(request: session.currentRequest),
+                answers: answers
+            ),
+            on: session,
+            allowed: session.capabilities.structuredAnswer,
+            failurePrefix: "Interview"
+        )
+    }
+
+    func dismissStructuredInterview(on session: FleetSession) {
+        performStructured(
+            .dismissStructured(
+                requestFingerprint: session.currentRequestFingerprint ?? "",
+                requestIdentity: FleetRequestIdentity.from(request: session.currentRequest)
+            ),
+            on: session,
+            allowed: session.provider == .claude && session.capabilities.structuredDismiss,
+            failurePrefix: "Interview rejection"
+        )
+    }
+
+    private func performStructured(
+        _ action: ControlAction,
+        on session: FleetSession,
+        allowed: Bool,
+        failurePrefix: String
+    ) {
+        guard canWrite,
+              pendingIntentID == nil,
+              negotiation?.capabilityIDs.contains("fleet.action.execute") == true,
+              selectedSessionKey == session.sessionKey,
+              allowed,
+              !session.sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              session.version > 0,
+              let fingerprint = session.currentRequestFingerprint,
+              !fingerprint.isEmpty,
+              let connection else {
+            controlNotice = "Interview action is unavailable or stale."
+            return
+        }
+        guard let current = sessions.first(where: { $0.sessionKey == session.sessionKey }),
+              current.version == session.version,
+              current.currentRequestFingerprint == fingerprint else {
+            controlNotice = "Fleet interview changed. Review current question before sending."
+            return
+        }
+        let requestID = UUID().uuidString
+        pendingIntentID = requestID
+        controlNotice = nil
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.pendingIntentID = nil }
+            do {
+                let result = try await connection.action(FleetActionParams(
+                    sessionKey: current.sessionKey,
+                    expectedVersion: current.version,
+                    requestID: requestID,
+                    action: action
+                ))
+                self.record(result.receipt)
+                self.controlNotice = "Delivered. Confirming Fleet state."
+                await self.refreshAuthoritativeState(using: connection)
+            } catch {
+                self.controlNotice = "\(failurePrefix) refused: \(String(describing: error))"
+            }
+        }
+    }
+
     func start(provider: FleetProvider, cwd: String, prompt: String?) {
         let trimmedCWD = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
         guard canStart,

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -99,6 +99,33 @@ indirect enum JSONValue: Codable, Equatable {
     }
 }
 
+extension JSONValue {
+    var objectValue: [String: JSONValue]? {
+        guard case let .object(value) = self else { return nil }
+        return value
+    }
+
+    var arrayValue: [JSONValue]? {
+        guard case let .array(value) = self else { return nil }
+        return value
+    }
+
+    var stringValue: String? {
+        guard case let .string(value) = self else { return nil }
+        return value
+    }
+
+    var boolValue: Bool? {
+        guard case let .bool(value) = self else { return nil }
+        return value
+    }
+
+    func value(_ names: String...) -> JSONValue? {
+        guard let object = objectValue else { return nil }
+        return names.lazy.compactMap { object[$0] }.first
+    }
+}
+
 struct FleetProtocolRange: Codable, Equatable {
     let min: UInt32
     let max: UInt32
@@ -182,7 +209,63 @@ struct FleetCapabilities: Codable, Equatable {
     let tmuxAttach: Bool
     let tmuxText: Bool
     let verifiedPicker: Bool
-    private enum CodingKeys: String, CodingKey { case structuredAnswer = "structured_answer", approvals, sendPrompt = "send_prompt", continueTurn = "continue_turn", retry, interrupt, start, stop, restart, kill, archive, tmuxAttach = "tmux_attach", tmuxText = "tmux_text", verifiedPicker = "verified_picker" }
+    let structuredDismiss: Bool
+    private enum CodingKeys: String, CodingKey { case structuredAnswer = "structured_answer", approvals, sendPrompt = "send_prompt", continueTurn = "continue_turn", retry, interrupt, start, stop, restart, kill, archive, tmuxAttach = "tmux_attach", tmuxText = "tmux_text", verifiedPicker = "verified_picker", structuredDismiss = "structured_dismiss" }
+
+    init(
+        structuredAnswer: Bool,
+        approvals: Bool,
+        sendPrompt: Bool,
+        continueTurn: Bool,
+        retry: Bool,
+        interrupt: Bool,
+        start: Bool,
+        stop: Bool,
+        restart: Bool,
+        kill: Bool,
+        archive: Bool,
+        tmuxAttach: Bool,
+        tmuxText: Bool,
+        verifiedPicker: Bool,
+        structuredDismiss: Bool = false
+    ) {
+        self.structuredAnswer = structuredAnswer
+        self.approvals = approvals
+        self.sendPrompt = sendPrompt
+        self.continueTurn = continueTurn
+        self.retry = retry
+        self.interrupt = interrupt
+        self.start = start
+        self.stop = stop
+        self.restart = restart
+        self.kill = kill
+        self.archive = archive
+        self.tmuxAttach = tmuxAttach
+        self.tmuxText = tmuxText
+        self.verifiedPicker = verifiedPicker
+        self.structuredDismiss = structuredDismiss
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            structuredAnswer: try c.decodeIfPresent(Bool.self, forKey: .structuredAnswer) ?? false,
+            approvals: try c.decodeIfPresent(Bool.self, forKey: .approvals) ?? false,
+            sendPrompt: try c.decodeIfPresent(Bool.self, forKey: .sendPrompt) ?? false,
+            continueTurn: try c.decodeIfPresent(Bool.self, forKey: .continueTurn) ?? false,
+            retry: try c.decodeIfPresent(Bool.self, forKey: .retry) ?? false,
+            interrupt: try c.decodeIfPresent(Bool.self, forKey: .interrupt) ?? false,
+            start: try c.decodeIfPresent(Bool.self, forKey: .start) ?? false,
+            stop: try c.decodeIfPresent(Bool.self, forKey: .stop) ?? false,
+            restart: try c.decodeIfPresent(Bool.self, forKey: .restart) ?? false,
+            kill: try c.decodeIfPresent(Bool.self, forKey: .kill) ?? false,
+            archive: try c.decodeIfPresent(Bool.self, forKey: .archive) ?? false,
+            tmuxAttach: try c.decodeIfPresent(Bool.self, forKey: .tmuxAttach) ?? false,
+            tmuxText: try c.decodeIfPresent(Bool.self, forKey: .tmuxText) ?? false,
+            verifiedPicker: try c.decodeIfPresent(Bool.self, forKey: .verifiedPicker) ?? false,
+            structuredDismiss: try c.decodeIfPresent(Bool.self, forKey: .structuredDismiss) ?? false
+        )
+    }
 }
 
 struct FleetSession: Codable, Equatable {
@@ -304,8 +387,26 @@ struct FleetRequestIdentity: Codable, Equatable {
     private enum CodingKeys: String, CodingKey { case requestID = "request_id", threadID = "thread_id", turnID = "turn_id", itemID = "item_id" }
 }
 
+extension FleetRequestIdentity {
+    static func from(request: JSONValue?) -> FleetRequestIdentity? {
+        guard let request else { return nil }
+        let payload = request.value("payload") ?? request
+        let identity = payload.value("identity") ?? payload
+        guard let requestID = identity.value("requestId", "request_id", "tool_use_id", "id") else {
+            return nil
+        }
+        return FleetRequestIdentity(
+            requestID: requestID,
+            threadID: identity.value("threadId", "thread_id")?.stringValue ?? "",
+            turnID: identity.value("turnId", "turn_id")?.stringValue ?? "",
+            itemID: identity.value("itemId", "item_id")?.stringValue ?? ""
+        )
+    }
+}
+
 enum ControlAction: Codable, Equatable {
     case structuredAnswer(requestFingerprint: String, requestIdentity: FleetRequestIdentity?, answers: [FleetQuestionAnswer])
+    case dismissStructured(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case approve(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case deny(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case verifiedPicker(requestFingerprint: String, key: String)
@@ -315,12 +416,13 @@ enum ControlAction: Codable, Equatable {
     case restart, stop, kill, archive
 
     private enum CodingKeys: String, CodingKey { case action, requestFingerprint = "request_fingerprint", requestIdentity = "request_identity", answers, key, text, provider, cwd, prompt }
-    private enum Tag: String, Codable { case structuredAnswer = "structured_answer", approve, deny, verifiedPicker = "verified_picker", sendPrompt = "send_prompt", `continue`, retry, interrupt, start, restart, stop, kill, archive }
+    private enum Tag: String, Codable { case structuredAnswer = "structured_answer", dismissStructured = "dismiss_structured", approve, deny, verifiedPicker = "verified_picker", sendPrompt = "send_prompt", `continue`, retry, interrupt, start, restart, stop, kill, archive }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         switch try c.decode(Tag.self, forKey: .action) {
         case .structuredAnswer: self = .structuredAnswer(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity), answers: try c.decode([FleetQuestionAnswer].self, forKey: .answers))
+        case .dismissStructured: self = .dismissStructured(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .approve: self = .approve(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .deny: self = .deny(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .verifiedPicker: self = .verifiedPicker(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), key: try c.decode(String.self, forKey: .key))
@@ -341,6 +443,8 @@ enum ControlAction: Codable, Equatable {
         switch self {
         case let .structuredAnswer(fingerprint, identity, answers):
             try c.encode(Tag.structuredAnswer, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity); try c.encode(answers, forKey: .answers)
+        case let .dismissStructured(fingerprint, identity):
+            try c.encode(Tag.dismissStructured, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
         case let .approve(fingerprint, identity):
             try c.encode(Tag.approve, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
         case let .deny(fingerprint, identity):

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -10,6 +10,7 @@ struct FleetWindowView: View {
     @State private var broadcastPresented = false
     @State private var atcPresented = false
     @State private var timelinePresented = false
+    @State private var answerQueuePresented = false
 
     private var visibleSessions: [FleetSession] {
         FleetRosterPresentation.visibleSessions(
@@ -40,6 +41,7 @@ struct FleetWindowView: View {
         .sheet(isPresented: $atcPresented) { FleetATCList(store: store) }
         .sheet(isPresented: $timelinePresented) { FleetTimelineList(store: store) }
         .sheet(isPresented: $broadcastPresented) { FleetBroadcastForm(store: store, isPresented: $broadcastPresented) }
+        .sheet(isPresented: $answerQueuePresented) { FleetAnswerQueue(store: store) }
         .onAppear(perform: selectFirstVisibleSession)
         .onReceive(store.$sessions) { selectFirstVisibleSession(in: $0) }
         .onChange(of: presentation.filters) { _, _ in selectFirstVisibleSession() }
@@ -131,6 +133,9 @@ struct FleetWindowView: View {
             Button("Start") { startPresented = true }
                 .disabled(!store.canStart)
                 .accessibilityIdentifier("fleet.start.open")
+            Button("Answer queue \(interviewCount)") { answerQueuePresented = true }
+                .disabled(interviewCount == 0)
+                .accessibilityIdentifier("fleet.answer-queue.open")
             Menu {
                 Button("Receipts") { receiptsPresented = true }.disabled(!store.canReadReceipts)
                 Button("ATC") { atcPresented = true }.disabled(!store.canReadATC)
@@ -179,6 +184,10 @@ struct FleetWindowView: View {
         }
     }
 
+    private var interviewCount: Int {
+        store.sessions.filter { FleetInterviewDeck(session: $0) != nil }.count
+    }
+
     private func selectFirstVisibleSession() {
         selectFirstVisibleSession(in: visibleSessions)
     }
@@ -193,6 +202,273 @@ struct FleetWindowView: View {
         guard !matching.isEmpty,
               !matching.contains(where: { $0.sessionKey == store.selectedSessionKey }) else { return }
         store.selectedSessionKey = matching.first?.sessionKey
+    }
+}
+
+private struct FleetAnswerQueue: View {
+    @ObservedObject var store: FleetStore
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedSessionKey: String?
+    @State private var selectedQuestionIndex = 0
+    @State private var selections: [String: Set<String>] = [:]
+    @State private var textAnswers: [String: String] = [:]
+    @State private var rejectConfirmation = false
+
+    private var decks: [FleetInterviewDeck] {
+        store.sessions.compactMap(FleetInterviewDeck.init(session:)).sorted {
+            FleetInterviewDeck.priority($0.session) < FleetInterviewDeck.priority($1.session)
+        }
+    }
+
+    private var deck: FleetInterviewDeck? {
+        decks.first(where: { $0.session.sessionKey == selectedSessionKey }) ?? decks.first
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Answer Queue")
+                        .font(.title2.weight(.bold))
+                    Text("Priority ordered. Delivery stays visible until Fleet confirms state.")
+                        .font(.subheadline)
+                        .foregroundStyle(FleetPalette.muted)
+                }
+                Spacer()
+                Button("Done", action: dismiss.callAsFunction)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(decks, id: \.session.sessionKey) { item in
+                        Button {
+                            choose(item)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.session.displayName ?? item.session.sessionKey)
+                                    .font(.subheadline.weight(.semibold))
+                                    .lineLimit(1)
+                                Text("\(item.questions.count) questions · \(item.session.provider.rawValue.uppercased())")
+                                    .font(.caption)
+                                    .foregroundStyle(FleetPalette.muted)
+                            }
+                            .padding(12)
+                            .frame(width: 210, alignment: .leading)
+                            .background(
+                                item.session.sessionKey == deck?.session.sessionKey ? FleetPalette.selected : FleetPalette.control,
+                                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+
+            if let deck, let question = deck.questions[safe: selectedQuestionIndex] {
+                questionPanel(deck: deck, question: question)
+            } else {
+                ContentUnavailableView("No structured interviews", systemImage: "checkmark.circle")
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 760, minHeight: 560)
+        .background(FleetPalette.canvas)
+        .onAppear { choose(decks.first) }
+        .onChange(of: decks.map(\.session.sessionKey)) { _, _ in choose(deck) }
+    }
+
+    @ViewBuilder private func questionPanel(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(Array(deck.questions.enumerated()), id: \.element.id) { index, item in
+                        Button {
+                            selectedQuestionIndex = index
+                        } label: {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text("\(index + 1). \(item.header)")
+                                    .font(.caption.weight(.bold))
+                                Text(answered(deck: deck, question: item) ? "Answered" : "Needs answer")
+                                    .font(.caption2)
+                                    .foregroundStyle(answered(deck: deck, question: item) ? FleetPalette.mint : FleetPalette.amber)
+                            }
+                            .padding(10)
+                            .frame(width: 150, alignment: .leading)
+                            .background(index == selectedQuestionIndex ? FleetPalette.selected : FleetPalette.control, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+
+            Text(question.header).font(.title3.weight(.semibold))
+            Text(question.text).font(.body).fixedSize(horizontal: false, vertical: true)
+
+            if question.options.isEmpty {
+                TextField("Type answer", text: textBinding(deck: deck, question: question), axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(3...8)
+            } else {
+                ForEach(question.options, id: \.self) { option in
+                    Button {
+                        toggle(option, deck: deck, question: question)
+                    } label: {
+                        HStack {
+                            Image(systemName: isSelected(option, deck: deck, question: question)
+                                  ? (question.multiSelect ? "checkmark.square.fill" : "largecircle.fill.circle")
+                                  : (question.multiSelect ? "square" : "circle"))
+                            Text(option)
+                            Spacer()
+                        }
+                        .padding(10)
+                        .background(FleetPalette.control, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                }
+                if isSelected("Other", deck: deck, question: question) {
+                    TextField("Describe Other", text: textBinding(deck: deck, question: question))
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+
+            HStack {
+                Button("← Previous") { moveQuestion(-1, deck: deck) }
+                    .disabled(selectedQuestionIndex == 0)
+                Button("Next →") { moveQuestion(1, deck: deck) }
+                    .disabled(selectedQuestionIndex + 1 == deck.questions.count)
+                Spacer()
+                if deck.session.provider == .claude && deck.session.capabilities.structuredDismiss {
+                    Button("Reject interview", role: .destructive) { rejectConfirmation = true }
+                }
+                Button("Submit all answers") { submit(deck) }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!complete(deck) || store.pendingIntentID != nil)
+            }
+
+            if let notice = store.controlNotice {
+                Text(notice).font(.caption).foregroundStyle(FleetPalette.amber)
+            }
+        }
+        .padding(18)
+        .background(FleetPalette.sidebar, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .onMoveCommand { direction in
+            if direction == .left { moveQuestion(-1, deck: deck) }
+            if direction == .right { moveQuestion(1, deck: deck) }
+        }
+        .confirmationDialog("Reject this structured interview?", isPresented: $rejectConfirmation) {
+            Button("Reject interview", role: .destructive) {
+                store.selectedSessionKey = deck.session.sessionKey
+                store.dismissStructuredInterview(on: deck.session)
+            }
+        } message: {
+            Text("Claude receives an explicit rejection. Draft answers remain until Fleet state changes.")
+        }
+    }
+
+    private func choose(_ item: FleetInterviewDeck?) {
+        guard let item else { return }
+        selectedSessionKey = item.session.sessionKey
+        store.selectedSessionKey = item.session.sessionKey
+        selectedQuestionIndex = min(selectedQuestionIndex, max(item.questions.count - 1, 0))
+    }
+
+    private func key(_ deck: FleetInterviewDeck, _ question: FleetInterviewQuestion) -> String {
+        "\(deck.session.sessionKey):\(deck.session.currentRequestFingerprint ?? ""): \(question.id)"
+    }
+
+    private func isSelected(_ option: String, deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Bool {
+        selections[key(deck, question), default: []].contains(option)
+    }
+
+    private func toggle(_ option: String, deck: FleetInterviewDeck, question: FleetInterviewQuestion) {
+        let answerKey = key(deck, question)
+        if question.multiSelect {
+            if selections[answerKey, default: []].contains(option) {
+                selections[answerKey, default: []].remove(option)
+            } else {
+                selections[answerKey, default: []].insert(option)
+            }
+        } else {
+            selections[answerKey] = [option]
+        }
+    }
+
+    private func textBinding(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Binding<String> {
+        let answerKey = key(deck, question)
+        return Binding(get: { textAnswers[answerKey, default: ""] }, set: { textAnswers[answerKey] = $0 })
+    }
+
+    private func answered(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Bool {
+        let answerKey = key(deck, question)
+        if question.options.isEmpty { return !textAnswers[answerKey, default: ""].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        let selected = selections[answerKey, default: []]
+        return !selected.isEmpty && (!selected.contains("Other") || !textAnswers[answerKey, default: ""].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private func complete(_ deck: FleetInterviewDeck) -> Bool {
+        deck.questions.allSatisfy { answered(deck: deck, question: $0) }
+    }
+
+    private func moveQuestion(_ delta: Int, deck: FleetInterviewDeck) {
+        selectedQuestionIndex = min(max(selectedQuestionIndex + delta, 0), deck.questions.count - 1)
+    }
+
+    private func submit(_ deck: FleetInterviewDeck) {
+        store.selectedSessionKey = deck.session.sessionKey
+        let answers = deck.questions.map { question in
+            let answerKey = key(deck, question)
+            let selections = Array(selections[answerKey, default: []]).sorted()
+            let text = textAnswers[answerKey]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return FleetQuestionAnswer(questionID: question.id, selectedOptions: selections, text: text?.isEmpty == false ? text : nil)
+        }
+        store.submitStructuredAnswers(answers, on: deck.session)
+    }
+}
+
+private struct FleetInterviewDeck {
+    let session: FleetSession
+    let questions: [FleetInterviewQuestion]
+
+    init?(session: FleetSession) {
+        guard session.attention == .ask,
+              session.capabilities.structuredAnswer,
+              session.currentRequestFingerprint != nil,
+              let request = session.currentRequest else { return nil }
+        let payload = request.value("payload") ?? request
+        let input = payload.value("tool_input", "input") ?? payload
+        let questions: [FleetInterviewQuestion] = input.value("questions")?.arrayValue?.enumerated().compactMap { index, value in
+            guard let text = value.value("question", "text")?.stringValue else { return nil }
+            let options = value.value("options")?.arrayValue?.compactMap { $0.stringValue ?? $0.value("label")?.stringValue } ?? []
+            return FleetInterviewQuestion(
+                id: value.value("id")?.stringValue ?? String(index),
+                header: value.value("header")?.stringValue ?? "Question \(index + 1)",
+                text: text,
+                options: options,
+                multiSelect: value.value("multiSelect", "multi_select")?.boolValue ?? false
+            )
+        } ?? []
+        guard !questions.isEmpty else { return nil }
+        self.session = session
+        self.questions = questions
+    }
+
+    static func priority(_ session: FleetSession) -> (Int, Int64) {
+        let attention = session.attention == .ask ? 0 : 1
+        return (attention, -session.attentionUpdatedAt)
+    }
+}
+
+private struct FleetInterviewQuestion: Identifiable {
+    let id: String
+    let header: String
+    let text: String
+    let options: [String]
+    let multiSelect: Bool
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }
 

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -182,6 +182,26 @@ final class FleetConnectionTests: XCTestCase {
         XCTAssertTrue(FleetOperatorAction.sendPrompt.isAvailable(in: capabilities))
     }
 
+    func testStructuredDismissWirePreservesExactIdentityAndOldCapabilitiesDefaultOff() throws {
+        let action = ControlAction.dismissStructured(
+            requestFingerprint: "sha256:request",
+            requestIdentity: FleetRequestIdentity(
+                requestID: .string("request-1"),
+                threadID: "thread-1",
+                turnID: "turn-2",
+                itemID: "item-3"
+            )
+        )
+        let data = try JSONEncoder().encode(action)
+        let encoded = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(encoded?["action"] as? String, "dismiss_structured")
+        XCTAssertEqual(encoded?["request_fingerprint"] as? String, "sha256:request")
+        XCTAssertEqual(try JSONDecoder().decode(ControlAction.self, from: data), action)
+
+        let legacy = try JSONDecoder().decode(FleetCapabilities.self, from: Data("{}".utf8))
+        XCTAssertFalse(legacy.structuredDismiss)
+    }
+
     @MainActor
     func testBroadcastReceiptMergePreservesDaemonInputOrder() {
         let existing = [receipt("old")]


### PR DESCRIPTION
## Summary
- keep structured interview drafts visible until authoritative Fleet state changes
- add Claude-only explicit rejection with exact request identity
- add macOS Fleet answer queue with session and question cards

## Validation
- cargo test -p ainb-hangar-proto -p ainb-plugin-notifyd -p ainb-plugin-hangar --lib
- cargo test -p ainb-hangar-daemon --lib
- xcodebuild test -quiet -project apps/ainb-fleet-macos/AINBFleet.xcodeproj -scheme AINBFleet -destination 'platform=macOS'
- tmux Fleet tripwire with staged current Hangar plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Fleet support for answering and rejecting structured interviews.
  - Added an answer queue showing pending interviews, with session and question navigation.
  - Added confirmation prompts, delivery status, and authoritative state refreshes.
  - Added capability indicators for supported structured-interview actions.

- **Bug Fixes**
  - Improved handling of stale requests, provider refusals, and rejected interviews.
  - Preserved request identity when submitting or dismissing interview prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->