### PR TITLE
TEMP DO NOT MERGE: hangar-e2e card tripwire flake baseline

### DIFF
--- a/ainb-tui/.ci-flake-probe
+++ b/ainb-tui/.ci-flake-probe
@@ -1,0 +1,2 @@
+CI flake baseline probe for the hangar-e2e card tripwires.
+Throwaway branch, never merged. Delete after the measurement.


### PR DESCRIPTION
Throwaway measurement for #619. Close and delete once counted.

#619's `hangar-e2e (ubuntu-latest)` failures were attributed to its send commits on the strength of a bisect. That attribution is now retracted: neither failing tripwire reaches `tmux_send` or Fleet `capture_pane` (traced independently twice), so no causal mechanism exists.

This branch is clean `main` plus one inert file, so `hangar-e2e` runs with NO send-path changes present.

Question: do `tripwire_tcp_card_rerun_e2e` and `tripwire_tcp_card_branch_pr_e2e` fail here too?

fails here => #619 is exonerated, the failures are suite flake
passes 3x  => the correlation with #619 needs a real explanation

Do not merge. No review needed.