### PR TITLE
fix(hangar): pipeline health review findings from #576

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/pipeline_view.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/pipeline_view.rs
@@ -351,12 +351,23 @@ mod tests {
         );
     }
 
-    /// With colour on, the lights carry 24-bit escapes and the padding is still
-    /// computed off the PLAIN width (a coloured strip lines up identically).
+    /// With colour on, the lights carry 24-bit escapes and every cell is still
+    /// padded to its PLAIN width, so a coloured strip lines up column-for-column
+    /// with the plain one.
+    ///
+    /// TWO stages on purpose. With one stage the only padded region is the end of
+    /// the line, which `stage_strip` then `trim_end`s away in BOTH the coloured
+    /// and the plain path, so the assertion collapses to `"tester ✗" ==
+    /// "tester ✗"` and passes however the padding is computed. A second stage puts
+    /// an interior cell in front of a `│` separator, which makes the pad width
+    /// load-bearing: get it wrong and the separator moves.
     #[test]
     fn lights_are_coloured_and_padding_ignores_escapes() {
         let health = PipelineHealth {
-            stages: vec![stage("QA", Some("tester"), Some(1), 0, 0, 0, 1, 0)],
+            stages: vec![
+                stage("QA", Some("tester"), Some(1), 0, 0, 0, 1, 0),
+                stage("Review", Some("reviewer"), None, 0, 1, 1, 0, 0),
+            ],
         };
         let colored = render(&health, true, true);
         assert!(
@@ -364,9 +375,32 @@ mod tests {
             "{}",
             colored[0]
         );
+
+        // The plain strip, pinned exactly: each column is as wide as its widest
+        // of the three rows (11 for QA's `1 (wip 0/1)`, 10 for Review's role
+        // cell), so the separator sits at the same offset on every row.
         let plain = render(&health, true, false);
-        let stripped: String = strip_ansi(&colored[3]);
-        assert_eq!(stripped, plain[3]);
+        assert_eq!(
+            &plain[2..],
+            [
+                "QA          │ Review",
+                "tester ✗    │ reviewer ●",
+                "1 (wip 0/1) │ 0",
+            ],
+            "rendered strip:\n{}",
+            plain.join("\n")
+        );
+
+        // Colouring changes the bytes and nothing else. If the pad count were
+        // taken off the RENDERED width the escapes would eat the padding and the
+        // separator would slide left on every coloured row.
+        for row in 2..plain.len() {
+            assert_eq!(
+                strip_ansi(&colored[row]),
+                plain[row],
+                "row {row} must be identical once the escapes are stripped"
+            );
+        }
     }
 
     fn strip_ansi(s: &str) -> String {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -729,10 +729,13 @@ pub async fn boards_list(
     let boards = BoardRepo::list(pool, &ws).await?;
     let mut out = Vec::with_capacity(boards.len());
     for b in boards {
-        // The pipeline health of every column of this board, folded once per
-        // board (0074/0076). A board with no role-gated column produces stages
-        // that are all `services_role = None`, which render nothing.
-        let health = ainb_hangar_store::service::pipeline_health::snapshot(
+        // The pipeline health of this board's columns, folded once per board
+        // (0074/0076) and ONLY when the board is a pull pipeline. `boards_list`
+        // is re-armed by the Boards screen on every pushed daemon event, and the
+        // fold's `role_agents_free` counts each candidate agent's active tasks
+        // once per (column x agent); a plain kanban board can never produce a
+        // light off that work, so it is skipped before it is paid for.
+        let health = ainb_hangar_store::service::pipeline_health::snapshot_if_pipeline(
             pool,
             &ws,
             &b.id,
@@ -757,8 +760,8 @@ pub async fn boards_list(
                 // under. `None` is skipped at serialisation, so a non-pipeline
                 // board's payload stays byte-identical to a pre-0074 producer's.
                 health: health
-                    .stages
                     .iter()
+                    .flat_map(|h| h.stages.iter())
                     .find(|s| s.column_id == c.id)
                     .filter(|s| s.services_role.is_some())
                     .map(|s| ainb_hangar_proto::snapshots::ColumnHealthWireRow {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/snapshots.rs
@@ -749,16 +749,26 @@ pub async fn boards_list(
                 fsm_state: c.fsm_state.clone(),
                 auto_move: c.auto_move,
                 cards: Vec::new(),
-                health: health.stages.iter().find(|s| s.column_id == c.id).map(|s| {
-                    ainb_hangar_proto::snapshots::ColumnHealthWireRow {
+                // Only a ROLE-GATED column carries health on the wire. The fold
+                // returns a row for EVERY column of the board (Backlog, Done,
+                // and every column of a plain kanban board), so emitting them
+                // unfiltered ships a `health` object on every column of every
+                // board and breaks the append-only promise the field was added
+                // under. `None` is skipped at serialisation, so a non-pipeline
+                // board's payload stays byte-identical to a pre-0074 producer's.
+                health: health
+                    .stages
+                    .iter()
+                    .find(|s| s.column_id == c.id)
+                    .filter(|s| s.services_role.is_some())
+                    .map(|s| ainb_hangar_proto::snapshots::ColumnHealthWireRow {
                         services_role: s.services_role.clone(),
                         wip_limit: s.wip_limit,
                         wip_active: s.wip_active,
                         role_agents: s.role_agents,
                         role_agents_free: s.role_agents_free,
                         stuck: s.stuck,
-                    }
-                }),
+                    }),
             })
             .collect();
         let mut unmapped = Vec::new();
@@ -4209,4 +4219,98 @@ pub async fn issue_timeline(
         entries.drain(..entries.len() - cap);
     }
     Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pipeline board (Backlog, a role-gated Review, Done) plus a plain kanban
+    /// board (Todo, Doing), both in the default workspace. Returns the workspace
+    /// id.
+    async fn seed_two_boards(pool: &sqlx::SqlitePool) -> String {
+        let ws = ainb_hangar_store::bootstrap::ensure_default_workspace(pool).await.unwrap();
+        for (id, name) in [("b-pipeline", "Pipeline"), ("b-kanban", "My kanban")] {
+            sqlx::query("INSERT INTO board (id, workspace_id, name, created_at) VALUES (?,?,?,0)")
+                .bind(id)
+                .bind(&ws)
+                .bind(name)
+                .execute(pool)
+                .await
+                .unwrap();
+        }
+        let cols: [(&str, &str, &str, i64, Option<&str>); 5] = [
+            ("p-backlog", "b-pipeline", "Backlog", 0, None),
+            ("p-review", "b-pipeline", "Review", 1, Some("reviewer")),
+            ("p-done", "b-pipeline", "Done", 2, None),
+            ("k-todo", "b-kanban", "Todo", 0, None),
+            ("k-doing", "b-kanban", "Doing", 1, None),
+        ];
+        for (id, board, name, ord, role) in cols {
+            sqlx::query(
+                "INSERT INTO board_column \
+                 (id, board_id, ord, name, fsm_state, auto_move, services_role) \
+                 VALUES (?,?,?,?,NULL,0,?)",
+            )
+            .bind(id)
+            .bind(board)
+            .bind(ord)
+            .bind(name)
+            .bind(role)
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+        ws
+    }
+
+    /// `health` rides the wire ONLY on a role-gated column, straight out of the
+    /// real producer.
+    ///
+    /// The fold behind it returns a row for every column of the board, so an
+    /// unfiltered producer ships `"health":{…}` on every plain kanban column too:
+    /// a wire change on a surface that promised to be append-only, and invisible
+    /// to any assertion made against a hand-built `BoardColumnWireRow`. This
+    /// serialises what `boards_list` actually produced.
+    #[tokio::test]
+    async fn boards_list_emits_health_only_on_role_gated_columns() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = seed_two_boards(pool).await;
+
+        let boards = boards_list(pool, &ws).await.unwrap();
+        let kanban = boards.iter().find(|b| b.name == "My kanban").expect("kanban board");
+        let pipeline = boards.iter().find(|b| b.name == "Pipeline").expect("pipeline board");
+
+        // Not one column of a board with no role gate carries health.
+        assert!(
+            kanban.columns.iter().all(|c| c.health.is_none()),
+            "a plain kanban board ships no health: {:?}",
+            kanban.columns.iter().map(|c| (&c.name, &c.health)).collect::<Vec<_>>()
+        );
+        let json = serde_json::to_string(kanban).unwrap();
+        assert!(
+            !json.contains("health"),
+            "a non-pipeline board's payload stays byte-identical to a pre-0074 producer's: {json}"
+        );
+
+        // On the pipeline board only the GATED stage carries it.
+        let gated: Vec<&str> = pipeline
+            .columns
+            .iter()
+            .filter(|c| c.health.is_some())
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(
+            gated,
+            vec!["Review"],
+            "Backlog and Done are not pull queues, so they carry no health"
+        );
+        assert_eq!(
+            pipeline.columns[1].health.as_ref().and_then(|h| h.services_role.as_deref()),
+            Some("reviewer"),
+            "and the gated stage carries its role verbatim"
+        );
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -2524,9 +2524,18 @@ async fn build_prompt(
 /// `None` when the issue is on no board, sits in a column that adds nothing, or
 /// the read faults.
 ///
-/// An issue can be carded on several boards; the pipeline board is the one that
-/// gates dispatch, so a stage that actually carries an addendum wins over one
-/// that does not, and ties break on `board_id` to keep the brief deterministic.
+/// An issue can be carded on several boards, and only one of them gates
+/// dispatch: a PIPELINE board, i.e. one carrying at least one role-gated column
+/// (0074). The lookup is constrained to those, so a personal kanban board that
+/// happens to card the same issue can never inject its own column text into a
+/// pipeline run. Without that constraint the winner was whichever `board_id`
+/// sorted lower, i.e. a ULID, i.e. board creation order, which has nothing to do
+/// with which board dispatched the work.
+///
+/// Within a pipeline board the stage that actually GATES (`services_role IS NOT
+/// NULL`) wins over an ungated column, and `board_id` breaks the remaining tie so
+/// the brief stays deterministic.
+///
 /// Best-effort by design: a store fault must degrade to "no stage layer", never
 /// strand a dispatch.
 async fn stage_prompt_for_issue(pool: &SqlitePool, issue_id: &str) -> Option<String> {
@@ -2534,7 +2543,10 @@ async fn stage_prompt_for_issue(pool: &SqlitePool, issue_id: &str) -> Option<Str
         "SELECT col.stage_prompt FROM board_card AS bc \
            JOIN board_column AS col ON col.id = bc.column_id \
           WHERE bc.issue_id = ? AND TRIM(COALESCE(col.stage_prompt, '')) <> '' \
-          ORDER BY bc.board_id LIMIT 1",
+            AND EXISTS (SELECT 1 FROM board_column AS gate \
+                         WHERE gate.board_id = bc.board_id \
+                           AND gate.services_role IS NOT NULL) \
+          ORDER BY (col.services_role IS NULL), bc.board_id LIMIT 1",
     )
     .bind(issue_id)
     .fetch_optional(pool)
@@ -4152,6 +4164,131 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(disp.invocation.prompt, INSTRUCTIONS);
+    }
+
+    /// The stage addendum comes from the PIPELINE board, never from some other
+    /// board that happens to card the same issue.
+    ///
+    /// An issue can be carded anywhere. Before the board constraint the lookup
+    /// selected from every board and broke ties on `board_id`, so a personal
+    /// kanban board created earlier (a lower ULID) silently won and its `Doing`
+    /// column's text was injected into a pipeline run's brief.
+    #[tokio::test]
+    async fn stage_prompt_comes_from_the_pipeline_board_not_a_personal_one() {
+        use ainb_hangar_store::bootstrap;
+        use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+
+        const PIPELINE_STAGE: &str = "Review gate: check migrations are additive.";
+        const PERSONAL_STAGE: &str = "My kanban note: remember to water the plants.";
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = bootstrap::ensure_default_workspace(pool).await.unwrap();
+        bootstrap::ensure_runtime(pool, &bootstrap::default_runtime_id(), 1)
+            .await
+            .unwrap();
+        let agent = bootstrap::create_agent(pool, &ws, "checker", "claude", None).await.unwrap();
+
+        let issue_id =
+            ainb_hangar_core::idgen::IdGen::new_ulid(&ainb_hangar_core::idgen::SystemIdGen);
+        IssueRepo::insert(
+            pool,
+            &NewIssue {
+                id: issue_id.clone(),
+                workspace_id: ws.clone(),
+                title: "Fix the login bug".into(),
+                description: None,
+                state: "open".into(),
+                creator: ainb_hangar_core::actor::ActorRef::new(
+                    ainb_hangar_core::actor::ActorKind::Member,
+                    "stevie",
+                )
+                .unwrap(),
+                created_at: 1,
+                priority: 0,
+                assignee: None,
+                due_date: None,
+                labels: Vec::new(),
+                parent_issue_id: None,
+                stage: None,
+                acceptance_criteria: Vec::new(),
+                context_refs: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Two boards carding the SAME issue. `b-personal` sorts BELOW `b-pipeline`,
+        // so under a plain `ORDER BY board_id` the personal board wins.
+        for (board, name) in [("b-personal", "My kanban"), ("b-pipeline", "Pipeline")] {
+            sqlx::query("INSERT INTO board (id, workspace_id, name, created_at) VALUES (?,?,?,0)")
+                .bind(board)
+                .bind(ws.as_str())
+                .bind(name)
+                .execute(pool)
+                .await
+                .unwrap();
+        }
+        // The personal board's Doing column: no role gate, but it carries text.
+        sqlx::query(
+            "INSERT INTO board_column \
+             (id, board_id, ord, name, fsm_state, auto_move, services_role, stage_prompt) \
+             VALUES ('c-doing','b-personal',0,'Doing',NULL,0,NULL,?)",
+        )
+        .bind(PERSONAL_STAGE)
+        .execute(pool)
+        .await
+        .unwrap();
+        // The pipeline board's role-gated Review stage.
+        sqlx::query(
+            "INSERT INTO board_column \
+             (id, board_id, ord, name, fsm_state, auto_move, services_role, stage_prompt) \
+             VALUES ('c-review','b-pipeline',0,'Review',NULL,1,'reviewer',?)",
+        )
+        .bind(PIPELINE_STAGE)
+        .execute(pool)
+        .await
+        .unwrap();
+        for (board, column) in [("b-personal", "c-doing"), ("b-pipeline", "c-review")] {
+            sqlx::query(
+                "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+                 VALUES (?,?,?,0,0)",
+            )
+            .bind(board)
+            .bind(&issue_id)
+            .bind(column)
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+
+        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
+            .await
+            .unwrap();
+        let brief = disp.invocation.prompt;
+        assert!(
+            brief.contains(PIPELINE_STAGE),
+            "the gating pipeline stage supplies the addendum, got:\n{brief}"
+        );
+        assert!(
+            !brief.contains(PERSONAL_STAGE),
+            "a non-pipeline board must never inject into a pipeline brief, got:\n{brief}"
+        );
+
+        // And when the pipeline stage adds nothing, the answer is NO stage layer,
+        // not a fallback onto whatever other board carries text.
+        sqlx::query("UPDATE board_column SET stage_prompt = NULL WHERE id = 'c-review'")
+            .execute(pool)
+            .await
+            .unwrap();
+        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
+            .await
+            .unwrap();
+        assert_eq!(
+            disp.invocation.prompt, "Fix the login bug",
+            "no gating addendum means the brief is the issue body alone"
+        );
     }
 
     /// A linked upstream issue (0043) appends a `Linked issue:` line to the brief so

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -4762,9 +4762,12 @@ mod tests {
             serde_json::from_str::<BoardsListResult>(&s).unwrap(),
             result
         );
-        // A column with no pipeline health OMITS the field entirely, so a
-        // non-pipeline board's payload stays byte-identical to a pre-0074
-        // producer's (append-only).
+        // `health: None` OMITS the field entirely rather than writing a null.
+        // This is a SERIALISATION assertion over a hand-built row: it pins
+        // `skip_serializing_if`, and nothing more. Whether the daemon actually
+        // leaves it `None` on a non-pipeline board is a property of the PRODUCER,
+        // which lives a crate away and is pinned by
+        // `rpc::snapshots::tests::boards_list_emits_health_only_on_role_gated_columns`.
         assert!(
             !s.contains("health"),
             "health must be omitted when absent: {s}"

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0077_task_queue_agent_status_index.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0077_task_queue_agent_status_index.sql
@@ -1,0 +1,32 @@
+-- Hangar v1 schema, migration 0077: index the per-agent active-task count.
+--
+-- WHAT IS SLOW. "how many active tasks does this agent hold?" is the per-agent
+-- concurrency cap, and it is asked as a correlated subquery:
+--
+--     SELECT COUNT(*) FROM agent_task_queue r
+--      WHERE r.agent_id = a.id AND r.status IN ('queued','dispatched','running')
+--
+-- The pull statement (`service::pull`) carries it, and so does the
+-- `role_agents_free` column of the health fold (`service::pipeline_health`).
+-- Nothing indexes `agent_task_queue.agent_id`: `idx_one_pending_task_per_issue_agent`
+-- (0012) is PARTIAL on `status IN ('queued','dispatched')` so it cannot serve a
+-- predicate that also admits `'running'`, and `idx_task_issue_status` (0074)
+-- leads on `issue_id`. Every evaluation is therefore a full scan of a table that
+-- grows without bound with task history.
+--
+-- WHY IT MATTERS NOW. The pull runs the subquery once per daemon tick, which was
+-- affordable. The health fold runs it once per (column x candidate agent) and is
+-- now read on EVERY `boards_list`, which the Boards screen re-arms on every
+-- pushed daemon event: six columns x five agents is thirty full scans per board
+-- refresh.
+--
+-- The index is NOT partial: `status` is the second column, so one index serves
+-- any status set the two callers ask for (they already differ), and a partial
+-- index pinned to today's `ACTIVE_STATUSES` would silently stop being usable the
+-- day that list changes. `(agent_id, status)` also covers both predicates
+-- entirely, so the count is answered from the index without touching the table.
+--
+-- Pure `CREATE INDEX`: no data is read or rewritten, and it is a no-op to roll
+-- forward onto a populated home.
+CREATE INDEX IF NOT EXISTS idx_task_agent_status
+    ON agent_task_queue (agent_id, status);

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pipeline_health.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pipeline_health.rs
@@ -126,6 +126,43 @@ impl PipelineHealth {
     }
 }
 
+/// Read one board's pipeline health, but ONLY when the board is a pipeline at
+/// all: `Ok(None)` for a board with no role-gated column.
+///
+/// The full fold is not free. `role_agents_free` counts each candidate agent's
+/// active tasks with a correlated subquery over `agent_task_queue`, once per
+/// (column x agent), and the caller that matters here is
+/// `boards_list`, which the Boards screen re-arms on every pushed daemon event
+/// for EVERY board in the workspace. A plain kanban board can never produce a
+/// non-empty light, so paying for that on one is pure waste.
+///
+/// The probe itself is served by `idx_board_column_pull` (0074), which is
+/// partial on exactly this predicate.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if a query fails.
+pub async fn snapshot_if_pipeline(
+    pool: &SqlitePool,
+    workspace: &WorkspaceId,
+    board_id: &str,
+    now_ms: i64,
+) -> Result<Option<PipelineHealth>, sqlx::Error> {
+    let gated: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM board_column col JOIN board bd ON bd.id = col.board_id \
+          WHERE col.board_id = ?1 AND bd.workspace_id = ?2 \
+            AND col.services_role IS NOT NULL LIMIT 1",
+    )
+    .bind(board_id)
+    .bind(workspace.as_str())
+    .fetch_optional(pool)
+    .await?;
+    if gated.is_none() {
+        return Ok(None);
+    }
+    snapshot(pool, workspace, board_id, now_ms).await.map(Some)
+}
+
 /// Read one board's pipeline health.
 ///
 /// `now_ms` is passed rather than read so the stuck light is deterministic under

--- a/ainb-tui/crates/ainb-hangar-store/tests/pipeline_health_roles.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pipeline_health_roles.rs
@@ -13,7 +13,7 @@
 use ainb_hangar_core::ids::WorkspaceId;
 use ainb_hangar_store::Store;
 use ainb_hangar_store::service::pipeline_health;
-use sqlx::SqlitePool;
+use sqlx::{Row, SqlitePool};
 
 /// Frozen "now" so the stuck light is deterministic.
 const NOW_MS: i64 = 1_700_000_500_000;
@@ -163,5 +163,73 @@ async fn uncovered_role_reports_red_until_an_agent_holds_it() {
         uncovered,
         vec!["tester"],
         "an archived holder does not cover a role"
+    );
+}
+
+/// The fold is SKIPPED on a board that gates nothing, and the per-agent
+/// active-task count it charges for is index-served.
+///
+/// `boards_list` re-reads this on every pushed daemon event, for every board in
+/// the workspace, and `role_agents_free` runs a correlated count over
+/// `agent_task_queue` once per (column x candidate agent). A plain kanban board
+/// can never produce a light off that work, so it must not pay for it; and the
+/// count that remains must not be a full table scan.
+#[tokio::test]
+async fn a_board_with_no_role_gate_skips_the_fold_and_the_agent_count_is_indexed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    let pool = store.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-1", "reviewer", 2).await;
+
+    // A plain kanban board: two columns, neither one a pull queue.
+    add_column(pool, "Todo", 0, None, None).await;
+    add_column(pool, "Doing", 1, None, None).await;
+    assert_eq!(
+        pipeline_health::snapshot_if_pipeline(pool, &ws(), "b-1", NOW_MS)
+            .await
+            .expect("probe"),
+        None,
+        "a board with no role-gated column is not a pipeline and folds nothing"
+    );
+
+    // Gate ONE column and the same board becomes a pipeline, folded in full.
+    sqlx::query("UPDATE board_column SET services_role = 'reviewer' WHERE id = 'Doing'")
+        .execute(pool)
+        .await
+        .expect("gate a column");
+    let health = pipeline_health::snapshot_if_pipeline(pool, &ws(), "b-1", NOW_MS)
+        .await
+        .expect("probe")
+        .expect("a gated column makes this a pipeline");
+    assert_eq!(
+        health.stages.len(),
+        2,
+        "the fold still covers EVERY column, gated or not"
+    );
+    let doing = health.stages.iter().find(|s| s.name == "Doing").expect("Doing stage");
+    assert_eq!(doing.role_agents, 1, "the reviewer covers it");
+
+    // Migration 0077: the per-agent active-task count is answered from an index
+    // rather than by scanning `agent_task_queue`, which grows with task history.
+    let rows = sqlx::query(
+        "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM agent_task_queue r \
+          WHERE r.agent_id = 'ag-1' AND r.status IN ('queued','dispatched','running')",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("query plan");
+    let plan = rows
+        .iter()
+        .map(|r| r.try_get::<String, _>("detail").unwrap_or_default())
+        .collect::<Vec<_>>()
+        .join(" | ");
+    assert!(
+        plan.contains("idx_task_agent_status"),
+        "the per-agent active-task count must use idx_task_agent_status, got: {plan}"
+    );
+    assert!(
+        !plan.contains("SCAN agent_task_queue"),
+        "and must not scan the table: {plan}"
     );
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -2875,13 +2875,24 @@ fn stage_name<'a>(board: &'a BoardView, health: &ColumnHealthWireRow) -> &'a str
 ///
 /// Keyed off the geometry `render_card_board` just returned, so the dot lands on
 /// the exact cell the widget painted its glyph in, at any width and any scroll.
+///
+/// The walk is over the LAYOUT, indexing back into `board.columns` through
+/// [`ColumnLayout::index`](card_board::ColumnLayout::index). The layout holds
+/// only the PAINTED WINDOW, which starts at the widget's `first_col` once the
+/// board scrolls horizontally, so zipping the canonical column list against it
+/// would shift every dot left by `first_col`, painting a stage's failure glyph
+/// on its right-hand neighbour, which is legitimate-looking output and therefore
+/// silent.
 fn paint_role_dots(
     buf: &mut WireBuffer,
     board: &BoardView,
     layout: &card_board::BoardLayout,
     area_w: u16,
 ) {
-    for (col, lay) in board.columns.iter().zip(layout.columns.iter()) {
+    for lay in &layout.columns {
+        let Some(col) = board.columns.get(lay.index) else {
+            continue;
+        };
         let Some(health) = col.health.as_ref() else {
             continue;
         };
@@ -4343,6 +4354,117 @@ mod tests {
         assert!(
             out.state.overlay().is_none(),
             "no overlay — a direct toggle"
+        );
+    }
+
+    /// A pipeline column carrying a role gate and a role-coverage count.
+    fn gated_col(
+        id: &str,
+        name: &str,
+        role: Option<&str>,
+        role_agents: i64,
+        role_agents_free: i64,
+    ) -> BoardColumnWireRow {
+        BoardColumnWireRow {
+            health: Some(ColumnHealthWireRow {
+                services_role: role.map(str::to_string),
+                wip_limit: None,
+                wip_active: 0,
+                role_agents,
+                role_agents_free,
+                stuck: 0,
+            }),
+            ..col(id, name, None, false, Vec::new())
+        }
+    }
+
+    /// The default six-stage pipeline: Backlog and Done ungated, QA's `tester`
+    /// role held by nobody (its dot is the RED `✗`), every other stage green.
+    fn six_stage_pipeline() -> BoardsListResult {
+        BoardsListResult {
+            boards: vec![BoardWireRow {
+                id: "b1".into(),
+                name: "Pipeline".into(),
+                auto_move: false,
+                columns: vec![
+                    gated_col("c0", "Backlog", None, 0, 0),
+                    gated_col("c1", "Triage", Some("triager"), 1, 1),
+                    gated_col("c2", "Implement", Some("implementer"), 1, 1),
+                    gated_col("c3", "Review", Some("reviewer"), 1, 1),
+                    gated_col("c4", "QA", Some("tester"), 0, 0),
+                    gated_col("c5", "Done", None, 0, 0),
+                ],
+                unmapped: Vec::new(),
+            }],
+        }
+    }
+
+    /// The symbol painted at `(x, y)`, last write winning (the buffer is sparse
+    /// and append-only, so the dot overpaint is the LAST cell at its coord).
+    fn cell_at(buf: &WireBuffer, x: u16, y: u16) -> Option<&Cell> {
+        buf.cells
+            .iter()
+            .rev()
+            .find(|(coord, _)| coord.x == x && coord.y == y)
+            .map(|(_, cell)| cell)
+    }
+
+    /// The role dot must land on the stage it describes AFTER the board scrolls
+    /// horizontally.
+    ///
+    /// At 80 cells the six-stage pipeline only fits five columns (`col_w =
+    /// max(80/6, 14) = 14`, `visible_cols = 5`), so focusing `Done` slides the
+    /// painted window to `first_col = 1` and `render_card_board` returns only the
+    /// painted window. Zipping the canonical `board.columns` against that window
+    /// shifts every dot one stage LEFT: QA's red `✗` paints on Done's header and
+    /// Review's green `●` on QA's, i.e. exactly the inversion of the signal this
+    /// strip exists to give, and both glyphs are legitimate output, so nothing
+    /// looks wrong.
+    #[test]
+    fn role_dots_stay_on_their_own_stage_when_the_board_scrolls() {
+        let mut state = BoardsState::from_snapshot(&six_stage_pipeline());
+        // Walk the column cursor to Done (index 5): one arrow key past the
+        // window, which is what slides it.
+        for _ in 0..5 {
+            state = reduce_boards(&state, BoardsEvent::FocusRight).state;
+        }
+        assert_eq!(state.focus().1, 5, "focused on Done");
+
+        let mut buf = WireBuffer::new(80, 16);
+        render_boards(&mut buf, 80, 0, 16, &state);
+
+        // Title row 0, health strip row 1 (this board IS a pipeline), hint band
+        // row 2, so the card board's header row is row 3.
+        let header_y = 3;
+        let map = painted(&buf);
+        assert!(
+            map.contains("QA"),
+            "QA is inside the painted window:\n{map}"
+        );
+
+        // The window starts at canonical column 1 (Triage), 14 cells per column:
+        // Triage@0, Implement@14, Review@28, QA@42, Done@56.
+        let qa_x = 42;
+        let done_x = 56;
+        assert_eq!(
+            cell_at(&buf, qa_x, header_y).map(|c| c.symbol.as_str()),
+            Some("✗"),
+            "QA has no tester, so ITS header carries the red ✗:\n{map}"
+        );
+        assert_eq!(
+            cell_at(&buf, qa_x, header_y).and_then(|c| c.fg),
+            Some(RED),
+            "and it is red, not the header accent"
+        );
+        assert_ne!(
+            cell_at(&buf, done_x, header_y).map(|c| c.symbol.as_str()),
+            Some("✗"),
+            "Done is ungated, so it must never inherit QA's failure glyph:\n{map}"
+        );
+        assert_eq!(
+            cell_at(&buf, 0, header_y).map(|c| c.symbol.as_str()),
+            Some("●"),
+            "the leftmost painted stage is Triage, whose triager is free:\n{map}"
         );
     }
 }


### PR DESCRIPTION
Fixes the P1 and the four P2s an Opus review found on merged PR #576
(`feat(hangar): pipeline health strip + per-stage prompt addendum`, 1f711da8).
Each finding got a test that was watched FAIL against the shipped code before
the fix landed. The P3s from the same review are deliberately out of scope.

## 1 (P1) Health dots rendered on the wrong stage once the board scrolled

`paint_role_dots` zipped the canonical `board.columns` against the layout
`render_card_board` returned, but that layout holds only the PAINTED WINDOW,
which starts at `first_col` once the board scrolls horizontally. Every dot was
shifted left by `first_col`.

At the documented 80-cell floor the default six-stage pipeline fits five columns
(`col_w = max(80/6, MIN_COL_W) = 14`, `visible_cols = 5`), so moving the column
cursor to `Done` slides the window to `first_col = 1`. With no agent holding
`tester`, QA's red `✗` painted on the DONE header and Review's green `●` on QA's:
the exact inversion of the signal the strip exists to give, silent because both
glyphs are legitimate output, and reachable with one arrow key.

The walk is now over the layout, indexing back through `ColumnLayout::index`,
the canonical position the widget already carries for hit-testing.

There was previously no test over the TUI half at all. `boards.rs` now has one
that scrolls the board and asserts the glyph and its colour land on QA, and that
Done does not inherit them. Against the old zip it fails with
`left: Some("●") right: Some("✗")` and a painted board showing `✗ Done (0)`.

## 2 (P2) The stage prompt could come from the wrong board

`stage_prompt_for_issue` selected from ANY board carding the issue, filtered only
on a non-empty `stage_prompt` and ordered by `bc.board_id`. An issue carded on
both the pipeline board and a personal kanban board got the personal board's
`Doing` text injected into the dispatch brief, and the winner was whichever ULID
sorted lower, i.e. board creation order.

The lookup is now constrained to boards carrying at least one role-gated column
(0074), which is what "the board that gates dispatch" means, and the gating
column is preferred within that board so the remaining tie-break is meaningful.

New test: an issue carded on both boards. Against the old query it fails with
`My kanban note: remember to water the plants.` at the head of the brief.

**One correction to the review.** It said "the pulled card's board is known at
dispatch time; constrain the query to it." It is known at PULL time
(`PulledCard::board_id`) and discarded there: `agent_task_queue` has no
`board_id` column, and `execute_claimed` reaches `build_prompt` with only the
`Task` row. Literally constraining to the pulled card's board would need a schema
change plus a matching answer for push-dispatched (`card_run`) tasks, which is
past the scope this PR was kept to. The pipeline-board constraint fixes the
reported failure without one. Residual: two pipeline boards carding the same
issue still tie-break on `board_id`.

## 3 (P2) `health` was emitted on every column of every board

`pipeline_health::snapshot` returns a row for every column of the board, so the
`find` in `boards_list` always matched and every plain kanban column shipped
`"health":{"wip_active":0,"role_agents":0,"role_agents_free":0,"stuck":0}`. The
#576 body's claim that it is "omitted entirely on a non-pipeline board" was
false. Now filtered on `services_role`.

The assertion meant to pin this (`ainb-hangar-proto`) builds a
`BoardColumnWireRow { health: None, .. }` by hand: it tests `skip_serializing_if`
and nothing more, which is why it stayed green. Its comment now says so, and the
producer is pinned where the producer lives, by a `boards_list` test over a real
store with one pipeline board and one plain kanban board. Against the old
producer it fails listing `("Todo", Some(ColumnHealthWireRow {...}))`,
`("Doing", Some(...))`.

## 4 (P2) The padding test was vacuous

`lights_are_coloured_and_padding_ignores_escapes` had a single-stage fixture, so
there was no `│` separator and the only padded region was end-of-line, which
`stage_strip` trims away in both the colour and no-colour path. The assertion
reduced to `"tester ✗" == "tester ✗"`.

The width maths itself is correct, so only the test changed: a second stage puts
an interior cell in front of a separator, the plain strip is pinned exactly, and
every stripped colour row is compared against it.

Verified against the mutation it exists to catch (padding taken off the rendered,
escape-laden width instead of the plain width): the new test fails on
`"QA │ Review"` vs `"QA          │ Review"`, while the single-stage version of
the same assertion, run side by side under the same mutation, still passes.

## 5 (P2) Health snapshot cost on every board refresh

`boards_list` folded health for every board in the workspace, and the Boards
screen re-arms it on every pushed daemon event. `role_agents_free` counts each
candidate agent's active tasks with a correlated subquery over
`agent_task_queue`, once per (column x agent): thirty evaluations per refresh for
a six-column board with five agents, over a table that grows without bound with
task history.

Both mitigations:

- **Skip the fold** on a board with no role-gated column, via a new
  `snapshot_if_pipeline`. The probe is served by 0074's `idx_board_column_pull`,
  partial on exactly that predicate.
- **Migration 0077** indexes `agent_task_queue (agent_id, status)`. Nothing
  indexed `agent_id`: `idx_one_pending_task_per_issue_agent` is partial on
  `status IN ('queued','dispatched')` so it cannot serve `'running'`, and
  `idx_task_issue_status` leads on `issue_id`. Deliberately not partial, so it
  keeps serving both callers if `ACTIVE_STATUSES` ever changes.

`EXPLAIN QUERY PLAN` on the exact predicate, asserted in the test: `SCAN r`
without the migration, `SEARCH r USING COVERING INDEX idx_task_agent_status
(agent_id=? AND status=?)` with it. The pull statement carries the same predicate
and gets the same win.

## Not in scope

The review's P3s are left for separate triage: the WIP-light tiebreak divergence
between CLI and TUI, `cell_width` counting chars rather than display width (the
`⏳` wide-char issue), the `stage-prompt` bare-invocation wipe, the dropped `EXCL`
column, `NO_COLOR`, the `Loading`-reads-green daemon light, and the `ptr::eq` in
`stage_name`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pipeline health indicators so they appear only on applicable pipeline boards and role-gated stages.
  * Prevented personal kanban board content from affecting pipeline stage prompts.
  * Fixed health indicators shifting to neighboring stages when horizontally scrolling.
  * Ensured boards without health data remain cleanly serialized without empty annotations.

* **Performance**
  * Improved responsiveness when calculating active task counts for pipeline health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->