### PR TITLE
build: sync Cargo.lock with the workspace version

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "ainb"
-version = "1.18.0"
+version = "1.20.0"
 dependencies = [
  "ainb-cli",
  "ainb-fleet-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-hangar-daemon"
-version = "1.18.0"
+version = "1.20.0"
 dependencies = [
  "agent-client-protocol",
  "ainb-acp",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-cts-v2"
-version = "1.18.0"
+version = "1.20.0"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-secrets",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-hangar"
-version = "1.18.0"
+version = "1.20.0"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-notifyd"
-version = "1.18.0"
+version = "1.20.0"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-web"
-version = "1.18.0"
+version = "1.20.0"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",


### PR DESCRIPTION
## Problem

The committed `ainb-tui/Cargo.lock` records the workspace members at `1.18.0` while the manifests are at `1.20.0`. Any build passing `--locked` fails immediately:

```
$ cargo metadata --locked --format-version 1
error: cannot update the lock file /.../ainb-tui/Cargo.lock because --locked was passed to prevent this
```

Nothing in CI passes `--locked` today, which is why main is green and this went unnoticed. A reproducible or release build that does would stop at its first cargo command.

## Fix

`cargo update --workspace`, which moves only the six workspace member versions. **No external dependency is touched** — the whole diff is 6 version lines.

## Verification

```
before:  cargo metadata --locked  ->  error, cannot update the lock file
after:   cargo metadata --locked  ->  OK
```

Found incidentally while building #655; kept separate to stay single-concern.