### PR TITLE
fix(test): stop the ACP permission test racing its own expected_version

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -266,16 +266,6 @@ impl Harness {
             .expect("delivery row")
     }
 
-    /// The session row's current optimistic-concurrency version, which every
-    /// `fleet/action` must carry.
-    async fn version(&self, session_key: &str) -> i64 {
-        sqlx::query_scalar("SELECT version FROM fleet_session WHERE session_key = ?")
-            .bind(session_key)
-            .fetch_one(self.store.pool())
-            .await
-            .expect("session version")
-    }
-
     /// Poll until the session has an OPEN attention row, and return it.
     async fn await_open_attention(&self, session_key: &str) -> (String, serde_json::Value) {
         let deadline = Instant::now() + Duration::from_secs(30);
@@ -314,34 +304,45 @@ impl Harness {
     }
 }
 
-/// Issue a `fleet/action` that carries `expected_version`, refreshing that
-/// version and retrying if the daemon reports a mismatch.
+/// The session's optimistic-concurrency version, taken from the SAME snapshot
+/// row that already shows `fingerprint` as the session's current ask.
 ///
-/// Reading the version and then acting on it is a read-then-act race: the
-/// session's version advances on writes these tests do not make (turn
-/// recording, turn-end commit, lifecycle convergence), so the value can be
-/// stale by the time the call lands. The optimistic-concurrency guard is not
-/// what these tests are about; they are about whether the answer reaches its
-/// adapter. Retrying with the fresh version keeps that the subject, and a
-/// mismatch surviving every attempt still fails the test.
-async fn fleet_action_versioned(
-    client: &mut Client,
-    harness: &Harness,
-    session_key: &str,
-    mut params: serde_json::Value,
-) -> serde_json::Value {
-    let mut reply = serde_json::Value::Null;
-    for _ in 0..3 {
-        params["expected_version"] = harness.version(session_key).await.into();
-        reply = client.call(methods::FLEET_ACTION, params.clone()).await;
-        let stale = reply["error"]["message"]
-            .as_str()
-            .is_some_and(|m| m.contains("version is") && m.contains("expected"));
-        if !stale {
-            return reply;
+/// `SessionActor::raise_permission` INSERTS the attention row before it applies
+/// the fleet event that records the ask, and that event is what bumps
+/// `fleet_session.version`. So a test that polls for the attention row and then
+/// reads the version reads a value from before its OWN ask, sends it as
+/// `expected_version`, and is refused by a guard doing its job: exactly the
+/// `version is 2, expected 1` flake, which is a race against a write the test
+/// provoked rather than against CI load.
+///
+/// One `fleet/snapshot` answers both questions from one read transaction, which
+/// is how every sibling test (and every real client) obtains a version: paired
+/// with the ask state it belongs to, never sampled out of band. Waiting for the
+/// fingerprint to appear waits for precisely the write that moved the version,
+/// and from then until the answer this test is about to send, nothing else
+/// writes the row.
+async fn version_showing_ask(client: &mut Client, session_key: &str, fingerprint: &str) -> i64 {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let snapshot = client.call(methods::FLEET_SNAPSHOT, serde_json::json!({})).await;
+        assert!(snapshot["error"].is_null(), "{snapshot}");
+        let row = snapshot["result"]["sessions"]
+            .as_array()
+            .expect("sessions")
+            .iter()
+            .find(|row| row["session_key"] == serde_json::json!(session_key))
+            .cloned();
+        if let Some(row) = row {
+            if row["current_request_fingerprint"] == serde_json::json!(fingerprint) {
+                return row["version"].as_i64().expect("version");
+            }
         }
+        assert!(
+            Instant::now() < deadline,
+            "the session row never caught up with the ask {fingerprint}: {snapshot}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
-    reply
 }
 
 struct Client {
@@ -847,26 +848,21 @@ async fn a_permission_round_trips_through_fleet_action() {
     // an ACP session can be blocked on SEVERAL asks at once and the row can name
     // only one of them, which is why the row-equality gate is off for ACP (see
     // `two_parked_permissions_are_both_answerable_over_the_wire`).
-    let stale = fleet_action_versioned(
-
-        &mut client,
-
-        &harness,
-
-        &session_key,
-
-        serde_json::json!({
+    let version = version_showing_ask(&mut client, &session_key, &fingerprint).await;
+    let stale = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
                 "session_key": session_key,
+                "expected_version": version,
                 "request_id": "req-acp-stale-answer",
                 "action": {
                     "action": "approve",
                     "request_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000",
                 },
             }),
-
-    )
-
-    .await;
+        )
+        .await;
     assert!(stale["error"].is_null(), "{stale}");
     assert_eq!(
         stale["result"]["receipt"]["status"], "FAILED",
@@ -886,17 +882,20 @@ async fn a_permission_round_trips_through_fleet_action() {
         .expect("attention row");
     assert_eq!(still_open, "open", "the refusal left the ask untouched");
 
-    let approved = fleet_action_versioned(
-        &mut client,
-        &harness,
-        &session_key,
-        serde_json::json!({
-            "session_key": session_key,
-            "request_id": "req-acp-answer",
-            "action": { "action": "approve", "request_fingerprint": fingerprint },
-        }),
-    )
-    .await;
+    // The SAME version the refusal was sent with: a refused action writes no
+    // fleet event, so nothing has moved the row in between. If that ever stops
+    // being true this fails loudly rather than silently retrying past it.
+    let approved = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": session_key,
+                "expected_version": version,
+                "request_id": "req-acp-answer",
+                "action": { "action": "approve", "request_fingerprint": fingerprint },
+            }),
+        )
+        .await;
     assert!(approved["error"].is_null(), "{approved}");
     assert_eq!(
         approved["result"]["receipt"]["status"], "DELIVERED",
@@ -1018,20 +1017,33 @@ async fn two_parked_permissions_are_both_answerable_over_the_wire() {
         tokio::time::sleep(Duration::from_millis(25)).await;
     };
 
+    // Both raises have reached the session row once it carries the NEWER ask:
+    // the actor raises them in order, and each raise applies its fleet event
+    // before the next begins, so this is the settled version rather than a
+    // sample taken mid-raise.
+    let settled = version_showing_ask(&mut client, &session_key, &asks[1].1).await;
+
     // OLDEST first: the fingerprint the session row is NOT carrying, and the
     // exact answer the old gate refused as stale.
     for (index, (attention_id, fingerprint)) in asks.iter().enumerate() {
-        let approved = fleet_action_versioned(
-            &mut client,
-            &harness,
-            &session_key,
-            serde_json::json!({
-                "session_key": session_key,
-                "request_id": format!("req-acp-two-answer-{index}"),
-                "action": { "action": "approve", "request_fingerprint": fingerprint },
-            }),
-        )
-        .await;
+        // Each answer applies its own `acp_permission_answered` event BEFORE
+        // `fleet/action` returns (`SessionActor::answer` awaits
+        // `retire_attention`), so the next expected version is exactly one
+        // higher. Counting is deliberate: re-reading here would reintroduce the
+        // read-then-send race, and if that ordering ever changes this fails
+        // deterministically instead of flaking.
+        let expected_version = settled + i64::try_from(index).expect("two asks");
+        let approved = client
+            .call(
+                methods::FLEET_ACTION,
+                serde_json::json!({
+                    "session_key": session_key,
+                    "expected_version": expected_version,
+                    "request_id": format!("req-acp-two-answer-{index}"),
+                    "action": { "action": "approve", "request_fingerprint": fingerprint },
+                }),
+            )
+            .await;
         assert!(approved["error"].is_null(), "ask {index}: {approved}");
         assert_eq!(
             approved["result"]["receipt"]["status"], "DELIVERED",

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -18,9 +18,9 @@
 //!   DURING the turn: the first `acp.message` precedes `acp.turn_completed`.
 //! * **R8** a permission round trips: attention row with option ids and the
 //!   pending JSON-RPC id, `fleet/action` Approve, a REAL outcome on the wire,
-//!   a fingerprint nothing raised refused, TWO concurrent asks both answerable,
-//!   and an adapter death mid-permission closing the rows instead of leaving
-//!   ghosts.
+//!   a fingerprint nothing raised refused, a STALE `expected_version` refused
+//!   with the ask left open, TWO concurrent asks both answerable, and an
+//!   adapter death mid-permission closing the rows instead of leaving ghosts.
 //! * **Receipts** an ACP chat leg leaves the same `fleet/receipt_get`-visible
 //!   action receipt a tmux leg does, despite bypassing `execute_fleet_action`.
 //!
@@ -942,6 +942,109 @@ async fn a_permission_round_trips_through_fleet_action() {
     .expect("fleet row");
     assert_eq!(attention_state, "NONE");
     assert_eq!(current, None);
+
+    harness.finish().await;
+}
+
+/// The optimistic-concurrency guard on `fleet/action`, with the version
+/// CONTROLLED rather than observed: an answer naming a version older than the
+/// session's is refused BEFORE it reaches the pool, the ask survives, and no
+/// receipt is minted for it.
+///
+/// `a_permission_round_trips_through_fleet_action` used to carry this claim by
+/// accident, by racing the version it had just read. That made a guard doing
+/// its job look like a flake, and told nobody whether the guard actually bites.
+/// Here the staleness is CONSTRUCTED by subtraction, so it is stale whatever
+/// else has written the row, and the assertion cannot pass or fail on timing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_stale_expected_version_is_refused_and_leaves_the_ask_open() {
+    let harness = Harness::start(
+        &[
+            ("FAKE_ACP_PERMISSION_SESSIONS", "*"),
+            ("FAKE_ACP_CHUNKS", "1"),
+        ],
+        |_| {},
+    )
+    .await;
+    let mut client = harness.client().await;
+    let (session_key, _scope) = harness.create_session(&mut client, None).await;
+
+    let sent = client
+        .call(
+            methods::FLEET_MESSAGE_SEND,
+            serde_json::json!({
+                "targets": [session_key],
+                "text": "rm -rf /tmp/fixture",
+                "request_id": "req-acp-stale-version",
+            }),
+        )
+        .await;
+    assert!(sent["error"].is_null(), "{sent}");
+    let (attention_id, payload) = harness.await_open_attention(&session_key).await;
+    let fingerprint = payload["requestFingerprint"].as_str().expect("fingerprint").to_string();
+    let version = version_showing_ask(&mut client, &session_key, &fingerprint).await;
+    assert!(
+        version > 1,
+        "the ask's own event moved the version, so version - 1 is genuinely \
+         stale rather than merely non-positive: {version}"
+    );
+
+    let refused = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": session_key,
+                "expected_version": version - 1,
+                "request_id": "req-acp-stale-version-answer",
+                "action": { "action": "approve", "request_fingerprint": fingerprint },
+            }),
+        )
+        .await;
+    assert_eq!(refused["error"]["code"], -32602, "{refused}");
+    assert!(
+        refused["error"]["message"].as_str().unwrap_or_default().contains("version is"),
+        "the refusal names the version it found: {refused}"
+    );
+
+    // REFUSED, not merely complained about: the answer never reached the pool,
+    // so the adapter is still blocked and the operator's ask is still clickable.
+    let (still_open,): (String,) = sqlx::query_as("SELECT state FROM attention WHERE id = ?")
+        .bind(&attention_id)
+        .fetch_one(harness.store.pool())
+        .await
+        .expect("attention row");
+    assert_eq!(still_open, "open");
+    // Validation runs ahead of the durable claim, so the refusal did not spend
+    // the request id either.
+    let receipt: Option<(String,)> =
+        sqlx::query_as("SELECT status FROM fleet_action_receipt WHERE request_id = ?")
+            .bind("req-acp-stale-version-answer")
+            .fetch_optional(harness.store.pool())
+            .await
+            .expect("receipt query");
+    assert!(
+        receipt.is_none(),
+        "a refused action must mint no receipt: {receipt:?}"
+    );
+
+    // ... and the honest version still answers that same ask, so what was
+    // refused was the version and not the answer.
+    let approved = client
+        .call(
+            methods::FLEET_ACTION,
+            serde_json::json!({
+                "session_key": session_key,
+                "expected_version": version,
+                "request_id": "req-acp-stale-version-retry",
+                "action": { "action": "approve", "request_fingerprint": fingerprint },
+            }),
+        )
+        .await;
+    assert!(approved["error"].is_null(), "{approved}");
+    assert_eq!(
+        approved["result"]["receipt"]["status"], "DELIVERED",
+        "{approved}"
+    );
 
     harness.finish().await;
 }


### PR DESCRIPTION
Closes #658.

## Which option, and why

**Option 2, and it replaces the retry helper from #644 (eb56a59f).** That helper
refreshed the version and retried three times. It made the flake rarer without
making the test honest, and it put a retry loop into three tests whose subject is
whether an answer reaches its adapter. It is deleted, along with the raw-SQL
`Harness::version` reader it was built on.

The issue's framing was that the version churns under CI load. Reading the code,
it does not. An ACP session's `fleet_session.version` has exactly three writers,
the only three `NewFleetEvent` sites in `acp_pool.rs`: `acp_permission_requested`,
`acp_permission_answered` and `acp_converged`. No chunk, turn or transcript write
touches it. So the race is not ambient load, it is one specific ordering:

```
SessionActor::raise_permission
  ┌──────────────────────┐   ┌───────────────────────────┐
  │ AttentionRepo::insert│──▶│ apply_event → version++   │
  └──────────────────────┘   └───────────────────────────┘
            ▲                             ▲
            │ await_open_attention        │ ... and the call lands HERE
            │ returns here                │
            └── harness.version() reads the PRE-ask value
```

The test polled for the attention row, which is inserted *first*, then read the
version, which the ask itself was about to bump. `version is 2, expected 1` is a
guard doing its job on a value the test read from before its own permission. CI
load only widens the gap between the two writes.

## The fix

Take the version from the same `fleet/snapshot` row that already shows the ask as
`current_request_fingerprint`. That is one read transaction, and it is how every
sibling test in `rpc_fleet.rs` and every real client obtains a version: paired
with the ask state it belongs to, never sampled out of band. Waiting for the
fingerprint to appear waits for precisely the write that moved the version, and
from then until the answer under test nothing else writes the row.

The two-ask test counts instead of re-reading: each answer applies its
`acp_permission_answered` event *before* `fleet/action` returns
(`SessionActor::answer` awaits `retire_attention`), so the next expected version
is exactly one higher. If that ordering ever changes the test fails
deterministically rather than flaking.

## The guard is still covered, properly

New `a_stale_expected_version_is_refused_and_leaves_the_ask_open`. The staleness
is **constructed** by subtracting from the observed version, so it is stale
whatever else has written the row and the assertion cannot turn on timing. It
asserts the refusal is real, not decorative: the ask stays `open`, no receipt is
minted (validation runs ahead of the durable claim), and the same ask still
answers under the honest version.

No assertion was weakened. The round-trip test now sends the *same* version for
the refused stale-fingerprint call and the approve that follows, which asserts by
construction that a refused action writes no fleet event.

## Sweep of the same read-then-send idiom

| site | verdict |
|---|---|
| `rpc_acp.rs` x3, via `fleet_action_versioned` | **fixed**; helper and `Harness::version` deleted |
| `rpc_acp_no_tmux.rs:267` raw-SQL version read | **left**; cannot race. It raises no permission and asserts its turn reached `DELIVERED` before reading, so none of the three writers can fire |
| `rpc_fleet.rs:291,492,808` | **left**; already read from `fleet/snapshot`, the correct idiom, and their sessions are hook-driven with the test as sole writer |
| `rpc_fleet.rs:322,388` (`version + 1`) | **left**; already controlled staleness, the claude/tmux twin of the new ACP test |
| `rpc_message_bus.rs:1233` | **left**; literal `1`, no read |
| `rpc_event_push.rs` | no `expected_version`; separate arrival-wait fix |

Production `deliver_message_leg` (`rpc/mod.rs:2036`) has the same read-then-send
with a one-shot retry. That is a client doing CAS correctly and is out of scope.

## Verification

`cargo test -p ainb-hangar-daemon --test rpc_acp` — 11 passed, 0 failed, exit 0.

**Ablation.** Neuter the guard in `execute_fleet_action` (hand
`validate_action_target` the version it is about to find, so the comparison
always holds) and the new test fails:

```
test a_stale_expected_version_is_refused_and_leaves_the_ask_open ... FAILED

panicked at crates/ainb-hangar-daemon/tests/rpc_acp.rs:1003:5:
assertion `left == right` failed: {"result":{"receipt":{
  "request_id":"req-acp-stale-version-answer","action_kind":"approve",
  "expected_version":1,"status":"DELIVERED",
  "detail":"acp permission handed to the adapter; option allow-once",
  "session_version":2}}}
  left: Null
 right: -32602

test result: FAILED. 0 passed; 1 failed; 10 filtered out
```

`expected_version: 1` against `session_version: 2` is DELIVERED without the
guard: a stale answer reaches the adapter. The guard is restored; the working
tree carries no part of the ablation.
