### PR TITLE
feat(fleet): queue structured interviews

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
@@ -23,7 +23,6 @@
 // cornflower-blue panels, selection-green indicator), matching Inbox/Daemons.
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -41,7 +40,9 @@ use ratatui::{
 };
 
 pub use crate::fleet::control::ActionFeedback;
-use crate::fleet::control::{FleetDaemonHealth, FleetHostUpdate, FleetHostUpdateSink};
+use crate::fleet::control::{
+    FleetDaemonHealth, FleetHostUpdate, FleetHostUpdateSink, FleetSnapshotUpdate,
+};
 use crate::fleet::read::jsonl_tail::AskUserQuestionData;
 
 // Palette shared with the rest of ainb-tui (see components/layout.rs).
@@ -57,49 +58,6 @@ const WAIT_AMBER: Color = Color::Rgb(220, 180, 90);
 
 /// Window in which an identical dispatch is treated as an accidental double tap.
 const DUPLICATE_DISPATCH_WINDOW: Duration = Duration::from_secs(2);
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-struct FleetGitContext {
-    repository_name: Option<String>,
-    branch_name: Option<String>,
-}
-
-fn resolve_fleet_git_context(cwd: &str) -> FleetGitContext {
-    let Ok(repository) = git2::Repository::discover(Path::new(cwd)) else {
-        return FleetGitContext::default();
-    };
-    let repository_name = repository.workdir().and_then(|worktree_root| {
-        let source_repository =
-            crate::interactive::InteractiveSessionManager::get_source_repository(worktree_root)
-                .unwrap_or_else(|| worktree_root.to_path_buf());
-        source_repository.file_name().and_then(|name| name.to_str()).map(str::to_string)
-    });
-    let branch_name = repository.head().ok().and_then(|head| {
-        if head.is_branch() {
-            head.shorthand().map(str::to_string)
-        } else {
-            head.target().map(|oid| oid.to_string().chars().take(8).collect())
-        }
-    });
-    FleetGitContext {
-        repository_name,
-        branch_name,
-    }
-}
-
-fn fleet_git_contexts<'a>(
-    cwds: impl IntoIterator<Item = &'a str>,
-) -> HashMap<String, FleetGitContext> {
-    let mut contexts = HashMap::new();
-    for cwd in cwds {
-        if !cwd.is_empty() {
-            contexts
-                .entry(cwd.to_string())
-                .or_insert_with(|| resolve_fleet_git_context(cwd));
-        }
-    }
-    contexts
-}
 
 /// Last dispatch memo used for short-window duplicate suppression.
 #[derive(Debug, Clone)]
@@ -230,10 +188,13 @@ impl FleetPanelState {
         }
     }
 
-    fn apply_snapshot(&mut self, snapshot: ainb_hangar_proto::fleet::FleetSnapshot) {
+    fn apply_snapshot(&mut self, update: FleetSnapshotUpdate) {
+        let FleetSnapshotUpdate {
+            snapshot,
+            git_contexts,
+        } = update;
         let sessions = snapshot.sessions;
         let selected_key = self.selected_row().map(|row| row.session_id.clone());
-        let git_contexts = fleet_git_contexts(sessions.iter().map(|session| session.cwd.as_str()));
         self.session_meta = sessions
             .iter()
             .cloned()
@@ -268,17 +229,16 @@ impl FleetPanelState {
             .ok()
             .map(|mut updates| std::mem::take(&mut *updates))
             .unwrap_or_default();
-        for update in updates {
-            match update {
-                FleetHostUpdate::Snapshot(snapshot) => self.apply_snapshot(snapshot),
-                FleetHostUpdate::Health(health) => {
-                    self.store = health.is_online().then_some(());
-                    if let FleetDaemonHealth::Offline(detail) = &health {
-                        self.set_feedback(format!("Fleet daemon unavailable: {detail}"));
-                    }
-                    self.daemon_health = health;
-                }
+        let (health_updates, newest_snapshot) = coalesce_host_updates(updates);
+        for health in health_updates {
+            self.store = health.is_online().then_some(());
+            if let FleetDaemonHealth::Offline(detail) = &health {
+                self.set_feedback(format!("Fleet daemon unavailable: {detail}"));
             }
+            self.daemon_health = health;
+        }
+        if let Some(snapshot) = newest_snapshot {
+            self.apply_snapshot(snapshot);
         }
     }
 
@@ -659,6 +619,22 @@ impl FleetPanelState {
             at,
         });
     }
+}
+
+/// Full snapshots supersede earlier snapshots, while connection-state changes
+/// remain ordered so the final terminal health is never lost.
+fn coalesce_host_updates(
+    updates: Vec<FleetHostUpdate>,
+) -> (Vec<FleetDaemonHealth>, Option<FleetSnapshotUpdate>) {
+    let mut health_updates = Vec::new();
+    let mut newest_snapshot = None;
+    for update in updates {
+        match update {
+            FleetHostUpdate::Snapshot(snapshot) => newest_snapshot = Some(snapshot),
+            FleetHostUpdate::Health(health) => health_updates.push(health),
+        }
+    }
+    (health_updates, newest_snapshot)
 }
 
 fn fleet_request_identity(
@@ -1458,80 +1434,6 @@ mod tests {
         buf.content().iter().map(|c| c.symbol()).collect::<String>()
     }
 
-    fn seed_git_repository(path: &Path) -> (git2::Repository, git2::Oid) {
-        std::fs::create_dir_all(path).expect("create repository directory");
-        let repository = git2::Repository::init(path).expect("initialize repository");
-        std::fs::write(path.join("README.md"), "seed\n").expect("write seed file");
-        let mut index = repository.index().expect("open index");
-        index.add_path(Path::new("README.md")).expect("stage seed file");
-        index.write().expect("write index");
-        let tree_id = index.write_tree().expect("write tree");
-        let tree = repository.find_tree(tree_id).expect("find tree");
-        let signature =
-            git2::Signature::now("Fleet Test", "fleet@example.invalid").expect("create signature");
-        let commit = repository
-            .commit(Some("HEAD"), &signature, &signature, "seed", &tree, &[])
-            .expect("create seed commit");
-        drop(tree);
-        (repository, commit)
-    }
-
-    #[test]
-    fn git_context_discovers_linked_worktree_from_nested_cwd() {
-        let temp = tempfile::tempdir().expect("create temp directory");
-        let source_path = temp.path().join("source-repo");
-        let (_source, _commit) = seed_git_repository(&source_path);
-        let worktree_path = temp.path().join("linked-worktree");
-        let output = std::process::Command::new("git")
-            .args(["worktree", "add", "-b", "feature/fleet-labels"])
-            .arg(&worktree_path)
-            .arg("HEAD")
-            .current_dir(&source_path)
-            .output()
-            .expect("run git worktree add");
-        assert!(
-            output.status.success(),
-            "git worktree add failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let nested = worktree_path.join("nested/path");
-        std::fs::create_dir_all(&nested).expect("create nested cwd");
-
-        let context = resolve_fleet_git_context(nested.to_str().expect("utf8 cwd"));
-
-        assert_eq!(context.repository_name.as_deref(), Some("source-repo"));
-        assert_eq!(context.branch_name.as_deref(), Some("feature/fleet-labels"));
-    }
-
-    #[test]
-    fn git_context_uses_short_commit_for_detached_head() {
-        let temp = tempfile::tempdir().expect("create temp directory");
-        let repository_path = temp.path().join("detached-repo");
-        let (repository, commit) = seed_git_repository(&repository_path);
-        repository.set_head_detached(commit).expect("detach HEAD");
-        let nested = repository_path.join("nested");
-        std::fs::create_dir_all(&nested).expect("create nested cwd");
-
-        let context = resolve_fleet_git_context(nested.to_str().expect("utf8 cwd"));
-
-        assert_eq!(context.repository_name.as_deref(), Some("detached-repo"));
-        let expected_commit = commit.to_string();
-        assert_eq!(context.branch_name.as_deref(), Some(&expected_commit[..8]));
-    }
-
-    #[test]
-    fn git_contexts_deduplicate_cwds_and_skip_missing_metadata() {
-        let temp = tempfile::tempdir().expect("create temp directory");
-        let non_git = temp.path().join("plain");
-        std::fs::create_dir_all(&non_git).expect("create non-git directory");
-        let cwd = non_git.to_str().expect("utf8 cwd");
-
-        let contexts = fleet_git_contexts(["", cwd, cwd]);
-
-        assert_eq!(contexts.len(), 1);
-        assert_eq!(contexts[cwd], FleetGitContext::default());
-    }
-
     #[test]
     fn renders_attention_first_operator_view() {
         let mut state = state_with(vec![
@@ -1574,8 +1476,8 @@ mod tests {
         assert!(out.contains("5 All 4"), "all lens missing: {out}");
         // Default lens shows only actionable rows.
         assert!(
-            out.contains("PRIORITY QUEUE"),
-            "priority queue missing: {out}"
+            out.contains("ACTION QUEUE"),
+            "action queue missing: {out}"
         );
         assert!(out.contains("INPUT"), "operator state missing: {out}");
         assert!(out.contains("deploy"), "ASK session label missing");
@@ -1851,14 +1753,20 @@ mod tests {
 
         let mut state = FleetPanelState::default();
         state.stream_updates.lock().expect("stream update queue").extend([
-            FleetHostUpdate::Snapshot(FleetSnapshot {
-                head_revision: 7,
-                sessions: Vec::new(),
+            FleetHostUpdate::Snapshot(FleetSnapshotUpdate {
+                snapshot: FleetSnapshot {
+                    head_revision: 7,
+                    sessions: Vec::new(),
+                },
+                git_contexts: HashMap::new(),
             }),
             FleetHostUpdate::Health(FleetDaemonHealth::Online),
-            FleetHostUpdate::Snapshot(FleetSnapshot {
-                head_revision: 9,
-                sessions: Vec::new(),
+            FleetHostUpdate::Snapshot(FleetSnapshotUpdate {
+                snapshot: FleetSnapshot {
+                    head_revision: 9,
+                    sessions: Vec::new(),
+                },
+                git_contexts: HashMap::new(),
             }),
             FleetHostUpdate::Health(FleetDaemonHealth::Offline("socket closed".into())),
         ]);
@@ -1872,6 +1780,46 @@ mod tests {
         );
         assert!(!state.daemon_online());
         assert!(state.feedback_line().contains("socket closed"));
+    }
+
+    #[test]
+    fn stream_update_coalescing_keeps_terminal_health_and_newest_snapshot() {
+        use ainb_hangar_proto::fleet::FleetSnapshot;
+
+        let (health, snapshot) = coalesce_host_updates(vec![
+            FleetHostUpdate::Health(FleetDaemonHealth::Connecting),
+            FleetHostUpdate::Snapshot(FleetSnapshotUpdate {
+                snapshot: FleetSnapshot {
+                    head_revision: 7,
+                    sessions: Vec::new(),
+                },
+                git_contexts: HashMap::new(),
+            }),
+            FleetHostUpdate::Health(FleetDaemonHealth::Online),
+            FleetHostUpdate::Snapshot(FleetSnapshotUpdate {
+                snapshot: FleetSnapshot {
+                    head_revision: 9,
+                    sessions: Vec::new(),
+                },
+                git_contexts: HashMap::new(),
+            }),
+            FleetHostUpdate::Health(FleetDaemonHealth::Offline("socket closed".into())),
+        ]);
+
+        assert_eq!(
+            health,
+            vec![
+                FleetDaemonHealth::Connecting,
+                FleetDaemonHealth::Online,
+                FleetDaemonHealth::Offline("socket closed".into()),
+            ],
+            "connection state order must survive snapshot coalescing"
+        );
+        assert_eq!(
+            snapshot.expect("newest snapshot retained").snapshot.head_revision,
+            9,
+            "replayed complete snapshots must collapse to the newest revision"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
@@ -1475,10 +1475,7 @@ mod tests {
         assert!(out.contains("4 Running 1"), "running lens missing: {out}");
         assert!(out.contains("5 All 4"), "all lens missing: {out}");
         // Default lens shows only actionable rows.
-        assert!(
-            out.contains("ACTION QUEUE"),
-            "action queue missing: {out}"
-        );
+        assert!(out.contains("ACTION QUEUE"), "action queue missing: {out}");
         assert!(out.contains("INPUT"), "operator state missing: {out}");
         assert!(out.contains("deploy"), "ASK session label missing");
         assert!(out.contains("api"), "ERR session label missing");

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -235,9 +235,7 @@ where
         }
         let canonical_cwd = canonical_cwd(&cwd);
         let head = fleet_git_head(&canonical_cwd);
-        let stale = cache
-            .get(&canonical_cwd)
-            .is_none_or(|entry| entry.head != head);
+        let stale = cache.get(&canonical_cwd).is_none_or(|entry| entry.head != head);
         if stale {
             cache.insert(
                 canonical_cwd.clone(),
@@ -721,7 +719,11 @@ mod tests {
         let path = temp.path().join("branch-repo");
         let (repository, commit) = seed_git_repository(&path);
         repository
-            .branch("next", &repository.find_commit(commit).expect("find commit"), false)
+            .branch(
+                "next",
+                &repository.find_commit(commit).expect("find commit"),
+                false,
+            )
             .expect("create next branch");
         let cwd = path.to_string_lossy().into_owned();
         let mut cache = HashMap::new();

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -27,6 +27,8 @@
 // `AtomicBool` guard) so key-repeat can't spawn unbounded worker threads or
 // double-send an answer to an agent.
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -56,6 +58,27 @@ pub enum FleetDaemonHealth {
     Offline(String),
 }
 
+/// Git labels resolved by the subscription worker, never by the render loop.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FleetGitContext {
+    pub repository_name: Option<String>,
+    pub branch_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct FleetGitCacheEntry {
+    head: Option<String>,
+    context: FleetGitContext,
+}
+
+/// A complete Fleet snapshot plus worker-resolved labels for its session CWDs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetSnapshotUpdate {
+    pub snapshot: FleetSnapshot,
+    /// Keyed by the exact CWD carried by each session in `snapshot`.
+    pub git_contexts: HashMap<String, FleetGitContext>,
+}
+
 impl FleetDaemonHealth {
     /// Whether authoritative control RPCs may be trusted right now.
     #[must_use]
@@ -68,7 +91,7 @@ impl FleetDaemonHealth {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FleetHostUpdate {
     /// Complete authoritative state at one durable revision.
-    Snapshot(FleetSnapshot),
+    Snapshot(FleetSnapshotUpdate),
     /// Subscription connection health changed.
     Health(FleetDaemonHealth),
 }
@@ -105,12 +128,13 @@ pub fn spawn_fleet_subscription(
 async fn run_fleet_subscription(updates: FleetHostUpdateSink, initial_cursor: i64) {
     let mut cursor = initial_cursor.max(0);
     let mut attempt = 0_u32;
+    let mut git_context_cache = HashMap::new();
     loop {
         publish_host_update(
             &updates,
             FleetHostUpdate::Health(FleetDaemonHealth::Connecting),
         );
-        let outcome = run_fleet_connection(&updates, &mut cursor).await;
+        let outcome = run_fleet_connection(&updates, &mut cursor, &mut git_context_cache).await;
         let detail = outcome.err().unwrap_or_else(|| "Fleet stream ended".to_string());
         publish_host_update(
             &updates,
@@ -124,6 +148,7 @@ async fn run_fleet_subscription(updates: FleetHostUpdateSink, initial_cursor: i6
 async fn run_fleet_connection(
     updates: &FleetHostUpdateSink,
     cursor: &mut i64,
+    git_context_cache: &mut HashMap<String, FleetGitCacheEntry>,
 ) -> Result<(), String> {
     let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
         .map_err(|error| error.to_string())?;
@@ -133,17 +158,18 @@ async fn run_fleet_connection(
         .map_err(|error| error.to_string())?;
 
     *cursor = subscription.snapshot.head_revision;
-    publish_host_update(updates, FleetHostUpdate::Snapshot(subscription.snapshot));
+    publish_snapshot(updates, subscription.snapshot, git_context_cache);
 
     for event in subscription.replay {
-        reconcile_revision(&client, updates, cursor, event.revision).await?;
+        reconcile_revision(&client, updates, cursor, event.revision, git_context_cache).await?;
     }
     publish_host_update(updates, FleetHostUpdate::Health(FleetDaemonHealth::Online));
 
     loop {
         match stream.next_event().await.map_err(|error| error.to_string())? {
             FleetStreamEvent::Revision(event) => {
-                reconcile_revision(&client, updates, cursor, event.revision).await?;
+                reconcile_revision(&client, updates, cursor, event.revision, git_context_cache)
+                    .await?;
             }
             FleetStreamEvent::ResyncRequired => {
                 return Err(format!("Fleet stream lagged after revision {cursor}"));
@@ -157,6 +183,7 @@ async fn reconcile_revision(
     updates: &FleetHostUpdateSink,
     cursor: &mut i64,
     revision: i64,
+    git_context_cache: &mut HashMap<String, FleetGitCacheEntry>,
 ) -> Result<(), String> {
     if revision <= *cursor {
         return Ok(());
@@ -169,8 +196,107 @@ async fn reconcile_revision(
         ));
     }
     *cursor = snapshot.head_revision;
-    publish_host_update(updates, FleetHostUpdate::Snapshot(snapshot));
+    publish_snapshot(updates, snapshot, git_context_cache);
     Ok(())
+}
+
+fn publish_snapshot(
+    updates: &FleetHostUpdateSink,
+    snapshot: FleetSnapshot,
+    git_context_cache: &mut HashMap<String, FleetGitCacheEntry>,
+) {
+    let git_contexts = cached_fleet_git_contexts(
+        snapshot.sessions.iter().map(|session| session.cwd.clone()),
+        git_context_cache,
+        resolve_fleet_git_context,
+    );
+    publish_host_update(
+        updates,
+        FleetHostUpdate::Snapshot(FleetSnapshotUpdate {
+            snapshot,
+            git_contexts,
+        }),
+    );
+}
+
+fn cached_fleet_git_contexts<I, F>(
+    cwds: I,
+    cache: &mut HashMap<String, FleetGitCacheEntry>,
+    mut resolve: F,
+) -> HashMap<String, FleetGitContext>
+where
+    I: IntoIterator<Item = String>,
+    F: FnMut(&str) -> FleetGitContext,
+{
+    let mut contexts = HashMap::new();
+    for cwd in cwds {
+        if cwd.is_empty() {
+            continue;
+        }
+        let canonical_cwd = canonical_cwd(&cwd);
+        let head = fleet_git_head(&canonical_cwd);
+        let stale = cache
+            .get(&canonical_cwd)
+            .is_none_or(|entry| entry.head != head);
+        if stale {
+            cache.insert(
+                canonical_cwd.clone(),
+                FleetGitCacheEntry {
+                    head,
+                    context: resolve(&canonical_cwd),
+                },
+            );
+        }
+        let context = cache
+            .get(&canonical_cwd)
+            .expect("cache entry inserted for nonempty cwd")
+            .context
+            .clone();
+        contexts.insert(cwd, context);
+    }
+    contexts
+}
+
+fn canonical_cwd(cwd: &str) -> String {
+    std::fs::canonicalize(cwd)
+        .unwrap_or_else(|_| PathBuf::from(cwd))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Detect a branch or detached-HEAD change without resolving full labels on
+/// every replayed snapshot. This runs on the subscription worker, never render.
+fn fleet_git_head(cwd: &str) -> Option<String> {
+    let repository = git2::Repository::discover(Path::new(cwd)).ok()?;
+    let head = repository.head().ok()?;
+    Some(format!(
+        "{}:{}",
+        head.name().unwrap_or("HEAD"),
+        head.target().map_or_else(|| "unborn".into(), |oid| oid.to_string())
+    ))
+}
+
+fn resolve_fleet_git_context(cwd: &str) -> FleetGitContext {
+    let Ok(repository) = git2::Repository::discover(Path::new(cwd)) else {
+        return FleetGitContext::default();
+    };
+    let repository_name = repository.workdir().and_then(|worktree_root| {
+        let source_repository =
+            crate::interactive::InteractiveSessionManager::get_source_repository(worktree_root)
+                .unwrap_or_else(|| worktree_root.to_path_buf());
+        source_repository.file_name().and_then(|name| name.to_str()).map(str::to_string)
+    });
+    let branch_name = repository.head().ok().and_then(|head| {
+        if head.is_branch() {
+            head.shorthand().map(str::to_string)
+        } else {
+            head.target().map(|oid| oid.to_string().chars().take(8).collect())
+        }
+    });
+    FleetGitContext {
+        repository_name,
+        branch_name,
+    }
 }
 
 fn publish_host_update(updates: &FleetHostUpdateSink, update: FleetHostUpdate) {
@@ -528,6 +654,136 @@ fn publish(feedback: &Mutex<ActionFeedback>, message: String) {
 mod tests {
     use super::*;
     use crate::fleet::types::{Session, SessionSource};
+
+    #[test]
+    fn git_context_cache_resolves_once_per_distinct_cwd_across_replayed_snapshots() {
+        let temp = tempfile::tempdir().expect("create cwd fixture");
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        std::fs::create_dir_all(&first).expect("create first cwd");
+        std::fs::create_dir_all(&second).expect("create second cwd");
+        let first = first.to_string_lossy().into_owned();
+        let second = second.to_string_lossy().into_owned();
+        let mut cache = HashMap::new();
+        let mut resolve_calls = Vec::new();
+
+        let first_snapshot =
+            cached_fleet_git_contexts(vec![first.clone(), first.clone()], &mut cache, |cwd| {
+                resolve_calls.push(cwd.to_string());
+                FleetGitContext::default()
+            });
+        let second_snapshot =
+            cached_fleet_git_contexts(vec![first.clone(), second.clone()], &mut cache, |cwd| {
+                resolve_calls.push(cwd.to_string());
+                FleetGitContext::default()
+            });
+
+        assert_eq!(
+            resolve_calls.len(),
+            2,
+            "replayed snapshots must resolve once per distinct canonical cwd, got {resolve_calls:?}"
+        );
+        assert!(
+            first_snapshot.contains_key(&first),
+            "first CWD context missing"
+        );
+        assert!(
+            second_snapshot.contains_key(&first),
+            "cached first CWD context missing"
+        );
+        assert!(
+            second_snapshot.contains_key(&second),
+            "changed CWD context missing"
+        );
+    }
+
+    fn seed_git_repository(path: &Path) -> (git2::Repository, git2::Oid) {
+        std::fs::create_dir_all(path).expect("create repository directory");
+        let repository = git2::Repository::init(path).expect("initialize repository");
+        std::fs::write(path.join("README.md"), "seed\n").expect("write seed file");
+        let mut index = repository.index().expect("open index");
+        index.add_path(Path::new("README.md")).expect("stage seed file");
+        index.write().expect("write index");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repository.find_tree(tree_id).expect("find tree");
+        let signature =
+            git2::Signature::now("Fleet Test", "fleet@example.invalid").expect("create signature");
+        let commit = repository
+            .commit(Some("HEAD"), &signature, &signature, "seed", &tree, &[])
+            .expect("create seed commit");
+        drop(tree);
+        (repository, commit)
+    }
+
+    #[test]
+    fn git_context_cache_refreshes_when_branch_changes_at_same_cwd() {
+        let temp = tempfile::tempdir().expect("create repository fixture");
+        let path = temp.path().join("branch-repo");
+        let (repository, commit) = seed_git_repository(&path);
+        repository
+            .branch("next", &repository.find_commit(commit).expect("find commit"), false)
+            .expect("create next branch");
+        let cwd = path.to_string_lossy().into_owned();
+        let mut cache = HashMap::new();
+        let mut resolves = 0;
+
+        let first = cached_fleet_git_contexts(vec![cwd.clone()], &mut cache, |cwd| {
+            resolves += 1;
+            resolve_fleet_git_context(cwd)
+        });
+        repository.set_head("refs/heads/next").expect("switch branch");
+        let second = cached_fleet_git_contexts(vec![cwd.clone()], &mut cache, |cwd| {
+            resolves += 1;
+            resolve_fleet_git_context(cwd)
+        });
+
+        assert_eq!(resolves, 2, "branch change must refresh cached labels");
+        assert_ne!(first[&cwd].branch_name.as_deref(), Some("next"));
+        assert_eq!(second[&cwd].branch_name.as_deref(), Some("next"));
+    }
+
+    #[test]
+    fn worker_git_context_discovers_linked_worktree_from_nested_cwd() {
+        let temp = tempfile::tempdir().expect("create temp directory");
+        let source_path = temp.path().join("source-repo");
+        let (_source, _commit) = seed_git_repository(&source_path);
+        let worktree_path = temp.path().join("linked-worktree");
+        let output = std::process::Command::new("git")
+            .args(["worktree", "add", "-b", "feature/fleet-labels"])
+            .arg(&worktree_path)
+            .arg("HEAD")
+            .current_dir(&source_path)
+            .output()
+            .expect("run git worktree add");
+        assert!(
+            output.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let nested = worktree_path.join("nested/path");
+        std::fs::create_dir_all(&nested).expect("create nested cwd");
+
+        let context = resolve_fleet_git_context(nested.to_str().expect("utf8 cwd"));
+
+        assert_eq!(context.repository_name.as_deref(), Some("source-repo"));
+        assert_eq!(context.branch_name.as_deref(), Some("feature/fleet-labels"));
+    }
+
+    #[test]
+    fn worker_git_context_uses_short_commit_for_detached_head() {
+        let temp = tempfile::tempdir().expect("create temp directory");
+        let repository_path = temp.path().join("detached-repo");
+        let (repository, commit) = seed_git_repository(&repository_path);
+        repository.set_head_detached(commit).expect("detach HEAD");
+        let nested = repository_path.join("nested");
+        std::fs::create_dir_all(&nested).expect("create nested cwd");
+
+        let context = resolve_fleet_git_context(nested.to_str().expect("utf8 cwd"));
+
+        assert_eq!(context.repository_name.as_deref(), Some("detached-repo"));
+        let expected_commit = commit.to_string();
+        assert_eq!(context.branch_name.as_deref(), Some(&expected_commit[..8]));
+    }
 
     fn session(id: &str, cwd: &str, src: SessionSource) -> Session {
         Session {

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -402,11 +402,12 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
             && c.contains("3 Completed 1")
             && c.contains("4 Running 1")
             && c.contains("5 All 4")
-            && c.contains("2 need you   1 running   0 idle   1 done")
-            && c.contains("PRIORITY QUEUE")
+            && c.contains("2 INPUT")
+            && c.contains("1 RUN")
+            && c.contains("ACTION QUEUE")
             && c.contains("INPUT")
             && c.contains("What release scope should Fleet use?")
-            && c.contains("WHAT NEEDS YOU")
+            && c.contains("NEEDS YOU")
             && c.contains("REMOTE")
     });
     let Some(open_cap) = opened else {
@@ -556,7 +557,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     // exercises Fleet's panel return path after that modal has closed.
     send_key(&session, "Escape");
     let draft_closed = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
-        c.contains("PRIORITY QUEUE") && !c.contains("STRUCTURED INTERVIEW")
+        c.contains("ACTION QUEUE") && !c.contains("STRUCTURED INTERVIEW")
     });
     assert!(
         draft_closed.is_some(),

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -405,7 +405,6 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
             && c.contains("2 INPUT")
             && c.contains("1 RUN")
             && c.contains("ACTION QUEUE")
-            && c.contains("INPUT")
             && c.contains("What release scope should Fleet use?")
             && c.contains("NEEDS YOU")
             && c.contains("REMOTE")

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -5151,7 +5151,7 @@ impl Plugin for HangarPlugin {
         Ok(())
     }
 
-    async fn handle_event(&mut self, _host: &HostClient, params: HandleEventParams) -> Result<()> {
+    async fn handle_event(&mut self, host: &HostClient, params: HandleEventParams) -> Result<()> {
         // Only socket:<stream_id> deliveries for our current stream concern us.
         let want = self.conn.stream_id().map(|id| format!("socket:{id}"));
         if want.as_deref() != Some(params.topic.as_str()) {
@@ -5161,9 +5161,10 @@ impl Plugin for HangarPlugin {
             Ok(event) => self.on_socket_event(&event),
             Err(e) => self.conn.on_error(format!("bad socket event: {e}")),
         }
-        // The reader mutex stays free after reduction. Render drains pending
-        // writes through `try_unix_socket_send`, retaining them if the writer is
-        // full instead of awaiting capacity from this inline callback.
+        // Try the first enqueue pass now so socket-driven refreshes do not wait
+        // for another render. This never awaits writer capacity; any unsent tail
+        // remains pending for a later render retry.
+        self.drain_pending_refreshes(host);
         Ok(())
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -28,6 +28,7 @@ use ainb_plugin_sdk::{
     UnixSocketEventKind, WireBuffer,
 };
 use async_trait::async_trait;
+use std::collections::BTreeMap;
 
 use crate::chrome::{Presence, render_footer, render_top_bar};
 use crate::connection::{ConnState, Connection, DEFAULT_WORKSPACE_ID};
@@ -196,6 +197,9 @@ const BOARD_CARD_RUN_REQ_ID: i64 = 43;
 /// card-create `@` autocomplete roster (spec F3). Host-scoped (a repo picker is
 /// not workspace-partitioned), fetched once alongside the other snapshots.
 const REPO_LIST_REQ_ID: i64 = 44;
+/// Snapshot request IDs are generation-tagged so replies from a workspace that
+/// was just left cannot be mistaken for the current workspace's fixed request.
+const SNAPSHOT_REQUEST_GENERATION_STRIDE: i64 = 1_000;
 /// JSON-RPC id for a `hangar/board_card_cancel` mutation (tcp T3 / F6). The reply
 /// is a `BoardCardCancelResult` surfaced as a transient board note; the card
 /// leaves the running state via the daemon's pushed `TaskFinished(Cancelled)`.
@@ -354,6 +358,10 @@ pub struct HangarPlugin {
     /// queue. Preserves one bundle under writer backpressure rather than
     /// restarting all snapshot requests on every redraw.
     snapshot_fetch_cursor: usize,
+    /// Current snapshot generation and its wire-id to handler-id correlation.
+    /// Switching workspace clears this map, making late replies harmless.
+    snapshot_generation: i64,
+    snapshot_response_ids: BTreeMap<i64, i64>,
     /// A Fleet event or lag notification requested a focused snapshot refresh.
     fleet_fetch_pending: bool,
     /// The workspace handshake or a lag notification requested a new gapless
@@ -607,6 +615,8 @@ impl Default for HangarPlugin {
             screens: ScreenStates::default(),
             fetch_pending: false,
             snapshot_fetch_cursor: 0,
+            snapshot_generation: 1,
+            snapshot_response_ids: BTreeMap::new(),
             fleet_fetch_pending: false,
             fleet_subscribe_pending: false,
             first_run: FirstRunModal::default(),
@@ -821,7 +831,7 @@ impl HangarPlugin {
     async fn connect(&mut self, host: &HostClient) {
         self.decoder = FrameDecoder::new();
         self.fetch_pending = false;
-        self.snapshot_fetch_cursor = 0;
+        self.reset_snapshot_generation();
         self.fleet_subscribe_pending = false;
         self.fleet_fetch_pending = false;
         self.conn.dialing();
@@ -1018,6 +1028,14 @@ impl HangarPlugin {
 
     /// React to one fully-decoded daemon response.
     fn on_daemon_response(&mut self, resp: &RpcResponse) {
+        if let RpcId::Number(wire_id) = resp.id {
+            if let Some(handler_id) = self.snapshot_response_ids.remove(&wire_id) {
+                let mut normalized = resp.clone();
+                normalized.id = RpcId::Number(handler_id);
+                self.on_daemon_response(&normalized);
+                return;
+            }
+        }
         match resp.id {
             // The auth ack precedes the subscribe ack (e38.1). Success is
             // silent (the subscribe ack drives the state machine forward); a
@@ -2333,12 +2351,14 @@ impl HangarPlugin {
         for (index, (id, method, params)) in
             requests.into_iter().enumerate().skip(self.snapshot_fetch_cursor)
         {
-            let Ok(body) = encode_request(id, method, params) else {
+            let wire_id = self.snapshot_wire_id(id);
+            let Ok(body) = encode_request(wire_id, method, params) else {
                 self.snapshot_fetch_cursor = index + 1;
                 continue;
             };
             match send(stream_id.clone(), body) {
                 Ok(NotificationEnqueueOutcome::Queued) => {
+                    self.snapshot_response_ids.insert(wire_id, id);
                     self.snapshot_fetch_cursor = index + 1;
                 }
                 Ok(NotificationEnqueueOutcome::Full) => return,
@@ -2358,6 +2378,18 @@ impl HangarPlugin {
         }
         self.fetch_pending = false;
         self.snapshot_fetch_cursor = 0;
+    }
+
+    fn snapshot_wire_id(&self, handler_id: i64) -> i64 {
+        self.snapshot_generation
+            .saturating_mul(SNAPSHOT_REQUEST_GENERATION_STRIDE)
+            .saturating_add(handler_id)
+    }
+
+    fn reset_snapshot_generation(&mut self) {
+        self.snapshot_generation = self.snapshot_generation.saturating_add(1);
+        self.snapshot_fetch_cursor = 0;
+        self.snapshot_response_ids.clear();
     }
 
     fn try_fetch_fleet_snapshot(
@@ -3832,7 +3864,7 @@ impl HangarPlugin {
         // the effective-active target.
         if rescope {
             self.fetch_pending = true;
-            self.snapshot_fetch_cursor = 0;
+            self.reset_snapshot_generation();
         }
     }
 
@@ -8145,6 +8177,39 @@ mod tests {
         assert_eq!(retry_attempts, 16, "retry skips the one queued request");
         assert!(!plugin.fetch_pending);
         assert_eq!(plugin.snapshot_fetch_cursor, 0);
+    }
+
+    #[test]
+    fn stale_snapshot_reply_after_rescope_cannot_overwrite_current_workspace() {
+        let mut plugin = connected_plugin_with_issue();
+        let stale_id = plugin.snapshot_wire_id(ISSUES_REQ_ID);
+        plugin.snapshot_response_ids.insert(stale_id, ISSUES_REQ_ID);
+
+        plugin.reset_snapshot_generation();
+        plugin.on_daemon_response(&RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(stale_id),
+            result: Some(serde_json::json!({ "issues": [] })),
+            error: None,
+        });
+        assert_eq!(
+            plugin.screens.issue_list.all_rows().len(),
+            1,
+            "old workspace reply must be ignored"
+        );
+
+        let current_id = plugin.snapshot_wire_id(ISSUES_REQ_ID);
+        plugin.snapshot_response_ids.insert(current_id, ISSUES_REQ_ID);
+        plugin.on_daemon_response(&RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(current_id),
+            result: Some(serde_json::json!({ "issues": [] })),
+            error: None,
+        });
+        assert!(
+            plugin.screens.issue_list.all_rows().is_empty(),
+            "current workspace reply must still apply"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -23,8 +23,9 @@
 use ainb_hangar_proto::events::HangarEvent;
 use ainb_hangar_proto::{RpcId, RpcResponse, methods as daemon_methods};
 use ainb_plugin_sdk::{
-    CliOutput, HandleEventParams, HandleKeyParams, HostClient, InitContext, KeyCode, Plugin,
-    RenderParams, Result, RpcError, UnixSocketEvent, UnixSocketEventKind, WireBuffer,
+    CliOutput, HandleEventParams, HandleKeyParams, HostClient, InitContext, KeyCode,
+    NotificationEnqueueOutcome, Plugin, RenderParams, Result, RpcError, UnixSocketEvent,
+    UnixSocketEventKind, WireBuffer,
 };
 use async_trait::async_trait;
 
@@ -347,8 +348,12 @@ pub struct HangarPlugin {
     /// Per-screen render-state caches filled from the daemon snapshot RPCs.
     screens: ScreenStates,
     /// Set when a subscribe ack just arrived, so `handle_event` knows to fire
-    /// the snapshot fetches (it has the `host` the sync decode path lacks).
+    /// the snapshot fetches during a later render.
     fetch_pending: bool,
+    /// Next request in the snapshot bundle that has not entered the host writer
+    /// queue. Preserves one bundle under writer backpressure rather than
+    /// restarting all snapshot requests on every redraw.
+    snapshot_fetch_cursor: usize,
     /// A Fleet event or lag notification requested a focused snapshot refresh.
     fleet_fetch_pending: bool,
     /// The workspace handshake or a lag notification requested a new gapless
@@ -601,6 +606,7 @@ impl Default for HangarPlugin {
             app: None,
             screens: ScreenStates::default(),
             fetch_pending: false,
+            snapshot_fetch_cursor: 0,
             fleet_fetch_pending: false,
             fleet_subscribe_pending: false,
             first_run: FirstRunModal::default(),
@@ -814,6 +820,8 @@ impl HangarPlugin {
     /// crashing the plugin.
     async fn connect(&mut self, host: &HostClient) {
         self.decoder = FrameDecoder::new();
+        self.fetch_pending = false;
+        self.snapshot_fetch_cursor = 0;
         self.fleet_subscribe_pending = false;
         self.fleet_fetch_pending = false;
         self.conn.dialing();
@@ -1020,8 +1028,8 @@ impl HangarPlugin {
                     self.conn.on_error(format!("daemon auth rejected: {}", err.message));
                 }
             }
-            // The subscribe ack completes the handshake and arms the snapshot
-            // fetch (issued by `handle_event`, which holds the `host`).
+            // The subscribe ack completes the handshake and arms snapshot
+            // delivery for the next render.
             RpcId::Number(SUBSCRIBE_REQ_ID) => {
                 if resp.error.is_some() {
                     self.conn.on_error("daemon rejected workspace/subscribe".to_string());
@@ -2204,11 +2212,13 @@ impl HangarPlugin {
         self.conn.on_event();
     }
 
-    /// Fire every `hangar/*` snapshot request over the daemon stream, framed for
-    /// the cap (one per landing screen — issues, agents, skills, autopilots,
-    /// tasks, daemon-health, usage, members, health). A send failure is logged but
-    /// non-fatal — the screens simply stay empty until the next subscribe.
-    async fn fetch_snapshots(&mut self, host: &HostClient) {
+    /// Try every pending `hangar/*` snapshot request without waiting for host
+    /// writer capacity. A full writer retains this cursor, so redraw retries the
+    /// unsent tail once instead of replaying the whole bundle.
+    fn try_fetch_snapshots(
+        &mut self,
+        send: &mut impl FnMut(String, Vec<u8>) -> Result<NotificationEnqueueOutcome>,
+    ) {
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
             return;
         };
@@ -2320,17 +2330,40 @@ impl HangarPlugin {
                 serde_json::json!({}),
             ),
         ];
-        for (id, method, params) in requests {
+        for (index, (id, method, params)) in
+            requests.into_iter().enumerate().skip(self.snapshot_fetch_cursor)
+        {
             let Ok(body) = encode_request(id, method, params) else {
+                self.snapshot_fetch_cursor = index + 1;
                 continue;
             };
-            if let Err(e) = host.unix_socket_send(stream_id.clone(), body).await {
-                let _ = host.log_info(format!("hangar: snapshot send failed: {e}")).await;
+            match send(stream_id.clone(), body) {
+                Ok(NotificationEnqueueOutcome::Queued) => {
+                    self.snapshot_fetch_cursor = index + 1;
+                }
+                Ok(NotificationEnqueueOutcome::Full) => return,
+                Ok(NotificationEnqueueOutcome::Closed) => {
+                    self.conn.on_error("host writer closed while refreshing snapshots");
+                    self.fetch_pending = false;
+                    self.snapshot_fetch_cursor = 0;
+                    return;
+                }
+                Err(error) => {
+                    self.conn.on_error(format!("snapshot refresh enqueue failed: {error}"));
+                    self.fetch_pending = false;
+                    self.snapshot_fetch_cursor = 0;
+                    return;
+                }
             }
         }
+        self.fetch_pending = false;
+        self.snapshot_fetch_cursor = 0;
     }
 
-    async fn fetch_fleet_snapshot(&mut self, host: &HostClient) {
+    fn try_fetch_fleet_snapshot(
+        &mut self,
+        send: &mut impl FnMut(String, Vec<u8>) -> Result<NotificationEnqueueOutcome>,
+    ) {
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
             return;
         };
@@ -2339,14 +2372,27 @@ impl HangarPlugin {
             daemon_methods::FLEET_SNAPSHOT,
             serde_json::json!({}),
         ) else {
+            self.fleet_fetch_pending = false;
             return;
         };
-        if let Err(error) = host.unix_socket_send(stream_id, body).await {
-            let _ = host.log_info(format!("hangar: fleet snapshot send failed: {error}")).await;
+        match send(stream_id, body) {
+            Ok(NotificationEnqueueOutcome::Queued) => self.fleet_fetch_pending = false,
+            Ok(NotificationEnqueueOutcome::Full) => {}
+            Ok(NotificationEnqueueOutcome::Closed) => {
+                self.conn.on_error("host writer closed while refreshing Fleet snapshot");
+                self.fleet_fetch_pending = false;
+            }
+            Err(error) => {
+                self.conn.on_error(format!("Fleet snapshot refresh enqueue failed: {error}"));
+                self.fleet_fetch_pending = false;
+            }
         }
     }
 
-    async fn subscribe_fleet(&mut self, host: &HostClient) {
+    fn try_subscribe_fleet(
+        &mut self,
+        send: &mut impl FnMut(String, Vec<u8>) -> Result<NotificationEnqueueOutcome>,
+    ) {
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
             return;
         };
@@ -2355,10 +2401,43 @@ impl HangarPlugin {
             daemon_methods::FLEET_SUBSCRIBE,
             serde_json::json!({ "after_revision": self.screens.fleet.head_revision() }),
         ) else {
+            self.fleet_subscribe_pending = false;
             return;
         };
-        if let Err(error) = host.unix_socket_send(stream_id, body).await {
-            let _ = host.log_info(format!("hangar: fleet subscribe send failed: {error}")).await;
+        match send(stream_id, body) {
+            Ok(NotificationEnqueueOutcome::Queued) => self.fleet_subscribe_pending = false,
+            Ok(NotificationEnqueueOutcome::Full) => {}
+            Ok(NotificationEnqueueOutcome::Closed) => {
+                self.conn.on_error("host writer closed while subscribing Fleet");
+                self.fleet_subscribe_pending = false;
+            }
+            Err(error) => {
+                self.conn.on_error(format!("Fleet subscribe enqueue failed: {error}"));
+                self.fleet_subscribe_pending = false;
+            }
+        }
+    }
+
+    /// Drain deferred snapshot writes from `render`, never from the SDK's
+    /// inline inbound-event reader.
+    fn drain_pending_refreshes(&mut self, host: &HostClient) {
+        self.drain_pending_refreshes_with(|stream_id, body| {
+            host.try_unix_socket_send(stream_id, body)
+        });
+    }
+
+    fn drain_pending_refreshes_with(
+        &mut self,
+        mut send: impl FnMut(String, Vec<u8>) -> Result<NotificationEnqueueOutcome>,
+    ) {
+        if self.fetch_pending {
+            self.try_fetch_snapshots(&mut send);
+        }
+        if self.fleet_fetch_pending {
+            self.try_fetch_fleet_snapshot(&mut send);
+        }
+        if self.fleet_subscribe_pending {
+            self.try_subscribe_fleet(&mut send);
         }
     }
 
@@ -3749,10 +3828,11 @@ impl HangarPlugin {
         // After an active-workspace switch/create/delete, re-pull every
         // workspace-scoped snapshot so the screens reflect the NEW tenant's data
         // (not the prior one's stale cache). `refresh_workspaces` already moved
-        // `ws_id`, and `fetch_snapshots` reads it, so the re-fetch is scoped to
+        // `ws_id`, and the deferred snapshot bundle reads it, so the re-fetch is scoped to
         // the effective-active target.
         if rescope {
-            self.fetch_snapshots(host).await;
+            self.fetch_pending = true;
+            self.snapshot_fetch_cursor = 0;
         }
     }
 
@@ -5071,7 +5151,7 @@ impl Plugin for HangarPlugin {
         Ok(())
     }
 
-    async fn handle_event(&mut self, host: &HostClient, params: HandleEventParams) -> Result<()> {
+    async fn handle_event(&mut self, _host: &HostClient, params: HandleEventParams) -> Result<()> {
         // Only socket:<stream_id> deliveries for our current stream concern us.
         let want = self.conn.stream_id().map(|id| format!("socket:{id}"));
         if want.as_deref() != Some(params.topic.as_str()) {
@@ -5081,17 +5161,9 @@ impl Plugin for HangarPlugin {
             Ok(event) => self.on_socket_event(&event),
             Err(e) => self.conn.on_error(format!("bad socket event: {e}")),
         }
-        // The subscribe ack (decoded above) arms the snapshot fetch; fire it now
-        // that we hold the host. One fetch per subscribe.
-        if std::mem::take(&mut self.fetch_pending) {
-            self.fetch_snapshots(host).await;
-        }
-        if std::mem::take(&mut self.fleet_fetch_pending) {
-            self.fetch_fleet_snapshot(host).await;
-        }
-        if std::mem::take(&mut self.fleet_subscribe_pending) {
-            self.subscribe_fleet(host).await;
-        }
+        // The reader mutex stays free after reduction. Render drains pending
+        // writes through `try_unix_socket_send`, retaining them if the writer is
+        // full instead of awaiting capacity from this inline callback.
         Ok(())
     }
 
@@ -5162,6 +5234,10 @@ impl Plugin for HangarPlugin {
             // safe there). Consumed (taken) by that render, so not level-held.
             || self.pending_issue_dispatch.is_some()
             || self.screens.pending_fleet_intent.is_some()
+            || (self.conn.is_connected()
+                && (self.fetch_pending
+                    || self.fleet_fetch_pending
+                    || self.fleet_subscribe_pending))
     }
 
     fn captures_text(&self) -> bool {
@@ -5210,6 +5286,7 @@ impl Plugin for HangarPlugin {
     }
 
     async fn render(&mut self, host: &HostClient, params: RenderParams) -> Result<WireBuffer> {
+        self.drain_pending_refreshes(host);
         if let Some(intent) = self.screens.take_pending_fleet_intent() {
             self.apply_fleet_intent(host, intent).await;
         }
@@ -7965,6 +8042,108 @@ mod tests {
         }));
         assert_eq!(plugin.screens.fleet.head_revision(), 12);
         assert!(plugin.fleet_fetch_pending);
+    }
+
+    #[test]
+    fn full_writer_defers_fleet_refresh_without_blocking_fleet_key_reduction() {
+        use crate::screen::fleet::{FleetCapabilities, FleetSessionRow};
+
+        let mut plugin = connected_plugin_with_issue();
+        plugin.on_daemon_event(&serde_json::json!({
+            "method": "fleet/event",
+            "params": {
+                "revision": 12,
+                "event_id": "evt-12",
+                "session_key": "codex:thread-1",
+                "observed_at": 100,
+                "provenance": "authoritative",
+                "event_type": "turn_started",
+                "payload": {},
+                "session_version": 3,
+                "applied": true
+            }
+        }));
+
+        let mut attempts = 0;
+        plugin.drain_pending_refreshes_with(|_, _| {
+            attempts += 1;
+            Ok(NotificationEnqueueOutcome::Full)
+        });
+        assert_eq!(attempts, 1, "one focused refresh enqueue is attempted");
+        assert!(
+            plugin.fleet_fetch_pending,
+            "full writer retains Fleet refresh"
+        );
+        assert!(
+            plugin.wants_redraw(),
+            "retained refresh schedules another render"
+        );
+
+        let row = |key: &str| FleetSessionRow {
+            session_key: key.into(),
+            provider: "claude".into(),
+            provider_session_id: None,
+            current_request_fingerprint: None,
+            current_request: None,
+            lifecycle_state: "IDLE".into(),
+            attention_state: "ASK".into(),
+            management_state: "managed".into(),
+            provenance: "hangar-authoritative".into(),
+            confidence: "authoritative".into(),
+            transport_health: "healthy".into(),
+            capabilities: FleetCapabilities::default(),
+            version: 1,
+            active_work_count: 0,
+            cwd: "/work".into(),
+            tmux_target: None,
+            display_name: Some(key.into()),
+            repository_name: Some("repo".into()),
+            branch_name: Some("main".into()),
+            discovered_at: 1,
+            last_observed_at: 1,
+            metadata_updated_at: 1,
+            lifecycle_updated_at: 1,
+            attention_updated_at: 1,
+            transport_updated_at: 1,
+        };
+        plugin.screens.fleet.set_sessions(vec![row("claude:one"), row("claude:two")]);
+
+        plugin.on_key(&char_press('F'));
+        plugin.on_key(&key_press(KeyCode::Down));
+        assert!(matches!(plugin.app_state().screen, Screen::Fleet));
+        assert_eq!(plugin.screens.fleet.selected_key(), Some("claude:two"));
+        assert!(
+            plugin.fleet_fetch_pending,
+            "key reduction never consumes refresh work"
+        );
+    }
+
+    #[test]
+    fn snapshot_bundle_retries_only_its_unsent_tail() {
+        let mut plugin = connected_plugin_with_issue();
+        plugin.fetch_pending = true;
+
+        let mut first_attempts = 0;
+        plugin.drain_pending_refreshes_with(|_, _| {
+            first_attempts += 1;
+            Ok(if first_attempts == 1 {
+                NotificationEnqueueOutcome::Queued
+            } else {
+                NotificationEnqueueOutcome::Full
+            })
+        });
+        assert_eq!(first_attempts, 2);
+        assert_eq!(plugin.snapshot_fetch_cursor, 1);
+        assert!(plugin.fetch_pending);
+
+        let mut retry_attempts = 0;
+        plugin.drain_pending_refreshes_with(|_, _| {
+            retry_attempts += 1;
+            Ok(NotificationEnqueueOutcome::Queued)
+        });
+        assert_eq!(retry_attempts, 16, "retry skips the one queued request");
+        assert!(!plugin.fetch_pending);
+        assert_eq!(plugin.snapshot_fetch_cursor, 0);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -2664,7 +2664,7 @@ fn render_interview(
         return;
     };
     let lane_count = queue.answers.len().min(3);
-    if bottom.saturating_sub(top) < (lane_count as u16 * 2 + 11) {
+    if bottom.saturating_sub(top) < (lane_count as u16 * 2 + 15) {
         return;
     }
     put_str(
@@ -4189,6 +4189,45 @@ mod tests {
         assert!(rendered.contains("Checks"));
         assert!(rendered.contains("0  /  2 answered"));
         assert!(rendered.contains("verified Fleet work only"));
+    }
+
+    #[test]
+    fn interview_renderer_keeps_active_card_usable_at_minimum_height() {
+        for session_count in [1_usize, 3] {
+            let mut state = FleetPaneState::default();
+            let mut rows = Vec::with_capacity(session_count);
+            for index in 0..session_count {
+                let mut row = session(
+                    &format!("claude:minimum-{index}"),
+                    "claude",
+                    "IDLE",
+                    "ASK",
+                    "managed",
+                );
+                row.current_request_fingerprint = Some(format!("minimum-{index}"));
+                row.current_request = Some(serde_json::json!({
+                    "questions": [{
+                        "id": "ship",
+                        "header": "Ship",
+                        "question": "Ship this?",
+                        "options": ["Yes"]
+                    }]
+                }));
+                rows.push(row);
+            }
+            state.set_sessions(rows);
+            let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+            let height = session_count as u16 * 2 + 15;
+            let mut buffer = WireBuffer::new(120, height + 1);
+            render_fleet(&mut buffer, 120, 0, height, &state);
+            let rendered = (0..height)
+                .map(|row| row_text(&buffer, row, 120))
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(rendered.contains("Ship"), "question missing at {height} rows: {rendered}");
+            assert!(rendered.contains("Yes"), "option missing at {height} rows: {rendered}");
+            assert!(rendered.contains("Enter next"), "footer missing at {height} rows: {rendered}");
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -18,11 +18,11 @@ const GOLD: Color = Color::rgb(251, 191, 36);
 const BLUE: Color = Color::rgb(96, 165, 250);
 const VIOLET: Color = Color::rgb(185, 140, 235);
 const GREEN: Color = Color::rgb(110, 200, 130);
+const SELECTION_GREEN: Color = Color::rgb(100, 200, 100);
 const ALERT: Color = Color::rgb(220, 90, 90);
 const SURFACE: Color = Color::rgb(15, 23, 42);
 const ACTIVE_CHIP: Color = Color::rgb(30, 64, 175);
 const CARD_BORDER: Color = Color::rgb(70, 80, 110);
-const SELECTED_OUTLINE: Color = Color::rgb(210, 130, 90);
 const BOLD: u16 = 1;
 
 /// Capability wire shape accepted from current and planned daemon snapshots.
@@ -2083,7 +2083,7 @@ fn render_session_card(
         return;
     }
     let border = if selected {
-        SELECTED_OUTLINE
+        SELECTION_GREEN
     } else {
         CARD_BORDER
     };
@@ -2093,7 +2093,7 @@ fn render_session_card(
     let content_width = usize::from(right.saturating_sub(5)).max(8);
     let identity = truncate_ellipsis(&session.repository_label(), content_width);
     let age = format_age(now_ms, session.last_observed_at);
-    let marker = if selected { "▸ " } else { "  " };
+    let marker = if selected { "▶ " } else { "  " };
     let branch = truncate_ellipsis(&session.branch_label(), content_width.saturating_sub(18));
 
     put_char(buffer, 0, row_y, '╭', border);
@@ -2138,11 +2138,7 @@ fn render_session_card(
         2,
         row_y.saturating_add(1),
         &format!("{marker}{identity}"),
-        if selected {
-            FG
-        } else {
-            operator_state_color(session)
-        },
+        if selected { SELECTION_GREEN } else { operator_state_color(session) },
         None,
         selected.then_some(BOLD).unwrap_or(0),
         inner_right,
@@ -4117,7 +4113,7 @@ mod tests {
     }
 
     #[test]
-    fn operator_cards_keep_semantic_colours_and_selected_outline_without_fill() {
+    fn operator_cards_keep_semantic_colours_and_selection_without_fill() {
         let mut error = session("error", "claude", "IDLE", "ERROR", "managed");
         error.current_request = Some(serde_json::json!({"message": "review failure"}));
         let mut state = FleetPaneState::default();
@@ -4125,7 +4121,7 @@ mod tests {
             session("input", "claude", "IDLE", "ASK", "managed"),
             session("running", "codex", "RUNNING", "NONE", "managed"),
             session("idle", "codex", "IDLE", "NONE", "managed"),
-            session("done", "claude", "COMPLETED", "NONE", "managed"),
+            session("done", "claude", "TURN_COMPLETE", "NONE", "managed"),
             error,
         ]);
         state = apply(&state, FleetEvent::SetFilter(FleetFilter::All)).state;
@@ -4134,13 +4130,14 @@ mod tests {
 
         assert_eq!(
             final_cell(&buffer, 0, 3).and_then(|cell| cell.fg),
-            Some(SELECTED_OUTLINE)
+            Some(SELECTION_GREEN)
         );
         assert_eq!(final_cell(&buffer, 2, 4).and_then(|cell| cell.bg), None);
-        for color in [GOLD, BLUE, VIOLET, GREEN, ALERT] {
-            assert!(
-                buffer.cells.iter().any(|(_, cell)| cell.fg == Some(color)),
-                "semantic colour {color:?} missing from Fleet cards"
+        for (row, color) in [(3, GOLD), (7, BLUE), (11, VIOLET), (15, GREEN), (19, ALERT)] {
+            assert_eq!(
+                final_cell(&buffer, 2, row).and_then(|cell| cell.fg),
+                Some(color),
+                "semantic color at card row {row}"
             );
         }
     }
@@ -4168,7 +4165,7 @@ mod tests {
         render_fleet(&mut buffer, 100, 0, 9, &state);
         let rendered = (0..9).map(|row| row_text(&buffer, row, 100)).collect::<Vec<_>>().join("\n");
         assert!(rendered.contains("session-17"));
-        assert!(rendered.contains("▸"));
+        assert!(rendered.contains("▶"));
         assert!(!rendered.contains("session-00"));
     }
 
@@ -4418,10 +4415,13 @@ mod tests {
         let mut state = FleetPaneState::default();
         state.set_sessions(vec![row]);
         state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
-        assert!(
-            state.is_capturing_text(),
-            "free-text answer must retain H and ? for its field"
-        );
+        state = apply(&state, FleetEvent::Key(FleetKey::Char('H'))).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Char('?'))).state;
+        let FleetMode::Answer(queue) = &state.mode else {
+            panic!("free-text interview expected");
+        };
+        let answer = queue.current().expect("active interview");
+        assert_eq!(answer.texts[answer.question_index], "H?");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -1051,10 +1051,13 @@ fn begin_structured_answer(state: &mut FleetPaneState) {
         state.feedback = Some("no actionable structured interviews".into());
         return;
     }
-    let active = answers
+    let Some(active) = answers
         .iter()
         .position(|answer| answer.session_key == selected_key)
-        .unwrap_or(0);
+    else {
+        state.feedback = Some("selected session has no structured interview".into());
+        return;
+    };
     state.mode = FleetMode::Answer(AnswerQueue { answers, active });
 }
 
@@ -2234,19 +2237,20 @@ fn render_detail(
     } else {
         CARD_BORDER
     };
-    if card_right > card_left.saturating_add(3) && y.saturating_add(4) < bottom {
-        for x in card_left.saturating_add(1)..card_right {
-            put_char(buffer, x, y, '─', border);
-            put_char(buffer, x, y.saturating_add(4), '─', border);
-        }
-        put_char(buffer, card_left, y, '╭', border);
-        put_char(buffer, card_right, y, '╮', border);
-        put_char(buffer, card_left, y.saturating_add(4), '╰', border);
-        put_char(buffer, card_right, y.saturating_add(4), '╯', border);
-        for card_y in y.saturating_add(1)..y.saturating_add(4) {
-            put_char(buffer, card_left, card_y, '│', border);
-            put_char(buffer, card_right, card_y, '│', border);
-        }
+    if card_right <= card_left.saturating_add(3) || y.saturating_add(4) >= bottom {
+        return;
+    }
+    for x in card_left.saturating_add(1)..card_right {
+        put_char(buffer, x, y, '─', border);
+        put_char(buffer, x, y.saturating_add(4), '─', border);
+    }
+    put_char(buffer, card_left, y, '╭', border);
+    put_char(buffer, card_right, y, '╮', border);
+    put_char(buffer, card_left, y.saturating_add(4), '╰', border);
+    put_char(buffer, card_right, y.saturating_add(4), '╯', border);
+    for card_y in y.saturating_add(1)..y.saturating_add(4) {
+        put_char(buffer, card_left, card_y, '│', border);
+        put_char(buffer, card_right, card_y, '│', border);
     }
     let card_content_left = left.saturating_add(2);
     let card_content_right = card_right;
@@ -2653,7 +2657,19 @@ fn render_interview(
     bottom: u16,
     queue: &AnswerQueue,
 ) {
+    if area_width == 0 || top >= bottom {
+        return;
+    }
     if area_width < 28 {
+        fill_background(buffer, 0, top, area_width, bottom, SURFACE);
+        put_str(
+            buffer,
+            0,
+            top,
+            "Enlarge pane to answer interview",
+            GOLD,
+            area_width,
+        );
         return;
     }
     fill_background(buffer, 0, top, area_width, bottom, SURFACE);
@@ -2665,6 +2681,14 @@ fn render_interview(
     };
     let lane_count = queue.answers.len().min(3);
     if bottom.saturating_sub(top) < (lane_count as u16 * 2 + 15) {
+        put_str(
+            buffer,
+            left,
+            top,
+            "Enlarge pane to answer interview",
+            GOLD,
+            right,
+        );
         return;
     }
     put_str(
@@ -2712,7 +2736,7 @@ fn render_interview(
             if active_lane { GOLD } else { MUTED },
             right,
         );
-        tab_x = tab_x.saturating_add(lane_label.len() as u16);
+        tab_x = tab_x.saturating_add(lane_label.chars().count() as u16);
         for (question_index, question) in lane.questions.iter().enumerate() {
             let done = answer_question_complete(lane, question_index, question);
             let active_card = active_lane && question_index == lane.question_index;
@@ -2722,7 +2746,8 @@ fn render_interview(
                 question_index + 1,
                 truncate(&question.header, 11)
             );
-            if tab_x.saturating_add(card.len() as u16) >= right {
+            let card_width = card.chars().count() as u16;
+            if tab_x.saturating_add(card_width) >= right {
                 break;
             }
             put_str(
@@ -2739,7 +2764,7 @@ fn render_interview(
                 },
                 right,
             );
-            tab_x = tab_x.saturating_add(card.len() as u16 + 1);
+            tab_x = tab_x.saturating_add(card_width + 1);
         }
     }
     for x in left..right {
@@ -3431,6 +3456,26 @@ mod tests {
     }
 
     #[test]
+    fn enter_refuses_to_open_another_sessions_interview() {
+        let mut interview = session("claude:interview", "claude", "IDLE", "ASK", "managed");
+        interview.current_request_fingerprint = Some("interview-request".into());
+        interview.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Ship?", "options": ["Yes"]}]
+        }));
+        let other = session("claude:other", "claude", "IDLE", "ASK", "managed");
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![interview, other]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Down)).state;
+
+        let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        assert!(matches!(state.mode, FleetMode::Browse));
+        assert_eq!(
+            state.feedback(),
+            Some("selected session has no structured interview")
+        );
+    }
+
+    #[test]
     fn interview_tabs_preserve_answers_and_refuse_incomplete_batch() {
         let mut row = session("claude:interview", "claude", "IDLE", "ASK", "managed");
         row.current_request_fingerprint = Some("interview-fingerprint".into());
@@ -4061,6 +4106,17 @@ mod tests {
     }
 
     #[test]
+    fn detail_does_not_write_below_its_pane() {
+        let state = state_with_roster();
+        let mut buffer = WireBuffer::new(120, 4);
+        render_detail(&mut buffer, 80, 120, 0, 3, &state);
+        assert!(
+            !buffer.cells.iter().any(|(coord, _)| coord.x >= 80 && coord.y >= 3),
+            "detail must stay inside the supplied pane"
+        );
+    }
+
+    #[test]
     fn operator_cards_keep_semantic_colours_and_selected_outline_without_fill() {
         let mut error = session("error", "claude", "IDLE", "ERROR", "managed");
         error.current_request = Some(serde_json::json!({"message": "review failure"}));
@@ -4189,6 +4245,26 @@ mod tests {
         assert!(rendered.contains("Checks"));
         assert!(rendered.contains("0  /  2 answered"));
         assert!(rendered.contains("verified Fleet work only"));
+    }
+
+    #[test]
+    fn interview_renderer_explains_when_pane_is_too_small() {
+        let mut row = session("claude:small", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("small-request".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Ship?", "options": ["Yes"]}]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+        let state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+
+        let mut narrow = WireBuffer::new(27, 30);
+        render_fleet(&mut narrow, 27, 0, 29, &state);
+        assert!(row_text(&narrow, 0, 27).contains("Enlarge pane"));
+
+        let mut short = WireBuffer::new(120, 17);
+        render_fleet(&mut short, 120, 0, 16, &state);
+        assert!(row_text(&short, 0, 120).contains("Enlarge pane"));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -4224,9 +4224,18 @@ mod tests {
                 .map(|row| row_text(&buffer, row, 120))
                 .collect::<Vec<_>>()
                 .join("\n");
-            assert!(rendered.contains("Ship"), "question missing at {height} rows: {rendered}");
-            assert!(rendered.contains("Yes"), "option missing at {height} rows: {rendered}");
-            assert!(rendered.contains("Enter next"), "footer missing at {height} rows: {rendered}");
+            assert!(
+                rendered.contains("Ship"),
+                "question missing at {height} rows: {rendered}"
+            );
+            assert!(
+                rendered.contains("Yes"),
+                "option missing at {height} rows: {rendered}"
+            );
+            assert!(
+                rendered.contains("Enter next"),
+                "footer missing at {height} rows: {rendered}"
+            );
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -16,11 +16,13 @@ const FG: Color = Color::rgb(226, 232, 240);
 const MUTED: Color = Color::rgb(148, 163, 184);
 const GOLD: Color = Color::rgb(251, 191, 36);
 const BLUE: Color = Color::rgb(96, 165, 250);
-const GREEN: Color = Color::rgb(94, 234, 212);
-const ALERT: Color = Color::rgb(251, 113, 133);
+const VIOLET: Color = Color::rgb(185, 140, 235);
+const GREEN: Color = Color::rgb(110, 200, 130);
+const ALERT: Color = Color::rgb(220, 90, 90);
 const SURFACE: Color = Color::rgb(15, 23, 42);
 const ACTIVE_CHIP: Color = Color::rgb(30, 64, 175);
-const SELECTED_ROW: Color = Color::rgb(30, 41, 59);
+const CARD_BORDER: Color = Color::rgb(70, 80, 110);
+const SELECTED_OUTLINE: Color = Color::rgb(210, 130, 90);
 const BOLD: u16 = 1;
 
 /// Capability wire shape accepted from current and planned daemon snapshots.
@@ -1822,7 +1824,7 @@ pub fn render_fleet(
     let visible = state.visible_sessions();
     let header_y = top.saturating_add(2);
     let rows_top = header_y.saturating_add(1);
-    const CARD_HEIGHT: u16 = 2;
+    const CARD_HEIGHT: u16 = 4;
     let capacity = usize::from(bottom.saturating_sub(rows_top) / CARD_HEIGHT);
     let selected_index = state
         .selected_key
@@ -1834,8 +1836,8 @@ pub fn render_fleet(
             || format!("0/{}", visible.len()),
             |index| format!("{}/{}", index + 1, visible.len()),
         );
-        let header = format!("  PRIORITY QUEUE  ·  {} sessions", visible.len());
-        put_str(buffer, 0, header_y, &header, MUTED, list_width);
+        let header = format!("  ACTION QUEUE  ·  {} sessions", visible.len());
+        put_str(buffer, 0, header_y, &header, FG, list_width);
         let position_width = position.chars().count() as u16;
         put_str(
             buffer,
@@ -1879,14 +1881,21 @@ fn render_focus_summary(
 ) {
     let count =
         |filter: FleetFilter| state.roster.iter().filter(|session| filter.matches(session)).count();
-    let summary = format!(
-        "{} need you   {} running   {} idle   {} done",
-        count(FleetFilter::NeedsInput),
-        count(FleetFilter::Running),
-        count(FleetFilter::Idle),
-        count(FleetFilter::Completed),
-    );
-    put_str(buffer, left, row, &summary, MUTED, right);
+    let chips = [
+        (count(FleetFilter::NeedsInput), "INPUT", GOLD),
+        (count(FleetFilter::Running), "RUN", BLUE),
+        (count(FleetFilter::Idle), "IDLE", VIOLET),
+        (count(FleetFilter::Completed), "DONE", GREEN),
+    ];
+    let mut x = left;
+    for (count, label, color) in chips {
+        let chip = format!(" {count} {label} ");
+        if x.saturating_add(chip.chars().count() as u16) >= right {
+            break;
+        }
+        put_str_styled(buffer, x, row, &chip, color, Some(SURFACE), BOLD, right);
+        x = x.saturating_add(chip.chars().count() as u16 + 1);
+    }
 }
 
 fn render_lenses(buffer: &mut WireBuffer, left: u16, row: u16, right: u16, state: &FleetPaneState) {
@@ -1987,49 +1996,95 @@ fn render_session_card(
     selected: bool,
     now_ms: i64,
 ) {
-    let marker = if selected { "▸" } else { " " };
-    let card_width = usize::from(right).saturating_sub(10).max(12);
-    let identity = truncate_ellipsis(&session.repository_label(), card_width);
-    let operator_state = home_state_label(session);
-    let age = format_age(now_ms, session.last_observed_at);
-    let title = format!("{marker} {identity}  {operator_state}  {age}");
-    let metadata = format!(
-        "  {}  ·  {}  ·  {}",
-        truncate_ellipsis(
-            &session.branch_label(),
-            usize::from(right).saturating_sub(24).max(8),
-        ),
-        provider_label(&session.provider),
-        session.attachment_label()
-    );
-    let color = if selected {
-        FG
+    if right < 8 {
+        return;
+    }
+    let border = if selected {
+        SELECTED_OUTLINE
     } else {
-        operator_state_color(session)
+        CARD_BORDER
     };
-    put_str_styled(
+    let status = home_state_label(session);
+    let status_color = operator_state_color(session);
+    let inner_right = right.saturating_sub(1);
+    let content_width = usize::from(right.saturating_sub(5)).max(8);
+    let identity = truncate_ellipsis(&session.repository_label(), content_width);
+    let age = format_age(now_ms, session.last_observed_at);
+    let marker = if selected { "▸ " } else { "  " };
+    let branch = truncate_ellipsis(&session.branch_label(), content_width.saturating_sub(18));
+
+    put_char(buffer, 0, row_y, '╭', border);
+    put_char(buffer, inner_right, row_y, '╮', border);
+    put_char(buffer, 0, row_y.saturating_add(1), '│', border);
+    put_char(buffer, inner_right, row_y.saturating_add(1), '│', border);
+    put_char(buffer, 0, row_y.saturating_add(2), '│', border);
+    put_char(buffer, inner_right, row_y.saturating_add(2), '│', border);
+    put_char(buffer, 0, row_y.saturating_add(3), '╰', border);
+    put_char(buffer, inner_right, row_y.saturating_add(3), '╯', border);
+    for x in 1..inner_right {
+        put_char(buffer, x, row_y, '─', border);
+    }
+
+    let age_width = age.chars().count() as u16;
+    let status_label = if selected {
+        let action = available_action_labels(session).into_iter().next().unwrap_or_default();
+        format!(" {status}  ·  {action} ")
+    } else {
+        format!(" {status} ")
+    };
+    let status_width =
+        usize::from(inner_right.saturating_sub(age_width.saturating_add(4)).saturating_sub(2));
+    put_str(
         buffer,
-        0,
+        2,
         row_y,
-        &title,
-        color,
-        selected.then_some(SELECTED_ROW),
-        if selected { BOLD } else { 0 },
-        right,
+        &truncate_ellipsis(&status_label, status_width),
+        status_color,
+        inner_right,
+    );
+    put_str(
+        buffer,
+        inner_right.saturating_sub(age_width.saturating_add(1)),
+        row_y,
+        &age,
+        MUTED,
+        inner_right,
     );
     put_str_styled(
         buffer,
-        0,
+        2,
         row_y.saturating_add(1),
-        &metadata,
-        if selected { MUTED } else { MUTED },
-        selected.then_some(SELECTED_ROW),
-        0,
-        right,
+        &format!("{marker}{identity}"),
+        if selected {
+            FG
+        } else {
+            operator_state_color(session)
+        },
+        None,
+        selected.then_some(BOLD).unwrap_or(0),
+        inner_right,
     );
+    put_str(
+        buffer,
+        2,
+        row_y.saturating_add(2),
+        &format!(
+            "{branch}  ·  {}  ·  {}",
+            provider_label(&session.provider),
+            session.attachment_label()
+        ),
+        MUTED,
+        inner_right,
+    );
+    for x in 1..inner_right {
+        put_char(buffer, x, row_y.saturating_add(3), '─', border);
+    }
 }
 
 fn home_state_label(session: &FleetSessionRow) -> &'static str {
+    if session.attention_state.eq_ignore_ascii_case("ERROR") {
+        return "ERROR";
+    }
     match session.operator_state() {
         "NEEDS INPUT" => "INPUT",
         "COMPLETED" => "DONE",
@@ -2048,10 +2103,14 @@ fn provider_label(provider: &str) -> &'static str {
 }
 
 fn operator_state_color(session: &FleetSessionRow) -> Color {
+    if session.attention_state.eq_ignore_ascii_case("ERROR") {
+        return ALERT;
+    }
     match session.operator_state() {
         "NEEDS INPUT" => attention_color(&session.attention_state),
-        "RUNNING" => GREEN,
-        "COMPLETED" => MUTED,
+        "RUNNING" => BLUE,
+        "IDLE" => VIOLET,
+        "COMPLETED" => GREEN,
         "UNKNOWN" => MUTED,
         _ => FG,
     }
@@ -2086,46 +2145,84 @@ fn render_detail(
         return;
     };
     let mut y = top;
-    let detail_width = usize::from(right.saturating_sub(left).saturating_sub(1)).max(1);
+    put_str(buffer, left, y, "NOW", GOLD, right);
+    y = y.saturating_add(1);
+    let card_left = left;
+    let card_right = right.saturating_sub(1);
+    let border = if session.is_actionable() {
+        GOLD
+    } else {
+        CARD_BORDER
+    };
+    if card_right > card_left.saturating_add(3) && y.saturating_add(4) < bottom {
+        for x in card_left.saturating_add(1)..card_right {
+            put_char(buffer, x, y, '─', border);
+            put_char(buffer, x, y.saturating_add(4), '─', border);
+        }
+        put_char(buffer, card_left, y, '╭', border);
+        put_char(buffer, card_right, y, '╮', border);
+        put_char(buffer, card_left, y.saturating_add(4), '╰', border);
+        put_char(buffer, card_right, y.saturating_add(4), '╯', border);
+        for card_y in y.saturating_add(1)..y.saturating_add(4) {
+            put_char(buffer, card_left, card_y, '│', border);
+            put_char(buffer, card_right, card_y, '│', border);
+        }
+    }
+    let card_content_left = left.saturating_add(2);
+    let card_content_right = card_right;
+    let card_width = usize::from(card_content_right.saturating_sub(card_content_left)).max(1);
+    put_str(
+        buffer,
+        card_content_left,
+        y,
+        home_state_label(session),
+        operator_state_color(session),
+        card_content_right,
+    );
+    y = y.saturating_add(1);
     put_str_styled(
         buffer,
-        left,
+        card_content_left,
         y,
-        &truncate_ellipsis(&session.repository_label(), detail_width),
+        &truncate_ellipsis(&session.repository_label(), card_width),
         FG,
         None,
         BOLD,
-        right,
+        card_content_right,
     );
     y = y.saturating_add(1);
     put_str(
         buffer,
-        left,
+        card_content_left,
         y,
-        &truncate_ellipsis(&session.branch_label(), detail_width),
+        &truncate_ellipsis(&session.branch_label(), card_width),
         BLUE,
-        right,
+        card_content_right,
     );
     y = y.saturating_add(1);
 
     let age = format_age(state.now_ms, session.last_observed_at);
     put_str(
         buffer,
-        left,
+        card_content_left,
         y,
         &format!(
-            "{}  ·  {}  ·  {}  ·  {age}",
-            home_state_label(session),
+            "{}  ·  {}  ·  {age}",
             provider_label(&session.provider),
             session.attachment_label()
         ),
-        operator_state_color(session),
-        right,
+        MUTED,
+        card_content_right,
     );
     y = y.saturating_add(2);
 
+    put_str(buffer, left, y, "QUEUE PULSE", MUTED, right);
+    y = y.saturating_add(1);
+    render_focus_summary(buffer, left, y, right, state);
+    y = y.saturating_add(2);
+
     if session.is_actionable() {
-        put_str(buffer, left, y, "WHAT NEEDS YOU", GOLD, right);
+        put_str(buffer, left, y, "NEEDS YOU", GOLD, right);
         y = y.saturating_add(1);
         if let Some(question) = session
             .current_request
@@ -2926,6 +3023,15 @@ mod tests {
             output.push(character);
         }
         output.trim_end().to_string()
+    }
+
+    fn final_cell(buffer: &WireBuffer, x: u16, y: u16) -> Option<&Cell> {
+        buffer
+            .cells
+            .iter()
+            .rev()
+            .find(|(coord, _)| coord.x == x && coord.y == y)
+            .map(|(_, cell)| cell)
     }
 
     #[test]
@@ -3795,27 +3901,59 @@ mod tests {
     }
 
     #[test]
-    fn attention_first_render_uses_priority_cards_and_compact_action_detail() {
+    fn attention_first_render_uses_operator_cards_and_compact_action_detail() {
         let state = apply(&state_with_roster(), FleetEvent::Tick(10_000)).state;
         let mut buffer = WireBuffer::new(120, 24);
         render_fleet(&mut buffer, 120, 0, 20, &state);
         assert!(row_text(&buffer, 0, 120).contains("1 Needs input 2"));
         assert!(row_text(&buffer, 0, 120).contains("5 All 3"));
         let header = row_text(&buffer, 2, 90);
-        let first_row = row_text(&buffer, 3, 90);
-        assert!(row_text(&buffer, 1, 90).contains("2 need you"));
-        assert!(header.contains("PRIORITY QUEUE"));
-        assert!(first_row.contains("agents-in-a-box"));
-        assert!(first_row.contains("INPUT"));
-        assert!(row_text(&buffer, 4, 90).contains("claude/ask"));
-        assert!(row_text(&buffer, 4, 90).contains("CLAUDE"));
-        assert!(row_text(&buffer, 4, 90).contains("TMUX"));
+        let card_status = row_text(&buffer, 3, 90);
+        assert!(row_text(&buffer, 1, 90).contains("2 INPUT"));
+        assert!(header.contains("ACTION QUEUE"));
+        assert!(card_status.contains("INPUT"));
+        assert!(card_status.contains("Enter Answer"));
+        assert!(row_text(&buffer, 4, 90).contains("agents-in-a-box"));
+        assert!(row_text(&buffer, 5, 90).contains("claude/ask"));
+        assert!(row_text(&buffer, 5, 90).contains("CLAUDE"));
+        assert!(row_text(&buffer, 5, 90).contains("TMUX"));
         let rendered: String =
             (0..20).map(|row| row_text(&buffer, row, 120)).collect::<Vec<_>>().join("\n");
-        assert!(rendered.contains("WHAT NEEDS YOU"));
+        assert!(rendered.contains("NOW"));
+        assert!(rendered.contains("QUEUE PULSE"));
+        assert!(rendered.contains("NEEDS YOU"));
         assert!(rendered.contains("Enter Answer"));
         assert!(!rendered.contains("CONNECTION"));
         assert!(!rendered.contains("REPOSITORY / BRANCH"));
+    }
+
+    #[test]
+    fn operator_cards_keep_semantic_colours_and_selected_outline_without_fill() {
+        let mut error = session("error", "claude", "IDLE", "ERROR", "managed");
+        error.current_request = Some(serde_json::json!({"message": "review failure"}));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![
+            session("input", "claude", "IDLE", "ASK", "managed"),
+            session("running", "codex", "RUNNING", "NONE", "managed"),
+            session("idle", "codex", "IDLE", "NONE", "managed"),
+            session("done", "claude", "COMPLETED", "NONE", "managed"),
+            error,
+        ]);
+        state = apply(&state, FleetEvent::SetFilter(FleetFilter::All)).state;
+        let mut buffer = WireBuffer::new(120, 30);
+        render_fleet(&mut buffer, 120, 0, 29, &state);
+
+        assert_eq!(
+            final_cell(&buffer, 0, 3).and_then(|cell| cell.fg),
+            Some(SELECTED_OUTLINE)
+        );
+        assert_eq!(final_cell(&buffer, 2, 4).and_then(|cell| cell.bg), None);
+        for color in [GOLD, BLUE, VIOLET, GREEN, ALERT] {
+            assert!(
+                buffer.cells.iter().any(|(_, cell)| cell.fg == Some(color)),
+                "semantic colour {color:?} missing from Fleet cards"
+            );
+        }
     }
 
     #[test]
@@ -3878,7 +4016,7 @@ mod tests {
         assert!(rendered.contains("REMOTE"));
         assert!(rendered.contains("NONE"));
         assert!(rendered.contains("branch unknown"));
-        assert!(rendered.contains("PRIORITY QUEUE"));
+        assert!(rendered.contains("ACTION QUEUE"));
         assert_eq!(
             wrap_text("Controls should never split ordinary words", 18),
             vec!["Controls should", "never split", "ordinary words"]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -602,8 +602,8 @@ impl Default for BroadcastState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum FleetMode {
     Browse,
-    Answer(AnswerState),
-    AnswerDismissConfirm(AnswerState),
+    Answer(AnswerQueue),
+    AnswerDismissConfirm(AnswerQueue),
     Start(StartState),
     Prompt {
         text: String,
@@ -649,6 +649,57 @@ struct AnswerState {
     texts: Vec<String>,
     editing_text: bool,
     delivery: AnswerDelivery,
+}
+
+/// Drafts for every actionable structured interview. `active` is a flattened
+/// card cursor: left/right crosses question and session boundaries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AnswerQueue {
+    answers: Vec<AnswerState>,
+    active: usize,
+}
+
+impl AnswerQueue {
+    fn current(&self) -> Option<&AnswerState> {
+        self.answers.get(self.active)
+    }
+
+    fn current_mut(&mut self) -> Option<&mut AnswerState> {
+        self.answers.get_mut(self.active)
+    }
+
+    fn move_card(&mut self, delta: isize) {
+        let Some(answer) = self.current() else { return };
+        let question_count = answer.questions.len();
+        if question_count == 0 {
+            return;
+        }
+        let question = answer.question_index as isize + delta;
+        if (0..question_count as isize).contains(&question) {
+            let answer = &mut self.answers[self.active];
+            answer.question_index = question as usize;
+            answer.option_cursor = 0;
+            answer.editing_text = answer.questions[answer.question_index].options.is_empty();
+            return;
+        }
+        let answer_count = self.answers.len();
+        if answer_count <= 1 {
+            return;
+        }
+        self.active = if delta.is_negative() {
+            self.active.checked_sub(1).unwrap_or(answer_count - 1)
+        } else {
+            (self.active + 1) % answer_count
+        };
+        let answer = &mut self.answers[self.active];
+        answer.question_index = if delta.is_negative() {
+            answer.questions.len().saturating_sub(1)
+        } else {
+            0
+        };
+        answer.option_cursor = 0;
+        answer.editing_text = answer.questions[answer.question_index].options.is_empty();
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -719,16 +770,17 @@ impl FleetPaneState {
     }
 
     pub fn is_capturing_text(&self) -> bool {
-        matches!(
-            self.mode,
+        match &self.mode {
             FleetMode::TypedConfirm { .. }
-                | FleetMode::Start(_)
-                | FleetMode::Prompt { .. }
-                | FleetMode::Broadcast(BroadcastState {
-                    stage: BroadcastStage::Compose,
-                    ..
-                })
-        )
+            | FleetMode::Start(_)
+            | FleetMode::Prompt { .. }
+            | FleetMode::Broadcast(BroadcastState {
+                stage: BroadcastStage::Compose,
+                ..
+            }) => true,
+            FleetMode::Answer(queue) => queue.current().is_some_and(|answer| answer.editing_text),
+            _ => false,
+        }
     }
 
     pub fn set_sessions(&mut self, roster: Vec<FleetSessionRow>) {
@@ -784,22 +836,29 @@ impl FleetPaneState {
     }
 
     fn discard_stale_answer(&mut self) {
-        let answer = match &self.mode {
-            FleetMode::Answer(answer) | FleetMode::AnswerDismissConfirm(answer) => answer,
+        let queue = match &mut self.mode {
+            FleetMode::Answer(queue) | FleetMode::AnswerDismissConfirm(queue) => queue,
             _ => return,
         };
-        let fresh = self
-            .roster
-            .iter()
-            .find(|row| row.session_key == answer.session_key)
-            .is_some_and(|row| {
-                row.version == answer.expected_version
-                    && row.current_request_fingerprint.as_deref()
-                        == Some(answer.request_fingerprint.as_str())
-            });
-        if !fresh {
+        let before = queue.answers.len();
+        queue.answers.retain(|answer| {
+            self.roster
+                .iter()
+                .find(|row| row.session_key == answer.session_key)
+                .is_some_and(|row| {
+                    row.version == answer.expected_version
+                        && row.current_request_fingerprint.as_deref()
+                            == Some(answer.request_fingerprint.as_str())
+                })
+        });
+        if queue.answers.is_empty() {
             self.mode = FleetMode::Browse;
             self.feedback = Some("interview closed: authoritative request changed".into());
+        } else {
+            queue.active = queue.active.min(queue.answers.len() - 1);
+            if queue.answers.len() != before {
+                self.feedback = Some("delivered interview removed from answer queue".into());
+            }
         }
     }
 }
@@ -873,10 +932,11 @@ pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction
         FleetEvent::Key(key) => reduce_key(&mut next, key),
         FleetEvent::RequestAction(action) => request_action(&mut next, action),
         FleetEvent::ActionSucceeded { session_key } => {
-            if let FleetMode::Answer(answer) = &next.mode {
-                if answer.session_key == session_key
-                    && answer.delivery == AnswerDelivery::Confirming
-                {
+            if let FleetMode::Answer(queue) = &next.mode {
+                if queue.answers.iter().any(|answer| {
+                    answer.session_key == session_key
+                        && answer.delivery == AnswerDelivery::Confirming
+                }) {
                     next.feedback = Some("delivered, confirming authoritative Fleet state".into());
                     return FleetReduction {
                         state: next,
@@ -892,8 +952,10 @@ pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction
             session_key,
             detail,
         } => {
-            if let FleetMode::Answer(answer) = &mut next.mode {
-                if answer.session_key == session_key {
+            if let FleetMode::Answer(queue) = &mut next.mode {
+                if let Some(answer) =
+                    queue.answers.iter_mut().find(|answer| answer.session_key == session_key)
+                {
                     answer.delivery = AnswerDelivery::Ready;
                 }
             }
@@ -926,8 +988,8 @@ pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction
 fn reduce_key(state: &mut FleetPaneState, key: FleetKey) -> Option<FleetIntent> {
     match state.mode.clone() {
         FleetMode::Browse => reduce_browse_key(state, key),
-        FleetMode::Answer(answer) => reduce_answer_key(state, answer, key),
-        FleetMode::AnswerDismissConfirm(answer) => reduce_answer_dismiss_key(state, answer, key),
+        FleetMode::Answer(queue) => reduce_answer_key(state, queue, key),
+        FleetMode::AnswerDismissConfirm(queue) => reduce_answer_dismiss_key(state, queue, key),
         FleetMode::Start(start) => reduce_start_key(state, start, key),
         FleetMode::Prompt { text } => reduce_prompt_key(state, text, key),
         FleetMode::Broadcast(broadcast) => reduce_broadcast_key(state, broadcast, key),
@@ -980,47 +1042,45 @@ pub(crate) fn reduce_browse_key(state: &mut FleetPaneState, key: FleetKey) -> Op
 }
 
 fn begin_structured_answer(state: &mut FleetPaneState) {
-    let Some(row) = state.selected_session().cloned() else {
+    let Some(selected_key) = state.selected_key.clone() else {
         state.feedback = Some("no Fleet session selected".into());
         return;
     };
-    if !row.attention_state.eq_ignore_ascii_case("ASK") {
-        state.feedback = Some("selected session has no structured question".into());
+    let answers: Vec<_> = state.roster.iter().filter_map(answer_state_from_row).collect();
+    if answers.is_empty() {
+        state.feedback = Some("no actionable structured interviews".into());
         return;
     }
-    if !row.is_managed() || !row.capabilities.contains("structured_answer") {
-        state.feedback = Some("structured answer unavailable for selected session".into());
-        return;
+    let active = answers
+        .iter()
+        .position(|answer| answer.session_key == selected_key)
+        .unwrap_or(0);
+    state.mode = FleetMode::Answer(AnswerQueue { answers, active });
+}
+
+fn answer_state_from_row(row: &FleetSessionRow) -> Option<AnswerState> {
+    if !row.attention_state.eq_ignore_ascii_case("ASK")
+        || !row.is_managed()
+        || !row.capabilities.contains("structured_answer")
+    {
+        return None;
     }
-    let Some(request_fingerprint) = row.current_request_fingerprint.clone() else {
-        state.feedback = Some("structured request fingerprint unavailable".into());
-        return;
-    };
-    let Some(request) = row.current_request.as_ref() else {
-        state.feedback = Some("structured request payload unavailable".into());
-        return;
-    };
+    let request_fingerprint = row.current_request_fingerprint.clone()?;
+    let request = row.current_request.as_ref()?;
     let questions = answer_questions(request);
-    if questions.is_empty() {
-        state.feedback = Some("structured request has no questions".into());
-        return;
-    }
-    let selections = vec![BTreeSet::new(); questions.len()];
-    let texts = vec![String::new(); questions.len()];
-    let editing_text = questions[0].options.is_empty();
-    state.mode = FleetMode::Answer(AnswerState {
-        session_key: row.session_key,
+    (!questions.is_empty()).then(|| AnswerState {
+        session_key: row.session_key.clone(),
         expected_version: row.version,
         request_fingerprint,
         request_identity: request_identity(request),
+        editing_text: questions[0].options.is_empty(),
+        selections: vec![BTreeSet::new(); questions.len()],
+        texts: vec![String::new(); questions.len()],
         questions,
         question_index: 0,
         option_cursor: 0,
-        selections,
-        texts,
-        editing_text,
         delivery: AnswerDelivery::Ready,
-    });
+    })
 }
 
 fn answer_questions(request: &serde_json::Value) -> Vec<AnswerQuestion> {
@@ -1113,16 +1173,33 @@ fn request_identity(
 
 fn reduce_answer_key(
     state: &mut FleetPaneState,
-    mut answer: AnswerState,
+    mut queue: AnswerQueue,
     key: FleetKey,
 ) -> Option<FleetIntent> {
     if key == FleetKey::Esc {
         state.mode = FleetMode::Browse;
         return None;
     }
+    let Some(mut answer) = queue.current().cloned() else {
+        state.mode = FleetMode::Browse;
+        return None;
+    };
     if answer.delivery == AnswerDelivery::Confirming {
+        match key {
+            FleetKey::Tab | FleetKey::Right => {
+                queue.move_card(1);
+                state.mode = FleetMode::Answer(queue);
+                return None;
+            }
+            FleetKey::BackTab | FleetKey::Left => {
+                queue.move_card(-1);
+                state.mode = FleetMode::Answer(queue);
+                return None;
+            }
+            _ => {}
+        }
         state.feedback = Some("waiting for authoritative Fleet state".into());
-        state.mode = FleetMode::Answer(answer);
+        state.mode = FleetMode::Answer(queue);
         return None;
     }
     if key == FleetKey::Char('x') {
@@ -1132,10 +1209,10 @@ fn reduce_answer_key(
             .find(|row| row.session_key == answer.session_key)
             .is_some_and(|row| row.capabilities.contains("structured_dismiss"));
         if can_dismiss {
-            state.mode = FleetMode::AnswerDismissConfirm(answer);
+            state.mode = FleetMode::AnswerDismissConfirm(queue);
         } else {
             state.feedback = Some("provider does not expose safe interview dismissal".into());
-            state.mode = FleetMode::Answer(answer);
+            state.mode = FleetMode::Answer(queue);
         }
         return None;
     }
@@ -1146,20 +1223,13 @@ fn reduce_answer_key(
     };
     match key {
         FleetKey::Tab | FleetKey::Right => {
-            answer.question_index = (answer.question_index + 1) % answer.questions.len();
-            answer.option_cursor = 0;
-            answer.editing_text = answer.questions[answer.question_index].options.is_empty();
-            state.mode = FleetMode::Answer(answer);
+            queue.move_card(1);
+            state.mode = FleetMode::Answer(queue);
             return None;
         }
         FleetKey::BackTab | FleetKey::Left => {
-            answer.question_index = answer
-                .question_index
-                .checked_sub(1)
-                .unwrap_or(answer.questions.len().saturating_sub(1));
-            answer.option_cursor = 0;
-            answer.editing_text = answer.questions[answer.question_index].options.is_empty();
-            state.mode = FleetMode::Answer(answer);
+            queue.move_card(-1);
+            state.mode = FleetMode::Answer(queue);
             return None;
         }
         _ => {}
@@ -1172,14 +1242,15 @@ fn reduce_answer_key(
             FleetKey::Enter if answer.texts[answer.question_index].trim().is_empty() => {
                 state.feedback = Some("answer text required".into());
             }
-            FleetKey::Enter => return advance_or_submit_answer(state, answer),
+            FleetKey::Enter => return advance_or_submit_answer(state, queue, answer),
             FleetKey::Char(character) => {
                 answer.texts[answer.question_index].push(character);
             }
             FleetKey::Space => answer.texts[answer.question_index].push(' '),
             _ => {}
         }
-        state.mode = FleetMode::Answer(answer);
+        queue.answers[queue.active] = answer;
+        state.mode = FleetMode::Answer(queue);
         return None;
     }
     match key {
@@ -1210,26 +1281,31 @@ fn reduce_answer_key(
             if selected_other && answer.texts[answer.question_index].trim().is_empty() {
                 answer.editing_text = true;
             } else {
-                return advance_or_submit_answer(state, answer);
+                return advance_or_submit_answer(state, queue, answer);
             }
         }
         _ => {}
     }
-    state.mode = FleetMode::Answer(answer);
+    queue.answers[queue.active] = answer;
+    state.mode = FleetMode::Answer(queue);
     None
 }
 
 fn reduce_answer_dismiss_key(
     state: &mut FleetPaneState,
-    mut answer: AnswerState,
+    mut queue: AnswerQueue,
     key: FleetKey,
 ) -> Option<FleetIntent> {
     match key {
         FleetKey::Esc => {
-            state.mode = FleetMode::Answer(answer);
+            state.mode = FleetMode::Answer(queue);
             None
         }
         FleetKey::Enter => {
+            let Some(answer) = queue.current_mut() else {
+                state.mode = FleetMode::Browse;
+                return None;
+            };
             answer.delivery = AnswerDelivery::Confirming;
             let intent = FleetIntent::Execute {
                 session_key: answer.session_key.clone(),
@@ -1239,11 +1315,11 @@ fn reduce_answer_dismiss_key(
                     request_identity: answer.request_identity.clone(),
                 },
             };
-            state.mode = FleetMode::Answer(answer);
+            state.mode = FleetMode::Answer(queue);
             Some(intent)
         }
         _ => {
-            state.mode = FleetMode::AnswerDismissConfirm(answer);
+            state.mode = FleetMode::AnswerDismissConfirm(queue);
             None
         }
     }
@@ -1251,13 +1327,15 @@ fn reduce_answer_dismiss_key(
 
 fn advance_or_submit_answer(
     state: &mut FleetPaneState,
+    mut queue: AnswerQueue,
     mut answer: AnswerState,
 ) -> Option<FleetIntent> {
     if answer.question_index + 1 < answer.questions.len() {
         answer.question_index += 1;
         answer.option_cursor = 0;
         answer.editing_text = answer.questions[answer.question_index].options.is_empty();
-        state.mode = FleetMode::Answer(answer);
+        queue.answers[queue.active] = answer;
+        state.mode = FleetMode::Answer(queue);
         return None;
     }
     if let Some(index) = answer.questions.iter().enumerate().find_map(|(index, question)| {
@@ -1267,7 +1345,8 @@ fn advance_or_submit_answer(
         answer.option_cursor = 0;
         answer.editing_text = answer.questions[index].options.is_empty();
         state.feedback = Some("complete every interview question before submit".into());
-        state.mode = FleetMode::Answer(answer);
+        queue.answers[queue.active] = answer;
+        state.mode = FleetMode::Answer(queue);
         return None;
     }
     let answers = answer
@@ -1298,7 +1377,8 @@ fn advance_or_submit_answer(
         })
         .collect();
     answer.delivery = AnswerDelivery::Confirming;
-    state.mode = FleetMode::Answer(answer.clone());
+    queue.answers[queue.active] = answer.clone();
+    state.mode = FleetMode::Answer(queue);
     Some(FleetIntent::Execute {
         session_key: answer.session_key,
         expected_version: answer.expected_version,
@@ -2479,15 +2559,18 @@ fn render_mode(
 ) {
     match &state.mode {
         FleetMode::Browse => {}
-        FleetMode::Answer(answer) => render_interview(buffer, area_width, top, bottom, answer),
-        FleetMode::AnswerDismissConfirm(answer) => render_modal(
+        FleetMode::Answer(queue) => render_interview(buffer, area_width, top, bottom, queue),
+        FleetMode::AnswerDismissConfirm(queue) => render_modal(
             buffer,
             area_width,
             top,
             bottom,
             "Reject structured interview",
             &[
-                format!("session: {}", answer.session_key),
+                format!(
+                    "session: {}",
+                    queue.current().map_or("unknown", |answer| answer.session_key.as_str())
+                ),
                 "This returns a rejected result to Claude.".into(),
                 "Enter rejects, Esc returns to draft".into(),
             ],
@@ -2568,72 +2651,108 @@ fn render_interview(
     area_width: u16,
     top: u16,
     bottom: u16,
-    answer: &AnswerState,
+    queue: &AnswerQueue,
 ) {
-    if area_width < 28 || bottom.saturating_sub(top) < 8 {
+    if area_width < 28 {
         return;
     }
     fill_background(buffer, 0, top, area_width, bottom, SURFACE);
     let left = 2;
     let right = area_width.saturating_sub(2);
     let title_y = top.saturating_add(1);
+    let Some(answer) = queue.current() else {
+        return;
+    };
+    let lane_count = queue.answers.len().min(3);
+    if bottom.saturating_sub(top) < (lane_count as u16 * 2 + 11) {
+        return;
+    }
     put_str(
         buffer,
         left,
         title_y,
-        "ANSWER QUEUE  ·  STRUCTURED INTERVIEW",
+        &format!(
+            "ANSWER QUEUE  ·  STRUCTURED INTERVIEW  ·  {} SESSIONS",
+            queue.answers.len()
+        ),
         GOLD,
         right,
     );
-    let answered = answer
-        .questions
-        .iter()
-        .enumerate()
-        .filter(|(index, question)| answer_question_complete(answer, *index, question))
-        .count();
+    let answered = queue.answers.iter().map(answered_questions).sum::<usize>();
+    let question_total = queue.answers.iter().map(|answer| answer.questions.len()).sum::<usize>();
     put_str(
         buffer,
         left,
         title_y.saturating_add(1),
         &format!(
-            "{}  /  {} answered     session: {}",
+            "{}  /  {} answered   active: {}",
             answered,
-            answer.questions.len(),
+            question_total,
             truncate(&answer.session_key, 28)
         ),
         MUTED,
         right,
     );
-    let mut tab_x = left;
     let tab_y = title_y.saturating_add(3);
-    for (index, question) in answer.questions.iter().enumerate() {
-        let active = index == answer.question_index;
-        let done = answer_question_complete(answer, index, question);
-        let marker = if done { "●" } else { "○" };
-        let tab = format!(
-            " {} {} {} ",
-            index + 1,
-            marker,
-            truncate(&question.header, 14)
+    for offset in 0..lane_count {
+        let index = (queue.active + offset) % queue.answers.len();
+        let lane = &queue.answers[index];
+        let active_lane = index == queue.active;
+        let mut tab_x = left;
+        let lane_label = format!(
+            "{} {}  ",
+            if active_lane { "▶" } else { " " },
+            truncate(&lane.session_key, 20)
         );
-        if tab_x.saturating_add(tab.len() as u16) >= right {
-            break;
-        }
         put_str(
             buffer,
             tab_x,
-            tab_y,
-            &tab,
-            if active { GREEN } else { MUTED },
+            tab_y.saturating_add((offset * 2) as u16),
+            &lane_label,
+            if active_lane { GOLD } else { MUTED },
             right,
         );
-        tab_x = tab_x.saturating_add(tab.len() as u16 + 1);
+        tab_x = tab_x.saturating_add(lane_label.len() as u16);
+        for (question_index, question) in lane.questions.iter().enumerate() {
+            let done = answer_question_complete(lane, question_index, question);
+            let active_card = active_lane && question_index == lane.question_index;
+            let card = format!(
+                "[{} {} {}]",
+                if done { "●" } else { "○" },
+                question_index + 1,
+                truncate(&question.header, 11)
+            );
+            if tab_x.saturating_add(card.len() as u16) >= right {
+                break;
+            }
+            put_str(
+                buffer,
+                tab_x,
+                tab_y.saturating_add((offset * 2) as u16),
+                &card,
+                if active_card {
+                    GREEN
+                } else if done {
+                    BLUE
+                } else {
+                    MUTED
+                },
+                right,
+            );
+            tab_x = tab_x.saturating_add(card.len() as u16 + 1);
+        }
     }
     for x in left..right {
-        put_char(buffer, x, tab_y.saturating_add(1), '─', BLUE);
+        put_char(
+            buffer,
+            x,
+            tab_y.saturating_add((lane_count * 2) as u16),
+            '─',
+            BLUE,
+        );
     }
     let question = &answer.questions[answer.question_index];
-    let content_top = tab_y.saturating_add(3);
+    let content_top = tab_y.saturating_add((lane_count * 2 + 2) as u16);
     put_str(
         buffer,
         left,
@@ -2719,10 +2838,13 @@ fn render_interview(
     for x in left..right {
         put_char(buffer, x, bottom.saturating_sub(2), '─', BLUE);
     }
+    let complete = answered_questions(answer) == answer.questions.len();
     let help = if answer.delivery == AnswerDelivery::Confirming {
         "Refreshing authoritative state, Esc leaves queue"
+    } else if complete {
+        "READY  ·  Enter submit this interview  ←→ card  x reject  Esc leave"
     } else if answer.editing_text {
-        "Type answer  Enter next  ←→ card  x reject  Esc leave"
+        "Type answer  Enter next  ←→ card across sessions  x reject  Esc leave"
     } else if question.multi_select {
         "↑↓ move  Space toggle  Enter next  ←→ card  x reject  Esc leave"
     } else {
@@ -2741,6 +2863,15 @@ fn answer_question_complete(answer: &AnswerState, index: usize, question: &Answe
         .any(|option| option.label.eq_ignore_ascii_case("other"));
     !answer.selections[index].is_empty()
         && (!selected_other || !answer.texts[index].trim().is_empty())
+}
+
+fn answered_questions(answer: &AnswerState) -> usize {
+    answer
+        .questions
+        .iter()
+        .enumerate()
+        .filter(|(index, question)| answer_question_complete(answer, *index, question))
+        .count()
 }
 
 fn render_broadcast_modal(
@@ -3329,9 +3460,10 @@ mod tests {
         state = apply(&state, FleetEvent::Key(FleetKey::Left)).state;
         state = apply(&state, FleetEvent::Key(FleetKey::Right)).state;
         state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
-        let FleetMode::Answer(answer) = &state.mode else {
+        let FleetMode::Answer(queue) = &state.mode else {
             panic!("arrow navigation must keep interview open");
         };
+        let answer = queue.current().expect("active interview");
         assert_eq!(answer.question_index, 1);
         assert_eq!(answer.selections[0], BTreeSet::from([0]));
         assert_eq!(answer.selections[1], BTreeSet::from([0]));
@@ -3360,9 +3492,10 @@ mod tests {
         state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
         state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
         let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
-        let FleetMode::Answer(answer) = &submitted.state.mode else {
+        let FleetMode::Answer(queue) = &submitted.state.mode else {
             panic!("delivered interview must remain visible");
         };
+        let answer = queue.current().expect("active interview");
         assert_eq!(answer.delivery, AnswerDelivery::Confirming);
 
         let delivered = apply(
@@ -4056,6 +4189,115 @@ mod tests {
         assert!(rendered.contains("Checks"));
         assert!(rendered.contains("0  /  2 answered"));
         assert!(rendered.contains("verified Fleet work only"));
+    }
+
+    #[test]
+    fn interview_queue_crosses_sessions_and_prunes_confirmed_delivery() {
+        let mut first = session("claude:first", "claude", "IDLE", "ASK", "managed");
+        first.current_request_fingerprint = Some("first-request".into());
+        first.current_request = Some(serde_json::json!({
+            "questions": [{"id": "first", "question": "First?", "options": ["Yes"]}]
+        }));
+        let mut second = session("codex:second", "codex", "IDLE", "ASK", "managed");
+        second.current_request_fingerprint = Some("second-request".into());
+        second.current_request = Some(serde_json::json!({
+            "payload": {"identity": {"requestId": "codex-2"}, "questions": [
+                {"id": "second", "question": "Second?", "options": ["Ship"]}
+            ]}
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![first.clone(), second]);
+
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let FleetMode::Answer(queue) = &state.mode else {
+            panic!("answer queue expected")
+        };
+        assert_eq!(queue.answers.len(), 2);
+        assert_eq!(
+            queue.current().map(|answer| answer.session_key.as_str()),
+            Some("claude:first")
+        );
+        let mut buffer = WireBuffer::new(140, 28);
+        render_fleet(&mut buffer, 140, 0, 26, &state);
+        let rendered: String =
+            (0..26).map(|row| row_text(&buffer, row, 140)).collect::<Vec<_>>().join("\n");
+        assert!(rendered.contains("claude:first"));
+        assert!(rendered.contains("codex:second"));
+
+        state = apply(&state, FleetEvent::Key(FleetKey::Right)).state;
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+        assert!(matches!(
+            submitted.intent,
+            Some(FleetIntent::Execute { session_key, action: FleetAction::StructuredAnswer { .. }, .. })
+                if session_key == "codex:second"
+        ));
+
+        let working = apply(&submitted.state, FleetEvent::Key(FleetKey::Left)).state;
+        let FleetMode::Answer(queue) = &working.mode else {
+            panic!("queue must remain usable")
+        };
+        assert_eq!(
+            queue.current().map(|answer| answer.session_key.as_str()),
+            Some("claude:first")
+        );
+
+        let delivered = apply(
+            &working,
+            FleetEvent::ActionSucceeded {
+                session_key: "codex:second".into(),
+            },
+        )
+        .state;
+        let reconciled = apply(&delivered, FleetEvent::Snapshot(vec![first])).state;
+        let FleetMode::Answer(queue) = &reconciled.mode else {
+            panic!("remaining interview must stay open")
+        };
+        assert_eq!(queue.answers.len(), 1);
+        assert_eq!(
+            queue.current().map(|answer| answer.session_key.as_str()),
+            Some("claude:first")
+        );
+        assert_eq!(
+            reconciled.feedback(),
+            Some("delivered interview removed from answer queue")
+        );
+    }
+
+    #[test]
+    fn interview_renderer_exposes_explicit_submit_for_complete_session() {
+        let mut row = session("claude:submit", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("submit-request".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{
+                "id": "submit", "question": "Submit?", "multiSelect": true, "options": ["Yes"]
+            }]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
+        let mut buffer = WireBuffer::new(120, 24);
+        render_fleet(&mut buffer, 120, 0, 22, &state);
+        let rendered: String =
+            (0..22).map(|row| row_text(&buffer, row, 120)).collect::<Vec<_>>().join("\n");
+        assert!(rendered.contains("READY"));
+        assert!(rendered.contains("Enter submit this interview"));
+    }
+
+    #[test]
+    fn interview_free_text_captures_host_reserved_characters() {
+        let mut row = session("codex:text", "codex", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("text-request".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{"id": "why", "question": "Why?", "options": []}]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        assert!(
+            state.is_capturing_text(),
+            "free-text answer must retain H and ? for its field"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -242,6 +242,9 @@ struct RedrawGovernor {
     /// `true` once the streak first exceeded the cap; suppresses both
     /// further honoring and repeat warnings until the next `reset`.
     tripped: bool,
+    /// One low-frequency probe has been scheduled after the cap tripped.
+    /// Prevents a persistent non-animation retry from spinning at frame rate.
+    probe_pending: bool,
 }
 
 impl RedrawGovernor {
@@ -255,7 +258,9 @@ impl RedrawGovernor {
     const fn observe_redraw(&mut self) -> RedrawDecision {
         if self.tripped {
             // Already over budget — keep dropping hints silently until a
-            // reset re-arms the animation.
+            // reset re-arms the animation. An idle-tick probe consumed this
+            // render, so a later tick may schedule the next bounded retry.
+            self.probe_pending = false;
             return RedrawDecision {
                 honor: false,
                 just_tripped: false,
@@ -282,6 +287,19 @@ impl RedrawGovernor {
     const fn reset(&mut self) {
         self.consecutive = 0;
         self.tripped = false;
+        self.probe_pending = false;
+    }
+
+    /// Permit exactly one render on the runtime's low-frequency idle tick
+    /// after a runaway stream was capped. This lets backpressured plugins
+    /// retry retained work without restoring a frame-rate redraw loop.
+    const fn schedule_probe(&mut self) -> bool {
+        if self.tripped && !self.probe_pending {
+            self.probe_pending = true;
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -488,7 +506,10 @@ impl PluginTask {
                         InboundEvent::Eof | InboundEvent::Error => self.handle_exit().await,
                     }
                 }
-                _ = idle_tick.tick() => self.maybe_idle_reap().await,
+                _ = idle_tick.tick() => {
+                    self.maybe_idle_reap().await;
+                    self.retry_capped_redraw();
+                }
             }
         }
     }
@@ -1462,6 +1483,20 @@ impl PluginTask {
         }
     }
 
+    /// Repaint a capped plugin at most once per idle tick (five seconds).
+    /// The next `redraw = true` remains capped, while plugins using the frame
+    /// to retry retained I/O get another nonblocking enqueue attempt.
+    fn retry_capped_redraw(&mut self) {
+        if !matches!(*self.state.read(), LifecycleState::Running)
+            || !self.redraw_governor.schedule_probe()
+        {
+            return;
+        }
+        if let Some(flag) = self.dirty.read().get(&self.plugin.id) {
+            flag.store(true, std::sync::atomic::Ordering::Release);
+        }
+    }
+
     async fn shutdown(&mut self) {
         if self.child.is_none() {
             return;
@@ -1951,6 +1986,29 @@ mod tests {
         );
         assert!(!after_input.just_tripped);
         assert_eq!(gov.consecutive, 1, "streak restarts at 1 after reset");
+    }
+
+    #[test]
+    fn governor_allows_one_idle_probe_after_cap() {
+        let mut gov = RedrawGovernor::default();
+        for _ in 0..=MAX_CONSECUTIVE_REDRAWS {
+            gov.observe_redraw();
+        }
+
+        assert!(gov.tripped, "fixture must cross the redraw cap");
+        assert!(gov.schedule_probe(), "idle tick schedules one retry render");
+        assert!(
+            !gov.schedule_probe(),
+            "another idle tick cannot queue a second retry before render"
+        );
+        assert!(
+            !gov.observe_redraw().honor,
+            "probe runs once without restoring frame-rate redraw"
+        );
+        assert!(
+            gov.schedule_probe(),
+            "a later idle tick can retry retained work again"
+        );
     }
 
     /// A `redraw = false` frame mid-stream resets the streak just like an

--- a/ainb-tui/crates/ainb-plugin-sdk-rust/src/host_client.rs
+++ b/ainb-tui/crates/ainb-plugin-sdk-rust/src/host_client.rs
@@ -53,6 +53,19 @@ use crate::{Result, SdkError};
 /// or a peer-reported `error` envelope.
 pub type RpcOutcome = std::result::Result<serde_json::Value, RpcError>;
 
+/// Result of attempting to enqueue a notification without waiting for writer
+/// capacity. Callers that run on the inbound event path must retain work on
+/// [`NotificationEnqueueOutcome::Full`] and retry from a later redraw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationEnqueueOutcome {
+    /// Writer accepted the frame.
+    Queued,
+    /// Writer queue is saturated. No frame was sent.
+    Full,
+    /// Writer task has stopped. No later retry can succeed.
+    Closed,
+}
+
 /// Pending-responses table shared between the server reader and the
 /// host client. Reader fills oneshots; client drains them.
 pub(crate) type Pending = Arc<Mutex<HashMap<i64, oneshot::Sender<RpcOutcome>>>>;
@@ -117,6 +130,26 @@ impl HostClient {
             .send(frame)
             .await
             .map_err(|_| SdkError::plugin("frames channel closed — server is shutting down"))
+    }
+
+    /// Enqueue a JSON-RPC notification without waiting for writer capacity.
+    fn try_send_notification<P: Serialize + Send + Sync>(
+        &self,
+        method: &str,
+        params: &P,
+    ) -> Result<NotificationEnqueueOutcome> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        let bytes = serde_json::to_vec(&body)?;
+        let frame = framing::encode(&bytes);
+        Ok(match self.inner.frames_tx.try_send(frame) {
+            Ok(()) => NotificationEnqueueOutcome::Queued,
+            Err(mpsc::error::TrySendError::Full(_)) => NotificationEnqueueOutcome::Full,
+            Err(mpsc::error::TrySendError::Closed(_)) => NotificationEnqueueOutcome::Closed,
+        })
     }
 
     /// Send a JSON-RPC request and await the response.
@@ -356,6 +389,23 @@ impl HostClient {
         self.send_notification(methods::HOST_UNIX_SOCKET_SEND, &params).await
     }
 
+    /// Attempt a unix-socket write without blocking the inbound event reader.
+    ///
+    /// `Full` means the host writer is backpressured. Keep the logical write
+    /// pending and retry later; awaiting [`Self::unix_socket_send`] from an
+    /// event handler can otherwise prevent that handler from receiving keys.
+    pub fn try_unix_socket_send(
+        &self,
+        stream_id: impl Into<String>,
+        bytes: impl Into<bytes::Bytes>,
+    ) -> Result<NotificationEnqueueOutcome> {
+        let params = UnixSocketSendParams {
+            stream_id: stream_id.into(),
+            bytes: bytes.into(),
+        };
+        self.try_send_notification(methods::HOST_UNIX_SOCKET_SEND, &params)
+    }
+
     /// Close a previously dialled unix socket. Notification —
     /// fire-and-forget. The host stops emitting `socket:<stream_id>`
     /// events; closure is also implicit on plugin shutdown.
@@ -500,6 +550,30 @@ mod tests {
         assert_eq!(v["method"], "host/log");
         assert!(v.get("id").is_none(), "notification must not have id");
         assert_eq!(v["params"]["level"], "info");
+    }
+
+    #[test]
+    fn nonblocking_notification_reports_queue_pressure() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let (client, _pending) = HostClient::new(tx);
+
+        assert_eq!(
+            client
+                .try_unix_socket_send("stream-1", bytes::Bytes::from_static(b"one"))
+                .unwrap(),
+            NotificationEnqueueOutcome::Queued
+        );
+        assert_eq!(
+            client
+                .try_unix_socket_send("stream-1", bytes::Bytes::from_static(b"two"))
+                .unwrap(),
+            NotificationEnqueueOutcome::Full
+        );
+
+        let frame = rx.try_recv().expect("first notification queued");
+        let body = decode_body(&frame);
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["method"], "host/unix_socket_send");
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-plugin-sdk-rust/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-sdk-rust/src/lib.rs
@@ -30,7 +30,7 @@ pub mod plugin;
 pub mod server;
 
 pub use error::{Result, SdkError};
-pub use host_client::HostClient;
+pub use host_client::{HostClient, NotificationEnqueueOutcome};
 pub use plugin::{CliOutput, InitContext, Plugin};
 pub use server::Server;
 


### PR DESCRIPTION
## Summary\n- open every actionable structured interview from Fleet\n- navigate cards across sessions without losing drafts\n- make per-session submission explicit and reconcile only delivered interviews\n\n## Validation\n- cargo fmt -p ainb-plugin-hangar --check\n- cargo test -q -p ainb-plugin-hangar --lib\n- cargo test -q -p ainb --test tripwire_fleet_panel_opens_and_answers -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fleet now supports multiple simultaneous structured interviews with separate drafts and easy navigation.
  - Added queue lanes, action summaries, status indicators, and clearer attention-needed labels.
  - Fleet snapshots can display repository and branch context, including worktrees and detached revisions.

- **Improvements**
  - Refreshes remain responsive during high activity or temporary connection backpressure.
  - Fleet updates are consolidated to show the latest available state while preserving important health notifications.
  - Improved redraw behavior helps keep the interface current without unnecessary activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->