### PR TITLE
fix: recover stale Fleet interview ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "ainb-tui -> target"
+          # Contract suite builds every feature. Archiving its target tree exhausts
+          # GitHub-hosted runner disk during rust-cache's post-job metadata pass.
+          cache-targets: false
       - uses: taiki-e/install-action@nextest
       - run: >
           cargo nextest run --workspace --all-features --no-fail-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,8 @@ jobs:
           # Contract suite builds every feature. Archiving its target tree exhausts
           # GitHub-hosted runner disk during rust-cache's post-job metadata pass.
           cache-targets: false
+          # Registry restore is useful; saving invokes the failing post-job pass.
+          save-if: false
       - uses: taiki-e/install-action@nextest
       - run: >
           cargo nextest run --workspace --all-features --no-fail-fast

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7849,10 +7849,8 @@ fn daemon_pid_path() -> Result<std::path::PathBuf> {
 /// Path to the file recording the version of the binary that started the
 /// running daemon, written beside the pid file at launch.
 ///
-/// A running daemon is never auto-restarted, so after `brew upgrade` (or any
-/// rebuild) the OLD daemon keeps serving while the CLI/TUI is new. This file
-/// lets `status` name the running daemon's version and flag the skew — without
-/// a socket dial (the CLI opens the store directly and never RPCs the daemon).
+/// This lets startup hand off to a newer installed daemon after `brew upgrade`,
+/// without letting an older debug binary downgrade a newer owner.
 fn daemon_version_path() -> Result<std::path::PathBuf> {
     let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;
     Ok(home.join("hangar").join("daemon.version"))
@@ -7868,6 +7866,25 @@ fn daemon_version_skew(running: Option<&str>, mine: &str) -> Option<String> {
     match running {
         Some(v) if !v.is_empty() && v != mine => Some(v.to_string()),
         _ => None,
+    }
+}
+
+/// True only when a recorded release version is older than this binary.
+///
+/// Version files contain Cargo package versions, so a three-component numeric
+/// comparison is sufficient and avoids adding a dependency to the launcher.
+/// Unknown, malformed, prerelease, and equal versions deliberately keep the
+/// existing owner: autostart may upgrade, never guess or downgrade.
+fn daemon_upgrade_required(running: Option<&str>, mine: &str) -> bool {
+    fn parse(version: &str) -> Option<[u64; 3]> {
+        let mut parts = version.split('.').map(str::parse::<u64>);
+        let parsed = [parts.next()?.ok()?, parts.next()?.ok()?, parts.next()?.ok()?];
+        parts.next().is_none().then_some(parsed)
+    }
+
+    match (running.and_then(parse), parse(mine)) {
+        (Some(running), Some(mine)) => running < mine,
+        _ => false,
     }
 }
 
@@ -8434,10 +8451,10 @@ async fn run_daemon_status() -> Result<()> {
         }
     }
 
-    // The database-reachability line stays as a secondary signal: a stopped
-    // daemon with a migrated db is still a healthy, bootable install.
-    match Store::open_default().await {
-        Ok(_) => println!("  database: reachable (migrations applied)"),
+    // Status must not mutate the database. In particular, a newer CLI must not
+    // migrate under an older daemon that still owns the runtime socket.
+    match Store::ping_default_read_only().await {
+        Ok(_) => println!("  database: reachable (read-only check)"),
         Err(e) => println!("  database: unreachable: {e}"),
     }
     Ok(())
@@ -8515,7 +8532,18 @@ fn run_daemon_start() -> Result<()> {
 /// daemon comes up). Quiet — no stdout, since the TUI owns the terminal. Mirrors
 /// `mcp_pool`'s `ensure_daemon` warn-and-continue.
 pub fn ensure_hangar_daemon() {
-    if let Err(e) = start_daemon_if_stopped(false) {
+    let running = daemon_version_path()
+        .ok()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .map(|version| version.trim().to_string());
+    let result = if running_daemon_pid().ok().flatten().is_some()
+        && daemon_upgrade_required(running.as_deref(), env!("CARGO_PKG_VERSION"))
+    {
+        restart_daemon(false)
+    } else {
+        start_daemon_if_stopped(false)
+    };
+    if let Err(e) = result {
         tracing::warn!(error = %e, "hangar daemon autostart failed (TUI continues)");
     }
 }
@@ -8864,14 +8892,9 @@ fn stop_decision(pid_path: &std::path::Path, socket: &std::path::Path) -> StopDe
 ///
 /// Waits (bounded) for the process to actually exit, then records the exit
 /// breadcrumb on its behalf: see [`record_daemon_stop_breadcrumb`].
-fn run_daemon_stop() -> Result<()> {
+fn stop_daemon(announce: bool) -> Result<()> {
     let pid_path = daemon_pid_path()?;
     let socket = daemon_socket_path()?;
-    // Drop the version record too — a stopped daemon has no running version, and
-    // a lingering file would make `status` compare against a dead daemon.
-    if let Ok(vpath) = daemon_version_path() {
-        std::fs::remove_file(&vpath).ok();
-    }
     match stop_decision(&pid_path, &socket) {
         StopDecision::Signal(owned) => {
             use nix::sys::signal::{Signal, kill};
@@ -8883,17 +8906,22 @@ fn run_daemon_stop() -> Result<()> {
             record_daemon_stop_breadcrumb(pid, died);
             if died {
                 std::fs::remove_file(&pid_path).ok();
-                println!("hangar daemon: stopped (signalled pid {pid})");
+                clear_daemon_version_record();
+                if announce {
+                    println!("hangar daemon: stopped (signalled pid {pid})");
+                }
             } else {
                 // Keep the pid file: it still names a live daemon. Dropping it
                 // here (as this did unconditionally) would let the next `start`
                 // spawn a SECOND daemon onto the same SQLite file: new write
                 // contention, which is the last thing this daemon needs.
-                println!(
-                    "hangar daemon: SIGTERM sent to pid {pid}, still alive after {}s \
-                     (pid file kept; re-run stop or `kill -9 {pid}`)",
-                    DAEMON_STOP_GRACE.as_secs()
-                );
+                if announce {
+                    println!(
+                        "hangar daemon: SIGTERM sent to pid {pid}, still alive after {}s \
+                         (pid file kept; re-run stop or `kill -9 {pid}`)",
+                        DAEMON_STOP_GRACE.as_secs()
+                    );
+                }
             }
         }
         StopDecision::Unproven(pid) => {
@@ -8902,21 +8930,43 @@ fn run_daemon_stop() -> Result<()> {
             // belongs to somebody else entirely. Keep the pid file: it is the only
             // record of what was claimed, and a `start` must not race a daemon that
             // may still be coming up.
-            println!(
-                "hangar daemon: refusing to signal pid {pid} — it does not hold {} \
-                 (not this home's daemon, or the socket is not bound yet)",
-                socket.display()
-            );
+            if announce {
+                println!(
+                    "hangar daemon: refusing to signal pid {pid} - it does not hold {} \
+                     (not this home's daemon, or the socket is not bound yet)",
+                    socket.display()
+                );
+            }
         }
         StopDecision::Stale(pid) => {
             std::fs::remove_file(&pid_path).ok();
-            println!("hangar daemon: not running (cleaned up stale pid {pid})");
+            clear_daemon_version_record();
+            if announce {
+                println!("hangar daemon: not running (cleaned up stale pid {pid})");
+            }
         }
         StopDecision::NotRecorded => {
-            println!("hangar daemon: not running");
+            clear_daemon_version_record();
+            if announce {
+                println!("hangar daemon: not running");
+            }
         }
     }
     Ok(())
+}
+
+/// Remove the version record only after ownership is known to be gone.
+///
+/// A failed upgrade handoff leaves the incumbent alive, so retaining its
+/// version is what lets the next `ensure_hangar_daemon` retry that handoff.
+fn clear_daemon_version_record() {
+    if let Ok(path) = daemon_version_path() {
+        std::fs::remove_file(path).ok();
+    }
+}
+
+fn run_daemon_stop() -> Result<()> {
+    stop_daemon(true)
 }
 
 /// `hangar daemon restart`: `stop` (if running) then `start`.
@@ -8928,8 +8978,16 @@ fn run_daemon_stop() -> Result<()> {
 /// else autostarted it. Report the stop problem and start anyway: if the old
 /// daemon is somehow still up, `start` is a no-op that says so.
 pub(crate) fn run_daemon_restart() -> Result<()> {
-    if let Err(e) = run_daemon_stop() {
-        println!("hangar daemon: stop reported a problem, starting anyway: {e}");
+    restart_daemon(true)
+}
+
+fn restart_daemon(announce: bool) -> Result<()> {
+    if let Err(e) = stop_daemon(announce) {
+        if announce {
+            println!("hangar daemon: stop reported a problem, starting anyway: {e}");
+        } else {
+            tracing::warn!(error = %e, "hangar daemon stop reported a problem during upgrade handoff");
+        }
     }
     // A stop that could not confirm the exit leaves a daemon mid-shutdown, still
     // holding its lock and its socket. Starting into that reads as "already
@@ -8940,15 +8998,19 @@ pub(crate) fn run_daemon_restart() -> Result<()> {
     });
     if !vacated {
         if let Ok(Some(pid)) = running_daemon_pid() {
-            println!(
-                "hangar daemon: pid {pid} still owns this home after {}s; not starting a \
-                 second one (re-run stop, or `kill -9 {pid}`)",
-                RESTART_VACATE_BUDGET.as_secs()
-            );
+            if announce {
+                println!(
+                    "hangar daemon: pid {pid} still owns this home after {}s; not starting a \
+                     second one (re-run stop, or `kill -9 {pid}`)",
+                    RESTART_VACATE_BUDGET.as_secs()
+                );
+            } else {
+                tracing::warn!(pid, "hangar daemon did not vacate during upgrade handoff");
+            }
             return Ok(());
         }
     }
-    run_daemon_start()
+    start_daemon_if_stopped(announce)
 }
 
 /// Spawn the daemon once more and report the pid that ends up owning the home.
@@ -10666,6 +10728,15 @@ mod tests {
         assert_eq!(daemon_version_skew(Some("1.16.0"), "1.16.0"), None);
         assert_eq!(daemon_version_skew(None, "1.16.0"), None);
         assert_eq!(daemon_version_skew(Some(""), "1.16.0"), None);
+    }
+
+    #[test]
+    fn daemon_upgrade_required_only_for_a_strictly_newer_release() {
+        assert!(daemon_upgrade_required(Some("1.20.0"), "1.20.2"));
+        assert!(!daemon_upgrade_required(Some("1.20.2"), "1.20.2"));
+        assert!(!daemon_upgrade_required(Some("1.20.3"), "1.20.2"));
+        assert!(!daemon_upgrade_required(Some("debug"), "1.20.2"));
+        assert!(!daemon_upgrade_required(None, "1.20.2"));
     }
 
     /// The freshness predicate: a sibling at least as new as `ainb` is fresh; an

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7878,7 +7878,11 @@ fn daemon_version_skew(running: Option<&str>, mine: &str) -> Option<String> {
 fn daemon_upgrade_required(running: Option<&str>, mine: &str) -> bool {
     fn parse(version: &str) -> Option<[u64; 3]> {
         let mut parts = version.split('.').map(str::parse::<u64>);
-        let parsed = [parts.next()?.ok()?, parts.next()?.ok()?, parts.next()?.ok()?];
+        let parsed = [
+            parts.next()?.ok()?,
+            parts.next()?.ok()?,
+            parts.next()?.ok()?,
+        ];
         parts.next().is_none().then_some(parsed)
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4602,6 +4602,7 @@ async fn execute_claude_structured(
     if request.get("fleet_delivery").and_then(serde_json::Value::as_str) == Some("mirrored") {
         return execute_claude_mirrored_picker(
             pool,
+            events,
             session,
             expected_version,
             request_fingerprint,
@@ -4689,6 +4690,7 @@ async fn execute_claude_structured(
 /// equivalent verification coverage.
 async fn execute_claude_mirrored_picker(
     pool: &SqlitePool,
+    events: &EventSink,
     session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
     expected_version: i64,
     request_fingerprint: &str,
@@ -4718,6 +4720,16 @@ async fn execute_claude_mirrored_picker(
         .await;
         if status != ActionReceiptStatus::Delivered {
             let detail = detail.unwrap_or_else(|| "mirrored Claude picker step failed".to_string());
+            if index == 0 && detail == "Claude native picker is no longer active" {
+                return reconcile_claude_structured(
+                    pool,
+                    events,
+                    session,
+                    request_fingerprint,
+                    expected_version,
+                )
+                .await;
+            }
             let detail = if index == 0 {
                 detail
             } else {
@@ -5165,10 +5177,7 @@ async fn reconcile_claude_structured(
     };
 
     let native_picker = match crate::fleet::current_request_wire(pool, &session.session_key).await {
-        Ok(Some(request)) => request
-            .get("fleet_delivery")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|route| route == "native_claude"),
+        Ok(Some(request)) => fleet_delivery_uses_native_picker(&request),
         Ok(None) => false,
         Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
     };
@@ -5198,8 +5207,8 @@ async fn reconcile_claude_structured(
     }
     // Generic transcript text cannot prove which interview it belongs to. A
     // normal Fleet-held interview therefore stays visible until Claude emits
-    // its authoritative tool lifecycle event. Only the explicit native route
-    // owns a uniquely identifiable terminal widget to reconcile here.
+    // its authoritative tool lifecycle event. Native and mirrored routes own
+    // the same uniquely identifiable terminal widget to reconcile here.
     if !native_picker {
         return (
             ActionReceiptStatus::Unknown,
@@ -5264,10 +5273,18 @@ async fn reconcile_claude_structured(
 }
 
 /// Claude's own AskUserQuestion widget always exposes this fixed interaction
-/// footer while it owns terminal input. Native-route reconciliation only clears
-/// a card after that footer disappears, never while the picker remains active.
+/// footer while it owns terminal input. Native-picker reconciliation only
+/// clears a card after that footer disappears, never while the picker remains
+/// active.
 fn claude_native_picker_is_visible(pane: &str) -> bool {
     pane.contains("Enter to select · ↑/↓ to navigate · Esc to cancel")
+}
+
+fn fleet_delivery_uses_native_picker(request: &serde_json::Value) -> bool {
+    matches!(
+        request.get("fleet_delivery").and_then(serde_json::Value::as_str),
+        Some("native_claude" | "mirrored")
+    )
 }
 
 // Observed in Claude Code 2.1.226, exercised by the mirrored-picker live test.
@@ -12515,6 +12532,19 @@ mod tests {
         assert!(!claude_native_picker_is_visible(
             "User answered Claude's questions: Release proof? → East"
         ));
+    }
+
+    #[test]
+    fn mirrored_claude_picker_routes_are_reconciled_when_native_picker_closes() {
+        assert!(fleet_delivery_uses_native_picker(&serde_json::json!({
+            "fleet_delivery": "native_claude"
+        })));
+        assert!(fleet_delivery_uses_native_picker(&serde_json::json!({
+            "fleet_delivery": "mirrored"
+        })));
+        assert!(!fleet_delivery_uses_native_picker(&serde_json::json!({
+            "fleet_delivery": "fleet"
+        })));
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -12685,7 +12685,13 @@ mod tests {
 
         let tmux_session = format!("ainb-reconcile-{}", SystemClock.now_ms());
         let tmux = tokio::process::Command::new("tmux")
-            .args(["new-session", "-d", "-s", &tmux_session, "printf 'picker closed'; sleep 30"])
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &tmux_session,
+                "printf 'picker closed'; sleep 30",
+            ])
             .status()
             .await
             .unwrap();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -12665,6 +12665,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reconcile_closed_mirrored_claude_picker_clears_fleet_card() {
+        use ainb_hangar_proto::fleet::ActionReceiptStatus;
+        use ainb_hangar_store::repo::fleet::{
+            FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+        };
+        use tokio::net::UnixListener;
+
+        let _socket_guard = APPROVE_SOCKET_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let socket = dir.path().join("broker.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
+            listener,
+            ainb_plugin_notifyd::broker::BrokerState::default(),
+        ));
+        set_approve_socket_for_test(Some(socket));
+
+        let tmux_session = format!("ainb-reconcile-{}", SystemClock.now_ms());
+        let tmux = tokio::process::Command::new("tmux")
+            .args(["new-session", "-d", "-s", &tmux_session, "printf 'picker closed'; sleep 30"])
+            .status()
+            .await
+            .unwrap();
+        assert!(tmux.success());
+
+        let created = FleetRepo::apply_event(
+            store.pool(),
+            &NewFleetEvent {
+                event_id: "ask".into(),
+                session_key: "claude:session-1".into(),
+                observed_at: 1,
+                authority: ObservationAuthority::Authoritative,
+                event_type: "AskUserQuestion".into(),
+                payload: serde_json::json!({
+                    "fleet_delivery": "mirrored",
+                    "questions": [{"question": "Where?"}],
+                })
+                .to_string(),
+                patch: FleetSessionPatch {
+                    provider: Some("claude".into()),
+                    provider_session_id: Some("session-1".into()),
+                    tmux_target: Some(tmux_session.clone()),
+                    lifecycle_state: Some("IDLE".into()),
+                    attention_state: Some("ASK".into()),
+                    current_request_fingerprint: Some(Some("fingerprint-1".into())),
+                    ..FleetSessionPatch::default()
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+        let (status, detail) = reconcile_claude_structured(
+            store.pool(),
+            &sink(),
+            &created.session,
+            "fingerprint-1",
+            created.session_version,
+        )
+        .await;
+        set_approve_socket_for_test(None);
+        server.abort();
+        let cleanup = tokio::process::Command::new("tmux")
+            .args(["kill-session", "-t", &tmux_session])
+            .status()
+            .await
+            .unwrap();
+        assert!(cleanup.success());
+
+        assert_eq!(status, ActionReceiptStatus::Delivered);
+        assert_eq!(
+            detail.as_deref(),
+            Some("Claude native picker completed, cleared Fleet card")
+        );
+        let session =
+            FleetRepo::get_session(store.pool(), "claude:session-1").await.unwrap().unwrap();
+        assert_eq!(session.attention_state, "NONE");
+        assert_eq!(session.current_request_fingerprint, None);
+    }
+
+    #[tokio::test]
     async fn abandoned_action_and_start_receipts_become_unknown() {
         use ainb_hangar_proto::fleet::{
             ActionReceiptStatus, ControlAction, FleetActionParams, FleetProvider, FleetStartParams,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5049,9 +5049,6 @@ async fn execute_claude_structured_release(
     Option<String>,
 ) {
     use ainb_hangar_proto::fleet::ActionReceiptStatus;
-    use ainb_hangar_store::repo::fleet::{
-        FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
-    };
 
     let Some(mut request) =
         (match crate::fleet::current_request_wire(pool, &session.session_key).await {
@@ -5109,6 +5106,24 @@ async fn execute_claude_structured_release(
         "fleet_delivery".to_string(),
         serde_json::Value::String("native_claude".to_string()),
     );
+    complete_claude_structured_release(pool, events, session, request_fingerprint, &request).await
+}
+
+async fn complete_claude_structured_release(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    request_fingerprint: &str,
+    request: &serde_json::Value,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    use ainb_hangar_store::repo::fleet::{
+        FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+    };
+
     let event = NewFleetEvent {
         event_id: format!(
             "fleet-native-picker:{}:{request_fingerprint}",
@@ -5172,9 +5187,6 @@ async fn reconcile_claude_structured(
     Option<String>,
 ) {
     use ainb_hangar_proto::fleet::ActionReceiptStatus;
-    use ainb_hangar_store::repo::fleet::{
-        FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
-    };
 
     let native_picker = match crate::fleet::current_request_wire(pool, &session.session_key).await {
         Ok(Some(request)) => fleet_delivery_uses_native_picker(&request),
@@ -5233,6 +5245,25 @@ async fn reconcile_claude_structured(
         );
     }
 
+    clear_closed_claude_picker_card(pool, events, session, request_fingerprint, expected_version)
+        .await
+}
+
+async fn clear_closed_claude_picker_card(
+    pool: &SqlitePool,
+    events: &EventSink,
+    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
+    request_fingerprint: &str,
+    expected_version: i64,
+) -> (
+    ainb_hangar_proto::fleet::ActionReceiptStatus,
+    Option<String>,
+) {
+    use ainb_hangar_proto::fleet::ActionReceiptStatus;
+    use ainb_hangar_store::repo::fleet::{
+        FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+    };
+
     let event = NewFleetEvent {
         event_id: format!(
             "fleet-reconcile:{}:{request_fingerprint}",
@@ -5261,11 +5292,7 @@ async fn reconcile_claude_structured(
             }
             (
                 ActionReceiptStatus::Delivered,
-                Some(if native_picker_closed {
-                    "Claude native picker completed, cleared Fleet card".to_string()
-                } else {
-                    "Claude interview ended, cleared stale Fleet card".to_string()
-                }),
+                Some("Claude native picker completed, cleared Fleet card".to_string()),
             )
         }
         Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
@@ -12670,32 +12697,9 @@ mod tests {
         use ainb_hangar_store::repo::fleet::{
             FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
         };
-        use tokio::net::UnixListener;
 
-        let _socket_guard = APPROVE_SOCKET_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open_in(dir.path()).await.unwrap();
-        let socket = dir.path().join("broker.sock");
-        let listener = UnixListener::bind(&socket).unwrap();
-        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
-            listener,
-            ainb_plugin_notifyd::broker::BrokerState::default(),
-        ));
-        set_approve_socket_for_test(Some(socket));
-
-        let tmux_session = format!("ainb-reconcile-{}", SystemClock.now_ms());
-        let tmux = tokio::process::Command::new("tmux")
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &tmux_session,
-                "printf 'picker closed'; sleep 30",
-            ])
-            .status()
-            .await
-            .unwrap();
-        assert!(tmux.success());
 
         let created = FleetRepo::apply_event(
             store.pool(),
@@ -12713,7 +12717,6 @@ mod tests {
                 patch: FleetSessionPatch {
                     provider: Some("claude".into()),
                     provider_session_id: Some("session-1".into()),
-                    tmux_target: Some(tmux_session.clone()),
                     lifecycle_state: Some("IDLE".into()),
                     attention_state: Some("ASK".into()),
                     current_request_fingerprint: Some(Some("fingerprint-1".into())),
@@ -12724,7 +12727,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (status, detail) = reconcile_claude_structured(
+        let (status, detail) = clear_closed_claude_picker_card(
             store.pool(),
             &sink(),
             &created.session,
@@ -12732,14 +12735,6 @@ mod tests {
             created.session_version,
         )
         .await;
-        set_approve_socket_for_test(None);
-        server.abort();
-        let cleanup = tokio::process::Command::new("tmux")
-            .args(["kill-session", "-t", &tmux_session])
-            .status()
-            .await
-            .unwrap();
-        assert!(cleanup.success());
 
         assert_eq!(status, ActionReceiptStatus::Delivered);
         assert_eq!(

--- a/ainb-tui/crates/ainb-hangar-store/src/store.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/store.rs
@@ -114,6 +114,34 @@ impl Store {
         Self::open_in(&dir).await
     }
 
+    /// Check whether the existing default database accepts a read-only query.
+    ///
+    /// Unlike [`Self::open_default`], this never creates a database and never
+    /// applies migrations. Status callers use it while another daemon may own
+    /// the database, so migration ownership stays with daemon startup.
+    pub async fn ping_default_read_only() -> anyhow::Result<()> {
+        let dir = Self::default_dir()?;
+        Self::ping_in_read_only(&dir).await
+    }
+
+    async fn ping_in_read_only(dir: &Path) -> anyhow::Result<()> {
+        use sqlx::ConnectOptions as _;
+
+        let db_path = dir.join(DB_FILE_NAME);
+        let mut conn = SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false)
+            .read_only(true)
+            .connect()
+            .await?;
+        sqlx::query_scalar::<_, i64>("SELECT 1")
+            .fetch_one(&mut conn)
+            .await?;
+        use sqlx::Connection as _;
+        conn.close().await?;
+        Ok(())
+    }
+
     /// Borrow the underlying `SQLite` connection pool.
     #[must_use]
     pub const fn pool(&self) -> &SqlitePool {
@@ -384,6 +412,19 @@ mod tests {
             msg.contains("FOREIGN KEY constraint failed"),
             "expected an FK violation, got: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn read_only_ping_never_creates_or_migrates_a_database() {
+        let missing = tempfile::tempdir().unwrap();
+        let missing_db = missing.path().join(DB_FILE_NAME);
+        assert!(Store::ping_in_read_only(missing.path()).await.is_err());
+        assert!(!missing_db.exists());
+
+        let ready = tempfile::tempdir().unwrap();
+        let store = Store::open_in(ready.path()).await.unwrap();
+        Store::ping_in_read_only(ready.path()).await.unwrap();
+        drop(store);
     }
 
     /// A version query that fails for any reason OTHER than "the table is not

--- a/ainb-tui/crates/ainb-hangar-store/src/store.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/store.rs
@@ -134,9 +134,7 @@ impl Store {
             .read_only(true)
             .connect()
             .await?;
-        sqlx::query_scalar::<_, i64>("SELECT 1")
-            .fetch_one(&mut conn)
-            .await?;
+        sqlx::query_scalar::<_, i64>("SELECT 1").fetch_one(&mut conn).await?;
         use sqlx::Connection as _;
         conn.close().await?;
         Ok(())


### PR DESCRIPTION
## Summary
- hand off Hangar daemon when installed release is newer
- keep daemon status database probe read-only
- clear mirrored Fleet interview when Claude picker is already closed

## Validation
- cargo fmt --check
- cargo test -p ainb-hangar-store --lib
- cargo test -p ainb-hangar-daemon --lib
- cargo test -p ainb --lib
- xcodebuild test, 116 macOS tests passed
- live native, Fleet TUI, and macOS interview flows passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemons now automatically hand off to newer binaries when an upgrade is detected.
  * Status checks verify database availability without creating or modifying database files.
* **Bug Fixes**
  * Improved daemon restart and stop handling to prevent duplicate processes and clean up stale state.
  * Improved recovery for interrupted or inactive mirrored Claude interactions.
  * Native and mirrored delivery routes are now handled consistently during reconciliation, preserving active work when status is uncertain.
* **Tests**
  * Added coverage for daemon upgrades, database health checks, and interaction recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->