### PR TITLE
feat(fleet): deliver standalone notch runtime

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
@@ -19,6 +19,7 @@ pub mod daemons;
 pub mod enrich_cache;
 pub mod msg;
 pub mod needs;
+pub mod runtime;
 pub mod sequence;
 pub mod standup;
 
@@ -40,6 +41,7 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
         Some(("msg", sub)) => msg::execute(sub, format).await,
         Some(("sequence", sub)) => sequence::execute(sub, format).await,
         Some(("needs", sub)) => needs::execute(sub, format).await,
+        Some(("runtime", sub)) => runtime::execute(sub, format).await,
         Some(("cost", sub)) => cost::execute(sub, format).await,
         Some(("daemon", sub)) => daemon::execute(sub, format).await,
         Some(("daemons", sub)) => daemons::execute(sub, format).await,

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/runtime.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/runtime.rs
@@ -1,0 +1,26 @@
+//! Standalone Fleet runtime installation.
+//!
+//! This is a CLI-only provisioning surface. The macOS app uses negotiated
+//! daemon RPC after setup, never this command or its output.
+
+use anyhow::{Result, bail};
+
+use crate::cli::OutputFormat;
+
+/// Install supported provider hooks and start both Fleet runtime daemons.
+///
+/// Both delegated operations are idempotent: daemon setup reuses its database
+/// and token, and hook installation atomically refreshes managed entries.
+pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
+    match matches.subcommand() {
+        Some(("install", _)) => {
+            crate::cli::hangar::run_daemon_setup().await?;
+            ainb_plugin_notifyd::cli::cmd_install(ainb_plugin_notifyd::install::Agent::ALL)?;
+            ainb_plugin_notifyd::cli::cmd_restart(false)?;
+            println!("fleet runtime: ready");
+            Ok(())
+        }
+        Some((other, _)) => bail!("unknown `ainb fleet runtime` subcommand: {other}"),
+        None => bail!("missing `ainb fleet runtime` subcommand"),
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/runtime.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/runtime.rs
@@ -9,12 +9,13 @@ use crate::cli::OutputFormat;
 
 /// Install supported provider hooks and start both Fleet runtime daemons.
 ///
-/// Both delegated operations are idempotent: daemon setup reuses its database
-/// and token, and hook installation atomically refreshes managed entries.
+/// Setup reuses the database and token, then restarts the daemon so an upgrade
+/// serves this binary's Fleet capabilities before the app connects.
 pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
     match matches.subcommand() {
         Some(("install", _)) => {
             crate::cli::hangar::run_daemon_setup().await?;
+            crate::cli::hangar::run_daemon_restart()?;
             ainb_plugin_notifyd::cli::cmd_install(ainb_plugin_notifyd::install::Agent::ALL)?;
             ainb_plugin_notifyd::cli::cmd_restart(false)?;
             println!("fleet runtime: ready");

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8543,7 +8543,7 @@ fn run_daemon_stop() -> Result<()> {
 }
 
 /// `hangar daemon restart`: `stop` (if running) then `start`.
-fn run_daemon_restart() -> Result<()> {
+pub(crate) fn run_daemon_restart() -> Result<()> {
     run_daemon_stop()?;
     run_daemon_start()
 }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8461,16 +8461,21 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     } else {
         format!("{} {}", bin.display(), args.join(" "))
     };
-    let mut child = std::process::Command::new(&bin)
+    let mut command = std::process::Command::new(&bin);
+    command
         .args(&args)
         // The child must not inherit this process's controlling terminal's
         // stdio; the daemon writes its own rolling JSONL log under the hangar
         // home, so discard the std streams.
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .with_context(|| format!("spawn daemon `{launched}`"))?;
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let mut child = command.spawn().with_context(|| format!("spawn daemon `{launched}`"))?;
 
     // A daemon that dies instantly (unbootable db, broken binary) used to look
     // identical to a clean start — the TUI's `[s]` action reported success and
@@ -8550,7 +8555,7 @@ fn run_daemon_restart() -> Result<()> {
 /// comes up authenticated, then `start`s the daemon. Idempotent: a second
 /// `setup` reuses the existing token + db and is a no-op start if the daemon is
 /// already up.
-async fn run_daemon_setup() -> Result<()> {
+pub(crate) async fn run_daemon_setup() -> Result<()> {
     // Ensure the database + migrations, and resolve the home the token lives in.
     let store = Store::open_default().await.context("open hangar database")?;
     let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -2176,6 +2176,14 @@ impl CliCommand for FleetCommand {
             "Unified runtime health of every long-running daemon \
              (phone bridge / notifyd / ATC / fleet daemon)",
         );
+        let runtime = Command::new("runtime")
+            .about("Install the standalone Fleet daemon and provider hooks")
+            .subcommand_required(true)
+            .arg_required_else_help(true)
+            .subcommand(
+                Command::new("install")
+                    .about("Idempotently start Hangar and install supported provider hooks"),
+            );
         // approve/deny share one arg shape: with a session-id they deliver the
         // decision to the waiting PermissionRequest hook via the approve
         // broker; without one they list the sessions currently blocked.
@@ -2217,7 +2225,7 @@ impl CliCommand for FleetCommand {
         app.subcommand(
             Command::new(self.name())
                 .about(
-                    "Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / daemons / atc / bridge",
+                    "Fleet orchestration: standup / broadcast / sequence / needs / cost / runtime / daemon / daemons / atc / bridge",
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
@@ -2231,6 +2239,7 @@ impl CliCommand for FleetCommand {
                 .subcommand(cost)
                 .subcommand(daemon)
                 .subcommand(daemons)
+                .subcommand(runtime)
                 .subcommand(atc)
                 .subcommand(bridge)
                 .subcommand(enrich_cache)
@@ -2659,7 +2668,7 @@ mod tests {
     }
 
     #[test]
-    fn fleet_exposes_thirteen_subcommands_including_approve_deny() {
+    fn fleet_exposes_fourteen_subcommands_including_runtime() {
         // The `fleet` namespace surface. Adding/removing a fleet subcommand MUST
         // update this count + list — it is the registry guard the daemons-
         // observability feature wired through. `daemon` (the watcher) and
@@ -2687,6 +2696,7 @@ mod tests {
                 "enrich-cache",
                 "msg",
                 "needs",
+                "runtime",
                 "sequence",
                 "standup",
             ],
@@ -2694,8 +2704,8 @@ mod tests {
         );
         assert_eq!(
             names.len(),
-            13,
-            "expected 13 fleet subcommands, got {names:?}"
+            14,
+            "expected 14 fleet subcommands, got {names:?}"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
@@ -67,6 +67,10 @@ ainb-hangar-proto = { path = "../ainb-hangar-proto" }
 # Claude's blocking broker owns exact structured-question and permission
 # delivery. Hangar calls its public wire client and never reads notifyd state.
 ainb-plugin-notifyd = { path = "../ainb-plugin-notifyd" }
+# Canonical provider-log scanner and model-rate projection behind the public
+# Fleet usage contract. Swift receives only its bounded, safe DTO.
+ainb-plugin-session-reader = { path = "../ainb-plugin-session-reader" }
+ainb-plugin-types-sessions = { path = "../ainb-plugin-types-sessions" }
 # e38.23 OS-level agent confinement: wraps the provider spawn in a Seatbelt
 # (macOS) / Landlock (Linux) FS sandbox so the agent subprocess can only
 # read/write the task's isolated roots. Gates the non-claude providers (e38.16).

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
@@ -1,0 +1,245 @@
+//! Bounded, daemon-owned Fleet Usage projection.
+//!
+//! Provider logs and canonical model-rate parsing stay behind this module. The
+//! public RPC receives only aggregates, never paths, transcripts, or calls.
+
+use std::collections::HashMap;
+
+use ainb_hangar_proto::fleet::{
+    FLEET_USAGE_MAX_BREAKDOWN_BUCKETS, FLEET_USAGE_MAX_DAILY_BUCKETS, FleetUsageBucket,
+    FleetUsageDailyBucket, FleetUsageModelBucket, FleetUsagePeriod, FleetUsageProjectBucket,
+    FleetUsageProviderBucket, FleetUsageSummaryResult, FleetUsageSummaryState,
+};
+use ainb_plugin_session_reader::scanner::{self, ProviderRoots};
+use ainb_plugin_types_sessions::{ProviderCall, TokenBucket, UsageData};
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+
+/// Scan canonical provider histories then expose the requested bounded window.
+///
+/// This runs on a blocking worker owned by the RPC handler. The scanner itself
+/// owns provider parsing and rate lookup, so this module does not duplicate
+/// provider-specific cost logic.
+#[must_use]
+pub fn scan_summary(period: FleetUsagePeriod) -> FleetUsageSummaryResult {
+    let roots = ProviderRoots::defaults();
+    if roots.claude_projects.is_none()
+        && roots.codex_sessions.is_none()
+        && roots.gemini_sessions.is_none()
+        && roots.copilot_sessions.is_none()
+        && roots.cursor_sessions.is_none()
+    {
+        return FleetUsageSummaryResult {
+            state: FleetUsageSummaryState::Unavailable,
+            generated_at: Some(Utc::now().timestamp_millis()),
+            start_at: None,
+            end_at: None,
+            totals: None,
+            daily: Vec::new(),
+            providers: Vec::new(),
+            models: Vec::new(),
+            projects: Vec::new(),
+            detail: Some("provider history roots are unavailable".to_string()),
+        };
+    }
+    summary_from_usage(scanner::scan(&roots), period, Utc::now())
+}
+
+fn summary_from_usage(
+    usage: UsageData,
+    period: FleetUsagePeriod,
+    now: DateTime<Utc>,
+) -> FleetUsageSummaryResult {
+    let (start, end) = window(period, now);
+    let calls: Vec<_> = usage
+        .calls
+        .into_iter()
+        .filter(|call| call.timestamp >= start && call.timestamp < end)
+        .collect();
+    let projected = scanner::aggregate(calls.clone());
+    let complete_costs = completeness(&calls);
+
+    let mut daily: Vec<_> = projected
+        .daily
+        .into_iter()
+        .map(|(date, bucket)| FleetUsageDailyBucket {
+            date: date.to_string(),
+            bucket: bucket_from(
+                &bucket,
+                complete_costs.daily.get(&date).copied().unwrap_or(true),
+            ),
+        })
+        .collect();
+    daily.truncate(FLEET_USAGE_MAX_DAILY_BUCKETS);
+
+    let mut providers: Vec<_> = grouped_usage(&calls, |call| call.provider.as_str().to_string())
+        .into_iter()
+        .map(|(provider, usage)| FleetUsageProviderBucket {
+            bucket: bucket_from(&usage.bucket, usage.complete_cost),
+            provider,
+        })
+        .collect();
+    sort_and_cap(&mut providers, |row| &row.bucket);
+
+    let mut models: Vec<_> = projected
+        .models
+        .into_iter()
+        .map(|row| FleetUsageModelBucket {
+            bucket: bucket_from(
+                &row.bucket,
+                complete_costs.models.get(&row.model).copied().unwrap_or(true),
+            ),
+            model: row.model,
+        })
+        .collect();
+    sort_and_cap(&mut models, |row| &row.bucket);
+
+    let mut projects: Vec<_> = projected
+        .projects
+        .into_iter()
+        .map(|row| FleetUsageProjectBucket {
+            bucket: bucket_from(
+                &row.bucket,
+                complete_costs.projects.get(&row.name).copied().unwrap_or(true),
+            ),
+            project: row.name,
+            repo: row.repo,
+        })
+        .collect();
+    sort_and_cap(&mut projects, |row| &row.bucket);
+
+    FleetUsageSummaryResult {
+        state: FleetUsageSummaryState::Ready,
+        generated_at: Some(now.timestamp_millis()),
+        start_at: Some(start.timestamp_millis()),
+        end_at: Some(end.timestamp_millis()),
+        totals: Some(bucket_from(
+            &projected.grand_total,
+            calls.iter().all(|call| call.cost_usd.is_some()),
+        )),
+        daily,
+        providers,
+        models,
+        projects,
+        detail: None,
+    }
+}
+
+fn window(period: FleetUsagePeriod, now: DateTime<Utc>) -> (DateTime<Utc>, DateTime<Utc>) {
+    let end_day = now.date_naive().succ_opt().expect("valid UTC date");
+    let days = match period {
+        FleetUsagePeriod::Today => 1,
+        FleetUsagePeriod::Trailing7Days => 7,
+        FleetUsagePeriod::Trailing30Days => 30,
+    };
+    let start_day = end_day - Duration::days(days);
+    (
+        start_day.and_hms_opt(0, 0, 0).expect("midnight UTC").and_utc(),
+        end_day.and_hms_opt(0, 0, 0).expect("midnight UTC").and_utc(),
+    )
+}
+
+#[derive(Default)]
+struct CostCompleteness {
+    daily: HashMap<NaiveDate, bool>,
+    models: HashMap<String, bool>,
+    projects: HashMap<String, bool>,
+}
+
+fn completeness(calls: &[ProviderCall]) -> CostCompleteness {
+    let mut result = CostCompleteness::default();
+    for call in calls {
+        let priced = call.cost_usd.is_some();
+        mark(&mut result.daily, call.timestamp.date_naive(), priced);
+        mark(&mut result.models, call.model.clone(), priced);
+        mark(&mut result.projects, call.project.clone(), priced);
+    }
+    result
+}
+
+fn mark<K: std::hash::Hash + Eq>(map: &mut HashMap<K, bool>, key: K, priced: bool) {
+    map.entry(key).and_modify(|complete| *complete &= priced).or_insert(priced);
+}
+
+struct GroupedUsage {
+    bucket: TokenBucket,
+    complete_cost: bool,
+}
+
+fn grouped_usage<F>(calls: &[ProviderCall], key: F) -> HashMap<String, GroupedUsage>
+where
+    F: Fn(&ProviderCall) -> String,
+{
+    let mut groups: HashMap<String, Vec<ProviderCall>> = HashMap::new();
+    for call in calls {
+        groups.entry(key(call)).or_default().push(call.clone());
+    }
+    groups
+        .into_iter()
+        .map(|(key, calls)| {
+            let complete_cost = calls.iter().all(|call| call.cost_usd.is_some());
+            let bucket = scanner::aggregate(calls).grand_total;
+            (
+                key,
+                GroupedUsage {
+                    bucket,
+                    complete_cost,
+                },
+            )
+        })
+        .collect()
+}
+
+fn bucket_from(bucket: &TokenBucket, complete_cost: bool) -> FleetUsageBucket {
+    FleetUsageBucket {
+        input_tokens: bucket.input_tokens,
+        cache_creation_tokens: bucket.cache_creation_tokens,
+        cache_read_tokens: bucket.cache_read_tokens,
+        output_tokens: bucket.output_tokens,
+        reasoning_tokens: bucket.reasoning_tokens,
+        call_count: u64::try_from(bucket.call_count).unwrap_or(u64::MAX),
+        session_count: u64::try_from(bucket.session_count).unwrap_or(u64::MAX),
+        project_count: u64::try_from(bucket.project_count).unwrap_or(u64::MAX),
+        cost_usd: complete_cost.then_some(bucket.cost_usd).flatten(),
+    }
+}
+
+fn sort_and_cap<T>(rows: &mut Vec<T>, bucket: impl Fn(&T) -> &FleetUsageBucket) {
+    rows.sort_by(|left, right| {
+        let left_total = bucket(left).input_tokens
+            + bucket(left).cache_creation_tokens
+            + bucket(left).cache_read_tokens
+            + bucket(left).output_tokens
+            + bucket(left).reasoning_tokens;
+        let right_total = bucket(right).input_tokens
+            + bucket(right).cache_creation_tokens
+            + bucket(right).cache_read_tokens
+            + bucket(right).output_tokens
+            + bucket(right).reasoning_tokens;
+        right_total.cmp(&left_total)
+    });
+    rows.truncate(FLEET_USAGE_MAX_BREAKDOWN_BUCKETS);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_windows_are_bounded_and_utc_aligned() {
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let (start, end) = window(FleetUsagePeriod::Trailing7Days, now);
+        assert_eq!(start.to_rfc3339(), "2026-07-31T00:00:00+00:00");
+        assert_eq!(end.to_rfc3339(), "2026-08-07T00:00:00+00:00");
+    }
+
+    #[test]
+    fn unknown_cost_never_becomes_zero() {
+        let bucket = TokenBucket {
+            input_tokens: 10,
+            cost_usd: Some(1.25),
+            ..TokenBucket::default()
+        };
+        assert_eq!(bucket_from(&bucket, false).cost_usd, None);
+        assert_eq!(bucket_from(&bucket, false).input_tokens, 10);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
@@ -4,6 +4,7 @@
 //! public RPC receives only aggregates, never paths, transcripts, or calls.
 
 use std::collections::HashMap;
+use std::time::{Duration as StdDuration, SystemTime};
 
 use ainb_hangar_proto::fleet::{
     FLEET_USAGE_MAX_BREAKDOWN_BUCKETS, FLEET_USAGE_MAX_DAILY_BUCKETS, FleetUsageBucket,
@@ -41,7 +42,11 @@ pub fn scan_summary(period: FleetUsagePeriod) -> FleetUsageSummaryResult {
             detail: Some("provider history roots are unavailable".to_string()),
         };
     }
-    summary_from_usage(scanner::scan(&roots), period, Utc::now())
+    let now = Utc::now();
+    let (start, _) = window(period, now);
+    let since = SystemTime::UNIX_EPOCH
+        + StdDuration::from_millis(u64::try_from(start.timestamp_millis()).unwrap_or_default());
+    summary_from_usage(scanner::scan_since(&roots, since), period, now)
 }
 
 fn summary_from_usage(

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -91,6 +91,8 @@ pub mod execenv;
 pub mod fleet;
 /// Claude and Codex provider transports for authoritative Fleet control.
 pub mod fleet_provider;
+/// Bounded canonical Usage projection for the public Fleet RPC.
+pub mod fleet_usage;
 /// The task-lifecycle state machine (T8): `statig` typed compile-time
 /// transitions.
 ///
@@ -449,11 +451,10 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     // hangar home so the T2 store boundary holds (no cross-read of notifyd's
     // rusqlite). The handle is dropped (process exit tears the task down,
     // mirroring the inbox aggregator); a failed ingest is logged, never fatal.
-    // The event-log path is home-based (matching the hook appender) independent
-    // of `$AINB_HANGAR_HOME`; the cursor rides the resolved hangar dir.
-    if let Some(events_jsonl) =
-        dirs::home_dir().map(|h| h.join(".agents-in-a-box").join("events.jsonl"))
+    // Hook and daemon use the same resolved runtime root, including isolated
+    // `$AINB_HANGAR_HOME` test and paid-runtime installs.
     {
+        let events_jsonl = dir.join("events.jsonl");
         let cursor = dir.join("hangar").join("attention_ingest.offset");
         let _attention_ingest = crate::attention_ingest::AttentionIngest::new(
             store.pool().clone(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1172,6 +1172,8 @@ async fn handle(
         methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
         methods::FLEET_START => handle_fleet_start(pool, req, events).await,
         methods::FLEET_TIMELINE => handle_fleet_timeline(pool, req).await,
+        methods::FLEET_RUNTIME_STATUS => handle_fleet_runtime_status(req, health).await,
+        methods::FLEET_USAGE_SUMMARY => handle_fleet_usage_summary(req).await,
         methods::FLEET_MESSAGE_SEND => handle_fleet_message_send(pool, req, events).await,
         methods::FLEET_MESSAGE_LIST => handle_fleet_message_list(pool, req).await,
         // Both subscribe acks carry a head cursor; their per-connection
@@ -1389,6 +1391,64 @@ async fn handle_fleet_timeline(
     to_value(&FleetTimelineResult {
         entries,
         next_after_revision,
+    })
+}
+
+/// Return a bounded daemon-owned usage projection without exposing provider
+/// histories, filesystem paths, or any TUI implementation detail.
+async fn handle_fleet_usage_summary(req: &RpcRequest) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FLEET_CAPABILITY_USAGE_READ, FleetUsageSummaryParams};
+
+    require_fleet_capability(FLEET_CAPABILITY_USAGE_READ)?;
+    let params: FleetUsageSummaryParams = parse_params(req, "{ period? }")?;
+    let summary =
+        tokio::task::spawn_blocking(move || crate::fleet_usage::scan_summary(params.period))
+            .await
+            .map_err(|error| RpcError {
+                code: INTERNAL_ERROR,
+                message: format!("usage summary worker failed: {error}"),
+                data: None,
+            })?;
+    to_value(&summary)
+}
+
+/// Return supported provider-hook health without leaking runtime files or
+/// asking the macOS client to inspect installation state directly.
+async fn handle_fleet_runtime_status(
+    req: &RpcRequest,
+    health: &DaemonHealth,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{
+        FLEET_CAPABILITY_RUNTIME_READ, FLEET_PROTOCOL_VERSION, FleetRuntimeHookStatus,
+        FleetRuntimeStatusParams, FleetRuntimeStatusResult,
+    };
+
+    require_fleet_capability(FLEET_CAPABILITY_RUNTIME_READ)?;
+    let _: FleetRuntimeStatusParams = parse_params(req, "{}")?;
+    let paths = ainb_plugin_notifyd::Paths::from_home().map_err(|error| RpcError {
+        code: INTERNAL_ERROR,
+        message: format!("runtime status unavailable: {error}"),
+        data: None,
+    })?;
+    let hooks = ainb_plugin_notifyd::status(&paths)
+        .map_err(|error| RpcError {
+            code: INTERNAL_ERROR,
+            message: format!("runtime status unavailable: {error}"),
+            data: None,
+        })?
+        .into_iter()
+        .map(|row| FleetRuntimeHookStatus {
+            provider: row.agent,
+            installed: row.installed,
+            hook_ready: row.hook_script_ok,
+            delivery_ready: row.socket_ok,
+            last_event: (!row.last_event.is_empty()).then_some(row.last_event),
+        })
+        .collect();
+    to_value(&FleetRuntimeStatusResult {
+        daemon_version: health.version.clone(),
+        protocol_version: FLEET_PROTOCOL_VERSION,
+        hooks,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -25,6 +25,10 @@ pub const FLEET_CAPABILITY_START_EXECUTE: &str = "fleet.start.execute";
 pub const FLEET_CAPABILITY_ATC_READ: &str = "fleet.atc.read";
 /// Negotiated capability for the payload-free Fleet revision timeline.
 pub const FLEET_CAPABILITY_TIMELINE_READ: &str = "fleet.timeline.read";
+/// Negotiated capability for bounded daemon-owned usage summaries.
+pub const FLEET_CAPABILITY_USAGE_READ: &str = "fleet.usage.read";
+/// Negotiated capability for runtime and provider-hook health.
+pub const FLEET_CAPABILITY_RUNTIME_READ: &str = "fleet.runtime.read";
 /// Negotiated capability required for chat-bus message sends.
 pub const FLEET_CAPABILITY_MESSAGE_SEND: &str = "fleet.message.send";
 /// Negotiated capability required for chat-bus message list and subscribe.
@@ -54,6 +58,8 @@ pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
     "fleet.subscription.resync",
     FLEET_CAPABILITY_TIMELINE_READ,
     FLEET_CAPABILITY_TRANSCRIPT_READ,
+    FLEET_CAPABILITY_RUNTIME_READ,
+    FLEET_CAPABILITY_USAGE_READ,
 ];
 
 /// Inclusive supported protocol version range.
@@ -503,6 +509,189 @@ pub struct FleetTimelineResult {
     pub entries: Vec<FleetTimelineEntry>,
     /// Cursor for the next page, or `null` when this page is empty.
     pub next_after_revision: Option<i64>,
+}
+
+/// Bounded reporting period accepted by `fleet/usage_summary`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetUsagePeriod {
+    /// Current UTC calendar day.
+    Today,
+    /// Seven completed-or-current UTC calendar days.
+    #[serde(rename = "trailing_7_days")]
+    #[default]
+    Trailing7Days,
+    /// Thirty completed-or-current UTC calendar days.
+    #[serde(rename = "trailing_30_days")]
+    Trailing30Days,
+}
+
+/// Parameters for `fleet/usage_summary`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetUsageSummaryParams {
+    /// Bounded period the daemon aggregates.
+    #[serde(default)]
+    pub period: FleetUsagePeriod,
+}
+
+/// Maximum daily buckets the daemon may return for one usage summary.
+pub const FLEET_USAGE_MAX_DAILY_BUCKETS: usize = 30;
+/// Maximum provider, model, or project buckets per usage-summary breakdown.
+pub const FLEET_USAGE_MAX_BREAKDOWN_BUCKETS: usize = 10;
+/// Maximum UTF-8 bytes in a safe usage-summary detail message.
+pub const FLEET_USAGE_DETAIL_MAX_BYTES: usize = 1_024;
+
+/// Availability of the daemon-owned usage projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetUsageSummaryState {
+    /// The daemon is building a summary; no durable totals are ready yet.
+    Scanning,
+    /// Complete summary for every configured usage source.
+    Ready,
+    /// Summary is useful but one or more sources could not be fully read.
+    Partial,
+    /// The daemon cannot provide a summary for this request.
+    Unavailable,
+}
+
+/// Aggregated token and optional canonical USD cost values.
+///
+/// `cost_usd` is `None` when no canonical model rate covers every included
+/// call. Clients must show tokens instead of synthesising a zero cost.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageBucket {
+    /// Input tokens.
+    pub input_tokens: u64,
+    /// Prompt-cache creation tokens.
+    pub cache_creation_tokens: u64,
+    /// Prompt-cache read tokens.
+    pub cache_read_tokens: u64,
+    /// Output tokens.
+    pub output_tokens: u64,
+    /// Reasoning tokens.
+    pub reasoning_tokens: u64,
+    /// Number of source calls contributing to this aggregate.
+    pub call_count: u64,
+    /// Number of distinct source sessions contributing to this aggregate.
+    pub session_count: u64,
+    /// Number of distinct projects contributing to this aggregate.
+    pub project_count: u64,
+    /// Canonical USD cost when fully priced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+}
+
+/// One daily usage bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageDailyBucket {
+    /// ISO-8601 UTC calendar date (`YYYY-MM-DD`).
+    pub date: String,
+    /// Daily aggregate.
+    pub bucket: FleetUsageBucket,
+}
+
+/// One provider usage bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageProviderBucket {
+    /// Canonical provider token from the usage producer.
+    pub provider: String,
+    /// Provider aggregate.
+    pub bucket: FleetUsageBucket,
+}
+
+/// One model usage bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageModelBucket {
+    /// Exact model identifier from the usage producer.
+    pub model: String,
+    /// Model aggregate.
+    pub bucket: FleetUsageBucket,
+}
+
+/// One project usage bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageProjectBucket {
+    /// Human-readable project aggregation key.
+    pub project: String,
+    /// Resolved upstream repository when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    /// Project aggregate.
+    pub bucket: FleetUsageBucket,
+}
+
+/// Bounded result for `fleet/usage_summary`.
+///
+/// Timestamps are epoch milliseconds. A non-`Ready` response may omit every
+/// projection field and use `detail` to explain the unavailable or partial
+/// source state without exposing local paths, credentials, or raw transcripts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageSummaryResult {
+    /// Current summary availability.
+    pub state: FleetUsageSummaryState,
+    /// Time the daemon generated this summary, in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated_at: Option<i64>,
+    /// Inclusive summary window start, in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_at: Option<i64>,
+    /// Exclusive summary window end, in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<i64>,
+    /// Aggregate for the requested period.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub totals: Option<FleetUsageBucket>,
+    /// Daily buckets, chronologically ordered and capped by
+    /// [`FLEET_USAGE_MAX_DAILY_BUCKETS`].
+    #[serde(default)]
+    pub daily: Vec<FleetUsageDailyBucket>,
+    /// Provider aggregates, producer-defined descending order and capped by
+    /// [`FLEET_USAGE_MAX_BREAKDOWN_BUCKETS`].
+    #[serde(default)]
+    pub providers: Vec<FleetUsageProviderBucket>,
+    /// Top model aggregates, capped by [`FLEET_USAGE_MAX_BREAKDOWN_BUCKETS`].
+    #[serde(default)]
+    pub models: Vec<FleetUsageModelBucket>,
+    /// Top project aggregates, capped by [`FLEET_USAGE_MAX_BREAKDOWN_BUCKETS`].
+    #[serde(default)]
+    pub projects: Vec<FleetUsageProjectBucket>,
+    /// Safe daemon status detail for partial or unavailable summaries, capped
+    /// by [`FLEET_USAGE_DETAIL_MAX_BYTES`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Parameters for `fleet/runtime_status`. Kept extensible for additive
+/// runtime probes without exposing daemon implementation state.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetRuntimeStatusParams {}
+
+/// Health of one supported provider hook.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetRuntimeHookStatus {
+    /// Stable provider identifier.
+    pub provider: String,
+    /// The supported installer recorded this provider as installed.
+    pub installed: bool,
+    /// The installed hook program is present and executable.
+    pub hook_ready: bool,
+    /// Hook delivery socket is currently accepting connections.
+    pub delivery_ready: bool,
+    /// The daemon has observed a recent provider event, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_event: Option<String>,
+}
+
+/// Bounded runtime health returned only by the public Fleet RPC.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetRuntimeStatusResult {
+    /// Daemon version serving this connection.
+    pub daemon_version: String,
+    /// Fleet protocol version serving this connection.
+    pub protocol_version: u32,
+    /// Supported provider hook states. No filesystem paths are exposed.
+    pub hooks: Vec<FleetRuntimeHookStatus>,
 }
 
 /// Initial result for a replay-safe Fleet subscription.
@@ -1124,6 +1313,8 @@ mod tests {
             FLEET_CAPABILITY_MESSAGE_SEND,
             FLEET_CAPABILITY_MESSAGE_READ,
             FLEET_CAPABILITY_TRANSCRIPT_READ,
+            FLEET_CAPABILITY_USAGE_READ,
+            FLEET_CAPABILITY_RUNTIME_READ,
         ] {
             assert!(
                 FLEET_PROTOCOL_CAPABILITY_IDS.contains(&id),
@@ -1229,6 +1420,66 @@ mod tests {
         round_trip(&FleetTranscriptSubscribeResult { head_order: None });
         round_trip(&FleetTranscriptEventParams {
             chunk: sample_chunk(),
+        });
+    }
+
+    #[test]
+    fn usage_summary_wire_contract_round_trips_with_optional_costs() {
+        assert_eq!(
+            serde_json::to_value(FleetUsagePeriod::Trailing7Days).unwrap(),
+            "trailing_7_days"
+        );
+        assert_eq!(
+            serde_json::to_value(FleetUsageSummaryState::Partial).unwrap(),
+            "partial"
+        );
+        round_trip(&FleetUsageSummaryParams {
+            period: FleetUsagePeriod::Trailing30Days,
+        });
+        round_trip(&FleetUsageSummaryResult {
+            state: FleetUsageSummaryState::Partial,
+            generated_at: Some(1_700_000_000_000),
+            start_at: Some(1_699_395_200_000),
+            end_at: Some(1_700_000_000_000),
+            totals: Some(FleetUsageBucket {
+                input_tokens: 100,
+                cache_creation_tokens: 20,
+                cache_read_tokens: 30,
+                output_tokens: 40,
+                reasoning_tokens: 50,
+                call_count: 2,
+                session_count: 1,
+                project_count: 1,
+                cost_usd: None,
+            }),
+            daily: vec![FleetUsageDailyBucket {
+                date: "2026-08-06".to_string(),
+                bucket: FleetUsageBucket {
+                    input_tokens: 100,
+                    cache_creation_tokens: 20,
+                    cache_read_tokens: 30,
+                    output_tokens: 40,
+                    reasoning_tokens: 50,
+                    call_count: 2,
+                    session_count: 1,
+                    project_count: 1,
+                    cost_usd: Some(1.25),
+                },
+            }],
+            providers: vec![FleetUsageProviderBucket {
+                provider: "claude".to_string(),
+                bucket: FleetUsageBucket::default(),
+            }],
+            models: vec![FleetUsageModelBucket {
+                model: "claude-sonnet-4-5".to_string(),
+                bucket: FleetUsageBucket::default(),
+            }],
+            projects: vec![FleetUsageProjectBucket {
+                project: "owner/repo".to_string(),
+                repo: Some("owner/repo".to_string()),
+                bucket: FleetUsageBucket::default(),
+            }],
+            detail: Some("copilot shutdown metrics unavailable".to_string()),
         });
     }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -410,6 +410,13 @@ pub const FLEET_RECEIPT_GET: &str = "fleet/receipt_get";
 pub const FLEET_START: &str = "fleet/start";
 /// Read bounded, payload-free Fleet revision timeline entries.
 pub const FLEET_TIMELINE: &str = "fleet/timeline";
+/// Read a bounded daemon-owned Fleet usage summary.
+///
+/// Params: [`crate::fleet::FleetUsageSummaryParams`]; result:
+/// [`crate::fleet::FleetUsageSummaryResult`]. Gated by `fleet.usage.read`.
+pub const FLEET_USAGE_SUMMARY: &str = "fleet/usage_summary";
+/// Read bounded daemon and provider-hook runtime health.
+pub const FLEET_RUNTIME_STATUS: &str = "fleet/runtime_status";
 /// Rebuild one stale Claude interview through the live daemon broker.
 pub const FLEET_REPROJECT_CLAUDE_INTERVIEW: &str = "fleet/reproject_claude_interview";
 /// Create a daemon-owned ACP session pair without spawning an adapter process.
@@ -1700,6 +1707,8 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_RECEIPT_GET,
     FLEET_START,
     FLEET_TIMELINE,
+    FLEET_USAGE_SUMMARY,
+    FLEET_RUNTIME_STATUS,
     FLEET_REPROJECT_CLAUDE_INTERVIEW,
     // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
     // tail, append-only wire.
@@ -1989,6 +1998,8 @@ mod tests {
             FLEET_RECEIPT_GET,
             FLEET_START,
             FLEET_TIMELINE,
+            FLEET_USAGE_SUMMARY,
+            FLEET_RUNTIME_STATUS,
             FLEET_REPROJECT_CLAUDE_INTERVIEW,
             HANGAR_DISPATCH_ATTEMPTS_LIST,
             HANGAR_ISSUE_TIMELINE,

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/paths.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/paths.rs
@@ -45,12 +45,18 @@ pub struct Paths {
 }
 
 impl Paths {
-    /// Resolve paths under the ainb base directory: `$AINB_HOME` when set
+    /// Resolve paths under the Hangar base directory: `$AINB_HANGAR_HOME` or
+    /// `$AINB_HOME` when set
     /// (the same override the fleet plumbing honours — the hook, the daemon,
     /// and the TUI/CLI deciders MUST all resolve the approve socket to the
     /// same base or a waiting hook parks on a socket nothing serves),
     /// otherwise `~/.agents-in-a-box/`. Fails if neither can be determined.
     pub fn from_home() -> anyhow::Result<Self> {
+        if let Ok(h) = std::env::var("AINB_HANGAR_HOME") {
+            if !h.is_empty() {
+                return Ok(Self::under(PathBuf::from(h)));
+            }
+        }
         if let Ok(h) = std::env::var("AINB_HOME") {
             if !h.is_empty() {
                 return Ok(Self::under(PathBuf::from(h)));

--- a/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-session-reader/Cargo.toml
@@ -18,6 +18,10 @@ ignored = ["ainb-plugin-sdk-rust"]
 name = "ainb-plugin-session-reader"
 path = "src/main.rs"
 
+[lib]
+name = "ainb_plugin_session_reader"
+path = "src/lib.rs"
+
 [dependencies]
 ainb-model-rates = { path = "../ainb-model-rates" }
 ainb-plugin-sdk-rust = { path = "../ainb-plugin-sdk-rust" }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/lib.rs
@@ -1,0 +1,15 @@
+//! Canonical local-provider usage reader.
+//!
+//! The plugin binary publishes this reader's output to TUI consumers. Hangar
+//! also uses the same scanner for its public Fleet usage contract, so provider
+//! parsing and model-rate logic remain single-sourced.
+
+#![forbid(unsafe_code)]
+
+#[cfg(not(target_arch = "wasm32"))]
+mod cache;
+mod config;
+mod fnv;
+mod parsers;
+pub mod plugin;
+pub mod scanner;

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/main.rs
@@ -12,16 +12,9 @@
 #![forbid(unsafe_code)]
 
 use ainb_plugin_sdk::{SdkError, Server};
-
-#[cfg(not(target_arch = "wasm32"))]
-mod cache;
-mod config;
-mod fnv;
-mod parsers;
-mod plugin;
-mod scanner;
+use ainb_plugin_session_reader::plugin::SessionReader;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), SdkError> {
-    Server::new(plugin::SessionReader::new()).run_stdio().await
+    Server::new(SessionReader::new()).run_stdio().await
 }

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/parsers/mod.rs
@@ -77,6 +77,12 @@ where
         ctx.stat_failures = ctx.stat_failures.saturating_add(1);
     }
 
+    if let (Some(minimum), Some((mtime, _))) = (ctx.minimum_mtime_nanos, stat) {
+        if mtime < minimum {
+            return Vec::new();
+        }
+    }
+
     if let (Some(watermark), Some((mtime, size))) = (ctx.watermark_nanos, stat) {
         if mtime < watermark {
             ctx.stable_present.push((path_str.clone(), mtime, size));

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -22,7 +22,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::time::{Duration as StdDuration, Instant};
+use std::time::{Duration as StdDuration, Instant, SystemTime, UNIX_EPOCH};
 
 use ainb_plugin_types_sessions::{
     BranchUsage, ModelUsage, NamedUsage, ProjectUsage, Provider, ProviderCall, ScanProgressEvent,
@@ -230,6 +230,9 @@ pub(crate) struct ScanCtx<'a> {
     /// partition entirely — every file is "recent" (the legacy full
     /// scan, byte-for-byte).
     pub(crate) watermark_nanos: Option<u64>,
+    /// Files older than this timestamp are outside a caller's requested
+    /// reporting window and are never read or parsed.
+    pub(crate) minimum_mtime_nanos: Option<u64>,
     pub(crate) stable_policy: StablePolicy,
     /// `(path, mtime_nanos, size)` of every stable file seen.
     pub(crate) stable_present: Vec<(String, u64, u64)>,
@@ -255,6 +258,26 @@ impl<'a> ScanCtx<'a> {
         Self {
             cache,
             watermark_nanos: None,
+            minimum_mtime_nanos: None,
+            stable_policy: StablePolicy::Skip,
+            stable_present: Vec::new(),
+            recent_present: Vec::new(),
+            stable_calls: Vec::new(),
+            stat_failures: 0,
+            counters: ScanCounters::default(),
+        }
+    }
+
+    /// Bounded full scan: preserve normal parsing rules while avoiding reads
+    /// for sessions whose files have not changed in the requested window.
+    pub(crate) fn full_since(
+        cache: &'a mut Option<crate::cache::UsageCache>,
+        minimum_mtime_nanos: u64,
+    ) -> Self {
+        Self {
+            cache,
+            watermark_nanos: None,
+            minimum_mtime_nanos: Some(minimum_mtime_nanos),
             stable_policy: StablePolicy::Skip,
             stable_present: Vec::new(),
             recent_present: Vec::new(),
@@ -273,6 +296,7 @@ impl<'a> ScanCtx<'a> {
         Self {
             cache,
             watermark_nanos: Some(watermark_nanos),
+            minimum_mtime_nanos: None,
             stable_policy,
             stable_present: Vec::new(),
             recent_present: Vec::new(),
@@ -349,6 +373,21 @@ pub fn scan(roots: &ProviderRoots) -> UsageData {
         }
         aggregate(all_calls)
     }
+}
+
+/// Scan provider files touched since `since`, then aggregate their canonical
+/// calls. Active sessions remain included because their JSONL files are
+/// appended as they receive events.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn scan_since(roots: &ProviderRoots, since: SystemTime) -> UsageData {
+    let minimum_mtime_nanos = since
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    let mut cache = None;
+    let mut reporter = ProgressReporter::noop();
+    let mut ctx = ScanCtx::full_since(&mut cache, minimum_mtime_nanos);
+    aggregate(walk_providers(roots, &mut ctx, &mut reporter))
 }
 
 /// Cache-aware scan. Pass `Some(cache)` to short-circuit per-file parses
@@ -1909,6 +1948,29 @@ mod tests {
     /// `now` so a watermark captured between writes cleanly splits them.
     fn tick() {
         std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    #[test]
+    fn scan_since_reads_only_files_touched_in_requested_window() {
+        let fx = IncrFixture::new();
+        fx.write_file(
+            "proj-old",
+            "old.jsonl",
+            &[claude_line("2026-05-01T10:00:00Z", "old", 100, 200)],
+        );
+        tick();
+        let cutoff = now_nanos();
+        tick();
+        fx.write_file(
+            "proj-new",
+            "new.jsonl",
+            &[claude_line("2026-06-01T10:00:00Z", "new", 10, 20)],
+        );
+
+        let since = UNIX_EPOCH + StdDuration::from_nanos(cutoff);
+        let usage = scan_since(&fx.roots, since);
+        assert_eq!(usage.calls.len(), 1);
+        assert_eq!(usage.calls[0].session_id, "new");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/scanner.rs
@@ -358,7 +358,7 @@ pub fn scan(roots: &ProviderRoots) -> UsageData {
 /// Gemini and Cursor parsers are stubs that don't read files; they're
 /// invoked without the cache.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn scan_with_cache(
+pub(crate) fn scan_with_cache(
     roots: &ProviderRoots,
     cache: &mut Option<crate::cache::UsageCache>,
 ) -> UsageData {
@@ -381,7 +381,7 @@ pub fn scan_with_cache(
 /// honest; their file counts are usually small enough that the
 /// under-count is invisible.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn scan_with_cache_and_progress(
+pub(crate) fn scan_with_cache_and_progress(
     roots: &ProviderRoots,
     cache: &mut Option<crate::cache::UsageCache>,
     reporter: &mut ProgressReporter,

--- a/apps/ainb-fleet-macos/Resources/Info.plist
+++ b/apps/ainb-fleet-macos/Resources/Info.plist
@@ -20,8 +20,6 @@
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>LSUIElement</key>
-	<true/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -1,39 +1,16 @@
+import Foundation
 import SwiftUI
 
-@main
-struct AINBFleetApp: App {
-    @StateObject private var store: FleetStore
-    @StateObject private var presentation: FleetPresentationStore
-    @NSApplicationDelegateAdaptor(FleetAppDelegate.self) private var appDelegate
-    private let desktop: FleetDesktopController
-
-    init() {
-        let defaults = Self.presentationDefaults
-        let fleetStore = FleetStore(readVersions: Self.testReadVersions)
-        let presentationStore = FleetPresentationStore(defaults: defaults)
-        _store = StateObject(wrappedValue: fleetStore)
-        _presentation = StateObject(wrappedValue: presentationStore)
-        let desktopController = FleetDesktopController(store: fleetStore, presentation: presentationStore)
-        desktop = desktopController
-        FleetDesktopController.shared = desktopController
-        Task { @MainActor in
-            fleetStore.start()
-            desktopController.launch()
-            #if DEBUG
-            if Self.testLaunchesFleetWindow {
-                desktopController.showFleet()
-            }
-            #endif
-        }
+enum FleetAppConfiguration {
+    static var isUITest: Bool {
+        #if DEBUG
+        ProcessInfo.processInfo.environment["AINB_FLEET_UI_TEST_MODE"] == "1"
+        #else
+        false
+        #endif
     }
 
-    var body: some Scene {
-        Settings {
-            FleetSettingsView(presentation: presentation.binding)
-        }
-    }
-
-    private static var testReadVersions: FleetProtocolRange {
+    static var readVersions: FleetProtocolRange {
         #if DEBUG
         // 3...3 excludes the daemon's v2, simulating a read-incompatible client
         // for the protocol-compatibility UI journey.
@@ -45,9 +22,9 @@ struct AINBFleetApp: App {
         return FleetProtocolRange(min: 1, max: 2)
     }
 
-    private static var presentationDefaults: UserDefaults {
+    static var presentationDefaults: UserDefaults {
         #if DEBUG
-        guard testLaunchesFleetWindow else { return .standard }
+        guard ProcessInfo.processInfo.environment["AINB_FLEET_TEST_ISOLATE_DEFAULTS"] == "1" else { return .standard }
         let suite = "dev.ainb.fleet.xcui"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
@@ -57,10 +34,33 @@ struct AINBFleetApp: App {
         #endif
     }
 
-    #if DEBUG
-    private static var testLaunchesFleetWindow: Bool {
-        CommandLine.arguments.contains("--fleet-test-open-window")
-            || ProcessInfo.processInfo.environment["AINB_FLEET_TEST_OPEN_WINDOW"] == "1"
+}
+
+@main
+struct AINBFleetApp: App {
+    @StateObject private var store: FleetStore
+    @StateObject private var presentation: FleetPresentationStore
+    @NSApplicationDelegateAdaptor(FleetAppDelegate.self) private var appDelegate
+    private let desktop: FleetDesktopController
+
+    init() {
+        let store = FleetStore(readVersions: FleetAppConfiguration.readVersions)
+        let presentation = FleetPresentationStore(defaults: FleetAppConfiguration.presentationDefaults)
+        let desktop = FleetDesktopController(store: store, presentation: presentation)
+        _store = StateObject(wrappedValue: store)
+        _presentation = StateObject(wrappedValue: presentation)
+        self.desktop = desktop
+        FleetDesktopController.shared = desktop
+        Task { @MainActor in
+            store.start()
+            desktop.launch()
+            if FleetAppConfiguration.isUITest {
+                NSApp.activate(ignoringOtherApps: true)
+            }
+        }
     }
-    #endif
+
+    var body: some Scene {
+        Settings { EmptyView() }
+    }
 }

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -97,7 +97,8 @@ final class FleetDesktopController: NSObject {
     }
 
     private func setNotchExpanded(_ expanded: Bool) {
-        DispatchQueue.main.async { [weak self] in self?.positionNotch() }
+        guard let panel = notchPanel else { return }
+        panel.setFrame(FleetNotchGeometry.frame(expanded: expanded, on: notchScreen(for: panel)), display: true)
     }
 
     func open(_ url: URL) {
@@ -114,11 +115,12 @@ final class FleetDesktopController: NSObject {
     }
 
     private func positionNotch() {
-        guard let panel = notchPanel,
-              let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main
-        else { return }
-        let frame = screen.frame
-        panel.setFrameOrigin(NSPoint(x: frame.midX - panel.frame.width / 2, y: frame.maxY - panel.frame.height))
+        guard let panel = notchPanel else { return }
+        panel.setFrame(FleetNotchGeometry.frame(expanded: navigation.isExpanded, on: notchScreen(for: panel)), display: true)
+    }
+
+    private func notchScreen(for panel: NSWindow) -> NSScreen? {
+        panel.screen ?? NSScreen.main ?? NSScreen.screens.first
     }
 }
 
@@ -201,10 +203,7 @@ private struct FleetNotchView: View {
     }
 
     private var notchSize: CGSize {
-        let requested = CGSize(width: navigation.isExpanded ? 920 : 320, height: navigation.isExpanded ? 720 : 38)
-        let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main
-        let visible = screen?.visibleFrame ?? CGRect(origin: .zero, size: requested)
-        return CGSize(width: min(requested.width, visible.width), height: min(requested.height, visible.height))
+        FleetNotchGeometry.size(expanded: navigation.isExpanded, on: NSScreen.main)
     }
 
     private var expandedContent: some View {
@@ -226,6 +225,14 @@ private struct FleetNotchView: View {
                         Label(providerLabel, systemImage: "slider.horizontal.3")
                     }
                     .accessibilityIdentifier("fleet.notch.provider-filter")
+                    Menu {
+                        ForEach(FleetRosterFocus.allCases) { focus in
+                            Button(focus.label) { presentation.preferences.filters.focus = focus }
+                        }
+                    } label: {
+                        Label(presentation.preferences.filters.focus.label, systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                    .accessibilityIdentifier("fleet.notch.focus-filter")
                     Button(action: toggleExpanded) { Image(systemName: "xmark") }
                         .accessibilityLabel("Close Fleet controls")
                 }
@@ -289,21 +296,6 @@ private struct FleetNotchView: View {
     private var rosterContent: some View {
         VStack(alignment: .leading, spacing: 14) {
 
-            if navigation.route == .sessions {
-                ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 7) {
-                    ForEach(FleetRosterFocus.allCases) { focus in
-                        FleetNotchFocusChip(
-                            focus: focus,
-                            selected: presentation.preferences.filters.focus == focus
-                        ) {
-                            toggleFocus(focus)
-                        }
-                    }
-                }
-            }
-            }
-
             HStack {
                 Text("\(routedSessions.count) of \(store.sessions.count) sessions")
                     .font(.caption.weight(.medium))
@@ -362,34 +354,24 @@ private struct FleetNotchView: View {
         store.selectedSessionKey = routedSessions.first?.sessionKey
     }
 
-    private func toggleFocus(_ focus: FleetRosterFocus) {
-        if presentation.preferences.filters.focus == focus, focus != .all {
-            presentation.preferences.filters.focus = .all
-        } else {
-            presentation.preferences.filters.focus = focus
-        }
-    }
 }
 
-private struct FleetNotchFocusChip: View {
-    let focus: FleetRosterFocus
-    let selected: Bool
-    let toggle: () -> Void
+private enum FleetNotchGeometry {
+    static func size(expanded: Bool, on screen: NSScreen?) -> CGSize {
+        let requested = CGSize(width: expanded ? 920 : 320, height: expanded ? 720 : 38)
+        let available = screen?.frame.size ?? requested
+        return CGSize(width: min(requested.width, available.width), height: min(requested.height, available.height))
+    }
 
-    var body: some View {
-        Button(action: toggle) {
-            Text(focus.label)
-                .font(.subheadline.weight(selected ? .bold : .medium))
-                .foregroundStyle(selected ? .black : Color.white.opacity(0.92))
-                .padding(.horizontal, 12)
-                .padding(.vertical, 7)
-                .background(selected ? FleetNotchPalette.mint : FleetNotchPalette.control, in: Capsule())
-                .overlay {
-                    Capsule().stroke(selected ? FleetNotchPalette.mint : FleetNotchPalette.muted.opacity(0.35), lineWidth: 1)
-                }
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("fleet.notch.filter.\(focus.rawValue)")
+    static func frame(expanded: Bool, on screen: NSScreen?) -> NSRect {
+        guard let screen else { return NSRect(origin: .zero, size: size(expanded: expanded, on: nil)) }
+        let size = size(expanded: expanded, on: screen)
+        return NSRect(
+            x: screen.frame.midX - size.width / 2,
+            y: screen.frame.maxY - size.height,
+            width: size.width,
+            height: size.height
+        )
     }
 }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -19,14 +19,36 @@ final class FleetPresentationStore: ObservableObject {
     }
 }
 
+enum FleetNotchRoute: String, CaseIterable, Identifiable {
+    case sessions, needsYou, interviews, usage, settings
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .sessions: "Sessions"
+        case .needsYou: "Needs you"
+        case .interviews: "Interviews"
+        case .usage: "Usage"
+        case .settings: "Settings"
+        }
+    }
+}
+
 @MainActor
-final class FleetDesktopController: NSObject, NSWindowDelegate {
+final class FleetNotchNavigation: ObservableObject {
+    @Published var isExpanded = false
+    @Published var route: FleetNotchRoute = .sessions
+}
+
+@MainActor
+final class FleetDesktopController: NSObject {
     static var shared: FleetDesktopController?
 
     private let store: FleetStore
     private let presentation: FleetPresentationStore
-    private var notchPanel: NSPanel?
-    private var fleetWindow: NSWindow?
+    private let navigation = FleetNotchNavigation()
+    private var notchPanel: NSWindow?
 
     init(store: FleetStore, presentation: FleetPresentationStore) {
         self.store = store
@@ -37,59 +59,45 @@ final class FleetDesktopController: NSObject, NSWindowDelegate {
     func launch() {
         if notchPanel == nil {
             let size = NSSize(width: 320, height: 38)
-            let panel = NSPanel(
-                contentRect: NSRect(origin: .zero, size: size),
-                styleMask: [.borderless, .nonactivatingPanel],
-                backing: .buffered,
-                defer: false
-            )
+            let panel: NSWindow
+            if FleetAppConfiguration.isUITest {
+                panel = NSWindow(
+                    contentRect: NSRect(origin: .zero, size: size),
+                    styleMask: [.borderless],
+                    backing: .buffered,
+                    defer: false
+                )
+            } else {
+                panel = NSPanel(
+                    contentRect: NSRect(origin: .zero, size: size),
+                    styleMask: [.borderless, .nonactivatingPanel],
+                    backing: .buffered,
+                    defer: false
+                )
+            }
             panel.isOpaque = false
             panel.backgroundColor = .clear
             panel.hasShadow = false
-            panel.level = .statusBar
+            panel.level = FleetAppConfiguration.isUITest ? .floating : .statusBar
             panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-            panel.contentView = NSHostingView(rootView: FleetNotchView(
+            let contentView = NSHostingView(rootView: FleetNotchView(
                 store: store,
                 presentation: presentation,
-                setExpanded: { [weak self] in self?.setNotchExpanded($0) },
-                openFleet: { [weak self] in
-                    self?.setNotchExpanded(false)
-                    self?.showFleet()
-                }
+                navigation: navigation,
+                setExpanded: { [weak self] in self?.setNotchExpanded($0) }
             ))
+            panel.contentView = contentView
             notchPanel = panel
         }
         positionNotch()
         notchPanel?.orderFrontRegardless()
-    }
-
-    func showFleet() {
-        NSApp.setActivationPolicy(.regular)
-        if fleetWindow == nil {
-            let window = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
-                styleMask: [.titled, .closable, .miniaturizable, .resizable],
-                backing: .buffered,
-                defer: false
-            )
-            window.title = "Fleet"
-            window.minSize = NSSize(width: 620, height: 520)
-            window.level = .floating
-            window.delegate = self
-            window.contentView = NSHostingView(rootView: FleetWindowView(store: store, presentation: presentation.binding))
-            window.center()
-            window.setFrameAutosaveName("AINBFleetWindow")
-            fleetWindow = window
+        if FleetAppConfiguration.isUITest {
+            notchPanel?.makeKey()
         }
-        fleetWindow?.makeKeyAndOrderFront(nil)
-        fleetWindow?.orderFrontRegardless()
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func setNotchExpanded(_ expanded: Bool) {
-        guard let panel = notchPanel else { return }
-        panel.setContentSize(NSSize(width: expanded ? 640 : 320, height: expanded ? 620 : 38))
-        positionNotch()
+        DispatchQueue.main.async { [weak self] in self?.positionNotch() }
     }
 
     func open(_ url: URL) {
@@ -100,14 +108,9 @@ final class FleetDesktopController: NSObject, NSWindowDelegate {
               !key.isEmpty else { return }
         store.refresh()
         store.selectedSessionKey = key
-        showFleet()
-    }
-
-    func windowWillClose(_ notification: Notification) {
-        guard let closingWindow = notification.object as? NSWindow,
-              closingWindow === fleetWindow else { return }
-        fleetWindow = nil
-        NSApp.setActivationPolicy(.accessory)
+        navigation.route = .needsYou
+        navigation.isExpanded = true
+        setNotchExpanded(true)
     }
 
     private func positionNotch() {
@@ -119,22 +122,24 @@ final class FleetDesktopController: NSObject, NSWindowDelegate {
     }
 }
 
+@MainActor
 final class FleetAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(FleetAppConfiguration.isUITest ? .regular : .accessory)
+    }
+
     func application(_ application: NSApplication, open urls: [URL]) {
-        Task { @MainActor in
-            urls.forEach { FleetDesktopController.shared?.open($0) }
-        }
+        urls.forEach { FleetDesktopController.shared?.open($0) }
     }
 }
 
 private struct FleetNotchView: View {
     @ObservedObject var store: FleetStore
     @ObservedObject var presentation: FleetPresentationStore
+    @ObservedObject var navigation: FleetNotchNavigation
     let setExpanded: (Bool) -> Void
-    let openFleet: () -> Void
-    @State private var isExpanded = false
     @State private var search = ""
-    @State private var interviewPresented = false
+    @State private var usagePeriod: FleetUsagePeriod = .trailing7Days
 
     private var visibleSessions: [FleetSession] {
         FleetRosterPresentation.visibleSessions(
@@ -146,8 +151,8 @@ private struct FleetNotchView: View {
     }
 
     private var selectedSession: FleetSession? {
-        guard let key = store.selectedSessionKey else { return visibleSessions.first }
-        return visibleSessions.first(where: { $0.sessionKey == key }) ?? visibleSessions.first
+        guard let key = store.selectedSessionKey else { return routedSessions.first }
+        return routedSessions.first(where: { $0.sessionKey == key }) ?? routedSessions.first
     }
 
     var body: some View {
@@ -156,22 +161,23 @@ private struct FleetNotchView: View {
                 header
             }
             .buttonStyle(.plain)
+            .frame(maxWidth: .infinity)
             .accessibilityIdentifier("fleet.notch")
             .accessibilityLabel(FleetStatusPresentation.label(active: store.activeCount, needsYou: store.needsYouCount, state: store.connectionState, sessions: store.sessions))
-            .accessibilityHint(isExpanded ? "Collapse Fleet controls" : "Expand Fleet controls")
+            .accessibilityHint(navigation.isExpanded ? "Collapse Fleet controls" : "Expand Fleet controls")
 
-            if isExpanded {
+            if navigation.isExpanded {
                 expandedContent
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
-        .frame(width: isExpanded ? 640 : 320, alignment: .top)
+        .frame(width: notchSize.width, height: notchSize.height, alignment: .top)
         .background(FleetNotchPalette.canvas, in: FleetNotchShape())
-        .onChange(of: isExpanded) { _, value in setExpanded(value) }
+        .onChange(of: navigation.isExpanded) { _, value in setExpanded(value) }
         .onChange(of: visibleSessions.map(\.sessionKey)) { _, _ in selectFirstVisibleSession() }
         .onChange(of: presentation.preferences.filters) { _, _ in selectFirstVisibleSession() }
+        .onChange(of: navigation.route) { _, _ in selectFirstVisibleSession() }
         .onAppear(perform: selectFirstVisibleSession)
-        .sheet(isPresented: $interviewPresented) { FleetAnswerQueue(store: store) }
     }
 
     private var header: some View {
@@ -184,7 +190,7 @@ private struct FleetNotchView: View {
             Spacer()
             Text(store.connectionState.isLive ? "\(store.activeCount) active · \(store.needsYouCount) needs you" : "Offline")
                 .foregroundStyle(FleetNotchPalette.muted)
-            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+            Image(systemName: navigation.isExpanded ? "chevron.up" : "chevron.down")
                 .font(.caption2.weight(.bold))
                 .foregroundStyle(FleetNotchPalette.muted)
         }
@@ -194,29 +200,97 @@ private struct FleetNotchView: View {
         .contentShape(Rectangle())
     }
 
+    private var notchSize: CGSize {
+        let requested = CGSize(width: navigation.isExpanded ? 920 : 320, height: navigation.isExpanded ? 720 : 38)
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main
+        let visible = screen?.visibleFrame ?? CGRect(origin: .zero, size: requested)
+        return CGSize(width: min(requested.width, visible.width), height: min(requested.height, visible.height))
+    }
+
     private var expandedContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 8) {
-                TextField("Search sessions", text: $search)
-                    .textFieldStyle(.roundedBorder)
-                    .accessibilityIdentifier("fleet.notch.search")
-                Menu {
-                    Button("All providers") { presentation.preferences.filters.provider = nil }
-                    Divider()
-                    Button("Claude") { presentation.preferences.filters.provider = .claude }
-                    Button("Codex") { presentation.preferences.filters.provider = .codex }
-                    Button("Copilot") { presentation.preferences.filters.provider = .copilot }
-                    Button("ACP") { presentation.preferences.filters.provider = .acp }
-                    Button("Unknown") { presentation.preferences.filters.provider = .unknown }
-                } label: {
-                    Label(providerLabel, systemImage: "slider.horizontal.3")
+            VStack(spacing: 14) {
+                HStack(spacing: 8) {
+                    TextField("Search sessions", text: $search)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("fleet.notch.search")
+                    Menu {
+                        Button("All providers") { presentation.preferences.filters.provider = nil }
+                        Divider()
+                        Button("Claude") { presentation.preferences.filters.provider = .claude }
+                        Button("Codex") { presentation.preferences.filters.provider = .codex }
+                        Button("Copilot") { presentation.preferences.filters.provider = .copilot }
+                        Button("ACP") { presentation.preferences.filters.provider = .acp }
+                        Button("Unknown") { presentation.preferences.filters.provider = .unknown }
+                    } label: {
+                        Label(providerLabel, systemImage: "slider.horizontal.3")
+                    }
+                    .accessibilityIdentifier("fleet.notch.provider-filter")
+                    Button(action: toggleExpanded) { Image(systemName: "xmark") }
+                        .accessibilityLabel("Close Fleet controls")
                 }
-                .accessibilityIdentifier("fleet.notch.provider-filter")
-                Button(action: toggleExpanded) { Image(systemName: "xmark") }
-                    .accessibilityLabel("Close Fleet controls")
-            }
 
-            ScrollView(.horizontal, showsIndicators: false) {
+                Picker("Fleet view", selection: $navigation.route) {
+                    ForEach(FleetNotchRoute.allCases) { route in
+                        Text(route.title).tag(route)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("fleet.notch.route")
+            }
+            .fixedSize(horizontal: false, vertical: true)
+
+            routeContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+        .padding(16)
+        .frame(height: 682, alignment: .top)
+    }
+
+    @ViewBuilder private var routeContent: some View {
+        if case .readIncompatible = store.connectionState {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(store.connectionState.message)
+                    .font(.headline)
+                Text("Update Fleet or install a compatible daemon before using controls.")
+                    .font(.caption)
+                    .foregroundStyle(FleetNotchPalette.muted)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(16)
+            .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        } else {
+            switch navigation.route {
+            case .sessions, .needsYou:
+                rosterContent
+            case .interviews:
+                FleetAnswerQueue(store: store) { navigation.route = .needsYou }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .usage:
+                FleetUsageView(store: store, period: $usagePeriod)
+            case .settings:
+                FleetRuntimeSettingsView(store: store, presentation: presentation.binding)
+            }
+        }
+    }
+
+    private var routedSessions: [FleetSession] {
+        if navigation.route == .needsYou {
+            return FleetRosterPresentation.visibleSessions(
+                store.sessions,
+                search: search,
+                filters: .attentionOnly,
+                sort: presentation.preferences.sort
+            )
+        }
+        return visibleSessions
+    }
+
+    private var rosterContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+
+            if navigation.route == .sessions {
+                ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 7) {
                     ForEach(FleetRosterFocus.allCases) { focus in
                         FleetNotchFocusChip(
@@ -228,9 +302,10 @@ private struct FleetNotchView: View {
                     }
                 }
             }
+            }
 
             HStack {
-                Text("\(visibleSessions.count) of \(store.sessions.count) sessions")
+                Text("\(routedSessions.count) of \(store.sessions.count) sessions")
                     .font(.caption.weight(.medium))
                     .foregroundStyle(FleetNotchPalette.muted)
                 Spacer()
@@ -241,7 +316,7 @@ private struct FleetNotchView: View {
 
             ScrollView {
                 LazyVStack(spacing: 6) {
-                    ForEach(visibleSessions, id: \.sessionKey) { session in
+                    ForEach(routedSessions, id: \.sessionKey) { session in
                         FleetNotchSessionRow(
                             session: session,
                             selected: selectedSession?.sessionKey == session.sessionKey,
@@ -252,7 +327,7 @@ private struct FleetNotchView: View {
                     }
                     if let selectedSession {
                         FleetNotchDetail(store: store, session: selectedSession) {
-                            interviewPresented = true
+                            navigation.route = .interviews
                         }
                             .padding(.top, 4)
                     } else {
@@ -264,19 +339,7 @@ private struct FleetNotchView: View {
                     }
                 }
             }
-
-            HStack {
-                Button("Show all \(store.sessions.count) sessions", action: openFleet)
-                    .buttonStyle(.bordered)
-                    .accessibilityIdentifier("fleet.notch.show-all")
-                Spacer()
-                Button("Expand to Fleet", action: openFleet)
-                    .buttonStyle(.borderedProminent)
-                    .accessibilityIdentifier("fleet.notch.expand-fleet")
-            }
         }
-        .padding(16)
-        .frame(height: 582, alignment: .top)
     }
 
     private var providerLabel: String {
@@ -291,12 +354,12 @@ private struct FleetNotchView: View {
     }
 
     private func toggleExpanded() {
-        withAnimation(.easeInOut(duration: 0.16)) { isExpanded.toggle() }
+        withAnimation(.easeInOut(duration: 0.16)) { navigation.isExpanded.toggle() }
     }
 
     private func selectFirstVisibleSession() {
-        guard !visibleSessions.contains(where: { $0.sessionKey == store.selectedSessionKey }) else { return }
-        store.selectedSessionKey = visibleSessions.first?.sessionKey
+        guard !routedSessions.contains(where: { $0.sessionKey == store.selectedSessionKey }) else { return }
+        store.selectedSessionKey = routedSessions.first?.sessionKey
     }
 
     private func toggleFocus(_ focus: FleetRosterFocus) {
@@ -428,7 +491,7 @@ private struct FleetNotchDetail: View {
                         .buttonStyle(.borderedProminent)
                         .disabled(!store.canDecideApproval(.allowOnce, on: session))
                     if session.provider == .codex && session.capabilities.approvalSession {
-                        Button("Bypass session") { store.decideApproval(.bypassSession, on: session) }
+                        Button("Always allow this session") { store.decideApproval(.bypassSession, on: session) }
                             .disabled(!store.canDecideApproval(.bypassSession, on: session))
                     }
                 }
@@ -456,6 +519,154 @@ private struct FleetNotchDetail: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .accessibilityIdentifier("fleet.notch.detail.\(session.sessionKey)")
+    }
+}
+
+private struct FleetUsageView: View {
+    @ObservedObject var store: FleetStore
+    @Binding var period: FleetUsagePeriod
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Picker("Usage period", selection: $period) {
+                    ForEach(FleetUsagePeriod.allCases) { option in Text(option.label).tag(option) }
+                }
+                .pickerStyle(.segmented)
+                Spacer()
+                Button("Refresh") { store.refreshUsage(period: period) }
+                    .disabled(!store.canReadUsage)
+            }
+
+            if !store.canReadUsage {
+                VStack(spacing: 8) {
+                    Image(systemName: "chart.bar.xaxis").font(.title2)
+                    Text("Usage unavailable").font(.headline)
+                    Text("This daemon does not advertise fleet.usage.read.").font(.caption)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let summary = store.usageSummary {
+                usage(summary)
+            } else {
+                ProgressView("Reading canonical provider usage…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onAppear { store.refreshUsage(period: period) }
+        .onChange(of: period) { _, value in store.refreshUsage(period: value) }
+        .accessibilityIdentifier("fleet.notch.usage")
+    }
+
+    @ViewBuilder private func usage(_ summary: FleetUsageSummaryResult) -> some View {
+        if let total = summary.totals {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(total.costUSD.map(currency) ?? tokens(total.totalTokens))
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                    Text(total.costUSD == nil ? "Tokens, price unavailable" : "Canonical provider cost")
+                        .font(.caption)
+                        .foregroundStyle(FleetNotchPalette.muted)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text("\(total.callCount) calls")
+                    Text("\(total.sessionCount) sessions")
+                    Text("\(total.projectCount) projects")
+                }
+                .font(.caption)
+                .foregroundStyle(FleetNotchPalette.muted)
+            }
+            .padding(16)
+            .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if !summary.daily.isEmpty { section("Daily", rows: summary.daily.map { "\($0.date)  \(value($0.bucket))" }) }
+                    if !summary.providers.isEmpty { section("Providers", rows: summary.providers.map { "\($0.provider.capitalized)  \(value($0.bucket))" }) }
+                    if !summary.models.isEmpty { section("Models", rows: summary.models.map { "\($0.model)  \(value($0.bucket))" }) }
+                    if !summary.projects.isEmpty { section("Projects", rows: summary.projects.map { "\($0.repo ?? $0.project)  \(value($0.bucket))" }) }
+                }
+            }
+        } else {
+            VStack(spacing: 8) {
+                Image(systemName: "chart.bar.xaxis").font(.title2)
+                Text("Usage \(summary.state.rawValue)").font(.headline)
+                Text(summary.detail ?? "Daemon returned no usable usage projection.").font(.caption)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func section(_ title: String, rows: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.headline)
+            ForEach(rows, id: \.self) { row in
+                Text(row).font(.caption).foregroundStyle(FleetNotchPalette.muted)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func value(_ bucket: FleetUsageBucket) -> String {
+        bucket.costUSD.map(currency) ?? tokens(bucket.totalTokens)
+    }
+
+    private func currency(_ value: Double) -> String { String(format: "$%.2f", value) }
+    private func tokens(_ value: UInt64) -> String { value.formatted(.number.notation(.compactName)) + " tokens" }
+}
+
+private struct FleetRuntimeSettingsView: View {
+    @ObservedObject var store: FleetStore
+    @Binding var presentation: FleetPresentationPreferences
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack {
+                    Text("Runtime").font(.headline)
+                    Spacer()
+                    Button("Refresh") { store.refreshRuntime() }.disabled(!store.canReadRuntime)
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Setup or repair")
+                        .font(.subheadline.weight(.semibold))
+                    Text("Install or repair Fleet runtime in Terminal, then refresh this view.")
+                        .font(.caption)
+                        .foregroundStyle(FleetNotchPalette.muted)
+                        .textSelection(.enabled)
+                }
+                .padding(10)
+                .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                if let runtime = store.runtimeStatus {
+                    Text("Daemon \(runtime.daemonVersion) · protocol \(runtime.protocolVersion)")
+                        .font(.caption).foregroundStyle(FleetNotchPalette.muted)
+                    ForEach(runtime.hooks, id: \.provider) { hook in
+                        HStack {
+                            Text(hook.provider.capitalized).fontWeight(.semibold)
+                            Spacer()
+                            Text(hook.installed && hook.hookReady ? "Installed" : "Setup required")
+                                .foregroundStyle(hook.installed && hook.hookReady ? .mint : .orange)
+                            Text(hook.deliveryReady ? "Live" : "Waiting")
+                                .foregroundStyle(FleetNotchPalette.muted)
+                        }
+                        .font(.caption)
+                        .padding(10)
+                        .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    }
+                } else {
+                    Text(store.connectionState.isLive ? "Runtime status unavailable." : store.connectionState.message)
+                        .font(.caption).foregroundStyle(FleetNotchPalette.muted)
+                }
+                Divider()
+                FleetSettingsView(presentation: $presentation)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.vertical, 2)
+        }
+        .onAppear(perform: store.refreshRuntime)
+        .accessibilityIdentifier("fleet.notch.settings")
     }
 }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -71,7 +71,7 @@ enum FleetApprovalDecision: Equatable {
         switch self {
         case .allowOnce: "Allow once"
         case .deny: "Deny"
-        case .bypassSession: "Bypass session"
+        case .bypassSession: "Always allow this session"
         }
     }
 
@@ -95,6 +95,8 @@ final class FleetStore: ObservableObject {
     @Published private(set) var atcInstances: [AtcInstance] = []
     @Published private(set) var atcSchedulerOwnership: AtcSchedulerOwnership?
     @Published private(set) var timeline: [FleetTimelineEntry] = []
+    @Published private(set) var usageSummary: FleetUsageSummaryResult?
+    @Published private(set) var runtimeStatus: FleetRuntimeStatusResult?
     @Published private(set) var pendingIntentID: String?
     @Published private(set) var controlNotice: String?
     @Published private(set) var lastStart: FleetStartResult?
@@ -161,6 +163,14 @@ final class FleetStore: ObservableObject {
 
     var canReadTimeline: Bool {
         connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.timeline.read") == true
+    }
+
+    var canReadUsage: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.usage.read") == true
+    }
+
+    var canReadRuntime: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.runtime.read") == true
     }
 
     var canStart: Bool {
@@ -488,6 +498,42 @@ final class FleetStore: ObservableObject {
         }
     }
 
+    /// Usage is requested only from the Usage route or its explicit refresh
+    /// control. It can scan local provider histories, so connection bootstrap
+    /// must remain fast and side-effect free.
+    func refreshUsage(period: FleetUsagePeriod = .trailing7Days) {
+        guard canReadUsage, let connection else {
+            usageSummary = nil
+            controlNotice = "Usage is unavailable for this daemon."
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                usageSummary = try await connection.usageSummary(FleetUsageSummaryParams(period: period))
+            } catch {
+                usageSummary = nil
+                controlNotice = "Usage refresh refused: \(String(describing: error))"
+            }
+        }
+    }
+
+    func refreshRuntime() {
+        guard canReadRuntime, let connection else {
+            runtimeStatus = nil
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                runtimeStatus = try await connection.runtimeStatus()
+            } catch {
+                runtimeStatus = nil
+                controlNotice = "Runtime status refused: \(String(describing: error))"
+            }
+        }
+    }
+
     private func beginConnection() {
         connectionGeneration &+= 1
         let generation = connectionGeneration
@@ -554,6 +600,11 @@ final class FleetStore: ObservableObject {
                 } catch {}
             } else {
                 timeline = []
+            }
+            if result.capabilityIDs.contains("fleet.runtime.read") {
+                runtimeStatus = try? await newConnection.runtimeStatus()
+            } else {
+                runtimeStatus = nil
             }
             connectionState = .live(daemonVersion: result.daemonVersion, writeCompatible: result.writeCompatible)
             established = true

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -172,6 +172,16 @@ actor FleetConnection {
         return try await request("fleet/timeline", params: params, result: FleetTimelineResult.self)
     }
 
+    func usageSummary(_ params: FleetUsageSummaryParams) async throws -> FleetUsageSummaryResult {
+        try requireReadCapability("fleet.usage.read")
+        return try await request("fleet/usage_summary", params: params, result: FleetUsageSummaryResult.self)
+    }
+
+    func runtimeStatus() async throws -> FleetRuntimeStatusResult {
+        try requireReadCapability("fleet.runtime.read")
+        return try await request("fleet/runtime_status", params: FleetRuntimeStatusParams(), result: FleetRuntimeStatusResult.self)
+    }
+
     func incoming() -> AsyncStream<FleetIncoming> {
         AsyncStream { continuation in
             let id = UUID()

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -545,6 +545,129 @@ struct FleetTimelineResult: Codable, Equatable {
     private enum CodingKeys: String, CodingKey { case entries, nextAfterRevision = "next_after_revision" }
 }
 
+enum FleetUsagePeriod: String, Codable, CaseIterable, Identifiable {
+    case today
+    case trailing7Days = "trailing_7_days"
+    case trailing30Days = "trailing_30_days"
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .today: "Today"
+        case .trailing7Days: "7 days"
+        case .trailing30Days: "30 days"
+        }
+    }
+}
+
+struct FleetUsageSummaryParams: Codable, Equatable {
+    let period: FleetUsagePeriod
+}
+
+enum FleetUsageSummaryState: String, Codable, Equatable {
+    case scanning, ready, partial, unavailable
+}
+
+struct FleetUsageBucket: Codable, Equatable {
+    let inputTokens: UInt64
+    let cacheCreationTokens: UInt64
+    let cacheReadTokens: UInt64
+    let outputTokens: UInt64
+    let reasoningTokens: UInt64
+    let callCount: UInt64
+    let sessionCount: UInt64
+    let projectCount: UInt64
+    let costUSD: Double?
+
+    var totalTokens: UInt64 {
+        inputTokens + cacheCreationTokens + cacheReadTokens + outputTokens + reasoningTokens
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case inputTokens = "input_tokens"
+        case cacheCreationTokens = "cache_creation_tokens"
+        case cacheReadTokens = "cache_read_tokens"
+        case outputTokens = "output_tokens"
+        case reasoningTokens = "reasoning_tokens"
+        case callCount = "call_count"
+        case sessionCount = "session_count"
+        case projectCount = "project_count"
+        case costUSD = "cost_usd"
+    }
+}
+
+struct FleetUsageDailyBucket: Codable, Equatable {
+    let date: String
+    let bucket: FleetUsageBucket
+}
+
+struct FleetUsageProviderBucket: Codable, Equatable {
+    let provider: String
+    let bucket: FleetUsageBucket
+}
+
+struct FleetUsageModelBucket: Codable, Equatable {
+    let model: String
+    let bucket: FleetUsageBucket
+}
+
+struct FleetUsageProjectBucket: Codable, Equatable {
+    let project: String
+    let repo: String?
+    let bucket: FleetUsageBucket
+}
+
+struct FleetUsageSummaryResult: Codable, Equatable {
+    let state: FleetUsageSummaryState
+    let generatedAt: Int64?
+    let startAt: Int64?
+    let endAt: Int64?
+    let totals: FleetUsageBucket?
+    let daily: [FleetUsageDailyBucket]
+    let providers: [FleetUsageProviderBucket]
+    let models: [FleetUsageModelBucket]
+    let projects: [FleetUsageProjectBucket]
+    let detail: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case generatedAt = "generated_at"
+        case startAt = "start_at"
+        case endAt = "end_at"
+        case totals, daily, providers, models, projects, detail
+    }
+}
+
+struct FleetRuntimeStatusParams: Codable, Equatable { init() {} }
+
+struct FleetRuntimeHookStatus: Codable, Equatable {
+    let provider: String
+    let installed: Bool
+    let hookReady: Bool
+    let deliveryReady: Bool
+    let lastEvent: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case provider, installed
+        case hookReady = "hook_ready"
+        case deliveryReady = "delivery_ready"
+        case lastEvent = "last_event"
+    }
+}
+
+struct FleetRuntimeStatusResult: Codable, Equatable {
+    let daemonVersion: String
+    let protocolVersion: UInt32
+    let hooks: [FleetRuntimeHookStatus]
+
+    private enum CodingKeys: String, CodingKey {
+        case daemonVersion = "daemon_version"
+        case protocolVersion = "protocol_version"
+        case hooks
+    }
+}
+
 struct FleetStartParams: Codable, Equatable {
     let requestID: String
     let provider: FleetProvider

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -208,6 +208,7 @@ struct FleetWindowView: View {
 
 struct FleetAnswerQueue: View {
     @ObservedObject var store: FleetStore
+    var onDone: (() -> Void)? = nil
     @Environment(\.dismiss) private var dismiss
     @State private var selectedSessionKey: String?
     @State private var selectedQuestionIndex = 0
@@ -236,7 +237,13 @@ struct FleetAnswerQueue: View {
                         .foregroundStyle(FleetPalette.muted)
                 }
                 Spacer()
-                Button("Done", action: dismiss.callAsFunction)
+                Button("Done") {
+                    if let onDone {
+                        onDone()
+                    } else {
+                        dismiss()
+                    }
+                }
             }
 
             ScrollView(.horizontal, showsIndicators: false) {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -89,7 +89,7 @@ final class FleetConnectionTests: XCTestCase {
         )
     }
 
-    func testOldCatalogueRefusesReceiptReadsAndStart() {
+    func testOldCatalogueRefusesNewReadCapabilitiesAndStart() {
         let oldCatalogue = FleetNegotiateResult(
             daemonVersion: "fixture-daemon-0.9.0",
             protocolVersion: 1,
@@ -103,6 +103,12 @@ final class FleetConnectionTests: XCTestCase {
         }
         XCTAssertThrowsError(try FleetConnection.validateCapability("fleet.start.execute", in: oldCatalogue)) {
             XCTAssertEqual($0 as? FleetConnectionError, .missingNegotiatedCapability("fleet.start.execute"))
+        }
+        XCTAssertThrowsError(try FleetConnection.validateCapability("fleet.runtime.read", in: oldCatalogue)) {
+            XCTAssertEqual($0 as? FleetConnectionError, .missingNegotiatedCapability("fleet.runtime.read"))
+        }
+        XCTAssertThrowsError(try FleetConnection.validateCapability("fleet.usage.read", in: oldCatalogue)) {
+            XCTAssertEqual($0 as? FleetConnectionError, .missingNegotiatedCapability("fleet.usage.read"))
         }
     }
 
@@ -168,6 +174,74 @@ final class FleetConnectionTests: XCTestCase {
         } catch let error as FleetConnectionError {
             XCTAssertEqual(error, .missingNegotiatedCapability("fleet.start.execute"))
         }
+        await fulfillment(of: [serverDone], timeout: 1)
+        try serverResult.throwIfRecorded()
+    }
+
+    func testUsageAndRuntimeReadOnlyRPCsRoundTripAfterNegotiation() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+        let serverDone = expectation(description: "usage and runtime RPC server finished")
+        let serverResult = SocketServerResult()
+
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                let authentication = try Self.readRequest(from: serverDescriptor)
+                try Self.writeResponse(to: serverDescriptor, request: authentication, result: [:])
+                let negotiation = try Self.readRequest(from: serverDescriptor)
+                try Self.writeResponse(to: serverDescriptor, request: negotiation, result: [
+                    "daemon_version": "fixture-daemon",
+                    "protocol_version": 2,
+                    "read_compatible": true,
+                    "write_compatible": false,
+                    "capability_ids": ["fleet.runtime.read", "fleet.usage.read"],
+                ])
+                let runtime = try Self.readRequest(from: serverDescriptor)
+                XCTAssertEqual(runtime["method"] as? String, "fleet/runtime_status")
+                try Self.writeResponse(to: serverDescriptor, request: runtime, result: [
+                    "daemon_version": "fixture-daemon",
+                    "protocol_version": 2,
+                    "hooks": [[
+                        "provider": "codex", "installed": true, "hook_ready": true,
+                        "delivery_ready": false, "last_event": NSNull(),
+                    ]],
+                ])
+                let usage = try Self.readRequest(from: serverDescriptor)
+                XCTAssertEqual(usage["method"] as? String, "fleet/usage_summary")
+                XCTAssertEqual((usage["params"] as? [String: Any])?["period"] as? String, "trailing_7_days")
+                try Self.writeResponse(to: serverDescriptor, request: usage, result: [
+                    "state": "ready", "generated_at": 1, "start_at": 0, "end_at": 1,
+                    "totals": [
+                        "input_tokens": 100, "cache_creation_tokens": 0, "cache_read_tokens": 0,
+                        "output_tokens": 23, "reasoning_tokens": 0, "call_count": 1,
+                        "session_count": 1, "project_count": 1, "cost_usd": NSNull(),
+                    ],
+                    "daily": [], "providers": [], "models": [], "projects": [], "detail": NSNull(),
+                ])
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: descriptors[0]
+        )
+        try await connection.connect()
+        defer { Task { await connection.close() } }
+        try await connection.authenticate(token: "mdt_test")
+        _ = try await connection.negotiate()
+        let runtime = try await connection.runtimeStatus()
+        let usage = try await connection.usageSummary(FleetUsageSummaryParams(period: .trailing7Days))
+
+        XCTAssertEqual(runtime.hooks.map(\.provider), ["codex"])
+        XCTAssertEqual(runtime.hooks.first?.deliveryReady, false)
+        XCTAssertEqual(usage.state, .ready)
+        XCTAssertEqual(usage.totals?.totalTokens, 123)
+        XCTAssertNil(usage.totals?.costUSD)
         await fulfillment(of: [serverDone], timeout: 1)
         try serverResult.throwIfRecorded()
     }

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -33,7 +33,7 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
     }
 
     @MainActor
-    func testNotchFilterSelectsOnlyVisibleSessions() throws {
+    func testNeedsYouRouteSelectsOnlyAttentionSessions() throws {
         try fixture.seed(eventID: "active", sessionID: "active", eventType: "UserPromptSubmit", observedAt: 1_700_000_000_001)
         try fixture.seed(eventID: "ask", provider: "codex", sessionID: "ask", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)
         launchApp()
@@ -41,17 +41,10 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
         let notch = app.buttons["fleet.notch"]
         waitFor(notch)
         notch.click()
-        app.buttons["fleet.notch.filter.all"].click()
-        waitFor(app.buttons["fleet.notch.row.claude:active"])
-        waitFor(app.buttons["fleet.notch.row.codex:ask"])
-
-        app.buttons["fleet.notch.filter.ask"].click()
+        app.segmentedControls["fleet.notch.route"].buttons["Needs you"].click()
         waitFor(app.buttons["fleet.notch.row.codex:ask"])
         XCTAssertFalse(app.buttons["fleet.notch.row.claude:active"].exists)
         waitFor(app.staticTexts["fleet.notch.detail.codex:ask"])
-
-        app.buttons["fleet.notch.filter.ask"].click()
-        waitFor(app.buttons["fleet.notch.row.claude:active"])
     }
 
     @MainActor

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -17,7 +17,7 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
     }
 
     @MainActor
-    func testNotchExpandsControlsAndExplicitCTAOpensFleetWindow() throws {
+    func testNotchExpandsToTheOnlyFleetSurface() throws {
         launchApp()
 
         let notch = app.buttons["fleet.notch"]
@@ -25,9 +25,11 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
         notch.click()
 
         waitFor(app.textFields["fleet.notch.search"])
-        XCTAssertFalse(app.windows["Fleet"].exists, "notch click must not open full Fleet")
-        app.buttons["fleet.notch.show-all"].click()
-        XCTAssertTrue(app.windows["Fleet"].waitForExistence(timeout: 8), app.debugDescription)
+        XCTAssertFalse(app.buttons["fleet.notch.show-all"].exists, "separate Fleet window CTA must not exist")
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "expanded-notch"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
     }
 
     @MainActor
@@ -53,12 +55,12 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
     }
 
     @MainActor
-    func testRealFixtureRendersAttentionRosterAndFiltersInFleetWindow() throws {
+    func testRealFixtureRendersAttentionRosterInExpandedNotch() throws {
         try fixture.seed(eventID: "alpha", sessionID: "alpha", eventType: "AskUserQuestion", observedAt: 1_700_000_000_001)
         try fixture.seed(eventID: "beta", provider: "codex", sessionID: "beta", eventType: "AskUserQuestion", observedAt: 1_700_000_000_002)
         try fixture.seed(eventID: "gamma", provider: "unknown", sessionID: "gamma", eventType: "AskUserQuestion", observedAt: 1_700_000_000_003)
         try fixture.seed(eventID: "running", sessionID: "running", eventType: "UserPromptSubmit", observedAt: 1_700_000_000_004)
-        launchFleetWindow()
+        launchExpandedNotch()
 
         waitFor(fleetRow("claude:alpha"))
         waitFor(fleetRow("codex:beta"))
@@ -68,9 +70,9 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
     }
 
     @MainActor
-    func testFleetWindowExposesVoiceOverLabels() throws {
+    func testExpandedNotchExposesVoiceOverLabels() throws {
         try fixture.seed(eventID: "alpha", sessionID: "alpha", eventType: "AskUserQuestion", observedAt: 1_700_000_000_001)
-        launchFleetWindow()
+        launchExpandedNotch()
         let row = fleetRow("claude:alpha")
         waitFor(row)
 

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift
@@ -4,7 +4,7 @@ final class OfflineAndReconnectJourneyTests: FleetUITestCase {
     @MainActor
     func testRealFixtureDisconnectShowsRetryWithoutLaunchingDaemon() throws {
         try fixture.seed(eventID: "alpha-running", sessionID: "alpha", eventType: "UserPromptSubmit", observedAt: 1_700_000_000_001)
-        launchFleetWindow()
+        launchExpandedNotch()
         waitFor(fleetRow("claude:alpha"))
 
         fixture.stop(removeHome: false)

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift
@@ -4,7 +4,7 @@ final class ProtocolCompatibilityJourneyTests: FleetUITestCase {
     @MainActor
     func testRealFixtureReportsReadIncompatibleDaemonProtocol() throws {
         try fixture.seed(eventID: "alpha", sessionID: "alpha", eventType: "SessionStart", observedAt: 1_700_000_000_001)
-        launchFleetWindow(arguments: ["--fleet-test-read-range=3...3"])
+        launchExpandedNotch(arguments: ["--fleet-test-read-range=3...3"])
 
         let incompatibility = textValue(beginningWith: "Daemon")
         waitFor(incompatibility)

--- a/apps/ainb-fleet-macos/UITests/Support/FleetUITestCase.swift
+++ b/apps/ainb-fleet-macos/UITests/Support/FleetUITestCase.swift
@@ -21,9 +21,8 @@ class FleetUITestCase: XCTestCase {
             app.terminate()
         }
         app.launchEnvironment["AINB_HANGAR_HOME"] = fixture.home.path
-        if arguments.contains("--fleet-test-open-window") {
-            app.launchEnvironment["AINB_FLEET_TEST_OPEN_WINDOW"] = "1"
-        }
+        app.launchEnvironment["AINB_FLEET_TEST_ISOLATE_DEFAULTS"] = "1"
+        app.launchEnvironment["AINB_FLEET_UI_TEST_MODE"] = "1"
         if arguments.contains("--fleet-test-read-range=3...3") {
             app.launchEnvironment["AINB_FLEET_TEST_READ_RANGE"] = "3...3"
         }
@@ -32,19 +31,16 @@ class FleetUITestCase: XCTestCase {
     }
 
     @MainActor
-    func launchFleetWindow(
+    func launchExpandedNotch(
         arguments: [String] = [],
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        launchApp(arguments: ["--fleet-test-open-window"] + arguments)
-        let fleetWindow = app.windows["Fleet"]
-        XCTAssertTrue(
-            fleetWindow.waitForExistence(timeout: 8),
-            "Fleet window missing after normal app launch. \(app.debugDescription)",
-            file: file,
-            line: line
-        )
+        launchApp(arguments: arguments)
+        let notch = app.buttons["fleet.notch"]
+        XCTAssertTrue(notch.waitForExistence(timeout: 8), "Fleet notch missing. \(app.debugDescription)", file: file, line: line)
+        notch.click()
+        XCTAssertTrue(app.textFields["fleet.notch.search"].waitForExistence(timeout: 8), "Fleet notch did not expand. \(app.debugDescription)", file: file, line: line)
     }
 
     @MainActor
@@ -60,13 +56,13 @@ class FleetUITestCase: XCTestCase {
     @MainActor
     func fleetRow(_ sessionKey: String) -> XCUIElement {
         app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "fleet.row.\(sessionKey)"))
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "fleet.notch.row.\(sessionKey)"))
             .firstMatch
     }
 
     @MainActor
     func fleetDetail(_ sessionKey: String) -> XCUIElement {
-        app.staticTexts["fleet.detail.\(sessionKey)"]
+        app.staticTexts["fleet.notch.detail.\(sessionKey)"]
     }
 
     @MainActor

--- a/docs/contracts/fleet-macos.md
+++ b/docs/contracts/fleet-macos.md
@@ -16,6 +16,30 @@ depend on the TUI, CLI output, daemon database, or Rust internals.
 | Authentication and socket handlers | `ainb-tui/crates/ainb-hangar-daemon/src/rpc/` | `apps/ainb-fleet-macos/Sources/FleetRPC/HangarLocation.swift` and `FleetConnection.swift` |
 | Executable daemon fixture | `ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs` | `apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift` |
 
+## Standalone runtime
+
+Fleet setup is an explicit CLI provisioning step:
+
+```sh
+ainb fleet runtime install
+```
+
+It idempotently starts or repairs the Hangar daemon and notifyd, then installs
+supported provider hooks. The app never invokes this command or interprets its
+output. After setup it discovers the daemon socket and token, negotiates the
+public protocol, then reports hook health through `fleet/runtime_status`.
+
+## Fleet-only read RPCs
+
+| Method | Capability | Purpose | Safety rule |
+| --- | --- | --- | --- |
+| `fleet/runtime_status` | `fleet.runtime.read` | Provider-hook installation and delivery health | No paths, logs, credentials, or hook files cross the boundary. |
+| `fleet/usage_summary` | `fleet.usage.read` | Bounded canonical provider Usage for today, 7 days, or 30 days | No transcripts or raw provider histories cross the boundary. Cost is absent when daemon pricing is unknown. |
+
+Fleet calls either method only after a compatible `fleet/negotiate` result
+advertises its capability. Missing capabilities remain unavailable UI states,
+never client-side fallback reads.
+
 ## Change rules
 
 - Adding optional response fields is compatible until Fleet needs to display them.

--- a/docs/man/ainb.1
+++ b/docs/man/ainb.1
@@ -187,11 +187,11 @@ Subcommands: install, update, remove, list, search, marketplace, lint,
 watch, tail
 .TP
 .B ainb fleet
-Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon
-/ daemons / atc / bridge
+Fleet orchestration: standup / broadcast / sequence / needs / cost / runtime
+/ daemon / daemons / atc / bridge
 .br
 Subcommands: approve, deny, standup, broadcast, msg, sequence, needs, cost,
-daemon, daemons, atc, bridge, enrich\-cache
+daemon, daemons, runtime, atc, bridge, enrich\-cache
 .TP
 .B ainb headroom
 Manage the ainb\-managed Headroom compression proxy

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2005,11 +2005,11 @@ Options:
 
 ## `ainb fleet`
 
-Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / daemons / atc / bridge
+Fleet orchestration: standup / broadcast / sequence / needs / cost / runtime / daemon / daemons / atc / bridge
 
 ```console
 $ ainb fleet --help
-Fleet orchestration: standup / broadcast / sequence / needs / cost / daemon / daemons / atc / bridge
+Fleet orchestration: standup / broadcast / sequence / needs / cost / runtime / daemon / daemons / atc / bridge
 
 Usage: ainb fleet [OPTIONS] <COMMAND>
 
@@ -2024,6 +2024,7 @@ Commands:
   cost          Per-session / model / day / group spend rollups + budget caps
   daemon        Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
   daemons       Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
+  runtime       Install the standalone Fleet daemon and provider hooks
   atc           Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)
   bridge        Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
   enrich-cache  Content-addressed enrich cache (the producer's write path)
@@ -2276,6 +2277,40 @@ $ ainb fleet daemons --help
 Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
 
 Usage: ainb fleet daemons [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb fleet runtime`
+
+Install the standalone Fleet daemon and provider hooks
+
+```console
+$ ainb fleet runtime --help
+Install the standalone Fleet daemon and provider hooks
+
+Usage: ainb fleet runtime [OPTIONS] <COMMAND>
+
+Commands:
+  install  Idempotently start Hangar and install supported provider hooks
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet runtime install`
+
+Idempotently start Hangar and install supported provider hooks
+
+```console
+$ ainb fleet runtime install --help
+Idempotently start Hangar and install supported provider hooks
+
+Usage: ainb fleet runtime install [OPTIONS]
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -119,7 +119,8 @@ if [ -z "${AINB_ENVELOPE}" ]; then
 fi
 
 # ----- 5. Delivery ------------------------------------------------------------
-AINB_DIR="${HOME}/.agents-in-a-box"
+AINB_DIR="${AINB_HANGAR_HOME:-${AINB_HOME:-${HOME}/.agents-in-a-box}}"
+export AINB_HOME="${AINB_DIR}"
 AINB_SOCK="${AINB_DIR}/notify.sock"
 AINB_FALLBACK="${AINB_DIR}/notify.fallback.jsonl"
 AINB_SPAWN_LOCK="${AINB_DIR}/notify.spawn.lock"


### PR DESCRIPTION
## Summary
- center Fleet in one fixed notch surface with one route selector and focused session filters
- add versioned daemon RPC for runtime health and bounded usage projections
- install and restart standalone Hangar, notifyd, and provider hooks through the CLI runtime command
- avoid full-history usage scans by skipping session files unchanged before requested window

## Verification
- cargo test -p ainb-hangar-proto fleet::tests --lib
- cargo test -p ainb-hangar-daemon fleet_usage --lib
- cargo test -p ainb-plugin-session-reader --lib
- cargo test -p ainb fleet_exposes_fourteen_subcommands_including_runtime --lib
- cargo fmt --check
- xcodebuild build plus Swift boundary and release diagnostic checks
- live authenticated daemon usage RPC returned populated aggregates

## Known local limitation
- XCUITest could not enter macOS automation mode twice on this host, before any test started. Release build and manual notch proof completed.