### PR TITLE
TEMP DO NOT MERGE: isolate the CI workflow commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,74 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
 
   # ────────────────────────────────────────────────────────────────────────────
+  # Fleet send-path integrity against a REAL tmux pane
+  #
+  # `Test` already COMPILES and selects this binary: `--all-features` turns on
+  # ainb-fleet-core's `tmux-tests` feature and `tmux_send_integrity` is not
+  # matched by that job's `not binary(/^tripwire_/)` filter. But neither runner
+  # image ships tmux, so there every test self-skips and the send-path proof is
+  # vacuously green. This job is the lane where it actually executes.
+  #
+  # The trailing grep is the point: an environment that silently degrades to
+  # SKIP is exactly the trap `run_all_tripwires.sh` documents for its macOS
+  # leg, and a skipped suite here would mean the chunked-write / capture-failure
+  # guarantees ship untested while CI stays green.
+  #
+  # Safe to run on a shared machine as well as a runner: the tests clear `TMUX`
+  # and pin `TMUX_TMPDIR` onto a pid-unique socket dir, so their panes live on a
+  # private tmux server and never join the ambient one.
+  # ────────────────────────────────────────────────────────────────────────────
+  fleet-send-tmux:
+    name: fleet send integrity (${{ matrix.os }})
+    needs: changes
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+      - uses: dtolnay/rust-toolchain@stable
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+      - uses: Swatinem/rust-cache@v2
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        with:
+          workspaces: "ainb-tui -> target"
+      # macOS runner images do NOT ship tmux (actions/runner-images macos-15
+      # README), the same reason `hangar-e2e` brew-installs it.
+      - name: Install tmux (apt-get on Linux, brew on macOS)
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y tmux
+          else
+            brew install tmux
+          fi
+      - name: Send-path integrity against a real tmux pane
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: |
+          set -o pipefail
+          cargo test -p ainb-fleet-core --features tmux-tests \
+            --test tmux_send_integrity --no-fail-fast -- --nocapture \
+            2>&1 | tee "$RUNNER_TEMP/tmux-send-integrity.log"
+          if grep -q '^SKIP:' "$RUNNER_TEMP/tmux-send-integrity.log"; then
+            echo "::error::tmux send-integrity suite SKIPped, so the send path was never exercised on this runner"
+            exit 1
+          fi
+        working-directory: ${{ env.WORKING_DIR }}
+
+  # ────────────────────────────────────────────────────────────────────────────
   # Hangar control-plane end-to-end tripwires (P0-P9)
   #
   # Mirrors the `ainb-hooks` per-feature pattern: install tmux on Linux, build


### PR DESCRIPTION
Throwaway experiment for #619. Close and delete once it reports.

Clean `main` plus ONE commit: the `.github/workflows/ci.yml` change that adds the `fleet-send-tmux` job. No Rust changes at all.

Why this is the decisive test. The earlier bisect proved a four-commit SET causes `hangar-e2e (ubuntu-latest)` to fail, and I wrongly read that as implicating the send path. But call-graph analysis (done twice, independently) proves neither failing tripwire reaches `tmux_send` or Fleet `capture_pane`. Both results hold at once only if the cause is the workflow commit that was sitting in that same set, which I cherry-picked and then failed to consider.

It also fits the shape the Rust theories never did: this is a CI-infrastructure change, which is exactly the kind of thing that is ubuntu-only.

red   => the CI change is the cause, both Rust commits are exonerated
green => look harder at the pair

Do not merge. No review needed.