### PR TITLE
feat(fleet): hand interviews back to Claude

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3315,6 +3315,7 @@ impl EventHandler {
                 let action_label = match &action {
                     FleetAction::StructuredAnswer { .. } => "answered ask",
                     FleetAction::DismissStructured { .. } => "rejected interview",
+                    FleetAction::ReleaseStructured { .. } => "opened Claude picker",
                     FleetAction::ReconcileStructured { .. } => "reconciled interview",
                     FleetAction::Approve { .. } => "approved request",
                     FleetAction::Deny { .. } => "denied request",

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3037,7 +3037,7 @@ impl EventHandler {
             KeyCode::Char('R') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart)),
             KeyCode::Char('s') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Stop)),
             KeyCode::Char('i') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Interrupt)),
-            KeyCode::Char('c') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Continue)),
+            KeyCode::Char('c') => Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('c'))),
             KeyCode::Char('e') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Retry)),
             KeyCode::Char('!') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Kill)),
             KeyCode::Char('#') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Archive)),
@@ -8830,6 +8830,10 @@ mod panel_back_tests {
         assert!(matches!(
             route(&mut state, KeyCode::Char('r')),
             Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('r')))
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('c')),
+            Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('c')))
         ));
         assert!(matches!(
             route(&mut state, KeyCode::F(5)),

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -997,6 +997,7 @@ fn structured_emit_json(
                 "permissionDecisionReason": reason,
             }
         }),
+        StructuredResolution::ReleasedToNative => return String::new(),
     };
     hook_output.to_string()
 }
@@ -1246,6 +1247,14 @@ fn hook_core_for_agent(
             &questions,
             ainb_plugin_notifyd::broker::CLIENT_AWAIT_DEADLINE,
         );
+        if matches!(
+            resolution,
+            ainb_plugin_notifyd::broker::StructuredResolution::ReleasedToNative
+        ) {
+            // Fleet explicitly yielded ownership. Returning no hook output lets
+            // Claude render its own AskUserQuestion picker unchanged.
+            return Ok(None);
+        }
         return Ok(Some(HookEmit::Structured(structured_emit_json(
             tool_input,
             &resolution,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -2530,6 +2530,9 @@ async fn execute_fleet_action(
             request_fingerprint,
             ..
         }
+        | ControlAction::ReleaseStructured {
+            request_fingerprint,
+        }
         | ControlAction::ReconcileStructured {
             request_fingerprint,
         }
@@ -2695,6 +2698,12 @@ async fn execute_fleet_action(
                 } if session.provider == "claude" => {
                     execute_claude_structured_dismiss(&session, request_fingerprint).await
                 }
+                ControlAction::ReleaseStructured {
+                    request_fingerprint,
+                } if session.provider == "claude" => {
+                    execute_claude_structured_release(pool, events, &session, request_fingerprint)
+                        .await
+                }
                 ControlAction::ReconcileStructured {
                     request_fingerprint,
                 } if session.provider == "claude" => {
@@ -2736,6 +2745,7 @@ async fn execute_fleet_action(
                 }
                 ControlAction::StructuredAnswer { .. }
                 | ControlAction::DismissStructured { .. }
+                | ControlAction::ReleaseStructured { .. }
                 | ControlAction::ReconcileStructured { .. }
                 | ControlAction::Approve { .. }
                 | ControlAction::ApproveForSession { .. }
@@ -3749,6 +3759,115 @@ async fn execute_claude_structured_dismiss(
     }
 }
 
+/// Yield one exact Fleet-held interview back to Claude's native picker.
+///
+/// The broker remains the compare-and-swap authority for this transition. The
+/// follow-up event preserves the same request fingerprint and payload, adding
+/// only the delivery-route marker consumed by Fleet clients after refresh.
+async fn execute_claude_structured_release(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    request_fingerprint: &str,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    use ainb_hangar_store::repo::fleet::{
+        FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+    };
+
+    let Some(mut request) =
+        (match crate::fleet::current_request_wire(pool, &session.session_key).await {
+            Ok(request) => request,
+            Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+        })
+    else {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("current Claude question is absent".to_string()),
+        );
+    };
+    let session_id = session.provider_session_id.clone().unwrap_or_default();
+    let fingerprint = request_fingerprint.to_string();
+    let socket = match approve_socket_path() {
+        Ok(socket) => socket,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let released = match tokio::task::spawn_blocking(move || {
+        ainb_plugin_notifyd::broker::client_release_structured(&socket, &session_id, &fingerprint)
+    })
+    .await
+    {
+        Ok(Ok(ack)) if ack.matched => true,
+        Ok(Ok(ack)) if ack.stale => {
+            return (
+                ActionReceiptStatus::Failed,
+                Some("Claude structured request is stale".to_string()),
+            );
+        }
+        Ok(Ok(ack)) => {
+            return (
+                ActionReceiptStatus::Failed,
+                ack.error.or_else(|| Some("Claude request no longer waiting".to_string())),
+            );
+        }
+        Ok(Err(error)) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    if !released {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("Claude request no longer waiting".to_string()),
+        );
+    }
+
+    let object = request.as_object_mut();
+    let Some(object) = object else {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("stored Claude question payload is invalid".to_string()),
+        );
+    };
+    object.insert(
+        "fleet_delivery".to_string(),
+        serde_json::Value::String("native_claude".to_string()),
+    );
+    let event = NewFleetEvent {
+        event_id: format!(
+            "fleet-native-picker:{}:{request_fingerprint}",
+            session.session_key
+        ),
+        session_key: session.session_key.clone(),
+        observed_at: SystemClock.now_ms(),
+        authority: ObservationAuthority::Authoritative,
+        event_type: "AskUserQuestion".to_string(),
+        payload: request.to_string(),
+        patch: FleetSessionPatch {
+            lifecycle_state: Some("IDLE".to_string()),
+            attention_state: Some("ASK".to_string()),
+            current_request_fingerprint: Some(Some(request_fingerprint.to_string())),
+            ..FleetSessionPatch::default()
+        },
+    };
+    match FleetRepo::apply_event(pool, &event).await {
+        Ok(result) => {
+            if !result.duplicate {
+                events.emit_fleet_revision(result.revision);
+            }
+            (
+                ActionReceiptStatus::Delivered,
+                Some("released to Claude native picker".to_string()),
+            )
+        }
+        Err(error) => (
+            ActionReceiptStatus::Failed,
+            Some(format!("released to Claude, Fleet refresh failed: {error}")),
+        ),
+    }
+}
+
 async fn reconcile_claude_structured(
     pool: &SqlitePool,
     events: &EventSink,
@@ -3762,6 +3881,15 @@ async fn reconcile_claude_structured(
     use ainb_hangar_proto::fleet::ActionReceiptStatus;
     use ainb_hangar_store::repo::fleet::{
         FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+    };
+
+    let native_picker = match crate::fleet::current_request_wire(pool, &session.session_key).await {
+        Ok(Some(request)) => request
+            .get("fleet_delivery")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|route| route == "native_claude"),
+        Ok(None) => false,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
     };
 
     let socket = match approve_socket_path() {
@@ -3787,6 +3915,16 @@ async fn reconcile_claude_structured(
             Some("Claude interview is live".to_string()),
         );
     }
+    // Generic transcript text cannot prove which interview it belongs to. A
+    // normal Fleet-held interview therefore stays visible until Claude emits
+    // its authoritative tool lifecycle event. Only the explicit native route
+    // owns a uniquely identifiable terminal widget to reconcile here.
+    if !native_picker {
+        return (
+            ActionReceiptStatus::Unknown,
+            Some("Claude interview liveness is unresolved; Fleet card retained".to_string()),
+        );
+    }
     let Some(target) = session.tmux_target.as_deref() else {
         return (
             ActionReceiptStatus::Unknown,
@@ -3797,7 +3935,8 @@ async fn reconcile_claude_structured(
         Ok(pane) => pane,
         Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
     };
-    if !claude_interview_was_declined(&pane) {
+    let native_picker_closed = !claude_native_picker_is_visible(&pane);
+    if !native_picker_closed {
         return (
             ActionReceiptStatus::Unknown,
             Some("Claude interview liveness is unresolved; Fleet card retained".to_string()),
@@ -3832,15 +3971,22 @@ async fn reconcile_claude_structured(
             }
             (
                 ActionReceiptStatus::Delivered,
-                Some("Claude interview ended, cleared stale Fleet card".to_string()),
+                Some(if native_picker_closed {
+                    "Claude native picker completed, cleared Fleet card".to_string()
+                } else {
+                    "Claude interview ended, cleared stale Fleet card".to_string()
+                }),
             )
         }
         Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
     }
 }
 
-fn claude_interview_was_declined(pane: &str) -> bool {
-    pane.contains("User declined to answer questions")
+/// Claude's own AskUserQuestion widget always exposes this fixed interaction
+/// footer while it owns terminal input. Native-route reconciliation only clears
+/// a card after that footer disappears, never while the picker remains active.
+fn claude_native_picker_is_visible(pane: &str) -> bool {
+    pane.contains("Enter to select · ↑/↓ to navigate · Esc to cancel")
 }
 
 fn approve_socket_path() -> std::io::Result<PathBuf> {
@@ -4550,9 +4696,9 @@ fn action_capability(
 ) -> bool {
     use ainb_hangar_proto::fleet::ControlAction;
     match action {
-        ControlAction::StructuredAnswer { .. } | ControlAction::ReconcileStructured { .. } => {
-            capabilities.structured_answer
-        }
+        ControlAction::StructuredAnswer { .. }
+        | ControlAction::ReleaseStructured { .. }
+        | ControlAction::ReconcileStructured { .. } => capabilities.structured_answer,
         ControlAction::DismissStructured { .. } => capabilities.structured_dismiss,
         ControlAction::Approve { .. } | ControlAction::Deny { .. } => capabilities.approvals,
         ControlAction::ApproveForSession { .. } => capabilities.approval_session,
@@ -11054,6 +11200,16 @@ mod tests {
         assert!(action_capability(&capabilities, &action));
     }
 
+    #[test]
+    fn native_claude_picker_footer_controls_reconcile_clearance() {
+        assert!(claude_native_picker_is_visible(
+            "Release proof?\nEnter to select · ↑/↓ to navigate · Esc to cancel"
+        ));
+        assert!(!claude_native_picker_is_visible(
+            "User answered Claude's questions: Release proof? → East"
+        ));
+    }
+
     #[tokio::test]
     async fn fleet_reproject_uses_daemon_broker_for_live_revision() {
         use ainb_hangar_proto::fleet::{
@@ -11169,16 +11325,6 @@ mod tests {
             session.current_request_fingerprint.as_deref(),
             Some("fingerprint-1")
         );
-    }
-
-    #[test]
-    fn declined_claude_interview_requires_native_completion_text() {
-        assert!(claude_interview_was_declined(
-            "User declined to answer questions\n · Where? (North / South)"
-        ));
-        assert!(!claude_interview_was_declined(
-            "Where is the place? (North / South)"
-        ));
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -812,6 +812,11 @@ pub enum ControlAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         request_identity: Option<FleetRequestIdentity>,
     },
+    /// Yield an intercepted Claude interview to its native terminal picker.
+    ReleaseStructured {
+        /// Provider request fingerprint verified against current state.
+        request_fingerprint: String,
+    },
     /// Reconcile one Claude interview against its live broker waiter.
     ReconcileStructured {
         /// Provider request fingerprint verified against current state.
@@ -889,6 +894,7 @@ impl ControlAction {
         match self {
             Self::StructuredAnswer { .. } => "structured_answer",
             Self::DismissStructured { .. } => "dismiss_structured",
+            Self::ReleaseStructured { .. } => "release_structured",
             Self::ReconcileStructured { .. } => "reconcile_structured",
             Self::Approve { .. } => "approve",
             Self::ApproveForSession { .. } => "approve_for_session",

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -4755,7 +4755,7 @@ mod tests {
             "codex:run",
             "codex",
             "IDLE",
-            "NONE",
+            "INPUT",
             "managed",
         )]);
         let ordinary_reduced = apply(&ordinary_state, FleetEvent::Key(FleetKey::Char('c')));

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -1155,7 +1155,19 @@ pub(crate) fn reduce_browse_key(state: &mut FleetPaneState, key: FleetKey) -> Op
         // navigated away instead of attaching.
         FleetKey::Char('a') => return attach_intent(state, true),
         FleetKey::Enter => begin_structured_answer(state),
-        FleetKey::Char('c') => return release_structured_intent(state),
+        FleetKey::Char('c') => {
+            let native_picker = state
+                .selected_key
+                .as_deref()
+                .and_then(|key| state.roster.iter().find(|row| row.session_key == key))
+                .is_some_and(native_claude_picker);
+            if let Some(intent) = release_structured_intent(state) {
+                return Some(intent);
+            }
+            if !native_picker {
+                return request_action(state, FleetAction::Continue);
+            }
+        }
         FleetKey::Char('t') => {
             state.mode = FleetMode::Start(StartState {
                 provider: ainb_hangar_proto::fleet::FleetProvider::Codex,
@@ -1211,13 +1223,15 @@ fn release_structured_intent(state: &mut FleetPaneState) -> Option<FleetIntent> 
         .selected_key
         .as_deref()
         .and_then(|key| state.roster.iter().find(|row| row.session_key == key))?;
+    if native_claude_picker(row) {
+        state.feedback = Some("Claude native picker route is unavailable".into());
+        return None;
+    }
     if !row.provider.eq_ignore_ascii_case("claude")
         || !row.is_managed()
         || !row.attention_state.eq_ignore_ascii_case("ASK")
         || !row.capabilities.contains("structured_answer")
-        || native_claude_picker(row)
     {
-        state.feedback = Some("Claude native picker route is unavailable".into());
         return None;
     }
     let request_fingerprint = row.current_request_fingerprint.clone()?;
@@ -4735,6 +4749,23 @@ mod tests {
             native_reduced.state.feedback.as_deref(),
             Some("Claude native picker route is unavailable")
         );
+
+        let mut ordinary_state = FleetPaneState::default();
+        ordinary_state.set_sessions(vec![session(
+            "codex:run",
+            "codex",
+            "IDLE",
+            "NONE",
+            "managed",
+        )]);
+        let ordinary_reduced = apply(&ordinary_state, FleetEvent::Key(FleetKey::Char('c')));
+        assert!(matches!(
+            ordinary_reduced.intent,
+            Some(FleetIntent::Execute {
+                action: FleetAction::Continue,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -422,6 +422,9 @@ pub enum FleetAction {
         request_fingerprint: String,
         request_identity: Option<ainb_hangar_proto::fleet::FleetRequestIdentity>,
     },
+    ReleaseStructured {
+        request_fingerprint: String,
+    },
     ReconcileStructured {
         request_fingerprint: String,
     },
@@ -470,6 +473,11 @@ impl FleetAction {
                 request_fingerprint,
                 request_identity,
             },
+            Self::ReleaseStructured {
+                request_fingerprint,
+            } => ControlAction::ReleaseStructured {
+                request_fingerprint,
+            },
             Self::ReconcileStructured {
                 request_fingerprint,
             } => ControlAction::ReconcileStructured {
@@ -511,6 +519,7 @@ impl FleetAction {
         match self {
             Self::StructuredAnswer { .. } => capabilities.contains("structured_answer"),
             Self::DismissStructured { .. } => capabilities.contains("structured_dismiss"),
+            Self::ReleaseStructured { .. } => capabilities.contains("structured_answer"),
             Self::ReconcileStructured { .. } => capabilities.contains("structured_answer"),
             Self::Approve { .. } | Self::Deny { .. } => capabilities.contains("approvals"),
             Self::SendText { .. } => {
@@ -531,6 +540,7 @@ impl FleetAction {
         match self {
             Self::StructuredAnswer { .. } => "structured_answer",
             Self::DismissStructured { .. } => "structured_dismiss",
+            Self::ReleaseStructured { .. } => "structured_answer",
             Self::ReconcileStructured { .. } => "structured_answer",
             Self::Approve { .. } | Self::Deny { .. } => "approvals",
             Self::SendText { .. } => "send_prompt or tmux_text",
@@ -550,6 +560,7 @@ impl FleetAction {
             self,
             Self::StructuredAnswer { .. }
                 | Self::DismissStructured { .. }
+                | Self::ReleaseStructured { .. }
                 | Self::ReconcileStructured { .. }
                 | Self::Approve { .. }
                 | Self::Deny { .. }
@@ -1144,6 +1155,7 @@ pub(crate) fn reduce_browse_key(state: &mut FleetPaneState, key: FleetKey) -> Op
         // navigated away instead of attaching.
         FleetKey::Char('a') => return attach_intent(state, true),
         FleetKey::Enter => begin_structured_answer(state),
+        FleetKey::Char('c') => return release_structured_intent(state),
         FleetKey::Char('t') => {
             state.mode = FleetMode::Start(StartState {
                 provider: ainb_hangar_proto::fleet::FleetProvider::Codex,
@@ -1193,11 +1205,45 @@ fn reconcile_structured_intent(state: &mut FleetPaneState) -> Option<FleetIntent
     })
 }
 
+/// Hand the selected Claude interview back to Claude's own terminal picker.
+fn release_structured_intent(state: &mut FleetPaneState) -> Option<FleetIntent> {
+    let row = state
+        .selected_key
+        .as_deref()
+        .and_then(|key| state.roster.iter().find(|row| row.session_key == key))?;
+    if !row.provider.eq_ignore_ascii_case("claude")
+        || !row.is_managed()
+        || !row.attention_state.eq_ignore_ascii_case("ASK")
+        || !row.capabilities.contains("structured_answer")
+        || native_claude_picker(row)
+    {
+        state.feedback = Some("Claude native picker route is unavailable".into());
+        return None;
+    }
+    let request_fingerprint = row.current_request_fingerprint.clone()?;
+    Some(FleetIntent::Execute {
+        session_key: row.session_key.clone(),
+        expected_version: row.version,
+        action: FleetAction::ReleaseStructured {
+            request_fingerprint,
+        },
+    })
+}
+
 fn begin_structured_answer(state: &mut FleetPaneState) {
     let Some(selected_key) = state.selected_key.clone() else {
         state.feedback = Some("no Fleet session selected".into());
         return;
     };
+    if state
+        .roster
+        .iter()
+        .find(|row| row.session_key == selected_key)
+        .is_some_and(native_claude_picker)
+    {
+        state.feedback = Some("Claude picker active, answer in the Claude session".into());
+        return;
+    }
     let answers: Vec<_> = state.roster.iter().filter_map(answer_state_from_row).collect();
     if answers.is_empty() {
         state.feedback = Some("no actionable structured interviews".into());
@@ -1208,6 +1254,14 @@ fn begin_structured_answer(state: &mut FleetPaneState) {
         return;
     };
     state.mode = FleetMode::Answer(AnswerQueue { answers, active });
+}
+
+fn native_claude_picker(row: &FleetSessionRow) -> bool {
+    row.current_request
+        .as_ref()
+        .and_then(|request| request.get("fleet_delivery"))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|route| route == "native_claude")
 }
 
 fn answer_state_from_row(row: &FleetSessionRow) -> Option<AnswerState> {
@@ -2490,6 +2544,19 @@ fn render_detail(
     if session.is_actionable() {
         put_str(buffer, left, y, "NEEDS YOU", GOLD, right);
         y = y.saturating_add(1);
+        if native_claude_picker(session) {
+            put_str(buffer, left, y, "CLAUDE PICKER ACTIVE", VIOLET, right);
+            y = y.saturating_add(1);
+            put_str(
+                buffer,
+                left,
+                y,
+                "Answer in Claude. Fleet mirrors state after submit.",
+                MUTED,
+                right,
+            );
+            y = y.saturating_add(2);
+        }
         if let Some(question_count) = session.structured_question_count() {
             put_str(
                 buffer,
@@ -2627,7 +2694,12 @@ fn available_action_labels(session: &FleetSessionRow) -> Vec<&'static str> {
         && session.is_managed()
         && session.capabilities.contains("structured_answer")
     {
-        actions.push("Enter Answer");
+        if native_claude_picker(session) {
+            actions.push("→ Open Claude");
+        } else {
+            actions.push("Enter Answer");
+            actions.push("c Open in Claude");
+        }
         actions.push("r Reconcile");
     }
     if session.attention_state.eq_ignore_ascii_case("APPROVAL")
@@ -4626,6 +4698,43 @@ mod tests {
         assert!(rendered.contains("Enter Answer"));
         assert!(!rendered.contains("CONNECTION"));
         assert!(!rendered.contains("REPOSITORY / BRANCH"));
+    }
+
+    #[test]
+    fn claude_interview_can_switch_to_native_picker_once() {
+        let mut row = session("claude:native", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("native-fp".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Ship?", "options": ["Yes"]}]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row]);
+        let reduced = apply(&state, FleetEvent::Key(FleetKey::Char('c')));
+        assert_eq!(
+            reduced.intent,
+            Some(FleetIntent::Execute {
+                session_key: "claude:native".into(),
+                expected_version: 7,
+                action: FleetAction::ReleaseStructured {
+                    request_fingerprint: "native-fp".into(),
+                },
+            })
+        );
+
+        let mut native = session("claude:native", "claude", "IDLE", "ASK", "managed");
+        native.current_request_fingerprint = Some("native-fp".into());
+        native.current_request = Some(serde_json::json!({
+            "fleet_delivery": "native_claude",
+            "questions": [{"id": "q", "question": "Ship?", "options": ["Yes"]}]
+        }));
+        let mut native_state = FleetPaneState::default();
+        native_state.set_sessions(vec![native]);
+        let native_reduced = apply(&native_state, FleetEvent::Key(FleetKey::Char('c')));
+        assert!(native_reduced.intent.is_none());
+        assert_eq!(
+            native_reduced.state.feedback.as_deref(),
+            Some("Claude native picker route is unavailable")
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -114,6 +114,9 @@ pub enum StructuredResolution {
         /// Human-readable safe failure reason.
         reason: String,
     },
+    /// Release the intercepted request so Claude can render its native picker.
+    /// No answer is fabricated. The hook must return no override for this state.
+    ReleasedToNative,
 }
 
 impl StructuredResolution {
@@ -640,6 +643,42 @@ impl BrokerState {
             false => StructuredAnswerAck::unmatched(),
         }
     }
+
+    /// Release only the exact current request to Claude's native picker.
+    fn release_structured(
+        &self,
+        session_id: &str,
+        request_fingerprint: &str,
+    ) -> StructuredAnswerAck {
+        let released = {
+            let map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            let Some(pending) = map.get(session_id) else {
+                return StructuredAnswerAck::unmatched();
+            };
+            let PendingKind::Structured {
+                request_fingerprint: current,
+                ..
+            } = &pending.kind
+            else {
+                return StructuredAnswerAck::stale();
+            };
+            if current != request_fingerprint {
+                return StructuredAnswerAck::stale();
+            }
+            match &pending.kind {
+                PendingKind::Structured { tx, .. } => {
+                    tx.send_replace(Some(StructuredResolution::ReleasedToNative));
+                    true
+                }
+                _ => false,
+            }
+        };
+        if released {
+            StructuredAnswerAck::matched()
+        } else {
+            StructuredAnswerAck::unmatched()
+        }
+    }
 }
 
 impl Default for BrokerState {
@@ -698,6 +737,12 @@ enum Request {
         session_id: String,
         request_fingerprint: String,
         reason: String,
+    },
+    /// Release an exact intercepted request to Claude's native picker.
+    #[serde(rename = "release_structured")]
+    ReleaseStructured {
+        session_id: String,
+        request_fingerprint: String,
     },
     /// Dump the pending session ids.
     List,
@@ -836,6 +881,13 @@ async fn handle_connection(stream: UnixStream, state: BrokerState) -> Result<()>
             reason,
         } => {
             let ack = state.dismiss_structured(&session_id, &request_fingerprint, reason);
+            write_line(reader.get_mut(), &ack).await?;
+        }
+        Request::ReleaseStructured {
+            session_id,
+            request_fingerprint,
+        } => {
+            let ack = state.release_structured(&session_id, &request_fingerprint);
             write_line(reader.get_mut(), &ack).await?;
         }
         Request::List => {
@@ -1069,6 +1121,26 @@ pub fn client_dismiss_structured(
             "session_id": session_id,
             "request_fingerprint": request_fingerprint,
             "reason": reason,
+        }),
+    )?;
+    serde_json::from_value(response)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+/// Release an intercepted interview so Claude renders its own picker. This is
+/// an exact-fingerprint transition, therefore a late route change cannot wake
+/// a newer interview in the same session.
+pub fn client_release_structured(
+    sock: &Path,
+    session_id: &str,
+    request_fingerprint: &str,
+) -> std::io::Result<StructuredAnswerAck> {
+    let response = client_round_trip(
+        sock,
+        &serde_json::json!({
+            "op": "release_structured",
+            "session_id": session_id,
+            "request_fingerprint": request_fingerprint,
         }),
     )?;
     serde_json::from_value(response)
@@ -1434,6 +1506,46 @@ mod tests {
                 reason: "operator rejected".into()
             }
         );
+
+        handle.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[tokio::test]
+    async fn structured_release_yields_only_the_exact_pending_request_to_native() {
+        let (sock, _state, handle) = spawn_broker(Duration::from_secs(30)).await;
+        let request = serde_json::json!({
+            "op": "await_structured",
+            "session_id": "ask-native",
+            "request_fingerprint": "fnv1a64:current",
+            "questions": [{"question": "Continue?", "options": ["Yes"]}],
+        });
+        let waiter_sock = sock.clone();
+        let waiter = tokio::spawn(async move {
+            round_trip(&waiter_sock, &serde_json::to_string(&request).unwrap()).await
+        });
+        wait_for_pending(&sock, "ask-native").await;
+
+        let stale_socket = sock.clone();
+        let stale = tokio::task::spawn_blocking(move || {
+            client_release_structured(&stale_socket, "ask-native", "fnv1a64:stale")
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(stale.stale);
+        let accepted_socket = sock.clone();
+        let accepted = tokio::task::spawn_blocking(move || {
+            client_release_structured(&accepted_socket, "ask-native", "fnv1a64:current")
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(accepted.matched);
+
+        let resolution: StructuredResolution =
+            serde_json::from_str(waiter.await.unwrap().trim()).unwrap();
+        assert_eq!(resolution, StructuredResolution::ReleasedToNative);
 
         handle.abort();
         let _ = std::fs::remove_file(&sock);

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -316,6 +316,15 @@ final class FleetStore: ObservableObject {
         )
     }
 
+    func openStructuredInterviewInClaude(on session: FleetSession) {
+        performStructured(
+            .releaseStructured(requestFingerprint: session.currentRequestFingerprint ?? ""),
+            on: session,
+            allowed: session.provider == .claude && session.capabilities.structuredAnswer,
+            failurePrefix: "Open Claude picker"
+        )
+    }
+
     func canDecideApproval(_ decision: FleetApprovalDecision, on session: FleetSession) -> Bool {
         guard session.attention == .approval,
               session.capabilities.approvals,

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -412,6 +412,7 @@ extension FleetRequestIdentity {
 enum ControlAction: Codable, Equatable {
     case structuredAnswer(requestFingerprint: String, requestIdentity: FleetRequestIdentity?, answers: [FleetQuestionAnswer])
     case dismissStructured(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
+    case releaseStructured(requestFingerprint: String)
     case approve(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case approveForSession(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case deny(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
@@ -422,13 +423,14 @@ enum ControlAction: Codable, Equatable {
     case restart, stop, kill, archive
 
     private enum CodingKeys: String, CodingKey { case action, requestFingerprint = "request_fingerprint", requestIdentity = "request_identity", answers, key, text, provider, cwd, prompt }
-    private enum Tag: String, Codable { case structuredAnswer = "structured_answer", dismissStructured = "dismiss_structured", approve, approveForSession = "approve_for_session", deny, verifiedPicker = "verified_picker", sendPrompt = "send_prompt", `continue`, retry, interrupt, start, restart, stop, kill, archive }
+    private enum Tag: String, Codable { case structuredAnswer = "structured_answer", dismissStructured = "dismiss_structured", releaseStructured = "release_structured", approve, approveForSession = "approve_for_session", deny, verifiedPicker = "verified_picker", sendPrompt = "send_prompt", `continue`, retry, interrupt, start, restart, stop, kill, archive }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         switch try c.decode(Tag.self, forKey: .action) {
         case .structuredAnswer: self = .structuredAnswer(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity), answers: try c.decode([FleetQuestionAnswer].self, forKey: .answers))
         case .dismissStructured: self = .dismissStructured(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
+        case .releaseStructured: self = .releaseStructured(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint))
         case .approve: self = .approve(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .approveForSession: self = .approveForSession(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .deny: self = .deny(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
@@ -452,6 +454,8 @@ enum ControlAction: Codable, Equatable {
             try c.encode(Tag.structuredAnswer, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity); try c.encode(answers, forKey: .answers)
         case let .dismissStructured(fingerprint, identity):
             try c.encode(Tag.dismissStructured, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
+        case let .releaseStructured(fingerprint):
+            try c.encode(Tag.releaseStructured, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint)
         case let .approve(fingerprint, identity):
             try c.encode(Tag.approve, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
         case let .approveForSession(fingerprint, identity):

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -311,6 +311,11 @@ struct FleetAnswerQueue: View {
 
             Text(question.header).font(.title3.weight(.semibold))
             Text(question.text).font(.body).fixedSize(horizontal: false, vertical: true)
+            if deck.nativePicker {
+                Text("Claude picker active. Answer in the attached Claude session, then Fleet refreshes the same interview state.")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(FleetPalette.mint)
+            }
 
             if question.options.isEmpty {
                 TextField("Type answer", text: textBinding(deck: deck, question: question), axis: .vertical)
@@ -348,9 +353,16 @@ struct FleetAnswerQueue: View {
                 if deck.session.provider == .claude && deck.session.capabilities.structuredDismiss {
                     Button("Reject interview", role: .destructive) { rejectConfirmation = true }
                 }
+                if deck.session.provider == .claude && !deck.nativePicker {
+                    Button("Open in Claude") {
+                        store.selectedSessionKey = deck.session.sessionKey
+                        store.openStructuredInterviewInClaude(on: deck.session)
+                    }
+                    .disabled(store.pendingIntentID != nil)
+                }
                 Button("Submit all answers") { submit(deck) }
                     .buttonStyle(.borderedProminent)
-                    .disabled(!complete(deck) || store.pendingIntentID != nil)
+                    .disabled(deck.nativePicker || !complete(deck) || store.pendingIntentID != nil)
             }
 
             if let notice = store.controlNotice {
@@ -436,6 +448,7 @@ struct FleetAnswerQueue: View {
 private struct FleetInterviewDeck {
     let session: FleetSession
     let questions: [FleetInterviewQuestion]
+    let nativePicker: Bool
 
     init?(session: FleetSession) {
         guard session.attention == .ask,
@@ -458,6 +471,7 @@ private struct FleetInterviewDeck {
         guard !questions.isEmpty else { return nil }
         self.session = session
         self.questions = questions
+        self.nativePicker = request.value("fleet_delivery")?.stringValue == "native_claude"
     }
 
     static func priority(_ session: FleetSession) -> (Int, Int64) {


### PR DESCRIPTION
## Summary
- add exact-fingerprint broker release for Claude structured interviews
- add Fleet and macOS Open in Claude controls
- retain normal cards until authoritative Claude lifecycle events; reconcile native picker completion safely

## Validation
- targeted broker, TUI, and daemon tests
- targeted Rust compile
- macOS Debug build
- live Fleet answer and native Claude picker delivery against f/test-for-interview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for opening intercepted Claude interviews in Claude’s native picker.
  - Added a Fleet action and `c` browse-key shortcut for releasing eligible interviews to Claude.
  - Added native-picker status indicators and guidance in Fleet details.
  - Added macOS support for launching structured interviews in Claude.

- **Bug Fixes**
  - Prevented answer submission when an interview is handled by Claude’s native picker.
  - Improved handling of unavailable, stale, or mismatched release requests.
  - Preserved Fleet-held interviews during reconciliation unless the native picker is no longer active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->