### PR TITLE
feat(hangar): pipeline health strip + per-stage prompt addendum

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -38,7 +38,7 @@ use clap::{Args, Subcommand};
 
 use ainb_hangar_core::acceptance::AcceptanceCriterion;
 use ainb_hangar_core::actor::{ActorKind, ActorRef};
-use ainb_hangar_core::clock::SystemClock;
+use ainb_hangar_core::clock::{HangarClock as _, SystemClock};
 use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use ainb_hangar_core::origin::IssueOrigin;
 use ainb_hangar_store::Store;
@@ -51,6 +51,10 @@ use ainb_hangar_store::service::cancel::CancelTaskService;
 use ainb_hangar_store::service::retry::{RetryDecision, RetryService};
 
 use crate::cli::OutputFormat;
+
+/// The `pipeline show` health-strip renderer (pure formatting, unit-tested
+/// without a database).
+mod pipeline_view;
 
 /// The default workspace slug + owner details now live in
 /// [`ainb_hangar_store::bootstrap`] — the single shared, idempotent lay-down the
@@ -137,6 +141,27 @@ pub enum PipelineCommand {
     Init(PipelineInitArgs),
     /// Show each stage with its role gate, WIP limit and current card count.
     Show(PipelineInitArgs),
+    /// Set (or clear) a stage's prompt addendum: the instruction every card
+    /// entering that stage carries, whichever agent pulls it.
+    StagePrompt(PipelineStagePromptArgs),
+}
+
+/// Arguments for `hangar pipeline stage-prompt`.
+#[derive(Args, Debug)]
+pub struct PipelineStagePromptArgs {
+    /// Workspace slug. Defaults to the bootstrapped `default` workspace.
+    #[arg(long)]
+    pub workspace: Option<String>,
+    /// The stage (board column) name, e.g. `Review`. Case-insensitive.
+    #[arg(long)]
+    pub stage: String,
+    /// The instruction to prepend to every brief pulled from this stage. Omit
+    /// (or pass `--clear`) to remove it.
+    #[arg(long)]
+    pub text: Option<String>,
+    /// Clear the stage's prompt addendum.
+    #[arg(long, conflicts_with = "text")]
+    pub clear: bool,
 }
 
 /// Arguments for `hangar pipeline init` / `hangar pipeline show`.
@@ -2533,11 +2558,11 @@ pub async fn dispatch(cmd: HangarCommand, format: OutputFormat) -> Result<()> {
 async fn dispatch_pipeline(cmd: PipelineCommand) -> Result<()> {
     use ainb_hangar_core::ids::WorkspaceId;
     use ainb_hangar_store::service::pipeline::PipelineService;
-    use sqlx::Row;
 
     let (args, init) = match cmd {
         PipelineCommand::Init(a) => (a, true),
         PipelineCommand::Show(a) => (a, false),
+        PipelineCommand::StagePrompt(a) => return run_pipeline_stage_prompt(a).await,
     };
     let store = Store::open_default().await.context("open hangar database")?;
     let workspace_id = resolve_skills_workspace(&store, args.workspace.as_deref()).await?;
@@ -2551,41 +2576,95 @@ async fn dispatch_pipeline(cmd: PipelineCommand) -> Result<()> {
         println!("pipeline board {board_id}");
     }
 
-    let rows = sqlx::query(
-        "SELECT col.name AS name, col.services_role AS role, col.wip_limit AS wip, \
-                col.excludes_prior_agent AS excl, \
-                (SELECT COUNT(*) FROM board_card bc WHERE bc.column_id = col.id) AS cards \
-           FROM board_column col JOIN board bd ON bd.id = col.board_id \
-          WHERE bd.workspace_id = ?1 AND bd.name = ?2 ORDER BY col.ord",
-    )
-    .bind(ws.as_str())
-    .bind(ainb_hangar_store::service::pipeline::DEFAULT_PIPELINE_BOARD)
-    .fetch_all(store.pool())
-    .await
-    .context("read the pipeline stages")?;
-
-    if rows.is_empty() {
+    let Some(board_id) = pipeline_board_id(&store, &ws).await? else {
         println!("no pipeline provisioned (run `ainb hangar pipeline init`)");
         return Ok(());
+    };
+    let health = ainb_hangar_store::service::pipeline_health::snapshot(
+        store.pool(),
+        &ws,
+        &board_id,
+        SystemClock.now_ms(),
+    )
+    .await
+    .context("read the pipeline health")?;
+
+    // The daemon light reuses the SAME pid-file probe `hangar daemon status`
+    // prints, so the strip and that command can never disagree about liveness.
+    let daemon_alive = daemon_pid_path()
+        .ok()
+        .and_then(|p| read_daemon_pid(&p))
+        .is_some_and(pid_is_running);
+    let color = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    for line in pipeline_view::render(&health, daemon_alive, color) {
+        println!("{line}");
     }
-    println!(
-        "{:<12} {:<14} {:>5} {:>6} {:>6}",
-        "STAGE", "ROLE", "WIP", "EXCL", "CARDS"
-    );
-    for r in &rows {
-        let name: String = r.try_get("name").unwrap_or_default();
-        let role: Option<String> = r.try_get("role").unwrap_or_default();
-        let wip: Option<i64> = r.try_get("wip").unwrap_or_default();
-        let excl: i64 = r.try_get("excl").unwrap_or_default();
-        let cards: i64 = r.try_get("cards").unwrap_or_default();
-        println!(
-            "{:<12} {:<14} {:>5} {:>6} {:>6}",
-            name,
-            role.as_deref().unwrap_or("-"),
-            wip.map_or_else(|| "-".to_string(), |w| w.to_string()),
-            if excl == 1 { "yes" } else { "-" },
-            cards
-        );
+    Ok(())
+}
+
+/// The workspace's pipeline board id, or `None` when it has never been
+/// provisioned.
+async fn pipeline_board_id(
+    store: &Store,
+    ws: &ainb_hangar_core::ids::WorkspaceId,
+) -> Result<Option<String>> {
+    sqlx::query_scalar::<_, String>("SELECT id FROM board WHERE workspace_id = ?1 AND name = ?2")
+        .bind(ws.as_str())
+        .bind(ainb_hangar_store::service::pipeline::DEFAULT_PIPELINE_BOARD)
+        .fetch_optional(store.pool())
+        .await
+        .context("look up the pipeline board")
+}
+
+/// `hangar pipeline stage-prompt`: set or clear one stage's prompt addendum
+/// (migration 0076).
+///
+/// Store-direct like the rest of `pipeline`, so it works against a bare database
+/// with no daemon running. The write goes through
+/// [`BoardRepo::column_update`](ainb_hangar_store::repo::board::BoardRepo::column_update)
+/// rather than a bespoke UPDATE, so it inherits that path's workspace/board
+/// ownership check.
+async fn run_pipeline_stage_prompt(args: PipelineStagePromptArgs) -> Result<()> {
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::repo::board::BoardRepo;
+
+    let store = Store::open_default().await.context("open hangar database")?;
+    let workspace_id = resolve_skills_workspace(&store, args.workspace.as_deref()).await?;
+    let ws = WorkspaceId::from_str(workspace_id).context("workspace id was empty")?;
+    let Some(board_id) = pipeline_board_id(&store, &ws).await? else {
+        anyhow::bail!("no pipeline provisioned (run `ainb hangar pipeline init`)");
+    };
+
+    let column_id: Option<String> = sqlx::query_scalar(
+        "SELECT id FROM board_column WHERE board_id = ?1 AND LOWER(name) = LOWER(?2)",
+    )
+    .bind(&board_id)
+    .bind(&args.stage)
+    .fetch_optional(store.pool())
+    .await
+    .context("look up the stage")?;
+    let column_id = column_id
+        .ok_or_else(|| anyhow::anyhow!("no stage named `{}` on the pipeline board", args.stage))?;
+
+    // `--clear`, or `--text` omitted entirely, clears; anything else sets.
+    let text = args.text.as_deref().map(str::trim).filter(|t| !t.is_empty());
+    let stage_prompt = if args.clear { None } else { text };
+    BoardRepo::column_update(
+        store.pool(),
+        &ws,
+        &board_id,
+        &column_id,
+        None,
+        None,
+        None,
+        Some(stage_prompt),
+    )
+    .await
+    .context("write the stage prompt")?;
+
+    match stage_prompt {
+        Some(t) => println!("stage `{}` prompt set ({} chars)", args.stage, t.len()),
+        None => println!("stage `{}` prompt cleared", args.stage),
     }
     Ok(())
 }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/pipeline_view.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/pipeline_view.rs
@@ -1,0 +1,388 @@
+//! The `ainb hangar pipeline show` renderer: four health lights over a stage
+//! strip.
+//!
+//! ```text
+//! ● daemon ok   ● roles covered   ● wip 1/2 Implement   ● 0 stuck
+//!
+//! Backlog │ Triage    │ Implement │ Review    │ QA       │ Done
+//!         │ triager ● │ impl ●    │ review ●  │ test ✗   │
+//!    2    │ 1         │ 1 (wip 2) │ 0 (wip 3) │ 0 (wip 1)│ 4
+//! ```
+//!
+//! Pure formatting only: it takes an already-computed
+//! [`PipelineHealth`](ainb_hangar_store::service::pipeline_health::PipelineHealth)
+//! plus the caller's daemon-liveness answer and returns lines. That keeps the
+//! whole render unit-testable with no database, no daemon and no terminal, which
+//! is what makes the strip's exact shape a committed assertion rather than
+//! something only visible by eye.
+//!
+//! Colour is a REQUIREMENT here, not decoration: the point of the strip is that a
+//! stall is visible without reading it. Palette matches the TUI style guide, and
+//! colour is dropped entirely when stdout is not a terminal so piped output stays
+//! plain text.
+
+use ainb_hangar_store::service::pipeline_health::{PipelineHealth, StageHealth};
+
+/// Palette (TUI style guide): green = healthy, amber = at a limit but working,
+/// red = the pipeline cannot move, muted = structure.
+const GREEN: (u8, u8, u8) = (100, 200, 100);
+const AMBER: (u8, u8, u8) = (255, 165, 0);
+const RED: (u8, u8, u8) = (230, 100, 100);
+const MUTED: (u8, u8, u8) = (120, 120, 140);
+const SOFT_WHITE: (u8, u8, u8) = (220, 220, 230);
+const RESET: &str = "\x1b[0m";
+
+/// One coloured run of text inside a cell.
+struct Seg {
+    text: String,
+    color: Option<(u8, u8, u8)>,
+}
+
+impl Seg {
+    fn new(text: impl Into<String>, color: (u8, u8, u8)) -> Self {
+        Self {
+            text: text.into(),
+            color: Some(color),
+        }
+    }
+    fn plain(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            color: None,
+        }
+    }
+}
+
+/// A cell is a sequence of coloured runs; its width is the PLAIN width, so
+/// padding is unaffected by whether colour is on.
+type Cell = Vec<Seg>;
+
+fn cell_width(cell: &Cell) -> usize {
+    cell.iter().map(|s| s.text.chars().count()).sum()
+}
+
+fn render_cell(cell: &Cell, width: usize, color: bool) -> String {
+    let mut out = String::new();
+    for seg in cell {
+        match (color, seg.color) {
+            (true, Some((r, g, b))) => {
+                out.push_str(&format!("\x1b[38;2;{r};{g};{b}m{}{RESET}", seg.text));
+            }
+            _ => out.push_str(&seg.text),
+        }
+    }
+    for _ in cell_width(cell)..width {
+        out.push(' ');
+    }
+    out
+}
+
+/// Render the whole `pipeline show` body: the light strip, a blank line, then the
+/// three-row stage strip.
+///
+/// `daemon_alive` is supplied by the caller because the CLI and the TUI each
+/// already have their own liveness notion (pid file / socket link) and a third
+/// one invented here would be free to disagree with both.
+#[must_use]
+pub fn render(health: &PipelineHealth, daemon_alive: bool, color: bool) -> Vec<String> {
+    let mut lines = vec![lights(health, daemon_alive, color), String::new()];
+    lines.extend(stage_strip(health, color));
+    lines
+}
+
+/// The four lights, left to right, on one line.
+fn lights(health: &PipelineHealth, daemon_alive: bool, color: bool) -> String {
+    let mut cells: Vec<Cell> = Vec::with_capacity(4);
+
+    cells.push(if daemon_alive {
+        vec![Seg::new("●", GREEN), Seg::plain(" daemon ok")]
+    } else {
+        vec![Seg::new("●", RED), Seg::plain(" daemon down")]
+    });
+
+    // The one that matters: a stage whose role nobody holds parks its cards
+    // forever and never reports an error, so the light NAMES the missing role
+    // rather than just going red.
+    let uncovered = health.uncovered();
+    cells.push(if uncovered.is_empty() {
+        vec![Seg::new("●", GREEN), Seg::plain(" roles covered")]
+    } else {
+        let roles: Vec<&str> =
+            uncovered.iter().filter_map(|s| s.services_role.as_deref()).collect();
+        vec![
+            Seg::new("●", RED),
+            Seg::plain(format!(" no agent: {}", roles.join(", "))),
+        ]
+    });
+
+    cells.push(match health.saturated() {
+        Some(s) => vec![
+            Seg::new("○", AMBER),
+            Seg::plain(format!(
+                " wip {}/{} {}",
+                s.wip_active,
+                s.wip_limit.unwrap_or_default(),
+                s.name
+            )),
+        ],
+        None => match tightest(health) {
+            Some(s) => vec![
+                Seg::new("●", GREEN),
+                Seg::plain(format!(
+                    " wip {}/{} {}",
+                    s.wip_active,
+                    s.wip_limit.unwrap_or_default(),
+                    s.name
+                )),
+            ],
+            None => vec![Seg::new("●", GREEN), Seg::plain(" wip unlimited")],
+        },
+    });
+
+    let stuck = health.stuck();
+    cells.push(vec![
+        Seg::new("●", if stuck > 0 { RED } else { GREEN }),
+        Seg::plain(format!(" {stuck} stuck")),
+    ]);
+
+    cells
+        .iter()
+        .map(|c| render_cell(c, cell_width(c), color))
+        .collect::<Vec<_>>()
+        .join("   ")
+}
+
+/// The capped stage with the least headroom — the one worth naming when nothing
+/// is saturated yet.
+///
+/// Ties break on the BUSIER stage: `1/2` and `0/1` both have one slot left, but
+/// the stage already doing work is the one an operator is watching.
+fn tightest(health: &PipelineHealth) -> Option<&StageHealth> {
+    health.stages.iter().filter(|s| s.wip_limit.is_some()).min_by_key(|s| {
+        (
+            s.wip_limit.unwrap_or_default() - s.wip_active,
+            -s.wip_active,
+        )
+    })
+}
+
+/// The three-row stage strip: names, role dots, card counts.
+fn stage_strip(health: &PipelineHealth, color: bool) -> Vec<String> {
+    if health.stages.is_empty() {
+        return vec!["no stages on this board".to_string()];
+    }
+    let mut names: Vec<Cell> = Vec::new();
+    let mut roles: Vec<Cell> = Vec::new();
+    let mut counts: Vec<Cell> = Vec::new();
+
+    for stage in &health.stages {
+        names.push(vec![Seg::new(stage.name.clone(), SOFT_WHITE)]);
+        roles.push(role_cell(stage));
+        counts.push(count_cell(stage));
+    }
+
+    let widths: Vec<usize> = (0..health.stages.len())
+        .map(|i| cell_width(&names[i]).max(cell_width(&roles[i])).max(cell_width(&counts[i])))
+        .collect();
+
+    let sep = if color {
+        format!("\x1b[38;2;{};{};{}m │ {RESET}", MUTED.0, MUTED.1, MUTED.2)
+    } else {
+        " │ ".to_string()
+    };
+    [names, roles, counts]
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(i, cell)| render_cell(cell, widths[i], color))
+                .collect::<Vec<_>>()
+                .join(&sep)
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}
+
+/// The per-stage role dot: `✗` when NO agent holds the role (red — cards can
+/// never be pulled), `○` when the role is held but every holder is at its own
+/// `max_concurrent_tasks` (amber — ordinary busyness), `●` when someone can pull
+/// right now (green). A stage with no role gate renders blank.
+fn role_cell(stage: &StageHealth) -> Cell {
+    let Some(role) = stage.services_role.as_deref() else {
+        return vec![Seg::plain("")];
+    };
+    let (glyph, color) = if stage.role_agents == 0 {
+        ("✗", RED)
+    } else if stage.role_agents_free == 0 {
+        ("○", AMBER)
+    } else {
+        ("●", GREEN)
+    };
+    vec![
+        Seg::new(role.to_string(), MUTED),
+        Seg::plain(" "),
+        Seg::new(glyph, color),
+    ]
+}
+
+/// The per-stage count row: card count, its WIP cap when it has one, and a `⏳n`
+/// suffix when cards are stuck here.
+fn count_cell(stage: &StageHealth) -> Cell {
+    let mut cell = vec![Seg::new(stage.cards.to_string(), SOFT_WHITE)];
+    if let Some(limit) = stage.wip_limit {
+        let color = if stage.wip_saturated() { AMBER } else { MUTED };
+        cell.push(Seg::new(
+            format!(" (wip {}/{limit})", stage.wip_active),
+            color,
+        ));
+    }
+    if stage.stuck > 0 {
+        cell.push(Seg::new(format!(" ⏳{}", stage.stuck), RED));
+    }
+    cell
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stage(
+        name: &str,
+        role: Option<&str>,
+        wip_limit: Option<i64>,
+        wip_active: i64,
+        role_agents: i64,
+        role_agents_free: i64,
+        cards: i64,
+        stuck: i64,
+    ) -> StageHealth {
+        StageHealth {
+            column_id: format!("col-{name}"),
+            name: name.to_string(),
+            ord: 0,
+            services_role: role.map(ToString::to_string),
+            wip_limit,
+            wip_active,
+            role_agents,
+            role_agents_free,
+            cards,
+            stuck,
+        }
+    }
+
+    /// The default six-stage pipeline with a missing tester renders the exact
+    /// strip an operator reads: `roles covered` RED naming `tester`, a `✗` under
+    /// QA, and every other stage green. Colour is off so the assertion is on the
+    /// LAYOUT; `lights_are_coloured` covers the escapes.
+    #[test]
+    fn renders_the_default_pipeline_with_an_uncovered_role() {
+        let health = PipelineHealth {
+            stages: vec![
+                stage("Backlog", None, None, 0, 0, 0, 2, 0),
+                stage("Triage", Some("triager"), None, 0, 1, 1, 1, 0),
+                stage("Implement", Some("implementer"), Some(2), 1, 2, 1, 1, 0),
+                stage("Review", Some("reviewer"), Some(3), 0, 1, 1, 0, 0),
+                stage("QA", Some("tester"), Some(1), 0, 0, 0, 1, 1),
+                stage("Done", None, None, 0, 0, 0, 4, 0),
+            ],
+        };
+        let out = render(&health, true, false);
+        assert_eq!(
+            out,
+            vec![
+                "● daemon ok   ● no agent: tester   ● wip 1/2 Implement   ● 1 stuck",
+                "",
+                "Backlog │ Triage    │ Implement     │ Review      │ QA             │ Done",
+                "        │ triager ● │ implementer ● │ reviewer ●  │ tester ✗       │",
+                "2       │ 1         │ 1 (wip 1/2)   │ 0 (wip 0/3) │ 1 (wip 0/1) ⏳1 │ 4",
+            ],
+            "rendered strip:\n{}",
+            out.join("\n")
+        );
+    }
+
+    /// Every light flips green when the roster covers every stage, and a stage
+    /// whose holders are all busy reads amber `○`, NOT red — busy is not broken.
+    #[test]
+    fn healthy_pipeline_reports_all_green_and_busy_reads_amber() {
+        let health = PipelineHealth {
+            stages: vec![
+                stage("Triage", Some("triager"), None, 0, 1, 0, 1, 0),
+                stage("Review", Some("reviewer"), Some(3), 1, 2, 2, 1, 0),
+            ],
+        };
+        let out = render(&health, true, false);
+        assert_eq!(
+            out[0],
+            "● daemon ok   ● roles covered   ● wip 1/3 Review   ● 0 stuck"
+        );
+        assert!(
+            out[3].contains("triager ○"),
+            "all-busy holders read amber: {}",
+            out[3]
+        );
+        assert!(
+            out[3].contains("reviewer ●"),
+            "a free holder reads green: {}",
+            out[3]
+        );
+    }
+
+    /// A dead daemon and a saturated stage each own their light.
+    #[test]
+    fn daemon_down_and_saturated_wip_each_light_up() {
+        let health = PipelineHealth {
+            stages: vec![stage(
+                "Implement",
+                Some("implementer"),
+                Some(2),
+                2,
+                1,
+                0,
+                3,
+                0,
+            )],
+        };
+        let out = render(&health, false, false);
+        assert_eq!(
+            out[0],
+            "● daemon down   ● roles covered   ○ wip 2/2 Implement   ● 0 stuck"
+        );
+    }
+
+    /// With colour on, the lights carry 24-bit escapes and the padding is still
+    /// computed off the PLAIN width (a coloured strip lines up identically).
+    #[test]
+    fn lights_are_coloured_and_padding_ignores_escapes() {
+        let health = PipelineHealth {
+            stages: vec![stage("QA", Some("tester"), Some(1), 0, 0, 0, 1, 0)],
+        };
+        let colored = render(&health, true, true);
+        assert!(
+            colored[0].contains("\x1b[38;2;230;100;100m●"),
+            "{}",
+            colored[0]
+        );
+        let plain = render(&health, true, false);
+        let stripped: String = strip_ansi(&colored[3]);
+        assert_eq!(stripped, plain[3]);
+    }
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5855,6 +5855,9 @@ async fn handle_board_column_update(
         params.name.as_deref(),
         fsm_state,
         params.auto_move,
+        // The stage addendum is set through `ainb hangar pipeline stage-prompt`
+        // (0076); this RPC leaves it untouched.
+        None,
     )
     .await
     .map_err(|e| board_repo_err(&e))?;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -729,6 +729,16 @@ pub async fn boards_list(
     let boards = BoardRepo::list(pool, &ws).await?;
     let mut out = Vec::with_capacity(boards.len());
     for b in boards {
+        // The pipeline health of every column of this board, folded once per
+        // board (0074/0076). A board with no role-gated column produces stages
+        // that are all `services_role = None`, which render nothing.
+        let health = ainb_hangar_store::service::pipeline_health::snapshot(
+            pool,
+            &ws,
+            &b.id,
+            SystemClock.now_ms(),
+        )
+        .await?;
         let mut columns: Vec<BoardColumnWireRow> = b
             .columns
             .iter()
@@ -739,6 +749,16 @@ pub async fn boards_list(
                 fsm_state: c.fsm_state.clone(),
                 auto_move: c.auto_move,
                 cards: Vec::new(),
+                health: health.stages.iter().find(|s| s.column_id == c.id).map(|s| {
+                    ainb_hangar_proto::snapshots::ColumnHealthWireRow {
+                        services_role: s.services_role.clone(),
+                        wip_limit: s.wip_limit,
+                        wip_active: s.wip_active,
+                        role_agents: s.role_agents,
+                        role_agents_free: s.role_agents_free,
+                        stuck: s.stuck,
+                    }
+                }),
             })
             .collect();
         let mut unmapped = Vec::new();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -2466,6 +2466,12 @@ async fn resolve_dispatch(
 /// 2. the agent's own `instructions` — a chat / autopilot task with no issue,
 /// 3. [`FALLBACK_PROMPT`] — so a provider is never spawned promptless (which is
 ///    an immediate non-zero exit, not a no-op).
+///
+/// On top of that, migration 0076's `board_column.stage_prompt` is a LAYER
+/// rather than a source: the stage the card currently sits in contributes its
+/// own instruction ("everything entering Review gets this") regardless of which
+/// agent pulled the card. It leads the issue body so specificity increases
+/// downward: agent instructions, then stage, then the issue itself.
 async fn build_prompt(
     pool: &SqlitePool,
     issue_id: Option<&str>,
@@ -2473,9 +2479,18 @@ async fn build_prompt(
 ) -> String {
     use ainb_hangar_store::repo::issue::IssueRepo;
 
+    let stage = match issue_id {
+        Some(id) => stage_prompt_for_issue(pool, id).await,
+        None => None,
+    };
     if let Some(issue_id) = issue_id {
         if let Ok(Some(issue)) = IssueRepo::get_by_id(pool, issue_id).await {
-            let mut brief = issue.title;
+            let mut brief = String::new();
+            if let Some(stage) = stage.as_deref() {
+                brief.push_str(stage);
+                brief.push_str("\n\n");
+            }
+            brief.push_str(&issue.title);
             if let Some(desc) = issue.description.filter(|d| !d.trim().is_empty()) {
                 brief.push_str("\n\n");
                 brief.push_str(&desc);
@@ -2493,10 +2508,39 @@ async fn build_prompt(
             }
         }
     }
-    agent_instructions
-        .map(str::trim)
-        .filter(|i| !i.is_empty())
-        .map_or_else(|| FALLBACK_PROMPT.to_string(), ToString::to_string)
+    // No usable issue body. The agent's own instructions become the brief, and the
+    // stage layer (reachable here when the card's issue row vanished mid-flight)
+    // still stacks BELOW them, the same ordering the issue path renders.
+    let instructions = agent_instructions.map(str::trim).filter(|i| !i.is_empty());
+    match (instructions, stage.as_deref()) {
+        (Some(i), Some(s)) => format!("{i}\n\n{s}"),
+        (Some(i), None) => i.to_string(),
+        (None, Some(s)) => s.to_string(),
+        (None, None) => FALLBACK_PROMPT.to_string(),
+    }
+}
+
+/// The `stage_prompt` (migration 0076) of the column the issue's card sits in, or
+/// `None` when the issue is on no board, sits in a column that adds nothing, or
+/// the read faults.
+///
+/// An issue can be carded on several boards; the pipeline board is the one that
+/// gates dispatch, so a stage that actually carries an addendum wins over one
+/// that does not, and ties break on `board_id` to keep the brief deterministic.
+/// Best-effort by design: a store fault must degrade to "no stage layer", never
+/// strand a dispatch.
+async fn stage_prompt_for_issue(pool: &SqlitePool, issue_id: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT col.stage_prompt FROM board_card AS bc \
+           JOIN board_column AS col ON col.id = bc.column_id \
+          WHERE bc.issue_id = ? AND TRIM(COALESCE(col.stage_prompt, '')) <> '' \
+          ORDER BY bc.board_id LIMIT 1",
+    )
+    .bind(issue_id)
+    .fetch_optional(pool)
+    .await
+    .unwrap_or_default()
+    .map(|s| s.trim().to_string())
 }
 
 /// Resolve the provider wire name and owning workspace for a task's agent
@@ -3976,6 +4020,138 @@ mod tests {
             "a prompt is never empty"
         );
         assert_eq!(disp.invocation.prompt, FALLBACK_PROMPT);
+    }
+
+    /// The stage a card sits in contributes its OWN instruction to the brief
+    /// (migration 0076), and its POSITION is the contract: below the agent
+    /// instructions, above the issue body, so specificity increases downward.
+    ///
+    /// Asserts ordering rather than mere presence: a stage prompt appended after
+    /// the issue description would still "contain" the text while inverting the
+    /// layering it exists to express.
+    #[tokio::test]
+    async fn stage_prompt_layers_between_agent_instructions_and_the_issue_body() {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+
+        const STAGE: &str = "Use /my-review-skill. Check migrations are additive.";
+        const INSTRUCTIONS: &str = "You are the reviewer on call.";
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
+        let agent =
+            bootstrap::create_agent(pool, &ws, "checker", "claude", Some(INSTRUCTIONS.into()))
+                .await
+                .unwrap();
+
+        let issue_id =
+            ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        IssueRepo::insert(
+            pool,
+            &NewIssue {
+                id: issue_id.clone(),
+                workspace_id: ws.clone(),
+                title: "Fix the login bug".into(),
+                description: Some("It 500s on empty password.".into()),
+                state: "open".into(),
+                creator: ainb_hangar_core::actor::ActorRef::new(
+                    ainb_hangar_core::actor::ActorKind::Member,
+                    "stevie",
+                )
+                .unwrap(),
+                created_at: 1,
+                priority: 0,
+                assignee: None,
+                due_date: None,
+                labels: Vec::new(),
+                parent_issue_id: None,
+                stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // A pipeline board whose Review stage carries the addendum, with the
+        // issue's card parked in it.
+        sqlx::query("INSERT INTO board (id, workspace_id, name, created_at) VALUES (?,?,?,0)")
+            .bind("b-1")
+            .bind(ws.as_str())
+            .bind("Pipeline")
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO board_column \
+             (id, board_id, ord, name, fsm_state, auto_move, services_role, stage_prompt) \
+             VALUES ('c-1','b-1',0,'Review',NULL,1,'reviewer',?)",
+        )
+        .bind(STAGE)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+             VALUES ('b-1',?,'c-1',0,0)",
+        )
+        .bind(&issue_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
+            .await
+            .unwrap();
+        let brief = disp.invocation.prompt;
+        assert_eq!(
+            brief,
+            format!("{STAGE}\n\nFix the login bug\n\nIt 500s on empty password."),
+            "the stage prompt leads the issue body"
+        );
+        let stage_at = brief.find(STAGE).expect("stage prompt in the brief");
+        let title_at = brief.find("Fix the login bug").expect("title in the brief");
+        let desc_at = brief.find("It 500s on empty").expect("description in the brief");
+        assert!(
+            stage_at < title_at && title_at < desc_at,
+            "ordering must be stage -> title -> description, got {stage_at}/{title_at}/{desc_at} \
+             in:\n{brief}"
+        );
+
+        // The other half of the layering: when the issue body is gone and the
+        // agent's own instructions become the brief, the stage still stacks BELOW
+        // them. Ordering, not presence, is what is asserted.
+        sqlx::query("DELETE FROM issue WHERE id = ?")
+            .bind(&issue_id)
+            .execute(pool)
+            .await
+            .unwrap();
+        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
+            .await
+            .unwrap();
+        let brief = disp.invocation.prompt;
+        let instr_at = brief.find(INSTRUCTIONS).expect("agent instructions in the brief");
+        let stage_at = brief.find(STAGE).expect("stage prompt in the brief");
+        assert!(
+            instr_at < stage_at,
+            "the stage layer sits BELOW the agent instructions, got:\n{brief}"
+        );
+
+        // A stage with no addendum changes nothing: the brief is byte-identical to
+        // the pre-0076 one.
+        sqlx::query("UPDATE board_column SET stage_prompt = NULL WHERE id = 'c-1'")
+            .execute(pool)
+            .await
+            .unwrap();
+        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
+            .await
+            .unwrap();
+        assert_eq!(disp.invocation.prompt, INSTRUCTIONS);
     }
 
     /// A linked upstream issue (0043) appends a `Linked issue:` line to the brief so

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -2337,6 +2337,41 @@ pub struct BoardColumnWireRow {
     pub auto_move: bool,
     /// The cards currently in this column (in board order).
     pub cards: Vec<BoardCardWireRow>,
+    /// The column's pull-pipeline health (0074/0076): its role gate, WIP
+    /// pressure, role coverage and stuck count, all derived at query time.
+    /// APPEND-ONLY, and `None` on a board that is not a pull pipeline, so a
+    /// pre-pipeline producer's payload stays byte-identical.
+    ///
+    /// Sent rather than derived client-side because NONE of it is otherwise on
+    /// the wire: the plugin sees neither `services_role`, nor the squad roster
+    /// that covers it, nor per-agent concurrency. Shipping the folded facts
+    /// keeps the board and `ainb hangar pipeline show` reading one computation
+    /// instead of two that can drift.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health: Option<ColumnHealthWireRow>,
+}
+
+/// One column's pipeline health, as folded by
+/// `ainb_hangar_store::service::pipeline_health` (the same snapshot the CLI
+/// strip renders).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ColumnHealthWireRow {
+    /// The role that gates pulling from this stage; `None` ⇒ not a pull queue
+    /// (Backlog / Done).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub services_role: Option<String>,
+    /// The stage's WIP cap, or `None` for unlimited.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wip_limit: Option<i64>,
+    /// Cards here holding an active task right now.
+    pub wip_active: i64,
+    /// Non-archived agents that HOLD this stage's role. Zero is the silent-stall
+    /// condition the board paints `✗` for.
+    pub role_agents: i64,
+    /// Of those, how many are under their own `max_concurrent_tasks`.
+    pub role_agents_free: i64,
+    /// Cards that have sat here with no active task past the stall threshold.
+    pub stuck: i64,
 }
 
 /// One board with its ordered columns and its cards
@@ -4717,6 +4752,7 @@ mod tests {
                         blocks: Vec::new(),
                         related: Vec::new(),
                     }],
+                    health: None,
                 }],
                 unmapped: Vec::new(),
             }],
@@ -4726,6 +4762,26 @@ mod tests {
             serde_json::from_str::<BoardsListResult>(&s).unwrap(),
             result
         );
+        // A column with no pipeline health OMITS the field entirely, so a
+        // non-pipeline board's payload stays byte-identical to a pre-0074
+        // producer's (append-only).
+        assert!(
+            !s.contains("health"),
+            "health must be omitted when absent: {s}"
+        );
+
+        // …and a role-gated stage round-trips its health verbatim.
+        let mut gated = result.clone();
+        gated.boards[0].columns[0].health = Some(ColumnHealthWireRow {
+            services_role: Some("reviewer".into()),
+            wip_limit: Some(3),
+            wip_active: 1,
+            role_agents: 2,
+            role_agents_free: 1,
+            stuck: 4,
+        });
+        let s = serde_json::to_string(&gated).unwrap();
+        assert_eq!(serde_json::from_str::<BoardsListResult>(&s).unwrap(), gated);
 
         // Omitted fsm_state => None (leave the mapping unchanged).
         let omitted: BoardColumnUpdateParams = serde_json::from_str(

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0076_column_stage_prompt.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0076_column_stage_prompt.sql
@@ -1,0 +1,23 @@
+-- Hangar v1 schema, migration 0076: per-stage prompt addendum.
+--
+-- 0074 turned board columns into role-gated pull queues, so a card now crosses
+-- several stages, each pulled by a DIFFERENT agent. What was missing is the
+-- instruction that belongs to the STAGE rather than to any one agent: "everything
+-- that enters Review gets this", independent of which reviewer happens to pull it.
+--
+-- Today's brief (`build_prompt`, `run_loop.rs`) layers agent instructions and the
+-- issue title + description; the workspace context prompt and the squad-leader
+-- briefing arrive separately as a materialised `CLAUDE.md` in the run workdir.
+-- `stage_prompt` slots in directly above the issue body, so specificity increases
+-- downward: workspace, then squad, then agent, then STAGE, then the issue itself.
+-- The stage text is the more general of the two, which is why it leads the issue
+-- rather than trailing it.
+--
+-- Additive `ALTER TABLE ... ADD COLUMN` with no default, the same O(1) catalog
+-- change 0074 used and safe on a populated home. NULL is the meaningful default
+-- and means exactly "this stage adds nothing", so every pre-existing column
+-- migrates to NULL and no existing brief changes by a single byte.
+--
+-- No index: the column is read once per dispatch by primary key (the card's
+-- `column_id`), never scanned or filtered on.
+ALTER TABLE board_column ADD COLUMN stage_prompt TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/board.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/board.rs
@@ -314,11 +314,12 @@ impl BoardRepo {
         Ok(column_id.to_string())
     }
 
-    /// Update a column's `name`, `fsm_state`, and/or `auto_move`.
+    /// Update a column's `name`, `fsm_state`, `auto_move`, and/or `stage_prompt`.
     ///
-    /// `name` / `auto_move`: `None` leaves unchanged. `fsm_state`: the OUTER
-    /// `None` leaves it unchanged; `Some(None)` clears it to NULL (a manual
-    /// column); `Some(Some(s))` sets it.
+    /// `name` / `auto_move`: `None` leaves unchanged. `fsm_state` and
+    /// `stage_prompt` are TRI-STATE: the OUTER `None` leaves it unchanged;
+    /// `Some(None)` clears it to NULL (a manual column / a stage that adds no
+    /// instruction); `Some(Some(s))` sets it.
     ///
     /// # Errors
     ///
@@ -332,6 +333,7 @@ impl BoardRepo {
         name: Option<&str>,
         fsm_state: Option<Option<&str>>,
         auto_move: Option<bool>,
+        stage_prompt: Option<Option<&str>>,
     ) -> Result<(), BoardRepoError> {
         let mut tx = pool.begin().await?;
         Self::ensure_column_in_ws(&mut tx, workspace, board_id, column_id).await?;
@@ -375,6 +377,13 @@ impl BoardRepo {
         if let Some(am) = auto_move {
             sqlx::query("UPDATE board_column SET auto_move = ? WHERE id = ?")
                 .bind(i64::from(am))
+                .bind(column_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+        if let Some(sp) = stage_prompt {
+            sqlx::query("UPDATE board_column SET stage_prompt = ? WHERE id = ?")
+                .bind(sp)
                 .bind(column_id)
                 .execute(&mut *tx)
                 .await?;
@@ -1417,9 +1426,10 @@ mod tests {
         .unwrap();
 
         // Flipping the manual `done` column's auto-move ON now clashes with c1: rejected.
-        let flip = BoardRepo::column_update(pool, &ws("ws-a"), "b1", "c3", None, None, Some(true))
-            .await
-            .unwrap_err();
+        let flip =
+            BoardRepo::column_update(pool, &ws("ws-a"), "b1", "c3", None, None, Some(true), None)
+                .await
+                .unwrap_err();
         assert!(
             matches!(flip, BoardRepoError::DuplicateAutoMove),
             "got {flip:?}"
@@ -1435,6 +1445,7 @@ mod tests {
             None,
             Some(Some("done")),
             Some(true),
+            None,
         )
         .await
         .unwrap();

--- a/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/mod.rs
@@ -45,6 +45,9 @@ pub mod mention;
 /// The DEFAULT six-stage pull pipeline (Backlog / Triage / Implement / Review /
 /// QA / Done) and the enqueue that places a card in its first role-gated stage.
 pub mod pipeline;
+/// The pipeline's four health lights (roles covered / WIP headroom / stuck
+/// cards, plus the per-stage role dot), all derived at query time.
+pub mod pipeline_health;
 /// Role-gated PULL of board work: a card in a role-gated column is the queue,
 /// and exactly one eligible agent takes it. The seam that replaces squad
 /// BROADCAST (one run per member) with one owner per card.

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pipeline_health.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pipeline_health.rs
@@ -1,0 +1,259 @@
+//! "Why is nothing moving?" answered in one strip.
+//!
+//! A role-gated pull pipeline ([`super::pipeline`]) stalls SILENTLY. Nothing
+//! errors, nothing retries, no task row is ever written: a card whose stage
+//! demands `reviewer` and whose workspace has no reviewer simply sits there,
+//! and finding that out today means reading the board, the squad roster and the
+//! agent list in three separate places. This module folds those three reads into
+//! one snapshot so both the CLI (`ainb hangar pipeline show`) and the Boards
+//! screen render the SAME four facts from the SAME query.
+//!
+//! ```text
+//!  ● daemon ok   ● roles covered   ○ wip 1/2 Implement   ● 0 stuck
+//! ```
+//!
+//! Three of the four lights are computed here; `daemon` is deliberately NOT,
+//! because each caller already has a liveness notion (the CLI reads the pid
+//! file, the plugin its socket link) and inventing a second one here would let
+//! them disagree.
+//!
+//! # Everything is derived at query time
+//!
+//! There is no health table, no cache and no background job. The snapshot is a
+//! read of live rows, so it cannot go stale and there is nothing to invalidate.
+//! The role-matching predicate is the SAME comma-separated, case-insensitive
+//! token match the pull statement gates on
+//! ([`super::pull`]), which is what makes a green "roles covered" light mean
+//! "the pull WILL fire" rather than "a role string looked similar".
+
+use ainb_hangar_core::ids::WorkspaceId;
+use sqlx::{Row, SqlitePool};
+
+/// How long a card may sit in a role-gated stage, with no active task, before it
+/// counts as STUCK.
+///
+/// Fifteen minutes is long enough that an ordinary hand-off between stages never
+/// trips it and short enough that an operator notices within a coffee break.
+//
+// ponytail: fixed on purpose. A stall threshold is the kind of knob that gets a
+// config key, a migration and a settings row before anyone has ever wanted a
+// second value. If someone actually asks for a different threshold, move it into
+// the `daemon_config` registry (`DAEMON_CONFIG_REGISTRY`), which already gives a
+// knob CLI get/set/list and a live daemon reload for free.
+pub const STUCK_AFTER_MS: i64 = 15 * 60 * 1000;
+
+/// The task statuses that count as an agent (or a card) being BUSY.
+const ACTIVE_STATUSES: &str = "'queued','dispatched','running'";
+
+/// One stage's health, as read off the live board.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StageHealth {
+    /// The column's stable id.
+    pub column_id: String,
+    /// The column's display name (`Review`).
+    pub name: String,
+    /// The column's left-to-right position.
+    pub ord: i64,
+    /// The role that gates pulling from this stage, or `None` when the stage is
+    /// not a pull queue at all (Backlog / Done).
+    pub services_role: Option<String>,
+    /// The stage's WIP cap, or `None` for unlimited.
+    pub wip_limit: Option<i64>,
+    /// Cards in this stage holding an active task right now (what `wip_limit` is
+    /// compared against by the pull statement).
+    pub wip_active: i64,
+    /// Non-archived agents in the workspace that HOLD this stage's role.
+    /// Zero is the silent-stall condition: cards here can never be pulled.
+    pub role_agents: i64,
+    /// Of those, how many are under their own `max_concurrent_tasks` — i.e. could
+    /// pull a card right now. Zero with `role_agents > 0` is ordinary busyness,
+    /// not a misconfiguration.
+    pub role_agents_free: i64,
+    /// Cards currently sitting in this stage.
+    pub cards: i64,
+    /// Cards that have sat here with no active task for longer than
+    /// [`STUCK_AFTER_MS`] (blocked cards excluded — those are waiting, not stuck).
+    pub stuck: i64,
+}
+
+impl StageHealth {
+    /// Whether this stage is a pull queue (has a role gate) at all.
+    #[must_use]
+    pub const fn is_gated(&self) -> bool {
+        self.services_role.is_some()
+    }
+
+    /// The stage nobody can serve: role-gated, and NO agent in the workspace
+    /// holds the role. This is the light that matters — cards park here forever
+    /// and nothing anywhere reports an error.
+    #[must_use]
+    pub const fn role_uncovered(&self) -> bool {
+        self.is_gated() && self.role_agents == 0
+    }
+
+    /// Whether the stage is AT its WIP cap (no headroom to pull another card).
+    #[must_use]
+    pub fn wip_saturated(&self) -> bool {
+        self.wip_limit.is_some_and(|limit| self.wip_active >= limit)
+    }
+}
+
+/// A whole pipeline board's health.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipelineHealth {
+    /// Every column of the board, in board order.
+    pub stages: Vec<StageHealth>,
+}
+
+impl PipelineHealth {
+    /// The role-gated stages no agent can serve, in board order. Empty ⇒ the
+    /// "roles covered" light is GREEN.
+    #[must_use]
+    pub fn uncovered(&self) -> Vec<&StageHealth> {
+        self.stages.iter().filter(|s| s.role_uncovered()).collect()
+    }
+
+    /// The first stage sitting at its WIP cap, if any.
+    #[must_use]
+    pub fn saturated(&self) -> Option<&StageHealth> {
+        self.stages.iter().find(|s| s.wip_saturated())
+    }
+
+    /// Total stuck cards across every gated stage.
+    #[must_use]
+    pub fn stuck(&self) -> i64 {
+        self.stages.iter().map(|s| s.stuck).sum()
+    }
+}
+
+/// Read one board's pipeline health.
+///
+/// `now_ms` is passed rather than read so the stuck light is deterministic under
+/// test (the same reason every service here takes a
+/// [`HangarClock`](ainb_hangar_core::clock::HangarClock)).
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if a query fails.
+pub async fn snapshot(
+    pool: &SqlitePool,
+    workspace: &WorkspaceId,
+    board_id: &str,
+    now_ms: i64,
+) -> Result<PipelineHealth, sqlx::Error> {
+    // One row per column. The two role counts share the pull statement's role
+    // predicate VERBATIM (comma-separated token, case-insensitive, whitespace
+    // stripped) so a green light and an actual pull cannot disagree; the second
+    // adds the pull's per-agent concurrency cap on top.
+    let sql = format!(
+        "SELECT col.id AS id, col.name AS name, col.ord AS ord, \
+                col.services_role AS role, col.wip_limit AS wip_limit, \
+                (SELECT COUNT(*) FROM board_card bc WHERE bc.column_id = col.id) AS cards, \
+                (SELECT COUNT(DISTINCT w.issue_id) FROM board_card w \
+                   JOIN agent_task_queue wq ON wq.issue_id = w.issue_id \
+                  WHERE w.column_id = col.id \
+                    AND wq.status IN ({ACTIVE_STATUSES})) AS wip_active, \
+                (SELECT COUNT(*) FROM agent a \
+                  WHERE a.workspace_id = bd.workspace_id AND a.archived = 0 \
+                    AND {ROLE_MATCH}) AS role_agents, \
+                (SELECT COUNT(*) FROM agent a \
+                  WHERE a.workspace_id = bd.workspace_id AND a.archived = 0 \
+                    AND {ROLE_MATCH} \
+                    AND (SELECT COUNT(*) FROM agent_task_queue r \
+                          WHERE r.agent_id = a.id \
+                            AND r.status IN ({ACTIVE_STATUSES})) < a.max_concurrent_tasks \
+                ) AS role_agents_free \
+           FROM board_column col JOIN board bd ON bd.id = col.board_id \
+          WHERE col.board_id = ?1 AND bd.workspace_id = ?2 \
+          ORDER BY col.ord"
+    );
+    let rows = sqlx::query(&sql)
+        .bind(board_id)
+        .bind(workspace.as_str())
+        .fetch_all(pool)
+        .await?;
+
+    let mut stages: Vec<StageHealth> = rows
+        .iter()
+        .map(|r| StageHealth {
+            column_id: r.try_get("id").unwrap_or_default(),
+            name: r.try_get("name").unwrap_or_default(),
+            ord: r.try_get("ord").unwrap_or_default(),
+            services_role: r.try_get("role").unwrap_or_default(),
+            wip_limit: r.try_get("wip_limit").unwrap_or_default(),
+            wip_active: r.try_get("wip_active").unwrap_or_default(),
+            role_agents: r.try_get("role_agents").unwrap_or_default(),
+            role_agents_free: r.try_get("role_agents_free").unwrap_or_default(),
+            cards: r.try_get("cards").unwrap_or_default(),
+            stuck: 0,
+        })
+        .collect();
+
+    for stage in &mut stages {
+        if stage.is_gated() {
+            stage.stuck = stuck_in_column(pool, &stage.column_id, now_ms).await?;
+        }
+    }
+    Ok(PipelineHealth { stages })
+}
+
+/// The pull statement's role predicate, correlated on `a` (the candidate agent),
+/// `col` (the stage) and `bd` (the board's workspace).
+///
+/// Kept as one string constant rather than retyped per query: this predicate IS
+/// the role gate, and a second, subtly different copy of it would make the health
+/// light lie about the very thing it exists to report.
+const ROLE_MATCH: &str = "col.services_role IS NOT NULL AND EXISTS ( \
+       SELECT 1 FROM squad_member sm JOIN squad sq ON sq.id = sm.squad_id \
+        WHERE sm.member_type = 'agent' AND sm.member_id = a.id \
+          AND sq.workspace_id = bd.workspace_id \
+          AND INSTR( \
+                ',' || REPLACE(LOWER(sm.role), ' ', '') || ',', \
+                ',' || LOWER(TRIM(col.services_role)) || ',' \
+              ) > 0 )";
+
+/// Count the STUCK cards of one gated column.
+///
+/// A card is stuck when it holds no active task, its issue is still open, and its
+/// last sign of life (the newest task's `finished_at`, or the card's `added_at`
+/// for a card that has never run) is older than [`STUCK_AFTER_MS`].
+///
+/// BLOCKED cards are then filtered out in Rust rather than in SQL: a card waiting
+/// on an unfinished blocker is behaving exactly as designed, and reporting it as
+/// stuck would make the light cry wolf. The blocker check reuses
+/// [`CardDependencyRepo::unfinished_blockers_of`](crate::repo::card_dependency::CardDependencyRepo::unfinished_blockers_of),
+/// the same read the board renders 🔒 from, instead of restating its
+/// generation-aware SQL a second time — and it only runs for the handful of cards
+/// that already aged past the threshold.
+async fn stuck_in_column(
+    pool: &SqlitePool,
+    column_id: &str,
+    now_ms: i64,
+) -> Result<i64, sqlx::Error> {
+    use crate::repo::card_dependency::CardDependencyRepo;
+
+    let cutoff = now_ms.saturating_sub(STUCK_AFTER_MS);
+    let sql = format!(
+        "SELECT bc.issue_id AS issue_id FROM board_card bc \
+           JOIN issue i ON i.id = bc.issue_id \
+          WHERE bc.column_id = ?1 \
+            AND i.state NOT IN ('closed','cancelled') \
+            AND NOT EXISTS (SELECT 1 FROM agent_task_queue t \
+                             WHERE t.issue_id = bc.issue_id \
+                               AND t.status IN ({ACTIVE_STATUSES})) \
+            AND COALESCE( \
+                  (SELECT MAX(f.finished_at) FROM agent_task_queue f \
+                    WHERE f.issue_id = bc.issue_id), \
+                  bc.added_at) < ?2"
+    );
+    let candidates: Vec<String> =
+        sqlx::query_scalar(&sql).bind(column_id).bind(cutoff).fetch_all(pool).await?;
+
+    let mut stuck = 0;
+    for issue_id in &candidates {
+        if CardDependencyRepo::unfinished_blockers_of(pool, issue_id).await?.is_empty() {
+            stuck += 1;
+        }
+    }
+    Ok(stuck)
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/pipeline_health_roles.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pipeline_health_roles.rs
@@ -1,0 +1,167 @@
+//! The `roles covered` light: the one health signal a stalled pipeline gives.
+//!
+//! A role-gated column whose role NO agent holds is the pipeline's silent
+//! failure. Nothing errors, no task row is written, no retry fires — the cards
+//! just sit there. This is the regression that matters, so it gets the test:
+//! RED with no holder, GREEN the moment an agent holds the role, through the
+//! same fold the CLI strip and the Boards screen both render.
+//!
+//! Built from raw SQL against the migrated schema (the `pull_role_gate.rs`
+//! convention) so the assertion is on the fold's own predicate and cannot be
+//! masked by a repo-level guard.
+
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::service::pipeline_health;
+use sqlx::SqlitePool;
+
+/// Frozen "now" so the stuck light is deterministic.
+const NOW_MS: i64 = 1_700_000_500_000;
+
+fn ws() -> WorkspaceId {
+    WorkspaceId::from_str("ws-1".to_string()).expect("workspace id")
+}
+
+async fn seed_world(pool: &SqlitePool) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','a','A',0)")
+        .execute(pool)
+        .await
+        .expect("workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u-1','a@x.dev',0)")
+        .execute(pool)
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','d-1','claude','local')",
+    )
+    .execute(pool)
+    .await
+    .expect("runtime");
+    sqlx::query(
+        "INSERT INTO board (id, workspace_id, name, created_at) VALUES ('b-1','ws-1','B',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("board");
+    sqlx::query(
+        "INSERT INTO squad (id, workspace_id, name, leader_type, leader_id, created_at) \
+         VALUES ('sq-1','ws-1','team1','agent','ag-lead',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("squad");
+}
+
+async fn add_agent(pool: &SqlitePool, id: &str, roles: &str, max_concurrent: i64) {
+    sqlx::query(
+        "INSERT INTO agent \
+         (id, workspace_id, name, runtime_id, visibility, owner_id, max_concurrent_tasks) \
+         VALUES (?1,'ws-1',?1,'rt-1','workspace','u-1',?2)",
+    )
+    .bind(id)
+    .bind(max_concurrent)
+    .execute(pool)
+    .await
+    .expect("agent");
+    sqlx::query(
+        "INSERT INTO squad_member (squad_id, member_type, member_id, role) \
+         VALUES ('sq-1','agent',?1,?2)",
+    )
+    .bind(id)
+    .bind(roles)
+    .execute(pool)
+    .await
+    .expect("squad member");
+}
+
+async fn add_column(pool: &SqlitePool, id: &str, ord: i64, role: Option<&str>, wip: Option<i64>) {
+    sqlx::query(
+        "INSERT INTO board_column \
+         (id, board_id, ord, name, fsm_state, auto_move, services_role, wip_limit, \
+          excludes_prior_agent) \
+         VALUES (?1,'b-1',?2,?1,NULL,1,?3,?4,0)",
+    )
+    .bind(id)
+    .bind(ord)
+    .bind(role)
+    .bind(wip)
+    .execute(pool)
+    .await
+    .expect("column");
+}
+
+async fn snapshot(pool: &SqlitePool) -> pipeline_health::PipelineHealth {
+    pipeline_health::snapshot(pool, &ws(), "b-1", NOW_MS)
+        .await
+        .expect("health snapshot")
+}
+
+/// A stage gated on a role NOBODY holds reports RED; hiring one agent that holds
+/// it flips the SAME stage GREEN, with no other change to the board.
+#[tokio::test]
+async fn uncovered_role_reports_red_until_an_agent_holds_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    let pool = store.pool();
+    seed_world(pool).await;
+
+    add_column(pool, "Backlog", 0, None, None).await;
+    add_column(pool, "Review", 1, Some("reviewer"), Some(3)).await;
+    add_column(pool, "QA", 2, Some("tester"), Some(1)).await;
+    // A reviewer exists; NO tester does. `implementer,reviewer` also pins the
+    // comma-separated token match the pull statement gates on.
+    add_agent(pool, "ag-1", "implementer,reviewer", 2).await;
+
+    let health = snapshot(pool).await;
+    let uncovered: Vec<&str> =
+        health.uncovered().iter().filter_map(|s| s.services_role.as_deref()).collect();
+    assert_eq!(uncovered, vec!["tester"], "only the unheld role is red");
+
+    let qa = health.stages.iter().find(|s| s.name == "QA").expect("QA stage");
+    assert!(qa.role_uncovered(), "QA has no tester: {qa:?}");
+    assert_eq!(qa.role_agents, 0);
+
+    let review = health.stages.iter().find(|s| s.name == "Review").expect("Review stage");
+    assert!(
+        !review.role_uncovered(),
+        "Review has a reviewer: {review:?}"
+    );
+    assert_eq!(review.role_agents, 1);
+    assert_eq!(
+        review.role_agents_free, 1,
+        "an idle holder can pull right now"
+    );
+
+    // An ungated column is not a pull queue and can never be uncovered.
+    let backlog = health.stages.iter().find(|s| s.name == "Backlog").expect("Backlog stage");
+    assert!(!backlog.is_gated());
+    assert!(!backlog.role_uncovered());
+
+    // Hire a tester. Same board, same query — the light must flip.
+    add_agent(pool, "ag-2", "tester", 1).await;
+    let health = snapshot(pool).await;
+    assert!(
+        health.uncovered().is_empty(),
+        "every role is now held: {:?}",
+        health.uncovered()
+    );
+    let qa = health.stages.iter().find(|s| s.name == "QA").expect("QA stage");
+    assert_eq!(qa.role_agents, 1);
+    assert_eq!(qa.role_agents_free, 1);
+
+    // An ARCHIVED agent does not cover a role: it can never be dispatched to, so
+    // counting it would make the light lie in exactly the case it exists for.
+    sqlx::query("UPDATE agent SET archived = 1 WHERE id = 'ag-2'")
+        .execute(pool)
+        .await
+        .expect("archive");
+    let health = snapshot(pool).await;
+    let uncovered: Vec<&str> =
+        health.uncovered().iter().filter_map(|s| s.services_role.as_deref()).collect();
+    assert_eq!(
+        uncovered,
+        vec!["tester"],
+        "an archived holder does not cover a role"
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -7082,6 +7082,7 @@ mod tests {
                     fsm_state: None,
                     auto_move: false,
                     cards: Vec::new(),
+                    health: None,
                 }],
                 unmapped: Vec::new(),
             }],
@@ -7200,6 +7201,7 @@ mod tests {
                                 related: Vec::new(),
                             },
                         ],
+                        health: None,
                     },
                     BoardColumnWireRow {
                         id: "c-done".into(),
@@ -7208,6 +7210,7 @@ mod tests {
                         fsm_state: None,
                         auto_move: false,
                         cards: Vec::new(),
+                        health: None,
                     },
                 ],
                 unmapped: Vec::new(),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -29,7 +29,9 @@
 //! auto-move, create/delete a board). Pure: no IO, no input mutation.
 
 use ainb_hangar_proto::events::MessageKind;
-use ainb_hangar_proto::snapshots::{BoardCardWireRow, BoardsListResult, CardMemberChip};
+use ainb_hangar_proto::snapshots::{
+    BoardCardWireRow, BoardsListResult, CardMemberChip, ColumnHealthWireRow,
+};
 use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
 
 use crate::screen::task_detail::ViewEntry;
@@ -141,6 +143,13 @@ const MUTED: Color = Color::rgb(120, 120, 140);
 const GREEN: Color = Color::rgb(100, 200, 120);
 /// Amber-red for the "couldn't load boards" error state.
 const ERROR_RED: Color = Color::rgb(235, 90, 90);
+/// Amber for a stage that is AT a limit but still working (WIP saturated, or a
+/// role whose every holder is busy). Deliberately NOT red: busy is not broken,
+/// and painting the two the same colour is what makes an operator stop reading
+/// the strip.
+const AMBER: Color = Color::rgb(255, 165, 0);
+/// Red for a pipeline that CANNOT move: a role nobody holds, or a stuck card.
+const RED: Color = Color::rgb(230, 100, 100);
 
 /// The load state of the Boards screen.
 ///
@@ -276,6 +285,9 @@ pub struct ColumnView {
     pub auto_move: bool,
     /// The cards in this column, in board order.
     pub cards: Vec<CardView>,
+    /// The column's pull-pipeline health (role gate, WIP pressure, role
+    /// coverage, stuck count), or `None` on a board that is not a pipeline.
+    pub health: Option<ColumnHealthWireRow>,
 }
 
 /// One board with its columns + its unmapped-card pool.
@@ -720,6 +732,7 @@ impl BoardsState {
                         fsm_state: c.fsm_state.clone(),
                         auto_move: c.auto_move,
                         cards: c.cards.iter().map(CardView::from_wire).collect(),
+                        health: c.health.clone(),
                     })
                     .collect(),
                 unmapped: b.unmapped.iter().map(CardView::from_wire).collect(),
@@ -2261,12 +2274,21 @@ pub fn render_boards(
         put_str(buf, x, top, note, GOLD, area_w);
     }
 
+    // The pipeline health strip, ONE row, directly under the title, but only on
+    // a board that actually is a pull pipeline. A plain kanban board keeps its
+    // existing layout to the cell, so nothing that reads this screen shifts.
+    let mut next_row = top.saturating_add(1);
+    if is_pipeline(board) {
+        render_health_strip(buf, area_w, next_row, board, state.status());
+        next_row = next_row.saturating_add(1);
+    }
+
     // Hint band NEXT to the widget (letters next to the controls they affect).
-    let hint_row = top.saturating_add(1);
+    let hint_row = next_row;
     render_hint_band(buf, area_w, hint_row);
 
     // Card-board body below the hint band.
-    let body_top = top.saturating_add(2);
+    let body_top = hint_row.saturating_add(1);
     if body_top >= bottom {
         return;
     }
@@ -2278,7 +2300,13 @@ pub fn render_boards(
     } else {
         None
     };
-    let _ = card_board::render_card_board(buf, area_w, body_top, bottom, &columns, selected);
+    let layout = card_board::render_card_board(buf, area_w, body_top, bottom, &columns, selected);
+    // Repaint each pipeline stage's leading glyph as a COLOUR-CODED role dot.
+    // Done as an overpaint keyed off the layout the board just returned rather
+    // than by widening `card_board::BoardColumn`: the widget paints a header in
+    // one accent colour, and a dot that cannot go red is exactly the signal this
+    // strip exists to give.
+    paint_role_dots(buf, board, &layout, area_w);
 
     // An open interactive overlay paints a banner over the top body rows so the
     // typed title / picked profile / run mode is visible (and greppable by the
@@ -2700,9 +2728,187 @@ fn board_columns(board: &BoardView) -> Vec<card_board::BoardColumn> {
     columns
 }
 
+/// Whether this board is a role-gated PULL PIPELINE, i.e. at least one column
+/// gates on a `services_role` (0074). A plain kanban board has none, gets no
+/// health strip, and keeps its existing layout untouched.
+fn is_pipeline(board: &BoardView) -> bool {
+    board
+        .columns
+        .iter()
+        .any(|c| c.health.as_ref().is_some_and(|h| h.services_role.is_some()))
+}
+
+/// The four health lights: daemon, role coverage, WIP headroom, stuck cards.
+///
+/// Answers "why is nothing moving?" in one row. Every light is derived from the
+/// snapshot the daemon already sent, so the strip cannot disagree with the board
+/// beneath it, and the colours are the whole point: a stalled pipeline reports no
+/// error anywhere, so RED here is the only signal an operator gets.
+fn render_health_strip(
+    buf: &mut WireBuffer,
+    area_w: u16,
+    row: u16,
+    board: &BoardView,
+    status: &BoardsStatus,
+) {
+    let stages: Vec<&ColumnHealthWireRow> =
+        board.columns.iter().filter_map(|c| c.health.as_ref()).collect();
+
+    // Liveness is the SAME socket link the rest of this screen reads: a board
+    // that rendered from a snapshot came off a live daemon, and a failed fetch is
+    // exactly how this screen already learns the daemon is gone. No second notion.
+    let alive = !matches!(status, BoardsStatus::Error(_));
+    let mut x = put_str(buf, 0, row, "●", if alive { GREEN } else { RED }, area_w);
+    x = put_str(
+        buf,
+        x,
+        row,
+        if alive {
+            " daemon ok   "
+        } else {
+            " daemon down   "
+        },
+        MUTED,
+        area_w,
+    );
+
+    // The light that matters: a stage whose role NO agent holds parks its cards
+    // forever, silently. Name the role rather than just going red.
+    let uncovered: Vec<&str> = stages
+        .iter()
+        .filter(|h| h.services_role.is_some() && h.role_agents == 0)
+        .filter_map(|h| h.services_role.as_deref())
+        .collect();
+    x = put_str(
+        buf,
+        x,
+        row,
+        "●",
+        if uncovered.is_empty() { GREEN } else { RED },
+        area_w,
+    );
+    x = if uncovered.is_empty() {
+        put_str(buf, x, row, " roles covered   ", MUTED, area_w)
+    } else {
+        put_str(
+            buf,
+            x,
+            row,
+            &format!(" no agent: {}   ", uncovered.join(", ")),
+            RED,
+            area_w,
+        )
+    };
+
+    // WIP: the stage at its cap if there is one, else the tightest capped stage.
+    let saturated = stages.iter().find(|h| h.wip_limit.is_some_and(|l| h.wip_active >= l));
+    let tightest = saturated.or_else(|| {
+        stages
+            .iter()
+            .filter(|h| h.wip_limit.is_some())
+            .max_by_key(|h| h.wip_active - h.wip_limit.unwrap_or_default())
+    });
+    match tightest {
+        Some(h) => {
+            let at_cap = saturated.is_some();
+            x = put_str(
+                buf,
+                x,
+                row,
+                if at_cap { "○" } else { "●" },
+                if at_cap { AMBER } else { GREEN },
+                area_w,
+            );
+            let name = stage_name(board, h);
+            x = put_str(
+                buf,
+                x,
+                row,
+                &format!(
+                    " wip {}/{} {name}   ",
+                    h.wip_active,
+                    h.wip_limit.unwrap_or_default()
+                ),
+                MUTED,
+                area_w,
+            );
+        }
+        None => {
+            x = put_str(buf, x, row, "●", GREEN, area_w);
+            x = put_str(buf, x, row, " wip unlimited   ", MUTED, area_w);
+        }
+    }
+
+    let stuck: i64 = stages.iter().map(|h| h.stuck).sum();
+    x = put_str(
+        buf,
+        x,
+        row,
+        "●",
+        if stuck > 0 { RED } else { GREEN },
+        area_w,
+    );
+    put_str(
+        buf,
+        x,
+        row,
+        &format!(" {stuck} stuck"),
+        if stuck > 0 { RED } else { MUTED },
+        area_w,
+    );
+}
+
+/// The display name of the column carrying `health` (the strip names the stage
+/// its WIP light is about).
+fn stage_name<'a>(board: &'a BoardView, health: &ColumnHealthWireRow) -> &'a str {
+    board
+        .columns
+        .iter()
+        .find(|c| c.health.as_ref().is_some_and(|h| std::ptr::eq(h, health)))
+        .map_or("", |c| c.name.as_str())
+}
+
+/// Overpaint each role-gated column's leading header glyph with a COLOUR-CODED
+/// role dot: `✗` red when no agent holds the stage's role (cards can never be
+/// pulled), `○` amber when every holder is at its own `max_concurrent_tasks`
+/// (busy, not broken), `●` green when someone can pull right now.
+///
+/// Keyed off the geometry `render_card_board` just returned, so the dot lands on
+/// the exact cell the widget painted its glyph in, at any width and any scroll.
+fn paint_role_dots(
+    buf: &mut WireBuffer,
+    board: &BoardView,
+    layout: &card_board::BoardLayout,
+    area_w: u16,
+) {
+    for (col, lay) in board.columns.iter().zip(layout.columns.iter()) {
+        let Some(health) = col.health.as_ref() else {
+            continue;
+        };
+        if health.services_role.is_none() {
+            continue;
+        }
+        let (glyph, colour) = if health.role_agents == 0 {
+            ("✗", RED)
+        } else if health.role_agents_free == 0 {
+            ("○", AMBER)
+        } else {
+            ("●", GREEN)
+        };
+        put_str(buf, lay.rect.x, lay.header_y, glyph, colour, area_w);
+    }
+}
+
 /// A column header carrying its FSM mapping (`Done→done` / `Done↦done` for an
 /// auto-move column) so the mapping reads on the board.
 fn column_header(c: &ColumnView) -> String {
+    // A pipeline stage names its ROLE GATE instead of an FSM mapping: every
+    // pipeline column deliberately carries `fsm_state = NULL` (see
+    // `service::pipeline`), so the gate is the only thing there is to show, and
+    // it is what the coloured dot beside it refers to.
+    if let Some(role) = c.health.as_ref().and_then(|h| h.services_role.as_deref()) {
+        return format!("{} ·{role}", c.name);
+    }
     match (&c.fsm_state, c.auto_move) {
         (Some(fs), true) => format!("{} ↦{}", c.name, fs),
         (Some(fs), false) => format!("{} ·{}", c.name, fs),
@@ -2832,6 +3038,7 @@ mod tests {
             fsm_state: fsm.map(str::to_string),
             auto_move: auto,
             cards,
+            health: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshot_boards.rs
@@ -49,6 +49,7 @@ fn col(
         fsm_state: fsm.map(str::to_string),
         auto_move: auto,
         cards,
+        health: None,
     }
 }
 

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -5427,9 +5427,10 @@ Provision and inspect the role-gated pull pipeline
 Usage: ainb hangar pipeline [OPTIONS] <COMMAND>
 
 Commands:
-  init  Provision the default six-stage pipeline (Backlog, Triage, Implement, Review, QA, Done). Idempotent; never rewrites an existing pipeline board
-  show  Show each stage with its role gate, WIP limit and current card count
-  help  Print this message or the help of the given subcommand(s)
+  init          Provision the default six-stage pipeline (Backlog, Triage, Implement, Review, QA, Done). Idempotent; never rewrites an existing pipeline board
+  show          Show each stage with its role gate, WIP limit and current card count
+  stage-prompt  Set (or clear) a stage's prompt addendum: the instruction every card entering that stage carries, whichever agent pulls it
+  help          Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -5465,6 +5466,25 @@ Usage: ainb hangar pipeline show [OPTIONS]
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug to provision. Defaults to the bootstrapped `default` workspace
+  -h, --help                   Print help
+```
+
+#### `ainb hangar pipeline stage-prompt`
+
+Set (or clear) a stage's prompt addendum: the instruction every card entering that stage carries, whichever agent pulls it
+
+```console
+$ ainb hangar pipeline stage-prompt --help
+Set (or clear) a stage's prompt addendum: the instruction every card entering that stage carries, whichever agent pulls it
+
+Usage: ainb hangar pipeline stage-prompt [OPTIONS] --stage <STAGE>
+
+Options:
+      --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
+      --workspace <WORKSPACE>  Workspace slug. Defaults to the bootstrapped `default` workspace
+      --stage <STAGE>          The stage (board column) name, e.g. `Review`. Case-insensitive
+      --text <TEXT>            The instruction to prepend to every brief pulled from this stage. Omit (or pass `--clear`) to remove it
+      --clear                  Clear the stage's prompt addendum
   -h, --help                   Print help
 ```
 


### PR DESCRIPTION
Two additive features on the role-gated pull pipeline (#547).

## 1. Pipeline health, four lights

A role-gated pipeline stalls silently: a stage demanding `reviewer` in a workspace with no reviewer writes no task row, raises no error and retries nothing. The cards just sit there. Finding that out meant reading the board, the squad roster and the agent list on three screens.

`service::pipeline_health` folds all three into one query-time snapshot (no table, no cache, no background job) and both surfaces render it.

`ainb hangar pipeline show`, against a seeded pipeline with three agents and no tester:

```
● daemon down   ● no agent: tester   ● wip 1/2 Implement   ● 2 stuck

Backlog │ Triage    │ Implement     │ Review         │ QA             │ Done
        │ triager ● │ implementer ● │ reviewer ●     │ tester ✗       │
1       │ 0         │ 1 (wip 1/2)   │ 1 (wip 0/3) ⏳1 │ 1 (wip 0/1) ⏳1 │ 0
```

The Boards screen paints the same four lights in one row under the title, and overpaints each stage's leading header glyph with the same colour-coded role dot.

Per-stage dot has three states, because busy is not broken:

| glyph | colour | meaning |
|---|---|---|
| `●` | green | a holder of the role is under its own `max_concurrent_tasks` and can pull now |
| `○` | amber | the role is held, but every holder is at capacity |
| `✗` | red | no non-archived agent holds the role: cards park here forever |

Notes on the four lights:
- **daemon** reuses the pid probe `hangar daemon status` prints (CLI) and the socket link the Boards screen already reads (TUI). No third liveness notion was invented.
- **roles covered** names the missing role rather than only going red, since the name is the whole diagnosis. Role matching reuses the pull statement's comma-separated, case-insensitive predicate verbatim, so green means the pull *will* fire.
- **stuck** uses a fixed 15 minute `const` with a `// ponytail:` note pointing at `DAEMON_CONFIG_REGISTRY` as the upgrade path. Blocked cards are excluded: a card waiting on a blocker behaves as designed.

**Wire vs client-side:** extended the wire. None of the inputs are otherwise available to the plugin, which sees neither `services_role`, nor `wip_limit`, nor the squad roster that covers a role, nor per-agent concurrency. Computing client-side was not possible, so `BoardColumnWireRow` gains one append-only optional `health` field (omitted entirely on a non-pipeline board). This is `ainb-hangar-proto`, **not** the `ainb-plugin-protocol` surface the `wire-surface.lock` gates, so no lock regeneration or protocol version bump is required. Verified: the full `ainb-plugin-cts-v2` suite including `wire_surface_gate` passes untouched.

## 2. Per-stage prompt addendum

Migration `0076` adds nullable `board_column.stage_prompt`. `build_prompt` stacks it directly above the issue title so specificity increases downward: agent instructions, then stage, then the issue body. NULL means the stage adds nothing, so every pre-existing column produces a byte-identical brief.

Settable with `ainb hangar pipeline stage-prompt --stage Review --text "Use /my-review-skill. Check migrations are additive."` (and `--clear`), routed through `BoardRepo::column_update` so it inherits that path's workspace ownership check.

## Tests

One per feature, both asserting the thing that would actually regress.

- `pipeline_health_roles.rs`: a column gated on a role nobody holds reports RED; hiring an agent that holds it flips the same stage GREEN; archiving that agent flips it back to RED.
- `stage_prompt_layers_between_agent_instructions_and_the_issue_body`: asserts ORDERING, not presence. Stage text precedes the issue title which precedes the description, and on the instructions path the stage stacks below the agent instructions. A stage with no addendum leaves the brief byte-identical.

Plus four unit tests pinning the exact rendered strip (layout and the ANSI escapes) with no database, daemon or terminal.

## Verification

- `cargo nextest run --workspace --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'`: 7929/7935 pass. The 6 failures are `components::layout::menu_bar_tests` ("menu token \"ew\" truncated at 80 cols"), pre-existing on `main` and in a file this branch never touches.
- `cargo nextest run --workspace -E 'package(ainb-plugin-cts-v2)'`: 42/42 pass, wire-surface gate included.
- `cargo fmt` clean; `cargo clippy` reports nothing in any file this branch touches (the workspace's pre-existing clippy debt lives in `ainb-fleet-core` / `ainb-hangar-core`, and CI does not gate on clippy).
- `docs/tui/cli.md` and `docs/man/ainb.1` regenerated from the binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipeline health visibility, including daemon status, role coverage, WIP pressure, and stuck-card indicators.
  * Added colored, terminal-aware pipeline displays with stage health markers.
  * Added support for setting or clearing prompts on pipeline stages.
  * Stage prompts are now included in task instructions for agents.

* **Documentation**
  * Documented the new pipeline stage prompt command and its options.

* **Bug Fixes**
  * Improved validation and clearer errors for missing pipelines or stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->