### PR TITLE
fix(fleet): reconcile Claude interviews

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -2965,7 +2965,8 @@ impl EventHandler {
     ///   - Enter            answer the selected structured question
     ///   - B                open broadcast composer for the current lens
     ///   - 1 / 2 / 3 / 4 / 5 switch Needs input / Idle / Completed / Running / All
-    ///   - r                restart the selected session after confirmation
+    ///   - r                reconcile the selected Claude interview
+    ///   - R                restart the selected session after confirmation
     ///   - q / Esc          back to the screen it was opened from (PanelBack)
     ///
     /// Routed through `PanelBack` so it pops the `previous_screen` that

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3026,9 +3026,8 @@ impl EventHandler {
                     Some(AppEvent::FleetPanelNewAtcOpen)
                 }
             }
-            KeyCode::Char('r' | 'R') => {
-                Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart))
-            }
+            KeyCode::Char('r') => Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('r'))),
+            KeyCode::Char('R') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart)),
             KeyCode::Char('s') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Stop)),
             KeyCode::Char('i') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Interrupt)),
             KeyCode::Char('c') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Continue)),
@@ -3303,6 +3302,7 @@ impl EventHandler {
                 let action_label = match &action {
                     FleetAction::StructuredAnswer { .. } => "answered ask",
                     FleetAction::DismissStructured { .. } => "rejected interview",
+                    FleetAction::ReconcileStructured { .. } => "reconciled interview",
                     FleetAction::Approve { .. } => "approved request",
                     FleetAction::Deny { .. } => "denied request",
                     FleetAction::SendText { .. } => "sent prompt",
@@ -8814,7 +8814,7 @@ mod panel_back_tests {
         ));
         assert!(matches!(
             route(&mut state, KeyCode::Char('r')),
-            Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart))
+            Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('r')))
         ));
 
         // Esc/q pop back to the saved origin, not hardcoded home.

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1216,7 +1216,6 @@ fn hook_core_for_agent(
         && base_event == "PreToolUse"
         && matcher.as_deref() == Some("AskUserQuestion")
         && !session_id.is_empty()
-        && is_fleet_member
     {
         let socket = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
         let (tool_input, questions, fingerprint) = match extract_structured_tool_input(payload) {
@@ -1249,11 +1248,14 @@ fn hook_core_for_agent(
     //    answers from the fleet UI (or `ainb fleet ... approve/deny`), then
     //    relays the verdict straight back as a `hookSpecificOutput` permission
     //    decision. Fleet members only — an unrelated host session must NOT wedge
-    //    on our socket. `client_await` re-dials to its deadline, so a notifyd
+    //    on our socket. AskUserQuestion is owned by the structured PreToolUse
+    //    path above, never by this generic permission path. `client_await`
+    //    re-dials to its deadline, so a notifyd
     //    restart mid-wait is survived; a dead socket / no answer deny-falls-back
     //    (never auto-approves).
     if agent == "claude"
         && base_event == "PermissionRequest"
+        && matcher.as_deref() != Some("AskUserQuestion")
         && !session_id.is_empty()
         && is_fleet_member
     {
@@ -2415,7 +2417,8 @@ mod tests {
         use tokio::net::UnixListener;
 
         let home = TempDir::new().unwrap();
-        let cwd = provision_atc(home.path(), "tower");
+        let cwd = home.path().join("plain-claude-worktree");
+        std::fs::create_dir_all(&cwd).unwrap();
         let paths = ainb_plugin_notifyd::paths::Paths::under(home.path());
         std::fs::create_dir_all(paths.approve_socket.parent().unwrap()).unwrap();
         let listener = UnixListener::bind(&paths.approve_socket).unwrap();
@@ -2459,7 +2462,7 @@ mod tests {
                 &hook_home,
                 "PreToolUse",
                 "ask-session",
-                hook_cwd.to_str().unwrap(),
+                hook_cwd.to_str().expect("temporary cwd is valid UTF-8"),
                 None,
                 None,
                 50,

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1127,6 +1127,10 @@ fn hook_core_for_agent(
     let self_inbox =
         (!session_id.is_empty()).then(|| plumbing::Inbox::open_in(&inbox_dir, session_id));
     let has_self_inbox = self_inbox.as_ref().is_some_and(|ib| !ib.is_empty());
+    let is_structured_ask = agent == "claude"
+        && base_event == "PreToolUse"
+        && matcher.as_deref() == Some("AskUserQuestion")
+        && !session_id.is_empty();
 
     // 1. Event log append — the durable record this session's lifecycle is
     //    event-sourced from. Replaces the per-event status/<id>.json write: notifyd
@@ -1139,7 +1143,7 @@ fn hook_core_for_agent(
     //    session ID writes a raw envelope. Broker-mediated structured answers
     //    and approvals remain limited to known Fleet members below.
     let is_fleet_member = our_parent.is_some() || has_self_inbox || atc_name.is_some();
-    if !session_id.is_empty() {
+    let append_event = || {
         let event_id = uuid::Uuid::new_v4().to_string();
         let raw_payload_stored = persist_raw_hook_payload(home, &event_id, payload).is_ok();
         let line = build_event_line_for_agent(
@@ -1155,6 +1159,9 @@ fn hook_core_for_agent(
             raw_payload_stored,
         );
         let _ = append_event_line(home, &line);
+    };
+    if !session_id.is_empty() && !is_structured_ask {
+        append_event();
     }
 
     // Self-heal the durable child→parent map. `ainb run` seeds only the live
@@ -1212,11 +1219,7 @@ fn hook_core_for_agent(
     // 4. PreToolUse(AskUserQuestion): block on exact structured answers and
     //    return the full original questions plus Claude's answer map. Labels
     //    never pass through generic text delivery.
-    if agent == "claude"
-        && base_event == "PreToolUse"
-        && matcher.as_deref() == Some("AskUserQuestion")
-        && !session_id.is_empty()
-    {
+    if is_structured_ask {
         let socket = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
         let (tool_input, questions, fingerprint) = match extract_structured_tool_input(payload) {
             Ok(request) => request,
@@ -1230,6 +1233,23 @@ fn hook_core_for_agent(
                 ))));
             }
         };
+        let registered = ainb_plugin_notifyd::broker::client_register_structured(
+            &socket,
+            session_id,
+            &fingerprint,
+            &questions,
+        )
+        .unwrap_or(false);
+        if !registered {
+            let resolution = ainb_plugin_notifyd::broker::StructuredResolution::Rejected {
+                reason: "Fleet structured broker unavailable".to_string(),
+            };
+            return Ok(Some(HookEmit::Structured(structured_emit_json(
+                tool_input,
+                &resolution,
+            ))));
+        }
+        append_event();
         let resolution = ainb_plugin_notifyd::broker::client_await_structured(
             &socket,
             session_id,
@@ -2488,6 +2508,11 @@ mod tests {
             original_questions.as_array().unwrap().clone()
         );
         let fingerprint = pending.request_fingerprint.unwrap();
+        let events = std::fs::read_to_string(home.path().join("events.jsonl")).unwrap();
+        assert!(
+            events.contains("ask-session"),
+            "Fleet event must appear only after broker registration"
+        );
 
         let stale_socket = paths.approve_socket.clone();
         let stale = tokio::task::spawn_blocking(move || {
@@ -2548,5 +2573,46 @@ mod tests {
 
         server.abort();
         let _ = std::fs::remove_file(&paths.approve_socket);
+    }
+
+    #[test]
+    fn ask_hook_without_broker_rejects_without_persisting_a_fleet_card() {
+        let home = TempDir::new().unwrap();
+        let cwd = home.path().join("plain-claude-worktree");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let payload = serde_json::json!({
+            "tool_name": "AskUserQuestion",
+            "tool_use_id": "toolu_missing_broker",
+            "tool_input": {
+                "questions": [{
+                    "question": "Continue?",
+                    "header": "Continue",
+                    "options": [{"label": "Yes"}]
+                }]
+            }
+        })
+        .to_string();
+
+        let emitted = hook_core(
+            home.path(),
+            "PreToolUse",
+            "missing-broker-session",
+            cwd.to_str().unwrap(),
+            None,
+            None,
+            50,
+            &payload,
+            Some("AskUserQuestion"),
+        )
+        .unwrap()
+        .expect("structured hook output");
+        let HookEmit::Structured(line) = emitted else {
+            panic!("AskUserQuestion must emit structured hook output");
+        };
+        assert!(line.contains("Fleet structured broker unavailable"));
+        assert!(
+            !home.path().join("events.jsonl").exists(),
+            "unregistered AskUserQuestion must never create an actionable Fleet card"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -188,7 +188,16 @@ pub async fn apply_hook(
     // Claude emits a PermissionRequest and then a generic notification around an
     // AskUserQuestion. They describe the same picker, not two operator actions.
     let event_type = canonical_hook_event_type(observation.event_type, observation.payload);
-    let preserve_active_request = observation.event_type == "Notification"
+    let source_event_type = observation
+        .payload
+        .pointer("/payload/hook_event_name")
+        .and_then(Value::as_str)
+        .unwrap_or(observation.event_type);
+    let duplicate_claude_structured_permission = provider == Provider::Claude
+        && source_event_type == "PermissionRequest"
+        && claude_hook_tool_name(observation.payload) == Some("AskUserQuestion");
+    let preserve_active_request = (observation.event_type == "Notification"
+        || duplicate_claude_structured_permission)
         && FleetRepo::get_session(pool, session_key.as_str())
             .await?
             .is_some_and(|session| {
@@ -429,14 +438,17 @@ pub async fn current_request_wire(
     session_key: &str,
 ) -> Result<Option<Value>, sqlx::Error> {
     sqlx::query_scalar::<_, String>(
-        "SELECT payload FROM fleet_event \
-         WHERE session_key = ? AND event_type IN (\
+        "SELECT event.payload FROM fleet_session AS session \
+         JOIN fleet_event AS event ON event.session_key = session.session_key \
+         WHERE session.session_key = ? \
+           AND event.request_fingerprint = session.current_request_fingerprint \
+           AND event.event_type IN (\
             'AskUserQuestion', 'PermissionRequest', \
             'item/tool/requestUserInput', \
             'item/commandExecution/requestApproval', \
             'item/fileChange/requestApproval', \
             'item/permissions/requestApproval'\
-         ) AND applied = 1 ORDER BY revision DESC LIMIT 1",
+         ) AND event.applied = 1 ORDER BY event.revision DESC LIMIT 1",
     )
     .bind(session_key)
     .fetch_optional(pool)
@@ -2032,13 +2044,16 @@ mod tests {
 
         let permission = serde_json::json!({
             "matcher": "AskUserQuestion",
-            "payload": { "tool_input": question.clone() }
+            "payload": {
+                "hook_event_name": "PermissionRequest",
+                "tool_name": "AskUserQuestion"
+            }
         });
         let notification = serde_json::json!({
             "payload": { "notification_type": "permission_prompt" }
         });
         for (event_id, event_type, payload, observed_at) in [
-            ("permission", "PermissionRequest", &permission, 2),
+            ("permission", "AskUserQuestion", &permission, 2),
             ("notification", "Notification", &notification, 3),
         ] {
             apply_hook(
@@ -2062,6 +2077,14 @@ mod tests {
             FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
         assert_eq!(session.attention_state, "ASK");
         assert_eq!(session.current_request_fingerprint, expected);
+        let current = current_request_wire(store.pool(), "claude:session-1")
+            .await
+            .unwrap()
+            .expect("the active Ask payload survives duplicate PermissionRequest");
+        assert_eq!(
+            current["payload"]["tool_input"]["questions"][0]["question"],
+            "When?"
+        );
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -45,7 +45,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(any(test, feature = "test-support"))]
 use std::sync::{OnceLock, RwLock};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
 use ainb_hangar_core::actor::{ActorKind, ActorRef, local_member};
@@ -85,9 +85,6 @@ const INTERNAL_ERROR: i32 = -32603;
 const PERMISSION_DENIED: i32 = -32000;
 /// Soft cap on one request body. Snapshot requests are tiny.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
-/// Bound the short hand-off between Claude's hook event and broker registration.
-const STRUCTURED_RECONCILE_GRACE: Duration = Duration::from_secs(1);
-const STRUCTURED_RECONCILE_POLL: Duration = Duration::from_millis(100);
 
 /// Cross-process, crash-safe ownership of one operation against one Hangar DB.
 ///
@@ -2701,32 +2698,40 @@ async fn reconcile_claude_structured(
         Ok(socket) => socket,
         Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
     };
+    let pending = match tokio::task::spawn_blocking(move || {
+        ainb_plugin_notifyd::broker::client_list(&socket)
+    })
+    .await
+    {
+        Ok(Ok(pending)) => pending,
+        Ok(Err(error)) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
     let session_id = session.provider_session_id.as_deref().unwrap_or_default();
-    let deadline = Instant::now() + STRUCTURED_RECONCILE_GRACE;
-    loop {
-        let socket = socket.clone();
-        let pending = match tokio::task::spawn_blocking(move || {
-            ainb_plugin_notifyd::broker::client_list(&socket)
-        })
-        .await
-        {
-            Ok(Ok(pending)) => pending,
-            Ok(Err(error)) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
-            Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
-        };
-        if pending.iter().any(|entry| {
-            entry.session_id == session_id
-                && entry.request_fingerprint.as_deref() == Some(request_fingerprint)
-        }) {
-            return (
-                ActionReceiptStatus::Delivered,
-                Some("Claude interview is live".to_string()),
-            );
-        }
-        if Instant::now() >= deadline {
-            break;
-        }
-        tokio::time::sleep(STRUCTURED_RECONCILE_POLL).await;
+    if pending.iter().any(|entry| {
+        entry.session_id == session_id
+            && entry.request_fingerprint.as_deref() == Some(request_fingerprint)
+    }) {
+        return (
+            ActionReceiptStatus::Delivered,
+            Some("Claude interview is live".to_string()),
+        );
+    }
+    let Some(target) = session.tmux_target.as_deref() else {
+        return (
+            ActionReceiptStatus::Unknown,
+            Some("Claude interview liveness is unresolved; Fleet card retained".to_string()),
+        );
+    };
+    let pane = match ainb_fleet_core::read::capture_pane(target, 0).await {
+        Ok(pane) => pane,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    if !claude_interview_was_declined(&pane) {
+        return (
+            ActionReceiptStatus::Unknown,
+            Some("Claude interview liveness is unresolved; Fleet card retained".to_string()),
+        );
     }
 
     let event = NewFleetEvent {
@@ -2762,6 +2767,10 @@ async fn reconcile_claude_structured(
         }
         Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
     }
+}
+
+fn claude_interview_was_declined(pane: &str) -> bool {
+    pane.contains("User declined to answer questions")
 }
 
 fn approve_socket_path() -> std::io::Result<PathBuf> {
@@ -9584,7 +9593,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reconcile_claude_structured_clears_only_a_missing_broker_waiter() {
+    async fn reconcile_claude_structured_retains_unproven_stale_card() {
         use ainb_hangar_proto::fleet::ActionReceiptStatus;
         use ainb_hangar_store::repo::fleet::{
             FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
@@ -9634,80 +9643,11 @@ mod tests {
         set_approve_socket_for_test(None);
         server.abort();
 
-        assert_eq!(status, ActionReceiptStatus::Delivered);
+        assert_eq!(status, ActionReceiptStatus::Unknown);
         assert_eq!(
             detail.as_deref(),
-            Some("Claude interview ended, cleared stale Fleet card")
+            Some("Claude interview liveness is unresolved; Fleet card retained")
         );
-        let session =
-            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
-        assert_eq!(session.attention_state, "NONE");
-        assert!(session.current_request_fingerprint.is_none());
-    }
-
-    #[tokio::test]
-    async fn reconcile_claude_structured_keeps_a_just_starting_waiter() {
-        use ainb_hangar_proto::fleet::ActionReceiptStatus;
-        use ainb_hangar_store::repo::fleet::{
-            FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
-        };
-        use tokio::net::UnixListener;
-
-        let _socket_guard = APPROVE_SOCKET_TEST_LOCK.lock().await;
-        let dir = tempfile::tempdir().unwrap();
-        let store = Store::open_in(dir.path()).await.unwrap();
-        let socket = dir.path().join("broker.sock");
-        let listener = UnixListener::bind(&socket).unwrap();
-        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
-            listener,
-            ainb_plugin_notifyd::broker::BrokerState::default(),
-        ));
-        set_approve_socket_for_test(Some(socket.clone()));
-        let created = FleetRepo::apply_event(
-            store.pool(),
-            &NewFleetEvent {
-                event_id: "ask".into(),
-                session_key: "claude:session-1".into(),
-                observed_at: 1,
-                authority: ObservationAuthority::Authoritative,
-                event_type: "AskUserQuestion".into(),
-                payload: serde_json::json!({"questions": [{"question": "Where?"}]}).to_string(),
-                patch: FleetSessionPatch {
-                    provider: Some("claude".into()),
-                    provider_session_id: Some("session-1".into()),
-                    lifecycle_state: Some("IDLE".into()),
-                    attention_state: Some("ASK".into()),
-                    current_request_fingerprint: Some(Some("fingerprint-1".into())),
-                    ..FleetSessionPatch::default()
-                },
-            },
-        )
-        .await
-        .unwrap();
-        let reconcile = tokio::spawn({
-            let pool = store.pool().clone();
-            let session = created.session.clone();
-            async move {
-                reconcile_claude_structured(&pool, &sink(), &session, "fingerprint-1", 1).await
-            }
-        });
-        tokio::time::sleep(Duration::from_millis(25)).await;
-        let waiter = tokio::task::spawn_blocking({
-            let socket = socket.clone();
-            move || {
-                ainb_plugin_notifyd::broker::client_await_structured(
-                    &socket,
-                    "session-1",
-                    "fingerprint-1",
-                    &[serde_json::json!({ "question": "Where?" })],
-                    Duration::from_secs(5),
-                )
-            }
-        });
-
-        let (status, detail) = reconcile.await.unwrap();
-        assert_eq!(status, ActionReceiptStatus::Delivered);
-        assert_eq!(detail.as_deref(), Some("Claude interview is live"));
         let session =
             FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
         assert_eq!(session.attention_state, "ASK");
@@ -9715,22 +9655,16 @@ mod tests {
             session.current_request_fingerprint.as_deref(),
             Some("fingerprint-1")
         );
+    }
 
-        let socket_for_dismiss = socket.clone();
-        tokio::task::spawn_blocking(move || {
-            ainb_plugin_notifyd::broker::client_dismiss_structured(
-                &socket_for_dismiss,
-                "session-1",
-                "fingerprint-1",
-                "test cleanup",
-            )
-        })
-        .await
-        .unwrap()
-        .unwrap();
-        waiter.await.unwrap();
-        set_approve_socket_for_test(None);
-        server.abort();
+    #[test]
+    fn declined_claude_interview_requires_native_completion_text() {
+        assert!(claude_interview_was_declined(
+            "User declined to answer questions\n · Where? (North / South)"
+        ));
+        assert!(!claude_interview_was_declined(
+            "Where is the place? (North / South)"
+        ));
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -45,7 +45,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(any(test, feature = "test-support"))]
 use std::sync::{OnceLock, RwLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ainb_hangar_core::activity::{ActivityAction, ActivityActor};
 use ainb_hangar_core::actor::{ActorKind, ActorRef, local_member};
@@ -85,6 +85,9 @@ const INTERNAL_ERROR: i32 = -32603;
 const PERMISSION_DENIED: i32 = -32000;
 /// Soft cap on one request body. Snapshot requests are tiny.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+/// Bound the short hand-off between Claude's hook event and broker registration.
+const STRUCTURED_RECONCILE_GRACE: Duration = Duration::from_secs(1);
+const STRUCTURED_RECONCILE_POLL: Duration = Duration::from_millis(100);
 
 /// Cross-process, crash-safe ownership of one operation against one Hangar DB.
 ///
@@ -2698,24 +2701,32 @@ async fn reconcile_claude_structured(
         Ok(socket) => socket,
         Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
     };
-    let pending = match tokio::task::spawn_blocking(move || {
-        ainb_plugin_notifyd::broker::client_list(&socket)
-    })
-    .await
-    {
-        Ok(Ok(pending)) => pending,
-        Ok(Err(error)) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
-        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
-    };
     let session_id = session.provider_session_id.as_deref().unwrap_or_default();
-    if pending.iter().any(|entry| {
-        entry.session_id == session_id
-            && entry.request_fingerprint.as_deref() == Some(request_fingerprint)
-    }) {
-        return (
-            ActionReceiptStatus::Delivered,
-            Some("Claude interview is live".to_string()),
-        );
+    let deadline = Instant::now() + STRUCTURED_RECONCILE_GRACE;
+    loop {
+        let socket = socket.clone();
+        let pending = match tokio::task::spawn_blocking(move || {
+            ainb_plugin_notifyd::broker::client_list(&socket)
+        })
+        .await
+        {
+            Ok(Ok(pending)) => pending,
+            Ok(Err(error)) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+            Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+        };
+        if pending.iter().any(|entry| {
+            entry.session_id == session_id
+                && entry.request_fingerprint.as_deref() == Some(request_fingerprint)
+        }) {
+            return (
+                ActionReceiptStatus::Delivered,
+                Some("Claude interview is live".to_string()),
+            );
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(STRUCTURED_RECONCILE_POLL).await;
     }
 
     let event = NewFleetEvent {
@@ -9485,6 +9496,8 @@ mod tests {
     use super::*;
     use ainb_hangar_store::Store;
 
+    static APPROVE_SOCKET_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     fn health() -> DaemonHealth {
         DaemonHealth {
             socket_path: "/tmp/hangar.sock".into(),
@@ -9578,6 +9591,7 @@ mod tests {
         };
         use tokio::net::UnixListener;
 
+        let _socket_guard = APPROVE_SOCKET_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
         let socket = dir.path().join("broker.sock");
@@ -9629,6 +9643,94 @@ mod tests {
             FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
         assert_eq!(session.attention_state, "NONE");
         assert!(session.current_request_fingerprint.is_none());
+    }
+
+    #[tokio::test]
+    async fn reconcile_claude_structured_keeps_a_just_starting_waiter() {
+        use ainb_hangar_proto::fleet::ActionReceiptStatus;
+        use ainb_hangar_store::repo::fleet::{
+            FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+        };
+        use tokio::net::UnixListener;
+
+        let _socket_guard = APPROVE_SOCKET_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let socket = dir.path().join("broker.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
+            listener,
+            ainb_plugin_notifyd::broker::BrokerState::default(),
+        ));
+        set_approve_socket_for_test(Some(socket.clone()));
+        let created = FleetRepo::apply_event(
+            store.pool(),
+            &NewFleetEvent {
+                event_id: "ask".into(),
+                session_key: "claude:session-1".into(),
+                observed_at: 1,
+                authority: ObservationAuthority::Authoritative,
+                event_type: "AskUserQuestion".into(),
+                payload: serde_json::json!({"questions": [{"question": "Where?"}]}).to_string(),
+                patch: FleetSessionPatch {
+                    provider: Some("claude".into()),
+                    provider_session_id: Some("session-1".into()),
+                    lifecycle_state: Some("IDLE".into()),
+                    attention_state: Some("ASK".into()),
+                    current_request_fingerprint: Some(Some("fingerprint-1".into())),
+                    ..FleetSessionPatch::default()
+                },
+            },
+        )
+        .await
+        .unwrap();
+        let reconcile = tokio::spawn({
+            let pool = store.pool().clone();
+            let session = created.session.clone();
+            async move {
+                reconcile_claude_structured(&pool, &sink(), &session, "fingerprint-1", 1).await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        let waiter = tokio::task::spawn_blocking({
+            let socket = socket.clone();
+            move || {
+                ainb_plugin_notifyd::broker::client_await_structured(
+                    &socket,
+                    "session-1",
+                    "fingerprint-1",
+                    &[serde_json::json!({ "question": "Where?" })],
+                    Duration::from_secs(5),
+                )
+            }
+        });
+
+        let (status, detail) = reconcile.await.unwrap();
+        assert_eq!(status, ActionReceiptStatus::Delivered);
+        assert_eq!(detail.as_deref(), Some("Claude interview is live"));
+        let session =
+            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
+        assert_eq!(session.attention_state, "ASK");
+        assert_eq!(
+            session.current_request_fingerprint.as_deref(),
+            Some("fingerprint-1")
+        );
+
+        let socket_for_dismiss = socket.clone();
+        tokio::task::spawn_blocking(move || {
+            ainb_plugin_notifyd::broker::client_dismiss_structured(
+                &socket_for_dismiss,
+                "session-1",
+                "fingerprint-1",
+                "test cleanup",
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        waiter.await.unwrap();
+        set_approve_socket_for_test(None);
+        server.abort();
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1501,6 +1501,9 @@ async fn execute_fleet_action(
             request_fingerprint,
             ..
         }
+        | ControlAction::ReconcileStructured {
+            request_fingerprint,
+        }
         | ControlAction::Approve {
             request_fingerprint,
             ..
@@ -1632,6 +1635,18 @@ async fn execute_fleet_action(
                 } if session.provider == "claude" => {
                     execute_claude_structured_dismiss(&session, request_fingerprint).await
                 }
+                ControlAction::ReconcileStructured {
+                    request_fingerprint,
+                } if session.provider == "claude" => {
+                    reconcile_claude_structured(
+                        pool,
+                        events,
+                        &session,
+                        request_fingerprint,
+                        params.expected_version,
+                    )
+                    .await
+                }
                 ControlAction::Approve {
                     request_fingerprint,
                     ..
@@ -1661,6 +1676,7 @@ async fn execute_fleet_action(
                 }
                 ControlAction::StructuredAnswer { .. }
                 | ControlAction::DismissStructured { .. }
+                | ControlAction::ReconcileStructured { .. }
                 | ControlAction::Approve { .. }
                 | ControlAction::Deny { .. } => (
                     ActionReceiptStatus::Unknown,
@@ -2663,6 +2679,80 @@ async fn execute_claude_structured_dismiss(
     }
 }
 
+async fn reconcile_claude_structured(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    request_fingerprint: &str,
+    expected_version: i64,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    use ainb_hangar_store::repo::fleet::{
+        FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+    };
+
+    let socket = match approve_socket_path() {
+        Ok(socket) => socket,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let pending = match tokio::task::spawn_blocking(move || {
+        ainb_plugin_notifyd::broker::client_list(&socket)
+    })
+    .await
+    {
+        Ok(Ok(pending)) => pending,
+        Ok(Err(error)) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let session_id = session.provider_session_id.as_deref().unwrap_or_default();
+    if pending.iter().any(|entry| {
+        entry.session_id == session_id
+            && entry.request_fingerprint.as_deref() == Some(request_fingerprint)
+    }) {
+        return (
+            ActionReceiptStatus::Delivered,
+            Some("Claude interview is live".to_string()),
+        );
+    }
+
+    let event = NewFleetEvent {
+        event_id: format!(
+            "fleet-reconcile:{}:{request_fingerprint}",
+            session.session_key
+        ),
+        session_key: session.session_key.clone(),
+        observed_at: SystemClock.now_ms(),
+        authority: ObservationAuthority::Authoritative,
+        event_type: "structured_interview_ended".to_string(),
+        payload: serde_json::json!({
+            "reason": "broker_no_longer_waiting",
+            "request_fingerprint": request_fingerprint,
+        })
+        .to_string(),
+        patch: FleetSessionPatch {
+            lifecycle_state: Some("IDLE".to_string()),
+            attention_state: Some("NONE".to_string()),
+            current_request_fingerprint: Some(None),
+            ..FleetSessionPatch::default()
+        },
+    };
+    match FleetRepo::apply_event_if_version(pool, &event, expected_version).await {
+        Ok(result) => {
+            if !result.duplicate {
+                events.emit_fleet_revision(result.revision);
+            }
+            (
+                ActionReceiptStatus::Delivered,
+                Some("Claude interview ended, cleared stale Fleet card".to_string()),
+            )
+        }
+        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+    }
+}
+
 fn approve_socket_path() -> std::io::Result<PathBuf> {
     #[cfg(any(test, feature = "test-support"))]
     if let Some(path) = APPROVE_SOCKET_OVERRIDE
@@ -2964,7 +3054,9 @@ fn action_capability(
 ) -> bool {
     use ainb_hangar_proto::fleet::ControlAction;
     match action {
-        ControlAction::StructuredAnswer { .. } => capabilities.structured_answer,
+        ControlAction::StructuredAnswer { .. } | ControlAction::ReconcileStructured { .. } => {
+            capabilities.structured_answer
+        }
         ControlAction::DismissStructured { .. } => capabilities.structured_dismiss,
         ControlAction::Approve { .. } | ControlAction::Deny { .. } => capabilities.approvals,
         ControlAction::VerifiedPicker { .. } => capabilities.verified_picker,
@@ -9476,6 +9568,67 @@ mod tests {
         let result: FleetReprojectClaudeInterviewResult =
             serde_json::from_value(response.result.unwrap()).unwrap();
         assert_eq!(revisions.recv().await.unwrap(), result.revision);
+    }
+
+    #[tokio::test]
+    async fn reconcile_claude_structured_clears_only_a_missing_broker_waiter() {
+        use ainb_hangar_proto::fleet::ActionReceiptStatus;
+        use ainb_hangar_store::repo::fleet::{
+            FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+        };
+        use tokio::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let socket = dir.path().join("broker.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
+            listener,
+            ainb_plugin_notifyd::broker::BrokerState::default(),
+        ));
+        set_approve_socket_for_test(Some(socket));
+        let created = FleetRepo::apply_event(
+            store.pool(),
+            &NewFleetEvent {
+                event_id: "ask".into(),
+                session_key: "claude:session-1".into(),
+                observed_at: 1,
+                authority: ObservationAuthority::Authoritative,
+                event_type: "AskUserQuestion".into(),
+                payload: serde_json::json!({"questions": [{"question": "Where?"}]}).to_string(),
+                patch: FleetSessionPatch {
+                    provider: Some("claude".into()),
+                    provider_session_id: Some("session-1".into()),
+                    lifecycle_state: Some("IDLE".into()),
+                    attention_state: Some("ASK".into()),
+                    current_request_fingerprint: Some(Some("fingerprint-1".into())),
+                    ..FleetSessionPatch::default()
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+        let (status, detail) = reconcile_claude_structured(
+            store.pool(),
+            &sink(),
+            &created.session,
+            "fingerprint-1",
+            created.session_version,
+        )
+        .await;
+        set_approve_socket_for_test(None);
+        server.abort();
+
+        assert_eq!(status, ActionReceiptStatus::Delivered);
+        assert_eq!(
+            detail.as_deref(),
+            Some("Claude interview ended, cleared stale Fleet card")
+        );
+        let session =
+            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
+        assert_eq!(session.attention_state, "NONE");
+        assert!(session.current_request_fingerprint.is_none());
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -539,6 +539,11 @@ pub enum ControlAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         request_identity: Option<FleetRequestIdentity>,
     },
+    /// Reconcile one Claude interview against its live broker waiter.
+    ReconcileStructured {
+        /// Provider request fingerprint verified against current state.
+        request_fingerprint: String,
+    },
     /// Approve exact provider request.
     Approve {
         /// Provider request fingerprint verified against current state.
@@ -603,6 +608,7 @@ impl ControlAction {
         match self {
             Self::StructuredAnswer { .. } => "structured_answer",
             Self::DismissStructured { .. } => "dismiss_structured",
+            Self::ReconcileStructured { .. } => "reconcile_structured",
             Self::Approve { .. } => "approve",
             Self::Deny { .. } => "deny",
             Self::VerifiedPicker { .. } => "verified_picker",

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -1739,7 +1739,6 @@ fn route_fleet(states: &mut ScreenStates, key: &KeyEvent) {
             KeyCode::Char { ch: '4' } => Some(FleetEvent::SetFilter(FleetFilter::Running)),
             KeyCode::Char { ch: '5' } => Some(FleetEvent::SetFilter(FleetFilter::All)),
             KeyCode::Char { ch: 's' } => Some(FleetEvent::RequestAction(FleetAction::Stop)),
-            KeyCode::Char { ch: 'r' } => Some(FleetEvent::RequestAction(FleetAction::Restart)),
             KeyCode::Char { ch: 'i' } => Some(FleetEvent::RequestAction(FleetAction::Interrupt)),
             KeyCode::Char { ch: 'n' } => {
                 Some(approval_event(&states.fleet, false, FleetAction::Continue))
@@ -2915,6 +2914,7 @@ mod fleet_routing_tests {
                 ("approvals".into(), true),
                 ("send_prompt".into(), true),
                 ("start".into(), true),
+                ("restart".into(), true),
             ])),
             version: 9,
             active_work_count: 0,
@@ -2968,5 +2968,22 @@ mod fleet_routing_tests {
             }) if text == "1"
         ));
         assert_eq!(states.fleet.filter(), FleetFilter::All);
+    }
+
+    #[test]
+    fn fleet_routes_r_to_reconcile_for_selected_structured_interview() {
+        let mut states = ScreenStates::default();
+        states.fleet.set_sessions(vec![row("ASK")]);
+
+        route_fleet(&mut states, &key(KeyCode::Char { ch: 'r' }));
+
+        assert!(matches!(
+            states.take_pending_fleet_intent(),
+            Some(FleetIntent::Execute {
+                session_key,
+                expected_version: 9,
+                action: FleetAction::ReconcileStructured { request_fingerprint },
+            }) if session_key == "claude:one" && request_fingerprint == "fingerprint"
+        ));
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -3884,7 +3884,13 @@ mod tests {
     #[test]
     fn reconcile_key_keeps_restart_confirmation_for_non_interview_session() {
         let mut state = FleetPaneState::default();
-        state.set_sessions(vec![session("claude:waiting", "claude", "IDLE", "WAITING", "managed")]);
+        state.set_sessions(vec![session(
+            "claude:waiting",
+            "claude",
+            "IDLE",
+            "WAITING",
+            "managed",
+        )]);
 
         let reduced = apply(&state, FleetEvent::Key(FleetKey::Char('r')));
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -1176,7 +1176,9 @@ fn reconcile_structured_intent(state: &mut FleetPaneState) -> Option<FleetIntent
         .as_deref()
         .and_then(|key| state.roster.iter().find(|row| row.session_key == key))?;
     let request_fingerprint = row.current_request_fingerprint.clone()?;
-    if !row.attention_state.eq_ignore_ascii_case("ASK")
+    if !row.provider.eq_ignore_ascii_case("claude")
+        || !row.is_managed()
+        || !row.attention_state.eq_ignore_ascii_case("ASK")
         || !row.capabilities.contains("structured_answer")
     {
         return None;
@@ -3891,6 +3893,25 @@ mod tests {
             "WAITING",
             "managed",
         )]);
+
+        let reduced = apply(&state, FleetEvent::Key(FleetKey::Char('r')));
+
+        assert!(reduced.intent.is_none());
+        assert!(matches!(
+            reduced.state.mode,
+            FleetMode::Confirm {
+                action: FleetAction::Restart,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reconcile_key_keeps_restart_confirmation_for_codex_interview() {
+        let mut state = FleetPaneState::default();
+        let mut row = session("codex:ask", "codex", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("fingerprint-1".into());
+        state.set_sessions(vec![row]);
 
         let reduced = apply(&state, FleetEvent::Key(FleetKey::Char('r')));
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -421,6 +421,9 @@ pub enum FleetAction {
         request_fingerprint: String,
         request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
     },
+    ReconcileStructured {
+        request_fingerprint: String,
+    },
     Approve {
         request_fingerprint: String,
         request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
@@ -466,6 +469,11 @@ impl FleetAction {
                 request_fingerprint,
                 request_identity,
             },
+            Self::ReconcileStructured {
+                request_fingerprint,
+            } => ControlAction::ReconcileStructured {
+                request_fingerprint,
+            },
             Self::Approve {
                 request_fingerprint,
                 request_identity,
@@ -502,6 +510,7 @@ impl FleetAction {
         match self {
             Self::StructuredAnswer { .. } => capabilities.contains("structured_answer"),
             Self::DismissStructured { .. } => capabilities.contains("structured_dismiss"),
+            Self::ReconcileStructured { .. } => capabilities.contains("structured_answer"),
             Self::Approve { .. } | Self::Deny { .. } => capabilities.contains("approvals"),
             Self::SendText { .. } => {
                 capabilities.contains("send_prompt") || capabilities.contains("tmux_text")
@@ -521,6 +530,7 @@ impl FleetAction {
         match self {
             Self::StructuredAnswer { .. } => "structured_answer",
             Self::DismissStructured { .. } => "structured_dismiss",
+            Self::ReconcileStructured { .. } => "structured_answer",
             Self::Approve { .. } | Self::Deny { .. } => "approvals",
             Self::SendText { .. } => "send_prompt or tmux_text",
             Self::VerifiedPicker { .. } => "verified_picker",
@@ -539,6 +549,7 @@ impl FleetAction {
             self,
             Self::StructuredAnswer { .. }
                 | Self::DismissStructured { .. }
+                | Self::ReconcileStructured { .. }
                 | Self::Approve { .. }
                 | Self::Deny { .. }
         )
@@ -1073,9 +1084,8 @@ fn reduce_answer_card_click(
             let answer = queue.current_mut().expect("answer queue changed during click");
             answer.question_index = question_index;
             answer.option_cursor = option_index;
-            let selected_other = answer.questions[question_index].options[option_index]
-                .label
-                .eq_ignore_ascii_case("other");
+            let selected_other =
+                is_free_text_option(&answer.questions[question_index].options[option_index].label);
             let selected = &mut answer.selections[question_index];
             if answer.questions[question_index].multi_select {
                 if !selected.remove(&option_index) {
@@ -1149,9 +1159,35 @@ pub(crate) fn reduce_browse_key(state: &mut FleetPaneState, key: FleetKey) -> Op
         // Broadcast is `b` only: the uppercase alias was dead (the hangar router
         // claims bare `B` as the Boards tab) (#450).
         FleetKey::Char('b') => state.mode = FleetMode::Broadcast(BroadcastState::default()),
+        FleetKey::Char('r') => {
+            if let Some(intent) = reconcile_structured_intent(state) {
+                return Some(intent);
+            }
+            return request_action(state, FleetAction::Restart);
+        }
         _ => {}
     }
     None
+}
+
+fn reconcile_structured_intent(state: &mut FleetPaneState) -> Option<FleetIntent> {
+    let row = state
+        .selected_key
+        .as_deref()
+        .and_then(|key| state.roster.iter().find(|row| row.session_key == key))?;
+    let request_fingerprint = row.current_request_fingerprint.clone()?;
+    if !row.attention_state.eq_ignore_ascii_case("ASK")
+        || !row.capabilities.contains("structured_answer")
+    {
+        return None;
+    }
+    Some(FleetIntent::Execute {
+        session_key: row.session_key.clone(),
+        expected_version: row.version,
+        action: FleetAction::ReconcileStructured {
+            request_fingerprint,
+        },
+    })
 }
 
 fn begin_structured_answer(state: &mut FleetPaneState) {
@@ -1220,34 +1256,7 @@ fn answer_questions(request: &serde_json::Value) -> Vec<AnswerQuestion> {
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or_default()
                 .to_string(),
-            options: question
-                .get("options")
-                .and_then(serde_json::Value::as_array)
-                .into_iter()
-                .flatten()
-                .filter_map(|option| {
-                    option.as_str().map_or_else(
-                        || {
-                            option.get("label").and_then(serde_json::Value::as_str).map(|label| {
-                                AnswerOption {
-                                    label: label.to_string(),
-                                    description: option
-                                        .get("description")
-                                        .and_then(serde_json::Value::as_str)
-                                        .unwrap_or_default()
-                                        .to_string(),
-                                }
-                            })
-                        },
-                        |label| {
-                            Some(AnswerOption {
-                                label: label.to_string(),
-                                description: String::new(),
-                            })
-                        },
-                    )
-                })
-                .collect(),
+            options: answer_options(question),
             multi_select: question
                 .get("multiSelect")
                 .or_else(|| question.get("multi_select"))
@@ -1255,6 +1264,51 @@ fn answer_questions(request: &serde_json::Value) -> Vec<AnswerQuestion> {
                 .unwrap_or(false),
         })
         .collect()
+}
+
+fn answer_options(question: &serde_json::Value) -> Vec<AnswerOption> {
+    let mut options: Vec<_> = question
+        .get("options")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|option| {
+            option.as_str().map_or_else(
+                || {
+                    option.get("label").and_then(serde_json::Value::as_str).map(|label| {
+                        AnswerOption {
+                            label: label.to_string(),
+                            description: option
+                                .get("description")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or_default()
+                                .to_string(),
+                        }
+                    })
+                },
+                |label| {
+                    Some(AnswerOption {
+                        label: label.to_string(),
+                        description: String::new(),
+                    })
+                },
+            )
+        })
+        .collect();
+    if !options.is_empty() && !options.iter().any(|option| is_free_text_option(&option.label)) {
+        options.push(AnswerOption {
+            label: "Type your own answer".to_string(),
+            description: "Enter a custom answer".to_string(),
+        });
+    }
+    options
+}
+
+fn is_free_text_option(label: &str) -> bool {
+    matches!(
+        label.trim().to_ascii_lowercase().as_str(),
+        "other" | "type something" | "type something." | "type your own answer"
+    )
 }
 
 fn request_identity(
@@ -1393,7 +1447,7 @@ fn reduce_answer_key(
             let selected_other = answer.selections[answer.question_index]
                 .iter()
                 .filter_map(|index| question.options.get(*index))
-                .any(|option| option.label.eq_ignore_ascii_case("other"));
+                .any(|option| is_free_text_option(&option.label));
             if selected_other && answer.texts[answer.question_index].trim().is_empty() {
                 answer.editing_text = true;
             } else {
@@ -1480,19 +1534,12 @@ fn submit_answer(
         .zip(&answer.texts)
         .map(|((question, selected), text)| {
             let text = (!text.trim().is_empty()).then(|| text.trim().to_string());
-            let selected_other = selected
+            let selected_options = selected
                 .iter()
                 .filter_map(|index| question.options.get(*index))
-                .any(|option| option.label.eq_ignore_ascii_case("other"));
-            let selected_options = if !question.multi_select && selected_other && text.is_some() {
-                Vec::new()
-            } else {
-                selected
-                    .iter()
-                    .filter_map(|index| question.options.get(*index))
-                    .map(|option| option.label.clone())
-                    .collect()
-            };
+                .filter(|option| !is_free_text_option(&option.label))
+                .map(|option| option.label.clone())
+                .collect();
             ainb_hangar_proto::fleet::FleetQuestionAnswer {
                 question_id: question.id.clone(),
                 selected_options,
@@ -2575,6 +2622,7 @@ fn available_action_labels(session: &FleetSessionRow) -> Vec<&'static str> {
         && session.capabilities.contains("structured_answer")
     {
         actions.push("Enter Answer");
+        actions.push("r Reconcile");
     }
     if session.attention_state.eq_ignore_ascii_case("APPROVAL")
         && session.capabilities.contains("approvals")
@@ -2596,7 +2644,11 @@ fn available_action_labels(session: &FleetSessionRow) -> Vec<&'static str> {
     if session.capabilities.contains("stop") {
         actions.push("s Stop");
     }
-    if session.capabilities.contains("restart") {
+    if session.capabilities.contains("restart")
+        && !(session.attention_state.eq_ignore_ascii_case("ASK")
+            && session.is_managed()
+            && session.capabilities.contains("structured_answer"))
+    {
         actions.push("r Restart");
     }
     actions
@@ -2984,7 +3036,7 @@ fn answer_card_hit(
                     }
                     if question_index == answer.question_index
                         && answer.selections[question_index].contains(&option_index)
-                        && option.label.eq_ignore_ascii_case("other")
+                        && is_free_text_option(&option.label)
                     {
                         option_row = option_row.saturating_add(1);
                     }
@@ -3032,7 +3084,7 @@ fn interview_card_height(answer: &AnswerState, question_index: usize, width: u16
                     && answer.selections[question_index]
                         .iter()
                         .filter_map(|index| question.options.get(*index))
-                        .any(|option| option.label.eq_ignore_ascii_case("other")),
+                        .any(|option| is_free_text_option(&option.label)),
             )
     };
     2 + question_text_line_count(question, width.saturating_sub(3)) + body_rows
@@ -3156,7 +3208,7 @@ fn render_interview_question_card(
                 );
                 y = y.saturating_add(1);
             }
-            if active && selected && option.label.eq_ignore_ascii_case("other") {
+            if active && selected && is_free_text_option(&option.label) {
                 if y < bottom.saturating_sub(2) {
                     put_str(
                         buffer,
@@ -3198,7 +3250,7 @@ fn answer_question_complete(answer: &AnswerState, index: usize, question: &Answe
     let selected_other = answer.selections[index]
         .iter()
         .filter_map(|option_index| question.options.get(*option_index))
-        .any(|option| option.label.eq_ignore_ascii_case("other"));
+        .any(|option| is_free_text_option(&option.label));
     !answer.selections[index].is_empty()
         && (!selected_other || !answer.texts[index].trim().is_empty())
 }
@@ -3769,6 +3821,81 @@ mod tests {
         assert_eq!(answers[0].selected_options, ["rg", "ast-grep"]);
         assert_eq!(answers[1].question_id, "ship");
         assert_eq!(answers[1].selected_options, ["Yes"]);
+    }
+
+    #[test]
+    fn claude_choice_list_adds_native_type_something_and_submits_text() {
+        let mut row = session("claude:ask", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("fingerprint-1".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{
+                "id": "region",
+                "question": "Where?",
+                "options": [{"label": "North"}, {"label": "South"}]
+            }]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        let FleetMode::Answer(queue) = &state.mode else {
+            panic!("structured interview expected");
+        };
+        assert_eq!(
+            queue.current().unwrap().questions[0].options[2].label,
+            "Type your own answer"
+        );
+        state = apply(&state, FleetEvent::Key(FleetKey::Down)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Down)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = type_text(state, "Inverness");
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Enter));
+
+        let Some(FleetIntent::Execute {
+            action: FleetAction::StructuredAnswer { answers, .. },
+            ..
+        }) = submitted.intent
+        else {
+            panic!("custom Claude answer must submit");
+        };
+        assert!(answers[0].selected_options.is_empty());
+        assert_eq!(answers[0].text.as_deref(), Some("Inverness"));
+    }
+
+    #[test]
+    fn reconcile_key_targets_only_the_selected_structured_interview() {
+        let mut row = session("claude:ask", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("fingerprint-1".into());
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+
+        assert_eq!(
+            apply(&state, FleetEvent::Key(FleetKey::Char('r'))).intent,
+            Some(FleetIntent::Execute {
+                session_key: "claude:ask".into(),
+                expected_version: 7,
+                action: FleetAction::ReconcileStructured {
+                    request_fingerprint: "fingerprint-1".into(),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn reconcile_key_keeps_restart_confirmation_for_non_interview_session() {
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![session("claude:waiting", "claude", "IDLE", "WAITING", "managed")]);
+
+        let reduced = apply(&state, FleetEvent::Key(FleetKey::Char('r')));
+
+        assert!(reduced.intent.is_none());
+        assert!(matches!(
+            reduced.state.mode,
+            FleetMode::Confirm {
+                action: FleetAction::Restart,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -56,7 +56,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tracing::{debug, error, warn};
 
 /// Default AWAIT ceiling — the BOTTOM of the timeout ladder, by design:
@@ -171,7 +171,7 @@ enum PendingKind {
     Structured {
         request_fingerprint: String,
         questions: Vec<serde_json::Value>,
-        tx: oneshot::Sender<StructuredResolution>,
+        tx: watch::Sender<Option<StructuredResolution>>,
     },
 }
 
@@ -344,7 +344,7 @@ impl BrokerState {
         let now = now_ms();
         let map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
         map.iter()
-            .map(|(session_id, pending)| {
+            .filter_map(|(session_id, pending)| {
                 let (tool, context, request_fingerprint, questions) = match &pending.kind {
                     PendingKind::Permission {
                         tool,
@@ -360,22 +360,27 @@ impl BrokerState {
                     PendingKind::Structured {
                         request_fingerprint,
                         questions,
-                        ..
-                    } => (
-                        "AskUserQuestion".to_string(),
-                        serde_json::to_string(questions).unwrap_or_default(),
-                        Some(request_fingerprint.clone()),
-                        questions.clone(),
-                    ),
+                        tx,
+                    } => {
+                        if tx.borrow().is_some() {
+                            return None;
+                        }
+                        (
+                            "AskUserQuestion".to_string(),
+                            serde_json::to_string(questions).unwrap_or_default(),
+                            Some(request_fingerprint.clone()),
+                            questions.clone(),
+                        )
+                    }
                 };
-                PendingInfo {
+                Some(PendingInfo {
                     session_id: session_id.clone(),
                     tool,
                     context,
                     request_fingerprint,
                     questions,
                     waiting_ms: now.saturating_sub(pending.since_ms),
-                }
+                })
             })
             .collect()
     }
@@ -464,33 +469,83 @@ impl BrokerState {
         }
     }
 
+    /// Register a structured request before its Fleet event is persisted.
+    ///
+    /// A matching later `await_structured` reuses this exact pending entry. This
+    /// creates the ordering fence Fleet needs: an actionable card never appears
+    /// before the broker can accept its answer.
+    fn register_structured(
+        &self,
+        session_id: String,
+        request_fingerprint: String,
+        questions: Vec<serde_json::Value>,
+    ) {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+        if map.get(&session_id).is_some_and(|pending| {
+            matches!(
+                &pending.kind,
+                PendingKind::Structured {
+                    request_fingerprint: current,
+                    ..
+                } if current == &request_fingerprint
+            )
+        }) {
+            return;
+        }
+        let (tx, _) = watch::channel(None);
+        map.insert(
+            session_id,
+            Pending {
+                id,
+                since_ms: now_ms(),
+                kind: PendingKind::Structured {
+                    request_fingerprint,
+                    questions,
+                    tx,
+                },
+            },
+        );
+    }
+
     async fn await_structured(
         &self,
         session_id: String,
         request_fingerprint: String,
         questions: Vec<serde_json::Value>,
     ) -> StructuredResolution {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        let (tx, rx) = oneshot::channel();
-        {
-            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
-            map.insert(
-                session_id.clone(),
-                Pending {
-                    id,
-                    since_ms: now_ms(),
-                    kind: PendingKind::Structured {
-                        request_fingerprint,
-                        questions,
-                        tx,
-                    },
-                },
-            );
-        }
+        self.register_structured(session_id.clone(), request_fingerprint.clone(), questions);
+        let (id, mut rx) = {
+            let map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            let Some(pending) = map.get(&session_id) else {
+                return StructuredResolution::superseded();
+            };
+            let PendingKind::Structured {
+                request_fingerprint: current,
+                tx,
+                ..
+            } = &pending.kind
+            else {
+                return StructuredResolution::superseded();
+            };
+            if current != &request_fingerprint {
+                return StructuredResolution::superseded();
+            }
+            (pending.id, tx.subscribe())
+        };
 
-        match tokio::time::timeout(self.await_timeout, rx).await {
-            Ok(Ok(resolution)) => resolution,
-            Ok(Err(_)) => StructuredResolution::superseded(),
+        let wait = async {
+            loop {
+                if let Some(resolution) = rx.borrow().clone() {
+                    return resolution;
+                }
+                if rx.changed().await.is_err() {
+                    return StructuredResolution::superseded();
+                }
+            }
+        };
+        let resolution = match tokio::time::timeout(self.await_timeout, wait).await {
+            Ok(resolution) => resolution,
             Err(_) => {
                 let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
                 if map.get(&session_id).is_some_and(|p| p.id == id) {
@@ -498,7 +553,12 @@ impl BrokerState {
                 }
                 StructuredResolution::timed_out()
             }
+        };
+        let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+        if map.get(&session_id).is_some_and(|p| p.id == id) {
+            map.remove(&session_id);
         }
+        resolution
     }
 
     fn answer_structured(
@@ -508,7 +568,7 @@ impl BrokerState {
         answers: Vec<StructuredQuestionAnswer>,
     ) -> StructuredAnswerAck {
         let taken = {
-            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            let map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
             let Some(pending) = map.get(session_id) else {
                 return StructuredAnswerAck::unmatched();
             };
@@ -526,21 +586,20 @@ impl BrokerState {
             if let Err(error) = validate_structured_answers(questions, &answers) {
                 return StructuredAnswerAck::invalid(error);
             }
-            map.remove(session_id)
+            match &pending.kind {
+                PendingKind::Structured { tx, .. } => {
+                    tx.send_replace(Some(StructuredResolution::Answered {
+                        answers: answers.clone(),
+                    }));
+                    true
+                }
+                _ => false,
+            }
         };
 
         match taken {
-            Some(Pending {
-                kind: PendingKind::Structured { tx, .. },
-                ..
-            }) => {
-                if tx.send(StructuredResolution::Answered { answers }).is_ok() {
-                    StructuredAnswerAck::matched()
-                } else {
-                    StructuredAnswerAck::unmatched()
-                }
-            }
-            _ => StructuredAnswerAck::unmatched(),
+            true => StructuredAnswerAck::matched(),
+            false => StructuredAnswerAck::unmatched(),
         }
     }
 
@@ -553,7 +612,7 @@ impl BrokerState {
         reason: String,
     ) -> StructuredAnswerAck {
         let taken = {
-            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            let map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
             let Some(pending) = map.get(session_id) else {
                 return StructuredAnswerAck::unmatched();
             };
@@ -567,21 +626,18 @@ impl BrokerState {
             if current != request_fingerprint {
                 return StructuredAnswerAck::stale();
             }
-            map.remove(session_id)
+            match &pending.kind {
+                PendingKind::Structured { tx, .. } => {
+                    tx.send_replace(Some(StructuredResolution::Rejected { reason }));
+                    true
+                }
+                _ => false,
+            }
         };
 
         match taken {
-            Some(Pending {
-                kind: PendingKind::Structured { tx, .. },
-                ..
-            }) => {
-                if tx.send(StructuredResolution::Rejected { reason }).is_ok() {
-                    StructuredAnswerAck::matched()
-                } else {
-                    StructuredAnswerAck::unmatched()
-                }
-            }
-            _ => StructuredAnswerAck::unmatched(),
+            true => StructuredAnswerAck::matched(),
+            false => StructuredAnswerAck::unmatched(),
         }
     }
 }
@@ -622,6 +678,13 @@ enum Request {
         request_fingerprint: String,
         questions: Vec<serde_json::Value>,
     },
+    /// Register a structured request before Fleet projects it as actionable.
+    #[serde(rename = "register_structured")]
+    RegisterStructured {
+        session_id: String,
+        request_fingerprint: String,
+        questions: Vec<serde_json::Value>,
+    },
     /// Human answers an exact current AskUserQuestion request.
     #[serde(rename = "answer_structured")]
     AnswerStructured {
@@ -646,6 +709,12 @@ struct DecideAck {
     ok: bool,
     /// True when a waiter was actually blocked on that session.
     matched: bool,
+}
+
+/// Response confirming the broker owns a structured request.
+#[derive(Debug, Serialize, Deserialize)]
+struct RegisterStructuredAck {
+    ok: bool,
 }
 
 /// Response to a LIST.
@@ -740,6 +809,18 @@ async fn handle_connection(stream: UnixStream, state: BrokerState) -> Result<()>
                 state.await_structured(session_id, request_fingerprint, questions).await
             };
             write_line(reader.get_mut(), &resolution).await?;
+        }
+        Request::RegisterStructured {
+            session_id,
+            request_fingerprint,
+            questions,
+        } => {
+            let ok =
+                !session_id.is_empty() && !request_fingerprint.is_empty() && !questions.is_empty();
+            if ok {
+                state.register_structured(session_id, request_fingerprint, questions);
+            }
+            write_line(reader.get_mut(), &RegisterStructuredAck { ok }).await?;
         }
         Request::AnswerStructured {
             session_id,
@@ -908,6 +989,30 @@ pub fn client_await_structured(
             Ok(None) | Err(_) => std::thread::sleep(REDIAL_INTERVAL),
         }
     }
+}
+
+/// Establish the broker-side structured-answer fence before Fleet persists the
+/// matching AskUserQuestion event. A later [`client_await_structured`] with the
+/// same exact request reuses this pending entry, including an answer delivered
+/// in the tiny interval between registration and hook blocking.
+pub fn client_register_structured(
+    sock: &Path,
+    session_id: &str,
+    request_fingerprint: &str,
+    questions: &[serde_json::Value],
+) -> std::io::Result<bool> {
+    let response = client_round_trip(
+        sock,
+        &serde_json::json!({
+            "op": "register_structured",
+            "session_id": session_id,
+            "request_fingerprint": request_fingerprint,
+            "questions": questions,
+        }),
+    )?;
+    serde_json::from_value::<RegisterStructuredAck>(response)
+        .map(|ack| ack.ok)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
 }
 
 fn try_await_structured_once(
@@ -1215,6 +1320,70 @@ mod tests {
             serde_json::from_str(round_trip(&sock, &answer_line).await.trim()).unwrap();
         assert!(!second.matched, "first structured answer must win");
         assert!(!second.stale);
+
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn structured_registration_keeps_an_early_answer_for_the_hook() {
+        let (sock, _state, handle) = spawn_broker(Duration::from_secs(30)).await;
+        let questions = vec![serde_json::json!({
+            "question": "Continue?",
+            "options": [{"label": "Yes"}],
+        })];
+        let fingerprint = "fnv1a64:registered";
+
+        let register_socket = sock.clone();
+        let registered = tokio::task::spawn_blocking(move || {
+            client_register_structured(&register_socket, "ask-registered", fingerprint, &questions)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(registered);
+
+        let answer_socket = sock.clone();
+        let accepted = tokio::task::spawn_blocking(move || {
+            client_answer_structured(
+                &answer_socket,
+                "ask-registered",
+                fingerprint,
+                &[StructuredQuestionAnswer {
+                    question: "Continue?".to_string(),
+                    selected_options: vec!["Yes".to_string()],
+                }],
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(accepted.matched);
+
+        let await_socket = sock.clone();
+        let resolution = tokio::task::spawn_blocking(move || {
+            client_await_structured(
+                &await_socket,
+                "ask-registered",
+                fingerprint,
+                &[serde_json::json!({
+                    "question": "Continue?",
+                    "options": [{"label": "Yes"}],
+                })],
+                Duration::from_secs(1),
+            )
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            resolution,
+            StructuredResolution::Answered {
+                answers: vec![StructuredQuestionAnswer {
+                    question: "Continue?".to_string(),
+                    selected_options: vec!["Yes".to_string()],
+                }],
+            }
+        );
 
         handle.abort();
         let _ = std::fs::remove_file(&sock);


### PR DESCRIPTION
## Summary
- await Claude structured interviews outside ATC membership
- retain PreToolUse Ask identity through duplicate permission hooks
- reconcile ended interviews and support custom Fleet answers

## Validation
- targeted broker, daemon, core, and Hangar Fleet tests
- tmux Fleet tripwire
- live Fleet answer delivery and native-cancel reconciliation
- release build and formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reconciling stale structured interviews from the Fleet panel.
  - Pressing lowercase `r` now reconciles structured interviews; regular sessions continue to use restart confirmation.
  - Added improved handling for custom free-text interview answers, including automatic “Type your own answer” options.

- **Bug Fixes**
  - Prevented duplicate permission prompts from replacing active interview requests.
  - Improved cleanup of ended interviews and stale session attention states.
  - Ensured submitted answers correctly separate predefined options from entered text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->