### PR TITLE
fix: improve Fleet notch roster

### DIFF
--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -329,6 +329,10 @@ private struct FleetNotchSessionRow: View {
     let connection: FleetConnectionState
     let select: () -> Void
 
+    private var identity: FleetSessionIdentity {
+        FleetRosterPresentation.sessionIdentity(for: session)
+    }
+
     var body: some View {
         Button(action: select) {
             HStack(alignment: .top, spacing: 10) {
@@ -337,7 +341,7 @@ private struct FleetNotchSessionRow: View {
                     .foregroundStyle(providerColor)
                     .frame(width: 25)
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(FleetRosterPresentation.sessionIdentity(for: session).repository)
+                    Text(identity.repository)
                         .font(.subheadline.weight(.semibold))
                         .lineLimit(1)
                     Text(metadata)
@@ -368,12 +372,11 @@ private struct FleetNotchSessionRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("fleet.notch.row.\(session.sessionKey)")
-        .accessibilityLabel(session.displayName ?? session.sessionKey)
+        .accessibilityLabel(identity.accessibilityLabel)
         .accessibilityValue(FleetRosterPresentation.semanticStatus(for: session, connection: connection))
     }
 
     private var metadata: String {
-        let identity = FleetRosterPresentation.sessionIdentity(for: session)
         return [identity.worktree, identity.branch].compactMap { $0 }.joined(separator: " · ")
     }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -219,10 +219,12 @@ private struct FleetNotchView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 7) {
                     ForEach(FleetRosterFocus.allCases) { focus in
-                        Button(focus.label) { presentation.preferences.filters.focus = focus }
-                            .buttonStyle(.bordered)
-                            .tint(presentation.preferences.filters.focus == focus ? FleetNotchPalette.mint : nil)
-                            .accessibilityIdentifier("fleet.notch.filter.\(focus.rawValue)")
+                        FleetNotchFocusChip(
+                            focus: focus,
+                            selected: presentation.preferences.filters.focus == focus
+                        ) {
+                            toggleFocus(focus)
+                        }
                     }
                 }
             }
@@ -296,6 +298,29 @@ private struct FleetNotchView: View {
         guard !visibleSessions.contains(where: { $0.sessionKey == store.selectedSessionKey }) else { return }
         store.selectedSessionKey = visibleSessions.first?.sessionKey
     }
+
+    private func toggleFocus(_ focus: FleetRosterFocus) {
+        if presentation.preferences.filters.focus == focus, focus != .all {
+            presentation.preferences.filters.focus = .all
+        } else {
+            presentation.preferences.filters.focus = focus
+        }
+    }
+}
+
+private struct FleetNotchFocusChip: View {
+    let focus: FleetRosterFocus
+    let selected: Bool
+    let toggle: () -> Void
+
+    var body: some View {
+        Button(action: toggle) {
+            Text(focus.label)
+        }
+        .buttonStyle(.bordered)
+        .tint(selected ? FleetNotchPalette.mint : .gray)
+        .accessibilityIdentifier("fleet.notch.filter.\(focus.rawValue)")
+    }
 }
 
 private struct FleetNotchSessionRow: View {
@@ -312,7 +337,7 @@ private struct FleetNotchSessionRow: View {
                     .foregroundStyle(providerColor)
                     .frame(width: 25)
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(session.displayName ?? session.sessionKey)
+                    Text(FleetRosterPresentation.sessionIdentity(for: session).repository)
                         .font(.subheadline.weight(.semibold))
                         .lineLimit(1)
                     Text(metadata)
@@ -348,8 +373,8 @@ private struct FleetNotchSessionRow: View {
     }
 
     private var metadata: String {
-        let repository = URL(fileURLWithPath: session.cwd).lastPathComponent
-        return repository.isEmpty || repository == session.cwd ? session.cwd : "\(repository) · \(session.cwd)"
+        let identity = FleetRosterPresentation.sessionIdentity(for: session)
+        return [identity.worktree, identity.branch].compactMap { $0 }.joined(separator: " · ")
     }
 
     private var activity: String {

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
@@ -158,6 +158,10 @@ struct FleetSessionIdentity: Equatable {
     let worktree: String?
     let branch: String?
 
+    var accessibilityLabel: String {
+        [repository, worktree, branch].compactMap { $0 }.joined(separator: ", ")
+    }
+
     init(session: FleetSession) {
         let path = URL(fileURLWithPath: session.cwd)
         let components = path.pathComponents

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
@@ -77,6 +77,10 @@ struct FleetPresentationPreferences: Codable, Equatable {
 }
 
 enum FleetRosterPresentation {
+    static func sessionIdentity(for session: FleetSession) -> FleetSessionIdentity {
+        FleetSessionIdentity(session: session)
+    }
+
     static func visibleSessions(
         _ sessions: [FleetSession],
         search: String,
@@ -146,5 +150,43 @@ enum FleetRosterPresentation {
         case .exited: return 2
         case .unknown: return 1
         }
+    }
+}
+
+struct FleetSessionIdentity: Equatable {
+    let repository: String
+    let worktree: String?
+    let branch: String?
+
+    init(session: FleetSession) {
+        let path = URL(fileURLWithPath: session.cwd)
+        let components = path.pathComponents
+        let worktreeIndex = components.lastIndex(of: "worktrees")
+        let candidate = worktreeIndex.flatMap { index -> String? in
+            let remainder = components.dropFirst(index + 1)
+            guard !remainder.isEmpty else { return nil }
+            return remainder.first == "by-name" ? remainder.dropFirst().last : remainder.last
+        } ?? path.lastPathComponent
+        let labels = candidate.split(separator: "--", omittingEmptySubsequences: true).map(String.init)
+
+        if labels.count >= 2 {
+            repository = labels[0]
+            worktree = candidate
+            branch = Self.branchLabel(labels[1])
+        } else {
+            repository = candidate.isEmpty || candidate == "/" ? (session.displayName ?? session.sessionKey) : candidate
+            worktree = candidate.isEmpty || candidate == "/" ? nil : candidate
+            branch = nil
+        }
+    }
+
+    private static func branchLabel(_ value: String) -> String {
+        for prefix in ["f", "feat", "fix", "ops", "chore", "docs"] {
+            let marker = "\(prefix)-"
+            if value.hasPrefix(marker) {
+                return "\(prefix)/\(value.dropFirst(marker.count))"
+            }
+        }
+        return value
     }
 }

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
@@ -165,7 +165,7 @@ struct FleetSessionIdentity: Equatable {
         let candidate = worktreeIndex.flatMap { index -> String? in
             let remainder = components.dropFirst(index + 1)
             guard !remainder.isEmpty else { return nil }
-            return remainder.first == "by-name" ? remainder.dropFirst().last : remainder.last
+            return remainder.first == "by-name" ? remainder.dropFirst().first : remainder.first
         } ?? path.lastPathComponent
         let labels = candidate.split(separator: "--", omittingEmptySubsequences: true).map(String.init)
 

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
@@ -84,7 +84,7 @@ final class FleetRosterPresentationTests: XCTestCase {
     }
 
     func testSessionIdentityUsesWorktreeRepositoryAndBranch() {
-        let value = session(key: "claude:uuid", lifecycle: .idle, cwd: "/Users/stevie/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-minor-bugs--abcd")
+        let value = session(key: "claude:uuid", lifecycle: .idle, cwd: "/Users/stevie/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-minor-bugs--abcd/apps/ainb-fleet-macos")
         let identity = FleetRosterPresentation.sessionIdentity(for: value)
         XCTAssertEqual(identity.repository, "agents-in-a-box")
         XCTAssertEqual(identity.worktree, "agents-in-a-box--f-minor-bugs--abcd")

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
@@ -83,6 +83,14 @@ final class FleetRosterPresentationTests: XCTestCase {
         XCTAssertEqual(decoded.activeWorkCount, 3)
     }
 
+    func testSessionIdentityUsesWorktreeRepositoryAndBranch() {
+        let value = session(key: "claude:uuid", lifecycle: .idle, cwd: "/Users/stevie/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-minor-bugs--abcd")
+        let identity = FleetRosterPresentation.sessionIdentity(for: value)
+        XCTAssertEqual(identity.repository, "agents-in-a-box")
+        XCTAssertEqual(identity.worktree, "agents-in-a-box--f-minor-bugs--abcd")
+        XCTAssertEqual(identity.branch, "f/minor-bugs")
+    }
+
     func testStatusIconPrefersDegradedSessionOverAttention() {
         let value = session(key: "degraded", lifecycle: .running, attention: .ask, management: .degraded)
         XCTAssertEqual(FleetStatusPresentation.symbol(for: .live(daemonVersion: "test", writeCompatible: true), needsYou: 1, sessions: [value]), "exclamationmark.circle.fill")
@@ -131,7 +139,7 @@ final class FleetRosterPresentationTests: XCTestCase {
         XCTAssertEqual(event.deepLink.absoluteString, "ainbfleet://session/codex%2Fa%3Fb%23c")
     }
 
-    private func session(key: String, lifecycle: LifecycleState, attention: AttentionState = .none, activeWorkCount: Int64? = nil, management: ManagementState = .managed, transportHealth: TransportHealth = .healthy, observedAt: Int64 = 1, revision: Int64 = 1) -> FleetSession {
-        FleetSession(sessionKey: key, provider: .codex, providerSessionID: nil, tmuxTarget: nil, processStartFingerprint: nil, cwd: "/workspace", displayName: key, lifecycle: lifecycle, activeWorkCount: activeWorkCount, attention: attention, currentRequestFingerprint: nil, currentRequest: nil, management: management, transportHealth: transportHealth, capabilities: FleetCapabilities(structuredAnswer: false, approvals: false, sendPrompt: false, continueTurn: false, retry: false, interrupt: false, start: false, stop: false, restart: false, kill: false, archive: false, tmuxAttach: false, tmuxText: false, verifiedPicker: false), provenance: .authoritative, confidence: .high, discoveredAt: observedAt, lastObservedAt: observedAt, lifecycleUpdatedAt: observedAt, attentionUpdatedAt: observedAt, version: 1, updatedRevision: revision)
+    private func session(key: String, lifecycle: LifecycleState, cwd: String = "/workspace", attention: AttentionState = .none, activeWorkCount: Int64? = nil, management: ManagementState = .managed, transportHealth: TransportHealth = .healthy, observedAt: Int64 = 1, revision: Int64 = 1) -> FleetSession {
+        FleetSession(sessionKey: key, provider: .codex, providerSessionID: nil, tmuxTarget: nil, processStartFingerprint: nil, cwd: cwd, displayName: key, lifecycle: lifecycle, activeWorkCount: activeWorkCount, attention: attention, currentRequestFingerprint: nil, currentRequest: nil, management: management, transportHealth: transportHealth, capabilities: FleetCapabilities(structuredAnswer: false, approvals: false, sendPrompt: false, continueTurn: false, retry: false, interrupt: false, start: false, stop: false, restart: false, kill: false, archive: false, tmuxAttach: false, tmuxText: false, verifiedPicker: false), provenance: .authoritative, confidence: .high, discoveredAt: observedAt, lastObservedAt: observedAt, lifecycleUpdatedAt: observedAt, attentionUpdatedAt: observedAt, version: 1, updatedRevision: revision)
     }
 }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
@@ -89,6 +89,7 @@ final class FleetRosterPresentationTests: XCTestCase {
         XCTAssertEqual(identity.repository, "agents-in-a-box")
         XCTAssertEqual(identity.worktree, "agents-in-a-box--f-minor-bugs--abcd")
         XCTAssertEqual(identity.branch, "f/minor-bugs")
+        XCTAssertEqual(identity.accessibilityLabel, "agents-in-a-box, agents-in-a-box--f-minor-bugs--abcd, f/minor-bugs")
     }
 
     func testStatusIconPrefersDegradedSessionOverAttention() {

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -47,6 +47,9 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
         waitFor(app.buttons["fleet.notch.row.codex:ask"])
         XCTAssertFalse(app.buttons["fleet.notch.row.claude:active"].exists)
         waitFor(app.staticTexts["fleet.notch.detail.codex:ask"])
+
+        app.buttons["fleet.notch.filter.ask"].click()
+        waitFor(app.buttons["fleet.notch.row.claude:active"])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- allow second click on active notch filter to clear it
- show repo, worktree, and branch instead of provider UUIDs
- cover identity labels and filter clearing

## Verification
- xcodebuild test -scheme AINBFleet -destination platform=macOS
- xcodebuild test -scheme FleetUITests -only-testing:FleetUITests/MenuBarRosterJourneyTests/testNotchFilterSelectsOnlyVisibleSessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved session labels to clearly show repository, worktree, and branch information.
  - Added toggle behavior to focus filters: selecting the active filter again returns to showing all sessions.

- **Bug Fixes**
  - Improved handling of sessions with missing or root working-directory paths.
  - Normalized recognized branch prefixes for more consistent display.

- **Tests**
  - Added coverage for session identity and filter toggling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->