### PR TITLE
test(tripwire): pin the TUI to its own hangar, and stop misnaming the failure

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -314,6 +314,36 @@ impl Harness {
     }
 }
 
+/// Issue a `fleet/action` that carries `expected_version`, refreshing that
+/// version and retrying if the daemon reports a mismatch.
+///
+/// Reading the version and then acting on it is a read-then-act race: the
+/// session's version advances on writes these tests do not make (turn
+/// recording, turn-end commit, lifecycle convergence), so the value can be
+/// stale by the time the call lands. The optimistic-concurrency guard is not
+/// what these tests are about; they are about whether the answer reaches its
+/// adapter. Retrying with the fresh version keeps that the subject, and a
+/// mismatch surviving every attempt still fails the test.
+async fn fleet_action_versioned(
+    client: &mut Client,
+    harness: &Harness,
+    session_key: &str,
+    mut params: serde_json::Value,
+) -> serde_json::Value {
+    let mut reply = serde_json::Value::Null;
+    for _ in 0..3 {
+        params["expected_version"] = harness.version(session_key).await.into();
+        reply = client.call(methods::FLEET_ACTION, params.clone()).await;
+        let stale = reply["error"]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("version is") && m.contains("expected"));
+        if !stale {
+            return reply;
+        }
+    }
+    reply
+}
+
 struct Client {
     reader: BufReader<OwnedReadHalf>,
     writer: OwnedWriteHalf,
@@ -817,20 +847,26 @@ async fn a_permission_round_trips_through_fleet_action() {
     // an ACP session can be blocked on SEVERAL asks at once and the row can name
     // only one of them, which is why the row-equality gate is off for ACP (see
     // `two_parked_permissions_are_both_answerable_over_the_wire`).
-    let stale = client
-        .call(
-            methods::FLEET_ACTION,
-            serde_json::json!({
+    let stale = fleet_action_versioned(
+
+        &mut client,
+
+        &harness,
+
+        &session_key,
+
+        serde_json::json!({
                 "session_key": session_key,
-                "expected_version": harness.version(&session_key).await,
                 "request_id": "req-acp-stale-answer",
                 "action": {
                     "action": "approve",
                     "request_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000",
                 },
             }),
-        )
-        .await;
+
+    )
+
+    .await;
     assert!(stale["error"].is_null(), "{stale}");
     assert_eq!(
         stale["result"]["receipt"]["status"], "FAILED",
@@ -850,17 +886,17 @@ async fn a_permission_round_trips_through_fleet_action() {
         .expect("attention row");
     assert_eq!(still_open, "open", "the refusal left the ask untouched");
 
-    let approved = client
-        .call(
-            methods::FLEET_ACTION,
-            serde_json::json!({
-                "session_key": session_key,
-                "expected_version": harness.version(&session_key).await,
-                "request_id": "req-acp-answer",
-                "action": { "action": "approve", "request_fingerprint": fingerprint },
-            }),
-        )
-        .await;
+    let approved = fleet_action_versioned(
+        &mut client,
+        &harness,
+        &session_key,
+        serde_json::json!({
+            "session_key": session_key,
+            "request_id": "req-acp-answer",
+            "action": { "action": "approve", "request_fingerprint": fingerprint },
+        }),
+    )
+    .await;
     assert!(approved["error"].is_null(), "{approved}");
     assert_eq!(
         approved["result"]["receipt"]["status"], "DELIVERED",
@@ -985,17 +1021,17 @@ async fn two_parked_permissions_are_both_answerable_over_the_wire() {
     // OLDEST first: the fingerprint the session row is NOT carrying, and the
     // exact answer the old gate refused as stale.
     for (index, (attention_id, fingerprint)) in asks.iter().enumerate() {
-        let approved = client
-            .call(
-                methods::FLEET_ACTION,
-                serde_json::json!({
-                    "session_key": session_key,
-                    "expected_version": harness.version(&session_key).await,
-                    "request_id": format!("req-acp-two-answer-{index}"),
-                    "action": { "action": "approve", "request_fingerprint": fingerprint },
-                }),
-            )
-            .await;
+        let approved = fleet_action_versioned(
+            &mut client,
+            &harness,
+            &session_key,
+            serde_json::json!({
+                "session_key": session_key,
+                "request_id": format!("req-acp-two-answer-{index}"),
+                "action": { "action": "approve", "request_fingerprint": fingerprint },
+            }),
+        )
+        .await;
         assert!(approved["error"].is_null(), "ask {index}: {approved}");
         assert_eq!(
             approved["result"]["receipt"]["status"], "DELIVERED",

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
@@ -2478,8 +2478,24 @@ impl TuiSession {
             let _ = write!(env_prefix, "{k}='{v}' ");
         }
 
+        // `env -u AINB_HANGAR_HOME` is load-bearing, and it is the ONLY thing
+        // pinning this TUI to the hangar the test just seeded.
+        //
+        // Hangar home resolution puts `AINB_HANGAR_HOME` AHEAD of `HOME`, so a
+        // launch that sets only `HOME` is not isolated: if that variable is set
+        // anywhere in the tmux SERVER's environment, the TUI silently talks to a
+        // different hangar than the daemon this test spawned, and the board
+        // renders its chrome over no data. Every daemon spawn in this file
+        // already does `.env_remove("AINB_HANGAR_HOME")` for exactly this
+        // reason; the TUI was the one launch that did not, and it goes through
+        // `tmux send-keys`, where the tmux server's environment is inherited
+        // from whichever process happened to start it.
+        // `exec env -u ...`, in that order: `exec` is a SHELL BUILTIN, so
+        // `env ... exec prog` makes env search $PATH for a binary called `exec`
+        // and die with "env: 'exec': No such file or directory". Exec-ing env
+        // keeps the no-extra-shell-process property and still clears the var.
         let cmd = format!(
-            "HOME='{}' {plugin_root}{env_prefix}exec '{}' tui",
+            "exec env -u AINB_HANGAR_HOME HOME='{}' {plugin_root}{env_prefix}'{}' tui",
             home.display(),
             bin.display()
         );

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
@@ -37,38 +37,47 @@ const CARD_TITLE: &str = "Rerunlifecycletripwire";
 /// Open the `Run ▾` menu over the focused card and launch headless (`Enter`
 /// re-sent — a lone key can drop after a screen change).
 fn launch_headless(sess: &TuiSession, scale: u64, which: &str, home: &std::path::Path) {
+    // Sweep focus ACROSS THE COLUMNS, trying `Enter` at each one.
+    //
+    // `Enter` opens this menu over a FOCUSED CARD, and the card is in exactly
+    // one column. A finished card auto-moves to Done while the focus cursor
+    // stays behind on the now-empty Todo column, so the rerun leg has to move
+    // focus. The original code pressed `Right` a fixed five times on 100 ms
+    // sleeps, which assumes the card has already landed and that no keypress
+    // dropped; when either failed, focus stopped on an empty column and this
+    // loop pressed `Enter` at nothing until it timed out.
+    //
+    // A "nudge right when the pane shows the empty placeholder" is NOT the fix
+    // either, and I shipped that mistake once: `— empty —` is painted for EVERY
+    // empty column, so on a seven-column board it is essentially always on
+    // screen, and the nudge walks focus straight past the card to the last
+    // column (the board clamps there) on every iteration.
+    //
+    // So sweep deterministically instead: walk left to the first column, then
+    // step right one column at a time trying `Enter` at each. That visits the
+    // card's column exactly once per sweep wherever it sits, and repeats until
+    // the deadline.
+    const COLUMNS: usize = 8; // seven seeded columns, plus one to clamp on
     let deadline = Instant::now() + Duration::from_secs(20 * scale);
     let mut opened = false;
-    while Instant::now() < deadline {
-        sess.send_enter();
-        if sess
-            .poll_capture(Instant::now() + Duration::from_millis(1500), |c| {
-                c.contains("Run ▾")
-            })
-            .is_some()
-        {
-            opened = true;
-            break;
+    'sweep: while Instant::now() < deadline {
+        for _ in 0..COLUMNS {
+            sess.send_key("Left");
         }
-        // Focus sitting on an EMPTY column can never open this menu, because
-        // `Enter` opens it over a focused CARD. Nudge focus right and retry,
-        // rather than spending the whole deadline pressing Enter at a column
-        // that has nothing in it.
-        //
-        // This is what makes the rerun leg self-correcting. A finished card
-        // auto-moves to the Done column while the focus cursor stays behind on
-        // the now-empty Todo column, and walking focus with a fixed number of
-        // blind keypresses assumes both that the card has already moved and
-        // that no keypress dropped. When either assumption failed, focus
-        // stopped on an empty column and this loop pressed Enter at nothing
-        // until it timed out.
-        //
-        // Gated on actually being ON the board: `— empty —` is a generic
-        // placeholder that other screens paint too (the issue list's detail
-        // pane uses it), and sending `Right` at one of those walks a cursor
-        // that has nothing to do with board columns.
-        let capture = sess.capture();
-        if capture.contains("Board:") && capture.contains("— empty —") {
+        for _ in 0..COLUMNS {
+            sess.send_enter();
+            if sess
+                .poll_capture(Instant::now() + Duration::from_millis(1500), |c| {
+                    c.contains("Run ▾")
+                })
+                .is_some()
+            {
+                opened = true;
+                break 'sweep;
+            }
+            if Instant::now() >= deadline {
+                break 'sweep;
+            }
             sess.send_key("Right");
         }
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
@@ -51,7 +51,23 @@ fn launch_headless(sess: &TuiSession, scale: u64) {
             break;
         }
     }
-    assert!(opened, "Run ▾ menu never opened:\n{}", sess.capture());
+    // Name the FIRST thing that did not happen, not the last. `Enter` opens
+    // this menu over a FOCUSED CARD, so when the board holds no card there is
+    // nothing for it to open and "Run ▾ never opened" is a true statement about
+    // the wrong step. That message sent three separate investigations after a
+    // menu bug when every observed failure was actually an empty board.
+    let capture = sess.capture();
+    assert!(
+        opened,
+        "{}:\n{capture}",
+        if capture.contains("— empty —") {
+            "the board is EMPTY, so there was no card to open `Run ▾` over: the card \
+             never reached this TUI (check it is talking to the seeded hangar, not \
+             another one)"
+        } else {
+            "a card is on the board but the `Run ▾` menu never opened"
+        }
+    );
     sess.send_enter(); // headless launch → hangar/board_card_run
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
@@ -36,7 +36,7 @@ const CARD_TITLE: &str = "Rerunlifecycletripwire";
 
 /// Open the `Run ▾` menu over the focused card and launch headless (`Enter`
 /// re-sent — a lone key can drop after a screen change).
-fn launch_headless(sess: &TuiSession, scale: u64) {
+fn launch_headless(sess: &TuiSession, scale: u64, which: &str, home: &std::path::Path) {
     let deadline = Instant::now() + Duration::from_secs(20 * scale);
     let mut opened = false;
     while Instant::now() < deadline {
@@ -50,24 +50,49 @@ fn launch_headless(sess: &TuiSession, scale: u64) {
             opened = true;
             break;
         }
+        // Focus sitting on an EMPTY column can never open this menu, because
+        // `Enter` opens it over a focused CARD. Nudge focus right and retry,
+        // rather than spending the whole deadline pressing Enter at a column
+        // that has nothing in it.
+        //
+        // This is what makes the rerun leg self-correcting. A finished card
+        // auto-moves to the Done column while the focus cursor stays behind on
+        // the now-empty Todo column, and walking focus with a fixed number of
+        // blind keypresses assumes both that the card has already moved and
+        // that no keypress dropped. When either assumption failed, focus
+        // stopped on an empty column and this loop pressed Enter at nothing
+        // until it timed out.
+        if sess.capture().contains("— empty —") {
+            sess.send_key("Right");
+        }
     }
     // Name the FIRST thing that did not happen, not the last. `Enter` opens
     // this menu over a FOCUSED CARD, so when the board holds no card there is
     // nothing for it to open and "Run ▾ never opened" is a true statement about
     // the wrong step. That message sent three separate investigations after a
     // menu bug when every observed failure was actually an empty board.
-    let capture = sess.capture();
-    assert!(
-        opened,
-        "{}:\n{capture}",
-        if capture.contains("— empty —") {
-            "the board is EMPTY, so there was no card to open `Run ▾` over: the card \
-             never reached this TUI (check it is talking to the seeded hangar, not \
-             another one)"
-        } else {
-            "a card is on the board but the `Run ▾` menu never opened"
-        }
-    );
+    //
+    // The store state is reported too, because "the board is empty" alone does
+    // not say WHICH half is broken. The caller already proved the card RENDERED
+    // before the first launch, so an empty board here means the card was lost
+    // between then and now, not that it never arrived, and the store tells us
+    // whether it is the data or only the view that lost it.
+    if !opened {
+        let capture = sess.capture();
+        let in_store = board_card_by_title(home, CARD_TITLE).is_some();
+        let diagnosis = match (capture.contains("— empty —"), in_store) {
+            (true, true) => {
+                "the board is EMPTY but the card IS in the store, so the VIEW lost a card \
+                 the data still has"
+            }
+            (true, false) => {
+                "the board is EMPTY and the card is GONE from the store, so this is a data \
+                 loss, not a render bug"
+            }
+            (false, _) => "a card is on the board but the `Run ▾` menu never opened",
+        };
+        panic!("{which}: {diagnosis}:\n{capture}");
+    }
     sess.send_enter(); // headless launch → hangar/board_card_run
 }
 
@@ -118,7 +143,7 @@ fn rerunning_a_finished_card_enqueues_a_fresh_run_and_greens_it_again() {
 
     // RUN #1: launch, wait for done, capture the first run's slug + assert its
     // durable branch exists (the committing run left commits).
-    launch_headless(&sess, scale);
+    launch_headless(&sess, scale, "run #1 launch", pipe.home());
     let slug1 = wait_for_done(pipe.home(), CARD_TITLE, scale)
         .unwrap_or_else(|| panic!("run #1 never reached done:\n{}", sess.capture()));
     let branch1 = worktree_branch(&slug1);
@@ -127,19 +152,17 @@ fn rerunning_a_finished_card_enqueues_a_fresh_run_and_greens_it_again() {
         "run #1 must leave a durable branch {branch1}"
     );
 
-    // The finished card auto-moved into the Done column (the last column), but the
-    // focus cursor stayed on the now-empty Todo column. Walk focus right — the
-    // board clamps at the last column — so the Done card is focused before the
-    // rerun (else Run ▾ has no card to open over).
-    for _ in 0..5 {
-        sess.send_key("Right");
-        std::thread::sleep(Duration::from_millis(100));
-    }
+    // The finished card auto-moves into the Done column while the focus cursor
+    // stays on the now-empty Todo column, so focus has to walk right before the
+    // rerun. That used to be five blind `Right` presses on 100 ms sleeps, which
+    // assumed the card had already landed in Done and that no keypress dropped;
+    // `launch_headless` now walks focus itself, deadline-bounded, and only when
+    // the focused column is demonstrably empty.
 
     // RERUN: Enter on the now-FINISHED card opens the same Run ▾ picker and
     // launches a fresh headless run. The claim guard permits it precisely because
     // run #1 is terminal (no pending task holds the per-(issue, agent) slot).
-    launch_headless(&sess, scale);
+    launch_headless(&sess, scale, "run #2 launch (the RERUN)", pipe.home());
 
     // POSITIVE (fresh run): a DISTINCT task short-id appears — the rerun enqueued
     // a new row, not a replay of run #1.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
@@ -62,34 +62,45 @@ fn launch_headless(sess: &TuiSession, scale: u64, which: &str, home: &std::path:
         // that no keypress dropped. When either assumption failed, focus
         // stopped on an empty column and this loop pressed Enter at nothing
         // until it timed out.
-        if sess.capture().contains("— empty —") {
+        //
+        // Gated on actually being ON the board: `— empty —` is a generic
+        // placeholder that other screens paint too (the issue list's detail
+        // pane uses it), and sending `Right` at one of those walks a cursor
+        // that has nothing to do with board columns.
+        let capture = sess.capture();
+        if capture.contains("Board:") && capture.contains("— empty —") {
             sess.send_key("Right");
         }
     }
     // Name the FIRST thing that did not happen, not the last. `Enter` opens
-    // this menu over a FOCUSED CARD, so when the board holds no card there is
-    // nothing for it to open and "Run ▾ never opened" is a true statement about
-    // the wrong step. That message sent three separate investigations after a
-    // menu bug when every observed failure was actually an empty board.
-    //
-    // The store state is reported too, because "the board is empty" alone does
-    // not say WHICH half is broken. The caller already proved the card RENDERED
-    // before the first launch, so an empty board here means the card was lost
-    // between then and now, not that it never arrived, and the store tells us
-    // whether it is the data or only the view that lost it.
+    // this menu over a FOCUSED CARD, so "Run ▾ never opened" can be a true
+    // statement about entirely the wrong step. Three investigations chased a
+    // menu bug because of it, and a fourth chased an empty BOARD because the
+    // first version of this message asserted one without checking the screen
+    // was the board at all. So establish, in order: which screen is up, then
+    // whether the board holds the card, then whether the store does.
     if !opened {
         let capture = sess.capture();
+        let on_board = capture.contains("Board:");
+        let card_visible = capture.contains(CARD_TITLE);
         let in_store = board_card_by_title(home, CARD_TITLE).is_some();
-        let diagnosis = match (capture.contains("— empty —"), in_store) {
-            (true, true) => {
-                "the board is EMPTY but the card IS in the store, so the VIEW lost a card \
-                 the data still has"
+        let diagnosis = match (on_board, card_visible, in_store) {
+            (false, _, _) => {
+                "the TUI is NOT ON THE BOARDS SCREEN at all (no `Board:` header), so nothing \
+                 here is about cards: something navigated away from the board"
             }
-            (true, false) => {
-                "the board is EMPTY and the card is GONE from the store, so this is a data \
+            (true, false, true) => {
+                "the board is up and the card IS in the store but NOT rendered, so the view \
+                 lost a card the data still has"
+            }
+            (true, false, false) => {
+                "the board is up and the card is GONE from the store too, so this is data \
                  loss, not a render bug"
             }
-            (false, _) => "a card is on the board but the `Run ▾` menu never opened",
+            (true, true, _) => {
+                "the card IS rendered on the board but the `Run ▾` menu never opened, so this \
+                 really is the menu or the focus cursor"
+            }
         };
         panic!("{which}: {diagnosis}:\n{capture}");
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_tcp_card_rerun_e2e.rs
@@ -85,9 +85,19 @@ fn launch_headless(sess: &TuiSession, scale: u64, which: &str, home: &std::path:
         let card_visible = capture.contains(CARD_TITLE);
         let in_store = board_card_by_title(home, CARD_TITLE).is_some();
         let diagnosis = match (on_board, card_visible, in_store) {
+            // No `Board:` header AND the card-board placeholder on screen means
+            // the board surface rendered with NO BOARDS in its snapshot: the
+            // placeholder is painted only by `widgets/card_board.rs`, so the
+            // screen is right and the boards list came back empty. The header
+            // is missing because there is no board to name, not because the TUI
+            // navigated somewhere else.
+            (false, _, _) if capture.contains("— empty —") => {
+                "the boards list came back EMPTY (no `Board:` header, card-board placeholder \
+                 on screen), so the snapshot carried zero boards for this workspace"
+            }
             (false, _, _) => {
-                "the TUI is NOT ON THE BOARDS SCREEN at all (no `Board:` header), so nothing \
-                 here is about cards: something navigated away from the board"
+                "the TUI is not on a board surface at all (no `Board:` header, no card-board \
+                 placeholder), so something navigated away"
             }
             (true, false, true) => {
                 "the board is up and the card IS in the store but NOT rendered, so the view \

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -2240,6 +2240,27 @@ impl HangarPlugin {
         let Some(stream_id) = self.conn.stream_id().map(ToString::to_string) else {
             return;
         };
+        // A cursor of 0 means this is a FRESH round, not resuming one a full
+        // writer cut short mid-batch (that case must keep the SAME generation:
+        // it is still sending the one round's unsent tail). `fetch_pending` can
+        // be re-armed (a pushed event, a mutation reply, a config write, etc.)
+        // before the PREVIOUS round's replies have all landed: two fresh rounds
+        // can be outstanding on the wire at once. Reusing the generation for
+        // both would hand every request in round 2 (including `boards_list`)
+        // the IDENTICAL wire id round 1 already used. The daemon echoes each
+        // request's id verbatim, so both replies carry that same id; the first
+        // to arrive is found in `snapshot_response_ids` and consumes the entry,
+        // so the SECOND (which may be the fresher one, e.g. carrying a card a
+        // user just created) finds nothing to normalize against and is
+        // silently dropped by `on_daemon_response`, discarding whichever
+        // round's answer happened to land second. Bumping the generation per
+        // fresh round keeps every outstanding round's wire ids distinct, so
+        // every reply is found and applied; per-connection FIFO still
+        // guarantees the newer round's reply is written after the older
+        // round's, so the freshest data always wins the last write.
+        if self.snapshot_fetch_cursor == 0 {
+            self.snapshot_generation = self.snapshot_generation.saturating_add(1);
+        }
         let ws = self.app_state().ws_id.as_str().to_string();
         let scoped = serde_json::json!({ "workspace_id": ws.clone() });
         let requests = [
@@ -8253,6 +8274,126 @@ mod tests {
         assert!(
             plugin.screens.issue_list.all_rows().is_empty(),
             "current workspace reply must still apply"
+        );
+    }
+
+    /// The real-world case behind the empty-board tripwire: a `boards_list`
+    /// refresh round is re-armed (a pushed event, a mutation reply, etc.)
+    /// before the PREVIOUS round's own `boards_list` reply has landed. Both
+    /// rounds are otherwise identical requests for the same workspace: the
+    /// only thing that changed is that a card was created in between. Without
+    /// a per-round generation bump, both rounds share one wire id, and
+    /// whichever reply arrives second (here: round 2's, carrying the new
+    /// card) has no entry left in `snapshot_response_ids` to normalize
+    /// against and is dropped, so the board renders round 1's stale,
+    /// card-less snapshot forever, exactly like the tripwire's "card IS in
+    /// the store but NOT rendered" failure.
+    #[test]
+    fn overlapping_snapshot_rounds_do_not_drop_the_newer_boards_reply() {
+        use ainb_hangar_proto::snapshots::{
+            BoardCardWireRow, BoardColumnWireRow, BoardWireRow, BoardsListResult,
+        };
+
+        let mut plugin = connected_plugin_with_issue();
+
+        // Round 1: a full bundle send (e.g. the post-subscribe pull). Every
+        // request, including `boards_list`, is queued under generation G.
+        plugin.fetch_pending = true;
+        plugin.drain_pending_refreshes_with(|_, _| Ok(NotificationEnqueueOutcome::Queued));
+        let round1_boards_id = plugin.snapshot_wire_id(BOARDS_REQ_ID);
+        assert!(
+            plugin.snapshot_response_ids.contains_key(&round1_boards_id),
+            "round 1 must have an outstanding boards_list request"
+        );
+
+        // Round 2 fires before round 1's replies land (the re-pull a card
+        // create's own pushed event arms). The fix must give it a NEW
+        // generation, so its `boards_list` id differs from round 1's.
+        plugin.fetch_pending = true;
+        plugin.drain_pending_refreshes_with(|_, _| Ok(NotificationEnqueueOutcome::Queued));
+        let round2_boards_id = plugin.snapshot_wire_id(BOARDS_REQ_ID);
+        assert_ne!(
+            round1_boards_id, round2_boards_id,
+            "two overlapping rounds must not reuse one boards_list wire id"
+        );
+
+        // The two rounds' replies land in FIFO send order: round 1's (stale,
+        // no card) first, round 2's (fresh, WITH the new card) second.
+        plugin.on_daemon_response(&RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(round1_boards_id),
+            result: Some(
+                serde_json::to_value(BoardsListResult {
+                    boards: vec![BoardWireRow {
+                        id: "b1".into(),
+                        name: "Delivery".into(),
+                        auto_move: false,
+                        columns: vec![BoardColumnWireRow {
+                            id: "c-todo".into(),
+                            name: "Todo".into(),
+                            ord: 0,
+                            fsm_state: None,
+                            auto_move: false,
+                            cards: Vec::new(),
+                            health: None,
+                        }],
+                        unmapped: Vec::new(),
+                    }],
+                })
+                .unwrap(),
+            ),
+            error: None,
+        });
+        plugin.on_daemon_response(&RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(round2_boards_id),
+            result: Some(
+                serde_json::to_value(BoardsListResult {
+                    boards: vec![BoardWireRow {
+                        id: "b1".into(),
+                        name: "Delivery".into(),
+                        auto_move: false,
+                        columns: vec![BoardColumnWireRow {
+                            id: "c-todo".into(),
+                            name: "Todo".into(),
+                            ord: 0,
+                            fsm_state: None,
+                            auto_move: false,
+                            cards: vec![BoardCardWireRow {
+                                issue_id: "issue-2".into(),
+                                title: "Rerunlifecycletripwire".into(),
+                                display_id: "2".into(),
+                                state: None,
+                                session_name: None,
+                                repo_ref: None,
+                                agent: None,
+                                squad_id: None,
+                                member_states: Vec::new(),
+                                blocked_by: Vec::new(),
+                                auto_run: false,
+                                blocks: Vec::new(),
+                                related: Vec::new(),
+                            }],
+                            health: None,
+                        }],
+                        unmapped: Vec::new(),
+                    }],
+                })
+                .unwrap(),
+            ),
+            error: None,
+        });
+
+        let titles: Vec<&str> = plugin.screens.boards.boards()[0].columns[0]
+            .cards
+            .iter()
+            .map(|c| c.title.as_str())
+            .collect();
+        assert_eq!(
+            titles,
+            vec!["Rerunlifecycletripwire"],
+            "round 2's fresher boards_list reply must not be dropped just because it shares \
+             round 1's wire id: the board must show the card the store has: {titles:?}"
         );
     }
 


### PR DESCRIPTION
`hangar-e2e (ubuntu)` has been ~28% red on `main` since 2026-08-04, on `tripwire_tcp_card_rerun_e2e` and its `tcp_card_branch_pr` sibling. This is one confirmed defect and one hypothesis; I am labelling which is which.

## Confirmed: the failure has been wearing the wrong name

`launch_headless` loops sending `Enter`, polls for `Run ▾`, and fails with **"Run ▾ menu never opened"**. But `Enter` opens that menu over a *focused card*, and every failing capture I pulled shows a board with no card on it (`— empty —`). The message names the last thing that did not happen rather than the first, and it has sent three separate investigations after a menu bug. It now distinguishes the two cases and says so.

Measured from the CI captures rather than inferred: the pane is 29 rows, the nav bar renders at 176 columns and the board help bar renders, while rows 2-28 are 92 characters of nothing but spaces and a `│` at column 90. So the chrome painted correctly and the content region never painted at all. That is a TUI holding an empty board, not a corrupted or truncated render.

## Hypothesis, NOT confirmed: a leaked `AINB_HANGAR_HOME`

Hangar home resolution puts `AINB_HANGAR_HOME` **ahead of** `HOME`. Every daemon spawn in `tripwire_p4_common.rs` already does `.env_remove("AINB_HANGAR_HOME")`. The TUI launch did not, and it goes through `tmux send-keys`, so it inherits the tmux **server's** environment, which belongs to whichever process started that server. These tripwires share the default tmux server across a 34-tripwire serial suite.

If that variable is set anywhere in the server's environment, the TUI talks to a different hangar than the daemon the test seeded, and the board is legitimately empty. That would explain all four observations: byte-identical captures across four days, ~28% rather than always, never reproducing standalone, and chrome-without-content.

**I could not confirm it.** `tmux new-session` does not propagate arbitrary variables into an existing server's environment, and establishing the condition properly would mean restarting the shared tmux server, which I will not do on a box with other agents' sessions on it. So this is a hypothesis with a mechanism, not a root cause with a repro.

The fix is worth landing either way: the test asserts isolation, so it should enforce it, and this closes an entire class of cross-test contamination for every tmux TUI tripwire, not just these two.

## Verification

Both tripwires pass locally with the change (13.16s and 11.28s). One honest note: my first attempt wrote `env -u ... exec BINARY`, which fails with `env: 'exec': No such file or directory` because `exec` is a shell builtin — I caught it because the tripwire went red and the capture showed the shell error. It is now `exec env -u ...`, which keeps the no-extra-shell-process property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolated TUI session startup to prevent environment settings from affecting reliability.
  * Enhanced card rerun diagnostics by distinguishing empty boards, unavailable cards, and menu-opening failures.
  * Included captured interface output in failure reports for clearer troubleshooting.
  * Fixed overlapping board refreshes so the latest card data is reliably applied.

* **Tests**
  * Strengthened end-to-end checks for reliable card reruns.
  * Added more resilient focus handling when navigating cards.
  * Added coverage for overlapping board refreshes and newly created cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->