### PR TITLE
fix(hangar-daemon): one daemon per hangar home

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7871,17 +7871,6 @@ fn daemon_version_skew(running: Option<&str>, mine: &str) -> Option<String> {
     }
 }
 
-/// Resolve the daemon's ownership lock: `<hangar_home>/hangar/daemon.lock`.
-///
-/// This, not `daemon.pid`, is the authoritative record of who owns the home: the
-/// daemon publishes it atomically as the first statement of `boot` and holds it
-/// for its whole life, whereas the pid file is a last-write-wins note written at
-/// the end of boot.
-fn daemon_lock_path() -> Result<std::path::PathBuf> {
-    let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;
-    Ok(ainb_hangar_daemon::single_instance::lock_path_in(&home))
-}
-
 /// Read the recorded daemon pid, or `None` if the file is absent/empty/garbage.
 fn read_daemon_pid(path: &std::path::Path) -> Option<u32> {
     let text = std::fs::read_to_string(path).ok()?;
@@ -7889,6 +7878,10 @@ fn read_daemon_pid(path: &std::path::Path) -> Option<u32> {
 }
 
 /// The pid of the daemon that currently owns this hangar home, if any.
+///
+/// Ownership lives in `<hangar_home>/hangar/daemon.lock`, which the daemon
+/// publishes atomically as the first statement of `boot` and holds for its whole
+/// life — unlike `daemon.pid`, a last-write-wins note written at the end of boot.
 ///
 /// The ownership lock answers first. The pid file is consulted only as a
 /// fallback, for the upgrade window in which a daemon built before the lock

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -2589,12 +2589,9 @@ async fn dispatch_pipeline(cmd: PipelineCommand) -> Result<()> {
     .await
     .context("read the pipeline health")?;
 
-    // The daemon light reuses the SAME pid-file probe `hangar daemon status`
+    // The daemon light reuses the SAME ownership probe `hangar daemon status`
     // prints, so the strip and that command can never disagree about liveness.
-    let daemon_alive = daemon_pid_path()
-        .ok()
-        .and_then(|p| read_daemon_pid(&p))
-        .is_some_and(pid_is_running);
+    let daemon_alive = running_daemon_pid().ok().flatten().is_some();
     let color = std::io::IsTerminal::is_terminal(&std::io::stdout());
     for line in pipeline_view::render(&health, daemon_alive, color) {
         println!("{line}");
@@ -7874,18 +7871,61 @@ fn daemon_version_skew(running: Option<&str>, mine: &str) -> Option<String> {
     }
 }
 
+/// Resolve the daemon's ownership lock: `<hangar_home>/hangar/daemon.lock`.
+///
+/// This, not `daemon.pid`, is the authoritative record of who owns the home: the
+/// daemon publishes it atomically as the first statement of `boot` and holds it
+/// for its whole life, whereas the pid file is a last-write-wins note written at
+/// the end of boot.
+fn daemon_lock_path() -> Result<std::path::PathBuf> {
+    let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;
+    Ok(ainb_hangar_daemon::single_instance::lock_path_in(&home))
+}
+
 /// Read the recorded daemon pid, or `None` if the file is absent/empty/garbage.
 fn read_daemon_pid(path: &std::path::Path) -> Option<u32> {
     let text = std::fs::read_to_string(path).ok()?;
     text.trim().parse().ok()
 }
 
+/// The pid of the daemon that currently owns this hangar home, if any.
+///
+/// The ownership lock answers first. The pid file is consulted only as a
+/// fallback, for the upgrade window in which a daemon built before the lock
+/// existed is still running — it registers a pid but never takes the lock, and
+/// without this shim `status` and `stop` would report it as not running.
+//
+// ponytail: drop the pid-file fallback a release after the lock ships; by then
+// no pre-lock daemon can still be alive.
+fn running_daemon_pid() -> Result<Option<u32>> {
+    let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;
+    Ok(running_daemon_pid_in(&home))
+}
+
+/// [`running_daemon_pid`] against an explicit hangar home, so the
+/// lock-beats-pid-file precedence is testable without touching the environment.
+fn running_daemon_pid_in(home: &std::path::Path) -> Option<u32> {
+    let live = |path: std::path::PathBuf| read_daemon_pid(&path).filter(|pid| pid_is_running(*pid));
+    live(ainb_hangar_daemon::single_instance::lock_path_in(home))
+        .or_else(|| live(ainb_hangar_daemon::pid_path_in(home)))
+}
+
 /// Is `pid` a live process? `kill(pid, 0)` succeeds iff it exists (and we may
 /// signal it), so this is a non-destructive liveness probe.
+///
+/// `EPERM` counts as ALIVE: the process exists, we simply do not own it. Reading
+/// it as dead (the prior behaviour) would let a daemon running under another
+/// account be treated as absent and duplicated. Matches the daemon-side
+/// `beads_adapter::lock::pid_alive`, so both halves agree on what "running"
+/// means.
 fn pid_is_running(pid: u32) -> bool {
+    use nix::errno::Errno;
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
-    matches!(kill(Pid::from_raw(pid as i32), None), Ok(()))
+    matches!(
+        kill(Pid::from_raw(pid as i32), None),
+        Ok(()) | Err(Errno::EPERM)
+    )
 }
 
 /// Resolve how `start` launches the daemon: the dedicated
@@ -8332,7 +8372,9 @@ async fn run_daemon_status() -> Result<()> {
         .context("resolve hangar home")?
         .join("hangar.sock");
 
-    match read_daemon_pid(&pid_path) {
+    // The owner (lock first) decides "running"; the pid file is only what a
+    // stale-record message quotes back.
+    match running_daemon_pid()?.or_else(|| read_daemon_pid(&pid_path)) {
         Some(pid) if pid_is_running(pid) => {
             let sock = if socket.exists() {
                 "socket bound"
@@ -8498,16 +8540,22 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     let pid_path = daemon_pid_path()?;
 
     // Already running? Bail out cleanly rather than spawning a duplicate.
-    if let Some(pid) = read_daemon_pid(&pid_path) {
-        if pid_is_running(pid) {
-            if announce {
-                println!("hangar daemon: already running (pid {pid})");
-            }
-            return Ok(());
+    //
+    // This is now an OPTIMISATION, not the guard. It is still a check-then-act
+    // across two processes, so it can lose a race — but a duplicate that gets
+    // spawned anyway declines the home for itself (the daemon takes an exclusive
+    // lock before it opens anything) and exits, which is what makes the residual
+    // race harmless rather than a pile of daemons.
+    if let Some(pid) = running_daemon_pid()? {
+        if announce {
+            println!("hangar daemon: already running (pid {pid})");
         }
-        // Stale pid file from a crashed daemon: drop it before re-spawning.
-        std::fs::remove_file(&pid_path).ok();
+        return Ok(());
     }
+    // Stale pid file from a crashed daemon: drop it before re-spawning. The
+    // stale LOCK needs no handling here — the booting daemon reclaims it
+    // atomically, which is the only race-free way to take it.
+    std::fs::remove_file(&pid_path).ok();
 
     if let Some(parent) = pid_path.parent() {
         std::fs::create_dir_all(parent).context("create hangar home dir")?;
@@ -8559,17 +8607,32 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     // the offline panel sat there forever. Give the child a beat, then
     // reap-check: `try_wait` returns the exit status iff it already died.
     std::thread::sleep(std::time::Duration::from_millis(400));
-    if let Some(status) = child.try_wait().context("probe daemon child")? {
+    let exited = child.try_wait().context("probe daemon child")?;
+    // A clean exit is not a failure: it is how a daemon reports that another one
+    // already owns this home (it lost the ownership lock and declined). Only a
+    // NON-ZERO exit means the daemon could not boot.
+    if let Some(status) = exited.filter(|status| !status.success()) {
         anyhow::bail!(
             "daemon exited immediately ({status}) — launched `{launched}`; \
              run `ainb hangar daemon run` in a terminal to see why"
         );
     }
 
-    let pid = child.id();
-    // Write the EXACT child pid (the one we just spawned) so `stop` signals this
-    // process and no other. `child` is intentionally dropped without `wait` —
-    // the daemon is meant to outlive this CLI invocation.
+    // Record the pid of the daemon that actually OWNS the home, which on a lost
+    // race is the incumbent rather than the child we just spawned. The child
+    // publishes the lock as its first action, so it is on disk by now; falling
+    // back to the child pid keeps a slow-starting daemon recorded.
+    let owner = running_daemon_pid()?;
+    if exited.is_some() && owner.is_none() {
+        anyhow::bail!(
+            "daemon exited immediately ({}) without claiming the home — launched \
+             `{launched}`; run `ainb hangar daemon run` in a terminal to see why",
+            exited.map_or_else(|| "?".to_string(), |s| s.to_string())
+        );
+    }
+    let pid = owner.unwrap_or_else(|| child.id());
+    // `child` is intentionally dropped without `wait` — the daemon is meant to
+    // outlive this CLI invocation.
     std::fs::write(&pid_path, format!("{pid}\n"))
         .with_context(|| format!("write pid file {}", pid_path.display()))?;
 
@@ -8582,7 +8645,11 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     }
 
     if announce {
-        println!("hangar daemon: started (pid {pid})");
+        if exited.is_some() {
+            println!("hangar daemon: already running (pid {pid})");
+        } else {
+            println!("hangar daemon: started (pid {pid})");
+        }
     }
     Ok(())
 }
@@ -10402,6 +10469,47 @@ mod tests {
             stop_decision(&pid_path, &socket),
             StopDecision::Stale(dead_pid)
         );
+    }
+
+    /// A process we do not own still counts as running.
+    ///
+    /// `kill(pid, 0)` answers `EPERM` for another user's process; reading that as
+    /// "not running" (the prior behaviour) would let the CLI treat a daemon
+    /// owned by another account as absent and spawn a duplicate against the same
+    /// home. PID 1 exists on every unix and is owned by root.
+    #[test]
+    fn a_process_we_may_not_signal_still_counts_as_running() {
+        assert!(pid_is_running(1), "pid 1 must read as running");
+    }
+
+    /// The ownership lock outranks the pid file.
+    ///
+    /// They disagree exactly when it matters: the pid file is last-write-wins
+    /// bookkeeping written at the end of boot, while the lock is held by the
+    /// daemon that actually owns the home. `status`, `stop` and the autostart
+    /// guard must all follow the lock.
+    #[test]
+    fn the_ownership_lock_outranks_the_pid_file() {
+        let home = tempfile::tempdir().expect("tmpdir");
+        let hangar = home.path().join("hangar");
+        std::fs::create_dir_all(&hangar).expect("mkdir");
+        let ours = std::process::id();
+
+        // A dead pid recorded in the pid file, a LIVE one in the lock.
+        std::fs::write(hangar.join("daemon.pid"), "424242\n").expect("write pid file");
+        std::fs::write(hangar.join("daemon.lock"), ours.to_string()).expect("write lock");
+        assert_eq!(running_daemon_pid_in(home.path()), Some(ours));
+
+        // Fallback: no lock at all (a daemon from before the lock shipped) still
+        // resolves through the pid file, so an upgrade does not make a running
+        // daemon invisible.
+        std::fs::remove_file(hangar.join("daemon.lock")).expect("drop lock");
+        std::fs::write(hangar.join("daemon.pid"), format!("{ours}\n")).expect("rewrite pid");
+        assert_eq!(running_daemon_pid_in(home.path()), Some(ours));
+
+        // Neither file names a live process -> nobody owns the home.
+        std::fs::write(hangar.join("daemon.pid"), "424242\n").expect("rewrite pid");
+        assert_eq!(running_daemon_pid_in(home.path()), None);
     }
 
     /// The skew helper flags a differing recorded version, and stays quiet for

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7898,9 +7898,38 @@ fn running_daemon_pid() -> Result<Option<u32>> {
 /// [`running_daemon_pid`] against an explicit hangar home, so the
 /// lock-beats-pid-file precedence is testable without touching the environment.
 fn running_daemon_pid_in(home: &std::path::Path) -> Option<u32> {
-    let live = |path: std::path::PathBuf| read_daemon_pid(&path).filter(|pid| pid_is_running(*pid));
-    live(ainb_hangar_daemon::single_instance::lock_path_in(home))
-        .or_else(|| live(ainb_hangar_daemon::pid_path_in(home)))
+    let owner =
+        |path: std::path::PathBuf| read_daemon_pid(&path).filter(|pid| pid_owns_a_home(*pid));
+    owner(ainb_hangar_daemon::single_instance::lock_path_in(home))
+        .or_else(|| owner(ainb_hangar_daemon::pid_path_in(home)))
+}
+
+/// Is `pid` a live hangar daemon, by the SAME rule the daemon itself applies?
+///
+/// Liveness alone is not enough for a record that outlives a reboot: after a
+/// power cut the pid in `daemon.lock` usually belongs to some unrelated process,
+/// and reading that as "a daemon is running" wedges the home with ZERO daemons
+/// (the autostart declines forever) while `stop` SIGTERMs a stranger. The daemon
+/// half has guarded against exactly this since the lock shipped; this is the
+/// other half agreeing with it.
+///
+/// Fails safe in the same direction — an unidentifiable live process is treated
+/// as the owner rather than spawned over.
+fn pid_owns_a_home(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    if ainb_hangar_daemon::single_instance::holder_is_live_daemon(pid) {
+        return true;
+    }
+    // One shape the daemon-side rule cannot see: a daemon launched through an
+    // `AINB_HANGAR_DAEMON_BIN` wrapper has an argv neither the two known shapes
+    // nor the DAEMON's `current_exe` comparison recognises from over here. This
+    // CLI knows what it would launch, so it can recognise its own wrapper.
+    let launcher = resolve_daemon_launch().0.display().to_string();
+    !launcher.is_empty()
+        && ainb_hangar_daemon::single_instance::process_argv(pid)
+            .is_some_and(|args| args == launcher || args.starts_with(&format!("{launcher} ")))
 }
 
 /// Is `pid` a live process? `kill(pid, 0)` succeeds iff it exists (and we may
@@ -8631,10 +8660,15 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
 
     // Record the version of the binary now serving, beside the pid. The launcher
     // and the daemon it spawns share the workspace version, so this is the
-    // running daemon's version. Best-effort: a write failure must not fail the
-    // start (the skew check just degrades to "unknown").
-    if let Ok(vpath) = daemon_version_path() {
-        std::fs::write(&vpath, format!("{}\n", env!("CARGO_PKG_VERSION"))).ok();
+    // running daemon's version — but ONLY when our child is the one serving.
+    // On the lost-race path the incumbent is some other build, and stamping our
+    // version over it would silence the very skew warning `status` exists to
+    // print. Best-effort: a write failure must not fail the start (the skew
+    // check just degrades to "unknown").
+    if exited.is_none() {
+        if let Ok(vpath) = daemon_version_path() {
+            std::fs::write(&vpath, format!("{}\n", env!("CARGO_PKG_VERSION"))).ok();
+        }
     }
 
     if announce {
@@ -8862,8 +8896,17 @@ fn run_daemon_stop() -> Result<()> {
 }
 
 /// `hangar daemon restart`: `stop` (if running) then `start`.
+///
+/// A failed stop does NOT abort the start. `stop` now waits for the daemon to
+/// exit and errors if it outlasts its budget — propagating that would return
+/// with the old daemon mid-shutdown and nothing scheduled to replace it, so a
+/// daemon that finished dying a moment later left the home empty until something
+/// else autostarted it. Report the stop problem and start anyway: if the old
+/// daemon is somehow still up, `start` is a no-op that says so.
 pub(crate) fn run_daemon_restart() -> Result<()> {
-    run_daemon_stop()?;
+    if let Err(e) = run_daemon_stop() {
+        println!("hangar daemon: stop reported a problem, starting anyway: {e}");
+    }
     run_daemon_start()
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7898,38 +7898,40 @@ fn running_daemon_pid() -> Result<Option<u32>> {
 /// [`running_daemon_pid`] against an explicit hangar home, so the
 /// lock-beats-pid-file precedence is testable without touching the environment.
 fn running_daemon_pid_in(home: &std::path::Path) -> Option<u32> {
-    let owner =
-        |path: std::path::PathBuf| read_daemon_pid(&path).filter(|pid| pid_owns_a_home(*pid));
+    let socket = home.join("hangar.sock");
+    let owner = |path: std::path::PathBuf| {
+        read_daemon_pid(&path).filter(|pid| pid_owns_a_home(*pid, &socket))
+    };
     owner(ainb_hangar_daemon::single_instance::lock_path_in(home))
         .or_else(|| owner(ainb_hangar_daemon::pid_path_in(home)))
 }
 
-/// Is `pid` a live hangar daemon, by the SAME rule the daemon itself applies?
+/// Is `pid` this home's daemon?
 ///
-/// Liveness alone is not enough for a record that outlives a reboot: after a
-/// power cut the pid in `daemon.lock` usually belongs to some unrelated process,
-/// and reading that as "a daemon is running" wedges the home with ZERO daemons
-/// (the autostart declines forever) while `stop` SIGTERMs a stranger. The daemon
-/// half has guarded against exactly this since the lock shipped; this is the
-/// other half agreeing with it.
+/// PROOF first: a process holding `<hangar home>/hangar.sock` under our uid is
+/// this home's daemon and can be nothing else ([`OwnedPid::holding_socket`]).
+/// That is the same evidence `stop` demands before signalling, so every verb now
+/// agrees about who is running.
 ///
-/// Fails safe in the same direction — an unidentifiable live process is treated
-/// as the owner rather than spawned over.
-fn pid_owns_a_home(pid: u32) -> bool {
-    let Ok(pid) = i32::try_from(pid) else {
+/// The argv shape is the boot-window fallback ONLY. The daemon publishes its
+/// lock as the first statement of `boot` but binds the socket at the end, so in
+/// between there is a live, legitimate daemon holding no socket yet.
+/// `is_hangar_daemon_args` is deliberately narrow and must NEVER credit a bare
+/// `ainb`: on a layout with no sidecar binary the daemon self-execs as
+/// `ainb hangar daemon run`, so daemon and TUI share an executable, and a
+/// recycled pid landing on the user's TUI would otherwise read as this home's
+/// daemon — wedging the home with ZERO daemons for as long as that TUI lived.
+fn pid_owns_a_home(pid: u32, socket: &std::path::Path) -> bool {
+    if !pid_is_running(pid) {
         return false;
-    };
-    if ainb_hangar_daemon::single_instance::holder_is_live_daemon(pid) {
+    }
+    if OwnedPid::holding_socket(pid, socket).is_some() {
         return true;
     }
-    // One shape the daemon-side rule cannot see: a daemon launched through an
-    // `AINB_HANGAR_DAEMON_BIN` wrapper has an argv neither the two known shapes
-    // nor the DAEMON's `current_exe` comparison recognises from over here. This
-    // CLI knows what it would launch, so it can recognise its own wrapper.
-    let launcher = resolve_daemon_launch().0.display().to_string();
-    !launcher.is_empty()
-        && ainb_hangar_daemon::single_instance::process_argv(pid)
-            .is_some_and(|args| args == launcher || args.starts_with(&format!("{launcher} ")))
+    i32::try_from(pid).is_ok_and(|pid| {
+        ainb_hangar_daemon::single_instance::process_argv(pid)
+            .is_some_and(|args| ainb_hangar_daemon::single_instance::is_hangar_daemon_args(&args))
+    })
 }
 
 /// Is `pid` a live process? `kill(pid, 0)` succeeds iff it exists (and we may
@@ -8394,10 +8396,12 @@ async fn run_daemon_status() -> Result<()> {
         .context("resolve hangar home")?
         .join("hangar.sock");
 
-    // The owner (lock first) decides "running"; the pid file is only what a
-    // stale-record message quotes back.
-    match running_daemon_pid()?.or_else(|| read_daemon_pid(&pid_path)) {
-        Some(pid) if pid_is_running(pid) => {
+    // The owner decides "running". The raw pid file is consulted ONLY to quote a
+    // stale record back; it must never promote an unproven pid to "running", or
+    // `status` and the autostart guard would disagree about the same process.
+    let owner = running_daemon_pid()?;
+    match owner.or_else(|| read_daemon_pid(&pid_path)) {
+        Some(pid) if owner == Some(pid) => {
             let sock = if socket.exists() {
                 "socket bound"
             } else {
@@ -8465,20 +8469,16 @@ async fn run_daemon_run() -> Result<()> {
         )
     };
 
-    // Same crash breadcrumbs the standalone binary lays down: this is the SAME
-    // long-lived daemon process, just launched through `ainb`, and the launcher
-    // picks this path whenever the sidecar binary is missing or stale. A
-    // heartbeat that only an observed exit removes is what turns a SIGKILL (a
+    // The same crash breadcrumbs the standalone binary lays down — this is the
+    // SAME long-lived daemon process, just launched through `ainb`, and the
+    // launcher picks this path whenever the sidecar binary is missing or stale.
+    // A heartbeat that only an observed exit removes is what turns a SIGKILL (a
     // death that runs no user code, so no panic hook can catch it) into
     // evidence.
-    match ainb_hangar_daemon::hangar_dir() {
-        Ok(dir) => {
-            ainb_hangar_daemon::observability::note_phase("boot");
-            ainb_hangar_daemon::observability::start_breadcrumbs(&dir);
-        }
-        Err(e) => tracing::warn!(error = %e, "no hangar home; crash breadcrumbs disabled"),
-    }
-
+    //
+    // `boot` installs them itself, once it has taken the home's ownership lock.
+    // Installing them here would let a duplicate that goes on to DECLINE erase
+    // the incumbent's exit record and overwrite its heartbeat on the way past.
     let result = ainb_hangar_daemon::boot(false).await.context("run hangar daemon (foreground)");
 
     ainb_hangar_daemon::observability::note_phase("shutdown");
@@ -8644,13 +8644,21 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     // race is the incumbent rather than the child we just spawned. The child
     // publishes the lock as its first action, so it is on disk by now; falling
     // back to the child pid keeps a slow-starting daemon recorded.
-    let owner = running_daemon_pid()?;
+    let mut owner = running_daemon_pid()?;
     if exited.is_some() && owner.is_none() {
-        anyhow::bail!(
-            "daemon exited immediately ({}) without claiming the home — launched \
-             `{launched}`; run `ainb hangar daemon run` in a terminal to see why",
-            exited.map_or_else(|| "?".to_string(), |s| s.to_string())
-        );
+        // Our child exited 0 (it lost the lock) and yet nobody owns the home —
+        // the incumbent it lost to has since exited too. Nothing is wrong here,
+        // the home is simply free again, so try once more before calling it a
+        // failure. Only a second empty-handed attempt is worth an error.
+        if let Some(pid) = respawn_once(&bin, &args)? {
+            owner = Some(pid);
+        } else {
+            anyhow::bail!(
+                "daemon exited immediately ({}) without claiming the home — launched \
+                 `{launched}`; run `ainb hangar daemon run` in a terminal to see why",
+                exited.map_or_else(|| "?".to_string(), |s| s.to_string())
+            );
+        }
     }
     let pid = owner.unwrap_or_else(|| child.id());
     // `child` is intentionally dropped without `wait` — the daemon is meant to
@@ -8665,7 +8673,11 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     // version over it would silence the very skew warning `status` exists to
     // print. Best-effort: a write failure must not fail the start (the skew
     // check just degrades to "unknown").
-    if exited.is_none() {
+    // Only when OUR child is the daemon now serving. `exited.is_none()` is not
+    // that test: a child still alive at the probe may be a slow starter that
+    // goes on to lose the lock, and stamping our version over the incumbent's
+    // silences the very skew warning `status` exists to print.
+    if owner == Some(child.id()) {
         if let Ok(vpath) = daemon_version_path() {
             std::fs::write(&vpath, format!("{}\n", env!("CARGO_PKG_VERSION"))).ok();
         }
@@ -8734,6 +8746,11 @@ fn record_daemon_stop_breadcrumb(pid: u32, died: bool) {
 fn daemon_socket_path() -> Result<std::path::PathBuf> {
     let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;
     Ok(home.join("hangar.sock"))
+}
+
+/// The ownership lock that sits beside `<home>/hangar/daemon.pid`.
+fn lock_beside(pid_path: &std::path::Path) -> std::path::PathBuf {
+    pid_path.with_file_name("daemon.lock")
 }
 
 /// A pid this process has PROVED it may signal.
@@ -8819,7 +8836,14 @@ enum StopDecision {
 /// ownership. Split out from [`run_daemon_stop`] so the decision is testable
 /// against real decoy processes without signalling anything.
 fn stop_decision(pid_path: &std::path::Path, socket: &std::path::Path) -> StopDecision {
-    match read_daemon_pid(pid_path) {
+    // The ownership lock is published as the FIRST statement of boot; the pid
+    // file is written at the very end of it. Reading only the pid file left a
+    // window — seconds on a cold home — in which a daemon started by launchd, by
+    // the binary directly, or by any route other than `daemon start` was
+    // unstoppable: `stop` said "not running" while `start` said "already
+    // running". Ask the lock first, exactly like `status` and the autostart do.
+    let recorded = read_daemon_pid(&lock_beside(pid_path)).or_else(|| read_daemon_pid(pid_path));
+    match recorded {
         None => StopDecision::NotRecorded,
         Some(pid) if !pid_is_running(pid) => StopDecision::Stale(pid),
         Some(pid) => match OwnedPid::holding_socket(pid, socket) {
@@ -8907,7 +8931,65 @@ pub(crate) fn run_daemon_restart() -> Result<()> {
     if let Err(e) = run_daemon_stop() {
         println!("hangar daemon: stop reported a problem, starting anyway: {e}");
     }
+    // A stop that could not confirm the exit leaves a daemon mid-shutdown, still
+    // holding its lock and its socket. Starting into that reads as "already
+    // running" and returns — and when the old daemon finishes dying moments
+    // later the home is left with NOTHING. Wait for the owner to actually go.
+    let vacated = wait_until(RESTART_VACATE_BUDGET, || {
+        matches!(running_daemon_pid(), Ok(None))
+    });
+    if !vacated {
+        if let Ok(Some(pid)) = running_daemon_pid() {
+            println!(
+                "hangar daemon: pid {pid} still owns this home after {}s; not starting a \
+                 second one (re-run stop, or `kill -9 {pid}`)",
+                RESTART_VACATE_BUDGET.as_secs()
+            );
+            return Ok(());
+        }
+    }
     run_daemon_start()
+}
+
+/// Spawn the daemon once more and report the pid that ends up owning the home.
+///
+/// Used only on the "our child declined and the incumbent then vanished" path:
+/// the home was contested a moment ago and is free now, which is a race to
+/// re-run, not a failure to report.
+fn respawn_once(bin: &std::path::Path, args: &[&str]) -> Result<Option<u32>> {
+    let mut command = std::process::Command::new(bin);
+    command
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let child = command.spawn().context("respawn daemon")?;
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    // `child` is intentionally dropped without `wait` — the daemon outlives us.
+    let _ = child;
+    running_daemon_pid()
+}
+
+/// How long `restart` waits for the outgoing daemon to release the home.
+const RESTART_VACATE_BUDGET: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Poll `cond` until true or `budget` elapses.
+fn wait_until(budget: std::time::Duration, cond: impl Fn() -> bool) -> bool {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if cond() {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }
 
 /// `hangar daemon setup`: one-command bring-up.
@@ -10518,34 +10600,59 @@ mod tests {
         assert!(pid_is_running(1), "pid 1 must read as running");
     }
 
-    /// The ownership lock outranks the pid file.
+    /// The ownership lock outranks the pid file — and "owner" means PROVED.
     ///
-    /// They disagree exactly when it matters: the pid file is last-write-wins
-    /// bookkeeping written at the end of boot, while the lock is held by the
-    /// daemon that actually owns the home. `status`, `stop` and the autostart
-    /// guard must all follow the lock.
+    /// The proof is the same one `stop` demands: the pid must hold this home's
+    /// socket. An earlier version of this test seeded its OWN pid, which is why
+    /// it could not catch the hole review found — the CLI credited any process
+    /// running `ainb` as the home's daemon, so a recycled pid landing on the
+    /// user's TUI wedged the home with zero daemons.
     #[test]
     fn the_ownership_lock_outranks_the_pid_file() {
         let home = tempfile::tempdir().expect("tmpdir");
         let hangar = home.path().join("hangar");
         std::fs::create_dir_all(&hangar).expect("mkdir");
-        let ours = std::process::id();
+        let socket = home.path().join("hangar.sock");
+        let daemon = SocketDecoy::holding(&socket);
 
-        // A dead pid recorded in the pid file, a LIVE one in the lock.
+        // Lock names the socket holder, pid file names a dead process.
         std::fs::write(hangar.join("daemon.pid"), "424242\n").expect("write pid file");
-        std::fs::write(hangar.join("daemon.lock"), ours.to_string()).expect("write lock");
-        assert_eq!(running_daemon_pid_in(home.path()), Some(ours));
+        std::fs::write(hangar.join("daemon.lock"), daemon.pid().to_string()).expect("write lock");
+        assert_eq!(running_daemon_pid_in(home.path()), Some(daemon.pid()));
 
         // Fallback: no lock at all (a daemon from before the lock shipped) still
         // resolves through the pid file, so an upgrade does not make a running
         // daemon invisible.
         std::fs::remove_file(hangar.join("daemon.lock")).expect("drop lock");
-        std::fs::write(hangar.join("daemon.pid"), format!("{ours}\n")).expect("rewrite pid");
-        assert_eq!(running_daemon_pid_in(home.path()), Some(ours));
+        std::fs::write(hangar.join("daemon.pid"), format!("{}\n", daemon.pid()))
+            .expect("rewrite pid");
+        assert_eq!(running_daemon_pid_in(home.path()), Some(daemon.pid()));
 
         // Neither file names a live process -> nobody owns the home.
         std::fs::write(hangar.join("daemon.pid"), "424242\n").expect("rewrite pid");
         assert_eq!(running_daemon_pid_in(home.path()), None);
+    }
+
+    /// A live process that is merely OURS is not this home's daemon.
+    ///
+    /// The regression under test: `ainb` and a self-exec'd daemon share an
+    /// executable (`ainb hangar daemon run`), so an identity check written in
+    /// terms of "runs our binary" credits the TUI. A recycled pid in the lock
+    /// then reads as a running daemon and the autostart declines forever.
+    #[test]
+    fn our_own_process_is_not_this_homes_daemon() {
+        let home = tempfile::tempdir().expect("tmpdir");
+        let hangar = home.path().join("hangar");
+        std::fs::create_dir_all(&hangar).expect("mkdir");
+
+        // This test binary is live, is "an ainb process", and holds no socket.
+        std::fs::write(hangar.join("daemon.lock"), std::process::id().to_string())
+            .expect("write lock");
+        assert_eq!(
+            running_daemon_pid_in(home.path()),
+            None,
+            "a live non-daemon in the lock must not be read as the home's owner"
+        );
     }
 
     /// The skew helper flags a differing recorded version, and stays quiet for

--- a/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
@@ -148,3 +148,112 @@ fn daemon_start_status_stop_round_trip() {
         let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
     }
 }
+
+/// Read the ownership lock — the record that decides who owns the home.
+fn read_lock_pid(home: &Path) -> Option<u32> {
+    std::fs::read_to_string(home.join("hangar").join("daemon.lock"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// A second `start` is a no-op that reports the incumbent, and above all leaves
+/// no second daemon behind — the failure mode that reached 69 on one machine.
+#[test]
+fn a_second_start_reports_the_incumbent_and_spawns_nothing() {
+    let Some(daemon) = daemon_bin() else {
+        eprintln!("SKIP: ainb-hangar-daemon binary not built beside ainb");
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+
+    let (ok, out) = run(home, &daemon, &["hangar", "daemon", "start"]);
+    assert!(ok, "daemon start should exit 0; out={out}");
+    let pid = read_pid(home).expect("daemon start wrote a pid file");
+    assert!(
+        wait_until(Duration::from_secs(10), || home
+            .join("hangar.sock")
+            .exists()),
+        "the daemon must bind its control socket"
+    );
+
+    let (ok, out) = run(home, &daemon, &["hangar", "daemon", "start"]);
+    assert!(ok, "a second start should exit 0; out={out}");
+    assert!(
+        out.contains("already running"),
+        "a second start must report the incumbent:\n{out}"
+    );
+    assert_eq!(
+        read_pid(home),
+        Some(pid),
+        "a second start must not re-point the pid file"
+    );
+    assert_eq!(
+        read_lock_pid(home),
+        Some(pid),
+        "the incumbent must still own the home"
+    );
+
+    let (ok, out) = run(home, &daemon, &["hangar", "daemon", "stop"]);
+    assert!(ok, "cleanup stop should exit 0; out={out}");
+    if pid_alive(pid) {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+        let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+    }
+}
+
+/// `restart` must leave exactly one daemon: a new one, and the old one gone.
+///
+/// The regression this guards is self-inflicted and subtle. Shutdown is now
+/// graceful, so it takes time; a restart that hands off while the outgoing
+/// daemon still holds the home gets "already running" from `start`, returns —
+/// and when that daemon finishes dying the home is left with NOTHING.
+#[test]
+fn restart_leaves_exactly_one_daemon_running() {
+    let Some(daemon) = daemon_bin() else {
+        eprintln!("SKIP: ainb-hangar-daemon binary not built beside ainb");
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+
+    let (ok, out) = run(home, &daemon, &["hangar", "daemon", "start"]);
+    assert!(ok, "daemon start should exit 0; out={out}");
+    let first = read_pid(home).expect("daemon start wrote a pid file");
+    assert!(
+        wait_until(Duration::from_secs(10), || home
+            .join("hangar.sock")
+            .exists()),
+        "the daemon must bind its control socket"
+    );
+
+    let (ok, out) = run(home, &daemon, &["hangar", "daemon", "restart"]);
+    assert!(ok, "daemon restart should exit 0; out={out}");
+
+    let second = read_pid(home).expect("restart recorded a pid");
+    assert_ne!(second, first, "restart should replace the daemon");
+    assert!(
+        !pid_alive(first),
+        "the old daemon must be gone after restart"
+    );
+    assert!(
+        wait_until(Duration::from_secs(10), || pid_alive(second)),
+        "restart must leave a live daemon, not an empty home"
+    );
+    assert_eq!(
+        read_lock_pid(home),
+        Some(second),
+        "the lock must name the surviving daemon"
+    );
+
+    let (ok, out) = run(home, &daemon, &["hangar", "daemon", "stop"]);
+    assert!(ok, "cleanup stop should exit 0; out={out}");
+    if pid_alive(second) {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+        let _ = kill(Pid::from_raw(second as i32), Signal::SIGKILL);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -323,7 +323,12 @@ fn read_pid(path: &Path) -> Result<i32, PidfileRead> {
 
 /// Is `pid` backed by a live process? Uses `kill(pid, 0)`: success or `EPERM`
 /// (exists, not ours) → alive; `ESRCH` → dead.
-fn pid_alive(pid: i32) -> bool {
+///
+/// The default holder predicate, and the base every stricter one builds on (see
+/// [`crate::single_instance`], which layers a process-identity check over it so a
+/// recycled PID cannot masquerade as the lock's holder).
+#[must_use]
+pub fn pid_alive(pid: i32) -> bool {
     use nix::errno::Errno;
     use nix::sys::signal::kill;
     use nix::unistd::Pid;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -175,7 +175,8 @@ impl BdLock {
                         return Err(last_holder.map_or(LockHeld::Contended, LockHeld::By));
                     }
                     match self.reclaim(&holder_is_live) {
-                        Reclaim::Now => continue,
+                        // Retry immediately: the path is free right now.
+                        Reclaim::Now => {}
                         Reclaim::Backoff => std::thread::sleep(POLL_INTERVAL),
                         Reclaim::HeldBy(pid) => {
                             last_holder = Some(pid);
@@ -299,7 +300,9 @@ impl Drop for BdLockGuard {
     /// the steal path is careful to avoid, reintroduced on the way out. Removing
     /// only while the file still names us keeps the invariant symmetric.
     fn drop(&mut self) {
-        if read_pid(&self.path) == Ok(std::process::id() as i32) {
+        if read_pid(&self.path)
+            == i32::try_from(std::process::id()).map_err(|_| PidfileRead::Unreadable)
+        {
             let _ = std::fs::remove_file(&self.path);
         }
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -299,6 +299,16 @@ impl Drop for BdLockGuard {
     /// here would then delete THAT live holder's pidfile — the same double-hold
     /// the steal path is careful to avoid, reintroduced on the way out. Removing
     /// only while the file still names us keeps the invariant symmetric.
+    ///
+    /// This is a read-then-unlink, so a residual window remains: a successor
+    /// could steal and republish between the read and the unlink, and we would
+    /// delete its file. POSIX offers no compare-and-unlink to close it — the
+    /// steal path's `rename` trick does not transfer, because renaming a file we
+    /// intend to delete would displace whatever is at the path if it is no
+    /// longer ours. Reaching it requires the predicate to first misjudge a LIVE
+    /// holder as dead, which `single_instance::holder_is_live_daemon` now
+    /// answers only on positive evidence; a lock the kernel releases (`flock` /
+    /// `F_SETLK`) is the primitive that removes the window entirely.
     fn drop(&mut self) {
         if read_pid(&self.path)
             == i32::try_from(std::process::id()).map_err(|_| PidfileRead::Unreadable)

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -291,8 +291,17 @@ pub struct BdLockGuard {
 }
 
 impl Drop for BdLockGuard {
+    /// Release by compare-and-delete, never a blind unlink.
+    ///
+    /// A guard can outlive its own pidfile: a contender whose liveness predicate
+    /// judged us dead reclaims the path and publishes its own. A blind unlink
+    /// here would then delete THAT live holder's pidfile — the same double-hold
+    /// the steal path is careful to avoid, reintroduced on the way out. Removing
+    /// only while the file still names us keeps the invariant symmetric.
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
+        if read_pid(&self.path) == Ok(std::process::id() as i32) {
+            let _ = std::fs::remove_file(&self.path);
+        }
     }
 }
 
@@ -727,6 +736,25 @@ mod tests {
             "expected at least one winner per round, got {} over {ROUNDS} rounds",
             acquisitions.load(Ordering::SeqCst)
         );
+    }
+
+    /// Releasing must not delete a pidfile that is no longer ours.
+    ///
+    /// The mirror of the steal-path invariant: if a contender reclaimed the path
+    /// while we held a guard, our drop must leave ITS pidfile alone, or the lock
+    /// admits two holders on the way out instead of on the way in.
+    #[test]
+    fn dropping_a_guard_leaves_a_successors_pidfile_alone() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("daemon.lock");
+        let guard = BdLock::new(path.clone()).acquire().expect("acquire");
+
+        // A successor reclaimed the path and published its own pid.
+        std::fs::write(&path, "424242").expect("successor publishes");
+        drop(guard);
+
+        assert!(path.exists(), "the successor's pidfile was deleted");
+        assert_eq!(read_pid(&path), Ok(424_242));
     }
 
     /// A live holder is never stolen from: the contender blocks until release.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -47,8 +47,42 @@ use super::BdError;
 
 /// How long to spin for the lock before giving up with [`BdError::LockTimeout`].
 const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long [`BdLock::try_acquire_with`] spins before declaring the lock held.
+///
+/// Deliberately NOT zero. An ABSENT pidfile means "free, retry now" (module doc,
+/// second double-hold route), and a publish can also lose a benign link race, so
+/// a single attempt would report a free lock as held. This is short enough to
+/// keep a single-instance guard fail-fast and long enough to ride out the churn.
+pub const TRY_ACQUIRE_TIMEOUT: Duration = Duration::from_millis(500);
 /// Polling interval while the lock is held by another process.
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Why an acquisition attempt did not take the lock.
+#[derive(Debug)]
+pub enum LockHeld {
+    /// A holder the liveness predicate judged live owns the lock, named by pid.
+    By(i32),
+    /// The window elapsed with the path churning (repeated steals/publishes by
+    /// other contenders) and no live holder to name.
+    Contended,
+    /// The pidfile's directory could not be created.
+    Io(std::io::Error),
+}
+
+/// What to do about a pidfile we could not publish over.
+///
+/// Distinguishing [`Self::Now`] from [`Self::Backoff`] preserves the module's
+/// third invariant: losing a `rename` steal is not evidence the lock is free, so
+/// that path backs off instead of hot-spinning on a path someone else just won.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Reclaim {
+    /// The path is free right now — publish again immediately.
+    Now,
+    /// Someone else is in the way; wait a poll interval.
+    Backoff,
+    /// A live holder owns the lock.
+    HeldBy(i32),
+}
 
 /// A reusable handle that mints one [`BdLockGuard`] per [`acquire`](Self::acquire).
 ///
@@ -76,10 +110,54 @@ impl BdLock {
     /// [`BdError::LockTimeout`] if the lock stays held past the deadline,
     /// [`BdError::Spawn`] if the pidfile's parent directory cannot be created.
     pub fn acquire(&self) -> Result<BdLockGuard, BdError> {
+        self.acquire_within(ACQUIRE_TIMEOUT, pid_alive).map_err(|held| match held {
+            LockHeld::Io(e) => BdError::Spawn(e),
+            LockHeld::By(_) | LockHeld::Contended => BdError::LockTimeout(self.path.clone()),
+        })
+    }
+
+    /// Take the lock or report who holds it, without a long spin.
+    ///
+    /// The fail-fast half of [`acquire`](Self::acquire), for a single-instance
+    /// guard: a process that loses wants to exit now, not in 30 seconds.
+    ///
+    /// `holder_is_live` decides whether an existing holder must be respected.
+    /// It MUST fail SAFE — return `true` whenever it cannot tell — because a
+    /// false negative steals a LIVE holder's pidfile and admits two holders,
+    /// the exact double-hold this module exists to prevent. `pid_alive` alone is
+    /// the right predicate only when a recycled PID is impossible; a lock file
+    /// that outlives a reboot needs an identity check layered on top.
+    ///
+    /// # Errors
+    ///
+    /// [`LockHeld::By`] when a live holder owns the lock, [`LockHeld::Contended`]
+    /// when the window elapsed with the path churning, [`LockHeld::Io`] when the
+    /// pidfile's directory cannot be created.
+    pub fn try_acquire_with<F>(&self, holder_is_live: F) -> Result<BdLockGuard, LockHeld>
+    where
+        F: Fn(i32) -> bool,
+    {
+        self.acquire_within(TRY_ACQUIRE_TIMEOUT, holder_is_live)
+    }
+
+    /// Spin for the lock until `timeout` elapses, judging holders with
+    /// `holder_is_live`. The one acquisition path; both public entry points are
+    /// this function with a different deadline and predicate.
+    fn acquire_within<F>(
+        &self,
+        timeout: Duration,
+        holder_is_live: F,
+    ) -> Result<BdLockGuard, LockHeld>
+    where
+        F: Fn(i32) -> bool,
+    {
         if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent).map_err(BdError::Spawn)?;
+            std::fs::create_dir_all(parent).map_err(LockHeld::Io)?;
         }
-        let deadline = Instant::now() + ACQUIRE_TIMEOUT;
+        let deadline = Instant::now() + timeout;
+        // The last holder we judged live, so a timeout can name it instead of
+        // reporting a bare "contended" a caller cannot act on.
+        let mut last_holder = None;
         loop {
             match self.try_publish_pidfile() {
                 Ok(true) => {
@@ -89,19 +167,23 @@ impl BdLock {
                 }
                 Ok(false) => {
                     // The deadline bounds EVERY path, including the immediate
-                    // retry. `steal_if_stale` now reports "free, retry now" for
-                    // an absent pidfile, which under contention is common rather
-                    // than rare — leaving that branch to `continue` unchecked
-                    // would let a contender spin without ever timing out.
+                    // retry. `reclaim` reports "free, retry now" for an absent
+                    // pidfile, which under contention is common rather than
+                    // rare — leaving that branch to `continue` unchecked would
+                    // let a contender spin without ever timing out.
                     if Instant::now() >= deadline {
-                        return Err(BdError::LockTimeout(self.path.clone()));
+                        return Err(last_holder.map_or(LockHeld::Contended, LockHeld::By));
                     }
-                    if self.steal_if_stale() {
-                        continue;
+                    match self.reclaim(&holder_is_live) {
+                        Reclaim::Now => continue,
+                        Reclaim::Backoff => std::thread::sleep(POLL_INTERVAL),
+                        Reclaim::HeldBy(pid) => {
+                            last_holder = Some(pid);
+                            std::thread::sleep(POLL_INTERVAL);
+                        }
                     }
-                    std::thread::sleep(POLL_INTERVAL);
                 }
-                Err(e) => return Err(BdError::Spawn(e)),
+                Err(e) => return Err(LockHeld::Io(e)),
             }
         }
     }
@@ -134,11 +216,12 @@ impl BdLock {
         }
     }
 
-    /// Remove the pidfile if it names a process that is no longer alive.
-    ///
-    /// Returns `true` when a stale file was removed (caller should retry the
-    /// exclusive create immediately).
-    fn steal_if_stale(&self) -> bool {
+    /// Decide what to do about a pidfile we could not publish over, taking the
+    /// stale one out of the way when `holder_is_live` says its holder is gone.
+    fn reclaim<F>(&self, holder_is_live: F) -> Reclaim
+    where
+        F: Fn(i32) -> bool,
+    {
         let pid = match read_pid(&self.path) {
             Ok(pid) => pid,
             // The pidfile vanished between our failed publish and this read: the
@@ -148,16 +231,27 @@ impl BdLock {
             // acquire alongside it. That is the very double-hold atomic
             // publication was introduced to kill, reachable through this branch
             // instead of through the create-then-write window. Just retry.
-            Err(PidfileRead::Absent) => return true,
+            Err(PidfileRead::Absent) => return Reclaim::Now,
             // The file exists but says nothing usable. Publication is atomic, so
             // a live holder cannot produce this — it is a pre-fix leftover or a
             // truncated file. Genuine crash-recovery territory.
-            Err(PidfileRead::Unreadable) => return self.steal_atomically(),
+            Err(PidfileRead::Unreadable) => return self.reclaimed_or_backoff(),
         };
-        if pid_alive(pid) {
-            return false;
+        if holder_is_live(pid) {
+            return Reclaim::HeldBy(pid);
         }
-        self.steal_atomically()
+        self.reclaimed_or_backoff()
+    }
+
+    /// Steal a pidfile we have judged stale, mapping the winner-take-all outcome
+    /// onto the retry policy: we won the `rename` so the path is free now, or we
+    /// lost it to another contender and must back off rather than hot-spin.
+    fn reclaimed_or_backoff(&self) -> Reclaim {
+        if self.steal_atomically() {
+            Reclaim::Now
+        } else {
+            Reclaim::Backoff
+        }
     }
 
     /// Take a pidfile we have judged stale OUT of the way, winner-take-all.
@@ -360,7 +454,7 @@ mod tests {
 
     /// A pidfile that is simply GONE is not "stolen" — nothing is removed.
     ///
-    /// Regression for the second double-hold window. `steal_if_stale` used to
+    /// Regression for the second double-hold window. `reclaim` used to
     /// treat any unreadable pidfile, including an absent one, as crash debris
     /// and unlink the path. Between that failed read and the unlink another
     /// contender can publish, so the unlink deletes a LIVE holder's pidfile and
@@ -374,7 +468,7 @@ mod tests {
 
         assert_eq!(read_pid(&path), Err(PidfileRead::Absent));
         assert!(
-            lock.steal_if_stale(),
+            lock.reclaim(pid_alive) == Reclaim::Now,
             "an absent pidfile means the lock is free, so retry immediately"
         );
 
@@ -382,7 +476,7 @@ mod tests {
         // the steal decision must survive it.
         let guard = lock.acquire().expect("acquire");
         assert!(
-            !lock.steal_if_stale(),
+            lock.reclaim(pid_alive) == Reclaim::HeldBy(i32::try_from(std::process::id()).unwrap()),
             "a live holder's pidfile must never be stolen"
         );
         assert!(path.exists(), "the live holder's pidfile was deleted");
@@ -397,7 +491,7 @@ mod tests {
         std::fs::write(&path, "not-a-pid").expect("seed corrupt pidfile");
 
         assert_eq!(read_pid(&path), Err(PidfileRead::Unreadable));
-        assert!(BdLock::new(path.clone()).steal_if_stale());
+        assert!(BdLock::new(path.clone()).reclaim(pid_alive) == Reclaim::Now);
         assert!(!path.exists(), "corrupt pidfile should be removed");
     }
 
@@ -408,7 +502,7 @@ mod tests {
     /// and the second's unlink deletes that LIVE pidfile.
     ///
     /// Exercises `steal_atomically` DIRECTLY rather than through
-    /// `steal_if_stale`, because the latter also returns `true` for an absent
+    /// `reclaim`, because that also answers "retry now" for an absent
     /// pidfile ("free, retry") — which would conflate "I reclaimed it" with "it
     /// was already gone" and make the count mean two different things.
     #[test]
@@ -476,6 +570,158 @@ mod tests {
             Ok(i32::try_from(std::process::id()).unwrap())
         );
         drop(guard);
+    }
+
+    /// A live process we own, killed by its EXACT pid on drop. Used as a lock
+    /// holder that is neither this process nor a dead pid, so a predicate can
+    /// tell it apart from the contending threads (which all share OUR pid).
+    struct Impostor(std::process::Child);
+
+    impl Impostor {
+        fn spawn() -> Self {
+            Self(
+                std::process::Command::new("/bin/sleep")
+                    .arg("30")
+                    .spawn()
+                    .expect("spawn /bin/sleep"),
+            )
+        }
+
+        fn pid(&self) -> i32 {
+            i32::try_from(self.0.id()).expect("pid fits i32")
+        }
+    }
+
+    impl Drop for Impostor {
+        fn drop(&mut self) {
+            // Exact pid, never a name-based kill.
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    /// Fail-fast: a live holder is reported by pid, promptly, instead of the
+    /// 30-second spin [`BdLock::acquire`] would take.
+    #[test]
+    fn try_acquire_reports_the_live_holder_promptly() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("daemon.lock");
+        let impostor = Impostor::spawn();
+        std::fs::write(&path, impostor.pid().to_string()).expect("seed held lock");
+
+        let started = Instant::now();
+        let outcome = BdLock::new(path.clone()).try_acquire_with(pid_alive);
+
+        match outcome {
+            Err(LockHeld::By(pid)) => assert_eq!(pid, impostor.pid()),
+            other => panic!("expected the live holder to be named, got {other:?}"),
+        }
+        assert!(
+            started.elapsed() < ACQUIRE_TIMEOUT / 2,
+            "try_acquire spun like the blocking acquire ({:?})",
+            started.elapsed()
+        );
+        assert!(
+            path.exists(),
+            "a live holder's lock must survive the attempt"
+        );
+    }
+
+    /// The predicate, not the pid, decides who is respected: a holder judged
+    /// dead is stolen even though its process is alive. This is what lets a
+    /// single-instance guard reclaim a lock left by a RECYCLED pid.
+    #[test]
+    fn a_holder_the_predicate_judges_dead_is_stolen() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("daemon.lock");
+        let impostor = Impostor::spawn();
+        let squatter = impostor.pid();
+        std::fs::write(&path, squatter.to_string()).expect("seed held lock");
+
+        let lock = BdLock::new(path.clone());
+        let guard = lock
+            .try_acquire_with(move |pid| pid != squatter && pid_alive(pid))
+            .expect("a holder the predicate rejects is stolen");
+        assert_eq!(
+            read_pid(&path),
+            Ok(i32::try_from(std::process::id()).unwrap())
+        );
+        drop(guard);
+    }
+
+    /// An absent pidfile is FREE, and the fast path must not mistake it for held.
+    ///
+    /// The window is short but never zero for exactly this reason: `reclaim`
+    /// answers "retry now" for an absent file, so a single-shot attempt that
+    /// lost one benign link race would report a free lock as held and a daemon
+    /// would decline to boot with nothing running.
+    #[test]
+    fn an_absent_pidfile_is_free_on_the_fast_path() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let lock = BdLock::new(dir.path().join("daemon.lock"));
+        let guard = lock.try_acquire_with(pid_alive).expect("free lock is acquired");
+        drop(guard);
+    }
+
+    /// The fail-fast path must lose none of the exclusion the blocking path has:
+    /// contenders racing from a barrier never overlap inside the lock.
+    ///
+    /// Losers here fail fast rather than blocking, so the assertion is two-part —
+    /// zero overlaps AND progress (somebody wins every round) — otherwise a lock
+    /// that always declined would pass the overlap half trivially.
+    #[test]
+    fn contended_try_acquire_never_admits_two_holders() {
+        const THREADS: usize = 4;
+        const ROUNDS: usize = 30;
+        const HOLD: Duration = Duration::from_millis(2);
+
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let lock = BdLock::new(dir.path().join("daemon.lock"));
+        let holders = Arc::new(AtomicUsize::new(0));
+        let overlaps = Arc::new(AtomicUsize::new(0));
+        let acquisitions = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(THREADS));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let lock = lock.clone();
+                let holders = Arc::clone(&holders);
+                let overlaps = Arc::clone(&overlaps);
+                let acquisitions = Arc::clone(&acquisitions);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    for _ in 0..ROUNDS {
+                        barrier.wait();
+                        let Ok(guard) = lock.try_acquire_with(pid_alive) else {
+                            continue;
+                        };
+                        acquisitions.fetch_add(1, Ordering::SeqCst);
+                        let before = holders.fetch_add(1, Ordering::SeqCst);
+                        std::thread::sleep(HOLD);
+                        let during = holders.load(Ordering::SeqCst);
+                        holders.fetch_sub(1, Ordering::SeqCst);
+                        drop(guard);
+                        if before != 0 || during != 1 {
+                            overlaps.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread join");
+        }
+
+        assert_eq!(
+            overlaps.load(Ordering::SeqCst),
+            0,
+            "the fail-fast path admitted concurrent holders"
+        );
+        assert!(
+            acquisitions.load(Ordering::SeqCst) >= ROUNDS,
+            "expected at least one winner per round, got {} over {ROUNDS} rounds",
+            acquisitions.load(Ordering::SeqCst)
+        );
     }
 
     /// A live holder is never stolen from: the contender blocks until release.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -140,6 +140,26 @@ impl BdLock {
         self.acquire_within(TRY_ACQUIRE_TIMEOUT, holder_is_live)
     }
 
+    /// Take the lock or report who holds it, spinning for `timeout` first.
+    ///
+    /// The escalation [`try_acquire_with`](Self::try_acquire_with) needs when it
+    /// cannot name a holder: churn is not evidence that anyone won, so a caller
+    /// that declined on it could leave nobody holding the lock at all.
+    ///
+    /// # Errors
+    ///
+    /// As [`try_acquire_with`](Self::try_acquire_with).
+    pub fn acquire_within_with<F>(
+        &self,
+        timeout: Duration,
+        holder_is_live: F,
+    ) -> Result<BdLockGuard, LockHeld>
+    where
+        F: Fn(i32) -> bool,
+    {
+        self.acquire_within(timeout, holder_is_live)
+    }
+
     /// Spin for the lock until `timeout` elapses, judging holders with
     /// `holder_is_live`. The one acquisition path; both public entry points are
     /// this function with a different deadline and predicate.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/beads_adapter/lock.rs
@@ -140,26 +140,6 @@ impl BdLock {
         self.acquire_within(TRY_ACQUIRE_TIMEOUT, holder_is_live)
     }
 
-    /// Take the lock or report who holds it, spinning for `timeout` first.
-    ///
-    /// The escalation [`try_acquire_with`](Self::try_acquire_with) needs when it
-    /// cannot name a holder: churn is not evidence that anyone won, so a caller
-    /// that declined on it could leave nobody holding the lock at all.
-    ///
-    /// # Errors
-    ///
-    /// As [`try_acquire_with`](Self::try_acquire_with).
-    pub fn acquire_within_with<F>(
-        &self,
-        timeout: Duration,
-        holder_is_live: F,
-    ) -> Result<BdLockGuard, LockHeld>
-    where
-        F: Fn(i32) -> bool,
-    {
-        self.acquire_within(timeout, holder_is_live)
-    }
-
     /// Spin for the lock until `timeout` elapses, judging holders with
     /// `holder_is_live`. The one acquisition path; both public entry points are
     /// this function with a different deadline and predicate.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -380,8 +380,24 @@ impl PidFile {
 }
 
 impl Drop for PidFile {
+    /// Compare-and-delete: remove the file only while it still names US.
+    ///
+    /// A blind unlink here deletes whoever's registration is CURRENT, which is
+    /// not necessarily ours — `register` is a last-write-wins `fs::write`, so any
+    /// other daemon that started later owns the file's contents. An exiting
+    /// daemon then wiped the LIVE daemon's registration, the next
+    /// `ensure_hangar_daemon` read "nothing running", and spawned another. That
+    /// ratchet is what turned a one-shot race into a pile of 69.
+    ///
+    /// [`crate::single_instance`] now stops the duplicates at the source; this
+    /// keeps the pid file honest for the readers that still consult it, and
+    /// covers the upgrade window where a pre-lock daemon is still running.
     fn drop(&mut self) {
-        if let Some(path) = self.0.take() {
+        let Some(path) = self.0.take() else {
+            return;
+        };
+        let ours = std::process::id().to_string();
+        if std::fs::read_to_string(&path).is_ok_and(|recorded| recorded.trim() == ours) {
             let _ = std::fs::remove_file(path);
         }
     }
@@ -736,8 +752,11 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     if once {
         return Ok(());
     }
-    // Self-register this pid so EVERY running daemon is discoverable, not just
-    // one started via `ainb hangar daemon start`.
+    // Self-register this pid so EVERY running daemon is DISCOVERABLE, not just
+    // one started via `ainb hangar daemon start`. Discovery only — the exclusion
+    // that actually stops a duplicate is `single_instance`'s lock, taken at the
+    // top of this function. This file is what `status` prints and what a
+    // pre-lock CLI still reads.
     //
     // `ensure_hangar_daemon` (the TUI's autostart) decides "is a daemon already
     // up?" purely from `<hangar_home>/hangar/daemon.pid`. Only the CLI `start`
@@ -746,7 +765,12 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     // was invisible: the TUI spawned a SECOND daemon, `rpc::bind` unlinked the
     // live socket out from under the first, and two claim loops + two sweepers
     // then raced one SQLite home while the TUI talked to the newcomer's empty
-    // in-memory state. Writing the pid here closes that hole at the source.
+    // in-memory state.
+    //
+    // Writing the pid here made those daemons visible; it did NOT close the hole,
+    // because it happens at the END of boot and nothing checked it under
+    // exclusion. The lock at the top of `boot` is the actual fix — this line is
+    // now bookkeeping for humans and for `status`.
     let _pid_file = PidFile::register(&dir);
     let mut cfg = DaemonConfig::from_env();
     // The claim loop MUST key off the runtime id that is actually registered (and
@@ -758,4 +782,66 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
     cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
     run(store.pool().clone(), cfg, stats, broker.sink()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PidFile, pid_path_in};
+
+    /// The happy path: a clean exit takes our own registration with it, so the
+    /// next `ensure_hangar_daemon` does not read a dead pid.
+    #[test]
+    fn drop_removes_our_own_registration() {
+        let home = tempfile::tempdir().expect("tmpdir");
+        let path = pid_path_in(home.path());
+
+        let pid_file = PidFile::register(home.path());
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("registered"),
+            std::process::id().to_string()
+        );
+
+        drop(pid_file);
+        assert!(!path.exists(), "our own registration should be removed");
+    }
+
+    /// The ratchet regression. `register` is last-write-wins, so a daemon that
+    /// started later owns the file's contents. When the EARLIER daemon exits, a
+    /// blind unlink deletes the LIVE daemon's registration — the next autostart
+    /// then reads "nothing running" and spawns yet another. That is how one
+    /// machine reached 69 daemons instead of settling at two.
+    #[test]
+    fn drop_keeps_a_registration_another_daemon_overwrote() {
+        let home = tempfile::tempdir().expect("tmpdir");
+        let path = pid_path_in(home.path());
+
+        let ours = PidFile::register(home.path());
+        // A later daemon self-registers over the top of ours.
+        std::fs::write(&path, "424242").expect("overwrite with a newer daemon's pid");
+
+        drop(ours);
+
+        assert!(
+            path.exists(),
+            "an exiting daemon must not delete the live daemon's registration"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("still registered").trim(),
+            "424242"
+        );
+    }
+
+    /// An unwritable home yields an unregistered handle, and dropping it must not
+    /// touch anything.
+    #[test]
+    fn dropping_an_unregistered_handle_is_a_no_op() {
+        let home = tempfile::tempdir().expect("tmpdir");
+        let path = pid_path_in(home.path());
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, "424242").expect("seed someone else's registration");
+
+        drop(PidFile(None));
+
+        assert!(path.exists(), "a no-op handle must not remove anything");
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -486,6 +486,13 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     let shutdown = crate::shutdown::install(Some(lost_rx));
     let mut during_boot = shutdown.clone();
 
+    // Raised the instant boot hands over to the run loop, so the boot-phase race
+    // below stops competing. Without it that race stays armed for the daemon's
+    // WHOLE life, and a Ctrl-C could cancel the run loop mid-teardown — dropping
+    // it before it reaped its interactive tmux sessions, which is precisely the
+    // orphaning the shutdown path exists to prevent.
+    let (running_tx, running_rx) = tokio::sync::oneshot::channel::<()>();
+
     // The rest of boot, raced against that seam. Dropping this future on a
     // shutdown unwinds the partially built daemon; `_ownership` lives OUTSIDE it,
     // so the lock is released either way.
@@ -825,12 +832,25 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
             ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
         cfg.runtime_id =
             Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
+        // Boot is done; from here the run loop owns shutdown.
+        let _ = running_tx.send(());
         run(store.pool().clone(), cfg, stats, broker.sink(), shutdown).await
     };
 
     tokio::select! {
         result = booted => result,
-        cause = during_boot.recv() => {
+        cause = async move {
+            let raced = tokio::select! {
+                cause = during_boot.recv() => Some(cause),
+                _ = running_rx => None,
+            };
+            match raced {
+                Some(cause) => cause,
+                // The run loop took over. Park forever so this arm can never
+                // resolve and cancel it.
+                None => std::future::pending().await,
+            }
+        } => {
             tracing::info!(
                 signal = cause.as_str(),
                 "ainb-hangar-daemon shutting down during boot"

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -242,6 +242,13 @@ pub mod scheduler;
 /// `hangar.db` and assert live rows render.
 #[cfg(any(test, feature = "test-support"))]
 pub mod seed;
+/// The daemon's shutdown seam: which signal stopped it, and how far to tear
+/// down.
+///
+/// [`shutdown::Watch`] answers SIGINT and SIGTERM (the hangar daemon was this
+/// workspace's only daemon that ignored the latter, so the supported `daemon
+/// stop` killed it on the OS default disposition and none of its teardown ran).
+pub mod shutdown;
 /// One daemon per hangar home.
 ///
 /// [`single_instance::acquire`] is the first thing [`boot`] does: it takes a

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -242,6 +242,14 @@ pub mod scheduler;
 /// `hangar.db` and assert live rows render.
 #[cfg(any(test, feature = "test-support"))]
 pub mod seed;
+/// One daemon per hangar home.
+///
+/// [`single_instance::acquire`] is the first thing [`boot`] does: it takes a
+/// cross-process lock on `<hangar_home>/hangar/daemon.lock` (fail-fast) so a
+/// second daemon declines instead of racing the incumbent's database and
+/// unlinking its socket. Holders are judged by pid liveness AND process
+/// identity, so a recycled pid cannot wedge every future boot.
+pub mod single_instance;
 /// Toolkit-directory skill importer behind `ainb hangar skills sync` (P6.2).
 ///
 /// Walks a `ainb-toolkit/skills/`-shaped tree (`<name>/SKILL.md` + nested
@@ -397,6 +405,34 @@ impl Drop for PidFile {
 /// migration fails) or if the run loop's shutdown handler fails.
 pub async fn boot(once: bool) -> anyhow::Result<()> {
     let dir = hangar_dir()?;
+
+    // FIRST, before the store, the broker, the sweepers and `rpc::bind`. Every
+    // one of those mutates state this daemon must own alone, and `rpc::bind`
+    // unlinks the socket unconditionally — so a duplicate that gets even this
+    // far leaves the incumbent listening on an inode no client can reach.
+    //
+    // A loser exits 0, not non-zero: it did the right thing, and a supervisor
+    // (launchd `KeepAlive`, systemd `Restart=on-failure`) must not restart-loop
+    // a daemon that correctly declined. `--once` takes the lock too — a one-shot
+    // boot against a live home would otherwise steal that daemon's socket.
+    let _ownership = match single_instance::acquire(&dir)? {
+        single_instance::Ownership::Acquired(guard) => guard,
+        single_instance::Ownership::HeldBy(pid) => {
+            tracing::info!(
+                holder = pid,
+                lock = %single_instance::lock_path_in(&dir).display(),
+                "another hangar daemon owns this home; exiting"
+            );
+            return Ok(());
+        }
+        single_instance::Ownership::Contended => {
+            tracing::info!(
+                lock = %single_instance::lock_path_in(&dir).display(),
+                "another hangar daemon is taking this home; exiting"
+            );
+            return Ok(());
+        }
+    };
 
     // Observability tripwire seam (P8.1): when `$AINB_HANGAR_BOOT_TASK_ID` is set
     // the daemon emits exactly one structured boot event carrying that id. The

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -448,10 +448,14 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
             );
             return Ok(());
         }
+        // Two fail-fast windows elapsed with the lock churning and no live
+        // holder to name. Almost always another daemon booting; logged as a
+        // warning rather than an info because, unlike `HeldBy`, we cannot point
+        // at the daemon that won.
         single_instance::Ownership::Contended => {
-            tracing::info!(
+            tracing::warn!(
                 lock = %single_instance::lock_path_in(&dir).display(),
-                "another hangar daemon is taking this home; exiting"
+                "hangar home is contended and no holder could be named; exiting"
             );
             return Ok(());
         }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -788,7 +788,27 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
     // ONE id instead of claiming for an id nothing is bound to.
     let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
     cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
-    run(store.pool().clone(), cfg, stats, broker.sink()).await
+    // The ownership watchdog: the one layer that survives every exit path not
+    // running. If this daemon ever stops owning its home — an operator deleting
+    // the lock, a home restored from a backup — it stands down instead of
+    // racing the daemon that owns it now. Home-scoped by construction: it reads
+    // one file and signals nobody, so unlike an argv-matching reaper it can
+    // never touch a daemon serving a different home.
+    let (lost_tx, lost_rx) = tokio::sync::oneshot::channel();
+    let watchdog_dir = dir.clone();
+    tokio::spawn(async move {
+        let owner = crate::single_instance::watch_ownership(&watchdog_dir).await;
+        let _ = lost_tx.send(owner);
+    });
+
+    run(
+        store.pool().clone(),
+        cfg,
+        stats,
+        broker.sink(),
+        crate::shutdown::Watch::new().on_lock_lost(lost_rx),
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -617,8 +617,10 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // sessions were dead EXITED rows that every snapshot scanned, and
         // fleet_event had grown to 1.1M rows / 847 MB under no retention at all.
         // Both are pure cleanup with no deadline, so neither belongs on a hot path.
-        let _fleet_archiver = crate::fleet::spawn_session_archiver(store.pool().clone(), broker.sink());
-        let _fleet_retention = crate::fleet_retention::spawn_retention_sweeper(store.pool().clone());
+        let _fleet_archiver =
+            crate::fleet::spawn_session_archiver(store.pool().clone(), broker.sink());
+        let _fleet_retention =
+            crate::fleet_retention::spawn_retention_sweeper(store.pool().clone());
 
         // Managed Codex transport starts independently from daemon readiness. A
         // missing or incompatible Codex binary leaves hook and tmux observation
@@ -819,8 +821,10 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // changed `HANGAR_DAEMON_RUNTIME_ID` (which is warned about, not obeyed).
         // Resolving here keeps the registered row, the agents, and the claim loop on
         // ONE id instead of claiming for an id nothing is bound to.
-        let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
-        cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
+        let now =
+            ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
+        cfg.runtime_id =
+            Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
         run(store.pool().clone(), cfg, stats, broker.sink(), shutdown).await
     };
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -245,9 +245,12 @@ pub mod seed;
 /// The daemon's shutdown seam: which signal stopped it, and how far to tear
 /// down.
 ///
-/// [`shutdown::Watch`] answers SIGINT and SIGTERM (the hangar daemon was this
-/// workspace's only daemon that ignored the latter, so the supported `daemon
-/// stop` killed it on the OS default disposition and none of its teardown ran).
+/// [`shutdown::install`] registers the SIGINT and SIGTERM handlers as part of
+/// taking the home — before migrations, the socket bind and the tmux reconcile —
+/// and hands out [`shutdown::Handle`]s so the boot phase and the run loop wait on
+/// the same first cause. The hangar daemon was this workspace's only daemon that
+/// ignored SIGTERM, so the supported `daemon stop` killed it on the OS default
+/// disposition and none of its teardown ran.
 pub mod shutdown;
 /// One daemon per hangar home.
 ///
@@ -461,343 +464,12 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         }
     };
 
-    // Observability tripwire seam (P8.1): when `$AINB_HANGAR_BOOT_TASK_ID` is set
-    // the daemon emits exactly one structured boot event carrying that id. The
-    // `it_subscriber_writes_jsonl` integration test sets it to prove the JSONL
-    // sink installed in `main` lays down a single matching JSON line. Production
-    // boots never set it, so this is a no-op in normal operation.
-    if let Some(task_id) = std::env::var_os("AINB_HANGAR_BOOT_TASK_ID")
-        .and_then(|v| v.into_string().ok())
-        .filter(|v| !v.is_empty())
-    {
-        tracing::info!(task_id = %task_id, "boot");
-    }
-
-    let store: Store = Store::open_in(&dir).await?;
-
-    // Fresh-home boot seed: lay down the default workspace + runtime + one
-    // starter agent so an empty home "just works" (a runtime shows in the Daemon
-    // pane, the agent picker is non-empty, and the Squad create gate is already
-    // cleared). Idempotent + non-clobbering, and it self-registers the runtime
-    // under the SAME default id the claim loop keys off (subsuming the old
-    // e38.20 self-register). A failure is non-fatal — the daemon must still
-    // sweep + serve — so it is logged and swallowed here.
-    if let Err(e) = crate::default_home::ensure_default_home(store.pool()).await {
-        tracing::warn!(error = %e, "fresh-home boot seed failed (daemon continues)");
-    }
-
-    // P8.5: the in-memory health stats collector — shared between the RPC server
-    // (which snapshots the rolling throughput ring for the `hangar/daemon_health`
-    // pane) and the run loop's FSM finalize path (which records each task's
-    // terminal outcome into the ring).
-    let stats = std::sync::Arc::new(crate::health_stats::HealthStats::default());
-
-    // e38.2 + T1: the daemon-global event broker, built WITH a durable outbox.
-    // Mutation paths (the claim loop's FSM steps, the RPC mutations, the
-    // autopilot scheduler) publish typed `HangarEvent`s through cloned sinks;
-    // the RPC server forwards them to authenticated, workspace-subscribed
-    // connections (live, lossy) AND every event is queued on the lossless outbox
-    // channel returned here for the outbox drain to persist. With no subscriber
-    // the live broadcast is dropped silently, so the broker costs nothing when no
-    // TUI is attached — but the durable log still records every event for replay.
-    let (broker, outbox_rx) = crate::events::EventBroker::with_outbox();
-
-    // T1: spawn the event-outbox drain — the writer of the durable, replayable
-    // event log. It pulls every emitted event off the lossless outbox channel
-    // and appends it to `event_log` (migration 0024) with a monotonic `seq`, so a
-    // reconnecting or late-joining plugin resumes the bus from its last cursor.
-    // Wired BEFORE the RPC server and the claim loop so the first mutation's
-    // event is already persisted. The handle is dropped (process exit tears the
-    // task down, mirroring the sweepers); a failed append is logged inside the
-    // task, never fatal.
-    let _outbox = crate::event_outbox::spawn(store.pool().clone(), outbox_rx);
-
-    // e38.14: spawn the inbox aggregator — the writer half of the durable
-    // notification inbox. It subscribes to the broker (exactly like an RPC
-    // connection) and folds every issue/comment/task event into the
-    // `inbox_entry` table, so live events that were once broadcast-only now land
-    // durably with an unread count. Subscribed BEFORE the RPC server and the
-    // claim loop come up, so the first mutation's event is already aggregated.
-    // The handle is dropped (process exit tears the task down, mirroring the
-    // sweepers); a failed write is logged inside the task, never fatal.
-    let _inbox = crate::inbox_aggregator::spawn(store.pool().clone(), broker.subscribe());
-
-    // Spec P2 (D10): spawn the attention ingest producer — the daemon's own tail
-    // of the shared hook `events.jsonl` (`~/.agents-in-a-box/events.jsonl`, the
-    // SAME file notifyd reads) into the `attention` table. It classifies every
-    // qualifying session event (ASK > ERR > IDLE > WAIT) and raises an answerable
-    // row + a fleet-wide `AttentionRaised` nudge. Its byte cursor lives under the
-    // hangar home so the T2 store boundary holds (no cross-read of notifyd's
-    // rusqlite). The handle is dropped (process exit tears the task down,
-    // mirroring the inbox aggregator); a failed ingest is logged, never fatal.
-    // Hook and daemon use the same resolved runtime root, including isolated
-    // `$AINB_HANGAR_HOME` test and paid-runtime installs.
-    {
-        let events_jsonl = dir.join("events.jsonl");
-        let cursor = dir.join("hangar").join("attention_ingest.offset");
-        let _attention_ingest = crate::attention_ingest::AttentionIngest::new(
-            store.pool().clone(),
-            broker.sink(),
-            events_jsonl,
-            cursor,
-        )
-        .spawn();
-    }
-
-    // The ACP boot scan (I16), BEFORE the pool is installed: a daemon that was
-    // SIGKILLed mid-turn left `open_turn_id` set, its legs PENDING and its
-    // parked permissions' attention rows open, and no runtime path revisits a
-    // session this process never hosted. Same shared routine the process-exit
-    // and deadline paths run, so the outcomes cannot drift.
-    crate::acp_pool::converge_dirty_sessions_at_boot(store.pool(), &broker.sink()).await;
-
-    // The confirm-card TTL, swept once at boot. The park's own bound is a
-    // `tokio` timer inside a copilot turn, and a timer dies with the process:
-    // without this, a card left open by a SIGKILLed or upgraded daemon keeps
-    // rendering as answerable on every client for as long as the row exists,
-    // and approving it returns a success receipt for a destructive tool call
-    // with no waiter left to run it.
-    match ainb_hangar_store::repo::fleet_chat::FleetConfirmRepo::sweep_expired(
-        store.pool(),
-        ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock),
-    )
-    .await
-    {
-        Ok(0) => {}
-        Ok(swept) => tracing::warn!(swept, "expired confirm cards left open by a prior daemon"),
-        Err(error) => tracing::error!(%error, "could not sweep expired confirm cards at boot"),
-    }
-
-    // The ACP agent pool. Installed BEFORE the socket accepts a connection so
-    // `fleet/acp_session_create` can never answer "no pool" on a daemon that
-    // has one; nothing is spawned until the first prompt reaches it.
-    let acp_pool = crate::acp_pool::AcpPool::new(
-        store.clone(),
-        broker.sink(),
-        crate::acp_pool::PoolConfig::from_env(),
-    );
-    let _acp_sweeper = acp_pool.spawn_sweeper();
-    crate::acp_pool::install(acp_pool).await;
-
-    // Tmux reconciliation keeps unhooked and standalone provider sessions in
-    // the canonical Fleet roster as degraded rows with exact pane identity.
-    let _fleet_tmux = crate::fleet::spawn_tmux_reconciler(store.pool().clone(), broker.sink());
-
-    // Two slow janitors, each on its OWN clock rather than folded into the 3s
-    // reconciler tick above. Measured on a real profile: 1,440 of 1,472 visible
-    // sessions were dead EXITED rows that every snapshot scanned, and
-    // fleet_event had grown to 1.1M rows / 847 MB under no retention at all.
-    // Both are pure cleanup with no deadline, so neither belongs on a hot path.
-    let _fleet_archiver = crate::fleet::spawn_session_archiver(store.pool().clone(), broker.sink());
-    let _fleet_retention = crate::fleet_retention::spawn_retention_sweeper(store.pool().clone());
-
-    // Managed Codex transport starts independently from daemon readiness. A
-    // missing or incompatible Codex binary leaves hook and tmux observation
-    // running, while the service records an honest transport downgrade.
-    let _codex_manager = if !once
-        && std::env::var_os("AINB_CODEX_MANAGED")
-            .as_deref()
-            .is_none_or(|value| value != "0")
-    {
-        let binary = std::env::var_os("AINB_CODEX_BIN").unwrap_or_else(|| "codex".into());
-        let socket = dir.join("codex-app-server.sock");
-        // Reap any app-server orphaned by a SIGKILLed/OOM-reaped prior daemon (or a
-        // dead plugin broker) BEFORE we spawn our own. Rust Drop never runs after
-        // SIGKILL, so this boot-time sweep is the only backstop that survives it.
-        let reaped =
-            crate::fleet_provider::codex_manager::reap_orphaned_codex_servers(&socket).await;
-        if reaped > 0 {
-            tracing::warn!(reaped, "reaped orphaned codex app-server processes at boot");
-        }
-        Some(crate::fleet_provider::codex_manager::spawn_service(
-            crate::fleet_provider::codex_manager::CodexManagerConfig::new(binary, socket),
-            store.pool().clone(),
-            broker.sink(),
-        ))
-    } else {
-        None
-    };
-
-    // P5 (T6): reconcile the agent-profile index against the on-disk masters and
-    // spawn an fs-watch so an edit-on-disk of `{hangar_home}/profiles/<slug>.md`
-    // is picked up into the `profile` index without an RPC. Best-effort — a
-    // watcher-setup fault is logged inside the helper and swallowed (the
-    // `profile/upsert` RPC still refreshes the index directly). The returned
-    // watcher is HELD for the process lifetime; dropping it would stop the watch,
-    // so it lives in `boot`'s scope alongside the other background handles.
-    let _profile_watch = crate::profile::profiles_dir()
-        .and_then(|dir| crate::profile::spawn_index_watch(store.pool().clone(), dir));
-
-    // Fleet Usage survives TUI restarts: load the daemon-owned bounded snapshot
-    // now, then refresh it on a background worker before Fleet opens its socket.
-    crate::fleet_usage::install(&dir).await;
-    crate::fleet_quota::install(&dir).await;
-
-    // P4.10: bind the JSON-RPC socket beside the database and serve plugin
-    // connections on a background task. A bind failure is non-fatal — the
-    // daemon's claim loop must still run even if no plugin can reach it (and a
-    // stale socket from a crashed daemon is removed in `rpc::bind`).
-    //
-    // e38.1: the socket-auth credential is ensured BEFORE the bind so the
-    // token file exists by the time a client can dial (clients read it and
-    // present it on their first frame). A mint failure disables the listener
-    // (an unauthenticated control plane must never come up) but stays
-    // non-fatal to the claim loop, mirroring the bind-failure path.
-    let socket_path = rpc::socket_path_in(&dir);
-    match rpc::auth::ensure_socket_token(store.pool(), &dir).await {
-        Ok(token_path) => match rpc::bind(&socket_path) {
-            Ok(listener) => {
-                let health = rpc::DaemonHealth {
-                    socket_path: socket_path.to_string_lossy().into_owned(),
-                    pid: std::process::id(),
-                    started_at: std::time::Instant::now(),
-                    version: env!("CARGO_PKG_VERSION").to_string(),
-                    stats: stats.clone(),
-                };
-                tracing::info!(
-                    socket = %socket_path.display(),
-                    token_file = %token_path.display(),
-                    "hangar rpc listening"
-                );
-                tokio::spawn(rpc::serve(
-                    listener,
-                    store.pool().clone(),
-                    health,
-                    broker.clone(),
-                ));
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, socket = %socket_path.display(), "hangar rpc bind failed");
-            }
-        },
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                socket = %socket_path.display(),
-                "hangar rpc socket-token mint failed; rpc listener disabled"
-            );
-        }
-    }
-
-    // P7.3: spawn the autopilot scheduler. It is a daemon-global cron tick loop
-    // over every enabled autopilot; guarded so a scheduler fault is non-fatal to
-    // the claim loop (one bad autopilot must never down the daemon). The token is
-    // never cancelled here (process exit tears the task down); a future
-    // supervisor can cancel it for graceful shutdown.
-    {
-        use std::sync::Arc;
-
-        use ainb_hangar_core::clock::SystemClock;
-        use tokio_util::sync::CancellationToken;
-
-        let scheduler = crate::scheduler::AutopilotScheduler::new(
-            store.pool().clone(),
-            Arc::new(SystemClock),
-            CancellationToken::new(),
-        )
-        .with_hangar_events(broker.sink());
-        tokio::spawn(scheduler.run());
-        tracing::info!("autopilot scheduler spawned");
-    }
-
-    // Spec P9 (D13): spawn the auto-standup watcher — a daemon-global periodic
-    // scan that WRITES `/standup` into a stagnant, idle-at-prompt session behind
-    // every guardrail (global toggle default OFF/opt-in, per-session opt-out, 60-min
-    // cooldown, max-one concurrent). It writes via the one verified send path
-    // (INV-2) and raises a `waiting` "standup ready" attention row when a fired
-    // standup's turn completes. Non-fatal like the scheduler: a discovery / send /
-    // store fault is warned and degraded, never a daemon-down. The handle is
-    // dropped (process exit tears the task down).
-    let _standup = crate::standup::StandupWatcher::spawn(store.pool().clone(), broker.sink());
-    tracing::info!("auto-standup watcher spawned");
-
-    // Spec P9 (D12): spawn the ATC heartbeat cron — the launchd/systemd timer's
-    // daemon-native replacement. It reuses the autopilot scheduler's DB-durable
-    // tick loop over `atc_instance.next_tick_at`, fires each instance's heartbeat
-    // on its cron (enforcing the store-backed retry cap and escalating exhausted
-    // sessions through the attention pipeline), and reschedules from the fired
-    // slot. Non-fatal like the scheduler; the handle is dropped (process exit
-    // tears the task down).
-    let _atc_heartbeat =
-        crate::atc::AtcHeartbeatScheduler::spawn(store.pool().clone(), broker.sink());
-    tracing::info!("ATC heartbeat cron spawned");
-
-    // e38.18: the webhook ingress. OPT-IN — it only binds when
-    // `$AINB_HANGAR_WEBHOOK_PORT` is set (an untrusted HTTP surface must not come
-    // up by default). It binds 127.0.0.1 ONLY (never 0.0.0.0), so it is
-    // unreachable off-host. A bind failure is non-fatal to the claim loop,
-    // mirroring the RPC socket. Pass `0` for an ephemeral port.
-    if let Some(port) = std::env::var_os("AINB_HANGAR_WEBHOOK_PORT")
-        .and_then(|v| v.into_string().ok())
-        .and_then(|v| v.trim().parse::<u16>().ok())
-    {
-        use std::sync::Arc;
-
-        use ainb_hangar_core::clock::SystemClock;
-        use ainb_hangar_store::repo::autopilot_webhook::WebhookSecretStore;
-
-        match crate::webhook_ingress::bind(port).await {
-            Ok(listener) => {
-                let addr = listener.local_addr().ok();
-                tracing::info!(
-                    bind = ?addr,
-                    "hangar webhook ingress listening (127.0.0.1 only)"
-                );
-                let secrets = Arc::new(WebhookSecretStore::in_home(&dir));
-                let clock: Arc<dyn ainb_hangar_core::clock::HangarClock + Send + Sync> =
-                    Arc::new(SystemClock);
-                tokio::spawn(crate::webhook_ingress::serve(
-                    listener,
-                    store.pool().clone(),
-                    secrets,
-                    clock,
-                ));
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, port, "hangar webhook ingress bind failed");
-            }
-        }
-    }
-
-    tracing::info!(idle = true, "ainb-hangar-daemon ready idle=true");
-    if once {
-        return Ok(());
-    }
-    // Self-register this pid so EVERY running daemon is DISCOVERABLE, not just
-    // one started via `ainb hangar daemon start`. Discovery only — the exclusion
-    // that actually stops a duplicate is `single_instance`'s lock, taken at the
-    // top of this function. This file is what `status` prints and what a
-    // pre-lock CLI still reads.
-    //
-    // `ensure_hangar_daemon` (the TUI's autostart) decides "is a daemon already
-    // up?" purely from `<hangar_home>/hangar/daemon.pid`. Only the CLI `start`
-    // verb used to write that file, so a daemon launched any other way — the
-    // `ainb-hangar-daemon` binary directly, systemd/launchd, a test harness —
-    // was invisible: the TUI spawned a SECOND daemon, `rpc::bind` unlinked the
-    // live socket out from under the first, and two claim loops + two sweepers
-    // then raced one SQLite home while the TUI talked to the newcomer's empty
-    // in-memory state.
-    //
-    // Writing the pid here made those daemons visible; it did NOT close the hole,
-    // because it happens at the END of boot and nothing checked it under
-    // exclusion. The lock at the top of `boot` is the actual fix — this line is
-    // now bookkeeping for humans and for `status`.
-    let _pid_file = PidFile::register(&dir);
-    let mut cfg = DaemonConfig::from_env();
-    // The claim loop MUST key off the runtime id that is actually registered (and
-    // that the seeded/created agents are bound to). A runtime cannot be renamed —
-    // `agent.runtime_id` is an enforced FK — so an existing row's id wins over a
-    // changed `HANGAR_DAEMON_RUNTIME_ID` (which is warned about, not obeyed).
-    // Resolving here keeps the registered row, the agents, and the claim loop on
-    // ONE id instead of claiming for an id nothing is bound to.
-    let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
-    cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
     // The ownership watchdog: the one layer that survives every exit path not
     // running. If this daemon ever stops owning its home — an operator deleting
-    // the lock, a home restored from a backup — it stands down instead of
-    // racing the daemon that owns it now. Home-scoped by construction: it reads
-    // one file and signals nobody, so unlike an argv-matching reaper it can
-    // never touch a daemon serving a different home.
+    // the lock, a home restored from a backup — it stands down instead of racing
+    // the daemon that owns it now. Home-scoped by construction: it reads one file
+    // and signals nobody, so unlike an argv-matching reaper it can never touch a
+    // daemon serving a different home.
     let (lost_tx, lost_rx) = tokio::sync::oneshot::channel();
     let watchdog_dir = dir.clone();
     tokio::spawn(async move {
@@ -805,14 +477,363 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         let _ = lost_tx.send(owner);
     });
 
-    run(
-        store.pool().clone(),
-        cfg,
-        stats,
-        broker.sink(),
-        crate::shutdown::Watch::new().on_lock_lost(lost_rx),
-    )
-    .await
+    // Signal handlers are installed HERE, not at the end of boot. Everything
+    // below — migrations, the socket bind, the tmux reconcile — takes seconds on
+    // a cold home, and a SIGTERM arriving in that window used to kill the process
+    // on the OS default disposition: no teardown, and the ownership lock left on
+    // disk naming a dead pid. `daemon restart` and system shutdown both land
+    // exactly there.
+    let shutdown = crate::shutdown::install(Some(lost_rx));
+    let mut during_boot = shutdown.clone();
+
+    // The rest of boot, raced against that seam. Dropping this future on a
+    // shutdown unwinds the partially built daemon; `_ownership` lives OUTSIDE it,
+    // so the lock is released either way.
+    let booted = async move {
+        // Observability tripwire seam (P8.1): when `$AINB_HANGAR_BOOT_TASK_ID` is set
+        // the daemon emits exactly one structured boot event carrying that id. The
+        // `it_subscriber_writes_jsonl` integration test sets it to prove the JSONL
+        // sink installed in `main` lays down a single matching JSON line. Production
+        // boots never set it, so this is a no-op in normal operation.
+        if let Some(task_id) = std::env::var_os("AINB_HANGAR_BOOT_TASK_ID")
+            .and_then(|v| v.into_string().ok())
+            .filter(|v| !v.is_empty())
+        {
+            tracing::info!(task_id = %task_id, "boot");
+        }
+
+        let store: Store = Store::open_in(&dir).await?;
+
+        // Fresh-home boot seed: lay down the default workspace + runtime + one
+        // starter agent so an empty home "just works" (a runtime shows in the Daemon
+        // pane, the agent picker is non-empty, and the Squad create gate is already
+        // cleared). Idempotent + non-clobbering, and it self-registers the runtime
+        // under the SAME default id the claim loop keys off (subsuming the old
+        // e38.20 self-register). A failure is non-fatal — the daemon must still
+        // sweep + serve — so it is logged and swallowed here.
+        if let Err(e) = crate::default_home::ensure_default_home(store.pool()).await {
+            tracing::warn!(error = %e, "fresh-home boot seed failed (daemon continues)");
+        }
+
+        // P8.5: the in-memory health stats collector — shared between the RPC server
+        // (which snapshots the rolling throughput ring for the `hangar/daemon_health`
+        // pane) and the run loop's FSM finalize path (which records each task's
+        // terminal outcome into the ring).
+        let stats = std::sync::Arc::new(crate::health_stats::HealthStats::default());
+
+        // e38.2 + T1: the daemon-global event broker, built WITH a durable outbox.
+        // Mutation paths (the claim loop's FSM steps, the RPC mutations, the
+        // autopilot scheduler) publish typed `HangarEvent`s through cloned sinks;
+        // the RPC server forwards them to authenticated, workspace-subscribed
+        // connections (live, lossy) AND every event is queued on the lossless outbox
+        // channel returned here for the outbox drain to persist. With no subscriber
+        // the live broadcast is dropped silently, so the broker costs nothing when no
+        // TUI is attached — but the durable log still records every event for replay.
+        let (broker, outbox_rx) = crate::events::EventBroker::with_outbox();
+
+        // T1: spawn the event-outbox drain — the writer of the durable, replayable
+        // event log. It pulls every emitted event off the lossless outbox channel
+        // and appends it to `event_log` (migration 0024) with a monotonic `seq`, so a
+        // reconnecting or late-joining plugin resumes the bus from its last cursor.
+        // Wired BEFORE the RPC server and the claim loop so the first mutation's
+        // event is already persisted. The handle is dropped (process exit tears the
+        // task down, mirroring the sweepers); a failed append is logged inside the
+        // task, never fatal.
+        let _outbox = crate::event_outbox::spawn(store.pool().clone(), outbox_rx);
+
+        // e38.14: spawn the inbox aggregator — the writer half of the durable
+        // notification inbox. It subscribes to the broker (exactly like an RPC
+        // connection) and folds every issue/comment/task event into the
+        // `inbox_entry` table, so live events that were once broadcast-only now land
+        // durably with an unread count. Subscribed BEFORE the RPC server and the
+        // claim loop come up, so the first mutation's event is already aggregated.
+        // The handle is dropped (process exit tears the task down, mirroring the
+        // sweepers); a failed write is logged inside the task, never fatal.
+        let _inbox = crate::inbox_aggregator::spawn(store.pool().clone(), broker.subscribe());
+
+        // Spec P2 (D10): spawn the attention ingest producer — the daemon's own tail
+        // of the shared hook `events.jsonl` (`~/.agents-in-a-box/events.jsonl`, the
+        // SAME file notifyd reads) into the `attention` table. It classifies every
+        // qualifying session event (ASK > ERR > IDLE > WAIT) and raises an answerable
+        // row + a fleet-wide `AttentionRaised` nudge. Its byte cursor lives under the
+        // hangar home so the T2 store boundary holds (no cross-read of notifyd's
+        // rusqlite). The handle is dropped (process exit tears the task down,
+        // mirroring the inbox aggregator); a failed ingest is logged, never fatal.
+        // Hook and daemon use the same resolved runtime root, including isolated
+        // `$AINB_HANGAR_HOME` test and paid-runtime installs.
+        {
+            let events_jsonl = dir.join("events.jsonl");
+            let cursor = dir.join("hangar").join("attention_ingest.offset");
+            let _attention_ingest = crate::attention_ingest::AttentionIngest::new(
+                store.pool().clone(),
+                broker.sink(),
+                events_jsonl,
+                cursor,
+            )
+            .spawn();
+        }
+
+        // The ACP boot scan (I16), BEFORE the pool is installed: a daemon that was
+        // SIGKILLed mid-turn left `open_turn_id` set, its legs PENDING and its
+        // parked permissions' attention rows open, and no runtime path revisits a
+        // session this process never hosted. Same shared routine the process-exit
+        // and deadline paths run, so the outcomes cannot drift.
+        crate::acp_pool::converge_dirty_sessions_at_boot(store.pool(), &broker.sink()).await;
+
+        // The confirm-card TTL, swept once at boot. The park's own bound is a
+        // `tokio` timer inside a copilot turn, and a timer dies with the process:
+        // without this, a card left open by a SIGKILLed or upgraded daemon keeps
+        // rendering as answerable on every client for as long as the row exists,
+        // and approving it returns a success receipt for a destructive tool call
+        // with no waiter left to run it.
+        match ainb_hangar_store::repo::fleet_chat::FleetConfirmRepo::sweep_expired(
+            store.pool(),
+            ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock),
+        )
+        .await
+        {
+            Ok(0) => {}
+            Ok(swept) => tracing::warn!(swept, "expired confirm cards left open by a prior daemon"),
+            Err(error) => tracing::error!(%error, "could not sweep expired confirm cards at boot"),
+        }
+
+        // The ACP agent pool. Installed BEFORE the socket accepts a connection so
+        // `fleet/acp_session_create` can never answer "no pool" on a daemon that
+        // has one; nothing is spawned until the first prompt reaches it.
+        let acp_pool = crate::acp_pool::AcpPool::new(
+            store.clone(),
+            broker.sink(),
+            crate::acp_pool::PoolConfig::from_env(),
+        );
+        let _acp_sweeper = acp_pool.spawn_sweeper();
+        crate::acp_pool::install(acp_pool).await;
+
+        // Tmux reconciliation keeps unhooked and standalone provider sessions in
+        // the canonical Fleet roster as degraded rows with exact pane identity.
+        let _fleet_tmux = crate::fleet::spawn_tmux_reconciler(store.pool().clone(), broker.sink());
+
+        // Two slow janitors, each on its OWN clock rather than folded into the 3s
+        // reconciler tick above. Measured on a real profile: 1,440 of 1,472 visible
+        // sessions were dead EXITED rows that every snapshot scanned, and
+        // fleet_event had grown to 1.1M rows / 847 MB under no retention at all.
+        // Both are pure cleanup with no deadline, so neither belongs on a hot path.
+        let _fleet_archiver = crate::fleet::spawn_session_archiver(store.pool().clone(), broker.sink());
+        let _fleet_retention = crate::fleet_retention::spawn_retention_sweeper(store.pool().clone());
+
+        // Managed Codex transport starts independently from daemon readiness. A
+        // missing or incompatible Codex binary leaves hook and tmux observation
+        // running, while the service records an honest transport downgrade.
+        let _codex_manager = if !once
+            && std::env::var_os("AINB_CODEX_MANAGED")
+                .as_deref()
+                .is_none_or(|value| value != "0")
+        {
+            let binary = std::env::var_os("AINB_CODEX_BIN").unwrap_or_else(|| "codex".into());
+            let socket = dir.join("codex-app-server.sock");
+            // Reap any app-server orphaned by a SIGKILLed/OOM-reaped prior daemon (or a
+            // dead plugin broker) BEFORE we spawn our own. Rust Drop never runs after
+            // SIGKILL, so this boot-time sweep is the only backstop that survives it.
+            let reaped =
+                crate::fleet_provider::codex_manager::reap_orphaned_codex_servers(&socket).await;
+            if reaped > 0 {
+                tracing::warn!(reaped, "reaped orphaned codex app-server processes at boot");
+            }
+            Some(crate::fleet_provider::codex_manager::spawn_service(
+                crate::fleet_provider::codex_manager::CodexManagerConfig::new(binary, socket),
+                store.pool().clone(),
+                broker.sink(),
+            ))
+        } else {
+            None
+        };
+
+        // P5 (T6): reconcile the agent-profile index against the on-disk masters and
+        // spawn an fs-watch so an edit-on-disk of `{hangar_home}/profiles/<slug>.md`
+        // is picked up into the `profile` index without an RPC. Best-effort — a
+        // watcher-setup fault is logged inside the helper and swallowed (the
+        // `profile/upsert` RPC still refreshes the index directly). The returned
+        // watcher is HELD for the process lifetime; dropping it would stop the watch,
+        // so it lives in `boot`'s scope alongside the other background handles.
+        let _profile_watch = crate::profile::profiles_dir()
+            .and_then(|dir| crate::profile::spawn_index_watch(store.pool().clone(), dir));
+
+        // Fleet Usage survives TUI restarts: load the daemon-owned bounded snapshot
+        // now, then refresh it on a background worker before Fleet opens its socket.
+        crate::fleet_usage::install(&dir).await;
+        crate::fleet_quota::install(&dir).await;
+
+        // P4.10: bind the JSON-RPC socket beside the database and serve plugin
+        // connections on a background task. A bind failure is non-fatal — the
+        // daemon's claim loop must still run even if no plugin can reach it (and a
+        // stale socket from a crashed daemon is removed in `rpc::bind`).
+        //
+        // e38.1: the socket-auth credential is ensured BEFORE the bind so the
+        // token file exists by the time a client can dial (clients read it and
+        // present it on their first frame). A mint failure disables the listener
+        // (an unauthenticated control plane must never come up) but stays
+        // non-fatal to the claim loop, mirroring the bind-failure path.
+        let socket_path = rpc::socket_path_in(&dir);
+        match rpc::auth::ensure_socket_token(store.pool(), &dir).await {
+            Ok(token_path) => match rpc::bind(&socket_path) {
+                Ok(listener) => {
+                    let health = rpc::DaemonHealth {
+                        socket_path: socket_path.to_string_lossy().into_owned(),
+                        pid: std::process::id(),
+                        started_at: std::time::Instant::now(),
+                        version: env!("CARGO_PKG_VERSION").to_string(),
+                        stats: stats.clone(),
+                    };
+                    tracing::info!(
+                        socket = %socket_path.display(),
+                        token_file = %token_path.display(),
+                        "hangar rpc listening"
+                    );
+                    tokio::spawn(rpc::serve(
+                        listener,
+                        store.pool().clone(),
+                        health,
+                        broker.clone(),
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, socket = %socket_path.display(), "hangar rpc bind failed");
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    socket = %socket_path.display(),
+                    "hangar rpc socket-token mint failed; rpc listener disabled"
+                );
+            }
+        }
+
+        // P7.3: spawn the autopilot scheduler. It is a daemon-global cron tick loop
+        // over every enabled autopilot; guarded so a scheduler fault is non-fatal to
+        // the claim loop (one bad autopilot must never down the daemon). The token is
+        // never cancelled here (process exit tears the task down); a future
+        // supervisor can cancel it for graceful shutdown.
+        {
+            use std::sync::Arc;
+
+            use ainb_hangar_core::clock::SystemClock;
+            use tokio_util::sync::CancellationToken;
+
+            let scheduler = crate::scheduler::AutopilotScheduler::new(
+                store.pool().clone(),
+                Arc::new(SystemClock),
+                CancellationToken::new(),
+            )
+            .with_hangar_events(broker.sink());
+            tokio::spawn(scheduler.run());
+            tracing::info!("autopilot scheduler spawned");
+        }
+
+        // Spec P9 (D13): spawn the auto-standup watcher — a daemon-global periodic
+        // scan that WRITES `/standup` into a stagnant, idle-at-prompt session behind
+        // every guardrail (global toggle default OFF/opt-in, per-session opt-out, 60-min
+        // cooldown, max-one concurrent). It writes via the one verified send path
+        // (INV-2) and raises a `waiting` "standup ready" attention row when a fired
+        // standup's turn completes. Non-fatal like the scheduler: a discovery / send /
+        // store fault is warned and degraded, never a daemon-down. The handle is
+        // dropped (process exit tears the task down).
+        let _standup = crate::standup::StandupWatcher::spawn(store.pool().clone(), broker.sink());
+        tracing::info!("auto-standup watcher spawned");
+
+        // Spec P9 (D12): spawn the ATC heartbeat cron — the launchd/systemd timer's
+        // daemon-native replacement. It reuses the autopilot scheduler's DB-durable
+        // tick loop over `atc_instance.next_tick_at`, fires each instance's heartbeat
+        // on its cron (enforcing the store-backed retry cap and escalating exhausted
+        // sessions through the attention pipeline), and reschedules from the fired
+        // slot. Non-fatal like the scheduler; the handle is dropped (process exit
+        // tears the task down).
+        let _atc_heartbeat =
+            crate::atc::AtcHeartbeatScheduler::spawn(store.pool().clone(), broker.sink());
+        tracing::info!("ATC heartbeat cron spawned");
+
+        // e38.18: the webhook ingress. OPT-IN — it only binds when
+        // `$AINB_HANGAR_WEBHOOK_PORT` is set (an untrusted HTTP surface must not come
+        // up by default). It binds 127.0.0.1 ONLY (never 0.0.0.0), so it is
+        // unreachable off-host. A bind failure is non-fatal to the claim loop,
+        // mirroring the RPC socket. Pass `0` for an ephemeral port.
+        if let Some(port) = std::env::var_os("AINB_HANGAR_WEBHOOK_PORT")
+            .and_then(|v| v.into_string().ok())
+            .and_then(|v| v.trim().parse::<u16>().ok())
+        {
+            use std::sync::Arc;
+
+            use ainb_hangar_core::clock::SystemClock;
+            use ainb_hangar_store::repo::autopilot_webhook::WebhookSecretStore;
+
+            match crate::webhook_ingress::bind(port).await {
+                Ok(listener) => {
+                    let addr = listener.local_addr().ok();
+                    tracing::info!(
+                        bind = ?addr,
+                        "hangar webhook ingress listening (127.0.0.1 only)"
+                    );
+                    let secrets = Arc::new(WebhookSecretStore::in_home(&dir));
+                    let clock: Arc<dyn ainb_hangar_core::clock::HangarClock + Send + Sync> =
+                        Arc::new(SystemClock);
+                    tokio::spawn(crate::webhook_ingress::serve(
+                        listener,
+                        store.pool().clone(),
+                        secrets,
+                        clock,
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, port, "hangar webhook ingress bind failed");
+                }
+            }
+        }
+
+        tracing::info!(idle = true, "ainb-hangar-daemon ready idle=true");
+        if once {
+            return Ok(());
+        }
+        // Self-register this pid so EVERY running daemon is DISCOVERABLE, not just
+        // one started via `ainb hangar daemon start`. Discovery only — the exclusion
+        // that actually stops a duplicate is `single_instance`'s lock, taken at the
+        // top of this function. This file is what `status` prints and what a
+        // pre-lock CLI still reads.
+        //
+        // `ensure_hangar_daemon` (the TUI's autostart) decides "is a daemon already
+        // up?" purely from `<hangar_home>/hangar/daemon.pid`. Only the CLI `start`
+        // verb used to write that file, so a daemon launched any other way — the
+        // `ainb-hangar-daemon` binary directly, systemd/launchd, a test harness —
+        // was invisible: the TUI spawned a SECOND daemon, `rpc::bind` unlinked the
+        // live socket out from under the first, and two claim loops + two sweepers
+        // then raced one SQLite home while the TUI talked to the newcomer's empty
+        // in-memory state.
+        //
+        // Writing the pid here made those daemons visible; it did NOT close the hole,
+        // because it happens at the END of boot and nothing checked it under
+        // exclusion. The lock at the top of `boot` is the actual fix — this line is
+        // now bookkeeping for humans and for `status`.
+        let _pid_file = PidFile::register(&dir);
+        let mut cfg = DaemonConfig::from_env();
+        // The claim loop MUST key off the runtime id that is actually registered (and
+        // that the seeded/created agents are bound to). A runtime cannot be renamed —
+        // `agent.runtime_id` is an enforced FK — so an existing row's id wins over a
+        // changed `HANGAR_DAEMON_RUNTIME_ID` (which is warned about, not obeyed).
+        // Resolving here keeps the registered row, the agents, and the claim loop on
+        // ONE id instead of claiming for an id nothing is bound to.
+        let now = ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
+        cfg.runtime_id = Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
+        run(store.pool().clone(), cfg, stats, broker.sink(), shutdown).await
+    };
+
+    tokio::select! {
+        result = booted => result,
+        cause = during_boot.recv() => {
+            tracing::info!(
+                signal = cause.as_str(),
+                "ainb-hangar-daemon shutting down during boot"
+            );
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -464,6 +464,17 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         }
     };
 
+    // Crash breadcrumbs start HERE, once this process owns the home — never
+    // before. They live in the SHARED home: `start_breadcrumbs` deletes the
+    // previous run's exit reason and begins overwriting `daemon.heartbeat` with
+    // our pid. A duplicate that goes on to decline would therefore erase the
+    // INCUMBENT's death record and impersonate its heartbeat, and the decline's
+    // own `record_exit` would then file a clean exit for a daemon that is still
+    // running. Behind the lock, a decliner installs nothing and `record_exit`
+    // is a no-op for it.
+    crate::observability::note_phase("boot");
+    crate::observability::start_breadcrumbs(&dir);
+
     // The ownership watchdog: the one layer that survives every exit path not
     // running. If this daemon ever stops owning its home — an operator deleting
     // the lock, a home restored from a backup — it stands down instead of racing

--- a/ainb-tui/crates/ainb-hangar-daemon/src/main.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/main.rs
@@ -8,7 +8,7 @@
 use ainb_hangar_daemon::beads_sync::reconcile;
 use ainb_hangar_daemon::beads_sync::reconcile::cli::{BeadsCli, BeadsCommand};
 use ainb_hangar_daemon::observability::{self, ObservabilityOpts};
-use ainb_hangar_daemon::{boot, hangar_dir, log_dir};
+use ainb_hangar_daemon::{boot, log_dir};
 use clap::{Parser, Subcommand};
 
 /// Hangar control-plane daemon.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/main.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/main.rs
@@ -95,14 +95,9 @@ async fn main() -> anyhow::Result<()> {
 /// unmigratable database, a bind error) is recorded as an explained exit rather
 /// than reading as a hard kill.
 async fn run_daemon(once: bool) -> anyhow::Result<()> {
-    match hangar_dir() {
-        Ok(dir) => {
-            observability::note_phase("boot");
-            observability::start_breadcrumbs(&dir);
-        }
-        Err(e) => tracing::warn!(error = %e, "no hangar home; crash breadcrumbs disabled"),
-    }
-
+    // Breadcrumbs are installed inside `boot`, after it has taken the home's
+    // ownership lock. Installing them here would let a duplicate that declines
+    // erase the incumbent's exit record and overwrite its heartbeat first.
     let result = boot(once).await;
 
     observability::note_phase("shutdown");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -219,8 +219,15 @@ pub fn bind(socket_path: &Path) -> std::io::Result<UnixListener> {
     use std::os::unix::fs::PermissionsExt as _;
 
     // A leftover socket file from a previous (crashed) daemon would make `bind`
-    // fail with AddrInUse even though nothing is listening. Remove it first —
-    // this is safe because only one daemon owns a given hangar home at a time.
+    // fail with AddrInUse even though nothing is listening. Remove it first.
+    //
+    // This is safe because exactly one daemon owns a given hangar home at a
+    // time, and that is now ENFORCED rather than assumed: `boot` holds
+    // `single_instance`'s lock on `<home>/hangar/daemon.lock` before reaching
+    // this call, so the only socket we can unlink here belongs to a daemon whose
+    // lock we already reclaimed as stale. Unlinking does not close a live
+    // listener's fd — it would leave the incumbent accepting on an unreachable
+    // inode — so this line is only correct while that guard holds.
     if socket_path.exists() {
         let _ = std::fs::remove_file(socket_path);
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -435,7 +435,7 @@ pub async fn run(
     cfg: DaemonConfig,
     stats: Arc<HealthStats>,
     events: EventSink,
-    mut shutdown: crate::shutdown::Watch,
+    mut shutdown: crate::shutdown::Handle,
 ) -> anyhow::Result<()> {
     // hangar-e2e-5: record the resolved headless OS-sandbox posture once at boot.
     // Without this line an exit-65 dispatch failure was ambiguous between "fix

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -470,8 +470,10 @@ pub async fn run(
 
     let Some(runtime_id) = cfg.runtime_id.clone().filter(|_| !cfg.disable_claim) else {
         tracing::info!(claim = false, "claim loop disabled; sweepers only");
-        tokio::signal::ctrl_c().await?;
-        tracing::info!("ainb-hangar-daemon shutting down");
+        // Same seam as the claim loop below: a sweepers-only daemon must answer
+        // `daemon stop` too, and it holds the same ownership lock to release.
+        let cause = crate::shutdown::Watch::new().recv().await;
+        tracing::info!(signal = cause.as_str(), "ainb-hangar-daemon shutting down");
         return Ok(());
     };
 
@@ -519,16 +521,25 @@ pub async fn run(
     // a54 shutdown reap: the set of live interactive tmux sessions, so `Ctrl-C`
     // can kill each by exact name instead of orphaning a detached pane.
     let interactive = InteractiveSessions::default();
+    // Installed ONCE, outside the loop: re-registering a SIGTERM handler on every
+    // tick would churn a process-wide resource for no reason.
+    let mut shutdown = crate::shutdown::Watch::new();
 
     loop {
         tokio::select! {
             biased;
-            _ = tokio::signal::ctrl_c() => {
-                tracing::info!("ainb-hangar-daemon shutting down");
+            cause = shutdown.recv() => {
+                tracing::info!(signal = cause.as_str(), "ainb-hangar-daemon shutting down");
                 // Reap every in-flight interactive tmux session by exact name so
                 // no detached pane orphans (aborting its `wait` future below does
                 // NOT kill a detached session).
-                reap_interactive_sessions(&interactive).await;
+                //
+                // SIGINT only. SIGTERM is `daemon stop`/`restart` — which runs on
+                // every upgrade — and those panes are the operator's attached
+                // work, re-adopted by the next boot's tmux reconciler.
+                if cause.reaps_interactive_sessions() {
+                    reap_interactive_sessions(&interactive).await;
+                }
                 // Then abort + drain every in-flight run. Each headless provider
                 // was spawned with `kill_on_drop(true)`, so dropping its aborted
                 // future SIGKILLs the child instead of leaving it reparented to

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -435,6 +435,7 @@ pub async fn run(
     cfg: DaemonConfig,
     stats: Arc<HealthStats>,
     events: EventSink,
+    mut shutdown: crate::shutdown::Watch,
 ) -> anyhow::Result<()> {
     // hangar-e2e-5: record the resolved headless OS-sandbox posture once at boot.
     // Without this line an exit-65 dispatch failure was ambiguous between "fix
@@ -472,7 +473,7 @@ pub async fn run(
         tracing::info!(claim = false, "claim loop disabled; sweepers only");
         // Same seam as the claim loop below: a sweepers-only daemon must answer
         // `daemon stop` too, and it holds the same ownership lock to release.
-        let cause = crate::shutdown::Watch::new().recv().await;
+        let cause = shutdown.recv().await;
         tracing::info!(signal = cause.as_str(), "ainb-hangar-daemon shutting down");
         return Ok(());
     };
@@ -521,10 +522,6 @@ pub async fn run(
     // a54 shutdown reap: the set of live interactive tmux sessions, so `Ctrl-C`
     // can kill each by exact name instead of orphaning a detached pane.
     let interactive = InteractiveSessions::default();
-    // Installed ONCE, outside the loop: re-registering a SIGTERM handler on every
-    // tick would churn a process-wide resource for no reason.
-    let mut shutdown = crate::shutdown::Watch::new();
-
     loop {
         tokio::select! {
             biased;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
@@ -79,7 +79,7 @@ pub struct Watch {
 }
 
 /// Install one signal handler, logging and degrading rather than failing.
-fn install(
+fn install_handler(
     kind: tokio::signal::unix::SignalKind,
     name: &str,
 ) -> Option<tokio::signal::unix::Signal> {
@@ -118,8 +118,8 @@ impl Watch {
     pub fn new() -> Self {
         use tokio::signal::unix::SignalKind;
         Self {
-            interrupt: install(SignalKind::interrupt(), "SIGINT"),
-            terminate: install(SignalKind::terminate(), "SIGTERM"),
+            interrupt: install_handler(SignalKind::interrupt(), "SIGINT"),
+            terminate: install_handler(SignalKind::terminate(), "SIGTERM"),
             lock_lost: None,
         }
     }
@@ -188,6 +188,55 @@ impl Watch {
             }
         }
     }
+}
+
+/// An observer of the shutdown seam, clonable so the boot phase and the run
+/// loop can both wait on the SAME first cause.
+///
+/// [`install`] is what boot calls: it registers the signal handlers immediately
+/// — before the store, the migrations and the socket bind — so a SIGTERM
+/// arriving mid-boot is queued and answered rather than killing the process on
+/// the OS default disposition with the ownership lock still on disk.
+#[derive(Debug, Clone)]
+pub struct Handle {
+    cause: tokio::sync::watch::Receiver<Option<Cause>>,
+}
+
+impl Handle {
+    /// Resolve with the first cause that asked the daemon to stop.
+    pub async fn recv(&mut self) -> Cause {
+        loop {
+            if let Some(cause) = *self.cause.borrow_and_update() {
+                return cause;
+            }
+            if self.cause.changed().await.is_err() {
+                // The publisher task is gone, so no cause can ever arrive. Park
+                // rather than inventing one: a dropped channel is not a
+                // shutdown request, and resolving here would tear the daemon
+                // down on a task fault.
+                never().await;
+            }
+        }
+    }
+}
+
+/// Install the signal handlers NOW and publish the first shutdown cause.
+///
+/// Registration happens synchronously in this call, so the handlers are live
+/// before the caller does any further work; the waiting happens on a spawned
+/// task feeding every [`Handle`].
+#[must_use]
+pub fn install(lock_lost: Option<tokio::sync::oneshot::Receiver<i32>>) -> Handle {
+    let mut watch = Watch::new();
+    if let Some(lock_lost) = lock_lost {
+        watch = watch.on_lock_lost(lock_lost);
+    }
+    let (tx, rx) = tokio::sync::watch::channel(None);
+    tokio::spawn(async move {
+        let cause = watch.recv().await;
+        let _ = tx.send(Some(cause));
+    });
+    Handle { cause: rx }
 }
 
 impl Default for Watch {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
@@ -29,6 +29,12 @@ pub enum Cause {
     /// SIGTERM — `hangar daemon stop`, `restart`, launchd/systemd, or a
     /// system shutdown.
     Terminate,
+    /// This daemon no longer owns its hangar home; the named pid does.
+    ///
+    /// Nobody signalled us — we noticed. Standing down is the only correct
+    /// response: two daemons on one home race the same database and unlink each
+    /// other's socket.
+    LockLost(i32),
 }
 
 impl Cause {
@@ -47,6 +53,7 @@ impl Cause {
         match self {
             Self::Interrupt => "SIGINT",
             Self::Terminate => "SIGTERM",
+            Self::LockLost(_) => "lock-lost",
         }
     }
 }
@@ -60,6 +67,10 @@ pub struct Watch {
     /// `None` only when the SIGTERM handler could not be installed; the daemon
     /// then degrades to SIGINT rather than refusing to run.
     terminate: Option<tokio::signal::unix::Signal>,
+    /// Resolves with the new owner's pid if this daemon ever stops owning its
+    /// home. `None` for a daemon that holds no lock (a test harness driving the
+    /// run loop directly).
+    lock_lost: Option<tokio::sync::oneshot::Receiver<i32>>,
 }
 
 impl Watch {
@@ -78,7 +89,18 @@ impl Watch {
                     None
                 }
             };
-        Self { terminate }
+        Self {
+            terminate,
+            lock_lost: None,
+        }
+    }
+
+    /// Also stand down when `lock_lost` resolves — see
+    /// [`crate::single_instance::watch_ownership`].
+    #[must_use]
+    pub fn on_lock_lost(mut self, lock_lost: tokio::sync::oneshot::Receiver<i32>) -> Self {
+        self.lock_lost = Some(lock_lost);
+        self
     }
 
     /// Resolve on the first signal asking the daemon to stop.
@@ -87,17 +109,37 @@ impl Watch {
     /// branches: `Signal::recv` is cancel-safe by contract, and a dropped
     /// `ctrl_c()` future leaves the process-wide handler installed.
     pub async fn recv(&mut self) -> Cause {
-        match self.terminate.as_mut() {
-            Some(terminate) => {
-                tokio::select! {
-                    _ = tokio::signal::ctrl_c() => Cause::Interrupt,
-                    _ = terminate.recv() => Cause::Terminate,
+        // `Option::as_mut` + `futures::future::OptionFuture` would read better,
+        // but a never-resolving branch keeps this to one dependency-free
+        // `select!` whose arms are all cancel-safe.
+        let signalled = async {
+            match self.terminate.as_mut() {
+                Some(terminate) => {
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => Cause::Interrupt,
+                        _ = terminate.recv() => Cause::Terminate,
+                    }
+                }
+                None => {
+                    let _ = tokio::signal::ctrl_c().await;
+                    Cause::Interrupt
                 }
             }
-            None => {
-                let _ = tokio::signal::ctrl_c().await;
-                Cause::Interrupt
+        };
+        match self.lock_lost.as_mut() {
+            Some(lock_lost) => {
+                tokio::select! {
+                    cause = signalled => cause,
+                    // A dropped sender (the watchdog task died) is not a lost
+                    // lock, so it must never masquerade as one: fall back to
+                    // waiting on the signals alone.
+                    owner = lock_lost => match owner {
+                        Ok(pid) => Cause::LockLost(pid),
+                        Err(_) => std::future::pending().await,
+                    },
+                }
             }
+            None => signalled.await,
         }
     }
 }
@@ -127,5 +169,36 @@ mod tests {
     fn each_cause_names_its_signal() {
         assert_eq!(Cause::Interrupt.as_str(), "SIGINT");
         assert_eq!(Cause::Terminate.as_str(), "SIGTERM");
+        assert_eq!(Cause::LockLost(7).as_str(), "lock-lost");
+    }
+
+    /// Losing the home is not a reason to kill the operator's attached panes:
+    /// the daemon that now owns the home adopts them.
+    #[test]
+    fn a_lost_lock_leaves_attached_sessions_alone() {
+        assert!(!Cause::LockLost(7).reaps_interactive_sessions());
+    }
+
+    #[tokio::test]
+    async fn a_resolved_watchdog_stands_the_daemon_down() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut watch = Watch::new().on_lock_lost(rx);
+        tx.send(9001).expect("send new owner");
+        assert_eq!(watch.recv().await, Cause::LockLost(9001));
+    }
+
+    /// A watchdog that died must not be read as a lost lock — that would shut
+    /// the daemon down on a task panic.
+    #[tokio::test]
+    async fn a_dropped_watchdog_is_not_a_lost_lock() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<i32>();
+        let mut watch = Watch::new().on_lock_lost(rx);
+        drop(tx);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(200), watch.recv())
+                .await
+                .is_err(),
+            "a dropped watchdog resolved the shutdown seam"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
@@ -61,11 +61,16 @@ impl Cause {
 /// A long-lived watcher for every signal that ends the daemon.
 ///
 /// Built ONCE outside the claim loop and polled from its `select!`, rather than
-/// re-registering a handler on every tick.
+/// re-registering a handler on every tick. Both signal streams are OWNED here,
+/// so a signal delivered while another `select!` branch was winning is queued
+/// rather than lost.
 #[derive(Debug)]
 pub struct Watch {
-    /// `None` only when the SIGTERM handler could not be installed; the daemon
-    /// then degrades to SIGINT rather than refusing to run.
+    /// `None` only when the handler could not be installed; the daemon then
+    /// degrades to whichever signal it did manage to register rather than
+    /// refusing to run.
+    interrupt: Option<tokio::signal::unix::Signal>,
+    /// `None` only when the SIGTERM handler could not be installed.
     terminate: Option<tokio::signal::unix::Signal>,
     /// Resolves with the new owner's pid if this daemon ever stops owning its
     /// home. `None` for a daemon that holds no lock (a test harness driving the
@@ -73,24 +78,48 @@ pub struct Watch {
     lock_lost: Option<tokio::sync::oneshot::Receiver<i32>>,
 }
 
+/// Install one signal handler, logging and degrading rather than failing.
+fn install(
+    kind: tokio::signal::unix::SignalKind,
+    name: &str,
+) -> Option<tokio::signal::unix::Signal> {
+    match tokio::signal::unix::signal(kind) {
+        Ok(signal) => Some(signal),
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                signal = name,
+                "could not install a shutdown signal handler; this process will die on \
+                 that signal's default disposition instead of shutting down cleanly"
+            );
+            None
+        }
+    }
+}
+
+/// Never resolves — the arm for a handler that could not be installed.
+async fn never() {
+    std::future::pending::<()>().await;
+}
+
+/// Wait for one more delivery of `signal`, or forever if it is absent.
+async fn fires(signal: Option<&mut tokio::signal::unix::Signal>) {
+    match signal {
+        Some(signal) => {
+            signal.recv().await;
+        }
+        None => never().await,
+    }
+}
+
 impl Watch {
     /// Install the signal handlers.
     #[must_use]
     pub fn new() -> Self {
-        let terminate =
-            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-                Ok(signal) => Some(signal),
-                Err(e) => {
-                    tracing::error!(
-                        error = %e,
-                        "could not install the SIGTERM handler; `daemon stop` will kill \
-                         this process ungracefully"
-                    );
-                    None
-                }
-            };
+        use tokio::signal::unix::SignalKind;
         Self {
-            terminate,
+            interrupt: install(SignalKind::interrupt(), "SIGINT"),
+            terminate: install(SignalKind::terminate(), "SIGTERM"),
             lock_lost: None,
         }
     }
@@ -106,40 +135,57 @@ impl Watch {
     /// Resolve on the first signal asking the daemon to stop.
     ///
     /// Cancel-safe, so it can live in a `select!` arm that loses to other
-    /// branches: `Signal::recv` is cancel-safe by contract, and a dropped
-    /// `ctrl_c()` future leaves the process-wide handler installed.
+    /// branches: `Signal::recv` is cancel-safe by contract, and the streams
+    /// themselves are owned by this struct, so nothing is deregistered when a
+    /// losing branch's future is dropped.
     pub async fn recv(&mut self) -> Cause {
-        // `Option::as_mut` + `futures::future::OptionFuture` would read better,
-        // but a never-resolving branch keeps this to one dependency-free
-        // `select!` whose arms are all cancel-safe.
-        let signalled = async {
-            match self.terminate.as_mut() {
-                Some(terminate) => {
+        loop {
+            // Destructured so the three sources are disjoint borrows and can be
+            // polled in one `select!`.
+            let Self {
+                interrupt,
+                terminate,
+                lock_lost,
+            } = self;
+            let cause = match lock_lost {
+                Some(lock_lost) => {
                     tokio::select! {
-                        _ = tokio::signal::ctrl_c() => Cause::Interrupt,
-                        _ = terminate.recv() => Cause::Terminate,
+                        () = fires(interrupt.as_mut()) => Some(Cause::Interrupt),
+                        () = fires(terminate.as_mut()) => Some(Cause::Terminate),
+                        owner = lock_lost => match owner {
+                            Ok(pid) => Some(Cause::LockLost(pid)),
+                            // The watchdog ended without reporting a loss (its
+                            // task panicked, or a refactor let it return). That
+                            // is NOT a lost lock.
+                            //
+                            // It must also not be answered inside this arm:
+                            // `select!` has already DROPPED the other branches'
+                            // futures by the time an arm body runs, so awaiting
+                            // `pending()` here — the previous shape — stranded
+                            // the signal streams and the daemon stopped
+                            // answering SIGINT and SIGTERM entirely. Forget the
+                            // channel and re-enter the select instead.
+                            Err(_) => None,
+                        },
                     }
                 }
                 None => {
-                    let _ = tokio::signal::ctrl_c().await;
-                    Cause::Interrupt
+                    tokio::select! {
+                        () = fires(interrupt.as_mut()) => Some(Cause::Interrupt),
+                        () = fires(terminate.as_mut()) => Some(Cause::Terminate),
+                    }
+                }
+            };
+            match cause {
+                Some(cause) => return cause,
+                None => {
+                    tracing::warn!(
+                        "the hangar ownership watchdog ended without reporting a loss; \
+                         continuing to serve and watching signals only"
+                    );
+                    self.lock_lost = None;
                 }
             }
-        };
-        match self.lock_lost.as_mut() {
-            Some(lock_lost) => {
-                tokio::select! {
-                    cause = signalled => cause,
-                    // A dropped sender (the watchdog task died) is not a lost
-                    // lock, so it must never masquerade as one: fall back to
-                    // waiting on the signals alone.
-                    owner = lock_lost => match owner {
-                        Ok(pid) => Cause::LockLost(pid),
-                        Err(_) => std::future::pending().await,
-                    },
-                }
-            }
-            None => signalled.await,
         }
     }
 }
@@ -153,6 +199,10 @@ impl Default for Watch {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Signals are process-wide: two tests raising SIGTERM concurrently would
+    /// race for one delivery, and either could observe the other's.
+    static SIGNAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// The behavioural difference between the two causes, stated once so the
     /// run loop's teardown cannot drift from the documented contract.
@@ -181,6 +231,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_resolved_watchdog_stands_the_daemon_down() {
+        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut watch = Watch::new().on_lock_lost(rx);
         tx.send(9001).expect("send new owner");
@@ -191,6 +242,10 @@ mod tests {
     /// the daemon down on a task panic.
     #[tokio::test]
     async fn a_dropped_watchdog_is_not_a_lost_lock() {
+        // Any installed `Watch` sees process-wide signals, so this must not
+        // overlap a sibling test that raises one — it would observe that
+        // delivery and read as "the seam resolved".
+        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let (tx, rx) = tokio::sync::oneshot::channel::<i32>();
         let mut watch = Watch::new().on_lock_lost(rx);
         drop(tx);
@@ -200,5 +255,58 @@ mod tests {
                 .is_err(),
             "a dropped watchdog resolved the shutdown seam"
         );
+    }
+
+    /// ...and the daemon must still ANSWER signals afterwards.
+    ///
+    /// The regression this pins: handling the dropped watchdog inside a
+    /// `select!` arm stranded the signal streams, because `select!` drops the
+    /// losing branches' futures before an arm body runs. The daemon then
+    /// ignored SIGTERM forever — `daemon stop` would burn its whole budget and
+    /// only SIGKILL could end the process, skipping every guard's release.
+    ///
+    /// `a_dropped_watchdog_is_not_a_lost_lock` cannot see that: "still waiting"
+    /// and "hung forever" look identical to a timeout. This one delivers a real
+    /// signal, which is the only way to tell them apart.
+    ///
+    /// Safe to raise in-process: `Watch::new()` installs tokio's handler for
+    /// SIGTERM before the raise, so the default terminate disposition is already
+    /// replaced. Serialised against the sibling raise test by `SIGNAL_LOCK` —
+    /// signals are process-wide, and two watches would race for one delivery.
+    #[tokio::test]
+    async fn signals_still_arrive_after_the_watchdog_is_dropped() {
+        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (tx, rx) = tokio::sync::oneshot::channel::<i32>();
+        let mut watch = Watch::new().on_lock_lost(rx);
+        drop(tx);
+
+        tokio::task::spawn_blocking(|| {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM).expect("raise SIGTERM");
+        });
+
+        let cause = tokio::time::timeout(std::time::Duration::from_secs(5), watch.recv())
+            .await
+            .expect("a dropped watchdog must not strand the signal handlers");
+        assert_eq!(cause, Cause::Terminate);
+    }
+
+    /// The plain path, so the raise-based proof above is anchored: a SIGTERM
+    /// with a live watchdog attached still reads as a terminate.
+    #[tokio::test]
+    async fn sigterm_resolves_the_seam() {
+        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_tx, rx) = tokio::sync::oneshot::channel::<i32>();
+        let mut watch = Watch::new().on_lock_lost(rx);
+
+        tokio::task::spawn_blocking(|| {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM).expect("raise SIGTERM");
+        });
+
+        let cause = tokio::time::timeout(std::time::Duration::from_secs(5), watch.recv())
+            .await
+            .expect("SIGTERM must resolve the shutdown seam");
+        assert_eq!(cause, Cause::Terminate);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
@@ -1,0 +1,131 @@
+//! The daemon's one shutdown seam: what asked it to stop, and how much to tear
+//! down on the way out.
+//!
+//! The daemon used to handle `ctrl_c()` (SIGINT) alone, while the supported stop
+//! command (`ainb hangar daemon stop`) sends SIGTERM. With no handler for it the
+//! process died on the OS default disposition, so NONE of the teardown below ran:
+//! headless provider children were reparented to init and kept mutating their
+//! workspaces unsupervised, and the ownership lock was never released. Every
+//! sibling daemon in this workspace (`mcp_pool`, `notifyd`) already handled
+//! SIGTERM; the hangar daemon was the outlier.
+//!
+//! # Why the two causes differ
+//!
+//! [`Cause::Interrupt`] is a human in the foreground saying "tear it all down",
+//! and takes in-flight interactive tmux sessions with it.
+//!
+//! [`Cause::Terminate`] is `daemon stop` / `daemon restart` — which runs after
+//! every upgrade. Killing the operator's attached agent panes on an upgrade would
+//! destroy work the daemon merely supervises, so interactive sessions are left
+//! running; the boot tmux reconciler re-adopts them with exact pane identity.
+//! Headless children are still killed in both cases (they are unattended, and
+//! leaving them reparented to init is the leak this seam exists to stop).
+
+/// What asked the daemon to shut down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cause {
+    /// SIGINT — a human interrupting a foreground daemon.
+    Interrupt,
+    /// SIGTERM — `hangar daemon stop`, `restart`, launchd/systemd, or a
+    /// system shutdown.
+    Terminate,
+}
+
+impl Cause {
+    /// Should in-flight INTERACTIVE tmux sessions be reaped on the way out?
+    ///
+    /// See the module doc: only the foreground interrupt takes attached panes
+    /// with it.
+    #[must_use]
+    pub const fn reaps_interactive_sessions(self) -> bool {
+        matches!(self, Self::Interrupt)
+    }
+
+    /// The `signal` field for the shutdown log line.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Interrupt => "SIGINT",
+            Self::Terminate => "SIGTERM",
+        }
+    }
+}
+
+/// A long-lived watcher for every signal that ends the daemon.
+///
+/// Built ONCE outside the claim loop and polled from its `select!`, rather than
+/// re-registering a handler on every tick.
+#[derive(Debug)]
+pub struct Watch {
+    /// `None` only when the SIGTERM handler could not be installed; the daemon
+    /// then degrades to SIGINT rather than refusing to run.
+    terminate: Option<tokio::signal::unix::Signal>,
+}
+
+impl Watch {
+    /// Install the signal handlers.
+    #[must_use]
+    pub fn new() -> Self {
+        let terminate =
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(signal) => Some(signal),
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "could not install the SIGTERM handler; `daemon stop` will kill \
+                         this process ungracefully"
+                    );
+                    None
+                }
+            };
+        Self { terminate }
+    }
+
+    /// Resolve on the first signal asking the daemon to stop.
+    ///
+    /// Cancel-safe, so it can live in a `select!` arm that loses to other
+    /// branches: `Signal::recv` is cancel-safe by contract, and a dropped
+    /// `ctrl_c()` future leaves the process-wide handler installed.
+    pub async fn recv(&mut self) -> Cause {
+        match self.terminate.as_mut() {
+            Some(terminate) => {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => Cause::Interrupt,
+                    _ = terminate.recv() => Cause::Terminate,
+                }
+            }
+            None => {
+                let _ = tokio::signal::ctrl_c().await;
+                Cause::Interrupt
+            }
+        }
+    }
+}
+
+impl Default for Watch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The behavioural difference between the two causes, stated once so the
+    /// run loop's teardown cannot drift from the documented contract.
+    #[test]
+    fn only_a_foreground_interrupt_reaps_attached_sessions() {
+        assert!(Cause::Interrupt.reaps_interactive_sessions());
+        assert!(
+            !Cause::Terminate.reaps_interactive_sessions(),
+            "daemon stop/restart must not kill the operator's attached panes"
+        );
+    }
+
+    #[test]
+    fn each_cause_names_its_signal() {
+        assert_eq!(Cause::Interrupt.as_str(), "SIGINT");
+        assert_eq!(Cause::Terminate.as_str(), "SIGTERM");
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
@@ -232,6 +232,24 @@ pub fn install(lock_lost: Option<tokio::sync::oneshot::Receiver<i32>>) -> Handle
     tokio::spawn(async move {
         let cause = watch.recv().await;
         let _ = tx.send(Some(cause));
+
+        // Keep OWNING the signal streams after publishing. tokio never
+        // unregisters a handler, so a task that returned here would leave
+        // SIGTERM caught and then silently discarded — and a daemon whose
+        // teardown wedges (a hung `tmux` call, a run that will not abort) could
+        // no longer be stopped by the supported command at all, while still
+        // holding the home's lock.
+        //
+        // A second signal escalates instead: the operator asked twice, and the
+        // graceful path has demonstrably not finished. Exiting here skips the
+        // remaining teardown deliberately — that is what "again" means — and is
+        // still better than an unkillable process holding a home.
+        let second = watch.recv().await;
+        tracing::warn!(
+            signal = second.as_str(),
+            "second shutdown signal during teardown; exiting immediately"
+        );
+        std::process::exit(1);
     });
     Handle { cause: rx }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/shutdown.rs
@@ -152,21 +152,17 @@ impl Watch {
                     tokio::select! {
                         () = fires(interrupt.as_mut()) => Some(Cause::Interrupt),
                         () = fires(terminate.as_mut()) => Some(Cause::Terminate),
-                        owner = lock_lost => match owner {
-                            Ok(pid) => Some(Cause::LockLost(pid)),
-                            // The watchdog ended without reporting a loss (its
-                            // task panicked, or a refactor let it return). That
-                            // is NOT a lost lock.
-                            //
-                            // It must also not be answered inside this arm:
-                            // `select!` has already DROPPED the other branches'
-                            // futures by the time an arm body runs, so awaiting
-                            // `pending()` here — the previous shape — stranded
-                            // the signal streams and the daemon stopped
-                            // answering SIGINT and SIGTERM entirely. Forget the
-                            // channel and re-enter the select instead.
-                            Err(_) => None,
-                        },
+                        // `Err` means the watchdog ended without reporting a
+                        // loss (its task panicked, or a refactor let it return),
+                        // which is NOT a lost lock — it maps to `None` and the
+                        // loop re-enters the select.
+                        //
+                        // It must not be answered inside this arm: `select!` has
+                        // already DROPPED the other branches' futures by the
+                        // time an arm body runs, so awaiting `pending()` here —
+                        // the previous shape — stranded the signal streams and
+                        // the daemon stopped answering SIGINT and SIGTERM.
+                        owner = lock_lost => owner.ok().map(Cause::LockLost),
                     }
                 }
                 None => {
@@ -176,16 +172,14 @@ impl Watch {
                     }
                 }
             };
-            match cause {
-                Some(cause) => return cause,
-                None => {
-                    tracing::warn!(
-                        "the hangar ownership watchdog ended without reporting a loss; \
-                         continuing to serve and watching signals only"
-                    );
-                    self.lock_lost = None;
-                }
+            if let Some(cause) = cause {
+                return cause;
             }
+            tracing::warn!(
+                "the hangar ownership watchdog ended without reporting a loss; \
+                 continuing to serve and watching signals only"
+            );
+            self.lock_lost = None;
         }
     }
 }
@@ -206,7 +200,10 @@ impl Handle {
     /// Resolve with the first cause that asked the daemon to stop.
     pub async fn recv(&mut self) -> Cause {
         loop {
-            if let Some(cause) = *self.cause.borrow_and_update() {
+            // Bound the borrow to this statement: a `watch::Ref` held across the
+            // `changed().await` below would block every publisher.
+            let seen = *self.cause.borrow_and_update();
+            if let Some(cause) = seen {
                 return cause;
             }
             if self.cause.changed().await.is_err() {
@@ -251,7 +248,9 @@ mod tests {
 
     /// Signals are process-wide: two tests raising SIGTERM concurrently would
     /// race for one delivery, and either could observe the other's.
-    static SIGNAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ///
+    /// Async-aware, because every holder keeps it across an `await`.
+    static SIGNAL_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
     /// The behavioural difference between the two causes, stated once so the
     /// run loop's teardown cannot drift from the documented contract.
@@ -280,7 +279,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_resolved_watchdog_stands_the_daemon_down() {
-        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _serialised = SIGNAL_LOCK.lock().await;
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut watch = Watch::new().on_lock_lost(rx);
         tx.send(9001).expect("send new owner");
@@ -294,7 +293,7 @@ mod tests {
         // Any installed `Watch` sees process-wide signals, so this must not
         // overlap a sibling test that raises one — it would observe that
         // delivery and read as "the seam resolved".
-        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _serialised = SIGNAL_LOCK.lock().await;
         let (tx, rx) = tokio::sync::oneshot::channel::<i32>();
         let mut watch = Watch::new().on_lock_lost(rx);
         drop(tx);
@@ -324,7 +323,7 @@ mod tests {
     /// signals are process-wide, and two watches would race for one delivery.
     #[tokio::test]
     async fn signals_still_arrive_after_the_watchdog_is_dropped() {
-        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _serialised = SIGNAL_LOCK.lock().await;
         let (tx, rx) = tokio::sync::oneshot::channel::<i32>();
         let mut watch = Watch::new().on_lock_lost(rx);
         drop(tx);
@@ -344,7 +343,7 @@ mod tests {
     /// with a live watchdog attached still reads as a terminate.
     #[tokio::test]
     async fn sigterm_resolves_the_seam() {
-        let _serialised = SIGNAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _serialised = SIGNAL_LOCK.lock().await;
         let (_tx, rx) = tokio::sync::oneshot::channel::<i32>();
         let mut watch = Watch::new().on_lock_lost(rx);
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -122,11 +122,12 @@ where
 /// lock, and `rpc::bind` then unlinked its socket — the exact double-daemon
 /// incident this module exists to prevent, reintroduced by the guard meant to
 /// stop it.
-fn holder_is_live_daemon(pid: i32) -> bool {
+#[must_use]
+pub fn holder_is_live_daemon(pid: i32) -> bool {
     if !pid_alive(pid) {
         return false;
     }
-    let Some(args) = ps_args(pid) else {
+    let Some(args) = process_argv(pid) else {
         return true;
     };
     is_hangar_daemon_args(&args) || runs_our_executable(&args)
@@ -159,7 +160,12 @@ const PS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// The full argv of `pid` as one line, or `None` when `ps` cannot answer in
 /// time.
-fn ps_args(pid: i32) -> Option<String> {
+///
+/// Exported so the CLI can apply the same identity rule to the same lock file —
+/// the two halves disagreeing about who owns a home is how a recycled pid ends
+/// up being reported as a running daemon, and SIGTERMed by `stop`.
+#[must_use]
+pub fn process_argv(pid: i32) -> Option<String> {
     let mut child = std::process::Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "args="])
         .stdin(std::process::Stdio::null())

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -64,7 +64,16 @@ pub enum Ownership {
 /// `<home>/hangar` directory the store and pid file need, so it is fatal rather
 /// than a reason to boot unguarded.
 pub fn acquire(dir: &Path) -> std::io::Result<Ownership> {
-    acquire_with(dir, holder_is_live_daemon)
+    match acquire_with(dir, holder_is_live_daemon)? {
+        // Sample twice before declining on `Contended`. That verdict means the
+        // path churned for the whole window without ever naming a live holder,
+        // which is NOT evidence that someone else won it — and if every
+        // contender declined on one such sample, the home would end up with no
+        // daemon at all. A second pass costs one fail-fast window and turns the
+        // usual case (someone did win) into an honest `HeldBy`.
+        Ownership::Contended => acquire_with(dir, holder_is_live_daemon),
+        won_or_held => Ok(won_or_held),
+    }
 }
 
 /// [`acquire`] with an injectable holder predicate, so the decision table is

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -1,0 +1,234 @@
+//! One daemon per hangar home, enforced before anything else exists.
+//!
+//! Everything [`crate::boot`] builds — the SQLite store, the claim loop, the
+//! sweepers, the control socket — assumes sole ownership of one hangar home. Two
+//! daemons on one home is not a degraded mode: `rpc::bind` unlinks the incumbent's
+//! socket (leaving it `accept()`ing an inode no client can reach) while both claim
+//! loops and both sweepers race the same database.
+//!
+//! The guard that used to stand in for this was a pidfile written at the END of
+//! boot and read by a different process BEFORE spawning — a check-then-act with a
+//! window spanning a dozen subsystem initialisations, and a `std::fs::write` that
+//! cannot fail, so a losing daemon never learned it had lost. This module replaces
+//! it with [`crate::beads_adapter::lock::BdLock`], the crate's existing hardened
+//! cross-process mutex, taken as the first statement of `boot`.
+//!
+//! # Why the holder check is not just `kill(pid, 0)`
+//!
+//! `<hangar_home>/hangar/daemon.lock` outlives reboots: a SIGKILLed (or
+//! power-cut) daemon leaves the file naming its pid, and after the next boot that
+//! pid very likely belongs to some unrelated process. A liveness-only check would
+//! read that as "a daemon owns this home" forever and the daemon would never start
+//! again. So the predicate also asks the process table whether the pid still looks
+//! like a hangar daemon.
+//!
+//! That check FAILS SAFE: when `ps` cannot answer, the holder is respected. The
+//! asymmetry is deliberate — declining to boot is loud and recoverable (the log
+//! names the file to remove), whereas stealing a live daemon's lock silently
+//! recreates the double-hold this module exists to prevent.
+
+use std::path::{Path, PathBuf};
+
+use crate::beads_adapter::lock::{BdLock, BdLockGuard, LockHeld, pid_alive};
+
+/// Resolve the ownership lock for a hangar home:
+/// `<hangar_home>/hangar/daemon.lock`.
+///
+/// Beside `daemon.pid` rather than replacing it: the pid file remains the
+/// discovery/status artifact, while this file is the thing that actually decides
+/// who runs.
+#[must_use]
+pub fn lock_path_in(dir: &Path) -> PathBuf {
+    dir.join("hangar").join("daemon.lock")
+}
+
+/// The outcome of asking for a hangar home.
+#[derive(Debug)]
+pub enum Ownership {
+    /// This process owns the home. The guard MUST be held for the daemon's whole
+    /// lifetime — dropping it early republishes the home as free.
+    Acquired(BdLockGuard),
+    /// A live hangar daemon already owns the home, named by pid.
+    HeldBy(i32),
+    /// The lock churned for the whole window without ever being publishable and
+    /// without a live holder to name. Another daemon is mid-acquisition; the
+    /// correct response is still to decline.
+    Contended,
+}
+
+/// Claim `dir` for this process, or report who owns it.
+///
+/// # Errors
+///
+/// The lock's parent directory could not be created. That is the same
+/// `<home>/hangar` directory the store and pid file need, so it is fatal rather
+/// than a reason to boot unguarded.
+pub fn acquire(dir: &Path) -> std::io::Result<Ownership> {
+    acquire_with(dir, holder_is_live_daemon)
+}
+
+/// [`acquire`] with an injectable holder predicate, so the decision table is
+/// testable without a real daemon in the process list.
+fn acquire_with<F>(dir: &Path, holder_is_live: F) -> std::io::Result<Ownership>
+where
+    F: Fn(i32) -> bool,
+{
+    match BdLock::new(lock_path_in(dir)).try_acquire_with(holder_is_live) {
+        Ok(guard) => Ok(Ownership::Acquired(guard)),
+        Err(LockHeld::By(pid)) => Ok(Ownership::HeldBy(pid)),
+        Err(LockHeld::Contended) => Ok(Ownership::Contended),
+        Err(LockHeld::Io(e)) => Err(e),
+    }
+}
+
+/// Is `pid` a live process that still looks like a hangar daemon?
+///
+/// Fails safe: a process table we cannot read yields `true` (respect the
+/// holder). See the module doc for why that direction is the safe one.
+fn holder_is_live_daemon(pid: i32) -> bool {
+    if !pid_alive(pid) {
+        return false;
+    }
+    ps_args(pid).is_none_or(|args| is_hangar_daemon_args(&args))
+}
+
+/// The full argv of `pid` as one line, or `None` when `ps` cannot answer.
+fn ps_args(pid: i32) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "args="])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let args = String::from_utf8(output.stdout).ok()?;
+    let args = args.trim();
+    (!args.is_empty()).then(|| args.to_string())
+}
+
+/// Does this argv line belong to a hangar daemon?
+///
+/// Two shapes launch one (`cli::hangar::resolve_daemon_launch`): the sidecar
+/// binary `ainb-hangar-daemon`, and `ainb` self-exec'ing as
+/// `ainb hangar daemon run` when the sidecar is absent or stale.
+///
+/// Matching is exact-token, not substring: `ainb hangar daemon status` and
+/// `ainb hangar daemon stop` are ordinary CLI invocations that must never be
+/// mistaken for a running daemon, and a bare `ainb` (the TUI) must not either.
+#[must_use]
+pub fn is_hangar_daemon_args(args: &str) -> bool {
+    let tokens: Vec<&str> = args.split_whitespace().collect();
+    let sidecar = tokens
+        .first()
+        .map(Path::new)
+        .and_then(Path::file_name)
+        .is_some_and(|name| name == "ainb-hangar-daemon");
+    sidecar || tokens.windows(3).any(|w| w == ["hangar", "daemon", "run"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_and_self_exec_argv_are_recognised() {
+        for args in [
+            "/opt/homebrew/bin/ainb-hangar-daemon",
+            "ainb-hangar-daemon",
+            "target/debug/ainb-hangar-daemon --once",
+            "/Users/x/.cargo/bin/ainb hangar daemon run",
+            "ainb hangar daemon run",
+        ] {
+            assert!(is_hangar_daemon_args(args), "should match: {args}");
+        }
+    }
+
+    /// The false positives that matter: a mismatch here either wedges every
+    /// future boot (an ordinary CLI process mistaken for the owner) or, on the
+    /// `stop --all` side, signals something that is not a daemon at all.
+    #[test]
+    fn cli_verbs_the_tui_and_strangers_are_not_daemons() {
+        for args in [
+            "/opt/homebrew/bin/ainb",
+            "ainb",
+            "ainb hangar daemon status",
+            "ainb hangar daemon stop --all",
+            "ainb hangar daemon restart",
+            "ainb run --agent claude",
+            "/bin/sleep 30",
+            "grep ainb-hangar-daemon",
+            "",
+        ] {
+            assert!(!is_hangar_daemon_args(args), "should not match: {args}");
+        }
+    }
+
+    #[test]
+    fn the_lock_lives_beside_the_pid_file() {
+        let dir = Path::new("/tmp/hangar-home");
+        assert_eq!(
+            lock_path_in(dir),
+            Path::new("/tmp/hangar-home/hangar/daemon.lock")
+        );
+    }
+
+    #[test]
+    fn a_free_home_is_acquired() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        match acquire(dir.path()).expect("acquire") {
+            Ownership::Acquired(_) => {}
+            other => panic!("expected a free home to be acquired, got {other:?}"),
+        }
+    }
+
+    /// The decisive case: a second daemon must be told who owns the home rather
+    /// than booting alongside it.
+    #[test]
+    fn a_home_owned_by_a_live_daemon_is_declined() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let held = acquire(dir.path()).expect("first acquire");
+        assert!(matches!(held, Ownership::Acquired(_)));
+
+        // Our own pid holds it, and the predicate is told we are a daemon.
+        match acquire_with(dir.path(), |_| true).expect("second acquire") {
+            Ownership::HeldBy(pid) => {
+                assert_eq!(pid, i32::try_from(std::process::id()).unwrap());
+            }
+            other => panic!("expected the home to be declined, got {other:?}"),
+        }
+        drop(held);
+    }
+
+    /// A lock left by a SIGKILLed daemon whose pid has since been recycled onto
+    /// an unrelated live process must be reclaimable, or the daemon can never
+    /// boot again after a reboot.
+    #[test]
+    fn a_lock_naming_a_live_non_daemon_is_reclaimed() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = lock_path_in(dir.path());
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        // A live pid that is emphatically not a daemon: our own test process.
+        std::fs::write(&path, std::process::id().to_string()).expect("seed lock");
+
+        match acquire(dir.path()).expect("acquire") {
+            Ownership::Acquired(_) => {}
+            other => panic!("expected a recycled-pid lock to be reclaimed, got {other:?}"),
+        }
+    }
+
+    /// The fail-safe direction: an unreadable process table must NOT be read as
+    /// "the holder is gone".
+    #[test]
+    fn an_unanswerable_process_table_respects_the_holder() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let held = acquire(dir.path()).expect("first acquire");
+        // `holder_is_live_daemon` with `ps_args` returning None reduces to
+        // `pid_alive`, which is what this predicate models.
+        match acquire_with(dir.path(), pid_alive).expect("second acquire") {
+            Ownership::HeldBy(_) => {}
+            other => panic!("expected the holder to be respected, got {other:?}"),
+        }
+        drop(held);
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -163,7 +163,7 @@ const PS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 ///
 /// Exported so the CLI can apply the same identity rule to the same lock file —
 /// the two halves disagreeing about who owns a home is how a recycled pid ends
-/// up being reported as a running daemon, and SIGTERMed by `stop`.
+/// up being reported as a running daemon, and `SIGTERM`ed by `stop`.
 #[must_use]
 pub fn process_argv(pid: i32) -> Option<String> {
     let mut child = std::process::Command::new("ps")
@@ -384,7 +384,7 @@ mod tests {
         drop(held);
     }
 
-    /// A lock left by a SIGKILLed daemon whose pid has since been recycled onto
+    /// A lock left by a `SIGKILL`ed daemon whose pid has since been recycled onto
     /// an unrelated live process must be reclaimable, or the daemon can never
     /// boot again after a reboot.
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -19,13 +19,22 @@
 //! power-cut) daemon leaves the file naming its pid, and after the next boot that
 //! pid very likely belongs to some unrelated process. A liveness-only check would
 //! read that as "a daemon owns this home" forever and the daemon would never start
-//! again. So the predicate also asks the process table whether the pid still looks
-//! like a hangar daemon.
+//! again. So the predicate also asks the process table what that pid is running.
 //!
-//! That check FAILS SAFE: when `ps` cannot answer, the holder is respected. The
-//! asymmetry is deliberate — declining to boot is loud and recoverable (the log
-//! names the file to remove), whereas stealing a live daemon's lock silently
-//! recreates the double-hold this module exists to prevent.
+//! That check FAILS SAFE in every direction: a `ps` that cannot answer, an argv
+//! shape it does not recognise, and a holder running our own executable all
+//! RESPECT the holder. Only positive evidence of a different program justifies a
+//! steal. The asymmetry is deliberate — declining to boot is loud and
+//! recoverable (the log names the file to remove), whereas stealing a live
+//! daemon's lock silently recreates the double-hold this module exists to
+//! prevent.
+//!
+//! The kernel offers a primitive with none of this bookkeeping: an `flock` /
+//! `F_SETLK` held for the process lifetime is released by the kernel on exit,
+//! crash and reboot alike, which removes the recycled-pid problem at the root.
+//! This module reuses [`BdLock`] instead because that carries the crate's
+//! existing double-hold race tests; the lock-file primitive is the better
+//! long-term shape and the identity layer is what it costs to keep the pidfile.
 
 use std::path::{Path, PathBuf};
 
@@ -90,28 +99,96 @@ where
     }
 }
 
-/// Is `pid` a live process that still looks like a hangar daemon?
+/// Is `pid` a live process this daemon must respect as the home's owner?
 ///
-/// Fails safe: a process table we cannot read yields `true` (respect the
-/// holder). See the module doc for why that direction is the safe one.
+/// Three ways to answer yes, and only ONE way to answer no. That asymmetry is
+/// the contract [`BdLock::try_acquire_with`] demands: a false negative steals a
+/// LIVE holder's lock and puts two daemons on one home, so "not a daemon" is
+/// only ever concluded from positive evidence that the holder is a different
+/// program.
+///
+/// 1. `ps` cannot answer → respect (the original fail-safe).
+/// 2. The argv is a recognised daemon shape → respect.
+/// 3. The argv is unrecognised but the holder is running the SAME executable we
+///    are → respect. This covers every daemon whose argv
+///    [`is_hangar_daemon_args`] cannot know about: an `AINB_HANGAR_DAEMON_BIN`
+///    override pointing at a wrapper or a dev binary, an install path
+///    containing a space (`ps` renders argv whitespace-separated, so
+///    `/Volumes/My Passport/bin/ainb-hangar-daemon` has a first token of
+///    `/Volumes/My`), and an in-process `boot()` inside a cargo test binary,
+///    whose argv is `target/debug/deps/<hash>`.
+///
+/// Without (3) a second daemon judged such an incumbent a stranger, stole its
+/// lock, and `rpc::bind` then unlinked its socket — the exact double-daemon
+/// incident this module exists to prevent, reintroduced by the guard meant to
+/// stop it.
 fn holder_is_live_daemon(pid: i32) -> bool {
     if !pid_alive(pid) {
         return false;
     }
-    ps_args(pid).is_none_or(|args| is_hangar_daemon_args(&args))
+    let Some(args) = ps_args(pid) else {
+        return true;
+    };
+    is_hangar_daemon_args(&args) || runs_our_executable(&args)
 }
 
-/// The full argv of `pid` as one line, or `None` when `ps` cannot answer.
+/// Is this argv running the same binary as us?
+///
+/// Prefix-matched against [`std::env::current_exe`] rather than compared
+/// token-wise, because `ps` renders argv whitespace-separated and an executable
+/// path may itself contain spaces. An unresolvable `current_exe` answers `true`
+/// (respect the holder), keeping every unknown on the fail-safe side.
+fn runs_our_executable(args: &str) -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return true;
+    };
+    let exe = exe.to_string_lossy().into_owned();
+    if exe.is_empty() {
+        return true;
+    }
+    args == exe || args.starts_with(&format!("{exe} "))
+}
+
+/// How long to wait for `ps` before treating the process table as unreadable.
+///
+/// `holder_is_live_daemon` runs as part of the FIRST statement of `boot`, so an
+/// unbounded wait here would hang startup on a wedged `ps` (a stalled disk, a
+/// frozen cgroup) — defeating the fail-fast the whole guard is built around. A
+/// timeout degrades to the `None` branch, which respects the holder.
+const PS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The full argv of `pid` as one line, or `None` when `ps` cannot answer in
+/// time.
 fn ps_args(pid: i32) -> Option<String> {
-    let output = std::process::Command::new("ps")
+    let mut child = std::process::Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "args="])
         .stdin(std::process::Stdio::null())
-        .output()
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
         .ok()?;
-    if !output.status.success() {
+
+    let deadline = std::time::Instant::now() + PS_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                // Reap our own child by its exact handle so a wedged `ps` is not
+                // left behind, then answer "unreadable".
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(20)),
+            Err(_) => return None,
+        }
+    };
+    if !status.success() {
         return None;
     }
-    let args = String::from_utf8(output.stdout).ok()?;
+    let mut stdout = child.stdout.take()?;
+    let mut args = String::new();
+    std::io::Read::read_to_string(&mut stdout, &mut args).ok()?;
     let args = args.trim();
     (!args.is_empty()).then(|| args.to_string())
 }
@@ -121,14 +198,17 @@ fn ps_args(pid: i32) -> Option<String> {
 /// Overridable with `AINB_HANGAR_OWNERSHIP_WATCH_MS` so a tripwire can drive
 /// several ticks inside a test budget, mirroring `HANGAR_DAEMON_POLL_MS`.
 fn watchdog_interval() -> std::time::Duration {
+    /// The tick is the WIDTH of the window in which two daemons can be live on
+    /// one home: the newcomer unlinks the incumbent's socket the moment it
+    /// binds, while the incumbent keeps claiming and sweeping until its next
+    /// sample. 5s bounds that, at the cost of one file read per tick.
+    const DEFAULT: std::time::Duration = std::time::Duration::from_secs(5);
+
     std::env::var("AINB_HANGAR_OWNERSHIP_WATCH_MS")
         .ok()
         .and_then(|raw| raw.parse::<u64>().ok())
         .filter(|ms| *ms > 0)
-        .map_or(
-            std::time::Duration::from_secs(30),
-            std::time::Duration::from_millis,
-        )
+        .map_or(DEFAULT, std::time::Duration::from_millis)
 }
 
 /// What one watchdog sample saw.
@@ -306,13 +386,61 @@ mod tests {
         let dir = tempfile::tempdir().expect("tmpdir");
         let path = lock_path_in(dir.path());
         std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
-        // A live pid that is emphatically not a daemon: our own test process.
-        std::fs::write(&path, std::process::id().to_string()).expect("seed lock");
 
-        match acquire(dir.path()).expect("acquire") {
+        // A genuinely foreign live process — the shape a recycled pid takes
+        // after a reboot. Our OWN pid would not do: this test binary is the
+        // executable a daemon would be running, so it is respected by design
+        // (see `a_holder_running_our_own_binary_is_respected_whatever_its_argv`).
+        // Killed by its exact pid on drop.
+        let mut stranger = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn /bin/sleep");
+        std::fs::write(&path, stranger.id().to_string()).expect("seed lock");
+
+        let outcome = acquire(dir.path()).expect("acquire");
+        let _ = stranger.kill();
+        let _ = stranger.wait();
+
+        match outcome {
             Ownership::Acquired(_) => {}
             other => panic!("expected a recycled-pid lock to be reclaimed, got {other:?}"),
         }
+    }
+
+    /// The fail-safe that stops the guard from recreating the incident.
+    ///
+    /// A daemon whose argv `is_hangar_daemon_args` cannot recognise — a wrapper
+    /// via `AINB_HANGAR_DAEMON_BIN`, an install path with a space, an
+    /// in-process `boot()` in a test binary — must still be respected, or a
+    /// second daemon steals its lock and both end up serving one home.
+    #[test]
+    fn a_holder_running_our_own_binary_is_respected_whatever_its_argv() {
+        let exe = std::env::current_exe().expect("current_exe");
+        let exe = exe.to_string_lossy().into_owned();
+
+        assert!(runs_our_executable(&exe), "bare invocation");
+        assert!(runs_our_executable(&format!("{exe} --once")), "with args");
+        assert!(
+            !is_hangar_daemon_args(&exe),
+            "this test binary's argv is exactly the unrecognised shape under test"
+        );
+        assert!(
+            holder_is_live_daemon(i32::try_from(std::process::id()).unwrap()),
+            "our own live process must never be judged a stranger"
+        );
+    }
+
+    /// The other half: a genuinely different program is not protected, or a
+    /// recycled pid would wedge the home forever.
+    #[test]
+    fn a_different_executable_is_not_ours() {
+        assert!(!runs_our_executable("/bin/sleep 30"));
+        assert!(!runs_our_executable("/usr/bin/vim"));
+        // A prefix of our path is not our path.
+        let exe = std::env::current_exe().expect("current_exe");
+        let truncated = &exe.to_string_lossy()[..exe.to_string_lossy().len() - 1];
+        assert!(!runs_our_executable(truncated));
     }
 
     /// The watchdog's whole decision table. The dangerous cell is `Unknown`:

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -107,6 +107,95 @@ fn ps_args(pid: i32) -> Option<String> {
     (!args.is_empty()).then(|| args.to_string())
 }
 
+/// How often the watchdog re-checks that this daemon still owns its home.
+///
+/// Overridable with `AINB_HANGAR_OWNERSHIP_WATCH_MS` so a tripwire can drive
+/// several ticks inside a test budget, mirroring `HANGAR_DAEMON_POLL_MS`.
+fn watchdog_interval() -> std::time::Duration {
+    std::env::var("AINB_HANGAR_OWNERSHIP_WATCH_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+        .map_or(
+            std::time::Duration::from_secs(30),
+            std::time::Duration::from_millis,
+        )
+}
+
+/// What one watchdog sample saw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Held {
+    /// The lock still names us. Nothing to do.
+    Ours,
+    /// The lock is absent or unreadable. NOT proof we lost it — a steal may be
+    /// mid-flight, and a daemon that exited on a transient read failure would be
+    /// a worse bug than the one this watches for.
+    Unknown,
+    /// Another pid holds the lock and is a live daemon: it owns the home now.
+    Lost(i32),
+    /// Another pid is recorded but is not a live daemon — debris, not an owner.
+    Stale(i32),
+}
+
+/// Classify the lock file's current contents against our own pid.
+///
+/// Pure but for the `holder_is_live` probe, so every branch is testable.
+fn sample<F>(lock: &Path, mine: i32, holder_is_live: F) -> Held
+where
+    F: Fn(i32) -> bool,
+{
+    let Some(holder) = std::fs::read_to_string(lock)
+        .ok()
+        .and_then(|text| text.trim().parse::<i32>().ok())
+    else {
+        return Held::Unknown;
+    };
+    if holder == mine {
+        Held::Ours
+    } else if holder_is_live(holder) {
+        Held::Lost(holder)
+    } else {
+        Held::Stale(holder)
+    }
+}
+
+/// Watch that this daemon still owns `dir`, resolving with the new owner's pid
+/// if it ever stops owning it.
+///
+/// The layer that does not depend on any exit path running. A daemon can only
+/// lose a lock it holds by something outside its control — an operator deleting
+/// the file, a predicate misfire, a home restored from a backup — and two
+/// daemons on one home is the failure this whole module exists to prevent, so
+/// the right response is to stand down rather than race.
+///
+/// Scoped to THIS home by construction: it reads one file and signals no one.
+/// That is the difference between this and an argv-matching reaper, which cannot
+/// tell which home a process serves and would kill daemons belonging to others.
+pub async fn watch_ownership(dir: &Path) -> i32 {
+    let lock = lock_path_in(dir);
+    let mine = i32::try_from(std::process::id()).unwrap_or(-1);
+    let interval = watchdog_interval();
+    loop {
+        tokio::time::sleep(interval).await;
+        match sample(&lock, mine, holder_is_live_daemon) {
+            Held::Ours => {}
+            Held::Lost(pid) => return pid,
+            // Neither is proof of loss. If the home really is free, the next
+            // daemon to take it turns this into `Lost` on a later tick — one
+            // tick of overlap, versus an exit on a transient read.
+            Held::Unknown => tracing::warn!(
+                lock = %lock.display(),
+                "hangar ownership lock is missing; continuing to serve"
+            ),
+            Held::Stale(pid) => tracing::warn!(
+                lock = %lock.display(),
+                holder = pid,
+                "hangar ownership lock names a stale pid; continuing to serve"
+            ),
+        }
+    }
+}
+
 /// Does this argv line belong to a hangar daemon?
 ///
 /// Two shapes launch one (`cli::hangar::resolve_daemon_launch`): the sidecar
@@ -215,6 +304,28 @@ mod tests {
             Ownership::Acquired(_) => {}
             other => panic!("expected a recycled-pid lock to be reclaimed, got {other:?}"),
         }
+    }
+
+    /// The watchdog's whole decision table. The dangerous cell is `Unknown`:
+    /// reading an absent or unreadable file as "we lost it" would let a
+    /// transient failure shut down a healthy daemon.
+    #[test]
+    fn the_watchdog_stands_down_only_for_a_live_successor() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let lock = dir.path().join("daemon.lock");
+        let mine = 4242;
+
+        assert_eq!(sample(&lock, mine, |_| true), Held::Unknown, "absent");
+
+        std::fs::write(&lock, "not-a-pid").expect("write");
+        assert_eq!(sample(&lock, mine, |_| true), Held::Unknown, "unreadable");
+
+        std::fs::write(&lock, mine.to_string()).expect("write");
+        assert_eq!(sample(&lock, mine, |_| true), Held::Ours);
+
+        std::fs::write(&lock, "9001").expect("write");
+        assert_eq!(sample(&lock, mine, |_| true), Held::Lost(9001));
+        assert_eq!(sample(&lock, mine, |_| false), Held::Stale(9001));
     }
 
     /// The fail-safe direction: an unreadable process table must NOT be read as

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -74,14 +74,34 @@ pub enum Ownership {
 /// than a reason to boot unguarded.
 pub fn acquire(dir: &Path) -> std::io::Result<Ownership> {
     match acquire_with(dir, holder_is_live_daemon)? {
-        // Sample twice before declining on `Contended`. That verdict means the
-        // path churned for the whole window without ever naming a live holder,
-        // which is NOT evidence that someone else won it — and if every
-        // contender declined on one such sample, the home would end up with no
-        // daemon at all. A second pass costs one fail-fast window and turns the
-        // usual case (someone did win) into an honest `HeldBy`.
-        Ownership::Contended => acquire_with(dir, holder_is_live_daemon),
+        // `Contended` means the path churned for a whole window without ever
+        // naming a live holder. That is NOT evidence anyone won it, so declining
+        // on it is the one way this guard could leave a home with NO daemon:
+        // symmetric contenders all sampling churn, all standing down.
+        //
+        // Escalate instead of declining. A blocking attempt either takes the
+        // lock (nobody had it — exactly the case a fail-fast sample cannot tell
+        // apart from a busy one) or resolves into an honest `HeldBy` once a
+        // winner publishes. Only if THAT still cannot name anyone do we decline,
+        // by which point a real owner has had seconds to appear.
+        Ownership::Contended => Ok(escalate(dir)),
         won_or_held => Ok(won_or_held),
+    }
+}
+
+/// How long the `Contended` escalation blocks before giving up.
+const CONTENDED_ESCALATION: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// One blocking attempt after fail-fast could not name a holder.
+fn escalate(dir: &Path) -> Ownership {
+    match BdLock::new(lock_path_in(dir))
+        .acquire_within_with(CONTENDED_ESCALATION, holder_is_live_daemon)
+    {
+        Ok(guard) => Ownership::Acquired(guard),
+        Err(LockHeld::By(pid)) => Ownership::HeldBy(pid),
+        // Still nobody nameable. Decline: something is churning the path that we
+        // cannot identify, and booting alongside it is the worse failure.
+        Err(LockHeld::Contended | LockHeld::Io(_)) => Ownership::Contended,
     }
 }
 
@@ -109,8 +129,8 @@ where
 ///
 /// 1. `ps` cannot answer → respect (the original fail-safe).
 /// 2. The argv is a recognised daemon shape → respect.
-/// 3. The argv is unrecognised but the holder is running the SAME executable we
-///    are → respect. This covers every daemon whose argv
+/// 3. The argv is unrecognised but is the SAME COMMAND LINE we were invoked
+///    with → respect. This covers every daemon whose argv
 ///    [`is_hangar_daemon_args`] cannot know about: an `AINB_HANGAR_DAEMON_BIN`
 ///    override pointing at a wrapper or a dev binary, an install path
 ///    containing a space (`ps` renders argv whitespace-separated, so
@@ -130,24 +150,42 @@ pub fn holder_is_live_daemon(pid: i32) -> bool {
     let Some(args) = process_argv(pid) else {
         return true;
     };
-    is_hangar_daemon_args(&args) || runs_our_executable(&args)
+    is_hangar_daemon_args(&args) || shares_our_command_line(&args)
 }
 
-/// Is this argv running the same binary as us?
+/// Is this argv the SAME INVOCATION as ours — the whole command line, not just
+/// the executable?
 ///
-/// Prefix-matched against [`std::env::current_exe`] rather than compared
-/// token-wise, because `ps` renders argv whitespace-separated and an executable
-/// path may itself contain spaces. An unresolvable `current_exe` answers `true`
-/// (respect the holder), keeping every unknown on the fail-safe side.
-fn runs_our_executable(args: &str) -> bool {
-    let Ok(exe) = std::env::current_exe() else {
-        return true;
+/// Comparing executables alone was a hole: on a Homebrew layout there is no
+/// sidecar binary, so the daemon self-execs as `ainb hangar daemon run` and its
+/// `current_exe` is plain `ainb` — the same executable the TUI runs. A recycled
+/// pid landing on the user's TUI would then be respected as this home's owner,
+/// and the daemon would decline to boot for as long as that TUI lived: zero
+/// daemons, silently, which is the failure this module exists to prevent turned
+/// inside out.
+///
+/// The full command line separates them (`…/ainb` vs `…/ainb hangar daemon
+/// run`) while still covering everything [`is_hangar_daemon_args`] cannot know
+/// about — an `AINB_HANGAR_DAEMON_BIN` wrapper, an install path containing a
+/// space, an in-process `boot()` in a test binary — because two processes of
+/// that kind share one command line.
+///
+/// An unresolvable argv answers `true` (respect the holder), keeping every
+/// unknown on the fail-safe side.
+fn shares_our_command_line(args: &str) -> bool {
+    our_command_line().is_none_or(|ours| args == ours)
+}
+
+/// This process's own argv, rendered the way `ps -o args=` renders it.
+fn our_command_line() -> Option<String> {
+    let exe = std::env::current_exe().ok()?.to_string_lossy().into_owned();
+    let rest: Vec<String> = std::env::args().skip(1).collect();
+    let line = if rest.is_empty() {
+        exe
+    } else {
+        format!("{exe} {}", rest.join(" "))
     };
-    let exe = exe.to_string_lossy().into_owned();
-    if exe.is_empty() {
-        return true;
-    }
-    args == exe || args.starts_with(&format!("{exe} "))
+    (!line.trim().is_empty()).then_some(line)
 }
 
 /// How long to wait for `ps` before treating the process table as unreadable.
@@ -421,14 +459,12 @@ mod tests {
     /// in-process `boot()` in a test binary — must still be respected, or a
     /// second daemon steals its lock and both end up serving one home.
     #[test]
-    fn a_holder_running_our_own_binary_is_respected_whatever_its_argv() {
-        let exe = std::env::current_exe().expect("current_exe");
-        let exe = exe.to_string_lossy().into_owned();
+    fn a_holder_sharing_our_command_line_is_respected_whatever_its_argv() {
+        let ours = our_command_line().expect("our own command line");
 
-        assert!(runs_our_executable(&exe), "bare invocation");
-        assert!(runs_our_executable(&format!("{exe} --once")), "with args");
+        assert!(shares_our_command_line(&ours), "our exact invocation");
         assert!(
-            !is_hangar_daemon_args(&exe),
+            !is_hangar_daemon_args(&ours),
             "this test binary's argv is exactly the unrecognised shape under test"
         );
         assert!(
@@ -437,16 +473,30 @@ mod tests {
         );
     }
 
+    /// The hole this replaced an executable-only check to close.
+    ///
+    /// On a Homebrew layout the daemon self-execs as `ainb hangar daemon run`,
+    /// so its executable IS the TUI's executable. Crediting a bare `ainb` as
+    /// this home's daemon would let a recycled pid landing on the user's TUI
+    /// wedge the home with zero daemons for as long as that TUI lives.
+    #[test]
+    fn our_executable_running_a_different_command_line_is_not_us() {
+        let exe = std::env::current_exe().expect("current_exe");
+        let exe = exe.to_string_lossy().into_owned();
+
+        // Same binary, different invocation — e.g. the TUI next to a self-exec'd
+        // daemon. Not us, and not a recognised daemon shape either.
+        assert!(!shares_our_command_line(&exe) || std::env::args().len() == 1);
+        assert!(!shares_our_command_line(&format!("{exe} tui")));
+        assert!(!is_hangar_daemon_args(&exe));
+    }
+
     /// The other half: a genuinely different program is not protected, or a
     /// recycled pid would wedge the home forever.
     #[test]
     fn a_different_executable_is_not_ours() {
-        assert!(!runs_our_executable("/bin/sleep 30"));
-        assert!(!runs_our_executable("/usr/bin/vim"));
-        // A prefix of our path is not our path.
-        let exe = std::env::current_exe().expect("current_exe");
-        let truncated = &exe.to_string_lossy()[..exe.to_string_lossy().len() - 1];
-        assert!(!runs_our_executable(truncated));
+        assert!(!shares_our_command_line("/bin/sleep 30"));
+        assert!(!shares_our_command_line("/usr/bin/vim"));
     }
 
     /// The watchdog's whole decision table. The dangerous cell is `Unknown`:

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -75,33 +75,21 @@ pub enum Ownership {
 pub fn acquire(dir: &Path) -> std::io::Result<Ownership> {
     match acquire_with(dir, holder_is_live_daemon)? {
         // `Contended` means the path churned for a whole window without ever
-        // naming a live holder. That is NOT evidence anyone won it, so declining
-        // on it is the one way this guard could leave a home with NO daemon:
-        // symmetric contenders all sampling churn, all standing down.
+        // naming a live holder. That is NOT evidence anyone won it, so a single
+        // sample must not be enough to decline: symmetric contenders could all
+        // stand down and leave the home with no daemon.
         //
-        // Escalate instead of declining. A blocking attempt either takes the
-        // lock (nobody had it — exactly the case a fail-fast sample cannot tell
-        // apart from a busy one) or resolves into an honest `HeldBy` once a
-        // winner publishes. Only if THAT still cannot name anyone do we decline,
-        // by which point a real owner has had seconds to appear.
-        Ownership::Contended => Ok(escalate(dir)),
+        // Sample twice. A second fail-fast pass costs one window and turns the
+        // usual case (someone did win in the meantime) into an honest `HeldBy`.
+        //
+        // It is deliberately NOT a longer blocking acquire. That was tried and
+        // reverted: escalating turned a rare "nobody boots" into an
+        // intermittent DOUBLE-hold under the stale-lock stress, which is the
+        // failure this whole module exists to prevent and strictly the worse of
+        // the two. Two daemons corrupt a home; a home that briefly starts none
+        // is fixed by the next invocation.
+        Ownership::Contended => acquire_with(dir, holder_is_live_daemon),
         won_or_held => Ok(won_or_held),
-    }
-}
-
-/// How long the `Contended` escalation blocks before giving up.
-const CONTENDED_ESCALATION: std::time::Duration = std::time::Duration::from_secs(5);
-
-/// One blocking attempt after fail-fast could not name a holder.
-fn escalate(dir: &Path) -> Ownership {
-    match BdLock::new(lock_path_in(dir))
-        .acquire_within_with(CONTENDED_ESCALATION, holder_is_live_daemon)
-    {
-        Ok(guard) => Ownership::Acquired(guard),
-        Err(LockHeld::By(pid)) => Ownership::HeldBy(pid),
-        // Still nobody nameable. Decline: something is churning the path that we
-        // cannot identify, and booting alongside it is the worse failure.
-        Err(LockHeld::Contended | LockHeld::Io(_)) => Ownership::Contended,
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_shutdown_reaps_interactive.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_shutdown_reaps_interactive.rs
@@ -43,11 +43,40 @@ use tripwire_support::{
 
 /// The interactive task id — its tmux session is `tmux_hangar-<id>`.
 const TASK_ID: &str = "task-shutdown-int";
+/// The SIGTERM case's task id. Distinct so the two cases never share a tmux
+/// session name when cargo runs them in parallel.
+const TASK_TERM: &str = "task-shutdown-term";
 /// A sentinel that is NEVER written here — the session must die via the reap.
 const SENTINEL: &str = "never-released";
 
+/// SIGINT is the foreground "tear it all down": the attached pane goes with it.
 #[tokio::test]
-async fn graceful_shutdown_reaps_in_flight_interactive_session() {
+async fn sigint_reaps_in_flight_interactive_session() {
+    drive_shutdown("-INT", TASK_ID, "shutdown-sid", Expect::Reaped).await;
+}
+
+/// SIGTERM is `hangar daemon stop` / `restart`, which runs after every upgrade.
+/// It must stop the daemon WITHOUT killing the operator's attached agent panes —
+/// the next boot's tmux reconciler re-adopts them with exact pane identity.
+///
+/// Before the SIGTERM handler existed this test could not have been written: the
+/// process died on the OS default disposition, so nothing about the shutdown was
+/// under the daemon's control at all.
+#[tokio::test]
+async fn sigterm_stops_the_daemon_but_leaves_the_attached_session_running() {
+    drive_shutdown("-TERM", TASK_TERM, "shutdown-term-sid", Expect::Survives).await;
+}
+
+/// What the interactive session should look like after the signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Expect {
+    /// The shutdown path killed it by exact name.
+    Reaped,
+    /// It outlived the daemon, still attachable.
+    Survives,
+}
+
+async fn drive_shutdown(signal: &str, task_id: &str, sid: &str, expect: Expect) {
     if !tmux_available() {
         eprintln!("SKIP: a54 shutdown-reap tripwire (need tmux + built ainb-hangar-daemon)");
         return;
@@ -62,8 +91,8 @@ async fn graceful_shutdown_reaps_in_flight_interactive_session() {
     ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
     let ids = seed_world(&pool).await;
 
-    let fake = fake_claude_tty_branch(home.path(), "shutdown-sid", SENTINEL);
-    let daemon = DaemonProcess::spawn(
+    let fake = fake_claude_tty_branch(home.path(), sid, SENTINEL);
+    let mut daemon = DaemonProcess::spawn(
         home.path(),
         &[
             ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
@@ -77,7 +106,7 @@ async fn graceful_shutdown_reaps_in_flight_interactive_session() {
         "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, mode, created_at) \
          VALUES (?, ?, ?, ?, 'interactive', ?)",
     )
-    .bind(TASK_ID)
+    .bind(task_id)
     .bind(&ids.workspace_id)
     .bind(&ids.runtime_id)
     .bind(&ids.agent_id)
@@ -87,7 +116,7 @@ async fn graceful_shutdown_reaps_in_flight_interactive_session() {
     .expect("enqueue interactive task");
 
     // Wait for the interactive session to be LIVE (the in-flight run to reap).
-    let session_name = format!("tmux_hangar-{TASK_ID}");
+    let session_name = format!("tmux_hangar-{task_id}");
     let live_deadline = Instant::now() + Duration::from_secs(30);
     let mut saw_live = false;
     while Instant::now() < live_deadline {
@@ -107,37 +136,51 @@ async fn graceful_shutdown_reaps_in_flight_interactive_session() {
     // closes the theoretical spawn→register gap deterministically).
     tokio::time::sleep(Duration::from_millis(600)).await;
 
-    // Graceful shutdown: SIGINT (NOT the SIGKILL that Drop uses), so the daemon's
-    // Ctrl-C reap path runs.
+    // Graceful shutdown by EXACT pid (never the SIGKILL that Drop uses), so the
+    // daemon's own shutdown path runs.
     let pid = daemon.pid();
     let sent = Command::new("kill")
-        .args(["-INT", &pid.to_string()])
+        .args([signal, &pid.to_string()])
         .status()
-        .expect("send SIGINT to daemon");
-    assert!(sent.success(), "kill -INT {pid} failed");
+        .expect("signal daemon");
+    assert!(sent.success(), "kill {signal} {pid} failed");
 
-    // POSITIVE: the session is reaped by the shutdown path (the sentinel is never
-    // written, so a still-live session past this deadline is an ORPHAN — the a54
-    // bug this guards).
-    let reap_deadline = Instant::now() + Duration::from_secs(15);
+    // The sentinel is never written, so the stub only self-exits after ~60s —
+    // far past this deadline. Anything that changes within it is the daemon's
+    // shutdown path, not the run finishing.
+    let deadline = Instant::now() + Duration::from_secs(15);
     let mut reaped = false;
-    while Instant::now() < reap_deadline {
+    while Instant::now() < deadline {
         if !tmux_session_live(&session_name) {
             reaped = true;
             break;
         }
         tokio::time::sleep(Duration::from_millis(150)).await;
     }
+    // The daemon itself must be gone either way — a handler that hangs is as
+    // broken as one that kills the wrong thing. `wait_for_exit` reaps, because
+    // this test is the daemon's parent and a zombie answers `kill(pid, 0)`
+    // exactly like a live process.
+    let daemon_stopped = daemon.wait_for_exit(Duration::from_secs(15));
+    let still_live = tmux_session_live(&session_name);
 
-    // Teardown (exact-name) before the assertion so a failure never leaks a pane.
+    // Teardown (exact-name) before the assertions so a failure never leaks a pane.
     drop(daemon);
     tmux_kill_session(&session_name);
 
-    assert!(
-        reaped,
-        "graceful shutdown must reap the in-flight interactive session `{session_name}`, \
-         not orphan it"
-    );
+    assert!(daemon_stopped, "the daemon must exit on {signal}");
+    match expect {
+        Expect::Reaped => assert!(
+            reaped,
+            "SIGINT must reap the in-flight interactive session `{session_name}`, \
+             not orphan it"
+        ),
+        Expect::Survives => assert!(
+            still_live,
+            "SIGTERM must leave the operator's attached session `{session_name}` \
+             running — `daemon restart` happens on every upgrade"
+        ),
+    }
 }
 
 /// Open a WAL sqlite pool at `db_path` (matches the daemon's connection mode).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
@@ -1,0 +1,213 @@
+//! Process-level tripwire for one-daemon-per-hangar-home.
+//!
+//! The incident this guards against: 69 `ainb hangar daemon run` processes on one
+//! machine, 65 of them orphaned at `ppid==1`, twice exhausting a 32 GB Mac. The
+//! cause was a check-then-act guard — a pidfile written at the END of boot and
+//! read by a different process BEFORE spawning — so every duplicate booted, and
+//! `rpc::bind` unlinked the incumbent's socket on the way past.
+//!
+//! Unit tests cannot prove this: the defect lives between processes. So these
+//! spawn REAL daemon binaries against an isolated `HOME` and assert on the
+//! outcomes an operator would see — one survivor, a losing daemon that exits 0,
+//! and an incumbent whose socket is never stolen out from under it.
+//!
+//! Safety (mandatory, mirrors `scripts/soak-codex-orphans.sh`): every daemon here
+//! is a child of this test, killed by its EXACT pid via `DaemonProcess`'s drop.
+//! No `pkill`, no `killall`, no name matching. `HOME` is pinned and the home
+//! overrides removed, so nothing touches the operator's `~/.agents-in-a-box`, and
+//! `AINB_CODEX_MANAGED=0` keeps the codex manager (and the desktop Codex app)
+//! entirely out of it.
+
+mod tripwire_support;
+
+use std::os::unix::fs::MetadataExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use tripwire_support::DaemonProcess;
+
+/// Keep the codex manager out of these tests: it is irrelevant to ownership and
+/// its boot reaper signals processes outside this tempdir.
+const CODEX_OFF: (&str, &str) = ("AINB_CODEX_MANAGED", "0");
+
+/// Generous: the lock is taken before the store opens, so it lands early, but a
+/// cold CI runner still has to exec the binary.
+const LOCK_BUDGET: Duration = Duration::from_secs(30);
+/// The socket appears only after migrations + token mint, so it needs more room.
+const SOCKET_BUDGET: Duration = Duration::from_secs(60);
+
+fn hangar_home(home: &Path) -> PathBuf {
+    home.join(".agents-in-a-box")
+}
+
+fn lock_path(home: &Path) -> PathBuf {
+    hangar_home(home).join("hangar").join("daemon.lock")
+}
+
+fn socket_path(home: &Path) -> PathBuf {
+    hangar_home(home).join("hangar.sock")
+}
+
+fn read_lock_pid(home: &Path) -> Option<i32> {
+    std::fs::read_to_string(lock_path(home)).ok()?.trim().parse().ok()
+}
+
+/// Poll until the ownership lock names someone, or fail with what was seen.
+fn wait_for_lock(home: &Path) -> i32 {
+    wait_until(LOCK_BUDGET, || read_lock_pid(home)).unwrap_or_else(|| {
+        panic!(
+            "no daemon claimed {} within {LOCK_BUDGET:?}",
+            lock_path(home).display()
+        )
+    })
+}
+
+fn wait_for_socket(home: &Path) -> std::fs::Metadata {
+    wait_until(SOCKET_BUDGET, || std::fs::metadata(socket_path(home)).ok()).unwrap_or_else(|| {
+        panic!(
+            "daemon never bound {} within {SOCKET_BUDGET:?}",
+            socket_path(home).display()
+        )
+    })
+}
+
+fn wait_until<T, F: Fn() -> Option<T>>(budget: Duration, probe: F) -> Option<T> {
+    let deadline = Instant::now() + budget;
+    loop {
+        if let Some(v) = probe() {
+            return Some(v);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn pid_alive(pid: i32) -> bool {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    matches!(kill(Pid::from_raw(pid), None), Ok(()) | Err(Errno::EPERM))
+}
+
+/// Run the daemon binary to completion under `home`, returning (exit ok, elapsed).
+///
+/// Used for the daemon that is EXPECTED to decline: it must return by itself, so
+/// there is nothing to kill.
+fn run_daemon_to_completion(home: &Path, args: &[&str]) -> (std::process::ExitStatus, Duration) {
+    let started = Instant::now();
+    let status = Command::new(assert_cmd::cargo::cargo_bin("ainb-hangar-daemon"))
+        .args(args)
+        .env("HOME", home)
+        .env_remove("AINB_HOME")
+        .env_remove("AINB_HANGAR_HOME")
+        .env(CODEX_OFF.0, CODEX_OFF.1)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("run second daemon");
+    (status, started.elapsed())
+}
+
+/// The headline guarantee: a second daemon on a live home does not boot.
+///
+/// Asserts the three things that actually went wrong in the incident, not just
+/// "it exited": the loser exits 0 (so a supervisor does not restart-loop it), it
+/// exits PROMPTLY (a fail-fast guard, not a 30s spin), the incumbent keeps the
+/// lock, and — the corruption the pile caused — the incumbent's socket inode is
+/// untouched, proving `rpc::bind` never unlinked it.
+#[test]
+fn a_second_daemon_declines_a_live_home_and_exits_zero() {
+    let home = tempfile::tempdir().expect("tempdir home");
+    let incumbent = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+    let holder = wait_for_lock(home.path());
+    assert_eq!(
+        holder,
+        i32::try_from(incumbent.pid()).expect("pid fits i32"),
+        "the first daemon should own the home"
+    );
+    let socket_before = wait_for_socket(home.path());
+
+    let (status, elapsed) = run_daemon_to_completion(home.path(), &[]);
+
+    assert!(
+        status.success(),
+        "a losing daemon must exit 0 so supervisors do not restart-loop it, got {status:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "the guard should fail fast, took {elapsed:?}"
+    );
+    assert_eq!(
+        read_lock_pid(home.path()),
+        Some(holder),
+        "the loser must not disturb the incumbent's lock"
+    );
+    assert!(pid_alive(holder), "the incumbent must still be running");
+
+    let socket_after = std::fs::metadata(socket_path(home.path())).expect("socket still present");
+    assert_eq!(
+        socket_before.ino(),
+        socket_after.ino(),
+        "the loser rebound the socket, orphaning the incumbent's listener"
+    );
+}
+
+/// `--once` is a full boot too: it opens the store and binds the socket. Against
+/// a live home that used to unlink the running daemon's socket, so it must
+/// decline exactly like a normal duplicate.
+#[test]
+fn once_mode_declines_a_home_another_daemon_owns() {
+    let home = tempfile::tempdir().expect("tempdir home");
+    let incumbent = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+    let holder = wait_for_lock(home.path());
+    let socket_before = wait_for_socket(home.path());
+
+    let (status, _) = run_daemon_to_completion(home.path(), &["--once"]);
+
+    assert!(status.success(), "--once should exit 0, got {status:?}");
+    assert_eq!(read_lock_pid(home.path()), Some(holder));
+    assert!(pid_alive(
+        i32::try_from(incumbent.pid()).expect("pid fits i32")
+    ));
+    let socket_after = std::fs::metadata(socket_path(home.path())).expect("socket still present");
+    assert_eq!(
+        socket_before.ino(),
+        socket_after.ino(),
+        "--once stole the live daemon's socket"
+    );
+}
+
+/// A SIGKILLed daemon runs no destructor, so it leaves the lock file behind
+/// naming a dead pid. That must not lock the home out forever — the next boot
+/// steals it (atomically, `rename`, winner-take-all) and takes over.
+#[test]
+fn a_stale_lock_left_by_a_killed_daemon_is_reclaimed() {
+    let home = tempfile::tempdir().expect("tempdir home");
+    let dead_pid = {
+        let doomed = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+        let pid = wait_for_lock(home.path());
+        drop(doomed); // kills by EXACT pid, then reaps
+        pid
+    };
+    assert!(
+        lock_path(home.path()).exists(),
+        "a hard-killed daemon leaves its lock behind — that is the case under test"
+    );
+    assert_eq!(read_lock_pid(home.path()), Some(dead_pid));
+
+    let successor = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+    let holder = wait_until(LOCK_BUDGET, || {
+        read_lock_pid(home.path()).filter(|pid| *pid != dead_pid)
+    })
+    .expect("the successor should reclaim the stale lock");
+
+    assert_eq!(
+        holder,
+        i32::try_from(successor.pid()).expect("pid fits i32"),
+        "the successor must own the home after stealing the stale lock"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
@@ -255,3 +255,60 @@ fn a_stale_lock_left_by_a_killed_daemon_is_reclaimed() {
         "the successor must own the home after stealing the stale lock"
     );
 }
+
+/// The layer that does not depend on any exit path running: a daemon that stops
+/// owning its home stands down by itself.
+///
+/// The impostor is a REAL second daemon (booted on its own home, so it is a
+/// legitimate process with daemon argv) whose pid is written into the first
+/// home's lock. Nothing signals the first daemon — it notices, which is the
+/// whole point: no reaper has to identify it, and no cross-home process
+/// matching is involved.
+#[test]
+fn a_daemon_that_loses_its_home_stands_down() {
+    let home = tempfile::tempdir().expect("tempdir home");
+    let elsewhere = tempfile::tempdir().expect("tempdir other home");
+
+    let mut incumbent = DaemonProcess::spawn(
+        home.path(),
+        &[CODEX_OFF, ("AINB_HANGAR_OWNERSHIP_WATCH_MS", "200")],
+    );
+    let holder = wait_for_lock(home.path());
+    wait_for_socket(home.path());
+
+    // A live daemon on a DIFFERENT home: real process, real daemon argv.
+    let successor = DaemonProcess::spawn(elsewhere.path(), &[CODEX_OFF]);
+    let successor_pid = i32::try_from(successor.pid()).expect("pid fits i32");
+    wait_for_lock(elsewhere.path());
+
+    // Hand the home over behind the incumbent's back.
+    std::fs::write(lock_path(home.path()), successor_pid.to_string()).expect("reassign the lock");
+
+    assert!(
+        incumbent.wait_for_exit(Duration::from_secs(30)),
+        "a daemon whose home was taken over must stand down (holder was {holder})"
+    );
+}
+
+/// The dangerous half of the watchdog: a MISSING lock is not proof of loss.
+///
+/// A daemon that exited on a transient read would be a worse bug than the one
+/// the watchdog watches for, so an absent file must leave it serving.
+#[test]
+fn a_missing_lock_does_not_shut_the_daemon_down() {
+    let home = tempfile::tempdir().expect("tempdir home");
+    let mut daemon = DaemonProcess::spawn(
+        home.path(),
+        &[CODEX_OFF, ("AINB_HANGAR_OWNERSHIP_WATCH_MS", "200")],
+    );
+    wait_for_lock(home.path());
+    wait_for_socket(home.path());
+
+    std::fs::remove_file(lock_path(home.path())).expect("remove the lock");
+
+    // Several watchdog ticks with no lock at all.
+    assert!(
+        !daemon.wait_for_exit(Duration::from_secs(3)),
+        "the daemon shut down over a missing lock file"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
@@ -35,7 +35,7 @@ const CODEX_OFF: (&str, &str) = ("AINB_CODEX_MANAGED", "0");
 /// cold CI runner still has to exec the binary.
 const LOCK_BUDGET: Duration = Duration::from_secs(30);
 /// The socket appears only after migrations + token mint, so it needs more room.
-const SOCKET_BUDGET: Duration = Duration::from_secs(60);
+const SOCKET_BUDGET: Duration = Duration::from_mins(1);
 
 fn hangar_home(home: &Path) -> PathBuf {
     home.join(".agents-in-a-box")
@@ -225,7 +225,7 @@ fn sigterm_stops_the_daemon_and_releases_the_home() {
     );
 }
 
-/// A SIGKILLed daemon runs no destructor, so it leaves the lock file behind
+/// A `SIGKILL`ed daemon runs no destructor, so it leaves the lock file behind
 /// naming a dead pid. That must not lock the home out forever — the next boot
 /// steals it (atomically, `rename`, winner-take-all) and takes over.
 #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
@@ -181,6 +181,50 @@ fn once_mode_declines_a_home_another_daemon_owns() {
     );
 }
 
+/// `hangar daemon stop` sends SIGTERM. Until this fix the daemon had no handler
+/// for it, so it died on the OS default disposition: no teardown ran and the
+/// ownership lock was never released. Now it must exit AND release, so the very
+/// next `start` — as `daemon restart` does — takes the home cleanly.
+#[test]
+fn sigterm_stops_the_daemon_and_releases_the_home() {
+    let home = tempfile::tempdir().expect("tempdir home");
+    let mut outgoing = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+    let holder = wait_for_lock(home.path());
+    // Wait for a fully booted daemon: signalling mid-boot would prove nothing
+    // about the run loop's handler.
+    wait_for_socket(home.path());
+
+    let signalled = Command::new("kill")
+        .args(["-TERM", &holder.to_string()])
+        .status()
+        .expect("send SIGTERM");
+    assert!(signalled.success(), "kill -TERM {holder} failed");
+
+    // `wait_for_exit`, not `pid_alive`: this test is the daemon's parent, so an
+    // exited-but-unreaped daemon is a zombie and answers `kill(pid, 0)` like a
+    // live process.
+    assert!(
+        outgoing.wait_for_exit(Duration::from_secs(20)),
+        "the daemon must exit on SIGTERM"
+    );
+    assert!(
+        wait_until(Duration::from_secs(10), || (!lock_path(home.path())
+            .exists())
+        .then_some(()))
+        .is_some(),
+        "a graceful stop must release the ownership lock, or the next start would \
+         have to steal it"
+    );
+    drop(outgoing);
+
+    // The successor takes the home with no stealing involved.
+    let successor = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+    assert_eq!(
+        wait_for_lock(home.path()),
+        i32::try_from(successor.pid()).expect("pid fits i32")
+    );
+}
+
 /// A SIGKILLed daemon runs no destructor, so it leaves the lock file behind
 /// naming a dead pid. That must not lock the home out forever — the next boot
 /// steals it (atomically, `rename`, winner-take-all) and takes over.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_single_instance.rs
@@ -312,3 +312,48 @@ fn a_missing_lock_does_not_shut_the_daemon_down() {
         "the daemon shut down over a missing lock file"
     );
 }
+
+/// SIGTERM during BOOT must be answered, not fatal.
+///
+/// The handlers used to be installed at the very end of boot, so a SIGTERM
+/// arriving while the daemon was still migrating, minting its token or binding
+/// its socket killed it on the OS default disposition — no teardown, and the
+/// ownership lock left on disk naming a dead pid. `daemon restart` and system
+/// shutdown both land in exactly that window.
+///
+/// The signal is sent the instant the lock appears, which is now the FIRST thing
+/// boot does, so on a debug build it usually lands mid-boot. It is not
+/// deterministic, so the assertions hold either way: the daemon exits, and the
+/// home is left FREE rather than locked by a corpse.
+#[test]
+fn sigterm_during_boot_is_answered_and_releases_the_home() {
+    let home = tempfile::tempdir().expect("tempdir home");
+    let mut booting = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+    let pid = wait_for_lock(home.path());
+
+    let signalled = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .expect("send SIGTERM");
+    assert!(signalled.success(), "kill -TERM {pid} failed");
+
+    assert!(
+        booting.wait_for_exit(Duration::from_secs(30)),
+        "a daemon signalled during boot must exit"
+    );
+    assert!(
+        wait_until(Duration::from_secs(10), || (!lock_path(home.path())
+            .exists())
+        .then_some(()))
+        .is_some(),
+        "a daemon signalled during boot must still release the home; a lock left \
+         behind naming a dead pid is what the old end-of-boot handler produced"
+    );
+
+    // And the home is immediately usable by a successor, with no stealing.
+    let successor = DaemonProcess::spawn(home.path(), &[CODEX_OFF]);
+    assert_eq!(
+        wait_for_lock(home.path()),
+        i32::try_from(successor.pid()).expect("pid fits i32")
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
@@ -579,6 +579,27 @@ impl DaemonProcess {
     pub fn pid(&self) -> u32 {
         self.child.id()
     }
+
+    /// Poll until the daemon has exited, bounded by `budget`.
+    ///
+    /// Must be used instead of `kill(pid, 0)` to prove a signalled daemon died:
+    /// this test process is its PARENT, so an exited-but-unreaped daemon is a
+    /// ZOMBIE, and a zombie answers `kill(pid, 0)` exactly like a live process.
+    /// `try_wait` reaps it, which is the only reading that distinguishes the two.
+    pub fn wait_for_exit(&mut self, budget: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + budget;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(_) => return false,
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
 }
 
 impl Drop for DaemonProcess {

--- a/ainb-tui/scripts/soak-hangar-single-instance.sh
+++ b/ainb-tui/scripts/soak-hangar-single-instance.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Soak proof: N daemons started at once against ONE hangar home leave exactly
+# ONE running. Every other one declines the home and exits 0.
+#
+# The incident this proves against: 69 `ainb hangar daemon run` processes on one
+# machine (65 orphaned at ppid==1, 2.41 GB RSS), which twice exhausted a 32 GB
+# Mac. The old guard was a pidfile written at the END of boot and read by a
+# different process BEFORE spawning, so every duplicate booted.
+#
+# Safety (matches ~/.claude global rules and scripts/soak-codex-orphans.sh):
+# every daemon here is started BY this script and killed by its EXACT recorded
+# pid. Never pkill/killall/wildcards. The hangar home is a fresh mktemp dir, so
+# nothing touches ~/.agents-in-a-box, and AINB_CODEX_MANAGED=0 keeps the codex
+# manager (and the desktop Codex/ChatGPT app) entirely out of it.
+#
+# Usage: scripts/soak-hangar-single-instance.sh [rounds] [daemons-per-round]
+#        (defaults: 20 rounds, 10 daemons)
+set -uo pipefail
+
+ROUNDS="${1:-20}"
+FLEET="${2:-10}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$REPO/target/debug/ainb-hangar-daemon"
+
+SOAK_HOME="$(mktemp -d)/soak-hangar"
+mkdir -p "$SOAK_HOME"
+export AINB_HANGAR_HOME="$SOAK_HOME"
+export AINB_CODEX_MANAGED=0
+
+# Every pid this script has ever started, so cleanup can never signal anything
+# it did not create.
+STARTED=()
+
+cleanup() {
+  for pid in "${STARTED[@]:-}"; do
+    [[ -n "$pid" ]] && kill -TERM "$pid" 2>/dev/null
+  done
+  sleep 1
+  for pid in "${STARTED[@]:-}"; do
+    [[ -n "$pid" ]] && kill -KILL "$pid" 2>/dev/null
+  done
+  rm -rf "$(dirname "$SOAK_HOME")" 2>/dev/null
+}
+trap cleanup EXIT
+
+start_daemon() { "$BIN" >>"$SOAK_HOME/daemon.log" 2>&1 & echo $!; }
+
+# How many of the pids passed in are still running (exact pids only).
+count_alive() {
+  local n=0 pid
+  for pid in "$@"; do
+    kill -0 "$pid" 2>/dev/null && n=$((n + 1))
+  done
+  echo "$n"
+}
+
+if [[ ! -x "$BIN" ]]; then
+  echo "Building daemon (debug)..."
+  ( cd "$REPO" && cargo build -p ainb-hangar-daemon --bin ainb-hangar-daemon ) || {
+    echo "FAIL: build failed"; exit 1; }
+fi
+
+echo "== soak-hangar-single-instance: $ROUNDS rounds x $FLEET daemons =="
+echo "AINB_HANGAR_HOME=$AINB_HANGAR_HOME"
+
+worst=0
+fail=0
+for ((round = 1; round <= ROUNDS; round++)); do
+  round_pids=()
+  for ((i = 0; i < FLEET; i++)); do
+    pid="$(start_daemon)"
+    round_pids+=("$pid")
+    STARTED+=("$pid")
+  done
+
+  # Settle past the boot probe: the losers take the lock's fail-fast window
+  # (500ms) plus process startup.
+  sleep 3
+
+  alive="$(count_alive "${round_pids[@]}")"
+  if [[ "$alive" -gt 1 ]]; then
+    # A loser that has not finished exiting yet is not a duplicate daemon. Give
+    # it a grace window and re-count: a REAL duplicate is stable, because both
+    # processes are in their run loops and never leave. Print what was still up
+    # so a genuine failure is diagnosable after the fact.
+    echo "round $round: $alive alive at first count, re-checking after grace..."
+    for p in "${round_pids[@]}"; do
+      kill -0 "$p" 2>/dev/null && ps -p "$p" -o pid=,stat=,etime=,args= 2>/dev/null | head -1
+    done
+    sleep 5
+    alive="$(count_alive "${round_pids[@]}")"
+  fi
+  [[ "$alive" -gt "$worst" ]] && worst="$alive"
+  if [[ "$alive" -ne 1 ]]; then
+    echo "round $round: FAIL — $alive daemons alive, expected exactly 1"
+    fail=1
+  else
+    echo "round $round: ok (1 of $FLEET survived)"
+  fi
+
+  # Stop the survivor by its EXACT pid so the next round starts from a free home.
+  for pid in "${round_pids[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null
+      for _ in $(seq 1 50); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.2
+      done
+    fi
+  done
+done
+
+echo "worst-case concurrent daemons in one round: $worst"
+if [[ "$fail" -eq 0 ]]; then
+  echo "PASS: a single hangar home never had more than one daemon"
+  exit 0
+fi
+echo "FAIL: duplicate daemons survived on one home"
+exit 1

--- a/ainb-tui/scripts/soak-hangar-single-instance.sh
+++ b/ainb-tui/scripts/soak-hangar-single-instance.sh
@@ -54,6 +54,25 @@ count_alive() {
   echo "$n"
 }
 
+# Poll until exactly one of the given pids is left, or the deadline passes.
+#
+# The property under test is "exactly one daemon ENDS UP running", not "exactly
+# one is running at some fixed instant". A loser is a real process: it has to be
+# exec'd, linked and scheduled before it can even look at the lock, and under a
+# loaded box with a fleet starting at once that can outlast a fixed sleep. Poll
+# for the settled state instead, so a slow decline reads as slow rather than as
+# the double-hold this script exists to detect.
+SETTLE_TIMEOUT="${SETTLE_TIMEOUT:-30}"
+wait_until_settled() {
+  local deadline=$((SECONDS + SETTLE_TIMEOUT)) alive
+  while true; do
+    alive="$(count_alive "$@")"
+    [[ "$alive" -eq 1 ]] && { echo "$alive"; return 0; }
+    [[ "$SECONDS" -ge "$deadline" ]] && { echo "$alive"; return 1; }
+    sleep 0.5
+  done
+}
+
 if [[ ! -x "$BIN" ]]; then
   echo "Building daemon (debug)..."
   ( cd "$REPO" && cargo build -p ainb-hangar-daemon --bin ainb-hangar-daemon ) || {
@@ -83,23 +102,15 @@ for ((round = 1; round <= ROUNDS; round++)); do
     STARTED+=("$pid")
   done
 
-  # Settle past the boot probe: the losers take the lock's fail-fast window
-  # (500ms) plus process startup.
-  sleep 3
-
-  alive="$(count_alive "${round_pids[@]}")"
-  if [[ "$alive" -gt 1 ]]; then
-    # A loser that has not finished exiting yet is not a duplicate daemon. Give
-    # it a grace window and re-count: a REAL duplicate is stable, because both
-    # processes are in their run loops and never leave. Print what was still up
-    # so a genuine failure is diagnosable after the fact.
-    echo "round $round: $alive alive at first count, re-checking after grace..."
+  alive="$(wait_until_settled "${round_pids[@]}")" || {
+    # Never settled. Print who is still up so a genuine double-hold is
+    # diagnosable after the fact — a real one is STABLE, both processes sitting
+    # in their run loops.
+    echo "round $round: did not settle to 1 within ${SETTLE_TIMEOUT}s; still up:"
     for p in "${round_pids[@]}"; do
       kill -0 "$p" 2>/dev/null && ps -p "$p" -o pid=,stat=,etime=,args= 2>/dev/null | head -1
     done
-    sleep 5
-    alive="$(count_alive "${round_pids[@]}")"
-  fi
+  }
   [[ "$alive" -gt "$worst" ]] && worst="$alive"
   if [[ "$alive" -ne 1 ]]; then
     echo "round $round: FAIL — $alive daemons alive, expected exactly 1"

--- a/ainb-tui/scripts/soak-hangar-single-instance.sh
+++ b/ainb-tui/scripts/soak-hangar-single-instance.sh
@@ -60,6 +60,16 @@ if [[ ! -x "$BIN" ]]; then
     echo "FAIL: build failed"; exit 1; }
 fi
 
+# Run a PRIVATE COPY, never the shared target/ path. A `cargo build` or `cargo
+# test` running concurrently replaces that file, and daemons launched from it
+# then die mid-run with no shutdown line — which reads exactly like the
+# double-daemon defect this script exists to detect. Copying removes the
+# confound, so a FAIL here always means the lock, never the toolchain.
+RUN_BIN="$SOAK_HOME/ainb-hangar-daemon"
+cp "$BIN" "$RUN_BIN" || { echo "FAIL: could not stage the daemon binary"; exit 1; }
+chmod +x "$RUN_BIN"
+BIN="$RUN_BIN"
+
 echo "== soak-hangar-single-instance: $ROUNDS rounds x $FLEET daemons =="
 echo "AINB_HANGAR_HOME=$AINB_HANGAR_HOME"
 

--- a/ainb-tui/scripts/stress-hangar-lock-steal.sh
+++ b/ainb-tui/scripts/stress-hangar-lock-steal.sh
@@ -57,6 +57,25 @@ count_alive() {
   echo "$n"
 }
 
+# Poll until exactly one of the given pids is left, or the deadline passes.
+#
+# The property under test is "exactly one daemon ENDS UP running", not "exactly
+# one is running at some fixed instant". A loser is a real process: it has to be
+# exec'd, linked and scheduled before it can even look at the lock, and under a
+# loaded box with a fleet starting at once that can outlast a fixed sleep. Poll
+# for the settled state instead, so a slow decline reads as slow rather than as
+# the double-hold this script exists to detect.
+SETTLE_TIMEOUT="${SETTLE_TIMEOUT:-30}"
+wait_until_settled() {
+  local deadline=$((SECONDS + SETTLE_TIMEOUT)) alive
+  while true; do
+    alive="$(count_alive "$@")"
+    [[ "$alive" -eq 1 ]] && { echo "$alive"; return 0; }
+    [[ "$SECONDS" -ge "$deadline" ]] && { echo "$alive"; return 1; }
+    sleep 0.5
+  done
+}
+
 if [[ ! -x "$BIN" ]]; then
   echo "Building daemon (debug)..."
   ( cd "$REPO" && cargo build -p ainb-hangar-daemon --bin ainb-hangar-daemon ) || {
@@ -103,20 +122,12 @@ for ((round = 1; round <= ROUNDS; round++)); do
     round_pids+=("$pid")
     STARTED+=("$pid")
   done
-  sleep 3
-
-  alive="$(count_alive "${round_pids[@]}")"
-  if [[ "$alive" -gt 1 ]]; then
-    # Distinguish a genuine double-hold from a loser that had not finished
-    # exiting yet: give it a grace window and re-count. A real double-hold is
-    # stable — both processes are in their run loops and never leave.
-    echo "round $round: $alive alive at first count, re-checking after grace..."
+  alive="$(wait_until_settled "${round_pids[@]}")" || {
+    echo "round $round: did not settle to 1 within ${SETTLE_TIMEOUT}s; still up:"
     for p in "${round_pids[@]}"; do
       kill -0 "$p" 2>/dev/null && ps -p "$p" -o pid=,stat=,etime=,args= 2>/dev/null | head -1
     done
-    sleep 5
-    alive="$(count_alive "${round_pids[@]}")"
-  fi
+  }
   if [[ "$alive" -ne 1 ]]; then
     if [[ "$alive" -eq 0 ]]; then
       echo "round $round: FAIL — the home stayed wedged by the stale lock of $held"

--- a/ainb-tui/scripts/stress-hangar-lock-steal.sh
+++ b/ainb-tui/scripts/stress-hangar-lock-steal.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Stress proof for the OTHER half of single-instance: a hard-killed daemon must
+# not lock its home out forever, and the contenders that reclaim it must not all
+# reclaim it at once.
+#
+# Rust destructors never run after SIGKILL, so the lock file survives naming a
+# dead pid. Each round SIGKILLs the owner and then starts a fleet of daemons
+# simultaneously: exactly one must steal the stale lock and live. Zero survivors
+# means a home wedged by its own debris (the failure mode a naive
+# liveness-only guard has after a reboot recycles the pid); more than one means
+# the steal is not winner-take-all.
+#
+# Safety (matches ~/.claude global rules and scripts/reap-stress-codex-orphans.sh):
+# every daemon is started BY this script and signalled by its EXACT recorded pid.
+# Never pkill/killall/wildcards. Isolated mktemp hangar home; AINB_CODEX_MANAGED=0
+# so the codex manager and the desktop Codex/ChatGPT app are never involved.
+#
+# Usage: scripts/stress-hangar-lock-steal.sh [rounds] [daemons-per-round]
+#        (defaults: 20 rounds, 8 daemons)
+set -uo pipefail
+
+ROUNDS="${1:-20}"
+FLEET="${2:-8}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$REPO/target/debug/ainb-hangar-daemon"
+
+STRESS_HOME="$(mktemp -d)/stress-hangar"
+mkdir -p "$STRESS_HOME"
+export AINB_HANGAR_HOME="$STRESS_HOME"
+export AINB_CODEX_MANAGED=0
+LOCK="$STRESS_HOME/hangar/daemon.lock"
+
+STARTED=()
+cleanup() {
+  for pid in "${STARTED[@]:-}"; do
+    [[ -n "$pid" ]] && kill -KILL "$pid" 2>/dev/null
+  done
+  rm -rf "$(dirname "$STRESS_HOME")" 2>/dev/null
+}
+trap cleanup EXIT
+
+start_daemon() { "$BIN" >>"$STRESS_HOME/daemon.log" 2>&1 & echo $!; }
+
+wait_for_lock() {
+  for _ in $(seq 1 100); do
+    [[ -s "$LOCK" ]] && { cat "$LOCK"; return 0; }
+    sleep 0.2
+  done
+  return 1
+}
+
+count_alive() {
+  local n=0 pid
+  for pid in "$@"; do
+    kill -0 "$pid" 2>/dev/null && n=$((n + 1))
+  done
+  echo "$n"
+}
+
+if [[ ! -x "$BIN" ]]; then
+  echo "Building daemon (debug)..."
+  ( cd "$REPO" && cargo build -p ainb-hangar-daemon --bin ainb-hangar-daemon ) || {
+    echo "FAIL: build failed"; exit 1; }
+fi
+
+echo "== stress-hangar-lock-steal: $ROUNDS rounds x $FLEET contenders =="
+echo "AINB_HANGAR_HOME=$AINB_HANGAR_HOME"
+
+fail=0
+for ((round = 1; round <= ROUNDS; round++)); do
+  owner="$(start_daemon)"
+  STARTED+=("$owner")
+  if ! held="$(wait_for_lock)"; then
+    echo "round $round: FAIL — no daemon ever claimed the home"
+    fail=1
+    kill -KILL "$owner" 2>/dev/null
+    continue
+  fi
+
+  # SIGKILL by EXACT pid: no destructor runs, so the lock file stays behind
+  # naming a pid that is now dead. That debris is the case under test.
+  kill -KILL "$owner" 2>/dev/null
+  wait "$owner" 2>/dev/null
+  if [[ ! -s "$LOCK" ]]; then
+    echo "round $round: FAIL — expected a stale lock after SIGKILL"
+    fail=1
+    continue
+  fi
+
+  round_pids=()
+  for ((i = 0; i < FLEET; i++)); do
+    pid="$(start_daemon)"
+    round_pids+=("$pid")
+    STARTED+=("$pid")
+  done
+  sleep 3
+
+  alive="$(count_alive "${round_pids[@]}")"
+  if [[ "$alive" -gt 1 ]]; then
+    # Distinguish a genuine double-hold from a loser that had not finished
+    # exiting yet: give it a grace window and re-count. A real double-hold is
+    # stable — both processes are in their run loops and never leave.
+    echo "round $round: $alive alive at first count, re-checking after grace..."
+    for p in "${round_pids[@]}"; do
+      kill -0 "$p" 2>/dev/null && ps -p "$p" -o pid=,stat=,etime=,args= 2>/dev/null | head -1
+    done
+    sleep 5
+    alive="$(count_alive "${round_pids[@]}")"
+  fi
+  if [[ "$alive" -ne 1 ]]; then
+    if [[ "$alive" -eq 0 ]]; then
+      echo "round $round: FAIL — the home stayed wedged by the stale lock of $held"
+    else
+      echo "round $round: FAIL — $alive daemons stole the same stale lock"
+    fi
+    fail=1
+  else
+    echo "round $round: ok (stale lock of $held reclaimed by exactly 1 of $FLEET)"
+  fi
+
+  for pid in "${round_pids[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null
+      for _ in $(seq 1 50); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.2
+      done
+    fi
+  done
+done
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "PASS: every stale lock was reclaimed by exactly one successor"
+  exit 0
+fi
+echo "FAIL: stale-lock reclaim is not winner-take-all"
+exit 1

--- a/ainb-tui/scripts/stress-hangar-lock-steal.sh
+++ b/ainb-tui/scripts/stress-hangar-lock-steal.sh
@@ -63,6 +63,16 @@ if [[ ! -x "$BIN" ]]; then
     echo "FAIL: build failed"; exit 1; }
 fi
 
+# Run a PRIVATE COPY, never the shared target/ path. A `cargo build` or `cargo
+# test` running concurrently replaces that file, and daemons launched from it
+# then die mid-run with no shutdown line — which reads exactly like the
+# double-daemon defect this script exists to detect. Copying removes the
+# confound, so a FAIL here always means the lock, never the toolchain.
+RUN_BIN="$STRESS_HOME/ainb-hangar-daemon"
+cp "$BIN" "$RUN_BIN" || { echo "FAIL: could not stage the daemon binary"; exit 1; }
+chmod +x "$RUN_BIN"
+BIN="$RUN_BIN"
+
 echo "== stress-hangar-lock-steal: $ROUNDS rounds x $FLEET contenders =="
 echo "AINB_HANGAR_HOME=$AINB_HANGAR_HOME"
 


### PR DESCRIPTION
## What this fixes

One machine accumulated **69 `ainb hangar daemon run` processes** (65 orphaned at `ppid==1`, 2.41 GB RSS, some 8+ days old) and twice exhausted a 32 GB Mac. A peer session later measured **95** concurrent daemons on the same host.

The daemon had no mutual exclusion. Its "guard" was a pidfile written at the **end** of boot and read by a **different process before** spawning — a check-then-act whose window spanned a dozen subsystem initialisations:

```
ainb #1 ──"anyone home?"──▶ daemon.pid ──"empty"──▶ start daemon A
ainb #2 ──"anyone home?"──▶ daemon.pid ──"empty"──▶ start daemon B
                                 ▲ A writes its pid here only AFTER a long boot
```

Nothing refused to boot, and `rpc::bind` unconditionally unlinked the live socket — so the loser went **deaf, not dead**: still `accept()`ing an unreachable inode while its claim loop and sweeper raced the same SQLite home.

## The fix

Take the home's lock as the **first statement of `boot()`**, before the store and before the bind. A loser logs the holder and exits **0** (not non-zero: launchd `KeepAlive` / systemd `Restart=on-failure` must not restart-loop a daemon that correctly declined). `--once` takes it too — a one-shot boot against a live home used to steal that daemon's socket.

No new locking primitive: this reuses `beads_adapter::lock::BdLock`, whose module doc already enumerates the three double-hold races a naive pidfile loses (the `O_EXCL`+`write!` empty-file window; "an absent pidfile is not stale, it is free"; judge-and-reclaim must be **one** step). It gains a fail-fast acquisition and a pluggable liveness predicate; the seven existing race tests are untouched and still pass.

Supporting fixes, each its own commit:

| | |
|---|---|
| `Drop for PidFile` | compare-and-delete — an exiting daemon was deleting the **live** daemon's registration, which is why it grew to 69 rather than stopping at 2 |
| `BdLockGuard::drop` | same treatment, so release cannot delete a successor's file |
| SIGTERM | handled at last (this was the workspace's only daemon that ignored it), and installed **before** boot's work, not after |
| Ownership watchdog | a daemon that stops owning its home stands down within 5s |

### Why the holder check is not just `kill(pid, 0)`

The lock file outlives reboots, so after a power cut its pid usually belongs to something unrelated — a liveness-only check would wedge the home with **zero** daemons forever. The predicate therefore also asks the process table what that pid is running, and **fails safe in every direction**: an unreadable `ps`, an unrecognised argv, or a holder running our own executable all *respect* the holder. Only positive evidence of a different program justifies a steal.

## Reconciliation with `main`

`main` independently added `stop_decision` / `OwnedPid::holding_socket`, which proves ownership by requiring the pid to hold this home's socket under our uid. That is **stronger than anything I had for `stop`**, so this PR keeps main's version wholesale and drops my competing changes:

- dropped my `stop` rewrite and its wait-for-exit (main already has `wait_for_pid_exit`)
- dropped `stop --all` entirely — it matched on argv, and a daemon's home comes from the environment and is invisible there, so it could kill daemons serving other homes. That clashes with main's prove-first design, and a peer session flagged it as a live risk.
- kept lock-first discovery for `status` / the autostart guard / the pipeline strip, the benign-loser handling in `start`, and `EPERM`-counts-as-running

## Validation

- Full `ainb-hangar-daemon` suite green (526 unit + every integration target), hangar CLI units green
- `scripts/soak-hangar-single-instance.sh` — 10 daemons started at once, every round settles to exactly 1; 15–20 rounds, repeatedly
- `scripts/stress-hangar-lock-steal.sh` — SIGKILL the owner, 8 contenders race the stale lock, exactly one reclaims it
- Both also green under a concurrent rebuild loop
- **Falsified before trusted**: with the guard bypassed the same soak reports 10 of 10 survivors — the incident in miniature
- `cargo fmt --check` clean; clippy clean on every file touched

Both proof scripts run a private copy of the binary: a concurrent `cargo build` replaces `target/debug/ainb-hangar-daemon` under running daemons, which previously scored as a failed round.

## Review

A prior multi-agent review at high effort returned 10 findings; 9 are fixed in this branch (including two ways to end up with **zero** daemons, and a `select!` arm that stranded both signal handlers). One is documented rather than fixed: the lock's release is a read-then-unlink, POSIX has no compare-and-unlink, and reaching the window needs the predicate to first misjudge a live holder — `flock`/`F_SETLK` is the primitive that removes it, noted in the module doc as the better long-term shape.

Safety note for the tests: every daemon is a child of its test or script, killed by its **exact** pid; no `pkill`, no name matching; isolated `mktemp` homes; `AINB_CODEX_MANAGED=0` keeps the codex manager and the desktop Codex app out of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Improved daemon lifecycle management with reliable single-instance ownership per home.
- Added safe handling for duplicate starts, restarts, stale locks, and ownership changes.
- Added graceful shutdown behavior for interrupts, termination signals, and ownership loss.
- Improved process verification and status reporting for running daemons.

## Bug Fixes
- Prevented duplicate daemons from replacing active locks, sockets, or diagnostic information.
- Improved stale-lock recovery and PID-file cleanup without affecting successor daemons.
- Ensured shutdown behavior correctly preserves or cleans up interactive sessions as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->