### PR TITLE
fix(fleet): make notch controls usable

### DIFF
--- a/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
+++ b/apps/ainb-fleet-macos/Sources/App/AINBFleetApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 
@@ -62,5 +63,11 @@ struct AINBFleetApp: App {
 
     var body: some Scene {
         Settings { EmptyView() }
+            .commands {
+                CommandGroup(replacing: .appTermination) {
+                    Button("Quit Fleet") { NSApp.terminate(nil) }
+                        .keyboardShortcut("q", modifiers: .command)
+                }
+            }
     }
 }

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -68,7 +68,7 @@ final class FleetDesktopController: NSObject {
                     defer: false
                 )
             } else {
-                panel = NSPanel(
+                panel = FleetNotchPanel(
                     contentRect: NSRect(origin: .zero, size: size),
                     styleMask: [.borderless, .nonactivatingPanel],
                     backing: .buffered,
@@ -80,6 +80,7 @@ final class FleetDesktopController: NSObject {
             panel.hasShadow = false
             panel.level = FleetAppConfiguration.isUITest ? .floating : .statusBar
             panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            (panel as? NSPanel)?.becomesKeyOnlyIfNeeded = true
             let contentView = NSHostingView(rootView: FleetNotchView(
                 store: store,
                 presentation: presentation,

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -234,8 +234,11 @@ private struct FleetNotchView: View {
                         Label(presentation.preferences.filters.focus.label, systemImage: "line.3.horizontal.decrease.circle")
                     }
                     .accessibilityIdentifier("fleet.notch.focus-filter")
-                    Button(action: toggleExpanded) { Image(systemName: "xmark") }
-                        .accessibilityLabel("Close Fleet controls")
+                    Button(action: quit) {
+                        Label("Quit", systemImage: "xmark")
+                    }
+                    .accessibilityIdentifier("fleet.notch.quit")
+                    .accessibilityLabel("Quit Fleet")
                 }
 
                 Picker("Fleet view", selection: $navigation.route) {
@@ -350,11 +353,19 @@ private struct FleetNotchView: View {
         withAnimation(.easeInOut(duration: 0.16)) { navigation.isExpanded.toggle() }
     }
 
+    private func quit() {
+        NSApp.terminate(nil)
+    }
+
     private func selectFirstVisibleSession() {
         guard !routedSessions.contains(where: { $0.sessionKey == store.selectedSessionKey }) else { return }
         store.selectedSessionKey = routedSessions.first?.sessionKey
     }
 
+}
+
+private final class FleetNotchPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
 }
 
 private enum FleetNotchGeometry {

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetRosterPresentation.swift
@@ -117,7 +117,16 @@ enum FleetRosterPresentation {
 
     static func matches(_ session: FleetSession, search: String, filters: FleetRosterFilters) -> Bool {
         let query = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let searchable = [session.sessionKey, session.displayName ?? "", session.cwd, session.provider.rawValue]
+        let identity = sessionIdentity(for: session)
+        let searchable = [
+            session.sessionKey,
+            session.displayName ?? "",
+            session.cwd,
+            session.provider.rawValue,
+            identity.repository,
+            identity.worktree ?? "",
+            identity.branch ?? "",
+        ]
         return (query.isEmpty || searchable.contains { $0.lowercased().contains(query) })
             && filters.focus.matches(session)
             && (!filters.attentionOnly || session.attention != .none)

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetRosterPresentationTests.swift
@@ -12,10 +12,17 @@ final class FleetRosterPresentationTests: XCTestCase {
         XCTAssertEqual(FleetRosterPresentation.visibleSessions(sessions, search: "", filters: .all).map(\.sessionKey), ["attention", "running-new", "running-old", "idle"])
     }
 
-    func testOnlyCanonicalFieldsParticipateInSearchAndFilters() {
-        let value = session(key: "codex-1", lifecycle: .running, attention: .approval)
+    func testSearchIncludesSessionIdentityAndCanonicalFields() {
+        let value = session(
+            key: "codex-1",
+            lifecycle: .running,
+            cwd: "/Users/stevie/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-minor-bugs--abcd",
+            attention: .approval
+        )
         XCTAssertTrue(FleetRosterPresentation.matches(value, search: "codex", filters: .attentionOnly))
-        XCTAssertTrue(FleetRosterPresentation.matches(value, search: "/workspace", filters: .all))
+        XCTAssertTrue(FleetRosterPresentation.matches(value, search: "/users/stevie", filters: .all))
+        XCTAssertTrue(FleetRosterPresentation.matches(value, search: "agents-in-a-box", filters: .all))
+        XCTAssertTrue(FleetRosterPresentation.matches(value, search: "f/minor-bugs", filters: .all))
         XCTAssertFalse(FleetRosterPresentation.matches(value, search: "request", filters: .all))
     }
 

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -25,6 +25,7 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
         notch.click()
 
         waitFor(app.textFields["fleet.notch.search"])
+        waitFor(app.buttons["fleet.notch.quit"])
         XCTAssertFalse(app.buttons["fleet.notch.show-all"].exists, "separate Fleet window CTA must not exist")
         let screenshot = XCTAttachment(screenshot: app.screenshot())
         screenshot.name = "expanded-notch"


### PR DESCRIPTION
## Summary
- make expanded-notch search accept keyboard input
- match search against repository, worktree, and branch identity
- add explicit Quit Fleet control and Cmd+Q

## Verification
- cargo fmt --all --check
- FleetRosterPresentationTests
- MenuBarRosterJourneyTests/testNotchExpandsToTheOnlyFleetSurface