### PR TITLE
feat(fleet): cache usage and quota

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
@@ -329,6 +329,11 @@ impl AttentionIngest {
                 tracing::warn!(error = %error, "fleet provider event projection link failed");
                 return LineOutcome::Retry;
             }
+            // Transcript writes commonly accompany hook events. The usage service
+            // coalesces this into one background scan, so Fleet converges without
+            // needing the TUI or a client-side filesystem read.
+            crate::fleet_usage::request_refresh().await;
+            crate::fleet_quota::request_refresh().await;
         }
 
         if !is_qualifying(semantic_event) {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_quota.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_quota.rs
@@ -1,0 +1,344 @@
+//! Bounded live provider-quota projection for Fleet.
+//!
+//! Claude writes authoritative quota windows through its statusline hook and
+//! Codex writes them through its stop-hook pull. Hangar reads those small,
+//! provider-produced caches, retains only the safe projection, and never leaks
+//! auth or statusline files through RPC.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use ainb_hangar_proto::fleet::{
+    FleetQuotaProvider, FleetQuotaSummaryResult, FleetQuotaWindow, FleetUsageSummaryState,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+const CACHE_VERSION: u32 = 1;
+const PROVIDER_CACHE_VERSION: u32 = 1;
+const SOURCE_MAX_AGE: Duration = Duration::from_secs(10 * 60);
+const LAST_KNOWN_SOURCE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SourceWindow {
+    pct: u8,
+    #[serde(default)]
+    resets_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SourceCache {
+    version: u32,
+    updated_at: String,
+    #[serde(default)]
+    five_hour: Option<SourceWindow>,
+    #[serde(default)]
+    seven_day: Option<SourceWindow>,
+    #[serde(default)]
+    plan_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedQuota {
+    version: u32,
+    summary: FleetQuotaSummaryResult,
+}
+
+#[derive(Default)]
+struct State {
+    cached: Option<CachedQuota>,
+    refreshing: bool,
+    last_error: Option<String>,
+}
+
+/// Daemon-owned quota cache with a single coalesced reader.
+pub struct QuotaService {
+    cache_path: PathBuf,
+    state: Mutex<State>,
+}
+
+impl QuotaService {
+    /// Load a durable quota projection, if one exists.
+    #[must_use]
+    pub fn new(home: &Path) -> Self {
+        let cache_path = home.join("hangar").join("fleet-quota.json");
+        Self {
+            state: Mutex::new(State {
+                cached: load_cache(&cache_path),
+                ..State::default()
+            }),
+            cache_path,
+        }
+    }
+
+    async fn summary(self: &Arc<Self>) -> FleetQuotaSummaryResult {
+        let (summary, should_refresh) = {
+            let state = self.state.lock().await;
+            let summary = state.cached.as_ref().map(|cached| {
+                let mut summary = cached.summary.clone();
+                if state.refreshing || state.last_error.is_some() {
+                    summary.state = FleetUsageSummaryState::Partial;
+                    summary.detail = Some(match &state.last_error {
+                        Some(error) => format!("using last known quota: {error}"),
+                        None => "refreshing quota in background".to_string(),
+                    });
+                }
+                summary
+            });
+            let generated_at = summary.as_ref().and_then(|row| row.generated_at).unwrap_or(0);
+            let age_ms = Utc::now().timestamp_millis().saturating_sub(generated_at);
+            (
+                summary,
+                generated_at == 0 || age_ms >= REFRESH_INTERVAL.as_millis() as i64,
+            )
+        };
+        if should_refresh {
+            self.request_refresh().await;
+            if let Some(mut summary) = summary {
+                summary.state = FleetUsageSummaryState::Partial;
+                summary.detail = Some(match summary.detail {
+                    Some(detail) => format!("{detail}; refreshing quota in background"),
+                    None => "refreshing quota in background".to_string(),
+                });
+                return summary;
+            }
+        }
+        summary.unwrap_or_else(|| {
+            let state = self.state.try_lock().ok();
+            match state.and_then(|state| state.last_error.clone()) {
+                Some(error) => unavailable(error),
+                None => scanning(),
+            }
+        })
+    }
+
+    /// Coalesce concurrent source-cache reads into one background worker.
+    pub async fn request_refresh(self: &Arc<Self>) {
+        {
+            let mut state = self.state.lock().await;
+            if state.refreshing {
+                return;
+            }
+            state.refreshing = true;
+            state.last_error = None;
+        }
+        let service = Arc::clone(self);
+        tokio::spawn(async move {
+            let result = tokio::task::spawn_blocking(read_live_quota)
+                .await
+                .map_err(|error| format!("quota worker failed: {error}"))
+                .and_then(|result| result);
+            let mut state = service.state.lock().await;
+            state.refreshing = false;
+            match result {
+                Ok(summary) => {
+                    let cached = CachedQuota {
+                        version: CACHE_VERSION,
+                        summary,
+                    };
+                    if let Err(error) = write_cache(&service.cache_path, &cached) {
+                        state.last_error =
+                            Some(format!("could not persist quota snapshot: {error}"));
+                    } else {
+                        state.cached = Some(cached);
+                    }
+                }
+                Err(error) => state.last_error = Some(error),
+            }
+        });
+    }
+
+    fn spawn_poller(self: &Arc<Self>) {
+        let weak = Arc::downgrade(self);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(REFRESH_INTERVAL);
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let Some(service) = weak.upgrade() else {
+                    break;
+                };
+                service.request_refresh().await;
+            }
+        });
+    }
+}
+
+static ACTIVE_SERVICE: OnceLock<tokio::sync::RwLock<Option<Arc<QuotaService>>>> = OnceLock::new();
+
+fn active_slot() -> &'static tokio::sync::RwLock<Option<Arc<QuotaService>>> {
+    ACTIVE_SERVICE.get_or_init(|| tokio::sync::RwLock::new(None))
+}
+
+/// Install quota refresh before Fleet opens its RPC socket.
+pub async fn install(home: &Path) {
+    let service = Arc::new(QuotaService::new(home));
+    service.request_refresh().await;
+    service.spawn_poller();
+    *active_slot().write().await = Some(service);
+}
+
+/// Refresh on hook activity. Repeated hook events join the in-flight reader.
+pub async fn request_refresh() {
+    if let Some(service) = active_slot().read().await.clone() {
+        service.request_refresh().await;
+    }
+}
+
+/// Return only the daemon-owned quota projection.
+pub async fn summary() -> FleetQuotaSummaryResult {
+    match active_slot().read().await.clone() {
+        Some(service) => service.summary().await,
+        None => unavailable("quota service is not initialized".to_string()),
+    }
+}
+
+fn read_live_quota() -> Result<FleetQuotaSummaryResult, String> {
+    let now = Utc::now();
+    let cache_dir = dirs::cache_dir()
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cache")))
+        .ok_or_else(|| "provider cache directory is unavailable".to_string())?
+        .join("ainb");
+
+    let claude_path = cache_dir.join("live.json");
+    let codex_path = cache_dir.join("codex-live.json");
+    let claude = read_provider(&claude_path, "claude", now, SOURCE_MAX_AGE);
+    let codex = read_provider(&codex_path, "codex", now, SOURCE_MAX_AGE);
+    let fresh = [claude.is_some(), codex.is_some()];
+    // No request is made with an expired statusline cache. Retain a bounded
+    // last-known projection so a first Fleet launch still explains the gap.
+    let providers = [
+        claude.or_else(|| read_provider(&claude_path, "claude", now, LAST_KNOWN_SOURCE_MAX_AGE)),
+        codex.or_else(|| read_provider(&codex_path, "codex", now, LAST_KNOWN_SOURCE_MAX_AGE)),
+    ];
+    let available: Vec<_> = providers.iter().filter_map(Clone::clone).collect();
+    if available.is_empty() {
+        return Err("no fresh provider quota cache is available".to_string());
+    }
+    let unavailable: Vec<_> = ["Claude", "Codex"]
+        .into_iter()
+        .zip(providers.iter())
+        .filter_map(|(name, provider)| provider.is_none().then_some(name))
+        .collect();
+    let stale: Vec<_> = ["Claude", "Codex"]
+        .into_iter()
+        .zip(fresh.into_iter().zip(providers.iter()))
+        .filter_map(|(name, (is_fresh, provider))| {
+            (!is_fresh && provider.is_some()).then_some(name)
+        })
+        .collect();
+    let mut detail = Vec::new();
+    if !stale.is_empty() {
+        detail.push(format!("{} quota is last known", stale.join(" and ")));
+    }
+    if !unavailable.is_empty() {
+        detail.push(format!("{} quota unavailable", unavailable.join(" and ")));
+    }
+    Ok(FleetQuotaSummaryResult {
+        state: if fresh.iter().all(|is_fresh| *is_fresh) {
+            FleetUsageSummaryState::Ready
+        } else {
+            FleetUsageSummaryState::Partial
+        },
+        generated_at: Some(now.timestamp_millis()),
+        providers: available,
+        detail: (!detail.is_empty()).then(|| detail.join("; ")),
+    })
+}
+
+fn read_provider(
+    path: &Path,
+    provider: &str,
+    now: DateTime<Utc>,
+    max_age: Duration,
+) -> Option<FleetQuotaProvider> {
+    let source: SourceCache = serde_json::from_slice(&std::fs::read(path).ok()?).ok()?;
+    if source.version != PROVIDER_CACHE_VERSION {
+        return None;
+    }
+    let updated_at = DateTime::parse_from_rfc3339(&source.updated_at).ok()?.with_timezone(&Utc);
+    let age = now.signed_duration_since(updated_at);
+    if age.num_seconds() < 0 || age.to_std().ok()? > max_age {
+        return None;
+    }
+    let window = |window: SourceWindow| FleetQuotaWindow {
+        used_percent: window.pct.min(100),
+        resets_at: window
+            .resets_at
+            .as_deref()
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.timestamp_millis()),
+        estimated: false,
+    };
+    Some(FleetQuotaProvider {
+        provider: provider.to_string(),
+        five_hour: source.five_hour.map(window),
+        seven_day: source.seven_day.map(window),
+        plan_type: source.plan_type,
+        updated_at: Some(updated_at.timestamp_millis()),
+    })
+}
+
+fn load_cache(path: &Path) -> Option<CachedQuota> {
+    let cached: CachedQuota = serde_json::from_slice(&std::fs::read(path).ok()?).ok()?;
+    (cached.version == CACHE_VERSION).then_some(cached)
+}
+
+fn write_cache(path: &Path, cached: &CachedQuota) -> std::io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Err(std::io::Error::other("quota cache has no parent directory"));
+    };
+    std::fs::create_dir_all(parent)?;
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    std::fs::write(
+        &tmp,
+        serde_json::to_vec(cached).map_err(std::io::Error::other)?,
+    )?;
+    std::fs::rename(tmp, path)
+}
+
+fn scanning() -> FleetQuotaSummaryResult {
+    FleetQuotaSummaryResult {
+        state: FleetUsageSummaryState::Scanning,
+        generated_at: None,
+        providers: Vec::new(),
+        detail: Some("reading provider quota caches".to_string()),
+    }
+}
+
+fn unavailable(detail: String) -> FleetQuotaSummaryResult {
+    FleetQuotaSummaryResult {
+        state: FleetUsageSummaryState::Unavailable,
+        generated_at: None,
+        providers: Vec::new(),
+        detail: Some(detail),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_provider_cache_is_not_presented_as_live_quota() {
+        let source = SourceCache {
+            version: PROVIDER_CACHE_VERSION,
+            updated_at: "2026-08-07T10:00:00Z".to_string(),
+            five_hour: Some(SourceWindow {
+                pct: 42,
+                resets_at: None,
+            }),
+            seven_day: None,
+            plan_type: None,
+        };
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("live.json");
+        std::fs::write(&path, serde_json::to_vec(&source).unwrap()).unwrap();
+        let now = "2026-08-07T10:11:00Z".parse::<DateTime<Utc>>().unwrap();
+        assert!(read_provider(&path, "claude", now, SOURCE_MAX_AGE).is_none());
+        assert!(read_provider(&path, "claude", now, LAST_KNOWN_SOURCE_MAX_AGE).is_some());
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
@@ -4,6 +4,8 @@
 //! public RPC receives only aggregates, never paths, transcripts, or calls.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration as StdDuration, SystemTime};
 
 use ainb_hangar_proto::fleet::{
@@ -14,14 +16,231 @@ use ainb_hangar_proto::fleet::{
 use ainb_plugin_session_reader::scanner::{self, ProviderRoots};
 use ainb_plugin_types_sessions::{ProviderCall, TokenBucket, UsageData};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
-/// Scan canonical provider histories then expose the requested bounded window.
+const CACHE_VERSION: u32 = 1;
+const REFRESH_INTERVAL: StdDuration = StdDuration::from_secs(15 * 60);
+
+/// Durable, bounded snapshot. Raw provider calls never leave the scan worker
+/// or land in this file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedSummaries {
+    version: u32,
+    summaries: Vec<CachedSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedSummary {
+    period: FleetUsagePeriod,
+    summary: FleetUsageSummaryResult,
+}
+
+#[derive(Default)]
+struct State {
+    refreshing: bool,
+    last_error: Option<String>,
+}
+
+/// One daemon-owned scanner shared by every Fleet connection.
 ///
-/// This runs on a blocking worker owned by the RPC handler. The scanner itself
-/// owns provider parsing and rate lookup, so this module does not duplicate
-/// provider-specific cost logic.
-#[must_use]
-pub fn scan_summary(period: FleetUsagePeriod) -> FleetUsageSummaryResult {
+/// The service serves its last complete snapshot immediately, runs at most one
+/// refresh at a time, and persists only public projections under Hangar home.
+pub struct UsageService {
+    cache_path: PathBuf,
+    cached: Mutex<Option<CachedSummaries>>,
+    state: Mutex<State>,
+}
+
+impl UsageService {
+    /// Load a durable snapshot, if one exists. A caller must invoke
+    /// [`Self::request_refresh`] after installation to warm it in the background.
+    #[must_use]
+    pub fn new(home: &Path) -> Self {
+        let cache_path = home.join("hangar").join("fleet-usage.json");
+        Self {
+            cached: Mutex::new(load_cache(&cache_path)),
+            cache_path,
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    async fn summary(self: &Arc<Self>, period: FleetUsagePeriod) -> FleetUsageSummaryResult {
+        let (summary, should_refresh) = {
+            let state = self.state.lock().await;
+            let cached = self.cached.lock().await;
+            let summary = cached
+                .as_ref()
+                .and_then(|cache| cache.summaries.iter().find(|row| row.period == period))
+                .map(|row| {
+                    let mut summary = row.summary.clone();
+                    if state.refreshing || state.last_error.is_some() {
+                        summary.state = FleetUsageSummaryState::Partial;
+                        summary.detail = Some(match &state.last_error {
+                            Some(error) => format!("using last complete snapshot: {error}"),
+                            None => "refreshing usage in background".to_string(),
+                        });
+                    }
+                    summary
+                });
+            let generated_at = summary.as_ref().and_then(|row| row.generated_at).unwrap_or(0);
+            let age_ms = Utc::now().timestamp_millis().saturating_sub(generated_at);
+            (
+                summary,
+                generated_at == 0 || age_ms >= REFRESH_INTERVAL.as_millis() as i64,
+            )
+        };
+        if should_refresh {
+            self.request_refresh().await;
+            if let Some(mut summary) = summary {
+                summary.state = FleetUsageSummaryState::Partial;
+                summary.detail = Some(match summary.detail {
+                    Some(detail) => format!("{detail}; refreshing usage in background"),
+                    None => "refreshing usage in background".to_string(),
+                });
+                return summary;
+            }
+        }
+        summary.unwrap_or_else(|| {
+            let state = self.state.try_lock().ok();
+            match state.and_then(|state| state.last_error.clone()) {
+                Some(error) => unavailable(error),
+                None => scanning(),
+            }
+        })
+    }
+
+    /// Coalesce concurrent refresh requests into one background worker.
+    pub async fn request_refresh(self: &Arc<Self>) {
+        {
+            let mut state = self.state.lock().await;
+            if state.refreshing {
+                return;
+            }
+            state.refreshing = true;
+            state.last_error = None;
+        }
+        let service = Arc::clone(self);
+        tokio::spawn(async move {
+            let scanned = tokio::task::spawn_blocking(scan_all_summaries).await;
+            let result = scanned
+                .map_err(|error| format!("usage worker failed: {error}"))
+                .and_then(|result| result);
+            let mut state = service.state.lock().await;
+            state.refreshing = false;
+            match result {
+                Ok(cached) => {
+                    if let Err(error) = write_cache(&service.cache_path, &cached) {
+                        state.last_error =
+                            Some(format!("could not persist usage snapshot: {error}"));
+                    } else {
+                        *service.cached.lock().await = Some(cached);
+                    }
+                }
+                Err(error) => state.last_error = Some(error),
+            }
+        });
+    }
+
+    fn spawn_poller(self: &Arc<Self>) {
+        let weak = Arc::downgrade(self);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(REFRESH_INTERVAL);
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let Some(service) = weak.upgrade() else {
+                    break;
+                };
+                service.request_refresh().await;
+            }
+        });
+    }
+}
+
+static ACTIVE_SERVICE: OnceLock<tokio::sync::RwLock<Option<Arc<UsageService>>>> = OnceLock::new();
+
+fn active_slot() -> &'static tokio::sync::RwLock<Option<Arc<UsageService>>> {
+    ACTIVE_SERVICE.get_or_init(|| tokio::sync::RwLock::new(None))
+}
+
+/// Install the process-wide service before the RPC listener opens.
+pub async fn install(home: &Path) {
+    let service = Arc::new(UsageService::new(home));
+    service.request_refresh().await;
+    service.spawn_poller();
+    *active_slot().write().await = Some(service);
+}
+
+/// Ask the scanner to catch up after a provider hook event.
+pub async fn request_refresh() {
+    if let Some(service) = active_slot().read().await.clone() {
+        service.request_refresh().await;
+    }
+}
+
+/// Read a cached projection without making RPC clients wait for filesystem work.
+pub async fn summary(period: FleetUsagePeriod) -> FleetUsageSummaryResult {
+    match active_slot().read().await.clone() {
+        Some(service) => service.summary(period).await,
+        None => unavailable("usage service is not initialized".to_string()),
+    }
+}
+
+fn load_cache(path: &Path) -> Option<CachedSummaries> {
+    let bytes = std::fs::read(path).ok()?;
+    let cached: CachedSummaries = serde_json::from_slice(&bytes).ok()?;
+    (cached.version == CACHE_VERSION).then_some(cached)
+}
+
+fn write_cache(path: &Path, cached: &CachedSummaries) -> std::io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Err(std::io::Error::other("usage cache has no parent directory"));
+    };
+    std::fs::create_dir_all(parent)?;
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    std::fs::write(
+        &tmp,
+        serde_json::to_vec(cached).map_err(std::io::Error::other)?,
+    )?;
+    std::fs::rename(tmp, path)
+}
+
+fn scanning() -> FleetUsageSummaryResult {
+    FleetUsageSummaryResult {
+        state: FleetUsageSummaryState::Scanning,
+        generated_at: None,
+        start_at: None,
+        end_at: None,
+        totals: None,
+        daily: Vec::new(),
+        providers: Vec::new(),
+        models: Vec::new(),
+        projects: Vec::new(),
+        detail: Some("building usage snapshot".to_string()),
+    }
+}
+
+fn unavailable(detail: String) -> FleetUsageSummaryResult {
+    FleetUsageSummaryResult {
+        state: FleetUsageSummaryState::Unavailable,
+        generated_at: None,
+        start_at: None,
+        end_at: None,
+        totals: None,
+        daily: Vec::new(),
+        providers: Vec::new(),
+        models: Vec::new(),
+        projects: Vec::new(),
+        detail: Some(detail),
+    }
+}
+
+/// Scan canonical provider histories once, then derive every public window.
+///
+/// The scanner owns provider parsing and rate lookup. This service stores only
+/// the bounded projections, never provider calls or their local paths.
+fn scan_all_summaries() -> Result<CachedSummaries, String> {
     let roots = ProviderRoots::defaults();
     if roots.claude_projects.is_none()
         && roots.codex_sessions.is_none()
@@ -29,36 +248,40 @@ pub fn scan_summary(period: FleetUsagePeriod) -> FleetUsageSummaryResult {
         && roots.copilot_sessions.is_none()
         && roots.cursor_sessions.is_none()
     {
-        return FleetUsageSummaryResult {
-            state: FleetUsageSummaryState::Unavailable,
-            generated_at: Some(Utc::now().timestamp_millis()),
-            start_at: None,
-            end_at: None,
-            totals: None,
-            daily: Vec::new(),
-            providers: Vec::new(),
-            models: Vec::new(),
-            projects: Vec::new(),
-            detail: Some("provider history roots are unavailable".to_string()),
-        };
+        return Err("provider history roots are unavailable".to_string());
     }
     let now = Utc::now();
-    let (start, _) = window(period, now);
+    let (start, _) = window(FleetUsagePeriod::Trailing30Days, now);
     let since = SystemTime::UNIX_EPOCH
         + StdDuration::from_millis(u64::try_from(start.timestamp_millis()).unwrap_or_default());
-    summary_from_usage(scanner::scan_since(&roots, since), period, now)
+    let usage = scanner::scan_since(&roots, since);
+    Ok(CachedSummaries {
+        version: CACHE_VERSION,
+        summaries: [
+            FleetUsagePeriod::Today,
+            FleetUsagePeriod::Trailing7Days,
+            FleetUsagePeriod::Trailing30Days,
+        ]
+        .into_iter()
+        .map(|period| CachedSummary {
+            period,
+            summary: summary_from_usage(&usage, period, now),
+        })
+        .collect(),
+    })
 }
 
 fn summary_from_usage(
-    usage: UsageData,
+    usage: &UsageData,
     period: FleetUsagePeriod,
     now: DateTime<Utc>,
 ) -> FleetUsageSummaryResult {
     let (start, end) = window(period, now);
     let calls: Vec<_> = usage
         .calls
-        .into_iter()
+        .iter()
         .filter(|call| call.timestamp >= start && call.timestamp < end)
+        .cloned()
         .collect();
     let projected = scanner::aggregate(calls.clone());
     let complete_costs = completeness(&calls);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -97,6 +97,8 @@ pub mod execenv;
 pub mod fleet;
 /// Claude and Codex provider transports for authoritative Fleet control.
 pub mod fleet_provider;
+/// Bounded live provider-quota projection for the public Fleet RPC.
+pub mod fleet_quota;
 /// Bounded canonical Usage projection for the public Fleet RPC.
 pub mod fleet_usage;
 /// The task-lifecycle state machine (T8): `statig` typed compile-time
@@ -529,6 +531,11 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     // so it lives in `boot`'s scope alongside the other background handles.
     let _profile_watch = crate::profile::profiles_dir()
         .and_then(|dir| crate::profile::spawn_index_watch(store.pool().clone(), dir));
+
+    // Fleet Usage survives TUI restarts: load the daemon-owned bounded snapshot
+    // now, then refresh it on a background worker before Fleet opens its socket.
+    crate::fleet_usage::install(&dir).await;
+    crate::fleet_quota::install(&dir).await;
 
     // P4.10: bind the JSON-RPC socket beside the database and serve plugin
     // connections on a background task. A bind failure is non-fatal — the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1177,6 +1177,7 @@ async fn handle(
         }
         methods::FLEET_RUNTIME_STATUS => handle_fleet_runtime_status(req, health).await,
         methods::FLEET_USAGE_SUMMARY => handle_fleet_usage_summary(req).await,
+        methods::FLEET_QUOTA_SUMMARY => handle_fleet_quota_summary(req).await,
         methods::FLEET_MESSAGE_SEND => handle_fleet_message_send(pool, req, events).await,
         methods::FLEET_MESSAGE_LIST => handle_fleet_message_list(pool, req).await,
         // Both subscribe acks carry a head cursor; their per-connection
@@ -1404,15 +1405,18 @@ async fn handle_fleet_usage_summary(req: &RpcRequest) -> Result<serde_json::Valu
 
     require_fleet_capability(FLEET_CAPABILITY_USAGE_READ)?;
     let params: FleetUsageSummaryParams = parse_params(req, "{ period? }")?;
-    let summary =
-        tokio::task::spawn_blocking(move || crate::fleet_usage::scan_summary(params.period))
-            .await
-            .map_err(|error| RpcError {
-                code: INTERNAL_ERROR,
-                message: format!("usage summary worker failed: {error}"),
-                data: None,
-            })?;
+    let summary = crate::fleet_usage::summary(params.period).await;
     to_value(&summary)
+}
+
+/// Return bounded daemon-owned live quota windows without exposing provider
+/// statusline caches or account credentials to the Fleet client.
+async fn handle_fleet_quota_summary(req: &RpcRequest) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FLEET_CAPABILITY_QUOTA_READ, FleetQuotaSummaryParams};
+
+    require_fleet_capability(FLEET_CAPABILITY_QUOTA_READ)?;
+    let _: FleetQuotaSummaryParams = parse_params(req, "{}")?;
+    to_value(&crate::fleet_quota::summary().await)
 }
 
 /// Return supported provider-hook health without leaking runtime files or

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -27,6 +27,8 @@ pub const FLEET_CAPABILITY_ATC_READ: &str = "fleet.atc.read";
 pub const FLEET_CAPABILITY_TIMELINE_READ: &str = "fleet.timeline.read";
 /// Negotiated capability for bounded daemon-owned usage summaries.
 pub const FLEET_CAPABILITY_USAGE_READ: &str = "fleet.usage.read";
+/// Negotiated capability for bounded live provider-quota summaries.
+pub const FLEET_CAPABILITY_QUOTA_READ: &str = "fleet.quota.read";
 /// Negotiated capability for runtime and provider-hook health.
 pub const FLEET_CAPABILITY_RUNTIME_READ: &str = "fleet.runtime.read";
 /// Negotiated capability required for chat-bus message sends.
@@ -52,6 +54,7 @@ pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
     FLEET_CAPABILITY_MESSAGE_SEND,
     "fleet.protocol.negotiate",
     FLEET_CAPABILITY_RECEIPT_READ,
+    FLEET_CAPABILITY_QUOTA_READ,
     "fleet.snapshot.read",
     FLEET_CAPABILITY_START_EXECUTE,
     "fleet.subscription.live",
@@ -659,6 +662,61 @@ pub struct FleetUsageSummaryResult {
     pub projects: Vec<FleetUsageProjectBucket>,
     /// Safe daemon status detail for partial or unavailable summaries, capped
     /// by [`FLEET_USAGE_DETAIL_MAX_BYTES`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// One live provider quota window. `used_percent` is provider-reported, so
+/// clients derive remaining quota as `100 - used_percent` without guessing a
+/// token cap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetQuotaWindow {
+    /// Provider-reported used percentage, clamped to 0..=100 by the producer.
+    pub used_percent: u8,
+    /// Absolute reset instant in epoch milliseconds when the provider supplied it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at: Option<i64>,
+    /// `true` when this came from local transcript estimation, not provider data.
+    #[serde(default)]
+    pub estimated: bool,
+}
+
+/// Parameters for `fleet/quota_summary`. Reserved for future provider filters.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetQuotaSummaryParams {}
+
+/// Live quota projection for one provider. Absent windows mean unavailable,
+/// not zero usage or unlimited capacity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetQuotaProvider {
+    /// Stable provider identifier, currently `claude` or `codex`.
+    pub provider: String,
+    /// Provider's rolling five-hour window, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub five_hour: Option<FleetQuotaWindow>,
+    /// Provider's rolling seven-day window, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day: Option<FleetQuotaWindow>,
+    /// Provider plan tier, when its source reports one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_type: Option<String>,
+    /// Source observation time in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<i64>,
+}
+
+/// Bounded daemon-owned live quota result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetQuotaSummaryResult {
+    /// Availability of the current projection.
+    pub state: FleetUsageSummaryState,
+    /// Time the daemon assembled this projection, in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated_at: Option<i64>,
+    /// At most one row per supported provider.
+    #[serde(default)]
+    pub providers: Vec<FleetQuotaProvider>,
+    /// Safe status detail for stale, partial, or unavailable data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
 }
@@ -1326,6 +1384,7 @@ mod tests {
             // point: the catalogue never advertises a -32601 method.
             FLEET_CAPABILITY_ACP_SPAWN,
             FLEET_CAPABILITY_USAGE_READ,
+            FLEET_CAPABILITY_QUOTA_READ,
             FLEET_CAPABILITY_RUNTIME_READ,
         ] {
             assert!(
@@ -1489,6 +1548,23 @@ mod tests {
             }],
             detail: Some("copilot shutdown metrics unavailable".to_string()),
         });
+        round_trip(&FleetQuotaSummaryResult {
+            state: FleetUsageSummaryState::Partial,
+            generated_at: Some(1_700_000_000_000),
+            providers: vec![FleetQuotaProvider {
+                provider: "claude".to_string(),
+                five_hour: Some(FleetQuotaWindow {
+                    used_percent: 42,
+                    resets_at: Some(1_700_018_000_000),
+                    estimated: false,
+                }),
+                seven_day: None,
+                plan_type: None,
+                updated_at: Some(1_700_000_000_000),
+            }],
+            detail: Some("Codex quota unavailable".to_string()),
+        });
+        round_trip(&FleetQuotaSummaryParams {});
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -415,6 +415,11 @@ pub const FLEET_TIMELINE: &str = "fleet/timeline";
 /// Params: [`crate::fleet::FleetUsageSummaryParams`]; result:
 /// [`crate::fleet::FleetUsageSummaryResult`]. Gated by `fleet.usage.read`.
 pub const FLEET_USAGE_SUMMARY: &str = "fleet/usage_summary";
+/// Read bounded daemon-owned live provider quota windows.
+///
+/// Result: [`crate::fleet::FleetQuotaSummaryResult`]. Gated by
+/// `fleet.quota.read`.
+pub const FLEET_QUOTA_SUMMARY: &str = "fleet/quota_summary";
 /// Read bounded daemon and provider-hook runtime health.
 pub const FLEET_RUNTIME_STATUS: &str = "fleet/runtime_status";
 /// Rebuild one stale Claude interview through the live daemon broker.
@@ -1708,6 +1713,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_START,
     FLEET_TIMELINE,
     FLEET_USAGE_SUMMARY,
+    FLEET_QUOTA_SUMMARY,
     FLEET_RUNTIME_STATUS,
     FLEET_REPROJECT_CLAUDE_INTERVIEW,
     // Dispatch reason codes (multica parity #12) — APPENDED at the catalogue
@@ -1999,6 +2005,7 @@ mod tests {
             FLEET_START,
             FLEET_TIMELINE,
             FLEET_USAGE_SUMMARY,
+            FLEET_QUOTA_SUMMARY,
             FLEET_RUNTIME_STATUS,
             FLEET_REPROJECT_CLAUDE_INTERVIEW,
             HANGAR_DISPATCH_ATTEMPTS_LIST,

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -516,7 +516,10 @@ private struct FleetUsageView: View {
                 }
                 .pickerStyle(.segmented)
                 Spacer()
-                Button("Refresh") { store.refreshUsage(period: period) }
+                Button("Refresh") {
+                    store.refreshUsage(period: period)
+                    store.refreshQuota()
+                }
                     .disabled(!store.canReadUsage)
             }
 
@@ -534,12 +537,18 @@ private struct FleetUsageView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .onAppear { store.refreshUsage(period: period) }
+        .onAppear {
+            store.refreshUsage(period: period)
+            store.refreshQuota()
+        }
         .onChange(of: period) { _, value in store.refreshUsage(period: value) }
         .accessibilityIdentifier("fleet.notch.usage")
     }
 
     @ViewBuilder private func usage(_ summary: FleetUsageSummaryResult) -> some View {
+        if let quotaSummary = store.quotaSummary {
+            quotaCard(quotaSummary)
+        }
         if let total = summary.totals {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 3) {
@@ -576,6 +585,60 @@ private struct FleetUsageView: View {
                 Text(summary.detail ?? "Daemon returned no usable usage projection.").font(.caption)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    @ViewBuilder private func quotaCard(_ summary: FleetQuotaSummaryResult) -> some View {
+        if !summary.providers.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Label("Live quota", systemImage: "gauge.with.dots.needle.67percent")
+                        .font(.headline)
+                    Spacer()
+                    Text(summary.state == .ready ? "Live" : summary.state.rawValue.capitalized)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(summary.state == .ready ? .mint : .orange)
+                }
+                ForEach(summary.providers, id: \.provider) { provider in
+                    HStack(spacing: 10) {
+                        Text(provider.provider.capitalized)
+                            .font(.subheadline.weight(.semibold))
+                            .frame(width: 58, alignment: .leading)
+                        quotaWindow("5h", window: provider.fiveHour)
+                        quotaWindow("Week", window: provider.sevenDay)
+                    }
+                }
+                if let detail = summary.detail {
+                    Text(detail).font(.caption).foregroundStyle(FleetNotchPalette.muted)
+                }
+            }
+            .padding(14)
+            .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        } else if let detail = summary.detail {
+            Label(detail, systemImage: "gauge.with.dots.needle.67percent")
+                .font(.caption)
+                .foregroundStyle(FleetNotchPalette.muted)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+
+    @ViewBuilder private func quotaWindow(_ label: String, window: FleetQuotaWindow?) -> some View {
+        if let window {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(label) · \(window.remainingPercent)% left")
+                    .font(.caption.weight(.semibold))
+                if let reset = window.resetsAt {
+                    Text(Date(timeIntervalSince1970: TimeInterval(reset) / 1_000), style: .relative)
+                        .font(.caption2)
+                        .foregroundStyle(FleetNotchPalette.muted)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 7)
+            .padding(.horizontal, 9)
+            .background(FleetNotchPalette.canvas, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
         }
     }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -96,6 +96,7 @@ final class FleetStore: ObservableObject {
     @Published private(set) var atcSchedulerOwnership: AtcSchedulerOwnership?
     @Published private(set) var timeline: [FleetTimelineEntry] = []
     @Published private(set) var usageSummary: FleetUsageSummaryResult?
+    @Published private(set) var quotaSummary: FleetQuotaSummaryResult?
     @Published private(set) var runtimeStatus: FleetRuntimeStatusResult?
     @Published private(set) var pendingIntentID: String?
     @Published private(set) var controlNotice: String?
@@ -167,6 +168,10 @@ final class FleetStore: ObservableObject {
 
     var canReadUsage: Bool {
         connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.usage.read") == true
+    }
+
+    var canReadQuota: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.quota.read") == true
     }
 
     var canReadRuntime: Bool {
@@ -514,6 +519,22 @@ final class FleetStore: ObservableObject {
             } catch {
                 usageSummary = nil
                 controlNotice = "Usage refresh refused: \(String(describing: error))"
+            }
+        }
+    }
+
+    func refreshQuota() {
+        guard canReadQuota, let connection else {
+            quotaSummary = nil
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                quotaSummary = try await connection.quotaSummary()
+            } catch {
+                quotaSummary = nil
+                controlNotice = "Quota refresh refused: \(String(describing: error))"
             }
         }
     }

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -177,6 +177,11 @@ actor FleetConnection {
         return try await request("fleet/usage_summary", params: params, result: FleetUsageSummaryResult.self)
     }
 
+    func quotaSummary() async throws -> FleetQuotaSummaryResult {
+        try requireReadCapability("fleet.quota.read")
+        return try await request("fleet/quota_summary", params: FleetQuotaSummaryParams(), result: FleetQuotaSummaryResult.self)
+    }
+
     func runtimeStatus() async throws -> FleetRuntimeStatusResult {
         try requireReadCapability("fleet.runtime.read")
         return try await request("fleet/runtime_status", params: FleetRuntimeStatusParams(), result: FleetRuntimeStatusResult.self)

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -639,6 +639,51 @@ struct FleetUsageSummaryResult: Codable, Equatable {
     }
 }
 
+struct FleetQuotaSummaryParams: Codable, Equatable { init() {} }
+
+struct FleetQuotaWindow: Codable, Equatable {
+    let usedPercent: UInt8
+    let resetsAt: Int64?
+    let estimated: Bool
+
+    var remainingPercent: UInt8 { 100 - min(usedPercent, 100) }
+
+    private enum CodingKeys: String, CodingKey {
+        case usedPercent = "used_percent"
+        case resetsAt = "resets_at"
+        case estimated
+    }
+}
+
+struct FleetQuotaProvider: Codable, Equatable {
+    let provider: String
+    let fiveHour: FleetQuotaWindow?
+    let sevenDay: FleetQuotaWindow?
+    let planType: String?
+    let updatedAt: Int64?
+
+    private enum CodingKeys: String, CodingKey {
+        case provider
+        case fiveHour = "five_hour"
+        case sevenDay = "seven_day"
+        case planType = "plan_type"
+        case updatedAt = "updated_at"
+    }
+}
+
+struct FleetQuotaSummaryResult: Codable, Equatable {
+    let state: FleetUsageSummaryState
+    let generatedAt: Int64?
+    let providers: [FleetQuotaProvider]
+    let detail: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case generatedAt = "generated_at"
+        case providers, detail
+    }
+}
+
 struct FleetRuntimeStatusParams: Codable, Equatable { init() {} }
 
 struct FleetRuntimeHookStatus: Codable, Equatable {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -197,7 +197,7 @@ final class FleetConnectionTests: XCTestCase {
                     "protocol_version": 2,
                     "read_compatible": true,
                     "write_compatible": false,
-                    "capability_ids": ["fleet.runtime.read", "fleet.usage.read"],
+                    "capability_ids": ["fleet.runtime.read", "fleet.usage.read", "fleet.quota.read"],
                 ])
                 let runtime = try Self.readRequest(from: serverDescriptor)
                 XCTAssertEqual(runtime["method"] as? String, "fleet/runtime_status")
@@ -221,6 +221,17 @@ final class FleetConnectionTests: XCTestCase {
                     ],
                     "daily": [], "providers": [], "models": [], "projects": [], "detail": NSNull(),
                 ])
+                let quota = try Self.readRequest(from: serverDescriptor)
+                XCTAssertEqual(quota["method"] as? String, "fleet/quota_summary")
+                try Self.writeResponse(to: serverDescriptor, request: quota, result: [
+                    "state": "ready", "generated_at": 1,
+                    "providers": [[
+                        "provider": "codex",
+                        "five_hour": ["used_percent": 42, "resets_at": 2_000, "estimated": false],
+                        "seven_day": NSNull(), "plan_type": "pro", "updated_at": 1,
+                    ]],
+                    "detail": NSNull(),
+                ])
             } catch {
                 serverResult.record(error)
             }
@@ -236,12 +247,14 @@ final class FleetConnectionTests: XCTestCase {
         _ = try await connection.negotiate()
         let runtime = try await connection.runtimeStatus()
         let usage = try await connection.usageSummary(FleetUsageSummaryParams(period: .trailing7Days))
+        let quota = try await connection.quotaSummary()
 
         XCTAssertEqual(runtime.hooks.map(\.provider), ["codex"])
         XCTAssertEqual(runtime.hooks.first?.deliveryReady, false)
         XCTAssertEqual(usage.state, .ready)
         XCTAssertEqual(usage.totals?.totalTokens, 123)
         XCTAssertNil(usage.totals?.costUSD)
+        XCTAssertEqual(quota.providers.first?.fiveHour?.remainingPercent, 58)
         await fulfillment(of: [serverDone], timeout: 1)
         try serverResult.throwIfRecorded()
     }


### PR DESCRIPTION
## Summary
- daemon-owned bounded historical usage cache
- daemon-owned live quota projection with last-known fallback
- Fleet macOS quota view

## Verification
- cargo test -p ainb-hangar-proto --lib
- cargo test -p ainb-hangar-daemon fleet_usage --lib
- cargo test -p ainb-hangar-daemon fleet_quota --lib
- cargo check -p ainb-hangar-daemon
- xcodebuild FleetConnectionTests
- standalone daemon and Fleet app runtime proof