### PR TITLE
style(hangar-plugin): satisfy stable rustfmt in fleet.rs

### DIFF
--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -1051,10 +1051,7 @@ fn begin_structured_answer(state: &mut FleetPaneState) {
         state.feedback = Some("no actionable structured interviews".into());
         return;
     }
-    let Some(active) = answers
-        .iter()
-        .position(|answer| answer.session_key == selected_key)
-    else {
+    let Some(active) = answers.iter().position(|answer| answer.session_key == selected_key) else {
         state.feedback = Some("selected session has no structured interview".into());
         return;
     };
@@ -2138,7 +2135,11 @@ fn render_session_card(
         2,
         row_y.saturating_add(1),
         &format!("{marker}{identity}"),
-        if selected { SELECTION_GREEN } else { operator_state_color(session) },
+        if selected {
+            SELECTION_GREEN
+        } else {
+            operator_state_color(session)
+        },
         None,
         selected.then_some(BOLD).unwrap_or(0),
         inner_right,


### PR DESCRIPTION
`Rustfmt` is red on main (`c6b448a4`). Two spots in `crates/ainb-plugin-hangar/src/screen/fleet.rs` drifted:

- `:1051` a let-else whose scrutinee fits on one line
- `:2138` an if-else in argument position that stable wants in block form

Both are ordinary stable rules, not the known nightly comment-width drift.

## Why this was hand-edited rather than `cargo fmt`

`rustfmt.toml` sets nightly-only options (`wrap_comments`, `format_code_in_doc_comments`, `comment_width`). Consequences:

- `cargo fmt --all` on **stable** warns about the unstable options and writes nothing, so it cannot fix these.
- `cargo +nightly fmt --all` fixes them but also applies the nightly-only comment rules, reformatting **hundreds of files** across the workspace.

Neither produces the minimal change. So the two spots were edited to exactly what stable asks for.

## Verification

```
cargo fmt --all -- --check   ->  0 diffs
files touched                ->  1
```

Not caused by any PR from this session; the drift arrived with #577 / #578. `Rustfmt` is not in the required-check set, which is why those merged green.