### PR TITLE
fix(tui): keep the Claude quota on the status bar

### DIFF
--- a/ainb-tui/crates/ainb-core/src/models/live_window.rs
+++ b/ainb-tui/crates/ainb-core/src/models/live_window.rs
@@ -174,14 +174,33 @@ fn overlay_codex(window: &mut LiveWindow, cache: &crate::cli::codex_statusline::
     window.codex_plan_type = cache.plan_type.clone();
 }
 
-/// Tier 1: read the statusline cache if fresh.
+/// Tier 1: read the statusline cache if fresh and it actually carries a
+/// window.
+///
+/// The windowless check is not redundant with freshness. The statusline
+/// writer rebuilds the whole cache on every render, so a payload that
+/// arrives without `rate_limits` (a headless/ACP session, or one that
+/// renders before its first API response) writes both windows as `null`
+/// with a current `updated_at`. Treating that as a hit would shadow
+/// Tier 2 and blank the entire `claude …` cluster for a full
+/// [`CACHE_MAX_AGE_SECS`] — 24h since the TTL widened. A cache with no
+/// windows carries no quota information, so it is a miss.
 fn current_tier1() -> Option<LiveWindow> {
     let path = cache_path()?;
     let cache = read_cache(&path)?;
     if !cache_is_fresh(&cache) {
         return None;
     }
+    if !cache_has_window(&cache) {
+        return None;
+    }
     Some(window_from_cache(cache))
+}
+
+/// Whether the cache carries any quota window at all. See
+/// [`current_tier1`] for why a windowless cache must not count as a hit.
+fn cache_has_window(cache: &LiveCache) -> bool {
+    cache.five_hour.is_some() || cache.seven_day.is_some()
 }
 
 fn cache_is_fresh(cache: &LiveCache) -> bool {
@@ -515,6 +534,42 @@ mod tests {
             model: None,
         };
         assert!(cache_is_fresh(&cache));
+    }
+
+    #[test]
+    fn windowless_cache_is_not_a_tier1_hit() {
+        // A statusline payload without `rate_limits` writes both windows as
+        // `null` with a current timestamp. Fresh, but carrying no quota —
+        // it must not shadow Tier 2, or the whole `claude …` cluster blanks
+        // for the full 24h TTL.
+        let mut cache = LiveCache {
+            version: crate::cli::statusline::CACHE_SCHEMA_VERSION,
+            updated_at: Utc::now().to_rfc3339(),
+            five_hour: None,
+            seven_day: None,
+            today_cost_usd: Some(1.23),
+            context_pct: Some(9),
+            model: Some("Opus 5".into()),
+        };
+        assert!(cache_is_fresh(&cache), "fixture must be fresh");
+        assert!(
+            !cache_has_window(&cache),
+            "no rate_limits → not a Tier 1 hit"
+        );
+
+        // Either window alone is enough to count.
+        cache.seven_day = Some(crate::cli::statusline::RateWindow {
+            pct: 86,
+            resets_at: None,
+        });
+        assert!(cache_has_window(&cache), "weekly alone still counts");
+
+        cache.seven_day = None;
+        cache.five_hour = Some(crate::cli::statusline::RateWindow {
+            pct: 2,
+            resets_at: None,
+        });
+        assert!(cache_has_window(&cache), "5h alone still counts");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/models/live_window.rs
+++ b/ainb-tui/crates/ainb-core/src/models/live_window.rs
@@ -23,11 +23,15 @@ use crate::models::usage::ProviderCall;
 
 /// Maximum age of the Tier 1 cache before we consider it stale and fall
 /// back to Tier 2. The Claude statusline cache is only rewritten while a
-/// Claude Code session is actively prompting (each render); 10 minutes
-/// keeps the last-known windows visible across a normal "tabbed away"
-/// gap instead of blinking out after a short idle. Matches the Codex
-/// cache TTL ([`CODEX_CACHE_MAX_AGE_SECS`]).
-pub const CACHE_MAX_AGE_SECS: u64 = 600;
+/// Claude Code session is actively prompting (each render), so a short
+/// TTL blanks the whole `claude …` cluster during any normal idle gap —
+/// overnight, a long meeting, a stretch of Codex-only work. 24 hours
+/// keeps the last-known windows on the bar instead, and still drops them
+/// once the data is old enough to be meaningless (the 5h window has
+/// reset several times over by then). Deliberately far longer than the
+/// Codex TTL ([`CODEX_CACHE_MAX_AGE_SECS`]) — Codex is refreshed by the
+/// TUI's own poller, Claude has no in-TUI driver.
+pub const CACHE_MAX_AGE_SECS: u64 = 86_400;
 
 /// Default token cap for the Pro 5-hour window when Tier 2 has to
 /// estimate burn percentage. Override via `AINB_TOKEN_LIMIT`.
@@ -514,14 +518,15 @@ mod tests {
     }
 
     #[test]
-    fn cache_stays_fresh_for_ten_minutes() {
-        // A 5-minute-old cache is fresh — keeps the Claude windows visible
-        // across a normal "tabbed away" gap (would have been stale under the
-        // old 120s window). Guards the 10-minute TTL against accidental revert.
-        assert!(CACHE_MAX_AGE_SECS >= 600, "TTL kept at >= 10 minutes");
+    fn cache_stays_fresh_for_a_day() {
+        // A 12-hour-old cache is still fresh — the statusline only writes
+        // while a Claude session is actively prompting, so anything shorter
+        // blanks the `claude …` cluster across an overnight or Codex-only
+        // gap. Guards the 24-hour TTL against accidental revert.
+        assert!(CACHE_MAX_AGE_SECS >= 86_400, "TTL kept at >= 24 hours");
         let cache = LiveCache {
             version: crate::cli::statusline::CACHE_SCHEMA_VERSION,
-            updated_at: (Utc::now() - chrono::Duration::seconds(300)).to_rfc3339(),
+            updated_at: (Utc::now() - chrono::Duration::hours(12)).to_rfc3339(),
             five_hour: None,
             seven_day: None,
             today_cost_usd: None,
@@ -530,7 +535,7 @@ mod tests {
         };
         assert!(
             cache_is_fresh(&cache),
-            "5-minute-old cache must still be fresh"
+            "12-hour-old cache must still be fresh"
         );
     }
 


### PR DESCRIPTION
## Problem

The `claude 5h NN% · wk NN%` cluster vanished from the TUI top status bar while `codex wk 82%` kept rendering, so the bar looked selectively broken.

Two stacked causes:

1. **TTL too short.** `~/Library/Caches/ainb/live.json` is only rewritten while a Claude Code session is actively prompting. At a 600s TTL any normal idle gap (overnight, a meeting, a stretch of Codex-only work) made the cache stale. Codex was unaffected because the TUI polls its cache itself every ~60s.
2. **A windowless cache shadowed the fallback.** The statusline writer rebuilds the whole cache on every render, so a payload without `rate_limits` writes `five_hour: null, seven_day: null` with a *current* timestamp. `current_tier1` checked only the timestamp, counted that as a hit, and returned early. `push_provider` hides a provider when both windows are `None`, so the whole claude cluster disappeared silently and Tier 2 was never consulted.

Reproduced directly: feeding a rate-limits-free payload to `ainb claudecode statusline --cache-only` writes `{version, updated_at}` with no windows, and the cluster goes.

## Change

- `CACHE_MAX_AGE_SECS` 600 → 86_400. Last-known windows stay on the bar for a day, then drop once the data is meaningless. Codex TTL left at 600s (it has its own in-TUI poller).
- `current_tier1` returns `None` when the cache carries neither window, so Tier 2 gets its chance instead of a day-long blank. Extracted as `cache_has_window` for testability.

## Tests

`cargo test -p ainb --lib live_window` — 21 passed.

- `cache_stays_fresh_for_a_day` (renamed from `cache_stays_fresh_for_ten_minutes`): a 12h-old cache is fresh; guards the TTL against accidental revert.
- `windowless_cache_is_not_a_tier1_hit`: fresh-but-windowless is not a hit; either window alone still counts.

## Not in this PR

Tier 2 (local JSONL) has a separate block-boundary bug from `11a27e00` — feeding `current_active_block` a list already clipped to `now-5h` pins `block.start` to `floor_to_hour(now-5h)`, so the in-block gate reduces to `now <= floor_to_hour(now)` and it returns `None` ~65% of the time. Fixing that on its own branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache freshness handling by extending the Tier 1 cache validity period to 24 hours.
  * Prevented caches without quota window information from being used, allowing fallback processing when needed.
  * Added coverage for cache expiration and missing quota window scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->