### PR TITLE
feat(daemons): show hangar runtime identity

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1020,6 +1020,7 @@ pub struct DaemonsFetchResult {
     pub approve_reason: String,
     pub hangar_running: bool,
     pub hangar_reason: String,
+    pub(crate) hangar_runtime: crate::cli::hangar::DaemonRuntimeStatus,
 }
 
 /// Live, lazily-refreshed snapshot for the Daemons overlay. Present only while
@@ -1036,6 +1037,7 @@ pub struct DaemonsOverlayState {
     pub approve_reason: String,
     pub hangar_running: bool,
     pub hangar_reason: String,
+    pub(crate) hangar_runtime: crate::cli::hangar::DaemonRuntimeStatus,
     pub loading: bool,
     pub last_refreshed: Option<std::time::Instant>,
     /// Receiver for the in-flight fetch (None = no fetch pending).
@@ -1058,6 +1060,7 @@ pub(crate) fn daemons_sync_probe() -> (
     Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
     (bool, String),
     (bool, String),
+    crate::cli::hangar::DaemonRuntimeStatus,
 ) {
     let mcp_alive = crate::mcp_pool::client::daemon_alive();
     let headroom_consumers = crate::interactive::SessionStore::load()
@@ -1084,7 +1087,15 @@ pub(crate) fn daemons_sync_probe() -> (
         .map_or((false, "not running".to_string()), |_| {
             (true, "serving".to_string())
         });
-    (mcp_alive, headroom_consumers, notifyd, approve, hangar)
+    let hangar_runtime = crate::cli::hangar::daemon_runtime_status();
+    (
+        mcp_alive,
+        headroom_consumers,
+        notifyd,
+        approve,
+        hangar,
+        hangar_runtime,
+    )
 }
 
 // ============================================================================
@@ -5010,6 +5021,7 @@ impl AppState {
             notifyd_restart_status: None,
             hangar_running: false,
             hangar_reason: "probing…".to_string(),
+            hangar_runtime: crate::cli::hangar::DaemonRuntimeStatus::default(),
             hangar_start_rx: None,
             hangar_start_status: None,
         });
@@ -5036,13 +5048,14 @@ impl AppState {
         tokio::spawn(async move {
             // Blocking I/O (control socket + file read + `ps` scan) on the
             // blocking pool.
-            let (mcp_alive, headroom_consumers, notifyd, approve, hangar) =
+            let (mcp_alive, headroom_consumers, notifyd, approve, hangar, hangar_runtime) =
                 tokio::task::spawn_blocking(daemons_sync_probe).await.unwrap_or((
                     false,
                     Vec::new(),
                     Vec::new(),
                     (false, "probe failed".to_string()),
                     (false, "probe failed".to_string()),
+                    crate::cli::hangar::DaemonRuntimeStatus::default(),
                 ));
             // Async HTTP probe of the Headroom /health + /stats endpoints.
             let headroom = crate::headroom::status().await;
@@ -5055,6 +5068,7 @@ impl AppState {
                 approve_reason: approve.1,
                 hangar_running: hangar.0,
                 hangar_reason: hangar.1,
+                hangar_runtime,
             };
             let _ = tx.send(result);
         });
@@ -5139,6 +5153,7 @@ impl AppState {
                 o.approve_reason = result.approve_reason;
                 o.hangar_running = result.hangar_running;
                 o.hangar_reason = result.hangar_reason;
+                o.hangar_runtime = result.hangar_runtime;
                 o.last_refreshed = Some(std::time::Instant::now());
             }
         }

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -7856,6 +7856,12 @@ fn daemon_version_path() -> Result<std::path::PathBuf> {
     Ok(home.join("hangar").join("daemon.version"))
 }
 
+/// Path to the exact executable that successfully claimed this Hangar home.
+fn daemon_binary_path() -> Result<std::path::PathBuf> {
+    let home = ainb_hangar_daemon::hangar_dir().context("resolve hangar home")?;
+    Ok(home.join("hangar").join("daemon.binary"))
+}
+
 /// Compare the recorded running-daemon version to `mine`, returning
 /// `Some(running)` when they disagree (the skew to warn about), else `None`.
 ///
@@ -7923,6 +7929,43 @@ fn running_daemon_version(pid: Option<u32>) -> Option<String> {
                 .and_then(ainb_hangar_daemon::single_instance::process_argv)
                 .and_then(|args| homebrew_daemon_version(&args))
         })
+}
+
+/// Runtime identity of the daemon that owns this Hangar home.
+///
+/// The Daemons overlay uses this exact probe rather than inferring ownership
+/// from a reachable socket. That keeps its displayed pid, launch path, version,
+/// and upgrade warning consistent with `ainb hangar daemon status`.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DaemonRuntimeStatus {
+    pub pid: Option<u32>,
+    pub command: Option<String>,
+    pub version: Option<String>,
+    /// A released daemon older than this binary is still serving this home.
+    pub old: bool,
+}
+
+/// Return the authoritative recorded owner and its launch identity.
+pub(crate) fn daemon_runtime_status() -> DaemonRuntimeStatus {
+    let pid = running_daemon_pid().ok().flatten();
+    let command = daemon_binary_path()
+        .ok()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .map(|path| path.trim().to_string())
+        .filter(|path| !path.is_empty())
+        .or_else(|| {
+            pid.and_then(|pid| i32::try_from(pid).ok())
+                .and_then(ainb_hangar_daemon::single_instance::process_binary)
+        });
+    let version = running_daemon_version(pid);
+    let old =
+        pid.is_some() && daemon_upgrade_required(version.as_deref(), env!("CARGO_PKG_VERSION"));
+    DaemonRuntimeStatus {
+        pid,
+        command,
+        version,
+        old,
+    }
 }
 
 /// Read the recorded daemon pid, or `None` if the file is absent/empty/garbage.
@@ -8753,6 +8796,9 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
         if let Ok(vpath) = daemon_version_path() {
             std::fs::write(&vpath, format!("{}\n", env!("CARGO_PKG_VERSION"))).ok();
         }
+        if let Ok(bpath) = daemon_binary_path() {
+            std::fs::write(&bpath, format!("{}\n", bin.display())).ok();
+        }
     }
 
     if announce {
@@ -8999,12 +9045,15 @@ fn stop_daemon(announce: bool) -> Result<()> {
     Ok(())
 }
 
-/// Remove the version record only after ownership is known to be gone.
+/// Remove launch identity records only after ownership is known to be gone.
 ///
 /// A failed upgrade handoff leaves the incumbent alive, so retaining its
 /// version is what lets the next `ensure_hangar_daemon` retry that handoff.
 fn clear_daemon_version_record() {
     if let Ok(path) = daemon_version_path() {
+        std::fs::remove_file(path).ok();
+    }
+    if let Ok(path) = daemon_binary_path() {
         std::fs::remove_file(path).ok();
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -42,7 +42,9 @@ fn centered(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 }
 
 pub fn render(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
-    let popup = centered(70, 55, area);
+    // Hangar has a second identity line. Keep it visible on a standard 80x24
+    // terminal instead of letting the fixed card rows squeeze it away.
+    let popup = centered(70, 70, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()
@@ -93,18 +95,15 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
         return;
     }
 
-    // Rows: MCP, Headroom, consumers, Hangar, then notifyd.
+    // Rows: MCP, Headroom, consumers, Hangar, then notifyd. No spacers: this
+    // must fit both the Hangar identity line and notifyd on an 80x24 terminal.
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(2), // MCP row
-            Constraint::Length(1), // spacer
-            Constraint::Length(2), // Headroom row
-            Constraint::Length(1), // spacer
-            Constraint::Length(2), // Headroom consumers
-            Constraint::Length(1), // spacer
-            Constraint::Length(2), // Hangar row
-            Constraint::Length(1), // spacer
+            Constraint::Length(1), // MCP row
+            Constraint::Length(1), // Headroom row
+            Constraint::Length(1), // Headroom consumers
+            Constraint::Length(2), // Hangar status + owner path
             Constraint::Min(3),    // notifyd section
         ])
         .split(area);
@@ -157,7 +156,7 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
         ));
     }
     let headroom_line = Line::from(headroom_spans);
-    frame.render_widget(Paragraph::new(headroom_line), rows[2]);
+    frame.render_widget(Paragraph::new(headroom_line), rows[1]);
 
     // ── Headroom consumers ────────────────────────────────────────────────────
     let consumers_text = if state.headroom_consumers.is_empty() {
@@ -174,7 +173,7 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
             consumers_text,
             Style::default().fg(MUTED_GRAY),
         ))),
-        rows[4],
+        rows[2],
     );
 
     // ── notifyd processes ───────────────────────────────────────────────────────
@@ -189,6 +188,24 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
             Style::default().fg(MUTED_GRAY),
         ),
     ];
+    if let Some(pid) = state.hangar_runtime.pid {
+        hangar.push(Span::styled(
+            format!("   pid {pid}"),
+            Style::default().fg(SOFT_WHITE),
+        ));
+    }
+    if let Some(version) = &state.hangar_runtime.version {
+        hangar.push(Span::styled(
+            format!("   v{version}"),
+            Style::default().fg(MUTED_GRAY),
+        ));
+    }
+    if state.hangar_runtime.old {
+        hangar.push(Span::styled(
+            "   ⚠ old",
+            Style::default().fg(CLAY).add_modifier(Modifier::BOLD),
+        ));
+    }
     if !state.hangar_running {
         hangar.push(Span::styled(
             "   S start",
@@ -201,9 +218,16 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
             Style::default().fg(MUTED_GRAY),
         ));
     }
-    frame.render_widget(Paragraph::new(Line::from(hangar)), rows[6]);
+    let mut hangar_lines = vec![Line::from(hangar)];
+    if let Some(command) = &state.hangar_runtime.command {
+        hangar_lines.push(Line::from(vec![
+            Span::styled("    owner ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(command.clone(), Style::default().fg(MUTED_GRAY)),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(hangar_lines), rows[3]);
 
-    render_notifyd_section(frame, rows[8], state);
+    render_notifyd_section(frame, rows[4], state);
 }
 
 /// Render every running `notifyd` process, one line each, with its
@@ -405,6 +429,7 @@ mod tests {
             notifyd_restart_status: None,
             hangar_running: false,
             hangar_reason: "not running".to_string(),
+            hangar_runtime: crate::cli::hangar::DaemonRuntimeStatus::default(),
             hangar_start_rx: None,
             hangar_start_status: None,
         }
@@ -453,6 +478,54 @@ mod tests {
     }
 
     #[test]
+    fn daemons_overlay_renders_hangar_owner_version_and_old_marker() {
+        let mut state = make_state(false, 8787, None, None);
+        state.hangar_running = true;
+        state.hangar_reason = "serving".to_string();
+        state.hangar_runtime = crate::cli::hangar::DaemonRuntimeStatus {
+            pid: Some(51851),
+            command: Some("/Users/stevie/d/git/ainb/ainb-tui/target/debug/ainb".to_string()),
+            version: Some("1.20.0".to_string()),
+            old: true,
+        };
+        let backend = TestBackend::new(180, 36);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, f.area(), &state)).unwrap();
+        let text = buffer_text(&term);
+
+        assert!(
+            text.contains("Hangar daemon"),
+            "Hangar row missing:\n{text}"
+        );
+        assert!(text.contains("pid 51851"), "owner pid missing:\n{text}");
+        assert!(text.contains("v1.20.0"), "daemon version missing:\n{text}");
+        assert!(text.contains("⚠ old"), "old marker missing:\n{text}");
+        assert!(
+            text.contains("target/debug/ainb"),
+            "owner path missing:\n{text}"
+        );
+    }
+
+    #[test]
+    fn daemons_overlay_keeps_hangar_owner_on_standard_terminal() {
+        let mut state = make_state(false, 8787, None, None);
+        state.hangar_running = true;
+        state.hangar_runtime = crate::cli::hangar::DaemonRuntimeStatus {
+            command: Some("/Users/stevie/d/git/ainb/ainb-tui/target/debug/ainb".to_string()),
+            ..Default::default()
+        };
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, f.area(), &state)).unwrap();
+        let text = buffer_text(&term);
+
+        assert!(
+            text.contains("owner /Users"),
+            "Hangar owner row missing:\n{text}"
+        );
+    }
+
+    #[test]
     fn daemons_overlay_renders_loading_state() {
         let state = DaemonsOverlayState {
             mcp_alive: false,
@@ -473,6 +546,7 @@ mod tests {
             notifyd_restart_status: None,
             hangar_running: false,
             hangar_reason: "not running".to_string(),
+            hangar_runtime: crate::cli::hangar::DaemonRuntimeStatus::default(),
             hangar_start_rx: None,
             hangar_start_status: None,
         };

--- a/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
@@ -160,6 +160,9 @@ fn daemon_start_status_stop_round_trip() {
         wait_until(Duration::from_secs(10), || pid_alive(pid)),
         "the started daemon pid {pid} must be alive"
     );
+    let binary = std::fs::read_to_string(home.join("hangar").join("daemon.binary"))
+        .expect("daemon start recorded its binary path");
+    assert_eq!(binary.trim(), daemon.display().to_string());
 
     // The socket binds shortly after boot; status reports running.
     let socket = home.join("hangar.sock");

--- a/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/single_instance.rs
@@ -184,16 +184,11 @@ fn our_command_line() -> Option<String> {
 /// timeout degrades to the `None` branch, which respects the holder.
 const PS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
-/// The full argv of `pid` as one line, or `None` when `ps` cannot answer in
-/// time.
-///
-/// Exported so the CLI can apply the same identity rule to the same lock file —
-/// the two halves disagreeing about who owns a home is how a recycled pid ends
-/// up being reported as a running daemon, and `SIGTERM`ed by `stop`.
-#[must_use]
-pub fn process_argv(pid: i32) -> Option<String> {
+/// Read one `ps -o` field for `pid`, with a bounded wait.
+fn process_ps_field(pid: i32, field: &str) -> Option<String> {
+    let field = format!("{field}=");
     let mut child = std::process::Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "args="])
+        .args(["-p", &pid.to_string(), "-o", &field])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -223,6 +218,25 @@ pub fn process_argv(pid: i32) -> Option<String> {
     std::io::Read::read_to_string(&mut stdout, &mut args).ok()?;
     let args = args.trim();
     (!args.is_empty()).then(|| args.to_string())
+}
+
+/// The full argv of `pid` as one line, or `None` when `ps` cannot answer in
+/// time.
+///
+/// Exported so the CLI can apply the same identity rule to the same lock file —
+/// the two halves disagreeing about who owns a home is how a recycled pid ends
+/// up being reported as a running daemon, and `SIGTERM`ed by `stop`.
+#[must_use]
+pub fn process_argv(pid: i32) -> Option<String> {
+    process_ps_field(pid, "args")
+}
+
+/// Executable path of `pid`, without its command-line arguments.
+///
+/// This is the stable, compact identity rendered in the Daemons overlay.
+#[must_use]
+pub fn process_binary(pid: i32) -> Option<String> {
+    process_ps_field(pid, "comm")
 }
 
 /// How often the watchdog re-checks that this daemon still owns its home.
@@ -340,6 +354,13 @@ pub fn is_hangar_daemon_args(args: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn process_binary_reports_current_executable_path() {
+        let pid = i32::try_from(std::process::id()).unwrap();
+        let path = process_binary(pid).expect("ps should report this test binary");
+        assert!(std::path::Path::new(&path).is_absolute(), "got {path}");
+    }
 
     #[test]
     fn sidecar_and_self_exec_argv_are_recognised() {


### PR DESCRIPTION
## Summary
- record the exact executable after Hangar daemon ownership is established
- show Hangar PID, version, owner path, and stale marker in Daemons
- retain this information across refreshes and prove it in the lifecycle and compact render tests

## Validation
- `cargo test -p ainb --lib daemons_overlay::tests::daemons_overlay_keeps_hangar_owner_on_standard_terminal -- --exact --nocapture`
- `cargo test -p ainb --test hangar_daemon_lifecycle_cli daemon_start_status_stop_round_trip -- --exact --nocapture`
- `cargo build -p ainb --bin ainb`
- live 80x24 TUI Daemons overlay proof