### PR TITLE
fix(fleet): unblock main — restore offline guard and fix interview pointer geometry

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3296,6 +3296,22 @@ impl EventHandler {
                 expected_version,
                 action,
             } => {
+                // An Offline daemon means the stream is down and cached rows are
+                // only good for "safe inspection" (see FleetDaemonHealth), which
+                // is exactly what the panel banner promises the user. Destructive
+                // and structured actions must not dispatch against that stale
+                // view. F5 / Ctrl-R force-refreshes back to Online, which is the
+                // intended way out of this state.
+                if action.is_high_risk() && !state.fleet_panel_state.daemon_online() {
+                    Self::reduce_fleet_event(
+                        state,
+                        FleetEvent::ActionFailed {
+                            session_key,
+                            detail: "Fleet daemon offline, high-risk action disabled".into(),
+                        },
+                    );
+                    return;
+                }
                 let action_label = match &action {
                     FleetAction::StructuredAnswer { .. } => "answered ask",
                     FleetAction::DismissStructured { .. } => "rejected interview",

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -2083,7 +2083,12 @@ mod tests {
         // An ATC-managed session appends one event line.
         // Stamp a transcript_path + the PreToolUse matcher into the payload to
         // assert they land in the canonical line.
-        let payload = r#"{"transcript_path":"/t/atc.jsonl","tool_name":"AskUserQuestion"}"#;
+        //
+        // Deliberately a NON-structured matcher: PreToolUse(AskUserQuestion) is
+        // fenced onto the structured-ask path, which appends only once the
+        // broker registers, and is covered by its own fail-open tests. This test
+        // is about the canonical line shape, not about that fence.
+        let payload = r#"{"transcript_path":"/t/atc.jsonl","tool_name":"Bash"}"#;
         hook_core(
             home.path(),
             "PreToolUse",
@@ -2093,7 +2098,7 @@ mod tests {
             None,
             7,
             payload,
-            Some("AskUserQuestion"),
+            Some("Bash"),
         )
         .unwrap();
         let lines = read_event_lines(home.path());
@@ -2101,7 +2106,7 @@ mod tests {
         let l = &lines[0];
         assert_eq!(l["session_id"], "atc-sid");
         assert_eq!(l["event_type"], "PreToolUse");
-        assert_eq!(l["matcher"], "AskUserQuestion");
+        assert_eq!(l["matcher"], "Bash");
         assert_eq!(l["transcript_path"], "/t/atc.jsonl");
         assert_eq!(l["agent"], "claude");
         assert_eq!(l["ts"], 7);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -3050,7 +3050,11 @@ fn answer_card_hit(
             }
             return Some(AnswerCardHit::Question(question_index));
         }
-        top = card_bottom.saturating_add(2);
+        // Cards render back-to-back with no blank row between them (the render
+        // loop advances to `bottom + 1`). Advancing by 2 here invented a gap, so
+        // every card below the first mapped clicks one row lower than it drew —
+        // clicking a visible option did nothing, and the row under it selected.
+        top = card_bottom.saturating_add(1);
     }
     None
 }
@@ -3060,7 +3064,9 @@ fn interview_card_view_start(answer: &AnswerState, width: u16, available_height:
     let mut used = interview_card_height(answer, first, width);
     while first > 0 {
         let candidate = first - 1;
-        let candidate_height = interview_card_height(answer, candidate, width).saturating_add(1);
+        // No inter-card gap — see `answer_card_hit`. Reserving one here made a
+        // prior completed card drop out of view a row before it had to.
+        let candidate_height = interview_card_height(answer, candidate, width);
         if used.saturating_add(candidate_height) > available_height {
             break;
         }
@@ -5031,11 +5037,14 @@ mod tests {
             },
         )
         .state;
+        // Q2's first option row. Every question carries an appended
+        // "Type your own answer" option (plus its description line), so each
+        // card is two rows taller than the option list alone implies.
         state = apply(
             &state,
             FleetEvent::AnswerCardClick {
                 column: 10,
-                row: 15,
+                row: 16,
                 area_width: 120,
                 area_height: 30,
             },


### PR DESCRIPTION
`Test (ubuntu-latest)` and `Test (macos-latest)` are required checks and have
been red on `main`, blocking every PR. Four tests were failing. Three of them
were real bugs, not stale tests.

### 1. Offline high-risk guard was deleted (regression)
`7640cf38` removed the guard from the host dispatch path but left the test.
Kill / Restart / Stop / Archive were dispatched against a stale cached view
while the panel banner says "high-risk actions disabled" and
`FleetDaemonHealth::Offline` documents cached rows as good only for "safe
inspection". Restored; F5 / Ctrl-R force-refresh is the intended way back to
Online.

### 2 & 3. Interview pointer geometry was off by one (user-visible bug)
Cards render back-to-back, but `answer_card_hit` and
`interview_card_view_start` both reserved a blank row between them. Every card
below the first mapped clicks one row low, so clicking a **visible** option did
nothing and the row beneath it selected that option instead. The same phantom
row also dropped a prior completed card out of view early.

This pre-dates `be0dd4b6` — the old test had encoded the buggy hit-test
geometry, so it passed while the UI was wrong. `be0dd4b6` changed card heights
and exposed it.

### 4. ATC event-line test was genuinely stale
`6bdc1d43` deliberately fenced `PreToolUse(AskUserQuestion)` onto the structured
broker path, which appends only after the broker registers (covered by its own
fail-open tests). The test only wants to assert the canonical line shape, so it
now uses a matcher that isn't diverted by that fence.

### Verification
- `ainb-plugin-hangar` lib suite: 490/490 pass
- All four target tests pass locally
- Root causes located by `git bisect run` (hangar) and by running the ATC test at
  `6bdc1d43~1` (passes) vs HEAD (fails), rather than inferred from diffs
- `cargo fmt --all --check` clean

Two tests fail locally on macOS but passed in CI before these changes and are
untouched by this diff: `ask_hook_returns_complete_structured_answer_without_text_routing`
(passes alone in 0.07s, blocks on the broker deadline under module-parallel runs)
and `resume_command_tmux::sessions_live_on_a_private_tmux_server_not_the_ambient_one`.
Flagging rather than hiding them; CI is the arbiter.

https://claude.ai/code/session_015n6rRJneeBnHxg4ARGrZPJ