### PR TITLE
feat(atc): add `ainb fleet atc repair` to rebuild a stale heartbeat unit

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -28,6 +28,7 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
         Some(("setup", sub)) => setup(sub, format).await,
         Some(("teardown", sub)) => teardown(sub, format).await,
         Some(("status", sub)) => status(sub, format).await,
+        Some(("repair", sub)) => repair(sub, format).await,
         Some(("list", _)) => list(format).await,
         Some(("heartbeat", sub)) => heartbeat(sub, format).await,
         Some(("hook", sub)) => hook(sub).await,
@@ -401,6 +402,114 @@ async fn teardown(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()
 }
 
 // --- status -----------------------------------------------------------------
+
+/// `ainb fleet atc repair <name>` (#615): rebuild the heartbeat unit from the
+/// CURRENT `PATH` and reload it.
+///
+/// Deliberately its own verb rather than a side effect of `status`, which must
+/// stay read-only: a diagnostic that silently mutates the system is a
+/// diagnostic nobody can trust. Also not folded into `setup`, which is far
+/// broader (it rewrites policy and meta, touches hooks, registers the daemon
+/// cron and may spawn a session) and so is not safe to reach for on a live
+/// instance just to repoint a unit.
+///
+/// Why rebuilding is the fix, and not merely reloading: the unit carries the
+/// `PATH` captured when it was installed. A binary that moves WITHIN that PATH
+/// already self-heals, since a missing program exits 127 and the scheduler
+/// retries on the next tick. A binary that moves OUTSIDE it never recovers, no
+/// matter how many times the existing unit is reloaded, because the stale PATH
+/// cannot reach the new location. Only re-deriving the unit from the current
+/// environment repairs that.
+async fn repair(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    let name = require_name(matches)?;
+    let force = matches.get_flag("force");
+    let paths = AtcPaths::resolve(&name)?;
+    if !paths.meta.exists() {
+        bail!(
+            "no ATC instance named '{name}' (expected {})",
+            paths.meta.display()
+        );
+    }
+    let meta = AtcMeta::from_json(&std::fs::read_to_string(&paths.meta)?)?;
+
+    let before = timer::installed_program_health(&name);
+    if !should_reinstall(&before, force) {
+        let program = before.program().unwrap_or("ainb").to_string();
+        emit_repair(
+            format,
+            &name,
+            &before,
+            None,
+            &format!("nothing to repair: the unit's program '{program}' resolves"),
+        );
+        return Ok(());
+    }
+
+    let written = timer::install(&meta).context("reinstalling the heartbeat timer")?;
+    let after = timer::installed_program_health(&name);
+    // Reinstalling does not guarantee a runnable unit: if `ainb` is not on the
+    // PATH we just captured either, the rebuild is honest about still being
+    // broken rather than reporting a repair that did not happen.
+    let note = match &after {
+        timer::ProgramHealth::Resolves(program) => {
+            format!("repaired: the unit now runs '{program}'")
+        }
+        _ => timer::install_would_be_unrunnable(&meta).unwrap_or_else(|| {
+            "reinstalled, but the unit's program still does not resolve".to_string()
+        }),
+    };
+    emit_repair(format, &name, &before, Some(&written), &note);
+    Ok(())
+}
+
+/// Whether `repair` should rewrite the unit.
+///
+/// A unit whose program already resolves is left alone unless asked: the
+/// reinstall itself is harmless, but it reloads a working timer, and doing that
+/// silently on every invocation makes `repair` unsafe to put in a script or a
+/// cron. `NoUnit` DOES reinstall: an instance with meta but no unit is exactly
+/// the state a repair should fix.
+fn should_reinstall(health: &timer::ProgramHealth, force: bool) -> bool {
+    force || !matches!(health, timer::ProgramHealth::Resolves(_))
+}
+
+/// Render a `repair` outcome in both output modes.
+fn emit_repair(
+    format: OutputFormat,
+    name: &str,
+    before: &timer::ProgramHealth,
+    written: Option<&[std::path::PathBuf]>,
+    note: &str,
+) {
+    let paths: Vec<String> =
+        written.unwrap_or(&[]).iter().map(|p| p.display().to_string()).collect();
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "action": "repair",
+                    "name": name,
+                    "reinstalled": written.is_some(),
+                    "units": paths,
+                    "problem_before": before.problem(),
+                    "program_before": before.program(),
+                    "message": note,
+                })
+            );
+        }
+        _ => {
+            println!("atc repair {name}");
+            if let Some(problem) = before.problem() {
+                println!("  was:  {problem}");
+            }
+            for p in &paths {
+                println!("  wrote: {p}");
+            }
+            println!("  {note}");
+        }
+    }
+}
 
 async fn status(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
     let name = require_name(matches)?;
@@ -2314,6 +2423,54 @@ mod tests {
     }
 
     // --- H-A1: the hook NEVER returns Err (always exit 0) --------------------
+
+    /// `repair` must not touch a healthy unit unless explicitly forced: a
+    /// diagnostic-adjacent verb that reloads a working timer on every call is
+    /// not safe to script.
+    #[test]
+    fn repair_only_rewrites_a_unit_that_needs_it() {
+        use crate::fleet::atc::timer::ProgramHealth;
+
+        let healthy = ProgramHealth::Resolves("ainb".into());
+        assert!(!should_reinstall(&healthy, false));
+        assert!(should_reinstall(&healthy, true), "--force must override");
+
+        // Every not-healthy state is repairable, including NoUnit (meta exists
+        // but the unit is gone) and Unreadable (we cannot prove it is fine).
+        for health in [
+            ProgramHealth::Missing("/gone/ainb".into()),
+            ProgramHealth::Unreadable("unrecognised unit shape".into()),
+            ProgramHealth::NoUnit,
+        ] {
+            assert!(
+                should_reinstall(&health, false),
+                "{health:?} should be repaired without --force"
+            );
+        }
+    }
+
+    /// Guards the clap wiring, which is otherwise only exercised by running the
+    /// real command (and that would install a unit into the operator's home).
+    #[test]
+    fn repair_is_registered_with_a_name_and_a_force_flag() {
+        let m = crate::cli::registry::build_atc_command()
+            .try_get_matches_from(["atc", "repair", "tower", "--force"])
+            .expect("repair should parse");
+        let (verb, sub) = m.subcommand().expect("subcommand");
+        assert_eq!(verb, "repair");
+        assert_eq!(
+            sub.get_one::<String>("name").map(String::as_str),
+            Some("tower")
+        );
+        assert!(sub.get_flag("force"));
+
+        // name is required, so a bare `repair` must not parse.
+        assert!(
+            crate::cli::registry::build_atc_command()
+                .try_get_matches_from(["atc", "repair"])
+                .is_err()
+        );
+    }
 
     #[test]
     fn hook_returns_ok_even_on_unrelated_session() {

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -2373,7 +2373,7 @@ impl CliCommand for FleetCommand {
 /// Build the `ainb fleet atc` subcommand tree: the persistent ATC brain's
 /// provisioning + management verbs. `heartbeat` is the internal timer-driven
 /// verb (hidden from `--help`).
-fn build_atc_command() -> Command {
+pub(crate) fn build_atc_command() -> Command {
     let interval = clap::Arg::new("interval")
         .long("interval")
         .value_parser(clap::value_parser!(u32))
@@ -2386,7 +2386,7 @@ fn build_atc_command() -> Command {
         );
 
     Command::new("atc")
-        .about("Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)")
+        .about("Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)")
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommand(
@@ -2425,6 +2425,24 @@ fn build_atc_command() -> Command {
                         .long("purge")
                         .action(clap::ArgAction::SetTrue)
                         .help("Also delete the instance dir (state.json + task-log.md)"),
+                ),
+        )
+        .subcommand(
+            Command::new("repair")
+                .about("Reinstall an ATC instance's heartbeat unit from the CURRENT PATH")
+                .long_about(
+                    "Rebuild and reload the local heartbeat unit for an instance whose program \
+                     no longer resolves. Touches ONLY the timer unit: it reuses the instance's \
+                     existing meta and leaves policy, hooks, the daemon cron and the session \
+                     alone, which is what makes it safe to run on a live instance. Use this \
+                     when `atc status` reports `program MISSING`.",
+                )
+                .arg(clap::Arg::new("name").required(true).help("Instance name"))
+                .arg(
+                    clap::Arg::new("force")
+                        .long("force")
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Reinstall even when the current unit's program resolves"),
                 ),
         )
         .subcommand(

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2027,7 +2027,7 @@ Commands:
   daemon        Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
   daemons       Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
   runtime       Install the standalone Fleet daemon and provider hooks
-  atc           Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)
+  atc           Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
   bridge        Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
   enrich-cache  Content-addressed enrich cache (the producer's write path)
   help          Print this message or the help of the given subcommand(s)
@@ -2409,17 +2409,18 @@ Options:
 
 ### `ainb fleet atc`
 
-Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)
+Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
 
 ```console
 $ ainb fleet atc --help
-Air Traffic Control — the persistent fleet brain (setup / status / list / teardown)
+Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
 
 Usage: ainb fleet atc [OPTIONS] <COMMAND>
 
 Commands:
   setup     Provision an ATC instance: CLAUDE.md policy + meta + heartbeat timer + session
   teardown  Remove an ATC instance's heartbeat timer + session
+  repair    Reinstall an ATC instance's heartbeat unit from the CURRENT PATH
   status    Report one ATC instance (meta + timer + session liveness)
   list      List all provisioned ATC instances
   inbox     Inspect / drain / commit a parent's durable completion inbox
@@ -2470,6 +2471,34 @@ Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
       --purge            Also delete the instance dir (state.json + task-log.md)
   -h, --help             Print help
+```
+
+#### `ainb fleet atc repair`
+
+Rebuild and reload the local heartbeat unit for an instance whose program no longer resolves. Touches ONLY the timer unit: it reuses the instance's existing meta and leaves policy, hooks, the daemon cron and the session alone, which is what makes it safe to run on a live instance. Use this when `atc status` reports `program MISSING`.
+
+```console
+$ ainb fleet atc repair --help
+Rebuild and reload the local heartbeat unit for an instance whose program no longer resolves. Touches ONLY the timer unit: it reuses the instance's existing meta and leaves policy, hooks, the daemon cron and the session alone, which is what makes it safe to run on a live instance. Use this when `atc status` reports `program MISSING`.
+
+Usage: ainb fleet atc repair [OPTIONS] <name>
+
+Arguments:
+  <name>
+          Instance name
+
+Options:
+      --force
+          Reinstall even when the current unit's program resolves
+
+      --format <format>
+          Output format
+          
+          [default: text]
+          [possible values: text, json, csv, markdown]
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 #### `ainb fleet atc status`


### PR DESCRIPTION
Closes #615.

## Why

#609 made a broken heartbeat unit **visible** (`program MISSING (<path>)` instead of a confident `timer installed: true`), which turned a silent outage into a loud one. It still left the operator to fix it by hand. This adds the fix.

## Why a separate verb

Peer-reviewed with Codex before implementing, and it landed on the same option the issue author leaned toward:

- **`atc status` stays read-only.** A diagnostic that silently mutates the system is a diagnostic nobody can trust.
- **`atc setup` is too broad.** It rewrites policy and meta, touches hooks, registers the daemon cron and may spawn a session. Not something to reach for on a live instance just to repoint a unit.
- **The heartbeat cannot self-repair.** If the program is missing, the heartbeat is precisely what is not running.

## Why it rebuilds rather than reloads

This is the part that matters. Since #611 the unit carries the `PATH` captured when it was installed:

| binary moves | outcome today |
|---|---|
| **within** the frozen PATH | already self-heals: exit 127, scheduler retries next tick |
| **outside** the frozen PATH | never recovers, however many times the unit is reloaded |

The second row is what repair exists for, and reloading the existing unit cannot fix it because the stale PATH cannot reach the new location. `repair` re-derives the unit from the **current** `unit_path_env()`.

## Behaviour

- Scope is one unit. Reuses the instance's existing meta; leaves policy, hooks, the daemon cron and the session alone. That is what makes it safe on a live instance.
- No-ops when the program already resolves, unless `--force`, so the verb is safe to script or cron.
- `--force` also migrates a legacy pre-#609 unit (absolute pinned path, no shell wrapper) to the current form.
- Honest on failure: if the rebuilt unit still cannot resolve, it says so rather than reporting a repair that did not happen.
- Text and single-document JSON output.

## No `bridge repair`

`ainb fleet bridge install` is already exactly this narrow idempotent rebuild, so a second verb would add vocabulary and zero capability.

## Verification

Live, against this host's real `main` instance, on the no-op path (which returns before any install, so it mutates nothing):

```console
$ ainb fleet atc repair main
atc repair main
  nothing to repair: the unit's program '/opt/homebrew/bin/ainb' resolves

$ ainb --format json fleet atc repair main
{"action":"repair","name":"main","reinstalled":false,"units":[],
 "problem_before":null,"program_before":"/opt/homebrew/bin/ainb",
 "message":"nothing to repair: the unit's program '/opt/homebrew/bin/ainb' resolves"}
```

A nonexistent instance exits 1 with `no ATC instance named '<x>' (expected <path>)` and installs nothing.

Tests: `repair_only_rewrites_a_unit_that_needs_it` pins the guard (healthy is skipped, `--force` overrides, and `Missing` / `Unreadable` / `NoUnit` are all repairable); `repair_is_registered_with_a_name_and_a_force_flag` guards the clap wiring, which is otherwise only exercised by running the real command and installing a unit into the operator's home. 267 pass in the touched modules, clippy clean.

`docs/tui/cli.md` is regenerated: the `atc` about string changed, and that file is freshness-gated by the `CLI reference freshness` job.
