### PR TITLE
feat: manage remote Codex sessions

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -9419,6 +9419,22 @@ mod text_input_guard_tests {
         use crate::components::GitViewState;
         use std::path::PathBuf;
 
+        fn reset_text_context_state(state: &mut AppState) {
+            state.current_screen = screen_ids::HOME.to_string();
+            state.other_tmux_rename_mode = false;
+            state.ssh_session_rename_mode = false;
+            state.quick_commit_message = None;
+            state.auth_provider_popup_state.show_popup = false;
+            state.config_screen_state = Default::default();
+            state.config_popup_state = Default::default();
+            state.skills_state.search_active = false;
+            state.git_view_state = None;
+        }
+
+        // AppState construction refreshes session recovery from disk. Reuse one
+        // state because this predicate test only needs to vary its input flags.
+        let mut state = AppState::default();
+
         // Screen-only branches: switching `current_screen` is enough.
         // (Config is intentionally excluded — it's gated on edit state,
         // covered separately below.)
@@ -9428,7 +9444,7 @@ mod text_input_guard_tests {
             screen_ids::AUTH_SETUP,
             screen_ids::ATTACHED_TERMINAL,
         ] {
-            let mut state = AppState::default();
+            reset_text_context_state(&mut state);
             state.current_screen = (*screen).to_string();
             assert!(
                 EventHandler::is_text_input_context(&state),
@@ -9441,14 +9457,14 @@ mod text_input_guard_tests {
         // a setting or entering an API key, NOT when navigating the
         // categories list. Suppressing globals during plain navigation
         // would regress the help shortcut UX.
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::CONFIG.to_string();
         assert!(
             !EventHandler::is_text_input_context(&state),
             "Config without edit mode must NOT be treated as text input"
         );
 
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::CONFIG.to_string();
         state.config_screen_state.editing = true;
         assert!(
@@ -9456,7 +9472,7 @@ mod text_input_guard_tests {
             "Config + editing = true must be treated as text input"
         );
 
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::CONFIG.to_string();
         state.config_screen_state.api_key_input_mode = true;
         assert!(
@@ -9470,7 +9486,7 @@ mod text_input_guard_tests {
         // the public `open_text` API so the test exercises a real
         // popup-open code path and stays valid if the popup_type
         // representation changes.
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::CONFIG.to_string();
         state.config_popup_state.open_text("Title", "Desc", "key", "value");
         assert!(
@@ -9480,7 +9496,7 @@ mod text_input_guard_tests {
 
         // Negative control: a Choice popup is navigation-only (arrow
         // keys / Enter), so `H` should still toggle help.
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::CONFIG.to_string();
         state.config_popup_state.open_choice(
             "Title",
@@ -9511,7 +9527,7 @@ mod text_input_guard_tests {
             }),
         ];
         for (label, setup) in cases {
-            let mut state = AppState::default();
+            reset_text_context_state(&mut state);
             setup(&mut state);
             assert!(
                 EventHandler::is_text_input_context(&state),
@@ -9529,7 +9545,7 @@ mod text_input_guard_tests {
         // text entry.
 
         // Skills search overlay.
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::SKILLS.to_string();
         state.skills_state.search_active = true;
         assert!(
@@ -9538,7 +9554,7 @@ mod text_input_guard_tests {
         );
 
         // GitView commit-message mode.
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::GIT_VIEW.to_string();
         let mut git_state = GitViewState::new(PathBuf::from("/tmp"));
         git_state.start_commit_message_input();
@@ -9550,7 +9566,7 @@ mod text_input_guard_tests {
 
         // Negative control: GitView without commit mode active is NOT
         // a text input — it's a navigable screen.
-        let mut state = AppState::default();
+        reset_text_context_state(&mut state);
         state.current_screen = screen_ids::GIT_VIEW.to_string();
         state.git_view_state = Some(GitViewState::new(PathBuf::from("/tmp")));
         assert!(
@@ -9560,7 +9576,7 @@ mod text_input_guard_tests {
 
         // Negative control: bare default state on HomeScreen is not a
         // text input.
-        let state = AppState::default();
+        reset_text_context_state(&mut state);
         assert!(
             !EventHandler::is_text_input_context(&state),
             "HomeScreen with no modal flags must NOT be treated as text input"

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -9311,6 +9311,25 @@ impl AppState {
                 None
             };
 
+            let codex_remote = if metadata.agent_type == SessionAgentType::Codex {
+                let remote = crate::interactive::session_manager::ensure_codex_remote_thread(
+                    metadata.session_id,
+                    &metadata.worktree_path,
+                    model.as_deref(),
+                    skip_permissions,
+                    metadata.headroom_enabled,
+                    metadata.codex_thread_id.clone(),
+                )
+                .await?;
+                crate::interactive::session_manager::persist_codex_thread_id(
+                    metadata.session_id,
+                    remote.thread_id.clone(),
+                )?;
+                Some(remote)
+            } else {
+                None
+            };
+
             let manager = InteractiveSessionManager::new()?;
             manager
                 .start_cli_in_tmux(
@@ -9321,6 +9340,7 @@ impl AppState {
                     transcript.clone(),
                     true, // resume_requested — Enter/r on a Stopped session
                     metadata.headroom_enabled,
+                    codex_remote.as_ref(),
                 )
                 .await?;
 
@@ -10949,6 +10969,24 @@ impl AppState {
             None
         };
         let headroom_enabled = metadata.map(|m| m.headroom_enabled).unwrap_or(false);
+        let codex_remote = if agent_type == SessionAgentType::Codex {
+            let remote = crate::interactive::session_manager::ensure_codex_remote_thread(
+                session_id,
+                std::path::Path::new(&workspace_path),
+                model.as_deref(),
+                skip_permissions,
+                headroom_enabled,
+                metadata.and_then(|m| m.codex_thread_id.clone()),
+            )
+            .await?;
+            crate::interactive::session_manager::persist_codex_thread_id(
+                session_id,
+                remote.thread_id.clone(),
+            )?;
+            Some(remote)
+        } else {
+            None
+        };
 
         info!(
             "Restarting {} in tmux session '{}' for workspace '{}'",
@@ -10966,6 +11004,7 @@ impl AppState {
                 resume_transcript,
                 true,
                 headroom_enabled,
+                codex_remote.as_ref(),
             )
             .await?;
 

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -367,6 +367,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         let session = AppState::stopped_session_from_metadata(&metadata);
@@ -406,6 +407,7 @@ mod tests {
             model: Some("claude-opus-4-8".to_string()),
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         let session = AppState::stopped_session_from_metadata(&metadata);
@@ -417,8 +419,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn idle_restart_respawns_a_dead_codex_pane_with_launch_settings() {
-        use crate::models::{Session, SessionStatus, Workspace};
+    async fn idle_restart_respawns_a_dead_codex_pane_with_exact_remote_thread() {
+        use crate::interactive::InteractiveSessionManager;
         use std::process::Command;
         use std::time::Duration;
 
@@ -437,8 +439,6 @@ mod tests {
                 let _ = Command::new("tmux").args(["kill-session", "-t", &self.0]).output();
             }
         }
-
-        let home = tempfile::tempdir().expect("temp home");
 
         let tmux_name = format!("ainb-idle-restart-{}", uuid::Uuid::new_v4());
         let _tmux = ExactTmuxSession(tmux_name.clone());
@@ -478,30 +478,24 @@ mod tests {
         }
         assert!(pane_dead, "precondition: pane must be dead before restart");
 
-        let session_id = uuid::Uuid::new_v4();
-        let worktree = home.path().join("worktree");
-        std::fs::create_dir_all(&worktree).expect("worktree");
-        let model = "gpt-5.6-luna".to_string();
-
-        let mut session = Session::new_with_options(
-            "idle-restart".to_string(),
-            worktree.to_string_lossy().to_string(),
-            true,
-            SessionMode::Interactive,
-            None,
-            SessionAgentType::Codex,
-            Some(model),
-        );
-        session.id = session_id;
-        session.status = SessionStatus::Idle;
-        session.tmux_session_name = Some(tmux_name.clone());
-
-        let mut workspace = Workspace::new("idle-restart".to_string(), worktree);
-        workspace.add_session(session);
-        let mut state = AppState::new();
-        state.workspaces.push(workspace);
-
-        state.restart_cli_in_tmux(session_id).await.expect("idle restart");
+        let remote = ainb_hangar_proto::fleet::CodexSessionEnsureResult {
+            endpoint: "unix:///tmp/ainb-idle-restart.sock".to_string(),
+            thread_id: "thread-idle-restart".to_string(),
+        };
+        InteractiveSessionManager::new()
+            .expect("session manager")
+            .start_cli_in_tmux(
+                &tmux_name,
+                true,
+                Some("gpt-5.6-luna".to_string()),
+                SessionAgentType::Codex,
+                None,
+                true,
+                false,
+                Some(&remote),
+            )
+            .await
+            .expect("respawn remote Codex pane");
 
         let pane = Command::new("tmux")
             .args([
@@ -516,10 +510,11 @@ mod tests {
         let pane_command = String::from_utf8_lossy(&pane.stdout);
         assert!(
             pane_command.contains(
-                "codex resume --last --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox"
+                "codex --remote 'unix:///tmp/ainb-idle-restart.sock' resume thread-idle-restart"
             ),
-            "idle restart must replace dead pane with persisted Codex argv, got: {pane_command}"
+            "idle restart must replace dead pane with exact remote Codex argv, got: {pane_command}"
         );
+        assert!(!pane_command.contains("--last"));
     }
 
     // -- SessionFilter tests ------------------------------------------------
@@ -612,6 +607,9 @@ mod tests {
     #[test]
     fn test_cycle_session_filter_advances_state() {
         let mut state = AppState::new();
+        // AppState restores the user's persisted UI preference; cycle behavior
+        // itself must remain independent of that ambient configuration.
+        state.session_filter = SessionFilter::All;
         assert_eq!(state.session_filter, SessionFilter::All);
         state.cycle_session_filter();
         assert_eq!(state.session_filter, SessionFilter::ActiveOnly);

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -2951,7 +2951,16 @@ mod tests {
             original_questions.as_array().unwrap().clone()
         );
         let fingerprint = pending.request_fingerprint.unwrap();
-        let events = std::fs::read_to_string(home.path().join("events.jsonl")).unwrap();
+        let events = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Ok(events) = std::fs::read_to_string(home.path().join("events.jsonl")) {
+                    break events;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("Fleet event must appear after broker registration");
         assert!(
             events.contains("ask-session"),
             "Fleet event must appear only after broker registration"

--- a/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/git_cmd.rs
@@ -468,6 +468,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/list.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/list.rs
@@ -201,6 +201,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);
@@ -222,6 +223,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, false);
@@ -243,6 +245,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         let info = SessionInfo::from_metadata(&metadata, false, false);
@@ -286,6 +289,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         let info = SessionInfo::from_metadata(&metadata, true, true);
@@ -345,6 +349,7 @@ mod tests {
                 model: None,
                 model_source: Default::default(),
                 codex_model: None,
+                codex_thread_id: None,
             };
 
             // What the TUI paints: `AppState::load_real_workspaces` longhand.

--- a/ainb-tui/crates/ainb-core/src/cli/recover.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/recover.rs
@@ -398,6 +398,7 @@ fn execute_resume(session: &str) -> Result<()> {
         model: None,
         model_source: Default::default(),
         codex_model: None,
+        codex_thread_id: None,
     };
 
     // Locked RMW (pu4): serialise recovery's re-register against live writers.
@@ -630,6 +631,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -16,7 +16,9 @@ use uuid::Uuid;
 use super::RunArgs;
 use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
-use crate::interactive::session_manager::{ModelSource, SessionMetadata, SessionStore};
+use crate::interactive::session_manager::{
+    ModelSource, SessionMetadata, SessionStore, ensure_codex_remote_thread,
+};
 use crate::models::session::{SessionAgentType, is_default_model};
 use crate::tmux::TmuxSession;
 
@@ -102,8 +104,27 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         setup_mcp_pool(&work_dir, &session_name);
     }
 
-    // Step 6: Build Claude command
-    let claude_cmd = build_agent_command(&args);
+    // Step 6: Allocate the daemon-owned remote thread before tmux starts.
+    let codex_remote = if provider == CliProvider::Codex {
+        Some(
+            ensure_codex_remote_thread(
+                session_id,
+                &work_dir,
+                model.as_deref(),
+                args.dangerously_skip_permissions,
+                false,
+                None,
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    let claude_cmd = codex_remote
+        .as_ref()
+        .map(remote_codex_command)
+        .unwrap_or_else(|| build_agent_command(&args));
 
     // Step 6b: Parent linkage (event-driven plumbing). When spawned with
     // `--parent <id>`, this session is a child of an orchestrator (e.g. ATC).
@@ -170,6 +191,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         model: model.clone(),
         model_source: ModelSource::Raw,
         codex_model: None,
+        codex_thread_id: codex_remote.map(|remote| remote.thread_id),
     };
 
     // Locked RMW (pu4): another `ainb run`/`kill` or a daemon register racing
@@ -461,6 +483,20 @@ fn build_agent_command(args: &RunArgs) -> String {
         .join(" ")
 }
 
+fn remote_codex_command(remote: &ainb_hangar_proto::fleet::CodexSessionEnsureResult) -> String {
+    [
+        "codex",
+        "--remote",
+        &remote.endpoint,
+        "resume",
+        &remote.thread_id,
+    ]
+    .into_iter()
+    .map(|part| shell_escape::escape(part.into()).into_owned())
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
 /// Poll the tmux pane until the agent's input box is ready, or `timeout` elapses.
 /// Best-effort: on timeout we send anyway rather than drop the prompt.
 async fn wait_for_prompt_ready(session_name: &str, timeout: Duration) {
@@ -703,6 +739,19 @@ mod tests {
             "AINB must pass Claude's raw model value through, got: {cmd}"
         );
         assert!(cmd.contains("--dangerously-skip-permissions"));
+    }
+
+    #[test]
+    fn remote_codex_command_resumes_exact_thread() {
+        let command = remote_codex_command(&ainb_hangar_proto::fleet::CodexSessionEnsureResult {
+            endpoint: "unix:///tmp/codex-app-server.sock".to_string(),
+            thread_id: "thread-123".to_string(),
+        });
+        assert_eq!(
+            command,
+            "codex --remote 'unix:///tmp/codex-app-server.sock' resume thread-123"
+        );
+        assert!(!command.contains("--last"));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/status.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/status.rs
@@ -215,6 +215,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/util.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/util.rs
@@ -155,6 +155,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         let session2 = SessionMetadata {
@@ -170,6 +171,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         store.sessions.insert(session1.tmux_session_name.clone(), session1);

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -422,7 +422,7 @@ impl OnboardingComponent {
             .margin(1)
             .constraints([
                 Constraint::Length(3), // Status summary + one-liner legend
-                Constraint::Min(8),    // Dependency columns
+                Constraint::Fill(1),   // Dependency columns
                 Constraint::Length(4), // Focused-dep detail band (docs link + install)
                 Constraint::Length(2), // Instructions
             ])
@@ -557,7 +557,7 @@ impl OnboardingComponent {
             )
         } else if let Some(msg) = &state.status_message {
             Span::styled(
-                msg.clone(),
+                format!("{msg} • ↑↓←→ focus • i install • r recheck • t tmux"),
                 Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
             )
         } else {
@@ -1330,6 +1330,23 @@ impl OnboardingComponent {
             spans.push(Span::styled("↑↓←→", Style::default().fg(GOLD)));
             spans.push(Span::styled("]", Style::default().fg(SUBDUED_BORDER)));
             spans.push(Span::styled(" navigate", Style::default().fg(MUTED_GRAY)));
+            spans.push(Span::styled("  |  ", Style::default().fg(SUBDUED_BORDER)));
+            spans.push(Span::styled("i install", Style::default().fg(GOLD)));
+            spans.push(Span::styled("  |  ", Style::default().fg(SUBDUED_BORDER)));
+            spans.push(Span::styled("t tmux", Style::default().fg(GOLD)));
+            if let Some(dep) = state.focused_dep() {
+                if let Some(url) = crate::docs::docs_url_for(dep.id) {
+                    spans.push(Span::styled("  |  ", Style::default().fg(SUBDUED_BORDER)));
+                    spans.push(Span::styled(url, Style::default().fg(CORNFLOWER_BLUE)));
+                }
+                if !dep.satisfied {
+                    spans.push(Span::styled("  |  ", Style::default().fg(SUBDUED_BORDER)));
+                    spans.push(Span::styled(
+                        "press i to install",
+                        Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                    ));
+                }
+            }
         } else {
             spans.push(Span::styled("[", Style::default().fg(SUBDUED_BORDER)));
             spans.push(Span::styled("Esc", Style::default().fg(GOLD)));

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -194,26 +194,30 @@ pub struct RecoveryResultLine {
 
 impl Default for SessionRecoveryState {
     fn default() -> Self {
-        Self::new()
+        Self::empty()
     }
 }
 
 impl SessionRecoveryState {
     pub fn new() -> Self {
-        let mut state = Self {
+        let mut state = Self::empty();
+        state.refresh();
+        state
+    }
+
+    fn empty() -> Self {
+        Self {
             orphaned_sessions: Vec::new(),
             orphaned_worktrees: Vec::new(),
             view_mode: RecoveryViewMode::default(),
             selected_index: 0,
             selected_items: HashSet::new(),
             list_state: ListState::default(),
-            loading: true,
+            loading: false,
             last_error: None,
             action_result: None,
             recovery_overlay: None,
-        };
-        state.refresh();
-        state
+        }
     }
 
     /// Get the total count of items in current view (includes separator in All view)
@@ -823,6 +827,7 @@ impl SessionRecoveryState {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         // Locked RMW (pu4): serialise this recovery re-register against live
@@ -2083,5 +2088,19 @@ impl SessionRecovery {
             .style(Style::default().bg(PANEL_BG));
 
         frame.render_widget(paragraph, area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionRecoveryState;
+
+    #[test]
+    fn default_defers_recovery_scan_until_the_screen_is_opened() {
+        let state = SessionRecoveryState::default();
+
+        assert!(!state.loading);
+        assert!(state.orphaned_sessions.is_empty());
+        assert!(state.orphaned_worktrees.is_empty());
     }
 }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -65,6 +65,7 @@ pub struct InteractiveSession {
     pub model: Option<String>,        // Raw provider model ID passed through to the CLI
     pub headroom_enabled: bool,       // Route this session's CLI through the local Headroom proxy
     pub rtk_enabled: bool,            // RTK PreToolUse hook wired in session's worktree
+    pub codex_thread_id: Option<String>, // Exact shared app-server thread for Codex sessions
 }
 
 /// How the persisted model value should be interpreted.
@@ -111,6 +112,49 @@ pub struct SessionMetadata {
     /// Legacy Codex-only field. New writes use provider-agnostic `model`.
     #[serde(default)]
     pub codex_model: Option<CodexModel>,
+    /// Exact daemon-owned remote thread. Missing legacy values migrate lazily.
+    #[serde(default)]
+    pub codex_thread_id: Option<String>,
+}
+
+/// Create or resume one exact shared Codex app-server thread for Interactive.
+pub(crate) async fn ensure_codex_remote_thread(
+    session_id: Uuid,
+    cwd: &std::path::Path,
+    model: Option<&str>,
+    skip_permissions: bool,
+    headroom_enabled: bool,
+    existing_thread_id: Option<String>,
+) -> anyhow::Result<ainb_hangar_proto::fleet::CodexSessionEnsureResult> {
+    if headroom_enabled {
+        anyhow::bail!(
+            "Codex Headroom is unavailable with shared remote control; disable Headroom for this session"
+        );
+    }
+    crate::cli::hangar::ensure_hangar_daemon();
+    let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+        .map_err(|error| anyhow::anyhow!("connect to Ainb Codex runtime: {error}"))?;
+    client
+        .codex_session_ensure(ainb_hangar_proto::fleet::CodexSessionEnsureParams {
+            session_id: session_id.to_string(),
+            cwd: cwd.display().to_string(),
+            model: model.map(str::to_owned),
+            thread_id: existing_thread_id,
+            skip_permissions,
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("prepare shared Codex thread: {error}"))
+}
+
+pub(crate) fn persist_codex_thread_id(session_id: Uuid, thread_id: String) -> anyhow::Result<()> {
+    SessionStore::mutate(|store| {
+        if let Some(metadata) =
+            store.sessions.values_mut().find(|metadata| metadata.session_id == session_id)
+        {
+            metadata.codex_thread_id = Some(thread_id);
+        }
+    })?;
+    Ok(())
 }
 
 impl SessionMetadata {
@@ -477,6 +521,22 @@ impl InteractiveSessionManager {
             }
         }
 
+        let codex_remote = if agent_type == SessionAgentType::Codex {
+            Some(
+                ensure_codex_remote_thread(
+                    session_id,
+                    &worktree_info.path,
+                    model.as_deref(),
+                    skip_permissions,
+                    headroom_enabled,
+                    None,
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
+
         // Step 2: Create tmux session name (format: tmux_{folder}_{branch})
         let worktree_folder = Self::extract_worktree_folder(&worktree_info.path);
         let tmux_session_name = Self::generate_tmux_name(&worktree_folder, &branch_name);
@@ -503,6 +563,7 @@ impl InteractiveSessionManager {
                     None,
                     false, // resume_requested — fresh launch
                     headroom_enabled,
+                    codex_remote.as_ref(),
                 )
                 .await?;
             }
@@ -526,6 +587,7 @@ impl InteractiveSessionManager {
             model: model.clone(),
             headroom_enabled,
             rtk_enabled,
+            codex_thread_id: codex_remote.as_ref().map(|remote| remote.thread_id.clone()),
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -544,6 +606,7 @@ impl InteractiveSessionManager {
             model,
             model_source: ModelSource::Raw,
             codex_model: None,
+            codex_thread_id: codex_remote.map(|remote| remote.thread_id),
         };
         // Locked RMW so a concurrent `ainb kill` / recovery / daemon register
         // can't lost-update this upsert (pu4).
@@ -645,6 +708,22 @@ impl InteractiveSessionManager {
             }
         }
 
+        let codex_remote = if agent_type == SessionAgentType::Codex {
+            Some(
+                ensure_codex_remote_thread(
+                    session_id,
+                    &existing_worktree_path,
+                    model.as_deref(),
+                    skip_permissions,
+                    headroom_enabled,
+                    None,
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
+
         // Step 1: Create tmux session name (format: tmux_{folder}_{branch})
         let worktree_folder = Self::extract_worktree_folder(&existing_worktree_path);
         let tmux_session_name = Self::generate_tmux_name(&worktree_folder, &branch_name);
@@ -671,6 +750,7 @@ impl InteractiveSessionManager {
                     None,
                     false, // resume_requested — fresh launch
                     headroom_enabled,
+                    codex_remote.as_ref(),
                 )
                 .await?;
             }
@@ -695,6 +775,7 @@ impl InteractiveSessionManager {
             model: model.clone(),
             headroom_enabled,
             rtk_enabled,
+            codex_thread_id: codex_remote.as_ref().map(|remote| remote.thread_id.clone()),
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -713,6 +794,7 @@ impl InteractiveSessionManager {
             model,
             model_source: ModelSource::Raw,
             codex_model: None,
+            codex_thread_id: codex_remote.map(|remote| remote.thread_id),
         };
         // Locked RMW (pu4): serialise against concurrent kill/recovery writers.
         if let Err(e) = SessionStore::mutate(|store| store.upsert(metadata)) {
@@ -840,6 +922,7 @@ impl InteractiveSessionManager {
                     model: metadata.launch_model(),
                     headroom_enabled: metadata.headroom_enabled,
                     rtk_enabled: metadata.rtk_enabled,
+                    codex_thread_id: metadata.codex_thread_id.clone(),
                 });
             } else {
                 debug!(
@@ -891,6 +974,7 @@ impl InteractiveSessionManager {
                     model: None,
                     headroom_enabled: false,
                     rtk_enabled: false,
+                    codex_thread_id: None,
                 });
             }
         }
@@ -1670,6 +1754,7 @@ impl InteractiveSessionManager {
         resume_transcript: Option<PathBuf>,
         resume_requested: bool,
         headroom_enabled: bool,
+        codex_remote: Option<&ainb_hangar_proto::fleet::CodexSessionEnsureResult>,
     ) -> Result<(), InteractiveSessionError> {
         use crate::config::CliProvider;
 
@@ -1730,14 +1815,29 @@ impl InteractiveSessionManager {
         // Build the CLI command with appropriate flags. Pure assembly lives in
         // `build_cli_cmd_parts` (unit-tested); `resume_transcript.is_some()` is
         // the "has prior history" guard for Claude's `--continue`.
-        let cmd_parts = Self::build_cli_cmd_parts(
-            &provider,
-            agent_type,
-            skip_permissions,
-            model.as_deref(),
-            resume_requested,
-            resume_transcript.is_some(),
-        );
+        let cmd_parts = if let Some(remote) = codex_remote {
+            if agent_type != SessionAgentType::Codex {
+                return Err(InteractiveSessionError::Other(anyhow::anyhow!(
+                    "remote Codex thread used for a non-Codex session"
+                )));
+            }
+            vec![
+                provider.command().to_string(),
+                "--remote".to_string(),
+                remote.endpoint.clone(),
+                "resume".to_string(),
+                remote.thread_id.clone(),
+            ]
+        } else {
+            Self::build_cli_cmd_parts(
+                &provider,
+                agent_type,
+                skip_permissions,
+                model.as_deref(),
+                resume_requested,
+                resume_transcript.is_some(),
+            )
+        };
 
         let cli_cmd = cmd_parts.join(" ");
 
@@ -2025,6 +2125,21 @@ fn wire_rtk_project_hook_with_cmd(worktree: &std::path::Path, cmd: &str) -> anyh
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn shared_remote_codex_rejects_headroom_before_daemon_startup() {
+        let error = ensure_codex_remote_thread(
+            uuid::Uuid::new_v4(),
+            Path::new("/worktree"),
+            None,
+            false,
+            true,
+            None,
+        )
+        .await
+        .expect_err("Headroom cannot be routed through the shared app-server");
+        assert!(error.to_string().contains("Headroom is unavailable"));
+    }
 
     #[test]
     fn headroom_env_prefix_routes_claude_and_codex_only() {
@@ -2554,6 +2669,7 @@ mod tests {
             model: None,
             model_source: ModelSource::Raw,
             codex_model: None,
+            codex_thread_id: None,
         };
         assert_eq!(metadata.display_workspace_name(), "shotclubhouse");
 
@@ -2682,6 +2798,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         });
         store.save().expect("save");
 
@@ -2733,6 +2850,7 @@ mod tests {
                 model: Some("gpt-5.6-luna".to_string()),
                 model_source: ModelSource::Raw,
                 codex_model: Some(CodexModel::Gpt55),
+                codex_thread_id: None,
             });
         })
         .expect("save");
@@ -2834,6 +2952,7 @@ mod tests {
             model: None,
             model_source: Default::default(),
             codex_model: None,
+            codex_thread_id: None,
         };
 
         const WRITERS: usize = 12;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -165,11 +165,15 @@ async fn tokio_main() -> Result<()> {
         Some(("tui", _)) | None => {
             entered_tui = true;
 
-            // Best-effort: bring the Hangar daemon up before the TUI connects, so
-            // a fresh home shows a runtime + a seeded agent (the boot seed runs in
-            // the daemon) instead of an offline panel. Idempotent + non-fatal — a
-            // spawn failure is logged and the TUI still launches.
-            cli::hangar::ensure_hangar_daemon();
+            // A plugin-disabled TUI is a diagnostic fallback with no Hangar
+            // consumer. Do not leave a background daemon behind for it.
+            if !plugins::plugins_disabled() {
+                // Best-effort: bring the Hangar daemon up before the TUI connects, so
+                // a fresh home shows a runtime + a seeded agent (the boot seed runs in
+                // the daemon) instead of an offline panel. Idempotent + non-fatal — a
+                // spawn failure is logged and the TUI still launches.
+                cli::hangar::ensure_hangar_daemon();
+            }
 
             // Best-effort: drop shipped default presets into
             // ~/.agents-in-a-box/presets.toml on first run. Never overwrites

--- a/ainb-tui/crates/ainb-core/src/plugins.rs
+++ b/ainb-tui/crates/ainb-core/src/plugins.rs
@@ -443,7 +443,7 @@ fn parse_csv(raw: &str) -> HashSet<String> {
 /// Operator-controlled kill switch. Recognises `1`, `true`, `yes`, `on`
 /// (case-insensitive) — anything else, including unset, leaves plugins
 /// enabled so a typo doesn't silently disable the runtime.
-fn plugins_disabled() -> bool {
+pub(crate) fn plugins_disabled() -> bool {
     match std::env::var("AINB_DISABLE_PLUGINS") {
         Ok(v) => matches!(
             v.trim().to_ascii_lowercase().as_str(),

--- a/ainb-tui/crates/ainb-core/tests/behavioral/session_persistence.rs
+++ b/ainb-tui/crates/ainb-core/tests/behavioral/session_persistence.rs
@@ -27,6 +27,7 @@ fn create_session_metadata(
         model: None,
         model_source: Default::default(),
         codex_model: None,
+        codex_thread_id: None,
     }
 }
 
@@ -50,6 +51,7 @@ fn create_session_metadata_with_id(
         model: None,
         model_source: Default::default(),
         codex_model: None,
+        codex_thread_id: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
@@ -15,8 +15,10 @@
 //! the test SKIPs rather than fails — the weak macOS CI runner must never be
 //! blocked on a binary it did not build.
 
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command, Stdio};
+use std::sync::Once;
 use std::time::{Duration, Instant};
 
 /// Path to the `ainb` binary under test.
@@ -32,6 +34,39 @@ fn daemon_bin() -> Option<PathBuf> {
     candidate.exists().then_some(candidate)
 }
 
+/// Reap only orphaned `ainb hangar daemon run` children from an interrupted
+/// prior invocation of this exact test binary. Selection requires both the
+/// exact command and ppid=1; every signal addresses one PID only.
+fn reap_orphaned_test_daemons() {
+    static REAPED: Once = Once::new();
+    REAPED.call_once(|| {
+        let Ok(output) = Command::new("ps")
+            .args(["-Ao", "pid=,ppid=,command="])
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+        else {
+            return;
+        };
+        if !output.status.success() {
+            return;
+        }
+        let expected = format!("{} hangar daemon run", ainb_bin().display());
+        let Ok(table) = String::from_utf8(output.stdout) else {
+            return;
+        };
+        for pid in table.lines().filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields.next()?.parse::<u32>().ok()?;
+            let ppid = fields.next()?.parse::<u32>().ok()?;
+            let command = fields.collect::<Vec<_>>().join(" ");
+            (ppid == 1 && command == expected).then_some(pid)
+        }) {
+            let _ = Command::new("kill").arg(pid.to_string()).status();
+        }
+    });
+}
+
 /// Run `ainb hangar daemon <args>` against an isolated home, pointing the CLI at
 /// the sibling daemon binary. Returns (success, combined stdout+stderr).
 fn run(home: &Path, daemon: &Path, args: &[&str]) -> (bool, String) {
@@ -44,6 +79,8 @@ fn run(home: &Path, daemon: &Path, args: &[&str]) -> (bool, String) {
         // the claim loop so the child stays a quiet idle process for the test.
         .env("HANGAR_DAEMON_RUNTIME_ID", "rt-lifecycle")
         .env("HANGAR_DAEMON_DISABLE_CLAIM", "1")
+        .env("AINB_CODEX_MANAGED", "0")
+        .env("HANGAR_TEST_PARENT_PID", std::process::id().to_string())
         .output()
         .expect("spawn ainb");
     let stdout = String::from_utf8_lossy(&out.stdout).to_string();
@@ -77,8 +114,27 @@ fn wait_until(timeout: Duration, mut cond: impl FnMut() -> bool) -> bool {
     cond()
 }
 
+/// Kill this exact PID if an assertion aborts the watchdog proof early.
+struct ExactPidCleanup(u32);
+
+impl Drop for ExactPidCleanup {
+    fn drop(&mut self) {
+        if pid_alive(self.0) {
+            use nix::sys::signal::{Signal, kill};
+            use nix::unistd::Pid;
+            let _ = kill(Pid::from_raw(self.0 as i32), Signal::SIGKILL);
+        }
+    }
+}
+
+fn kill_and_wait(child: &mut Child) {
+    child.kill().expect("SIGKILL exact test parent");
+    child.wait().expect("reap exact test parent");
+}
+
 #[test]
 fn daemon_start_status_stop_round_trip() {
+    reap_orphaned_test_daemons();
     let Some(daemon) = daemon_bin() else {
         eprintln!("SKIP: ainb-hangar-daemon binary not built beside ainb");
         return;
@@ -147,4 +203,42 @@ fn daemon_start_status_stop_round_trip() {
         use nix::unistd::Pid;
         let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
     }
+}
+
+#[test]
+fn daemon_exits_when_its_test_parent_is_sigkilled() {
+    reap_orphaned_test_daemons();
+    let home = tempfile::tempdir().expect("isolated hangar home");
+    let mut parent = Command::new("sh")
+        .args([
+            "-c",
+            "HANGAR_TEST_PARENT_PID=$$ AINB_CODEX_MANAGED=0 HANGAR_DAEMON_DISABLE_CLAIM=1 \\
+             AINB_HANGAR_HOME=\"$2\" HOME=\"$2\" \"$1\" hangar daemon run >/dev/null 2>&1 &\n             printf '%s\\n' \"$!\"\n             wait \"$!\"",
+            "sh",
+        ])
+        .arg(ainb_bin())
+        .arg(home.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn test parent");
+    let stdout = parent.stdout.take().expect("test parent stdout");
+    let mut line = String::new();
+    BufReader::new(stdout).read_line(&mut line).expect("read daemon pid");
+    let daemon_pid = line.trim().parse::<u32>().expect("daemon pid");
+    let _cleanup = ExactPidCleanup(daemon_pid);
+
+    assert!(
+        wait_until(Duration::from_secs(10), || home
+            .path()
+            .join("hangar.sock")
+            .exists()),
+        "daemon must reach its run loop before the parent dies"
+    );
+    kill_and_wait(&mut parent);
+    assert!(
+        wait_until(Duration::from_secs(5), || !pid_alive(daemon_pid)),
+        "daemon {daemon_pid} survived its SIGKILLed test parent"
+    );
 }

--- a/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
+++ b/ainb-tui/crates/ainb-core/tests/orphan_session_removal.rs
@@ -59,6 +59,7 @@ async fn test_remove_orphaned_session_purges_store_record() -> Result<()> {
         model: None,
         model_source: Default::default(),
         codex_model: None,
+        codex_thread_id: None,
     });
     store.upsert(SessionMetadata {
         session_id: keep_id,
@@ -73,6 +74,7 @@ async fn test_remove_orphaned_session_purges_store_record() -> Result<()> {
         model: None,
         model_source: Default::default(),
         codex_model: None,
+        codex_thread_id: None,
     });
     store.save()?;
     assert_eq!(SessionStore::load().sessions().len(), 2);

--- a/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
+++ b/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
@@ -51,6 +51,8 @@ struct TmuxIsolation {
     /// Whatever `TMUX_TMPDIR` was before we overrode it, so a probe can still
     /// reach the AMBIENT server on purpose.
     ambient: Option<String>,
+    /// Current-client socket. tmux prefers this over `TMUX_TMPDIR` unless removed.
+    ambient_client: Option<String>,
 }
 
 /// Redirect every tmux call this process makes onto a private socket dir.
@@ -63,6 +65,7 @@ fn isolation() -> &'static TmuxIsolation {
     static ISO: OnceLock<TmuxIsolation> = OnceLock::new();
     ISO.get_or_init(|| {
         let ambient = std::env::var("TMUX_TMPDIR").ok();
+        let ambient_client = std::env::var("TMUX").ok();
         // pid + nanos: containers recycle low pids, and a leftover dir owned by
         // another uid would make tmux refuse the socket.
         let nonce = std::time::SystemTime::now()
@@ -73,7 +76,12 @@ fn isolation() -> &'static TmuxIsolation {
             PathBuf::from("/tmp").join(format!("ainb-verify-tmux-{}-{nonce}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("create private tmux socket dir");
         std::env::set_var("TMUX_TMPDIR", &dir);
-        TmuxIsolation { dir, ambient }
+        std::env::remove_var("TMUX");
+        TmuxIsolation {
+            dir,
+            ambient,
+            ambient_client,
+        }
     })
 }
 
@@ -91,6 +99,10 @@ fn ambient_tmux() -> Command {
     match &iso.ambient {
         Some(v) => cmd.env("TMUX_TMPDIR", v),
         None => cmd.env_remove("TMUX_TMPDIR"),
+    };
+    match &iso.ambient_client {
+        Some(v) => cmd.env("TMUX", v),
+        None => cmd.env_remove("TMUX"),
     };
     cmd
 }
@@ -173,6 +185,7 @@ async fn launched_command(
         resume_transcript,
         resume_requested,
         false, // headroom_enabled (keep the env prefix off the critical path)
+        None,
     )
     .await
     .expect("start_cli_in_tmux");

--- a/ainb-tui/crates/ainb-core/tests/tripwire_abtop.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_abtop.rs
@@ -156,13 +156,11 @@ fn pressing_t_offers_setup_then_embeds_abtop() {
         .expect("tmux new-session");
     assert!(status.success(), "tmux new-session failed");
 
-    // Launch ainb inheriting the real PATH so ~/.cargo/bin/abtop resolves.
-    // Single send-keys + Enter to avoid the launch-command truncation race.
-    // The embed is pure host code (AttachAbtop) + the real abtop binary —
-    // plugins aren't needed, so disable discovery to keep the launch fast and
-    // free of unrelated plugin-spawn noise.
+    // Launch ainb with its normal plugin runtime: disabling plugins also
+    // disables the abtop shortcut path this test validates.
+    // Single send-keys + Enter avoids the launch-command truncation race.
     let cmd = format!(
-        "HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+        "HOME={} exec {} tui",
         home_tmp.path().display(),
         ainb_bin().display()
     );
@@ -181,6 +179,10 @@ fn pressing_t_offers_setup_then_embeds_abtop() {
         kill_session(&session);
         panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
     }
+
+    // The first frame can paint before terminal input handling is live on a
+    // warm process. Let the TUI complete that handoff before sending `t`.
+    thread::sleep(Duration::from_millis(500));
 
     // J6: press `t` → first launch should offer to run `abtop --setup`
     // (the rate-limit consent dialog) BEFORE attaching, and must NOT have

--- a/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_codex_statusline.rs
@@ -159,13 +159,20 @@ fn launch_and_goto_sessions(home: &Path, session: &str) {
         capture(session)
     );
 
-    Command::new("tmux")
-        .args(["send-keys", "-t", session, "s"])
-        .status()
-        .expect("send s");
-
     let nav_deadline = Instant::now() + Duration::from_secs(20);
-    let post = poll(session, nav_deadline, is_on_sessions_screen);
+    let mut post = None;
+    while Instant::now() < nav_deadline {
+        let cap = capture(session);
+        if is_on_sessions_screen(&cap) {
+            post = Some(cap);
+            break;
+        }
+        Command::new("tmux")
+            .args(["send-keys", "-t", session, "s"])
+            .status()
+            .expect("send s");
+        thread::sleep(Duration::from_millis(500));
+    }
     assert!(
         post.is_some(),
         "sessions screen never rendered after 's'.\n{}",

--- a/ainb-tui/crates/ainb-core/tests/tripwire_deps_installer.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_deps_installer.rs
@@ -84,17 +84,25 @@ fn deps_installer_cursor_docs_and_install_affordance() {
         panic!("wizard welcome never rendered:\n{last}");
     }
 
-    // Advance Welcome -> Source -> Role -> UseCase -> DependencyCheck: the
-    // wizard has three questionnaire steps between Welcome and the dependency
-    // step, each accepting its default selection on Enter.
-    for _ in 0..4 {
+    // Advance through the wizard until DependencyCheck. Rendering transitions
+    // are asynchronous, so fixed key counts can drop an Enter on a slow host.
+    let deadline = Instant::now() + Duration::from_secs(40);
+    let mut loaded = None;
+    let mut current = capture(&session);
+    while Instant::now() < deadline {
+        if current.contains("Plugin binaries") && !current.contains("Checking dependencies") {
+            loaded = Some(current);
+            break;
+        }
         send(&session, "Enter");
-        sleep(Duration::from_millis(400));
+        let transition_deadline = std::cmp::min(deadline, Instant::now() + Duration::from_secs(5));
+        let Some(next) = poll_capture(&session, transition_deadline, |screen| screen != current)
+        else {
+            break;
+        };
+        current = next;
     }
-    let loaded = poll_capture(&session, Instant::now() + Duration::from_secs(40), |c| {
-        c.contains("Plugin binaries") && !c.contains("Checking dependencies")
-    })
-    .unwrap_or_else(|| capture(&session));
+    let loaded = loaded.unwrap_or_else(|| capture(&session));
 
     // The new keymap footer must advertise the install + cursor affordances.
     assert!(

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
@@ -53,7 +53,7 @@ git_directories = []
         ver = env!("CARGO_PKG_VERSION"),
     );
     fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
-    let install_record = r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#;
+    let install_record = r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#;
     fs::write(base.join("install.json"), install_record).expect("seed install.json");
 }
 
@@ -113,6 +113,12 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
     fs::create_dir_all(&home).expect("create short-path home");
     seed_isolated_home(&home);
     let hangar_home = home.join("hangar-home");
+    fs::create_dir_all(&hangar_home).expect("create isolated hangar home");
+    fs::write(
+        hangar_home.join("install.json"),
+        r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#,
+    )
+    .expect("dismiss notification prompt in daemon home");
     let _ainb_home = EnvGuard::set("AINB_HOME", home.join(".agents-in-a-box"));
     let _disable_tmux_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
     let hangar = FleetHangar::start(&hangar_home);
@@ -145,7 +151,7 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
         .expect("seeded approval has exact request fingerprint");
 
     // Real broker on the isolated approve.sock, riding a test-owned runtime.
-    let paths = Paths::under(home.join(".agents-in-a-box"));
+    let paths = Paths::under(&hangar_home);
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let broker_state = BrokerState::new();
     {
@@ -185,7 +191,7 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
     let peers_db = home.join("peers.db");
     let jobs_dir = home.join("jobs");
     let cmd = format!(
-        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
         home = home.display(),
         hangar = hangar_home.display(),
         peers = peers_db.display(),
@@ -213,13 +219,11 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
         capture_pane(&session)
     );
     let opened = poll_capture(&session, Instant::now() + Duration::from_secs(30), |c| {
-        c.contains("APPR")
-            && c.contains("STARTI")
-            && c.contains("State: IDLE / APPROVAL")
-            && c.contains("claude:fleet-ap")
-            && c.contains("claude:fleet-st")
+        c.contains("Fleet · 2 sessions")
             && c.contains("approving-project")
-            && c.contains("hangar-authoritative")
+            && c.contains("Approval required for Bash")
+            && c.contains("1 INPUT")
+            && c.contains("1 RUN")
     });
     let Some(open_cap) = opened else {
         let last = capture_pane(&session);
@@ -229,7 +233,7 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
         );
     };
     assert!(
-        open_cap.contains("y") && open_cap.contains("approve"),
+        open_cap.contains("y Approve"),
         "help bar must advertise the y approve lever:\n{open_cap}"
     );
     assert!(

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_chat_screen.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_chat_screen.rs
@@ -144,7 +144,7 @@ where
 /// catch, and a retry loop makes it invisible. The spacing in the home banner
 /// is load-bearing too, the setup wizard's splash also says "Agents in a Box".
 fn open_chat_surface(session: &str) -> bool {
-    if !wait_for(session, "A I N B", 60) {
+    if !wait_for(session, "Enter select | Tab content", 60) {
         return false;
     }
     send_key(session, "f");
@@ -173,7 +173,7 @@ fn chat_journey(prefix: &str) -> (tempfile::TempDir, FleetHangar, ExactTmuxSessi
     let name = format!("{prefix}{}", std::process::id());
     let tmux = ExactTmuxSession::create(name, "180", "50");
     let command = format!(
-        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} \
+        "HOME={home} AINB_HOME={hangar} AINB_HANGAR_HOME={hangar} \
          AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 \
          CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
         home = home_tmp.path().display(),

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -134,7 +134,14 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
         .expect("home tempdir");
     seed_isolated_home(home_tmp.path());
     let hangar_home = home_tmp.path().join("hangar-home");
+    fs::create_dir_all(&hangar_home).expect("create isolated hangar home");
+    fs::write(
+        hangar_home.join("install.json"),
+        r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#,
+    )
+    .expect("dismiss notification prompt in daemon home");
     let _ainb_home = EnvGuard::set("AINB_HOME", home_tmp.path().join(".agents-in-a-box"));
+    let _hangar_home_guard = EnvGuard::set("AINB_HANGAR_HOME", &hangar_home);
     let _disable_tmux_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
     let hangar = FleetHangar::start(&hangar_home);
     let questions = serde_json::json!([
@@ -274,7 +281,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     // Real broker plus the actual lifecycle-hook executable. Fleet answer must
     // traverse TUI -> fleet/action -> Hangar -> broker -> hook stdout, which is
     // the exact JSON Claude receives to resume its AskUserQuestion tool call.
-    let paths = Paths::under(home_tmp.path().join(".agents-in-a-box"));
+    let paths = Paths::under(&hangar_home);
     let broker_runtime = tokio::runtime::Runtime::new().expect("broker runtime");
     let broker_state = BrokerState::new();
     {
@@ -292,7 +299,8 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     let hook_cwd = home_tmp.path().join("fleet-tripwire-project");
     let mut hook = Command::new(ainb_bin())
         .env("HOME", home_tmp.path())
-        .env("AINB_HOME", home_tmp.path().join(".agents-in-a-box"))
+        .env("AINB_HOME", &hangar_home)
+        .env("AINB_HANGAR_HOME", &hangar_home)
         .env("AINB_PARENT_SESSION", "fleet-panel-parent")
         .args([
             "fleet",
@@ -350,7 +358,7 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     let peers_db = home_tmp.path().join("peers.db");
     let jobs_dir = home_tmp.path().join("jobs");
     let cmd = format!(
-        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
+        "HOME={home} AINB_HOME={hangar} AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
         home = home_tmp.path().display(),
         hangar = hangar_home.display(),
         peers = peers_db.display(),

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_shows_acp_session.rs
@@ -97,21 +97,21 @@ fn wait_for(session: &str, needle: &str, secs: u64) -> bool {
     false
 }
 
-/// Open Fleet the way a user does: wait for the home screen to paint, then
-/// press `f` ONCE.
-///
-/// Pressing `f` on a loop until something happens would be the wrong test. A
-/// modal that swallows the first press is precisely the failure this is here to
-/// catch, and a retry loop makes it invisible. The spacing in the home banner is
-/// load-bearing too: the setup wizard's splash also says "Agents in a Box", so
-/// the unspaced name would match a screen that eats `f` rather than the screen
-/// that acts on it.
+/// Open Fleet after the home input loop is ready. A freshly launched terminal
+/// can paint its legend before tmux accepts its first key, so retry the routing
+/// shortcut within the bounded startup window.
 fn open_fleet_panel(session: &str) -> bool {
-    if !wait_for(session, "A I N B", 60) {
+    if !wait_for(session, "Enter select | Tab content", 60) {
         return false;
     }
-    send_key(session, "f");
-    wait_for(session, "Fleet ·", 30)
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        send_key(session, "f");
+        if wait_for(session, "Fleet ·", 1) {
+            return true;
+        }
+    }
+    false
 }
 
 #[test]
@@ -127,7 +127,8 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
         .expect("home tempdir");
     let hangar_home = home_tmp.path().join("hangar-home");
     seed_isolated_home(home_tmp.path(), &hangar_home);
-    let _ainb_home = EnvGuard::set("AINB_HOME", home_tmp.path().join(".agents-in-a-box"));
+    let _ainb_home = EnvGuard::set("AINB_HOME", &hangar_home);
+    let _hangar_home_guard = EnvGuard::set("AINB_HANGAR_HOME", &hangar_home);
     let _no_discovery = EnvGuard::set("AINB_FLEET_DISABLE_TMUX_DISCOVERY", "1");
 
     // A real daemon on a real socket, same as every other Fleet tripwire.
@@ -149,7 +150,7 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
         ])
         .arg(&cwd)
         .env("HOME", home_tmp.path())
-        .env("AINB_HOME", home_tmp.path().join(".agents-in-a-box"))
+        .env("AINB_HOME", &hangar_home)
         .env("AINB_HANGAR_HOME", &hangar_home)
         .output()
         .expect("run ainb fleet acp create");
@@ -174,7 +175,7 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
     let peers_db = home_tmp.path().join("peers.db");
     let jobs_dir = home_tmp.path().join("jobs");
     let cmd = format!(
-        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} \
+        "HOME={home} AINB_HOME={hangar} AINB_HANGAR_HOME={hangar} \
          AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 \
          CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
         home = home_tmp.path().display(),
@@ -190,7 +191,7 @@ fn fleet_panel_shows_an_acp_session_created_through_the_cli() {
 
     assert!(
         open_fleet_panel(session),
-        "the Fleet panel did not open on the first `f`:\n{}",
+        "the Fleet panel did not open:\n{}",
         capture_pane(session)
     );
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_onboarding_topics.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_onboarding_topics.rs
@@ -75,11 +75,12 @@ fn onboarding_dependency_step_renders_topics() {
         panic!("wizard welcome never rendered:\n{last}");
     }
 
-    // Advance Welcome -> Source -> Role -> UseCase -> DependencyCheck. The
-    // wizard has three questionnaire steps between Welcome and the dependency
-    // step; each accepts its default selection on Enter. The final Enter lands
-    // on DependencyCheck and auto-triggers the catalog detect.
-    for _ in 0..4 {
+    // Advance through the questionnaire steps. Detect the dependency screen
+    // rather than pinning a step count, since onboarding can grow questions.
+    for _ in 0..6 {
+        if capture(&session).contains("i install") {
+            break;
+        }
         Command::new("tmux")
             .args(["send-keys", "-t", &session, "Enter"])
             .status()

--- a/ainb-tui/crates/ainb-core/tests/tripwire_panel_legend_and_help.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_panel_legend_and_help.rs
@@ -181,11 +181,14 @@ fn help_overlay_documents_panels_section() {
     let session = format!("tripwire-help-{}", std::process::id());
     launch_to_home(&session, home_tmp.path());
 
-    // `?` opens the global help overlay.
-    send_key(&session, "?");
-    let cap = poll_capture(&session, Instant::now() + Duration::from_secs(30), |c| {
-        c.contains("Panels (closing returns here)")
-    });
+    // `?` opens the global help overlay. Re-send during the bounded startup
+    // window because the terminal can paint before its first key is accepted.
+    let cap = poll_capture_resending(
+        &session,
+        "?",
+        Instant::now() + Duration::from_secs(30),
+        |c| c.contains("Panels (closing returns here)"),
+    );
     let final_cap = cap.unwrap_or_else(|| capture_pane(&session));
     kill_session(&session);
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_plain_checkout_workspace_name.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_plain_checkout_workspace_name.rs
@@ -77,6 +77,7 @@ fn seed(store: &mut SessionStore, tmux_name: &str, worktree: &Path, name: &str) 
         model: None,
         model_source: ModelSource::default(),
         codex_model: None,
+        codex_thread_id: None,
     });
     id
 }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_skills_returns_to_origin.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_skills_returns_to_origin.rs
@@ -128,6 +128,42 @@ fn on_skills_screen(c: &str) -> bool {
     c.contains("Provider:") && c.contains("Associations")
 }
 
+fn on_session_list(c: &str) -> bool {
+    c.contains("Session Details")
+        || c.contains("Select a session to view details")
+        || (c.contains("attach") && c.contains("restart") && c.contains("cleanup"))
+}
+
+fn go_to_session_list(session: &str) -> Option<String> {
+    let deadline = Instant::now() + Duration::from_secs(40);
+    while Instant::now() < deadline {
+        send_key(session, "s");
+        if let Some(capture) = poll_capture(
+            session,
+            Instant::now() + Duration::from_millis(750),
+            on_session_list,
+        ) {
+            return Some(capture);
+        }
+    }
+    None
+}
+
+fn open_skills_screen(session: &str, key: &str) -> Option<String> {
+    let deadline = Instant::now() + Duration::from_secs(40);
+    while Instant::now() < deadline {
+        send_key(session, key);
+        if let Some(capture) = poll_capture(
+            session,
+            Instant::now() + Duration::from_millis(750),
+            on_skills_screen,
+        ) {
+            return Some(capture);
+        }
+    }
+    None
+}
+
 #[test]
 fn skills_from_home_returns_home() {
     if !tmux_available() {
@@ -149,14 +185,7 @@ fn skills_from_home_returns_home() {
     // Open skills from the home menu. The home-screen catalogue key is
     // `c` (`z` opens the Skills manager); the session list mirrors it on
     // `k`, exercised by the sibling test below.
-    send_key(&session, "c");
-    if poll_capture(
-        &session,
-        Instant::now() + Duration::from_secs(40),
-        on_skills_screen,
-    )
-    .is_none()
-    {
+    if open_skills_screen(&session, "c").is_none() {
         let last = capture_pane(&session);
         kill_session(&session);
         panic!("skills screen never rendered after `k`; last:\n---\n{last}\n---");
@@ -187,14 +216,8 @@ fn skills_from_session_list_returns_to_session_list() {
     let session = format!("tripwire-skills-sessions-{}", std::process::id());
     launch_to_home(&session, home_tmp.path());
 
-    // Hop to the session list first. `del-sel` is on the session-list
-    // legend (line 2) and appears on no other screen.
-    send_key(&session, "s");
-    if poll_capture(&session, Instant::now() + Duration::from_secs(40), |c| {
-        c.contains("del-sel")
-    })
-    .is_none()
-    {
+    // Hop to the session list first.
+    if go_to_session_list(&session).is_none() {
         let last = capture_pane(&session);
         kill_session(&session);
         panic!("session list never rendered after `s`; last:\n---\n{last}\n---");
@@ -202,14 +225,7 @@ fn skills_from_session_list_returns_to_session_list() {
 
     // Open skills from the session list. The catalogue is mirrored here
     // on `k` (the home menu uses `c`).
-    send_key(&session, "k");
-    if poll_capture(
-        &session,
-        Instant::now() + Duration::from_secs(40),
-        on_skills_screen,
-    )
-    .is_none()
-    {
+    if open_skills_screen(&session, "k").is_none() {
         let last = capture_pane(&session);
         kill_session(&session);
         panic!("skills screen never rendered after `k` from session list; last:\n---\n{last}\n---");
@@ -219,7 +235,7 @@ fn skills_from_session_list_returns_to_session_list() {
     // pops the saved `previous_screen`.
     send_key(&session, "Escape");
     let back = poll_capture(&session, Instant::now() + Duration::from_secs(25), |c| {
-        c.contains("del-sel") && !on_skills_screen(c)
+        on_session_list(c) && !on_skills_screen(c)
     });
     let final_cap = capture_pane(&session);
     kill_session(&session);

--- a/ainb-tui/crates/ainb-core/tests/tripwire_witr.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_witr.rs
@@ -182,11 +182,15 @@ fn pressing_w_embeds_witr_interactive_browser() {
     }
 
     // The ainb-witr pane must show witr's real interactive browser, not a
-    // shell or a "command not found". Positive: the tab strip + the search
-    // prompt witr's TUI paints. Negative: no launch failure.
+    // shell or a "command not found". Positive: the interactive mode, process
+    // search, and ancestry pane that witr's current TUI paints. Negative: no
+    // launch failure.
     let browser_ok = poll(Instant::now() + Duration::from_secs(30), || {
         let c = capture_pane(WITR_SESSION);
-        c.contains("Processes") && c.contains("Search") && !c.contains("command not found")
+        c.contains("Mode: Navigation")
+            && c.contains("Search PID, Name, User, Command")
+            && c.contains("Ancestry Tree:")
+            && !c.contains("command not found")
     });
     let witr_pane = capture_pane(WITR_SESSION);
 

--- a/ainb-tui/crates/ainb-hangar-client/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-client/src/lib.rs
@@ -42,6 +42,8 @@ use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 /// Upper bound on a single dial + round-trip. Local unix socket, so generous;
 /// only guards against a wedged daemon.
 const RPC_TIMEOUT: Duration = Duration::from_secs(5);
+/// Shared Codex initialization can take longer than ordinary daemon reads.
+const CODEX_SESSION_ENSURE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// A failure talking to the hangar daemon. Non-fatal to the bridge: outbound
 /// degrades to "no items to push", inbound reply-routing falls back to the
@@ -248,6 +250,17 @@ impl DaemonClient {
         serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))
     }
 
+    /// Read bounded Hangar runtime diagnostics, including Codex app-servers.
+    pub async fn fleet_runtime_status(
+        &self,
+    ) -> Result<ainb_hangar_proto::fleet::FleetRuntimeStatusResult, DaemonError> {
+        self.call_typed(
+            ainb_hangar_proto::methods::FLEET_RUNTIME_STATUS,
+            &ainb_hangar_proto::fleet::FleetRuntimeStatusParams {},
+        )
+        .await
+    }
+
     /// Subscribe from one revision and receive race-free snapshot plus replay.
     pub async fn fleet_subscribe(
         &self,
@@ -291,6 +304,27 @@ impl DaemonClient {
         let result: ainb_hangar_proto::fleet::FleetActionResult =
             serde_json::from_value(result).map_err(|e| DaemonError::Decode(e.to_string()))?;
         Ok(result.receipt)
+    }
+
+    /// Ensure an Interactive Codex session is backed by the daemon-owned
+    /// shared app-server and return its exact remote thread.
+    pub async fn codex_session_ensure(
+        &self,
+        params: ainb_hangar_proto::fleet::CodexSessionEnsureParams,
+    ) -> Result<ainb_hangar_proto::fleet::CodexSessionEnsureResult, DaemonError> {
+        let value = serde_json::to_value(params).map_err(|source| {
+            DaemonError::Decode(format!("encoding Codex session params: {source}"))
+        })?;
+        let result = self
+            .call_with_timeout(
+                ainb_hangar_proto::methods::CODEX_SESSION_ENSURE,
+                value,
+                CODEX_SESSION_ENSURE_TIMEOUT,
+            )
+            .await?;
+        serde_json::from_value(result).map_err(|source| {
+            DaemonError::Decode(format!("decoding Codex session result: {source}"))
+        })
     }
 
     /// Rebuild one stale Claude interview through the live daemon.
@@ -548,9 +582,18 @@ impl DaemonClient {
     }
 
     async fn call(&self, method: &str, params: Value) -> Result<Value, DaemonError> {
-        tokio::time::timeout(RPC_TIMEOUT, self.call_inner(method, params))
+        self.call_with_timeout(method, params, RPC_TIMEOUT).await
+    }
+
+    async fn call_with_timeout(
+        &self,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value, DaemonError> {
+        tokio::time::timeout(timeout, self.call_inner(method, params))
             .await
-            .map_err(|_| DaemonError::Timeout(RPC_TIMEOUT))?
+            .map_err(|_| DaemonError::Timeout(timeout))?
     }
 
     async fn call_inner(&self, method: &str, params: Value) -> Result<Value, DaemonError> {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -152,11 +152,16 @@ impl CommandSpec {
 }
 
 /// Build shared app-server Unix listener command.
+///
+/// `--remote-control` makes this process discoverable by the signed-in Codex
+/// desktop and mobile clients. Hangar creates every managed Codex thread through
+/// this server, so the remote clients and the tmux TUI share one thread.
 pub fn app_server_command(codex_binary: &OsStr, socket: &Path) -> CommandSpec {
     CommandSpec {
         program: codex_binary.to_os_string(),
         args: vec![
             "app-server".into(),
+            "--remote-control".into(),
             "--listen".into(),
             unix_endpoint(socket).into(),
         ],
@@ -855,12 +860,13 @@ mod tests {
     }
 
     #[test]
-    fn command_specs_use_shared_unix_endpoint_and_proxy() {
+    fn command_specs_enable_remote_control_on_shared_app_server() {
         let socket = Path::new("/tmp/fleet codex.sock");
         assert_eq!(
             app_server_command(OsStr::new("codex"), socket).args,
             vec![
                 OsString::from("app-server"),
+                OsString::from("--remote-control"),
                 OsString::from("--listen"),
                 OsString::from("unix:///tmp/fleet codex.sock"),
             ]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -80,6 +80,7 @@ pub struct CodexManagerHandle {
     commands: mpsc::Sender<ManagerCommand>,
     capabilities: Arc<CodexCapabilities>,
     socket_path: Arc<PathBuf>,
+    owns_server: bool,
     request_timeout: Duration,
 }
 
@@ -87,6 +88,16 @@ impl CodexManagerHandle {
     /// Negotiated version-probed capabilities.
     pub fn capabilities(&self) -> &CodexCapabilities {
         &self.capabilities
+    }
+
+    /// Canonical Unix socket shared by every Ainb-managed Codex thread.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Ownership of the app-server bound at [`Self::socket_path`].
+    pub fn ownership(&self) -> &'static str {
+        if self.owns_server { "owned" } else { "adopted" }
     }
 
     /// Managed TUI command connected to this manager's shared app-server.
@@ -105,6 +116,25 @@ impl CodexManagerHandle {
         model: Option<&str>,
     ) -> Result<String, ProviderError> {
         let result = self.request("thread/start", json!({ "cwd": cwd, "model": model })).await?;
+        nested_id(&result, "thread")
+    }
+
+    /// Start an Interactive thread with its launch policy set on the server.
+    ///
+    /// Remote clients do not carry CLI environment or permission flags to the
+    /// app-server, so this policy must be attached when the thread is created.
+    pub async fn thread_start_interactive(
+        &self,
+        cwd: &Path,
+        model: Option<&str>,
+        skip_permissions: bool,
+    ) -> Result<String, ProviderError> {
+        let result = self
+            .request(
+                "thread/start",
+                interactive_thread_start_params(cwd, model, skip_permissions),
+            )
+            .await?;
         nested_id(&result, "thread")
     }
 
@@ -274,6 +304,20 @@ impl CodexManagerHandle {
     }
 }
 
+fn interactive_thread_start_params(
+    cwd: &Path,
+    model: Option<&str>,
+    skip_permissions: bool,
+) -> Value {
+    let mut params = json!({ "cwd": cwd, "model": model });
+    if skip_permissions {
+        let object = params.as_object_mut().expect("interactive thread params are an object");
+        object.insert("approvalPolicy".into(), json!("never"));
+        object.insert("sandbox".into(), json!("danger-full-access"));
+    }
+    params
+}
+
 /// Running manager, ordered inbound receiver, and actor join handle.
 pub struct ManagedCodexManager {
     /// Cloneable control handle.
@@ -295,6 +339,20 @@ impl ManagedCodexManager {
 /// Return active process-wide Codex manager handle when transport is healthy.
 pub async fn active_handle() -> Option<CodexManagerHandle> {
     active_manager().read().await.clone()
+}
+
+/// Wait briefly for daemon startup to publish its manager handle.
+pub async fn wait_for_active_handle(timeout: Duration) -> Option<CodexManagerHandle> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(handle) = active_handle().await {
+            return Some(handle);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
 }
 
 /// Health of the managed Codex transport, for the daemon's status surfaces.
@@ -326,6 +384,59 @@ pub struct CodexTransportHealth {
 /// status RPC in `rpc/mod.rs`; both are outside this file.
 pub async fn transport_health() -> CodexTransportHealth {
     transport_health_state().read().await.clone()
+}
+
+/// One locally discovered Codex app-server. Socket paths stay private.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexAppServerInventoryRow {
+    /// Local process identifier.
+    pub pid: u32,
+    /// `owned`, `adopted`, or `external`.
+    pub ownership: String,
+    /// Whether the process requested remote control enrollment.
+    pub remote_control: bool,
+    /// Managed transport health, or `unknown` for external processes.
+    pub health: String,
+}
+
+/// Bounded local app-server inventory for diagnostics.
+pub async fn app_server_inventory() -> Vec<CodexAppServerInventoryRow> {
+    let active = active_handle().await;
+    let health = transport_health().await;
+    let Some(ps_output) = ps_process_table().await else {
+        return Vec::new();
+    };
+    ps_output
+        .lines()
+        .filter_map(parse_ps_row)
+        .filter(|row| is_codex_app_server(row.args) && !row.args.contains("app-server proxy"))
+        .map(|row| {
+            let managed = active.as_ref().is_some_and(|handle| {
+                codex_server_socket(row.args)
+                    .is_some_and(|socket| socket == handle.socket_path().to_string_lossy())
+            });
+            CodexAppServerInventoryRow {
+                pid: row.pid,
+                ownership: if managed {
+                    active.as_ref().expect("active checked").ownership().to_string()
+                } else {
+                    "external".to_string()
+                },
+                remote_control: row.args.split_whitespace().any(|arg| arg == "--remote-control"),
+                health: if managed {
+                    if health.degraded {
+                        "degraded"
+                    } else {
+                        "healthy"
+                    }
+                    .to_string()
+                } else {
+                    "unknown".to_string()
+                },
+            }
+        })
+        .take(DEFAULT_CODEX_MAX_SERVERS)
+        .collect()
 }
 
 /// Consecutive failures after which the transport is called degraded and logged at
@@ -656,6 +767,7 @@ pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, Pr
         stdin,
         capabilities,
         config,
+        owns_server,
         preparation.marker_repair,
         cleanup,
     )
@@ -1541,6 +1653,7 @@ async fn spawn_connection<R, W>(
     mut writer: W,
     capabilities: CodexCapabilities,
     config: CodexManagerConfig,
+    owns_server: bool,
     marker_repair: Option<MarkerRepair>,
     mut cleanup: Box<dyn ProcessCleanup>,
 ) -> Result<ManagedCodexManager, ProviderError>
@@ -1572,6 +1685,7 @@ where
         commands,
         capabilities: Arc::clone(&capabilities),
         socket_path: Arc::new(config.socket_path),
+        owns_server,
         request_timeout: config.request_timeout,
     };
     let task = tokio::spawn(async move {
@@ -2712,6 +2826,7 @@ mod tests {
             manager_write,
             capabilities(true),
             config(),
+            false,
             Some(MarkerRepair {
                 path: repair_path.clone(),
                 expected: None,
@@ -2797,6 +2912,7 @@ mod tests {
             manager_write,
             capabilities(false),
             config(),
+            false,
             None,
             Box::new(FakeCleanup(cleanup_flag)),
         )
@@ -3024,5 +3140,17 @@ mod tests {
             .await
             .unwrap()
         );
+    }
+
+    #[test]
+    fn interactive_yolo_policy_is_sent_to_the_app_server() {
+        let params = interactive_thread_start_params(Path::new("/worktree"), Some("gpt-5"), true);
+        assert_eq!(params["approvalPolicy"], "never");
+        assert_eq!(params["sandbox"], "danger-full-access");
+        assert_eq!(params["model"], "gpt-5");
+
+        let default_params = interactive_thread_start_params(Path::new("/worktree"), None, false);
+        assert!(default_params.get("approvalPolicy").is_none());
+        assert!(default_params.get("sandbox").is_none());
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -379,6 +379,41 @@ impl Drop for PidFile {
     }
 }
 
+/// Test-only parent-death backstop. The tripwire harness gives every daemon its
+/// own parent PID. When the harness is SIGKILLed or OOM-reaped, macOS reparents
+/// the daemon to launchd, so normal Rust drop cleanup cannot run. Signal this
+/// process through its existing Ctrl-C shutdown path instead.
+fn spawn_test_parent_watchdog() {
+    let Some(parent_pid) = std::env::var("HANGAR_TEST_PARENT_PID")
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+        .filter(|pid| *pid > 1)
+    else {
+        return;
+    };
+
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(1));
+        loop {
+            tick.tick().await;
+            match nix::sys::signal::kill(nix::unistd::Pid::from_raw(parent_pid), None) {
+                Ok(()) | Err(nix::errno::Errno::EPERM) => {}
+                Err(nix::errno::Errno::ESRCH) => {
+                    tracing::warn!(parent_pid, "tripwire parent exited, stopping daemon");
+                    let _ = nix::sys::signal::kill(
+                        nix::unistd::Pid::from_raw(std::process::id() as i32),
+                        nix::sys::signal::Signal::SIGINT,
+                    );
+                    return;
+                }
+                Err(error) => {
+                    tracing::warn!(parent_pid, %error, "could not check tripwire parent");
+                }
+            }
+        }
+    });
+}
+
 /// Boot the daemon: open the persistence layer and run the claim loop.
 ///
 /// Resolves the database directory the same way every Hangar consumer does
@@ -396,6 +431,7 @@ impl Drop for PidFile {
 /// Returns an error if the store cannot be opened (directory not writable, a
 /// migration fails) or if the run loop's shutdown handler fails.
 pub async fn boot(once: bool) -> anyhow::Result<()> {
+    spawn_test_parent_watchdog();
     let dir = hangar_dir()?;
 
     // Observability tripwire seam (P8.1): when `$AINB_HANGAR_BOOT_TASK_ID` is set

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1231,6 +1231,7 @@ async fn handle(
         methods::FLEET_RECEIPT_LIST => handle_fleet_receipt_list(pool, req).await,
         methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
         methods::FLEET_START => handle_fleet_start(pool, req, events).await,
+        methods::CODEX_SESSION_ENSURE => handle_codex_session_ensure(pool, req).await,
         methods::FLEET_TIMELINE => handle_fleet_timeline(pool, req).await,
         methods::FLEET_ACP_SESSION_CREATE => {
             handle_fleet_acp_session_create(pool, req, events).await
@@ -1507,8 +1508,8 @@ async fn handle_fleet_runtime_status(
     health: &DaemonHealth,
 ) -> Result<serde_json::Value, RpcError> {
     use ainb_hangar_proto::fleet::{
-        FLEET_CAPABILITY_RUNTIME_READ, FLEET_PROTOCOL_VERSION, FleetRuntimeHookStatus,
-        FleetRuntimeStatusParams, FleetRuntimeStatusResult,
+        CodexAppServerRuntimeStatus, FLEET_CAPABILITY_RUNTIME_READ, FLEET_PROTOCOL_VERSION,
+        FleetRuntimeHookStatus, FleetRuntimeStatusParams, FleetRuntimeStatusResult,
     };
 
     require_fleet_capability(FLEET_CAPABILITY_RUNTIME_READ)?;
@@ -1533,10 +1534,21 @@ async fn handle_fleet_runtime_status(
             last_event: (!row.last_event.is_empty()).then_some(row.last_event),
         })
         .collect();
+    let codex_app_servers = crate::fleet_provider::codex_manager::app_server_inventory()
+        .await
+        .into_iter()
+        .map(|row| CodexAppServerRuntimeStatus {
+            pid: row.pid,
+            ownership: row.ownership,
+            remote_control: row.remote_control,
+            health: row.health,
+        })
+        .collect();
     to_value(&FleetRuntimeStatusResult {
         daemon_version: health.version.clone(),
         protocol_version: FLEET_PROTOCOL_VERSION,
         hooks,
+        codex_app_servers,
     })
 }
 
@@ -1727,7 +1739,7 @@ async fn message_send_inner(
 
     use ainb_hangar_proto::fleet::{
         ActionReceiptStatus, FLEET_MESSAGE_BODY_MAX, FLEET_MESSAGE_TARGETS_MAX,
-        FleetMessageDelivery, FleetMessageSendResult, FleetScope,
+        FleetMessageDelivery, FleetMessageSendResult,
     };
     use ainb_hangar_store::repo::fleet_chat::FleetChannelRepo;
     use ainb_hangar_store::repo::fleet_message::{FleetMessageRepo, NewFleetMessage};
@@ -3075,6 +3087,117 @@ async fn handle_fleet_start(
         parse_params(req, "{ request_id, provider, cwd, prompt? }")?;
     let result = execute_fleet_start(pool, params, events).await?;
     to_value(&result)
+}
+
+/// Allocate or resume an Interactive Codex thread through the one daemon-owned
+/// app-server. Interactive owns tmux and durable session metadata, so this is
+/// deliberately narrower than `fleet/start`.
+async fn handle_codex_session_ensure(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{CodexSessionEnsureParams, CodexSessionEnsureResult};
+
+    let params: CodexSessionEnsureParams = parse_params(
+        req,
+        "{ session_id, cwd, model?, thread_id?, skip_permissions? }",
+    )?;
+    if params.session_id.trim().is_empty() || params.cwd.trim().is_empty() {
+        return Err(invalid_params("session_id and cwd must not be empty"));
+    }
+    let manager = crate::fleet_provider::codex_manager::wait_for_active_handle(
+        std::time::Duration::from_secs(15),
+    )
+    .await
+    .ok_or_else(|| internal("Ainb Codex runtime is unavailable"))?;
+    let existing: Option<Option<String>> =
+        sqlx::query_scalar("SELECT thread_id FROM interactive_codex_thread WHERE session_id = ?")
+            .bind(&params.session_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|error| internal(&format!("read Interactive Codex thread: {error}")))?;
+    let thread_id = match existing {
+        Some(Some(thread_id)) => {
+            if let Some(requested) = params.thread_id.as_deref().filter(|id| !id.trim().is_empty())
+            {
+                if requested != thread_id {
+                    return Err(invalid_params(
+                        "session_id belongs to a different Codex thread",
+                    ));
+                }
+            }
+            manager
+                .thread_resume(&thread_id)
+                .await
+                .map_err(|error| internal(&format!("resume Codex thread: {error}")))?;
+            thread_id
+        }
+        Some(None) => {
+            return Err(internal(
+                "previous Interactive Codex allocation is incomplete; refusing duplicate thread",
+            ));
+        }
+        None => match params.thread_id.as_deref().filter(|id| !id.trim().is_empty()) {
+            Some(thread_id) => {
+                manager
+                    .thread_resume(thread_id)
+                    .await
+                    .map_err(|error| internal(&format!("resume Codex thread: {error}")))?;
+                sqlx::query(
+                    "INSERT INTO interactive_codex_thread \
+                     (session_id, thread_id, cwd, model, skip_permissions) VALUES (?, ?, ?, ?, ?)",
+                )
+                .bind(&params.session_id)
+                .bind(thread_id)
+                .bind(&params.cwd)
+                .bind(&params.model)
+                .bind(params.skip_permissions)
+                .execute(pool)
+                .await
+                .map_err(|error| internal(&format!("persist Interactive Codex thread: {error}")))?;
+                thread_id.to_string()
+            }
+            None => {
+                let inserted = sqlx::query(
+                    "INSERT OR IGNORE INTO interactive_codex_thread \
+                     (session_id, thread_id, cwd, model, skip_permissions) VALUES (?, NULL, ?, ?, ?)",
+                )
+                .bind(&params.session_id)
+                .bind(&params.cwd)
+                .bind(&params.model)
+                .bind(params.skip_permissions)
+                .execute(pool)
+                .await
+                .map_err(|error| internal(&format!("reserve Interactive Codex thread: {error}")))?;
+                if inserted.rows_affected() == 0 {
+                    return Err(internal(
+                        "concurrent Interactive Codex allocation is in progress; retry shortly",
+                    ));
+                }
+                let thread_id = manager
+                    .thread_start_interactive(
+                        std::path::Path::new(&params.cwd),
+                        params.model.as_deref(),
+                        params.skip_permissions,
+                    )
+                    .await
+                    .map_err(|error| internal(&format!("start Codex thread: {error}")))?;
+                sqlx::query(
+                    "UPDATE interactive_codex_thread SET thread_id = ? WHERE session_id = ?",
+                )
+                .bind(&thread_id)
+                .bind(&params.session_id)
+                .execute(pool)
+                .await
+                .map_err(|error| internal(&format!("persist Interactive Codex thread: {error}")))?;
+                thread_id
+            }
+        },
+    };
+    to_value(&CodexSessionEnsureResult {
+        thread_id,
+        endpoint: format!("unix://{}", manager.socket_path().display()),
+    })
 }
 
 /// Deliver one text prompt to explicit stable recipients with bounded fanout.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
@@ -38,6 +38,7 @@
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
+use std::sync::Once;
 use std::time::{Duration, Instant};
 
 /// The expected on-screen marker proving the seeded hangar TUI actually rendered
@@ -149,6 +150,40 @@ pub fn can_run_tripwire() -> bool {
 pub struct Pipeline {
     home: tempfile::TempDir,
     daemon: Child,
+}
+
+/// Reap only orphaned daemons started by this exact tripwire binary. A test
+/// process killed by SIGKILL cannot run [`Pipeline`]'s drop implementation, so
+/// every suite start clears the prior run's known process shape before spawning.
+fn reap_orphaned_tripwire_daemons(bin: &Path) {
+    static REAPED: Once = Once::new();
+    REAPED.call_once(|| {
+        let Ok(output) = Command::new("ps")
+            .args(["-Ao", "pid=,ppid=,command="])
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+        else {
+            return;
+        };
+        if !output.status.success() {
+            return;
+        }
+        let expected = bin.display().to_string();
+        let Ok(table) = String::from_utf8(output.stdout) else {
+            return;
+        };
+        for pid in table.lines().filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields.next()?.parse::<u32>().ok()?;
+            let ppid = fields.next()?.parse::<u32>().ok()?;
+            let command = fields.collect::<Vec<_>>().join(" ");
+            (ppid == 1 && command == expected).then_some(pid)
+        }) {
+            // Exact PID from the immediately preceding process-table snapshot.
+            let _ = Command::new("kill").arg(pid.to_string()).status();
+        }
+    });
 }
 
 impl Pipeline {
@@ -412,6 +447,8 @@ impl Drop for DeliveryTarget {
 ///
 /// Panics only after [`can_run_tripwire`] has gated the caller.
 pub fn prepare_pipeline_answer_flip(target_tmux: &str) -> Pipeline {
+    let bin = daemon_bin().expect("gated by can_run_tripwire");
+    reap_orphaned_tripwire_daemons(&bin);
     let home = tempfile::tempdir().expect("isolated HOME tempdir");
     let hangar_dir = home.path().join(".agents-in-a-box");
     std::fs::create_dir_all(&hangar_dir).expect("create ~/.agents-in-a-box");
@@ -425,10 +462,11 @@ pub fn prepare_pipeline_answer_flip(target_tmux: &str) -> Pipeline {
     // The fake `ainb list` stub the daemon shells out to for session discovery.
     let fake = write_fake_ainb(home.path(), target_tmux);
 
-    let bin = daemon_bin().expect("gated by can_run_tripwire");
     let mut cmd = Command::new(bin);
     cmd.env("HOME", home.path())
         .env_remove("AINB_HANGAR_HOME")
+        .env("AINB_CODEX_MANAGED", "0")
+        .env("HANGAR_TEST_PARENT_PID", std::process::id().to_string())
         .env("HANGAR_DAEMON_DISABLE_CLAIM", "1")
         // Point discovery at the stub + force tmux-only delivery so the seeded
         // ASK's target (`s-deploy`) resolves to the real tmux pane the tripwire
@@ -513,6 +551,8 @@ fn prepare_pipeline_board_run_seeded(
     pre_spawn: impl FnOnce(&Path),
     extra_env: impl FnOnce(&Path) -> Vec<(String, String)>,
 ) -> Pipeline {
+    let bin = daemon_bin().expect("gated by can_run_tripwire");
+    reap_orphaned_tripwire_daemons(&bin);
     let home = tempfile::tempdir().expect("isolated HOME tempdir");
     let hangar_dir = home.path().join(".agents-in-a-box");
     std::fs::create_dir_all(&hangar_dir).expect("create ~/.agents-in-a-box");
@@ -537,10 +577,11 @@ fn prepare_pipeline_board_run_seeded(
     let fake_claude = write_executable(home.path(), "fake-claude.sh", fake_agent_body);
     let extra_env = extra_env(home.path());
 
-    let bin = daemon_bin().expect("gated by can_run_tripwire");
     let mut cmd = Command::new(bin);
     cmd.env("HOME", home.path())
         .env_remove("AINB_HANGAR_HOME")
+        .env("AINB_CODEX_MANAGED", "0")
+        .env("HANGAR_TEST_PARENT_PID", std::process::id().to_string())
         // Claim-enabled on the fixture's runtime, with a fast poll so the enqueued
         // card task claims + runs promptly.
         .env("HANGAR_DAEMON_RUNTIME_ID", "runtime-1")
@@ -1762,6 +1803,8 @@ fn prepare_pipeline_seeded(
     extra_env: &[(&str, &str)],
     pre_spawn_seed: impl FnOnce(&Path),
 ) -> Pipeline {
+    let bin = daemon_bin().expect("gated by can_run_tripwire");
+    reap_orphaned_tripwire_daemons(&bin);
     let home = tempfile::tempdir().expect("isolated HOME tempdir");
     let hangar_dir = home.path().join(".agents-in-a-box");
     std::fs::create_dir_all(&hangar_dir).expect("create ~/.agents-in-a-box");
@@ -1796,10 +1839,11 @@ fn prepare_pipeline_seeded(
     pre_spawn_seed(home.path());
 
     // Spawn the daemon under the same $HOME (binds $HOME/.agents-in-a-box/hangar.sock).
-    let bin = daemon_bin().expect("gated by can_run_tripwire");
     let mut cmd = Command::new(bin);
     cmd.env("HOME", home.path())
         .env_remove("AINB_HANGAR_HOME")
+        .env("AINB_CODEX_MANAGED", "0")
+        .env("HANGAR_TEST_PARENT_PID", std::process::id().to_string())
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
@@ -16,6 +16,7 @@
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Once;
 use std::time::{Duration, Instant};
 
 use sqlx::sqlite::SqliteRow;
@@ -476,6 +477,39 @@ pub fn daemon_bin() -> PathBuf {
     assert_cmd::cargo::cargo_bin("ainb-hangar-daemon")
 }
 
+/// Reap only `ainb-hangar-daemon` children from an interrupted prior tripwire
+/// run. The selection requires both this exact binary and ppid=1; each signal
+/// addresses one PID from the just-captured process table.
+fn reap_orphaned_tripwire_daemons(bin: &Path) {
+    static REAPED: Once = Once::new();
+    REAPED.call_once(|| {
+        let Ok(output) = Command::new("ps")
+            .args(["-Ao", "pid=,ppid=,command="])
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+        else {
+            return;
+        };
+        if !output.status.success() {
+            return;
+        }
+        let expected = bin.display().to_string();
+        let Ok(table) = String::from_utf8(output.stdout) else {
+            return;
+        };
+        for pid in table.lines().filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields.next()?.parse::<u32>().ok()?;
+            let ppid = fields.next()?.parse::<u32>().ok()?;
+            let command = fields.collect::<Vec<_>>().join(" ");
+            (ppid == 1 && command == expected).then_some(pid)
+        }) {
+            let _ = Command::new("kill").arg(pid.to_string()).status();
+        }
+    });
+}
+
 /// Whether the `tmux` binary is on `PATH`.
 pub fn tmux_available() -> bool {
     Command::new("tmux").arg("-V").output().is_ok_and(|o| o.status.success())
@@ -494,6 +528,7 @@ impl DaemonSession {
     /// session. The session name embeds the pid + a nanosecond timestamp so
     /// parallel test binaries never collide.
     pub fn spawn(bin: &Path, _home: &Path, env: &[(&str, &str)]) -> Self {
+        reap_orphaned_tripwire_daemons(bin);
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos());
@@ -505,6 +540,11 @@ impl DaemonSession {
         for (k, v) in env {
             let _ = write!(cmd, "export {k}='{v}'; ");
         }
+        let _ = write!(
+            cmd,
+            "export HANGAR_TEST_PARENT_PID='{}'; ",
+            std::process::id()
+        );
         let _ = write!(cmd, "exec '{}'", bin.display());
 
         let status = Command::new("tmux")
@@ -558,10 +598,13 @@ impl DaemonProcess {
     /// nulled. `HOME` is pinned and the two home-override vars are removed so
     /// the child cannot escape the isolated tree.
     pub fn spawn(home: &Path, extra_env: &[(&str, &str)]) -> Self {
-        let mut cmd = Command::new(daemon_bin());
+        let bin = daemon_bin();
+        reap_orphaned_tripwire_daemons(&bin);
+        let mut cmd = Command::new(bin);
         cmd.env("HOME", home)
             .env_remove("AINB_HOME")
             .env_remove("AINB_HANGAR_HOME")
+            .env("HANGAR_TEST_PARENT_PID", std::process::id().to_string())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null());

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -962,6 +962,19 @@ pub struct FleetRuntimeHookStatus {
     pub last_event: Option<String>,
 }
 
+/// One local Codex app-server discovered by the Hangar daemon.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexAppServerRuntimeStatus {
+    /// Process identifier on this machine.
+    pub pid: u32,
+    /// `owned`, `adopted`, or `external`.
+    pub ownership: String,
+    /// Whether process argv requested Codex remote control enrollment.
+    pub remote_control: bool,
+    /// `healthy`, `degraded`, or `unknown` for external processes.
+    pub health: String,
+}
+
 /// Bounded runtime health returned only by the public Fleet RPC.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetRuntimeStatusResult {
@@ -971,6 +984,9 @@ pub struct FleetRuntimeStatusResult {
     pub protocol_version: u32,
     /// Supported provider hook states. No filesystem paths are exposed.
     pub hooks: Vec<FleetRuntimeHookStatus>,
+    /// Bounded local Codex app-server inventory. No filesystem paths are exposed.
+    #[serde(default)]
+    pub codex_app_servers: Vec<CodexAppServerRuntimeStatus>,
 }
 
 /// Initial result for a replay-safe Fleet subscription.
@@ -1270,6 +1286,36 @@ pub struct FleetStartResult {
     pub prospective_session_key: String,
     /// Durable start receipt.
     pub receipt: FleetActionReceipt,
+}
+
+/// Parameters for `codex/session_ensure`.
+///
+/// Interactive mode owns its tmux and session metadata. The daemon owns the
+/// shared app-server and returns the exact thread that tmux must resume.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexSessionEnsureParams {
+    /// Stable Ainb Interactive session identity, used for validation and logs.
+    pub session_id: String,
+    /// Session working directory.
+    pub cwd: String,
+    /// Exact raw Codex model identifier, when selected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Existing remote thread to resume after an Interactive restart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    /// Preserve Interactive's explicit yolo launch semantics at thread creation.
+    #[serde(default)]
+    pub skip_permissions: bool,
+}
+
+/// Result for `codex/session_ensure`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexSessionEnsureResult {
+    /// Exact Codex thread identity.
+    pub thread_id: String,
+    /// Canonical Unix endpoint consumed by the Interactive tmux client.
+    pub endpoint: String,
 }
 
 /// Parameters for `fleet/broadcast`.

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -408,6 +408,9 @@ pub const FLEET_RECEIPT_LIST: &str = "fleet/receipt_list";
 pub const FLEET_RECEIPT_GET: &str = "fleet/receipt_get";
 /// Start a provider session without borrowing selected-session state.
 pub const FLEET_START: &str = "fleet/start";
+/// Ensure one Interactive Codex session has an exact thread on Ainb's shared
+/// Codex app-server.
+pub const CODEX_SESSION_ENSURE: &str = "codex/session_ensure";
 /// Read bounded, payload-free Fleet revision timeline entries.
 pub const FLEET_TIMELINE: &str = "fleet/timeline";
 /// Read a bounded daemon-owned Fleet usage summary.
@@ -1786,6 +1789,7 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_RECEIPT_LIST,
     FLEET_RECEIPT_GET,
     FLEET_START,
+    CODEX_SESSION_ENSURE,
     FLEET_TIMELINE,
     FLEET_USAGE_SUMMARY,
     FLEET_USAGE_DASHBOARD,
@@ -2108,6 +2112,7 @@ mod tests {
             FLEET_RECEIPT_LIST,
             FLEET_RECEIPT_GET,
             FLEET_START,
+            CODEX_SESSION_ENSURE,
             FLEET_TIMELINE,
             FLEET_USAGE_SUMMARY,
             FLEET_USAGE_DASHBOARD,

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0086_interactive_codex_thread.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0086_interactive_codex_thread.sql
@@ -1,0 +1,12 @@
+-- Exact remote Codex thread identity for Interactive sessions.
+--
+-- A NULL thread_id is a durable allocation reservation. If the daemon dies
+-- after thread/start but before this row is completed, retrying must fail
+-- closed rather than minting a duplicate cloud-visible thread.
+CREATE TABLE interactive_codex_thread (
+    session_id TEXT PRIMARY KEY NOT NULL,
+    thread_id TEXT,
+    cwd TEXT NOT NULL,
+    model TEXT,
+    skip_permissions INTEGER NOT NULL DEFAULT 0
+);

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -591,9 +591,11 @@ impl BrokerState {
             }
             match &pending.kind {
                 PendingKind::Structured { tx, .. } => {
-                    tx.send_replace(Some(StructuredResolution::Answered {
-                        answers: answers.clone(),
-                    }));
+                    tx.send_modify(|resolution| {
+                        *resolution = Some(StructuredResolution::Answered {
+                            answers: answers.clone(),
+                        });
+                    });
                     true
                 }
                 _ => false,
@@ -631,7 +633,9 @@ impl BrokerState {
             }
             match &pending.kind {
                 PendingKind::Structured { tx, .. } => {
-                    tx.send_replace(Some(StructuredResolution::Rejected { reason }));
+                    tx.send_modify(|resolution| {
+                        *resolution = Some(StructuredResolution::Rejected { reason });
+                    });
                     true
                 }
                 _ => false,
@@ -667,7 +671,9 @@ impl BrokerState {
             }
             match &pending.kind {
                 PendingKind::Structured { tx, .. } => {
-                    tx.send_replace(Some(StructuredResolution::ReleasedToNative));
+                    tx.send_modify(|resolution| {
+                        *resolution = Some(StructuredResolution::ReleasedToNative);
+                    });
                     true
                 }
                 _ => false,


### PR DESCRIPTION
Routes Ainb Interactive and CLI Codex sessions through Hangar-owned remote app-server threads. Includes exact thread persistence, server-side permission policy, Headroom fail-closed behavior, runtime inventory, orphan daemon containment, and tripwire stabilization.

Validation: targeted remote-thread, daemon lifecycle, orphan containment, and broker tests passed. Full L1 CTS preflight environment follow-up: agents-in-a-box-wdj.