### PR TITLE
fix(hangar): close the pull-pipeline review findings from #547

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -5180,6 +5180,10 @@ async fn run_squad_instructions(store: &Store, args: SquadInstructionsArgs) -> R
 /// `agent` member) — the daemon-free proof of the same service the RPC drives.
 /// `--invoker` names the user the gap #8 invocation gate judges every dispatch
 /// target by; omitted, the service resolves the workspace owner.
+///
+/// The run GENERATION is resolved here, exactly as the RPC handler does, so a
+/// dispatch of a card that has run before sits at the issue's new max rather
+/// than under its history.
 async fn run_squad_assign(store: &Store, args: SquadAssignArgs) -> Result<()> {
     use ainb_hangar_core::ids::WorkspaceId;
     use ainb_hangar_store::service::squad_assign::{SquadAssignRequest, SquadAssignService};
@@ -5190,11 +5194,28 @@ async fn run_squad_assign(store: &Store, args: SquadAssignArgs) -> Result<()> {
         Some(token) => Some(resolve_user_id(store, token).await?),
         None => None,
     };
+    // Mint the run generation the same way the RPC path does
+    // (`squad_assign_generation`). Leaving it at the `0` default silently stamps
+    // the whole dispatch BELOW the issue's existing `MAX(generation)` whenever
+    // the card has run before, and every generation-scoped fold (the aggregate
+    // terminal state, the blocker-finished predicate, the auto-move) reads that
+    // max and looks at that generation alone. A `--redundant 3` cluster at 0
+    // behind a stage that finished at 1 is therefore invisible: the blocker reads
+    // as finished and a dependent card auto-runs while three implementations are
+    // still live.
+    let generation = match args.issue.as_deref() {
+        Some(issue_id) => TaskRepo::next_generation_for_issue(store.pool(), issue_id)
+            .await
+            .context("resolve the run generation")?,
+        // An issueless ad-hoc dispatch has no history to sit behind.
+        None => 0,
+    };
     let request = SquadAssignRequest {
         issue_id: args.issue.as_deref(),
         work_dir: args.work_dir.as_deref(),
         priority: args.priority,
         invoker: invoker.as_deref(),
+        generation,
         // The CLI assign carries no card repo/agent (tcp T4): the task runs in-tree,
         // exactly the pre-T4 behaviour.
         ..SquadAssignRequest::default()

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -5289,10 +5289,14 @@ fn squad_assign_cli_err(
         SquadAssignError::MemberAgentMissing(id) => {
             anyhow::anyhow!("squad member agent `{id}` not found")
         }
-        // Two pre-flight refusals that write NO task row: the gap-#8 invocation
-        // gate, and the parity-#26 archived-squad guard. Both are surfaced
-        // verbatim so the CLI exits non-zero with the store's own reason.
-        e @ (SquadAssignError::NotInvocable { .. } | SquadAssignError::Archived(_)) => {
+        // Pre-flight refusals that write NO task row: the gap-#8 invocation gate,
+        // the parity-#26 archived-squad guard, and the two stage guards a
+        // `--redundant` cluster is subject to on a role-gated card. All are
+        // surfaced verbatim so the CLI exits non-zero with the store's own reason.
+        e @ (SquadAssignError::NotInvocable { .. }
+        | SquadAssignError::Archived(_)
+        | SquadAssignError::ActiveRun(_)
+        | SquadAssignError::StageRoleUnheld { .. }) => {
             anyhow::anyhow!("{e}")
         }
         db @ SquadAssignError::Db(_) => anyhow::Error::new(db).context("squad assign failed"),

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -2642,3 +2642,187 @@ fn issue_subscribe_rejects_a_malformed_actor() {
     assert!(!ok, "a malformed actor must exit non-zero; out={out}");
     assert!(out.contains("bad --actor"), "the refusal text:\n{out}");
 }
+
+/// Seed a runtime and `count` agents into the test's hangar db, returning their
+/// ids. Mirrors [`seed_agent`]'s open-the-same-file pattern; must run AFTER a
+/// verb that bootstraps the workspace.
+fn seed_agents(home: &std::path::Path, count: usize) -> Vec<String> {
+    use ainb_hangar_store::Store;
+    use ainb_hangar_store::repo::agent::{Agent, AgentRepo};
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let store = Store::open_in(home).await.expect("open hangar db");
+        let pool = store.pool();
+        let workspace_id: String = sqlx::query_scalar("SELECT id FROM workspace LIMIT 1")
+            .fetch_one(pool)
+            .await
+            .expect("default workspace exists");
+        let owner_id: String = sqlx::query_scalar("SELECT id FROM user LIMIT 1")
+            .fetch_one(pool)
+            .await
+            .expect("default owner exists");
+        sqlx::query(
+            "INSERT INTO agent_runtime \
+             (id, workspace_id, daemon_id, provider, runtime_mode, status) \
+             VALUES ('rt-1', ?, 'daemon-1', 'claude', 'local', 'online')",
+        )
+        .bind(&workspace_id)
+        .execute(pool)
+        .await
+        .expect("insert runtime");
+        let mut ids = Vec::new();
+        for n in 0..count {
+            let id = format!("agent-{n}");
+            AgentRepo::insert(
+                pool,
+                &Agent {
+                    id: id.clone(),
+                    workspace_id: workspace_id.clone(),
+                    name: format!("Builder {n}"),
+                    runtime_id: "rt-1".into(),
+                    instructions: None,
+                    visibility: "workspace".into(),
+                    permission_mode: "private".into(),
+                    owner_id: owner_id.clone(),
+                    ..Agent::default()
+                },
+            )
+            .await
+            .expect("insert agent");
+            ids.push(id);
+        }
+        ids
+    })
+}
+
+/// Insert a PRIOR, already-finished run on `issue_id` at `generation`, so the
+/// issue's `MAX(generation)` is non-zero before the CLI dispatches again.
+fn seed_finished_run(home: &std::path::Path, issue_id: &str, agent_id: &str, generation: i64) {
+    use ainb_hangar_store::Store;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let store = Store::open_in(home).await.expect("open hangar db");
+        let workspace_id: String = sqlx::query_scalar("SELECT id FROM workspace LIMIT 1")
+            .fetch_one(store.pool())
+            .await
+            .expect("default workspace exists");
+        sqlx::query(
+            "INSERT INTO agent_task_queue \
+             (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, generation) \
+             VALUES ('t-prior', ?, 'rt-1', ?, ?, 'done', 0, ?)",
+        )
+        .bind(&workspace_id)
+        .bind(agent_id)
+        .bind(issue_id)
+        .bind(generation)
+        .execute(store.pool())
+        .await
+        .expect("insert prior run");
+    });
+}
+
+/// Read `(generation, run_group)` for every task on `issue_id`, oldest id first.
+fn task_generations(home: &std::path::Path, issue_id: &str) -> Vec<(i64, Option<String>)> {
+    use ainb_hangar_store::Store;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let store = Store::open_in(home).await.expect("open hangar db");
+        sqlx::query_as(
+            "SELECT generation, run_group FROM agent_task_queue \
+              WHERE issue_id = ? ORDER BY id",
+        )
+        .bind(issue_id)
+        .fetch_all(store.pool())
+        .await
+        .expect("read generations")
+    })
+}
+
+/// `hangar squad assign --redundant N` must stamp a RESOLVED generation, never
+/// the `0` sentinel.
+///
+/// Every generation-scoped fold (the aggregate terminal state, the
+/// blocker-finished predicate, the auto-move) reads `MAX(generation)` for the
+/// issue and looks at that generation ALONE, so a cluster stamped `0` behind a
+/// prior run at generation 1 sits BELOW the max and is invisible to all of them.
+/// The concrete harm: `unfinished_blockers_of` probes generation 1, sees the
+/// prior stage done with nothing active, declares the blocker finished, and a
+/// dependent card auto-runs while three implementations are still live.
+///
+/// The RPC path resolves this correctly (`squad_assign_generation`); the CLI
+/// built its request with `..SquadAssignRequest::default()`, which yields
+/// `generation: 0`.
+#[test]
+fn squad_assign_redundant_stamps_a_resolved_generation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let issue = create_issue(tmp.path(), "Blocker card");
+    let agents = seed_agents(tmp.path(), 3);
+    // A prior stage of this same card already ran and finished at generation 1.
+    seed_finished_run(tmp.path(), &issue, &agents[0], 1);
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "squad",
+            "create",
+            "shippers",
+            "--leader",
+            &format!("agent:{}", agents[0]),
+        ],
+    );
+    assert!(ok, "squad create should exit 0; out={out}");
+    let squad_id = out
+        .lines()
+        .find_map(|l| l.split('(').nth(1).and_then(|s| s.split(')').next()))
+        .expect("create output carries the squad id")
+        .to_string();
+    for agent in &agents[1..] {
+        let (ok, out) = run(
+            tmp.path(),
+            &[
+                "hangar",
+                "squad",
+                "add-member",
+                &squad_id,
+                "--member",
+                &format!("agent:{agent}"),
+            ],
+        );
+        assert!(ok, "add-member should exit 0; out={out}");
+    }
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "squad",
+            "assign",
+            &squad_id,
+            "--issue",
+            &issue,
+            "--redundant",
+            "3",
+        ],
+    );
+    assert!(ok, "squad assign --redundant should exit 0; out={out}");
+
+    let rows = task_generations(tmp.path(), &issue);
+    let cluster: Vec<i64> =
+        rows.iter().filter(|(_, group)| group.is_some()).map(|(gen, _)| *gen).collect();
+    assert_eq!(cluster.len(), 3, "three clustered runs:\n{rows:?}");
+    let max = rows.iter().map(|(gen, _)| *gen).max().expect("tasks exist");
+    assert!(
+        cluster.iter().all(|gen| *gen == max),
+        "the cluster must sit at the issue's MAX(generation) or every \
+         generation-scoped fold looks straight past it; rows={rows:?}"
+    );
+    assert!(
+        cluster.iter().all(|gen| *gen > 1),
+        "the cluster must be a NEW generation, above the prior run's 1; \
+         rows={rows:?}"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/board.rs
@@ -212,6 +212,14 @@ pub async fn advance_issue_lifecycle_after_transition(
 /// [`advance_issue_lifecycle_after_transition`], which no-ops on `failed` /
 /// `cancelled`), so a failed or still-running set never advances the issue.
 ///
+/// # A finished STAGE is not a finished ISSUE
+///
+/// A pipeline card crosses several role-gated stages, each its own run. The
+/// `done` aggregate of ONE stage therefore does not mean the issue is done, and
+/// promoting on it marked a card `done` with Review and QA still to go. The
+/// promotion is held back while [`pipeline_stages_remain`] reports a role-gated
+/// column to the right of where the card now sits.
+///
 /// Best-effort — every fault is logged and swallowed (the task's terminal state
 /// has already committed).
 pub async fn advance_issue_lifecycle_after_terminal(pool: &SqlitePool, task: &Task) {
@@ -227,9 +235,68 @@ pub async fn advance_issue_lifecycle_after_terminal(pool: &SqlitePool, task: &Ta
     match TaskRepo::issue_aggregate_terminal_state(pool, ws.as_str(), issue_id).await {
         // Active set not drained — a sibling still runs; do not advance yet.
         Ok(None) => {}
-        Ok(Some(state)) => advance_issue_lifecycle_after_transition(pool, task, &state).await,
+        Ok(Some(state)) => {
+            // A pipeline card completes ONE STAGE at a time, and a stage is not
+            // the issue. Promoting on the first stage's aggregate marked the
+            // issue `done` with Review and QA still to run, so it rendered Done
+            // on the default Kanban and in `hangar/issues_list` three stages
+            // early. `is_terminal()` then FROZE it there, so the remaining stages
+            // could never move it again.
+            //
+            // This runs AFTER `auto_move_after_terminal` at every call site, so
+            // the card has already advanced: "a role-gated column to the right of
+            // where the card now sits" means stages remain. A card that has
+            // reached the pipeline's terminal column has none, and advances
+            // normally. Every non-pipeline issue (no card, or a board with no
+            // role-gated columns) answers false and is unaffected.
+            if state == "done" && pipeline_stages_remain(pool, issue_id).await {
+                tracing::info!(
+                    task_id = %task.id,
+                    issue_id = %issue_id,
+                    "issue lifecycle: stage finished but the card has stages left; staying In Progress"
+                );
+                return;
+            }
+            advance_issue_lifecycle_after_transition(pool, task, &state).await;
+        }
         Err(e) => {
             tracing::warn!(error = %e, task_id = %task.id, "issue lifecycle terminal advance: aggregate read failed");
+        }
+    }
+}
+
+/// Whether `issue_id`'s card still has a ROLE-GATED column to its RIGHT, i.e.
+/// the pipeline has stages left to run.
+///
+/// `false` for an issue on no board, an issue on a board with no role-gated
+/// columns (every board predating migration 0074), and a card that has reached
+/// the terminal column of its pipeline. Those are exactly the cases where the
+/// task's terminal outcome IS the issue's outcome.
+///
+/// Best-effort like every hook in this module: a store fault answers `false`, so
+/// a fault degrades to the pre-existing behaviour (advance the issue) rather
+/// than stranding an issue at `in_progress` forever.
+async fn pipeline_stages_remain(pool: &SqlitePool, issue_id: &str) -> bool {
+    let found: Result<Option<i64>, _> = sqlx::query_scalar(
+        "SELECT 1 FROM board_card AS bc \
+           JOIN board_column AS cur ON cur.id = bc.column_id \
+          WHERE bc.issue_id = ?1 \
+            AND EXISTS ( \
+                 SELECT 1 FROM board_column AS n \
+                  WHERE n.board_id = bc.board_id \
+                    AND n.services_role IS NOT NULL \
+                    AND n.ord > cur.ord \
+                ) \
+          LIMIT 1",
+    )
+    .bind(issue_id)
+    .fetch_optional(pool)
+    .await;
+    match found {
+        Ok(row) => row.is_some(),
+        Err(e) => {
+            tracing::warn!(error = %e, issue_id = %issue_id, "issue lifecycle: reading remaining stages failed; treating the issue as complete");
+            false
         }
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5661,6 +5661,15 @@ fn squad_assign_err(e: &ainb_hangar_store::service::squad_assign::SquadAssignErr
         SquadAssignError::Archived(id) => invalid_params(&format!(
             "squad `{id}` is archived — restore it before assigning work"
         )),
+        // The two stage guards a `--redundant` cluster is subject to on a
+        // role-gated card. Client errors: the operator waits for the live run, or
+        // grants an agent the stage's role, and re-issues.
+        SquadAssignError::ActiveRun(id) => invalid_params(&format!(
+            "card `{id}` already has a run in flight; let it finish before asking for redundancy"
+        )),
+        SquadAssignError::StageRoleUnheld { role, squad_id } => invalid_params(&format!(
+            "no agent in squad `{squad_id}` holds the role `{role}` this card's stage services"
+        )),
         SquadAssignError::Db(db) => store_err(db),
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/issue_lifecycle_advances_on_task_fsm.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/issue_lifecycle_advances_on_task_fsm.rs
@@ -216,3 +216,93 @@ async fn null_issue_chat_task_advance_is_a_noop() {
         "a null-issue chat task leaves every issue untouched"
     );
 }
+
+/// Provision the default six-stage pipeline in the fixture's workspace and park
+/// `issue-1`'s card in the column named `column`.
+async fn park_issue1_in_pipeline(pool: &SqlitePool, column: &str) {
+    use ainb_hangar_core::clock::FixedClock;
+    use ainb_hangar_core::idgen::SystemIdGen;
+    use ainb_hangar_core::ids::WorkspaceId;
+    use ainb_hangar_store::service::pipeline::PipelineService;
+
+    let ws = WorkspaceId::from_str(WS_ID.to_string()).expect("workspace id");
+    PipelineService::provision_default(pool, &ws, &SystemIdGen, &FixedClock(0))
+        .await
+        .expect("provision the pipeline");
+    let (board_id, column_id): (String, String) = sqlx::query_as(
+        "SELECT b.id, c.id FROM board AS b JOIN board_column AS c ON c.board_id = b.id \
+          WHERE b.workspace_id = ?1 AND c.name = ?2",
+    )
+    .bind(WS_ID)
+    .bind(column)
+    .fetch_one(pool)
+    .await
+    .expect("the pipeline column exists");
+    sqlx::query("DELETE FROM board_card WHERE issue_id = 'issue-1'")
+        .execute(pool)
+        .await
+        .expect("clear any seeded card");
+    sqlx::query(
+        "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+         VALUES (?1, 'issue-1', ?2, 0, 0)",
+    )
+    .bind(&board_id)
+    .bind(&column_id)
+    .execute(pool)
+    .await
+    .expect("park the card");
+}
+
+/// A card MID-PIPELINE must not render as Done.
+///
+/// The lifecycle advance promoted the issue to `done` the moment the FIRST
+/// stage's aggregate landed, and `is_terminal()` then froze it there. So a card
+/// that had only finished Implement, with Review and QA still to run, already
+/// rendered Done on the default Kanban and in `hangar/issues_list`. Worse, the
+/// terminal freeze meant the remaining stages could never move it again.
+#[tokio::test]
+async fn a_card_mid_pipeline_does_not_render_done() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_p4_fixture(store.pool()).await.unwrap();
+    let pool = store.pool();
+    // The Implement stage has just finished, so the card has ADVANCED into
+    // Review. Two stages remain.
+    park_issue1_in_pipeline(pool, "Review").await;
+
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_transition(pool, &task, "running").await;
+    set_task1_status(pool, "done").await;
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_terminal(pool, &task).await;
+
+    assert_eq!(
+        issue1_state(pool).await,
+        "in_progress",
+        "Review and QA are still to run, so the issue is not Done"
+    );
+}
+
+/// The other side of the same rule: a card that has reached the pipeline's
+/// TERMINAL column has no stage left, so its issue does advance to Done.
+#[tokio::test]
+async fn a_card_at_the_end_of_the_pipeline_does_render_done() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open_in(dir.path()).await.unwrap();
+    seed_p4_fixture(store.pool()).await.unwrap();
+    let pool = store.pool();
+    // QA finished and the card advanced into the ungated Done column.
+    park_issue1_in_pipeline(pool, "Done").await;
+
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_transition(pool, &task, "running").await;
+    set_task1_status(pool, "done").await;
+    let task = task1(pool).await;
+    advance_issue_lifecycle_after_terminal(pool, &task).await;
+
+    assert_eq!(
+        issue1_state(pool).await,
+        "done",
+        "the card walked the whole pipeline, so the issue is Done"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0077_task_board_column.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0077_task_board_column.sql
@@ -1,0 +1,52 @@
+-- Hangar v1 schema, migration 0077: record WHICH pipeline stage a task served.
+--
+-- Closes the FINALIZE WINDOW that let one pipeline stage execute TWICE.
+--
+-- 0074 made a role-gated board column a pull queue and
+-- `PullService::advance_after_stage` the handoff to the next one. But the two
+-- writes are not one transaction and cannot be: the task row commits `done` in
+-- the claim loop's finalize, then four awaited best-effort steps run (usage
+-- persist, run branch, run history, the `TaskFinished` event), and only then
+-- does `auto_move_after_terminal` reach the advance. Execution is spawned off
+-- the main loop, so the pull tick runs concurrently on its 1000ms timer and
+-- observes the card in between: terminal task, card still parked in the column
+-- it just ran in.
+--
+-- In that window every one of 0074's predicates passes. The one-owner guard
+-- reads the ACTIVE set (`queued`/`dispatched`/`running`) and a `done` task is
+-- not in it. `excludes_prior_agent` is 0 on Implement, so the SAME implementer
+-- re-pulls the card it just finished and a second full Implement run starts; on
+-- Review and QA the flag only excludes the agent that already holds a `done`
+-- row, so a DIFFERENT reviewer double-reviews. `advance_after_stage` then sees
+-- an active task and refuses, so the card sits until the duplicate drains.
+--
+-- The missing fact is WHICH COLUMN a task served. Without it "this issue has a
+-- `done` task at the current generation" cannot be told apart from "the advance
+-- already happened and the next stage is legitimately waiting to be pulled":
+-- both look identical from `agent_task_queue` alone, and a guard written on the
+-- generation alone would freeze every pipeline at its first stage.
+--
+-- With the stage recorded, the pull statement asks the precise question: does
+-- the card's CURRENT column already hold a `done` task at the card's CURRENT
+-- generation? In the finalize window the answer is yes and the card is skipped;
+-- once advanced, the card sits in a DIFFERENT column and the answer is no.
+-- Scoping to the current generation is what keeps a re-enqueued card (moved back
+-- to an earlier stage for another pass) pullable rather than frozen by its own
+-- history.
+--
+-- Additive `ALTER TABLE ... ADD COLUMN` with no default, the O(1) catalog change
+-- 0074 and 0076 used, safe on a populated home. NULL is meaningful and means
+-- "this task did not come from a board column": every pre-existing row, and
+-- every task written by the push paths (`run_card`, the squad leader brief, an
+-- infra retry) that never consulted a board. Only the pull statement writes it,
+-- so only a pull is subject to the finished-stage guard.
+ALTER TABLE agent_task_queue ADD COLUMN board_column_id TEXT;
+
+-- The guard's probe: given a candidate card, "does this issue have a `done` task
+-- in THIS column?". `(issue_id, board_column_id)` is the selective prefix and
+-- `status` completes the probe inside the index rather than fetching each row.
+-- Partial, so the NULL `board_column_id` of every push-path task, which is the
+-- overwhelming majority of the table, stays out of the index entirely.
+CREATE INDEX idx_task_issue_board_column
+    ON agent_task_queue (issue_id, board_column_id, status)
+    WHERE board_column_id IS NOT NULL;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0078_task_board_column.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0078_task_board_column.sql
@@ -1,4 +1,4 @@
--- Hangar v1 schema, migration 0077: record WHICH pipeline stage a task served.
+-- Hangar v1 schema, migration 0078: record WHICH pipeline stage a task served.
 --
 -- Closes the FINALIZE WINDOW that let one pipeline stage execute TWICE.
 --

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -155,6 +155,50 @@ impl PullService {
         idgen: &dyn IdGen,
         clock: &dyn HangarClock,
     ) -> Result<Option<PulledCard>, sqlx::Error> {
+        Self::pull(pool, runtime_id, None, idgen, clock).await
+    }
+
+    /// Pull ONE eligible card for `runtime_id`, constrained to `issue_id`.
+    ///
+    /// Identical to [`Self::pull_for_runtime`] in every predicate; it merely
+    /// refuses to answer with a different card. The daemon's idle tick wants the
+    /// unconstrained form (take the most urgent work anywhere), but a caller that
+    /// just enqueued ONE card and needs to report the task that owns THAT card
+    /// must not be handed whatever the board ranked first: the pull orders by
+    /// `col.ord DESC` ("pull from the right"), so a card already sitting in a
+    /// LATER stage outranks the one just placed in the first, and its task id
+    /// would flow out as the dispatch's answer.
+    ///
+    /// Returns `Ok(None)` when this card specifically is not pullable right now,
+    /// which is the ordinary "enqueued, waiting for an eligible agent" case.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the statement or a row decode fails.
+    #[tracing::instrument(
+        name = "card.pull_issue",
+        skip(pool, idgen, clock),
+        fields(runtime_id = %runtime_id, issue_id = %issue_id, task_id = tracing::field::Empty, services_role = tracing::field::Empty)
+    )]
+    pub async fn pull_issue_for_runtime(
+        pool: &SqlitePool,
+        runtime_id: &str,
+        issue_id: &str,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+    ) -> Result<Option<PulledCard>, sqlx::Error> {
+        Self::pull(pool, runtime_id, Some(issue_id), idgen, clock).await
+    }
+
+    /// The shared body of both pull entry points. `only_issue = None` is the
+    /// unconstrained board-wide pull; `Some(id)` narrows it to one card.
+    async fn pull(
+        pool: &SqlitePool,
+        runtime_id: &str,
+        only_issue: Option<&str>,
+        idgen: &dyn IdGen,
+        clock: &dyn HangarClock,
+    ) -> Result<Option<PulledCard>, sqlx::Error> {
         let task_id = idgen.new_ulid();
         let now = clock.now_ms();
 
@@ -162,6 +206,7 @@ impl PullService {
             .bind(&task_id)
             .bind(now)
             .bind(runtime_id)
+            .bind(only_issue)
             .fetch_optional(pool)
             .await?;
 
@@ -298,7 +343,12 @@ RETURNING board_id, column_id";
 /// The atomic pull statement: select the most urgent pullable `(card, agent)`
 /// pair for the runtime and INSERT its `queued` task row in one statement.
 ///
-/// `?1` = new task id, `?2` = `created_at` (now), `?3` = `runtime_id`.
+/// `?1` = new task id, `?2` = `created_at` (now), `?3` = `runtime_id`, `?4` =
+/// an OPTIONAL issue to narrow to (NULL = the whole board).
+///
+/// `?4` keeps the constrained and unconstrained pulls ONE statement rather than
+/// two that can drift: a caller that just enqueued one card and must report the
+/// task owning THAT card gets exactly the same six predicates, only narrower.
 ///
 /// `agent_kind` is derived from the PULLING AGENT, not from the card. Under pull
 /// the agent is chosen per stage, so the provider CLI that runs the stage must be
@@ -377,6 +427,7 @@ SELECT ?1, \
   JOIN issue AS i ON i.id = bc.issue_id \
   JOIN agent AS a ON a.workspace_id = bd.workspace_id \
  WHERE col.services_role IS NOT NULL \
+   AND (?4 IS NULL OR bc.issue_id = ?4) \
    AND a.runtime_id = ?3 \
    AND a.archived = 0 \
    AND i.state NOT IN ('closed','cancelled') \

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -63,7 +63,7 @@
 //!    other predicate passes (predicate 3 reads the ACTIVE set, and a `done`
 //!    task is not in it). Without this the same implementer re-pulls the card it
 //!    just finished, and a different reviewer double-reviews. `board_column_id`
-//!    (migration 0077) is what makes the question answerable; see that file for
+//!    (migration 0078) is what makes the question answerable; see that file for
 //!    why the generation alone is not enough. Scoping to the current generation
 //!    is what keeps a RE-ENQUEUED card, moved back to an earlier stage for
 //!    another pass, pullable rather than frozen by its own history.
@@ -398,7 +398,7 @@ RETURNING board_id, column_id";
 /// its pipeline. Without that half, adding `done` here would freeze every
 /// pipeline after its first stage.
 ///
-/// `board_column_id` (migration 0077) records WHICH STAGE the run serves. Only
+/// `board_column_id` (migration 0078) records WHICH STAGE the run serves. Only
 /// the pull writes it; every push-path task leaves it NULL. It exists so the
 /// finished-stage predicate can distinguish "this stage is done and the card has
 /// not advanced yet" (the finalize window, must not re-pull) from "the card DID

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -302,7 +302,16 @@ impl PullService {
 ///
 /// `?1` = `issue_id`. The new `ord` appends the card to the end of its target
 /// column, consistent with a manual `card_move` and with the auto-move hook.
-const ADVANCE_SQL: &str = "\
+///
+/// # Why this is `pub`
+///
+/// For the same reason [`PULL_SQL`] is: so the MUTATION PROOFS in
+/// `tests/pipeline_advance.rs` can delete exactly one guard and assert the
+/// corresponding refusal goes away. Every guard here is a REFUSAL, and a test
+/// that only ever runs the real statement proves the card stayed put; it cannot
+/// prove that the clause under test is what kept it there, and would keep
+/// passing if the clause were deleted and some other accident covered for it.
+pub const ADVANCE_SQL: &str = "\
 UPDATE board_card \
    SET column_id = ( \
         SELECT n.id FROM board_column AS n \

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -41,7 +41,7 @@
 //! agents can therefore never take the same card, and the guarantee holds across
 //! processes, not just across tasks in one daemon.
 //!
-//! # The five predicates
+//! # The six predicates
 //!
 //! A `(card, agent)` pair is *pullable* when ALL of these hold:
 //!
@@ -55,12 +55,24 @@
 //!    (`queued`/`dispatched`/`running`) task at all. This is strictly stronger
 //!    than the pre-existing per-(issue, agent) guard, and it is what makes
 //!    "exactly one task running per card" true rather than merely likely.
-//! 4. **Prior-agent exclusion.** On a column with `excludes_prior_agent = 1`, an
+//! 4. **The stage is not already finished.** The card's CURRENT column holds no
+//!    `done` task at the card's CURRENT generation. This is the FINALIZE WINDOW
+//!    guard: `done` commits in the claim loop's finalize, four awaited
+//!    best-effort steps run, and only then does the advance move the card, so a
+//!    concurrent pull tick sees a terminal stage on an unmoved card and every
+//!    other predicate passes (predicate 3 reads the ACTIVE set, and a `done`
+//!    task is not in it). Without this the same implementer re-pulls the card it
+//!    just finished, and a different reviewer double-reviews. `board_column_id`
+//!    (migration 0077) is what makes the question answerable; see that file for
+//!    why the generation alone is not enough. Scoping to the current generation
+//!    is what keeps a RE-ENQUEUED card, moved back to an earlier stage for
+//!    another pass, pullable rather than frozen by its own history.
+//! 5. **Prior-agent exclusion.** On a column with `excludes_prior_agent = 1`, an
 //!    agent that already holds a `done` task on this card may not take it. This
 //!    is the reviewer-is-never-the-implementer rule. Note the direction of
 //!    failure: if the only eligible agent implemented the card, the card WAITS
 //!    rather than being self-reviewed.
-//! 5. **Not blocked, and the agent has capacity.** Unfinished `card_dependency`
+//! 6. **Not blocked, and the agent has capacity.** Unfinished `card_dependency`
 //!    blockers make a card unpullable at every stage (the F7 refuse-run guard,
 //!    reused verbatim from
 //!    [`CardDependencyRepo::unfinished_blockers_of`](crate::repo::card_dependency::CardDependencyRepo::unfinished_blockers_of)),
@@ -315,6 +327,13 @@ RETURNING board_id, column_id";
 /// read across stages, so nothing new is introduced. The first stage of a card
 /// has no `done` predecessor and correctly chains to NULL.
 ///
+/// `board_column_id` (migration 0077) records WHICH STAGE the run serves. Only
+/// the pull writes it; every push-path task leaves it NULL. It exists so the
+/// finished-stage predicate can distinguish "this stage is done and the card has
+/// not advanced yet" (the finalize window, must not re-pull) from "the card DID
+/// advance and the next stage is waiting" (must pull). Read from
+/// `agent_task_queue` alone those two states are identical.
+///
 /// # Why this is `pub`
 ///
 /// So the MUTATION PROOFS in `tests/pull_role_gate.rs` can delete exactly one
@@ -327,7 +346,8 @@ RETURNING board_id, column_id";
 pub const PULL_SQL: &str = "\
 INSERT INTO agent_task_queue \
     (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, \
-     priority, generation, agent_kind, repo_ref, squad_id, parent_task_id) \
+     priority, generation, agent_kind, repo_ref, squad_id, parent_task_id, \
+     board_column_id) \
 SELECT ?1, \
        bd.workspace_id, \
        a.runtime_id, \
@@ -349,7 +369,8 @@ SELECT ?1, \
        i.squad_id, \
        (SELECT p.id FROM agent_task_queue AS p \
          WHERE p.issue_id = bc.issue_id AND p.status = 'done' \
-         ORDER BY p.generation DESC, p.finished_at DESC, p.id DESC LIMIT 1) \
+         ORDER BY p.generation DESC, p.finished_at DESC, p.id DESC LIMIT 1), \
+       bc.column_id \
   FROM board_card AS bc \
   JOIN board_column AS col ON col.id = bc.column_id \
   JOIN board AS bd ON bd.id = bc.board_id \
@@ -380,6 +401,14 @@ SELECT ?1, \
         SELECT 1 FROM agent_task_queue AS o \
          WHERE o.issue_id = bc.issue_id \
            AND o.status IN ('queued','dispatched','running') \
+       ) \
+   AND NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS f \
+         WHERE f.issue_id = bc.issue_id \
+           AND f.status = 'done' \
+           AND f.board_column_id = bc.column_id \
+           AND f.generation = (SELECT MAX(g4.generation) FROM agent_task_queue AS g4 \
+                                WHERE g4.issue_id = bc.issue_id) \
        ) \
    AND ( col.excludes_prior_agent = 0 OR NOT EXISTS ( \
         SELECT 1 FROM agent_task_queue AS p \

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -386,6 +386,18 @@ RETURNING board_id, column_id";
 /// read across stages, so nothing new is introduced. The first stage of a card
 /// has no `done` predecessor and correctly chains to NULL.
 ///
+/// The closed-issue guard names `done` FIRST because that is the token the
+/// codebase actually writes: `IssueLifecycle::as_str` produces `done`, and
+/// migration 0023 rewrote the stored legacy values forward. `closed` is kept
+/// only for the beads-sync reconciler, which still writes it. Listing `closed`
+/// alone made the guard inert for every hangar-native issue.
+///
+/// This guard is only safe because the lifecycle no longer promotes an issue to
+/// `done` when its FIRST stage lands: `advance_issue_lifecycle_after_terminal`
+/// holds the issue at `in_progress` until the card reaches the terminal column of
+/// its pipeline. Without that half, adding `done` here would freeze every
+/// pipeline after its first stage.
+///
 /// `board_column_id` (migration 0077) records WHICH STAGE the run serves. Only
 /// the pull writes it; every push-path task leaves it NULL. It exists so the
 /// finished-stage predicate can distinguish "this stage is done and the card has
@@ -439,7 +451,7 @@ SELECT ?1, \
    AND (?4 IS NULL OR bc.issue_id = ?4) \
    AND a.runtime_id = ?3 \
    AND a.archived = 0 \
-   AND i.state NOT IN ('closed','cancelled') \
+   AND i.state NOT IN ('done','cancelled','closed') \
    AND EXISTS ( \
         SELECT 1 FROM squad_member AS sm \
           JOIN squad AS sq ON sq.id = sm.squad_id \

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -128,6 +128,24 @@ pub enum SquadAssignError {
     /// phase, so NO task row is written — restore the squad to assign to it again.
     #[error("squad `{0}` is archived — restore it before assigning work")]
     Archived(String),
+    /// A `--redundant` cluster was asked for on a ROLE-GATED card that already
+    /// holds an active (`queued` / `dispatched` / `running`) task. Redundancy
+    /// REPLACES the single owner of a stage; it does not stack on top of one, so
+    /// this refuses rather than putting N more concurrent runs on a live stage.
+    /// Pre-flight, so NO row is written.
+    #[error("card `{0}` already has a run in flight; let it finish before asking for redundancy")]
+    ActiveRun(String),
+    /// A `--redundant` cluster was asked for on a ROLE-GATED card whose stage no
+    /// dispatch target services. Redundancy is redundancy WITHIN a stage, so
+    /// dispatching to whoever happened to be in the squad would be exactly the
+    /// role-blind dispatch migration 0074 ended. Pre-flight, so NO row is written.
+    #[error("no agent in squad `{squad_id}` holds the role `{role}` this card's stage services")]
+    StageRoleUnheld {
+        /// The stage's `board_column.services_role`.
+        role: String,
+        /// The squad that was asked to service it.
+        squad_id: String,
+    },
     /// An underlying store failure (resolve, lookup, or enqueue).
     #[error(transparent)]
     Db(#[from] sqlx::Error),
@@ -458,11 +476,10 @@ impl SquadAssignService {
     ///
     /// This is the explicit opt-in that keeps intentional parallelism alive now
     /// that [`Self::assign_fanout`] no longer broadcasts: N independent attempts
-    /// at one problem, or several reviewers over one artifact. The difference
-    /// from the removed defect is entirely in the intent and the evidence. A
-    /// broadcast was the DEFAULT, was unbounded (one run per member, however many
-    /// that happened to be), and left no trace saying the parallelism was wanted.
-    /// This is opt-in, explicitly capped at `copies`, and every row carries the
+    /// at one problem, or several reviewers over one artifact. A broadcast was
+    /// the DEFAULT, was unbounded (one run per member, however many that happened
+    /// to be), and left no trace saying the parallelism was wanted. This is
+    /// opt-in, explicitly capped at `copies`, and every row carries the
     /// `run_group` that identifies the cluster, so "why are there three runs on
     /// this card" is answerable from the row itself.
     ///
@@ -475,12 +492,37 @@ impl SquadAssignService {
     /// dependent stays blocked until the WHOLE cluster drains rather than
     /// unblocking on the first copy home.
     ///
+    /// # Redundancy is redundancy WITHIN A STAGE
+    ///
+    /// This writes rows directly rather than going through
+    /// [`PullService`](crate::service::pull::PullService), so it has to reproduce
+    /// the parts of the pull contract that still apply. On a card sitting in a
+    /// ROLE-GATED column it therefore:
+    ///
+    ///   * dispatches ONLY to agents that hold that column's `services_role`, and
+    ///     refuses outright when nobody does. Dispatching to whoever happened to
+    ///     be in the squad is the role-blind dispatch migration 0074 ended, and it
+    ///     would hand an Implement-stage card to a tester;
+    ///   * refuses a card that already holds an ACTIVE task. Redundancy REPLACES
+    ///     the single owner of a stage, it does not stack on top of one;
+    ///   * stamps each row's `board_column_id`, so the cluster is a stage like any
+    ///     other and the pull's finished-stage guard sees it.
+    ///
+    /// The WIP limit is DELIBERATELY not applied: exceeding the per-column cap is
+    /// the entire point of asking for redundancy, and unlike the other predicates
+    /// it protects throughput rather than correctness.
+    ///
+    /// A card that is NOT in a role-gated column (no pipeline provisioned, parked
+    /// in Backlog or Done, or an issueless ad-hoc dispatch) has no stage to gate
+    /// against, so it keeps the plain leader-plus-members behaviour.
+    ///
     /// # Errors
     ///
     /// The same rejections as [`Self::assign_fanout`]: an archived squad, a
     /// human / unknown / dangling leader, a dangling member ref, or a target the
-    /// effective invoker may not invoke. All are pre-flight, so a rejection
-    /// writes zero rows.
+    /// effective invoker may not invoke. Plus, on a role-gated card,
+    /// [`SquadAssignError::ActiveRun`] and [`SquadAssignError::StageRoleUnheld`].
+    /// All are pre-flight, so a rejection writes zero rows.
     pub async fn assign_redundant(
         pool: &SqlitePool,
         workspace: &WorkspaceId,
@@ -505,6 +547,22 @@ impl SquadAssignService {
         let invoker = Self::effective_invoker(pool, workspace, request).await?;
         Self::gate(pool, &leader, &invoker).await?;
 
+        // The STAGE this cluster serves, if the card is in a role-gated column.
+        // Resolved before any candidate work so a refusal costs one query.
+        let stage = match request.issue_id {
+            Some(issue_id) => Self::gated_stage_of(pool, workspace, issue_id).await?,
+            None => None,
+        };
+        if let (Some(issue_id), Some(_)) = (request.issue_id, stage.as_ref()) {
+            // Redundancy REPLACES the single owner of a stage rather than stacking
+            // on it: three more concurrent runs alongside a live one is the
+            // several-runs-on-one-card shape the pull pipeline exists to remove,
+            // and they would not even share the live run's generation.
+            if Self::has_active_task(pool, issue_id).await? {
+                return Err(SquadAssignError::ActiveRun(issue_id.to_string()));
+            }
+        }
+
         // Resolve + gate EVERY candidate before writing, so a bad member ref
         // rejects the whole cluster rather than leaving a partial fan-out. The
         // leader leads the candidate list, then distinct agent members in id
@@ -521,6 +579,26 @@ impl SquadAssignService {
                 .ok_or_else(|| SquadAssignError::MemberAgentMissing(agent_id.clone()))?;
             Self::gate(pool, &member, &invoker).await?;
             targets.push((agent_id, member.runtime_id));
+        }
+
+        // THE ROLE GATE. On a role-gated card only agents servicing THAT stage may
+        // take a copy. Filtered after the invocation gate so a foreign / private
+        // member still rejects the whole dispatch rather than being quietly
+        // dropped by the role filter first.
+        if let Some((_, role)) = stage.as_ref() {
+            let mut eligible = Vec::new();
+            for (agent_id, runtime_id) in targets {
+                if Self::holds_role(pool, workspace, &agent_id, role).await? {
+                    eligible.push((agent_id, runtime_id));
+                }
+            }
+            if eligible.is_empty() {
+                return Err(SquadAssignError::StageRoleUnheld {
+                    role: role.clone(),
+                    squad_id: squad_id.to_string(),
+                });
+            }
+            targets = eligible;
         }
         targets.truncate(copies);
 
@@ -547,6 +625,17 @@ impl SquadAssignService {
             .await?;
             Self::stamp_dispatch_fields(&mut tx, &task_id, request).await?;
             TaskRepo::set_squad_id_in_tx(&mut tx, &task_id, squad_id).await?;
+            // Record the STAGE each copy serves, exactly as the pull does for a
+            // single owner, so the cluster is a stage like any other: the pull's
+            // finished-stage guard sees it, and the card is not re-pulled in the
+            // window between the last copy finishing and the advance moving it.
+            if let Some((column_id, _)) = stage.as_ref() {
+                sqlx::query("UPDATE agent_task_queue SET board_column_id = ?1 WHERE id = ?2")
+                    .bind(column_id)
+                    .bind(&task_id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
             sqlx::query("UPDATE agent_task_queue SET run_group = ?1 WHERE id = ?2")
                 .bind(&run_group)
                 .bind(&task_id)
@@ -623,6 +712,86 @@ impl SquadAssignService {
             }
         }
         Ok(None)
+    }
+
+    /// The ROLE-GATED stage `issue_id`'s card currently sits in, as
+    /// `(column_id, services_role)`, or `None` when it is not in one.
+    ///
+    /// `None` covers a workspace with no pipeline, a card parked in an ungated
+    /// column (Backlog / Done, or any column predating migration 0074), and an
+    /// issue that is on no board at all. Scoped to `workspace` so a card carried
+    /// by another tenant's board can never decide this dispatch's stage; the
+    /// earliest stage wins when a card sits on several boards, which is
+    /// deterministic rather than whichever row the planner returned first.
+    async fn gated_stage_of(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        issue_id: &str,
+    ) -> Result<Option<(String, String)>, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT bc.column_id, col.services_role \
+               FROM board_card AS bc \
+               JOIN board_column AS col ON col.id = bc.column_id \
+               JOIN board AS bd ON bd.id = bc.board_id \
+              WHERE bc.issue_id = ?1 \
+                AND bd.workspace_id = ?2 \
+                AND col.services_role IS NOT NULL \
+              ORDER BY col.ord, col.id \
+              LIMIT 1",
+        )
+        .bind(issue_id)
+        .bind(workspace.as_str())
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// Whether `issue_id` currently holds any ACTIVE task. The same active set
+    /// the pull's one-owner-per-card predicate reads.
+    async fn has_active_task(pool: &SqlitePool, issue_id: &str) -> Result<bool, sqlx::Error> {
+        let found: Option<i64> = sqlx::query_scalar(
+            "SELECT 1 FROM agent_task_queue \
+              WHERE issue_id = ?1 AND status IN ('queued','dispatched','running') LIMIT 1",
+        )
+        .bind(issue_id)
+        .fetch_optional(pool)
+        .await?;
+        Ok(found.is_some())
+    }
+
+    /// Whether `agent_id` HOLDS `role` through any squad membership in
+    /// `workspace`.
+    ///
+    /// Matched exactly as
+    /// [`PULL_SQL`](crate::service::pull::PULL_SQL) matches it: a
+    /// COMMA-SEPARATED TOKEN set, case-insensitively and ignoring spaces, via
+    /// `INSTR` over comma-delimited needles rather than `LIKE`, so a role
+    /// containing `%` or `_` cannot act as a wildcard and silently over-match.
+    /// Keeping the two identical is what stops a `--redundant` cluster admitting
+    /// an agent the ordinary pull would refuse.
+    async fn holds_role(
+        pool: &SqlitePool,
+        workspace: &WorkspaceId,
+        agent_id: &str,
+        role: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let found: Option<i64> = sqlx::query_scalar(
+            "SELECT 1 FROM squad_member AS sm \
+               JOIN squad AS sq ON sq.id = sm.squad_id \
+              WHERE sm.member_type = 'agent' \
+                AND sm.member_id = ?1 \
+                AND sq.workspace_id = ?2 \
+                AND INSTR( \
+                      ',' || REPLACE(LOWER(sm.role), ' ', '') || ',', \
+                      ',' || LOWER(TRIM(?3)) || ',' \
+                    ) > 0 \
+              LIMIT 1",
+        )
+        .bind(agent_id)
+        .bind(workspace.as_str())
+        .bind(role)
+        .fetch_optional(pool)
+        .await?;
+        Ok(found.is_some())
     }
 
     /// Stamp the card's `repo_ref` + resolved `agent_kind` onto a fanned-out task

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -379,7 +379,8 @@ impl SquadAssignService {
             match PipelineService::enqueue(pool, workspace, issue_id, clock).await {
                 Ok(_) => {
                     let pulled =
-                        Self::pull_once_in_workspace(pool, workspace, idgen, clock).await?;
+                        Self::pull_once_in_workspace(pool, workspace, issue_id, idgen, clock)
+                            .await?;
                     return Ok(SquadFanout {
                         leader: SquadAssignment {
                             // The single OWNER of the stage. Empty when the card is
@@ -574,8 +575,8 @@ impl SquadAssignService {
         })
     }
 
-    /// Attempt ONE pull across every runtime in `workspace`, stopping at the
-    /// first that yields.
+    /// Attempt ONE pull of `issue_id` across every runtime in `workspace`,
+    /// stopping at the first that yields.
     ///
     /// Used by [`Self::assign_fanout`] so a squad dispatch answers with the task
     /// that actually owns the work rather than merely "the card is on the board".
@@ -583,10 +584,23 @@ impl SquadAssignService {
     /// makes the dispatch synchronous from the operator's point of view; the
     /// daemon's own tick still covers the case where no agent is eligible yet.
     ///
+    /// # Why this is narrowed to ONE issue
+    ///
+    /// The unconstrained pull answers with whatever the BOARD ranks first, and
+    /// the ranking (`priority DESC, col.ord DESC, ...`, "pull from the right")
+    /// actively PREFERS a later-stage card. A dispatch of a freshly-enqueued
+    /// card, which sits in the FIRST stage, therefore reported the task id of any
+    /// card already sitting further down the pipeline. That id flows through
+    /// `SquadFanout.leader.task_id` into the run result and the dispatch log, so
+    /// an operator cancelling or attaching by it reached a different card's
+    /// agent. The daemon tick still pulls board-wide; only this answer is
+    /// narrowed.
+    ///
     /// At most ONE card is ever taken, whichever runtime wins.
     async fn pull_once_in_workspace(
         pool: &SqlitePool,
         workspace: &WorkspaceId,
+        issue_id: &str,
         idgen: &dyn IdGen,
         clock: &dyn HangarClock,
     ) -> Result<Option<crate::service::pull::PulledCard>, sqlx::Error> {
@@ -596,9 +610,14 @@ impl SquadAssignService {
                 .fetch_all(pool)
                 .await?;
         for runtime_id in runtimes {
-            if let Some(p) =
-                crate::service::pull::PullService::pull_for_runtime(pool, &runtime_id, idgen, clock)
-                    .await?
+            if let Some(p) = crate::service::pull::PullService::pull_issue_for_runtime(
+                pool,
+                &runtime_id,
+                issue_id,
+                idgen,
+                clock,
+            )
+            .await?
             {
                 return Ok(Some(p));
             }

--- a/ainb-tui/crates/ainb-hangar-store/tests/pipeline_advance.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pipeline_advance.rs
@@ -1,0 +1,588 @@
+//! [`PullService::advance_after_stage`] contract tests: the HANDOFF that makes a
+//! pipeline a pipeline.
+//!
+//! # Why this file exists
+//!
+//! The advance had NO automated coverage. It is referenced from exactly one
+//! place (`board.rs`'s `advance_pipeline_stage`) and from no test in the
+//! workspace, and its only proof was `live_pipeline_walks_four_stages`, which
+//! sits behind the `live-e2e` cargo feature. That feature has zero references in
+//! `.github/workflows/`, so it never runs in CI, and it cannot: it needs real
+//! authenticated provider CLIs. The gate is inherently local, so the invariants
+//! are pinned here instead, against a real ephemeral `SQLite` database.
+//!
+//! What the statement must guarantee:
+//!   * it steps EXACTLY ONE column, never jumping to the end of the board,
+//!   * it refuses at the last column rather than running off the end,
+//!   * it refuses while the card still holds an active task,
+//!   * it refuses when either `auto_move` kill-switch is off,
+//!   * it refuses on a column that is not role-gated,
+//!   * a board deleted mid-run is a clean no-op, not an error.
+//!
+//! The refusals matter as much as the move: every one of them is a case where
+//! the card must stay exactly where it is, and a statement that moved it anyway
+//! would strand work or skip a review stage silently.
+//!
+//! # Every refusal carries a MUTATION PROOF
+//!
+//! A test that only runs the real statement proves the card STAYED PUT. It
+//! cannot prove that the guard under test is what kept it there: delete the
+//! guard and the test may well keep passing because another clause happened to
+//! refuse the same row. So each refusal is paired with a `mutation_proof_*` test
+//! that deletes exactly that guard from [`ADVANCE_SQL`] and asserts the card NOW
+//! MOVES. The mutant is the code without that one guard, which is the only way
+//! to show these tests are not vacuous, given the guards were already in place
+//! when this file was written.
+
+use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_core::idgen::IdGen;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::service::pull::{ADVANCE_SQL, PullService};
+use sqlx::SqlitePool;
+
+const NOW_MS: i64 = 1_700_000_500_000;
+
+/// Deterministic id generator over a seeded sequence.
+struct SeqIdGen {
+    next: std::sync::Mutex<Vec<String>>,
+}
+
+impl SeqIdGen {
+    fn new(ids: &[&str]) -> Self {
+        Self {
+            next: std::sync::Mutex::new(ids.iter().rev().map(|s| (*s).to_string()).collect()),
+        }
+    }
+}
+
+impl IdGen for SeqIdGen {
+    fn new_ulid(&self) -> String {
+        self.next.lock().expect("idgen lock").pop().expect("ran out of seeded ids")
+    }
+}
+
+async fn store() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("open store");
+    (dir, store)
+}
+
+/// One workspace, one runtime, one board with the master `auto_move` on.
+async fn seed_world(pool: &SqlitePool) {
+    sqlx::query("INSERT INTO workspace (id, slug, name, created_at) VALUES ('ws-1','a','A',0)")
+        .execute(pool)
+        .await
+        .expect("workspace");
+    sqlx::query("INSERT INTO user (id, email, created_at) VALUES ('u-1','a@x.dev',0)")
+        .execute(pool)
+        .await
+        .expect("user");
+    sqlx::query(
+        "INSERT INTO agent_runtime (id, workspace_id, daemon_id, provider, runtime_mode) \
+         VALUES ('rt-1','ws-1','d-1','claude','local')",
+    )
+    .execute(pool)
+    .await
+    .expect("runtime");
+    sqlx::query(
+        "INSERT INTO board (id, workspace_id, name, auto_move, created_at) \
+         VALUES ('b-1','ws-1','Pipeline',1,0)",
+    )
+    .execute(pool)
+    .await
+    .expect("board");
+    sqlx::query(
+        "INSERT INTO squad (id, workspace_id, name, leader_type, leader_id, created_at) \
+         VALUES ('sq-1','ws-1','team1','agent','ag-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("squad");
+    // A bare agent for the hand-inserted task rows to reference. It joins NO
+    // squad, so it holds no role and can never itself pull a card.
+    sqlx::query(
+        "INSERT INTO agent \
+         (id, workspace_id, name, runtime_id, visibility, owner_id, max_concurrent_tasks) \
+         VALUES ('ag-1','ws-1','ag-1','rt-1','workspace','u-1',5)",
+    )
+    .execute(pool)
+    .await
+    .expect("bare agent");
+}
+
+async fn add_agent(pool: &SqlitePool, id: &str, roles: &str) {
+    sqlx::query(
+        "INSERT INTO agent \
+         (id, workspace_id, name, runtime_id, visibility, owner_id, max_concurrent_tasks) \
+         VALUES (?1,'ws-1',?1,'rt-1','workspace','u-1',5)",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("agent");
+    sqlx::query(
+        "INSERT INTO squad_member (squad_id, member_type, member_id, role) \
+         VALUES ('sq-1','agent',?1,?2)",
+    )
+    .bind(id)
+    .bind(roles)
+    .execute(pool)
+    .await
+    .expect("squad member");
+}
+
+/// Add a column. `role = None` leaves it ungated; `auto_move` is the per-column
+/// kill-switch the advance consults.
+async fn add_column(pool: &SqlitePool, id: &str, ord: i64, role: Option<&str>, auto_move: bool) {
+    sqlx::query(
+        "INSERT INTO board_column \
+         (id, board_id, ord, name, fsm_state, auto_move, services_role, wip_limit, \
+          excludes_prior_agent) \
+         VALUES (?1,'b-1',?2,?1,NULL,?3,?4,NULL,0)",
+    )
+    .bind(id)
+    .bind(ord)
+    .bind(i64::from(auto_move))
+    .bind(role)
+    .execute(pool)
+    .await
+    .expect("column");
+}
+
+async fn add_card(pool: &SqlitePool, issue_id: &str, column_id: Option<&str>) {
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at, priority) \
+         VALUES (?1,'ws-1',?1,'open','member','u-1',0,0)",
+    )
+    .bind(issue_id)
+    .execute(pool)
+    .await
+    .expect("issue");
+    sqlx::query(
+        "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+         VALUES ('b-1',?1,?2,0,0)",
+    )
+    .bind(issue_id)
+    .bind(column_id)
+    .execute(pool)
+    .await
+    .expect("card");
+}
+
+/// Insert a task on the card directly, for setting up prior / concurrent state.
+async fn add_task(pool: &SqlitePool, id: &str, issue_id: &str, status: &str) {
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, generation) \
+         VALUES (?1,'ws-1','rt-1','ag-1',?2,?3,0,1)",
+    )
+    .bind(id)
+    .bind(issue_id)
+    .bind(status)
+    .execute(pool)
+    .await
+    .expect("task");
+}
+
+/// Run a MUTANT of the advance: [`ADVANCE_SQL`] with `guard` deleted.
+///
+/// Panics if `guard` is not found verbatim, so a reworded clause breaks the
+/// proof loudly instead of silently turning it into a no-op that tests nothing.
+async fn advance_mutant(pool: &SqlitePool, issue_id: &str, guard: &str) {
+    assert!(
+        ADVANCE_SQL.contains(guard),
+        "mutation target not found verbatim in ADVANCE_SQL; the proof would test nothing:\n{guard}"
+    );
+    let mutated = ADVANCE_SQL.replace(guard, " ");
+    sqlx::query(&mutated).bind(issue_id).fetch_all(pool).await.expect("mutant runs");
+}
+
+/// Where the card sits now.
+async fn column_of(pool: &SqlitePool, issue_id: &str) -> Option<String> {
+    sqlx::query_scalar("SELECT column_id FROM board_card WHERE issue_id = ?1")
+        .bind(issue_id)
+        .fetch_one(pool)
+        .await
+        .expect("card exists")
+}
+
+/// A four-stage board: Backlog (ungated), Triage, Implement, Review, Done
+/// (ungated). Mirrors the shipped `DEFAULT_STAGES` shape without depending on it.
+async fn seed_pipeline(pool: &SqlitePool) {
+    seed_world(pool).await;
+    add_column(pool, "col-backlog", 0, None, true).await;
+    add_column(pool, "col-triage", 1, Some("triager"), true).await;
+    add_column(pool, "col-impl", 2, Some("implementer"), true).await;
+    add_column(pool, "col-review", 3, Some("reviewer"), true).await;
+    add_column(pool, "col-done", 4, None, true).await;
+}
+
+// ---------------------------------------------------------------------------
+// The move itself
+// ---------------------------------------------------------------------------
+
+/// THE REGRESSION: the advance steps EXACTLY ONE column, never jumping to the
+/// end. A statement that landed the card in Done on the first completion would
+/// look like a working pipeline and would in fact never review anything.
+#[tokio::test]
+async fn advance_steps_exactly_one_column() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", Some("col-triage")).await;
+    add_task(pool, "t-1", "i-1", "done").await;
+
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert_eq!(moved, vec![("b-1".to_string(), "col-impl".to_string())]);
+    assert_eq!(
+        column_of(pool, "i-1").await.as_deref(),
+        Some("col-impl"),
+        "Triage hands to Implement, not to Review and not to Done"
+    );
+
+    // Each further advance is one more step, so the card WALKS the board.
+    PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert_eq!(column_of(pool, "i-1").await.as_deref(), Some("col-review"));
+    PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert_eq!(
+        column_of(pool, "i-1").await.as_deref(),
+        Some("col-done"),
+        "the last gated stage hands to the ungated parking column"
+    );
+}
+
+/// The advanced card APPENDS to its target column rather than colliding with the
+/// cards already there, matching a manual `card_move`.
+#[tokio::test]
+async fn advance_appends_to_the_end_of_the_target_column() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-sitting", Some("col-impl")).await;
+    sqlx::query("UPDATE board_card SET ord = 7 WHERE issue_id='i-sitting'")
+        .execute(pool)
+        .await
+        .expect("seed an occupied target column");
+    add_card(pool, "i-1", Some("col-triage")).await;
+
+    PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+
+    let ord: i64 = sqlx::query_scalar("SELECT ord FROM board_card WHERE issue_id='i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("read ord");
+    assert_eq!(
+        ord, 8,
+        "the card lands after the cards already in the column"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The refusals
+// ---------------------------------------------------------------------------
+
+/// At the LAST column of the board there is nowhere to go, so the card stays put
+/// and the statement reports nothing moved. Without the "a column to the right
+/// exists" guard the `column_id` sub-select yields NULL and the card would be
+/// silently knocked OFF the board into a NULL column.
+#[tokio::test]
+async fn advance_at_the_last_column_does_not_run_off_the_end() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    // A single gated column IS the last column: no Done to park in.
+    add_column(pool, "col-only", 0, Some("implementer"), true).await;
+    add_card(pool, "i-1", Some("col-only")).await;
+
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert!(moved.is_empty(), "there is no column to the right");
+    assert_eq!(
+        column_of(pool, "i-1").await.as_deref(),
+        Some("col-only"),
+        "the card must stay put, NOT be knocked into a NULL column"
+    );
+}
+
+/// A card that still holds an ACTIVE task does not advance. This is what makes a
+/// deliberate `--redundant` fan-out advance only once ALL its runs have drained,
+/// rather than on the first one home.
+#[tokio::test]
+async fn advance_refuses_while_the_card_still_has_an_active_task() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", Some("col-triage")).await;
+    add_task(pool, "t-done", "i-1", "done").await;
+    add_task(pool, "t-live", "i-1", "running").await;
+
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert!(moved.is_empty(), "a sibling is still running");
+    assert_eq!(column_of(pool, "i-1").await.as_deref(), Some("col-triage"));
+
+    // Drain it, and the card advances.
+    sqlx::query("UPDATE agent_task_queue SET status='done' WHERE id='t-live'")
+        .execute(pool)
+        .await
+        .expect("drain");
+    PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert_eq!(column_of(pool, "i-1").await.as_deref(), Some("col-impl"));
+}
+
+/// The board's MASTER `auto_move` kill-switch freezes the advance: the operator
+/// wants to move cards by hand.
+#[tokio::test]
+async fn advance_respects_the_board_auto_move_kill_switch() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", Some("col-triage")).await;
+    sqlx::query("UPDATE board SET auto_move = 0 WHERE id='b-1'")
+        .execute(pool)
+        .await
+        .expect("switch the board off");
+
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert!(moved.is_empty(), "the board's auto_move is off");
+    assert_eq!(column_of(pool, "i-1").await.as_deref(), Some("col-triage"));
+}
+
+/// The per-COLUMN `auto_move` kill-switch does the same for one stage alone: a
+/// stage an operator wants to sign off by hand holds its cards.
+#[tokio::test]
+async fn advance_respects_the_column_auto_move_kill_switch() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_column(pool, "col-triage", 1, Some("triager"), false).await;
+    add_column(pool, "col-impl", 2, Some("implementer"), true).await;
+    add_card(pool, "i-1", Some("col-triage")).await;
+
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert!(moved.is_empty(), "this column's auto_move is off");
+    assert_eq!(column_of(pool, "i-1").await.as_deref(), Some("col-triage"));
+}
+
+/// A card parked in a column that is NOT role-gated (Backlog, Done, or any
+/// column on a board predating migration 0074) is not in the pipeline at all, so
+/// a finished task on it must never drag it rightwards.
+#[tokio::test]
+async fn advance_refuses_from_an_ungated_column() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", Some("col-backlog")).await;
+    add_task(pool, "t-1", "i-1", "done").await;
+
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert!(moved.is_empty(), "Backlog is not a pipeline stage");
+    assert_eq!(column_of(pool, "i-1").await.as_deref(), Some("col-backlog"));
+}
+
+/// A card with NO column at all (`board_card.column_id IS NULL`) has no stage to
+/// advance from, and the NULL must not be treated as "before the first column".
+#[tokio::test]
+async fn advance_refuses_a_card_with_no_column() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", None).await;
+
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert!(moved.is_empty(), "a card with no column has no next column");
+    assert_eq!(column_of(pool, "i-1").await, None);
+}
+
+/// A board DELETED while its card's stage was running is a clean no-op. The
+/// advance is a best-effort hook fired after the task's terminal state has
+/// already committed, so it must never error the claim loop over a board that
+/// vanished underneath it.
+#[tokio::test]
+async fn advance_survives_a_board_deleted_mid_run() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", Some("col-triage")).await;
+    add_task(pool, "t-1", "i-1", "done").await;
+
+    // Tear the board down in FK-safe order, exactly as a board delete does.
+    for stmt in [
+        "DELETE FROM board_card WHERE board_id='b-1'",
+        "DELETE FROM board_column WHERE board_id='b-1'",
+        "DELETE FROM board WHERE id='b-1'",
+    ] {
+        sqlx::query(stmt).execute(pool).await.expect("tear the board down");
+    }
+
+    let moved = PullService::advance_after_stage(pool, "i-1")
+        .await
+        .expect("advance must not error");
+    assert!(moved.is_empty(), "there is no card left to move");
+}
+
+/// An issue that has never been on a board at all is a no-op, not an error: the
+/// hook fires for every terminal task, including plain non-pipeline runs.
+#[tokio::test]
+async fn advance_on_an_issue_with_no_card_is_a_no_op() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+
+    let moved = PullService::advance_after_stage(pool, "i-nowhere")
+        .await
+        .expect("advance must not error");
+    assert!(moved.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Mutation proofs: each refusal, with its guard deleted
+// ---------------------------------------------------------------------------
+
+/// Without the "a column to the right exists" guard, the last column's card is
+/// knocked clean OFF the board: both sub-selects yield NULL, so `column_id`
+/// becomes NULL and the card vanishes from every column.
+#[tokio::test]
+async fn mutation_proof_without_the_last_column_guard_the_card_falls_off_the_board() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_column(pool, "col-only", 0, Some("implementer"), true).await;
+    add_card(pool, "i-1", Some("col-only")).await;
+
+    advance_mutant(pool, "i-1", LAST_COLUMN_GUARD).await;
+    assert_eq!(
+        column_of(pool, "i-1").await,
+        None,
+        "the mutant moved the card into a NULL column, off the board entirely"
+    );
+}
+
+/// Without the gating guard, a `done` task drags a card out of BACKLOG, which is
+/// not a pipeline stage at all, and also ignores both `auto_move` kill-switches.
+#[tokio::test]
+async fn mutation_proof_without_the_gate_guard_an_ungated_card_advances() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", Some("col-backlog")).await;
+    sqlx::query("UPDATE board SET auto_move = 0 WHERE id='b-1'")
+        .execute(pool)
+        .await
+        .expect("switch the board off too");
+
+    advance_mutant(pool, "i-1", GATE_GUARD).await;
+    assert_eq!(
+        column_of(pool, "i-1").await.as_deref(),
+        Some("col-triage"),
+        "the mutant advanced an ungated card on a board with auto_move OFF"
+    );
+}
+
+/// Without the active-task guard, the FIRST sibling home advances the card while
+/// the rest of a `--redundant` cluster is still running.
+#[tokio::test]
+async fn mutation_proof_without_the_active_guard_a_running_card_advances() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_card(pool, "i-1", Some("col-triage")).await;
+    add_task(pool, "t-done", "i-1", "done").await;
+    add_task(pool, "t-live", "i-1", "running").await;
+
+    advance_mutant(pool, "i-1", ACTIVE_TASK_GUARD).await;
+    assert_eq!(
+        column_of(pool, "i-1").await.as_deref(),
+        Some("col-impl"),
+        "the mutant handed the card to the next stage mid-run"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mutation targets: the exact substrings the proofs delete from ADVANCE_SQL.
+// ---------------------------------------------------------------------------
+
+/// The card must sit in a ROLE-GATED column with both `auto_move` switches on.
+const GATE_GUARD: &str = "\
+   AND EXISTS ( \
+        SELECT 1 FROM board_column AS cur \
+          JOIN board AS bd ON bd.id = cur.board_id \
+         WHERE cur.id = board_card.column_id \
+           AND cur.services_role IS NOT NULL \
+           AND cur.auto_move = 1 \
+           AND bd.auto_move = 1 \
+       ) ";
+
+/// The card must hold NO active task.
+const ACTIVE_TASK_GUARD: &str = "\
+   AND NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS t \
+         WHERE t.issue_id = board_card.issue_id \
+           AND t.status IN ('queued','dispatched','running') \
+       ) ";
+
+/// There must BE a column to the right.
+const LAST_COLUMN_GUARD: &str = "\
+   AND EXISTS ( \
+        SELECT 1 FROM board_column AS n3 \
+         WHERE n3.board_id = board_card.board_id \
+           AND n3.ord > (SELECT cur3.ord FROM board_column AS cur3 \
+                          WHERE cur3.id = board_card.column_id) \
+       ) ";
+
+// ---------------------------------------------------------------------------
+// The advance and the pull, together
+// ---------------------------------------------------------------------------
+
+/// The full handoff: an implementer finishes, the card advances, and a DIFFERENT
+/// role takes the next stage. This is the loop the daemon actually runs, minus
+/// the provider CLIs the `live-e2e` gate needs.
+#[tokio::test]
+async fn a_card_walks_the_pipeline_one_stage_per_role() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_pipeline(pool).await;
+    add_agent(pool, "ag-triage", "triager").await;
+    add_agent(pool, "ag-impl", "implementer").await;
+    add_agent(pool, "ag-rev", "reviewer").await;
+    add_card(pool, "i-1", Some("col-triage")).await;
+
+    let mut walked = Vec::new();
+    for (task_id, column) in [
+        ("t-1", "col-triage"),
+        ("t-2", "col-impl"),
+        ("t-3", "col-review"),
+    ] {
+        let pulled = PullService::pull_for_runtime(
+            pool,
+            "rt-1",
+            &SeqIdGen::new(&[task_id]),
+            &FixedClock(NOW_MS),
+        )
+        .await
+        .expect("pull runs")
+        .expect("a card is pullable at this stage");
+        assert_eq!(pulled.column_id, column);
+        walked.push((pulled.agent_id.clone(), pulled.generation));
+        sqlx::query("UPDATE agent_task_queue SET status='done' WHERE id=?1")
+            .bind(task_id)
+            .execute(pool)
+            .await
+            .expect("finish the stage");
+        PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    }
+
+    assert_eq!(
+        walked,
+        vec![
+            ("ag-triage".to_string(), 1),
+            ("ag-impl".to_string(), 2),
+            ("ag-rev".to_string(), 3),
+        ],
+        "one owner per stage, a different role each time, one generation each"
+    );
+    assert_eq!(
+        column_of(pool, "i-1").await.as_deref(),
+        Some("col-done"),
+        "the card ends parked in the ungated Done column"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -757,6 +757,66 @@ async fn a_re_enqueued_card_is_pullable_again_at_an_earlier_stage() {
     assert_eq!(again.generation, 3);
 }
 
+// ---------------------------------------------------------------------------
+// The closed-issue guard
+// ---------------------------------------------------------------------------
+
+/// A CLOSED issue is not pullable, tested against the token the codebase
+/// actually WRITES.
+///
+/// The guard read `i.state NOT IN ('closed','cancelled')`. `closed` is the
+/// LEGACY token: `IssueLifecycle::as_str` writes `done`, and migration 0023
+/// rewrote the stored legacy values forward. So the only issues the guard ever
+/// excluded were beads-synced ones (`beads_sync/reconcile.rs` still writes
+/// `closed`); a hangar-native closed issue stayed fully pullable and an agent
+/// could be handed a card for work somebody had already closed.
+#[tokio::test]
+async fn a_closed_issue_is_not_pullable() {
+    for state in ["done", "cancelled", "closed"] {
+        let (_d, s) = store().await;
+        let pool = s.pool();
+        seed_world(pool).await;
+        add_agent(pool, "ag-impl", "implementer", 5).await;
+        add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+        add_card(pool, "i-1", "col-impl", 0).await;
+        sqlx::query("UPDATE issue SET state = ?1 WHERE id='i-1'")
+            .bind(state)
+            .execute(pool)
+            .await
+            .expect("close the issue");
+
+        assert!(
+            pull(pool, "t-1").await.is_none(),
+            "an issue in state `{state}` is closed and must not be pulled"
+        );
+    }
+}
+
+/// The live states stay pullable, so the guard closes the hole without freezing
+/// the pipeline. `in_progress` matters most: a card walking the pipeline sits
+/// there for every stage after the first.
+#[tokio::test]
+async fn a_live_issue_is_still_pullable() {
+    for state in ["open", "todo", "in_progress", "in_review", "backlog"] {
+        let (_d, s) = store().await;
+        let pool = s.pool();
+        seed_world(pool).await;
+        add_agent(pool, "ag-impl", "implementer", 5).await;
+        add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+        add_card(pool, "i-1", "col-impl", 0).await;
+        sqlx::query("UPDATE issue SET state = ?1 WHERE id='i-1'")
+            .bind(state)
+            .execute(pool)
+            .await
+            .expect("set the issue state");
+
+        assert!(
+            pull(pool, "t-1").await.is_some(),
+            "an issue in state `{state}` is live and must stay pullable"
+        );
+    }
+}
+
 /// A card with an UNFINISHED blocker is not pullable at any stage (the F7
 /// refuse-run guard, reused verbatim), and becomes pullable once the blocker's
 /// latest generation drains with a `done`.

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -225,6 +225,9 @@ async fn pull_mutant(pool: &SqlitePool, id: &str, clause: &str) -> Option<String
         .bind(id)
         .bind(NOW_MS)
         .bind("rt-1")
+        // `?4` narrows the pull to one issue; NULL is the whole board, which is
+        // what every mutation proof exercises.
+        .bind(Option::<&str>::None)
         .fetch_optional(pool)
         .await
         .expect("mutant runs");

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -586,6 +586,174 @@ async fn sequential_pulls_never_double_assign_one_card() {
     assert_eq!(n, 1, "exactly one task exists for the card");
 }
 
+// ---------------------------------------------------------------------------
+// The FINALIZE WINDOW: a stage that has committed `done` but not yet advanced
+// ---------------------------------------------------------------------------
+
+/// Mark `task_id` `done` WITHOUT running the stage advance.
+///
+/// This is the finalize window reproduced exactly. In the daemon the task row
+/// commits `done` first, then four awaited best-effort steps run (usage, run
+/// branch, run history, the `TaskFinished` event), and only THEN does
+/// `auto_move_after_terminal` reach `PullService::advance_after_stage`. The pull
+/// tick runs concurrently on a 1000ms timer, so it observes precisely this
+/// state: terminal task, card still in the column it ran in.
+///
+/// A SEQUENTIAL double-pull test (`sequential_pulls_never_double_assign_one_card`)
+/// cannot see this: its first task is still `queued`, so the one-owner guard
+/// covers for the missing predicate. Only a terminal-but-unadvanced card exposes
+/// it.
+async fn finish_without_advancing(pool: &SqlitePool, task_id: &str) {
+    sqlx::query("UPDATE agent_task_queue SET status='done', finished_at=?2 WHERE id=?1")
+        .bind(task_id)
+        .bind(NOW_MS)
+        .execute(pool)
+        .await
+        .expect("terminalise the task");
+}
+
+/// A card whose CURRENT stage has already finished is not pullable again while
+/// it waits to be advanced.
+///
+/// Without this the SAME implementer re-pulls the card it just finished and a
+/// second full Implement run starts, which is the two-runs-on-one-card defect
+/// the whole pull pipeline exists to remove.
+#[tokio::test]
+async fn a_finished_stage_is_not_re_pulled_before_the_card_advances() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    let first = pull(pool, "t-1").await.expect("the implementer takes the card");
+    assert_eq!(first.agent_id, "ag-impl");
+    finish_without_advancing(pool, "t-1").await;
+
+    assert!(
+        pull(pool, "t-2").await.is_none(),
+        "the stage is done and the card has not moved: re-pulling it starts a \
+         SECOND Implement run on the same card"
+    );
+
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id='i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("count");
+    assert_eq!(n, 1, "exactly one Implement run exists for the card");
+}
+
+/// The same window on a stage with `excludes_prior_agent = 1`: that flag only
+/// blocks the agent that already holds a `done` task, so a DIFFERENT reviewer
+/// is free to take the card and double-review it.
+#[tokio::test]
+async fn a_finished_review_is_not_re_pulled_by_a_second_reviewer() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-rev-a", "reviewer", 5).await;
+    add_agent(pool, "ag-rev-b", "reviewer", 5).await;
+    add_column(pool, "col-rev", 1, Some("reviewer"), None, true).await;
+    add_card(pool, "i-1", "col-rev", 0).await;
+
+    let first = pull(pool, "t-1").await.expect("a reviewer takes the card");
+    finish_without_advancing(pool, "t-1").await;
+
+    let second = pull(pool, "t-2").await;
+    assert!(
+        second.is_none(),
+        "the review is done and the card has not moved; the prior-agent flag \
+         only excludes {}, so the OTHER reviewer double-reviews",
+        first.agent_id
+    );
+}
+
+/// The positive control: once the card DOES advance, the next stage is pullable
+/// again. The finished-stage guard must close the window, not the pipeline.
+#[tokio::test]
+async fn the_next_stage_is_pullable_once_the_card_advances() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_agent(pool, "ag-rev", "reviewer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_column(pool, "col-rev", 2, Some("reviewer"), None, true).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    pull(pool, "t-1").await.expect("the implementer takes the card");
+    finish_without_advancing(pool, "t-1").await;
+    let moved = PullService::advance_after_stage(pool, "i-1").await.expect("advance runs");
+    assert_eq!(moved, vec![("b-1".to_string(), "col-rev".to_string())]);
+
+    let review = pull(pool, "t-2").await.expect("the reviewer takes the advanced card");
+    assert_eq!(review.agent_id, "ag-rev");
+    assert_eq!(review.column_id, "col-rev");
+    assert_eq!(review.generation, 2, "each stage is its own generation");
+}
+
+/// With the finished-stage predicate DELETED, the finalize window hands the card
+/// straight back out, the pre-change behaviour, and the exact double-execution
+/// the criticals reported.
+#[tokio::test]
+async fn mutation_proof_without_the_finished_stage_predicate_the_card_runs_twice() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    pull(pool, "t-1").await.expect("the implementer takes the card");
+    finish_without_advancing(pool, "t-1").await;
+
+    let winner = pull_mutant(pool, "t-2", FINISHED_STAGE_CLAUSE).await;
+    assert_eq!(
+        winner.as_deref(),
+        Some("ag-impl"),
+        "without the guard the implementer re-pulls the card it just finished"
+    );
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_task_queue WHERE issue_id='i-1'")
+        .fetch_one(pool)
+        .await
+        .expect("count");
+    assert_eq!(n, 2, "the mutant started a second run of the same stage");
+}
+
+/// A card RE-ENQUEUED to an earlier stage after a full walk is pullable again:
+/// the guard is scoped to the CURRENT generation, so an old `done` in that
+/// column does not freeze the card forever.
+#[tokio::test]
+async fn a_re_enqueued_card_is_pullable_again_at_an_earlier_stage() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_world(pool).await;
+    add_agent(pool, "ag-impl", "implementer", 5).await;
+    add_agent(pool, "ag-rev", "reviewer", 5).await;
+    add_column(pool, "col-impl", 1, Some("implementer"), None, false).await;
+    add_column(pool, "col-rev", 2, Some("reviewer"), None, true).await;
+    add_card(pool, "i-1", "col-impl", 0).await;
+
+    // Walk Implement then Review, so `col-impl` carries an old `done`.
+    pull(pool, "t-1").await.expect("implement");
+    finish_without_advancing(pool, "t-1").await;
+    PullService::advance_after_stage(pool, "i-1").await.expect("advance to review");
+    pull(pool, "t-2").await.expect("review");
+    finish_without_advancing(pool, "t-2").await;
+
+    // Re-enqueue: move the card back to the first stage, exactly as
+    // `PipelineService::enqueue` does for a "run this again from the top".
+    sqlx::query("UPDATE board_card SET column_id='col-impl' WHERE issue_id='i-1'")
+        .execute(pool)
+        .await
+        .expect("re-enqueue");
+
+    let again = pull(pool, "t-3").await.expect("the re-enqueued card runs again");
+    assert_eq!(again.column_id, "col-impl");
+    assert_eq!(again.generation, 3);
+}
+
 /// A card with an UNFINISHED blocker is not pullable at any stage (the F7
 /// refuse-run guard, reused verbatim), and becomes pullable once the blocker's
 /// latest generation drains with a `done`.
@@ -794,6 +962,18 @@ const PRIOR_AGENT_CLAUSE: &str = "\
            AND p.agent_id = a.id \
            AND p.status = 'done' \
        ) ) ";
+
+/// The FINALIZE WINDOW guard: the card's current column must not already hold a
+/// `done` task at the card's current generation.
+const FINISHED_STAGE_CLAUSE: &str = "\
+   AND NOT EXISTS ( \
+        SELECT 1 FROM agent_task_queue AS f \
+         WHERE f.issue_id = bc.issue_id \
+           AND f.status = 'done' \
+           AND f.board_column_id = bc.column_id \
+           AND f.generation = (SELECT MAX(g4.generation) FROM agent_task_queue AS g4 \
+                                WHERE g4.issue_id = bc.issue_id) \
+       ) ";
 
 /// The supporting one-owner-per-card guard.
 const ONE_OWNER_CLAUSE: &str = "\

--- a/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
@@ -26,7 +26,9 @@ use ainb_hangar_core::idgen::SystemIdGen;
 use ainb_hangar_core::ids::WorkspaceId;
 use ainb_hangar_store::Store;
 use ainb_hangar_store::service::pipeline::PipelineService;
-use ainb_hangar_store::service::squad_assign::{SquadAssignRequest, SquadAssignService};
+use ainb_hangar_store::service::squad_assign::{
+    SquadAssignError, SquadAssignRequest, SquadAssignService,
+};
 use sqlx::SqlitePool;
 
 const NOW_MS: i64 = 1_700_000_500_000;
@@ -106,6 +108,30 @@ async fn store() -> (tempfile::TempDir, Store) {
     let dir = tempfile::tempdir().expect("tempdir");
     let store = Store::open_in(dir.path()).await.expect("open store");
     (dir, store)
+}
+
+/// Park `issue_id`'s card in the pipeline column named `column`, returning that
+/// column's id. Requires the default pipeline to be provisioned.
+async fn park_card_in(pool: &SqlitePool, issue_id: &str, column: &str) -> String {
+    let (board_id, column_id): (String, String) = sqlx::query_as(
+        "SELECT b.id, c.id FROM board AS b JOIN board_column AS c ON c.board_id = b.id \
+          WHERE b.workspace_id = 'ws-1' AND c.name = ?1",
+    )
+    .bind(column)
+    .fetch_one(pool)
+    .await
+    .expect("the pipeline column exists");
+    sqlx::query(
+        "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+         VALUES (?1, ?2, ?3, 0, 0)",
+    )
+    .bind(&board_id)
+    .bind(issue_id)
+    .bind(&column_id)
+    .execute(pool)
+    .await
+    .expect("park the card");
+    column_id
 }
 
 /// Add `i-dep`, blocked by `blocker`.
@@ -526,6 +552,180 @@ async fn redundant_more_than_the_roster_dispatches_to_everyone() {
         4,
         "leader plus three members, capped by the roster"
     );
+}
+
+/// Redundancy is redundancy WITHIN A STAGE: on a card sitting in a role-gated
+/// column, only agents that HOLD that column's `services_role` may be handed a
+/// copy.
+///
+/// `assign_redundant` writes rows straight through `TaskRepo::insert_in_tx` with
+/// no board awareness at all, so it dispatched to the leader plus every member in
+/// id order regardless of role. On an Implement-stage card that hands the work to
+/// a tester, which is precisely the role-blind dispatch migration 0074 exists to
+/// end.
+#[tokio::test]
+async fn redundant_on_a_gated_card_only_dispatches_to_that_stages_role() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+    park_card_in(pool, "i-1", "Implement").await;
+
+    SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            generation: 1,
+            ..SquadAssignRequest::default()
+        },
+        3,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("redundant dispatch");
+
+    let mut owners: Vec<String> =
+        sqlx::query_scalar("SELECT agent_id FROM agent_task_queue WHERE issue_id='i-1'")
+            .fetch_all(pool)
+            .await
+            .expect("read owners");
+    owners.sort();
+    assert_eq!(
+        owners,
+        vec!["ag-a".to_string(), "ag-lead".to_string()],
+        "only the two implementers may take an Implement-stage card; the \
+         reviewer and the tester must not be handed a copy"
+    );
+}
+
+/// Every copy of a stage cluster records the STAGE it serves, so the pull's
+/// finished-stage guard treats the cluster exactly like a single-owner run.
+#[tokio::test]
+async fn redundant_copies_record_the_stage_they_serve() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+    let column = park_card_in(pool, "i-1", "Implement").await;
+
+    SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            generation: 1,
+            ..SquadAssignRequest::default()
+        },
+        2,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("redundant dispatch");
+
+    let stamped: Vec<Option<String>> =
+        sqlx::query_scalar("SELECT board_column_id FROM agent_task_queue WHERE issue_id='i-1'")
+            .fetch_all(pool)
+            .await
+            .expect("read the stage stamp");
+    assert!(
+        !stamped.is_empty() && stamped.iter().all(|c| c.as_deref() == Some(column.as_str())),
+        "every copy must name the stage it serves: {stamped:?}"
+    );
+}
+
+/// Redundancy REPLACES the single owner of a stage; it does not stack on top of
+/// one. A card that already has a pulled run in flight refuses, rather than
+/// acquiring three more concurrent runs of the same stage.
+#[tokio::test]
+async fn redundant_refuses_a_gated_card_that_already_has_an_active_run() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+    park_card_in(pool, "i-1", "Implement").await;
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, generation) \
+         VALUES ('t-live','ws-1','rt-1','ag-a','i-1','running',0,1)",
+    )
+    .execute(pool)
+    .await
+    .expect("a run already in flight");
+
+    let err = SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            generation: 2,
+            ..SquadAssignRequest::default()
+        },
+        3,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect_err("stacking onto a live stage must be refused");
+    assert!(
+        matches!(err, SquadAssignError::ActiveRun(ref id) if id == "i-1"),
+        "expected an active-run refusal, got {err:?}"
+    );
+    assert_eq!(
+        task_count(pool).await,
+        1,
+        "a refusal writes zero rows: only the run already in flight remains"
+    );
+}
+
+/// A stage nobody holds the role for refuses outright rather than silently
+/// dispatching to whoever happened to be in the squad.
+#[tokio::test]
+async fn redundant_refuses_when_no_member_holds_the_stages_role() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+    // Nobody in this squad services Triage except the leader; strip that role.
+    sqlx::query("UPDATE squad_member SET role='implementer' WHERE member_id='ag-lead'")
+        .execute(pool)
+        .await
+        .expect("strip the triager role");
+    park_card_in(pool, "i-1", "Triage").await;
+
+    let err = SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            generation: 1,
+            ..SquadAssignRequest::default()
+        },
+        3,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect_err("no eligible agent must refuse");
+    assert!(
+        matches!(err, SquadAssignError::StageRoleUnheld { ref role, .. } if role == "triager"),
+        "expected a role refusal, got {err:?}"
+    );
+    assert_eq!(task_count(pool).await, 0, "a refusal writes zero rows");
 }
 
 /// FANOUT-SEMANTICS, preserved for the surviving multi-task shape: a dependent

--- a/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
@@ -108,6 +108,42 @@ async fn store() -> (tempfile::TempDir, Store) {
     (dir, store)
 }
 
+/// Add `i-dep`, blocked by `blocker`.
+async fn seed_dependent_on(pool: &SqlitePool, blocker: &str) {
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('i-dep','ws-1','dependent','open','member','u-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("dependent issue");
+    sqlx::query(
+        "INSERT INTO card_dependency \
+         (workspace_id, dependent_issue_id, blocker_issue_id, created_at, link_type) \
+         VALUES ('ws-1','i-dep',?1,0,'blocked_by')",
+    )
+    .bind(blocker)
+    .execute(pool)
+    .await
+    .expect("dependency");
+}
+
+/// Give `issue_id` a PRIOR stage that already ran and finished at `generation`,
+/// so the issue's `MAX(generation)` is non-zero before the next dispatch.
+async fn seed_finished_prior_run(pool: &SqlitePool, issue_id: &str, generation: i64) {
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, generation) \
+         VALUES ('t-prior','ws-1','rt-1','ag-lead',?1,'done',0,?2)",
+    )
+    .bind(issue_id)
+    .bind(generation)
+    .execute(pool)
+    .await
+    .expect("prior run");
+}
+
 /// Count every task row on the issue, in ANY status. Deliberately unfiltered:
 /// the defect was N rows written at once, so any filter could hide it.
 async fn task_count(pool: &SqlitePool) -> i64 {
@@ -505,37 +541,39 @@ async fn redundant_more_than_the_roster_dispatches_to_everyone() {
 /// The three states that must each keep the dependent blocked: any sibling still
 /// active, all siblings terminal but NONE succeeded, and a success that arrived
 /// in an older generation.
+///
+/// # The fixture deliberately carries PRIOR history
+///
+/// The blocker already ran a stage that finished at generation 1. Without it the
+/// cluster's generation is trivially the max whatever it is stamped with, and
+/// this test would pass even against a caller that left the generation at the
+/// `0` default, which is exactly the defect
+/// [`a_generation_zero_cluster_is_invisible_to_blocked_detection`] pins. The
+/// generation is resolved the way both real callers resolve it.
 #[tokio::test]
 async fn dependent_waits_for_the_whole_redundant_cluster_to_drain() {
     use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+    use ainb_hangar_store::repo::task::TaskRepo;
 
     let (_d, s) = store().await;
     let pool = s.pool();
     seed_squad_of_three(pool).await;
-    sqlx::query(
-        "INSERT INTO issue \
-         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
-         VALUES ('i-dep','ws-1','dependent','open','member','u-1',0)",
-    )
-    .execute(pool)
-    .await
-    .expect("dependent issue");
-    sqlx::query(
-        "INSERT INTO card_dependency \
-         (workspace_id, dependent_issue_id, blocker_issue_id, created_at, link_type) \
-         VALUES ('ws-1','i-dep','i-1',0,'blocked_by')",
-    )
-    .execute(pool)
-    .await
-    .expect("dependency");
+    seed_dependent_on(pool, "i-1").await;
+    seed_finished_prior_run(pool, "i-1", 1).await;
 
-    // A deliberate cluster of three concurrent runs on the blocker.
+    // A deliberate cluster of three concurrent runs on the blocker, at a freshly
+    // minted generation (2) rather than the `0` default.
+    let generation = TaskRepo::next_generation_for_issue(pool, "i-1")
+        .await
+        .expect("resolve the generation");
+    assert_eq!(generation, 2, "the prior run put the issue at generation 1");
     SquadAssignService::assign_redundant(
         pool,
         &ws(),
         "sq-1",
         &SquadAssignRequest {
             issue_id: Some("i-1"),
+            generation,
             ..SquadAssignRequest::default()
         },
         3,
@@ -545,11 +583,13 @@ async fn dependent_waits_for_the_whole_redundant_cluster_to_drain() {
     .await
     .expect("redundant dispatch");
 
-    let ids: Vec<String> =
-        sqlx::query_scalar("SELECT id FROM agent_task_queue WHERE issue_id='i-1' ORDER BY id")
-            .fetch_all(pool)
-            .await
-            .expect("cluster ids");
+    let ids: Vec<String> = sqlx::query_scalar(
+        "SELECT id FROM agent_task_queue \
+          WHERE issue_id='i-1' AND run_group IS NOT NULL ORDER BY id",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("cluster ids");
     assert_eq!(ids.len(), 3);
 
     let blocked = |pool: &sqlx::SqlitePool| {
@@ -594,6 +634,78 @@ async fn dependent_waits_for_the_whole_redundant_cluster_to_drain() {
     assert!(
         !blocked(pool).await,
         "the cluster has drained with a success, so the dependent unblocks"
+    );
+}
+
+/// WHY the generation must be resolved rather than left at the `0` default:
+/// a cluster stamped `0` behind a prior run is INVISIBLE to blocked-detection.
+///
+/// Every generation-scoped fold reads the issue's `MAX(generation)` and then
+/// looks at that generation ALONE. A cluster at `0` sitting behind a stage that
+/// finished at 1 is below the max, so `unfinished_blockers_of` probes generation
+/// 1, sees a `done` task with nothing active, and declares the blocker finished.
+/// The dependent then unblocks (and auto-runs, if it opted in) while three
+/// implementations of the blocker are still live.
+///
+/// This is the harm the CLI's `..SquadAssignRequest::default()` caused, kept as a
+/// standing description of the failure mode rather than as a claim about any one
+/// caller.
+#[tokio::test]
+async fn a_generation_zero_cluster_is_invisible_to_blocked_detection() {
+    use ainb_hangar_store::repo::card_dependency::CardDependencyRepo;
+
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    seed_dependent_on(pool, "i-1").await;
+    seed_finished_prior_run(pool, "i-1", 1).await;
+
+    // The defect: stamp the cluster with the `0` default instead of resolving it.
+    SquadAssignService::assign_redundant(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        3,
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("redundant dispatch");
+
+    let live: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM agent_task_queue \
+          WHERE issue_id='i-1' AND status IN ('queued','dispatched','running')",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("count live runs");
+    assert_eq!(live, 3, "three implementations are live on the blocker");
+
+    let remaining = CardDependencyRepo::unfinished_blockers_of(pool, "i-dep")
+        .await
+        .expect("blockers");
+    assert!(
+        remaining.is_empty(),
+        "the fold reads MAX(generation)=1 and never sees the generation-0 cluster, \
+         so the blocker reads as FINISHED while three runs are live"
+    );
+
+    // Resolved to the real next generation, the very same cluster IS seen.
+    sqlx::query("UPDATE agent_task_queue SET generation = 2 WHERE run_group IS NOT NULL")
+        .execute(pool)
+        .await
+        .expect("restamp the cluster");
+    let remaining = CardDependencyRepo::unfinished_blockers_of(pool, "i-dep")
+        .await
+        .expect("blockers");
+    assert_eq!(
+        remaining,
+        vec!["i-1".to_string()],
+        "at the issue's real max generation the live cluster blocks the dependent"
     );
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/squad_no_broadcast.rs
@@ -214,6 +214,84 @@ async fn dispatch_places_the_card_in_the_first_role_gated_stage() {
     assert_eq!(cards, 1, "one card, one place on the board");
 }
 
+/// A dispatch must be answered with a task belonging to the issue it DISPATCHED,
+/// never with whatever the board happened to rank first.
+///
+/// `assign_fanout` enqueues the issue and then pulls. The pull ordering is
+/// `priority DESC, col.ord DESC, ...`, "pull from the right", which actively
+/// PREFERS a later-stage card. So a card already sitting in Review outranks the
+/// one just placed in Triage, and its task id is what flows out through
+/// `SquadFanout.leader.task_id`, into `BoardCardRunResult.task_id` and the
+/// dispatch log. An operator who cancels or attaches by that id reaches a
+/// DIFFERENT card's agent.
+#[tokio::test]
+async fn a_dispatch_is_answered_with_its_own_cards_task() {
+    let (_d, s) = store().await;
+    let pool = s.pool();
+    seed_squad_of_three(pool).await;
+    PipelineService::provision_default(pool, &ws(), &SystemIdGen, &FixedClock(NOW_MS))
+        .await
+        .expect("provision");
+
+    // A SECOND card already sits in Review (ord 3) with an eligible reviewer.
+    // Same priority as the one about to be dispatched, so only the column
+    // ordering separates them.
+    sqlx::query(
+        "INSERT INTO issue \
+         (id, workspace_id, title, state, creator_type, creator_id, created_at) \
+         VALUES ('i-2','ws-1','Already in review','open','member','u-1',0)",
+    )
+    .execute(pool)
+    .await
+    .expect("second issue");
+    let (board_id, review_col): (String, String) = sqlx::query_as(
+        "SELECT b.id, c.id FROM board AS b JOIN board_column AS c ON c.board_id = b.id \
+          WHERE b.workspace_id='ws-1' AND c.name='Review'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("review column");
+    sqlx::query(
+        "INSERT INTO board_card (board_id, issue_id, column_id, added_at, ord) \
+         VALUES (?1,'i-2',?2,0,0)",
+    )
+    .bind(&board_id)
+    .bind(&review_col)
+    .execute(pool)
+    .await
+    .expect("park the second card in review");
+
+    let out = SquadAssignService::assign_fanout(
+        pool,
+        &ws(),
+        "sq-1",
+        &SquadAssignRequest {
+            issue_id: Some("i-1"),
+            ..SquadAssignRequest::default()
+        },
+        &SystemIdGen,
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("fanout");
+
+    assert!(
+        !out.leader.task_id.is_empty(),
+        "the dispatched card has an eligible triager, so a task must exist"
+    );
+    let answered: String =
+        sqlx::query_scalar("SELECT issue_id FROM agent_task_queue WHERE id = ?1")
+            .bind(&out.leader.task_id)
+            .fetch_one(pool)
+            .await
+            .expect("the answered task exists");
+    assert_eq!(
+        answered, "i-1",
+        "the dispatch answered with a task belonging to a DIFFERENT card, so \
+         cancelling or attaching by this id reaches the wrong agent"
+    );
+}
+
 /// Even with NO pipeline provisioned, a squad dispatch is ONE task. The
 /// no-pipeline fallback briefs the leader alone: the member broadcast is gone
 /// outright, not merely bypassed when a pipeline happens to exist.


### PR DESCRIPTION
Fixes the two criticals and four majors from the review of #547 (role-gated pull pipeline, merged 526b0363). One commit per finding, plus one housekeeping commit.

## C-2: a pipeline stage could execute TWICE

`1e02495e`. The task row commits `done`, four awaited best-effort steps run (usage, run branch, run history, the `TaskFinished` event), and only then does `auto_move_after_terminal` reach the advance. Execution is spawned off the main loop, so the pull tick evaluates the card in between: terminal task, card still parked in the column it ran in.

Every existing predicate passes there. The one-owner guard reads the ACTIVE set and a `done` task is not in it, so the SAME implementer re-pulls the card it just finished; on Review and QA `excludes_prior_agent` only blocks the agent holding the `done` row, so a DIFFERENT reviewer double-reviews.

Migration 0078 records WHICH stage a task served (`board_column_id`, NULL for every push-path task), because the generation alone cannot tell "done but not yet advanced" from "advanced, next stage waiting". `PULL_SQL` gains a sixth predicate refusing a card whose CURRENT column already holds a `done` task at the card's CURRENT generation.

## C-1: a dispatch could be answered with another card's task

`545b1bc8`. `assign_fanout` pulled with no issue filter, and the ordering ("pull from the right") prefers a later-stage card, so a freshly-enqueued card in the first stage was answered with the task id of any card further down the pipeline. `PULL_SQL` gains an optional `?4` issue narrowing rather than a second statement, so the two pulls cannot drift.

## M-1: `advance_after_stage` had no automated test

`4ab75fd6`. Its only proof was behind the `live-e2e` feature, which never runs in CI. New `tests/pipeline_advance.rs` covers the move and every refusal. The guards were already in place, so `ADVANCE_SQL` is made `pub` (as `PULL_SQL` already is, for the reason that file states) and each refusal carries a mutation proof.

## M-4: the CLI stamped generation 0

`cd445664`. Generation-scoped folds read `MAX(generation)`, so a `--redundant` cluster at 0 behind a stage that finished at 1 is invisible: the blocker reads as finished and a dependent auto-runs with three implementations live. The CLI now resolves the generation the way the RPC does. The store test meant to preserve this could not fail (its fixture had no prior task); its fixture is repaired and a companion test pins the failure mode.

## M-5: `--redundant` bypassed the role gate

`ead9e8d5`. Chose **(a)**: redundancy is redundancy WITHIN a stage. On a role-gated card it now dispatches only to agents holding that column's role, refuses a card with an active run, and stamps each copy's `board_column_id`. The WIP limit stays deliberately bypassed. A card not in a role-gated column is unchanged. The module docs no longer claim a difference from broadcast that was not the real one.

## M-6: the closed-issue guard was inert, and issues rendered Done early

`0fde36fc`. The guard tested `closed`, the legacy token; `IssueLifecycle::as_str` writes `done`, so a hangar-native closed issue stayed pullable. Adding `done` alone would freeze every pipeline, because the lifecycle promoted the issue to `done` on the FIRST stage's aggregate and `is_terminal()` froze it there, rendering a card Done three stages early. Both halves are fixed together: the promotion is held while a role-gated column exists to the right of where the card sits.

## Verification

Every new test was watched FAIL before its fix and pass after; the evidence is in each commit message and the task thread.

- `cargo nextest run --workspace --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'`: 7985/7987. The two failures are `test_cycle_session_filter_advances_state` (lib + bin, one test), which fails identically on `origin/main` with the same `left: ActiveOnly / right: All` and is untouched by this diff.
- The two inverted tripwires (`tripwire_tcp_squad_card_fanout_e2e`, `tripwire_tcp_card_dependency_chain_e2e`): 8/8 green.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p ainb-hangar-store -p ainb-hangar-daemon -p ainb -- -D warnings`: every finding is in `ainb-hangar-core`, which this diff does not touch.

One deviation worth stating: `--all-features` enables `live-e2e`, which skips on CI (no `claude` on PATH) but runs for real locally, spawning provider CLIs. It ran for 15 minutes before being stopped; the clean 7987-test figure above excludes that one binary.

## One housekeeping commit

`380c9c36` renumbers this branch's migration from 0077 to 0078. main shipped its own `0077_task_queue_agent_status_index` while this branch was open, and sqlx keys `_sqlx_migrations` on the numeric prefix, so two 0077 files abort every migrate with `UNIQUE constraint failed` and the daemon cannot boot. The Fleet macOS contract job caught it on the first push: all nine `testRealDaemon*` cases failed on that error rather than on anything they assert. Renumber only, and safe because the migration has never been applied to a durable database.

Not in scope, left for separate triage: M-2, M-3, the unused `idx_board_column_pull`, the missing `agent_task_queue(agent_id)` index, the write-only `run_group` index, the `ON CONFLICT` column_id reset, the `pull.rs` multi-board read-back, and the duplicated blocked predicate.