### PR TITLE
feat(fleet): notch usage dashboard over a versioned Hangar RPC

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
@@ -9,9 +9,13 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration as StdDuration, SystemTime};
 
 use ainb_hangar_proto::fleet::{
-    FLEET_USAGE_MAX_BREAKDOWN_BUCKETS, FLEET_USAGE_MAX_DAILY_BUCKETS, FleetUsageBucket,
-    FleetUsageDailyBucket, FleetUsageModelBucket, FleetUsagePeriod, FleetUsageProjectBucket,
-    FleetUsageProviderBucket, FleetUsageSummaryResult, FleetUsageSummaryState,
+    FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS, FLEET_DASHBOARD_MAX_HEATMAP_CELLS,
+    FLEET_DASHBOARD_MAX_WEEKLY_BUCKETS, FLEET_USAGE_MAX_BREAKDOWN_BUCKETS,
+    FLEET_USAGE_MAX_DAILY_BUCKETS, FleetHeatmapCell, FleetUsageBranchBucket, FleetUsageBucket,
+    FleetUsageDailyBucket, FleetUsageDashboardResult, FleetUsageForecast, FleetUsageModelBucket,
+    FleetUsageNamedBucket, FleetUsagePeriod, FleetUsageProjectBucket, FleetUsageProviderBucket,
+    FleetUsageSessionBucket, FleetUsageSummaryResult, FleetUsageSummaryState,
+    FleetUsageWeeklyBucket,
 };
 use ainb_plugin_session_reader::scanner::{self, ProviderRoots};
 use ainb_plugin_types_sessions::{ProviderCall, TokenBucket, UsageData};
@@ -19,7 +23,7 @@ use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
-const CACHE_VERSION: u32 = 1;
+const CACHE_VERSION: u32 = 2;
 const REFRESH_INTERVAL: StdDuration = StdDuration::from_secs(15 * 60);
 
 /// Durable, bounded snapshot. Raw provider calls never leave the scan worker
@@ -28,6 +32,8 @@ const REFRESH_INTERVAL: StdDuration = StdDuration::from_secs(15 * 60);
 struct CachedSummaries {
     version: u32,
     summaries: Vec<CachedSummary>,
+    #[serde(default)]
+    dashboard: Option<FleetUsageDashboardResult>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,6 +69,48 @@ impl UsageService {
             cache_path,
             state: Mutex::new(State::default()),
         }
+    }
+
+    async fn dashboard(self: &Arc<Self>) -> FleetUsageDashboardResult {
+        let (dashboard, should_refresh) = {
+            let state = self.state.lock().await;
+            let cached = self.cached.lock().await;
+            let dashboard = cached.as_ref().and_then(|cache| {
+                let mut d = cache.dashboard.clone()?;
+                if state.refreshing || state.last_error.is_some() {
+                    d.state = FleetUsageSummaryState::Partial;
+                    d.detail = Some(match &state.last_error {
+                        Some(error) => format!("using last complete snapshot: {error}"),
+                        None => "refreshing usage in background".to_string(),
+                    });
+                }
+                Some(d)
+            });
+            let generated_at = dashboard.as_ref().and_then(|d| d.generated_at).unwrap_or(0);
+            let age_ms = Utc::now().timestamp_millis().saturating_sub(generated_at);
+            (
+                dashboard,
+                generated_at == 0 || age_ms >= REFRESH_INTERVAL.as_millis() as i64,
+            )
+        };
+        if should_refresh {
+            self.request_refresh().await;
+            if let Some(mut d) = dashboard {
+                d.state = FleetUsageSummaryState::Partial;
+                d.detail = Some(match d.detail {
+                    Some(detail) => format!("{detail}; refreshing usage in background"),
+                    None => "refreshing usage in background".to_string(),
+                });
+                return d;
+            }
+        }
+        dashboard.unwrap_or_else(|| {
+            let state = self.state.try_lock().ok();
+            match state.and_then(|state| state.last_error.clone()) {
+                Some(error) => dashboard_unavailable(error),
+                None => dashboard_scanning(),
+            }
+        })
     }
 
     async fn summary(self: &Arc<Self>, period: FleetUsagePeriod) -> FleetUsageSummaryResult {
@@ -187,6 +235,14 @@ pub async fn summary(period: FleetUsagePeriod) -> FleetUsageSummaryResult {
     }
 }
 
+/// Read the cached rich dashboard projection.
+pub async fn dashboard() -> FleetUsageDashboardResult {
+    match active_slot().read().await.clone() {
+        Some(service) => service.dashboard().await,
+        None => dashboard_unavailable("usage service is not initialized".to_string()),
+    }
+}
+
 fn load_cache(path: &Path) -> Option<CachedSummaries> {
     let bytes = std::fs::read(path).ok()?;
     let cached: CachedSummaries = serde_json::from_slice(&bytes).ok()?;
@@ -236,10 +292,62 @@ fn unavailable(detail: String) -> FleetUsageSummaryResult {
     }
 }
 
+fn dashboard_scanning() -> FleetUsageDashboardResult {
+    FleetUsageDashboardResult {
+        state: FleetUsageSummaryState::Scanning,
+        generated_at: None,
+        start_at: None,
+        end_at: None,
+        cost_complete: false,
+        totals: None,
+        weekly: Vec::new(),
+        heatmap: Vec::new(),
+        forecast: None,
+        providers: Vec::new(),
+        models: Vec::new(),
+        projects: Vec::new(),
+        sessions: Vec::new(),
+        branches: Vec::new(),
+        tools: Vec::new(),
+        mcp_servers: Vec::new(),
+        shell_commands: Vec::new(),
+        detail: Some("building usage dashboard".to_string()),
+    }
+}
+
+fn dashboard_unavailable(detail: String) -> FleetUsageDashboardResult {
+    FleetUsageDashboardResult {
+        state: FleetUsageSummaryState::Unavailable,
+        generated_at: None,
+        start_at: None,
+        end_at: None,
+        cost_complete: false,
+        totals: None,
+        weekly: Vec::new(),
+        heatmap: Vec::new(),
+        forecast: None,
+        providers: Vec::new(),
+        models: Vec::new(),
+        projects: Vec::new(),
+        sessions: Vec::new(),
+        branches: Vec::new(),
+        tools: Vec::new(),
+        mcp_servers: Vec::new(),
+        shell_commands: Vec::new(),
+        detail: Some(detail),
+    }
+}
+
 /// Scan canonical provider histories once, then derive every public window.
 ///
 /// The scanner owns provider parsing and rate lookup. This service stores only
 /// the bounded projections, never provider calls or their local paths.
+/// Number of days in the 53-week dashboard window.
+const DASHBOARD_DAYS: i64 = 371;
+
+/// Trailing window the 30-day forecast extrapolates from.
+const TRAILING_FORECAST_DAYS: i64 = 7;
+
 fn scan_all_summaries() -> Result<CachedSummaries, String> {
     let roots = ProviderRoots::defaults();
     if roots.claude_projects.is_none()
@@ -251,9 +359,22 @@ fn scan_all_summaries() -> Result<CachedSummaries, String> {
         return Err("provider history roots are unavailable".to_string());
     }
     let now = Utc::now();
-    let (start, _) = window(FleetUsagePeriod::Trailing30Days, now);
+    // Widen the scan window to 53 weeks (371 days) so the dashboard can
+    // project the full heatmap and weekly history. The summary windows
+    // (today / 7d / 30d) are subsets that filter within this data.
+    let dashboard_start =
+        now.date_naive().succ_opt().expect("valid UTC date") - Duration::days(DASHBOARD_DAYS);
     let since = SystemTime::UNIX_EPOCH
-        + StdDuration::from_millis(u64::try_from(start.timestamp_millis()).unwrap_or_default());
+        + StdDuration::from_millis(
+            u64::try_from(
+                dashboard_start
+                    .and_hms_opt(0, 0, 0)
+                    .expect("midnight UTC")
+                    .and_utc()
+                    .timestamp_millis(),
+            )
+            .unwrap_or_default(),
+        );
     let usage = scanner::scan_since(&roots, since);
     Ok(CachedSummaries {
         version: CACHE_VERSION,
@@ -268,6 +389,7 @@ fn scan_all_summaries() -> Result<CachedSummaries, String> {
             summary: summary_from_usage(&usage, period, now),
         })
         .collect(),
+        dashboard: Some(dashboard_from_usage(&usage, now)),
     })
 }
 
@@ -371,6 +493,14 @@ struct CostCompleteness {
     daily: HashMap<NaiveDate, bool>,
     models: HashMap<String, bool>,
     projects: HashMap<String, bool>,
+    sessions: HashMap<String, bool>,
+    branches: HashMap<String, bool>,
+}
+
+/// Composite session key shared by the completeness map and the wire row, so a
+/// session's priced-ness is looked up under exactly the key it is reported as.
+fn session_key(provider: &str, project: &str, session_id: &str) -> String {
+    format!("{provider}:{project}:{session_id}")
 }
 
 fn completeness(calls: &[ProviderCall]) -> CostCompleteness {
@@ -380,6 +510,16 @@ fn completeness(calls: &[ProviderCall]) -> CostCompleteness {
         mark(&mut result.daily, call.timestamp.date_naive(), priced);
         mark(&mut result.models, call.model.clone(), priced);
         mark(&mut result.projects, call.project.clone(), priced);
+        mark(
+            &mut result.sessions,
+            session_key(call.provider.as_str(), &call.project, &call.session_id),
+            priced,
+        );
+        // The scanner only buckets non-empty branches; mirror that so a blank
+        // branch does not create a phantom completeness entry.
+        if let Some(branch) = call.branch.as_deref().filter(|b| !b.is_empty()) {
+            mark(&mut result.branches, branch.to_string(), priced);
+        }
     }
     result
 }
@@ -432,6 +572,21 @@ fn bucket_from(bucket: &TokenBucket, complete_cost: bool) -> FleetUsageBucket {
 }
 
 fn sort_and_cap<T>(rows: &mut Vec<T>, bucket: impl Fn(&T) -> &FleetUsageBucket) {
+    sort_and_cap_n(rows, FLEET_USAGE_MAX_BREAKDOWN_BUCKETS, bucket);
+}
+
+/// Cap a chronologically ASCENDING series, keeping the most recent `cap` rows.
+///
+/// `Vec::truncate` keeps the front, which on a time series means keeping the
+/// oldest rows and discarding the present -- the opposite of what a dashboard
+/// wants.
+fn keep_newest<T>(rows: &mut Vec<T>, cap: usize) {
+    if rows.len() > cap {
+        rows.drain(..rows.len() - cap);
+    }
+}
+
+fn sort_and_cap_n<T>(rows: &mut Vec<T>, cap: usize, bucket: impl Fn(&T) -> &FleetUsageBucket) {
     rows.sort_by(|left, right| {
         let left_total = bucket(left).input_tokens
             + bucket(left).cache_creation_tokens
@@ -445,7 +600,259 @@ fn sort_and_cap<T>(rows: &mut Vec<T>, bucket: impl Fn(&T) -> &FleetUsageBucket) 
             + bucket(right).reasoning_tokens;
         right_total.cmp(&left_total)
     });
-    rows.truncate(FLEET_USAGE_MAX_BREAKDOWN_BUCKETS);
+    rows.truncate(cap);
+}
+
+// ---------------------------------------------------------------------------
+// fleet/usage_dashboard projection
+// ---------------------------------------------------------------------------
+
+fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDashboardResult {
+    let end_day = now.date_naive().succ_opt().expect("valid UTC date");
+    let start_day = end_day - Duration::days(DASHBOARD_DAYS);
+    let start = start_day.and_hms_opt(0, 0, 0).expect("midnight UTC").and_utc();
+    let end = end_day.and_hms_opt(0, 0, 0).expect("midnight UTC").and_utc();
+
+    let calls: Vec<_> = usage
+        .calls
+        .iter()
+        .filter(|call| call.timestamp >= start && call.timestamp < end)
+        .cloned()
+        .collect();
+    let projected = scanner::aggregate(calls.clone());
+    let cost_complete = calls.iter().all(|call| call.cost_usd.is_some());
+
+    // Weekly buckets from scanner's pre-computed weekly aggregates.
+    let mut weekly: Vec<_> = projected
+        .weekly
+        .into_iter()
+        .map(|(week_start, bucket)| FleetUsageWeeklyBucket {
+            week_start: week_start.to_string(),
+            bucket: bucket_from(&bucket, cost_complete),
+        })
+        .collect();
+    // Ascending by week (scanner keys off a BTreeMap), and a 371-day window
+    // touches 54 ISO weeks whenever it does not open on a Monday. Cap from the
+    // FRONT so the week we drop is the oldest, never the current one.
+    keep_newest(&mut weekly, FLEET_DASHBOARD_MAX_WEEKLY_BUCKETS);
+
+    // Heatmap: one cell per calendar day with call count and cost.
+    let mut daily_map: HashMap<NaiveDate, (u64, Option<f64>)> = HashMap::new();
+    for call in &calls {
+        let day = call.timestamp.date_naive();
+        let entry = daily_map.entry(day).or_insert((0, Some(0.0)));
+        entry.0 += 1;
+        match (entry.1, call.cost_usd) {
+            (Some(acc), Some(cost)) => entry.1 = Some(acc + cost),
+            _ => entry.1 = None,
+        }
+    }
+    let mut heatmap: Vec<_> = daily_map
+        .into_iter()
+        .map(|(date, (count, cost))| FleetHeatmapCell {
+            date: date.to_string(),
+            call_count: count,
+            cost_usd: cost,
+        })
+        .collect();
+    heatmap.sort_by_key(|cell| cell.date.clone());
+    keep_newest(&mut heatmap, FLEET_DASHBOARD_MAX_HEATMAP_CELLS);
+
+    // Forecast: linear extrapolation from trailing 7 days of daily data.
+    let forecast = build_forecast(&projected.daily, now);
+
+    // Provider / model / project breakdowns (reuse existing helpers).
+    let mut providers: Vec<_> = grouped_usage(&calls, |call| call.provider.as_str().to_string())
+        .into_iter()
+        .map(|(provider, gu)| FleetUsageProviderBucket {
+            bucket: bucket_from(&gu.bucket, gu.complete_cost),
+            provider,
+        })
+        .collect();
+    sort_and_cap(&mut providers, |row| &row.bucket);
+
+    let completeness = completeness(&calls);
+    let mut models: Vec<_> = projected
+        .models
+        .into_iter()
+        .map(|row| FleetUsageModelBucket {
+            bucket: bucket_from(
+                &row.bucket,
+                completeness.models.get(&row.model).copied().unwrap_or(true),
+            ),
+            model: row.model,
+        })
+        .collect();
+    sort_and_cap(&mut models, |row| &row.bucket);
+
+    let mut projects: Vec<_> = projected
+        .projects
+        .into_iter()
+        .map(|row| FleetUsageProjectBucket {
+            bucket: bucket_from(
+                &row.bucket,
+                completeness.projects.get(&row.name).copied().unwrap_or(true),
+            ),
+            project: row.name,
+            repo: row.repo,
+        })
+        .collect();
+    sort_and_cap(&mut projects, |row| &row.bucket);
+
+    // Session breakdowns.
+    let mut sessions: Vec<_> = projected
+        .sessions
+        .into_iter()
+        .map(|row| {
+            let key = session_key(row.provider.as_str(), &row.project, &row.session_id);
+            let priced = completeness.sessions.get(&key).copied().unwrap_or(true);
+            FleetUsageSessionBucket {
+                session_id: key,
+                provider: row.provider.as_str().to_string(),
+                project: row.project,
+                bucket: bucket_from(&row.bucket, priced),
+            }
+        })
+        .collect();
+    sessions.sort_by(|a, b| {
+        let total = |s: &FleetUsageSessionBucket| {
+            s.bucket.input_tokens
+                + s.bucket.cache_creation_tokens
+                + s.bucket.cache_read_tokens
+                + s.bucket.output_tokens
+                + s.bucket.reasoning_tokens
+        };
+        total(b).cmp(&total(a))
+    });
+    sessions.truncate(FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS);
+
+    // Branch breakdowns.
+    let mut branches: Vec<_> = projected
+        .branches
+        .into_iter()
+        .map(|row| {
+            let priced = completeness.branches.get(&row.branch).copied().unwrap_or(true);
+            FleetUsageBranchBucket {
+                bucket: bucket_from(&row.bucket, priced),
+                branch: row.branch,
+            }
+        })
+        .collect();
+    branches.sort_by(|a, b| {
+        let total = |s: &FleetUsageBranchBucket| {
+            s.bucket.input_tokens
+                + s.bucket.cache_creation_tokens
+                + s.bucket.cache_read_tokens
+                + s.bucket.output_tokens
+                + s.bucket.reasoning_tokens
+        };
+        total(b).cmp(&total(a))
+    });
+    branches.truncate(FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS);
+
+    // Tool / MCP / shell named-count breakdowns.
+    let mut tools: Vec<_> = projected
+        .tools
+        .into_iter()
+        .map(|row| FleetUsageNamedBucket {
+            name: row.name,
+            call_count: u64::try_from(row.calls).unwrap_or(u64::MAX),
+        })
+        .collect();
+    tools.sort_by(|a, b| b.call_count.cmp(&a.call_count));
+    tools.truncate(FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS);
+
+    let mut mcp_servers: Vec<_> = projected
+        .mcp_servers
+        .into_iter()
+        .map(|row| FleetUsageNamedBucket {
+            name: row.name,
+            call_count: u64::try_from(row.calls).unwrap_or(u64::MAX),
+        })
+        .collect();
+    mcp_servers.sort_by(|a, b| b.call_count.cmp(&a.call_count));
+    mcp_servers.truncate(FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS);
+
+    let mut shell_commands: Vec<_> = projected
+        .shell_commands
+        .into_iter()
+        .map(|row| FleetUsageNamedBucket {
+            name: row.name,
+            call_count: u64::try_from(row.calls).unwrap_or(u64::MAX),
+        })
+        .collect();
+    shell_commands.sort_by(|a, b| b.call_count.cmp(&a.call_count));
+    shell_commands.truncate(FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS);
+
+    FleetUsageDashboardResult {
+        state: FleetUsageSummaryState::Ready,
+        generated_at: Some(now.timestamp_millis()),
+        start_at: Some(start.timestamp_millis()),
+        end_at: Some(end.timestamp_millis()),
+        cost_complete,
+        totals: Some(bucket_from(&projected.grand_total, cost_complete)),
+        weekly,
+        heatmap,
+        forecast,
+        providers,
+        models,
+        projects,
+        sessions,
+        branches,
+        tools,
+        mcp_servers,
+        shell_commands,
+        detail: None,
+    }
+}
+
+/// Trailing-7-day linear forecast.
+fn build_forecast(
+    daily: &[(NaiveDate, TokenBucket)],
+    now: DateTime<Utc>,
+) -> Option<FleetUsageForecast> {
+    let cutoff = now.date_naive() - Duration::days(TRAILING_FORECAST_DAYS);
+    let trailing: Vec<_> = daily.iter().filter(|(date, _)| *date > cutoff).collect();
+    let earliest = trailing.iter().map(|(date, _)| *date).min()?;
+
+    // Average over CALENDAR days, not days that happen to have data. The next 30
+    // days will contain idle days too, so dividing by active days only would
+    // quote an "every day is a working day" rate and overstate the projection --
+    // for someone who works two days a week, by roughly 3.5x.
+    //
+    // The span is capped at the 7-day window and floored at 1, so a brand-new
+    // user with a single day of history is not diluted by six days of absence
+    // they were never around for.
+    let span_days = (now.date_naive() - earliest).num_days() + 1;
+    let denominator = span_days.clamp(1, TRAILING_FORECAST_DAYS) as u64;
+
+    let total_tokens: u64 = trailing
+        .iter()
+        .map(|(_, b)| {
+            b.input_tokens
+                + b.cache_creation_tokens
+                + b.cache_read_tokens
+                + b.output_tokens
+                + b.reasoning_tokens
+        })
+        .sum();
+    let avg_daily_tokens = total_tokens / denominator;
+
+    let total_cost: Option<f64> =
+        trailing.iter().try_fold(0.0_f64, |acc, (_, b)| b.cost_usd.map(|c| acc + c));
+    let avg_daily_cost = total_cost.map(|c| c / denominator as f64);
+
+    Some(FleetUsageForecast {
+        projected_30d_cost_usd: avg_daily_cost.map(|c| c * 30.0),
+        // Saturating: a pathological token total must not wrap into a small
+        // number and quote a reassuring forecast.
+        projected_30d_tokens: avg_daily_tokens.saturating_mul(30),
+        avg_daily_cost_usd: avg_daily_cost,
+        avg_daily_tokens,
+        // Reports the DENOMINATOR, so the client's "avg/day (Nd sample)" label
+        // describes the divisor actually used.
+        sample_days: u32::try_from(denominator).unwrap_or(u32::MAX),
+    })
 }
 
 #[cfg(test)]
@@ -469,5 +876,332 @@ mod tests {
         };
         assert_eq!(bucket_from(&bucket, false).cost_usd, None);
         assert_eq!(bucket_from(&bucket, false).input_tokens, 10);
+    }
+
+    #[test]
+    fn dashboard_from_usage_projects_all_dimensions() {
+        use ainb_plugin_types_sessions::{
+            BranchUsage, ModelUsage, NamedUsage, ProjectUsage, Provider, SessionUsage,
+        };
+
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let call_ts = now - Duration::hours(1);
+        let bucket = TokenBucket {
+            input_tokens: 100,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 50,
+            output_tokens: 200,
+            reasoning_tokens: 0,
+            call_count: 1,
+            session_count: 1,
+            project_count: 1,
+            cost_usd: Some(0.005),
+        };
+        let call = ProviderCall {
+            id: 1,
+            provider: Provider::Claude,
+            model: "claude-sonnet-4-5".into(),
+            session_id: "s1".into(),
+            project: "ainb".into(),
+            project_path: "/repo".into(),
+            timestamp: call_ts,
+            input_tokens: 100,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 50,
+            output_tokens: 200,
+            reasoning_tokens: 0,
+            cost_usd: Some(0.005),
+            tools: vec!["Read".into()],
+            bash_commands: vec!["cargo test".into()],
+            user_message: "test".into(),
+            branch: Some("feat/dash".into()),
+        };
+        let usage = UsageData {
+            daily: vec![(call_ts.date_naive(), bucket)],
+            weekly: vec![(NaiveDate::from_ymd_opt(2026, 8, 3).unwrap(), bucket)],
+            projects: vec![ProjectUsage {
+                name: "ainb".into(),
+                path: "/repo".into(),
+                bucket,
+                repo: Some("stevengonsalvez/agents-in-a-box".into()),
+            }],
+            grand_total: bucket,
+            calls: vec![call],
+            sessions: vec![SessionUsage {
+                provider: Provider::Claude,
+                project: "ainb".into(),
+                project_path: "/repo".into(),
+                session_id: "s1".into(),
+                first_timestamp: call_ts,
+                last_timestamp: call_ts,
+                bucket,
+            }],
+            models: vec![ModelUsage {
+                model: "claude-sonnet-4-5".into(),
+                bucket,
+            }],
+            activities: vec![],
+            tools: vec![NamedUsage {
+                name: "Read".into(),
+                calls: 1,
+            }],
+            mcp_servers: vec![],
+            shell_commands: vec![NamedUsage {
+                name: "cargo test".into(),
+                calls: 1,
+            }],
+            branches: vec![BranchUsage {
+                branch: "feat/dash".into(),
+                bucket,
+            }],
+            model_project_counts: vec![],
+        };
+
+        let result = dashboard_from_usage(&usage, now);
+
+        assert_eq!(result.state, FleetUsageSummaryState::Ready);
+        assert!(result.generated_at.is_some());
+        assert!(result.cost_complete);
+        assert!(result.totals.is_some());
+        // Heatmap should have the one day.
+        assert_eq!(result.heatmap.len(), 1);
+        assert_eq!(result.heatmap[0].call_count, 1);
+        // Weekly should have the one week.
+        assert_eq!(result.weekly.len(), 1);
+        assert_eq!(result.weekly[0].week_start, "2026-08-03");
+        // Forecast from 1 trailing day.
+        assert!(result.forecast.is_some());
+        let forecast = result.forecast.unwrap();
+        assert_eq!(forecast.sample_days, 1);
+        assert!(forecast.avg_daily_cost_usd.is_some());
+        // Dimension breakdowns.
+        assert_eq!(result.sessions.len(), 1);
+        assert!(result.sessions[0].session_id.contains("claude"));
+        assert_eq!(result.branches.len(), 1);
+        assert_eq!(result.branches[0].branch, "feat/dash");
+        assert_eq!(result.tools.len(), 1);
+        assert_eq!(result.tools[0].name, "Read");
+        assert_eq!(result.shell_commands.len(), 1);
+        assert_eq!(result.shell_commands[0].name, "cargo test");
+        assert_eq!(result.providers.len(), 1);
+        assert_eq!(result.models.len(), 1);
+        assert_eq!(result.projects.len(), 1);
+    }
+
+    /// A 371-day window only aligns to exactly 53 ISO weeks when it starts on a
+    /// Monday; on the other six days it touches 54, and the extra one is the
+    /// CURRENT week. Capping must therefore drop the oldest week, never the
+    /// newest -- a dashboard that silently omits this week is worse than one
+    /// that omits a week from last year.
+    #[test]
+    fn weekly_cap_keeps_the_current_week() {
+        use ainb_plugin_types_sessions::Provider;
+        use chrono::Datelike;
+
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        // end_day is tomorrow, so the window opens 371 days before that.
+        let start_day = now.date_naive().succ_opt().unwrap() - Duration::days(DASHBOARD_DAYS);
+        assert_ne!(
+            start_day.weekday(),
+            chrono::Weekday::Mon,
+            "fixture must exercise the unaligned case"
+        );
+
+        // One call per week across the whole window, plus one today. Stepping by
+        // 7 from a Friday lands on 2026-07-31 and stops, so today's call must be
+        // added explicitly -- without it the current ISO week is never populated
+        // and the test proves nothing.
+        let mut days: Vec<NaiveDate> = Vec::new();
+        let mut day = start_day;
+        while day <= now.date_naive() {
+            days.push(day);
+            day += Duration::days(7);
+        }
+        if days.last() != Some(&now.date_naive()) {
+            days.push(now.date_naive());
+        }
+
+        let mut calls: Vec<ProviderCall> = Vec::new();
+        let mut id = 0_u64;
+        for day in days {
+            id += 1;
+            calls.push(ProviderCall {
+                id,
+                provider: Provider::Claude,
+                model: "claude-sonnet-4-5".into(),
+                session_id: format!("s{id}"),
+                project: "ainb".into(),
+                project_path: "/repo".into(),
+                timestamp: day.and_hms_opt(12, 0, 0).unwrap().and_utc(),
+                input_tokens: 10,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                output_tokens: 10,
+                reasoning_tokens: 0,
+                cost_usd: Some(0.001),
+                tools: vec![],
+                bash_commands: vec![],
+                user_message: String::new(),
+                branch: None,
+            });
+        }
+
+        let usage = UsageData {
+            calls,
+            ..UsageData::default()
+        };
+        let result = dashboard_from_usage(&usage, now);
+
+        assert!(
+            result.weekly.len() <= FLEET_DASHBOARD_MAX_WEEKLY_BUCKETS,
+            "weekly must stay within the wire cap"
+        );
+        let newest = result.weekly.last().expect("dashboard must report at least one week");
+        assert_eq!(
+            newest.week_start, "2026-08-03",
+            "capping dropped the current week instead of the oldest one"
+        );
+    }
+
+    /// Cost completeness is per-row, not global. One unpriced call in an
+    /// unrelated session must not blank the cost of every OTHER session and
+    /// branch -- over a 53-week window a single unknown model would otherwise
+    /// wipe cost off the entire dashboard.
+    #[test]
+    fn one_unpriced_call_only_blanks_its_own_session_and_branch() {
+        use ainb_plugin_types_sessions::Provider;
+
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let call = |id: u64, session: &str, branch: &str, cost: Option<f64>| ProviderCall {
+            id,
+            provider: Provider::Claude,
+            model: "claude-sonnet-4-5".into(),
+            session_id: session.into(),
+            project: "ainb".into(),
+            project_path: "/repo".into(),
+            timestamp: now - Duration::hours(1),
+            input_tokens: 10,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 10,
+            reasoning_tokens: 0,
+            cost_usd: cost,
+            tools: vec![],
+            bash_commands: vec![],
+            user_message: String::new(),
+            branch: Some(branch.into()),
+        };
+
+        let usage = UsageData {
+            calls: vec![
+                call(1, "priced", "feat/priced", Some(0.01)),
+                call(2, "unpriced", "feat/unpriced", None),
+            ],
+            ..UsageData::default()
+        };
+        let result = dashboard_from_usage(&usage, now);
+
+        let priced = result
+            .sessions
+            .iter()
+            .find(|s| s.session_id.ends_with(":priced"))
+            .expect("priced session present");
+        let unpriced = result
+            .sessions
+            .iter()
+            .find(|s| s.session_id.ends_with(":unpriced"))
+            .expect("unpriced session present");
+        assert_eq!(
+            priced.bucket.cost_usd,
+            Some(0.01),
+            "a fully priced session must keep its cost"
+        );
+        assert_eq!(
+            unpriced.bucket.cost_usd, None,
+            "an unpriced session must report no cost, never 0.0"
+        );
+
+        let priced_branch = result
+            .branches
+            .iter()
+            .find(|b| b.branch == "feat/priced")
+            .expect("priced branch present");
+        let unpriced_branch = result
+            .branches
+            .iter()
+            .find(|b| b.branch == "feat/unpriced")
+            .expect("unpriced branch present");
+        assert_eq!(priced_branch.bucket.cost_usd, Some(0.01));
+        assert_eq!(unpriced_branch.bucket.cost_usd, None);
+
+        // The dashboard as a whole is still honestly flagged incomplete.
+        assert!(!result.cost_complete);
+    }
+
+    /// The forecast answers "what will the next 30 days cost", and those 30 days
+    /// include idle days. Averaging only over days that HAVE data would quote a
+    /// working-day rate and overstate an intermittent user's projection.
+    #[test]
+    fn forecast_averages_over_calendar_days_not_active_days() {
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let day = |offset: i64| now.date_naive() - Duration::days(offset);
+        let spend = |cost: f64| TokenBucket {
+            input_tokens: 100,
+            cost_usd: Some(cost),
+            ..TokenBucket::default()
+        };
+
+        // Worked 2 days out of a 7-day span: $10 total.
+        let forecast = build_forecast(&[(day(6), spend(5.0)), (day(0), spend(5.0))], now)
+            .expect("trailing data yields a forecast");
+
+        assert_eq!(
+            forecast.sample_days, 7,
+            "the divisor is the calendar span, and is what gets reported"
+        );
+        assert_eq!(
+            forecast.avg_daily_cost_usd,
+            Some(10.0 / 7.0),
+            "$10 over a 7-day span is a 7-day average, not a 2-day one"
+        );
+        // Guard the actual regression: the active-day divisor would have said $5/day.
+        assert!(
+            forecast.avg_daily_cost_usd < Some(5.0),
+            "averaging over active days only would overstate the rate"
+        );
+    }
+
+    /// A brand-new user has no idle days to average in yet; diluting their one
+    /// day of history across a week they were never present for would understate
+    /// the projection just as badly.
+    #[test]
+    fn forecast_does_not_dilute_a_single_day_of_history() {
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let bucket = TokenBucket {
+            input_tokens: 100,
+            cost_usd: Some(3.0),
+            ..TokenBucket::default()
+        };
+
+        let forecast = build_forecast(&[(now.date_naive(), bucket)], now).expect("forecast");
+
+        assert_eq!(forecast.sample_days, 1);
+        assert_eq!(forecast.avg_daily_cost_usd, Some(3.0));
+        assert_eq!(forecast.projected_30d_cost_usd, Some(90.0));
+    }
+
+    #[test]
+    fn forecast_requires_trailing_data() {
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        // Empty daily data yields no forecast.
+        assert!(build_forecast(&[], now).is_none());
+        // Data older than 7 days is excluded.
+        let old_date = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
+        let bucket = TokenBucket {
+            input_tokens: 100,
+            cost_usd: Some(1.0),
+            ..TokenBucket::default()
+        };
+        assert!(build_forecast(&[(old_date, bucket)], now).is_none());
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_usage.rs
@@ -246,7 +246,12 @@ pub async fn dashboard() -> FleetUsageDashboardResult {
 fn load_cache(path: &Path) -> Option<CachedSummaries> {
     let bytes = std::fs::read(path).ok()?;
     let cached: CachedSummaries = serde_json::from_slice(&bytes).ok()?;
-    (cached.version == CACHE_VERSION).then_some(cached)
+    // Accept OLDER caches, not just the current version. `CachedSummary` is
+    // unchanged across the v1 to v2 bump and `dashboard` defaults to None, so a
+    // v1 file still answers fleet/usage_summary correctly while the dashboard
+    // fills in on the next refresh. Rejecting it would drop the stable endpoint
+    // to SCANNING until a cold rescan of the whole corpus finished.
+    (cached.version <= CACHE_VERSION).then_some(cached)
 }
 
 fn write_cache(path: &Path, cached: &CachedSummaries) -> std::io::Result<()> {
@@ -491,6 +496,7 @@ fn window(period: FleetUsagePeriod, now: DateTime<Utc>) -> (DateTime<Utc>, DateT
 #[derive(Default)]
 struct CostCompleteness {
     daily: HashMap<NaiveDate, bool>,
+    weeks: HashMap<NaiveDate, bool>,
     models: HashMap<String, bool>,
     projects: HashMap<String, bool>,
     sessions: HashMap<String, bool>,
@@ -503,11 +509,41 @@ fn session_key(provider: &str, project: &str, session_id: &str) -> String {
     format!("{provider}:{project}:{session_id}")
 }
 
+/// Reduce a shell command line to just its program name.
+///
+/// The dashboard reports WHICH programs an operator runs, never the arguments
+/// they ran them with. Arguments are where absolute paths and credentials live,
+/// and this value reaches both the wire and a world-readable cache file.
+///
+/// Leading `VAR=value` assignments are skipped rather than reported, since an
+/// inline `API_KEY=...` would otherwise become the bucket name and defeat the
+/// whole point. A basename is taken so `/usr/local/bin/foo` and `foo` agree and
+/// no install prefix leaks. Anything unrecognisable degrades to `"other"`
+/// rather than falling back to the raw string.
+fn program_name(command: &str) -> String {
+    command
+        .split_whitespace()
+        .find(|token| !token.contains('='))
+        .and_then(|token| token.rsplit('/').next())
+        .filter(|name| !name.is_empty())
+        .map_or_else(|| "other".to_string(), ToString::to_string)
+}
+
+/// Monday anchoring the ISO week containing `date`, matching how the scanner
+/// keys its weekly buckets. The completeness map has to agree with the bucket
+/// map or the lookup silently misses.
+fn week_anchor(date: NaiveDate) -> NaiveDate {
+    use chrono::Datelike;
+    date - Duration::days(i64::from(date.weekday().num_days_from_monday()))
+}
+
 fn completeness(calls: &[ProviderCall]) -> CostCompleteness {
     let mut result = CostCompleteness::default();
     for call in calls {
         let priced = call.cost_usd.is_some();
-        mark(&mut result.daily, call.timestamp.date_naive(), priced);
+        let day = call.timestamp.date_naive();
+        mark(&mut result.daily, day, priced);
+        mark(&mut result.weeks, week_anchor(day), priced);
         mark(&mut result.models, call.model.clone(), priced);
         mark(&mut result.projects, call.project.clone(), priced);
         mark(
@@ -621,14 +657,22 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
         .collect();
     let projected = scanner::aggregate(calls.clone());
     let cost_complete = calls.iter().all(|call| call.cost_usd.is_some());
+    let completeness = completeness(&calls);
 
     // Weekly buckets from scanner's pre-computed weekly aggregates.
+    //
+    // Priced-ness is per week, not the global flag: the scanner sums costs with
+    // None coalescing, so a week containing one unpriced call would otherwise
+    // report a partial sum as if it were the whole week's spend.
     let mut weekly: Vec<_> = projected
         .weekly
         .into_iter()
         .map(|(week_start, bucket)| FleetUsageWeeklyBucket {
+            bucket: bucket_from(
+                &bucket,
+                completeness.weeks.get(&week_start).copied().unwrap_or(false),
+            ),
             week_start: week_start.to_string(),
-            bucket: bucket_from(&bucket, cost_complete),
         })
         .collect();
     // Ascending by week (scanner keys off a BTreeMap), and a 371-day window
@@ -659,7 +703,12 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
     keep_newest(&mut heatmap, FLEET_DASHBOARD_MAX_HEATMAP_CELLS);
 
     // Forecast: linear extrapolation from trailing 7 days of daily data.
-    let forecast = build_forecast(&projected.daily, now);
+    //
+    // Gated on per-day completeness. The scanner coalesces None when summing a
+    // day's cost, so an ungated forecast would quote a confident dollar figure
+    // built from a partial sum, counting every unpriced call as free, while the
+    // totals beside it correctly render null.
+    let forecast = build_forecast(&projected.daily, &completeness.daily, now);
 
     // Provider / model / project breakdowns (reuse existing helpers).
     let mut providers: Vec<_> = grouped_usage(&calls, |call| call.provider.as_str().to_string())
@@ -671,14 +720,13 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
         .collect();
     sort_and_cap(&mut providers, |row| &row.bucket);
 
-    let completeness = completeness(&calls);
     let mut models: Vec<_> = projected
         .models
         .into_iter()
         .map(|row| FleetUsageModelBucket {
             bucket: bucket_from(
                 &row.bucket,
-                completeness.models.get(&row.model).copied().unwrap_or(true),
+                completeness.models.get(&row.model).copied().unwrap_or(false),
             ),
             model: row.model,
         })
@@ -691,7 +739,7 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
         .map(|row| FleetUsageProjectBucket {
             bucket: bucket_from(
                 &row.bucket,
-                completeness.projects.get(&row.name).copied().unwrap_or(true),
+                completeness.projects.get(&row.name).copied().unwrap_or(false),
             ),
             project: row.name,
             repo: row.repo,
@@ -705,9 +753,13 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
         .into_iter()
         .map(|row| {
             let key = session_key(row.provider.as_str(), &row.project, &row.session_id);
-            let priced = completeness.sessions.get(&key).copied().unwrap_or(true);
+            let priced = completeness.sessions.get(&key).copied().unwrap_or(false);
             FleetUsageSessionBucket {
-                session_id: key,
+                // The BARE session id. provider, project and session_id are
+                // already three fields on this struct, so the composite added
+                // nothing a client could use: it cannot even be re-split, since
+                // a project label may itself contain a colon.
+                session_id: row.session_id,
                 provider: row.provider.as_str().to_string(),
                 project: row.project,
                 bucket: bucket_from(&row.bucket, priced),
@@ -731,7 +783,7 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
         .branches
         .into_iter()
         .map(|row| {
-            let priced = completeness.branches.get(&row.branch).copied().unwrap_or(true);
+            let priced = completeness.branches.get(&row.branch).copied().unwrap_or(false);
             FleetUsageBranchBucket {
                 bucket: bucket_from(&row.bucket, priced),
                 branch: row.branch,
@@ -773,15 +825,24 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
     mcp_servers.sort_by(|a, b| b.call_count.cmp(&a.call_count));
     mcp_servers.truncate(FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS);
 
-    let mut shell_commands: Vec<_> = projected
-        .shell_commands
+    // Only the PROGRAM name leaves this module, never the command line. The
+    // scanner keys these on the verbatim `input.command`, which routinely
+    // carries absolute paths and can carry credentials, and this result is both
+    // sent over the wire and written to a world-readable cache file. Shipping a
+    // program name matches how `tools` ships a tool name and keeps the promise
+    // in this module's header.
+    let mut by_program: HashMap<String, u64> = HashMap::new();
+    for row in projected.shell_commands {
+        *by_program.entry(program_name(&row.name)).or_default() +=
+            u64::try_from(row.calls).unwrap_or(u64::MAX);
+    }
+    let mut shell_commands: Vec<_> = by_program
         .into_iter()
-        .map(|row| FleetUsageNamedBucket {
-            name: row.name,
-            call_count: u64::try_from(row.calls).unwrap_or(u64::MAX),
-        })
+        .map(|(name, call_count)| FleetUsageNamedBucket { name, call_count })
         .collect();
-    shell_commands.sort_by(|a, b| b.call_count.cmp(&a.call_count));
+    // Tie-break by name so a cap boundary is deterministic across scans.
+    shell_commands
+        .sort_by(|a, b| b.call_count.cmp(&a.call_count).then_with(|| a.name.cmp(&b.name)));
     shell_commands.truncate(FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS);
 
     FleetUsageDashboardResult {
@@ -807,8 +868,12 @@ fn dashboard_from_usage(usage: &UsageData, now: DateTime<Utc>) -> FleetUsageDash
 }
 
 /// Trailing-7-day linear forecast.
+///
+/// `day_completeness` gates the cost leg only; the token projection is always
+/// exact and does not depend on pricing.
 fn build_forecast(
     daily: &[(NaiveDate, TokenBucket)],
+    day_completeness: &HashMap<NaiveDate, bool>,
     now: DateTime<Utc>,
 ) -> Option<FleetUsageForecast> {
     let cutoff = now.date_naive() - Duration::days(TRAILING_FORECAST_DAYS);
@@ -820,11 +885,18 @@ fn build_forecast(
     // quote an "every day is a working day" rate and overstate the projection --
     // for someone who works two days a week, by roughly 3.5x.
     //
-    // The span is capped at the 7-day window and floored at 1, so a brand-new
-    // user with a single day of history is not diluted by six days of absence
-    // they were never around for.
-    let span_days = (now.date_naive() - earliest).num_days() + 1;
-    let denominator = span_days.clamp(1, TRAILING_FORECAST_DAYS) as u64;
+    // Shortening the window to the observed span is ONLY right for an account
+    // with no earlier history: a long-time user who happened to be idle for six
+    // days and worked today would otherwise be divided by 1 and projected at 30x
+    // a single day. Any activity at or before the cutoff proves the account is
+    // not new, so the full window is the honest divisor.
+    let has_earlier_history = daily.iter().any(|(date, _)| *date <= cutoff);
+    let denominator = if has_earlier_history {
+        TRAILING_FORECAST_DAYS as u64
+    } else {
+        let span_days = (now.date_naive() - earliest).num_days() + 1;
+        span_days.clamp(1, TRAILING_FORECAST_DAYS) as u64
+    };
 
     let total_tokens: u64 = trailing
         .iter()
@@ -838,8 +910,16 @@ fn build_forecast(
         .sum();
     let avg_daily_tokens = total_tokens / denominator;
 
-    let total_cost: Option<f64> =
-        trailing.iter().try_fold(0.0_f64, |acc, (_, b)| b.cost_usd.map(|c| acc + c));
+    // A sampled day whose cost is only partially known makes the whole
+    // projection unknowable. The scanner coalesces None when summing a day, so
+    // without this gate an unpriced call silently counts as $0 and the forecast
+    // reads as confident and cheap.
+    let all_sampled_days_priced = trailing
+        .iter()
+        .all(|(date, _)| day_completeness.get(date).copied().unwrap_or(false));
+    let total_cost: Option<f64> = all_sampled_days_priced
+        .then(|| trailing.iter().try_fold(0.0_f64, |acc, (_, b)| b.cost_usd.map(|c| acc + c)))
+        .flatten();
     let avg_daily_cost = total_cost.map(|c| c / denominator as f64);
 
     Some(FleetUsageForecast {
@@ -976,13 +1056,20 @@ mod tests {
         assert!(forecast.avg_daily_cost_usd.is_some());
         // Dimension breakdowns.
         assert_eq!(result.sessions.len(), 1);
-        assert!(result.sessions[0].session_id.contains("claude"));
+        assert_eq!(
+            result.sessions[0].session_id, "s1",
+            "the bare session id ships, not a composite"
+        );
+        assert_eq!(result.sessions[0].provider, "claude");
         assert_eq!(result.branches.len(), 1);
         assert_eq!(result.branches[0].branch, "feat/dash");
         assert_eq!(result.tools.len(), 1);
         assert_eq!(result.tools[0].name, "Read");
         assert_eq!(result.shell_commands.len(), 1);
-        assert_eq!(result.shell_commands[0].name, "cargo test");
+        assert_eq!(
+            result.shell_commands[0].name, "cargo",
+            "only the program name leaves the daemon"
+        );
         assert_eq!(result.providers.len(), 1);
         assert_eq!(result.models.len(), 1);
         assert_eq!(result.projects.len(), 1);
@@ -1104,12 +1191,12 @@ mod tests {
         let priced = result
             .sessions
             .iter()
-            .find(|s| s.session_id.ends_with(":priced"))
+            .find(|s| s.session_id == "priced")
             .expect("priced session present");
         let unpriced = result
             .sessions
             .iter()
-            .find(|s| s.session_id.ends_with(":unpriced"))
+            .find(|s| s.session_id == "unpriced")
             .expect("unpriced session present");
         assert_eq!(
             priced.bucket.cost_usd,
@@ -1152,8 +1239,13 @@ mod tests {
         };
 
         // Worked 2 days out of a 7-day span: $10 total.
-        let forecast = build_forecast(&[(day(6), spend(5.0)), (day(0), spend(5.0))], now)
-            .expect("trailing data yields a forecast");
+        let priced_days = HashMap::from([(day(6), true), (day(0), true)]);
+        let forecast = build_forecast(
+            &[(day(6), spend(5.0)), (day(0), spend(5.0))],
+            &priced_days,
+            now,
+        )
+        .expect("trailing data yields a forecast");
 
         assert_eq!(
             forecast.sample_days, 7,
@@ -1183,18 +1275,216 @@ mod tests {
             ..TokenBucket::default()
         };
 
-        let forecast = build_forecast(&[(now.date_naive(), bucket)], now).expect("forecast");
+        let priced_days = HashMap::from([(now.date_naive(), true)]);
+        let forecast =
+            build_forecast(&[(now.date_naive(), bucket)], &priced_days, now).expect("forecast");
 
         assert_eq!(forecast.sample_days, 1);
         assert_eq!(forecast.avg_daily_cost_usd, Some(3.0));
         assert_eq!(forecast.projected_30d_cost_usd, Some(90.0));
     }
 
+    /// Command ARGUMENTS are where absolute paths and credentials live, and this
+    /// result reaches both the wire and a world-readable cache file. Only the
+    /// program name may leave the daemon.
+    #[test]
+    fn shell_commands_ship_the_program_only_never_the_arguments() {
+        assert_eq!(program_name("cargo test --workspace"), "cargo");
+        // An absolute install prefix must not leak, and must fold together with
+        // the bare invocation of the same program.
+        assert_eq!(
+            program_name("/usr/local/bin/rg --hidden /Users/someone/src"),
+            "rg"
+        );
+        // A leading inline assignment is skipped: reporting it would make the
+        // secret itself the bucket name.
+        assert_eq!(
+            program_name("API_KEY=sk-live-abc123 ./deploy.sh --prod"),
+            "deploy.sh"
+        );
+        assert_eq!(program_name(""), "other");
+        assert_eq!(program_name("FOO=1 BAR=2"), "other");
+
+        // Nothing resembling an argument survives the full projection, and
+        // variants of one program collapse into a single counted row.
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let call = |id: u64, cmd: &str| ProviderCall {
+            id,
+            provider: ainb_plugin_types_sessions::Provider::Claude,
+            model: "claude-sonnet-4-5".into(),
+            session_id: format!("s{id}"),
+            project: "ainb".into(),
+            project_path: "/repo".into(),
+            timestamp: now - Duration::hours(1),
+            input_tokens: 1,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 1,
+            reasoning_tokens: 0,
+            cost_usd: Some(0.01),
+            tools: vec![],
+            bash_commands: vec![cmd.to_string()],
+            user_message: String::new(),
+            branch: None,
+        };
+        let usage = UsageData {
+            calls: vec![
+                call(1, "git commit -m 'secret /Users/someone/private'"),
+                call(2, "git push origin main"),
+                call(
+                    3,
+                    "curl -H 'Authorization: Bearer sk-live-xyz' https://api.example.com",
+                ),
+            ],
+            ..UsageData::default()
+        };
+        let result = dashboard_from_usage(&usage, now);
+
+        let git = result.shell_commands.iter().find(|r| r.name == "git").expect("git row");
+        assert_eq!(git.call_count, 2, "both git invocations fold into one row");
+        for row in &result.shell_commands {
+            assert!(
+                !row.name.contains(' ') && !row.name.contains('/'),
+                "a bare program name cannot carry arguments or paths, got {:?}",
+                row.name
+            );
+        }
+        let shipped = format!("{:?}", result.shell_commands);
+        for leaked in ["Bearer", "sk-live", "/Users/", "secret", "origin"] {
+            assert!(
+                !shipped.contains(leaked),
+                "{leaked} must never reach the wire"
+            );
+        }
+    }
+
+    /// A week containing one unpriced call must report no cost rather than a
+    /// partial sum. The scanner coalesces None when summing, so the partial
+    /// figure would otherwise read as the whole week's spend.
+    #[test]
+    fn one_unpriced_call_only_blanks_its_own_week() {
+        use ainb_plugin_types_sessions::Provider;
+
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let call = |id: u64, day: NaiveDate, cost: Option<f64>| ProviderCall {
+            id,
+            provider: Provider::Claude,
+            model: "claude-sonnet-4-5".into(),
+            session_id: format!("s{id}"),
+            project: "ainb".into(),
+            project_path: "/repo".into(),
+            timestamp: day.and_hms_opt(12, 0, 0).unwrap().and_utc(),
+            input_tokens: 10,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 10,
+            reasoning_tokens: 0,
+            cost_usd: cost,
+            tools: vec![],
+            bash_commands: vec![],
+            user_message: String::new(),
+            branch: None,
+        };
+        // This week (Mon 2026-08-03) is fully priced; last week has one gap.
+        let this_week = NaiveDate::from_ymd_opt(2026, 8, 4).unwrap();
+        let last_week = NaiveDate::from_ymd_opt(2026, 7, 28).unwrap();
+        let usage = UsageData {
+            calls: vec![
+                call(1, this_week, Some(0.02)),
+                call(2, last_week, Some(0.05)),
+                call(3, last_week, None),
+            ],
+            ..UsageData::default()
+        };
+        let result = dashboard_from_usage(&usage, now);
+
+        let priced =
+            result.weekly.iter().find(|w| w.week_start == "2026-08-03").expect("this week");
+        let partial =
+            result.weekly.iter().find(|w| w.week_start == "2026-07-27").expect("last week");
+        assert_eq!(
+            priced.bucket.cost_usd,
+            Some(0.02),
+            "a fully priced week keeps its cost"
+        );
+        assert_eq!(
+            partial.bucket.cost_usd, None,
+            "a week with an unpriced call must not report the partial sum as its total"
+        );
+    }
+
+    /// The forecast is the only cost surface that does not flow through
+    /// `bucket_from`, so it needs its own gate: quoting a confident dollar
+    /// projection built from partial day sums is the exact failure the
+    /// never-zero rule exists to prevent.
+    #[test]
+    fn forecast_reports_no_cost_when_a_sampled_day_is_unpriced() {
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let day = |offset: i64| now.date_naive() - Duration::days(offset);
+        let bucket = |cost: f64| TokenBucket {
+            input_tokens: 100,
+            cost_usd: Some(cost),
+            ..TokenBucket::default()
+        };
+        let daily = [(day(1), bucket(5.0)), (day(0), bucket(5.0))];
+
+        // Day 0's cost is a partial sum, so the projection is unknowable.
+        let gapped = HashMap::from([(day(1), true), (day(0), false)]);
+        let forecast = build_forecast(&daily, &gapped, now).expect("forecast");
+        assert_eq!(
+            forecast.projected_30d_cost_usd, None,
+            "an unpriced sampled day must blank the cost projection, not count it as free"
+        );
+        assert_eq!(forecast.avg_daily_cost_usd, None);
+        // Tokens are exact regardless of pricing, so they must still be reported.
+        assert!(
+            forecast.projected_30d_tokens > 0,
+            "the token projection does not depend on price"
+        );
+
+        let complete = HashMap::from([(day(1), true), (day(0), true)]);
+        let priced = build_forecast(&daily, &complete, now).expect("forecast");
+        assert!(
+            priced.projected_30d_cost_usd.is_some(),
+            "a fully priced sample still forecasts"
+        );
+    }
+
+    /// A long-time user who was idle all week and worked today must not be
+    /// divided by one and projected at 30x a single day. Earlier history is the
+    /// evidence that distinguishes them from a genuinely new account.
+    #[test]
+    fn forecast_does_not_treat_a_long_idle_user_as_brand_new() {
+        let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let day = |offset: i64| now.date_naive() - Duration::days(offset);
+        let spend = |cost: f64| TokenBucket {
+            input_tokens: 100,
+            cost_usd: Some(cost),
+            ..TokenBucket::default()
+        };
+
+        // Activity 90 days ago proves the account is not new, then a $7 day today.
+        let daily = [(day(90), spend(1.0)), (day(0), spend(7.0))];
+        let priced = HashMap::from([(day(90), true), (day(0), true)]);
+        let forecast = build_forecast(&daily, &priced, now).expect("forecast");
+
+        assert_eq!(
+            forecast.sample_days, 7,
+            "an established account uses the full window"
+        );
+        assert_eq!(
+            forecast.avg_daily_cost_usd,
+            Some(1.0),
+            "$7 over 7 days, not $7 over 1"
+        );
+        assert_eq!(forecast.projected_30d_cost_usd, Some(30.0));
+    }
+
     #[test]
     fn forecast_requires_trailing_data() {
         let now = "2026-08-06T15:00:00Z".parse::<DateTime<Utc>>().unwrap();
         // Empty daily data yields no forecast.
-        assert!(build_forecast(&[], now).is_none());
+        assert!(build_forecast(&[], &HashMap::new(), now).is_none());
         // Data older than 7 days is excluded.
         let old_date = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
         let bucket = TokenBucket {
@@ -1202,6 +1492,6 @@ mod tests {
             cost_usd: Some(1.0),
             ..TokenBucket::default()
         };
-        assert!(build_forecast(&[(old_date, bucket)], now).is_none());
+        assert!(build_forecast(&[(old_date, bucket)], &HashMap::new(), now).is_none());
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1177,6 +1177,7 @@ async fn handle(
         }
         methods::FLEET_RUNTIME_STATUS => handle_fleet_runtime_status(req, health).await,
         methods::FLEET_USAGE_SUMMARY => handle_fleet_usage_summary(req).await,
+        methods::FLEET_USAGE_DASHBOARD => handle_fleet_usage_dashboard(req).await,
         methods::FLEET_QUOTA_SUMMARY => handle_fleet_quota_summary(req).await,
         methods::FLEET_MESSAGE_SEND => handle_fleet_message_send(pool, req, events).await,
         methods::FLEET_MESSAGE_LIST => handle_fleet_message_list(pool, req).await,
@@ -1408,6 +1409,17 @@ async fn handle_fleet_usage_summary(req: &RpcRequest) -> Result<serde_json::Valu
     let params: FleetUsageSummaryParams = parse_params(req, "{ period? }")?;
     let summary = crate::fleet_usage::summary(params.period).await;
     to_value(&summary)
+}
+
+/// Return the rich usage dashboard with 53-week history, heatmap, forecast,
+/// and extended dimension breakdowns.
+async fn handle_fleet_usage_dashboard(req: &RpcRequest) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{FLEET_CAPABILITY_DASHBOARD_READ, FleetUsageDashboardParams};
+
+    require_fleet_capability(FLEET_CAPABILITY_DASHBOARD_READ)?;
+    let _: FleetUsageDashboardParams = parse_params(req, "{}")?;
+    let dashboard = crate::fleet_usage::dashboard().await;
+    to_value(&dashboard)
 }
 
 /// Return bounded daemon-owned live quota windows without exposing provider

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -29,6 +29,8 @@ pub const FLEET_CAPABILITY_TIMELINE_READ: &str = "fleet.timeline.read";
 pub const FLEET_CAPABILITY_USAGE_READ: &str = "fleet.usage.read";
 /// Negotiated capability for bounded live provider-quota summaries.
 pub const FLEET_CAPABILITY_QUOTA_READ: &str = "fleet.quota.read";
+/// Negotiated capability for the rich usage dashboard with 53-week history.
+pub const FLEET_CAPABILITY_DASHBOARD_READ: &str = "fleet.dashboard.read";
 /// Negotiated capability for runtime and provider-hook health.
 pub const FLEET_CAPABILITY_RUNTIME_READ: &str = "fleet.runtime.read";
 /// Negotiated capability required for chat-bus message sends.
@@ -82,6 +84,7 @@ pub const FLEET_PROTOCOL_CAPABILITY_IDS: &[&str] = &[
     FLEET_CAPABILITY_TRANSCRIPT_READ,
     FLEET_CAPABILITY_RUNTIME_READ,
     FLEET_CAPABILITY_USAGE_READ,
+    FLEET_CAPABILITY_DASHBOARD_READ,
 ];
 
 /// Inclusive supported protocol version range.
@@ -680,6 +683,158 @@ pub struct FleetUsageSummaryResult {
     pub projects: Vec<FleetUsageProjectBucket>,
     /// Safe daemon status detail for partial or unavailable summaries, capped
     /// by [`FLEET_USAGE_DETAIL_MAX_BYTES`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// fleet/usage_dashboard
+// ---------------------------------------------------------------------------
+
+/// Maximum weekly buckets the daemon returns for a dashboard response.
+pub const FLEET_DASHBOARD_MAX_WEEKLY_BUCKETS: usize = 53;
+/// Maximum heatmap cells (one per day, 53 weeks).
+pub const FLEET_DASHBOARD_MAX_HEATMAP_CELLS: usize = 371;
+/// Maximum session/branch/tool/mcp/shell breakdown buckets.
+pub const FLEET_DASHBOARD_MAX_DIMENSION_BUCKETS: usize = 20;
+
+/// Parameters for `fleet/usage_dashboard`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetUsageDashboardParams {}
+
+/// One heatmap cell representing a single calendar day.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetHeatmapCell {
+    /// ISO-8601 UTC calendar date.
+    pub date: String,
+    /// Number of distinct API calls on this day.
+    pub call_count: u64,
+    /// Canonical USD cost when fully priced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+}
+
+/// One weekly usage bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageWeeklyBucket {
+    /// ISO-8601 UTC date of Monday starting this week.
+    pub week_start: String,
+    /// Weekly aggregate.
+    pub bucket: FleetUsageBucket,
+}
+
+/// One session usage bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageSessionBucket {
+    /// Session identity (provider:project:session_id).
+    pub session_id: String,
+    /// Provider for this session.
+    pub provider: String,
+    /// Project for this session.
+    pub project: String,
+    /// Session aggregate.
+    pub bucket: FleetUsageBucket,
+}
+
+/// One branch usage bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageBranchBucket {
+    /// Git branch name.
+    pub branch: String,
+    /// Branch aggregate.
+    pub bucket: FleetUsageBucket,
+}
+
+/// One named dimension bucket (tools, MCP servers, shell commands).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageNamedBucket {
+    /// Dimension key (tool name, MCP server, shell command).
+    pub name: String,
+    /// Number of calls using this dimension.
+    pub call_count: u64,
+}
+
+/// Simple linear forecast from trailing daily data.
+///
+/// Averages are taken over CALENDAR days in the trailing window, not over the
+/// days that happen to have data: the next 30 days will contain idle days too,
+/// so an active-days-only divisor would quote a working-day rate and overstate
+/// an intermittent user's projection.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageForecast {
+    /// Projected cost for the next 30 days in USD, when fully priced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projected_30d_cost_usd: Option<f64>,
+    /// Projected total tokens for the next 30 days.
+    pub projected_30d_tokens: u64,
+    /// Mean cost per calendar day across `sample_days`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avg_daily_cost_usd: Option<f64>,
+    /// Mean tokens per calendar day across `sample_days`.
+    pub avg_daily_tokens: u64,
+    /// The divisor actually used: calendar days spanned by the trailing window,
+    /// capped at 7 and floored at 1 so a first-day user is not diluted across a
+    /// week they were not present for.
+    pub sample_days: u32,
+}
+
+/// Bounded rich dashboard result for `fleet/usage_dashboard`.
+///
+/// Extends `fleet/usage_summary` with 53-week history, heatmap, forecast,
+/// and additional breakdowns. `fleet/usage_summary` remains the stable
+/// lightweight endpoint for quick checks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetUsageDashboardResult {
+    /// Current dashboard availability.
+    pub state: FleetUsageSummaryState,
+    /// Time the daemon generated this dashboard, in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated_at: Option<i64>,
+    /// Inclusive window start, in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_at: Option<i64>,
+    /// Exclusive window end, in epoch milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<i64>,
+    /// Whether every included call has a canonical USD rate.
+    pub cost_complete: bool,
+    /// Aggregate for the full 53-week window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub totals: Option<FleetUsageBucket>,
+    /// Weekly buckets, chronologically ordered.
+    #[serde(default)]
+    pub weekly: Vec<FleetUsageWeeklyBucket>,
+    /// Daily activity heatmap cells for 53 weeks.
+    #[serde(default)]
+    pub heatmap: Vec<FleetHeatmapCell>,
+    /// Linear forecast from trailing data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forecast: Option<FleetUsageForecast>,
+    /// Provider breakdowns.
+    #[serde(default)]
+    pub providers: Vec<FleetUsageProviderBucket>,
+    /// Top model breakdowns.
+    #[serde(default)]
+    pub models: Vec<FleetUsageModelBucket>,
+    /// Top project breakdowns.
+    #[serde(default)]
+    pub projects: Vec<FleetUsageProjectBucket>,
+    /// Top session breakdowns.
+    #[serde(default)]
+    pub sessions: Vec<FleetUsageSessionBucket>,
+    /// Top branch breakdowns.
+    #[serde(default)]
+    pub branches: Vec<FleetUsageBranchBucket>,
+    /// Top tool usage counts.
+    #[serde(default)]
+    pub tools: Vec<FleetUsageNamedBucket>,
+    /// Top MCP server usage counts.
+    #[serde(default)]
+    pub mcp_servers: Vec<FleetUsageNamedBucket>,
+    /// Top shell command usage counts.
+    #[serde(default)]
+    pub shell_commands: Vec<FleetUsageNamedBucket>,
+    /// Safe daemon status detail.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
 }
@@ -1450,6 +1605,7 @@ mod tests {
             FLEET_CAPABILITY_USAGE_READ,
             FLEET_CAPABILITY_QUOTA_READ,
             FLEET_CAPABILITY_RUNTIME_READ,
+            FLEET_CAPABILITY_DASHBOARD_READ,
         ] {
             assert!(
                 FLEET_PROTOCOL_CAPABILITY_IDS.contains(&id),
@@ -1643,5 +1799,67 @@ mod tests {
         .unwrap();
         // Delivery states reuse the durable receipt vocabulary verbatim.
         assert_eq!(delivery["state"], "REJECTED");
+    }
+
+    #[test]
+    fn usage_dashboard_wire_contract_round_trips() {
+        round_trip(&FleetUsageDashboardParams {});
+        round_trip(&FleetUsageDashboardResult {
+            state: FleetUsageSummaryState::Ready,
+            generated_at: Some(1_700_000_000_000),
+            start_at: Some(1_668_000_000_000),
+            end_at: Some(1_700_000_000_000),
+            cost_complete: false,
+            totals: Some(FleetUsageBucket {
+                input_tokens: 500_000,
+                cache_creation_tokens: 10_000,
+                cache_read_tokens: 20_000,
+                output_tokens: 100_000,
+                reasoning_tokens: 5_000,
+                call_count: 42,
+                session_count: 7,
+                project_count: 3,
+                cost_usd: Some(12.50),
+            }),
+            weekly: vec![FleetUsageWeeklyBucket {
+                week_start: "2026-07-28".to_string(),
+                bucket: FleetUsageBucket::default(),
+            }],
+            heatmap: vec![FleetHeatmapCell {
+                date: "2026-08-06".to_string(),
+                call_count: 15,
+                cost_usd: Some(2.30),
+            }],
+            forecast: Some(FleetUsageForecast {
+                projected_30d_cost_usd: Some(125.00),
+                projected_30d_tokens: 5_000_000,
+                avg_daily_cost_usd: Some(4.17),
+                avg_daily_tokens: 166_667,
+                sample_days: 7,
+            }),
+            providers: vec![],
+            models: vec![],
+            projects: vec![],
+            sessions: vec![FleetUsageSessionBucket {
+                session_id: "claude:myproject:sess-1".to_string(),
+                provider: "claude".to_string(),
+                project: "myproject".to_string(),
+                bucket: FleetUsageBucket::default(),
+            }],
+            branches: vec![FleetUsageBranchBucket {
+                branch: "feat/my-feature".to_string(),
+                bucket: FleetUsageBucket::default(),
+            }],
+            tools: vec![FleetUsageNamedBucket {
+                name: "Edit".to_string(),
+                call_count: 100,
+            }],
+            mcp_servers: vec![],
+            shell_commands: vec![FleetUsageNamedBucket {
+                name: "cargo test".to_string(),
+                call_count: 30,
+            }],
+            detail: None,
+        });
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -415,6 +415,12 @@ pub const FLEET_TIMELINE: &str = "fleet/timeline";
 /// Params: [`crate::fleet::FleetUsageSummaryParams`]; result:
 /// [`crate::fleet::FleetUsageSummaryResult`]. Gated by `fleet.usage.read`.
 pub const FLEET_USAGE_SUMMARY: &str = "fleet/usage_summary";
+/// Read the rich usage dashboard with 53-week history, heatmap, forecast,
+/// and extended breakdowns.
+///
+/// Params: [`crate::fleet::FleetUsageDashboardParams`]; result:
+/// [`crate::fleet::FleetUsageDashboardResult`]. Gated by `fleet.dashboard.read`.
+pub const FLEET_USAGE_DASHBOARD: &str = "fleet/usage_dashboard";
 /// Read bounded daemon-owned live provider quota windows.
 ///
 /// Result: [`crate::fleet::FleetQuotaSummaryResult`]. Gated by
@@ -1724,6 +1730,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_START,
     FLEET_TIMELINE,
     FLEET_USAGE_SUMMARY,
+    FLEET_USAGE_DASHBOARD,
     FLEET_QUOTA_SUMMARY,
     FLEET_RUNTIME_STATUS,
     FLEET_REPROJECT_CLAUDE_INTERVIEW,
@@ -2017,6 +2024,7 @@ mod tests {
             FLEET_START,
             FLEET_TIMELINE,
             FLEET_USAGE_SUMMARY,
+            FLEET_USAGE_DASHBOARD,
             FLEET_QUOTA_SUMMARY,
             FLEET_RUNTIME_STATUS,
             FLEET_REPROJECT_CLAUDE_INTERVIEW,

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -19,8 +19,11 @@ final class FleetPresentationStore: ObservableObject {
     }
 }
 
+/// Interviews are answered inline in the session detail, so there is no separate
+/// Interviews destination -- a tab that only re-showed the roster was a dead end
+/// in a nav that is meant to be the single one.
 enum FleetNotchRoute: String, CaseIterable, Identifiable {
-    case sessions, needsYou, interviews, usage, settings
+    case sessions, needsYou, usage, settings
 
     var id: Self { self }
 
@@ -28,7 +31,6 @@ enum FleetNotchRoute: String, CaseIterable, Identifiable {
         switch self {
         case .sessions: "Sessions"
         case .needsYou: "Needs you"
-        case .interviews: "Interviews"
         case .usage: "Usage"
         case .settings: "Settings"
         }
@@ -274,9 +276,6 @@ private struct FleetNotchView: View {
             switch navigation.route {
             case .sessions, .needsYou:
                 rosterContent
-            case .interviews:
-                FleetAnswerQueue(store: store) { navigation.route = .needsYou }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .usage:
                 FleetUsageView(store: store, period: $usagePeriod)
             case .settings:
@@ -322,9 +321,13 @@ private struct FleetNotchView: View {
                         }
                     }
                     if let selectedSession {
-                        FleetNotchDetail(store: store, session: selectedSession) {
-                            navigation.route = .interviews
-                        }
+                        FleetNotchDetail(store: store, session: selectedSession)
+                            // Identity must change with the session AND with the
+                            // question set. Without this SwiftUI reuses the view
+                            // and its @State, so a draft cursor from a 5-question
+                            // interview survives into a 2-question one and lands
+                            // out of range, leaving the new interview unanswerable.
+                            .id("\(selectedSession.sessionKey):\(selectedSession.currentRequestFingerprint ?? "")")
                             .padding(.top, 4)
                     } else {
                         Text("No matching sessions")
@@ -468,7 +471,19 @@ private struct FleetNotchSessionRow: View {
 private struct FleetNotchDetail: View {
     @ObservedObject var store: FleetStore
     let session: FleetSession
-    let answerInterview: () -> Void
+
+    @State private var questionIndex = 0
+    @State private var selections: [String: Set<String>] = [:]
+    @State private var textAnswers: [String: String] = [:]
+    @State private var rejectConfirmation = false
+
+    private var deck: FleetInterviewDeck? { FleetInterviewDeck(session: session) }
+
+    /// A deck is never empty (its initialiser fails on zero questions), so the
+    /// clamp always yields a valid row even if a stale cursor survives.
+    private func clampedIndex(_ deck: FleetInterviewDeck) -> Int {
+        min(max(questionIndex, 0), deck.questions.count - 1)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -489,15 +504,14 @@ private struct FleetNotchDetail: View {
                             .disabled(!store.canDecideApproval(.bypassSession, on: session))
                     }
                 }
+            } else if let deck, let question = deck.questions[safe: clampedIndex(deck)] {
+                inlineInterview(deck: deck, question: question)
             } else if session.attention == .ask {
                 Text("Interview ready")
                     .font(.headline)
-                Text("Answer this structured interview without leaving the notch.")
+                Text("Structured answer capability not available for this session.")
                     .font(.caption)
                     .foregroundStyle(FleetNotchPalette.muted)
-                Button("Answer interview", action: answerInterview)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!session.capabilities.structuredAnswer)
             } else {
                 Text(FleetRosterPresentation.semanticStatus(for: session, connection: store.connectionState))
                     .font(.caption)
@@ -513,48 +527,221 @@ private struct FleetNotchDetail: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .accessibilityIdentifier("fleet.notch.detail.\(session.sessionKey)")
+        .confirmationDialog("Reject this interview?", isPresented: $rejectConfirmation) {
+            Button("Reject", role: .destructive) {
+                store.selectedSessionKey = session.sessionKey
+                store.dismissStructuredInterview(on: session)
+            }
+        }
+    }
+
+    // MARK: - Inline interview
+
+    @ViewBuilder private func inlineInterview(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> some View {
+        // Question tabs
+        if deck.questions.count > 1 {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(Array(deck.questions.enumerated()), id: \.element.id) { index, q in
+                        Button {
+                            questionIndex = index
+                        } label: {
+                            Text("\(index + 1). \(q.header)")
+                                .font(.caption2.weight(.semibold))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(
+                                    index == questionIndex ? FleetNotchPalette.selected : FleetNotchPalette.canvas,
+                                    in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                )
+                                .foregroundStyle(answered(deck: deck, question: q) ? .mint : .primary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+
+        Text(question.header).font(.subheadline.weight(.semibold))
+        Text(question.text).font(.caption).fixedSize(horizontal: false, vertical: true)
+
+        if question.options.isEmpty {
+            TextField("Type answer", text: textBinding(deck: deck, question: question), axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(2...5)
+                .font(.caption)
+        } else {
+            ForEach(question.options, id: \.self) { option in
+                Button {
+                    toggle(option, deck: deck, question: question)
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: isSelected(option, deck: deck, question: question)
+                              ? (question.multiSelect ? "checkmark.square.fill" : "largecircle.fill.circle")
+                              : (question.multiSelect ? "square" : "circle"))
+                            .font(.caption)
+                        Text(option).font(.caption)
+                        Spacer()
+                    }
+                    .padding(6)
+                    .background(FleetNotchPalette.canvas, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+            if isSelected("Other", deck: deck, question: question) {
+                TextField("Describe Other", text: textBinding(deck: deck, question: question))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption)
+            }
+        }
+
+        HStack(spacing: 8) {
+            if deck.questions.count > 1 {
+                Button("\u{2190}") { questionIndex = max(questionIndex - 1, 0) }
+                    .disabled(questionIndex == 0)
+                Button("\u{2192}") { questionIndex = min(questionIndex + 1, deck.questions.count - 1) }
+                    .disabled(questionIndex + 1 >= deck.questions.count)
+            }
+            Spacer()
+            if session.capabilities.structuredDismiss {
+                Button("Reject", role: .destructive) { rejectConfirmation = true }
+                    .font(.caption)
+            }
+            Button("Submit") { submit(deck) }
+                .buttonStyle(.borderedProminent)
+                .font(.caption)
+                .disabled(!complete(deck) || store.pendingIntentID != nil)
+        }
+    }
+
+    // MARK: - Interview state helpers
+
+    private func answerKey(_ deck: FleetInterviewDeck, _ question: FleetInterviewQuestion) -> String {
+        "\(deck.session.sessionKey):\(deck.session.currentRequestFingerprint ?? ""):\(question.id)"
+    }
+
+    private func isSelected(_ option: String, deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Bool {
+        selections[answerKey(deck, question), default: []].contains(option)
+    }
+
+    private func toggle(_ option: String, deck: FleetInterviewDeck, question: FleetInterviewQuestion) {
+        let key = answerKey(deck, question)
+        if question.multiSelect {
+            if selections[key, default: []].contains(option) {
+                selections[key, default: []].remove(option)
+            } else {
+                selections[key, default: []].insert(option)
+            }
+        } else {
+            selections[key] = [option]
+        }
+    }
+
+    private func textBinding(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Binding<String> {
+        let key = answerKey(deck, question)
+        return Binding(get: { textAnswers[key, default: ""] }, set: { textAnswers[key] = $0 })
+    }
+
+    private func answered(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Bool {
+        let key = answerKey(deck, question)
+        if question.options.isEmpty { return !textAnswers[key, default: ""].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        let selected = selections[key, default: []]
+        return !selected.isEmpty && (!selected.contains("Other") || !textAnswers[key, default: ""].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private func complete(_ deck: FleetInterviewDeck) -> Bool {
+        deck.questions.allSatisfy { answered(deck: deck, question: $0) }
+    }
+
+    private func submit(_ deck: FleetInterviewDeck) {
+        store.selectedSessionKey = session.sessionKey
+        let answers = deck.questions.map { question in
+            let key = answerKey(deck, question)
+            let selected = Array(selections[key, default: []]).sorted()
+            let text = textAnswers[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return FleetQuestionAnswer(questionID: question.id, selectedOptions: selected, text: text?.isEmpty == false ? text : nil)
+        }
+        store.submitStructuredAnswers(answers, on: session)
+    }
+}
+
+private enum UsageMode: String, CaseIterable, Identifiable {
+    case quick, dashboard
+    var id: Self { self }
+    var label: String {
+        switch self {
+        case .quick: "Quick"
+        case .dashboard: "Dashboard"
+        }
     }
 }
 
 private struct FleetUsageView: View {
     @ObservedObject var store: FleetStore
     @Binding var period: FleetUsagePeriod
+    @State private var mode: UsageMode = .quick
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack {
-                Picker("Usage period", selection: $period) {
-                    ForEach(FleetUsagePeriod.allCases) { option in Text(option.label).tag(option) }
+                Picker("Mode", selection: $mode) {
+                    ForEach(UsageMode.allCases) { m in Text(m.label).tag(m) }
                 }
                 .pickerStyle(.segmented)
+                .frame(maxWidth: 180)
+
+                if mode == .quick {
+                    Picker("Usage period", selection: $period) {
+                        ForEach(FleetUsagePeriod.allCases) { option in Text(option.label).tag(option) }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
                 Spacer()
                 Button("Refresh") {
-                    store.refreshUsage(period: period)
-                    store.refreshQuota()
+                    if mode == .quick {
+                        store.refreshUsage(period: period)
+                        store.refreshQuota()
+                    } else {
+                        store.refreshDashboard()
+                        store.refreshQuota()
+                    }
                 }
-                    .disabled(!store.canReadUsage)
+                .disabled(mode == .quick ? !store.canReadUsage : !store.canReadDashboard)
             }
 
-            if !store.canReadUsage {
-                VStack(spacing: 8) {
-                    Image(systemName: "chart.bar.xaxis").font(.title2)
-                    Text("Usage unavailable").font(.headline)
-                    Text("This daemon does not advertise fleet.usage.read.").font(.caption)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let summary = store.usageSummary {
-                usage(summary)
-            } else {
-                ProgressView("Reading canonical provider usage…")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            switch mode {
+            case .quick:
+                quickContent
+            case .dashboard:
+                dashboardContent
             }
         }
         .onAppear {
             store.refreshUsage(period: period)
             store.refreshQuota()
+            store.refreshDashboard()
         }
         .onChange(of: period) { _, value in store.refreshUsage(period: value) }
         .accessibilityIdentifier("fleet.notch.usage")
+    }
+
+    // MARK: - Quick mode (existing summary view)
+
+    @ViewBuilder private var quickContent: some View {
+        if !store.canReadUsage {
+            VStack(spacing: 8) {
+                Image(systemName: "chart.bar.xaxis").font(.title2)
+                Text("Usage unavailable").font(.headline)
+                Text("This daemon does not advertise fleet.usage.read.").font(.caption)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let summary = store.usageSummary {
+            usage(summary)
+        } else {
+            ProgressView("Reading canonical provider usage\u{2026}")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
     }
 
     @ViewBuilder private func usage(_ summary: FleetUsageSummaryResult) -> some View {
@@ -562,25 +749,7 @@ private struct FleetUsageView: View {
             quotaCard(quotaSummary)
         }
         if let total = summary.totals {
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(total.costUSD.map(currency) ?? tokens(total.totalTokens))
-                        .font(.system(size: 34, weight: .bold, design: .rounded))
-                    Text(total.costUSD == nil ? "Tokens, price unavailable" : "Canonical provider cost")
-                        .font(.caption)
-                        .foregroundStyle(FleetNotchPalette.muted)
-                }
-                Spacer()
-                VStack(alignment: .trailing, spacing: 3) {
-                    Text("\(total.callCount) calls")
-                    Text("\(total.sessionCount) sessions")
-                    Text("\(total.projectCount) projects")
-                }
-                .font(.caption)
-                .foregroundStyle(FleetNotchPalette.muted)
-            }
-            .padding(16)
-            .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            totalsHero(total)
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
@@ -598,6 +767,160 @@ private struct FleetUsageView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    // MARK: - Dashboard mode (53-week rich view)
+
+    @ViewBuilder private var dashboardContent: some View {
+        if !store.canReadDashboard {
+            VStack(spacing: 8) {
+                Image(systemName: "chart.bar.xaxis").font(.title2)
+                Text("Dashboard unavailable").font(.headline)
+                Text("This daemon does not advertise fleet.dashboard.read.").font(.caption)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let dash = store.usageDashboard {
+            dashboardBody(dash)
+        } else {
+            ProgressView("Building 53-week dashboard\u{2026}")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    @ViewBuilder private func dashboardBody(_ dash: FleetUsageDashboardResult) -> some View {
+        if let quotaSummary = store.quotaSummary {
+            quotaCard(quotaSummary)
+        }
+
+        if let total = dash.totals {
+            totalsHero(total)
+        }
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                // Forecast card
+                if let f = dash.forecast {
+                    forecastCard(f)
+                }
+
+                // Activity heatmap (mini grid)
+                if !dash.heatmap.isEmpty {
+                    heatmapCard(dash.heatmap)
+                }
+
+                // Weekly trend
+                if !dash.weekly.isEmpty {
+                    section("Weekly", rows: dash.weekly.map { "\($0.weekStart)  \(value($0.bucket))" })
+                }
+
+                // Dimension breakdowns
+                if !dash.providers.isEmpty { section("Providers", rows: dash.providers.map { "\($0.provider.capitalized)  \(value($0.bucket))" }) }
+                if !dash.models.isEmpty { section("Models", rows: dash.models.map { "\($0.model)  \(value($0.bucket))" }) }
+                if !dash.projects.isEmpty { section("Projects", rows: dash.projects.map { "\($0.repo ?? $0.project)  \(value($0.bucket))" }) }
+                if !dash.sessions.isEmpty { section("Sessions", rows: dash.sessions.map { "\($0.provider):\($0.project)  \(value($0.bucket))" }) }
+                if !dash.branches.isEmpty { section("Branches", rows: dash.branches.map { "\($0.branch)  \(value($0.bucket))" }) }
+                if !dash.tools.isEmpty { namedSection("Tools", rows: dash.tools) }
+                if !dash.mcpServers.isEmpty { namedSection("MCP Servers", rows: dash.mcpServers) }
+                if !dash.shellCommands.isEmpty { namedSection("Shell Commands", rows: dash.shellCommands) }
+
+                if let detail = dash.detail {
+                    Text(detail).font(.caption).foregroundStyle(FleetNotchPalette.muted)
+                }
+                if !dash.costComplete {
+                    Label("Some calls have no canonical price", systemImage: "exclamationmark.triangle")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared components
+
+    private func totalsHero(_ total: FleetUsageBucket) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(total.costUSD.map(currency) ?? tokens(total.totalTokens))
+                    .font(.system(size: 34, weight: .bold, design: .rounded))
+                Text(total.costUSD == nil ? "Tokens, price unavailable" : "Canonical provider cost")
+                    .font(.caption)
+                    .foregroundStyle(FleetNotchPalette.muted)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 3) {
+                Text("\(total.callCount) calls")
+                Text("\(total.sessionCount) sessions")
+                Text("\(total.projectCount) projects")
+            }
+            .font(.caption)
+            .foregroundStyle(FleetNotchPalette.muted)
+        }
+        .padding(16)
+        .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    @ViewBuilder private func forecastCard(_ f: FleetUsageForecast) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("30-day forecast", systemImage: "chart.line.uptrend.xyaxis")
+                .font(.headline)
+            HStack(spacing: 20) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(f.projected30dCostUSD.map(currency) ?? tokens(f.projected30dTokens))
+                        .font(.title2.weight(.semibold))
+                    Text("projected").font(.caption2).foregroundStyle(FleetNotchPalette.muted)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(f.avgDailyCostUSD.map(currency) ?? tokens(f.avgDailyTokens))
+                        .font(.subheadline.weight(.semibold))
+                    Text("avg/day (\(f.sampleDays)d sample)").font(.caption2).foregroundStyle(FleetNotchPalette.muted)
+                }
+            }
+        }
+        .padding(14)
+        .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    @ViewBuilder private func heatmapCard(_ cells: [FleetHeatmapCell]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Activity").font(.headline)
+            heatmapGrid(cells)
+        }
+        .padding(14)
+        .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    /// Week-per-column, weekday-per-row -- the conventional contribution grid.
+    /// A `LazyVGrid` would fill row-major, putting 53 consecutive DAYS in each
+    /// row so nothing lines up by weekday; columns have to be built explicitly.
+    private func heatmapGrid(_ cells: [FleetHeatmapCell]) -> some View {
+        let weeks = FleetHeatmapLayout.weekColumns(cells)
+        let maxCalls = cells.map(\.callCount).max() ?? 0
+        return ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: 2) {
+                ForEach(weeks, id: \.weekStart) { week in
+                    VStack(spacing: 2) {
+                        ForEach(0..<7, id: \.self) { weekday in
+                            heatmapCellView(week.days[weekday], max: maxCalls)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private func heatmapCellView(_ cell: FleetHeatmapCell?, max: UInt64) -> some View {
+        RoundedRectangle(cornerRadius: 2)
+            .fill(cell.map { heatmapColor($0.callCount, max: max) } ?? Color.clear)
+            .frame(width: 10, height: 10)
+            .help(cell.map { "\($0.date): \($0.callCount) calls" } ?? "")
+    }
+
+    /// Zero calls is a real, meaningful value (an idle day) and must render as
+    /// the empty track, not as the faintest shade of "active".
+    private func heatmapColor(_ count: UInt64, max: UInt64) -> Color {
+        guard count > 0, max > 0 else { return FleetNotchPalette.canvas }
+        let intensity = Double(count) / Double(max)
+        return FleetNotchPalette.mint.opacity(0.2 + 0.8 * intensity)
     }
 
     @ViewBuilder private func quotaCard(_ summary: FleetQuotaSummaryResult) -> some View {
@@ -639,7 +962,7 @@ private struct FleetUsageView: View {
     @ViewBuilder private func quotaWindow(_ label: String, window: FleetQuotaWindow?) -> some View {
         if let window {
             VStack(alignment: .leading, spacing: 1) {
-                Text("\(label) · \(window.remainingPercent)% left")
+                Text("\(label) \u{00b7} \(window.remainingPercent)% left")
                     .font(.caption.weight(.semibold))
                 if let reset = window.resetsAt {
                     Text(Date(timeIntervalSince1970: TimeInterval(reset) / 1_000), style: .relative)
@@ -666,12 +989,78 @@ private struct FleetUsageView: View {
         .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
+    private func namedSection(_ title: String, rows: [FleetUsageNamedBucket]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.headline)
+            ForEach(rows, id: \.name) { row in
+                HStack {
+                    Text(row.name).font(.caption)
+                    Spacer()
+                    Text("\(row.callCount) calls").font(.caption).foregroundStyle(FleetNotchPalette.muted)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(FleetNotchPalette.detail, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
     private func value(_ bucket: FleetUsageBucket) -> String {
         bucket.costUSD.map(currency) ?? tokens(bucket.totalTokens)
     }
 
     private func currency(_ value: Double) -> String { String(format: "$%.2f", value) }
     private func tokens(_ value: UInt64) -> String { value.formatted(.number.notation(.compactName)) + " tokens" }
+}
+
+/// Arranges flat daily cells into contribution-graph columns.
+///
+/// Pure and non-private so the weekday alignment can be pinned by a test: an
+/// off-by-one here silently shifts every day into the wrong row, which looks
+/// plausible on screen and is invisible to a compiler.
+enum FleetHeatmapLayout {
+    struct Week: Equatable {
+        let weekStart: String
+        /// Monday-first, 7 slots; nil where the window has no cell for that day.
+        let days: [FleetHeatmapCell?]
+    }
+
+    /// The daemon emits `yyyy-MM-dd` in UTC, so parse in UTC with a fixed
+    /// locale -- a device calendar could otherwise shift a day across a boundary.
+    static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        return calendar
+    }()
+
+    static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    static func weekColumns(_ cells: [FleetHeatmapCell]) -> [Week] {
+        var buckets: [Date: [Int: FleetHeatmapCell]] = [:]
+        for cell in cells {
+            guard let date = formatter.date(from: cell.date) else { continue }
+            // ISO weekday: 1 = Monday ... 7 = Sunday. Map to a 0-based row.
+            let weekday = calendar.component(.weekday, from: date)
+            let row = (weekday + 5) % 7
+            guard let monday = calendar.date(byAdding: .day, value: -row, to: date) else { continue }
+            let key = calendar.startOfDay(for: monday)
+            buckets[key, default: [:]][row] = cell
+        }
+        return buckets.keys.sorted().map { monday in
+            let byRow = buckets[monday] ?? [:]
+            return Week(
+                weekStart: formatter.string(from: monday),
+                days: (0..<7).map { byRow[$0] }
+            )
+        }
+    }
 }
 
 private struct FleetRuntimeSettingsView: View {

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -96,6 +96,7 @@ final class FleetStore: ObservableObject {
     @Published private(set) var atcSchedulerOwnership: AtcSchedulerOwnership?
     @Published private(set) var timeline: [FleetTimelineEntry] = []
     @Published private(set) var usageSummary: FleetUsageSummaryResult?
+    @Published private(set) var usageDashboard: FleetUsageDashboardResult?
     @Published private(set) var quotaSummary: FleetQuotaSummaryResult?
     @Published private(set) var runtimeStatus: FleetRuntimeStatusResult?
     @Published private(set) var pendingIntentID: String?
@@ -168,6 +169,10 @@ final class FleetStore: ObservableObject {
 
     var canReadUsage: Bool {
         connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.usage.read") == true
+    }
+
+    var canReadDashboard: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.dashboard.read") == true
     }
 
     var canReadQuota: Bool {
@@ -528,6 +533,22 @@ final class FleetStore: ObservableObject {
             } catch {
                 usageSummary = nil
                 controlNotice = "Usage refresh refused: \(String(describing: error))"
+            }
+        }
+    }
+
+    func refreshDashboard() {
+        guard canReadDashboard, let connection else {
+            usageDashboard = nil
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                usageDashboard = try await connection.usageDashboard()
+            } catch {
+                usageDashboard = nil
+                controlNotice = "Dashboard refresh refused: \(String(describing: error))"
             }
         }
     }

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -177,6 +177,11 @@ actor FleetConnection {
         return try await request("fleet/usage_summary", params: params, result: FleetUsageSummaryResult.self)
     }
 
+    func usageDashboard() async throws -> FleetUsageDashboardResult {
+        try requireReadCapability("fleet.dashboard.read")
+        return try await request("fleet/usage_dashboard", params: FleetUsageDashboardParams(), result: FleetUsageDashboardResult.self)
+    }
+
     func quotaSummary() async throws -> FleetQuotaSummaryResult {
         try requireReadCapability("fleet.quota.read")
         return try await request("fleet/quota_summary", params: FleetQuotaSummaryParams(), result: FleetQuotaSummaryResult.self)

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -643,6 +643,110 @@ struct FleetUsageSummaryResult: Codable, Equatable {
     }
 }
 
+// MARK: - fleet/usage_dashboard
+
+struct FleetUsageDashboardParams: Codable, Equatable { init() {} }
+
+struct FleetHeatmapCell: Codable, Equatable {
+    let date: String
+    let callCount: UInt64
+    let costUSD: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case date
+        case callCount = "call_count"
+        case costUSD = "cost_usd"
+    }
+}
+
+struct FleetUsageWeeklyBucket: Codable, Equatable {
+    let weekStart: String
+    let bucket: FleetUsageBucket
+
+    private enum CodingKeys: String, CodingKey {
+        case weekStart = "week_start"
+        case bucket
+    }
+}
+
+struct FleetUsageSessionBucket: Codable, Equatable {
+    let sessionID: String
+    let provider: String
+    let project: String
+    let bucket: FleetUsageBucket
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionID = "session_id"
+        case provider, project, bucket
+    }
+}
+
+struct FleetUsageBranchBucket: Codable, Equatable {
+    let branch: String
+    let bucket: FleetUsageBucket
+}
+
+struct FleetUsageNamedBucket: Codable, Equatable {
+    let name: String
+    let callCount: UInt64
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case callCount = "call_count"
+    }
+}
+
+struct FleetUsageForecast: Codable, Equatable {
+    let projected30dCostUSD: Double?
+    let projected30dTokens: UInt64
+    let avgDailyCostUSD: Double?
+    let avgDailyTokens: UInt64
+    let sampleDays: UInt32
+
+    private enum CodingKeys: String, CodingKey {
+        case projected30dCostUSD = "projected_30d_cost_usd"
+        case projected30dTokens = "projected_30d_tokens"
+        case avgDailyCostUSD = "avg_daily_cost_usd"
+        case avgDailyTokens = "avg_daily_tokens"
+        case sampleDays = "sample_days"
+    }
+}
+
+struct FleetUsageDashboardResult: Codable, Equatable {
+    let state: FleetUsageSummaryState
+    let generatedAt: Int64?
+    let startAt: Int64?
+    let endAt: Int64?
+    let costComplete: Bool
+    let totals: FleetUsageBucket?
+    let weekly: [FleetUsageWeeklyBucket]
+    let heatmap: [FleetHeatmapCell]
+    let forecast: FleetUsageForecast?
+    let providers: [FleetUsageProviderBucket]
+    let models: [FleetUsageModelBucket]
+    let projects: [FleetUsageProjectBucket]
+    let sessions: [FleetUsageSessionBucket]
+    let branches: [FleetUsageBranchBucket]
+    let tools: [FleetUsageNamedBucket]
+    let mcpServers: [FleetUsageNamedBucket]
+    let shellCommands: [FleetUsageNamedBucket]
+    let detail: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case generatedAt = "generated_at"
+        case startAt = "start_at"
+        case endAt = "end_at"
+        case costComplete = "cost_complete"
+        case totals, weekly, heatmap, forecast
+        case providers, models, projects, sessions, branches
+        case tools
+        case mcpServers = "mcp_servers"
+        case shellCommands = "shell_commands"
+        case detail
+    }
+}
+
 struct FleetQuotaSummaryParams: Codable, Equatable { init() {} }
 
 struct FleetQuotaWindow: Codable, Equatable {

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -569,9 +569,16 @@ struct FleetUsageSummaryParams: Codable, Equatable {
     let period: FleetUsagePeriod
 }
 
-enum FleetUsageSummaryState: String, Codable, Equatable {
+enum FleetUsageSummaryState: String, Encodable, Equatable {
     case scanning, ready, partial, unavailable
 }
+
+// Usage state gates a whole panel, and both the summary and the dashboard embed
+// it. Left as a plain synthesized `Codable` it threw on any value this build did
+// not know, so a daemon adding one state blanked the entire panel rather than
+// degrading it. Unknown degrades to `.unavailable`: the panel then renders its
+// explanatory empty state instead of over-promising `.ready` with no data.
+extension FleetUsageSummaryState: TolerantWireEnum { static var wireFallback: Self { .unavailable } }
 
 struct FleetUsageBucket: Codable, Equatable {
     let inputTokens: UInt64

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -445,7 +445,7 @@ struct FleetAnswerQueue: View {
     }
 }
 
-private struct FleetInterviewDeck {
+struct FleetInterviewDeck {
     let session: FleetSession
     let questions: [FleetInterviewQuestion]
     let nativePicker: Bool
@@ -480,7 +480,7 @@ private struct FleetInterviewDeck {
     }
 }
 
-private struct FleetInterviewQuestion: Identifiable {
+struct FleetInterviewQuestion: Identifiable {
     let id: String
     let header: String
     let text: String
@@ -488,7 +488,7 @@ private struct FleetInterviewQuestion: Identifiable {
     let multiSelect: Bool
 }
 
-private extension Array {
+extension Array {
     subscript(safe index: Int) -> Element? {
         indices.contains(index) ? self[index] : nil
     }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/CanonicalFixtureTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/CanonicalFixtureTests.swift
@@ -22,6 +22,92 @@ final class CanonicalFixtureTests: XCTestCase {
         )
     }
 
+    /// Pins the snake_case wire contract for `fleet/usage_dashboard`. The daemon
+    /// side is Rust, so a renamed key here is a silent cross-language break that
+    /// no compiler catches.
+    func testUsageDashboardResultRoundTrips() throws {
+        let bucket = #"{"input_tokens":50000,"cache_creation_tokens":2000,"cache_read_tokens":5000,"output_tokens":30000,"reasoning_tokens":0,"call_count":150,"session_count":3,"project_count":2,"cost_usd":12.5}"#
+        try assertJSON(
+            """
+            {"state":"ready","generated_at":1700000000000,"start_at":1680000000000,"end_at":1700000000000,\
+            "cost_complete":true,"totals":\(bucket),\
+            "weekly":[{"week_start":"2026-08-03","bucket":\(bucket)}],\
+            "heatmap":[{"date":"2026-08-06","call_count":5,"cost_usd":0.5}],\
+            "forecast":{"projected_30d_cost_usd":15,"projected_30d_tokens":120000,"avg_daily_cost_usd":0.5,"avg_daily_tokens":4000,"sample_days":7},\
+            "providers":[{"provider":"claude","bucket":\(bucket)}],\
+            "models":[{"model":"claude-sonnet-4-5","bucket":\(bucket)}],\
+            "projects":[{"project":"ainb","repo":"stevengonsalvez/agents-in-a-box","bucket":\(bucket)}],\
+            "sessions":[{"session_id":"claude:ainb:s1","provider":"claude","project":"ainb","bucket":\(bucket)}],\
+            "branches":[{"branch":"main","bucket":\(bucket)}],\
+            "tools":[{"name":"Read","call_count":50}],\
+            "mcp_servers":[{"name":"context7","call_count":10}],\
+            "shell_commands":[{"name":"cargo test","call_count":25}]}
+            """,
+            as: FleetUsageDashboardResult.self
+        )
+    }
+
+    /// The daemon reports `scanning`/`unavailable` with every aggregate absent.
+    /// Those must decode to nil rather than throwing, or the panel goes blank
+    /// on exactly the states it exists to explain.
+    func testDashboardDecodesWhenAggregatesAreAbsent() throws {
+        let json = #"{"state":"scanning","cost_complete":false,"weekly":[],"heatmap":[],"providers":[],"models":[],"projects":[],"sessions":[],"branches":[],"tools":[],"mcp_servers":[],"shell_commands":[],"detail":"Reading provider logs"}"#
+        let result = try FleetWire.decoder().decode(FleetUsageDashboardResult.self, from: Data(json.utf8))
+        XCTAssertEqual(result.state, .scanning)
+        XCTAssertNil(result.totals)
+        XCTAssertNil(result.forecast)
+        XCTAssertNil(result.generatedAt)
+        XCTAssertTrue(result.weekly.isEmpty)
+        XCTAssertEqual(result.detail, "Reading provider logs")
+        XCTAssertFalse(result.costComplete)
+    }
+
+    /// Tokens-without-price is a real daemon state (unknown model pricing). It
+    /// must stay nil and never collapse to 0.0, which would read as "free".
+    func testDashboardKeepsUnpricedCostNilRatherThanZero() throws {
+        let bucket = #"{"input_tokens":10,"cache_creation_tokens":0,"cache_read_tokens":0,"output_tokens":10,"reasoning_tokens":0,"call_count":1,"session_count":1,"project_count":1}"#
+        let json = """
+        {"state":"partial","cost_complete":false,"totals":\(bucket),"weekly":[],"heatmap":[{"date":"2026-08-06","call_count":1}],\
+        "providers":[],"models":[],"projects":[],"sessions":[],"branches":[],"tools":[],"mcp_servers":[],"shell_commands":[]}
+        """
+        let result = try FleetWire.decoder().decode(FleetUsageDashboardResult.self, from: Data(json.utf8))
+        XCTAssertNil(result.totals?.costUSD)
+        XCTAssertEqual(result.totals?.totalTokens, 20)
+        XCTAssertNil(result.heatmap.first?.costUSD)
+    }
+
+    /// The heatmap is a week-per-column grid, so a day landing in the wrong row
+    /// is invisible to the compiler and plausible on screen. 2026-08-03 is a
+    /// Monday and 2026-08-09 the Sunday that closes the same ISO week.
+    func testHeatmapPlacesDaysInMondayFirstWeekdayRows() throws {
+        let cells = [
+            FleetHeatmapCell(date: "2026-08-03", callCount: 1, costUSD: nil),  // Monday
+            FleetHeatmapCell(date: "2026-08-06", callCount: 2, costUSD: nil),  // Thursday
+            FleetHeatmapCell(date: "2026-08-09", callCount: 3, costUSD: nil),  // Sunday
+            FleetHeatmapCell(date: "2026-08-10", callCount: 4, costUSD: nil),  // next Monday
+        ]
+        let weeks = FleetHeatmapLayout.weekColumns(cells)
+
+        XCTAssertEqual(weeks.count, 2, "four days spanning a Sunday boundary make two columns")
+        XCTAssertEqual(weeks[0].weekStart, "2026-08-03")
+        XCTAssertEqual(weeks[0].days[0]?.callCount, 1, "Monday is row 0")
+        XCTAssertEqual(weeks[0].days[3]?.callCount, 2, "Thursday is row 3")
+        XCTAssertEqual(weeks[0].days[6]?.callCount, 3, "Sunday is row 6, closing the week")
+        XCTAssertNil(weeks[0].days[1], "a day with no data stays an empty slot")
+        XCTAssertEqual(weeks[1].weekStart, "2026-08-10")
+        XCTAssertEqual(weeks[1].days[0]?.callCount, 4, "the next Monday opens a new column")
+        XCTAssertTrue(weeks.allSatisfy { $0.days.count == 7 }, "every column is a full week")
+    }
+
+    func testHeatmapSkipsUnparseableDatesRatherThanCrashing() throws {
+        let weeks = FleetHeatmapLayout.weekColumns([
+            FleetHeatmapCell(date: "not-a-date", callCount: 9, costUSD: nil),
+            FleetHeatmapCell(date: "2026-08-03", callCount: 1, costUSD: nil),
+        ])
+        XCTAssertEqual(weeks.count, 1)
+        XCTAssertEqual(weeks[0].days[0]?.callCount, 1)
+    }
+
     func testReplayStateRejectsInconsistentForms() {
         XCTAssertThrowsError(try FleetWire.decoder().decode(FleetReplayState.self, from: Data(#"{"state":"complete","reason":"bootstrap"}"#.utf8)))
         XCTAssertThrowsError(try FleetWire.decoder().decode(FleetReplayState.self, from: Data(#"{"state":"snapshot_reset"}"#.utf8)))

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
@@ -42,6 +42,25 @@ final class FleetWireForwardCompatibilityTests: XCTestCase {
         XCTAssertEqual(try decode(FleetConfidence.self, "CERTAIN"), .low)
     }
 
+    /// Usage state gates the whole usage/dashboard panel. An unknown state must
+    /// degrade to `.unavailable` (which renders an explanatory empty state), not
+    /// throw -- and not decode as `.ready`, which would promise data that is not
+    /// there.
+    func testUnknownUsageStateDegradesInsteadOfBlankingThePanel() throws {
+        XCTAssertEqual(try decode(FleetUsageSummaryState.self, "degraded"), .unavailable)
+        XCTAssertEqual(try decode(FleetUsageSummaryState.self, "ready"), .ready)
+        XCTAssertEqual(try decode(FleetUsageSummaryState.self, "scanning"), .scanning)
+    }
+
+    /// The regression that matters for the dashboard: one unknown state value
+    /// must not fail the decode of the entire result.
+    func testUnknownUsageStateDoesNotFailTheWholeDashboard() throws {
+        let json = #"{"state":"recalibrating","cost_complete":false,"weekly":[],"heatmap":[],"providers":[],"models":[],"projects":[],"sessions":[],"branches":[],"tools":[],"mcp_servers":[],"shell_commands":[],"detail":"daemon is newer than this build"}"#
+        let result = try JSONDecoder().decode(FleetUsageDashboardResult.self, from: Data(json.utf8))
+        XCTAssertEqual(result.state, .unavailable)
+        XCTAssertEqual(result.detail, "daemon is newer than this build")
+    }
+
     func testKnownValuesStillRoundTripThroughEncoding() throws {
         let encoded = try JSONEncoder().encode(FleetProvider.codex)
         XCTAssertEqual(String(decoding: encoded, as: UTF8.self), "\"codex\"")


### PR DESCRIPTION
Adds a versioned `fleet/usage_dashboard` Hangar RPC and the notch UI that consumes it, plus inline interview answering.

## What this adds

A new aggregate-only RPC returning 53 weeks of usage: weekly buckets, a daily activity heatmap, a 30-day forecast, and breakdowns by provider, model, project, session, branch, tool, MCP server and shell command. The macOS notch renders it as a Dashboard mode alongside the existing period summary.

`fleet/usage_summary` is untouched and remains the lightweight endpoint. Paid entitlement stays deferred.

## Constraints honoured

- **Aggregates only.** The on-disk cache serialises only `FleetUsageSummaryResult` and `FleetUsageDashboardResult`. No `ProviderCall`, so no prompts, transcripts or credentials. **One violation was found and fixed during review, see S1 below.**
- **USD only, local device only.**
- **Unknown price stays `null`,** never `0.0`. Three ways this could have shown a wrong number were found and fixed, see C2 to C6.
- **Cache version 1 to 2.** A v1 cache is now accepted rather than discarded, so the stable endpoint keeps answering across the upgrade.
- Fleet consumes the versioned RPC only; no TUI state, SQLite, provider-log or Headroom access from Swift.

## Defects found and fixed

Every fix below is pinned by a test that was verified to go **red** without it and green with it. Findings marked (R) came from an independent adversarial review pass after the first round.

### Security and data handling

| | Defect | Impact |
|---|---|---|
| **S1** (R) | Shell commands shipped **verbatim** | The scanner keys `shell_commands` on the raw `input.command`, so the top 20 full command lines reached the wire **and** a mode-`0644` `fleet-usage.json`. Arguments routinely carry absolute paths and can carry credentials. Broke the aggregates-only constraint and this module's own header. Now only the program name ships, counts re-aggregated so `cargo test` and `cargo build` fold into one row, and leading `VAR=value` assignments are skipped so an inline `API_KEY` cannot become the bucket name. |
| **S2** (R) | Composite `session_id` duplicated the project label | Shipped `provider:project:session_id` while `provider` and `project` were already separate fields, and a client could not re-split it since a project label may contain a colon. Ships the bare id. |

### Cost correctness

| | Defect | Impact |
|---|---|---|
| **C1** | Sessions and branches used a single global `cost_complete` | One call with an unknown model rate blanked cost for **every** session and branch row across 53 weeks. |
| **C2** (R) | `weekly` still used that global flag | Same bug class, 53 rows. The scanner coalesces `None` when summing, so a week holding one unpriced call reported a **partial sum as the whole week's spend**. Now tracked per Monday anchor. |
| **C3** (R) | The forecast bypassed the `bucket_from` gate | The only cost surface not flowing through the completeness chokepoint. It quoted a confident dollar projection counting unpriced calls as free, while the totals beside it correctly showed nothing. Cost leg now gated on per-day completeness; the token projection is unaffected since it does not depend on pricing. |
| **C4** | Forecast averaged over days-with-data | Overstated the 30-day projection by ~3.5x for someone working 2 days a week. Now averages over calendar days. |
| **C5** (R) | ...and then treated a **long-idle** user as brand new | The fix for C4 shortened the divisor to the observed span, so someone idle six days who worked today was divided by 1 and projected at **30x a single day**. Earlier history is now the evidence distinguishing an established account from a new one. |
| **C6** (R) | Dashboard completeness lookups failed **open** | A missing key produced a confident wrong number rather than an honest null. Now fail closed. The summary path deliberately keeps its existing behaviour, since that endpoint's contract is fixed. |

### Correctness and UI

| | Defect | Impact |
|---|---|---|
| **U1** | `Vec::truncate` capped a chronologically ascending series | **The dashboard never showed the current week.** A 371-day window spans 54 ISO weeks unless it opens on a Monday, so on 6 days out of 7 the newest week was dropped. |
| **U2** | Heatmap used a 53-column `LazyVGrid` | Fills row-major, so each row was 53 consecutive days and nothing aligned by weekday. Rebuilt as week columns behind a pure, testable layout type. |
| **U3** | `FleetNotchDetail` `@State` survived session switches | A cursor left at question 5 carried into a 2-question interview and landed out of range, **leaving the new interview unanswerable.** |
| **U4** | `FleetUsageSummaryState` was the last plain-`Codable` wire enum | A daemon adding a state threw and **blanked the whole panel** instead of degrading it. Now `TolerantWireEnum`. |
| **U5** | Dead `Interviews` route | Rendered a tab that only re-showed the roster. Removed, since interviews are answered inline now. |
| **U6** (R) | v1 cache needlessly discarded on upgrade | Dropped the **stable** `usage_summary` to `SCANNING` until a cold rescan of the whole corpus finished. `CachedSummary` is unchanged across the bump, so an older cache is now accepted. |

## Verification

| Check | Result |
|---|---|
| `ainb-hangar-daemon` + `ainb-hangar-proto` | 1056 passed, 0 failed |
| `fleet_usage` unit tests | 12 passed, including 5 new regression tests |
| Swift `FleetRPCTests` | 94 passed, 0 failed |
| `cargo fmt --check` | clean |
| Swift app build | succeeded |

Two intermittent reds appeared under heavy host load (`workdir_provision::worktree_on_ainb_slug_branch`, `acp_pool::an_adapter_death_closes_every_parked_permission`). Both pass in isolation and **neither file is in this diff**; they are pre-existing timing flakes, not regressions.

All 18 Rust-to-Swift wire field names and their optionality were cross-checked mechanically against the serde definitions. This mattered: an earlier draft fixture invented `cache_write_tokens` and `total_tokens`, neither of which exist.

## CI: green on current main

**All checks pass: 21 pass, 1 skipped (an opt-in smoke job), 0 failures**, on the rebased tip against current main.

Getting there took a rebase and one re-run, and the reds along the way were worth recording because they were all environmental rather than code:

| Attempt | Failing test | Verdict |
|---|---|---|
| Local full suite | `acp_pool::an_adapter_death_closes_every_parked_permission` | passes in isolation |
| CI, pre-rebase | `tripwire_tcp_card_branch_pr_e2e`, `tripwire_tcp_card_rerun_e2e` | see below |
| CI, pre-rebase re-run | `rpc_acp::two_parked_permissions_are_both_answerable_over_the_wire` | passes on retry |
| CI, rebased | `rpc_event_push::subscribed_connection_receives_task_finished_event` | passes 3/3 locally |
| CI, rebased re-run | none | **green** |

The decisive evidence is that the SAME commit was green on macOS for both `Test` and `hangar-e2e` while red on ubuntu. A logic defect cannot be platform-selective, so the cause is the ubuntu runner environment, not this diff. Supporting that: `tripwire_tcp_card_rerun_e2e` also fails on main's ubuntu with none of this code, `hangar-e2e` fails on main in 4 of the last 8 runs, and every failing test named above is outside this PR's 11 files. All are socket, tmux or timing sensitive; the Kanban ones rendered an entirely empty board pane, meaning the TUI never painted.

Two re-runs were used in total, one per tip. None of these are among the repo's five frozen contract tests, so re-running is legitimate here rather than laundering a red, and each re-run went green rather than being retried repeatedly.

**Rebased onto current main** (was 44 behind, now 0). All 8 commits replayed with zero conflicts and the net change is byte-identical: same 11 files, 1956 insertions, 63 deletions. Main had added to the same `ALL_METHODS` and capability arrays, so the merged registry was checked explicitly: 155 entries, 155 unique, no duplicates, dispatch arm present exactly once.

Re-verified locally on the rebased tree: proto 117 pass, daemon lib 429 pass, `fleet_usage` 12 pass, Swift 94 pass, `cargo fmt --check` clean, all 8 commits still signed.

## Open items

- **Signed Debug build and screenshots are deferred.** The build host was heavily oversubscribed (load ~74 on 10 cores, ~330 MB swap free) and the build would likely have been reaped. Named here rather than dropped silently.
- **`mcp_servers` is always empty.** `scanner::emit` hardcodes an empty vec by design, so the MCP panel renders permanently blank. Either derive it from `mcp__<server>__` tool-name prefixes or drop the field before the wire freezes. Not addressed here.
- **No RPC-level integration test.** The dispatch arm, capability call and param parsing are covered only through the projection's unit tests.
- **`require_fleet_capability` is not enforcement.** It tests membership in a compile-time constant, so it can never refuse; an un-negotiated client gets data, not an error. This is **pre-existing** across all 10 fleet capability sites and documented as by-design, and this PR follows the same pattern. Flagging it because this PR is the first to put per-session data behind that gate.
- **Four other wire enums** (`ActionReceiptStatus`, `FleetTimelineKind`, `AtcSchedulerOwnership`, `FleetReplayResetReason`) are still plain `Codable` and carry the same forward-compatibility risk as U4. Out of scope.
- **The review-fix commit is not split by concern.** Its 19 hunks share the completeness map and the forecast signature, and all new tests sit in one block; splitting would have risked a non-compiling intermediate that could not be build-verified under the host load above. The commit body enumerates each fix.
- **Only the branch tip is build-verified**, not each intermediate commit, for the same reason.

Do not merge yet.

---
https://claude.ai/code/session_01WiXwHCr1FTST8wQJVN9F1o
