### PR TITLE
test(fleet): pin the channel-modal path, and trace the key seam

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "ainb"
-version = "1.20.0"
+version = "1.20.4"
 dependencies = [
  "ainb-cli",
  "ainb-fleet-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-hangar-daemon"
-version = "1.20.0"
+version = "1.20.4"
 dependencies = [
  "agent-client-protocol",
  "ainb-acp",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-cts-v2"
-version = "1.20.0"
+version = "1.20.4"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-secrets",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-hangar"
-version = "1.20.0"
+version = "1.20.4"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-notifyd"
-version = "1.20.0"
+version = "1.20.4"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-web"
-version = "1.20.0"
+version = "1.20.4"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -6279,6 +6279,18 @@ impl EventHandler {
             }
             AppEvent::FleetPanelCanonicalKey(key) => {
                 Self::reduce_fleet_event(state, FleetEvent::Key(key));
+                // Every modal on this panel opens by routing a canonical key
+                // into the shared reducer, so "the key did nothing" and "the
+                // reducer never saw it" look identical from the outside. One
+                // line at the seam tells them apart, which black-box probing
+                // could not: run with `RUST_LOG=ainb=debug` and read the JSONL
+                // under `~/.agents-in-a-box/logs/`.
+                tracing::debug!(
+                    target: "ainb::app::events",
+                    ?key,
+                    modal_open = state.fleet_panel_state.canonical_modal_open(),
+                    "fleet canonical key reduced"
+                );
             }
             AppEvent::FleetPanelAnswerCardClick {
                 column,
@@ -8992,7 +9004,10 @@ mod panel_back_tests {
         // the plugin's `FleetKey::Char('N')` arm (fleet.rs:1351).
         let n = route(&mut state, KeyCode::Char('N'));
         assert!(
-            matches!(n, Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('N')))),
+            matches!(
+                n,
+                Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('N')))
+            ),
             "`N` must route to FleetPanelCanonicalKey(Char('N')); got {n:?}"
         );
         EventHandler::process_event(n.unwrap(), &mut state);

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -8967,6 +8967,76 @@ mod panel_back_tests {
         ));
     }
 
+    /// #667: `N` on the Fleet panel is advertised in the help bar
+    /// (`N channel`) but was reported dead in a real tmux run — no form, no
+    /// feedback. Every layer looked correct on inspection (router arm,
+    /// shared reducer, renderer match), so this pins the mechanism at the
+    /// host boundary: routing THROUGH `process_event` into a real render
+    /// pass, not just checking which `AppEvent` the router returns.
+    ///
+    /// It also pins down the second reported symptom (subsequent keys, and
+    /// "chat needs two Escapes") as the SAME modal-capture behaviour, not a
+    /// separate bug: once `N` opens the channel-create form, the panel is
+    /// modal and every key — including the lens digits — routes into the
+    /// canonical reducer until a single Esc closes it.
+    #[test]
+    fn fleet_panel_shift_n_opens_and_renders_channel_create_modal() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        let mut state = AppState::default();
+        EventHandler::process_event(AppEvent::GoToFleetPanel, &mut state);
+        let route =
+            |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
+
+        // Router arm: `N` must resolve to the canonical forward, matching
+        // the plugin's `FleetKey::Char('N')` arm (fleet.rs:1351).
+        let n = route(&mut state, KeyCode::Char('N'));
+        assert!(
+            matches!(n, Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('N')))),
+            "`N` must route to FleetPanelCanonicalKey(Char('N')); got {n:?}"
+        );
+        EventHandler::process_event(n.unwrap(), &mut state);
+        assert!(
+            state.fleet_panel_state.canonical_modal_open(),
+            "`N` opened nothing at the host layer"
+        );
+
+        // Render pass: the modal must actually paint, not just flip a mode
+        // flag no renderer reaches.
+        let backend = ratatui::backend::TestBackend::new(100, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                crate::components::fleet_panel::render(f, f.area(), &mut state.fleet_panel_state)
+            })
+            .unwrap();
+        let rendered: String =
+            terminal.backend().buffer().content().iter().map(|c| c.symbol()).collect();
+        assert!(
+            rendered.contains("New channel"),
+            "channel-create modal did not render; got:\n{rendered}"
+        );
+
+        // Modal capture: while it is open, a lens digit must NOT fall
+        // through to FleetPanelSetFilter — it belongs to the canonical
+        // reducer, same as every other open Fleet mode.
+        let five = route(&mut state, KeyCode::Char('5'));
+        assert!(
+            matches!(five, Some(AppEvent::FleetPanelCanonicalKey(_))),
+            "with the channel-create modal open, '5' must route into the \
+             canonical reducer, not FleetPanelSetFilter; got {five:?}"
+        );
+
+        // One Esc closes it and routing returns to normal — pins that this
+        // form needs exactly one Esc, unlike the chat surface's reported two.
+        EventHandler::process_event(AppEvent::FleetPanelCanonicalKey(FleetKey::Esc), &mut state);
+        assert!(!state.fleet_panel_state.canonical_modal_open());
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('5')),
+            Some(AppEvent::FleetPanelSetFilter(FleetFilter::All))
+        ));
+    }
+
     #[test]
     fn fleet_embedded_attach_uses_exact_target_without_fullscreen_async_action() {
         if std::process::Command::new("tmux").arg("-V").status().is_err() {

--- a/explainers/chat-bus-proven.html
+++ b/explainers/chat-bus-proven.html
@@ -550,11 +550,24 @@
       where it can be driven deterministically, which is not the same claim as a message actually
       reaching a live process.</p>
 
-    <p><b>No real ACP adapter has ever run in CI or in any recording on this page.</b> Every ACP run,
+    <p><b>No real ACP adapter runs in CI or in any recording on this page.</b> Every ACP run here,
       part 1's j2 through j4 and part 2's j6 and j7, uses the <code>fake_acp_adapter</code> fixture.
-      The real-adapter tests exist and skip until an adapter is installed; the adapters were measured
-      by hand against the real thing when their protocol behaviour was pinned, but that measurement
-      is not itself in this page's proof.</p>
+      The real-adapter tests exist and skip until an adapter is installed.</p>
+
+    <p><b>Both real adapters have now been run by hand, once, and the result was worth having.</b>
+      <code>@zed-industries/claude-agent-acp</code> and <code>@zed-industries/codex-acp</code> were
+      installed and driven through a live daemon on 2026-08-12. Neither produced an agent reply on
+      that host: <code>codex-acp</code> could not reach its models API from the sandbox, and
+      <code>claude-agent-acp</code> was refused before it was ever prompted, with
+      <span class="assert">refusing to prompt a session whose permission mode is unproven &middot;
+      permission mode "default" was not established (observed Some("bypassPermissions"))</span>.</p>
+
+    <p>That refusal is invariant I13 firing against reality rather than a fixture, and it is the
+      exact hazard part 1's spike wrote down: an ambient <code>bypassPermissions</code> silently
+      disabling the whole permission surface. The daemon saw the adapter claim a mode it had not
+      pinned and declined to prompt it. The turn was not lost either, the pool requeued it under the
+      I6 rule, and both sessions converged with no open turn. So the SAFETY path is now proven
+      against real adapters; the HAPPY path still is not.</p>
 
     <p><b>The guardrail's operator-named-sessions state is not wired to a live turn yet.</b>
       <code>fleet/copilot_gate</code> currently builds an empty <code>Guardrail</code> for every


### PR DESCRIPTION
Fallout from hand-driving the TUI. **No product bug was found**: the defect I reported in #667 was mine, from reading a truncated pane capture. #667 is closed as invalid with the correction. What is here is the instrumentation and the test that settled it, both worth keeping.

## What happened

I drove the real TUI with `tmux send-keys`, captured the pane with `head -12` on a **50-line** pane, and reported that `N` opened nothing. The modal renders at lines 23-25:

```
┌─ New channel ──────────────────┐
│─Channels (0)───────────────────┘
│─> + new channel────────────────
```

It had been opening correctly the whole time. A second "finding" (the panel swallowing keys until a second `Esc`) was the same error compounded: once `N` opened a modal I could not see, `canonical_modal_open()` was true so later keys routed into it, and one `Esc` closed it. That is correct modal behaviour, identical to Prompt, Start, Broadcast and Answer.

An independent review could not reproduce either symptom and said so rather than shipping a speculative fix, including a raw-key trace proving `Char('N')` arrives correctly. That was the right answer.

## What this PR keeps

**A host-level regression test.** Drives `GoToFleetPanel` then `N` through the real router, does a real `ratatui::Terminal` draw of `components::fleet_panel::render`, and asserts the buffer contains "New channel" and that one `Esc` restores filter routing. A plugin-only test cannot reach the render pass, which is exactly why the existing plugin tests passed while three people were uncertain whether the feature worked.

**One debug line at the reducer seam.** Every modal on this panel opens by routing a canonical key into the shared reducer, so "the key did nothing" and "the reducer never saw it" are indistinguishable from outside. With `RUST_LOG=ainb=debug` this prints:

```
"fleet canonical key reduced", key: Char('N'), modal_open: true
```

`modal_open: true` against an apparently unchanged pane is what redirected the search from routing to rendering, and from there to my own truncation.

**A lockfile refresh.** The workspace is at 1.20.4; the committed lockfile still carried 1.20.0 for the in-tree crates, so the first build on a clean checkout rewrote it.

**An explainer correction, and this one matters.** The page claimed no real ACP adapter had ever run. Both are now installed (`@zed-industries/claude-agent-acp`, `@zed-industries/codex-acp`) and were driven through a live daemon for the first time. Neither produced a reply on that host, but `claude-agent-acp` was refused before it was ever prompted:

```
refusing to prompt a session whose permission mode is unproven
permission mode "default" was not established (observed Some("bypassPermissions"))
```

That is invariant I13 firing against reality rather than a fixture, on the exact hazard part 1's spike documented. The turn was not lost (requeued under I6) and both sessions converged with no open turn. **The safety path is now proven against real adapters; the happy path is not** — `codex-acp` could not reach its models API from the sandbox.

## Verification

`cargo test -p ainb --lib fleet_panel`: 23 passed, 0 failed, including the new test.