### PR TITLE
fix(bridge): stop pinning an absolute ainb path in the phone-bridge service unit

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
@@ -21,8 +21,11 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
             // Writing the unit is not the same as being able to start it. Say
             // so at install time rather than leaving the operator to discover
             // a dead bridge from `status` they had no reason to run.
+            // stderr, not `emit`: in --format json the result must stay a
+            // single document on stdout, and a warning is not the result.
+            // Matches how `fleet atc setup` surfaces the same condition.
             if let Some(warning) = crate::fleet::bridge::install_would_be_unrunnable() {
-                emit(format, &format!("warning: {warning}"));
+                eprintln!("warning: {warning}");
             }
             Ok(())
         }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
@@ -18,6 +18,12 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
                 format,
                 &format!("phone bridge installed: {}", path.display()),
             );
+            // Writing the unit is not the same as being able to start it. Say
+            // so at install time rather than leaving the operator to discover
+            // a dead bridge from `status` they had no reason to run.
+            if let Some(warning) = crate::fleet::bridge::install_would_be_unrunnable() {
+                emit(format, &format!("warning: {warning}"));
+            }
             Ok(())
         }
         Some(("uninstall", _)) => {

--- a/ainb-tui/crates/ainb-core/src/fleet/atc/timer.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/atc/timer.rs
@@ -72,6 +72,13 @@ fn build_plist_with(bin: &str, path: &str, meta: &AtcMeta) -> String {
     let argv = heartbeat_argv_with(bin, &meta.name);
     let home = dirs::home_dir().map(|p| p.display().to_string()).unwrap_or_default();
     let log = home_log_path(&meta.name);
+    // Escaped like `args_xml` below. A PATH or HOME containing `&` or `<` (an
+    // `R&D` directory is enough) otherwise emits malformed XML that launchctl
+    // refuses, while the substring health parser still finds an intact
+    // ProgramArguments array and calls the dead timer healthy.
+    let path = xml_escape(&path);
+    let home = xml_escape(&home);
+    let log = xml_escape(&log);
 
     let args_xml: String = argv
         .iter()

--- a/ainb-tui/crates/ainb-core/src/fleet/atc/timer.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/atc/timer.rs
@@ -16,41 +16,22 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 
 use crate::fleet::atc::meta::AtcMeta;
+use crate::fleet::unit_program;
+// Choosing the binary, wrapping it in a shell, and parsing it back out to
+// check it resolves are shared with the phone-bridge service unit, which had
+// the identical defect (#608). Re-exported so `installed_program_health`'s
+// return type stays reachable as `timer::ProgramHealth`.
+pub use crate::fleet::unit_program::ProgramHealth;
 
 /// launchd label / systemd unit stem for an instance.
 fn unit_stem(name: &str) -> String {
     format!("com.agentsinabox.atc.{name}")
 }
 
-/// A path that is guaranteed present and never moves, used to reach a binary
-/// whose location is not.
-const SHELL: &str = "/bin/sh";
-
-/// Resolve the `ainb` binary for the timer command.
-///
-/// Deliberately NOT `current_exe()`: that freezes an absolute path (e.g.
-/// `~/.cargo/bin/ainb`) into the unit forever, so a later `brew install ainb`
-/// leaves the scheduler exec'ing a path that no longer exists (exit 78
-/// `EX_CONFIG`, penalty box, heartbeat silently dead). `ainb` stays a bare name
-/// here and is resolved by the shell at every firing, against the `PATH` the
-/// unit carries. `$AINB_BIN` is the explicit override for installs that are not
-/// on `PATH`.
+/// Resolve the `ainb` binary for the timer command. See
+/// [`unit_program::ainb_bin_from`] for why this is never `current_exe()`.
 fn ainb_bin() -> String {
-    ainb_bin_from(std::env::var("AINB_BIN").ok().as_deref())
-}
-
-fn ainb_bin_from(override_var: Option<&str>) -> String {
-    match override_var {
-        Some(b) if !b.is_empty() => b.to_string(),
-        _ => "ainb".to_string(),
-    }
-}
-
-/// The `PATH` written into the unit, and therefore the one the shell resolves a
-/// bare `ainb` against at firing time.
-fn unit_path_env() -> String {
-    std::env::var("PATH")
-        .unwrap_or_else(|_| "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".into())
+    unit_program::ainb_bin_from(std::env::var("AINB_BIN").ok().as_deref())
 }
 
 /// The heartbeat command argv the timer runs.
@@ -66,14 +47,7 @@ fn unit_path_env() -> String {
 /// which is the whole point: the heartbeat survives a cargo-to-homebrew move
 /// with no reinstall.
 fn heartbeat_argv_with(bin: &str, name: &str) -> Vec<String> {
-    let command = [bin, "fleet", "atc", "heartbeat", name]
-        .iter()
-        .map(|a| shell_quote(a))
-        .collect::<Vec<_>>()
-        .join(" ");
-    // `exec` so the shell replaces itself with ainb rather than lingering as a
-    // parent for the life of the heartbeat.
-    vec![SHELL.into(), "-c".into(), format!("exec {command}")]
+    unit_program::shell_wrapped_argv(bin, &["fleet", "atc", "heartbeat", name])
 }
 
 // --- macOS launchd ----------------------------------------------------------
@@ -90,7 +64,7 @@ pub fn launchd_plist_path(name: &str) -> Result<PathBuf> {
 /// Build the launchd plist XML for the heartbeat timer (`StartInterval`).
 #[must_use]
 pub fn build_plist(meta: &AtcMeta) -> String {
-    build_plist_with(&ainb_bin(), &unit_path_env(), meta)
+    build_plist_with(&ainb_bin(), &unit_program::unit_path_env(), meta)
 }
 
 fn build_plist_with(bin: &str, path: &str, meta: &AtcMeta) -> String {
@@ -160,13 +134,13 @@ fn systemd_user_dir() -> Result<PathBuf> {
 /// Build the systemd service unit (the oneshot that fires one heartbeat).
 #[must_use]
 pub fn build_systemd_service(meta: &AtcMeta) -> String {
-    build_systemd_service_with(&ainb_bin(), &unit_path_env(), meta)
+    build_systemd_service_with(&ainb_bin(), &unit_program::unit_path_env(), meta)
 }
 
 fn build_systemd_service_with(bin: &str, path: &str, meta: &AtcMeta) -> String {
     let argv = heartbeat_argv_with(bin, &meta.name)
         .iter()
-        .map(|a| shell_quote(a))
+        .map(|a| unit_program::shell_quote(a))
         .collect::<Vec<_>>()
         .join(" ");
     // ExecStart is an absolute /bin/sh, so systemd's fixed compile-time binary
@@ -232,7 +206,7 @@ pub fn install_would_be_unrunnable(meta: &AtcMeta) -> Option<String> {
     } else {
         build_systemd_service(meta)
     };
-    match unit_program_health(&unit) {
+    match unit_program::unit_program_health(&unit) {
         ProgramHealth::Missing(p) => Some(format!(
             "'{p}' is not on the PATH the timer will run with, so the heartbeat cannot fire. \
              Install ainb somewhere on PATH, or set AINB_BIN to its full path and re-run setup."
@@ -260,44 +234,6 @@ pub fn is_installed(name: &str) -> bool {
     }
 }
 
-/// What `atc status` needs to know about the program an installed unit will try
-/// to run. Every variant is distinct on purpose: an unreadable or unrecognised
-/// unit is NOT the same as a healthy one, and reporting it as healthy is the
-/// exact false positive this whole check exists to remove.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ProgramHealth {
-    /// No unit installed for this instance.
-    NoUnit,
-    /// The unit's program resolves; the timer can fire.
-    Resolves(String),
-    /// The unit's program does not resolve; the timer can never fire.
-    Missing(String),
-    /// The unit exists but could not be read or understood, so its health is
-    /// unknown and must not be reported as good.
-    Unreadable(String),
-}
-
-impl ProgramHealth {
-    /// The program path, when one could be parsed out of the unit.
-    #[must_use]
-    pub fn program(&self) -> Option<&str> {
-        match self {
-            Self::Resolves(p) | Self::Missing(p) => Some(p),
-            Self::NoUnit | Self::Unreadable(_) => None,
-        }
-    }
-
-    /// A short note for the status line, when something is wrong.
-    #[must_use]
-    pub fn problem(&self) -> Option<String> {
-        match self {
-            Self::Missing(p) => Some(format!("program MISSING ({p})")),
-            Self::Unreadable(why) => Some(format!("program UNKNOWN ({why})")),
-            Self::NoUnit | Self::Resolves(_) => None,
-        }
-    }
-}
-
 /// Health of the program the installed unit for `name` would run.
 pub fn installed_program_health(name: &str) -> ProgramHealth {
     let unit = if cfg!(target_os = "macos") {
@@ -312,123 +248,9 @@ pub fn installed_program_health(name: &str) -> ProgramHealth {
         return ProgramHealth::NoUnit;
     }
     match std::fs::read_to_string(&unit) {
-        Ok(text) => unit_program_health(&text),
+        Ok(text) => unit_program::unit_program_health(&text),
         Err(e) => ProgramHealth::Unreadable(format!("cannot read {}: {e}", unit.display())),
     }
-}
-
-/// Health of the program a unit's text describes.
-fn unit_program_health(text: &str) -> ProgramHealth {
-    let Some(argv) = unit_argv(text) else {
-        return ProgramHealth::Unreadable("unrecognised unit shape".into());
-    };
-    let Some(program) = program_from_argv(&argv) else {
-        return ProgramHealth::Unreadable("no program in unit".into());
-    };
-    if program_resolves_in(&program, unit_search_path(text).as_deref()) {
-        ProgramHealth::Resolves(program)
-    } else {
-        ProgramHealth::Missing(program)
-    }
-}
-
-/// The full argv a unit will run: launchd's `ProgramArguments` array, or the
-/// tokens of a systemd `ExecStart=` line.
-fn unit_argv(text: &str) -> Option<Vec<String>> {
-    plist_program_arguments(text).or_else(|| systemd_exec_start_argv(text))
-}
-
-/// The binary whose availability actually decides whether the timer can fire.
-///
-/// Units are written as `/bin/sh -c "exec ainb ..."`, so `argv[0]` is the shell
-/// and tells us nothing; the interesting name is the first word of the script.
-/// Units written before that change (`ainb ...` directly) are still understood,
-/// so a status call against an old unit reports on the right binary.
-fn program_from_argv(argv: &[String]) -> Option<String> {
-    let first = argv.first()?;
-    if is_shell(first) {
-        if let Some(script) = argv.iter().skip(1).find(|a| !a.starts_with('-')) {
-            let tokens = shell_split(script);
-            let head = tokens.iter().find(|t| *t != "exec")?;
-            return Some(head.clone());
-        }
-    }
-    Some(first.clone())
-}
-
-fn is_shell(program: &str) -> bool {
-    matches!(
-        std::path::Path::new(program).file_name().and_then(|n| n.to_str()),
-        Some("sh" | "bash" | "zsh" | "dash")
-    )
-}
-
-/// The `PATH` the unit itself carries, which is what the shell resolves a bare
-/// program against. NOT the `PATH` of whoever is running `atc status`.
-fn unit_search_path(text: &str) -> Option<String> {
-    plist_string_after_key(text, "PATH").or_else(|| systemd_environment_path(text))
-}
-
-/// Whether a unit's program resolves to something executable. An explicit path
-/// is checked directly; a bare name is looked up under `search_path` (the
-/// unit's own `PATH`), falling back to the caller's `$PATH` when the unit
-/// carries none.
-///
-/// `which` rather than `Path::exists()` on purpose: `exists()` is true for a
-/// directory or a non-executable file, either of which would let a bogus
-/// `$AINB_BIN` report healthy while the scheduler cannot exec it.
-fn program_resolves_in(program: &str, search_path: Option<&str>) -> bool {
-    if program.is_empty() {
-        return false;
-    }
-    if program.contains('/') {
-        return which::which(program).is_ok();
-    }
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
-    search_path.map_or_else(
-        || which::which(program).is_ok(),
-        |path| which::which_in(program, Some(path), cwd).is_ok(),
-    )
-}
-
-/// Every `<string>` inside the `ProgramArguments` array of a launchd plist.
-fn plist_program_arguments(xml: &str) -> Option<Vec<String>> {
-    let after_key = xml.split_once("<key>ProgramArguments</key>")?.1;
-    let (array, _) = after_key.split_once("<array>")?.1.split_once("</array>")?;
-    let argv: Vec<String> = array
-        .match_indices("<string>")
-        .filter_map(|(i, _)| {
-            let rest = &array[i + "<string>".len()..];
-            let (value, _) = rest.split_once("</string>")?;
-            Some(xml_unescape(value.trim()))
-        })
-        .collect();
-    (!argv.is_empty()).then_some(argv)
-}
-
-/// The `<string>` value following `<key>{key}</key>` in a launchd plist.
-fn plist_string_after_key(xml: &str, key: &str) -> Option<String> {
-    let after = xml.split_once(&format!("<key>{key}</key>"))?.1;
-    let open = after.split_once("<string>")?.1;
-    let (value, _) = open.split_once("</string>")?;
-    let value = xml_unescape(value.trim());
-    (!value.is_empty()).then_some(value)
-}
-
-/// Tokens of the `ExecStart=` line of a systemd service unit.
-fn systemd_exec_start_argv(unit: &str) -> Option<Vec<String>> {
-    let line = unit.lines().map(str::trim).find_map(|l| l.strip_prefix("ExecStart="))?;
-    let argv = shell_split(line.trim());
-    (!argv.is_empty()).then_some(argv)
-}
-
-/// The `PATH` assignment of a systemd service unit's `Environment=` lines.
-fn systemd_environment_path(unit: &str) -> Option<String> {
-    let value = unit.lines().map(str::trim).find_map(|line| {
-        let assignment = line.strip_prefix("Environment=")?.trim().trim_matches('"');
-        assignment.strip_prefix("PATH=").map(str::to_string)
-    })?;
-    (!value.is_empty()).then_some(value)
 }
 
 fn install_launchd(meta: &AtcMeta) -> Result<Vec<PathBuf>> {
@@ -514,62 +336,6 @@ fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
 
-fn xml_unescape(s: &str) -> String {
-    s.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
-}
-
-/// Inverse of `shell_quote`: split a command line into argv.
-///
-/// Must handle `shell_quote`'s `'\''` escaping, so a path containing an
-/// apostrophe round-trips instead of being truncated at the quote.
-fn shell_split(s: &str) -> Vec<String> {
-    let mut argv = Vec::new();
-    let mut current = String::new();
-    let mut has_token = false;
-    let mut in_quotes = false;
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        match c {
-            '\'' => {
-                in_quotes = !in_quotes;
-                has_token = true;
-            }
-            '\\' if !in_quotes => {
-                if let Some(escaped) = chars.next() {
-                    current.push(escaped);
-                    has_token = true;
-                }
-            }
-            c if c.is_whitespace() && !in_quotes => {
-                if has_token {
-                    argv.push(std::mem::take(&mut current));
-                    has_token = false;
-                }
-            }
-            c => {
-                current.push(c);
-                has_token = true;
-            }
-        }
-    }
-    if has_token {
-        argv.push(current);
-    }
-    argv
-}
-
-fn shell_quote(s: &str) -> String {
-    if s.is_empty() {
-        return "''".into();
-    }
-    if s.chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '-' | '_'))
-    {
-        return s.to_string();
-    }
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -631,20 +397,6 @@ mod tests {
         assert_eq!(xml_escape("a<b>&c"), "a&lt;b&gt;&amp;c");
     }
 
-    #[test]
-    fn shell_quote_wraps_spaces() {
-        assert_eq!(shell_quote("a b"), "'a b'");
-        assert_eq!(shell_quote("plain"), "plain");
-        assert_eq!(shell_quote("/usr/bin/ainb"), "/usr/bin/ainb");
-    }
-
-    #[test]
-    fn ainb_bin_is_bare_unless_explicitly_overridden() {
-        assert_eq!(ainb_bin_from(None), "ainb");
-        assert_eq!(ainb_bin_from(Some("")), "ainb");
-        assert_eq!(ainb_bin_from(Some("/opt/custom/ainb")), "/opt/custom/ainb");
-    }
-
     /// Regression for the 32-day silent outage: `current_exe()` must never be
     /// frozen into a unit. A cargo-installed ainb that later moved to homebrew
     /// left the scheduler exec'ing a path that no longer existed.
@@ -678,109 +430,19 @@ mod tests {
         assert!(service_for("ainb", "/usr/bin").contains("ExecStart=/bin/sh -c "));
     }
 
-    #[test]
-    fn program_from_argv_sees_through_the_shell_wrapper() {
-        let argv = heartbeat_argv_with("ainb", "tower");
-        assert_eq!(program_from_argv(&argv).as_deref(), Some("ainb"));
-
-        let overridden = heartbeat_argv_with("/opt/custom/ainb", "tower");
-        assert_eq!(
-            program_from_argv(&overridden).as_deref(),
-            Some("/opt/custom/ainb")
-        );
-    }
-
-    /// Units written before the shell wrapper existed must still be judged on
-    /// the right binary, not silently reported as unrecognised.
-    #[test]
-    fn program_from_argv_understands_legacy_direct_units() {
-        let legacy: Vec<String> = ["/Users/old/.cargo/bin/ainb", "fleet", "atc", "heartbeat"]
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect();
-        assert_eq!(
-            program_from_argv(&legacy).as_deref(),
-            Some("/Users/old/.cargo/bin/ainb")
-        );
-    }
-
-    /// `shell_split` must be the true inverse of `shell_quote`, including its
-    /// `'\''` escaping, or a path with an apostrophe reports as MISSING while
-    /// the timer is firing perfectly well.
-    #[test]
-    fn shell_split_round_trips_shell_quote() {
-        for original in [
-            "/home/obrien/bin/ainb",
-            "/home/o'brien/bin/ainb",
-            "/opt/my apps/ainb",
-            "plain",
-        ] {
-            let quoted = shell_quote(original);
-            assert_eq!(
-                shell_split(&quoted),
-                vec![original.to_string()],
-                "round trip failed for {original}"
-            );
-        }
-        assert_eq!(
-            shell_split("exec ainb fleet atc heartbeat tower"),
-            vec!["exec", "ainb", "fleet", "atc", "heartbeat", "tower"]
-        );
-    }
-
-    /// The apostrophe case end to end, through both unit flavours.
+    /// The apostrophe case end to end, through both unit flavours: if the
+    /// quoting round trip mangled the path, the reported program would differ
+    /// from `bin` and the timer would be misdiagnosed.
     #[test]
     fn a_path_with_an_apostrophe_survives_the_round_trip() {
         let bin = "/home/o'brien/bin/ainb";
         for unit in [plist_for(bin, "/usr/bin"), service_for(bin, "/usr/bin")] {
-            let argv = unit_argv(&unit).expect("argv");
             assert_eq!(
-                program_from_argv(&argv).as_deref(),
-                Some(bin),
+                unit_program::unit_program_health(&unit),
+                ProgramHealth::Missing(bin.to_string()),
                 "apostrophe path mangled in: {unit}"
             );
         }
-    }
-
-    #[test]
-    fn program_resolution_distinguishes_present_from_moved() {
-        assert!(program_resolves_in("/bin/sh", None));
-        assert!(!program_resolves_in("/nonexistent/cargo/bin/ainb", None));
-        assert!(!program_resolves_in("", None));
-        assert!(program_resolves_in("sh", None));
-        assert!(!program_resolves_in(
-            "ainb-definitely-not-a-real-binary",
-            None
-        ));
-    }
-
-    /// `exists()` would call a directory or a non-executable file healthy; the
-    /// shell cannot exec either, so neither may pass.
-    #[test]
-    fn program_resolution_requires_something_executable() {
-        let dir = std::env::temp_dir();
-        assert!(
-            dir.exists(),
-            "temp dir should exist for the premise to hold"
-        );
-        assert!(!program_resolves_in(&dir.display().to_string(), None));
-
-        let not_executable = dir.join("ainb-timer-test-not-executable");
-        std::fs::write(&not_executable, b"#!/bin/sh\n").expect("write fixture");
-        assert!(!program_resolves_in(
-            &not_executable.display().to_string(),
-            None
-        ));
-        let _ = std::fs::remove_file(&not_executable);
-    }
-
-    /// A bare program must be judged against the PATH the UNIT carries, which
-    /// is what the shell will use, not against whatever `$PATH` the operator
-    /// happens to be running `atc status` with.
-    #[test]
-    fn bare_program_resolves_against_the_units_own_path() {
-        assert!(program_resolves_in("sh", Some("/bin:/usr/bin")));
-        assert!(!program_resolves_in("sh", Some("/nonexistent/bin")));
     }
 
     #[test]
@@ -791,12 +453,10 @@ mod tests {
             service.contains(&format!("Environment=\"PATH={path}\"")),
             "systemd service carries no PATH: {service}"
         );
-        assert_eq!(unit_search_path(&service).as_deref(), Some(path));
-        assert_eq!(
-            unit_search_path(&plist_for("ainb", path)).as_deref(),
-            Some(path)
+        assert!(
+            plist_for("ainb", path).contains(&format!("<string>{path}</string>")),
+            "plist carries no PATH"
         );
-        assert_eq!(unit_search_path("not a unit at all"), None);
     }
 
     /// The status-line decision, over whole units in both flavours: a unit
@@ -806,7 +466,7 @@ mod tests {
         let moved = "/Users/nobody/.cargo/bin/ainb";
         for unit in [plist_for(moved, "/usr/bin"), service_for(moved, "/usr/bin")] {
             assert_eq!(
-                unit_program_health(&unit),
+                unit_program::unit_program_health(&unit),
                 ProgramHealth::Missing(moved.to_string()),
                 "moved binary not flagged: {unit}"
             );
@@ -816,7 +476,7 @@ mod tests {
             service_for("sh", "/bin:/usr/bin"),
         ] {
             assert_eq!(
-                unit_program_health(&unit),
+                unit_program::unit_program_health(&unit),
                 ProgramHealth::Resolves("sh".to_string()),
                 "resolvable binary wrongly flagged: {unit}"
             );
@@ -828,45 +488,12 @@ mod tests {
     #[test]
     fn a_unit_whose_path_cannot_reach_the_binary_is_flagged() {
         assert_eq!(
-            unit_program_health(&plist_for("sh", "/nonexistent/bin")),
+            unit_program::unit_program_health(&plist_for("sh", "/nonexistent/bin")),
             ProgramHealth::Missing("sh".into())
         );
         assert_eq!(
-            unit_program_health(&service_for("sh", "/nonexistent/bin")),
+            unit_program::unit_program_health(&service_for("sh", "/nonexistent/bin")),
             ProgramHealth::Missing("sh".into())
-        );
-    }
-
-    /// An unreadable or unrecognised unit is NOT healthy. Collapsing it into
-    /// the healthy case is the original false positive, reintroduced.
-    #[test]
-    fn an_unparsable_unit_is_never_reported_healthy() {
-        for junk in ["", "not a unit at all", "<plist><dict></dict></plist>"] {
-            let health = unit_program_health(junk);
-            assert!(
-                matches!(health, ProgramHealth::Unreadable(_)),
-                "junk unit reported as {health:?}"
-            );
-            assert!(
-                health.problem().is_some(),
-                "no problem surfaced for junk unit"
-            );
-            assert!(health.program().is_none());
-        }
-    }
-
-    #[test]
-    fn program_health_renders_a_status_note_only_when_something_is_wrong() {
-        assert_eq!(ProgramHealth::NoUnit.problem(), None);
-        assert_eq!(ProgramHealth::Resolves("ainb".into()).problem(), None);
-        assert_eq!(
-            ProgramHealth::Missing("/gone/ainb".into()).problem().as_deref(),
-            Some("program MISSING (/gone/ainb)")
-        );
-        assert!(
-            ProgramHealth::Unreadable("boom".into())
-                .problem()
-                .is_some_and(|p| p.contains("UNKNOWN"))
         );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/atc/timer.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/atc/timer.rs
@@ -244,13 +244,7 @@ pub fn installed_program_health(name: &str) -> ProgramHealth {
     let Ok(unit) = unit else {
         return ProgramHealth::Unreadable("cannot resolve unit path".into());
     };
-    if !unit.exists() {
-        return ProgramHealth::NoUnit;
-    }
-    match std::fs::read_to_string(&unit) {
-        Ok(text) => unit_program::unit_program_health(&text),
-        Err(e) => ProgramHealth::Unreadable(format!("cannot read {}: {e}", unit.display())),
-    }
+    unit_program::unit_program_health_at(&unit)
 }
 
 fn install_launchd(meta: &AtcMeta) -> Result<Vec<PathBuf>> {

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
@@ -108,6 +108,14 @@ pub fn install() -> Result<std::path::PathBuf> {
     service::install()
 }
 
+/// `Some(warning)` when the unit `install` would write names a program that
+/// does not resolve, so the CLI can say so rather than reporting a success
+/// that can never start.
+#[must_use]
+pub fn install_would_be_unrunnable() -> Option<String> {
+    service::install_would_be_unrunnable()
+}
+
 /// Uninstall the bridge service. Returns the removed unit path, if any.
 pub fn uninstall() -> Result<Option<std::path::PathBuf>> {
     service::uninstall()

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
@@ -12,25 +12,33 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
+use crate::fleet::unit_program;
+
 const LABEL: &str = "com.agentsinabox.phone-bridge";
 const SYSTEMD_UNIT: &str = "ainb-phone-bridge.service";
 
 /// Resolved paths used to build the service definition.
 #[derive(Debug, Clone)]
 pub struct ServicePaths {
-    /// Absolute path to the running `ainb` binary (ProgramArguments[0]).
-    pub ainb_bin: PathBuf,
+    /// The `ainb` binary to exec (ProgramArguments[0] / first ExecStart token).
+    /// Bare `ainb` unless `$AINB_BIN` overrides it — see [`resolve_paths`].
+    pub ainb_bin: String,
     /// `~/.agents-in-a-box/phone-bridge.log`.
     pub log_path: PathBuf,
     /// Optional config override to propagate into the unit env.
     pub config_override: Option<String>,
 }
 
-/// Resolve the service paths from the current process. The binary is the
-/// canonical absolute path to the running `ainb` so the service runs the exact
-/// binary the operator installed from.
+/// Resolve the service paths from the current process.
+///
+/// The binary is deliberately NOT `current_exe()`: that freezes a
+/// version-scoped absolute path (`/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb`,
+/// `~/.cargo/bin/ainb`) into the unit, and the next `brew upgrade ainb` deletes
+/// it — launchd then exits 78 `EX_CONFIG` and parks the bridge in the penalty
+/// box forever. Bare `ainb` re-resolves at every launch against the `PATH` the
+/// unit carries; `$AINB_BIN` remains the explicit override. See issue #608.
 pub fn resolve_paths() -> Result<ServicePaths> {
-    let ainb_bin = std::env::current_exe().context("resolving the current ainb binary path")?;
+    let ainb_bin = unit_program::ainb_bin_from(std::env::var("AINB_BIN").ok().as_deref());
     let mut log_path = dirs::home_dir().context("no home directory")?;
     log_path.push(".agents-in-a-box");
     log_path.push("phone-bridge.log");
@@ -45,7 +53,7 @@ pub fn resolve_paths() -> Result<ServicePaths> {
 /// ProgramArguments / ExecStart argv: `<ainb> fleet bridge run`. No token, ever.
 fn daemon_argv(paths: &ServicePaths) -> Vec<String> {
     vec![
-        paths.ainb_bin.to_string_lossy().into_owned(),
+        paths.ainb_bin.clone(),
         "fleet".to_string(),
         "bridge".to_string(),
         "run".to_string(),
@@ -66,8 +74,7 @@ fn launchd_plist_path() -> Result<PathBuf> {
 /// (token never present, argv correct, env scoped).
 #[must_use]
 pub fn build_plist(paths: &ServicePaths) -> String {
-    let path_env = std::env::var("PATH")
-        .unwrap_or_else(|_| "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".to_string());
+    let path_env = unit_program::unit_path_env();
     let home = dirs::home_dir().unwrap_or_default();
     let argv = daemon_argv(paths)
         .into_iter()
@@ -187,6 +194,13 @@ pub fn build_systemd_unit(paths: &ServicePaths) -> String {
         .as_ref()
         .map(|c| format!("Environment=AINB_CONFIG_PATH={c}\n"))
         .unwrap_or_default();
+    // The unit carries its own PATH, exactly as the plist does. Without it a
+    // bare `ainb` would be resolved against systemd's fixed compile-time search
+    // path (/usr/local/bin:/usr/bin:/bin), which misses `~/.cargo/bin` and
+    // `~/.local/bin` — a $PATH supplied via Environment= is what systemd (250+)
+    // searches instead. On older systemd, an install outside the fixed list
+    // needs the explicit $AINB_BIN override; `bridge status` now says so out
+    // loud rather than reporting a unit that can never start as healthy.
     format!(
         "[Unit]\n\
          Description=ainb phone bridge (Telegram + Slack)\n\
@@ -195,6 +209,7 @@ pub fn build_systemd_unit(paths: &ServicePaths) -> String {
          \n\
          [Service]\n\
          Type=simple\n\
+         Environment=\"PATH={path}\"\n\
          {config_env}\
          ExecStart={exec_start}\n\
          Restart=always\n\
@@ -205,6 +220,7 @@ pub fn build_systemd_unit(paths: &ServicePaths) -> String {
          [Install]\n\
          WantedBy=default.target\n",
         log = paths.log_path.display(),
+        path = unit_program::unit_path_env(),
     )
 }
 
@@ -264,30 +280,30 @@ pub fn uninstall() -> Result<Option<PathBuf>> {
 }
 
 /// Human-readable install status for the current platform.
+///
+/// A unit file existing is NOT the same as a working bridge: if the binary it
+/// points at has moved (a `brew upgrade` deleting the old Cellar directory),
+/// launchd exits 78 `EX_CONFIG` and parks the job forever while `installed`
+/// keeps claiming health. So the program is resolved too — see issue #608.
 pub fn status() -> Result<String> {
-    if cfg!(target_os = "macos") {
-        let p = launchd_plist_path()?;
-        Ok(format!(
-            "launchd: {} ({})",
-            if p.exists() {
-                "installed"
-            } else {
-                "not installed"
-            },
-            p.display()
-        ))
+    let (kind, unit) = if cfg!(target_os = "macos") {
+        ("launchd", launchd_plist_path()?)
     } else {
-        let p = systemd_unit_path()?;
-        Ok(format!(
-            "systemd: {} ({})",
-            if p.exists() {
-                "installed"
-            } else {
-                "not installed"
-            },
-            p.display()
-        ))
+        ("systemd", systemd_unit_path()?)
+    };
+    if !unit.exists() {
+        return Ok(format!("{kind}: not installed ({})", unit.display()));
     }
+    let note = std::fs::read_to_string(&unit)
+        .ok()
+        .and_then(|text| unit_program::missing_program(&text))
+        .map_or_else(String::new, |program| {
+            format!(
+                ", program MISSING ({program})\n  \
+                 ↳ the bridge can never start — re-run `ainb fleet bridge install` to repoint it"
+            )
+        });
+    Ok(format!("{kind}: installed ({}){note}", unit.display()))
 }
 
 #[cfg(test)]
@@ -296,7 +312,7 @@ mod tests {
 
     fn paths() -> ServicePaths {
         ServicePaths {
-            ainb_bin: PathBuf::from("/usr/local/bin/ainb"),
+            ainb_bin: "ainb".to_string(),
             log_path: PathBuf::from("/home/u/.agents-in-a-box/phone-bridge.log"),
             config_override: None,
         }
@@ -305,7 +321,7 @@ mod tests {
     #[test]
     fn plist_argv_is_fleet_bridge_run_and_carries_no_token() {
         let xml = build_plist(&paths());
-        assert!(xml.contains("<string>/usr/local/bin/ainb</string>"));
+        assert!(xml.contains("<string>ainb</string>"));
         assert!(xml.contains("<string>fleet</string>"));
         assert!(xml.contains("<string>bridge</string>"));
         assert!(xml.contains("<string>run</string>"));
@@ -337,7 +353,7 @@ mod tests {
     #[test]
     fn systemd_exec_start_is_fleet_bridge_run() {
         let unit = build_systemd_unit(&paths());
-        assert!(unit.contains("ExecStart=/usr/local/bin/ainb fleet bridge run"));
+        assert!(unit.contains("ExecStart=ainb fleet bridge run"));
         assert!(unit.contains("Restart=always"));
         assert!(!unit.to_lowercase().contains("token"));
     }
@@ -348,5 +364,87 @@ mod tests {
         p.config_override = Some("/custom/config.toml".to_string());
         let unit = build_systemd_unit(&p);
         assert!(unit.contains("Environment=AINB_CONFIG_PATH=/custom/config.toml"));
+    }
+
+    /// Regression for issue #608: `ainb fleet bridge install` on a homebrew
+    /// install pinned `/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb` — a
+    /// VERSION directory that the next `brew upgrade` deletes. Nothing derived
+    /// from `current_exe()` may reach a unit.
+    #[test]
+    fn units_do_not_pin_an_absolute_binary_path() {
+        let resolved = resolve_paths().expect("resolve_paths");
+        let plist = build_plist(&resolved);
+        let unit = build_systemd_unit(&resolved);
+
+        let exe = std::env::current_exe().expect("current_exe");
+        let exe = exe.display().to_string();
+        assert!(!plist.contains(&exe), "plist pinned current_exe: {plist}");
+        assert!(
+            !unit.contains(&exe),
+            "systemd unit pinned current_exe: {unit}"
+        );
+
+        // Absent an explicit $AINB_BIN override, argv[0] carries no directory
+        // component at all, so there is no Cellar/cargo prefix to go stale.
+        if std::env::var("AINB_BIN").unwrap_or_default().is_empty() {
+            for text in [&plist, &unit] {
+                let program = unit_program::unit_program(text).expect("argv[0]");
+                assert_eq!(program, "ainb", "argv[0] should be bare, got {program}");
+            }
+        }
+    }
+
+    /// A bare argv[0] is only exec'able if the unit tells the scheduler where
+    /// to look; systemd otherwise searches a fixed compile-time path.
+    #[test]
+    fn units_carry_the_path_their_bare_argv0_needs() {
+        let expected = unit_program::unit_path_env();
+        let unit = build_systemd_unit(&paths());
+        assert!(
+            unit.contains(&format!("Environment=\"PATH={expected}\"")),
+            "systemd unit carries no PATH: {unit}"
+        );
+        assert_eq!(
+            unit_program::unit_search_path(&unit).as_deref(),
+            Some(&*expected)
+        );
+        assert_eq!(
+            unit_program::unit_search_path(&build_plist(&paths())).as_deref(),
+            Some(&*expected)
+        );
+    }
+
+    /// The decision `status()` makes: a unit whose program has moved is
+    /// flagged, a resolvable one is not. Run over whole units in both flavours
+    /// so the bare case is judged against the unit's own PATH.
+    #[test]
+    fn status_flags_a_unit_whose_program_is_missing() {
+        let plist = build_plist(&paths());
+        let unit = build_systemd_unit(&paths());
+        // Substitute argv[0] where it actually sits — bare `ainb` is too short
+        // to replace safely across a whole unit (the log path contains it).
+        let repoint = |text: &str, to: &str| {
+            text.replace("<string>ainb</string>", &format!("<string>{to}</string>"))
+                .replace("ExecStart=ainb ", &format!("ExecStart={to} "))
+        };
+
+        for base in [&plist, &unit] {
+            let stale = repoint(
+                base,
+                "/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb",
+            );
+            assert_eq!(
+                unit_program::missing_program(&stale),
+                Some("/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb".into()),
+                "moved binary not flagged: {stale}"
+            );
+
+            let healthy = repoint(base, "sh");
+            assert_eq!(
+                unit_program::missing_program(&healthy),
+                None,
+                "resolvable binary wrongly flagged: {healthy}"
+            );
+        }
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
@@ -140,11 +140,17 @@ pub fn build_plist(paths: &ServicePaths) -> String {
     )
 }
 
+/// systemd resolves `%` specifiers inside unit values, so a literal `%` in a
+/// PATH or config path has to be doubled or the whole assignment is corrupted.
+fn systemd_escape(s: &str) -> String {
+    s.replace('%', "%%")
+}
+
 fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
 
-fn install_launchd(paths: &ServicePaths) -> Result<PathBuf> {
+fn install_launchd(paths: &ServicePaths, activate: bool) -> Result<PathBuf> {
     let plist_path = launchd_plist_path()?;
     if let Some(parent) = plist_path.parent() {
         std::fs::create_dir_all(parent).ok();
@@ -154,13 +160,17 @@ fn install_launchd(paths: &ServicePaths) -> Result<PathBuf> {
     }
     std::fs::write(&plist_path, build_plist(paths))
         .with_context(|| format!("writing {}", plist_path.display()))?;
-    // Idempotent reload: unload (ignore errors), then load.
+    // Idempotent reload: unload (ignore errors), then load. The unload runs
+    // even when we will not re-load, so a previously-good unit does not keep
+    // running against a definition that has since gone stale.
     let _ = std::process::Command::new("launchctl")
         .args(["unload", &plist_path.to_string_lossy()])
         .output();
-    let _ = std::process::Command::new("launchctl")
-        .args(["load", &plist_path.to_string_lossy()])
-        .output();
+    if activate {
+        let _ = std::process::Command::new("launchctl")
+            .args(["load", &plist_path.to_string_lossy()])
+            .output();
+    }
     Ok(plist_path)
 }
 
@@ -199,13 +209,13 @@ pub fn build_systemd_unit(paths: &ServicePaths) -> String {
     // (which the shell DOES honour) is what finds ainb, at every launch.
     let exec_start = daemon_argv(paths)
         .iter()
-        .map(|a| unit_program::shell_quote(a))
+        .map(|a| systemd_escape(&unit_program::shell_quote(a)))
         .collect::<Vec<_>>()
         .join(" ");
     let config_env = paths
         .config_override
         .as_ref()
-        .map(|c| format!("Environment=AINB_CONFIG_PATH={c}\n"))
+        .map(|c| format!("Environment=\"AINB_CONFIG_PATH={}\"\n", systemd_escape(c)))
         .unwrap_or_default();
     format!(
         "[Unit]\n\
@@ -219,18 +229,18 @@ pub fn build_systemd_unit(paths: &ServicePaths) -> String {
          {config_env}\
          ExecStart={exec_start}\n\
          Restart=always\n\
-         RestartSec=10\n\
+         RestartSec=60\n\
          StandardOutput=append:{log}\n\
          StandardError=append:{log}\n\
          \n\
          [Install]\n\
          WantedBy=default.target\n",
         log = paths.log_path.display(),
-        path = unit_program::unit_path_env(),
+        path = systemd_escape(&unit_program::unit_path_env()),
     )
 }
 
-fn install_systemd(paths: &ServicePaths) -> Result<PathBuf> {
+fn install_systemd(paths: &ServicePaths, activate: bool) -> Result<PathBuf> {
     let unit_path = systemd_unit_path()?;
     if let Some(parent) = unit_path.parent() {
         std::fs::create_dir_all(parent).ok();
@@ -243,9 +253,11 @@ fn install_systemd(paths: &ServicePaths) -> Result<PathBuf> {
     let _ = std::process::Command::new("systemctl")
         .args(["--user", "daemon-reload"])
         .output();
-    let _ = std::process::Command::new("systemctl")
-        .args(["--user", "enable", "--now", SYSTEMD_UNIT])
-        .output();
+    if activate {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "enable", "--now", SYSTEMD_UNIT])
+            .output();
+    }
     Ok(unit_path)
 }
 
@@ -267,12 +279,19 @@ fn teardown_systemd() -> Result<Option<PathBuf>> {
 // ── Public API ──────────────────────────────────────────────────────────────
 
 /// Provision the daemon service for the current platform. Idempotent.
+///
+/// The unit is always written, but it is only STARTED when its program
+/// resolves. Starting one we already know is broken is not harmless: the shell
+/// wrapper means the scheduler spawns successfully and `exec ainb` exits 127,
+/// so `KeepAlive` / `Restart=always` respawn it forever into an unrotated log.
+/// Writing it inactive leaves the operator a unit to reload once PATH is fixed.
 pub fn install() -> Result<PathBuf> {
     let paths = resolve_paths()?;
+    let activate = unit_would_be_unrunnable(&paths).is_none();
     if cfg!(target_os = "macos") {
-        install_launchd(&paths)
+        install_launchd(&paths, activate)
     } else {
-        install_systemd(&paths)
+        install_systemd(&paths, activate)
     }
 }
 
@@ -285,11 +304,14 @@ pub fn install() -> Result<PathBuf> {
 /// [`crate::fleet::atc::timer::install_would_be_unrunnable`].
 #[must_use]
 pub fn install_would_be_unrunnable() -> Option<String> {
-    let paths = resolve_paths().ok()?;
+    unit_would_be_unrunnable(&resolve_paths().ok()?)
+}
+
+fn unit_would_be_unrunnable(paths: &ServicePaths) -> Option<String> {
     let unit = if cfg!(target_os = "macos") {
-        build_plist(&paths)
+        build_plist(paths)
     } else {
-        build_systemd_unit(&paths)
+        build_systemd_unit(paths)
     };
     match unit_program::unit_program_health(&unit) {
         unit_program::ProgramHealth::Missing(p) => Some(format!(
@@ -406,7 +428,7 @@ mod tests {
         let mut p = paths();
         p.config_override = Some("/custom/config.toml".to_string());
         let unit = build_systemd_unit(&p);
-        assert!(unit.contains("Environment=AINB_CONFIG_PATH=/custom/config.toml"));
+        assert!(unit.contains("Environment=\"AINB_CONFIG_PATH=/custom/config.toml\""));
     }
 
     /// Regression for issue #608: `ainb fleet bridge install` on a homebrew
@@ -566,6 +588,29 @@ mod tests {
             !note.contains("can never start"),
             "UNKNOWN must not assert a failure it cannot determine: {note}"
         );
+    }
+
+    /// systemd resolves `%` specifiers inside unit values, and splits an
+    /// unquoted assignment at whitespace. Both would corrupt a real config
+    /// path.
+    #[test]
+    fn systemd_env_assignments_are_quoted_and_percent_escaped() {
+        let mut p = paths();
+        p.config_override = Some("/home/u/My Configs/50%/config.toml".to_string());
+        let unit = build_systemd_unit(&p);
+        assert!(
+            unit.contains("Environment=\"AINB_CONFIG_PATH=/home/u/My Configs/50%%/config.toml\""),
+            "config env not quoted and escaped: {unit}"
+        );
+        // The PATH line gets the same treatment.
+        assert!(!unit.lines().any(|l| l.starts_with("Environment=PATH=")));
+    }
+
+    /// Crash-recovery latency should not silently differ by platform.
+    #[test]
+    fn both_platforms_use_the_same_restart_backoff() {
+        assert!(build_plist(&paths()).contains("<integer>60</integer>"));
+        assert!(build_systemd_unit(&paths()).contains("RestartSec=60"));
     }
 
     /// A stale unit installed by an older ainb has no shell wrapper at all.

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
@@ -20,8 +20,9 @@ const SYSTEMD_UNIT: &str = "ainb-phone-bridge.service";
 /// Resolved paths used to build the service definition.
 #[derive(Debug, Clone)]
 pub struct ServicePaths {
-    /// The `ainb` binary to exec (ProgramArguments[0] / first ExecStart token).
-    /// Bare `ainb` unless `$AINB_BIN` overrides it — see [`resolve_paths`].
+    /// The `ainb` binary the unit's command runs. Bare `ainb` unless
+    /// `$AINB_BIN` overrides it — see [`resolve_paths`]. NOT necessarily
+    /// `argv[0]`: on launchd that is the shell wrapping this command.
     pub ainb_bin: String,
     /// `~/.agents-in-a-box/phone-bridge.log`.
     pub log_path: PathBuf,
@@ -32,11 +33,12 @@ pub struct ServicePaths {
 /// Resolve the service paths from the current process.
 ///
 /// The binary is deliberately NOT `current_exe()`: that freezes a
-/// version-scoped absolute path (`/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb`,
-/// `~/.cargo/bin/ainb`) into the unit, and the next `brew upgrade ainb` deletes
-/// it — launchd then exits 78 `EX_CONFIG` and parks the bridge in the penalty
-/// box forever. Bare `ainb` re-resolves at every launch against the `PATH` the
-/// unit carries; `$AINB_BIN` remains the explicit override. See issue #608.
+/// version-scoped absolute path (a `/opt/homebrew/Cellar/ainb/<version>/libexec`
+/// directory, `~/.cargo/bin/ainb`) into the unit, and the next
+/// `brew upgrade ainb` deletes it — launchd then exits 78 `EX_CONFIG` and parks
+/// the bridge in the penalty box forever. Bare `ainb` is looked up again at
+/// every launch, by the shell the unit runs it through (see [`daemon_argv`]);
+/// `$AINB_BIN` remains the explicit override. See issue #608.
 pub fn resolve_paths() -> Result<ServicePaths> {
     let ainb_bin = unit_program::ainb_bin_from(std::env::var("AINB_BIN").ok().as_deref());
     let mut log_path = dirs::home_dir().context("no home directory")?;
@@ -50,14 +52,19 @@ pub fn resolve_paths() -> Result<ServicePaths> {
     })
 }
 
-/// ProgramArguments / ExecStart argv: `<ainb> fleet bridge run`. No token, ever.
+/// The command the daemon runs: `<ainb> fleet bridge run`. No token, ever.
+const DAEMON_ARGS: [&str; 3] = ["fleet", "bridge", "run"];
+
+/// launchd `ProgramArguments`: `/bin/sh -c "exec <ainb> fleet bridge run"`.
+///
+/// The shell wrapper is load-bearing, not cosmetic. launchd resolves
+/// `ProgramArguments[0]` against its OWN job environment and ignores the
+/// plist's `EnvironmentVariables` PATH entirely, so a bare `ainb` there does
+/// not spawn at all — worse than the pinned path it replaces. Probed against
+/// launchd with this exact plist shape: bare `argv[0]` with the plist PATH set
+/// exits 78 `EX_CONFIG` and never runs, `/bin/sh -c "exec …"` exits 0.
 fn daemon_argv(paths: &ServicePaths) -> Vec<String> {
-    vec![
-        paths.ainb_bin.clone(),
-        "fleet".to_string(),
-        "bridge".to_string(),
-        "run".to_string(),
-    ]
+    unit_program::shell_wrapped_argv(&paths.ainb_bin, &DAEMON_ARGS)
 }
 
 // ── macOS launchd ───────────────────────────────────────────────────────────
@@ -178,15 +185,19 @@ fn systemd_unit_path() -> Result<PathBuf> {
 /// Render the systemd user unit. Public for unit testing.
 #[must_use]
 pub fn build_systemd_unit(paths: &ServicePaths) -> String {
-    let exec_start = daemon_argv(paths)
-        .iter()
-        .map(|a| {
-            if a.contains(char::is_whitespace) {
-                format!("\"{a}\"")
-            } else {
-                a.clone()
-            }
-        })
+    // Unlike launchd, systemd DOES resolve a non-absolute `ExecStart` against
+    // the $PATH the unit supplies via Environment=, so no shell wrapper is
+    // needed here — hence the direct argv rather than `daemon_argv`.
+    //
+    // Caveat, and the reason `bridge status` checks: that is systemd 250+
+    // behaviour. Older systemd searches a fixed compile-time list
+    // (/usr/local/bin:/usr/bin:/bin) that misses `~/.cargo/bin` and
+    // `~/.local/bin`, where an install outside that list needs the explicit
+    // $AINB_BIN override. Status reports such a unit as MISSING rather than
+    // certifying a service that can never start as healthy.
+    let exec_start = std::iter::once(paths.ainb_bin.as_str())
+        .chain(DAEMON_ARGS)
+        .map(unit_program::shell_quote)
         .collect::<Vec<_>>()
         .join(" ");
     let config_env = paths
@@ -194,13 +205,6 @@ pub fn build_systemd_unit(paths: &ServicePaths) -> String {
         .as_ref()
         .map(|c| format!("Environment=AINB_CONFIG_PATH={c}\n"))
         .unwrap_or_default();
-    // The unit carries its own PATH, exactly as the plist does. Without it a
-    // bare `ainb` would be resolved against systemd's fixed compile-time search
-    // path (/usr/local/bin:/usr/bin:/bin), which misses `~/.cargo/bin` and
-    // `~/.local/bin` — a $PATH supplied via Environment= is what systemd (250+)
-    // searches instead. On older systemd, an install outside the fixed list
-    // needs the explicit $AINB_BIN override; `bridge status` now says so out
-    // loud rather than reporting a unit that can never start as healthy.
     format!(
         "[Unit]\n\
          Description=ainb phone bridge (Telegram + Slack)\n\
@@ -294,15 +298,18 @@ pub fn status() -> Result<String> {
     if !unit.exists() {
         return Ok(format!("{kind}: not installed ({})", unit.display()));
     }
-    let note = std::fs::read_to_string(&unit)
-        .ok()
-        .and_then(|text| unit_program::missing_program(&text))
-        .map_or_else(String::new, |program| {
-            format!(
-                ", program MISSING ({program})\n  \
-                 ↳ the bridge can never start — re-run `ainb fleet bridge install` to repoint it"
-            )
-        });
+    let health = match std::fs::read_to_string(&unit) {
+        Ok(text) => unit_program::unit_program_health(&text),
+        Err(e) => {
+            unit_program::ProgramHealth::Unreadable(format!("cannot read {}: {e}", unit.display()))
+        }
+    };
+    let note = health.problem().map_or_else(String::new, |problem| {
+        format!(
+            ", {problem}\n  \
+             ↳ the bridge can never start — re-run `ainb fleet bridge install` to repoint it"
+        )
+    });
     Ok(format!("{kind}: installed ({}){note}", unit.display()))
 }
 
@@ -318,13 +325,16 @@ mod tests {
         }
     }
 
+    /// A Cellar path for a version that cannot be installed, so the "moved
+    /// binary" assertions never depend on what this host happens to have.
+    const GONE: &str = "/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb";
+
     #[test]
     fn plist_argv_is_fleet_bridge_run_and_carries_no_token() {
         let xml = build_plist(&paths());
-        assert!(xml.contains("<string>ainb</string>"));
-        assert!(xml.contains("<string>fleet</string>"));
-        assert!(xml.contains("<string>bridge</string>"));
-        assert!(xml.contains("<string>run</string>"));
+        assert!(xml.contains("<string>/bin/sh</string>"));
+        assert!(xml.contains("<string>-c</string>"));
+        assert!(xml.contains("<string>exec ainb fleet bridge run</string>"));
         // No token leakage: nothing token-ish in the rendered plist.
         let lower = xml.to_lowercase();
         assert!(!lower.contains("token"), "plist must never embed a token");
@@ -367,9 +377,9 @@ mod tests {
     }
 
     /// Regression for issue #608: `ainb fleet bridge install` on a homebrew
-    /// install pinned `/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb` — a
-    /// VERSION directory that the next `brew upgrade` deletes. Nothing derived
-    /// from `current_exe()` may reach a unit.
+    /// install pinned the Cellar VERSION directory, which the next
+    /// `brew upgrade` deletes. Nothing derived from `current_exe()` may reach
+    /// a unit.
     #[test]
     fn units_do_not_pin_an_absolute_binary_path() {
         let resolved = resolve_paths().expect("resolve_paths");
@@ -384,33 +394,54 @@ mod tests {
             "systemd unit pinned current_exe: {unit}"
         );
 
-        // Absent an explicit $AINB_BIN override, argv[0] carries no directory
-        // component at all, so there is no Cellar/cargo prefix to go stale.
+        // Absent an explicit $AINB_BIN override, the program the unit actually
+        // runs carries no directory component, so there is no Cellar/cargo
+        // prefix that a later upgrade can invalidate.
         if std::env::var("AINB_BIN").unwrap_or_default().is_empty() {
             for text in [&plist, &unit] {
-                let program = unit_program::unit_program(text).expect("argv[0]");
-                assert_eq!(program, "ainb", "argv[0] should be bare, got {program}");
+                let program = unit_program::unit_program_health(text)
+                    .program()
+                    .map(str::to_string)
+                    .expect("program");
+                assert_eq!(program, "ainb", "program should be bare, got {program}");
             }
         }
     }
 
-    /// A bare argv[0] is only exec'able if the unit tells the scheduler where
-    /// to look; systemd otherwise searches a fixed compile-time path.
+    /// launchd will NOT PATH-search `ProgramArguments[0]`; it resolves it
+    /// against its own job environment and ignores the plist's
+    /// `EnvironmentVariables` PATH. So the plist must hand it an absolute
+    /// `/bin/sh` and let the shell — which does honour PATH — find `ainb`.
+    /// A bare `ainb` here would not spawn at all.
     #[test]
-    fn units_carry_the_path_their_bare_argv0_needs() {
+    fn launchd_gets_an_absolute_program_and_defers_lookup_to_the_shell() {
+        let plist = build_plist(&paths());
+        let argv0 = plist
+            .split_once("<key>ProgramArguments</key>")
+            .and_then(|(_, rest)| rest.split_once("<string>"))
+            .and_then(|(_, rest)| rest.split_once("</string>"))
+            .map(|(v, _)| v.trim().to_string())
+            .expect("argv[0]");
+        assert_eq!(argv0, "/bin/sh");
+        assert!(
+            std::path::Path::new(&argv0).is_absolute(),
+            "launchd cannot spawn a non-absolute argv[0]"
+        );
+        // And the PATH the shell will use is still written into the plist.
+        assert!(plist.contains("<key>PATH</key>"));
+    }
+
+    /// systemd, unlike launchd, DOES resolve a non-absolute `ExecStart`
+    /// against the `$PATH` the unit supplies, so no shell wrapper is needed —
+    /// but the unit must actually supply that PATH.
+    #[test]
+    fn systemd_unit_carries_the_path_its_bare_exec_start_needs() {
         let expected = unit_program::unit_path_env();
         let unit = build_systemd_unit(&paths());
+        assert!(unit.contains("ExecStart=ainb fleet bridge run"));
         assert!(
             unit.contains(&format!("Environment=\"PATH={expected}\"")),
             "systemd unit carries no PATH: {unit}"
-        );
-        assert_eq!(
-            unit_program::unit_search_path(&unit).as_deref(),
-            Some(&*expected)
-        );
-        assert_eq!(
-            unit_program::unit_search_path(&build_plist(&paths())).as_deref(),
-            Some(&*expected)
         );
     }
 
@@ -419,32 +450,63 @@ mod tests {
     /// so the bare case is judged against the unit's own PATH.
     #[test]
     fn status_flags_a_unit_whose_program_is_missing() {
-        let plist = build_plist(&paths());
-        let unit = build_systemd_unit(&paths());
-        // Substitute argv[0] where it actually sits — bare `ainb` is too short
-        // to replace safely across a whole unit (the log path contains it).
-        let repoint = |text: &str, to: &str| {
-            text.replace("<string>ainb</string>", &format!("<string>{to}</string>"))
-                .replace("ExecStart=ainb ", &format!("ExecStart={to} "))
+        use unit_program::ProgramHealth;
+
+        // Repoint the binary at the one place it appears in each flavour: the
+        // shell command string for launchd, the ExecStart line for systemd.
+        let repoint = |to: &str| {
+            let mut p = paths();
+            p.ainb_bin = to.to_string();
+            [build_plist(&p), build_systemd_unit(&p)]
         };
 
-        for base in [&plist, &unit] {
-            let stale = repoint(
-                base,
-                "/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb",
-            );
+        for stale in repoint(GONE) {
             assert_eq!(
-                unit_program::missing_program(&stale),
-                Some("/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb".into()),
+                unit_program::unit_program_health(&stale),
+                ProgramHealth::Missing(GONE.into()),
                 "moved binary not flagged: {stale}"
             );
-
-            let healthy = repoint(base, "sh");
+        }
+        // `ls`, not `sh`: a shell name is treated as a wrapper and unwrapped,
+        // so it cannot stand in for an ordinary resolvable binary here.
+        for healthy in repoint("ls") {
             assert_eq!(
-                unit_program::missing_program(&healthy),
-                None,
+                unit_program::unit_program_health(&healthy),
+                ProgramHealth::Resolves("ls".into()),
                 "resolvable binary wrongly flagged: {healthy}"
             );
         }
+    }
+
+    /// The wrapper must not become a blindfold: `/bin/sh` always resolves, so
+    /// a detector reading `argv[0]` would certify every broken bridge as
+    /// healthy — the exact bug class #608 is about.
+    #[test]
+    fn the_shell_wrapper_does_not_hide_a_dead_binary_from_status() {
+        let mut p = paths();
+        p.ainb_bin = GONE.to_string();
+        let plist = build_plist(&p);
+        assert!(
+            plist.contains("<string>/bin/sh</string>"),
+            "premise: {plist}"
+        );
+        assert_eq!(
+            unit_program::unit_program_health(&plist).program(),
+            Some(GONE)
+        );
+    }
+
+    /// A stale unit installed by an older ainb has no shell wrapper at all.
+    /// It must still be judged on its pinned binary, not reported unreadable.
+    #[test]
+    fn a_legacy_unwrapped_unit_is_still_flagged() {
+        let legacy = format!(
+            "<key>ProgramArguments</key>\n<array>\n\t<string>{GONE}</string>\n\t\
+             <string>fleet</string>\n\t<string>bridge</string>\n\t<string>run</string>\n</array>"
+        );
+        assert_eq!(
+            unit_program::unit_program_health(&legacy),
+            unit_program::ProgramHealth::Missing(GONE.into())
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
@@ -21,7 +21,7 @@ const SYSTEMD_UNIT: &str = "ainb-phone-bridge.service";
 #[derive(Debug, Clone)]
 pub struct ServicePaths {
     /// The `ainb` binary the unit's command runs. Bare `ainb` unless
-    /// `$AINB_BIN` overrides it — see [`resolve_paths`]. NOT necessarily
+    /// `$AINB_BIN` overrides it, see [`resolve_paths`]. NOT necessarily
     /// `argv[0]`: on launchd that is the shell wrapping this command.
     pub ainb_bin: String,
     /// `~/.agents-in-a-box/phone-bridge.log`.
@@ -35,7 +35,7 @@ pub struct ServicePaths {
 /// The binary is deliberately NOT `current_exe()`: that freezes a
 /// version-scoped absolute path (a `/opt/homebrew/Cellar/ainb/<version>/libexec`
 /// directory, `~/.cargo/bin/ainb`) into the unit, and the next
-/// `brew upgrade ainb` deletes it — launchd then exits 78 `EX_CONFIG` and parks
+/// `brew upgrade ainb` deletes it, so launchd exits 78 `EX_CONFIG` and parks
 /// the bridge in the penalty box forever. Bare `ainb` is looked up again at
 /// every launch, by the shell the unit runs it through (see [`daemon_argv`]);
 /// `$AINB_BIN` remains the explicit override. See issue #608.
@@ -60,7 +60,7 @@ const DAEMON_ARGS: [&str; 3] = ["fleet", "bridge", "run"];
 /// The shell wrapper is load-bearing, not cosmetic. launchd resolves
 /// `ProgramArguments[0]` against its OWN job environment and ignores the
 /// plist's `EnvironmentVariables` PATH entirely, so a bare `ainb` there does
-/// not spawn at all — worse than the pinned path it replaces. Probed against
+/// not spawn at all, which is worse than the pinned path it replaces. Probed against
 /// launchd with this exact plist shape: bare `argv[0]` with the plist PATH set
 /// exits 78 `EX_CONFIG` and never runs, `/bin/sh -c "exec …"` exits 0.
 fn daemon_argv(paths: &ServicePaths) -> Vec<String> {
@@ -116,8 +116,12 @@ pub fn build_plist(paths: &ServicePaths) -> String {
 	<true/>
 	<key>KeepAlive</key>
 	<true/>
+	<!-- 60s, not 10s: with the shell wrapper launchd always spawns something,
+	     so a missing ainb is now an exit 127 that KeepAlive retries rather
+	     than a spawn failure that parks the job. The install-time check is
+	     the real guard; this bounds the log growth if one slips past. -->
 	<key>ThrottleInterval</key>
-	<integer>10</integer>
+	<integer>60</integer>
 	<key>LowPriorityIO</key>
 	<true/>
 	<key>StandardOutPath</key>
@@ -185,19 +189,17 @@ fn systemd_unit_path() -> Result<PathBuf> {
 /// Render the systemd user unit. Public for unit testing.
 #[must_use]
 pub fn build_systemd_unit(paths: &ServicePaths) -> String {
-    // Unlike launchd, systemd DOES resolve a non-absolute `ExecStart` against
-    // the $PATH the unit supplies via Environment=, so no shell wrapper is
-    // needed here — hence the direct argv rather than `daemon_argv`.
-    //
-    // Caveat, and the reason `bridge status` checks: that is systemd 250+
-    // behaviour. Older systemd searches a fixed compile-time list
-    // (/usr/local/bin:/usr/bin:/bin) that misses `~/.cargo/bin` and
-    // `~/.local/bin`, where an install outside that list needs the explicit
-    // $AINB_BIN override. Status reports such a unit as MISSING rather than
-    // certifying a service that can never start as healthy.
-    let exec_start = std::iter::once(paths.ainb_bin.as_str())
-        .chain(DAEMON_ARGS)
-        .map(unit_program::shell_quote)
+    // Same shell wrapper as the plist, for the same reason. systemd.service(5)
+    // is explicit that a non-absolute ExecStart is NOT looked up on $PATH:
+    // "Systemd has never looked at the PATH variable for resolving non
+    // absolute binaries", it uses a fixed compile-time list
+    // (/usr/local/bin:/usr/bin:/bin) that misses ~/.cargo/bin and
+    // ~/.local/bin. A bare `ainb` would fail 203/EXEC on every start.
+    // ExecStart is therefore an absolute /bin/sh, and the unit's own PATH
+    // (which the shell DOES honour) is what finds ainb, at every launch.
+    let exec_start = daemon_argv(paths)
+        .iter()
+        .map(|a| unit_program::shell_quote(a))
         .collect::<Vec<_>>()
         .join(" ");
     let config_env = paths
@@ -274,6 +276,30 @@ pub fn install() -> Result<PathBuf> {
     }
 }
 
+/// `Some(warning)` when the unit `install` would write names a program that
+/// does not resolve, so the caller can say so instead of reporting a success
+/// that can never start.
+///
+/// Pinning `current_exe()` used to make this true by construction; resolving
+/// at launch time does not, so it is checked. Mirrors
+/// [`crate::fleet::atc::timer::install_would_be_unrunnable`].
+#[must_use]
+pub fn install_would_be_unrunnable() -> Option<String> {
+    let paths = resolve_paths().ok()?;
+    let unit = if cfg!(target_os = "macos") {
+        build_plist(&paths)
+    } else {
+        build_systemd_unit(&paths)
+    };
+    match unit_program::unit_program_health(&unit) {
+        unit_program::ProgramHealth::Missing(p) => Some(format!(
+            "'{p}' is not on the PATH the bridge will run with, so the daemon cannot start. \
+             Install ainb somewhere on PATH, or set AINB_BIN to its full path and re-run install."
+        )),
+        _ => None,
+    }
+}
+
 /// Remove the daemon service. Safe to call when nothing is installed.
 pub fn uninstall() -> Result<Option<PathBuf>> {
     if cfg!(target_os = "macos") {
@@ -288,28 +314,35 @@ pub fn uninstall() -> Result<Option<PathBuf>> {
 /// A unit file existing is NOT the same as a working bridge: if the binary it
 /// points at has moved (a `brew upgrade` deleting the old Cellar directory),
 /// launchd exits 78 `EX_CONFIG` and parks the job forever while `installed`
-/// keeps claiming health. So the program is resolved too — see issue #608.
+/// keeps claiming health. So the program is resolved too. See issue #608.
 pub fn status() -> Result<String> {
     let (kind, unit) = if cfg!(target_os = "macos") {
         ("launchd", launchd_plist_path()?)
     } else {
         ("systemd", systemd_unit_path()?)
     };
-    if !unit.exists() {
+    let health = unit_program::unit_program_health_at(&unit);
+    if matches!(health, unit_program::ProgramHealth::NoUnit) {
         return Ok(format!("{kind}: not installed ({})", unit.display()));
     }
-    let health = match std::fs::read_to_string(&unit) {
-        Ok(text) => unit_program::unit_program_health(&text),
-        Err(e) => {
-            unit_program::ProgramHealth::Unreadable(format!("cannot read {}: {e}", unit.display()))
+    // The advice has to match how much we actually know. MISSING is a verdict;
+    // UNKNOWN means the unit did not parse, which is not evidence that the
+    // bridge is broken, and telling someone to reinstall a running service on
+    // that basis is its own false positive.
+    let note = match &health {
+        unit_program::ProgramHealth::Missing(program) => format!(
+            ", program MISSING ({program})\n  \
+             the bridge can never start: re-run `ainb fleet bridge install` to repoint it"
+        ),
+        unit_program::ProgramHealth::Unreadable(why) => format!(
+            ", program UNKNOWN ({why})\n  \
+             could not verify the program this unit runs; inspect {} by hand",
+            unit.display()
+        ),
+        unit_program::ProgramHealth::Resolves(_) | unit_program::ProgramHealth::NoUnit => {
+            String::new()
         }
     };
-    let note = health.problem().map_or_else(String::new, |problem| {
-        format!(
-            ", {problem}\n  \
-             ↳ the bridge can never start — re-run `ainb fleet bridge install` to repoint it"
-        )
-    });
     Ok(format!("{kind}: installed ({}){note}", unit.display()))
 }
 
@@ -363,7 +396,7 @@ mod tests {
     #[test]
     fn systemd_exec_start_is_fleet_bridge_run() {
         let unit = build_systemd_unit(&paths());
-        assert!(unit.contains("ExecStart=ainb fleet bridge run"));
+        assert!(unit.contains("ExecStart=/bin/sh -c 'exec ainb fleet bridge run'"));
         assert!(unit.contains("Restart=always"));
         assert!(!unit.to_lowercase().contains("token"));
     }
@@ -411,7 +444,7 @@ mod tests {
     /// launchd will NOT PATH-search `ProgramArguments[0]`; it resolves it
     /// against its own job environment and ignores the plist's
     /// `EnvironmentVariables` PATH. So the plist must hand it an absolute
-    /// `/bin/sh` and let the shell — which does honour PATH — find `ainb`.
+    /// `/bin/sh` and let the shell, which does honour PATH, find `ainb`.
     /// A bare `ainb` here would not spawn at all.
     #[test]
     fn launchd_gets_an_absolute_program_and_defers_lookup_to_the_shell() {
@@ -431,17 +464,41 @@ mod tests {
         assert!(plist.contains("<key>PATH</key>"));
     }
 
-    /// systemd, unlike launchd, DOES resolve a non-absolute `ExecStart`
-    /// against the `$PATH` the unit supplies, so no shell wrapper is needed —
-    /// but the unit must actually supply that PATH.
+    /// systemd resolves a non-absolute ExecStart against a fixed compile-time
+    /// list, NEVER the unit's own Environment=PATH ("Systemd has never looked
+    /// at the PATH variable for resolving non absolute binaries",
+    /// systemd.service(5)). So ExecStart must be an absolute /bin/sh, and the
+    /// PATH the unit carries is for the shell, which does honour it.
     #[test]
-    fn systemd_unit_carries_the_path_its_bare_exec_start_needs() {
+    fn systemd_defers_lookup_to_the_shell_and_carries_its_path() {
         let expected = unit_program::unit_path_env();
         let unit = build_systemd_unit(&paths());
-        assert!(unit.contains("ExecStart=ainb fleet bridge run"));
+        assert!(
+            unit.contains("ExecStart=/bin/sh -c "),
+            "ExecStart must be an absolute shell: {unit}"
+        );
+        assert!(
+            !unit.contains("ExecStart=ainb"),
+            "a bare ExecStart fails 203/EXEC: {unit}"
+        );
         assert!(
             unit.contains(&format!("Environment=\"PATH={expected}\"")),
             "systemd unit carries no PATH: {unit}"
+        );
+    }
+
+    /// The regression the bare-ExecStart version shipped: systemd could not
+    /// start the unit, and status resolved the same bare name against the
+    /// unit's inert PATH and called it healthy.
+    #[test]
+    fn a_systemd_unit_is_never_reported_healthy_on_a_path_systemd_ignores() {
+        let mut p = paths();
+        p.ainb_bin = GONE.to_string();
+        let unit = build_systemd_unit(&p);
+        assert_eq!(
+            unit_program::unit_program_health(&unit),
+            unit_program::ProgramHealth::Missing(GONE.into()),
+            "moved binary not flagged in systemd unit: {unit}"
         );
     }
 
@@ -480,7 +537,7 @@ mod tests {
 
     /// The wrapper must not become a blindfold: `/bin/sh` always resolves, so
     /// a detector reading `argv[0]` would certify every broken bridge as
-    /// healthy — the exact bug class #608 is about.
+    /// healthy: the exact bug class #608 is about.
     #[test]
     fn the_shell_wrapper_does_not_hide_a_dead_binary_from_status() {
         let mut p = paths();
@@ -493,6 +550,21 @@ mod tests {
         assert_eq!(
             unit_program::unit_program_health(&plist).program(),
             Some(GONE)
+        );
+    }
+
+    /// UNKNOWN is not a verdict of failure. Telling someone to reinstall a
+    /// running bridge because we could not parse its unit is its own false
+    /// positive, the same class this change exists to remove.
+    #[test]
+    fn an_unparsable_unit_is_not_told_it_can_never_start() {
+        let health = unit_program::unit_program_health("hand edited, not a unit");
+        assert!(matches!(health, unit_program::ProgramHealth::Unreadable(_)));
+        let note = health.problem().expect("problem");
+        assert!(note.contains("UNKNOWN"));
+        assert!(
+            !note.contains("can never start"),
+            "UNKNOWN must not assert a failure it cannot determine: {note}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/mod.rs
@@ -24,6 +24,7 @@ pub mod control;
 pub mod daemons;
 pub mod plumbing;
 pub mod read;
+pub mod unit_program;
 
 pub use ainb_fleet_core::fleet::{discover, enrich_cache, send, types};
 

--- a/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
@@ -50,6 +50,15 @@ fn absolutize_explicit_path(bin: &str) -> String {
     if !bin.contains('/') {
         return bin.to_string();
     }
+    // A tilde reaches us unexpanded when it came from a config file or a
+    // quoted assignment rather than the shell. Joining it to the cwd would
+    // produce `/cwd/~/bin/ainb`, which cannot exist, so expand it here: we
+    // shell-quote the result, so the shell will not expand it later either.
+    if let Some(rest) = bin.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest).display().to_string();
+        }
+    }
     let path = std::path::Path::new(bin);
     if path.is_absolute() {
         return bin.to_string();
@@ -65,12 +74,20 @@ fn absolutize_explicit_path(bin: &str) -> String {
 /// unit inherits only those, the bridge dies the moment they go away: the #608
 /// failure shape again, moved from the binary path to the `PATH`. So the
 /// standard install directories are always appended as a floor.
+/// Relative entries are dropped. The scheduler launches the unit from `/`, so
+/// a `.` or `target/debug` inherited from the installing shell means something
+/// different there than it did here, and keeping it would let the health check
+/// resolve a binary the daemon can never reach. Dropping them also keeps a
+/// project-local bin directory from deciding which `ainb` runs at every boot.
 #[must_use]
 pub fn unit_path_env() -> String {
     let current = std::env::var("PATH").unwrap_or_default();
     let mut out: Vec<&str> = Vec::new();
     for dir in current.split(':').chain(STANDARD_BIN_DIRS.split(':')) {
-        if !dir.is_empty() && !out.contains(&dir) {
+        if dir.is_empty() || !std::path::Path::new(dir).is_absolute() {
+            continue;
+        }
+        if !out.contains(&dir) {
             out.push(dir);
         }
     }
@@ -296,7 +313,15 @@ fn shell_split(s: &str) -> Vec<String> {
     let mut chars = s.chars();
     while let Some(c) = chars.next() {
         match c {
-            '\'' | '"' if quote.is_none() => {
+            // `'` may open anywhere, because `shell_quote` emits `'\''` to
+            // escape an apostrophe mid-token. `"` opens only at a token
+            // boundary: we never emit it, and a legacy unit could carry one as
+            // an ordinary character inside a path.
+            '\'' if quote.is_none() => {
+                quote = Some(c);
+                has_token = true;
+            }
+            '"' if quote.is_none() && !has_token => {
                 quote = Some(c);
                 has_token = true;
             }
@@ -610,6 +635,51 @@ mod tests {
             )
             .as_deref(),
             Some("/opt/my apps/ainb")
+        );
+    }
+
+    /// An unexpanded tilde must not be glued to the cwd: `/cwd/~/bin/ainb`
+    /// cannot exist, and we shell-quote the result so no later expansion saves
+    /// it.
+    #[test]
+    fn a_tilde_override_is_expanded_not_prefixed() {
+        let resolved = ainb_bin_from(Some("~/bin/ainb"));
+        assert!(!resolved.contains('~'), "tilde survived: {resolved}");
+        assert!(std::path::Path::new(&resolved).is_absolute());
+        assert!(resolved.ends_with("bin/ainb"));
+        if let Some(home) = dirs::home_dir() {
+            assert!(resolved.starts_with(&home.display().to_string()));
+        }
+    }
+
+    /// A relative PATH entry means something different from `/`, which is
+    /// where the scheduler launches. Keeping it would let the health check
+    /// resolve a binary the daemon can never reach, and would let a
+    /// project-local bin dir decide which ainb runs at boot.
+    #[test]
+    fn unit_path_drops_relative_entries() {
+        let path = unit_path_env();
+        for dir in path.split(':') {
+            assert!(
+                std::path::Path::new(dir).is_absolute(),
+                "relative entry {dir} survived into the unit PATH: {path}"
+            );
+        }
+    }
+
+    /// `"` opens a quote only at a token boundary. Legacy units double-quoted
+    /// whitespace arguments, but a `"` inside a path was passed through raw,
+    /// and `shell_quote` never emits one.
+    #[test]
+    fn a_literal_double_quote_inside_a_token_is_not_a_quote() {
+        assert_eq!(
+            shell_split("/opt/wi\"rd/ainb fleet bridge run"),
+            vec!["/opt/wi\"rd/ainb", "fleet", "bridge", "run"]
+        );
+        // ...while a leading one still opens, which is what legacy units used.
+        assert_eq!(
+            shell_split("\"/opt/my apps/ainb\" fleet bridge run"),
+            vec!["/opt/my apps/ainb", "fleet", "bridge", "run"]
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
@@ -1,0 +1,248 @@
+// ABOUTME: The `ainb` binary a scheduler unit runs — how it is chosen when the
+// unit is written, and how it is checked when status is reported.
+//
+// Shared by every fleet feature that installs a launchd plist or a systemd user
+// unit (the ATC heartbeat timer, the phone bridge daemon). All of them hit the
+// same failure: freezing `current_exe()` into the unit pins a version-scoped
+// path (`~/.cargo/bin/ainb`, `/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb`),
+// the next upgrade deletes it, and the scheduler exits 78 `EX_CONFIG` into the
+// penalty box while `status` keeps reporting the unit as installed because it
+// only ever stat'd the unit FILE. See issue #608.
+//
+// Two halves, matching the two halves of the fix:
+// - generation: [`ainb_bin_from`] + [`unit_path_env`] emit a bare `argv[0]`
+//   resolved at fire time against the `PATH` the unit carries.
+// - inspection: [`missing_program`] parses `argv[0]` back out of an installed
+//   unit and says whether the scheduler could actually exec it.
+
+use std::path::PathBuf;
+
+/// Resolve the `ainb` binary to write as a unit's `argv[0]`.
+///
+/// Deliberately NOT `current_exe()`: that freezes an absolute path into the
+/// unit forever, so a later `brew upgrade` (or cargo → homebrew move) leaves
+/// the scheduler exec'ing a path that no longer exists. Bare `ainb`
+/// re-resolves at every launch against the `PATH` the unit already carries.
+/// `$AINB_BIN` stays as the explicit override for installs that are not on
+/// `PATH`.
+#[must_use]
+pub fn ainb_bin_from(override_var: Option<&str>) -> String {
+    match override_var {
+        Some(b) if !b.is_empty() => b.to_string(),
+        _ => "ainb".to_string(),
+    }
+}
+
+/// The `PATH` to write into a unit, and therefore the one a bare `argv[0]` is
+/// resolved against at launch time.
+#[must_use]
+pub fn unit_path_env() -> String {
+    std::env::var("PATH")
+        .unwrap_or_else(|_| "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".into())
+}
+
+/// Extract `argv[0]` from a unit's text — launchd plist XML or a systemd
+/// service unit. Returns `None` when the shape is not recognised.
+#[must_use]
+pub fn unit_program(text: &str) -> Option<String> {
+    plist_program(text).or_else(|| systemd_exec_start_program(text))
+}
+
+/// The `PATH` the unit itself carries, which is what the scheduler resolves a
+/// bare `argv[0]` against — NOT the `PATH` of whoever is running `status`.
+#[must_use]
+pub fn unit_search_path(text: &str) -> Option<String> {
+    plist_string_after_key(text, "PATH").or_else(|| systemd_environment_path(text))
+}
+
+/// `Some(program)` when the unit's `argv[0]` does not resolve to an executable
+/// under the unit's own `PATH` — i.e. the unit is installed but can never run.
+/// `None` when it resolves, or when the text carries no recognisable `argv[0]`.
+#[must_use]
+pub fn missing_program(unit_text: &str) -> Option<String> {
+    let program = unit_program(unit_text)?;
+    let search_path = unit_search_path(unit_text);
+    (!program_resolves_in(&program, search_path.as_deref())).then_some(program)
+}
+
+/// Whether a unit's `argv[0]` resolves to something executable. An explicit
+/// path is checked directly; a bare name is looked up under `search_path` (the
+/// unit's own `PATH`), falling back to the caller's `$PATH` when the unit
+/// carries none.
+///
+/// `which` rather than `Path::exists()` on purpose: `exists()` is true for a
+/// directory or a non-executable file, either of which would let a bogus
+/// `$AINB_BIN` report healthy while the scheduler cannot exec it.
+#[must_use]
+pub fn program_resolves_in(program: &str, search_path: Option<&str>) -> bool {
+    if program.is_empty() {
+        return false;
+    }
+    if program.contains('/') {
+        return which::which(program).is_ok();
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+    search_path.map_or_else(
+        || which::which(program).is_ok(),
+        |path| which::which_in(program, Some(path), cwd).is_ok(),
+    )
+}
+
+/// First `<string>` inside the `ProgramArguments` array of a launchd plist.
+fn plist_program(xml: &str) -> Option<String> {
+    let after_key = xml.split_once("<key>ProgramArguments</key>")?.1;
+    let array = after_key.split_once("<array>")?.1;
+    first_plist_string(array)
+}
+
+/// The `<string>` value following `<key>{key}</key>` in a launchd plist.
+fn plist_string_after_key(xml: &str, key: &str) -> Option<String> {
+    first_plist_string(xml.split_once(&format!("<key>{key}</key>"))?.1)
+}
+
+fn first_plist_string(xml: &str) -> Option<String> {
+    let open = xml.split_once("<string>")?.1;
+    let (value, _) = open.split_once("</string>")?;
+    let value = xml_unescape(value.trim());
+    (!value.is_empty()).then_some(value)
+}
+
+/// First token of the `ExecStart=` line of a systemd service unit.
+fn systemd_exec_start_program(unit: &str) -> Option<String> {
+    let line = unit.lines().map(str::trim).find_map(|l| l.strip_prefix("ExecStart="))?;
+    shell_unquote_first_token(line.trim())
+}
+
+/// The `PATH` assignment of a systemd service unit's `Environment=` lines.
+fn systemd_environment_path(unit: &str) -> Option<String> {
+    let value = unit.lines().map(str::trim).find_map(|line| {
+        let assignment = line.strip_prefix("Environment=")?.trim().trim_matches('"');
+        assignment.strip_prefix("PATH=").map(str::to_string)
+    })?;
+    (!value.is_empty()).then_some(value)
+}
+
+fn xml_unescape(s: &str) -> String {
+    s.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+}
+
+/// Recover `argv[0]` from an `ExecStart=` line we wrote ourselves. Both quote
+/// styles are accepted because the fleet unit writers disagree: the ATC timer
+/// shell-quotes with `'`, the bridge with `"`.
+fn shell_unquote_first_token(s: &str) -> Option<String> {
+    let s = s.trim_start();
+    for quote in ['\'', '"'] {
+        if let Some(rest) = s.strip_prefix(quote) {
+            let (quoted, _) = rest.split_once(quote)?;
+            return Some(quoted.to_string());
+        }
+    }
+    let token = s.split_whitespace().next()?;
+    (!token.is_empty()).then(|| token.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ainb_bin_is_bare_unless_explicitly_overridden() {
+        assert_eq!(ainb_bin_from(None), "ainb");
+        assert_eq!(ainb_bin_from(Some("")), "ainb");
+        assert_eq!(ainb_bin_from(Some("/opt/custom/ainb")), "/opt/custom/ainb");
+    }
+
+    #[test]
+    fn unit_program_reads_argv0_from_both_unit_flavours() {
+        assert_eq!(
+            unit_program("<key>ProgramArguments</key>\n<array>\n\t<string>ainb</string>"),
+            Some("ainb".into())
+        );
+        assert_eq!(
+            unit_program("[Service]\nExecStart=ainb fleet bridge run\n"),
+            Some("ainb".into())
+        );
+        assert_eq!(unit_program("not a unit at all"), None);
+    }
+
+    #[test]
+    fn unit_program_survives_quoting_and_escaping() {
+        assert_eq!(
+            plist_program("<key>ProgramArguments</key>\n<array>\n<string>/a&amp;b/ainb</string>"),
+            Some("/a&b/ainb".into())
+        );
+        // Both writers' quote styles: the ATC timer emits `'`, the bridge `"`.
+        assert_eq!(
+            systemd_exec_start_program("[Service]\nExecStart='/a b/ainb' fleet atc heartbeat x\n"),
+            Some("/a b/ainb".into())
+        );
+        assert_eq!(
+            systemd_exec_start_program("[Service]\nExecStart=\"/a b/ainb\" fleet bridge run\n"),
+            Some("/a b/ainb".into())
+        );
+    }
+
+    #[test]
+    fn program_resolution_distinguishes_present_from_moved() {
+        assert!(program_resolves_in("/bin/sh", None));
+        assert!(!program_resolves_in(
+            "/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb",
+            None
+        ));
+        assert!(!program_resolves_in("", None));
+        assert!(program_resolves_in("sh", None));
+        assert!(!program_resolves_in(
+            "ainb-definitely-not-a-real-binary",
+            None
+        ));
+    }
+
+    /// `exists()` would call a directory or a non-executable file healthy; the
+    /// scheduler cannot exec either, so neither may pass.
+    #[test]
+    fn program_resolution_requires_something_executable() {
+        let dir = std::env::temp_dir();
+        assert!(
+            dir.exists(),
+            "temp dir should exist for the premise to hold"
+        );
+        assert!(!program_resolves_in(&dir.display().to_string(), None));
+
+        let not_executable = dir.join("ainb-unit-program-test-not-executable");
+        std::fs::write(&not_executable, b"#!/bin/sh\n").expect("write fixture");
+        assert!(!program_resolves_in(
+            &not_executable.display().to_string(),
+            None
+        ));
+        let _ = std::fs::remove_file(&not_executable);
+    }
+
+    /// A bare `argv[0]` must be judged against the PATH the UNIT carries — the
+    /// one the scheduler will use — not against whatever `$PATH` the operator
+    /// happens to be running `status` with.
+    #[test]
+    fn bare_program_resolves_against_the_units_own_path() {
+        assert!(program_resolves_in("sh", Some("/bin:/usr/bin")));
+        assert!(!program_resolves_in("sh", Some("/nonexistent/bin")));
+
+        let unreachable =
+            "[Service]\nEnvironment=\"PATH=/nonexistent/bin\"\nExecStart=sh fleet bridge run\n";
+        assert_eq!(missing_program(unreachable), Some("sh".into()));
+        let reachable =
+            "[Service]\nEnvironment=\"PATH=/bin:/usr/bin\"\nExecStart=sh fleet bridge run\n";
+        assert_eq!(missing_program(reachable), None);
+    }
+
+    #[test]
+    fn unit_search_path_reads_both_unit_flavours() {
+        assert_eq!(
+            unit_search_path("<key>PATH</key>\n\t<string>/bin:/usr/bin</string>").as_deref(),
+            Some("/bin:/usr/bin")
+        );
+        assert_eq!(
+            unit_search_path("[Service]\nEnvironment=\"PATH=/bin\"\n").as_deref(),
+            Some("/bin")
+        );
+        assert_eq!(unit_search_path("not a unit at all"), None);
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
@@ -445,10 +445,20 @@ mod tests {
     /// false positive the whole check exists to remove.
     #[test]
     fn an_unrecognised_unit_is_unknown_not_healthy() {
-        let health = unit_program_health("this is not a unit");
-        assert!(matches!(health, ProgramHealth::Unreadable(_)));
-        assert!(health.problem().unwrap().contains("UNKNOWN"));
-        assert_eq!(health.program(), None);
+        for junk in ["", "this is not a unit", "<plist><dict></dict></plist>"] {
+            let health = unit_program_health(junk);
+            assert!(
+                matches!(health, ProgramHealth::Unreadable(_)),
+                "junk unit reported as {health:?}"
+            );
+            assert!(health.problem().unwrap().contains("UNKNOWN"));
+            assert_eq!(health.program(), None);
+        }
+        assert!(
+            ProgramHealth::Unreadable("boom".into())
+                .problem()
+                .is_some_and(|p| p.contains("UNKNOWN"))
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
@@ -4,27 +4,29 @@
 // Shared by every fleet feature that installs a launchd plist or a systemd user
 // unit (the ATC heartbeat timer, the phone bridge daemon). All of them hit the
 // same failure: freezing `current_exe()` into the unit pins a version-scoped
-// path (`~/.cargo/bin/ainb`, `/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb`),
-// the next upgrade deletes it, and the scheduler exits 78 `EX_CONFIG` into the
-// penalty box while `status` keeps reporting the unit as installed because it
-// only ever stat'd the unit FILE. See issue #608.
+// path (`~/.cargo/bin/ainb`, a `/opt/homebrew/Cellar/ainb/<version>/libexec`
+// directory), the next upgrade deletes it, and the scheduler exits 78
+// `EX_CONFIG` into the penalty box while `status` keeps reporting the unit as
+// installed because it only ever stat'd the unit FILE. See issue #608.
 //
 // Two halves, matching the two halves of the fix:
-// - generation: [`ainb_bin_from`] + [`unit_path_env`] emit a bare `argv[0]`
-//   resolved at fire time against the `PATH` the unit carries.
-// - inspection: [`missing_program`] parses `argv[0]` back out of an installed
-//   unit and says whether the scheduler could actually exec it.
+// - generation: [`ainb_bin_from`] + [`unit_path_env`] + [`shell_wrapped_argv`]
+//   emit a command whose binary is looked up at every launch.
+// - inspection: [`unit_program_health`] parses the real program back out of an
+//   installed unit and says whether the scheduler could actually run it.
 
 use std::path::PathBuf;
 
-/// Resolve the `ainb` binary to write as a unit's `argv[0]`.
+/// The shell that performs the `PATH` lookup on behalf of the scheduler.
+pub const SHELL: &str = "/bin/sh";
+
+/// Resolve the `ainb` binary to write into a unit's command.
 ///
 /// Deliberately NOT `current_exe()`: that freezes an absolute path into the
 /// unit forever, so a later `brew upgrade` (or cargo → homebrew move) leaves
-/// the scheduler exec'ing a path that no longer exists. Bare `ainb`
-/// re-resolves at every launch against the `PATH` the unit already carries.
-/// `$AINB_BIN` stays as the explicit override for installs that are not on
-/// `PATH`.
+/// the scheduler running a path that no longer exists. Bare `ainb` is
+/// re-resolved at every launch. `$AINB_BIN` stays as the explicit override for
+/// installs that are not on `PATH`.
 #[must_use]
 pub fn ainb_bin_from(override_var: Option<&str>) -> String {
     match override_var {
@@ -33,48 +35,139 @@ pub fn ainb_bin_from(override_var: Option<&str>) -> String {
     }
 }
 
-/// The `PATH` to write into a unit, and therefore the one a bare `argv[0]` is
-/// resolved against at launch time.
+/// The `PATH` to write into a unit, and therefore the one the shell resolves a
+/// bare program against at launch time.
 #[must_use]
 pub fn unit_path_env() -> String {
     std::env::var("PATH")
         .unwrap_or_else(|_| "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".into())
 }
 
-/// Extract `argv[0]` from a unit's text — launchd plist XML or a systemd
-/// service unit. Returns `None` when the shape is not recognised.
+/// Wrap a command as `/bin/sh -c "exec <command>"`.
+///
+/// `argv[0]` of the resulting unit is the SHELL, not `ainb`, and that is the
+/// point. Neither scheduler does the `PATH` lookup a naive reading suggests:
+/// launchd resolves `ProgramArguments[0]` against its own job environment and
+/// ignores the plist's `EnvironmentVariables` PATH entirely — a bare name there
+/// fails to spawn before the process ever starts — and systemd resolves a
+/// non-absolute `ExecStart` against a fixed compile-time list that excludes
+/// `~/.cargo/bin` and `~/.local/bin`. Going through `/bin/sh -c` moves the
+/// lookup somewhere that DOES honour the unit's `PATH`, and does it at every
+/// launch rather than freezing it at install time.
+///
+/// `exec` so the shell replaces itself with `ainb` rather than lingering as a
+/// parent — which also keeps launchd's `KeepAlive` watching the real process.
 #[must_use]
-pub fn unit_program(text: &str) -> Option<String> {
-    plist_program(text).or_else(|| systemd_exec_start_program(text))
+pub fn shell_wrapped_argv(bin: &str, args: &[&str]) -> Vec<String> {
+    let command = std::iter::once(bin)
+        .chain(args.iter().copied())
+        .map(shell_quote)
+        .collect::<Vec<_>>()
+        .join(" ");
+    vec![SHELL.into(), "-c".into(), format!("exec {command}")]
 }
 
-/// The `PATH` the unit itself carries, which is what the scheduler resolves a
-/// bare `argv[0]` against — NOT the `PATH` of whoever is running `status`.
+/// What a `status` command needs to know about the program an installed unit
+/// will try to run. Every variant is distinct on purpose: an unreadable or
+/// unrecognised unit is NOT the same as a healthy one, and reporting it as
+/// healthy is the exact false positive this whole check exists to remove.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProgramHealth {
+    /// No unit installed.
+    NoUnit,
+    /// The unit's program resolves; the unit can run.
+    Resolves(String),
+    /// The unit's program does not resolve; the unit can never run.
+    Missing(String),
+    /// The unit exists but could not be read or understood, so its health is
+    /// unknown and must not be reported as good.
+    Unreadable(String),
+}
+
+impl ProgramHealth {
+    /// The program path, when one could be parsed out of the unit.
+    #[must_use]
+    pub fn program(&self) -> Option<&str> {
+        match self {
+            Self::Resolves(p) | Self::Missing(p) => Some(p),
+            Self::NoUnit | Self::Unreadable(_) => None,
+        }
+    }
+
+    /// A short note for the status line, when something is wrong.
+    #[must_use]
+    pub fn problem(&self) -> Option<String> {
+        match self {
+            Self::Missing(p) => Some(format!("program MISSING ({p})")),
+            Self::Unreadable(why) => Some(format!("program UNKNOWN ({why})")),
+            Self::NoUnit | Self::Resolves(_) => None,
+        }
+    }
+}
+
+/// Health of the program a unit's text describes.
 #[must_use]
-pub fn unit_search_path(text: &str) -> Option<String> {
+pub fn unit_program_health(text: &str) -> ProgramHealth {
+    let Some(argv) = unit_argv(text) else {
+        return ProgramHealth::Unreadable("unrecognised unit shape".into());
+    };
+    let Some(program) = program_from_argv(&argv) else {
+        return ProgramHealth::Unreadable("no program in unit".into());
+    };
+    if program_resolves_in(&program, unit_search_path(text).as_deref()) {
+        ProgramHealth::Resolves(program)
+    } else {
+        ProgramHealth::Missing(program)
+    }
+}
+
+/// The full argv a unit will run: launchd's `ProgramArguments` array, or the
+/// tokens of a systemd `ExecStart=` line.
+fn unit_argv(text: &str) -> Option<Vec<String>> {
+    plist_program_arguments(text).or_else(|| systemd_exec_start_argv(text))
+}
+
+/// The binary whose availability actually decides whether the unit can run.
+///
+/// Units are written as `/bin/sh -c "exec ainb …"`, so `argv[0]` is the shell
+/// and always resolves — reporting on it would certify every broken unit as
+/// healthy. Look through the wrapper to the command it runs. Units written
+/// before the wrapper existed (a direct absolute path) still report on that
+/// path, which is what makes an already-installed stale unit detectable.
+fn program_from_argv(argv: &[String]) -> Option<String> {
+    let first = argv.first()?;
+    if is_shell(first) {
+        if let Some(script) = argv.iter().skip(1).find(|a| !a.starts_with('-')) {
+            let tokens = shell_split(script);
+            let head = tokens.iter().find(|t| *t != "exec")?;
+            return Some(head.clone());
+        }
+    }
+    Some(first.clone())
+}
+
+fn is_shell(program: &str) -> bool {
+    matches!(
+        std::path::Path::new(program).file_name().and_then(|n| n.to_str()),
+        Some("sh" | "bash" | "zsh" | "dash")
+    )
+}
+
+/// The `PATH` the unit itself carries, which is what the shell resolves a bare
+/// program against. NOT the `PATH` of whoever is running the status command.
+fn unit_search_path(text: &str) -> Option<String> {
     plist_string_after_key(text, "PATH").or_else(|| systemd_environment_path(text))
 }
 
-/// `Some(program)` when the unit's `argv[0]` does not resolve to an executable
-/// under the unit's own `PATH` — i.e. the unit is installed but can never run.
-/// `None` when it resolves, or when the text carries no recognisable `argv[0]`.
-#[must_use]
-pub fn missing_program(unit_text: &str) -> Option<String> {
-    let program = unit_program(unit_text)?;
-    let search_path = unit_search_path(unit_text);
-    (!program_resolves_in(&program, search_path.as_deref())).then_some(program)
-}
-
-/// Whether a unit's `argv[0]` resolves to something executable. An explicit
-/// path is checked directly; a bare name is looked up under `search_path` (the
+/// Whether a unit's program resolves to something executable. An explicit path
+/// is checked directly; a bare name is looked up under `search_path` (the
 /// unit's own `PATH`), falling back to the caller's `$PATH` when the unit
 /// carries none.
 ///
 /// `which` rather than `Path::exists()` on purpose: `exists()` is true for a
 /// directory or a non-executable file, either of which would let a bogus
-/// `$AINB_BIN` report healthy while the scheduler cannot exec it.
-#[must_use]
-pub fn program_resolves_in(program: &str, search_path: Option<&str>) -> bool {
+/// `$AINB_BIN` report healthy while the scheduler cannot run it.
+fn program_resolves_in(program: &str, search_path: Option<&str>) -> bool {
     if program.is_empty() {
         return false;
     }
@@ -88,29 +181,35 @@ pub fn program_resolves_in(program: &str, search_path: Option<&str>) -> bool {
     )
 }
 
-/// First `<string>` inside the `ProgramArguments` array of a launchd plist.
-fn plist_program(xml: &str) -> Option<String> {
+/// Every `<string>` inside the `ProgramArguments` array of a launchd plist.
+fn plist_program_arguments(xml: &str) -> Option<Vec<String>> {
     let after_key = xml.split_once("<key>ProgramArguments</key>")?.1;
-    let array = after_key.split_once("<array>")?.1;
-    first_plist_string(array)
+    let (array, _) = after_key.split_once("<array>")?.1.split_once("</array>")?;
+    let argv: Vec<String> = array
+        .match_indices("<string>")
+        .filter_map(|(i, _)| {
+            let rest = &array[i + "<string>".len()..];
+            let (value, _) = rest.split_once("</string>")?;
+            Some(xml_unescape(value.trim()))
+        })
+        .collect();
+    (!argv.is_empty()).then_some(argv)
 }
 
 /// The `<string>` value following `<key>{key}</key>` in a launchd plist.
 fn plist_string_after_key(xml: &str, key: &str) -> Option<String> {
-    first_plist_string(xml.split_once(&format!("<key>{key}</key>"))?.1)
-}
-
-fn first_plist_string(xml: &str) -> Option<String> {
-    let open = xml.split_once("<string>")?.1;
+    let after = xml.split_once(&format!("<key>{key}</key>"))?.1;
+    let open = after.split_once("<string>")?.1;
     let (value, _) = open.split_once("</string>")?;
     let value = xml_unescape(value.trim());
     (!value.is_empty()).then_some(value)
 }
 
-/// First token of the `ExecStart=` line of a systemd service unit.
-fn systemd_exec_start_program(unit: &str) -> Option<String> {
+/// The argv of a systemd service unit's `ExecStart=` line.
+fn systemd_exec_start_argv(unit: &str) -> Option<Vec<String>> {
     let line = unit.lines().map(str::trim).find_map(|l| l.strip_prefix("ExecStart="))?;
-    shell_unquote_first_token(line.trim())
+    let argv = shell_split(line.trim());
+    (!argv.is_empty()).then_some(argv)
 }
 
 /// The `PATH` assignment of a systemd service unit's `Environment=` lines.
@@ -126,24 +225,64 @@ fn xml_unescape(s: &str) -> String {
     s.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
 }
 
-/// Recover `argv[0]` from an `ExecStart=` line we wrote ourselves. Both quote
-/// styles are accepted because the fleet unit writers disagree: the ATC timer
-/// shell-quotes with `'`, the bridge with `"`.
-fn shell_unquote_first_token(s: &str) -> Option<String> {
-    let s = s.trim_start();
-    for quote in ['\'', '"'] {
-        if let Some(rest) = s.strip_prefix(quote) {
-            let (quoted, _) = rest.split_once(quote)?;
-            return Some(quoted.to_string());
+/// Inverse of [`shell_quote`]: split a command line into argv.
+fn shell_split(s: &str) -> Vec<String> {
+    let mut argv = Vec::new();
+    let mut current = String::new();
+    let mut has_token = false;
+    let mut in_quotes = false;
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' => {
+                in_quotes = !in_quotes;
+                has_token = true;
+            }
+            '\\' if !in_quotes => {
+                if let Some(escaped) = chars.next() {
+                    current.push(escaped);
+                    has_token = true;
+                }
+            }
+            c if c.is_whitespace() && !in_quotes => {
+                if has_token {
+                    argv.push(std::mem::take(&mut current));
+                    has_token = false;
+                }
+            }
+            c => {
+                current.push(c);
+                has_token = true;
+            }
         }
     }
-    let token = s.split_whitespace().next()?;
-    (!token.is_empty()).then(|| token.to_string())
+    if has_token {
+        argv.push(current);
+    }
+    argv
+}
+
+/// Quote a token for a `/bin/sh -c` command line.
+#[must_use]
+pub fn shell_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".into();
+    }
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '-' | '_'))
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A Cellar path for a version that cannot be installed, so the "moved
+    /// binary" assertions never depend on what this host happens to have.
+    const GONE: &str = "/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb";
 
     #[test]
     fn ainb_bin_is_bare_unless_explicitly_overridden() {
@@ -152,43 +291,104 @@ mod tests {
         assert_eq!(ainb_bin_from(Some("/opt/custom/ainb")), "/opt/custom/ainb");
     }
 
+    /// launchd will not PATH-search `ProgramArguments[0]`, so the unit must
+    /// hand it an absolute `/bin/sh` and let the shell do the lookup.
     #[test]
-    fn unit_program_reads_argv0_from_both_unit_flavours() {
-        assert_eq!(
-            unit_program("<key>ProgramArguments</key>\n<array>\n\t<string>ainb</string>"),
-            Some("ainb".into())
+    fn shell_wrapper_puts_an_absolute_shell_at_argv0() {
+        let argv = shell_wrapped_argv("ainb", &["fleet", "bridge", "run"]);
+        assert_eq!(argv[0], "/bin/sh");
+        assert_eq!(argv[1], "-c");
+        assert_eq!(argv[2], "exec ainb fleet bridge run");
+        assert!(
+            std::path::Path::new(&argv[0]).is_absolute(),
+            "argv[0] must be absolute or launchd cannot spawn it"
         );
-        assert_eq!(
-            unit_program("[Service]\nExecStart=ainb fleet bridge run\n"),
-            Some("ainb".into())
-        );
-        assert_eq!(unit_program("not a unit at all"), None);
     }
 
     #[test]
-    fn unit_program_survives_quoting_and_escaping() {
+    fn program_from_argv_sees_through_the_shell_wrapper() {
+        let argv = shell_wrapped_argv("ainb", &["fleet", "bridge", "run"]);
+        assert_eq!(program_from_argv(&argv).as_deref(), Some("ainb"));
+
+        let overridden = shell_wrapped_argv("/opt/custom/ainb", &["fleet", "bridge", "run"]);
         assert_eq!(
-            plist_program("<key>ProgramArguments</key>\n<array>\n<string>/a&amp;b/ainb</string>"),
-            Some("/a&b/ainb".into())
+            program_from_argv(&overridden).as_deref(),
+            Some("/opt/custom/ainb")
         );
-        // Both writers' quote styles: the ATC timer emits `'`, the bridge `"`.
+    }
+
+    /// Reporting on the wrapper's `argv[0]` would certify every broken unit as
+    /// healthy, since `/bin/sh` always resolves.
+    #[test]
+    fn shell_wrapper_does_not_mask_a_missing_binary() {
+        let argv = shell_wrapped_argv(GONE, &["fleet", "bridge", "run"]);
+        let program = program_from_argv(&argv).expect("program");
+        assert_eq!(program, GONE);
+        assert!(!program_resolves_in(&program, None));
+    }
+
+    /// Units written before the wrapper existed must still be judged on the
+    /// right binary — that is what makes an already-installed stale unit
+    /// detectable rather than silently unrecognised.
+    #[test]
+    fn program_from_argv_understands_legacy_direct_units() {
+        let legacy: Vec<String> =
+            [GONE, "fleet", "bridge", "run"].iter().map(|s| (*s).to_string()).collect();
+        assert_eq!(program_from_argv(&legacy).as_deref(), Some(GONE));
+    }
+
+    /// `shell_split` must be the true inverse of `shell_quote`, including its
+    /// `'\''` escaping, or a path with an apostrophe reports as MISSING while
+    /// the service is running perfectly well.
+    #[test]
+    fn shell_split_round_trips_shell_quote() {
+        for original in [
+            "/home/obrien/bin/ainb",
+            "/home/o'brien/bin/ainb",
+            "/opt/my apps/ainb",
+            "plain",
+        ] {
+            let quoted = shell_quote(original);
+            assert_eq!(
+                shell_split(&quoted),
+                vec![original.to_string()],
+                "round trip failed for {original}"
+            );
+        }
         assert_eq!(
-            systemd_exec_start_program("[Service]\nExecStart='/a b/ainb' fleet atc heartbeat x\n"),
-            Some("/a b/ainb".into())
+            shell_split("exec ainb fleet bridge run"),
+            vec!["exec", "ainb", "fleet", "bridge", "run"]
+        );
+    }
+
+    #[test]
+    fn unit_argv_reads_both_unit_flavours() {
+        let plist = "<key>ProgramArguments</key>\n<array>\n\t<string>/bin/sh</string>\n\t\
+                     <string>-c</string>\n\t<string>exec ainb fleet bridge run</string>\n</array>";
+        assert_eq!(
+            unit_argv(plist),
+            Some(vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "exec ainb fleet bridge run".into()
+            ])
         );
         assert_eq!(
-            systemd_exec_start_program("[Service]\nExecStart=\"/a b/ainb\" fleet bridge run\n"),
-            Some("/a b/ainb".into())
+            unit_argv("[Service]\nExecStart=ainb fleet bridge run\n"),
+            Some(vec![
+                "ainb".into(),
+                "fleet".into(),
+                "bridge".into(),
+                "run".into()
+            ])
         );
+        assert_eq!(unit_argv("not a unit at all"), None);
     }
 
     #[test]
     fn program_resolution_distinguishes_present_from_moved() {
         assert!(program_resolves_in("/bin/sh", None));
-        assert!(!program_resolves_in(
-            "/opt/homebrew/Cellar/ainb/0.0.0-uninstalled/libexec/ainb",
-            None
-        ));
+        assert!(!program_resolves_in(GONE, None));
         assert!(!program_resolves_in("", None));
         assert!(program_resolves_in("sh", None));
         assert!(!program_resolves_in(
@@ -198,7 +398,7 @@ mod tests {
     }
 
     /// `exists()` would call a directory or a non-executable file healthy; the
-    /// scheduler cannot exec either, so neither may pass.
+    /// scheduler cannot run either, so neither may pass.
     #[test]
     fn program_resolution_requires_something_executable() {
         let dir = std::env::temp_dir();
@@ -217,20 +417,48 @@ mod tests {
         let _ = std::fs::remove_file(&not_executable);
     }
 
-    /// A bare `argv[0]` must be judged against the PATH the UNIT carries — the
-    /// one the scheduler will use — not against whatever `$PATH` the operator
-    /// happens to be running `status` with.
+    /// A bare program must be judged against the PATH the UNIT carries — the
+    /// one the shell will use — not against whatever `$PATH` the operator
+    /// happens to be running the status command with.
     #[test]
     fn bare_program_resolves_against_the_units_own_path() {
         assert!(program_resolves_in("sh", Some("/bin:/usr/bin")));
         assert!(!program_resolves_in("sh", Some("/nonexistent/bin")));
 
+        // `ls`, not `sh`: a shell at argv[0] is treated as a wrapper and
+        // unwrapped, so it cannot stand in for an ordinary program here.
         let unreachable =
-            "[Service]\nEnvironment=\"PATH=/nonexistent/bin\"\nExecStart=sh fleet bridge run\n";
-        assert_eq!(missing_program(unreachable), Some("sh".into()));
+            "[Service]\nEnvironment=\"PATH=/nonexistent/bin\"\nExecStart=ls fleet bridge run\n";
+        assert_eq!(
+            unit_program_health(unreachable),
+            ProgramHealth::Missing("ls".into())
+        );
         let reachable =
-            "[Service]\nEnvironment=\"PATH=/bin:/usr/bin\"\nExecStart=sh fleet bridge run\n";
-        assert_eq!(missing_program(reachable), None);
+            "[Service]\nEnvironment=\"PATH=/bin:/usr/bin\"\nExecStart=ls fleet bridge run\n";
+        assert_eq!(
+            unit_program_health(reachable),
+            ProgramHealth::Resolves("ls".into())
+        );
+    }
+
+    /// An unparseable unit must not be reported as healthy — that is the same
+    /// false positive the whole check exists to remove.
+    #[test]
+    fn an_unrecognised_unit_is_unknown_not_healthy() {
+        let health = unit_program_health("this is not a unit");
+        assert!(matches!(health, ProgramHealth::Unreadable(_)));
+        assert!(health.problem().unwrap().contains("UNKNOWN"));
+        assert_eq!(health.program(), None);
+    }
+
+    #[test]
+    fn health_reports_a_problem_only_when_there_is_one() {
+        assert_eq!(ProgramHealth::NoUnit.problem(), None);
+        assert_eq!(ProgramHealth::Resolves("ainb".into()).problem(), None);
+        assert_eq!(
+            ProgramHealth::Missing("/gone/ainb".into()).problem().as_deref(),
+            Some("program MISSING (/gone/ainb)")
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/unit_program.rs
@@ -1,4 +1,4 @@
-// ABOUTME: The `ainb` binary a scheduler unit runs — how it is chosen when the
+// ABOUTME: The `ainb` binary a scheduler unit runs: how it is chosen when the
 // unit is written, and how it is checked when status is reported.
 //
 // Shared by every fleet feature that installs a launchd plist or a systemd user
@@ -20,27 +20,61 @@ use std::path::PathBuf;
 /// The shell that performs the `PATH` lookup on behalf of the scheduler.
 pub const SHELL: &str = "/bin/sh";
 
+/// Directories a unit can always fall back on, whatever the installing shell
+/// happened to have on `PATH`.
+const STANDARD_BIN_DIRS: &str = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+
 /// Resolve the `ainb` binary to write into a unit's command.
 ///
 /// Deliberately NOT `current_exe()`: that freezes an absolute path into the
-/// unit forever, so a later `brew upgrade` (or cargo → homebrew move) leaves
+/// unit forever, so a later `brew upgrade` (or cargo to homebrew move) leaves
 /// the scheduler running a path that no longer exists. Bare `ainb` is
 /// re-resolved at every launch. `$AINB_BIN` stays as the explicit override for
 /// installs that are not on `PATH`.
+///
+/// A relative `$AINB_BIN` is made absolute against the installing process's
+/// cwd, because the unit will NOT run with that cwd: both schedulers launch
+/// from `/`, so `./target/release/ainb` written verbatim can never be found.
 #[must_use]
 pub fn ainb_bin_from(override_var: Option<&str>) -> String {
     match override_var {
-        Some(b) if !b.is_empty() => b.to_string(),
+        Some(b) if !b.is_empty() => absolutize_explicit_path(b),
         _ => "ainb".to_string(),
     }
 }
 
+/// Leave a bare name alone (the shell resolves it on `PATH`); anchor an
+/// explicit but relative path to the cwd so it still means the same file once
+/// the scheduler runs it from `/`.
+fn absolutize_explicit_path(bin: &str) -> String {
+    if !bin.contains('/') {
+        return bin.to_string();
+    }
+    let path = std::path::Path::new(bin);
+    if path.is_absolute() {
+        return bin.to_string();
+    }
+    std::path::absolute(path).map_or_else(|_| bin.to_string(), |p| p.display().to_string())
+}
+
 /// The `PATH` to write into a unit, and therefore the one the shell resolves a
 /// bare program against at launch time.
+///
+/// The installing shell's `PATH` alone is not enough. It can carry entries that
+/// vanish (direnv, nix, a `target/debug` used for one `cargo run`), and if the
+/// unit inherits only those, the bridge dies the moment they go away: the #608
+/// failure shape again, moved from the binary path to the `PATH`. So the
+/// standard install directories are always appended as a floor.
 #[must_use]
 pub fn unit_path_env() -> String {
-    std::env::var("PATH")
-        .unwrap_or_else(|_| "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".into())
+    let current = std::env::var("PATH").unwrap_or_default();
+    let mut out: Vec<&str> = Vec::new();
+    for dir in current.split(':').chain(STANDARD_BIN_DIRS.split(':')) {
+        if !dir.is_empty() && !out.contains(&dir) {
+            out.push(dir);
+        }
+    }
+    out.join(":")
 }
 
 /// Wrap a command as `/bin/sh -c "exec <command>"`.
@@ -48,15 +82,15 @@ pub fn unit_path_env() -> String {
 /// `argv[0]` of the resulting unit is the SHELL, not `ainb`, and that is the
 /// point. Neither scheduler does the `PATH` lookup a naive reading suggests:
 /// launchd resolves `ProgramArguments[0]` against its own job environment and
-/// ignores the plist's `EnvironmentVariables` PATH entirely — a bare name there
-/// fails to spawn before the process ever starts — and systemd resolves a
+/// ignores the plist's `EnvironmentVariables` PATH entirely (a bare name there
+/// fails to spawn before the process ever starts), and systemd resolves a
 /// non-absolute `ExecStart` against a fixed compile-time list that excludes
 /// `~/.cargo/bin` and `~/.local/bin`. Going through `/bin/sh -c` moves the
 /// lookup somewhere that DOES honour the unit's `PATH`, and does it at every
 /// launch rather than freezing it at install time.
 ///
 /// `exec` so the shell replaces itself with `ainb` rather than lingering as a
-/// parent — which also keeps launchd's `KeepAlive` watching the real process.
+/// parent, which also keeps launchd's `KeepAlive` watching the real process.
 #[must_use]
 pub fn shell_wrapped_argv(bin: &str, args: &[&str]) -> Vec<String> {
     let command = std::iter::once(bin)
@@ -105,6 +139,22 @@ impl ProgramHealth {
     }
 }
 
+/// Health of the program the unit file at `unit` would run.
+///
+/// The single place that turns "a unit path" into a verdict, so the ATC timer
+/// and the phone bridge cannot drift into reporting different health for the
+/// same class of broken unit.
+#[must_use]
+pub fn unit_program_health_at(unit: &std::path::Path) -> ProgramHealth {
+    if !unit.exists() {
+        return ProgramHealth::NoUnit;
+    }
+    match std::fs::read_to_string(unit) {
+        Ok(text) => unit_program_health(&text),
+        Err(e) => ProgramHealth::Unreadable(format!("cannot read {}: {e}", unit.display())),
+    }
+}
+
 /// Health of the program a unit's text describes.
 #[must_use]
 pub fn unit_program_health(text: &str) -> ProgramHealth {
@@ -130,7 +180,7 @@ fn unit_argv(text: &str) -> Option<Vec<String>> {
 /// The binary whose availability actually decides whether the unit can run.
 ///
 /// Units are written as `/bin/sh -c "exec ainb …"`, so `argv[0]` is the shell
-/// and always resolves — reporting on it would certify every broken unit as
+/// and always resolves, so reporting on it would certify every broken unit as
 /// healthy. Look through the wrapper to the command it runs. Units written
 /// before the wrapper existed (a direct absolute path) still report on that
 /// path, which is what makes an already-installed stale unit detectable.
@@ -172,6 +222,13 @@ fn program_resolves_in(program: &str, search_path: Option<&str>) -> bool {
         return false;
     }
     if program.contains('/') {
+        // A relative path is judged against the CALLER's cwd by `which`, but
+        // the scheduler launches from `/`, so it can never mean the same file.
+        // Report it unresolvable rather than letting the verdict depend on
+        // which directory the operator happened to run `status` from.
+        if !std::path::Path::new(program).is_absolute() {
+            return false;
+        }
         return which::which(program).is_ok();
     }
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
@@ -226,25 +283,34 @@ fn xml_unescape(s: &str) -> String {
 }
 
 /// Inverse of [`shell_quote`]: split a command line into argv.
+///
+/// Both quote styles are honoured. We only ever emit `'`, but an installed
+/// unit may predate that: earlier bridge code wrapped whitespace arguments in
+/// `"`, and systemd honours `"` in `ExecStart` too. Misparsing one of those
+/// makes `status` report a running service as MISSING.
 fn shell_split(s: &str) -> Vec<String> {
     let mut argv = Vec::new();
     let mut current = String::new();
     let mut has_token = false;
-    let mut in_quotes = false;
+    let mut quote: Option<char> = None;
     let mut chars = s.chars();
     while let Some(c) = chars.next() {
         match c {
-            '\'' => {
-                in_quotes = !in_quotes;
+            '\'' | '"' if quote.is_none() => {
+                quote = Some(c);
                 has_token = true;
             }
-            '\\' if !in_quotes => {
+            c if quote == Some(c) => {
+                quote = None;
+                has_token = true;
+            }
+            '\\' if quote.is_none() => {
                 if let Some(escaped) = chars.next() {
                     current.push(escaped);
                     has_token = true;
                 }
             }
-            c if c.is_whitespace() && !in_quotes => {
+            c if c.is_whitespace() && quote.is_none() => {
                 if has_token {
                     argv.push(std::mem::take(&mut current));
                     has_token = false;
@@ -328,7 +394,7 @@ mod tests {
     }
 
     /// Units written before the wrapper existed must still be judged on the
-    /// right binary — that is what makes an already-installed stale unit
+    /// right binary. That is what makes an already-installed stale unit
     /// detectable rather than silently unrecognised.
     #[test]
     fn program_from_argv_understands_legacy_direct_units() {
@@ -417,8 +483,8 @@ mod tests {
         let _ = std::fs::remove_file(&not_executable);
     }
 
-    /// A bare program must be judged against the PATH the UNIT carries — the
-    /// one the shell will use — not against whatever `$PATH` the operator
+    /// A bare program must be judged against the PATH the UNIT carries (the
+    /// one the shell will use), not against whatever `$PATH` the operator
     /// happens to be running the status command with.
     #[test]
     fn bare_program_resolves_against_the_units_own_path() {
@@ -441,7 +507,7 @@ mod tests {
         );
     }
 
-    /// An unparseable unit must not be reported as healthy — that is the same
+    /// An unparseable unit must not be reported as healthy. That is the same
     /// false positive the whole check exists to remove.
     #[test]
     fn an_unrecognised_unit_is_unknown_not_healthy() {
@@ -469,6 +535,98 @@ mod tests {
             ProgramHealth::Missing("/gone/ainb".into()).problem().as_deref(),
             Some("program MISSING (/gone/ainb)")
         );
+    }
+
+    /// The scheduler launches from `/`, so a relative `$AINB_BIN` written
+    /// verbatim can never be found. Anchor it at install time instead.
+    #[test]
+    fn a_relative_binary_override_is_made_absolute() {
+        let cwd = std::env::current_dir().expect("cwd");
+        let resolved = ainb_bin_from(Some("./target/release/ainb"));
+        assert!(
+            std::path::Path::new(&resolved).is_absolute(),
+            "relative override left relative: {resolved}"
+        );
+        assert!(resolved.starts_with(&cwd.display().to_string()));
+        assert!(resolved.ends_with("target/release/ainb"));
+        // A bare name is NOT a path; the shell resolves it on PATH.
+        assert_eq!(ainb_bin_from(Some("ainb")), "ainb");
+        assert_eq!(ainb_bin_from(Some("/opt/custom/ainb")), "/opt/custom/ainb");
+    }
+
+    /// A relative program in an already-installed unit must read as broken
+    /// regardless of where `status` is run from, because the scheduler runs
+    /// the unit from `/` and can never resolve it.
+    #[test]
+    fn a_relative_program_never_reports_healthy() {
+        // `target/debug/ainb` may well exist relative to the test's cwd; the
+        // point is that this must not make it count as resolvable.
+        assert!(!program_resolves_in("target/debug/ainb", None));
+        assert!(!program_resolves_in("./ainb", Some("/bin:/usr/bin")));
+        // The absolute form is still judged on its merits.
+        assert!(program_resolves_in("/bin/sh", None));
+    }
+
+    /// The unit's PATH must not be only what the installing shell happened to
+    /// have: a direnv/nix/`target/debug` entry that later vanishes would
+    /// strand the unit, which is #608 one level up.
+    #[test]
+    fn unit_path_always_includes_the_standard_dirs() {
+        let path = unit_path_env();
+        for dir in STANDARD_BIN_DIRS.split(':') {
+            assert!(
+                path.split(':').any(|d| d == dir),
+                "unit PATH is missing the {dir} floor: {path}"
+            );
+        }
+        // No duplicates, so the entry order stays meaningful.
+        let dirs: Vec<&str> = path.split(':').collect();
+        let mut unique = dirs.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(dirs.len(), unique.len(), "duplicate PATH entries: {path}");
+    }
+
+    /// Units written before this change double-quoted whitespace arguments,
+    /// and systemd honours `"` too. Misparsing one reports a running service
+    /// as MISSING and sends the operator to reinstall it for nothing.
+    #[test]
+    fn shell_split_handles_legacy_double_quoted_units() {
+        assert_eq!(
+            systemd_exec_start_argv(
+                "[Service]\nExecStart=\"/opt/my apps/ainb\" fleet bridge run\n"
+            ),
+            Some(vec![
+                "/opt/my apps/ainb".into(),
+                "fleet".into(),
+                "bridge".into(),
+                "run".into()
+            ])
+        );
+        assert_eq!(
+            program_from_argv(
+                &unit_argv("[Service]\nExecStart=\"/opt/my apps/ainb\" fleet bridge run\n")
+                    .expect("argv")
+            )
+            .as_deref(),
+            Some("/opt/my apps/ainb")
+        );
+    }
+
+    #[test]
+    fn unit_program_health_at_separates_absent_from_unreadable() {
+        let dir = std::env::temp_dir();
+        let absent = dir.join("ainb-unit-program-test-absent.plist");
+        let _ = std::fs::remove_file(&absent);
+        assert_eq!(unit_program_health_at(&absent), ProgramHealth::NoUnit);
+
+        let junk = dir.join("ainb-unit-program-test-junk.plist");
+        std::fs::write(&junk, b"not a unit").expect("write fixture");
+        assert!(matches!(
+            unit_program_health_at(&junk),
+            ProgramHealth::Unreadable(_)
+        ));
+        let _ = std::fs::remove_file(&junk);
     }
 
     #[test]


### PR DESCRIPTION
## What

`ainb fleet bridge install` baked an **absolute, version-scoped** path into the launchd plist. Confirmed live on a homebrew host:

```console
$ plutil -extract ProgramArguments json -o - ~/Library/LaunchAgents/com.agentsinabox.phone-bridge.plist
["/opt/homebrew/Cellar/ainb/1.18.0/libexec/ainb","fleet","bridge","run"]
```

`/opt/homebrew/Cellar/ainb/1.18.0/` is the Cellar **version** directory. The next `brew upgrade ainb` deletes it, launchd exits 78 `EX_CONFIG` and parks in the penalty box, and the bridge dies **silently** because `bridge status` only stat'd the unit FILE.

Same root cause as #608 in a different file. #609 fixed the ATC timer and has merged; this fixes the phone bridge and deduplicates the two onto one module. #608 stays open, #609 owns closing it.

## Both schedulers reach the binary through a shell

Neither scheduler does the `PATH` lookup a naive reading suggests, and they fail differently:

**launchd** resolves `ProgramArguments[0]` against its own job environment and ignores the plist's `EnvironmentVariables` PATH entirely. Probed on a real host with the exact plist shape this emits:

| `ProgramArguments[0]` | plist `PATH` set | result |
|---|---|---|
| bare `ainbprobe` | yes | **exit 78 `EX_CONFIG`**, never ran |
| `/bin/sh -c 'exec ainbprobe'` | yes | **exit 0**, ran |

**systemd** resolves a non-absolute `ExecStart` against a fixed compile-time list, never the unit's `Environment=PATH`. From `systemd.service(5)`:

> Systemd has never looked at the PATH variable for resolving non absolute binaries.

So both units run `/bin/sh -c "exec ainb …"` with the unit carrying its own `PATH`, which the shell does honour. `exec` means the shell replaces itself, so `KeepAlive` watches the real process. `$AINB_BIN` remains the explicit override, absolutised (and tilde-expanded) at install time because the scheduler launches from `/`.

## Status stops lying, and install stops starting broken units

`bridge status` parses the real program back out of the installed unit, sees **through** the `/bin/sh` wrapper (reporting on `argv[0]` would certify every broken unit healthy, since `/bin/sh` always resolves), still understands legacy unwrapped units, and judges it against **the PATH the unit carries**, not the caller's. `ProgramHealth` distinguishes `Missing` from `Unreadable`, so an unparseable unit reports UNKNOWN rather than passing as good or being told it can never start.

`install()` writes the unit but only **starts** it when the program resolves. Starting a known-broken one is not harmless: the shell spawns fine and `exec ainb` exits 127, so `KeepAlive` / `Restart=always` respawn forever into an unrotated log.

## Shared module

`crates/ainb-core/src/fleet/unit_program.rs` owns the machinery both units need. `timer.rs` went **872 to 517 lines** pointing at it; `ProgramHealth` is re-exported so `cli/fleet/atc.rs` needed no edit. The behaviour is #609's, moved rather than rewritten.

## Known trade-off: the unit no longer pins binary identity

Deliberate, and worth a reviewer's attention.

Resolving `ainb` by name at launch is the point of #608 and what #609 shipped. The cost is that **PATH order now chooses the binary**: installing while a stale `ainb` sits earlier on PATH runs the old build, and status cannot tell. Re-pinning would restore exactly the upgrade breakage this branch removes, so it is not done here.

Narrowed rather than ignored: relative PATH entries (`.`, `target/debug`, a direnv-added relative bin dir) are now **dropped** before the PATH is written into the unit. That removes the project-local-directory case, which is the sharp edge. What remains is that an absolute directory on your own PATH can supply the binary, which is true of any PATH-resolved tool.

Restoring binary-identity pinning is a design change spanning both the bridge and the ATC timer, and belongs with the cross-cutting work in #615, not here.

## Review

Two high-effort review passes, 20 findings, 19 fixed and 1 (the trade-off above) explicitly skipped with the residual stated.

The two that mattered most were both cases where the fix reintroduced the bug class it was removing: the systemd unit failing `203/EXEC` while status called it healthy, and `install()` leaving a known-broken unit crash-looping next to a printed warning.

Also fixed: `which::which` resolving a relative program against the caller's cwd; the frozen install-time PATH re-creating #608 one level up (standard bin dirs are now appended as a floor); the ATC plist interpolating `PATH`/`HOME`/`log` into XML without escaping (an `R&D` directory produced malformed XML launchctl rejects, while status reported healthy); systemd `Environment=` assignments unquoted and `%` unescaped; `--format json` install emitting two documents on stdout; `shell_split` mishandling both legacy double-quoted units and literal quotes; tilde `$AINB_BIN`; and `RestartSec` left asymmetric with the launchd throttle.

## Tests

47 pass: `cargo test -p ainb --lib -- fleet::unit_program fleet::bridge::service fleet::atc::timer`

Highlights: `units_do_not_pin_an_absolute_binary_path` is **mutation-checked** (reintroducing `current_exe()` fails it); `the_shell_wrapper_does_not_hide_a_dead_binary_from_status` pins the wrapper-blindfold case; `a_legacy_unwrapped_unit_is_still_flagged` covers units already installed by an older `ainb`; plus coverage for relative-PATH dropping, tilde expansion, quote-boundary parsing, systemd quoting/escaping, and `which`-not-`exists()`.

## CI note

`hangar-e2e (ubuntu-latest)` is intermittent and unrelated: `ainb-hangar-daemon` has **no dependency edge to `ainb-core`**, so it cannot compile or call anything in this diff, and a different test failed on each of three runs. It also fails independently on main. Every other check, including all three macOS jobs, `Contracts` and `Rustfmt`, is green.

Related: #608 (do not auto-close, #609 owns it), #615.
