### PR TITLE
fix(usage): correct model rates, fix unpriced-row ranking, add Activity heatmap

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/ainb-core",
+    "crates/ainb-model-rates",
     "crates/ainb-fleet-core",
     "crates/ainb-web",
     "crates/ainb-plugin-burndown",

--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -24,6 +24,7 @@ name = "ainb"
 path = "src/lib.rs"
 
 [dependencies]
+ainb-model-rates = { path = "../ainb-model-rates" }
 # Core
 tokio = { workspace = true }
 ratatui = { workspace = true }

--- a/ainb-tui/crates/ainb-core/src/models/usage.rs
+++ b/ainb-tui/crates/ainb-core/src/models/usage.rs
@@ -2846,78 +2846,10 @@ where
     *map.entry(key).or_default() += 1;
 }
 
-fn estimate_cost_usd(
-    model: &str,
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_creation_tokens: u64,
-    cache_read_tokens: u64,
-    reasoning_tokens: u64,
-) -> Option<f64> {
-    let rates = model_rates(model)?;
-    Some(
-        input_tokens as f64 * rates.input
-            + (output_tokens + reasoning_tokens) as f64 * rates.output
-            + cache_creation_tokens as f64 * rates.cache_write
-            + cache_read_tokens as f64 * rates.cache_read,
-    )
-}
-
-struct ModelRates {
-    input: f64,
-    output: f64,
-    cache_write: f64,
-    cache_read: f64,
-}
-
-fn model_rates(model: &str) -> Option<ModelRates> {
-    let canonical = canonical_model_name(model);
-    let (input_per_million, output_per_million) = if canonical.starts_with("claude-opus") {
-        (15.0, 75.0)
-    } else if canonical.starts_with("claude-sonnet") || canonical.starts_with("claude-3-5-sonnet") {
-        (3.0, 15.0)
-    } else if canonical.starts_with("claude-haiku") || canonical.starts_with("claude-3-5-haiku") {
-        (0.8, 4.0)
-    } else if canonical.starts_with("gpt-5")
-        || canonical.starts_with("gpt-4.1")
-        || canonical.starts_with("gpt-4o")
-    {
-        (1.25, 10.0)
-    } else {
-        return None;
-    };
-
-    let input = input_per_million / 1_000_000.0;
-    let output = output_per_million / 1_000_000.0;
-    Some(ModelRates {
-        input,
-        output,
-        cache_write: input * 1.25,
-        cache_read: input * 0.1,
-    })
-}
-
-fn canonical_model_name(model: &str) -> String {
-    let without_prefix = model
-        .split('@')
-        .next()
-        .unwrap_or(model)
-        .trim_start_matches("anthropic/")
-        .trim_start_matches("openai/")
-        .to_string();
-
-    if without_prefix
-        .rsplit('-')
-        .next()
-        .is_some_and(|suffix| suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_digit()))
-    {
-        without_prefix
-            .rsplit_once('-')
-            .map_or(without_prefix.clone(), |(name, _)| name.to_string())
-    } else {
-        without_prefix
-    }
-}
+// Rates live in `ainb-model-rates` — one table, three consumers. Keeping a
+// local copy here is what let every Opus sit at the retired $15/$75 rate for
+// three model generations.
+use ainb_model_rates::estimate_cost_usd;
 
 /// Format a token count in human-readable form (e.g., "1.2B", "456M", "12K").
 pub fn format_tokens_short(n: u64) -> String {

--- a/ainb-tui/crates/ainb-core/src/models/usage.rs
+++ b/ainb-tui/crates/ainb-core/src/models/usage.rs
@@ -1997,8 +1997,9 @@ fn sorted_activities(map: HashMap<ActivityCategory, ActivityAccumulator>) -> Vec
         })
         .collect();
     rows.sort_by(|a, b| {
-        bucket_sort_value(&b.bucket)
-            .total_cmp(&bucket_sort_value(&a.bucket))
+        bucket_has_cost(&b.bucket)
+            .cmp(&bucket_has_cost(&a.bucket))
+            .then_with(|| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)))
             .then_with(|| activity_rank(a.category).cmp(&activity_rank(b.category)))
     });
     rows
@@ -2810,8 +2811,20 @@ fn merge_cost(left: Option<f64>, right: Option<f64>) -> Option<f64> {
     }
 }
 
+/// Ranking weight for a bucket: cost when known, token count as a stand-in when
+/// not — but see [`sort_by_bucket_desc`], which keeps the two apart.
 fn bucket_sort_value(bucket: &TokenBucket) -> f64 {
     bucket.cost_usd.unwrap_or(bucket.total() as f64)
+}
+
+/// `true` when this bucket has a real dollar figure behind it.
+///
+/// Ranking must sort on this *before* the numeric weight. Comparing dollars
+/// against raw token counts puts every unpriced row (a model with no published
+/// rate) above every priced one, because tokens outnumber dollars by ~5 orders
+/// of magnitude — which is what made the top-N panels look empty.
+fn bucket_has_cost(bucket: &TokenBucket) -> bool {
+    bucket.cost_usd.is_some()
 }
 
 /// Sort `rows` in-place by bucket weight (descending), where each row's
@@ -2823,7 +2836,11 @@ fn sort_by_bucket_desc<T, F>(rows: &mut Vec<T>, key: F)
 where
     F: Fn(&T) -> &TokenBucket,
 {
-    rows.sort_by(|a, b| bucket_sort_value(key(b)).total_cmp(&bucket_sort_value(key(a))));
+    rows.sort_by(|a, b| {
+        bucket_has_cost(key(b))
+            .cmp(&bucket_has_cost(key(a)))
+            .then_with(|| bucket_sort_value(key(b)).total_cmp(&bucket_sort_value(key(a))))
+    });
 }
 
 /// Merge `bucket` into the entry at `key` in a `String -> TokenBucket`

--- a/ainb-tui/crates/ainb-core/tests/tripwire_burndown_heatmap.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_burndown_heatmap.rs
@@ -1,0 +1,311 @@
+//! Tripwire: the Activity tab's contribution heatmap renders in the real TUI.
+//!
+//! `cargo test` proves the grid math (`heatmap.rs` has its own unit tests). It
+//! cannot prove the tab is reachable, that the plugin's key wire delivers `]`,
+//! `M` and the arrows, or that the grid actually paints — the Activity tab
+//! replaced the Daily and Weekly tabs, so a mistake in the tab enum or the
+//! render dispatch would leave a blank panel that no unit test would notice.
+//!
+//! Assertions pair a POSITIVE marker (grid chrome that only the heatmap draws)
+//! with a NEGATIVE placeholder check, per the tripwire rules — asserting on
+//! chrome like "Usage Analytics" alone would pass with an empty panel.
+//!
+//! Runs against the deterministic `tripwire_keys` fixture with `AINB_NOW`
+//! pinned, so the grid's "today" column and the detail strip's date are stable
+//! across machines. Skips gracefully without tmux or staged plugins.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn plugins_staged() -> Option<PathBuf> {
+    let bin = ainb_bin();
+    let mut dir = bin.parent()?;
+    for _ in 0..6 {
+        let candidate = dir.join("dist").join("plugins");
+        if candidate.join("burndown").join("burndown").exists()
+            && candidate.join("session-reader").join("session-reader").exists()
+        {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("tripwire_keys")
+}
+
+fn fixture_now() -> String {
+    fs::read_to_string(fixture_root().join("FIXTURE_NOW.txt"))
+        .expect("FIXTURE_NOW.txt present")
+        .trim()
+        .to_string()
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("mkdir dst");
+    for entry in fs::read_dir(src).expect("read_dir src") {
+        let entry = entry.expect("dir entry");
+        let ty = entry.file_type().expect("file_type");
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_all(&from, &to);
+        } else if ty.is_file() {
+            fs::copy(&from, &to).expect("copy file");
+        }
+    }
+}
+
+fn seed_fixture_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create config dir");
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+
+    // Suppress the ainb-hooks first-run dialog; it overlays home and eats `i`.
+    fs::write(
+        home.join(".agents-in-a-box").join("install.json"),
+        r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#,
+    )
+    .expect("seed install.json");
+
+    let fixture = fixture_root();
+    let claude_src = fixture.join("claude").join("projects");
+    if claude_src.is_dir() {
+        copy_dir_all(&claude_src, &home.join(".claude").join("projects"));
+    }
+    let codex_src = fixture.join("codex").join("sessions");
+    if codex_src.is_dir() {
+        copy_dir_all(&codex_src, &home.join(".codex").join("sessions"));
+    }
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+fn send_key(session: &str, key: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+}
+
+/// Send a key once, then wait for the frame to change and settle.
+///
+/// Send-once matters here: `M` cycles the metric, so re-pressing it on every
+/// poll iteration would keep rotating past the state under assertion.
+fn send_key_and_settle(session: &str, key: &str) -> String {
+    let before = capture_pane(session);
+    send_key(session, key);
+    let deadline = Instant::now() + Duration::from_secs(6);
+    let mut last = before.clone();
+    let mut changed = false;
+    let mut stable_since: Option<Instant> = None;
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(150));
+        let cur = capture_pane(session);
+        if cur != before {
+            changed = true;
+        }
+        if cur == last {
+            if changed
+                && stable_since.get_or_insert_with(Instant::now).elapsed()
+                    >= Duration::from_millis(350)
+            {
+                return cur;
+            }
+        } else {
+            last = cur;
+            stable_since = None;
+        }
+    }
+    last
+}
+
+fn kill_session(session: &str) {
+    let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
+}
+
+/// The grid is present only when its own chrome is: the weekday gutter, the
+/// legend ends, and at least one cell glyph. None of these appear on any other
+/// burndown tab, so this cannot pass on a blank or wrong panel.
+fn heatmap_rendered(cap: &str) -> bool {
+    cap.contains("Mon")
+        && cap.contains("Wed")
+        && cap.contains("Fri")
+        && cap.contains("Less")
+        && cap.contains("More")
+        && cap.chars().any(|c| matches!(c, '░' | '▒' | '▓' | '█' | '·'))
+}
+
+#[test]
+fn activity_tab_renders_heatmap_and_responds_to_keys() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+    let Some(plugin_root) = plugins_staged() else {
+        eprintln!("SKIP: dist/plugins not staged — run `scripts/build-plugins.sh`");
+        return;
+    };
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_fixture_home(home_tmp.path());
+
+    let session = format!("tripwire-heatmap-{}", std::process::id());
+    let status = Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session, "-x", "200", "-y", "50"])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
+
+    let cmd = format!(
+        "HOME={} AINB_PLUGIN_ROOT={} AINB_NOW={} exec {} tui",
+        home_tmp.path().display(),
+        plugin_root.display(),
+        fixture_now(),
+        ainb_bin().display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("tmux send launch cmd");
+
+    let home_deadline = Instant::now() + Duration::from_secs(90);
+    if poll_capture(&session, home_deadline, |c| c.contains("Stats") && c.contains("[i]")).is_none()
+    {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
+    }
+
+    send_key(&session, "i");
+    let data_deadline = Instant::now() + Duration::from_secs(90);
+    let Some(burndown) = poll_capture(&session, data_deadline, |c| {
+        c.contains("Usage Analytics")
+            && !c.contains("Waiting for session-reader plugin")
+            && c.contains('$')
+    }) else {
+        let last = capture_pane(&session);
+        kill_session(&session);
+        panic!("burndown never rendered real data; last:\n---\n{last}\n---");
+    };
+
+    // Pre-press negative: we must NOT already be looking at the heatmap, or
+    // the post-press assertion proves nothing.
+    assert!(
+        !heatmap_rendered(&burndown),
+        "expected to start on Burndown, not Activity:\n---\n{burndown}\n---"
+    );
+    assert!(
+        burndown.contains("Activity"),
+        "Activity tab missing from the tab strip:\n---\n{burndown}\n---"
+    );
+
+    // `]` walks Burndown → Activity.
+    let activity = send_key_and_settle(&session, "]");
+    if !heatmap_rendered(&activity) {
+        kill_session(&session);
+        panic!("Activity tab did not render the heatmap grid:\n---\n{activity}\n---");
+    }
+    // `[cost]` — brackets mark the active metric, so this asserts which metric
+    // is selected rather than merely that the word "cost" appears somewhere.
+    assert!(
+        activity.contains("Metric:") && activity.contains("[cost]"),
+        "metric selector missing or not defaulting to cost:\n---\n{activity}\n---"
+    );
+    // The detail strip carries the selected day's real figures, which is where
+    // the exact numbers went when Daily was removed.
+    assert!(
+        activity.contains("tokens") && activity.contains("calls"),
+        "per-day detail strip missing:\n---\n{activity}\n---"
+    );
+
+    // `M` cycles the metric — cost → tokens. Send once (it's a cycle, not a
+    // toggle to re-assert).
+    let after_metric = send_key_and_settle(&session, "M");
+    assert!(
+        after_metric != activity,
+        "M did not change the render:\n---\n{after_metric}\n---"
+    );
+    assert!(
+        heatmap_rendered(&after_metric),
+        "grid vanished after switching metric:\n---\n{after_metric}\n---"
+    );
+    assert!(
+        after_metric.contains("[tokens]") && !after_metric.contains("[cost]"),
+        "M did not advance the selected metric cost -> tokens:\n---\n{after_metric}\n---"
+    );
+
+    // Arrow moves the day cursor, which retitles the detail strip.
+    let after_left = send_key_and_settle(&session, "Left");
+    assert!(
+        heatmap_rendered(&after_left),
+        "grid vanished after cursor move:\n---\n{after_left}\n---"
+    );
+    assert!(
+        after_left != after_metric,
+        "Left did not move the heatmap cursor:\n---\n{after_left}\n---"
+    );
+
+    // Return path: `[` walks back to Burndown and the grid goes away. Tab
+    // navigation that only works forwards is exactly how the Esc-swallow bug
+    // shipped past four tripwires.
+    let back = send_key_and_settle(&session, "[");
+    kill_session(&session);
+    assert!(
+        !heatmap_rendered(&back),
+        "`[` did not leave the Activity tab:\n---\n{back}\n---"
+    );
+    assert!(
+        back.contains("Usage Analytics"),
+        "returning from Activity left the burndown screen entirely:\n---\n{back}\n---"
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_burndown_heatmap.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_burndown_heatmap.rs
@@ -219,7 +219,10 @@ fn activity_tab_renders_heatmap_and_responds_to_keys() {
         .expect("tmux send launch cmd");
 
     let home_deadline = Instant::now() + Duration::from_secs(90);
-    if poll_capture(&session, home_deadline, |c| c.contains("Stats") && c.contains("[i]")).is_none()
+    if poll_capture(&session, home_deadline, |c| {
+        c.contains("Stats") && c.contains("[i]")
+    })
+    .is_none()
     {
         let last = capture_pane(&session);
         kill_session(&session);

--- a/ainb-tui/crates/ainb-model-rates/Cargo.toml
+++ b/ainb-tui/crates/ainb-model-rates/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ainb-model-rates"
+version = "0.1.0"
+edition = "2021"
+
+# Deliberately dependency-free: this crate is linked by the host *and* by
+# subprocess plugins (session-reader, burndown). Adding a dep here adds it to
+# every one of them, so keep it a leaf.
+[dependencies]

--- a/ainb-tui/crates/ainb-model-rates/src/lib.rs
+++ b/ainb-tui/crates/ainb-model-rates/src/lib.rs
@@ -1,0 +1,295 @@
+// ABOUTME: Single source of truth for per-model token pricing.
+//
+// This table used to exist as three byte-identical copies (session-reader's
+// parser, the host's legacy `models/usage.rs`, and burndown's CLI path). They
+// drifted the only way copies can: nobody updated them, and every Opus stayed
+// at the retired $15/$75 rate across three model generations, overstating Opus
+// spend ~3x. One table, three consumers, one place to edit.
+
+//! Per-model token rates and cost estimation.
+//!
+//! Rates are US dollars per 1M tokens, list price, Anthropic/OpenAI first-party.
+//! A model with no published price returns `None` — callers must treat that as
+//! "price unknown", never as zero (see [`estimate_cost_usd`]).
+
+/// Per-*token* rates (not per-million — [`model_rates`] does that division).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ModelRates {
+    pub input: f64,
+    pub output: f64,
+    pub cache_write: f64,
+    pub cache_read: f64,
+}
+
+/// Cost in USD for one call, or `None` when the model has no published price.
+///
+/// `None` is load-bearing: it flows into `TokenBucket::cost_usd` and every
+/// ranking site, which must sink unpriced rows rather than treat them as free
+/// or (worse) rank them by raw token count.
+#[allow(clippy::too_many_arguments)]
+pub fn estimate_cost_usd(
+    model: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    reasoning_tokens: u64,
+) -> Option<f64> {
+    let rates = model_rates(model)?;
+    Some(
+        input_tokens as f64 * rates.input
+            + (output_tokens + reasoning_tokens) as f64 * rates.output
+            + cache_creation_tokens as f64 * rates.cache_write
+            + cache_read_tokens as f64 * rates.cache_read,
+    )
+}
+
+/// Resolve a model id to its rates.
+///
+/// **Ordering is load-bearing.** Every arm is a prefix test, so the more
+/// specific id must be tested first: `"claude-opus-5"` starts with
+/// `"claude-opus"`, and `"gpt-5.6-sol"` starts with `"gpt-5"`. Appending a new
+/// model to the bottom of this function is the one way to silently break it —
+/// the catch-all above it swallows the match and the new rate never fires.
+pub fn model_rates(model: &str) -> Option<ModelRates> {
+    let canonical = canonical_model_name(model);
+    let m = canonical.as_str();
+
+    let (input_per_million, output_per_million) = if let Some(r) = anthropic_rates(m) {
+        r
+    } else if let Some(r) = openai_rates(m) {
+        r
+    } else {
+        return None;
+    };
+
+    let input = input_per_million / 1_000_000.0;
+    let output = output_per_million / 1_000_000.0;
+    Some(ModelRates {
+        input,
+        output,
+        // Anthropic bills cache writes at 1.25x input and cache reads at 0.1x.
+        // OpenAI's cached input is also 0.1x list, and it does not bill a
+        // separate cache write at all — the 1.25x is harmless there because
+        // OpenAI transcripts carry no cache-creation tokens to multiply.
+        cache_write: input * 1.25,
+        cache_read: input * 0.1,
+    })
+}
+
+/// Anthropic list prices, most-specific prefix first.
+fn anthropic_rates(m: &str) -> Option<(f64, f64)> {
+    // Fable / Mythos — the top capability tier, priced above Opus.
+    if m.starts_with("claude-fable") || m.starts_with("claude-mythos") {
+        return Some((10.0, 50.0));
+    }
+    // Current Opus generations dropped to $5/$25. Opus 4.5 and older stay at
+    // the old $15/$75, so this cannot be one blanket `claude-opus` arm.
+    if m.starts_with("claude-opus-5")
+        || m.starts_with("claude-opus-4-8")
+        || m.starts_with("claude-opus-4-7")
+        || m.starts_with("claude-opus-4-6")
+    {
+        return Some((5.0, 25.0));
+    }
+    // `claude-3-opus` is the retired Opus 3 id, which does not share the
+    // `claude-opus-*` shape.
+    if m.starts_with("claude-opus") || m.starts_with("claude-3-opus") {
+        return Some((15.0, 75.0));
+    }
+    if m.starts_with("claude-sonnet") || m.starts_with("claude-3-5-sonnet") {
+        // Sonnet 5 carries a $2/$10 introductory rate through 2026-08-31. We
+        // bill list deliberately: a date branch here would need a hardcoded
+        // cliff that breaks the moment the promo is extended or pulled early,
+        // and list self-corrects on that date with no code change.
+        return Some((3.0, 15.0));
+    }
+    if m.starts_with("claude-3-5-haiku") {
+        return Some((0.8, 4.0));
+    }
+    if m.starts_with("claude-haiku") {
+        return Some((1.0, 5.0));
+    }
+    None
+}
+
+/// OpenAI list prices, most-specific prefix first.
+fn openai_rates(m: &str) -> Option<(f64, f64)> {
+    // GPT-5.6 family: three tiers at three price points. Bare `gpt-5.6`
+    // aliases to Sol, so it shares Sol's rate.
+    if m.starts_with("gpt-5.6-terra") {
+        return Some((2.5, 15.0));
+    }
+    if m.starts_with("gpt-5.6-luna") {
+        return Some((1.0, 6.0));
+    }
+    if m.starts_with("gpt-5.6") {
+        return Some((5.0, 30.0));
+    }
+    if m.starts_with("gpt-5.5-pro") {
+        return Some((30.0, 180.0));
+    }
+    if m.starts_with("gpt-5.5") {
+        return Some((5.0, 30.0));
+    }
+    if m.starts_with("gpt-5.4-nano") {
+        return Some((0.2, 1.25));
+    }
+    if m.starts_with("gpt-5.4-mini") {
+        return Some((0.75, 4.5));
+    }
+    if m.starts_with("gpt-5.4-pro") {
+        return Some((30.0, 180.0));
+    }
+    if m.starts_with("gpt-5.4") {
+        return Some((2.5, 15.0));
+    }
+    if m.starts_with("gpt-5-nano") {
+        return Some((0.05, 0.4));
+    }
+    if m.starts_with("gpt-5-mini") {
+        return Some((0.25, 2.0));
+    }
+    if m.starts_with("gpt-5") || m.starts_with("gpt-4.1") || m.starts_with("gpt-4o") {
+        return Some((1.25, 10.0));
+    }
+    None
+}
+
+/// Strip vendor prefixes, `@`-suffixed platform versions, and an 8-digit date
+/// snapshot suffix so `claude-3-5-sonnet-20241022` prices like
+/// `claude-3-5-sonnet`.
+pub fn canonical_model_name(model: &str) -> String {
+    let without_prefix = model
+        .split('@')
+        .next()
+        .unwrap_or(model)
+        .trim_start_matches("anthropic/")
+        .trim_start_matches("openai/")
+        .to_string();
+
+    if without_prefix
+        .rsplit('-')
+        .next()
+        .is_some_and(|suffix| suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        without_prefix
+            .rsplit_once('-')
+            .map_or(without_prefix.clone(), |(name, _)| name.to_string())
+    } else {
+        without_prefix
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rate for 1M input tokens, i.e. the published per-million input price.
+    fn input_per_million(model: &str) -> f64 {
+        estimate_cost_usd(model, 1_000_000, 0, 0, 0, 0).expect("model should be priced")
+    }
+
+    fn output_per_million(model: &str) -> f64 {
+        estimate_cost_usd(model, 0, 1_000_000, 0, 0, 0).expect("model should be priced")
+    }
+
+    #[test]
+    fn unknown_model_has_no_price() {
+        assert!(estimate_cost_usd("totally-made-up", 100, 100, 0, 0, 0).is_none());
+        // Claude Code's placeholder for non-model turns must stay unpriced
+        // rather than being guessed at.
+        assert!(model_rates("<synthetic>").is_none());
+    }
+
+    #[test]
+    fn current_opus_generations_are_5_25_not_the_retired_15_75() {
+        // The bug this crate exists to stop: every one of these used to be
+        // priced at 15/75, inflating reported Opus spend ~3x.
+        for model in [
+            "claude-opus-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+        ] {
+            assert_eq!(input_per_million(model), 5.0, "{model} input");
+            assert_eq!(output_per_million(model), 25.0, "{model} output");
+        }
+    }
+
+    #[test]
+    fn legacy_opus_keeps_the_old_15_75() {
+        for model in ["claude-opus-4-5", "claude-opus-4-1", "claude-3-opus"] {
+            assert_eq!(input_per_million(model), 15.0, "{model} input");
+            assert_eq!(output_per_million(model), 75.0, "{model} output");
+        }
+    }
+
+    #[test]
+    fn fable_and_mythos_are_priced_above_opus() {
+        for model in ["claude-fable-5", "claude-mythos-5"] {
+            assert_eq!(input_per_million(model), 10.0, "{model} input");
+            assert_eq!(output_per_million(model), 50.0, "{model} output");
+        }
+    }
+
+    #[test]
+    fn sonnet_is_3_15_and_haiku_4_5_is_1_5() {
+        assert_eq!(input_per_million("claude-sonnet-5"), 3.0);
+        assert_eq!(input_per_million("claude-sonnet-4-6"), 3.0);
+        assert_eq!(input_per_million("claude-haiku-4-5"), 1.0);
+        assert_eq!(output_per_million("claude-haiku-4-5"), 5.0);
+        // Haiku 3.5 was cheaper than 4.5 — the legacy arm must survive.
+        assert_eq!(input_per_million("claude-3-5-haiku"), 0.8);
+    }
+
+    #[test]
+    fn gpt_5_6_tiers_are_distinct() {
+        assert_eq!(input_per_million("gpt-5.6-sol"), 5.0);
+        assert_eq!(output_per_million("gpt-5.6-sol"), 30.0);
+        assert_eq!(input_per_million("gpt-5.6-terra"), 2.5);
+        assert_eq!(output_per_million("gpt-5.6-terra"), 15.0);
+        assert_eq!(input_per_million("gpt-5.6-luna"), 1.0);
+        assert_eq!(output_per_million("gpt-5.6-luna"), 6.0);
+        // Bare `gpt-5.6` aliases to Sol.
+        assert_eq!(input_per_million("gpt-5.6"), 5.0);
+    }
+
+    #[test]
+    fn specific_prefixes_win_over_general_ones() {
+        // The ordering trap: every one of these also matches a shorter prefix
+        // that appears later in the function. If someone appends a new arm to
+        // the bottom instead of ordering it, this test fires.
+        assert_ne!(input_per_million("gpt-5.6-terra"), input_per_million("gpt-5.6-sol"));
+        assert_ne!(input_per_million("gpt-5.4-mini"), input_per_million("gpt-5.4"));
+        assert_ne!(input_per_million("gpt-5-mini"), input_per_million("gpt-5"));
+        assert_ne!(input_per_million("claude-opus-5"), input_per_million("claude-opus-4-5"));
+    }
+
+    #[test]
+    fn dated_snapshot_suffix_is_stripped() {
+        assert_eq!(input_per_million("claude-3-5-sonnet-20241022"), 3.0);
+        assert_eq!(input_per_million("claude-haiku-4-5-20251001"), 1.0);
+        assert_eq!(input_per_million("claude-sonnet-4-5-20250929"), 3.0);
+    }
+
+    #[test]
+    fn vendor_prefix_and_platform_version_are_stripped() {
+        assert_eq!(input_per_million("anthropic/claude-opus-5"), 5.0);
+        assert_eq!(input_per_million("openai/gpt-5.6-sol"), 5.0);
+        assert_eq!(input_per_million("claude-opus-4-5@20251101"), 15.0);
+    }
+
+    #[test]
+    fn cache_write_is_1_25x_input_and_cache_read_is_0_1x() {
+        let rates = model_rates("claude-opus-5").expect("priced");
+        assert!((rates.cache_write - rates.input * 1.25).abs() < f64::EPSILON);
+        assert!((rates.cache_read - rates.input * 0.1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn reasoning_tokens_bill_at_the_output_rate() {
+        let with_reasoning = estimate_cost_usd("gpt-5.6-sol", 0, 0, 0, 0, 1_000_000);
+        assert_eq!(with_reasoning, Some(30.0));
+    }
+}

--- a/ainb-tui/crates/ainb-model-rates/src/lib.rs
+++ b/ainb-tui/crates/ainb-model-rates/src/lib.rs
@@ -55,8 +55,7 @@ pub fn model_rates(model: &str) -> Option<ModelRates> {
     let canonical = canonical_model_name(model);
     let m = canonical.as_str();
 
-    let (input_per_million, output_per_million) =
-        anthropic_rates(m).or_else(|| openai_rates(m))?;
+    let (input_per_million, output_per_million) = anthropic_rates(m).or_else(|| openai_rates(m))?;
 
     let input = input_per_million / 1_000_000.0;
     let output = output_per_million / 1_000_000.0;
@@ -255,10 +254,19 @@ mod tests {
         // The ordering trap: every one of these also matches a shorter prefix
         // that appears later in the function. If someone appends a new arm to
         // the bottom instead of ordering it, this test fires.
-        assert_ne!(input_per_million("gpt-5.6-terra"), input_per_million("gpt-5.6-sol"));
-        assert_ne!(input_per_million("gpt-5.4-mini"), input_per_million("gpt-5.4"));
+        assert_ne!(
+            input_per_million("gpt-5.6-terra"),
+            input_per_million("gpt-5.6-sol")
+        );
+        assert_ne!(
+            input_per_million("gpt-5.4-mini"),
+            input_per_million("gpt-5.4")
+        );
         assert_ne!(input_per_million("gpt-5-mini"), input_per_million("gpt-5"));
-        assert_ne!(input_per_million("claude-opus-5"), input_per_million("claude-opus-4-5"));
+        assert_ne!(
+            input_per_million("claude-opus-5"),
+            input_per_million("claude-opus-4-5")
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-model-rates/src/lib.rs
+++ b/ainb-tui/crates/ainb-model-rates/src/lib.rs
@@ -55,13 +55,8 @@ pub fn model_rates(model: &str) -> Option<ModelRates> {
     let canonical = canonical_model_name(model);
     let m = canonical.as_str();
 
-    let (input_per_million, output_per_million) = if let Some(r) = anthropic_rates(m) {
-        r
-    } else if let Some(r) = openai_rates(m) {
-        r
-    } else {
-        return None;
-    };
+    let (input_per_million, output_per_million) =
+        anthropic_rates(m).or_else(|| openai_rates(m))?;
 
     let input = input_per_million / 1_000_000.0;
     let output = output_per_million / 1_000_000.0;

--- a/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
@@ -21,6 +21,7 @@ name = "ainb-plugin-burndown"
 path = "src/main.rs"
 
 [dependencies]
+ainb-model-rates = { path = "../ainb-model-rates" }
 ainb-plugin-sdk-rust = { path = "../ainb-plugin-sdk-rust" }
 ainb-plugin-types-sessions = { path = "../ainb-plugin-types-sessions" }
 

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -3356,78 +3356,10 @@ where
     *map.entry(key).or_default() += 1;
 }
 
-fn estimate_cost_usd(
-    model: &str,
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_creation_tokens: u64,
-    cache_read_tokens: u64,
-    reasoning_tokens: u64,
-) -> Option<f64> {
-    let rates = model_rates(model)?;
-    Some(
-        input_tokens as f64 * rates.input
-            + (output_tokens + reasoning_tokens) as f64 * rates.output
-            + cache_creation_tokens as f64 * rates.cache_write
-            + cache_read_tokens as f64 * rates.cache_read,
-    )
-}
-
-struct ModelRates {
-    input: f64,
-    output: f64,
-    cache_write: f64,
-    cache_read: f64,
-}
-
-fn model_rates(model: &str) -> Option<ModelRates> {
-    let canonical = canonical_model_name(model);
-    let (input_per_million, output_per_million) = if canonical.starts_with("claude-opus") {
-        (15.0, 75.0)
-    } else if canonical.starts_with("claude-sonnet") || canonical.starts_with("claude-3-5-sonnet") {
-        (3.0, 15.0)
-    } else if canonical.starts_with("claude-haiku") || canonical.starts_with("claude-3-5-haiku") {
-        (0.8, 4.0)
-    } else if canonical.starts_with("gpt-5")
-        || canonical.starts_with("gpt-4.1")
-        || canonical.starts_with("gpt-4o")
-    {
-        (1.25, 10.0)
-    } else {
-        return None;
-    };
-
-    let input = input_per_million / 1_000_000.0;
-    let output = output_per_million / 1_000_000.0;
-    Some(ModelRates {
-        input,
-        output,
-        cache_write: input * 1.25,
-        cache_read: input * 0.1,
-    })
-}
-
-fn canonical_model_name(model: &str) -> String {
-    let without_prefix = model
-        .split('@')
-        .next()
-        .unwrap_or(model)
-        .trim_start_matches("anthropic/")
-        .trim_start_matches("openai/")
-        .to_string();
-
-    if without_prefix
-        .rsplit('-')
-        .next()
-        .is_some_and(|suffix| suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_digit()))
-    {
-        without_prefix
-            .rsplit_once('-')
-            .map_or(without_prefix.clone(), |(name, _)| name.to_string())
-    } else {
-        without_prefix
-    }
-}
+// Rates live in `ainb-model-rates` — one table, three consumers. Keeping a
+// local copy here is what let every Opus sit at the retired $15/$75 rate for
+// three model generations.
+use ainb_model_rates::estimate_cost_usd;
 
 /// Format a token count in human-readable form (e.g., "1.2B", "456M", "12K").
 pub fn format_tokens_short(n: u64) -> String {

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -2486,8 +2486,9 @@ fn sorted_activities(map: HashMap<ActivityCategory, ActivityAccumulator>) -> Vec
         })
         .collect();
     rows.sort_by(|a, b| {
-        bucket_sort_value(&b.bucket)
-            .total_cmp(&bucket_sort_value(&a.bucket))
+        bucket_has_cost(&b.bucket)
+            .cmp(&bucket_has_cost(&a.bucket))
+            .then_with(|| bucket_sort_value(&b.bucket).total_cmp(&bucket_sort_value(&a.bucket)))
             .then_with(|| activity_rank(a.category).cmp(&activity_rank(b.category)))
     });
     rows
@@ -3320,8 +3321,20 @@ fn merge_cost(left: Option<f64>, right: Option<f64>) -> Option<f64> {
     }
 }
 
+/// Ranking weight for a bucket: cost when known, token count as a stand-in when
+/// not — but see [`sort_by_bucket_desc`], which keeps the two apart.
 fn bucket_sort_value(bucket: &TokenBucket) -> f64 {
     bucket.cost_usd.unwrap_or(bucket.total() as f64)
+}
+
+/// `true` when this bucket has a real dollar figure behind it.
+///
+/// Ranking must sort on this *before* the numeric weight. Comparing dollars
+/// against raw token counts puts every unpriced row (a model with no published
+/// rate) above every priced one, because tokens outnumber dollars by ~5 orders
+/// of magnitude — which is what made the top-N panels look empty.
+fn bucket_has_cost(bucket: &TokenBucket) -> bool {
+    bucket.cost_usd.is_some()
 }
 
 /// Sort `rows` in-place by bucket weight (descending), where each row's
@@ -3333,7 +3346,11 @@ fn sort_by_bucket_desc<T, F>(rows: &mut Vec<T>, key: F)
 where
     F: Fn(&T) -> &TokenBucket,
 {
-    rows.sort_by(|a, b| bucket_sort_value(key(b)).total_cmp(&bucket_sort_value(key(a))));
+    rows.sort_by(|a, b| {
+        bucket_has_cost(key(b))
+            .cmp(&bucket_has_cost(key(a)))
+            .then_with(|| bucket_sort_value(key(b)).total_cmp(&bucket_sort_value(key(a))))
+    });
 }
 
 /// Merge `bucket` into the entry at `key` in a `String -> TokenBucket`
@@ -4513,6 +4530,49 @@ mod tests {
 
     fn calls_aggregated(calls: Vec<ProviderCall>) -> UsageData {
         aggregate_calls(calls)
+    }
+
+    /// A model with no published rate must never outrank a priced one.
+    ///
+    /// Regression: ranking on `cost_usd.unwrap_or(tokens)` compared dollars
+    /// against token counts, so one unpriced model with a big cache footprint
+    /// took every slot in By Project / By Model / Top Sessions / Leaderboard and
+    /// the panels rendered as a wall of `cost n/a`.
+    #[test]
+    fn unpriced_rows_sink_below_priced_rows() {
+        let now = Utc::now();
+        // Unpriced, enormous: 500M tokens but no rate.
+        let unpriced = ProviderCallBuilder::new()
+            .with_id(1)
+            .with_model("model-with-no-published-rate")
+            .with_project("noisy")
+            .with_timestamp(now)
+            .with_input_tokens(500_000_000)
+            .build();
+        // Priced, small: a real dollar figure, far fewer tokens.
+        let priced = ProviderCallBuilder::new()
+            .with_id(2)
+            .with_model("claude-opus-5")
+            .with_project("real")
+            .with_timestamp(now)
+            .with_input_tokens(1_000_000)
+            .with_cost(5.0)
+            .build();
+
+        let data = calls_aggregated(vec![unpriced, priced]);
+
+        assert_eq!(
+            data.models[0].model, "claude-opus-5",
+            "priced model must rank above an unpriced one regardless of token count"
+        );
+        assert_eq!(
+            data.projects[0].name, "real",
+            "priced project must rank above an unpriced one"
+        );
+        assert!(
+            data.models[1].bucket.cost_usd.is_none(),
+            "the unpriced row should still be present, just last"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/data/usage.rs
@@ -2974,7 +2974,7 @@ fn project_matches(call: &ProviderCall, include: &[String], exclude: &[String]) 
 /// (RFC 3339, e.g. `2026-05-11T00:00:00Z`) when set so deterministic
 /// tripwire fixtures can pin the calendar day; otherwise falls back to
 /// the real local clock.
-fn local_now() -> DateTime<Local> {
+pub(crate) fn local_now() -> DateTime<Local> {
     if let Ok(raw) = std::env::var("AINB_NOW") {
         if let Ok(parsed) = DateTime::parse_from_rfc3339(raw.trim()) {
             return parsed.with_timezone(&Local);

--- a/ainb-tui/crates/ainb-plugin-burndown/src/heatmap.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/heatmap.rs
@@ -1,0 +1,715 @@
+// ABOUTME: Pure data layer for the GitHub-style contribution heatmap —
+// ABOUTME: day bucketing, intensity levels, cursor movement, per-day model
+// ABOUTME: breakdown. No ratatui, no clock reads, so it unit-tests headless.
+//! The render side owns only glyphs and colours; every decision that can be
+//! wrong (which day a call belongs to, how hot a day is, whether a day is
+//! genuinely idle or merely unpriced) lives here where a test can pin it.
+//!
+//! Two invariants drive the design:
+//!
+//! * **`today` is injected, never read.** `Local::now()` inside a builder makes
+//!   the grid untestable and makes the TUI's "today" drift mid-session.
+//! * **A pricing gap is not a day off.** A day with traffic but no published
+//!   rate renders [`CellLevel::Unpriced`] under the cost metric instead of
+//!   collapsing into the same blank cell as a day you did not work. This is the
+//!   same concern that makes `data::usage::sort_by_bucket_desc` rank priced
+//!   rows above unpriced ones rather than comparing dollars to tokens.
+
+use std::collections::HashMap;
+
+use chrono::{Datelike, Duration, Local, NaiveDate};
+
+use crate::data::usage::UsageData;
+
+/// Lower bound on the grid width. A zero-column grid has no `first_date`,
+/// so callers asking for one get a single week rather than a panic path.
+const MIN_WEEKS: usize = 1;
+
+/// Upper bound on the grid width (~10 years). The grid is rebuilt on the
+/// render path; an unclamped `weeks` turns a bad config value into an
+/// unbounded per-frame allocation.
+const MAX_WEEKS: usize = 520;
+
+const DAYS_PER_WEEK: usize = 7;
+
+/// GitHub's canvas width; the grid never reflows to the active period, so a
+/// short period lights fewer cells rather than collapsing the grid.
+pub const WEEKS_IN_CANVAS: usize = 53;
+
+const MONTH_ABBREVS: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/// Which quantity the heatmap colours by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HeatMetric {
+    #[default]
+    Cost,
+    Tokens,
+    Calls,
+    Sessions,
+}
+
+impl HeatMetric {
+    /// Selector order, kept in lockstep with [`HeatMetric::next`] so the
+    /// visible list and the hotkey cycle cannot drift apart.
+    pub const ALL: &'static [HeatMetric] = &[Self::Cost, Self::Tokens, Self::Calls, Self::Sessions];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Cost => "cost",
+            Self::Tokens => "tokens",
+            Self::Calls => "calls",
+            Self::Sessions => "sessions",
+        }
+    }
+
+    /// Cycle order for the metric hotkey. Wraps back to `Cost`.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Cost => Self::Tokens,
+            Self::Tokens => Self::Calls,
+            Self::Calls => Self::Sessions,
+            Self::Sessions => Self::Cost,
+        }
+    }
+}
+
+/// Intensity bucket for one day cell.
+///
+/// `Unpriced` is deliberately not part of the ordered ramp: it means "we
+/// cannot say how hot this day was", which is a different statement from
+/// any of `Empty`..`L4`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellLevel {
+    Empty,
+    L1,
+    L2,
+    L3,
+    L4,
+    Unpriced,
+}
+
+impl CellLevel {
+    /// The less-to-more legend ramp. [`CellLevel::Unpriced`] is excluded on
+    /// purpose: `✗` means "value unknown", which is not a step on the
+    /// intensity scale and gets its own legend entry.
+    pub const SCALE: &'static [CellLevel] = &[Self::Empty, Self::L1, Self::L2, Self::L3, Self::L4];
+
+    pub fn glyph(self) -> char {
+        match self {
+            Self::Empty => '·',
+            Self::L1 => '░',
+            Self::L2 => '▒',
+            Self::L3 => '▓',
+            Self::L4 => '█',
+            Self::Unpriced => '✗',
+        }
+    }
+}
+
+/// One day's totals plus its resolved intensity.
+///
+/// `cost_usd` stays `Option` rather than collapsing to `0.0` so the render
+/// side can print "n/a" instead of a misleading `$0.00`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DayCell {
+    pub date:     NaiveDate,
+    pub cost_usd: Option<f64>,
+    pub tokens:   u64,
+    pub calls:    usize,
+    pub sessions: usize,
+    pub level:    CellLevel,
+}
+
+impl DayCell {
+    /// `true` when the day saw traffic, regardless of whether it was priced.
+    fn is_active(&self) -> bool {
+        self.tokens > 0 || self.calls > 0
+    }
+
+    /// The day's value under `metric`. Unpriced days read as `0.0` under
+    /// `Cost`; callers that care about the distinction check
+    /// [`DayCell::is_active`] first.
+    fn value(&self, metric: HeatMetric) -> f64 {
+        match metric {
+            HeatMetric::Cost => self.cost_usd.unwrap_or(0.0),
+            HeatMetric::Tokens => self.tokens as f64,
+            HeatMetric::Calls => self.calls as f64,
+            HeatMetric::Sessions => self.sessions as f64,
+        }
+    }
+}
+
+/// A fixed-width calendar canvas ending on the week that contains `today`.
+///
+/// The shape is rectangular by construction: `weeks.len()` columns of
+/// exactly 7 slots each, Monday-first. Slots outside the covered date span
+/// (leading days of the oldest week, trailing days after `today`) are
+/// `None`, which keeps the renderer free of any date arithmetic.
+#[derive(Debug, Clone)]
+pub struct HeatmapGrid {
+    pub weeks:     Vec<Vec<Option<DayCell>>>,
+    pub metric:    HeatMetric,
+    pub max_value: f64,
+}
+
+impl HeatmapGrid {
+    pub fn build(data: &UsageData, metric: HeatMetric, today: NaiveDate, weeks: usize) -> Self {
+        let weeks = weeks.clamp(MIN_WEEKS, MAX_WEEKS);
+        let span_days = weeks * DAYS_PER_WEEK;
+
+        // Monday of the oldest column. Saturating at the calendar floor
+        // keeps an absurd `today` (or `weeks`) off the panic path; the grid
+        // just covers fewer real days.
+        let last_monday = monday_of(today);
+        let first_date = last_monday
+            .checked_sub_signed(Duration::days(((weeks - 1) * DAYS_PER_WEEK) as i64))
+            .unwrap_or(NaiveDate::MIN);
+
+        let totals = daily_totals(data, first_date, today);
+
+        let mut cells: Vec<Option<DayCell>> = Vec::with_capacity(span_days);
+        for offset in 0..span_days {
+            let Some(date) = first_date.checked_add_signed(Duration::days(offset as i64)) else {
+                cells.push(None);
+                continue;
+            };
+            if date > today {
+                cells.push(None);
+                continue;
+            }
+            let bucket = totals.get(&date);
+            cells.push(Some(DayCell {
+                date,
+                cost_usd: bucket.and_then(|b| b.cost_usd),
+                tokens: bucket.map_or(0, |b| b.tokens),
+                calls: bucket.map_or(0, |b| b.calls),
+                sessions: bucket.map_or(0, |b| b.sessions),
+                // Filled in below, once the whole span is known.
+                level: CellLevel::Empty,
+            }));
+        }
+
+        // Unpriced days contribute nothing to the scale: their cost is
+        // unknown, not zero, so folding them in either way would be a lie.
+        // Stated explicitly rather than relying on `unwrap_or(0.0)`.
+        let max_value = cells
+            .iter()
+            .flatten()
+            .filter(|cell| !(metric == HeatMetric::Cost && cell.cost_usd.is_none()))
+            .map(|cell| cell.value(metric))
+            .fold(0.0_f64, f64::max);
+
+        for cell in cells.iter_mut().flatten() {
+            cell.level = level_for(cell, metric, max_value);
+        }
+
+        let weeks_grid = cells.chunks(DAYS_PER_WEEK).map(<[Option<DayCell>]>::to_vec).collect();
+
+        Self {
+            weeks: weeks_grid,
+            metric,
+            max_value,
+        }
+    }
+
+    /// O(1) lookup by date. `None` for any date outside the covered span.
+    pub fn cell(&self, date: NaiveDate) -> Option<&DayCell> {
+        let offset = (date - self.first_date()).num_days();
+        let offset = usize::try_from(offset).ok()?;
+        let (col, row) = (offset / DAYS_PER_WEEK, offset % DAYS_PER_WEEK);
+        self.weeks.get(col)?.get(row)?.as_ref()
+    }
+
+    /// Move a cursor `dx` columns and `dy` rows, clamped to the covered
+    /// span. Clamping rather than wrapping keeps arrow-key navigation from
+    /// teleporting the cursor across a year when it hits an edge.
+    pub fn step(&self, from: NaiveDate, dx: i32, dy: i32) -> NaiveDate {
+        let first = self.first_date();
+        let last = self.last_date();
+        let span = (last - first).num_days();
+
+        let delta = i64::from(dx) * DAYS_PER_WEEK as i64 + i64::from(dy);
+        let target = (from - first).num_days().saturating_add(delta);
+
+        first.checked_add_signed(Duration::days(target.clamp(0, span))).unwrap_or(last)
+    }
+
+    /// Monday of the oldest column. Not necessarily a day with data.
+    pub fn first_date(&self) -> NaiveDate {
+        self.weeks
+            .first()
+            .and_then(|week| week.iter().flatten().next())
+            .map_or(NaiveDate::MIN, |cell| cell.date)
+    }
+
+    /// The most recent covered day, i.e. the `today` passed to [`Self::build`].
+    pub fn last_date(&self) -> NaiveDate {
+        self.weeks
+            .iter()
+            .rev()
+            .flat_map(|week| week.iter().rev())
+            .flatten()
+            .next()
+            .map_or(self.first_date(), |cell| cell.date)
+    }
+
+    /// One entry per column; `Some(abbrev)` only where a column starts a
+    /// month that the previous column did not cover. The oldest column is
+    /// always labelled so the axis has an anchor.
+    pub fn month_labels(&self) -> Vec<Option<&'static str>> {
+        let mut labels = Vec::with_capacity(self.weeks.len());
+        let mut previous_month: Option<u32> = None;
+        for (col, _) in self.weeks.iter().enumerate() {
+            let Some(start) = self
+                .first_date()
+                .checked_add_signed(Duration::days((col * DAYS_PER_WEEK) as i64))
+            else {
+                labels.push(None);
+                continue;
+            };
+            let month = start.month();
+            let changed = previous_month != Some(month);
+            previous_month = Some(month);
+            labels.push(if changed { month_abbrev(month) } else { None });
+        }
+        labels
+    }
+}
+
+/// Top models for one day, ranked cost-first then tokens, capped at `limit`.
+///
+/// Mirrors `data::usage::sort_by_bucket_desc`: an unpriced model never
+/// outranks a priced one, because a token count compared against a dollar
+/// figure wins by five orders of magnitude and empties the panel.
+pub fn day_model_breakdown(
+    data: &UsageData,
+    date: NaiveDate,
+    limit: usize,
+) -> Vec<(String, Option<f64>, u64)> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let mut per_model: HashMap<&str, (Option<f64>, u64)> = HashMap::new();
+    for call in &data.calls {
+        if local_day(call.timestamp) != date {
+            continue;
+        }
+        let entry = per_model.entry(call.model.as_str()).or_insert((None, 0));
+        entry.0 = match (entry.0, call.cost_usd) {
+            (Some(acc), Some(add)) => Some(acc + add),
+            (Some(acc), None) => Some(acc),
+            (None, other) => other,
+        };
+        entry.1 = entry.1.saturating_add(call_tokens(call));
+    }
+
+    let mut rows: Vec<(String, Option<f64>, u64)> = per_model
+        .into_iter()
+        .map(|(model, (cost, tokens))| (model.to_string(), cost, tokens))
+        .collect();
+
+    rows.sort_by(|a, b| {
+        b.1.is_some()
+            .cmp(&a.1.is_some())
+            .then_with(|| rank_value(b).total_cmp(&rank_value(a)))
+            // Name tiebreak so equal rows keep a stable, reproducible order.
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    rows.truncate(limit);
+    rows
+}
+
+fn rank_value(row: &(String, Option<f64>, u64)) -> f64 {
+    row.1.unwrap_or(row.2 as f64)
+}
+
+fn call_tokens(call: &crate::data::usage::ProviderCall) -> u64 {
+    call.input_tokens
+        .saturating_add(call.cache_creation_tokens)
+        .saturating_add(call.cache_read_tokens)
+        .saturating_add(call.output_tokens)
+        .saturating_add(call.reasoning_tokens)
+}
+
+/// Day bucketing is local-tz throughout the burndown pipeline (see
+/// `data::usage::aggregate_calls`); cached timestamps are UTC, so the
+/// conversion happens at every read boundary including this one.
+fn local_day(timestamp: chrono::DateTime<chrono::Utc>) -> NaiveDate {
+    timestamp.with_timezone(&Local).date_naive()
+}
+
+/// Flat per-day totals for the covered span, lifted from the already
+/// local-tz-bucketed `data.daily` rather than rescanning `data.calls`:
+/// the grid is rebuilt every frame and `calls` can run to six figures.
+struct DayTotals {
+    cost_usd: Option<f64>,
+    tokens:   u64,
+    calls:    usize,
+    sessions: usize,
+}
+
+fn daily_totals(
+    data: &UsageData,
+    first: NaiveDate,
+    last: NaiveDate,
+) -> HashMap<NaiveDate, DayTotals> {
+    data.daily
+        .iter()
+        .filter(|(date, _)| *date >= first && *date <= last)
+        .map(|(date, bucket)| {
+            (
+                *date,
+                DayTotals {
+                    cost_usd: bucket.cost_usd,
+                    tokens:   bucket.total(),
+                    calls:    bucket.call_count,
+                    sessions: bucket.session_count,
+                },
+            )
+        })
+        .collect()
+}
+
+fn level_for(cell: &DayCell, metric: HeatMetric, max_value: f64) -> CellLevel {
+    if metric == HeatMetric::Cost && cell.cost_usd.is_none() {
+        return if cell.is_active() {
+            CellLevel::Unpriced
+        } else {
+            CellLevel::Empty
+        };
+    }
+
+    let value = cell.value(metric);
+    if value <= 0.0 {
+        return CellLevel::Empty;
+    }
+    if max_value <= 0.0 {
+        return CellLevel::L1;
+    }
+
+    let ratio = value / max_value;
+    if ratio <= 0.25 {
+        CellLevel::L1
+    } else if ratio <= 0.5 {
+        CellLevel::L2
+    } else if ratio <= 0.75 {
+        CellLevel::L3
+    } else {
+        CellLevel::L4
+    }
+}
+
+fn monday_of(date: NaiveDate) -> NaiveDate {
+    let back = i64::from(date.weekday().num_days_from_monday());
+    date.checked_sub_signed(Duration::days(back)).unwrap_or(date)
+}
+
+fn month_abbrev(month: u32) -> Option<&'static str> {
+    let index = usize::try_from(month.checked_sub(1)?).ok()?;
+    MONTH_ABBREVS.get(index).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::data::usage::TokenBucket;
+    use crate::test_support::ProviderCallBuilder;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap_or(NaiveDate::MIN)
+    }
+
+    /// A bucket with `tokens` split across input, `calls` calls, `sessions`
+    /// sessions, and an optional price.
+    fn bucket(tokens: u64, calls: usize, sessions: usize, cost: Option<f64>) -> TokenBucket {
+        TokenBucket {
+            input_tokens: tokens,
+            call_count: calls,
+            session_count: sessions,
+            cost_usd: cost,
+            ..TokenBucket::default()
+        }
+    }
+
+    fn data_with_days(days: &[(NaiveDate, TokenBucket)]) -> UsageData {
+        UsageData {
+            daily: days.to_vec(),
+            ..UsageData::default()
+        }
+    }
+
+    #[test]
+    fn heatmap_zero_day_is_empty_and_max_day_is_l4() {
+        let today = date(2026, 3, 12);
+        let data = data_with_days(&[
+            (date(2026, 3, 9), bucket(0, 0, 0, Some(0.0))),
+            (date(2026, 3, 10), bucket(1_000, 4, 1, Some(2.50))),
+            (date(2026, 3, 11), bucket(9_000, 40, 3, Some(10.0))),
+        ]);
+
+        let grid = HeatmapGrid::build(&data, HeatMetric::Cost, today, 4);
+
+        assert_eq!(grid.max_value, 10.0);
+        let zero = grid.cell(date(2026, 3, 9));
+        assert_eq!(zero.map(|c| c.level), Some(CellLevel::Empty));
+        let hottest = grid.cell(date(2026, 3, 11));
+        assert_eq!(hottest.map(|c| c.level), Some(CellLevel::L4));
+        // 2.50 / 10.00 = 25% -> the top of the L1 bucket.
+        assert_eq!(
+            grid.cell(date(2026, 3, 10)).map(|c| c.level),
+            Some(CellLevel::L1)
+        );
+        // A day with no row at all is still a real (idle) cell.
+        assert_eq!(
+            grid.cell(date(2026, 3, 8)).map(|c| c.level),
+            Some(CellLevel::Empty)
+        );
+    }
+
+    #[test]
+    fn heatmap_unpriced_day_is_marked_under_cost_only() {
+        let today = date(2026, 3, 12);
+        let data = data_with_days(&[
+            (date(2026, 3, 10), bucket(500_000, 30, 2, None)),
+            (date(2026, 3, 11), bucket(1_000, 5, 1, Some(4.0))),
+        ]);
+
+        let cost = HeatmapGrid::build(&data, HeatMetric::Cost, today, 4);
+        assert_eq!(
+            cost.cell(date(2026, 3, 10)).map(|c| c.level),
+            Some(CellLevel::Unpriced),
+            "an active day with no published rate must not render as a day off"
+        );
+        assert_eq!(
+            cost.max_value, 4.0,
+            "the unpriced day must not participate in the cost scale"
+        );
+
+        let tokens = HeatmapGrid::build(&data, HeatMetric::Tokens, today, 4);
+        assert_eq!(
+            tokens.cell(date(2026, 3, 10)).map(|c| c.level),
+            Some(CellLevel::L4),
+            "under a non-cost metric the same day is just the busiest cell"
+        );
+        assert_eq!(tokens.max_value, 500_000.0);
+    }
+
+    #[test]
+    fn heatmap_grid_is_rectangular_and_stops_at_today() {
+        // 2026-03-12 is a Thursday: rows 4..6 of the last column are future.
+        let today = date(2026, 3, 12);
+        let grid = HeatmapGrid::build(&UsageData::default(), HeatMetric::Cost, today, 6);
+
+        assert_eq!(grid.weeks.len(), 6);
+        for week in &grid.weeks {
+            assert_eq!(week.len(), 7, "every column must have exactly 7 slots");
+        }
+
+        let last = grid.weeks.last().map(Vec::as_slice).unwrap_or_default();
+        let present: Vec<bool> = last.iter().map(Option::is_some).collect();
+        assert_eq!(
+            present,
+            vec![true, true, true, true, false, false, false],
+            "slots after today are None"
+        );
+
+        assert_eq!(grid.last_date(), today);
+        assert_eq!(grid.first_date(), date(2026, 2, 2));
+        assert_eq!(
+            grid.first_date().weekday(),
+            chrono::Weekday::Mon,
+            "column 0 starts on a Monday"
+        );
+        assert!(
+            grid.cell(date(2026, 3, 13)).is_none(),
+            "tomorrow is not covered"
+        );
+        assert!(grid.cell(date(2026, 2, 1)).is_none(), "before the span");
+    }
+
+    #[test]
+    fn heatmap_step_moves_by_week_and_day_and_clamps() {
+        let today = date(2026, 3, 12);
+        let grid = HeatmapGrid::build(&UsageData::default(), HeatMetric::Cost, today, 6);
+        let first = grid.first_date();
+
+        let mid = date(2026, 3, 4);
+        assert_eq!(grid.step(mid, 0, 1), date(2026, 3, 5));
+        assert_eq!(grid.step(mid, 0, -1), date(2026, 3, 3));
+        assert_eq!(grid.step(mid, -1, 0), date(2026, 2, 25));
+        assert_eq!(grid.step(mid, 1, 0), date(2026, 3, 11));
+
+        assert_eq!(grid.step(first, -1, 0), first, "clamps at the oldest edge");
+        assert_eq!(grid.step(first, 0, -99), first);
+        assert_eq!(grid.step(today, 1, 0), today, "clamps at today");
+        assert_eq!(grid.step(today, 0, 99), today);
+        // A cursor that starts out of range is pulled back inside.
+        assert_eq!(grid.step(date(2030, 1, 1), 0, 0), today);
+        assert_eq!(grid.step(date(2020, 1, 1), 0, 0), first);
+    }
+
+    #[test]
+    fn heatmap_month_labels_mark_only_month_starts() {
+        let today = date(2026, 3, 12);
+        let grid = HeatmapGrid::build(&UsageData::default(), HeatMetric::Cost, today, 6);
+
+        // Columns start 2026-02-02, 02-09, 02-16, 02-23, 03-02, 03-09.
+        assert_eq!(
+            grid.month_labels(),
+            vec![Some("Feb"), None, None, None, Some("Mar"), None]
+        );
+    }
+
+    #[test]
+    fn heatmap_day_breakdown_ranks_priced_above_unpriced() {
+        let stamp = Utc.with_ymd_and_hms(2026, 3, 10, 12, 0, 0).single().unwrap_or_else(Utc::now);
+        let day = local_day(stamp);
+
+        let data = UsageData {
+            calls: vec![
+                ProviderCallBuilder::new()
+                    .with_model("mystery-model")
+                    .with_timestamp(stamp)
+                    .with_input_tokens(500_000_000)
+                    .build(),
+                ProviderCallBuilder::new()
+                    .with_model("claude-sonnet-4-5")
+                    .with_timestamp(stamp)
+                    .with_input_tokens(1_000)
+                    .with_cost(0.01)
+                    .build(),
+                // A different day must not leak into the breakdown.
+                ProviderCallBuilder::new()
+                    .with_model("other-day-model")
+                    .with_timestamp(stamp - Duration::days(3))
+                    .with_input_tokens(9_000)
+                    .with_cost(99.0)
+                    .build(),
+            ],
+            ..UsageData::default()
+        };
+
+        let rows = day_model_breakdown(&data, day, 5);
+        assert_eq!(rows.len(), 2, "only the requested day's models");
+        assert_eq!(
+            rows.first().map(|r| r.0.as_str()),
+            Some("claude-sonnet-4-5")
+        );
+        assert_eq!(rows.get(1).map(|r| r.0.as_str()), Some("mystery-model"));
+        assert_eq!(rows.get(1).and_then(|r| r.1), None);
+        assert_eq!(rows.get(1).map(|r| r.2), Some(500_000_000));
+
+        assert!(day_model_breakdown(&data, day, 0).is_empty());
+        assert_eq!(day_model_breakdown(&data, day, 1).len(), 1);
+    }
+
+    #[test]
+    fn heatmap_empty_data_does_not_panic() {
+        let today = date(2026, 3, 12);
+        let data = UsageData::default();
+
+        for metric in [
+            HeatMetric::Cost,
+            HeatMetric::Tokens,
+            HeatMetric::Calls,
+            HeatMetric::Sessions,
+        ] {
+            let grid = HeatmapGrid::build(&data, metric, today, 0);
+            assert_eq!(grid.weeks.len(), 1, "weeks is clamped up to one column");
+            assert_eq!(grid.max_value, 0.0);
+            assert!(
+                grid.weeks.iter().flatten().flatten().all(|cell| cell.level == CellLevel::Empty)
+            );
+            assert_eq!(grid.last_date(), today);
+            assert_eq!(grid.step(today, -5, -5), grid.first_date());
+            assert!(day_model_breakdown(&data, today, 5).is_empty());
+        }
+    }
+
+    #[test]
+    fn heatmap_metric_cycles_and_labels() {
+        assert_eq!(HeatMetric::default(), HeatMetric::Cost);
+        let mut metric = HeatMetric::Cost;
+        let mut seen = Vec::new();
+        for _ in 0..4 {
+            seen.push(metric.label());
+            metric = metric.next();
+        }
+        assert_eq!(seen, vec!["cost", "tokens", "calls", "sessions"]);
+        assert_eq!(metric, HeatMetric::Cost, "the cycle wraps");
+    }
+
+    #[test]
+    fn heatmap_metric_all_matches_next_cycle() {
+        let mut metric = HeatMetric::default();
+        let cycled: Vec<HeatMetric> = (0..HeatMetric::ALL.len())
+            .map(|_| {
+                let current = metric;
+                metric = metric.next();
+                current
+            })
+            .collect();
+        assert_eq!(
+            cycled,
+            HeatMetric::ALL.to_vec(),
+            "the selector order and the hotkey cycle must not drift apart"
+        );
+        assert_eq!(metric, HeatMetric::default(), "one full lap returns home");
+    }
+
+    #[test]
+    fn heatmap_scale_is_the_ramp_without_unpriced() {
+        assert_eq!(
+            CellLevel::SCALE,
+            &[
+                CellLevel::Empty,
+                CellLevel::L1,
+                CellLevel::L2,
+                CellLevel::L3,
+                CellLevel::L4
+            ]
+        );
+        assert!(
+            !CellLevel::SCALE.contains(&CellLevel::Unpriced),
+            "'unknown' is not a step on a less-to-more scale"
+        );
+    }
+
+    #[test]
+    fn heatmap_canvas_width_covers_a_full_year() {
+        assert_eq!(WEEKS_IN_CANVAS, 53);
+        let today = date(2026, 3, 12);
+        let grid = HeatmapGrid::build(
+            &UsageData::default(),
+            HeatMetric::Cost,
+            today,
+            WEEKS_IN_CANVAS,
+        );
+        assert_eq!(grid.weeks.len(), WEEKS_IN_CANVAS);
+        assert!(
+            (grid.last_date() - grid.first_date()).num_days() >= 365,
+            "the fixed canvas always spans at least a year"
+        );
+    }
+
+    #[test]
+    fn heatmap_cell_glyphs_are_distinct() {
+        let glyphs: Vec<char> = [
+            CellLevel::Empty,
+            CellLevel::L1,
+            CellLevel::L2,
+            CellLevel::L3,
+            CellLevel::L4,
+            CellLevel::Unpriced,
+        ]
+        .into_iter()
+        .map(CellLevel::glyph)
+        .collect();
+        assert_eq!(glyphs, vec!['·', '░', '▒', '▓', '█', '✗']);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/src/heatmap.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/heatmap.rs
@@ -114,12 +114,12 @@ impl CellLevel {
 /// side can print "n/a" instead of a misleading `$0.00`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DayCell {
-    pub date:     NaiveDate,
+    pub date: NaiveDate,
     pub cost_usd: Option<f64>,
-    pub tokens:   u64,
-    pub calls:    usize,
+    pub tokens: u64,
+    pub calls: usize,
     pub sessions: usize,
-    pub level:    CellLevel,
+    pub level: CellLevel,
 }
 
 impl DayCell {
@@ -149,8 +149,8 @@ impl DayCell {
 /// `None`, which keeps the renderer free of any date arithmetic.
 #[derive(Debug, Clone)]
 pub struct HeatmapGrid {
-    pub weeks:     Vec<Vec<Option<DayCell>>>,
-    pub metric:    HeatMetric,
+    pub weeks: Vec<Vec<Option<DayCell>>>,
+    pub metric: HeatMetric,
     pub max_value: f64,
 }
 
@@ -346,8 +346,8 @@ fn local_day(timestamp: chrono::DateTime<chrono::Utc>) -> NaiveDate {
 /// the grid is rebuilt every frame and `calls` can run to six figures.
 struct DayTotals {
     cost_usd: Option<f64>,
-    tokens:   u64,
-    calls:    usize,
+    tokens: u64,
+    calls: usize,
     sessions: usize,
 }
 
@@ -364,8 +364,8 @@ fn daily_totals(
                 *date,
                 DayTotals {
                     cost_usd: bucket.cost_usd,
-                    tokens:   bucket.total(),
-                    calls:    bucket.call_count,
+                    tokens: bucket.total(),
+                    calls: bucket.call_count,
                     sessions: bucket.session_count,
                 },
             )

--- a/ainb-tui/crates/ainb-plugin-burndown/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/lib.rs
@@ -30,6 +30,7 @@ pub mod cache;
 pub mod cli;
 pub mod config;
 pub mod data;
+pub mod heatmap;
 pub mod live_window;
 pub mod output_format;
 pub mod plugin;

--- a/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/plugin.rs
@@ -1016,6 +1016,15 @@ impl BurndownPlugin {
                 self.ui.set_period(UsagePeriod::SpecificQuarter(year, q));
             }
             KeyCode::Char { ch: 'a' } => self.ui.set_period(UsagePeriod::All),
+            // Activity owns Left/Right for cursor movement; these must precede
+            // the provider arms below, which are unguarded catch-alls. Provider
+            // switching stays reachable on this tab via `p`.
+            KeyCode::Left if self.ui.active_tab == crate::ui::UsageTab::Activity => {
+                self.ui.heatmap_move(-1, 0)
+            }
+            KeyCode::Right if self.ui.active_tab == crate::ui::UsageTab::Activity => {
+                self.ui.heatmap_move(1, 0)
+            }
             KeyCode::Left => self.ui.prev_provider(),
             KeyCode::Right => self.ui.next_provider(),
             KeyCode::Tab => self.ui.focus_next_panel(),
@@ -1055,6 +1064,17 @@ impl BurndownPlugin {
             // `[`/`]` focus table columns (handled above); when NOT zoomed
             // they cycle the outer UsageTab so every tab — including the
             // Savings observability card — is keyboard-reachable.
+            // ── Activity-tab heatmap navigation. Guarded on the active tab so
+            // these keys keep their existing meaning everywhere else.
+            KeyCode::Up if self.ui.active_tab == crate::ui::UsageTab::Activity => {
+                self.ui.heatmap_move(0, -1)
+            }
+            KeyCode::Down if self.ui.active_tab == crate::ui::UsageTab::Activity => {
+                self.ui.heatmap_move(0, 1)
+            }
+            KeyCode::Char { ch: 'M' } if self.ui.active_tab == crate::ui::UsageTab::Activity => {
+                self.ui.heatmap_cycle_metric()
+            }
             KeyCode::Char { ch: '[' } => self.ui.prev_tab(),
             KeyCode::Char { ch: ']' } => self.ui.next_tab(),
 
@@ -1065,6 +1085,12 @@ impl BurndownPlugin {
             KeyCode::Down if self.ui.is_zoomed() => self.ui.zoom_row_down(),
             KeyCode::Char { ch: 'j' } if self.ui.is_zoomed() && !self.ui.zoom_search_active => {
                 self.ui.zoom_row_down()
+            }
+            // On the Activity tab Enter pivots to the selected day rather than
+            // committing a table row — there are no rows on a heatmap.
+            KeyCode::Enter if self.ui.active_tab == crate::ui::UsageTab::Activity => {
+                self.ui.data = self.data.clone();
+                let _ = self.ui.heatmap_commit_day();
             }
             KeyCode::Enter => {
                 // `commit_focused_row` resolves the row through
@@ -1274,10 +1300,9 @@ mod handle_key_dispatch_tests {
         let mut p = BurndownPlugin::default();
         assert_eq!(p.ui.active_tab, UsageTab::Burndown, "starts on Burndown");
 
-        // `]` walks forward: Burndown → Daily → Weekly → Projects → Optimize → Savings.
+        // `]` walks forward: Burndown → Activity → Projects → Optimize → Savings.
         for expect in [
-            UsageTab::Daily,
-            UsageTab::Weekly,
+            UsageTab::Activity,
             UsageTab::Projects,
             UsageTab::Optimize,
             UsageTab::Savings,

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -718,7 +718,9 @@ impl UsageViewState {
     /// needs no new filter machinery, and the chip strip renders the range so
     /// the narrowed state stays visible.
     pub fn heatmap_commit_day(&mut self) -> bool {
-        let Some(day) = self.heatmap_cursor.or_else(|| Some(crate::data::usage::local_now().date_naive()))
+        let Some(day) = self
+            .heatmap_cursor
+            .or_else(|| Some(crate::data::usage::local_now().date_naive()))
         else {
             return false;
         };
@@ -1610,7 +1612,10 @@ fn render_activity(buf: &mut Buffer, area: Rect, data: &UsageData, state: &Usage
         }
     }
     ratatui::widgets::Widget::render(
-        Paragraph::new(Line::from(Span::styled(ruler, Style::default().fg(MUTED_GRAY)))),
+        Paragraph::new(Line::from(Span::styled(
+            ruler,
+            Style::default().fg(MUTED_GRAY),
+        ))),
         Rect::new(inner.x, y, inner.width, 1),
         buf,
     );
@@ -1618,7 +1623,13 @@ fn render_activity(buf: &mut Buffer, area: Rect, data: &UsageData, state: &Usage
 
     // Seven day-rows. Only Mon/Wed/Fri are labelled, as GitHub does.
     for (row, label) in [
-        (0usize, "Mon"), (1, ""), (2, "Wed"), (3, ""), (4, "Fri"), (5, ""), (6, ""),
+        (0usize, "Mon"),
+        (1, ""),
+        (2, "Wed"),
+        (3, ""),
+        (4, "Fri"),
+        (5, ""),
+        (6, ""),
     ] {
         if y >= inner.y.saturating_add(inner.height) {
             break;
@@ -1636,7 +1647,8 @@ fn render_activity(buf: &mut Buffer, area: Rect, data: &UsageData, state: &Usage
                     (
                         cell.level.glyph(),
                         if selected {
-                            base.bg(LIST_HIGHLIGHT_BG).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+                            base.bg(LIST_HIGHLIGHT_BG)
+                                .add_modifier(Modifier::BOLD | Modifier::REVERSED)
                         } else {
                             base
                         },
@@ -1679,7 +1691,13 @@ fn render_activity(buf: &mut Buffer, area: Rect, data: &UsageData, state: &Usage
     // Detail strip — the exact figures the Daily tab used to carry.
     if y < inner.y.saturating_add(inner.height) {
         let height = inner.y.saturating_add(inner.height).saturating_sub(y);
-        render_activity_detail(buf, Rect::new(inner.x, y, inner.width, height), data, &grid, cursor);
+        render_activity_detail(
+            buf,
+            Rect::new(inner.x, y, inner.width, height),
+            data,
+            &grid,
+            cursor,
+        );
     }
 }
 
@@ -1724,7 +1742,10 @@ fn render_activity_detail(
             Style::default().fg(TERMINAL_ACCENT).add_modifier(Modifier::BOLD),
         ),
         Span::styled(
-            format!("{} tokens   ", crate::data::usage::format_tokens_short(cell.tokens)),
+            format!(
+                "{} tokens   ",
+                crate::data::usage::format_tokens_short(cell.tokens)
+            ),
             Style::default().fg(SOFT_WHITE),
         ),
         Span::styled(
@@ -3898,7 +3919,11 @@ fn render_leaderboard_panel(buf: &mut Buffer, area: Rect, data: &UsageData, focu
             spans.extend(ratio_gradient_spans(cost, max, bar_w));
             spans.push(Span::raw(" "));
             spans.push(Span::styled(
-                format!("{:>w$}", format_cost_or_tokens(&project.bucket), w = value_w),
+                format!(
+                    "{:>w$}",
+                    format_cost_or_tokens(&project.bucket),
+                    w = value_w
+                ),
                 Style::default().fg(TERMINAL_ACCENT),
             ));
             Line::from(spans)
@@ -4816,7 +4841,10 @@ fn format_cost(cost: Option<f64>) -> String {
 fn format_cost_or_tokens(bucket: &crate::data::usage::TokenBucket) -> String {
     match bucket.cost_usd {
         Some(value) => format!("${value:.2}"),
-        None => format!("\u{2014} {}", crate::data::usage::format_tokens_short(bucket.total())),
+        None => format!(
+            "\u{2014} {}",
+            crate::data::usage::format_tokens_short(bucket.total())
+        ),
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -266,6 +266,12 @@ pub struct UsageViewState {
     /// True when the zoom view's `/` fuzzy-search overlay is active.
     /// Resets on zoom exit (we deliberately do *not* persist a search
     /// across zoom cycles — the brief is "search clears on zoom exit").
+    /// Metric driving heatmap cell intensity on the Activity tab. Cost by
+    /// default — this is a spend tool — cycled with `M`.
+    pub heat_metric: crate::heatmap::HeatMetric,
+    /// Selected day on the Activity tab. `None` until the first render, which
+    /// seeds it to the most recent day so the cursor never starts off-canvas.
+    pub heatmap_cursor: Option<chrono::NaiveDate>,
     pub zoom_search_active: bool,
     /// Live query buffer for the zoom-mode fuzzy search.
     pub zoom_search_query: String,
@@ -341,6 +347,8 @@ impl Default for UsageViewState {
         Self {
             active_tab: UsageTab::Burndown,
             data: None,
+            heat_metric: crate::heatmap::HeatMetric::default(),
+            heatmap_cursor: None,
             fresh_pivot: false,
             loading: false,
             scroll_offset: 0,
@@ -680,6 +688,45 @@ impl UsageViewState {
     /// resolve the row by index because that's what the user is
     /// looking at when focus is active (we render from filtered_data
     /// at draw time, which is the same source).
+    /// Move the Activity-tab cursor by `dx` weeks / `dy` days, seeding it to
+    /// today on first use. Clamped inside the canvas by the grid itself.
+    pub fn heatmap_move(&mut self, dx: i32, dy: i32) {
+        let today = crate::data::usage::local_now().date_naive();
+        let from = self.heatmap_cursor.unwrap_or(today);
+        let Some(data) = self.data.as_ref() else {
+            self.heatmap_cursor = Some(from);
+            return;
+        };
+        let grid = crate::heatmap::HeatmapGrid::build(
+            data,
+            self.heat_metric,
+            today,
+            crate::heatmap::WEEKS_IN_CANVAS,
+        );
+        self.heatmap_cursor = Some(grid.step(from, dx, dy));
+    }
+
+    /// Cycle the heatmap's intensity metric (cost → tokens → calls → sessions).
+    pub fn heatmap_cycle_metric(&mut self) {
+        self.heat_metric = self.heat_metric.next();
+    }
+
+    /// Pivot every other panel to the selected day.
+    ///
+    /// Implemented as a single-day `Custom` period rather than a new date chip:
+    /// the period range already flows through `filter_usage_data_full`, so this
+    /// needs no new filter machinery, and the chip strip renders the range so
+    /// the narrowed state stays visible.
+    pub fn heatmap_commit_day(&mut self) -> bool {
+        let Some(day) = self.heatmap_cursor.or_else(|| Some(crate::data::usage::local_now().date_naive()))
+        else {
+            return false;
+        };
+        self.period = UsagePeriod::Custom { from: day, to: day };
+        self.scroll_offset = 0;
+        true
+    }
+
     pub fn commit_focused_row(&mut self) -> bool {
         let Some((target, value, owner_project)) = self.resolve_focused_row() else {
             return false;

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -3345,7 +3345,7 @@ fn render_project_panel(buf: &mut Buffer, area: Rect, rows: &[ProjectUsage], foc
     let value_w = rows
         .iter()
         .take(cap)
-        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .map(|r| format_cost_or_tokens(&r.bucket).chars().count())
         .max()
         .unwrap_or(7)
         .max(7);
@@ -3365,7 +3365,7 @@ fn render_project_panel(buf: &mut Buffer, area: Rect, rows: &[ProjectUsage], foc
             spans.extend(ratio_gradient_spans(cost, max, bar_w));
             spans.push(Span::raw(" "));
             spans.push(Span::styled(
-                format!("{:>w$}", format_cost(row.bucket.cost_usd), w = value_w),
+                format!("{:>w$}", format_cost_or_tokens(&row.bucket), w = value_w),
                 Style::default().fg(TERMINAL_ACCENT),
             ));
             Line::from(spans)
@@ -3395,7 +3395,7 @@ fn render_branch_panel(buf: &mut Buffer, area: Rect, rows: &[BranchUsage], focus
     let value_w = rows
         .iter()
         .take(cap)
-        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .map(|r| format_cost_or_tokens(&r.bucket).chars().count())
         .max()
         .unwrap_or(7)
         .max(7);
@@ -3415,7 +3415,7 @@ fn render_branch_panel(buf: &mut Buffer, area: Rect, rows: &[BranchUsage], focus
             spans.extend(ratio_gradient_spans(cost, max, bar_w));
             spans.push(Span::raw(" "));
             spans.push(Span::styled(
-                format!("{:>w$}", format_cost(row.bucket.cost_usd), w = value_w),
+                format!("{:>w$}", format_cost_or_tokens(&row.bucket), w = value_w),
                 Style::default().fg(TERMINAL_ACCENT),
             ));
             Line::from(spans)
@@ -3477,7 +3477,7 @@ fn render_live_panel(buf: &mut Buffer, area: Rect, rows: &[SessionUsage], focus:
     let value_w = rows
         .iter()
         .take(cap)
-        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .map(|r| format_cost_or_tokens(&r.bucket).chars().count())
         .max()
         .unwrap_or(7)
         .max(7);
@@ -3503,7 +3503,7 @@ fn render_live_panel(buf: &mut Buffer, area: Rect, rows: &[SessionUsage], focus:
                 ),
                 Span::styled(" · ", Style::default().fg(MUTED_GRAY)),
                 Span::styled(
-                    format!("{:>w$}", format_cost(row.bucket.cost_usd), w = value_w),
+                    format!("{:>w$}", format_cost_or_tokens(&row.bucket), w = value_w),
                     Style::default().fg(TERMINAL_ACCENT),
                 ),
             ])
@@ -3717,7 +3717,7 @@ fn render_leaderboard_panel(buf: &mut Buffer, area: Rect, data: &UsageData, focu
         .projects
         .iter()
         .take(cap)
-        .map(|r| format_cost(r.bucket.cost_usd).chars().count())
+        .map(|r| format_cost_or_tokens(&r.bucket).chars().count())
         .max()
         .unwrap_or(7)
         .max(7);
@@ -3753,7 +3753,7 @@ fn render_leaderboard_panel(buf: &mut Buffer, area: Rect, data: &UsageData, focu
             spans.extend(ratio_gradient_spans(cost, max, bar_w));
             spans.push(Span::raw(" "));
             spans.push(Span::styled(
-                format!("{:>w$}", format_cost(project.bucket.cost_usd), w = value_w),
+                format!("{:>w$}", format_cost_or_tokens(&project.bucket), w = value_w),
                 Style::default().fg(TERMINAL_ACCENT),
             ));
             Line::from(spans)
@@ -4659,7 +4659,20 @@ fn input_label(mode: UsageInputMode) -> &'static str {
 
 fn format_cost(cost: Option<f64>) -> String {
     cost.map(|value| format!("${value:.2}"))
-        .unwrap_or_else(|| "cost n/a".to_string())
+        // `—` reads as "no published price"; the old `cost n/a` read as "no
+        // data", which is a different thing and sent people looking for a
+        // parsing bug when the real answer was a missing rate.
+        .unwrap_or_else(|| "\u{2014}".to_string())
+}
+
+/// Value column for the ranked bar panels: a dollar figure when we have a rate
+/// for the model, otherwise an em dash plus the token count so the row still
+/// carries its magnitude instead of reading as empty.
+fn format_cost_or_tokens(bucket: &crate::data::usage::TokenBucket) -> String {
+    match bucket.cost_usd {
+        Some(value) => format!("${value:.2}"),
+        None => format!("\u{2014} {}", crate::data::usage::format_tokens_short(bucket.total())),
+    }
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/ui.rs
@@ -51,8 +51,11 @@ const BAR_THRESHOLD_MED: f64 = 0.33;
 pub enum UsageTab {
     #[default]
     Burndown,
-    Daily,
-    Weekly,
+    /// GitHub-style contribution heatmap. Replaces the old Daily and Weekly
+    /// tables: the same per-day buckets, read as a year-long canvas instead of
+    /// two scrolling lists, with the exact figures moved into a cursor-driven
+    /// detail strip.
+    Activity,
     Projects,
     Optimize,
     Savings,
@@ -62,8 +65,7 @@ impl UsageTab {
     fn all() -> &'static [UsageTab] {
         &[
             UsageTab::Burndown,
-            UsageTab::Daily,
-            UsageTab::Weekly,
+            UsageTab::Activity,
             UsageTab::Projects,
             UsageTab::Optimize,
             UsageTab::Savings,
@@ -73,8 +75,7 @@ impl UsageTab {
     fn title(&self) -> &'static str {
         match self {
             UsageTab::Burndown => "Burndown",
-            UsageTab::Daily => "Daily",
-            UsageTab::Weekly => "Weekly",
+            UsageTab::Activity => "Activity",
             UsageTab::Projects => "By Project",
             UsageTab::Optimize => "Optimize",
             UsageTab::Savings => "Savings",
@@ -83,9 +84,8 @@ impl UsageTab {
 
     fn next(&self) -> Self {
         match self {
-            UsageTab::Burndown => UsageTab::Daily,
-            UsageTab::Daily => UsageTab::Weekly,
-            UsageTab::Weekly => UsageTab::Projects,
+            UsageTab::Burndown => UsageTab::Activity,
+            UsageTab::Activity => UsageTab::Projects,
             UsageTab::Projects => UsageTab::Optimize,
             UsageTab::Optimize => UsageTab::Savings,
             UsageTab::Savings => UsageTab::Burndown,
@@ -95,9 +95,8 @@ impl UsageTab {
     fn prev(&self) -> Self {
         match self {
             UsageTab::Burndown => UsageTab::Savings,
-            UsageTab::Daily => UsageTab::Burndown,
-            UsageTab::Weekly => UsageTab::Daily,
-            UsageTab::Projects => UsageTab::Weekly,
+            UsageTab::Activity => UsageTab::Burndown,
+            UsageTab::Projects => UsageTab::Activity,
             UsageTab::Optimize => UsageTab::Projects,
             UsageTab::Savings => UsageTab::Optimize,
         }
@@ -517,8 +516,9 @@ impl UsageViewState {
         match &self.data {
             None => 0,
             Some(data) => match self.active_tab {
-                UsageTab::Daily => data.daily.len(),
-                UsageTab::Weekly => data.weekly.len(),
+                // The heatmap is a fixed canvas, not a scrolling list: it has
+                // no rows to page through, so scroll keys are inert here.
+                UsageTab::Activity => 0,
                 UsageTab::Projects => data.projects.len(),
                 UsageTab::Burndown => {
                     data.daily.len()
@@ -1060,12 +1060,7 @@ pub fn render(buf: &mut Buffer, area: Rect, state: &UsageViewState) {
             render_no_data(buf, layout[content_idx], state);
         } else {
             match state.active_tab {
-                UsageTab::Daily => {
-                    render_daily(buf, layout[content_idx], data, state.scroll_offset)
-                }
-                UsageTab::Weekly => {
-                    render_weekly(buf, layout[content_idx], data, state.scroll_offset)
-                }
+                UsageTab::Activity => render_activity(buf, layout[content_idx], data, state),
                 UsageTab::Projects => {
                     render_projects(buf, layout[content_idx], data, state.scroll_offset)
                 }
@@ -1528,147 +1523,250 @@ pub(crate) fn scan_progress_headline(progress: &ScanProgressEvent) -> String {
     }
 }
 
-fn render_daily(buf: &mut Buffer, area: Rect, data: &UsageData, scroll_offset: usize) {
+/// GitHub-style contribution heatmap: a fixed 53-week canvas, one column per
+/// week, plus a cursor-driven detail strip carrying the exact figures the old
+/// Daily table used to show.
+///
+/// The canvas is deliberately independent of the period chips. A year-long
+/// grid that reflows to 1 column on `1 Today` reads as broken, so the period
+/// selector does not reshape it — Enter is the way this tab narrows the view.
+fn render_activity(buf: &mut Buffer, area: Rect, data: &UsageData, state: &UsageViewState) {
+    use crate::heatmap::{HeatmapGrid, WEEKS_IN_CANVAS};
+
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(CORNFLOWER_BLUE))
+        .title(Span::styled(
+            " 🔥 Activity ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
         .style(Style::default().bg(DARK_BG));
-
     let inner = block.inner(area);
     ratatui::widgets::Widget::render(block, area, buf);
 
-    if data.daily.is_empty() {
-        let p = Paragraph::new("  No usage data found.").style(Style::default().fg(MUTED_GRAY));
-        ratatui::widgets::Widget::render(p, inner, buf);
+    if inner.width < 24 || inner.height < 8 {
         return;
     }
 
-    // Split into table + bar chart
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
-        .split(inner);
+    let today = crate::data::usage::local_now().date_naive();
+    let grid = HeatmapGrid::build(data, state.heat_metric, today, WEEKS_IN_CANVAS);
+    let cursor = state.heatmap_cursor.unwrap_or(today);
 
-    // Table
-    let header = Row::new(vec![
-        "Date", "Total", "Input", "Cache", "Output", "Sessions",
-    ])
-    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
-    .bottom_margin(1);
+    // Two chars per column (glyph + gap) keeps the grid readable at terminal
+    // aspect ratios; the day-label gutter costs 4.
+    const GUTTER: u16 = 4;
+    let visible_cols = ((inner.width.saturating_sub(GUTTER)) / 2) as usize;
+    // Truncate the OLDEST weeks when the terminal is too narrow — today must
+    // stay on screen, since a heatmap you can't see the present in is useless.
+    let skip = grid.weeks.len().saturating_sub(visible_cols.max(1));
+    let columns: Vec<_> = grid.weeks.iter().skip(skip).collect();
 
-    let visible_rows = chunks[0].height.saturating_sub(2) as usize;
-    let total_rows = data.daily.len();
-    // Default scroll to bottom (show most recent)
-    let effective_offset = if scroll_offset == 0 && total_rows > visible_rows {
-        total_rows.saturating_sub(visible_rows)
-    } else {
-        scroll_offset
-    };
+    let mut y = inner.y;
 
-    let rows: Vec<Row> = data
-        .daily
-        .iter()
-        .skip(effective_offset)
-        .take(visible_rows)
-        .map(|(date, bucket)| {
-            Row::new(vec![
-                date.format("%Y-%m-%d").to_string(),
-                format_tokens_short(bucket.total()),
-                format_tokens_short(bucket.input_tokens),
-                format_tokens_short(bucket.cache_read_tokens + bucket.cache_creation_tokens),
-                format_tokens_short(bucket.output_tokens),
-                format!("{}", bucket.session_count),
-            ])
-            .style(Style::default().fg(SOFT_WHITE))
-        })
-        .collect();
+    // Metric selector.
+    let mut metric_spans = vec![Span::styled("Metric: ", Style::default().fg(MUTED_GRAY))];
+    for metric in crate::heatmap::HeatMetric::ALL {
+        let selected = *metric == state.heat_metric;
+        // Bracket the active metric as well as highlighting it. Colour alone
+        // is invisible in a monochrome terminal, in a plain-text pane capture,
+        // and to anyone who can't distinguish the highlight — the brackets
+        // make the selection legible everywhere.
+        metric_spans.push(Span::styled(
+            if selected {
+                format!("[{}]", metric.label())
+            } else {
+                format!(" {} ", metric.label())
+            },
+            if selected {
+                Style::default().bg(GOLD).fg(DARK_BG).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(MUTED_GRAY)
+            },
+        ));
+    }
+    metric_spans.push(Span::styled("  M cycle", Style::default().fg(MUTED_GRAY)));
+    ratatui::widgets::Widget::render(
+        Paragraph::new(Line::from(metric_spans)),
+        Rect::new(inner.x, y, inner.width, 1),
+        buf,
+    );
+    y = y.saturating_add(2);
 
-    let widths = [
-        Constraint::Length(12),
-        Constraint::Length(10),
-        Constraint::Length(10),
-        Constraint::Length(10),
-        Constraint::Length(10),
-        Constraint::Length(8),
-    ];
+    // Month ruler.
+    let labels = grid.month_labels();
+    let mut ruler = String::from("    ");
+    for (idx, _) in columns.iter().enumerate() {
+        match labels.get(skip + idx).copied().flatten() {
+            // A 3-char month name in a 2-char column would overlap its
+            // neighbour, so a labelled column borrows the next one's space and
+            // the next label is skipped by the grid builder.
+            Some(name) => ruler.push_str(name),
+            None => {
+                if ruler.len() < (4 + (idx + 1) * 2) {
+                    ruler.push_str("  ");
+                }
+            }
+        }
+    }
+    ratatui::widgets::Widget::render(
+        Paragraph::new(Line::from(Span::styled(ruler, Style::default().fg(MUTED_GRAY)))),
+        Rect::new(inner.x, y, inner.width, 1),
+        buf,
+    );
+    y = y.saturating_add(1);
 
-    let table = Table::new(rows, widths).header(header).column_spacing(1);
+    // Seven day-rows. Only Mon/Wed/Fri are labelled, as GitHub does.
+    for (row, label) in [
+        (0usize, "Mon"), (1, ""), (2, "Wed"), (3, ""), (4, "Fri"), (5, ""), (6, ""),
+    ] {
+        if y >= inner.y.saturating_add(inner.height) {
+            break;
+        }
+        let mut spans = vec![Span::styled(
+            format!("{label:<4}"),
+            Style::default().fg(MUTED_GRAY),
+        )];
+        for week in &columns {
+            let cell = week.get(row).and_then(|c| c.as_ref());
+            let (glyph, style) = match cell {
+                Some(cell) => {
+                    let selected = cell.date == cursor;
+                    let base = heat_style(cell.level);
+                    (
+                        cell.level.glyph(),
+                        if selected {
+                            base.bg(LIST_HIGHLIGHT_BG).add_modifier(Modifier::BOLD | Modifier::REVERSED)
+                        } else {
+                            base
+                        },
+                    )
+                }
+                None => (' ', Style::default()),
+            };
+            spans.push(Span::styled(glyph.to_string(), style));
+            spans.push(Span::raw(" "));
+        }
+        ratatui::widgets::Widget::render(
+            Paragraph::new(Line::from(spans)),
+            Rect::new(inner.x, y, inner.width, 1),
+            buf,
+        );
+        y = y.saturating_add(1);
+    }
 
-    ratatui::widgets::Widget::render(table, chunks[0], buf);
+    // Legend.
+    y = y.saturating_add(1);
+    if y < inner.y.saturating_add(inner.height) {
+        let mut legend = vec![Span::styled(" Less ", Style::default().fg(MUTED_GRAY))];
+        for level in crate::heatmap::CellLevel::SCALE {
+            legend.push(Span::styled(level.glyph().to_string(), heat_style(*level)));
+            legend.push(Span::raw(" "));
+        }
+        legend.push(Span::styled("More   ", Style::default().fg(MUTED_GRAY)));
+        legend.push(Span::styled(
+            "✗ = activity, no published rate",
+            Style::default().fg(TERMINAL_ACCENT),
+        ));
+        ratatui::widgets::Widget::render(
+            Paragraph::new(Line::from(legend)),
+            Rect::new(inner.x, y, inner.width, 1),
+            buf,
+        );
+        y = y.saturating_add(2);
+    }
 
-    // Bar chart (last N days that fit)
-    render_bar_chart(buf, chunks[1], data);
+    // Detail strip — the exact figures the Daily tab used to carry.
+    if y < inner.y.saturating_add(inner.height) {
+        let height = inner.y.saturating_add(inner.height).saturating_sub(y);
+        render_activity_detail(buf, Rect::new(inner.x, y, inner.width, height), data, &grid, cursor);
+    }
 }
 
-fn render_weekly(buf: &mut Buffer, area: Rect, data: &UsageData, scroll_offset: usize) {
+/// Per-day breakdown under the grid: totals plus the day's top models.
+fn render_activity_detail(
+    buf: &mut Buffer,
+    area: Rect,
+    data: &UsageData,
+    grid: &crate::heatmap::HeatmapGrid,
+    cursor: chrono::NaiveDate,
+) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(CORNFLOWER_BLUE))
-        .style(Style::default().bg(DARK_BG));
-
+        .title(Span::styled(
+            format!(" {cursor} "),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
+        .style(Style::default().bg(PANEL_BG));
     let inner = block.inner(area);
     ratatui::widgets::Widget::render(block, area, buf);
-
-    if data.weekly.is_empty() {
-        let p = Paragraph::new("  No usage data found.").style(Style::default().fg(MUTED_GRAY));
-        ratatui::widgets::Widget::render(p, inner, buf);
+    if inner.height == 0 {
         return;
     }
 
-    let header = Row::new(vec![
-        "Week Start",
-        "Total",
-        "Input",
-        "Cache",
-        "Output",
-        "Sessions",
-        "Projects",
-    ])
-    .style(Style::default().fg(GOLD).add_modifier(Modifier::BOLD))
-    .bottom_margin(1);
-
-    let visible_rows = inner.height.saturating_sub(2) as usize;
-    let total_rows = data.weekly.len();
-    let effective_offset = if scroll_offset == 0 && total_rows > visible_rows {
-        total_rows.saturating_sub(visible_rows)
-    } else {
-        scroll_offset
+    let Some(cell) = grid.cell(cursor) else {
+        ratatui::widgets::Widget::render(
+            Paragraph::new(Span::styled(
+                "  No activity on this day.",
+                Style::default().fg(MUTED_GRAY),
+            )),
+            inner,
+            buf,
+        );
+        return;
     };
 
-    let rows: Vec<Row> = data
-        .weekly
-        .iter()
-        .skip(effective_offset)
-        .take(visible_rows)
-        .map(|(date, bucket)| {
-            Row::new(vec![
-                date.format("%Y-%m-%d").to_string(),
-                format_tokens_short(bucket.total()),
-                format_tokens_short(bucket.input_tokens),
-                format_tokens_short(bucket.cache_read_tokens + bucket.cache_creation_tokens),
-                format_tokens_short(bucket.output_tokens),
-                format!("{}", bucket.session_count),
-                format!("{}", bucket.project_count),
-            ])
-            .style(Style::default().fg(SOFT_WHITE))
-        })
-        .collect();
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            format!(" {:<10}", format_cost(cell.cost_usd)),
+            Style::default().fg(TERMINAL_ACCENT).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{} tokens   ", crate::data::usage::format_tokens_short(cell.tokens)),
+            Style::default().fg(SOFT_WHITE),
+        ),
+        Span::styled(
+            format!("{} calls   {} sessions", cell.calls, cell.sessions),
+            Style::default().fg(MUTED_GRAY),
+        ),
+    ])];
 
-    let widths = [
-        Constraint::Length(12),
-        Constraint::Length(10),
-        Constraint::Length(10),
-        Constraint::Length(10),
-        Constraint::Length(10),
-        Constraint::Length(8),
-        Constraint::Length(8),
-    ];
+    // Cap at whatever the strip can actually show, minus the totals row.
+    let model_rows = inner.height.saturating_sub(1) as usize;
+    for (model, cost, tokens) in crate::heatmap::day_model_breakdown(data, cursor, model_rows) {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("   {:<28}", truncate_string(&model, 28)),
+                Style::default().fg(SOFT_WHITE),
+            ),
+            Span::styled(
+                format!("{:>10}  ", format_cost(cost)),
+                Style::default().fg(TERMINAL_ACCENT),
+            ),
+            Span::styled(
+                crate::data::usage::format_tokens_short(tokens),
+                Style::default().fg(MUTED_GRAY),
+            ),
+        ]));
+    }
 
-    let table = Table::new(rows, widths).header(header).column_spacing(1);
+    ratatui::widgets::Widget::render(Paragraph::new(lines), inner, buf);
+}
 
-    ratatui::widgets::Widget::render(table, inner, buf);
+/// Colour ramp for a heat level. Unpriced gets the accent colour rather than a
+/// green step so it reads as "missing rate", not "quiet day".
+fn heat_style(level: crate::heatmap::CellLevel) -> Style {
+    use crate::heatmap::CellLevel;
+    match level {
+        CellLevel::Empty => Style::default().fg(MUTED_GRAY),
+        CellLevel::L1 => Style::default().fg(Color::Rgb(60, 110, 70)),
+        CellLevel::L2 => Style::default().fg(Color::Rgb(80, 160, 90)),
+        CellLevel::L3 => Style::default().fg(Color::Rgb(110, 200, 120)),
+        CellLevel::L4 => Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+        CellLevel::Unpriced => Style::default().fg(TERMINAL_ACCENT).add_modifier(Modifier::BOLD),
+    }
 }
 
 fn render_projects(buf: &mut Buffer, area: Rect, data: &UsageData, scroll_offset: usize) {

--- a/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
@@ -19,6 +19,7 @@ name = "ainb-plugin-session-reader"
 path = "src/main.rs"
 
 [dependencies]
+ainb-model-rates = { path = "../ainb-model-rates" }
 ainb-plugin-sdk-rust = { path = "../ainb-plugin-sdk-rust" }
 ainb-plugin-types-sessions = { path = "../ainb-plugin-types-sessions" }
 

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
@@ -82,7 +82,24 @@ fn with_busy_retry<T>(mut op: impl FnMut() -> rusqlite::Result<T>) -> rusqlite::
 ///
 /// v2: adds the single-row `stable_aggregate` table holding the
 /// bincode'd incremental-refresh rollup. Additive over v1.
-pub const SCHEMA_VERSION: i64 = 2;
+///
+/// v3: **price invalidation, not a shape change.** Cached rows store
+/// `cost_usd` as computed at parse time, so a correction to the rate table
+/// cannot reach an already-cached file — its fingerprint is unchanged, so it
+/// is never re-parsed. v3 drops the cached rows once so the corrected Opus
+/// rate ($15/$75 → $5/$25) actually lands. **Any future rate-table edit needs
+/// the same bump** — see [`RATE_TABLE_REVISION`].
+pub const SCHEMA_VERSION: i64 = 3;
+
+/// Bump this, and `SCHEMA_VERSION` with it, whenever `ainb-model-rates`
+/// changes a published rate.
+///
+/// The cache keys on `(path, mtime, size)`. None of those change when a price
+/// changes, so without a bump the old dollars persist for every already-parsed
+/// file — indefinitely, and invisibly, because the numbers still look
+/// plausible. Correcting a rate without bumping is a silent no-op for existing
+/// users.
+pub const RATE_TABLE_REVISION: i64 = 1;
 
 /// Cache error surface.
 #[derive(Debug, thiserror::Error)]
@@ -325,6 +342,18 @@ impl UsageCache {
             )?;
         }
 
+        if version < 3 {
+            // Price invalidation. Cached blobs carry `cost_usd` frozen at parse
+            // time and their fingerprints don't change when a rate does, so the
+            // rows have to go for a corrected rate to take effect. Dropping
+            // them costs one full re-parse on the next scan — the same work a
+            // `--hard` refresh does, once.
+            conn.execute_batch(
+                "DELETE FROM file_cache;
+                 DELETE FROM stable_aggregate;",
+            )?;
+        }
+
         // Only stamp UP. A db written by a NEWER build (two ainb
         // versions sharing one usage.sqlite) must keep its higher
         // version: stamping it down would make the newer binary re-run
@@ -481,7 +510,7 @@ mod tests {
     }
 
     #[test]
-    fn v1_db_migrates_to_v2_preserving_file_cache() {
+    fn v1_db_migrates_to_v3_dropping_price_stale_rows() {
         // Hand-build a v1-schema DB (file_cache only, user_version=1)
         // with one row, then open through UsageCache and assert the
         // migration is additive: the parse row survives, the version
@@ -517,14 +546,20 @@ mod tests {
             .conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("pragma");
-        assert_eq!(version, 2, "v1 db migrated to v2");
+        assert_eq!(version, SCHEMA_VERSION, "v1 db migrated to the current schema");
 
-        let hit = cache.lookup("/tmp/v1.jsonl", 5, 6).expect("lookup").expect("hit");
-        assert_eq!(hit[0].id, 7, "pre-migration parse row survives");
+        // v3 drops cached rows on purpose. They carry `cost_usd` frozen at
+        // parse time, and their (path, mtime, size) key does not change when a
+        // rate is corrected — so keeping them would serve the old Opus price
+        // forever on any file already in the cache.
+        assert!(
+            cache.lookup("/tmp/v1.jsonl", 5, 6).expect("lookup").is_none(),
+            "price-stale parse rows must be dropped so corrected rates take effect"
+        );
 
         assert!(
             cache.load_stable().expect("load").is_none(),
-            "fresh v2 upgrade has no stable aggregate yet"
+            "fresh upgrade has no stable aggregate yet"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/cache.rs
@@ -546,7 +546,10 @@ mod tests {
             .conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("pragma");
-        assert_eq!(version, SCHEMA_VERSION, "v1 db migrated to the current schema");
+        assert_eq!(
+            version, SCHEMA_VERSION,
+            "v1 db migrated to the current schema"
+        );
 
         // v3 drops cached rows on purpose. They carry `cost_usd` frozen at
         // parse time, and their (path, mtime, size) key does not change when a

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/cost.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/cost.rs
@@ -1,80 +1,11 @@
-//! Cost estimation. Lifted verbatim from the Phase 6b plugin so the
-//! Phase 7c subprocess port produces the same dollar figures for the
-//! same input as the wasm cdylib it replaces.
+//! Cost estimation — re-export of the shared rate table.
+//!
+//! The table itself lives in `ainb-model-rates` so the parser, the host's
+//! legacy usage path, and burndown's CLI all price identically. It used to be
+//! copied into all three, which is how every Opus stayed at the retired
+//! $15/$75 rate for three model generations.
 
-struct ModelRates {
-    input: f64,
-    output: f64,
-    cache_write: f64,
-    cache_read: f64,
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn estimate_cost_usd(
-    model: &str,
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_creation_tokens: u64,
-    cache_read_tokens: u64,
-    reasoning_tokens: u64,
-) -> Option<f64> {
-    let rates = model_rates(model)?;
-    Some(
-        input_tokens as f64 * rates.input
-            + (output_tokens + reasoning_tokens) as f64 * rates.output
-            + cache_creation_tokens as f64 * rates.cache_write
-            + cache_read_tokens as f64 * rates.cache_read,
-    )
-}
-
-fn model_rates(model: &str) -> Option<ModelRates> {
-    let canonical = canonical_model_name(model);
-    let (input_per_million, output_per_million) = if canonical.starts_with("claude-opus") {
-        (15.0, 75.0)
-    } else if canonical.starts_with("claude-sonnet") || canonical.starts_with("claude-3-5-sonnet") {
-        (3.0, 15.0)
-    } else if canonical.starts_with("claude-haiku") || canonical.starts_with("claude-3-5-haiku") {
-        (0.8, 4.0)
-    } else if canonical.starts_with("gpt-5")
-        || canonical.starts_with("gpt-4.1")
-        || canonical.starts_with("gpt-4o")
-    {
-        (1.25, 10.0)
-    } else {
-        return None;
-    };
-
-    let input = input_per_million / 1_000_000.0;
-    let output = output_per_million / 1_000_000.0;
-    Some(ModelRates {
-        input,
-        output,
-        cache_write: input * 1.25,
-        cache_read: input * 0.1,
-    })
-}
-
-fn canonical_model_name(model: &str) -> String {
-    let without_prefix = model
-        .split('@')
-        .next()
-        .unwrap_or(model)
-        .trim_start_matches("anthropic/")
-        .trim_start_matches("openai/")
-        .to_string();
-
-    if without_prefix
-        .rsplit('-')
-        .next()
-        .is_some_and(|suffix| suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_digit()))
-    {
-        without_prefix
-            .rsplit_once('-')
-            .map_or(without_prefix.clone(), |(name, _)| name.to_string())
-    } else {
-        without_prefix
-    }
-}
+pub use ainb_model_rates::estimate_cost_usd;
 
 #[cfg(test)]
 mod tests {
@@ -101,5 +32,34 @@ mod tests {
     fn date_stamped_claude_strips_to_canonical() {
         let cost = estimate_cost_usd("claude-3-5-sonnet-20241022", 1_000_000, 0, 0, 0, 0);
         assert!((cost.unwrap() - 3.0).abs() < 1e-6);
+    }
+
+    /// The parser is the ingest path for every provider, so it is the right
+    /// place to assert the models we actually see in transcripts today are
+    /// priced at all — an unpriced model silently becomes `cost_usd: None`.
+    #[test]
+    fn every_model_seen_in_live_transcripts_is_priced() {
+        for model in [
+            "claude-fable-5",
+            "claude-opus-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-5",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "gpt-5",
+            "gpt-5-mini",
+        ] {
+            assert!(
+                estimate_cost_usd(model, 1_000, 1_000, 0, 0, 0).is_some(),
+                "{model} has no published rate — burndown will render it as `cost n/a`"
+            );
+        }
     }
 }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -1202,15 +1202,24 @@ fn week_start(date: NaiveDate) -> NaiveDate {
     date - Duration::days(i64::from(days))
 }
 
+/// Rank rows by cost, sinking rows whose model has no published price.
+///
+/// The `is_some()` term is load-bearing. Ranking on
+/// `cost_usd.unwrap_or(total() as f64)` mixes dollars with raw token counts, and
+/// tokens are ~5 orders of magnitude larger — so a single unpriced model
+/// (`claude-fable-5` before it had a rate, `<synthetic>` always) outranks every
+/// priced row and monopolises every top-N panel. That is the "empty burndown"
+/// bug: the panels weren't empty, they were full of `cost n/a` rows.
 #[allow(clippy::cast_precision_loss)]
 fn sort_by_total_desc<T, F>(mut rows: Vec<T>, key: F) -> Vec<T>
 where
     F: Fn(&T) -> TokenBucket,
 {
     rows.sort_by(|a, b| {
-        let av = key(a).cost_usd.unwrap_or(key(a).total() as f64);
-        let bv = key(b).cost_usd.unwrap_or(key(b).total() as f64);
-        bv.total_cmp(&av)
+        let (ab, bb) = (key(a), key(b));
+        let av = (ab.cost_usd.is_some(), ab.cost_usd.unwrap_or(ab.total() as f64));
+        let bv = (bb.cost_usd.is_some(), bb.cost_usd.unwrap_or(bb.total() as f64));
+        bv.0.cmp(&av.0).then_with(|| bv.1.total_cmp(&av.1))
     });
     rows
 }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -1217,8 +1217,14 @@ where
 {
     rows.sort_by(|a, b| {
         let (ab, bb) = (key(a), key(b));
-        let av = (ab.cost_usd.is_some(), ab.cost_usd.unwrap_or(ab.total() as f64));
-        let bv = (bb.cost_usd.is_some(), bb.cost_usd.unwrap_or(bb.total() as f64));
+        let av = (
+            ab.cost_usd.is_some(),
+            ab.cost_usd.unwrap_or(ab.total() as f64),
+        );
+        let bv = (
+            bb.cost_usd.is_some(),
+            bb.cost_usd.unwrap_or(bb.total() as f64),
+        );
         bv.0.cmp(&av.0).then_with(|| bv.1.total_cmp(&av.1))
     });
     rows


### PR DESCRIPTION
## What

Corrects model pricing across the usage/burndown stack, fixes the ranking bug that made the burndown panels look empty, and replaces the Daily + Weekly tabs with a GitHub-style Activity heatmap.

Reported symptom: burndown panels rendering as a wall of `cost n/a`.

## The pricing bugs

The rate table existed as **three byte-identical copies** (session-reader's parser, the host's legacy usage path, burndown's CLI). Nobody kept them in sync, so:

| Model | Was | Now |
|---|---|---|
| Opus 5 / 4.8 / 4.7 / 4.6 | 15/75 | **5/25** |
| Opus 4.5 and older | 15/75 | 15/75 (unchanged) |
| Fable / Mythos | *unpriced* | **10/50** |
| Haiku 4.5 | 0.8/4 | **1/5** |
| gpt-5.6 sol / terra / luna | 1.25/10 | **5/30, 2.5/15, 1/6** |
| gpt-5.5, gpt-5.4 tiers | 1.25/10 | 5/30, 2.5/15 + mini/nano |

Now one `ainb-model-rates` crate, three consumers.

Measured against a real ~15k-call, 7-day window: **total $7,000.00 → $3,661.92**. `claude-opus-4-8` went $5,950.49 → $1,992.91, matching the hand-computed 5/25 figure exactly.

## The ranking bug (the reported symptom)

Ranking keyed on `cost_usd.unwrap_or(total_tokens as f64)` — dollars compared against token counts, ~5 orders of magnitude apart. Any model with no published rate outranked every priced row and took every slot in By Project / By Branch / Top Sessions / By Model / Leaderboard. The panels weren't empty; they were full of unpriced rows. Now keyed on `(cost.is_some(), value)`.

Unpriced rows also render as `— 282.3M` rather than `cost n/a`, so "no published price" reads differently from "no data".

## Cache invalidation — the reason the fix wouldn't have shipped

Cached `ProviderCall` rows store `cost_usd` frozen at parse time, and the cache keys on `(path, mtime, size)` — none of which change when a price changes. The corrected rates initially did **nothing**, and `--hard` didn't help either. Every existing user would have upgraded and kept seeing the old Opus prices indefinitely, with numbers plausible enough that nobody would question them.

Schema v3 drops the cached rows once. `RATE_TABLE_REVISION` documents that any future rate edit needs the same bump.

**Upgrade note:** first scan after upgrade re-parses full history (~70s on a 15k-call dataset, once).

## Activity heatmap

Replaces the Daily and Weekly tabs. Fixed 53-week canvas, cost/tokens/calls/sessions metric via `M`, arrows move the day cursor, Enter pivots every other panel to that day (as a single-day `Custom` period — no new filter machinery). The exact per-day figures Daily used to carry move into a cursor-driven detail strip.

An active day whose models have no published rate gets its own `✗` glyph — a pricing gap must not render as a day off.

## Verification

- 353 unit tests green (11 rates, 229 burndown, 113 session-reader)
- New tripwire drives the real TUI in tmux: `]` → grid renders, `M` → metric advances, Left → cursor moves, `[` → returns. **Validated by falsification** — stubbing out `render_activity` makes it fail, reverting makes it pass
- End-to-end verified against real data via `ainb usage report`

## Known-red, pre-existing

`tripwire_burndown_keys` fails, and it fails on `main` too. It asserts on a `p filter:` chip that the provider-bar redesign removed — the string is absent from `ui.rs` at this branch's merge-base *and* on current main, and neither that test nor `ui.rs` was touched by main since. Not caused by this PR; happy to fix in a follow-up.

## Deferred (deliberately)

- **Bundled LiteLLM snapshot + refresh.** codeburn (which this view was ported from) pulls LiteLLM's pricing JSON at build time with a 24h runtime re-fetch, rather than hardcoding. Same crate API would take it as a drop-in — the upgrade path if hand-maintenance rots again.
- **1.6× 1-hour-cache-write and 6× fast-mode multipliers.** codeburn models both; we model neither.
- **Sonnet 5 introductory pricing** (2/10 until 2026-08-31) — billing list 3/15 instead, to avoid a hardcoded date cliff that breaks if the promo moves.
- `usage.model_aliases` and `CurrencyConfig.usd_rate` are written by the CLI and read by nothing — dead config, separate cleanup.
