### PR TITLE
fix: recover remote Codex sessions

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "ainb"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "ainb-cli",
  "ainb-fleet-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-hangar-daemon"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "agent-client-protocol",
  "ainb-acp",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-cts-v2"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-secrets",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-hangar"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-notifyd"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-web"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8814,6 +8814,8 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
 /// How long `stop` waits for the signalled daemon to actually exit before
 /// giving up on confirming it.
 const DAEMON_STOP_GRACE: std::time::Duration = std::time::Duration::from_secs(3);
+/// Last-resort bound after a verified daemon ignores graceful shutdown.
+const DAEMON_STOP_KILL_GRACE: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Block until `pid` is gone or `grace` elapses; `true` iff it exited.
 ///
@@ -8844,7 +8846,7 @@ fn wait_for_pid_exit(pid: u32, grace: std::time::Duration) -> bool {
 ///
 /// When the process did NOT die, the heartbeat is left alone (it is still the
 /// truth) and the reason records the unconfirmed kill.
-fn record_daemon_stop_breadcrumb(pid: u32, died: bool) {
+fn record_daemon_stop_breadcrumb(pid: u32, died: bool, signal: &str) {
     let Ok(home) = ainb_hangar_daemon::hangar_dir() else {
         return;
     };
@@ -8852,7 +8854,7 @@ fn record_daemon_stop_breadcrumb(pid: u32, died: bool) {
         ainb_hangar_daemon::observability::record_external_exit(
             &home,
             pid,
-            "stopped by `ainb hangar daemon stop` (SIGTERM, exit confirmed)",
+            &format!("stopped by `ainb hangar daemon stop` ({signal}, exit confirmed)"),
         );
     } else {
         tracing::warn!(pid, "daemon survived SIGTERM; leaving heartbeat in place");
@@ -8992,8 +8994,18 @@ fn stop_daemon(announce: bool) -> Result<()> {
             let pid = owned.0;
             kill(Pid::from_raw(pid as i32), Signal::SIGTERM)
                 .with_context(|| format!("send SIGTERM to pid {pid}"))?;
-            let died = wait_for_pid_exit(pid, DAEMON_STOP_GRACE);
-            record_daemon_stop_breadcrumb(pid, died);
+            let mut died = wait_for_pid_exit(pid, DAEMON_STOP_GRACE);
+            let mut signal = "SIGTERM";
+            if !died {
+                // `OwnedPid` proves this is OUR daemon holding OUR socket. A
+                // wedged signal handler must not turn repeated starts into an
+                // orphaned-daemon pile, so escalation remains exact-pid only.
+                kill(Pid::from_raw(pid as i32), Signal::SIGKILL)
+                    .with_context(|| format!("send SIGKILL to unresponsive pid {pid}"))?;
+                died = wait_for_pid_exit(pid, DAEMON_STOP_KILL_GRACE);
+                signal = "SIGKILL after SIGTERM grace";
+            }
+            record_daemon_stop_breadcrumb(pid, died, signal);
             if died {
                 std::fs::remove_file(&pid_path).ok();
                 clear_daemon_version_record();

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -513,6 +513,8 @@ fn remote_codex_command(
 ) -> String {
     let mut parts = vec![
         "codex".to_string(),
+        "--disable".to_string(),
+        "apps".to_string(),
         "--remote".to_string(),
         remote.endpoint.clone(),
         "-C".to_string(),
@@ -791,7 +793,7 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
+            "codex --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
         );
         assert!(!command.contains("--last"));
     }
@@ -809,7 +811,7 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
+            "codex --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -513,8 +513,6 @@ fn remote_codex_command(
 ) -> String {
     let mut parts = vec![
         "codex".to_string(),
-        "--disable".to_string(),
-        "apps".to_string(),
         "--remote".to_string(),
         remote.endpoint.clone(),
         "-C".to_string(),
@@ -793,7 +791,7 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
+            "codex --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
         );
         assert!(!command.contains("--last"));
     }
@@ -811,7 +809,7 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
+            "codex --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1909,8 +1909,6 @@ impl InteractiveSessionManager {
             }
             let mut command = vec![
                 provider.command().to_string(),
-                "--disable".to_string(),
-                "apps".to_string(),
                 "--remote".to_string(),
                 remote.endpoint.clone(),
                 "-C".to_string(),

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -181,7 +181,7 @@ pub(crate) async fn claim_codex_remote_thread(
             );
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
+    }
 }
 
 pub(crate) fn persist_codex_thread_id(session_id: Uuid, thread_id: String) -> anyhow::Result<()> {

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -181,7 +181,7 @@ pub(crate) async fn claim_codex_remote_thread(
             );
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+        }
 }
 
 pub(crate) fn persist_codex_thread_id(session_id: Uuid, thread_id: String) -> anyhow::Result<()> {

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -144,12 +144,29 @@ pub(crate) async fn ensure_codex_remote_thread(
         })
         .await
         .map_err(|error| {
-            anyhow::anyhow!(
-                "Codex remote session unavailable. Verify Codex is signed in and retry. \
-                 If it persists, restart Ainb with `ainb hangar daemon stop` then \
-                 `ainb hangar daemon start`. Details: {error}"
-            )
+            let message = format_codex_remote_control_failure(&error.to_string());
+            warn!(error = %error, "{message}");
+            anyhow::Error::msg(error.to_string()).context(message)
         })
+}
+
+/// Short actionable TUI message for a shared Codex bridge failure.
+///
+/// The detailed transport error remains in daemon and client logs. Showing it in
+/// the three-line notification hid the user action behind nested RPC context.
+fn format_codex_remote_control_failure(cause: &str) -> &'static str {
+    if cause.contains("WebSocket handshake")
+        || cause.contains("Handshake not finished")
+        || cause.contains("invalid token")
+    {
+        "Codex bridge conflict. Restart Ainb, then retry."
+    } else if cause.contains("timed out") || cause.contains("still starting") {
+        "Codex bridge starting. Retry session in 5 seconds."
+    } else if cause.contains("not found") || cause.contains("cannot generate app-server schema") {
+        "Codex unavailable. Update Codex, then retry."
+    } else {
+        "Codex remote control unavailable. Check Hangar logs, then retry."
+    }
 }
 
 /// Wait briefly for the freshly started remote terminal to publish its exact
@@ -2204,6 +2221,26 @@ fn wire_rtk_project_hook_with_cmd(worktree: &std::path::Path, cmd: &str) -> anyh
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shared_remote_codex_failures_show_a_short_next_action() {
+        assert_eq!(
+            format_codex_remote_control_failure("Codex app-server WebSocket handshake failed: invalid token"),
+            "Codex bridge conflict. Restart Ainb, then retry."
+        );
+        assert_eq!(
+            format_codex_remote_control_failure("Codex manager command timed out"),
+            "Codex bridge starting. Retry session in 5 seconds."
+        );
+        assert_eq!(
+            format_codex_remote_control_failure("installed Codex cannot generate app-server schema"),
+            "Codex unavailable. Update Codex, then retry."
+        );
+        assert_eq!(
+            format_codex_remote_control_failure("daemon RPC rejected request"),
+            "Codex remote control unavailable. Check Hangar logs, then retry."
+        );
+    }
 
     #[tokio::test]
     async fn shared_remote_codex_rejects_headroom_before_daemon_startup() {

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1909,6 +1909,8 @@ impl InteractiveSessionManager {
             }
             let mut command = vec![
                 provider.command().to_string(),
+                "--disable".to_string(),
+                "apps".to_string(),
                 "--remote".to_string(),
                 remote.endpoint.clone(),
                 "-C".to_string(),

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
@@ -191,7 +191,7 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
     let peers_db = home.join("peers.db");
     let jobs_dir = home.join("jobs");
     let cmd = format!(
-        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
+        "HOME={home} AINB_HOME={home}/.agents-in-a-box AINB_HANGAR_HOME={hangar} AINB_FLEET_DISABLE_TMUX_DISCOVERY=1 AINB_DISABLE_PLUGINS=1 CLAUDE_PEERS_DB={peers} AINB_FLEET_JOBS_DIR={jobs} exec {bin} tui",
         home = home.display(),
         hangar = hangar_home.display(),
         peers = peers_db.display(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -189,7 +189,12 @@ pub fn managed_tui_command(
     socket: &Path,
     additional_args: impl IntoIterator<Item = OsString>,
 ) -> CommandSpec {
-    let mut args = vec!["--remote".into(), unix_endpoint(socket).into()];
+    let mut args = vec![
+        "--disable".into(),
+        "apps".into(),
+        "--remote".into(),
+        unix_endpoint(socket).into(),
+    ];
     args.extend(additional_args);
     CommandSpec {
         program: codex_binary.to_os_string(),
@@ -892,6 +897,8 @@ mod tests {
             )
             .args,
             vec![
+                OsString::from("--disable"),
+                OsString::from("apps"),
                 OsString::from("--remote"),
                 OsString::from("unix:///tmp/fleet codex.sock"),
                 OsString::from("--model"),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -161,7 +161,7 @@ pub fn app_server_command(codex_binary: &OsStr, socket: &Path) -> CommandSpec {
         program: codex_binary.to_os_string(),
         args: vec![
             "--disable".into(),
-            "enable_mcp_apps".into(),
+            "apps".into(),
             "app-server".into(),
             "--remote-control".into(),
             "--listen".into(),
@@ -868,7 +868,7 @@ mod tests {
             app_server_command(OsStr::new("codex"), socket).args,
             vec![
                 OsString::from("--disable"),
-                OsString::from("enable_mcp_apps"),
+                OsString::from("apps"),
                 OsString::from("app-server"),
                 OsString::from("--remote-control"),
                 OsString::from("--listen"),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -160,6 +160,8 @@ pub fn app_server_command(codex_binary: &OsStr, socket: &Path) -> CommandSpec {
     CommandSpec {
         program: codex_binary.to_os_string(),
         args: vec![
+            "--disable".into(),
+            "enable_mcp_apps".into(),
             "app-server".into(),
             "--remote-control".into(),
             "--listen".into(),
@@ -865,6 +867,8 @@ mod tests {
         assert_eq!(
             app_server_command(OsStr::new("codex"), socket).args,
             vec![
+                OsString::from("--disable"),
+                OsString::from("enable_mcp_apps"),
                 OsString::from("app-server"),
                 OsString::from("--remote-control"),
                 OsString::from("--listen"),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -1,9 +1,9 @@
 //! Codex app-server control adapter.
 //!
-//! Codex app-server speaks JSON-RPC over stdio, WebSocket, or WebSocket over a
-//! Unix socket. Fleet uses `codex app-server proxy --sock PATH` as its stdio
-//! bridge to the shared Unix endpoint. This keeps framing inside Codex while
-//! preserving exact JSON-RPC request IDs for structured responses.
+//! Codex app-server speaks JSON-RPC over stdio or WebSocket, including WebSocket
+//! over a Unix socket. Hangar connects its shared Unix listener directly with a
+//! WebSocket. `codex app-server proxy --sock PATH` targets the separate managed
+//! daemon control socket, not an arbitrary listener.
 
 use std::collections::VecDeque;
 use std::ffi::{OsStr, OsString};
@@ -168,7 +168,7 @@ pub fn app_server_command(codex_binary: &OsStr, socket: &Path) -> CommandSpec {
     }
 }
 
-/// Build stdio proxy command for shared app-server Unix endpoint.
+/// Build stdio proxy command for Codex's managed daemon control socket.
 pub fn proxy_command(codex_binary: &OsStr, socket: &Path) -> CommandSpec {
     CommandSpec {
         program: codex_binary.to_os_string(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -1228,13 +1228,6 @@ fn legacy_proxy_daemon_pairs(ps_output: &str, live_socket: &Path) -> Vec<(u32, u
         .collect()
 }
 
-fn legacy_proxy_daemon_pids(ps_output: &str, live_socket: &Path) -> Vec<u32> {
-    legacy_proxy_daemon_pairs(ps_output, live_socket)
-        .into_iter()
-        .map(|(pid, _)| pid)
-        .collect()
-}
-
 /// Confirm a selected daemon remains the same process before signalling it.
 ///
 /// A PID is reusable after the first process exits, so the start fingerprint is
@@ -2506,7 +2499,7 @@ mod tests {
             socket = socket.display(),
             other = other.display(),
         );
-        assert_eq!(legacy_proxy_daemon_pids(&dump, &socket), vec![810]);
+        assert_eq!(legacy_proxy_daemon_pairs(&dump, &socket), vec![(810, 811)]);
     }
 
     #[test]
@@ -2521,7 +2514,7 @@ mod tests {
               821   820 /opt/codex/bin/codex app-server proxy --sock /tmp/foreign.sock\n",
             socket = socket.display(),
         );
-        assert!(legacy_proxy_daemon_pids(&dump, &socket).is_empty());
+        assert!(legacy_proxy_daemon_pairs(&dump, &socket).is_empty());
     }
 
     /// Quoting the markers is not being them. Every line below contains both

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -1199,6 +1199,8 @@ fn codex_orphans_to_reap(ps_output: &str, adoption_credible: impl Fn(&str) -> bo
 struct LegacyProxyDaemon {
     pid: u32,
     process_start_fingerprint: String,
+    proxy_pid: u32,
+    proxy_start_fingerprint: String,
 }
 
 /// Select orphaned legacy Hangar daemon pids whose direct proxy child targets
@@ -1207,22 +1209,29 @@ struct LegacyProxyDaemon {
 /// A proxy on its own is not authority to signal anything. The parent-child
 /// relationship confines this compatibility recovery to the obsolete Ainb
 /// topology that predated the native WebSocket manager.
-fn legacy_proxy_daemon_pids(ps_output: &str, live_socket: &Path) -> Vec<u32> {
+fn legacy_proxy_daemon_pairs(ps_output: &str, live_socket: &Path) -> Vec<(u32, u32)> {
     let expected_socket = live_socket.to_string_lossy();
     let rows = ps_output.lines().filter_map(parse_ps_row).collect::<Vec<_>>();
     rows.iter()
         .filter(|parent| {
             parent.ppid == 1 && crate::single_instance::is_hangar_daemon_args(parent.args)
         })
-        .filter(|parent| {
-            rows.iter().any(|child| {
-                child.ppid == parent.pid
+        .flat_map(|parent| {
+            rows.iter().filter_map(|child| {
+                (child.ppid == parent.pid
                     && is_codex_app_server(child.args)
                     && codex_proxy_socket(child.args)
-                        .is_some_and(|socket| socket == expected_socket)
+                        .is_some_and(|socket| socket == expected_socket))
+                .then_some((parent.pid, child.pid))
             })
         })
-        .map(|parent| parent.pid)
+        .collect()
+}
+
+fn legacy_proxy_daemon_pids(ps_output: &str, live_socket: &Path) -> Vec<u32> {
+    legacy_proxy_daemon_pairs(ps_output, live_socket)
+        .into_iter()
+        .map(|(pid, _)| pid)
         .collect()
 }
 
@@ -1238,9 +1247,30 @@ async fn legacy_proxy_daemon_is_current(
     process_identity(candidate.pid)
         .await
         .is_some_and(|identity| identity.process_start_fingerprint == candidate.process_start_fingerprint)
+        && process_identity(candidate.proxy_pid).await.is_some_and(|identity| {
+            identity.process_start_fingerprint == candidate.proxy_start_fingerprint
+        })
         && ps_process_table()
             .await
-            .is_some_and(|ps_output| legacy_proxy_daemon_pids(&ps_output, live_socket).contains(&candidate.pid))
+            .is_some_and(|ps_output| {
+                legacy_proxy_daemon_pairs(&ps_output, live_socket)
+                    .contains(&(candidate.pid, candidate.proxy_pid))
+            })
+}
+
+/// Confirm the proxy child remains the exact same process after its parent exits.
+async fn legacy_proxy_child_is_current(candidate: &LegacyProxyDaemon, live_socket: &Path) -> bool {
+    process_identity(candidate.proxy_pid)
+        .await
+        .is_some_and(|identity| identity.process_start_fingerprint == candidate.proxy_start_fingerprint)
+        && ps_process_table().await.is_some_and(|ps_output| {
+            ps_output.lines().filter_map(parse_ps_row).any(|row| {
+                row.pid == candidate.proxy_pid
+                    && is_codex_app_server(row.args)
+                    && codex_proxy_socket(row.args)
+                        .is_some_and(|socket| socket == live_socket.to_string_lossy())
+            })
+        })
 }
 
 /// From ppid==1 orphan candidates, drop our own pid and the pid(s) listening on our
@@ -1520,13 +1550,18 @@ pub async fn reap_legacy_codex_proxy_daemons(live_socket: &Path) -> usize {
         return 0;
     };
     let mut reaped = 0;
-    for pid in legacy_proxy_daemon_pids(&ps_output, live_socket) {
+    for (pid, proxy_pid) in legacy_proxy_daemon_pairs(&ps_output, live_socket) {
         let Some(identity) = process_identity(pid).await else {
+            continue;
+        };
+        let Some(proxy_identity) = process_identity(proxy_pid).await else {
             continue;
         };
         let candidate = LegacyProxyDaemon {
             pid,
             process_start_fingerprint: identity.process_start_fingerprint,
+            proxy_pid,
+            proxy_start_fingerprint: proxy_identity.process_start_fingerprint,
         };
         if !legacy_proxy_daemon_is_current(&candidate, live_socket).await {
             continue;
@@ -1538,30 +1573,82 @@ pub async fn reap_legacy_codex_proxy_daemons(live_socket: &Path) -> usize {
                 continue;
             }
         }
-        if wait_for_exit(&[pid], ReapTiming::PRODUCTION.term_grace, ReapTiming::PRODUCTION.poll, &nix_signal)
+        let parent_exited = wait_for_exit(
+            &[pid],
+            ReapTiming::PRODUCTION.term_grace,
+            ReapTiming::PRODUCTION.poll,
+            &nix_signal,
+        )
+        .await
+        .is_empty();
+        if parent_exited {
+            reaped += 1;
+        } else {
+            if !legacy_proxy_daemon_is_current(&candidate, live_socket).await {
+                continue;
+            }
+            match nix_signal(pid, Some(Signal::SIGKILL)) {
+                Ok(()) | Err(Errno::ESRCH) => {}
+                Err(error) => {
+                    tracing::warn!(pid, error = %error, "failed to kill legacy codex proxy daemon");
+                    continue;
+                }
+            }
+            if wait_for_exit(
+                &[pid],
+                ReapTiming::PRODUCTION.kill_confirm,
+                ReapTiming::PRODUCTION.poll,
+                &nix_signal,
+            )
             .await
             .is_empty()
-        {
-            reaped += 1;
-            continue;
-        }
-        if !legacy_proxy_daemon_is_current(&candidate, live_socket).await {
-            continue;
-        }
-        match nix_signal(pid, Some(Signal::SIGKILL)) {
-            Ok(()) | Err(Errno::ESRCH) => {}
-            Err(error) => {
-                tracing::warn!(pid, error = %error, "failed to kill legacy codex proxy daemon");
+            {
+                reaped += 1;
+            } else {
+                tracing::error!(pid, "legacy codex proxy daemon survived SIGKILL");
                 continue;
             }
         }
-        if wait_for_exit(&[pid], ReapTiming::PRODUCTION.kill_confirm, ReapTiming::PRODUCTION.poll, &nix_signal)
-            .await
-            .is_empty()
+        if !legacy_proxy_child_is_current(&candidate, live_socket).await {
+            continue;
+        }
+        match nix_signal(proxy_pid, Some(Signal::SIGTERM)) {
+            Ok(()) | Err(Errno::ESRCH) => {}
+            Err(error) => {
+                tracing::warn!(proxy_pid, error = %error, "failed to stop legacy codex proxy child");
+                continue;
+            }
+        }
+        if wait_for_exit(
+            &[proxy_pid],
+            ReapTiming::PRODUCTION.term_grace,
+            ReapTiming::PRODUCTION.poll,
+            &nix_signal,
+        )
+        .await
+        .is_empty()
         {
-            reaped += 1;
-        } else {
-            tracing::error!(pid, "legacy codex proxy daemon survived SIGKILL");
+            continue;
+        }
+        if !legacy_proxy_child_is_current(&candidate, live_socket).await {
+            continue;
+        }
+        if let Err(error) = nix_signal(proxy_pid, Some(Signal::SIGKILL)) {
+            if error != Errno::ESRCH {
+                tracing::warn!(proxy_pid, error = %error, "failed to kill legacy codex proxy child");
+            }
+            continue;
+        }
+        if !wait_for_exit(
+            &[proxy_pid],
+            ReapTiming::PRODUCTION.kill_confirm,
+            ReapTiming::PRODUCTION.poll,
+            &nix_signal,
+        )
+        .await
+        .is_empty()
+        {
+            tracing::error!(proxy_pid, "legacy codex proxy child survived SIGKILL");
         }
     }
     reaped

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -122,7 +122,12 @@ impl CodexManagerHandle {
         cwd: &Path,
         model: Option<&str>,
     ) -> Result<String, ProviderError> {
-        let result = self.request("thread/start", json!({ "cwd": cwd, "model": model })).await?;
+        let result = self
+            .request(
+                "thread/start",
+                json!({ "cwd": cwd, "model": model, "ephemeral": false }),
+            )
+            .await?;
         nested_id(&result, "thread")
     }
 
@@ -316,7 +321,7 @@ fn interactive_thread_start_params(
     model: Option<&str>,
     skip_permissions: bool,
 ) -> Value {
-    let mut params = json!({ "cwd": cwd, "model": model });
+    let mut params = json!({ "cwd": cwd, "model": model, "ephemeral": false });
     if skip_permissions {
         let object = params.as_object_mut().expect("interactive thread params are an object");
         object.insert("approvalPolicy".into(), json!("never"));
@@ -2141,6 +2146,8 @@ mod tests {
 
         let manager = spawn(config).await.expect("initialize managed Codex listener");
         assert!(socket_path.exists());
+        let thread_id = manager.handle.thread_start(dir.path(), None).await.unwrap();
+        manager.handle.thread_resume(&thread_id).await.unwrap();
         manager.handle.shutdown().await.expect("shutdown managed listener");
         manager.wait().await.expect("reap managed listener");
         assert!(!socket_path.exists());
@@ -3244,9 +3251,11 @@ mod tests {
         assert_eq!(params["approvalPolicy"], "never");
         assert_eq!(params["sandbox"], "danger-full-access");
         assert_eq!(params["model"], "gpt-5");
+        assert_eq!(params["ephemeral"], false);
 
         let default_params = interactive_thread_start_params(Path::new("/worktree"), None, false);
         assert!(default_params.get("approvalPolicy").is_none());
         assert!(default_params.get("sandbox").is_none());
+        assert_eq!(default_params["ephemeral"], false);
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -1190,6 +1190,59 @@ fn codex_orphans_to_reap(ps_output: &str, adoption_credible: impl Fn(&str) -> bo
         .collect()
 }
 
+/// An obsolete pre-lock Hangar daemon that still drives a legacy stdio proxy.
+///
+/// This is deliberately narrower than the app-server orphan reaper. The old
+/// daemon must be orphaned, recognisably Hangar, and have a direct child proxy
+/// for this exact home socket before Ainb is allowed to stop it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LegacyProxyDaemon {
+    pid: u32,
+    process_start_fingerprint: String,
+}
+
+/// Select orphaned legacy Hangar daemon pids whose direct proxy child targets
+/// `live_socket`.
+///
+/// A proxy on its own is not authority to signal anything. The parent-child
+/// relationship confines this compatibility recovery to the obsolete Ainb
+/// topology that predated the native WebSocket manager.
+fn legacy_proxy_daemon_pids(ps_output: &str, live_socket: &Path) -> Vec<u32> {
+    let expected_socket = live_socket.to_string_lossy();
+    let rows = ps_output.lines().filter_map(parse_ps_row).collect::<Vec<_>>();
+    rows.iter()
+        .filter(|parent| {
+            parent.ppid == 1 && crate::single_instance::is_hangar_daemon_args(parent.args)
+        })
+        .filter(|parent| {
+            rows.iter().any(|child| {
+                child.ppid == parent.pid
+                    && is_codex_app_server(child.args)
+                    && codex_proxy_socket(child.args)
+                        .is_some_and(|socket| socket == expected_socket)
+            })
+        })
+        .map(|parent| parent.pid)
+        .collect()
+}
+
+/// Confirm a selected daemon remains the same process before signalling it.
+///
+/// A PID is reusable after the first process exits, so the start fingerprint is
+/// required before both TERM and KILL. The fresh process-table check also proves
+/// the legacy parent-child topology still targets this exact home.
+async fn legacy_proxy_daemon_is_current(
+    candidate: &LegacyProxyDaemon,
+    live_socket: &Path,
+) -> bool {
+    process_identity(candidate.pid)
+        .await
+        .is_some_and(|identity| identity.process_start_fingerprint == candidate.process_start_fingerprint)
+        && ps_process_table()
+            .await
+            .is_some_and(|ps_output| legacy_proxy_daemon_pids(&ps_output, live_socket).contains(&candidate.pid))
+}
+
 /// From ppid==1 orphan candidates, drop our own pid and the pid(s) listening on our
 /// shared socket, then return who to signal.
 ///
@@ -1453,6 +1506,65 @@ async fn terminate_orphans(
         tracing::error!(pid, "orphaned codex app-server survived SIGKILL");
     }
     outcome
+}
+
+/// Stop obsolete orphaned Hangar daemons that still run the legacy Codex proxy
+/// against this home's native WebSocket socket.
+///
+/// This runs only during boot. Current Hangar never launches the proxy, so a
+/// periodic process-table scan would add cost without improving recovery. The
+/// parent is revalidated by start fingerprint and direct-child topology before
+/// each signal, preventing PID reuse or an argv change from widening authority.
+pub async fn reap_legacy_codex_proxy_daemons(live_socket: &Path) -> usize {
+    let Some(ps_output) = ps_process_table().await else {
+        return 0;
+    };
+    let mut reaped = 0;
+    for pid in legacy_proxy_daemon_pids(&ps_output, live_socket) {
+        let Some(identity) = process_identity(pid).await else {
+            continue;
+        };
+        let candidate = LegacyProxyDaemon {
+            pid,
+            process_start_fingerprint: identity.process_start_fingerprint,
+        };
+        if !legacy_proxy_daemon_is_current(&candidate, live_socket).await {
+            continue;
+        }
+        match nix_signal(pid, Some(Signal::SIGTERM)) {
+            Ok(()) | Err(Errno::ESRCH) => {}
+            Err(error) => {
+                tracing::warn!(pid, error = %error, "failed to stop legacy codex proxy daemon");
+                continue;
+            }
+        }
+        if wait_for_exit(&[pid], ReapTiming::PRODUCTION.term_grace, ReapTiming::PRODUCTION.poll, &nix_signal)
+            .await
+            .is_empty()
+        {
+            reaped += 1;
+            continue;
+        }
+        if !legacy_proxy_daemon_is_current(&candidate, live_socket).await {
+            continue;
+        }
+        match nix_signal(pid, Some(Signal::SIGKILL)) {
+            Ok(()) | Err(Errno::ESRCH) => {}
+            Err(error) => {
+                tracing::warn!(pid, error = %error, "failed to kill legacy codex proxy daemon");
+                continue;
+            }
+        }
+        if wait_for_exit(&[pid], ReapTiming::PRODUCTION.kill_confirm, ReapTiming::PRODUCTION.poll, &nix_signal)
+            .await
+            .is_empty()
+        {
+            reaped += 1;
+        } else {
+            tracing::error!(pid, "legacy codex proxy daemon survived SIGKILL");
+        }
+    }
+    reaped
 }
 
 /// Reap codex app-server processes orphaned by a prior daemon or plugin broker.
@@ -2288,6 +2400,41 @@ mod tests {
         // The desktop app has neither `bin/codex` nor ppid==1.
         let desktop = "  900     1 /Applications/ChatGPT.app/Contents/Resources/codex --foo\n";
         assert!(codex_orphans_to_reap(desktop, |_| true).is_empty());
+    }
+
+    #[test]
+    fn legacy_proxy_recovery_targets_only_its_orphaned_hangar_parent() {
+        let home = tempfile::tempdir().unwrap();
+        let socket = home.path().join("codex-app-server.sock");
+        let other = home.path().join("other.sock");
+        let dump = format!(
+            "  PID  PPID ARGS\n\
+              810     1 /tmp/ainb-hangar-daemon\n\
+              811   810 /opt/codex/bin/codex app-server proxy --sock {socket}\n\
+              820     1 /tmp/ainb-hangar-daemon\n\
+              821   820 /opt/codex/bin/codex app-server proxy --sock {other}\n\
+              830     1 /tmp/not-ainb\n\
+              831   830 /opt/codex/bin/codex app-server proxy --sock {socket}\n\
+              840     1 /opt/codex/bin/codex app-server proxy --sock {socket}\n",
+            socket = socket.display(),
+            other = other.display(),
+        );
+        assert_eq!(legacy_proxy_daemon_pids(&dump, &socket), vec![810]);
+    }
+
+    #[test]
+    fn legacy_proxy_recovery_requires_direct_child_and_exact_socket() {
+        let home = tempfile::tempdir().unwrap();
+        let socket = home.path().join("codex-app-server.sock");
+        let dump = format!(
+            "  PID  PPID ARGS\n\
+              810     1 /tmp/ainb-hangar-daemon\n\
+              811  9999 /opt/codex/bin/codex app-server proxy --sock {socket}\n\
+              820     1 /tmp/ainb-hangar-daemon\n\
+              821   820 /opt/codex/bin/codex app-server proxy --sock /tmp/foreign.sock\n",
+            socket = socket.display(),
+        );
+        assert!(legacy_proxy_daemon_pids(&dump, &socket).is_empty());
     }
 
     /// Quoting the markers is not being them. Every line below contains both

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -442,7 +442,7 @@ pub async fn app_server_inventory() -> Vec<CodexAppServerInventoryRow> {
                 },
             }
         })
-        .take(DEFAULT_CODEX_MAX_SERVERS)
+        .take(APP_SERVER_INVENTORY_LIMIT)
         .collect()
 }
 
@@ -646,7 +646,6 @@ pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, Pr
             "installed Codex cannot generate app-server schema".into(),
         ));
     }
-    enforce_codex_server_cap().await?;
     let preparation = prepare_socket(&config.socket_path, &config.codex_binary).await?;
     let mut owns_server = preparation.owns_server;
     let owner_marker_path = socket_owner_marker(&config.socket_path);
@@ -1013,8 +1012,9 @@ fn bound_by_child(child_pid: u32, listeners: Option<&[u32]>) -> bool {
     listeners.is_none_or(|pids| pids.len() == 1 && pids[0] == child_pid)
 }
 
-/// Default max concurrent codex app-server processes before `spawn` refuses more.
-const DEFAULT_CODEX_MAX_SERVERS: usize = 8;
+/// Diagnostic output bound. This never gates spawning: other Codex clients and
+/// IDEs own independent app-servers, while Ainb reuses only its exact socket.
+const APP_SERVER_INVENTORY_LIMIT: usize = 8;
 
 /// One `ps -Ao pid,ppid,args` row, borrowed from the dump.
 struct PsRow<'a> {
@@ -1184,19 +1184,6 @@ fn codex_orphans_to_reap(ps_output: &str, adoption_credible: impl Fn(&str) -> bo
         .collect()
 }
 
-/// Count of live codex app-server SERVERS (any ppid) in a `ps` dump: argv contains
-/// `bin/codex` AND `app-server`, but NOT `app-server proxy`. Used to fail loud
-/// before piling on more. Proxy processes are excluded because each real server is
-/// fronted by a proxy; counting both would trip the cap at half the real server
-/// count (~4 server+proxy pairs against the default cap of 8).
-fn live_codex_app_server_count(ps_output: &str) -> usize {
-    ps_output
-        .lines()
-        .filter_map(parse_ps_row)
-        .filter(|row| is_codex_app_server(row.args) && !row.args.contains("app-server proxy"))
-        .count()
-}
-
 /// From ppid==1 orphan candidates, drop our own pid and the pid(s) listening on our
 /// shared socket, then return who to signal.
 ///
@@ -1212,24 +1199,6 @@ fn reap_targets(candidates: &[u32], listeners: Option<&[u32]>, self_pid: u32) ->
         .collect()
 }
 
-/// Configured cap on concurrent codex app-server servers (`AINB_CODEX_MAX_SERVERS`,
-/// default `DEFAULT_CODEX_MAX_SERVERS`). A non-numeric override falls back to default.
-/// Clamped to a floor of 1 so `AINB_CODEX_MAX_SERVERS=0` cannot permanently refuse
-/// every spawn (the daemon must always be able to bring up at least one server).
-fn codex_server_cap() -> usize {
-    std::env::var("AINB_CODEX_MAX_SERVERS")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_CODEX_MAX_SERVERS)
-        .max(1)
-}
-
-/// Whether the live codex app-server count in a `ps` dump has reached `cap`.
-/// Pure so the boundary (`count >= cap`) is unit-tested without spawning `ps`.
-fn codex_server_cap_reached(ps_output: &str, cap: usize) -> bool {
-    live_codex_app_server_count(ps_output) >= cap
-}
-
 /// Read the full process table via `ps -Ao pid,ppid,args`, or `None` on failure.
 async fn ps_process_table() -> Option<String> {
     let output = Command::new("ps")
@@ -1241,27 +1210,6 @@ async fn ps_process_table() -> Option<String> {
         .ok()
         .filter(|output| output.status.success())?;
     String::from_utf8(output.stdout).ok()
-}
-
-/// Refuse to spawn another shared app-server once the cap is already live.
-///
-/// Turns a silent process pileup (a SIGKILL/OOM leak loop that never runs Drop)
-/// into a loud spawn error the service loop logs and backs off on. Fails open when
-/// `ps` cannot answer: we never wedge boot on a host without a readable process
-/// table.
-async fn enforce_codex_server_cap() -> Result<(), ProviderError> {
-    let cap = codex_server_cap();
-    let Some(ps_output) = ps_process_table().await else {
-        return Ok(());
-    };
-    if codex_server_cap_reached(&ps_output, cap) {
-        let live = live_codex_app_server_count(&ps_output);
-        return Err(ProviderError::Transport(format!(
-            "refusing to spawn Codex app-server: {live} already live, at or above cap {cap} \
-             (raise with AINB_CODEX_MAX_SERVERS)"
-        )));
-    }
-    Ok(())
 }
 
 /// Waits governing one reap sweep's SIGTERM → SIGKILL escalation.
@@ -2353,11 +2301,6 @@ mod tests {
                 codex_orphans_to_reap(line, |_| true).is_empty(),
                 "must not target: {line}"
             );
-            assert_eq!(
-                live_codex_app_server_count(line),
-                0,
-                "must not count: {line}"
-            );
         }
 
         // The real shapes still match, from both `codex ...` and `node .../codex ...`.
@@ -2820,29 +2763,6 @@ mod tests {
         assert_eq!(reap_targets(&candidates, None, 999), vec![501, 777]);
         // Our own pid is never a target.
         assert_eq!(reap_targets(&[501, 777, 999], None, 999), vec![501, 777]);
-    }
-
-    #[test]
-    fn live_count_counts_servers_not_proxies() {
-        // 501 + 777 are real servers = 2. The 1500 `app-server proxy` line is a
-        // consumer, not a server, so it is NOT counted (counting proxies would trip
-        // the cap at half the real server count). Desktop app + header excluded.
-        assert_eq!(live_codex_app_server_count(PS_FIXTURE), 2);
-        // A lone proxy line, regardless of ppid, counts as zero servers.
-        let proxy_only = " 1500     1 /home/u/.nvm/bin/codex app-server proxy --sock /tmp/x.sock\n";
-        assert_eq!(live_codex_app_server_count(proxy_only), 0);
-    }
-
-    #[test]
-    fn cap_reached_at_or_above_boundary() {
-        // Fixture has 2 live SERVERS (proxies excluded).
-        assert!(!codex_server_cap_reached(PS_FIXTURE, 3)); // below the cap
-        assert!(codex_server_cap_reached(PS_FIXTURE, 2)); // at the cap
-        assert!(codex_server_cap_reached(PS_FIXTURE, 1)); // above the cap
-        assert!(!codex_server_cap_reached(
-            PS_FIXTURE,
-            DEFAULT_CODEX_MAX_SERVERS
-        ));
     }
 
     struct FakeCleanup(Arc<AtomicBool>);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -125,7 +125,7 @@ impl CodexManagerHandle {
         let result = self
             .request(
                 "thread/start",
-                json!({ "cwd": cwd, "model": model, "ephemeral": false }),
+                json!({ "cwd": cwd, "model": model, "ephemeral": false, "threadSource": "user" }),
             )
             .await?;
         nested_id(&result, "thread")
@@ -321,7 +321,8 @@ fn interactive_thread_start_params(
     model: Option<&str>,
     skip_permissions: bool,
 ) -> Value {
-    let mut params = json!({ "cwd": cwd, "model": model, "ephemeral": false });
+    let mut params =
+        json!({ "cwd": cwd, "model": model, "ephemeral": false, "threadSource": "user" });
     if skip_permissions {
         let object = params.as_object_mut().expect("interactive thread params are an object");
         object.insert("approvalPolicy".into(), json!("never"));
@@ -3252,10 +3253,12 @@ mod tests {
         assert_eq!(params["sandbox"], "danger-full-access");
         assert_eq!(params["model"], "gpt-5");
         assert_eq!(params["ephemeral"], false);
+        assert_eq!(params["threadSource"], "user");
 
         let default_params = interactive_thread_start_params(Path::new("/worktree"), None, false);
         assert!(default_params.get("approvalPolicy").is_none());
         assert!(default_params.get("sandbox").is_none());
         assert_eq!(default_params["ephemeral"], false);
+        assert_eq!(default_params["threadSource"], "user");
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -701,6 +701,16 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         {
             let binary = std::env::var_os("AINB_CODEX_BIN").unwrap_or_else(|| "codex".into());
             let socket = dir.join("codex-app-server.sock");
+            // Older Ainb daemons used `codex app-server proxy` against this same
+            // path. A pre-lock daemon can survive an upgrade and keep sending
+            // stdin JSON-RPC into the native WebSocket listener. Recover only
+            // the exact orphaned parent-child legacy topology for this home.
+            let legacy_reaped =
+                crate::fleet_provider::codex_manager::reap_legacy_codex_proxy_daemons(&socket)
+                    .await;
+            if legacy_reaped > 0 {
+                tracing::warn!(legacy_reaped, "reaped obsolete codex proxy daemon at boot");
+            }
             // Reap any app-server orphaned by a SIGKILLed/OOM-reaped prior daemon (or a
             // dead plugin broker) BEFORE we spawn our own. Rust Drop never runs after
             // SIGKILL, so this boot-time sweep is the only backstop that survives it.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3540,7 +3540,7 @@ fn codex_started_thread_id(payload: &str, cwd: &str) -> Option<String> {
         .display()
         .to_string();
     (event_cwd == cwd
-        && thread.get("source")?.as_str() == Some("vscode")
+        && thread.get("source")?.as_str() == Some("cli")
         && thread.get("threadSource")?.as_str() == Some("user")
         && thread.get("forkedFromId").is_some_and(serde_json::Value::is_null))
     .then(|| thread.get("id")?.as_str().map(str::to_owned))
@@ -12961,7 +12961,7 @@ mod tests {
             "params": { "thread": {
                 "id": "thread-1",
                 "cwd": cwd,
-                "source": "vscode",
+                "source": "cli",
                 "threadSource": "user",
                 "forkedFromId": null
             } }
@@ -12973,7 +12973,7 @@ mod tests {
             Some("thread-1".to_string())
         );
         assert_eq!(codex_started_thread_id(&payload, "/wrong-cwd"), None);
-        let non_tui = payload.replace("\"source\":\"vscode\"", "\"source\":\"appServer\"");
+        let non_tui = payload.replace("\"source\":\"cli\"", "\"source\":\"appServer\"");
         assert_eq!(codex_started_thread_id(&non_tui, &cwd), None);
         let fork = payload.replace("\"forkedFromId\":null", "\"forkedFromId\":\"parent\"");
         assert_eq!(codex_started_thread_id(&fork, &cwd), None);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3540,7 +3540,7 @@ fn codex_started_thread_id(payload: &str, cwd: &str) -> Option<String> {
         .display()
         .to_string();
     (event_cwd == cwd
-        && thread.get("source")?.as_str() == Some("cli")
+        && thread.get("source")?.as_str() == Some("vscode")
         && thread.get("threadSource")?.as_str() == Some("user")
         && thread.get("forkedFromId").is_some_and(serde_json::Value::is_null))
     .then(|| thread.get("id")?.as_str().map(str::to_owned))
@@ -12961,7 +12961,7 @@ mod tests {
             "params": { "thread": {
                 "id": "thread-1",
                 "cwd": cwd,
-                "source": "cli",
+                "source": "vscode",
                 "threadSource": "user",
                 "forkedFromId": null
             } }
@@ -12973,7 +12973,7 @@ mod tests {
             Some("thread-1".to_string())
         );
         assert_eq!(codex_started_thread_id(&payload, "/wrong-cwd"), None);
-        let non_tui = payload.replace("\"source\":\"cli\"", "\"source\":\"appServer\"");
+        let non_tui = payload.replace("\"source\":\"vscode\"", "\"source\":\"appServer\"");
         assert_eq!(codex_started_thread_id(&non_tui, &cwd), None);
         let fork = payload.replace("\"forkedFromId\":null", "\"forkedFromId\":\"parent\"");
         assert_eq!(codex_started_thread_id(&fork, &cwd), None);

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -1321,7 +1321,8 @@ pub struct FleetStartResult {
 /// Parameters for `codex/session_ensure`.
 ///
 /// Interactive mode owns its tmux and session metadata. The daemon owns the
-/// shared app-server and returns the exact thread that tmux must resume.
+/// shared app-server. A new terminal creates its thread itself, then claims the
+/// resulting exact identity through this same request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodexSessionEnsureParams {
     /// Stable Ainb Interactive session identity, used for validation and logs.
@@ -1342,7 +1343,9 @@ pub struct CodexSessionEnsureParams {
 /// Result for `codex/session_ensure`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodexSessionEnsureResult {
-    /// Exact Codex thread identity, absent until the fresh remote TUI creates it.
+    /// Exact Codex thread identity once the remote terminal has started it.
+    /// `None` tells the caller to launch a fresh remote terminal without
+    /// `resume`, then retry this request to claim its `thread/started` event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thread_id: Option<String>,
     /// Canonical Unix endpoint consumed by the Interactive tmux client.

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0087_interactive_codex_thread_launch_state.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0087_interactive_codex_thread_launch_state.sql
@@ -1,0 +1,12 @@
+-- Fresh remote Codex clients create their own thread.  The reservation
+-- snapshots the source-ledger cursor before tmux starts, so a later claim
+-- cannot adopt an older same-directory thread.
+ALTER TABLE interactive_codex_thread ADD COLUMN event_watermark INTEGER;
+ALTER TABLE interactive_codex_thread ADD COLUMN resumable INTEGER NOT NULL DEFAULT 0;
+
+-- Codex does not attach an Ainb correlation token to `thread/started`.
+-- One pending launch per exact working directory makes cursor-plus-cwd
+-- matching unambiguous without serializing unrelated projects.
+CREATE UNIQUE INDEX interactive_codex_thread_one_pending_cwd
+    ON interactive_codex_thread(cwd)
+    WHERE thread_id IS NULL;

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -65,7 +65,7 @@
 //! those repos apply are still required, because an FK proves only that a parent
 //! row exists, never which workspace owns it.
 
-use sqlx::SqlitePool;
+use sqlx::{SqlitePool, migrate::Migrate};
 
 mod store;
 pub use store::Store;
@@ -116,8 +116,93 @@ pub mod test_support;
 /// Returns an error if a migration fails to apply (for example a checksum
 /// mismatch on a previously applied migration, or malformed SQL).
 pub async fn apply_migrations(pool: &SqlitePool) -> anyhow::Result<()> {
-    sqlx::migrate!("./migrations").run(pool).await?;
+    let migrator = sqlx::migrate!("./migrations");
+    reconcile_superseded_codex_launch_migrations(pool, &migrator).await?;
+    migrator.run(pool).await?;
     Ok(())
+}
+
+/// Migration 0087 landed after 0089/0090 and duplicated their two columns.
+/// It never needs to run: 0088 drops its transient index, while 0089/0090 own
+/// the durable columns. Record the matching checksum before SQLx executes it.
+async fn reconcile_superseded_codex_launch_migrations(
+    pool: &SqlitePool,
+    migrator: &sqlx::migrate::Migrator,
+) -> anyhow::Result<()> {
+    let mut connection = pool.acquire().await?;
+    (&mut *connection).ensure_migrations_table().await?;
+    let applied: std::collections::HashSet<i64> =
+        sqlx::query_scalar("SELECT version FROM _sqlx_migrations")
+            .fetch_all(&mut *connection)
+            .await?
+            .into_iter()
+            .collect();
+    let columns: std::collections::HashSet<String> =
+        sqlx::query_scalar("SELECT name FROM pragma_table_info('interactive_codex_thread')")
+            .fetch_all(&mut *connection)
+            .await?
+            .into_iter()
+            .collect();
+
+    let mut superseded = Vec::new();
+    if !applied.contains(&87) {
+        superseded.push(87);
+    }
+    if columns.contains("resumable") && !applied.contains(&89) {
+        superseded.push(89);
+    }
+    if columns.contains("event_watermark") && !applied.contains(&90) {
+        superseded.push(90);
+    }
+    for version in superseded {
+        let migration = migrator
+            .iter()
+            .find(|migration| migration.version == version)
+            .ok_or_else(|| anyhow::anyhow!("missing embedded migration {version}"))?;
+        sqlx::query(
+            "INSERT OR IGNORE INTO _sqlx_migrations \
+             (version, description, success, checksum, execution_time) VALUES (?, ?, TRUE, ?, -1)",
+        )
+        .bind(migration.version)
+        .bind(&*migration.description)
+        .bind(&*migration.checksum)
+        .execute(&mut *connection)
+        .await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod migration_tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    #[tokio::test]
+    async fn superseded_codex_launch_migrations_bootstrap_and_recover() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        apply_migrations(&pool).await.unwrap();
+
+        for version in [87_i64, 89, 90] {
+            let present: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?",
+            )
+            .bind(version)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(present, 1, "migration {version} was not recorded");
+        }
+
+        sqlx::query("DELETE FROM _sqlx_migrations WHERE version IN (87, 89, 90)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        apply_migrations(&pool).await.unwrap();
+    }
 }
 
 /// Probe whether the LIVE database has drifted away from the schema this

--- a/ainb-tui/docs/solutions/no-orphaned-codex-app-servers.md
+++ b/ainb-tui/docs/solutions/no-orphaned-codex-app-servers.md
@@ -61,10 +61,10 @@ Three layers, none of which depend on an exit path running:
    because both share the `bin/codex … app-server` shape. Dead Source-A and
    Source-B servers have no live proxy targeting their socket, so both get
    reaped.
-3. **Cap that fails loud.** `spawn()` refuses to start a server once
-   `AINB_CODEX_MAX_SERVERS` (default 8, floor 1) live `codex app-server`
-   processes already exist, turning a silent 900-process pileup into a visible
-   error at spawn ~9.
+3. **Scoped ownership.** Ainb only adopts or reuses its exact configured socket.
+   Other Codex clients and IDEs remain external diagnostics and never gate Ainb
+   startup. The reaper and exact-socket race check, not a machine-wide process
+   count, bound Ainb's own lifecycle.
 
 ### Why the daemon owns cleanup (no Claude Code hook)
 
@@ -100,7 +100,7 @@ rationale. We retain them.
 ## How to run / test
 
 ```bash
-# Rust: reaper + cap + race fix
+# Rust: reaper + race fix
 cargo test -p ainb-hangar-daemon
 cargo fmt --check
 


### PR DESCRIPTION
## Summary
- recover scoped legacy proxy collisions at Hangar boot
- reconcile superseded interactive Codex migrations
- claim live TUI-created remote Codex threads correctly
- disable Codex Apps on shared remote sessions

## Validation
- normal AINB Interactive Codex launch persisted remote thread `019ff60a-f319-7a20-9355-654dbf8ad09c`
- connected remote-control bridge `MB1412-4805.local`
- focused store and daemon regressions plus `cargo build -p ainb` running from fresh main-based branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved remote Codex session handling, including thread metadata and more reliable resume behavior.
  - Added safeguards to adopt the correct service socket and clean up obsolete background processes.
  - Improved startup recovery for existing installations and interrupted database migrations.

- **Bug Fixes**
  - Remote Codex commands now run with app integrations disabled for more consistent behavior.
  - Unresponsive services are force-stopped after the shutdown grace period.
  - Remote-control failures now display shorter, actionable messages while retaining diagnostic details in logs.

- **Documentation**
  - Clarified remote thread creation, service ownership, cleanup, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->