### PR TITLE
fix: restore Fleet interview delivery

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3004,6 +3004,10 @@ impl EventHandler {
             return Some(AppEvent::FleetPanelCanonicalKey(key));
         }
         match key_event.code {
+            KeyCode::F(5) => Some(AppEvent::FleetPanelRefresh),
+            KeyCode::Char('r') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                Some(AppEvent::FleetPanelRefresh)
+            }
             KeyCode::Esc | KeyCode::Char('q') => Some(AppEvent::PanelBack),
             KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::FleetPanelMoveUp),
             KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::FleetPanelMoveDown),
@@ -3292,16 +3296,6 @@ impl EventHandler {
                 expected_version,
                 action,
             } => {
-                if action.is_high_risk() && !state.fleet_panel_state.daemon_online() {
-                    Self::reduce_fleet_event(
-                        state,
-                        FleetEvent::ActionFailed {
-                            session_key,
-                            detail: "Fleet daemon offline, high-risk action disabled".into(),
-                        },
-                    );
-                    return;
-                }
                 let action_label = match &action {
                     FleetAction::StructuredAnswer { .. } => "answered ask",
                     FleetAction::DismissStructured { .. } => "rejected interview",
@@ -6198,7 +6192,7 @@ impl EventHandler {
                     state.fleet_panel_state.option_prev();
                 }
             }
-            AppEvent::FleetPanelRefresh => state.fleet_panel_state.refresh(),
+            AppEvent::FleetPanelRefresh => state.fleet_panel_state.force_refresh(),
             AppEvent::FleetPanelNewAtcOpen => state.fleet_panel_state.open_new_atc(),
             AppEvent::FleetPanelNewAtcType(c) => state.fleet_panel_state.new_atc_type(c),
             AppEvent::FleetPanelNewAtcBackspace => state.fleet_panel_state.new_atc_backspace(),
@@ -8819,6 +8813,17 @@ mod panel_back_tests {
         assert!(matches!(
             route(&mut state, KeyCode::Char('r')),
             Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('r')))
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::F(5)),
+            Some(AppEvent::FleetPanelRefresh)
+        ));
+        assert!(matches!(
+            EventHandler::handle_key_event(
+                KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+                &mut state
+            ),
+            Some(AppEvent::FleetPanelRefresh)
         ));
 
         // Esc/q pop back to the saved origin, not hardcoded home.

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -123,6 +123,7 @@ async fn setup(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
             // at it (no-op if a prior notifyd install already extracted it).
             let paths_nd = ainb_plugin_notifyd::paths::Paths::under(home.join(".agents-in-a-box"));
             let _ = ainb_plugin_notifyd::install::extract_hook_script(&paths_nd);
+            let _ = ainb_plugin_notifyd::install::extract_hook_bin(&paths_nd);
             match plumbing::settings::install_claude_hooks(&home, &script) {
                 Ok(_) => hooks_installed = true,
                 Err(e) => tracing::warn!("failed to install lifecycle hooks: {e}"),

--- a/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
+++ b/ainb-tui/crates/ainb-core/src/components/fleet_panel.rs
@@ -16,7 +16,7 @@
 //   - B                  broadcast a ping prompt to the selected session
 //   - y                  approve the selected APPROVE permission request
 //   - n                  deny (on an APPROVE row) / open the new-ATC prompt (elsewhere)
-//   - r                  force-refresh from the store
+//   - F5                 force-refresh from the daemon snapshot
 //   - q / Esc            back to the previous screen
 //
 // Style follows the ainb-tui guide (rounded borders, gold titles,
@@ -171,6 +171,13 @@ impl FleetPanelState {
     pub fn refresh(&mut self) {
         self.drain_stream_updates();
         self.drain_canonical_updates();
+    }
+
+    /// Request a fresh daemon snapshot on a worker thread, then apply any
+    /// completed stream/action updates immediately.
+    pub fn force_refresh(&mut self) {
+        crate::fleet::control::request_fleet_snapshot(Arc::clone(&self.stream_updates));
+        self.refresh();
     }
 
     fn start_subscription(&mut self) {
@@ -944,7 +951,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &mut FleetPanelState) {
         .unwrap_or("no attachment");
     frame.render_widget(
         Paragraph::new(format!(
-            "1-5 views  ↑↓ select  Enter answer  {attach_help}  B broadcast  q/Esc back"
+            "1-5 views  ↑↓ select  Enter answer  F5 refresh  {attach_help}  B broadcast  q/Esc back"
         ))
         .style(Style::default().fg(MUTED_GRAY)),
         Rect::new(

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -99,6 +99,49 @@ pub enum FleetHostUpdate {
 /// Shared ordered queue drained by the UI thread.
 pub type FleetHostUpdateSink = Arc<Mutex<Vec<FleetHostUpdate>>>;
 
+/// Fetch one fresh authoritative snapshot without waiting for the persistent
+/// revision stream to reconnect. Direct action RPCs use the same short-lived
+/// authenticated transport, so this remains useful after a stream disconnect.
+pub fn request_fleet_snapshot(updates: FleetHostUpdateSink) {
+    let _ = std::thread::Builder::new()
+        .name("ainb-fleet-refresh".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    publish_host_update(
+                        &updates,
+                        FleetHostUpdate::Health(FleetDaemonHealth::Offline(format!(
+                            "refresh runtime failed: {error}"
+                        ))),
+                    );
+                    return;
+                }
+            };
+            runtime.block_on(async move {
+                let result = async {
+                    let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+                        .map_err(|error| error.to_string())?;
+                    client.fleet_snapshot().await.map_err(|error| error.to_string())
+                }
+                .await;
+                match result {
+                    Ok(snapshot) => {
+                        let mut git_context_cache = HashMap::new();
+                        publish_snapshot(&updates, snapshot, &mut git_context_cache);
+                        publish_host_update(&updates, FleetHostUpdate::Health(FleetDaemonHealth::Online));
+                    }
+                    Err(error) => publish_host_update(
+                        &updates,
+                        FleetHostUpdate::Health(FleetDaemonHealth::Offline(format!(
+                            "refresh failed: {error}"
+                        ))),
+                    ),
+                }
+            });
+        });
+}
+
 /// Start one persistent Fleet stream worker.
 pub fn spawn_fleet_subscription(
     updates: FleetHostUpdateSink,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -4031,6 +4031,14 @@ impl HangarPlugin {
         // before we mutate `self.screens` and `self.app` below.
         let app = self.app_state().clone();
 
+        // Fleet's stream can lag a missed provider hook. Keep a direct snapshot
+        // pull on an unambiguous key so the operator can reconcile immediately.
+        if matches!(app.screen, Screen::Fleet) && key.code == (KeyCode::F { n: 5 }) {
+            self.fleet_fetch_pending = true;
+            self.conn.on_event();
+            return;
+        }
+
         // e38.29: while the issue list is capturing free text (the `/` filter or
         // the `c` create-title input), every key — including the global
         // tab-switch chars (`1`/`K`/`,`/`q`/…) — is typed text, NOT a nav key.
@@ -8151,6 +8159,21 @@ mod tests {
         assert!(
             plugin.fleet_fetch_pending,
             "key reduction never consumes refresh work"
+        );
+    }
+
+    #[test]
+    fn fleet_f5_arms_direct_snapshot_refresh() {
+        let mut plugin = connected_plugin_with_issue();
+        plugin.on_key(&char_press('F'));
+        assert!(matches!(plugin.app_state().screen, Screen::Fleet));
+
+        plugin.fleet_fetch_pending = false;
+        plugin.on_key(&key_press(KeyCode::F { n: 5 }));
+
+        assert!(
+            plugin.fleet_fetch_pending,
+            "F5 must request a direct Fleet snapshot"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -2090,7 +2090,7 @@ pub fn render_fleet(
             || format!("0/{}", visible.len()),
             |index| format!("{}/{}", index + 1, visible.len()),
         );
-        let header = format!("  ACTION QUEUE  ·  {} sessions", visible.len());
+        let header = format!("  ACTION QUEUE  ·  {} sessions  ·  F5 refresh", visible.len());
         put_str(buffer, 0, header_y, &header, FG, list_width);
         let position_width = position.chars().count() as u16;
         put_str(

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -185,6 +185,26 @@ pub fn canonical_hook_script(paths: &Paths) -> PathBuf {
     paths.base.join("hooks").join("notify.sh")
 }
 
+/// Where the installer records the exact `ainb` binary that extracted the
+/// hook. Hook processes do not inherit a developer shell's `AINB_BIN`, so
+/// resolving `ainb` from PATH can silently select an older Homebrew build.
+pub fn canonical_hook_bin(paths: &Paths) -> PathBuf {
+    paths.base.join("hooks").join("ainb-bin")
+}
+
+/// Record the executable running the installer for later hook invocations.
+pub fn extract_hook_bin(paths: &Paths) -> Result<PathBuf> {
+    let bin = std::env::current_exe().context("resolving installing ainb binary")?;
+    let dest = canonical_hook_bin(paths);
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    write_atomic(&dest, &format!("{}\n", bin.display()))
+        .with_context(|| format!("writing {}", dest.display()))?;
+    Ok(dest)
+}
+
 /// Extract the embedded `notify.sh` to its canonical location with
 /// executable permissions. Idempotent — overwrites any existing
 /// version of the script (so re-running install always picks up the
@@ -278,12 +298,28 @@ fn register_claude_plugin() -> ClaudeRegister {
             .args(["plugin", "marketplace", "add", CLAUDE_MARKETPLACE_SOURCE])
             .output();
     }
-    // Install (idempotent: an already-installed plugin counts as success).
-    match Command::new("claude").args(["plugin", "install", CLAUDE_PLUGIN_REF]).output() {
-        Ok(o) if o.status.success() => ClaudeRegister::Registered,
+    // Install, then update. `install` is idempotent but does not refresh an
+    // existing cached marketplace plugin, leaving hook code behind `ainb`.
+    let installed = match Command::new("claude").args(["plugin", "install", CLAUDE_PLUGIN_REF]).output() {
+        Ok(o) if o.status.success() => true,
         Ok(o) => {
             let msg = first_line(&o.stderr, &o.stdout);
             if msg.to_lowercase().contains("already") {
+                true
+            } else {
+                return ClaudeRegister::Failed(msg);
+            }
+        }
+        Err(e) => return ClaudeRegister::Failed(e.to_string()),
+    };
+    if !installed {
+        return ClaudeRegister::Failed("plugin install did not complete".into());
+    }
+    match Command::new("claude").args(["plugin", "update", CLAUDE_PLUGIN_REF]).output() {
+        Ok(o) if o.status.success() => ClaudeRegister::Registered,
+        Ok(o) => {
+            let msg = first_line(&o.stderr, &o.stdout);
+            if msg.to_lowercase().contains("already") || msg.to_lowercase().contains("latest") {
                 ClaudeRegister::Registered
             } else {
                 ClaudeRegister::Failed(msg)
@@ -322,6 +358,7 @@ pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Resul
         .ensure_base()
         .with_context(|| format!("creating {}", paths.base.display()))?;
     let hook_script = extract_hook_script(paths)?;
+    extract_hook_bin(paths)?;
     let stall_guard = extract_stall_guard(paths)?;
 
     let mut record = InstallRecord::load(paths)?;
@@ -851,6 +888,17 @@ mod tests {
         );
         let content = std::fs::read_to_string(&dest).unwrap();
         assert!(content.contains("ainb-hooks"));
+    }
+
+    #[test]
+    fn extract_hook_bin_records_installing_binary() {
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        let dest = extract_hook_bin(&p).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest).unwrap().trim(),
+            std::env::current_exe().unwrap().display().to_string()
+        );
     }
 
     #[test]

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ainb-hooks",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc. stall_guard.py additionally blocks turn-end when a session would idle on in-flight work with no wake armed, so ATC-managed sessions do not silently park on a running CI job.",
   "author": {
     "name": "Agents-in-a-Box"

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -145,10 +145,12 @@ ainb_send() {
   return 2
 }
 
-# Dev launches set AINB_BIN to their freshly built binary. Do not fall back to
-# a different installed `ainb`: that silently projects hook events with stale
-# Fleet code while the visible TUI is current.
+# Dev launches set AINB_BIN to their freshly built binary. Hook processes do
+# not inherit that shell, so use the installer-recorded binary before PATH.
 AINB_HOOK_BIN="${AINB_BIN:-}"
+if [ -z "${AINB_HOOK_BIN}" ] && [ -r "${AINB_DIR}/hooks/ainb-bin" ]; then
+  IFS= read -r AINB_HOOK_BIN < "${AINB_DIR}/hooks/ainb-bin" || true
+fi
 if [ -z "${AINB_HOOK_BIN}" ]; then
   AINB_HOOK_BIN="$(command -v ainb 2>/dev/null || true)"
 fi


### PR DESCRIPTION
Restores Fleet interview delivery by pinning the runtime hook binary, removing stale-stream action gating, and adding direct F5 refresh in the active Hangar Fleet surface.

Validation:
- targeted Fleet, Hangar, and notifyd tests
- hook shell syntax
- disposable Fleet-to-Claude tmux round trip
- staged Hangar F5 capture