### PR TITLE
fix(fleet): name every session so the roster's name search works

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -286,6 +286,34 @@ fn observed_model_pair(observation: &HookObservation<'_>) -> (Option<String>, Op
     )
 }
 
+/// The operator-facing label for a session: the final component of its `cwd`,
+/// which for an ainb worktree is `<repo>--<branch>--<hash>`.
+///
+/// This is the label the Fleet screens ALREADY derive from `cwd` when a session
+/// has no stored name (`repository_label` in the hangar plugin, `short_session`
+/// in the host panel), so nothing here is a second naming scheme: it moves the
+/// existing one to the writer, where a remote client that cannot see this
+/// filesystem can search and paint the same text.
+///
+/// `None` for anything that would put identity rather than work on the wire: a
+/// bare home directory's leaf IS the account name, and a root or empty path has
+/// no label to give. `None` leaves any stored name untouched, because the
+/// metadata group merges per field (`assign_option_if_some`), so a nameless
+/// observation never blanks a named row.
+pub(crate) fn display_name_for_cwd(cwd: &str) -> Option<String> {
+    let path = std::path::Path::new(cwd.trim());
+    if matches!(
+        path.parent().and_then(std::path::Path::to_str),
+        Some("/Users" | "/home")
+    ) {
+        return None;
+    }
+    path.file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
 /// Apply one exact provider hook and wake revision subscribers after commit.
 pub async fn apply_hook(
     pool: &SqlitePool,
@@ -370,6 +398,7 @@ pub async fn apply_hook(
             tmux_target: tmux_target.clone(),
             process_start_fingerprint: process_start_fingerprint.clone(),
             cwd: Some(observation.cwd.to_string()),
+            display_name: display_name_for_cwd(observation.cwd),
             management_state: (provider == Provider::Claude).then(|| "MANAGED".to_string()),
             capabilities: (provider == Provider::Claude)
                 .then(|| claude_managed_capabilities(exact_tmux_identity)),
@@ -946,6 +975,7 @@ pub async fn register_managed_codex_tmux(
             tmux_target: Some(target),
             process_start_fingerprint: Some(fingerprint),
             cwd: Some(cwd.to_string()),
+            display_name: display_name_for_cwd(cwd),
             management_state: Some("MANAGED".to_string()),
             capabilities: Some(with_tmux_capabilities(
                 &with_managed_lifecycle_capabilities(
@@ -2163,6 +2193,7 @@ fn tmux_event(session: &FleetSession, observed_at: i64) -> NewFleetEvent {
             tmux_target: session.exact_tmux_target.clone(),
             process_start_fingerprint: session.process_start_fingerprint.clone(),
             cwd: Some(session.cwd.clone()),
+            display_name: display_name_for_cwd(&session.cwd),
             management_state: Some(management_token(session.management).to_string()),
             capabilities: Some(degraded_capabilities()),
             confidence: Some(confidence_token(session.confidence).to_string()),
@@ -2802,6 +2833,243 @@ mod tests {
         assert_eq!(unobserved.model, None);
         assert_eq!(unobserved.reasoning_effort, None);
         assert_eq!(unobserved.model_updated_at, 0);
+    }
+
+    /// A session reached the roster the ordinary way (a provider hook) must
+    /// carry a human label. `display_name` was `NULL` on every row for the
+    /// field's whole life, so the macOS roster's name-search leg matched
+    /// nothing while still LOOKING like it worked, because the cwd and
+    /// session-key legs kept matching.
+    #[tokio::test]
+    async fn hook_discovered_session_gets_a_worktree_display_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+
+        apply_hook(
+            store.pool(),
+            &sink,
+            HookObservation {
+                event_id: "hook-named".to_string(),
+                provider: "claude",
+                provider_session_id: "sess-named",
+                event_type: "PreToolUse",
+                cwd: "/Users/dev/.agents-in-a-box/worktrees/by-name/ainb--f-search--9c1e",
+                payload: &serde_json::json!({}),
+                observed_at: 1,
+                transcript_model: None,
+            },
+        )
+        .await
+        .expect("hook applies");
+
+        let session = FleetRepo::get_session(store.pool(), "claude:sess-named")
+            .await
+            .expect("session query")
+            .expect("session exists");
+        assert_eq!(
+            session.display_name.as_deref(),
+            Some("ainb--f-search--9c1e"),
+            "an operator searches the worktree name, so the daemon must store it"
+        );
+    }
+
+    /// The tmux discovery path is the only writer for a session no hook ever
+    /// reaches, so it must name its rows too.
+    #[tokio::test]
+    async fn tmux_discovered_session_gets_a_display_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+
+        let discovered = FleetSession {
+            cwd: "/Users/dev/d/git/ai-coder-rules".to_string(),
+            ..tmux_discovery_fixture()
+        };
+        let event = tmux_event(&discovered, 1);
+        FleetRepo::apply_event(store.pool(), &event).await.expect("discovery applies");
+
+        let session = FleetRepo::get_session(store.pool(), &event.session_key)
+            .await
+            .expect("session query")
+            .expect("session exists");
+        assert_eq!(
+            session.display_name.as_deref(),
+            Some("ai-coder-rules"),
+            "tmux discovery must name the row it creates"
+        );
+    }
+
+    /// The metadata state group merges field by field. A later observation that
+    /// cannot derive a name (an empty cwd) must leave the stored one alone
+    /// rather than blank it, which is `assign_option_if_some`'s contract and the
+    /// second hypothesis this bug could have had.
+    #[tokio::test]
+    async fn a_later_nameless_observation_does_not_blank_the_display_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+
+        for (event_id, cwd, observed_at) in [
+            ("hook-named", "/Users/dev/work/ainb--f-search--9c1e", 1),
+            ("hook-nameless", "", 2),
+        ] {
+            apply_hook(
+                store.pool(),
+                &sink,
+                HookObservation {
+                    event_id: event_id.to_string(),
+                    provider: "claude",
+                    provider_session_id: "sess-keeps-name",
+                    event_type: "PreToolUse",
+                    cwd,
+                    payload: &serde_json::json!({}),
+                    observed_at,
+                    transcript_model: None,
+                },
+            )
+            .await
+            .expect("hook applies");
+        }
+
+        let session = FleetRepo::get_session(store.pool(), "claude:sess-keeps-name")
+            .await
+            .expect("session query")
+            .expect("session exists");
+        assert_eq!(
+            session.display_name.as_deref(),
+            Some("ainb--f-search--9c1e"),
+            "an observation with no name of its own must not clear the stored one"
+        );
+    }
+
+    /// The label is derived from the cwd and from nothing else, so the exact
+    /// component it picks is the contract. The refusals matter most: this value
+    /// crosses the wire to the macOS client, and a bare home directory would put
+    /// the account name on it.
+    #[test]
+    fn display_name_for_cwd_names_the_worktree_and_refuses_identity() {
+        for (cwd, expected) in [
+            (
+                "/Users/dev/.agents-in-a-box/worktrees/by-name/ainb--f-search--9c1e",
+                Some("ainb--f-search--9c1e"),
+            ),
+            ("/Users/dev/d/git/ai-coder-rules", Some("ai-coder-rules")),
+            ("/Users/dev/d/git/ai-coder-rules/", Some("ai-coder-rules")),
+            ("/tmp/scratch", Some("scratch")),
+            // An account's home, on either platform layout: the leaf IS the
+            // username.
+            ("/Users/dev", None),
+            ("/home/dev", None),
+            ("/", None),
+            ("", None),
+            ("   ", None),
+        ] {
+            assert_eq!(
+                display_name_for_cwd(cwd).as_deref(),
+                expected,
+                "cwd {cwd:?} must derive {expected:?}"
+            );
+        }
+    }
+
+    /// Every row already on disk was written by a build that never authored a
+    /// name, and a session nothing observes again would stay nameless forever.
+    /// The boot repair names them with the same rule the writers use, and leaves
+    /// a name it did not author alone.
+    #[tokio::test]
+    async fn boot_backfill_names_rows_written_before_the_writers_did() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+
+        for (event_id, session_id, cwd) in [
+            (
+                "hook-old",
+                "sess-old",
+                "/Users/dev/work/ainb--f-search--9c1e",
+            ),
+            ("hook-homeless", "sess-homeless", "/Users/dev"),
+        ] {
+            apply_hook(
+                store.pool(),
+                &sink,
+                HookObservation {
+                    event_id: event_id.to_string(),
+                    provider: "claude",
+                    provider_session_id: session_id,
+                    event_type: "PreToolUse",
+                    cwd,
+                    payload: &serde_json::json!({}),
+                    observed_at: 1,
+                    transcript_model: None,
+                },
+            )
+            .await
+            .expect("hook applies");
+        }
+        // Exactly the on-disk shape an older build left: a real row, no name.
+        sqlx::query("UPDATE fleet_session SET display_name = NULL")
+            .execute(store.pool())
+            .await
+            .expect("strip names");
+
+        let named = FleetRepo::backfill_display_names(store.pool(), display_name_for_cwd)
+            .await
+            .expect("backfill runs");
+        assert_eq!(named, 1, "only the row the rule can name is repaired");
+
+        let repaired = FleetRepo::get_session(store.pool(), "claude:sess-old")
+            .await
+            .expect("session query")
+            .expect("session exists");
+        assert_eq!(
+            repaired.display_name.as_deref(),
+            Some("ainb--f-search--9c1e")
+        );
+
+        let homeless = FleetRepo::get_session(store.pool(), "claude:sess-homeless")
+            .await
+            .expect("session query")
+            .expect("session exists");
+        assert_eq!(
+            homeless.display_name, None,
+            "a home directory's leaf is the account name and must stay unnamed"
+        );
+
+        // Idempotent: a second boot finds nothing left to repair.
+        assert_eq!(
+            FleetRepo::backfill_display_names(store.pool(), display_name_for_cwd)
+                .await
+                .expect("second backfill runs"),
+            0
+        );
+    }
+
+    /// A tmux-discovered session with just enough shape to reach `tmux_event`.
+    fn tmux_discovery_fixture() -> FleetSession {
+        let target = "tmux_ai-coder-rules:1.1";
+        let fingerprint = "pane=%9;pid=909;session_started=1700000000";
+        FleetSession {
+            session_key: SessionKey::legacy(Provider::Claude, target, fingerprint),
+            provider: Provider::Claude,
+            provider_session_id: None,
+            cwd: String::new(),
+            exact_tmux_target: Some(target.to_string()),
+            pane_pid: Some(909),
+            process_start_fingerprint: Some(fingerprint.to_string()),
+            lifecycle: LifecycleState::Idle,
+            attention: AttentionState::None,
+            management: ManagementState::Degraded,
+            capabilities: ainb_fleet_core::types::Capabilities::degraded_tmux(),
+            provenance: std::collections::BTreeSet::from([
+                ainb_fleet_core::types::Provenance::Tmux,
+            ]),
+            confidence: Confidence::Inferred,
+            transport_health: TransportHealth::Healthy,
+            first_seen_ms: Some(1_700_000_000_000),
+            last_seen_ms: None,
+            version: 0,
+        }
     }
 
     /// The reaper retires what nothing can observe, and then goes quiet.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -626,6 +626,21 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         let _acp_sweeper = acp_pool.spawn_sweeper();
         crate::acp_pool::install(acp_pool).await;
 
+        // Name the rows written before the daemon authored `display_name` at all.
+        // Every existing row is NULL there, and a session nothing observes again
+        // would never be named by the writers alone, so the roster's name search
+        // would stay dead for exactly the sessions an operator has to search for.
+        match ainb_hangar_store::repo::fleet::FleetRepo::backfill_display_names(
+            store.pool(),
+            crate::fleet::display_name_for_cwd,
+        )
+        .await
+        {
+            Ok(0) => {}
+            Ok(named) => tracing::info!(named, "named fleet sessions left unnamed by older builds"),
+            Err(error) => tracing::error!(%error, "could not backfill fleet display names at boot"),
+        }
+
         // Tmux reconciliation keeps unhooked and standalone provider sessions in
         // the canonical Fleet roster as degraded rows with exact pane identity.
         let _fleet_tmux = crate::fleet::spawn_tmux_reconciler(store.pool().clone(), broker.sink());

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5608,6 +5608,7 @@ async fn handle_fleet_acp_session_create(
             // `FleetProvider::Acp`; anything else would render as Unknown.
             provider: Some(crate::acp_pool::ACP_PROVIDER_TOKEN.to_string()),
             cwd: Some(params.cwd.clone()),
+            display_name: crate::fleet::display_name_for_cwd(&params.cwd),
             management_state: Some("MANAGED".to_string()),
             capabilities: Some(acp_capabilities()),
             confidence: Some("HIGH".to_string()),

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -789,6 +789,52 @@ impl FleetRepo {
         Ok(Some(revision))
     }
 
+    /// Name the rows that were written before anything authored a
+    /// `display_name`, using the caller's rule.
+    ///
+    /// A repair, not an observation: it fills a column that was NULL for the
+    /// field's whole life without touching `version`, `updated_revision`, or any
+    /// group's authority, so no client sees a state change and no event is
+    /// logged for a name nobody changed. Rows the rule declines stay NULL and
+    /// are retried on the next call.
+    ///
+    /// The rule is the CALLER's, so the label the operator sees has exactly one
+    /// author and this layer stays free of presentation.
+    ///
+    /// # Errors
+    /// Propagates the `SQLite` read or write failure.
+    pub async fn backfill_display_names<F>(
+        pool: &SqlitePool,
+        derive: F,
+    ) -> Result<usize, sqlx::Error>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let nameless: Vec<(String, String)> = sqlx::query_as(
+            "SELECT session_key, cwd FROM fleet_session \
+             WHERE display_name IS NULL OR display_name = ''",
+        )
+        .fetch_all(pool)
+        .await?;
+        let named: Vec<(String, String)> = nameless
+            .into_iter()
+            .filter_map(|(session_key, cwd)| Some((session_key, derive(&cwd)?)))
+            .collect();
+        if named.is_empty() {
+            return Ok(0);
+        }
+        let mut tx = pool.begin().await?;
+        for (session_key, display_name) in &named {
+            sqlx::query("UPDATE fleet_session SET display_name = ? WHERE session_key = ?")
+                .bind(display_name)
+                .bind(session_key)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(named.len())
+    }
+
     /// Read the archived roster, most recently observed first.
     ///
     /// Archiving hides a row from [`Self::snapshot`], it does not delete it, so
@@ -1659,6 +1705,90 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
         (dir, store)
+    }
+
+    /// The boot repair names rows written before `display_name` existed, and
+    /// does it WITHOUT touching `version` or `updated_revision`.
+    ///
+    /// That invariant is the whole reason this is a repair rather than an
+    /// observation: bumping either would mint a revision on every existing row
+    /// at boot, and every connected client would re-snapshot a fleet-wide change
+    /// for a name nobody actually changed. On the live host this pass covers
+    /// 1724 rows, so the churn would not be small.
+    #[tokio::test]
+    async fn backfill_names_nameless_rows_without_minting_a_revision() {
+        let (_dir, store) = store().await;
+        for (key, cwd) in [
+            ("claude:s-named", "/Users/dev/d/git/ai-coder-rules"),
+            ("claude:s-declined", "/Users/dev"),
+        ] {
+            FleetRepo::apply_event(
+                store.pool(),
+                &event(
+                    &format!("e-{key}"),
+                    key,
+                    100,
+                    ObservationAuthority::Authoritative,
+                    FleetSessionPatch {
+                        provider: Some("claude".to_string()),
+                        cwd: Some(cwd.to_string()),
+                        ..FleetSessionPatch::default()
+                    },
+                ),
+            )
+            .await
+            .unwrap();
+        }
+
+        let before = FleetRepo::get_session(store.pool(), "claude:s-named")
+            .await
+            .unwrap()
+            .expect("seeded session");
+        assert_eq!(before.display_name, None, "precondition: unnamed");
+
+        // The caller owns the rule, exactly as the daemon passes its own.
+        let derive = |cwd: &str| -> Option<String> {
+            let trimmed = cwd.trim_end_matches('/');
+            let path = std::path::Path::new(trimmed);
+            if matches!(
+                path.parent().and_then(std::path::Path::to_str),
+                Some("/Users" | "/home")
+            ) {
+                return None;
+            }
+            path.file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+        };
+
+        let named = FleetRepo::backfill_display_names(store.pool(), derive).await.unwrap();
+        assert_eq!(named, 1, "only the row the rule accepts is named");
+
+        let after = FleetRepo::get_session(store.pool(), "claude:s-named")
+            .await
+            .unwrap()
+            .expect("session survives");
+        assert_eq!(after.display_name.as_deref(), Some("ai-coder-rules"));
+        assert_eq!(
+            (after.version, after.updated_revision),
+            (before.version, before.updated_revision),
+            "a repair must not mint a revision, or every client re-snapshots at boot"
+        );
+
+        let declined = FleetRepo::get_session(store.pool(), "claude:s-declined")
+            .await
+            .unwrap()
+            .expect("declined session survives");
+        assert_eq!(
+            declined.display_name, None,
+            "a cwd that would name the operator's home stays NULL rather than leaking identity"
+        );
+
+        // Idempotent: the named row is not rewritten, so a long-lived daemon
+        // does no work per boot beyond the rows it still cannot name.
+        let second = FleetRepo::backfill_display_names(store.pool(), derive).await.unwrap();
+        assert_eq!(second, 0, "second boot names nothing new");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #650.

## Problem

`display_name` was NULL on **every** session (83/83 visible on the live host), so the roster's name-search leg matched a column nothing ever wrote. Searching a session by its human name returned nothing.

The failure was silent: the other search terms (cwd, session key, model) still matched, so a session looked *absent* rather than *unnamed*.

## Fix

Two commits, two concerns.

**1. Name new sessions.** `display_name_for_cwd` takes the last path component of the session's cwd, which for this fleet is the worktree name an operator already recognises. Wired into the three registration sites (hook ingest, managed codex, and the spawn RPC path).

**2. Name existing rows.** A boot-time repair fills rows written before the writers existed. A session nothing observes again would never be named by the writers alone, so the search would stay dead for exactly the dormant sessions you have to search for.

## Identity guard

`display_name` goes over the wire to the macOS client, so this must never carry a path or an account name. A cwd whose parent is `/Users` or `/home` is **refused**, because that path IS the home directory and its final component is the operator's account name.

Verified against all 393 distinct cwds on a live host: `/Users/<user>` and `/home/<user>` return `None`; real repo names survive. Zero values containing a path separator or a bare account name reached the wire.

## The repair does not mint a revision

`backfill_display_names` deliberately leaves `version`, `updated_revision` and every group's authority untouched. On the live host the pass covers **1724 rows**; minting a revision each would make every connected client re-snapshot the entire fleet at boot for a name nobody changed. Pinned by `backfill_names_nameless_rows_without_minting_a_revision`.

## Validation, live daemon against the real 101,545-event corpus

```
sessions on wire:    264
with display_name:   180
LEAKS on wire:         0
```

Of the named rows: 67% are meaningful worktree names, 21% are ULIDs and 12% generic (`main`, `workdir`) — and **all** of those latter two live under `/private/var/folders/.../T/` temp paths, i.e. tripwire and test sessions. Every real session gets a searchable name.

The 84 unnamed rows are exactly the ones that should be: 82 whose cwd is the home directory itself (correctly refused) and 2 with an empty cwd.

## Tests

- `display_name_for_cwd_names_the_worktree_and_refuses_identity`
- `hook_discovered_session_gets_a_worktree_display_name`
- `tmux_discovered_session_gets_a_display_name`
- `a_later_nameless_observation_does_not_blank_the_display_name`
- `backfill_names_nameless_rows_without_minting_a_revision`

Green: 506 daemon lib, 70 store across binaries, `cargo check --workspace --all-targets`, `cargo fmt --check`.

Branched off current main and compiled there deliberately: a branch-only build cannot catch a semantic merge conflict, which is what broke main earlier today when #645 and #646 each landed green.

## Noted, not fixed here

`ainb-tui/Cargo.lock` on main is stale (lock says 1.18.0, workspace is 1.20.0). A local build refreshes it. Left alone to keep this PR single-concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet sessions now display names based on their working-directory folder.
  * Newly created sessions, including ACP and managed terminal sessions, automatically receive a display name.
* **Improvements**
  * Existing sessions without names are automatically updated when the application starts.
  * Names omit sensitive or unhelpful paths such as home directories and filesystem roots.
  * Existing names are preserved when later session updates do not provide a usable name.
* **Bug Fixes**
  * Improved consistency of session names across terminal discovery and registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->