### PR TITLE
style: restore rustfmt clean tree

### DIFF
--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -103,43 +103,44 @@ pub type FleetHostUpdateSink = Arc<Mutex<Vec<FleetHostUpdate>>>;
 /// revision stream to reconnect. Direct action RPCs use the same short-lived
 /// authenticated transport, so this remains useful after a stream disconnect.
 pub fn request_fleet_snapshot(updates: FleetHostUpdateSink) {
-    let _ = std::thread::Builder::new()
-        .name("ainb-fleet-refresh".into())
-        .spawn(move || {
-            let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-                Ok(runtime) => runtime,
-                Err(error) => {
+    let _ = std::thread::Builder::new().name("ainb-fleet-refresh".into()).spawn(move || {
+        let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                publish_host_update(
+                    &updates,
+                    FleetHostUpdate::Health(FleetDaemonHealth::Offline(format!(
+                        "refresh runtime failed: {error}"
+                    ))),
+                );
+                return;
+            }
+        };
+        runtime.block_on(async move {
+            let result = async {
+                let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+                    .map_err(|error| error.to_string())?;
+                client.fleet_snapshot().await.map_err(|error| error.to_string())
+            }
+            .await;
+            match result {
+                Ok(snapshot) => {
+                    let mut git_context_cache = HashMap::new();
+                    publish_snapshot(&updates, snapshot, &mut git_context_cache);
                     publish_host_update(
                         &updates,
-                        FleetHostUpdate::Health(FleetDaemonHealth::Offline(format!(
-                            "refresh runtime failed: {error}"
-                        ))),
+                        FleetHostUpdate::Health(FleetDaemonHealth::Online),
                     );
-                    return;
                 }
-            };
-            runtime.block_on(async move {
-                let result = async {
-                    let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
-                        .map_err(|error| error.to_string())?;
-                    client.fleet_snapshot().await.map_err(|error| error.to_string())
-                }
-                .await;
-                match result {
-                    Ok(snapshot) => {
-                        let mut git_context_cache = HashMap::new();
-                        publish_snapshot(&updates, snapshot, &mut git_context_cache);
-                        publish_host_update(&updates, FleetHostUpdate::Health(FleetDaemonHealth::Online));
-                    }
-                    Err(error) => publish_host_update(
-                        &updates,
-                        FleetHostUpdate::Health(FleetDaemonHealth::Offline(format!(
-                            "refresh failed: {error}"
-                        ))),
-                    ),
-                }
-            });
+                Err(error) => publish_host_update(
+                    &updates,
+                    FleetHostUpdate::Health(FleetDaemonHealth::Offline(format!(
+                        "refresh failed: {error}"
+                    ))),
+                ),
+            }
         });
+    });
 }
 
 /// Start one persistent Fleet stream worker.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -2090,7 +2090,10 @@ pub fn render_fleet(
             || format!("0/{}", visible.len()),
             |index| format!("{}/{}", index + 1, visible.len()),
         );
-        let header = format!("  ACTION QUEUE  ·  {} sessions  ·  F5 refresh", visible.len());
+        let header = format!(
+            "  ACTION QUEUE  ·  {} sessions  ·  F5 refresh",
+            visible.len()
+        );
         put_str(buffer, 0, header_y, &header, FG, list_width);
         let position_width = position.chars().count() as u16;
         put_str(

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -300,18 +300,19 @@ fn register_claude_plugin() -> ClaudeRegister {
     }
     // Install, then update. `install` is idempotent but does not refresh an
     // existing cached marketplace plugin, leaving hook code behind `ainb`.
-    let installed = match Command::new("claude").args(["plugin", "install", CLAUDE_PLUGIN_REF]).output() {
-        Ok(o) if o.status.success() => true,
-        Ok(o) => {
-            let msg = first_line(&o.stderr, &o.stdout);
-            if msg.to_lowercase().contains("already") {
-                true
-            } else {
-                return ClaudeRegister::Failed(msg);
+    let installed =
+        match Command::new("claude").args(["plugin", "install", CLAUDE_PLUGIN_REF]).output() {
+            Ok(o) if o.status.success() => true,
+            Ok(o) => {
+                let msg = first_line(&o.stderr, &o.stdout);
+                if msg.to_lowercase().contains("already") {
+                    true
+                } else {
+                    return ClaudeRegister::Failed(msg);
+                }
             }
-        }
-        Err(e) => return ClaudeRegister::Failed(e.to_string()),
-    };
+            Err(e) => return ClaudeRegister::Failed(e.to_string()),
+        };
     if !installed {
         return ClaudeRegister::Failed("plugin install did not complete".into());
     }


### PR DESCRIPTION
The `Rustfmt` CI job is red on `main`: three files carry hand-formatted
code that `cargo fmt --all --check` rejects. Nothing here changes
behaviour; it is the output of `cargo fmt --all` under the pinned
1.96.0 toolchain, split one commit per file.

- `ainb-core/src/fleet/control.rs` — `thread::Builder` chain re-wrapped
- `ainb-plugin-hangar/src/screen/fleet.rs` — ACTION QUEUE header split
- `ainb-plugin-notifyd/src/install.rs` — plugin-install match re-indented

Verified with `cargo fmt --all -- --check` (0 diffs) and
`cargo check --workspace --all-targets`.

https://claude.ai/code/session_015n6rRJneeBnHxg4ARGrZPJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fleet roster headers now display the current session count.
  - Added an **F5 refresh** hint to the action-queue header, making the refresh shortcut easier to discover.

- **Style**
  - Improved presentation and readability of Fleet-related interface headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->