### PR TITLE
fix: launch remote Codex interactive sessions

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tokio-util",
  "toml",
  "tracing",

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -8492,7 +8492,7 @@ impl AppState {
                     session_id,
                     skip_permissions,
                     agent_type,
-                    model,
+                    model.clone(),
                     existing_worktree,
                     base_start_point,
                     headroom_enabled,
@@ -11014,7 +11014,7 @@ impl AppState {
             .start_cli_in_tmux(
                 &tmux_session_name,
                 skip_permissions,
-                model,
+                model.clone(),
                 agent_type,
                 resume_transcript,
                 true,

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -9330,7 +9330,7 @@ impl AppState {
                 .start_cli_in_tmux(
                     &metadata.tmux_session_name,
                     skip_permissions,
-                    model,
+                    model.clone(),
                     metadata.agent_type,
                     transcript.clone(),
                     true, // resume_requested — Enter/r on a Stopped session

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -9311,8 +9311,8 @@ impl AppState {
                 None
             };
 
-            let codex_remote = if metadata.agent_type == SessionAgentType::Codex {
-                let remote = crate::interactive::session_manager::ensure_codex_remote_thread(
+            let mut codex_remote = if metadata.agent_type == SessionAgentType::Codex {
+                Some(crate::interactive::session_manager::ensure_codex_remote_thread(
                     metadata.session_id,
                     &metadata.worktree_path,
                     model.as_deref(),
@@ -9320,12 +9320,7 @@ impl AppState {
                     metadata.headroom_enabled,
                     metadata.codex_thread_id.clone(),
                 )
-                .await?;
-                crate::interactive::session_manager::persist_codex_thread_id(
-                    metadata.session_id,
-                    remote.thread_id.clone(),
-                )?;
-                Some(remote)
+                .await?)
             } else {
                 None
             };
@@ -9343,6 +9338,31 @@ impl AppState {
                     codex_remote.as_ref(),
                 )
                 .await?;
+
+            if codex_remote
+                .as_ref()
+                .is_some_and(|remote| remote.thread_id.is_none())
+            {
+                codex_remote = Some(
+                    crate::interactive::session_manager::claim_codex_remote_thread(
+                        metadata.session_id,
+                        &metadata.worktree_path,
+                        model.as_deref(),
+                        skip_permissions,
+                        metadata.headroom_enabled,
+                    )
+                    .await?,
+                );
+            }
+            if let Some(thread_id) = codex_remote
+                .as_ref()
+                .and_then(|remote| remote.thread_id.as_deref())
+            {
+                crate::interactive::session_manager::persist_codex_thread_id(
+                    metadata.session_id,
+                    thread_id.to_string(),
+                )?;
+            }
 
             // Re-register live tmux handle and flip status to Running.
             let tmux_session = crate::tmux::TmuxSession::new(
@@ -10969,8 +10989,8 @@ impl AppState {
             None
         };
         let headroom_enabled = metadata.map(|m| m.headroom_enabled).unwrap_or(false);
-        let codex_remote = if agent_type == SessionAgentType::Codex {
-            let remote = crate::interactive::session_manager::ensure_codex_remote_thread(
+        let mut codex_remote = if agent_type == SessionAgentType::Codex {
+            Some(crate::interactive::session_manager::ensure_codex_remote_thread(
                 session_id,
                 std::path::Path::new(&workspace_path),
                 model.as_deref(),
@@ -10978,12 +10998,7 @@ impl AppState {
                 headroom_enabled,
                 metadata.and_then(|m| m.codex_thread_id.clone()),
             )
-            .await?;
-            crate::interactive::session_manager::persist_codex_thread_id(
-                session_id,
-                remote.thread_id.clone(),
-            )?;
-            Some(remote)
+            .await?)
         } else {
             None
         };
@@ -11007,6 +11022,31 @@ impl AppState {
                 codex_remote.as_ref(),
             )
             .await?;
+
+        if codex_remote
+            .as_ref()
+            .is_some_and(|remote| remote.thread_id.is_none())
+        {
+            codex_remote = Some(
+                crate::interactive::session_manager::claim_codex_remote_thread(
+                    session_id,
+                    std::path::Path::new(&workspace_path),
+                    model.as_deref(),
+                    skip_permissions,
+                    headroom_enabled,
+                )
+                .await?,
+            );
+        }
+        if let Some(thread_id) = codex_remote
+            .as_ref()
+            .and_then(|remote| remote.thread_id.as_deref())
+        {
+            crate::interactive::session_manager::persist_codex_thread_id(
+                session_id,
+                thread_id.to_string(),
+            )?;
+        }
 
         if let Some(session) = self.find_session_mut(session_id) {
             session.set_status(crate::models::SessionStatus::Running);

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -8612,7 +8612,7 @@ impl AppState {
                     base_start_point,
                     skip_permissions,
                     agent_type,
-                    model,
+                    model.clone(),
                     headroom_enabled,
                     rtk_enabled,
                 )

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -9312,15 +9312,17 @@ impl AppState {
             };
 
             let mut codex_remote = if metadata.agent_type == SessionAgentType::Codex {
-                Some(crate::interactive::session_manager::ensure_codex_remote_thread(
-                    metadata.session_id,
-                    &metadata.worktree_path,
-                    model.as_deref(),
-                    skip_permissions,
-                    metadata.headroom_enabled,
-                    metadata.codex_thread_id.clone(),
+                Some(
+                    crate::interactive::session_manager::ensure_codex_remote_thread(
+                        metadata.session_id,
+                        &metadata.worktree_path,
+                        model.as_deref(),
+                        skip_permissions,
+                        metadata.headroom_enabled,
+                        metadata.codex_thread_id.clone(),
+                    )
+                    .await?,
                 )
-                .await?)
             } else {
                 None
             };
@@ -9329,6 +9331,7 @@ impl AppState {
             manager
                 .start_cli_in_tmux(
                     &metadata.tmux_session_name,
+                    &metadata.worktree_path,
                     skip_permissions,
                     model.clone(),
                     metadata.agent_type,
@@ -9339,10 +9342,7 @@ impl AppState {
                 )
                 .await?;
 
-            if codex_remote
-                .as_ref()
-                .is_some_and(|remote| remote.thread_id.is_none())
-            {
+            if codex_remote.as_ref().is_some_and(|remote| remote.thread_id.is_none()) {
                 codex_remote = Some(
                     crate::interactive::session_manager::claim_codex_remote_thread(
                         metadata.session_id,
@@ -9354,9 +9354,8 @@ impl AppState {
                     .await?,
                 );
             }
-            if let Some(thread_id) = codex_remote
-                .as_ref()
-                .and_then(|remote| remote.thread_id.as_deref())
+            if let Some(thread_id) =
+                codex_remote.as_ref().and_then(|remote| remote.thread_id.as_deref())
             {
                 crate::interactive::session_manager::persist_codex_thread_id(
                     metadata.session_id,
@@ -10990,15 +10989,17 @@ impl AppState {
         };
         let headroom_enabled = metadata.map(|m| m.headroom_enabled).unwrap_or(false);
         let mut codex_remote = if agent_type == SessionAgentType::Codex {
-            Some(crate::interactive::session_manager::ensure_codex_remote_thread(
-                session_id,
-                std::path::Path::new(&workspace_path),
-                model.as_deref(),
-                skip_permissions,
-                headroom_enabled,
-                metadata.and_then(|m| m.codex_thread_id.clone()),
+            Some(
+                crate::interactive::session_manager::ensure_codex_remote_thread(
+                    session_id,
+                    std::path::Path::new(&workspace_path),
+                    model.as_deref(),
+                    skip_permissions,
+                    headroom_enabled,
+                    metadata.and_then(|m| m.codex_thread_id.clone()),
+                )
+                .await?,
             )
-            .await?)
         } else {
             None
         };
@@ -11013,6 +11014,7 @@ impl AppState {
         InteractiveSessionManager::new()?
             .start_cli_in_tmux(
                 &tmux_session_name,
+                std::path::Path::new(&workspace_path),
                 skip_permissions,
                 model.clone(),
                 agent_type,
@@ -11023,10 +11025,7 @@ impl AppState {
             )
             .await?;
 
-        if codex_remote
-            .as_ref()
-            .is_some_and(|remote| remote.thread_id.is_none())
-        {
+        if codex_remote.as_ref().is_some_and(|remote| remote.thread_id.is_none()) {
             codex_remote = Some(
                 crate::interactive::session_manager::claim_codex_remote_thread(
                     session_id,
@@ -11038,9 +11037,8 @@ impl AppState {
                 .await?,
             );
         }
-        if let Some(thread_id) = codex_remote
-            .as_ref()
-            .and_then(|remote| remote.thread_id.as_deref())
+        if let Some(thread_id) =
+            codex_remote.as_ref().and_then(|remote| remote.thread_id.as_deref())
         {
             crate::interactive::session_manager::persist_codex_thread_id(
                 session_id,

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -480,7 +480,7 @@ mod tests {
 
         let remote = ainb_hangar_proto::fleet::CodexSessionEnsureResult {
             endpoint: "unix:///tmp/ainb-idle-restart.sock".to_string(),
-            thread_id: "thread-idle-restart".to_string(),
+            thread_id: Some("thread-idle-restart".to_string()),
         };
         InteractiveSessionManager::new()
             .expect("session manager")

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -442,6 +442,7 @@ mod tests {
 
         let tmux_name = format!("ainb-idle-restart-{}", uuid::Uuid::new_v4());
         let _tmux = ExactTmuxSession(tmux_name.clone());
+        let working_dir = std::env::current_dir().expect("current directory");
         assert!(
             Command::new("tmux")
                 .args(["new-session", "-d", "-s", &tmux_name])
@@ -486,6 +487,7 @@ mod tests {
             .expect("session manager")
             .start_cli_in_tmux(
                 &tmux_name,
+                &working_dir,
                 true,
                 Some("gpt-5.6-luna".to_string()),
                 SessionAgentType::Codex,

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -17,7 +17,7 @@ use super::RunArgs;
 use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{
-    ModelSource, SessionMetadata, SessionStore, ensure_codex_remote_thread,
+    ModelSource, SessionMetadata, SessionStore, claim_codex_remote_thread, ensure_codex_remote_thread,
 };
 use crate::models::session::{SessionAgentType, is_default_model};
 use crate::tmux::TmuxSession;
@@ -155,6 +155,20 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
     let tmux_name = tmux.name().to_string();
     info!("Started tmux session: {}", tmux_name);
+
+    let codex_remote = match codex_remote {
+        Some(remote) if remote.thread_id.is_none() => Some(
+            claim_codex_remote_thread(
+                session_id,
+                &work_dir,
+                model.as_deref(),
+                args.dangerously_skip_permissions,
+                false,
+            )
+            .await?,
+        ),
+        remote => remote,
+    };
 
     // Step 8: send the initial prompt (if any) once the input box is ready.
     // A fixed sleep loses keystrokes into Claude Code's not-yet-ready splash.
@@ -484,14 +498,12 @@ fn build_agent_command(args: &RunArgs) -> String {
 }
 
 fn remote_codex_command(remote: &ainb_hangar_proto::fleet::CodexSessionEnsureResult) -> String {
-    [
-        "codex",
-        "--remote",
-        &remote.endpoint,
-        "resume",
-        &remote.thread_id,
-    ]
-    .into_iter()
+    let mut parts = vec!["codex".to_string(), "--remote".to_string(), remote.endpoint.clone()];
+    if let Some(thread_id) = remote.thread_id.as_ref() {
+        parts.extend(["resume".to_string(), thread_id.clone()]);
+    }
+    parts
+    .iter()
     .map(|part| shell_escape::escape(part.into()).into_owned())
     .collect::<Vec<_>>()
     .join(" ")
@@ -745,13 +757,22 @@ mod tests {
     fn remote_codex_command_resumes_exact_thread() {
         let command = remote_codex_command(&ainb_hangar_proto::fleet::CodexSessionEnsureResult {
             endpoint: "unix:///tmp/codex-app-server.sock".to_string(),
-            thread_id: "thread-123".to_string(),
+            thread_id: Some("thread-123".to_string()),
         });
         assert_eq!(
             command,
             "codex --remote 'unix:///tmp/codex-app-server.sock' resume thread-123"
         );
         assert!(!command.contains("--last"));
+    }
+
+    #[test]
+    fn remote_codex_command_starts_fresh_thread() {
+        let command = remote_codex_command(&ainb_hangar_proto::fleet::CodexSessionEnsureResult {
+            endpoint: "unix:///tmp/codex-app-server.sock".to_string(),
+            thread_id: None,
+        });
+        assert_eq!(command, "codex --remote 'unix:///tmp/codex-app-server.sock'");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -17,7 +17,8 @@ use super::RunArgs;
 use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{
-    ModelSource, SessionMetadata, SessionStore, claim_codex_remote_thread, ensure_codex_remote_thread,
+    ModelSource, SessionMetadata, SessionStore, claim_codex_remote_thread,
+    ensure_codex_remote_thread,
 };
 use crate::models::session::{SessionAgentType, is_default_model};
 use crate::tmux::TmuxSession;
@@ -123,7 +124,14 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
     let claude_cmd = codex_remote
         .as_ref()
-        .map(remote_codex_command)
+        .map(|remote| {
+            remote_codex_command(
+                remote,
+                &work_dir,
+                model.as_deref(),
+                args.dangerously_skip_permissions,
+            )
+        })
         .unwrap_or_else(|| build_agent_command(&args));
 
     // Step 6b: Parent linkage (event-driven plumbing). When spawned with
@@ -497,16 +505,33 @@ fn build_agent_command(args: &RunArgs) -> String {
         .join(" ")
 }
 
-fn remote_codex_command(remote: &ainb_hangar_proto::fleet::CodexSessionEnsureResult) -> String {
-    let mut parts = vec!["codex".to_string(), "--remote".to_string(), remote.endpoint.clone()];
+fn remote_codex_command(
+    remote: &ainb_hangar_proto::fleet::CodexSessionEnsureResult,
+    cwd: &std::path::Path,
+    model: Option<&str>,
+    skip_permissions: bool,
+) -> String {
+    let mut parts = vec![
+        "codex".to_string(),
+        "--remote".to_string(),
+        remote.endpoint.clone(),
+        "-C".to_string(),
+        cwd.display().to_string(),
+    ];
+    if let Some(model) = model.filter(|model| !model.is_empty() && *model != "default") {
+        parts.extend(["--model".to_string(), model.to_string()]);
+    }
+    if skip_permissions {
+        parts.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+    }
     if let Some(thread_id) = remote.thread_id.as_ref() {
         parts.extend(["resume".to_string(), thread_id.clone()]);
     }
     parts
-    .iter()
-    .map(|part| shell_escape::escape(part.into()).into_owned())
-    .collect::<Vec<_>>()
-    .join(" ")
+        .iter()
+        .map(|part| shell_escape::escape(part.into()).into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Poll the tmux pane until the agent's input box is ready, or `timeout` elapses.
@@ -755,24 +780,37 @@ mod tests {
 
     #[test]
     fn remote_codex_command_resumes_exact_thread() {
-        let command = remote_codex_command(&ainb_hangar_proto::fleet::CodexSessionEnsureResult {
-            endpoint: "unix:///tmp/codex-app-server.sock".to_string(),
-            thread_id: Some("thread-123".to_string()),
-        });
+        let command = remote_codex_command(
+            &ainb_hangar_proto::fleet::CodexSessionEnsureResult {
+                endpoint: "unix:///tmp/codex-app-server.sock".to_string(),
+                thread_id: Some("thread-123".to_string()),
+            },
+            std::path::Path::new("/tmp/worktree"),
+            Some("gpt-5.6-luna"),
+            true,
+        );
         assert_eq!(
             command,
-            "codex --remote 'unix:///tmp/codex-app-server.sock' resume thread-123"
+            "codex --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
         );
         assert!(!command.contains("--last"));
     }
 
     #[test]
     fn remote_codex_command_starts_fresh_thread() {
-        let command = remote_codex_command(&ainb_hangar_proto::fleet::CodexSessionEnsureResult {
-            endpoint: "unix:///tmp/codex-app-server.sock".to_string(),
-            thread_id: None,
-        });
-        assert_eq!(command, "codex --remote 'unix:///tmp/codex-app-server.sock'");
+        let command = remote_codex_command(
+            &ainb_hangar_proto::fleet::CodexSessionEnsureResult {
+                endpoint: "unix:///tmp/codex-app-server.sock".to_string(),
+                thread_id: None,
+            },
+            std::path::Path::new("/tmp/worktree"),
+            None,
+            false,
+        );
+        assert_eq!(
+            command,
+            "codex --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -205,7 +205,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         model: model.clone(),
         model_source: ModelSource::Raw,
         codex_model: None,
-        codex_thread_id: codex_remote.map(|remote| remote.thread_id),
+        codex_thread_id: codex_remote.and_then(|remote| remote.thread_id),
     };
 
     // Locked RMW (pu4): another `ainb run`/`kill` or a daemon register racing

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -589,6 +589,7 @@ impl InteractiveSessionManager {
                 );
                 self.start_cli_in_tmux(
                     &tmux_session_name,
+                    &worktree_info.path,
                     skip_permissions,
                     model.clone(),
                     agent_type,
@@ -633,9 +634,7 @@ impl InteractiveSessionManager {
             model: model.clone(),
             headroom_enabled,
             rtk_enabled,
-            codex_thread_id: codex_remote
-                .as_ref()
-                .and_then(|remote| remote.thread_id.clone()),
+            codex_thread_id: codex_remote.as_ref().and_then(|remote| remote.thread_id.clone()),
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -792,6 +791,7 @@ impl InteractiveSessionManager {
                 );
                 self.start_cli_in_tmux(
                     &tmux_session_name,
+                    &existing_worktree_path,
                     skip_permissions,
                     model.clone(),
                     agent_type,
@@ -837,9 +837,7 @@ impl InteractiveSessionManager {
             model: model.clone(),
             headroom_enabled,
             rtk_enabled,
-            codex_thread_id: codex_remote
-                .as_ref()
-                .and_then(|remote| remote.thread_id.clone()),
+            codex_thread_id: codex_remote.as_ref().and_then(|remote| remote.thread_id.clone()),
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -1812,6 +1810,7 @@ impl InteractiveSessionManager {
     pub async fn start_cli_in_tmux(
         &self,
         session_name: &str,
+        working_dir: &std::path::Path,
         skip_permissions: bool,
         model: Option<String>,
         agent_type: SessionAgentType,
@@ -1889,7 +1888,15 @@ impl InteractiveSessionManager {
                 provider.command().to_string(),
                 "--remote".to_string(),
                 remote.endpoint.clone(),
+                "-C".to_string(),
+                working_dir.display().to_string(),
             ];
+            if let Some(model) = model.as_deref().filter(|model| !is_default_model(model)) {
+                command.extend(["--model".to_string(), model.to_string()]);
+            }
+            if skip_permissions {
+                command.push(provider.skip_permissions_flag().to_string());
+            }
             if let Some(thread_id) = remote.thread_id.as_ref() {
                 command.extend(["resume".to_string(), thread_id.clone()]);
             }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -143,7 +143,13 @@ pub(crate) async fn ensure_codex_remote_thread(
             skip_permissions,
         })
         .await
-        .map_err(|error| anyhow::anyhow!("prepare shared Codex thread: {error}"))
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "Codex remote session unavailable. Verify Codex is signed in and retry. \
+                 If it persists, restart Ainb with `ainb hangar daemon stop` then \
+                 `ainb hangar daemon start`. Details: {error}"
+            )
+        })
 }
 
 /// Wait briefly for the freshly started remote terminal to publish its exact

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -146,6 +146,38 @@ pub(crate) async fn ensure_codex_remote_thread(
         .map_err(|error| anyhow::anyhow!("prepare shared Codex thread: {error}"))
 }
 
+/// Wait briefly for the freshly started remote terminal to publish its exact
+/// thread identity through the daemon's app-server event stream.
+pub(crate) async fn claim_codex_remote_thread(
+    session_id: Uuid,
+    cwd: &std::path::Path,
+    model: Option<&str>,
+    skip_permissions: bool,
+    headroom_enabled: bool,
+) -> anyhow::Result<ainb_hangar_proto::fleet::CodexSessionEnsureResult> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let remote = ensure_codex_remote_thread(
+            session_id,
+            cwd,
+            model,
+            skip_permissions,
+            headroom_enabled,
+            None,
+        )
+        .await?;
+        if remote.thread_id.is_some() {
+            return Ok(remote);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "Codex started but did not publish a remote thread within 10 seconds; keep the pane open and retry"
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
 pub(crate) fn persist_codex_thread_id(session_id: Uuid, thread_id: String) -> anyhow::Result<()> {
     SessionStore::mutate(|store| {
         if let Some(metadata) =
@@ -572,6 +604,20 @@ impl InteractiveSessionManager {
             }
         }
 
+        let codex_remote = match codex_remote {
+            Some(remote) if remote.thread_id.is_none() => Some(
+                claim_codex_remote_thread(
+                    session_id,
+                    &worktree_info.path,
+                    model.as_deref(),
+                    skip_permissions,
+                    headroom_enabled,
+                )
+                .await?,
+            ),
+            remote => remote,
+        };
+
         // Step 5: Create session record
         let created_at = Utc::now();
         let session = InteractiveSession {
@@ -587,7 +633,9 @@ impl InteractiveSessionManager {
             model: model.clone(),
             headroom_enabled,
             rtk_enabled,
-            codex_thread_id: codex_remote.as_ref().map(|remote| remote.thread_id.clone()),
+            codex_thread_id: codex_remote
+                .as_ref()
+                .and_then(|remote| remote.thread_id.clone()),
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -606,7 +654,7 @@ impl InteractiveSessionManager {
             model,
             model_source: ModelSource::Raw,
             codex_model: None,
-            codex_thread_id: codex_remote.map(|remote| remote.thread_id),
+            codex_thread_id: codex_remote.and_then(|remote| remote.thread_id),
         };
         // Locked RMW so a concurrent `ainb kill` / recovery / daemon register
         // can't lost-update this upsert (pu4).
@@ -759,6 +807,20 @@ impl InteractiveSessionManager {
             }
         }
 
+        let codex_remote = match codex_remote {
+            Some(remote) if remote.thread_id.is_none() => Some(
+                claim_codex_remote_thread(
+                    session_id,
+                    &existing_worktree_path,
+                    model.as_deref(),
+                    skip_permissions,
+                    headroom_enabled,
+                )
+                .await?,
+            ),
+            remote => remote,
+        };
+
         // Step 4: Create session record
         let created_at = Utc::now();
         let worktree_path_clone = existing_worktree_path.clone();
@@ -775,7 +837,9 @@ impl InteractiveSessionManager {
             model: model.clone(),
             headroom_enabled,
             rtk_enabled,
-            codex_thread_id: codex_remote.as_ref().map(|remote| remote.thread_id.clone()),
+            codex_thread_id: codex_remote
+                .as_ref()
+                .and_then(|remote| remote.thread_id.clone()),
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -794,7 +858,7 @@ impl InteractiveSessionManager {
             model,
             model_source: ModelSource::Raw,
             codex_model: None,
-            codex_thread_id: codex_remote.map(|remote| remote.thread_id),
+            codex_thread_id: codex_remote.and_then(|remote| remote.thread_id),
         };
         // Locked RMW (pu4): serialise against concurrent kill/recovery writers.
         if let Err(e) = SessionStore::mutate(|store| store.upsert(metadata)) {
@@ -1821,13 +1885,15 @@ impl InteractiveSessionManager {
                     "remote Codex thread used for a non-Codex session"
                 )));
             }
-            vec![
+            let mut command = vec![
                 provider.command().to_string(),
                 "--remote".to_string(),
                 remote.endpoint.clone(),
-                "resume".to_string(),
-                remote.thread_id.clone(),
-            ]
+            ];
+            if let Some(thread_id) = remote.thread_id.as_ref() {
+                command.extend(["resume".to_string(), thread_id.clone()]);
+            }
+            command
         } else {
             Self::build_cli_cmd_parts(
                 &provider,

--- a/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
+++ b/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
@@ -37,7 +37,7 @@
 
 use ainb::interactive::session_manager::InteractiveSessionManager;
 use ainb::models::session::SessionAgentType;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -180,6 +180,7 @@ async fn launched_command(
     let mgr = InteractiveSessionManager::new().expect("manager");
     mgr.start_cli_in_tmux(
         name,
+        Path::new("/tmp"),
         true, // skip_permissions (yolo)
         model.map(str::to_string),
         agent,

--- a/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
@@ -117,6 +117,7 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 futures-util = { workspace = true }
+tokio-tungstenite = { workspace = true }
 # P6.2 skill importer: parse the YAML frontmatter block of each `SKILL.md`
 # (`name:` / `description:`) when syncing `toolkit/packages/skills/`.
 serde_yaml = { workspace = true }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -675,13 +675,11 @@ pub async fn ingest_codex_inbound(
     .await?;
     if method == "turn/started" {
         if let Some(thread_id) = envelope.raw.get("params").and_then(codex_thread_id) {
-            sqlx::query(
-                "UPDATE interactive_codex_thread SET resumable = 1 WHERE thread_id = ?",
-            )
-            .bind(thread_id)
-            .execute(pool)
-            .await
-            .map_err(FleetProviderEventError::from)?;
+            sqlx::query("UPDATE interactive_codex_thread SET resumable = 1 WHERE thread_id = ?")
+                .bind(thread_id)
+                .execute(pool)
+                .await
+                .map_err(FleetProviderEventError::from)?;
         }
     }
     reduce_codex_source_event(pool, events, &event_id, envelope, capabilities, observed_at).await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -668,11 +668,22 @@ pub async fn ingest_codex_inbound(
             provider_session_id,
             observed_at,
             received_at: observed_at,
-            event_type: method,
+            event_type: method.clone(),
             raw_payload: serde_json::to_string(&envelope.raw).unwrap_or_default(),
         },
     )
     .await?;
+    if method == "turn/started" {
+        if let Some(thread_id) = envelope.raw.get("params").and_then(codex_thread_id) {
+            sqlx::query(
+                "UPDATE interactive_codex_thread SET resumable = 1 WHERE thread_id = ?",
+            )
+            .bind(thread_id)
+            .execute(pool)
+            .await
+            .map_err(FleetProviderEventError::from)?;
+        }
+    }
     reduce_codex_source_event(pool, events, &event_id, envelope, capabilities, observed_at).await
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -15,25 +15,30 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use futures_util::{SinkExt, StreamExt};
 use nix::errno::Errno;
 use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::process::{Child, Command};
 use tokio::sync::RwLock;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep};
+use tokio_tungstenite::{WebSocketStream, client_async, tungstenite::Message};
+
+#[cfg(test)]
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::codex::{
     CodexApprovalKind, CodexApprovalRequest, CodexCapabilities, CodexInboundEnvelope,
     CodexQuestionRequest, CommandSpec, RpcRequestId, app_server_command, managed_tui_command,
-    parse_inbound_envelope, probe_codex, proxy_command,
+    parse_inbound_envelope, probe_codex,
 };
 use super::{ApprovalDecision, ProviderError, ProviderReceipt, QuestionAnswer};
 
@@ -630,7 +635,7 @@ fn epoch_millis() -> i64 {
         })
 }
 
-/// Spawn shared app-server, one proxy, initialize protocol, then start manager.
+/// Spawn shared app-server, connect its Unix WebSocket, initialize protocol, then start manager.
 pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, ProviderError> {
     let probe_binary = config.codex_binary.clone();
     let capabilities = tokio::task::spawn_blocking(move || probe_codex(&probe_binary))
@@ -641,24 +646,7 @@ pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, Pr
             "installed Codex cannot generate app-server schema".into(),
         ));
     }
-    if !capabilities.stdio_proxy {
-        return Err(ProviderError::Unsupported(
-            "installed Codex has no app-server stdio proxy".into(),
-        ));
-    }
-
-    // Fail loud before we add another app-server to an already-piled-up host. A
-    // SIGKILLed daemon leaks its child at ppid==1; the boot reaper handles that,
-    // but this cap is the second line of defence against an unbounded spawn loop
-    // (e.g. a wedged service-retry). Surfaces as a Transport error the service loop
-    // logs + backs off on, never a silent 900-process pileup.
-    //
-    // This runs BEFORE prepare_socket, so at the cap the daemon also declines to
-    // ADOPT the one healthy shared server it might otherwise reuse; an intentional,
-    // honest downgrade: on an already-saturated host we refuse loudly rather than
-    // quietly join the pile.
     enforce_codex_server_cap().await?;
-
     let preparation = prepare_socket(&config.socket_path, &config.codex_binary).await?;
     let mut owns_server = preparation.owns_server;
     let owner_marker_path = socket_owner_marker(&config.socket_path);
@@ -716,15 +704,8 @@ pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, Pr
         }
     };
 
-    let mut proxy_command = tokio_command(proxy_command(&config.codex_binary, &config.socket_path));
-    proxy_command.kill_on_drop(true);
-    let mut proxy = match proxy_command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(proxy) => proxy,
+    let socket = match UnixStream::connect(&config.socket_path).await {
+        Ok(socket) => socket,
         Err(error) => {
             if let Some(server) = server.as_mut() {
                 stop_child(server).await;
@@ -732,43 +713,33 @@ pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, Pr
             if owns_server {
                 remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
             }
-            return Err(error.into());
+            return Err(ProviderError::Transport(format!(
+                "Codex app-server Unix socket connection failed: {error}"
+            )));
         }
     };
-    let Some(stdin) = proxy.stdin.take() else {
-        stop_child(&mut proxy).await;
-        if let Some(server) = server.as_mut() {
-            stop_child(server).await;
+    let websocket = match client_async("ws://localhost/", socket).await {
+        Ok((websocket, _)) => websocket,
+        Err(error) => {
+            if let Some(server) = server.as_mut() {
+                stop_child(server).await;
+            }
+            if owns_server {
+                remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
+            }
+            return Err(ProviderError::Transport(format!(
+                "Codex app-server WebSocket handshake failed: {error}"
+            )));
         }
-        if owns_server {
-            remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
-        }
-        return Err(ProviderError::Transport(
-            "Codex proxy stdin unavailable".into(),
-        ));
     };
-    let Some(stdout) = proxy.stdout.take() else {
-        stop_child(&mut proxy).await;
-        if let Some(server) = server.as_mut() {
-            stop_child(server).await;
-        }
-        if owns_server {
-            remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
-        }
-        return Err(ProviderError::Transport(
-            "Codex proxy stdout unavailable".into(),
-        ));
-    };
-    let cleanup: Box<dyn ProcessCleanup> = Box::new(ChildCleanup {
+    let cleanup: Box<dyn ProcessCleanup> = Box::new(ServerCleanup {
         server,
-        proxy,
         owned_socket_path: owns_server.then(|| config.socket_path.clone()),
         owner_marker_path: owns_server.then_some(owner_marker_path),
     });
 
     spawn_connection(
-        BufReader::new(stdout),
-        stdin,
+        WebSocketTransport { websocket },
         capabilities,
         config,
         owns_server,
@@ -1692,9 +1663,103 @@ struct PendingRequest {
     reply: oneshot::Sender<Result<Value, ProviderError>>,
 }
 
-async fn spawn_connection<R, W>(
-    mut reader: R,
-    mut writer: W,
+type JsonRpcFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ProviderError>> + Send + 'a>>;
+
+trait JsonRpcTransport: Send {
+    fn write_message<'a>(&'a mut self, message: &'a Value) -> JsonRpcFuture<'a, ()>;
+    fn read_message<'a>(&'a mut self) -> JsonRpcFuture<'a, Value>;
+}
+
+#[cfg(test)]
+struct LineTransport<R, W> {
+    reader: R,
+    writer: W,
+}
+
+#[cfg(test)]
+impl<R, W> LineTransport<R, W> {
+    const fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+}
+
+#[cfg(test)]
+impl<R, W> JsonRpcTransport for LineTransport<R, W>
+where
+    R: AsyncBufRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
+{
+    fn write_message<'a>(&'a mut self, message: &'a Value) -> JsonRpcFuture<'a, ()> {
+        Box::pin(write_message(&mut self.writer, message))
+    }
+
+    fn read_message<'a>(&'a mut self) -> JsonRpcFuture<'a, Value> {
+        Box::pin(read_message(&mut self.reader))
+    }
+}
+
+struct WebSocketTransport {
+    websocket: WebSocketStream<UnixStream>,
+}
+
+impl JsonRpcTransport for WebSocketTransport {
+    fn write_message<'a>(&'a mut self, message: &'a Value) -> JsonRpcFuture<'a, ()> {
+        Box::pin(async move {
+            let text = serde_json::to_string(message)?;
+            self.websocket.send(Message::Text(text)).await.map_err(|error| {
+                ProviderError::Transport(format!(
+                    "Codex app-server WebSocket write failed: {error}"
+                ))
+            })
+        })
+    }
+
+    fn read_message<'a>(&'a mut self) -> JsonRpcFuture<'a, Value> {
+        Box::pin(async move {
+            loop {
+                let message = self
+                    .websocket
+                    .next()
+                    .await
+                    .ok_or_else(|| {
+                        ProviderError::Transport("Codex app-server WebSocket closed".into())
+                    })?
+                    .map_err(|error| {
+                        ProviderError::Transport(format!(
+                            "Codex app-server WebSocket read failed: {error}"
+                        ))
+                    })?;
+                match message {
+                    Message::Text(text) => {
+                        return serde_json::from_str(&text).map_err(ProviderError::from);
+                    }
+                    Message::Ping(payload) => {
+                        self.websocket.send(Message::Pong(payload)).await.map_err(|error| {
+                            ProviderError::Transport(format!(
+                                "Codex app-server WebSocket pong failed: {error}"
+                            ))
+                        })?
+                    }
+                    Message::Pong(_) => {}
+                    Message::Close(frame) => {
+                        return Err(ProviderError::Transport(format!(
+                            "Codex app-server WebSocket closed: {frame:?}"
+                        )));
+                    }
+                    Message::Binary(_) => {
+                        return Err(ProviderError::Protocol(
+                            "Codex app-server sent a binary WebSocket message".into(),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+        })
+    }
+}
+
+async fn spawn_connection<T>(
+    mut transport: T,
     capabilities: CodexCapabilities,
     config: CodexManagerConfig,
     owns_server: bool,
@@ -1702,13 +1767,12 @@ async fn spawn_connection<R, W>(
     mut cleanup: Box<dyn ProcessCleanup>,
 ) -> Result<ManagedCodexManager, ProviderError>
 where
-    R: AsyncBufRead + Unpin + Send + 'static,
-    W: AsyncWrite + Unpin + Send + 'static,
+    T: JsonRpcTransport + 'static,
 {
     let (events_tx, events) = mpsc::channel(config.event_capacity.max(1));
     let bootstrap = tokio::time::timeout(
         config.startup_timeout,
-        initialize_connection(&mut reader, &mut writer, &config.client_version, &events_tx),
+        initialize_connection(&mut transport, &config.client_version, &events_tx),
     )
     .await
     .map_err(|_| ProviderError::Transport("Codex initialize timed out".into()))
@@ -1733,7 +1797,7 @@ where
         request_timeout: config.request_timeout,
     };
     let task = tokio::spawn(async move {
-        let result = run_actor(reader, writer, command_rx, events_tx).await;
+        let result = run_actor(transport, command_rx, events_tx).await;
         cleanup.cleanup().await;
         result
     });
@@ -1744,19 +1808,16 @@ where
     })
 }
 
-async fn initialize_connection<R, W>(
-    reader: &mut R,
-    writer: &mut W,
+async fn initialize_connection<T>(
+    transport: &mut T,
     client_version: &str,
     events: &mpsc::Sender<CodexInboundEnvelope>,
 ) -> Result<(), ProviderError>
 where
-    R: AsyncBufRead + Unpin,
-    W: AsyncWrite + Unpin,
+    T: JsonRpcTransport,
 {
-    write_message(
-        writer,
-        &json!({
+    transport
+        .write_message(&json!({
             "jsonrpc": "2.0",
             "id": INITIALIZE_ID,
             "method": "initialize",
@@ -1768,12 +1829,11 @@ where
                 },
                 "capabilities": { "experimentalApi": true },
             },
-        }),
-    )
-    .await?;
+        }))
+        .await?;
 
     loop {
-        let message = read_message(reader).await?;
+        let message = transport.read_message().await?;
         if message.get("id") == Some(&json!(INITIALIZE_ID)) {
             if let Some(error) = message.get("error") {
                 return Err(ProviderError::Protocol(format!(
@@ -1794,22 +1854,18 @@ where
             .map_err(|_| ProviderError::Transport("Codex event receiver closed".into()))?;
     }
 
-    write_message(
-        writer,
-        &json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }),
-    )
-    .await
+    transport
+        .write_message(&json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }))
+        .await
 }
 
-async fn run_actor<R, W>(
-    mut reader: R,
-    mut writer: W,
+async fn run_actor<T>(
+    mut transport: T,
     mut commands: mpsc::Receiver<ManagerCommand>,
     events: mpsc::Sender<CodexInboundEnvelope>,
 ) -> Result<(), ProviderError>
 where
-    R: AsyncBufRead + Unpin,
-    W: AsyncWrite + Unpin,
+    T: JsonRpcTransport,
 {
     let mut next_id = INITIALIZE_ID + 1;
     let mut pending = BTreeMap::<u64, PendingRequest>::new();
@@ -1828,8 +1884,7 @@ where
                         next_id = next_id.checked_add(1).ok_or_else(|| {
                             ProviderError::Protocol("Codex JSON-RPC request id exhausted".into())
                         })?;
-                        if let Err(error) = write_message(
-                            &mut writer,
+                        if let Err(error) = transport.write_message(
                             &json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
                         ).await {
                             let _ = reply.send(Err(error));
@@ -1838,8 +1893,7 @@ where
                         pending.insert(id, PendingRequest { method, reply });
                     }
                     ManagerCommand::Respond { request_id, result, reply } => {
-                        let outcome = write_message(
-                            &mut writer,
+                        let outcome = transport.write_message(
                             &json!({ "jsonrpc": "2.0", "id": request_id.as_value(), "result": result }),
                         ).await;
                         let _ = reply.send(outcome);
@@ -1851,7 +1905,7 @@ where
                     }
                 }
             }
-            message = read_message(&mut reader) => {
+            message = transport.read_message() => {
                 let message = message?;
                 if message.get("result").is_some() || message.get("error").is_some() {
                     if let Some(id) = message.get("id").and_then(Value::as_u64) {
@@ -1886,6 +1940,7 @@ fn fail_pending(pending: &mut BTreeMap<u64, PendingRequest>, reason: &str) {
     }
 }
 
+#[cfg(test)]
 async fn write_message<W: AsyncWrite + Unpin>(
     writer: &mut W,
     message: &Value,
@@ -1897,6 +1952,7 @@ async fn write_message<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
+#[cfg(test)]
 async fn read_message<R: AsyncBufRead + Unpin>(reader: &mut R) -> Result<Value, ProviderError> {
     let mut line = String::new();
     if reader.read_line(&mut line).await? == 0 {
@@ -1987,17 +2043,15 @@ trait ProcessCleanup: Send {
     fn cleanup(&mut self) -> CleanupFuture<'_>;
 }
 
-struct ChildCleanup {
+struct ServerCleanup {
     server: Option<Child>,
-    proxy: Child,
     owned_socket_path: Option<PathBuf>,
     owner_marker_path: Option<PathBuf>,
 }
 
-impl ProcessCleanup for ChildCleanup {
+impl ProcessCleanup for ServerCleanup {
     fn cleanup(&mut self) -> CleanupFuture<'_> {
         Box::pin(async move {
-            stop_child(&mut self.proxy).await;
             if let Some(server) = self.server.as_mut() {
                 stop_child(server).await;
             }
@@ -2023,9 +2077,8 @@ async fn remove_owned_socket(socket_path: Option<&Path>, owner_marker_path: Opti
     }
 }
 
-impl Drop for ChildCleanup {
+impl Drop for ServerCleanup {
     fn drop(&mut self) {
-        let _ = self.proxy.start_kill();
         if let Some(server) = self.server.as_mut() {
             let _ = server.start_kill();
         }
@@ -2045,6 +2098,7 @@ mod tests {
 
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, duplex, split};
     use tokio::net::UnixListener;
+    use tokio_tungstenite::accept_async;
 
     use super::*;
     use crate::fleet_provider::codex::CodexInbound;
@@ -2085,6 +2139,63 @@ mod tests {
         assert!(!bound_by_child(42, Some(&[])));
         // `lsof` unavailable: trust the spawn rather than kill a healthy server.
         assert!(bound_by_child(42, None));
+    }
+
+    #[tokio::test]
+    async fn websocket_transport_round_trips_json_over_unix_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("app-server.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            let message = websocket.next().await.unwrap().unwrap();
+            let Message::Text(text) = message else {
+                panic!("expected JSON text frame");
+            };
+            assert_eq!(
+                serde_json::from_str::<Value>(&text).unwrap()["method"],
+                "initialize"
+            );
+            websocket
+                .send(Message::Text(
+                    json!({ "jsonrpc": "2.0", "id": 1, "result": {} }).to_string(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let socket = UnixStream::connect(&socket_path).await.unwrap();
+        let (websocket, _) = client_async("ws://localhost/", socket).await.unwrap();
+        let mut transport = WebSocketTransport { websocket };
+        transport
+            .write_message(&json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize" }))
+            .await
+            .unwrap();
+        assert_eq!(transport.read_message().await.unwrap()["id"], 1);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a locally installed Codex app-server"]
+    async fn managed_codex_listener_initializes_over_unix_websocket() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("codex-app-server.sock");
+        let config = CodexManagerConfig {
+            codex_binary: std::env::var_os("AINB_TEST_CODEX_BINARY")
+                .unwrap_or_else(|| "codex".into()),
+            socket_path: socket_path.clone(),
+            client_version: "test".into(),
+            startup_timeout: Duration::from_secs(10),
+            request_timeout: Duration::from_secs(10),
+            event_capacity: 8,
+        };
+
+        let manager = spawn(config).await.expect("initialize managed Codex listener");
+        assert!(socket_path.exists());
+        manager.handle.shutdown().await.expect("shutdown managed listener");
+        manager.wait().await.expect("reap managed listener");
+        assert!(!socket_path.exists());
     }
 
     /// A realistic `ps -Ao pid,ppid,args` dump: header, one adopted ppid==1
@@ -2889,8 +3000,7 @@ mod tests {
         });
 
         let mut manager = spawn_connection(
-            BufReader::new(manager_read),
-            manager_write,
+            LineTransport::new(BufReader::new(manager_read), manager_write),
             capabilities(true),
             config(),
             false,
@@ -2975,8 +3085,7 @@ mod tests {
         });
         let cleanup_flag = Arc::new(AtomicBool::new(false));
         let manager = spawn_connection(
-            BufReader::new(manager_read),
-            manager_write,
+            LineTransport::new(BufReader::new(manager_read), manager_write),
             capabilities(false),
             config(),
             false,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3318,7 +3318,7 @@ async fn handle_codex_session_ensure(
     if params.session_id.trim().is_empty() || params.cwd.trim().is_empty() {
         return Err(invalid_params("session_id and cwd must not be empty"));
     }
-    let manager = crate::fleet_provider::codex_manager::wait_for_active_handle(
+    let manager = match crate::fleet_provider::codex_manager::wait_for_active_handle(
         std::time::Duration::from_secs(15),
     )
     .await
@@ -3377,6 +3377,7 @@ async fn handle_codex_session_ensure(
         Some((None, _, watermark)) => claim_pending_codex_thread(
             pool,
             &params.session_id,
+            &cwd,
             watermark.unwrap_or_default(),
         )
         .await?,
@@ -3463,6 +3464,7 @@ async fn reserve_pending_codex_thread(
 async fn claim_pending_codex_thread(
     pool: &SqlitePool,
     session_id: &str,
+    cwd: &str,
     watermark: i64,
 ) -> Result<Option<String>, RpcError> {
     let payloads: Vec<String> = sqlx::query_scalar(
@@ -3476,7 +3478,7 @@ async fn claim_pending_codex_thread(
     .await
     .map_err(|error| internal(&format!("read pending Codex thread: {error}")))?;
     for payload in payloads {
-        let Some(thread_id) = codex_started_thread_id(&payload) else {
+        let Some(thread_id) = codex_started_thread_id(&payload, cwd) else {
             continue;
         };
         let claimed = sqlx::query(
@@ -3496,10 +3498,19 @@ async fn claim_pending_codex_thread(
     Ok(None)
 }
 
-fn codex_started_thread_id(payload: &str) -> Option<String> {
+fn codex_started_thread_id(payload: &str, cwd: &str) -> Option<String> {
     let payload: serde_json::Value = serde_json::from_str(payload).ok()?;
     let thread = payload.pointer("/params/thread")?;
-    thread.get("id")?.as_str().map(str::to_owned)
+    let event_cwd = thread.get("cwd")?.as_str()?;
+    let event_cwd = std::fs::canonicalize(event_cwd)
+        .unwrap_or_else(|_| std::path::PathBuf::from(event_cwd))
+        .display()
+        .to_string();
+    (event_cwd == cwd
+        && thread.get("threadSource")?.as_str() == Some("user")
+        && thread.get("forkedFromId").is_some_and(serde_json::Value::is_null))
+    .then(|| thread.get("id")?.as_str().map(str::to_owned))
+    .flatten()
 }
 
 /// Deliver one text prompt to explicit stable recipients with bounded fanout.
@@ -12909,18 +12920,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn codex_started_thread_claim_reads_thread_id() {
+    fn codex_started_thread_claim_requires_fresh_tui_thread_in_exact_cwd() {
+        let cwd = std::env::current_dir().unwrap().display().to_string();
         let payload = serde_json::json!({
             "method": "thread/started",
-            "params": { "thread": { "id": "thread-1", "cwd": "/app-server-cwd" } }
+            "params": { "thread": {
+                "id": "thread-1",
+                "cwd": cwd,
+                "threadSource": "user",
+                "forkedFromId": null
+            } }
         })
         .to_string();
 
         assert_eq!(
-            codex_started_thread_id(&payload),
+            codex_started_thread_id(&payload, &cwd),
             Some("thread-1".to_string())
         );
-        assert_eq!(codex_started_thread_id("{}"), None);
+        assert_eq!(codex_started_thread_id(&payload, "/wrong-cwd"), None);
+        let fork = payload.replace("\"forkedFromId\":null", "\"forkedFromId\":\"parent\"");
+        assert_eq!(codex_started_thread_id(&fork, &cwd), None);
     }
     use ainb_hangar_store::Store;
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3377,7 +3377,6 @@ async fn handle_codex_session_ensure(
         Some((None, _, watermark)) => claim_pending_codex_thread(
             pool,
             &params.session_id,
-            &cwd,
             watermark.unwrap_or_default(),
         )
         .await?,
@@ -3386,8 +3385,7 @@ async fn handle_codex_session_ensure(
                 match manager.thread_resume(thread_id).await {
                     Ok(_) => {}
                     Err(error) if error.to_string().contains("no rollout found") => {
-                        let watermark = codex_event_watermark(pool).await?;
-                        reserve_pending_codex_thread(pool, &params, &cwd, watermark).await?;
+                        reserve_pending_codex_thread(pool, &params, &cwd).await?;
                         return to_value(&CodexSessionEnsureResult {
                             thread_id: None,
                             endpoint: format!("unix://{}", manager.socket_path().display()),
@@ -3410,8 +3408,7 @@ async fn handle_codex_session_ensure(
                 Some(thread_id.to_string())
             }
             None => {
-                let watermark = codex_event_watermark(pool).await?;
-                reserve_pending_codex_thread(pool, &params, &cwd, watermark).await?;
+                reserve_pending_codex_thread(pool, &params, &cwd).await?;
                 None
             }
         },
@@ -3433,31 +3430,39 @@ async fn reserve_pending_codex_thread(
     pool: &SqlitePool,
     params: &ainb_hangar_proto::fleet::CodexSessionEnsureParams,
     cwd: &str,
-    watermark: i64,
 ) -> Result<(), RpcError> {
-    let inserted = sqlx::query(
-        "INSERT INTO interactive_codex_thread \
-         (session_id, thread_id, cwd, model, skip_permissions, event_watermark) \
-         VALUES (?, NULL, ?, ?, ?, ?)",
-    )
-    .bind(&params.session_id)
-    .bind(cwd)
-    .bind(&params.model)
-    .bind(params.skip_permissions)
-    .bind(watermark)
-    .execute(pool)
-    .await
-    .map_err(|error| internal(&format!("reserve Interactive Codex thread: {error}")))?;
-    if inserted.rows_affected() == 0 {
-        return Err(internal("reserve Interactive Codex thread affected no rows"));
+    // `thread/started` has no client correlation field. The migration admits
+    // one pending row globally, so wait for its launch to claim before taking
+    // the next cursor. This private app-server endpoint has one Ainb owner.
+    for _ in 0..100 {
+        let watermark = codex_event_watermark(pool).await?;
+        let inserted = sqlx::query(
+            "INSERT INTO interactive_codex_thread \
+             (session_id, thread_id, cwd, model, skip_permissions, event_watermark) \
+             VALUES (?, NULL, ?, ?, ?, ?)",
+        )
+        .bind(&params.session_id)
+        .bind(cwd)
+        .bind(&params.model)
+        .bind(params.skip_permissions)
+        .bind(watermark)
+        .execute(pool)
+        .await;
+        match inserted {
+            Ok(result) if result.rows_affected() == 1 => return Ok(()),
+            Ok(_) => return Err(internal("reserve Interactive Codex thread affected no rows")),
+            Err(sqlx::Error::Database(error)) if error.message().contains("UNIQUE constraint failed") => {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            Err(error) => return Err(internal(&format!("reserve Interactive Codex thread: {error}"))),
+        }
     }
-    Ok(())
+    Err(internal("another Ainb Codex session is still starting; retry shortly"))
 }
 
 async fn claim_pending_codex_thread(
     pool: &SqlitePool,
     session_id: &str,
-    cwd: &str,
     watermark: i64,
 ) -> Result<Option<String>, RpcError> {
     let payloads: Vec<String> = sqlx::query_scalar(
@@ -3471,7 +3476,7 @@ async fn claim_pending_codex_thread(
     .await
     .map_err(|error| internal(&format!("read pending Codex thread: {error}")))?;
     for payload in payloads {
-        let Some(thread_id) = codex_started_thread_for_cwd(&payload, cwd) else {
+        let Some(thread_id) = codex_started_thread_id(&payload) else {
             continue;
         };
         let claimed = sqlx::query(
@@ -3491,17 +3496,10 @@ async fn claim_pending_codex_thread(
     Ok(None)
 }
 
-fn codex_started_thread_for_cwd(payload: &str, cwd: &str) -> Option<String> {
+fn codex_started_thread_id(payload: &str) -> Option<String> {
     let payload: serde_json::Value = serde_json::from_str(payload).ok()?;
     let thread = payload.pointer("/params/thread")?;
-    let event_cwd = thread.get("cwd")?.as_str()?;
-    let event_cwd = std::fs::canonicalize(event_cwd)
-        .unwrap_or_else(|_| std::path::PathBuf::from(event_cwd))
-        .display()
-        .to_string();
-    (event_cwd == cwd)
-        .then(|| thread.get("id")?.as_str().map(str::to_owned))
-        .flatten()
+    thread.get("id")?.as_str().map(str::to_owned)
 }
 
 /// Deliver one text prompt to explicit stable recipients with bounded fanout.
@@ -12911,19 +12909,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn codex_started_thread_claim_requires_exact_cwd() {
-        let cwd = std::env::current_dir().unwrap().display().to_string();
+    fn codex_started_thread_claim_reads_thread_id() {
         let payload = serde_json::json!({
             "method": "thread/started",
-            "params": { "thread": { "id": "thread-1", "cwd": cwd } }
+            "params": { "thread": { "id": "thread-1", "cwd": "/app-server-cwd" } }
         })
         .to_string();
 
         assert_eq!(
-            codex_started_thread_for_cwd(&payload, &cwd),
+            codex_started_thread_id(&payload),
             Some("thread-1".to_string())
         );
-        assert_eq!(codex_started_thread_for_cwd(&payload, "/wrong-cwd"), None);
+        assert_eq!(codex_started_thread_id("{}"), None);
     }
     use ainb_hangar_store::Store;
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3302,9 +3302,9 @@ async fn handle_fleet_start(
     to_value(&result)
 }
 
-/// Allocate or resume an Interactive Codex thread through the one daemon-owned
-/// app-server. Interactive owns tmux and durable session metadata, so this is
-/// deliberately narrower than `fleet/start`.
+/// Reserve or resume one Interactive Codex thread through the daemon-owned
+/// app-server. A fresh terminal makes its own thread because Codex does not
+/// materialize an empty server-created thread for a second connection to resume.
 async fn handle_codex_session_ensure(
     pool: &SqlitePool,
     req: &RpcRequest,
@@ -3322,15 +3322,31 @@ async fn handle_codex_session_ensure(
         std::time::Duration::from_secs(15),
     )
     .await
-    .ok_or_else(|| internal("Ainb Codex runtime is unavailable"))?;
-    let existing: Option<Option<String>> =
-        sqlx::query_scalar("SELECT thread_id FROM interactive_codex_thread WHERE session_id = ?")
-            .bind(&params.session_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|error| internal(&format!("read Interactive Codex thread: {error}")))?;
+    {
+        Some(manager) => manager,
+        None => {
+            let detail = crate::fleet_provider::codex_manager::transport_health()
+                .await
+                .last_failure
+                .unwrap_or_else(|| "still starting".to_string());
+            return Err(internal(&format!(
+                "Ainb Codex remote control unavailable: {detail}"
+            )));
+        }
+    };
+    let cwd = std::fs::canonicalize(&params.cwd)
+        .unwrap_or_else(|_| std::path::PathBuf::from(&params.cwd))
+        .display()
+        .to_string();
+    let existing: Option<(Option<String>, i64, Option<i64>)> = sqlx::query_as(
+        "SELECT thread_id, resumable, event_watermark FROM interactive_codex_thread WHERE session_id = ?",
+    )
+    .bind(&params.session_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| internal(&format!("read Interactive Codex thread: {error}")))?;
     let thread_id = match existing {
-        Some(Some(thread_id)) => {
+        Some((Some(thread_id), resumable, _)) => {
             if let Some(requested) = params.thread_id.as_deref().filter(|id| !id.trim().is_empty())
             {
                 if requested != thread_id {
@@ -3339,71 +3355,64 @@ async fn handle_codex_session_ensure(
                     ));
                 }
             }
-            manager
-                .thread_resume(&thread_id)
-                .await
-                .map_err(|error| internal(&format!("resume Codex thread: {error}")))?;
-            thread_id
+            match manager.thread_resume(&thread_id).await {
+                Ok(_) => Some(thread_id),
+                Err(error) if resumable == 0 && error.to_string().contains("no rollout found") => {
+                    let watermark = codex_event_watermark(pool).await?;
+                    sqlx::query(
+                        "UPDATE interactive_codex_thread \
+                         SET thread_id = NULL, resumable = 0, event_watermark = ? \
+                         WHERE session_id = ?",
+                    )
+                    .bind(watermark)
+                    .bind(&params.session_id)
+                    .execute(pool)
+                    .await
+                    .map_err(|error| internal(&format!("reset empty Codex thread: {error}")))?;
+                    None
+                }
+                Err(error) => return Err(internal(&format!("resume Codex thread: {error}"))),
+            }
         }
-        Some(None) => {
-            return Err(internal(
-                "previous Interactive Codex allocation is incomplete; refusing duplicate thread",
-            ));
-        }
+        Some((None, _, watermark)) => claim_pending_codex_thread(
+            pool,
+            &params.session_id,
+            &cwd,
+            watermark.unwrap_or_default(),
+        )
+        .await?,
         None => match params.thread_id.as_deref().filter(|id| !id.trim().is_empty()) {
             Some(thread_id) => {
-                manager
-                    .thread_resume(thread_id)
-                    .await
-                    .map_err(|error| internal(&format!("resume Codex thread: {error}")))?;
+                match manager.thread_resume(thread_id).await {
+                    Ok(_) => {}
+                    Err(error) if error.to_string().contains("no rollout found") => {
+                        let watermark = codex_event_watermark(pool).await?;
+                        reserve_pending_codex_thread(pool, &params, &cwd, watermark).await?;
+                        return to_value(&CodexSessionEnsureResult {
+                            thread_id: None,
+                            endpoint: format!("unix://{}", manager.socket_path().display()),
+                        });
+                    }
+                    Err(error) => return Err(internal(&format!("resume Codex thread: {error}"))),
+                }
                 sqlx::query(
                     "INSERT INTO interactive_codex_thread \
-                     (session_id, thread_id, cwd, model, skip_permissions) VALUES (?, ?, ?, ?, ?)",
+                     (session_id, thread_id, cwd, model, skip_permissions, resumable) VALUES (?, ?, ?, ?, ?, 1)",
                 )
                 .bind(&params.session_id)
                 .bind(thread_id)
-                .bind(&params.cwd)
+                .bind(&cwd)
                 .bind(&params.model)
                 .bind(params.skip_permissions)
                 .execute(pool)
                 .await
                 .map_err(|error| internal(&format!("persist Interactive Codex thread: {error}")))?;
-                thread_id.to_string()
+                Some(thread_id.to_string())
             }
             None => {
-                let inserted = sqlx::query(
-                    "INSERT OR IGNORE INTO interactive_codex_thread \
-                     (session_id, thread_id, cwd, model, skip_permissions) VALUES (?, NULL, ?, ?, ?)",
-                )
-                .bind(&params.session_id)
-                .bind(&params.cwd)
-                .bind(&params.model)
-                .bind(params.skip_permissions)
-                .execute(pool)
-                .await
-                .map_err(|error| internal(&format!("reserve Interactive Codex thread: {error}")))?;
-                if inserted.rows_affected() == 0 {
-                    return Err(internal(
-                        "concurrent Interactive Codex allocation is in progress; retry shortly",
-                    ));
-                }
-                let thread_id = manager
-                    .thread_start_interactive(
-                        std::path::Path::new(&params.cwd),
-                        params.model.as_deref(),
-                        params.skip_permissions,
-                    )
-                    .await
-                    .map_err(|error| internal(&format!("start Codex thread: {error}")))?;
-                sqlx::query(
-                    "UPDATE interactive_codex_thread SET thread_id = ? WHERE session_id = ?",
-                )
-                .bind(&thread_id)
-                .bind(&params.session_id)
-                .execute(pool)
-                .await
-                .map_err(|error| internal(&format!("persist Interactive Codex thread: {error}")))?;
-                thread_id
+                let watermark = codex_event_watermark(pool).await?;
+                reserve_pending_codex_thread(pool, &params, &cwd, watermark).await?;
+                None
             }
         },
     };
@@ -3411,6 +3420,88 @@ async fn handle_codex_session_ensure(
         thread_id,
         endpoint: format!("unix://{}", manager.socket_path().display()),
     })
+}
+
+async fn codex_event_watermark(pool: &SqlitePool) -> Result<i64, RpcError> {
+    sqlx::query_scalar("SELECT COALESCE(MAX(ingest_order), 0) FROM fleet_provider_event")
+        .fetch_one(pool)
+        .await
+        .map_err(|error| internal(&format!("read Codex event cursor: {error}")))
+}
+
+async fn reserve_pending_codex_thread(
+    pool: &SqlitePool,
+    params: &ainb_hangar_proto::fleet::CodexSessionEnsureParams,
+    cwd: &str,
+    watermark: i64,
+) -> Result<(), RpcError> {
+    let inserted = sqlx::query(
+        "INSERT INTO interactive_codex_thread \
+         (session_id, thread_id, cwd, model, skip_permissions, event_watermark) \
+         VALUES (?, NULL, ?, ?, ?, ?)",
+    )
+    .bind(&params.session_id)
+    .bind(cwd)
+    .bind(&params.model)
+    .bind(params.skip_permissions)
+    .bind(watermark)
+    .execute(pool)
+    .await
+    .map_err(|error| internal(&format!("reserve Interactive Codex thread: {error}")))?;
+    if inserted.rows_affected() == 0 {
+        return Err(internal("reserve Interactive Codex thread affected no rows"));
+    }
+    Ok(())
+}
+
+async fn claim_pending_codex_thread(
+    pool: &SqlitePool,
+    session_id: &str,
+    cwd: &str,
+    watermark: i64,
+) -> Result<Option<String>, RpcError> {
+    let payloads: Vec<String> = sqlx::query_scalar(
+        "SELECT raw_payload FROM fleet_provider_event \
+         WHERE provider = 'codex' AND source = 'codex_app_server' \
+           AND event_type = 'thread/started' AND ingest_order > ? \
+         ORDER BY ingest_order ASC LIMIT 32",
+    )
+    .bind(watermark)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| internal(&format!("read pending Codex thread: {error}")))?;
+    for payload in payloads {
+        let Some(thread_id) = codex_started_thread_for_cwd(&payload, cwd) else {
+            continue;
+        };
+        let claimed = sqlx::query(
+            "UPDATE interactive_codex_thread SET thread_id = ? \
+             WHERE session_id = ? AND thread_id IS NULL",
+        )
+        .bind(&thread_id)
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .map_err(|error| internal(&format!("claim Interactive Codex thread: {error}")))?;
+        if claimed.rows_affected() == 1 {
+            return Ok(Some(thread_id));
+        }
+        return Ok(None);
+    }
+    Ok(None)
+}
+
+fn codex_started_thread_for_cwd(payload: &str, cwd: &str) -> Option<String> {
+    let payload: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let thread = payload.pointer("/params/thread")?;
+    let event_cwd = thread.get("cwd")?.as_str()?;
+    let event_cwd = std::fs::canonicalize(event_cwd)
+        .unwrap_or_else(|_| std::path::PathBuf::from(event_cwd))
+        .display()
+        .to_string();
+    (event_cwd == cwd)
+        .then(|| thread.get("id")?.as_str().map(str::to_owned))
+        .flatten()
 }
 
 /// Deliver one text prompt to explicit stable recipients with bounded fanout.
@@ -12818,6 +12909,22 @@ async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn codex_started_thread_claim_requires_exact_cwd() {
+        let cwd = std::env::current_dir().unwrap().display().to_string();
+        let payload = serde_json::json!({
+            "method": "thread/started",
+            "params": { "thread": { "id": "thread-1", "cwd": cwd } }
+        })
+        .to_string();
+
+        assert_eq!(
+            codex_started_thread_for_cwd(&payload, &cwd),
+            Some("thread-1".to_string())
+        );
+        assert_eq!(codex_started_thread_for_cwd(&payload, "/wrong-cwd"), None);
+    }
     use ainb_hangar_store::Store;
 
     static APPROVE_SOCKET_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3356,7 +3356,16 @@ async fn handle_codex_session_ensure(
                 }
             }
             match manager.thread_resume(&thread_id).await {
-                Ok(_) => Some(thread_id),
+                Ok(_) => {
+                    sqlx::query(
+                        "UPDATE interactive_codex_thread SET resumable = 1 WHERE session_id = ?",
+                    )
+                    .bind(&params.session_id)
+                    .execute(pool)
+                    .await
+                    .map_err(|error| internal(&format!("mark Codex thread resumable: {error}")))?;
+                    Some(thread_id)
+                }
                 Err(error) if resumable == 0 && error.to_string().contains("no rollout found") => {
                     let watermark = codex_event_watermark(pool).await?;
                     sqlx::query(
@@ -3436,11 +3445,21 @@ async fn reserve_pending_codex_thread(
     // one pending row globally, so wait for its launch to claim before taking
     // the next cursor. This private app-server endpoint has one Ainb owner.
     for _ in 0..100 {
+        // A client can die between this reservation and tmux launch. A short
+        // lease preserves the global correlation guard without wedging every
+        // later Interactive launch forever.
+        sqlx::query(
+            "DELETE FROM interactive_codex_thread \
+             WHERE thread_id IS NULL AND reserved_at < unixepoch() - 15",
+        )
+        .execute(pool)
+        .await
+        .map_err(|error| internal(&format!("expire pending Codex launch: {error}")))?;
         let watermark = codex_event_watermark(pool).await?;
         let inserted = sqlx::query(
             "INSERT INTO interactive_codex_thread \
-             (session_id, thread_id, cwd, model, skip_permissions, event_watermark) \
-             VALUES (?, NULL, ?, ?, ?, ?)",
+             (session_id, thread_id, cwd, model, skip_permissions, event_watermark, reserved_at) \
+             VALUES (?, NULL, ?, ?, ?, ?, unixepoch())",
         )
         .bind(&params.session_id)
         .bind(cwd)
@@ -3471,7 +3490,7 @@ async fn claim_pending_codex_thread(
         "SELECT raw_payload FROM fleet_provider_event \
          WHERE provider = 'codex' AND source = 'codex_app_server' \
            AND event_type = 'thread/started' AND ingest_order > ? \
-         ORDER BY ingest_order ASC LIMIT 32",
+         ORDER BY ingest_order ASC",
     )
     .bind(watermark)
     .fetch_all(pool)
@@ -3507,6 +3526,7 @@ fn codex_started_thread_id(payload: &str, cwd: &str) -> Option<String> {
         .display()
         .to_string();
     (event_cwd == cwd
+        && thread.get("source")?.as_str() == Some("vscode")
         && thread.get("threadSource")?.as_str() == Some("user")
         && thread.get("forkedFromId").is_some_and(serde_json::Value::is_null))
     .then(|| thread.get("id")?.as_str().map(str::to_owned))
@@ -12927,6 +12947,7 @@ mod tests {
             "params": { "thread": {
                 "id": "thread-1",
                 "cwd": cwd,
+                "source": "vscode",
                 "threadSource": "user",
                 "forkedFromId": null
             } }
@@ -12938,6 +12959,8 @@ mod tests {
             Some("thread-1".to_string())
         );
         assert_eq!(codex_started_thread_id(&payload, "/wrong-cwd"), None);
+        let non_tui = payload.replace("\"source\":\"vscode\"", "\"source\":\"appServer\"");
+        assert_eq!(codex_started_thread_id(&non_tui, &cwd), None);
         let fork = payload.replace("\"forkedFromId\":null", "\"forkedFromId\":\"parent\"");
         assert_eq!(codex_started_thread_id(&fork, &cwd), None);
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3383,13 +3383,15 @@ async fn handle_codex_session_ensure(
                 Err(error) => return Err(internal(&format!("resume Codex thread: {error}"))),
             }
         }
-        Some((None, _, watermark)) => claim_pending_codex_thread(
-            pool,
-            &params.session_id,
-            &cwd,
-            watermark.unwrap_or_default(),
-        )
-        .await?,
+        Some((None, _, watermark)) => {
+            claim_pending_codex_thread(
+                pool,
+                &params.session_id,
+                &cwd,
+                watermark.unwrap_or_default(),
+            )
+            .await?
+        }
         None => match params.thread_id.as_deref().filter(|id| !id.trim().is_empty()) {
             Some(thread_id) => {
                 match manager.thread_resume(thread_id).await {
@@ -3470,14 +3472,26 @@ async fn reserve_pending_codex_thread(
         .await;
         match inserted {
             Ok(result) if result.rows_affected() == 1 => return Ok(()),
-            Ok(_) => return Err(internal("reserve Interactive Codex thread affected no rows")),
-            Err(sqlx::Error::Database(error)) if error.message().contains("UNIQUE constraint failed") => {
+            Ok(_) => {
+                return Err(internal(
+                    "reserve Interactive Codex thread affected no rows",
+                ));
+            }
+            Err(sqlx::Error::Database(error))
+                if error.message().contains("UNIQUE constraint failed") =>
+            {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
-            Err(error) => return Err(internal(&format!("reserve Interactive Codex thread: {error}"))),
+            Err(error) => {
+                return Err(internal(&format!(
+                    "reserve Interactive Codex thread: {error}"
+                )));
+            }
         }
     }
-    Err(internal("another Ainb Codex session is still starting; retry shortly"))
+    Err(internal(
+        "another Ainb Codex session is still starting; retry shortly",
+    ))
 }
 
 async fn claim_pending_codex_thread(

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -1342,8 +1342,9 @@ pub struct CodexSessionEnsureParams {
 /// Result for `codex/session_ensure`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodexSessionEnsureResult {
-    /// Exact Codex thread identity.
-    pub thread_id: String,
+    /// Exact Codex thread identity, absent until the fresh remote TUI creates it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
     /// Canonical Unix endpoint consumed by the Interactive tmux client.
     pub endpoint: String,
 }

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0088_interactive_codex_thread_global_launch.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0088_interactive_codex_thread_global_launch.sql
@@ -3,6 +3,9 @@
 -- There is no caller correlation token. Serialize fresh launches globally on
 -- Ainb's private endpoint, then claim the first event after its cursor.
 DROP INDEX IF EXISTS interactive_codex_thread_one_pending_cwd;
+-- Old cwd-based reservations cannot be matched by the shared app-server.
+-- Discard only those threadless rows before enforcing the global gate.
+DELETE FROM interactive_codex_thread WHERE thread_id IS NULL;
 CREATE UNIQUE INDEX interactive_codex_thread_one_pending_launch
     ON interactive_codex_thread(1)
     WHERE thread_id IS NULL;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0088_interactive_codex_thread_global_launch.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0088_interactive_codex_thread_global_launch.sql
@@ -1,0 +1,8 @@
+-- A remote client creates its thread inside the shared app-server process,
+-- so `thread/started.cwd` is that process directory, not the session worktree.
+-- There is no caller correlation token. Serialize fresh launches globally on
+-- Ainb's private endpoint, then claim the first event after its cursor.
+DROP INDEX IF EXISTS interactive_codex_thread_one_pending_cwd;
+CREATE UNIQUE INDEX interactive_codex_thread_one_pending_launch
+    ON interactive_codex_thread(1)
+    WHERE thread_id IS NULL;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0089_interactive_codex_thread_resumable.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0089_interactive_codex_thread_resumable.sql
@@ -1,0 +1,3 @@
+-- A thread becomes resumable only after its first turn persisted a rollout.
+ALTER TABLE interactive_codex_thread
+    ADD COLUMN resumable INTEGER NOT NULL DEFAULT 0;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0090_interactive_codex_thread_event_watermark.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0090_interactive_codex_thread_event_watermark.sql
@@ -1,0 +1,3 @@
+-- Cursor prevents a pending launch claiming a thread that predated it.
+ALTER TABLE interactive_codex_thread
+    ADD COLUMN event_watermark INTEGER;

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0091_interactive_codex_thread_reservation_lease.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0091_interactive_codex_thread_reservation_lease.sql
@@ -1,0 +1,3 @@
+-- A crashed client cannot hold the global fresh-launch reservation forever.
+ALTER TABLE interactive_codex_thread
+    ADD COLUMN reserved_at INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
Fixes normal Interactive Codex session creation on Codex 0.147.

Root causes:
- Unix `app-server proxy --sock` returned no initialize response.
- Fresh app-server thread IDs have no rollout and cannot be resumed.
- Missing migrations for resumability and event cursor blocked upgraded homes.

Changes:
- Connect daemon manager via Unix WebSocket.
- Let fresh remote TUI create its own thread, then bind exact ID.
- Preserve cwd, model, and permissions on remote launch.
- Add migration and recovery guards for stale launches.
- Show concrete recovery guidance on launch failure.

Validated:
- Focused daemon/core tests.
- Built `ainb`.
- Real isolated `ainb run --tool codex`: live Codex pane, exact persisted thread ID, paired remote transport.
- Forced stale reservation then verified next launch succeeds.