### PR TITLE
fix(fleet): render ACP sessions as ACP, and prove it on the TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,16 @@ jobs:
           needs.changes.outputs.relevant != 'false')
         run: cargo test -p ainb --test tripwire_inbox_opens_and_renders --no-fail-fast
         working-directory: ${{ env.WORKING_DIR }}
+      - name: Tripwire — Fleet panel renders an ACP session
+        # The TUI is the operating surface. The chat bus shipped a daemon and a
+        # CLI, and the panel maps the ACP wire token in ONE place, falling back
+        # to `unknown` in silence. Without this, that line has no coverage on
+        # the screen an operator actually looks at.
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: cargo test -p ainb --test tripwire_fleet_panel_shows_acp_session --no-fail-fast
+        working-directory: ${{ env.WORKING_DIR }}
       - name: Sandbox script safety guards (rm -rf belts)
         if: >-
           always() && (github.event_name != 'pull_request' ||

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
@@ -1,0 +1,190 @@
+//! Tripwire: an ACP chat session created through the real CLI is VISIBLE in the
+//! real Fleet panel, labelled `acp`, in a live terminal.
+//!
+//! Part 1 of the chat bus shipped a daemon and a CLI, and every end-to-end proof
+//! it carried drove those two. The TUI is the operating surface, and it consumed
+//! part 1's changes without anything ever opening it: `FleetProvider::Acp` maps
+//! to the string `acp` at exactly one line of `ainb-plugin-hangar`
+//! (`src/screen/fleet.rs`), and a wire token the panel does not recognise falls
+//! to `unknown` SILENTLY. That is a one-line regression nothing else would
+//! catch, on the screen the operator actually looks at.
+//!
+//! So this drives the real `ainb` binary in tmux against an isolated Hangar,
+//! creates the session the way a user would (`ainb fleet acp create`), and reads
+//! the pane.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[path = "support/fleet_hangar.rs"]
+mod fleet_hangar;
+
+use fleet_hangar::{EnvGuard, ExactTmuxSession, FleetHangar};
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux").arg("-V").output().is_ok_and(|o| o.status.success())
+}
+
+/// A HOME with onboarding complete and the notify prompt dismissed, so no
+/// first-run modal eats the `f` that opens the panel.
+fn seed_isolated_home(home: &Path) {
+    let base = home.join(".agents-in-a-box");
+    let cfg = base.join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    fs::write(
+        cfg.join("onboarding.toml"),
+        format!(
+            r#"completed = true
+completed_at = "2026-08-08T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+            ver = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("seed onboarding.toml");
+    fs::write(
+        base.join("install.json"),
+        r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#,
+    )
+    .expect("seed install.json");
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn send_key(session: &str, key: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+}
+
+/// Press `f` until the Fleet panel is actually on screen.
+fn open_fleet_panel(session: &str) -> Option<String> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        let capture = capture_pane(session);
+        if capture.contains("Fleet ·") {
+            return Some(capture);
+        }
+        send_key(session, "f");
+        thread::sleep(Duration::from_millis(500));
+    }
+    None
+}
+
+#[test]
+fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::Builder::new()
+        .prefix("ainb-acpv-")
+        .tempdir_in("/tmp")
+        .expect("home tempdir");
+    seed_isolated_home(home_tmp.path());
+    let hangar_home = home_tmp.path().join("hangar-home");
+    let _ainb_home = EnvGuard::set("AINB_HOME", home_tmp.path().join(".agents-in-a-box"));
+    let _no_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
+
+    // A real daemon on a real socket, same as every other Fleet tripwire.
+    let _hangar = FleetHangar::start(&hangar_home);
+
+    // The user's own path to an ACP session: the CLI, over the daemon socket.
+    let cwd = home_tmp.path().join("acp-project");
+    fs::create_dir_all(&cwd).expect("create project dir");
+    let created = Command::new(ainb_bin())
+        .args([
+            "--format",
+            "json",
+            "fleet",
+            "acp",
+            "create",
+            "--provider",
+            "claude-agent-acp",
+            "--cwd",
+        ])
+        .arg(&cwd)
+        .env("HOME", home_tmp.path())
+        .env("AINB_HOME", home_tmp.path().join(".agents-in-a-box"))
+        .env("AINB_HANGAR_HOME", &hangar_home)
+        .output()
+        .expect("run ainb fleet acp create");
+    assert!(
+        created.status.success(),
+        "acp create failed: {}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let session_key = serde_json::from_slice::<serde_json::Value>(&created.stdout)
+        .expect("acp create prints one JSON document")["session_key"]
+        .as_str()
+        .expect("a session_key")
+        .to_string();
+    assert!(session_key.starts_with("acp:"), "unexpected key: {session_key}");
+
+    let name = format!("ainb-acp-panel-{}", std::process::id());
+    let tmux = ExactTmuxSession::create(name, "180", "50");
+    let session = tmux.name();
+    let peers_db = home_tmp.path().join("peers.db");
+    let jobs_dir = home_tmp.path().join("jobs");
+    let cmd = format!(
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} \
+         AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 \
+         CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
+        home = home_tmp.path().display(),
+        hangar = hangar_home.display(),
+        peers = peers_db.display(),
+        jobs = jobs_dir.display(),
+        bin = ainb_bin().display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, &cmd, "C-m"])
+        .status()
+        .expect("launch the TUI");
+
+    let panel = open_fleet_panel(session).unwrap_or_else(|| {
+        panic!("the Fleet panel never opened:\n{}", capture_pane(session));
+    });
+
+    // The pane must show the session AS an ACP session. `unknown` here is the
+    // exact silent regression this tripwire exists for: the panel maps the wire
+    // token in one place and falls back rather than failing.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut last = panel;
+    let mut seen = false;
+    while Instant::now() < deadline {
+        last = capture_pane(session);
+        if last.contains("acp") {
+            seen = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    send_key(session, "Escape");
+
+    assert!(
+        seen,
+        "the Fleet panel never rendered the ACP session {session_key} as `acp`\npane:\n{last}"
+    );
+    assert!(
+        !last.contains("unknown"),
+        "the panel rendered a session as `unknown`, which is how an unmapped \
+         provider token degrades silently\npane:\n{last}"
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
@@ -34,7 +34,7 @@ fn tmux_available() -> bool {
 
 /// A HOME with onboarding complete and the notify prompt dismissed, so no
 /// first-run modal eats the `f` that opens the panel.
-fn seed_isolated_home(home: &Path) {
+fn seed_isolated_home(home: &Path, hangar_home: &Path) {
     let base = home.join(".agents-in-a-box");
     let cfg = base.join("config");
     fs::create_dir_all(&cfg).expect("create isolated config dir");
@@ -51,6 +51,15 @@ git_directories = []
         ),
     )
     .expect("seed onboarding.toml");
+    // `notifyd::Paths::from_home` resolves `AINB_HANGAR_HOME` BEFORE `AINB_HOME`,
+    // and this test sets both, so the record has to exist under the hangar home
+    // or the install offer fires and its modal swallows the `f`.
+    seed_notify_dismissed(&base);
+    seed_notify_dismissed(hangar_home);
+}
+
+fn seed_notify_dismissed(base: &Path) {
+    fs::create_dir_all(base).expect("create notify record dir");
     fs::write(
         base.join("install.json"),
         r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#,
@@ -98,8 +107,8 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
         .prefix("ainb-acpv-")
         .tempdir_in("/tmp")
         .expect("home tempdir");
-    seed_isolated_home(home_tmp.path());
     let hangar_home = home_tmp.path().join("hangar-home");
+    seed_isolated_home(home_tmp.path(), &hangar_home);
     let _ainb_home = EnvGuard::set("AINB_HOME", home_tmp.path().join(".agents-in-a-box"));
     let _no_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
@@ -3,11 +3,15 @@
 //!
 //! Part 1 of the chat bus shipped a daemon and a CLI, and every end-to-end proof
 //! it carried drove those two. The TUI is the operating surface, and it consumed
-//! part 1's changes without anything ever opening it: `FleetProvider::Acp` maps
-//! to the string `acp` at exactly one line of `ainb-plugin-hangar`
-//! (`src/screen/fleet.rs`), and a wire token the panel does not recognise falls
-//! to `unknown` SILENTLY. That is a one-line regression nothing else would
-//! catch, on the screen the operator actually looks at.
+//! part 1's changes without anything ever opening it.
+//!
+//! Writing this found the bug it was written to imagine. `ainb-plugin-hangar`
+//! maps a provider TWICE: `FleetSessionRow::from` turns `FleetProvider::Acp`
+//! into the wire token `acp`, and `provider_label` turns that token into what
+//! the operator reads. Part 1 updated the first and not the second, so a chat
+//! session rendered as UNKNOWN on the panel while every daemon-level and
+//! CLI-level test stayed green. That is the class of regression only this
+//! surface can catch.
 //!
 //! So this drives the real `ainb` binary in tmux against an isolated Hangar,
 //! creates the session the way a user would (`ainb fleet acp create`), and reads
@@ -170,33 +174,41 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
         .status()
         .expect("launch the TUI");
 
-    let panel = open_fleet_panel(session).unwrap_or_else(|| {
+    open_fleet_panel(session).unwrap_or_else(|| {
         panic!("the Fleet panel never opened:\n{}", capture_pane(session));
     });
 
-    // The pane must show the session AS an ACP session. `unknown` here is the
-    // exact silent regression this tripwire exists for: the panel maps the wire
-    // token in one place and falls back rather than failing.
+    // The panel lands on the action queue, which shows only what needs the
+    // operator; an idle chat session is not on it. `5` is the All view, the
+    // key the pane itself advertises, and the first screen that renders rows.
+    send_key(session, "5");
+
+    // A row reads `<branch>  ·  <PROVIDER>  ·  <attachment>`, so match the
+    // provider IN its row rather than anywhere in the pane: a bare `contains`
+    // would pass on any incidental occurrence and prove nothing.
     let deadline = Instant::now() + Duration::from_secs(20);
-    let mut last = panel;
-    let mut seen = false;
+    let mut last = String::new();
+    let mut labelled = None;
     while Instant::now() < deadline {
         last = capture_pane(session);
-        if last.contains("acp") {
-            seen = true;
+        labelled = last.lines().find(|line| line.contains("·  ACP  ·")).map(str::to_string);
+        if labelled.is_some() {
             break;
         }
         thread::sleep(Duration::from_millis(500));
     }
     send_key(session, "Escape");
 
+    // UNKNOWN in the provider column is the exact silent regression this
+    // tripwire exists for: the panel maps a provider twice (wire token, then
+    // display label) and the display half falls back instead of failing.
     assert!(
-        seen,
-        "the Fleet panel never rendered the ACP session {session_key} as `acp`\npane:\n{last}"
+        !last.contains("·  UNKNOWN  ·"),
+        "the panel rendered a session's provider as UNKNOWN, which is how an \
+         unmapped provider degrades silently\npane:\n{last}"
     );
     assert!(
-        !last.contains("unknown"),
-        "the panel rendered a session as `unknown`, which is how an unmapped \
-         provider token degrades silently\npane:\n{last}"
+        labelled.is_some(),
+        "the Fleet panel never rendered the ACP session {session_key} as ACP\npane:\n{last}"
     );
 }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
@@ -86,18 +86,32 @@ fn send_key(session: &str, key: &str) {
         .expect("tmux send-keys");
 }
 
-/// Press `f` until the Fleet panel is actually on screen.
-fn open_fleet_panel(session: &str) -> Option<String> {
-    let deadline = Instant::now() + Duration::from_secs(20);
+fn wait_for(session: &str, needle: &str, secs: u64) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(secs);
     while Instant::now() < deadline {
-        let capture = capture_pane(session);
-        if capture.contains("Fleet ·") {
-            return Some(capture);
+        if capture_pane(session).contains(needle) {
+            return true;
         }
-        send_key(session, "f");
         thread::sleep(Duration::from_millis(500));
     }
-    None
+    false
+}
+
+/// Open Fleet the way a user does: wait for the home screen to paint, then
+/// press `f` ONCE.
+///
+/// Pressing `f` on a loop until something happens would be the wrong test. A
+/// modal that swallows the first press is precisely the failure this is here to
+/// catch, and a retry loop makes it invisible. The spacing in the home banner is
+/// load-bearing too: the setup wizard's splash also says "Agents in a Box", so
+/// the unspaced name would match a screen that eats `f` rather than the screen
+/// that acts on it.
+fn open_fleet_panel(session: &str) -> bool {
+    if !wait_for(session, "A I N B", 60) {
+        return false;
+    }
+    send_key(session, "f");
+    wait_for(session, "Fleet ·", 30)
 }
 
 #[test]
@@ -174,9 +188,11 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
         .status()
         .expect("launch the TUI");
 
-    open_fleet_panel(session).unwrap_or_else(|| {
-        panic!("the Fleet panel never opened:\n{}", capture_pane(session));
-    });
+    assert!(
+        open_fleet_panel(session),
+        "the Fleet panel did not open on the first `f`:\n{}",
+        capture_pane(session)
+    );
 
     // The panel lands on the action queue, which shows only what needs the
     // operator; an idle chat session is not on it. `5` is the All view, the

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
@@ -136,7 +136,10 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
         .as_str()
         .expect("a session_key")
         .to_string();
-    assert!(session_key.starts_with("acp:"), "unexpected key: {session_key}");
+    assert!(
+        session_key.starts_with("acp:"),
+        "unexpected key: {session_key}"
+    );
 
     let name = format!("ainb-acp-panel-{}", std::process::id());
     let tmux = ExactTmuxSession::create(name, "180", "50");

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -2421,11 +2421,23 @@ fn home_state_label(session: &FleetSessionRow) -> &'static str {
     }
 }
 
+/// The on-screen label for a row's provider token.
+///
+/// This is the SECOND mapping of the same fact: `FleetSessionRow::from`
+/// turns a `FleetProvider` into a wire token, and this turns that token
+/// into what the operator reads. A provider added to one and not the
+/// other degrades to `UNKNOWN` on screen with nothing failing, which is
+/// how `acp` and `copilot` shipped invisible. `every_wire_provider_has_a_label`
+/// is what keeps the two in step.
 fn provider_label(provider: &str) -> &'static str {
     if provider.eq_ignore_ascii_case("claude") {
         "CLAUDE"
     } else if provider.eq_ignore_ascii_case("codex") {
         "CODEX"
+    } else if provider.eq_ignore_ascii_case("copilot") {
+        "COPILOT"
+    } else if provider.eq_ignore_ascii_case("acp") {
+        "ACP"
     } else {
         "UNKNOWN"
     }
@@ -5330,6 +5342,74 @@ mod tests {
         assert!(flags.contains("text_send"));
         assert!(!flags.contains("kill"));
         assert!(json.contains("verified_picker"));
+    }
+
+    /// The panel maps a provider TWICE: `FleetSessionRow::from` produces the
+    /// wire token, `provider_label` turns that token into what the operator
+    /// reads. `acp` shipped with only the first half, so a chat session
+    /// rendered as UNKNOWN on the one screen an operator actually looks at,
+    /// and every daemon-level and CLI-level test stayed green. This walks a
+    /// provider through BOTH mappings so the halves cannot drift apart again.
+    #[test]
+    fn every_wire_provider_renders_a_label_operators_can_read() {
+        use ainb_hangar_proto::fleet::{
+            AttentionState, FleetCapabilities as ProtoCapabilities, FleetConfidence,
+            FleetProvenance, FleetProvider, FleetSession, LifecycleState, ManagementState,
+            TransportHealth,
+        };
+
+        // Exhaustive on purpose: a new `FleetProvider` variant must fail to
+        // compile here rather than quietly degrade to UNKNOWN on the panel.
+        fn operators_should_recognise(provider: FleetProvider) -> bool {
+            match provider {
+                FleetProvider::Claude
+                | FleetProvider::Codex
+                | FleetProvider::Copilot
+                | FleetProvider::Acp => true,
+                FleetProvider::Unknown => false,
+            }
+        }
+
+        for provider in [
+            FleetProvider::Claude,
+            FleetProvider::Codex,
+            FleetProvider::Copilot,
+            FleetProvider::Acp,
+            FleetProvider::Unknown,
+        ] {
+            let row = FleetSessionRow::from(FleetSession {
+                session_key: "provider:1".into(),
+                provider,
+                provider_session_id: None,
+                tmux_target: None,
+                process_start_fingerprint: None,
+                cwd: "/work".into(),
+                display_name: None,
+                lifecycle: LifecycleState::Idle,
+                attention: AttentionState::None,
+                current_request_fingerprint: None,
+                current_request: None,
+                management: ManagementState::Managed,
+                transport_health: TransportHealth::Healthy,
+                capabilities: ProtoCapabilities::default(),
+                provenance: FleetProvenance::Authoritative,
+                confidence: FleetConfidence::High,
+                discovered_at: 0,
+                last_observed_at: 0,
+                lifecycle_updated_at: 0,
+                attention_updated_at: 0,
+                active_work_count: 0,
+                version: 1,
+                updated_revision: 1,
+            });
+            let label = provider_label(&row.provider);
+            assert_eq!(
+                label != "UNKNOWN",
+                operators_should_recognise(provider),
+                "{provider:?} reaches the panel as wire token `{}` and renders as `{label}`",
+                row.provider
+            );
+        }
     }
 
     #[test]

--- a/explainers/chat-bus-proven.html
+++ b/explainers/chat-bus-proven.html
@@ -78,6 +78,8 @@
   tr:last-child td { border-bottom: none; }
   td code { font-size: 12px; }
   .pass { color: var(--olive); font-weight: 600; }
+  .dl { font-family: var(--mono); font-size: 11.5px; color: var(--gray-500); }
+  .dl:hover { color: var(--slate); }
 </style>
 </head>
 <body>
@@ -89,6 +91,7 @@
     <a href="#what">What shipped</a>
     <a href="#arch">How it works</a>
     <a href="#proof">The proof</a>
+    <a href="#recordings">All recordings</a>
     <a href="#proof" class="l2">j1 bus on tmux</a>
     <a href="#proof" class="l2">j2 ACP streaming</a>
     <a href="#proof" class="l2">j3 resume</a>
@@ -112,9 +115,9 @@
       <h1>The ainb chat bus: built, proven, recorded</h1>
       <div class="tldr" id="tldr">
         <b>TL;DR</b> ainb can now hold a conversation. Messages go to running tmux sessions AND to
-        headless ACP agents (Claude, Codex) through one bus, with receipts per recipient, live
+        headless ACP agents through one bus, with receipts per recipient, live
         execution transcripts, actionable permission prompts, and resume across a daemon crash. Six
-        phases, seven merged PRs, sixteen named invariants, and nine live journeys recorded end to
+        phases, five merged PRs, sixteen named invariants, and nine live journeys recorded end to
         end against real processes. Every recording below is an uncut run, and every frame was read
         to confirm it shows the assertion it claims.
       </div>
@@ -177,16 +180,22 @@
     <h2 id="proof">The proof</h2>
     <p>Every recording is one uncut run of <code>ainb-tui/scripts/chat-bus-smoke.sh</code>. Each run
       builds a scratch world: its own hangar home, a real daemon, the real <code>ainb</code> binary,
-      three real tmux sessions, and an ACP adapter. Nothing is mocked at the edges, and nothing is
-      cut. Frames were extracted from every tape and read; the assertion text quoted under each
-      recording is text that was actually on screen.</p>
+      three real tmux sessions, and an ACP adapter. Frames were extracted from every tape and read;
+      the assertion text quoted under each recording is text that was actually on screen.</p>
+    <p><b>What is real and what is not, precisely.</b> The daemon, the store, the CLI, the tmux
+      sessions and the protocol traffic are real: these runs speak the same wire the TUI and the
+      macOS app speak. The ACP agent on the far end is a scripted fixture that implements the
+      protocol, not a live Claude or Codex process, because no adapter is installed on this
+      machine. Every tape says so in its own banner (<code>adapter mode: fixture</code>). The
+      adapters themselves were measured by hand against the real thing when the protocol behaviour
+      was pinned, and the real-adapter tests are written and skip until an adapter is present.</p>
 
     <figure>
       <img src="https://robust-rocket-8zjr.here.now/media/j1.gif" alt="Journey 1: one message reaching three real tmux panes verbatim">
       <figcaption><b>j1 . the bus on tmux.</b> One <code>msg send</code> to three targets, three
         DELIVERED receipts, the payload verbatim in every pane, and a follower that was already
         streaming when it happened.<br>
-        <span class="assert">RECEIVED:[j1 ...] hello fleet, deliver me verbatim &middot; 3/3 DELIVERED &middot; 3/3 panes verbatim &middot; follower saw it</span></figcaption>
+        <span class="assert">RECEIVED:[j1 ...] hello fleet, deliver me verbatim &middot; 3/3 DELIVERED &middot; 3/3 panes verbatim &middot; follower saw it</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j1.mp4">download the full j1 run (mp4)</a></figcaption>
     </figure>
 
     <figure>
@@ -194,7 +203,7 @@
       <figcaption><b>j2 . ACP with live transcript.</b> A chunk is readable while the delivery is
         still PENDING, which is the whole point of the side channel, and the timeline gets exactly
         one message against seven transcript chunks.<br>
-        <span class="assert">7 transcript chunks &middot; 1 timeline reply &middot; first chunk line 3 &lt; turn end line 8</span></figcaption>
+        <span class="assert">7 transcript chunks &middot; 1 timeline reply &middot; first chunk line 3 &lt; turn end line 8</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j2.mp4">download the full j2 run (mp4)</a></figcaption>
     </figure>
 
     <figure>
@@ -202,8 +211,9 @@
       <figcaption><b>j3 . resume across a daemon SIGKILL.</b> The daemon is killed mid-turn and
         restarted; the conversation continues on the same session key, through the adapter's own
         <code>session/load</code> rather than the fallback, with the interrupted leg converged and no
-        ghost approval rows left behind.<br>
-        <span class="assert">resumed via [loaded] on the same session_key &middot; 2 agent replies &middot; 0 ghost attention rows</span></figcaption>
+        ghost approval rows left behind. The journey asserts the path is <code>loaded</code>, so a
+        daemon that silently fell back to re-priming fails this rather than passing quietly.<br>
+        <span class="assert">resumed via [loaded] on the same session_key &middot; 2 agent replies &middot; 0 ghost attention rows</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j3.mp4">download the full j3 run (mp4)</a></figcaption>
     </figure>
 
     <figure>
@@ -211,7 +221,7 @@
       <figcaption><b>j4 . the adapter dies, the daemon lives.</b> The in-flight leg converges with an
         enumerated reason, the daemon pid is unchanged, and the same scope accepts the next message
         with no restart. Before this work the honest answer was "restart the daemon".<br>
-        <span class="assert">converged UNKNOWN/adapter_exit &middot; same daemon pid &middot; next message DELIVERED</span></figcaption>
+        <span class="assert">converged UNKNOWN/adapter_exit &middot; same daemon pid &middot; next message DELIVERED</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j4.mp4">download the full j4 run (mp4)</a></figcaption>
     </figure>
 
     <h2 id="faults">The fault matrix</h2>
@@ -222,14 +232,14 @@
       <figcaption><b>j5a . bounded queue.</b> Prompts pile up behind a wedged turn until one is
         refused, rather than the queue growing without bound. The depth is discovered from the
         running pool, not hard-coded in the test.<br>
-        <span class="assert">queue accepted 32 prompts, then REJECTED/queue_full</span></figcaption>
+        <span class="assert">queue accepted 32 prompts, then REJECTED/queue_full</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j5a.mp4">download the full j5a run (mp4)</a></figcaption>
     </figure>
 
     <figure>
       <img src="https://robust-rocket-8zjr.here.now/media/j5b.gif" alt="Turn deadline converges a hung adapter">
       <figcaption><b>j5b . turn deadline.</b> An adapter that never ends its turn cannot hold a scope
         forever: the deadline cancels that session only, and the scope is immediately reusable.<br>
-        <span class="assert">converged UNKNOWN/turn_deadline after the deadline &middot; scope reusable</span></figcaption>
+        <span class="assert">converged UNKNOWN/turn_deadline after the deadline &middot; scope reusable</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j5b.mp4">download the full j5b run (mp4)</a></figcaption>
     </figure>
 
     <figure>
@@ -237,7 +247,7 @@
       <figcaption><b>j5c . idempotency.</b> The same request id twice delivers once. The same id with
         different text is refused with a typed error and a distinct exit code, and never reaches the
         pane.<br>
-        <span class="assert">one delivery for two identical sends &middot; exit 5 on the conflicting third</span></figcaption>
+        <span class="assert">one delivery for two identical sends &middot; exit 5 on the conflicting third</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j5c.mp4">download the full j5c run (mp4)</a></figcaption>
     </figure>
 
     <figure>
@@ -246,15 +256,39 @@
         the option ids and the pending request id, an operator approves over the same wire the TUI
         uses, and the adapter gets a real answer rather than the "transport is not active" shrug the
         pre-port code returned.<br>
-        <span class="assert">attention row -&gt; fleet/action approve -&gt; DELIVERED, row closed</span></figcaption>
+        <span class="assert">attention row -&gt; fleet/action approve -&gt; DELIVERED, row closed</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j5d.mp4">download the full j5d run (mp4)</a></figcaption>
     </figure>
 
     <figure>
       <img src="https://robust-rocket-8zjr.here.now/media/j5e.gif" alt="Unknown target rejected per delivery">
       <figcaption><b>j5e . unknown target.</b> One bad recipient in a broadcast is rejected on its own
         leg with a reason; the request itself still succeeds and the message is still persisted.<br>
-        <span class="assert">DELIVERED + REJECTED/target_unknown in one request, message persisted</span></figcaption>
+        <span class="assert">DELIVERED + REJECTED/target_unknown in one request, message persisted</span><br><a class="dl" href="https://robust-rocket-8zjr.here.now/media/j5e.mp4">download the full j5e run (mp4)</a></figcaption>
     </figure>
+
+    <h2 id="recordings">All recordings</h2>
+    <p>Nine tapes, one per journey, each an uncut run. They live in the repo at
+      <code>explainers/recordings/chat-bus/</code> next to
+      <code>EXPECTED-OUTCOMES.md</code>, which names the exact frame text each one must
+      show. There is deliberately no whole-suite tape: three attempts to capture the
+      fifteen minute run died mid-recording, and a tape that stops after four journeys
+      looks like evidence without being any. Run the suite yourself instead, it is one
+      command.</p>
+
+    <table>
+      <thead><tr><th>Journey</th><th>What it proves</th><th>Files</th></tr></thead>
+      <tbody>
+        <tr><td><code>j1</code></td><td>the bus on tmux, three panes</td><td><a href="https://robust-rocket-8zjr.here.now/media/j1.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j1.mp4">mp4</a></td></tr>
+        <tr><td><code>j2</code></td><td>ACP with live transcript</td><td><a href="https://robust-rocket-8zjr.here.now/media/j2.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j2.mp4">mp4</a></td></tr>
+        <tr><td><code>j3</code></td><td>resume across a daemon SIGKILL</td><td><a href="https://robust-rocket-8zjr.here.now/media/j3.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j3.mp4">mp4</a></td></tr>
+        <tr><td><code>j4</code></td><td>adapter dies, daemon lives</td><td><a href="https://robust-rocket-8zjr.here.now/media/j4.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j4.mp4">mp4</a></td></tr>
+        <tr><td><code>j5a</code></td><td>bounded queue overflow</td><td><a href="https://robust-rocket-8zjr.here.now/media/j5a.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j5a.mp4">mp4</a></td></tr>
+        <tr><td><code>j5b</code></td><td>turn deadline</td><td><a href="https://robust-rocket-8zjr.here.now/media/j5b.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j5b.mp4">mp4</a></td></tr>
+        <tr><td><code>j5c</code></td><td>idempotency replay</td><td><a href="https://robust-rocket-8zjr.here.now/media/j5c.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j5c.mp4">mp4</a></td></tr>
+        <tr><td><code>j5d</code></td><td>permission round trip</td><td><a href="https://robust-rocket-8zjr.here.now/media/j5d.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j5d.mp4">mp4</a></td></tr>
+        <tr><td><code>j5e</code></td><td>unknown target</td><td><a href="https://robust-rocket-8zjr.here.now/media/j5e.gif">gif</a> · <a href="https://robust-rocket-8zjr.here.now/media/j5e.mp4">mp4</a></td></tr>
+      </tbody>
+    </table>
 
     <h2 id="caught">What the reviews caught</h2>
     <p>Every phase was built by one agent, reviewed adversarially by another, then reviewed again


### PR DESCRIPTION
Part 1 of the chat bus shipped a daemon and a CLI, and every end-to-end proof it carried drove those two. The TUI is the operating surface, and nothing ever opened it. This adds a tripwire that does, and the tripwire immediately found a real bug.

## The bug

`ainb-plugin-hangar/src/screen/fleet.rs` maps a provider **twice**:

- `FleetSessionRow::from` turns `FleetProvider::Acp` into the wire token `acp`
- `provider_label` turns that token into the label an operator reads

Part 1 updated the first and not the second. `provider_label` knew only `claude` and `codex`, so everything else fell through to `UNKNOWN`. An ACP chat session rendered as **UNKNOWN** on the Fleet panel while every daemon-level and CLI-level test stayed green. `copilot` was wrong the same way, and that one matters more in part 2.

The fix teaches `provider_label` the remaining providers and adds `every_wire_provider_renders_a_label_operators_can_read`, which walks a provider through *both* mappings. Its inner match is exhaustive on purpose, so a new `FleetProvider` variant fails to compile here rather than quietly degrading on screen.

Mutation proof that the guard bites (reverted after):

```
test screen::fleet::tests::every_wire_provider_renders_a_label_operators_can_read ... FAILED
assertion `left == right` failed: Copilot reaches the panel as wire token `copilot` and renders as `UNKNOWN`
```

## The tripwire

`tripwire_fleet_panel_shows_acp_session` drives the real `ainb` binary in tmux against an isolated Hangar, creates the session the way a user would (`ainb fleet acp create`), opens the Fleet panel with `f`, and reads the pane.

Two things it taught us about the panel, both now encoded:

- It opens on the **action queue**, which shows only what needs the operator, so an idle chat session is not on it. The pane says so itself: *"Sessions are running, idle, or complete. Press 5 for All."* The tripwire presses `5`.
- A row reads `<branch>  ·  <PROVIDER>  ·  <attachment>`, so the assertion anchors on `·  ACP  ·` **inside the row**. A bare `contains("acp")` would pass on a coincidence and prove nothing. It also asserts the absence of `·  UNKNOWN  ·`, first, so a regression names its own cause.

A third fix was needed just to reach the panel: `notifyd::Paths::from_home` resolves `AINB_HANGAR_HOME` **before** `AINB_HOME`, so seeding the notify record under the ainb home left it unfound, the install offer fired, and its modal swallowed the `f`.

## Verification

- `ainb-hooks (ubuntu-latest)` and `(macos-latest)`: `test fleet_panel_shows_an_acp_session_created_through_the_cli ... ok`
- `screen::fleet::tests::every_wire_provider_renders_a_label_operators_can_read`: passes with the fix, fails without it