### PR TITLE
fix: retain session status filter

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -961,6 +961,10 @@ impl EventHandler {
                         }
                     }
 
+                    if state.sessions_pane_state.is_on_filter_toggle(x, y) {
+                        return Some(AppEvent::CycleSessionFilter);
+                    }
+
                     if state.sessions_pane_state.is_on_toggle(x, y) {
                         state.sessions_pane_state.toggle_collapsed();
                         Self::persist_sessions_pane_preferences(state);

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -582,6 +582,7 @@ pub struct SessionsPaneState {
     last_preview_rect: Option<Rect>,
     last_list_scroll_offset: usize,
     last_attachable_click: Option<(AttachableRef, Instant)>,
+    filter_toggle_area: Option<Rect>,
 }
 
 impl Default for SessionsPaneState {
@@ -595,6 +596,7 @@ impl Default for SessionsPaneState {
             last_preview_rect: None,
             last_list_scroll_offset: 0,
             last_attachable_click: None,
+            filter_toggle_area: None,
         }
     }
 }
@@ -614,6 +616,19 @@ impl SessionsPaneState {
 
     pub fn set_list_scroll_offset(&mut self, offset: usize) {
         self.last_list_scroll_offset = offset;
+    }
+
+    pub fn set_filter_toggle_area(&mut self, area: Rect) {
+        self.filter_toggle_area = Some(area);
+    }
+
+    pub fn is_on_filter_toggle(&self, x: u16, y: u16) -> bool {
+        self.filter_toggle_area.is_some_and(|area| {
+            x >= area.x
+                && x < area.x.saturating_add(area.width)
+                && y >= area.y
+                && y < area.y.saturating_add(area.height)
+        })
     }
 
     pub fn last_content_width(&self) -> Option<u16> {
@@ -2769,13 +2784,14 @@ impl ClaudeChatState {
     }
 }
 
-/// View filter for the session tree, cycled by `Shift+F` on the sessions screen.
+/// View filter for the session tree, cycled by `Shift+F` or its clickable title chip.
 ///
 /// Phase 2 of `load_interactive_mode_sessions` started surfacing Stopped sessions
 /// (tmux-dead but worktree-alive) alongside Running ones. With many worktrees
 /// the tree gets crowded; this filter lets the user hide stopped rows or focus
-/// on stopped-only without losing access. In-memory only (resets each launch).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// on stopped-only without losing access. Persisted in UI preferences.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SessionFilter {
     #[default]
     All,
@@ -2800,6 +2816,14 @@ impl SessionFilter {
             Self::All => None,
             Self::ActiveOnly => Some("active"),
             Self::StoppedOnly => Some("stopped"),
+        }
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::ActiveOnly => "active",
+            Self::StoppedOnly => "stopped",
         }
     }
 }
@@ -3454,7 +3478,7 @@ impl Default for AppState {
             shell_selected: false,
             selected_sessions: HashSet::new(),
             expand_all_workspaces: true, // Default to expanded view
-            session_filter: SessionFilter::All,
+            session_filter: app_config.ui_preferences.session_filter,
             current_screen: screen_ids::HOME.to_string(),
             should_quit: false,
             logs: HashMap::new(),
@@ -6521,6 +6545,10 @@ impl AppState {
     /// Resets the session selection so it doesn't point to a now-hidden row.
     pub fn cycle_session_filter(&mut self) {
         self.session_filter = self.session_filter.next();
+        self.app_config.ui_preferences.session_filter = self.session_filter;
+        if let Err(e) = self.app_config.save() {
+            warn!("Failed to persist session filter: {}", e);
+        }
         // Selection indices are positional over the *displayed* list. Resetting
         // to the first session of the first workspace is simplest and matches
         // what `load_real_workspaces` already does after a refresh.

--- a/ainb-tui/crates/ainb-core/src/components/help.rs
+++ b/ainb-tui/crates/ainb-core/src/components/help.rs
@@ -43,7 +43,7 @@ impl HelpComponent {
             ),
             row(
                 "→",
-                "Attach in a split pane (keeps the session list visible)",
+                "Pane attach (keeps the session list visible)",
             ),
             row("1-9", "Quick-attach to numbered session"),
             row("Enter", "Resume (stopped) / attach (running)"),

--- a/ainb-tui/crates/ainb-core/src/components/help.rs
+++ b/ainb-tui/crates/ainb-core/src/components/help.rs
@@ -41,10 +41,7 @@ impl HelpComponent {
                 "a",
                 "Attach — full-screen takeover (Ctrl+B then D to leave)",
             ),
-            row(
-                "→",
-                "Pane attach (keeps the session list visible)",
-            ),
+            row("→", "Pane attach (keeps the session list visible)"),
             row("1-9", "Quick-attach to numbered session"),
             row("Enter", "Resume (stopped) / attach (running)"),
             row("r", "Resume stopped session (tmux)"),

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -366,7 +366,7 @@ impl LayoutComponent {
             key("a", SELECTION_GREEN),
             desc("ttach "),
             key("→", SELECTION_GREEN),
-            desc(" pane "),
+            desc(" Pane attach "),
             key("1-9", SELECTION_GREEN),
             desc(" quick "),
             key("Space", SELECTION_GREEN),
@@ -489,7 +489,7 @@ impl LayoutComponent {
                 key("a", SELECTION_GREEN),
                 desc("ttach  "),
                 key("→", SELECTION_GREEN),
-                desc(" pane  "),
+                desc(" Pane attach  "),
                 key("1-9", SELECTION_GREEN),
                 desc(" quick  "),
                 key("Space", SELECTION_GREEN),
@@ -1519,7 +1519,7 @@ mod menu_bar_tests {
             "xpand",   // expand
             "focus",   // Tab focus
             "ttach",   // attach
-            "pane",    // A — in-pane interactive embed
+            "Pane attach",
             "1-9",     // quick attach
             "Space",   // multi-select
             "tar",     // star
@@ -1608,7 +1608,7 @@ mod menu_bar_tests {
         for token in [
             "ew",      // new
             "ttach",   // attach
-            "pane",    // A — in-pane interactive embed
+            "Pane attach",
             "1-9",     // quick attach
             "Space",   // multi-select
             "tar",     // star

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -1515,10 +1515,10 @@ mod menu_bar_tests {
 
         // The restart slot shows `r resume`.
         for token in [
-            "ew",      // new
-            "xpand",   // expand
-            "focus",   // Tab focus
-            "ttach",   // attach
+            "ew",    // new
+            "xpand", // expand
+            "focus", // Tab focus
+            "ttach", // attach
             "Pane attach",
             "1-9",     // quick attach
             "Space",   // multi-select
@@ -1606,8 +1606,8 @@ mod menu_bar_tests {
         );
 
         for token in [
-            "ew",      // new
-            "ttach",   // attach
+            "ew",    // new
+            "ttach", // attach
             "Pane attach",
             "1-9",     // quick attach
             "Space",   // multi-select

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -306,9 +306,9 @@ impl LayoutComponent {
             return;
         }
         // Below this width the two-column split can't hold the widest
-        // session-action line (~41 cols) plus the panels column without
+        // session-action line (~50 cols) plus the panels column without
         // clipping, so fall back to the stacked legend.
-        const TWO_COL_MIN_WIDTH: u16 = 100;
+        const TWO_COL_MIN_WIDTH: u16 = 110;
         if area.width >= TWO_COL_MIN_WIDTH {
             self.render_menu_bar_two_col(frame, area, state);
         } else {
@@ -1501,7 +1501,8 @@ mod menu_bar_tests {
         use ratatui::{Terminal, backend::TestBackend};
 
         let layout = LayoutComponent::new();
-        let state = AppState::default();
+        let mut state = AppState::default();
+        state.app_config.ui_preferences.show_session_menu_bar = true;
         let mut terminal = Terminal::new(TestBackend::new(80, 6)).unwrap();
         terminal
             .draw(|f| {
@@ -1577,7 +1578,8 @@ mod menu_bar_tests {
         use ratatui::{Terminal, backend::TestBackend};
 
         let layout = LayoutComponent::new();
-        let state = AppState::default();
+        let mut state = AppState::default();
+        state.app_config.ui_preferences.show_session_menu_bar = true;
         // Comfortably above TWO_COL_MIN_WIDTH so the split path renders.
         let mut terminal = Terminal::new(TestBackend::new(140, 6)).unwrap();
         terminal
@@ -1641,7 +1643,7 @@ mod menu_bar_tests {
         }
     }
 
-    /// The two-column split first engages at exactly `TWO_COL_MIN_WIDTH` (100),
+    /// The two-column split first engages at exactly `TWO_COL_MIN_WIDTH` (110),
     /// which is also where its columns are narrowest and clipping would first
     /// bite. Render at the boundary and assert the longest token in each column
     /// (`re-auth` on the left, `home`/`abtop` on the right) survives and the
@@ -1654,8 +1656,9 @@ mod menu_bar_tests {
         use ratatui::{Terminal, backend::TestBackend};
 
         let layout = LayoutComponent::new();
-        let state = AppState::default();
-        let mut terminal = Terminal::new(TestBackend::new(100, 6)).unwrap();
+        let mut state = AppState::default();
+        state.app_config.ui_preferences.show_session_menu_bar = true;
+        let mut terminal = Terminal::new(TestBackend::new(110, 6)).unwrap();
         terminal.draw(|f| layout.render_menu_bar(f, f.size(), &state)).unwrap();
 
         let buf = terminal.backend().buffer();
@@ -1669,16 +1672,16 @@ mod menu_bar_tests {
         for token in ["re-auth", "resume", "del-sel", "abtop", "home", "witr"] {
             assert!(
                 rendered.contains(token),
-                "token {token:?} clipped at threshold width 100:\nRendered:\n{rendered}"
+                "token {token:?} clipped at threshold width 110:\nRendered:\n{rendered}"
             );
         }
-        // Inner edges (cols 1 and 98) must stay blank on every content row.
+        // Inner edges (cols 1 and 108) must stay blank on every content row.
         for y in 1..=4u16 {
             let left = buf.get(1, y).symbol().to_string();
-            let right = buf.get(98, y).symbol().to_string();
+            let right = buf.get(108, y).symbol().to_string();
             assert!(
                 left == " " && right == " ",
-                "menu row {y} clipped to the edge at width 100. left={left:?} right={right:?}"
+                "menu row {y} clipped to the edge at width 110. left={left:?} right={right:?}"
             );
         }
     }

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -41,7 +41,10 @@ const PILL_RIGHT: &str = "\u{e0b4}"; //
 
 use ainb_plugin_notifyd::AlertKind;
 
-use crate::app::AppState;
+use crate::app::{
+    AppState,
+    state::{AttachableRef, SessionListRowTarget},
+};
 use crate::models::{SessionAgentType, SessionMode, SessionStatus, ShellSessionStatus, Workspace};
 
 /// Width of the leading badge slot rendered before every list row.
@@ -74,6 +77,31 @@ fn next_badge(attach_no: &mut usize) -> Span<'static> {
 
 pub struct SessionListComponent {
     list_state: ListState,
+}
+
+fn selected_row_target(state: &AppState) -> Option<SessionListRowTarget> {
+    if let Some(workspace_idx) = state.selected_workspace_index {
+        return match (state.selected_session_index, state.shell_selected) {
+            (Some(session_idx), _) => Some(SessionListRowTarget::Attachable(
+                AttachableRef::WorkspaceSession {
+                    workspace_idx,
+                    session_idx,
+                },
+            )),
+            (None, true) => Some(SessionListRowTarget::Attachable(
+                AttachableRef::WorkspaceShell { workspace_idx },
+            )),
+            (None, false) => Some(SessionListRowTarget::WorkspaceHeader { workspace_idx }),
+        };
+    }
+    state
+        .selected_ssh_session_index
+        .map(|ssh_idx| SessionListRowTarget::Attachable(AttachableRef::SshSession { ssh_idx }))
+        .or_else(|| {
+            state.selected_other_tmux_index.map(|other_idx| {
+                SessionListRowTarget::Attachable(AttachableRef::OtherTmux { other_idx })
+            })
+        })
 }
 
 impl Default for SessionListComponent {
@@ -798,120 +826,30 @@ impl SessionListComponent {
     }
 
     fn update_selection(&mut self, state: &AppState) {
-        if let Some(workspace_idx) = state.selected_workspace_index {
-            let mut current_index = 0;
-            let mut workspace_header_index = 0;
-
-            // When expand_all is true, we need to count items from all workspaces
-            for (idx, workspace) in state.workspaces.iter().enumerate() {
-                if idx == workspace_idx {
-                    // Found the selected workspace
-                    current_index += idx; // Add workspace line itself (accounting for skipped sessions)
-
-                    // When expand_all, add all sessions from prior workspaces
-                    if state.expand_all_workspaces {
-                        for prior_workspace in state.workspaces.iter().take(idx) {
-                            current_index += prior_workspace.sessions.len();
-                            if prior_workspace.shell_session.is_some() {
-                                current_index += 1;
-                            }
-                        }
-                    }
-
-                    // Remember the workspace header position before adding session offset
-                    workspace_header_index = current_index;
-
-                    // Add session offset if a regular session is selected
-                    if let Some(session_idx) = state.selected_session_index {
-                        current_index += session_idx + 1;
-                    } else if state.shell_selected {
-                        // Shell selected: add all regular sessions + 1 for shell
-                        current_index += workspace.sessions.len() + 1;
-                    }
-                    break;
-                }
-            }
-
-            self.list_state.select(Some(current_index));
-
-            // Ensure the parent workspace header stays visible when a child session is selected.
-            // ratatui auto-scrolls to show the selected item, but this can push the parent
-            // folder line off the top of the viewport. Clamp the scroll offset so the
-            // workspace header is always the topmost visible item (at minimum).
-            if state.selected_session_index.is_some() || state.shell_selected {
-                let current_offset = self.list_state.offset();
-                if current_offset > workspace_header_index {
-                    *self.list_state.offset_mut() = workspace_header_index;
-                }
-            }
-        } else if state.selected_ssh_session_index.is_some() {
-            // Selection is in "SSH Sessions" section
-            let mut current_index = 0;
-
-            // Count all workspace items first
-            for workspace in &state.workspaces {
-                current_index += 1; // Workspace header
-                if state.expand_all_workspaces {
-                    current_index += workspace.sessions.len();
-                    if workspace.shell_session.is_some() {
-                        current_index += 1;
-                    }
-                }
-            }
-
-            // Add separator + "SSH Sessions" header
-            if !state.workspaces.is_empty() && !state.ssh_sessions.is_empty() {
-                current_index += 1; // Empty separator line
-            }
-            current_index += 1; // "SSH Sessions" header
-
-            // Add offset for selected SSH session
-            if let Some(ssh_idx) = state.selected_ssh_session_index {
-                current_index += ssh_idx;
-            }
-
-            self.list_state.select(Some(current_index));
-        } else if state.selected_other_tmux_index.is_some() {
-            // Selection is in "Other tmux" section
-            let mut current_index = 0;
-
-            // Count all workspace items first
-            for workspace in &state.workspaces {
-                current_index += 1; // Workspace header
-                if state.expand_all_workspaces {
-                    current_index += workspace.sessions.len();
-                    if workspace.shell_session.is_some() {
-                        current_index += 1;
-                    }
-                }
-            }
-
-            // Add SSH Sessions section
-            if !state.ssh_sessions.is_empty() {
-                if !state.workspaces.is_empty() {
-                    current_index += 1; // Empty separator line
-                }
-                current_index += 1; // "SSH Sessions" header
-                if state.ssh_sessions_expanded {
-                    current_index += state.ssh_sessions.len();
-                }
-            }
-
-            // Add separator + "Other tmux" header
-            let has_items_above = !state.workspaces.is_empty() || !state.ssh_sessions.is_empty();
-            if has_items_above && !state.other_tmux_sessions.is_empty() {
-                current_index += 1; // Empty separator line
-            }
-            current_index += 1; // "Other tmux" header
-
-            // Add offset for selected other session
-            if let Some(other_idx) = state.selected_other_tmux_index {
-                current_index += other_idx;
-            }
-
-            self.list_state.select(Some(current_index));
-        } else {
+        let Some(selected) = selected_row_target(state) else {
             self.list_state.select(None);
+            return;
+        };
+        let item_count = Self::build_list_items_static(state).len();
+        let selected_index =
+            (0..item_count).find(|&index| state.session_list_row_target(index) == Some(selected));
+        self.list_state.select(selected_index);
+
+        let workspace_header = match selected {
+            SessionListRowTarget::Attachable(
+                AttachableRef::WorkspaceSession { workspace_idx, .. }
+                | AttachableRef::WorkspaceShell { workspace_idx },
+            ) => Some(SessionListRowTarget::WorkspaceHeader { workspace_idx }),
+            _ => None,
+        };
+        if let Some(workspace_header) = workspace_header {
+            if let Some(header_index) = (0..item_count)
+                .find(|&index| state.session_list_row_target(index) == Some(workspace_header))
+            {
+                if self.list_state.offset() > header_index {
+                    *self.list_state.offset_mut() = header_index;
+                }
+            }
         }
     }
 
@@ -986,5 +924,44 @@ fn agent_brand_color(agent: &SessionAgentType) -> Color {
         SessionAgentType::Kiro => BRAND_KIRO,
         SessionAgentType::Shell => BRAND_SHELL,
         SessionAgentType::Ssh => BRAND_SSH,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::state::SessionFilter;
+    use crate::models::{Session, SessionStatus};
+
+    #[test]
+    fn selection_uses_visible_row_when_stopped_sessions_are_filtered() {
+        let mut state = AppState::new();
+        state.workspaces.clear();
+        state.session_filter = SessionFilter::ActiveOnly;
+        state.expand_all_workspaces = true;
+
+        let mut workspace = Workspace::new("workspace".to_string(), "/tmp/workspace".into());
+        let stopped = Session::new("stopped".to_string(), "/tmp/workspace".to_string());
+        let mut running = Session::new("running".to_string(), "/tmp/workspace".to_string());
+        running.status = SessionStatus::Running;
+        workspace.add_session(stopped);
+        workspace.add_session(running);
+        state.workspaces.push(workspace);
+        state.selected_workspace_index = Some(0);
+        state.selected_session_index = Some(1);
+
+        let mut list = SessionListComponent::new();
+        list.update_selection(&state);
+
+        let selected_row = list.list_state.selected().expect("visible selection");
+        assert_eq!(
+            state.session_list_row_target(selected_row),
+            Some(SessionListRowTarget::Attachable(
+                AttachableRef::WorkspaceSession {
+                    workspace_idx: 0,
+                    session_idx: 1,
+                }
+            ))
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -137,13 +137,15 @@ impl SessionListComponent {
                     .add_modifier(Modifier::BOLD),
             ),
         ];
-        if let Some(label) = state.session_filter.title_label() {
-            title_spans.push(Span::raw(" "));
-            title_spans.push(Span::styled(
-                format!("[{}]", label),
-                Style::default().fg(GOLD),
-            ));
-        }
+        let filter_label = format!("F [{}]", state.session_filter.label());
+        let title_prefix = format!(" \u{f07b} Workspaces ({workspace_count}) ");
+        state.sessions_pane_state.set_filter_toggle_area(Rect::new(
+            area.x.saturating_add(1 + title_prefix.chars().count() as u16),
+            area.y,
+            filter_label.chars().count() as u16,
+            1,
+        ));
+        title_spans.push(Span::styled(filter_label, Style::default().fg(GOLD)));
         title_spans.push(Span::raw(" "));
         // 'B' is the keyboard twin of clicking the [-] glyph (hint lives next
         // to the control it drives, not in the bottom menu bar).

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -1680,7 +1680,8 @@ mod old_config_tests {
             session_filter: SessionFilter::ActiveOnly,
             ..UiPreferences::default()
         };
-        let decoded: UiPreferences = toml::from_str(&toml::to_string(&preferences).unwrap()).unwrap();
+        let decoded: UiPreferences =
+            toml::from_str(&toml::to_string(&preferences).unwrap()).unwrap();
         assert_eq!(decoded.session_filter, SessionFilter::ActiveOnly);
     }
 

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -3,6 +3,7 @@
 
 #![allow(dead_code)]
 
+use crate::app::state::SessionFilter;
 use crate::audit::{self, AuditResult, AuditTrigger};
 use anyhow::{Context, Result};
 use dirs;
@@ -687,6 +688,10 @@ pub struct UiPreferences {
     #[serde(default = "default_true")]
     pub show_session_menu_bar: bool,
 
+    /// Session-status filter retained across workspace refreshes and restarts.
+    #[serde(default)]
+    pub session_filter: SessionFilter,
+
     /// Preferred editor command (e.g., "code", "cursor", "nvim")
     /// If None, falls back to: code -> $EDITOR -> error
     #[serde(default)]
@@ -760,6 +765,7 @@ impl Default for UiPreferences {
             show_container_status: true,
             show_git_status: true,
             show_session_menu_bar: true,
+            session_filter: SessionFilter::default(),
             preferred_editor: None,
             home_sidebar_width: None,
             sessions_sidebar_width: None,
@@ -996,6 +1002,7 @@ impl AppConfig {
             self.ui_preferences.show_container_status = other.ui_preferences.show_container_status;
             self.ui_preferences.show_git_status = other.ui_preferences.show_git_status;
             self.ui_preferences.show_session_menu_bar = other.ui_preferences.show_session_menu_bar;
+            self.ui_preferences.session_filter = other.ui_preferences.session_filter;
         }
         // Old configs keep the default (true) values
         if other.ui_preferences.preferred_editor.is_some() {
@@ -1668,6 +1675,16 @@ mod old_config_tests {
     use super::*;
 
     #[test]
+    fn session_filter_preference_round_trips() {
+        let preferences = UiPreferences {
+            session_filter: SessionFilter::ActiveOnly,
+            ..UiPreferences::default()
+        };
+        let decoded: UiPreferences = toml::from_str(&toml::to_string(&preferences).unwrap()).unwrap();
+        assert_eq!(decoded.session_filter, SessionFilter::ActiveOnly);
+    }
+
+    #[test]
     fn test_old_config_merge_keeps_default_true_for_booleans() {
         // Start with defaults (which have true for show_container_status and show_git_status)
         let mut defaults = AppConfig::default();
@@ -1687,6 +1704,7 @@ mod old_config_tests {
                 show_container_status: false,
                 show_git_status: false,
                 show_session_menu_bar: false,
+                session_filter: SessionFilter::default(),
                 preferred_editor: None,
                 home_sidebar_width: None,
                 sessions_sidebar_width: None,
@@ -1733,6 +1751,7 @@ mod old_config_tests {
                 show_container_status: false,
                 show_git_status: false,
                 show_session_menu_bar: false,
+                session_filter: SessionFilter::default(),
                 preferred_editor: None,
                 home_sidebar_width: Some(38),
                 sessions_sidebar_width: Some(46),


### PR DESCRIPTION
Retains the selected session-status filter across refreshes and restarts.

Adds clickable F [all|active|stopped] control.

Renames right-arrow in-pane attach action to Pane attach.

Checks: rustup run stable cargo fmt --all -- --check; cargo test -p ainb session_filter --lib --quiet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible session-list filter toggle labeled `F [<filter>]`.
  * Clicking the filter label now cycles through available session filters.
  * Session filter preferences are preserved in configuration.

* **UI Improvements**
  * Clarified pane-attachment labels and shortcut descriptions throughout the interface.
  * Updated help text to better explain the pane-attach action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->