### PR TITLE
feat(fleet): mirror Claude interviews

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1588,7 +1588,7 @@ fn hook_core_for_agent(
     let append_event = || {
         let event_id = uuid::Uuid::new_v4().to_string();
         let raw_payload_stored = persist_raw_hook_payload(home, &event_id, payload).is_ok();
-        let line = build_event_line_for_agent(
+        let mut line = build_event_line_for_agent(
             now_ms,
             &event_id,
             agent,
@@ -1600,9 +1600,12 @@ fn hook_core_for_agent(
             our_parent.as_deref(),
             raw_payload_stored,
         );
+        if is_structured_ask {
+            line["fleet_delivery"] = serde_json::Value::String("mirrored".to_string());
+        }
         let _ = append_event_line(home, &line);
     };
-    if !session_id.is_empty() && !is_structured_ask {
+    if !session_id.is_empty() {
         append_event();
     }
 
@@ -1658,47 +1661,12 @@ fn hook_core_for_agent(
         }
     }
 
-    // 4. PreToolUse(AskUserQuestion): block on exact structured answers and
-    //    return the full original questions plus Claude's answer map. Labels
-    //    never pass through generic text delivery.
+    // 4. PreToolUse(AskUserQuestion): keep Claude's native picker visible while
+    //    the durable hook event exposes the same request to Fleet. Fleet routes
+    //    a selected answer back through the verified picker transport, so neither
+    //    surface owns a separate answer lifecycle.
     if is_structured_ask {
-        let socket = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
-        let (tool_input, questions, fingerprint) = match extract_structured_tool_input(payload) {
-            Ok(request) => request,
-            Err(_) => return Ok(None),
-        };
-        let registered = ainb_plugin_notifyd::broker::client_register_structured(
-            &socket,
-            session_id,
-            &fingerprint,
-            &questions,
-        )
-        .unwrap_or(false);
-        if !registered {
-            // Fleet is an optional control surface. A broker outage must not
-            // reject Claude's native AskUserQuestion tool invocation.
-            return Ok(None);
-        }
-        append_event();
-        let resolution = ainb_plugin_notifyd::broker::client_await_structured(
-            &socket,
-            session_id,
-            &fingerprint,
-            &questions,
-            ainb_plugin_notifyd::broker::CLIENT_AWAIT_DEADLINE,
-        );
-        if matches!(
-            resolution,
-            ainb_plugin_notifyd::broker::StructuredResolution::ReleasedToNative
-        ) {
-            // Fleet explicitly yielded ownership. Returning no hook output lets
-            // Claude render its own AskUserQuestion picker unchanged.
-            return Ok(None);
-        }
-        return Ok(Some(HookEmit::Structured(structured_emit_json(
-            tool_input,
-            &resolution,
-        ))));
+        return Ok(None);
     }
 
     // 5. PermissionRequest: SYNCHRONOUS approve/deny round-trip. The waiting
@@ -2872,154 +2840,48 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn ask_hook_returns_complete_structured_answer_without_text_routing() {
-        use ainb_plugin_notifyd::broker::{
-            BrokerState, StructuredQuestionAnswer, client_answer_structured, client_list,
-        };
-        use tokio::net::UnixListener;
-
+    #[test]
+    fn ask_hook_mirrors_native_picker_and_persists_fleet_request() {
         let home = TempDir::new().unwrap();
         let cwd = home.path().join("plain-claude-worktree");
         std::fs::create_dir_all(&cwd).unwrap();
-        let paths = ainb_plugin_notifyd::paths::Paths::under(home.path());
-        std::fs::create_dir_all(paths.approve_socket.parent().unwrap()).unwrap();
-        let listener = UnixListener::bind(&paths.approve_socket).unwrap();
-        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
-            listener,
-            BrokerState::with_timeout(std::time::Duration::from_secs(30)),
-        ));
-
         let payload = serde_json::json!({
             "tool_name": "AskUserQuestion",
-            "tool_use_id": "toolu_ask_1",
+            "tool_use_id": "toolu_mirrored",
             "tool_input": {
-                "questions": [
-                    {
-                        "question": "Region?",
-                        "header": "Region",
-                        "options": [
-                            {"label": "EU", "description": "Europe"},
-                            {"label": "US", "description": "United States"}
-                        ],
-                        "multiSelect": false
-                    },
-                    {
-                        "question": "Checks?",
-                        "header": "Checks",
-                        "options": [
-                            {"label": "Lint", "description": "Run linter"},
-                            {"label": "Test", "description": "Run tests"}
-                        ],
-                        "multiSelect": true
-                    }
-                ]
+                "questions": [{
+                    "question": "Continue?",
+                    "header": "Continue",
+                    "options": [{"label": "Yes"}, {"label": "No"}]
+                }]
             }
-        });
-        let original_questions = payload["tool_input"]["questions"].clone();
-        let hook_home = home.path().to_path_buf();
-        let hook_cwd = cwd.clone();
-        let hook_payload = payload.to_string();
-        let waiter = tokio::task::spawn_blocking(move || {
-            hook_core(
-                &hook_home,
-                "PreToolUse",
-                "ask-session",
-                hook_cwd.to_str().expect("temporary cwd is valid UTF-8"),
-                None,
-                None,
-                50,
-                &hook_payload,
-                Some("AskUserQuestion"),
-            )
-        });
+        })
+        .to_string();
 
-        let pending = loop {
-            let socket = paths.approve_socket.clone();
-            let listed = tokio::task::spawn_blocking(move || client_list(&socket))
-                .await
-                .unwrap()
-                .unwrap_or_default();
-            if let Some(pending) = listed.into_iter().find(|item| item.session_id == "ask-session")
-            {
-                break pending;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        };
-        assert_eq!(
-            pending.questions,
-            original_questions.as_array().unwrap().clone()
-        );
-        let fingerprint = pending.request_fingerprint.unwrap();
+        let emitted = hook_core(
+            home.path(),
+            "PreToolUse",
+            "mirrored-session",
+            cwd.to_str().unwrap(),
+            None,
+            None,
+            50,
+            &payload,
+            Some("AskUserQuestion"),
+        )
+        .unwrap();
+        assert!(emitted.is_none(), "Claude must render its native picker");
         let events = std::fs::read_to_string(home.path().join("events.jsonl")).unwrap();
-        assert!(
-            events.contains("ask-session"),
-            "Fleet event must appear only after broker registration"
+        let event: serde_json::Value = serde_json::from_str(events.trim()).unwrap();
+        assert_eq!(event["fleet_delivery"], "mirrored");
+        assert_eq!(
+            event["payload"]["tool_input"]["questions"][0]["question"],
+            "Continue?"
         );
-
-        let stale_socket = paths.approve_socket.clone();
-        let stale = tokio::task::spawn_blocking(move || {
-            client_answer_structured(
-                &stale_socket,
-                "ask-session",
-                "fnv1a64:stale",
-                &[StructuredQuestionAnswer {
-                    question: "Region?".to_string(),
-                    selected_options: vec!["EU".to_string()],
-                }],
-            )
-        })
-        .await
-        .unwrap()
-        .unwrap();
-        assert!(stale.stale);
-        assert!(!stale.matched);
-
-        let answer_socket = paths.approve_socket.clone();
-        let accepted = tokio::task::spawn_blocking(move || {
-            client_answer_structured(
-                &answer_socket,
-                "ask-session",
-                &fingerprint,
-                &[
-                    StructuredQuestionAnswer {
-                        question: "Region?".to_string(),
-                        selected_options: vec!["EU".to_string()],
-                    },
-                    StructuredQuestionAnswer {
-                        question: "Checks?".to_string(),
-                        selected_options: vec!["Lint".to_string(), "Test".to_string()],
-                    },
-                ],
-            )
-        })
-        .await
-        .unwrap()
-        .unwrap();
-        assert!(accepted.matched);
-
-        let emitted = waiter.await.unwrap().unwrap().expect("structured hook output");
-        let HookEmit::Structured(line) = emitted else {
-            panic!("AskUserQuestion must emit structured hook output");
-        };
-        let output: serde_json::Value = serde_json::from_str(&line).unwrap();
-        let specific = &output["hookSpecificOutput"];
-        assert_eq!(specific["hookEventName"], "PreToolUse");
-        assert_eq!(specific["permissionDecision"], "allow");
-        assert_eq!(specific["updatedInput"]["questions"], original_questions);
-        assert_eq!(specific["updatedInput"]["answers"]["Region?"], "EU");
-        assert_eq!(specific["updatedInput"]["answers"]["Checks?"], "Lint, Test");
-        assert!(
-            output.get("text").is_none(),
-            "must not route labels as generic text"
-        );
-
-        server.abort();
-        let _ = std::fs::remove_file(&paths.approve_socket);
     }
 
     #[test]
-    fn ask_hook_without_broker_fails_open_without_persisting_a_fleet_card() {
+    fn ask_hook_without_broker_fails_open_and_persists_a_mirrored_fleet_card() {
         let home = TempDir::new().unwrap();
         let cwd = home.path().join("plain-claude-worktree");
         std::fs::create_dir_all(&cwd).unwrap();
@@ -3052,10 +2914,8 @@ mod tests {
             emitted.is_none(),
             "unavailable Fleet broker must leave Claude's native interview unblocked"
         );
-        assert!(
-            !home.path().join("events.jsonl").exists(),
-            "unregistered AskUserQuestion must never create an actionable Fleet card"
-        );
+        let events = std::fs::read_to_string(home.path().join("events.jsonl")).unwrap();
+        assert!(events.contains("\"fleet_delivery\":\"mirrored\""));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3448,8 +3448,15 @@ async fn execute_fleet_action(
                     answers,
                     ..
                 } if session.provider == "claude" => {
-                    execute_claude_structured(pool, events, &session, request_fingerprint, answers)
-                        .await
+                    execute_claude_structured(
+                        pool,
+                        events,
+                        &session,
+                        params.expected_version,
+                        request_fingerprint,
+                        answers,
+                    )
+                    .await
                 }
                 ControlAction::DismissStructured {
                     request_fingerprint,
@@ -3839,7 +3846,10 @@ async fn kill_tmux_session_exact(session_name: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod fleet_launch_tests {
-    use super::{managed_codex_tmux_args, managed_codex_tmux_name, verify_picker_pane};
+    use super::{
+        MirroredClaudePickerStep, managed_codex_tmux_args, managed_codex_tmux_name,
+        mirrored_claude_picker_steps, verify_picker_pane,
+    };
     use std::ffi::{OsStr, OsString};
     use std::path::Path;
 
@@ -3961,6 +3971,88 @@ mod fleet_launch_tests {
                     2. No";
         let error = verify_picker_pane("claude", &request, pane).unwrap_err();
         assert!(error.contains("newer picker"));
+    }
+
+    #[test]
+    fn mirrored_claude_picker_routes_multi_question_answers_and_submit() {
+        let questions = vec![
+            serde_json::json!({
+                "id": "region",
+                "question": "Deploy to which region?",
+                "options": [{"label": "Europe"}, {"label": "United States"}]
+            }),
+            serde_json::json!({
+                "id": "checks",
+                "question": "Which checks should run?",
+                "multiSelect": true,
+                "options": [{"label": "Lint"}, {"label": "Test"}, {"label": "Tripwire"}]
+            }),
+        ];
+        let answers = vec![
+            ainb_hangar_proto::fleet::FleetQuestionAnswer {
+                question_id: "region".to_string(),
+                selected_options: vec!["United States".to_string()],
+                text: None,
+            },
+            ainb_hangar_proto::fleet::FleetQuestionAnswer {
+                question_id: "checks".to_string(),
+                selected_options: vec!["Test".to_string(), "Tripwire".to_string()],
+                text: None,
+            },
+        ];
+        assert_eq!(
+            mirrored_claude_picker_steps(&questions, &answers),
+            Ok(vec![
+                MirroredClaudePickerStep::QuestionKey {
+                    question: questions[0].clone(),
+                    key: "Down".to_string()
+                },
+                MirroredClaudePickerStep::QuestionKey {
+                    question: questions[0].clone(),
+                    key: "Enter".to_string()
+                },
+                MirroredClaudePickerStep::QuestionKey {
+                    question: questions[1].clone(),
+                    key: "Down".to_string()
+                },
+                MirroredClaudePickerStep::QuestionKey {
+                    question: questions[1].clone(),
+                    key: "Space".to_string()
+                },
+                MirroredClaudePickerStep::QuestionKey {
+                    question: questions[1].clone(),
+                    key: "Down".to_string()
+                },
+                MirroredClaudePickerStep::QuestionKey {
+                    question: questions[1].clone(),
+                    key: "Space".to_string()
+                },
+                MirroredClaudePickerStep::QuestionKey {
+                    question: questions[1].clone(),
+                    key: "Tab".to_string()
+                },
+                MirroredClaudePickerStep::Submit { answers },
+            ])
+        );
+    }
+
+    #[test]
+    fn mirrored_claude_picker_rejects_unverified_text_route() {
+        let questions = vec![serde_json::json!({
+            "id": "region",
+            "question": "Deploy to which region?",
+            "options": [{"label": "Europe"}]
+        })];
+        let answers = vec![ainb_hangar_proto::fleet::FleetQuestionAnswer {
+            question_id: "region".to_string(),
+            selected_options: vec![],
+            text: Some("Custom region".to_string()),
+        }];
+        assert!(
+            mirrored_claude_picker_steps(&questions, &answers)
+                .unwrap_err()
+                .contains("free-text")
+        );
     }
 }
 
@@ -4443,6 +4535,7 @@ async fn execute_claude_structured(
     pool: &SqlitePool,
     events: &EventSink,
     session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    expected_version: i64,
     request_fingerprint: &str,
     answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
 ) -> (
@@ -4468,6 +4561,17 @@ async fn execute_claude_structured(
             Some("stored Claude question payload is invalid".to_string()),
         );
     };
+    if request.get("fleet_delivery").and_then(serde_json::Value::as_str) == Some("mirrored") {
+        return execute_claude_mirrored_picker(
+            pool,
+            session,
+            expected_version,
+            request_fingerprint,
+            questions,
+            answers,
+        )
+        .await;
+    }
     let mut mapped = Vec::with_capacity(answers.len());
     for answer in answers {
         let question = questions.iter().enumerate().find_map(|(index, question)| {
@@ -4538,6 +4642,255 @@ async fn execute_claude_structured(
         Ok(Err(error)) => (ActionReceiptStatus::Failed, Some(error.to_string())),
         Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
     }
+}
+
+/// Submit one mirrored Claude interview through its visible native picker.
+///
+/// Every key is checked against the exact request and live native screen before
+/// delivery. Free-text controls stay unavailable until their input state has
+/// equivalent verification coverage.
+async fn execute_claude_mirrored_picker(
+    pool: &SqlitePool,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    expected_version: i64,
+    request_fingerprint: &str,
+    questions: &[serde_json::Value],
+    answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+
+    let steps = match mirrored_claude_picker_steps(questions, answers) {
+        Ok(steps) => steps,
+        Err(detail) => return (ActionReceiptStatus::Rejected, Some(detail)),
+    };
+    for step in steps {
+        let (status, detail) = verified_tmux_picker_for_mirrored_step(
+            pool,
+            session,
+            expected_version,
+            request_fingerprint,
+            &step,
+        )
+        .await;
+        if status != ActionReceiptStatus::Delivered {
+            return (status, detail);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    }
+    (
+        ActionReceiptStatus::Delivered,
+        Some("mirrored Claude native picker".to_string()),
+    )
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum MirroredClaudePickerStep {
+    QuestionKey {
+        question: serde_json::Value,
+        key: String,
+    },
+    Submit {
+        answers: Vec<ainb_hangar_proto::fleet::FleetQuestionAnswer>,
+    },
+}
+
+fn mirrored_claude_picker_steps(
+    questions: &[serde_json::Value],
+    answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
+) -> Result<Vec<MirroredClaudePickerStep>, String> {
+    if questions.len() != answers.len() || questions.is_empty() {
+        return Err("mirrored Claude answers do not cover every question".to_string());
+    }
+    let mut steps = Vec::new();
+    for (index, question) in questions.iter().enumerate() {
+        let question_id = question
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| index.to_string());
+        let answer = answers
+            .iter()
+            .find(|answer| answer.question_id == question_id)
+            .ok_or_else(|| "mirrored Claude question is stale".to_string())?;
+        if answer.text.as_deref().is_some_and(|text| !text.trim().is_empty()) {
+            return Err("mirrored Claude free-text answer is not available yet".to_string());
+        }
+        let options = question
+            .get("options")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| "mirrored Claude options are absent".to_string())?;
+        let mut selected = answer
+            .selected_options
+            .iter()
+            .map(|label| {
+                options
+                    .iter()
+                    .position(|option| {
+                        option.get("label").and_then(serde_json::Value::as_str) == Some(label)
+                    })
+                    .ok_or_else(|| "mirrored Claude option is stale".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        selected.sort_unstable();
+        selected.dedup();
+        if selected.len() != answer.selected_options.len() || selected.is_empty() {
+            return Err("mirrored Claude requires listed options".to_string());
+        }
+        let multi_select = question
+            .get("multiSelect")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if !multi_select && selected.len() != 1 {
+            return Err("mirrored Claude single-select requires one option".to_string());
+        }
+        let mut cursor = 0;
+        for selected_index in selected {
+            for _ in cursor..selected_index {
+                steps.push(MirroredClaudePickerStep::QuestionKey {
+                    question: question.clone(),
+                    key: "Down".to_string(),
+                });
+            }
+            steps.push(MirroredClaudePickerStep::QuestionKey {
+                question: question.clone(),
+                key: if multi_select { "Space" } else { "Enter" }.to_string(),
+            });
+            cursor = selected_index;
+        }
+        if multi_select {
+            steps.push(MirroredClaudePickerStep::QuestionKey {
+                question: question.clone(),
+                key: "Tab".to_string(),
+            });
+        }
+    }
+    steps.push(MirroredClaudePickerStep::Submit {
+        answers: answers.to_vec(),
+    });
+    Ok(steps)
+}
+
+async fn verified_tmux_picker_for_mirrored_step(
+    pool: &SqlitePool,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    expected_version: i64,
+    request_fingerprint: &str,
+    step: &MirroredClaudePickerStep,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    let (Some(target), Some(fingerprint)) = (
+        session.tmux_target.as_deref(),
+        session.process_start_fingerprint.as_deref(),
+    ) else {
+        return (
+            ActionReceiptStatus::Unknown,
+            Some(DETAIL_TMUX_IDENTITY_UNKNOWN.to_string()),
+        );
+    };
+    let discovered = match ainb_fleet_core::discover::discover_all_tmux_panes().await {
+        Ok(discovered) => discovered,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    if !discovered.iter().any(|candidate| {
+        candidate.exact_tmux_target.as_deref() == Some(target)
+            && candidate.process_start_fingerprint.as_deref() == Some(fingerprint)
+            && candidate.provider.as_str() == session.provider
+    }) {
+        return (
+            ActionReceiptStatus::Failed,
+            Some("tmux provider or process identity changed".to_string()),
+        );
+    }
+    let pane = match ainb_fleet_core::read::capture_pane(target, 0).await {
+        Ok(pane) => pane,
+        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
+    };
+    let verified = match step {
+        MirroredClaudePickerStep::QuestionKey { question, .. } => {
+            verify_claude_picker_question(question, &pane)
+        }
+        MirroredClaudePickerStep::Submit { answers } => verify_claude_picker_submit(answers, &pane),
+    };
+    if let Err(detail) = verified {
+        return (ActionReceiptStatus::Failed, Some(detail));
+    }
+    if let Err(error) = ainb_hangar_store::repo::fleet::FleetRepo::validate_action_target(
+        pool,
+        &session.session_key,
+        expected_version,
+        Some(request_fingerprint),
+    )
+    .await
+    {
+        return (ActionReceiptStatus::Failed, Some(error.to_string()));
+    }
+    let key = match step {
+        MirroredClaudePickerStep::QuestionKey { key, .. } => key,
+        MirroredClaudePickerStep::Submit { .. } => "Enter",
+    };
+    match ainb_fleet_core::send::tmux_send_picker_key(target, key).await {
+        Ok(()) => (
+            ActionReceiptStatus::Delivered,
+            Some(format!("mirrored tmux picker ({target})")),
+        ),
+        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
+    }
+}
+
+fn verify_claude_picker_question(question: &serde_json::Value, pane: &str) -> Result<(), String> {
+    if !claude_native_picker_is_visible(pane) {
+        return Err("Claude native picker is no longer active".to_string());
+    }
+    let prompt = question
+        .get("question")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "mirrored Claude question text is absent".to_string())?;
+    let visible = normalize_picker_text(pane);
+    let start = visible
+        .rfind(&normalize_picker_text(prompt))
+        .ok_or_else(|| "visible picker prompt does not match current question".to_string())?;
+    let mut cursor = start + normalize_picker_text(prompt).len();
+    for option in question
+        .get("options")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mirrored Claude options are absent".to_string())?
+    {
+        let label = option
+            .get("label")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mirrored Claude option label is absent".to_string())?;
+        let label = normalize_picker_text(label);
+        let offset = visible[cursor..].find(&label).ok_or_else(|| {
+            "visible picker option order does not match current question".to_string()
+        })?;
+        cursor += offset + label.len();
+    }
+    Ok(())
+}
+
+fn verify_claude_picker_submit(
+    answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
+    pane: &str,
+) -> Result<(), String> {
+    if !pane.contains("Review your answers") || !pane.contains("Submit answers") {
+        return Err("Claude native picker is not ready to submit".to_string());
+    }
+    for answer in answers {
+        for selected in &answer.selected_options {
+            if !pane.contains(selected) {
+                return Err(
+                    "Claude native picker review does not match selected answer".to_string()
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// One-line render of a delivered interview answer for the attention row's audit

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4029,7 +4029,7 @@ mod fleet_launch_tests {
                 },
                 MirroredClaudePickerStep::QuestionKey {
                     question: questions[1].clone(),
-                    key: "Tab".to_string()
+                    key: "Enter".to_string()
                 },
                 MirroredClaudePickerStep::Submit { answers },
             ])
@@ -4666,7 +4666,10 @@ async fn execute_claude_mirrored_picker(
         Ok(steps) => steps,
         Err(detail) => return (ActionReceiptStatus::Rejected, Some(detail)),
     };
-    for step in steps {
+    for (index, step) in steps.into_iter().enumerate() {
+        if index > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        }
         let (status, detail) = verified_tmux_picker_for_mirrored_step(
             pool,
             session,
@@ -4676,9 +4679,14 @@ async fn execute_claude_mirrored_picker(
         )
         .await;
         if status != ActionReceiptStatus::Delivered {
-            return (status, detail);
+            let detail = detail.unwrap_or_else(|| "mirrored Claude picker step failed".to_string());
+            let detail = if index == 0 {
+                detail
+            } else {
+                format!("{detail}; native picker already advanced {index} key(s)")
+            };
+            return (status, Some(detail));
         }
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     }
     (
         ActionReceiptStatus::Delivered,
@@ -4763,7 +4771,7 @@ fn mirrored_claude_picker_steps(
         if multi_select {
             steps.push(MirroredClaudePickerStep::QuestionKey {
                 question: question.clone(),
-                key: "Tab".to_string(),
+                key: "Enter".to_string(),
             });
         }
     }
@@ -4878,12 +4886,15 @@ fn verify_claude_picker_submit(
     answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
     pane: &str,
 ) -> Result<(), String> {
-    if !pane.contains("Review your answers") || !pane.contains("Submit answers") {
+    let visible = normalize_picker_text(pane);
+    if !visible.contains(&normalize_picker_text(CLAUDE_PICKER_REVIEW_HEADING))
+        || !visible.contains(&normalize_picker_text(CLAUDE_PICKER_SUBMIT_ACTION))
+    {
         return Err("Claude native picker is not ready to submit".to_string());
     }
     for answer in answers {
         for selected in &answer.selected_options {
-            if !pane.contains(selected) {
+            if !visible.contains(&normalize_picker_text(selected)) {
                 return Err(
                     "Claude native picker review does not match selected answer".to_string()
                 );
@@ -5212,6 +5223,10 @@ async fn reconcile_claude_structured(
 fn claude_native_picker_is_visible(pane: &str) -> bool {
     pane.contains("Enter to select · ↑/↓ to navigate · Esc to cancel")
 }
+
+// Observed in Claude Code 2.1.226, exercised by the mirrored-picker live test.
+const CLAUDE_PICKER_REVIEW_HEADING: &str = "Review your answers";
+const CLAUDE_PICKER_SUBMIT_ACTION: &str = "Submit answers";
 
 /// The approve broker socket this daemon delivers answers and permission
 /// decisions on.

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -526,6 +526,11 @@ private struct FleetNotchDetail: View {
                     }
                 }
             } else if let deck, let question = deck.questions[safe: clampedIndex(deck)] {
+                if deck.mirroredPicker {
+                    Text("Claude picker also open. Submit here selects same answer there.")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(FleetNotchPalette.mint)
+                }
                 inlineInterview(deck: deck, question: question)
             } else if session.attention == .ask {
                 Text("Interview ready")

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -527,7 +527,7 @@ private struct FleetNotchDetail: View {
                 }
             } else if let deck, let question = deck.questions[safe: clampedIndex(deck)] {
                 if deck.mirroredPicker {
-                    Text("Claude picker also open. Submit here selects same answer there.")
+                    Text("Claude picker is also open. Submit here to select the same answer there. Text answers unavailable.")
                         .font(.caption.weight(.medium))
                         .foregroundStyle(FleetNotchPalette.mint)
                 }
@@ -642,7 +642,7 @@ private struct FleetNotchDetail: View {
             Button("Submit") { submit(deck) }
                 .buttonStyle(.borderedProminent)
                 .font(.caption)
-                .disabled(!complete(deck) || store.pendingIntentID != nil)
+                .disabled(!complete(deck) || (deck.mirroredPicker && hasTextAnswer(deck)) || store.pendingIntentID != nil)
         }
     }
 
@@ -672,6 +672,12 @@ private struct FleetNotchDetail: View {
     private func textBinding(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Binding<String> {
         let key = answerKey(deck, question)
         return Binding(get: { textAnswers[key, default: ""] }, set: { textAnswers[key] = $0 })
+    }
+
+    private func hasTextAnswer(_ deck: FleetInterviewDeck) -> Bool {
+        deck.questions.contains {
+            !textAnswers[answerKey(deck, $0), default: ""].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
     }
 
     private func answered(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Bool {

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -114,6 +114,7 @@ final class FleetStore: ObservableObject {
     private var connection: FleetConnection?
     private var connectionTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
+    private var authoritativeRepairTask: Task<Void, Never>?
     private var connectionGeneration: UInt = 0
     private var projection = FleetProjection.empty
     private var negotiation: FleetNegotiateResult?
@@ -142,6 +143,7 @@ final class FleetStore: ObservableObject {
     deinit {
         connectionTask?.cancel()
         reconnectTask?.cancel()
+        authoritativeRepairTask?.cancel()
     }
 
     var activeCount: Int {
@@ -202,6 +204,7 @@ final class FleetStore: ObservableObject {
     func start() {
         guard connectionTask == nil, reconnectTask == nil else { return }
         connectionState = .connecting
+        startAuthoritativeRepair()
         beginConnection()
     }
 
@@ -231,10 +234,23 @@ final class FleetStore: ObservableObject {
         connectionTask = nil
         reconnectTask?.cancel()
         reconnectTask = nil
+        authoritativeRepairTask?.cancel()
+        authoritativeRepairTask = nil
         let currentConnection = connection
         connection = nil
         negotiation = nil
         Task { await currentConnection?.close() }
+    }
+
+    private func startAuthoritativeRepair() {
+        guard authoritativeRepairTask == nil else { return }
+        authoritativeRepairTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(10))
+                guard let self, let connection = self.connection else { continue }
+                await self.refreshAuthoritativeState(using: connection)
+            }
+        }
     }
 
     func canPerform(_ action: FleetOperatorAction, on session: FleetSession) -> Bool {

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -312,7 +312,7 @@ struct FleetAnswerQueue: View {
             Text(question.header).font(.title3.weight(.semibold))
             Text(question.text).font(.body).fixedSize(horizontal: false, vertical: true)
             if deck.mirroredPicker {
-                Text("Claude picker is also open. Submit here to select the same answer there.")
+                Text("Claude picker is also open. Submit here to select the same answer there. Text answers unavailable.")
                     .font(.callout.weight(.medium))
                     .foregroundStyle(FleetPalette.mint)
             }
@@ -367,7 +367,7 @@ struct FleetAnswerQueue: View {
                 }
                 Button("Submit all answers") { submit(deck) }
                     .buttonStyle(.borderedProminent)
-                    .disabled(deck.nativePicker || !complete(deck) || store.pendingIntentID != nil)
+                    .disabled(deck.nativePicker || !complete(deck) || (deck.mirroredPicker && hasTextAnswer(deck)) || store.pendingIntentID != nil)
             }
 
             if let notice = store.controlNotice {
@@ -421,6 +421,12 @@ struct FleetAnswerQueue: View {
     private func textBinding(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Binding<String> {
         let answerKey = key(deck, question)
         return Binding(get: { textAnswers[answerKey, default: ""] }, set: { textAnswers[answerKey] = $0 })
+    }
+
+    private func hasTextAnswer(_ deck: FleetInterviewDeck) -> Bool {
+        deck.questions.contains {
+            !textAnswers[key(deck, $0), default: ""].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
     }
 
     private func answered(deck: FleetInterviewDeck, question: FleetInterviewQuestion) -> Bool {

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -311,6 +311,11 @@ struct FleetAnswerQueue: View {
 
             Text(question.header).font(.title3.weight(.semibold))
             Text(question.text).font(.body).fixedSize(horizontal: false, vertical: true)
+            if deck.mirroredPicker {
+                Text("Claude picker is also open. Submit here to select the same answer there.")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(FleetPalette.mint)
+            }
             if deck.nativePicker {
                 Text("Claude picker active. Answer in the attached Claude session, then Fleet refreshes the same interview state.")
                     .font(.callout.weight(.medium))
@@ -449,6 +454,7 @@ struct FleetInterviewDeck {
     let session: FleetSession
     let questions: [FleetInterviewQuestion]
     let nativePicker: Bool
+    let mirroredPicker: Bool
 
     init?(session: FleetSession) {
         guard session.attention == .ask,
@@ -472,6 +478,7 @@ struct FleetInterviewDeck {
         self.session = session
         self.questions = questions
         self.nativePicker = request.value("fleet_delivery")?.stringValue == "native_claude"
+        self.mirroredPicker = request.value("fleet_delivery")?.stringValue == "mirrored"
     }
 
     static func priority(_ session: FleetSession) -> (Int, Int64) {

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ainb-hooks",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc. stall_guard.py additionally blocks turn-end when a session would idle on in-flight work with no wake armed, so ATC-managed sessions do not silently park on a running CI job.",
   "author": {
     "name": "Agents-in-a-Box"
@@ -13,7 +13,7 @@
     "UserPromptSubmit": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "UserPromptExpansion": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "MessageDisplay": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
-    "PreToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 3600 }] }],
+    "PreToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 10 }] }],
     "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "PostToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "PostToolUseFailure": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],


### PR DESCRIPTION
## Summary
- preserve Claude native interview while mirroring it into Fleet
- route Fleet selections through verified native-picker keys
- show mirror ownership in Mac Fleet and repair state every 10 seconds
- register nonblocking PreToolUse hook with Claude supported 10-second timeout

## Proof
- `cargo test -p ainb cli::fleet::atc::tests::ask_hook_mirrors_native_picker_and_persists_fleet_request --lib`
- `cargo test -p ainb-hangar-daemon mirrored_claude_picker --lib`
- `xcodebuild test -project apps/ainb-fleet-macos/AINBFleet.xcodeproj -scheme AINBFleet -destination 'platform=macOS' -only-testing:FleetRPCTests/FleetProjectionReducerTests`\n- live native, Fleet TUI, and Mac Fleet round trips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude’s native pickers are preserved for structured questions, with Fleet mirroring selections.
  - Mirrored picker submissions support validated navigation, selection, and confirmation.
  - The desktop app now explains when a submission also selects the answer in Claude’s picker.
  - Fleet state refreshes automatically every 10 seconds.

- **Bug Fixes**
  - Structured questions are recorded reliably, including when Fleet is unavailable.
  - Unsupported free-text responses are rejected safely.

- **Chores**
  - Updated the plugin version and reduced hook timeout duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->