### PR TITLE
feat(fleet): confirm structured interview delivery

### DIFF
--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -11,13 +11,14 @@
 //! 2. a real isolated Hangar store, reducer, daemon socket, and auth token.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use ainb_plugin_notifyd::Paths;
-use ainb_plugin_notifyd::broker::{self, BrokerState, StructuredResolution};
+use ainb_plugin_notifyd::broker::{self, BrokerState};
 
 #[path = "support/fleet_hangar.rs"]
 mod fleet_hangar;
@@ -301,8 +302,9 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         .clone()
         .expect("seeded ASK has exact request fingerprint");
 
-    // Real broker plus real structured hook waiter. Fleet answer must traverse
-    // TUI -> fleet/action -> Hangar -> broker and unblock exact request.
+    // Real broker plus the actual lifecycle-hook executable. Fleet answer must
+    // traverse TUI -> fleet/action -> Hangar -> broker -> hook stdout, which is
+    // the exact JSON Claude receives to resume its AskUserQuestion tool call.
     let paths = Paths::under(home_tmp.path().join(".agents-in-a-box"));
     let broker_runtime = tokio::runtime::Runtime::new().expect("broker runtime");
     let broker_state = BrokerState::new();
@@ -314,48 +316,91 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
             broker::serve(listener, state).await;
         });
     }
-    let waiter = {
-        let sock = paths.approve_socket.clone();
-        let fingerprint = request_fingerprint.clone();
-        thread::spawn(move || {
-            broker::client_await_structured(
-                &sock,
-                "fleet-panel-ask-1",
-                &fingerprint,
-                &[
-                    serde_json::json!({
-                        "id": "scope",
-                        "question": "What release scope should Fleet use?",
-                        "header": "Scope",
-                        "options": [
-                            {"label": "Focused", "description": "ship only verified Fleet work"},
-                            {"label": "Broad", "description": "include adjacent changes"}
-                        ]
-                    }),
-                    serde_json::json!({
-                        "id": "validation",
-                        "question": "Which proof should gate launch?",
-                        "header": "Validation",
-                        "multiSelect": true,
-                        "options": [
-                            {"label": "Tests", "description": "run targeted Rust coverage"},
-                            {"label": "Tripwire", "description": "capture live terminal truth"}
-                        ]
-                    }),
-                    serde_json::json!({
-                        "id": "rollout",
-                        "question": "When should the release launch?",
-                        "header": "Rollout",
-                        "options": [
-                            {"label": "Now", "description": "start after proof completes"},
-                            {"label": "Later", "description": "hold for a manual window"}
-                        ]
-                    }),
-                ],
-                Duration::from_secs(60),
-            )
-        })
-    };
+    let hook_payload = serde_json::json!({
+        "tool_use_id": "ask-tool-1",
+        "tool_input": {
+            "questions": [
+                {
+                    "id": "scope",
+                    "question": "What release scope should Fleet use?",
+                    "header": "Scope",
+                    "options": [
+                        {"label": "Focused", "description": "ship only verified Fleet work"},
+                        {"label": "Broad", "description": "include adjacent changes"}
+                    ]
+                },
+                {
+                    "id": "validation",
+                    "question": "Which proof should gate launch?",
+                    "header": "Validation",
+                    "multiSelect": true,
+                    "options": [
+                        {"label": "Tests", "description": "run targeted Rust coverage"},
+                        {"label": "Tripwire", "description": "capture live terminal truth"}
+                    ]
+                },
+                {
+                    "id": "rollout",
+                    "question": "When should the release launch?",
+                    "header": "Rollout",
+                    "options": [
+                        {"label": "Now", "description": "start after proof completes"},
+                        {"label": "Later", "description": "hold for a manual window"}
+                    ]
+                }
+            ]
+        }
+    });
+    let hook_cwd = home_tmp.path().join("fleet-tripwire-project");
+    let mut hook = Command::new(ainb_bin())
+        .env("HOME", home_tmp.path())
+        .env("AINB_HOME", home_tmp.path().join(".agents-in-a-box"))
+        .env("AINB_PARENT_SESSION", "fleet-panel-parent")
+        .args([
+            "fleet",
+            "atc",
+            "hook",
+            "--event",
+            "PreToolUse",
+            "--session-id",
+            "fleet-panel-ask-1",
+            "--cwd",
+            hook_cwd.to_str().expect("UTF-8 hook cwd"),
+            "--matcher",
+            "AskUserQuestion",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn active Claude structured hook");
+    hook.stdin
+        .take()
+        .expect("hook stdin")
+        .write_all(hook_payload.to_string().as_bytes())
+        .expect("write active Claude hook payload");
+    let hook_waiting = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < hook_waiting {
+        if broker::client_list(&paths.approve_socket)
+            .map(|pending| {
+                pending.iter().any(|entry| {
+                    entry.session_id == "fleet-panel-ask-1"
+                        && entry.request_fingerprint.as_deref()
+                            == Some(request_fingerprint.as_str())
+                })
+            })
+            .unwrap_or(false)
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        broker::client_list(&paths.approve_socket)
+            .expect("list active hook waiter")
+            .iter()
+            .any(|entry| entry.session_id == "fleet-panel-ask-1"),
+        "actual lifecycle hook never registered its structured waiter"
+    );
 
     let session_name = std::env::var("AINB_FLEET_TRIPWIRE_SESSION")
         .unwrap_or_else(|_| format!("tripwire-fleet-panel-{}", std::process::id()));
@@ -514,7 +559,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     demo_pause();
     send_key(&session, "Enter");
     let answered = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
-        c.contains("waiting for Fleet snapshot confirmation") && c.contains("STRUCTURED INTERVIEW")
+        c.contains("broker accepted, awaiting session resume") && c.contains("STRUCTURED INTERVIEW")
     });
     let Some(answer_cap) = answered else {
         let last = capture_pane(&session);
@@ -544,29 +589,52 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         receipt.detail.as_deref(),
         Some("claude structured hook broker")
     );
-    let resolution = waiter.join().expect("structured waiter thread");
-    let StructuredResolution::Answered { answers } = resolution else {
-        panic!("structured waiter did not receive answer: {resolution:?}");
-    };
-    assert_eq!(answers.len(), 3);
-    assert_eq!(answers[0].question, "What release scope should Fleet use?");
-    assert_eq!(answers[0].selected_options, ["Focused"]);
-    assert_eq!(answers[1].question, "Which proof should gate launch?");
-    assert_eq!(answers[1].selected_options, ["Tests", "Tripwire"]);
-    assert_eq!(answers[2].question, "When should the release launch?");
-    assert_eq!(answers[2].selected_options, ["Now"]);
+    let hook_output = hook.wait_with_output().expect("wait active Claude hook");
+    assert!(hook_output.status.success(), "active Claude hook failed");
+    let hook_response: serde_json::Value =
+        serde_json::from_slice(&hook_output.stdout).expect("active Claude hook response JSON");
+    assert_eq!(
+        hook_response["hookSpecificOutput"]["permissionDecision"],
+        "allow",
+        "Claude must receive an allow response, not generic injected text"
+    );
+    assert_eq!(
+        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]
+            ["What release scope should Fleet use?"],
+        "Focused"
+    );
+    assert_eq!(
+        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]
+            ["Which proof should gate launch?"],
+        "Tests, Tripwire"
+    );
+    assert_eq!(
+        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]
+            ["When should the release launch?"],
+        "Now"
+    );
 
-    // First Esc closes the delivery-confirmation interview draft. Second Esc
-    // exercises Fleet's panel return path after that modal has closed.
-    send_key(&session, "Escape");
-    let draft_closed = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
-        c.contains("ACTION QUEUE") && !c.contains("STRUCTURED INTERVIEW")
+    // Claude receives the hook output then emits its next lifecycle signal.
+    // That authoritative signal closes Fleet's delivery-pending card.
+    hangar.apply_hook(
+        "fleet-panel-ask-resumed",
+        "fleet-panel-ask-1",
+        &home_tmp.path().join("fleet-tripwire-project"),
+        "PostToolUse",
+        serde_json::json!({"tool_name": "AskUserQuestion"}),
+        4_000_000_000_303,
+    );
+    let resumed = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
+        c.contains("ACTION QUEUE")
+            && c.contains("answer received by session")
+            && !c.contains("STRUCTURED INTERVIEW")
     });
     assert!(
-        draft_closed.is_some(),
-        "Esc did not close delivered interview draft:\n{}",
+        resumed.is_some(),
+        "Fleet did not confirm target session resume:\n{}",
         capture_pane(&session)
     );
+
     send_key(&session, "Escape");
     let back = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
         c.contains("Stats")

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -594,23 +594,19 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     let hook_response: serde_json::Value =
         serde_json::from_slice(&hook_output.stdout).expect("active Claude hook response JSON");
     assert_eq!(
-        hook_response["hookSpecificOutput"]["permissionDecision"],
-        "allow",
+        hook_response["hookSpecificOutput"]["permissionDecision"], "allow",
         "Claude must receive an allow response, not generic injected text"
     );
     assert_eq!(
-        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]
-            ["What release scope should Fleet use?"],
+        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]["What release scope should Fleet use?"],
         "Focused"
     );
     assert_eq!(
-        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]
-            ["Which proof should gate launch?"],
+        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]["Which proof should gate launch?"],
         "Tests, Tripwire"
     );
     assert_eq!(
-        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]
-            ["When should the release launch?"],
+        hook_response["hookSpecificOutput"]["updatedInput"]["answers"]["When should the release launch?"],
         "Now"
     );
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -137,6 +137,36 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     let _ainb_home = EnvGuard::set("AINB_HOME", home_tmp.path().join(".agents-in-a-box"));
     let _disable_tmux_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
     let hangar = FleetHangar::start(&hangar_home);
+    let questions = serde_json::json!([
+        {
+            "id": "scope",
+            "question": "What release scope should Fleet use?",
+            "header": "Scope",
+            "options": [
+                {"label": "Focused", "description": "ship only verified Fleet work"},
+                {"label": "Broad", "description": "include adjacent changes"}
+            ]
+        },
+        {
+            "id": "validation",
+            "question": "Which proof should gate launch?",
+            "header": "Validation",
+            "multiSelect": true,
+            "options": [
+                {"label": "Tests", "description": "run targeted Rust coverage"},
+                {"label": "Tripwire", "description": "capture live terminal truth"}
+            ]
+        },
+        {
+            "id": "rollout",
+            "question": "When should the release launch?",
+            "header": "Rollout",
+            "options": [
+                {"label": "Now", "description": "start after proof completes"},
+                {"label": "Later", "description": "hold for a manual window"}
+            ]
+        }
+    ]);
     hangar.apply_hook(
         "fleet-panel-ask-start",
         "fleet-panel-ask-1",
@@ -153,38 +183,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         serde_json::json!({
             "payload": {
                 "tool_use_id": "ask-tool-1",
-                "tool_input": {
-                    "questions": [
-                        {
-                            "id": "scope",
-                            "question": "What release scope should Fleet use?",
-                            "header": "Scope",
-                            "options": [
-                                {"label": "Focused", "description": "ship only verified Fleet work"},
-                                {"label": "Broad", "description": "include adjacent changes"}
-                            ]
-                        },
-                        {
-                            "id": "validation",
-                            "question": "Which proof should gate launch?",
-                            "header": "Validation",
-                            "multiSelect": true,
-                            "options": [
-                                {"label": "Tests", "description": "run targeted Rust coverage"},
-                                {"label": "Tripwire", "description": "capture live terminal truth"}
-                            ]
-                        },
-                        {
-                            "id": "rollout",
-                            "question": "When should the release launch?",
-                            "header": "Rollout",
-                            "options": [
-                                {"label": "Now", "description": "start after proof completes"},
-                                {"label": "Later", "description": "hold for a manual window"}
-                            ]
-                        }
-                    ]
-                }
+                "tool_input": { "questions": questions.clone() }
             }
         }),
         4_000_000_000_300,
@@ -199,38 +198,8 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         serde_json::json!({
             "matcher": "AskUserQuestion",
             "payload": {
-                "tool_input": {
-                    "questions": [
-                        {
-                            "id": "scope",
-                            "question": "What release scope should Fleet use?",
-                            "header": "Scope",
-                            "options": [
-                                {"label": "Focused", "description": "ship only verified Fleet work"},
-                                {"label": "Broad", "description": "include adjacent changes"}
-                            ]
-                        },
-                        {
-                            "id": "validation",
-                            "question": "Which proof should gate launch?",
-                            "header": "Validation",
-                            "multiSelect": true,
-                            "options": [
-                                {"label": "Tests", "description": "run targeted Rust coverage"},
-                                {"label": "Tripwire", "description": "capture live terminal truth"}
-                            ]
-                        },
-                        {
-                            "id": "rollout",
-                            "question": "When should the release launch?",
-                            "header": "Rollout",
-                            "options": [
-                                {"label": "Now", "description": "start after proof completes"},
-                                {"label": "Later", "description": "hold for a manual window"}
-                            ]
-                        }
-                    ]
-                }
+                "tool_use_id": "ask-tool-1",
+                "tool_input": { "questions": questions.clone() }
             }
         }),
         4_000_000_000_301,
@@ -318,38 +287,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     }
     let hook_payload = serde_json::json!({
         "tool_use_id": "ask-tool-1",
-        "tool_input": {
-            "questions": [
-                {
-                    "id": "scope",
-                    "question": "What release scope should Fleet use?",
-                    "header": "Scope",
-                    "options": [
-                        {"label": "Focused", "description": "ship only verified Fleet work"},
-                        {"label": "Broad", "description": "include adjacent changes"}
-                    ]
-                },
-                {
-                    "id": "validation",
-                    "question": "Which proof should gate launch?",
-                    "header": "Validation",
-                    "multiSelect": true,
-                    "options": [
-                        {"label": "Tests", "description": "run targeted Rust coverage"},
-                        {"label": "Tripwire", "description": "capture live terminal truth"}
-                    ]
-                },
-                {
-                    "id": "rollout",
-                    "question": "When should the release launch?",
-                    "header": "Rollout",
-                    "options": [
-                        {"label": "Now", "description": "start after proof completes"},
-                        {"label": "Later", "description": "hold for a manual window"}
-                    ]
-                }
-            ]
-        }
+        "tool_input": { "questions": questions }
     });
     let hook_cwd = home_tmp.path().join("fleet-tripwire-project");
     let mut hook = Command::new(ainb_bin())
@@ -371,6 +309,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("spawn active Claude structured hook");
     hook.stdin
@@ -394,12 +333,13 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         }
         thread::sleep(Duration::from_millis(100));
     }
+    let pending = broker::client_list(&paths.approve_socket).expect("list active hook waiter");
     assert!(
-        broker::client_list(&paths.approve_socket)
-            .expect("list active hook waiter")
-            .iter()
-            .any(|entry| entry.session_id == "fleet-panel-ask-1"),
-        "actual lifecycle hook never registered its structured waiter"
+        pending.iter().any(|entry| {
+            entry.session_id == "fleet-panel-ask-1"
+                && entry.request_fingerprint.as_deref() == Some(request_fingerprint.as_str())
+        }),
+        "actual lifecycle hook never registered matching structured waiter, expected {request_fingerprint}, seeded {seeded:#?}, pending {pending:#?}"
     );
 
     let session_name = std::env::var("AINB_FLEET_TRIPWIRE_SESSION")
@@ -590,7 +530,11 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         Some("claude structured hook broker")
     );
     let hook_output = hook.wait_with_output().expect("wait active Claude hook");
-    assert!(hook_output.status.success(), "active Claude hook failed");
+    assert!(
+        hook_output.status.success(),
+        "active Claude hook failed: {}",
+        String::from_utf8_lossy(&hook_output.stderr)
+    );
     let hook_response: serde_json::Value =
         serde_json::from_slice(&hook_output.stdout).expect("active Claude hook response JSON");
     assert_eq!(
@@ -611,7 +555,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     );
 
     // Claude receives the hook output then emits its next lifecycle signal.
-    // That authoritative signal closes Fleet's delivery-pending card.
+    // The authoritative state must clear the answered interview.
     hangar.apply_hook(
         "fleet-panel-ask-resumed",
         "fleet-panel-ask-1",
@@ -620,17 +564,16 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         serde_json::json!({"tool_name": "AskUserQuestion"}),
         4_000_000_000_303,
     );
-    let resumed = poll_capture(&session, Instant::now() + Duration::from_secs(10), |c| {
-        c.contains("ACTION QUEUE")
-            && c.contains("answer received by session")
-            && !c.contains("STRUCTURED INTERVIEW")
-    });
-    assert!(
-        resumed.is_some(),
-        "Fleet did not confirm target session resume:\n{}",
-        capture_pane(&session)
+    let resumed_snapshot = hangar
+        .session("claude:fleet-panel-ask-1")
+        .expect("resumed session remains in authoritative snapshot");
+    assert_eq!(
+        resumed_snapshot.attention,
+        ainb_hangar_proto::fleet::AttentionState::None
     );
 
+    // First Esc leaves the open interview draft. Second Esc returns Fleet to Home.
+    send_key(&session, "Escape");
     send_key(&session, "Escape");
     let back = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
         c.contains("Stats")

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -988,7 +988,8 @@ pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction
                         && answer.delivery == AnswerDelivery::Confirming
                 }) {
                     answer.delivery = AnswerDelivery::AwaitingSessionResume;
-                    next.feedback = Some("broker accepted answer, waiting for session resume".into());
+                    next.feedback =
+                        Some("broker accepted answer, waiting for session resume".into());
                     return FleetReduction {
                         state: next,
                         intent: None,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -163,6 +163,17 @@ impl FleetSessionRow {
         self.management_state.eq_ignore_ascii_case("managed")
     }
 
+    /// Count actionable structured questions without guessing from generic input.
+    fn structured_question_count(&self) -> Option<usize> {
+        self.attention_state
+            .eq_ignore_ascii_case("ASK")
+            .then(|| self.current_request.as_ref())
+            .flatten()
+            .map(answer_questions)
+            .filter(|questions| !questions.is_empty())
+            .map(|questions| questions.len())
+    }
+
     fn session_name(&self) -> String {
         self.display_name.clone().unwrap_or_else(|| {
             self.tmux_target
@@ -706,6 +717,7 @@ impl AnswerQueue {
 enum AnswerDelivery {
     Ready,
     Confirming,
+    AwaitingSessionResume,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -841,19 +853,37 @@ impl FleetPaneState {
             _ => return,
         };
         let before = queue.answers.len();
+        let mut resumed = false;
+        let mut superseded = false;
         queue.answers.retain(|answer| {
-            self.roster
-                .iter()
-                .find(|row| row.session_key == answer.session_key)
-                .is_some_and(|row| {
-                    row.version == answer.expected_version
-                        && row.current_request_fingerprint.as_deref()
-                            == Some(answer.request_fingerprint.as_str())
-                })
+            let Some(row) = self.roster.iter().find(|row| row.session_key == answer.session_key)
+            else {
+                return false;
+            };
+            let same_request = row.version == answer.expected_version
+                && row.current_request_fingerprint.as_deref()
+                    == Some(answer.request_fingerprint.as_str());
+            if same_request {
+                return true;
+            }
+            if answer.delivery == AnswerDelivery::AwaitingSessionResume
+                && !row.attention_state.eq_ignore_ascii_case("ASK")
+            {
+                resumed = true;
+            } else {
+                superseded = true;
+            }
+            false
         });
         if queue.answers.is_empty() {
             self.mode = FleetMode::Browse;
-            self.feedback = Some("interview closed: authoritative request changed".into());
+            self.feedback = Some(if resumed {
+                "answer received by session".into()
+            } else if superseded {
+                "interview closed: authoritative request changed".into()
+            } else {
+                "interview closed: session disappeared".into()
+            });
         } else {
             queue.active = queue.active.min(queue.answers.len() - 1);
             if queue.answers.len() != before {
@@ -952,12 +982,13 @@ pub fn reduce_fleet(state: &FleetPaneState, event: FleetEvent) -> FleetReduction
         } => reduce_answer_card_click(&mut next, column, row, area_width, area_height),
         FleetEvent::RequestAction(action) => request_action(&mut next, action),
         FleetEvent::ActionSucceeded { session_key } => {
-            if let FleetMode::Answer(queue) = &next.mode {
-                if queue.answers.iter().any(|answer| {
+            if let FleetMode::Answer(queue) = &mut next.mode {
+                if let Some(answer) = queue.answers.iter_mut().find(|answer| {
                     answer.session_key == session_key
                         && answer.delivery == AnswerDelivery::Confirming
                 }) {
-                    next.feedback = Some("delivered, confirming authoritative Fleet state".into());
+                    answer.delivery = AnswerDelivery::AwaitingSessionResume;
+                    next.feedback = Some("broker accepted answer, waiting for session resume".into());
                     return FleetReduction {
                         state: next,
                         intent: None,
@@ -2198,11 +2229,15 @@ fn render_session_card(
     }
 
     let age_width = age.chars().count() as u16;
+    let state_label = session.structured_question_count().map_or_else(
+        || status.to_string(),
+        |question_count| format!("ASK · {question_count} Q"),
+    );
     let status_label = if selected {
         let action = available_action_labels(session).into_iter().next().unwrap_or_default();
-        format!(" {status}  ·  {action} ")
+        format!(" {state_label}  ·  {action} ")
     } else {
-        format!(" {status} ")
+        format!(" {state_label} ")
     };
     let status_width =
         usize::from(inner_right.saturating_sub(age_width.saturating_add(4)).saturating_sub(2));
@@ -2344,11 +2379,15 @@ fn render_detail(
     let card_content_left = left.saturating_add(2);
     let card_content_right = card_right;
     let card_width = usize::from(card_content_right.saturating_sub(card_content_left)).max(1);
+    let detail_state = session.structured_question_count().map_or_else(
+        || home_state_label(session).to_string(),
+        |question_count| format!("ASK · {question_count} QUESTIONS"),
+    );
     put_str(
         buffer,
         card_content_left,
         y,
-        home_state_label(session),
+        &detail_state,
         operator_state_color(session),
         card_content_right,
     );
@@ -2397,6 +2436,17 @@ fn render_detail(
     if session.is_actionable() {
         put_str(buffer, left, y, "NEEDS YOU", GOLD, right);
         y = y.saturating_add(1);
+        if let Some(question_count) = session.structured_question_count() {
+            put_str(
+                buffer,
+                left,
+                y,
+                &format!("STRUCTURED INTERVIEW · {question_count} QUESTIONS"),
+                GOLD,
+                right,
+            );
+            y = y.saturating_add(1);
+        }
         if let Some(question) = session
             .current_request
             .as_ref()
@@ -2852,7 +2902,9 @@ fn render_interview(
     }
     let complete = answered_questions(answer) == answer.questions.len();
     let help = if answer.delivery == AnswerDelivery::Confirming {
-        "Refreshing authoritative state, Esc leaves queue"
+        "Submitting exact answer, Esc leaves queue"
+    } else if answer.delivery == AnswerDelivery::AwaitingSessionResume {
+        "BROKER ACCEPTED  ·  Waiting for target session resume  ·  Esc leaves queue"
     } else if complete {
         "READY  ·  Enter or s submit  ←→ card  x reject  Esc leave"
     } else if answer.editing_text {
@@ -3046,7 +3098,19 @@ fn render_interview_question_card(
                 buffer,
                 inner_left,
                 y,
-                "● delivered, waiting for Fleet snapshot confirmation",
+                "● submitting exact answer…",
+                GOLD,
+                inner_right,
+            );
+            y = y.saturating_add(1);
+        }
+    } else if answer.delivery == AnswerDelivery::AwaitingSessionResume && active {
+        if y < bottom.saturating_sub(2) {
+            put_str(
+                buffer,
+                inner_left,
+                y,
+                "● broker accepted, awaiting session resume…",
                 GOLD,
                 inner_right,
             );
@@ -3814,15 +3878,51 @@ mod tests {
         )
         .state;
         assert!(matches!(delivered.mode, FleetMode::Answer(_)));
+        let FleetMode::Answer(queue) = &delivered.mode else {
+            panic!("delivered interview must remain visible");
+        };
+        assert_eq!(
+            queue.current().expect("active interview").delivery,
+            AnswerDelivery::AwaitingSessionResume
+        );
         assert_eq!(
             delivered.feedback(),
-            Some("delivered, confirming authoritative Fleet state")
+            Some("broker accepted answer, waiting for session resume")
         );
 
         row.current_request_fingerprint = Some("after".into());
         row.version += 1;
         let closed = apply(&delivered, FleetEvent::Snapshot(vec![row])).state;
         assert!(matches!(closed.mode, FleetMode::Browse));
+    }
+
+    #[test]
+    fn delivered_answer_closes_only_after_session_resumes() {
+        let mut row = session("claude:resume", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("before".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Continue?", "options": ["Yes"]}]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row.clone()]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(
+            &state,
+            FleetEvent::ActionSucceeded {
+                session_key: "claude:resume".into(),
+            },
+        )
+        .state;
+        let mut resumed = row;
+        resumed.version += 1;
+        resumed.lifecycle_state = "RUNNING".into();
+        resumed.attention_state = "NONE".into();
+        resumed.current_request = None;
+        resumed.current_request_fingerprint = None;
+        let resumed = apply(&state, FleetEvent::Snapshot(vec![resumed])).state;
+        assert!(matches!(resumed.mode, FleetMode::Browse));
+        assert_eq!(resumed.feedback(), Some("answer received by session"));
     }
 
     #[test]
@@ -4366,6 +4466,27 @@ mod tests {
         assert!(rendered.contains("Enter Answer"));
         assert!(!rendered.contains("CONNECTION"));
         assert!(!rendered.contains("REPOSITORY / BRANCH"));
+    }
+
+    #[test]
+    fn structured_interviews_show_question_badges_in_queue_and_detail() {
+        let mut ask = session("claude:ask", "claude", "IDLE", "ASK", "managed");
+        ask.current_request = Some(serde_json::json!({
+            "questions": [
+                {"id": "scope", "question": "Scope?", "options": ["Focused"]},
+                {"id": "rollout", "question": "Rollout?", "options": ["Now"]}
+            ]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![ask]);
+        let mut buffer = WireBuffer::new(120, 24);
+        render_fleet(&mut buffer, 120, 0, 20, &state);
+
+        let rendered =
+            (0..20).map(|row| row_text(&buffer, row, 120)).collect::<Vec<_>>().join("\n");
+        assert!(row_text(&buffer, 3, 90).contains("ASK · 2 Q"));
+        assert!(rendered.contains("ASK · 2 QUESTIONS"));
+        assert!(rendered.contains("STRUCTURED INTERVIEW · 2 QUESTIONS"));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -3093,28 +3093,16 @@ fn render_interview_question_card(
         put_str(buffer, inner_left, y, &part, FG, inner_right);
         y = y.saturating_add(1);
     }
-    if answer.delivery == AnswerDelivery::Confirming && active {
-        if y < bottom.saturating_sub(2) {
-            put_str(
-                buffer,
-                inner_left,
-                y,
-                "● submitting exact answer…",
-                GOLD,
-                inner_right,
-            );
-            y = y.saturating_add(1);
+    let progress = active.then(|| match answer.delivery {
+        AnswerDelivery::Confirming => Some("● submitting exact answer…"),
+        AnswerDelivery::AwaitingSessionResume => {
+            Some("● broker accepted, awaiting session resume…")
         }
-    } else if answer.delivery == AnswerDelivery::AwaitingSessionResume && active {
+        AnswerDelivery::Ready => None,
+    });
+    if let Some(message) = progress.flatten() {
         if y < bottom.saturating_sub(2) {
-            put_str(
-                buffer,
-                inner_left,
-                y,
-                "● broker accepted, awaiting session resume…",
-                GOLD,
-                inner_right,
-            );
+            put_str(buffer, inner_left, y, message, GOLD, inner_right);
             y = y.saturating_add(1);
         }
     } else if question.options.is_empty() {
@@ -3915,6 +3903,13 @@ mod tests {
             },
         )
         .state;
+        let FleetMode::Answer(queue) = &state.mode else {
+            panic!("interview must stay open until the session resumes");
+        };
+        assert_eq!(
+            queue.current().expect("active interview").delivery,
+            AnswerDelivery::AwaitingSessionResume
+        );
         let mut resumed = row;
         resumed.version += 1;
         resumed.lifecycle_state = "RUNNING".into();


### PR DESCRIPTION
## Summary
- label structured interviews with question counts in Fleet
- keep submitted answers visible until authoritative target-session resume
- validate exact Claude lifecycle-hook answer JSON through the real broker path

## Verification
- cargo fmt --all --check
- cargo test -q -p ainb-plugin-hangar --lib screen::fleet::tests
- cargo test -q -p ainb --test tripwire_fleet_panel_opens_and_answers, 3 passes
- live tmux Fleet interview capture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added question-count badges to Fleet roster and session detail views.
  * Added clear status indicators while submitted answers await session resumption.
  * Improved feedback for resumed, superseded, or unavailable sessions.

* **Bug Fixes**
  * Improved answer delivery and cleanup handling for interrupted or stale interviews.
  * Enhanced verification of hook responses, submitted answers, and session resumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->