### PR TITLE
fix(hooks): honor AINB_BIN for ATC events

### DIFF
--- a/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
@@ -14,6 +14,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
+use std::{fs, os::unix::fs::PermissionsExt};
 
 use ainb_plugin_notifyd::{Paths, RetentionPolicy, RunConfig, Store, run_daemon};
 
@@ -107,6 +108,51 @@ fn fire_copilot_hook(script: &Path, home: &Path, json: &str) {
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
+}
+
+#[test]
+fn atc_hook_prefers_ainb_bin_over_path() {
+    let script = hook_script();
+    let dir = tempfile::tempdir().unwrap();
+    let explicit_bin = dir.path().join("source-ainb");
+    let path_dir = dir.path().join("path-bin");
+    let path_bin = path_dir.join("ainb");
+    let capture = dir.path().join("captured-bin");
+    fs::create_dir(&path_dir).unwrap();
+
+    for (bin, marker) in [(&explicit_bin, "explicit"), (&path_bin, "path")] {
+        fs::write(
+            bin,
+            format!("#!/usr/bin/env bash\nprintf '%s' '{marker}' > \"$AINB_HOOK_CAPTURE\"\n"),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(bin).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(bin, permissions).unwrap();
+    }
+
+    let original_path = std::env::var("PATH").unwrap();
+    let out = Command::new("bash")
+        .arg(&script)
+        .env("AINB_AGENT", "claude")
+        .env("AINB_MANAGED", "atc")
+        .env("AINB_BIN", &explicit_bin)
+        .env("AINB_HOOK_CAPTURE", &capture)
+        .env("AINB_NOTIFY_DISABLE_LAZY_SPAWN", "1")
+        .env("PATH", format!("{}:{original_path}", path_dir.display()))
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(
+                br#"{"hook_event_name":"Stop","session_id":"sess-hook-bin","cwd":"/tmp"}"#,
+            )?;
+            child.wait()
+        })
+        .expect("running hook");
+
+    assert!(out.success(), "hook failed: {out}");
+    assert_eq!(fs::read_to_string(capture).unwrap(), "explicit");
 }
 
 #[tokio::test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
@@ -114,16 +114,20 @@ fn fire_copilot_hook(script: &Path, home: &Path, json: &str) {
 fn atc_hook_prefers_ainb_bin_over_path() {
     let script = hook_script();
     let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
     let explicit_bin = dir.path().join("source-ainb");
     let path_dir = dir.path().join("path-bin");
     let path_bin = path_dir.join("ainb");
     let capture = dir.path().join("captured-bin");
+    fs::create_dir(&home).unwrap();
     fs::create_dir(&path_dir).unwrap();
 
     for (bin, marker) in [(&explicit_bin, "explicit"), (&path_bin, "path")] {
         fs::write(
             bin,
-            format!("#!/usr/bin/env bash\nprintf '%s' '{marker}' > \"$AINB_HOOK_CAPTURE\"\n"),
+            format!(
+                "#!/usr/bin/env bash\nprintf '%s %s\\n' '{marker}' \"$*\" >> \"$AINB_HOOK_CAPTURE\"\n"
+            ),
         )
         .unwrap();
         let mut permissions = fs::metadata(bin).unwrap().permissions();
@@ -134,11 +138,11 @@ fn atc_hook_prefers_ainb_bin_over_path() {
     let original_path = std::env::var("PATH").unwrap();
     let out = Command::new("bash")
         .arg(&script)
+        .env("HOME", &home)
         .env("AINB_AGENT", "claude")
         .env("AINB_MANAGED", "atc")
         .env("AINB_BIN", &explicit_bin)
         .env("AINB_HOOK_CAPTURE", &capture)
-        .env("AINB_NOTIFY_DISABLE_LAZY_SPAWN", "1")
         .env("PATH", format!("{}:{original_path}", path_dir.display()))
         .stdin(std::process::Stdio::piped())
         .spawn()
@@ -152,7 +156,10 @@ fn atc_hook_prefers_ainb_bin_over_path() {
         .expect("running hook");
 
     assert!(out.success(), "hook failed: {out}");
-    assert_eq!(fs::read_to_string(capture).unwrap(), "explicit");
+    let calls = fs::read_to_string(capture).unwrap();
+    assert!(calls.contains("explicit notifyd"), "calls: {calls}");
+    assert!(calls.contains("explicit fleet atc hook"), "calls: {calls}");
+    assert!(!calls.contains("path "), "calls: {calls}");
 }
 
 #[tokio::test]

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -144,6 +144,14 @@ ainb_send() {
   return 2
 }
 
+# Dev launches set AINB_BIN to their freshly built binary. Do not fall back to
+# a different installed `ainb`: that silently projects hook events with stale
+# Fleet code while the visible TUI is current.
+AINB_HOOK_BIN="${AINB_BIN:-}"
+if [ -z "${AINB_HOOK_BIN}" ]; then
+  AINB_HOOK_BIN="$(command -v ainb 2>/dev/null || true)"
+fi
+
 ainb_socket_alive() {
   # True only when a daemon is actually ACCEPTING on the socket. A bare
   # socket *file* left behind by a crashed daemon must NOT count — testing
@@ -172,7 +180,7 @@ ainb_lazy_spawn() {
   if ainb_socket_alive; then
     return 0
   fi
-  if ! command -v ainb >/dev/null 2>&1; then
+  if [ -z "${AINB_HOOK_BIN}" ] || [ ! -x "${AINB_HOOK_BIN}" ]; then
     return 1
   fi
   # Mutual exclusion across concurrent first-fires. `mkdir` is atomic on
@@ -197,7 +205,7 @@ ainb_lazy_spawn() {
   # the suspected cause of daemons wedging in startup before they ever
   # bind), stdout/stderr discarded, nohup so a closing pane/tmux can't
   # SIGHUP it.
-  nohup ainb notifyd </dev/null >/dev/null 2>&1 &
+  nohup "${AINB_HOOK_BIN}" notifyd </dev/null >/dev/null 2>&1 &
   # Wait up to 1s for the socket to come up, then release the lock.
   ainb_attempts=0
   while [ "${ainb_attempts}" -lt 100 ]; do
@@ -232,13 +240,6 @@ fi
 # parent inbox commit, and — on Stop — the synchronous drain that prints
 # {"decision":"block",...}). The shell only forwards what it already parsed and
 # relays the command's stdout verbatim so Claude Code sees the block JSON.
-# Dev launches set AINB_BIN to their freshly built binary. Do not fall back to
-# a different installed `ainb`: that silently projects hook events with stale
-# Fleet code while the visible TUI is current.
-AINB_HOOK_BIN="${AINB_BIN:-}"
-if [ -z "${AINB_HOOK_BIN}" ]; then
-  AINB_HOOK_BIN="$(command -v ainb 2>/dev/null || true)"
-fi
 if { [ "${AINB_MANAGED:-}" = "atc" ] || [ "${AINB_AGENT:-}" = "claude" ] || [ "${AINB_AGENT:-}" = "codex" ]; } \
   && [ -n "${AINB_HOOK_BIN}" ] && [ -x "${AINB_HOOK_BIN}" ]; then
   AINB_HOOK_EVENT="${AINB_HOOK_EVENT:-${AINB_RAW_EVENT}}"

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -232,8 +232,15 @@ fi
 # parent inbox commit, and — on Stop — the synchronous drain that prints
 # {"decision":"block",...}). The shell only forwards what it already parsed and
 # relays the command's stdout verbatim so Claude Code sees the block JSON.
+# Dev launches set AINB_BIN to their freshly built binary. Do not fall back to
+# a different installed `ainb`: that silently projects hook events with stale
+# Fleet code while the visible TUI is current.
+AINB_HOOK_BIN="${AINB_BIN:-}"
+if [ -z "${AINB_HOOK_BIN}" ]; then
+  AINB_HOOK_BIN="$(command -v ainb 2>/dev/null || true)"
+fi
 if { [ "${AINB_MANAGED:-}" = "atc" ] || [ "${AINB_AGENT:-}" = "claude" ] || [ "${AINB_AGENT:-}" = "codex" ]; } \
-  && command -v ainb >/dev/null 2>&1; then
+  && [ -n "${AINB_HOOK_BIN}" ] && [ -x "${AINB_HOOK_BIN}" ]; then
   AINB_HOOK_EVENT="${AINB_HOOK_EVENT:-${AINB_RAW_EVENT}}"
   # Resolve the matcher to forward: the managed command sets AINB_HOOK_MATCHER
   # (e.g. AskUserQuestion for the PreToolUse hook); otherwise fall back to the
@@ -245,7 +252,7 @@ if { [ "${AINB_MANAGED:-}" = "atc" ] || [ "${AINB_AGENT:-}" = "claude" ] || [ "$
   # Forward the original payload on stdin so the Rust side can extract a
   # done_summary (last assistant line) + transcript_path without re-reading the
   # transcript.
-  AINB_HOOK_OUT="$(printf '%s' "${AINB_INPUT}" | ainb fleet atc hook \
+  AINB_HOOK_OUT="$(printf '%s' "${AINB_INPUT}" | "${AINB_HOOK_BIN}" fleet atc hook \
     --event "${AINB_HOOK_EVENT}" \
     --session-id "${AINB_SESSION_ID}" \
     --cwd "${AINB_CWD}" \


### PR DESCRIPTION
## Summary
- route ATC lifecycle hook through explicit `AINB_BIN` when present
- retain PATH fallback for installed use
- add regression coverage for source binary precedence

## Verification
- `bash -n plugins/ainb-hooks/hooks/notify.sh`
- `cargo test -p ainb-plugin-notifyd --test end_to_end`
- `cargo build -p ainb --bin ainb -p ainb-plugin-notifyd`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hook execution now prioritizes the explicitly configured `AINB_BIN` executable over the version found on `PATH`.
  - Added validation to ensure the selected executable exists and is runnable before processing ATC events.
  - Improved reliability when invoking ATC hooks with custom binary configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->