### PR TITLE
test(atc): wait for the event log instead of racing it

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -2733,6 +2733,30 @@ mod tests {
     /// `drain_with_budget` and the error propagates out of `hook_core`. The
     /// `hook()` swallow wrapper ([`swallow_hook_result`]) then maps that Err to
     /// `Ok(())` → exit 0, which we assert directly on the real error value.
+    /// Read `events.jsonl` once the daemon has actually written it.
+    ///
+    /// The hook returning is NOT proof the event reached disk: the daemon
+    /// writes that log on its own schedule. Reading it straight away is a race
+    /// that loses on a slow runner, and it panics with `NotFound`, which reads
+    /// like a missing feature rather than the timing bug it is.
+    fn events_jsonl(home: &std::path::Path) -> String {
+        let path = home.join("events.jsonl");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            match std::fs::read_to_string(&path) {
+                Ok(text) if !text.trim().is_empty() => return text,
+                other => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "the daemon never wrote {}: {other:?}",
+                        path.display()
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+            }
+        }
+    }
+
     #[test]
     fn forced_drain_error_is_swallowed_to_ok() {
         let home = TempDir::new().unwrap();
@@ -2871,7 +2895,7 @@ mod tests {
         )
         .unwrap();
         assert!(emitted.is_none(), "Claude must render its native picker");
-        let events = std::fs::read_to_string(home.path().join("events.jsonl")).unwrap();
+        let events = events_jsonl(home.path());
         let event: serde_json::Value = serde_json::from_str(events.trim()).unwrap();
         assert_eq!(event["fleet_delivery"], "mirrored");
         assert_eq!(
@@ -2914,7 +2938,7 @@ mod tests {
             emitted.is_none(),
             "unavailable Fleet broker must leave Claude's native interview unblocked"
         );
-        let events = std::fs::read_to_string(home.path().join("events.jsonl")).unwrap();
+        let events = events_jsonl(home.path());
         assert!(events.contains("\"fleet_delivery\":\"mirrored\""));
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_event_push.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_event_push.rs
@@ -36,6 +36,19 @@ struct Client {
     writer: OwnedWriteHalf,
 }
 
+/// How long an assertion that an event MUST ARRIVE is willing to wait.
+///
+/// These are arrival assertions, not latency assertions: the property is that
+/// the subscriber receives the frame, not that it receives it quickly. Five
+/// seconds was enough on a dev box and not on a loaded hosted macOS runner,
+/// where it failed as "subscribed connection must receive a hangar/event
+/// frame" and read like a lost event rather than a slow one.
+///
+/// The ABSENCE assertions in this file deliberately keep their short waits: a
+/// longer wait there only makes the suite slower, since nothing arriving is
+/// what they are proving.
+const EVENT_ARRIVAL_BUDGET: Duration = Duration::from_secs(30);
+
 impl Client {
     /// Poll-connect until the accept loop is up, then split the stream.
     async fn connect(socket_path: &std::path::Path) -> Self {
@@ -224,7 +237,7 @@ async fn subscribed_connection_receives_task_finished_event() {
 
     // The subscribed connection receives the typed event frame.
     let event = sub
-        .next_event(Duration::from_secs(5))
+        .next_event(EVENT_ARRIVAL_BUDGET)
         .await
         .expect("subscribed connection must receive a hangar/event frame");
     assert_eq!(event["event"], "task_finished", "wrong event: {event}");
@@ -274,7 +287,7 @@ async fn event_never_crosses_workspace_boundary() {
     // Positive marker first: A's subscriber sees the event (so the negative
     // below proves isolation, not a broken pipeline).
     let event = sub_a
-        .next_event(Duration::from_secs(5))
+        .next_event(EVENT_ARRIVAL_BUDGET)
         .await
         .expect("workspace A's subscriber must receive the event");
     assert_eq!(event["event"], "task_finished");


### PR DESCRIPTION
`main` has been red on `Test (macos-latest)` since the atc repair verb landed:

```
thread 'cli::fleet::atc::tests::ask_hook_returns_complete_structured_answer_without_text_routing'
panicked at crates/ainb-core/src/cli/fleet/atc.rs:2954:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound }
```

The test polls until the pending request appears, then immediately reads `events.jsonl`. But the poll only proves the REQUEST landed; the daemon writes the event log on its own schedule. On a slow runner the file is not there yet, so the read panics with NotFound, which reads like a missing feature rather than the timing bug it is. It passes on ubuntu, which is why it looked like noise.

Now it polls the file to a 10 second deadline and fails with the last read error if the event genuinely never arrives, so a real regression still goes red and says why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by waiting for asynchronously written event data.
  * Added a timeout with a clear failure message when the expected session event is not recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->