### PR TITLE
fix(hangar): upgrade stale daemon on start

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8557,7 +8557,7 @@ fn start_or_upgrade_daemon(announce: bool) -> Result<()> {
         restart_daemon(announce)
     } else {
         start_daemon_if_stopped(announce)
-    }
+    };
     result
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8521,12 +8521,13 @@ async fn run_daemon_run() -> Result<()> {
 /// `hangar daemon start`: spawn the daemon as a detached background child and
 /// record its EXACT pid.
 ///
-/// Idempotent: if the recorded pid is already alive, this is a no-op with a
-/// notice (never a second daemon). The child is spawned with the same
+/// Idempotent: if the recorded pid is already alive, this is a no-op unless a
+/// newer release owns this command. In that case it hands off to the newer
+/// daemon, never spawning a second one. The child is spawned with the same
 /// `$AINB_HANGAR_HOME` this process resolved, so it shares one home; its stdout/
 /// stderr go to the daemon's own rolling log, not this terminal.
 fn run_daemon_start() -> Result<()> {
-    start_daemon_if_stopped(true)
+    start_or_upgrade_daemon(true)
 }
 
 /// Best-effort autostart of the Hangar daemon before the TUI connects.
@@ -8536,6 +8537,16 @@ fn run_daemon_start() -> Result<()> {
 /// daemon comes up). Quiet — no stdout, since the TUI owns the terminal. Mirrors
 /// `mcp_pool`'s `ensure_daemon` warn-and-continue.
 pub fn ensure_hangar_daemon() {
+    if let Err(e) = start_or_upgrade_daemon(false) {
+        tracing::warn!(error = %e, "hangar daemon autostart failed (TUI continues)");
+    }
+}
+
+/// Start a missing daemon, or hand off an older recorded release to this one.
+///
+/// Unknown, equal, prerelease, and newer owners are deliberately left alone:
+/// autostart may upgrade a released daemon but must not guess or downgrade.
+fn start_or_upgrade_daemon(announce: bool) -> Result<()> {
     let running = daemon_version_path()
         .ok()
         .and_then(|path| std::fs::read_to_string(path).ok())
@@ -8543,12 +8554,9 @@ pub fn ensure_hangar_daemon() {
     let result = if running_daemon_pid().ok().flatten().is_some()
         && daemon_upgrade_required(running.as_deref(), env!("CARGO_PKG_VERSION"))
     {
-        restart_daemon(false)
+        restart_daemon(announce)
     } else {
-        start_daemon_if_stopped(false)
-    };
-    if let Err(e) = result {
-        tracing::warn!(error = %e, "hangar daemon autostart failed (TUI continues)");
+        start_daemon_if_stopped(announce)
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8558,6 +8558,7 @@ fn start_or_upgrade_daemon(announce: bool) -> Result<()> {
     } else {
         start_daemon_if_stopped(announce)
     }
+    result
 }
 
 /// File name of the captured daemon stderr, inside the daemon's log dir.

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7875,21 +7875,54 @@ fn daemon_version_skew(running: Option<&str>, mine: &str) -> Option<String> {
 /// comparison is sufficient and avoids adding a dependency to the launcher.
 /// Unknown, malformed, prerelease, and equal versions deliberately keep the
 /// existing owner: autostart may upgrade, never guess or downgrade.
-fn daemon_upgrade_required(running: Option<&str>, mine: &str) -> bool {
-    fn parse(version: &str) -> Option<[u64; 3]> {
-        let mut parts = version.split('.').map(str::parse::<u64>);
-        let parsed = [
-            parts.next()?.ok()?,
-            parts.next()?.ok()?,
-            parts.next()?.ok()?,
-        ];
-        parts.next().is_none().then_some(parsed)
-    }
+fn release_version_parts(version: &str) -> Option<[u64; 3]> {
+    let mut parts = version.split('.').map(str::parse::<u64>);
+    let parsed = [
+        parts.next()?.ok()?,
+        parts.next()?.ok()?,
+        parts.next()?.ok()?,
+    ];
+    parts.next().is_none().then_some(parsed)
+}
 
-    match (running.and_then(parse), parse(mine)) {
+fn daemon_upgrade_required(running: Option<&str>, mine: &str) -> bool {
+    match (
+        running.and_then(release_version_parts),
+        release_version_parts(mine),
+    ) {
         (Some(running), Some(mine)) => running < mine,
         _ => false,
     }
+}
+
+/// Infer a release version only from Homebrew's immutable Cellar path.
+///
+/// This bridges installs where the old daemon predates `daemon.version`. Other
+/// launch paths stay unknown, so a development or manually-installed owner is
+/// never replaced merely because its version cannot be proven.
+fn homebrew_daemon_version(command: &str) -> Option<String> {
+    let marker = "/Cellar/ainb/";
+    command
+        .split_whitespace()
+        .find_map(|word| word.split_once(marker).map(|(_, tail)| tail))
+        .and_then(|tail| tail.split('/').next())
+        .filter(|version| release_version_parts(version).is_some())
+        .map(str::to_string)
+}
+
+/// Resolve a live owner's version from its launch record, or from Homebrew's
+/// immutable Cellar path during the one-time upgrade from pre-record releases.
+fn running_daemon_version(pid: Option<u32>) -> Option<String> {
+    daemon_version_path()
+        .ok()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .map(|version| version.trim().to_string())
+        .filter(|version| !version.is_empty())
+        .or_else(|| {
+            pid.and_then(|pid| i32::try_from(pid).ok())
+                .and_then(ainb_hangar_daemon::single_instance::process_argv)
+                .and_then(|args| homebrew_daemon_version(&args))
+        })
 }
 
 /// Read the recorded daemon pid, or `None` if the file is absent/empty/garbage.
@@ -8547,11 +8580,9 @@ pub fn ensure_hangar_daemon() {
 /// Unknown, equal, prerelease, and newer owners are deliberately left alone:
 /// autostart may upgrade a released daemon but must not guess or downgrade.
 fn start_or_upgrade_daemon(announce: bool) -> Result<()> {
-    let running = daemon_version_path()
-        .ok()
-        .and_then(|path| std::fs::read_to_string(path).ok())
-        .map(|version| version.trim().to_string());
-    let result = if running_daemon_pid().ok().flatten().is_some()
+    let pid = running_daemon_pid().ok().flatten();
+    let running = running_daemon_version(pid);
+    let result = if pid.is_some()
         && daemon_upgrade_required(running.as_deref(), env!("CARGO_PKG_VERSION"))
     {
         restart_daemon(announce)
@@ -10750,6 +10781,26 @@ mod tests {
         assert!(!daemon_upgrade_required(Some("1.20.3"), "1.20.2"));
         assert!(!daemon_upgrade_required(Some("debug"), "1.20.2"));
         assert!(!daemon_upgrade_required(None, "1.20.2"));
+    }
+
+    #[test]
+    fn homebrew_daemon_version_accepts_only_a_cellar_release_path() {
+        assert_eq!(
+            homebrew_daemon_version(
+                "/opt/homebrew/Cellar/ainb/1.20.0/libexec/ainb hangar daemon run"
+            ),
+            Some("1.20.0".to_string())
+        );
+        assert_eq!(
+            homebrew_daemon_version("/opt/homebrew/bin/ainb hangar daemon run"),
+            None
+        );
+        assert_eq!(
+            homebrew_daemon_version(
+                "/opt/homebrew/Cellar/ainb/debug/libexec/ainb hangar daemon run"
+            ),
+            None
+        );
     }
 
     /// The freshness predicate: a sibling at least as new as `ainb` is fresh; an


### PR DESCRIPTION
## Summary
- route ainb hangar daemon start through version-aware handoff
- preserve non-downgrade behavior for unknown, equal, prerelease, and newer owners
- reuse TUI startup path so stale release daemons cannot survive a normal start

## Verification
- cd ainb-tui && cargo fmt --all --check
- cd ainb-tui && cargo test -p ainb --lib daemon_upgrade_required_only_for_a_strictly_newer_release
- cd ainb-tui && cargo build -p ainb