### PR TITLE
fix(recordings): make every chat-bus tape reproducible

### DIFF
--- a/explainers/recordings/chat-bus/EXPECTED-OUTCOMES.md
+++ b/explainers/recordings/chat-bus/EXPECTED-OUTCOMES.md
@@ -185,7 +185,7 @@ Recording gotchas, all of them learned by losing a tape to each:
   produced a 7 second blur. vhs captures on screen change; leave it alone.
 - Terminate on `Wait+Screen@<n>s /SMOKE-RESULT .../`, never a fixed `Sleep`.
   A `Sleep` that ends before the journey does yields a banner with no verdict,
-  which looks like evidence and is not. `j1`–`j5e` still use fixed `Sleep`s.
+  which looks like evidence and is not. Every tape here now does this.
 - Keep the pattern out of the TYPED command. `Wait+Screen` matches the whole
   screen, and the shell echoes the command as it is typed, so a tape that types
   its own sentinel matches instantly and records three seconds of nothing.

--- a/explainers/recordings/chat-bus/j1.tape
+++ b/explainers/recordings/chat-bus/j1.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j1"
 Enter
-Sleep 260s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j1 /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j2.tape
+++ b/explainers/recordings/chat-bus/j2.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j2"
 Enter
-Sleep 220s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j2 /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j3.tape
+++ b/explainers/recordings/chat-bus/j3.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j3"
 Enter
-Sleep 260s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j3 /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j4.tape
+++ b/explainers/recordings/chat-bus/j4.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j4"
 Enter
-Sleep 220s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j4 /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j5a.tape
+++ b/explainers/recordings/chat-bus/j5a.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j5a"
 Enter
-Sleep 220s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j5a /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j5b.tape
+++ b/explainers/recordings/chat-bus/j5b.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j5b"
 Enter
-Sleep 260s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j5b /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j5c.tape
+++ b/explainers/recordings/chat-bus/j5c.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j5c"
 Enter
-Sleep 200s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j5c /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j5d.tape
+++ b/explainers/recordings/chat-bus/j5d.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j5d"
 Enter
-Sleep 220s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j5d /
+Sleep 3s

--- a/explainers/recordings/chat-bus/j5e.tape
+++ b/explainers/recordings/chat-bus/j5e.tape
@@ -17,9 +17,11 @@ Set Padding 16
 Set Shell bash
 Set TypingSpeed 25ms
 
-Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
-Enter
-Sleep 1s
 Type "./ainb-tui/scripts/chat-bus-smoke.sh j5e"
 Enter
-Sleep 200s
+# Terminates on the VERDICT, never a guessed Sleep: a tape whose Sleep ends
+# before the journey does yields a banner with no verdict, which looks like
+# evidence and is not. The pattern is NOT in the typed command above, because
+# `Wait+Screen` matches the whole screen and the shell echoes what it types.
+Wait+Screen@900s /SMOKE-RESULT j5e /
+Sleep 3s


### PR DESCRIPTION
The nine part 1 tapes could not be re-run as committed. Each one did:

```
Type "cd /home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-chat-bus-e2e"
...
Sleep 260s
```

Two problems, both of which quietly turn evidence into a one-shot artifact:

- the `cd` names a scratch worktree on one machine that no longer exists, so the tape fails on any other checkout
- it ends on a guessed duration. A `Sleep` that expires before the journey does records a banner with no verdict, which looks like evidence and is not. That failure mode is already documented in `EXPECTED-OUTCOMES.md` as a fail signature, and these nine tapes were the ones still exposed to it.

They now run from the repo root (where vhs is invoked) and terminate on the journey's own `SMOKE-RESULT` line, matching j6 and j7. The terminator pattern is deliberately not present in the typed command, because `Wait+Screen` matches the whole screen and the shell echoes what it types, so a tape that types its own sentinel matches instantly and records nothing.

No recording is regenerated here: the committed gifs and mp4s are still the runs that were frame-verified. This only fixes the ability to reproduce them.

`vhs validate` passes on all eleven tapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved smoke-test recording reliability by synchronizing completion with the final test verdict instead of fixed wait times.
  - Recording journeys now continue from the current working context, reducing unnecessary setup steps.
  - Added brief post-verdict pauses to ensure final results are captured consistently.

- **Documentation**
  - Updated recording guidance to reflect verdict-based completion for all smoke-test journeys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->