### PR TITLE
fix(fleet): set the model fields #645 added to test constructors

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -4586,6 +4586,7 @@ mod tests {
                     "process_start_fingerprint": hook_fingerprint,
                 }),
                 observed_at: 2_000,
+                transcript_model: None,
             },
         )
         .await
@@ -4711,6 +4712,7 @@ mod tests {
                     "process_start_fingerprint": fingerprint,
                 }),
                 observed_at,
+                transcript_model: None,
             },
         )
         .await
@@ -5049,6 +5051,10 @@ mod tests {
             attention_authority: "inferred".to_string(),
             transport_updated_at: 0,
             transport_authority: "inferred".to_string(),
+            model: None,
+            reasoning_effort: None,
+            model_updated_at: 0,
+            model_authority: "inferred".to_string(),
             version: 1,
             updated_revision: 1,
         }


### PR DESCRIPTION
main does not compile. `cargo test --no-run` fails, taking `Test (ubuntu-latest)`, `Test (macos-latest)` and `Contracts` down with it.

## Cause

A semantic merge conflict between two PRs that were each green on their own:

- #645 added `transcript_model` to `HookObservation`, and `model`, `reasoning_effort`, `model_updated_at`, `model_authority` to `FleetSessionRow`.
- #646 added test constructors written before those fields existed.

They touch different lines, so git merged them without a textual conflict and the break only appeared once both were on main.

```
fleet.rs:4578  HookObservation  missing transcript_model
fleet.rs:4703  HookObservation  missing transcript_model
fleet.rs:5023  FleetSessionRow  missing model, model_authority, model_updated_at, reasoning_effort
```

## Fix

Set the new fields, following the conventions already in the file rather than inventing values:

- `blank_row()` sets every sibling group to `*_updated_at: 0` and `*_authority: "inferred"`, so the model group matches. Production agrees: `fleet.rs` stamps `"inferred"` when `model_at == 0`, i.e. never observed.
- Both `HookObservation` sites take `transcript_model: None`, matching the existing construction in the same module.

Verified locally with the exact command CI runs: `cargo test --workspace --lib --tests --all-features --no-run` exits 0, zero errors.

This is a prerequisite for cutting the next release: the release workflow tags whatever main points at, so a red main would ship a tree that does not build.

https://claude.ai/code/session_01Ewk3aqXacgcQNynJrYLhQd