### PR TITLE
build: add Fleet dev launcher

### DIFF
--- a/ainb-tui/justfile
+++ b/ainb-tui/justfile
@@ -38,6 +38,20 @@ dev *args:
     "$AINB" hangar daemon status
     exec "$AINB" {{args}}
 
+# This mirrors `just dev`: Fleet must connect to the freshly-built Hangar
+# daemon, not an older installed binary, so runtime install restarts it first.
+# Build and open the native macOS Fleet app.
+fleet:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo build -p ainb --bin ainb -p ainb-hangar-daemon
+    AINB="$(pwd)/target/debug/ainb"
+    export AINB_BIN="$AINB"
+    "$AINB" fleet runtime install
+    BUILD_DIR="${TMPDIR:-/tmp}/ainb-fleet-derived-data"
+    xcodebuild -project ../apps/ainb-fleet-macos/AINBFleet.xcodeproj -scheme AINBFleet -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath "$BUILD_DIR" build
+    open "$BUILD_DIR/Build/Products/Debug/AINBFleet.app"
+
 # Run tests
 test:
     cargo test


### PR DESCRIPTION
## Summary
- add `just fleet` beside `just dev`
- build the local runtime, provision daemon hooks, then build and open Fleet

## Verification
- `just --show fleet`
- `just fleet`
- verified Debug Fleet process launched from derived data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined command to build and launch the native macOS Fleet application.
  * Automatically prepares the CLI, daemon, and Fleet runtime before opening the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->