### PR TITLE
f/interview surface

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3062,7 +3062,11 @@ impl EventHandler {
             KeyCode::Char('N') => Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('N'))),
             KeyCode::Char('r') => Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('r'))),
             KeyCode::Char('R') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart)),
-            KeyCode::Char('s') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Stop)),
+            // Lowercase `s` belongs to the structured interview queue. Keep
+            // it reserved even if a concurrent snapshot just closed that
+            // queue: a stale key must never turn a submitted answer into Stop.
+            // Destructive stop remains available on uppercase `S`.
+            KeyCode::Char('S') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Stop)),
             KeyCode::Char('i') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Interrupt)),
             KeyCode::Char('c') => Some(AppEvent::FleetPanelCanonicalKey(FleetKey::Char('c'))),
             KeyCode::Char('e') => Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Retry)),
@@ -8972,6 +8976,14 @@ mod panel_back_tests {
         assert!(matches!(
             route(&mut state, KeyCode::Char('R')),
             Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Restart))
+        ));
+        assert!(
+            route(&mut state, KeyCode::Char('s')).is_none(),
+            "lowercase s is reserved for structured-interview submit"
+        );
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('S')),
+            Some(AppEvent::FleetPanelCanonicalAction(FleetAction::Stop))
         ));
         assert!(matches!(
             route(&mut state, KeyCode::Char('!')),

--- a/ainb-tui/crates/ainb-core/src/cli/doctor.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/doctor.rs
@@ -1,30 +1,180 @@
-// ABOUTME: `ainb doctor` — classified dependency health check for the reflect /
-// statusline toolchain. Thin wrapper over `crate::cli::deps`; prints what's
-// installed, what needs it, and the exact commands to fix anything missing.
+// ABOUTME: `ainb doctor` — one health report for skills, dependencies, hooks,
+// and daemons. Preserves skill-manager checks while adding runtime diagnostics.
 
 use anyhow::Result;
+use serde::Serialize;
 
 use super::OutputFormat;
 use crate::cli::deps::{self, RealEnv};
 
-/// Classified dependency check for the reflect / statusline toolchain.
-///
-/// Takes no positional/flag args of its own; the global `--format` flag
-/// selects text vs json output.
+#[derive(Serialize)]
+struct DoctorReport<'a> {
+    skill_doctor: String,
+    skill_doctor_error: Option<String>,
+    dependencies: &'a [deps::DepReport],
+    hooks: Option<ainb_plugin_notifyd::HookHealth>,
+    hooks_error: Option<String>,
+    daemons: Vec<crate::fleet::daemons::DaemonStatus>,
+    daemons_error: Option<String>,
+}
+
+/// Full machine health check. `--offline` skips skill-source network probes.
 #[derive(clap::Args)]
-pub struct DoctorArgs {}
+pub struct DoctorArgs {
+    /// Skip skill-source reachability checks. Runtime checks stay local.
+    #[arg(long)]
+    pub offline: bool,
+}
 
 /// Entry point for `ainb doctor`.
 #[allow(clippy::unused_async)]
-pub async fn execute(_args: DoctorArgs, format: OutputFormat) -> Result<()> {
-    let reports = deps::detect(&RealEnv);
+pub async fn execute(args: DoctorArgs, format: OutputFormat) -> Result<()> {
+    let dependencies = deps::detect(&RealEnv);
+    let (hooks, hooks_error) = match ainb_plugin_notifyd::Paths::from_home() {
+        Ok(paths) => (Some(ainb_plugin_notifyd::hook_health(&paths)), None),
+        Err(error) => (None, Some(error.to_string())),
+    };
+    let (daemons, daemons_error) = match crate::fleet::daemons::collect() {
+        Ok(rows) => (rows, None),
+        Err(error) => (Vec::new(), Some(error.to_string())),
+    };
     match format {
         OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&reports)?);
+            let (skill_doctor, skill_doctor_error) = run_skill_doctor(args.offline);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&DoctorReport {
+                    skill_doctor,
+                    skill_doctor_error: skill_doctor_error.clone(),
+                    dependencies: &dependencies,
+                    hooks,
+                    hooks_error,
+                    daemons,
+                    daemons_error,
+                })?
+            );
+            if let Some(error) = skill_doctor_error {
+                return Err(anyhow::anyhow!(error));
+            }
         }
         OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
-            deps::print_text(&reports);
+            deps::print_text(&dependencies);
+            print_runtime_text(
+                hooks.as_ref(),
+                hooks_error.as_deref(),
+                &daemons,
+                daemons_error.as_deref(),
+            );
+            // The skill check can traverse several tool homes. Render the
+            // runtime result first so a slow skill scan never hides a dead
+            // hook or daemon from the user.
+            let (skill_doctor, skill_doctor_error) = run_skill_doctor(args.offline);
+            println!("\nSKILL HEALTH");
+            println!("------------");
+            print!("{skill_doctor}");
+            if let Some(error) = skill_doctor_error {
+                return Err(anyhow::anyhow!(error));
+            }
         }
     }
     Ok(())
+}
+
+fn run_skill_doctor(offline: bool) -> (String, Option<String>) {
+    let home = ainb_skill_core::paths::default_ainb_home();
+    let mut output = Vec::new();
+    let result = ainb_cli::doctor::dispatch(&home, ainb_cli::DoctorArgs { offline }, &mut output);
+    (
+        String::from_utf8_lossy(&output).into_owned(),
+        result.err().map(|error| error.to_string()),
+    )
+}
+
+fn print_runtime_text(
+    hooks: Option<&ainb_plugin_notifyd::HookHealth>,
+    hooks_error: Option<&str>,
+    daemons: &[crate::fleet::daemons::DaemonStatus],
+    daemons_error: Option<&str>,
+) {
+    println!("\nRUNTIME HEALTH");
+    println!("--------------");
+    match hooks {
+        Some(hooks) => {
+            let installed = hooks.installed_version.as_deref().unwrap_or("not installed");
+            println!(
+                "hooks (ainb-hooks): installed {installed} | bundled {} | {}",
+                hooks.bundled_version,
+                if hooks.version_current {
+                    "current"
+                } else {
+                    "update needed"
+                }
+            );
+            println!(
+                "  script: {}",
+                if hooks.script_ready {
+                    "ready"
+                } else {
+                    "BROKEN"
+                }
+            );
+            println!(
+                "  hook binary: {}",
+                if hooks.hook_binary_ready {
+                    "ready"
+                } else {
+                    "BROKEN"
+                }
+            );
+            println!(
+                "  notifyd: {} | approval broker: {}",
+                if hooks.notify_socket_live {
+                    "running"
+                } else {
+                    "idle (starts on hook)"
+                },
+                if hooks.approve_socket_live {
+                    "running"
+                } else {
+                    "idle"
+                }
+            );
+            for agent in &hooks.agents {
+                println!(
+                    "  {}: {} — {}",
+                    agent.agent,
+                    if agent.wiring_ready {
+                        "wired"
+                    } else {
+                        "NOT WIRED"
+                    },
+                    agent.detail
+                );
+            }
+            if let Some(event) = &hooks.last_event {
+                println!("  last event: {event}");
+            }
+            for issue in &hooks.issues {
+                println!("  ! {}: {}", issue.component, issue.message);
+                println!("    fix: {}", issue.repair);
+            }
+        }
+        None => println!(
+            "hooks: cannot inspect — {}",
+            hooks_error.unwrap_or("unknown error")
+        ),
+    }
+    match daemons_error {
+        Some(error) => println!("\ndaemons: cannot inspect — {error}"),
+        None => {
+            println!("\ndaemons:");
+            print!(
+                "{}",
+                crate::cli::fleet::daemons::render_text(
+                    daemons,
+                    crate::fleet::daemons::heartbeat::now_ms()
+                )
+            );
+        }
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -493,16 +493,14 @@ impl CliCommand for DoctorCommand {
             // `.about()` + `.after_help()` are applied AFTER `augment_args` so
             // they win: the derive macro otherwise overwrites the command
             // description + help with the `DoctorArgs` doc-comment.
-            // `ainb doctor` is intercepted before clap (main.rs
-            // SKILL_MANAGER_CLI_COMMANDS) and runs the skill-manager doctor; this
-            // registry entry only labels the root `--help` list + feeds shell
-            // completions, so its description must match what actually runs. The
-            // reflect/statusline dependency check lives at `ainb reflect check`.
+            // `ainb doctor` is the combined health surface: it runs the
+            // skill-manager checks, dependency checks, hook wiring checks, and
+            // daemon health in one place.
             <crate::cli::doctor::DoctorArgs as clap::Args>::augment_args(Command::new(self.name()))
-                .about("Health-check the skill manifest, lockfile, deployed files + sources")
+                .about("Health-check skills, dependencies, hooks, and daemons")
                 .after_help(
                     "EXAMPLES:\n  \
-                     ainb doctor                      Health-check skill manifest/lockfile/deployed files\n  \
+                     ainb doctor                      Health-check skills, dependencies, hooks, and daemons\n  \
                      ainb doctor --offline            Skip source-reachability network checks",
                 ),
         )

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -19,6 +19,7 @@ use ratatui::{
 use crate::cli::fleet::daemons::{fmt_ago, fmt_duration_ms};
 use crate::fleet::daemons::heartbeat::now_ms;
 use crate::fleet::daemons::probe::{DaemonState, DaemonStatus};
+use ainb_plugin_notifyd::{HookHealth, Paths};
 
 // Palette shared with the rest of ainb-tui (see components/layout.rs).
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
@@ -45,6 +46,9 @@ pub struct Snapshot {
     pub rows: Vec<DaemonStatus>,
     /// The clock the cached rows' relative-time columns are measured against.
     pub collected_at_ms: i64,
+    /// Most-recent hook wiring health. Collected beside daemon state, never in
+    /// the render path.
+    pub hook_health: Option<HookHealth>,
 }
 
 /// All state owned by the Daemons screen. Stored at app-level so the cached
@@ -98,6 +102,7 @@ impl DaemonsState {
         Snapshot {
             rows: guard.rows.clone(),
             collected_at_ms: guard.collected_at_ms,
+            hook_health: guard.hook_health.clone(),
         }
     }
 }
@@ -105,11 +110,16 @@ impl DaemonsState {
 /// Run one collect and publish it into `shared`. Shared by the background thread
 /// and the test seam so the publish/merge logic is exercised without a thread.
 fn collect_into(shared: &Mutex<Snapshot>) {
+    // Hook health only opens local files and attempts local Unix sockets. It
+    // still belongs here, not in render: hooks may live on a slow volume and a
+    // stale socket can block briefly while connecting.
+    let hook_health = Paths::from_home().ok().map(|paths| ainb_plugin_notifyd::hook_health(&paths));
     match crate::fleet::daemons::collect() {
         Ok(rows) => {
             let mut guard = shared.lock().unwrap_or_else(|p| p.into_inner());
             guard.rows = rows;
             guard.collected_at_ms = now_ms();
+            guard.hook_health = hook_health;
         }
         // Best-effort: an error leaves the prior snapshot in place (and logs)
         // rather than blanking the view.
@@ -165,8 +175,128 @@ pub fn render(frame: &mut Frame, area: Rect, state: &mut DaemonsState) {
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
 
-    render_table(frame, chunks[0], &snapshot);
+    // Keep the daemon table usable in short terminals. A normal 24+ row
+    // terminal gets the full Hooks section; compact terminals retain the
+    // original daemon-only table and `ainb doctor` remains the detailed view.
+    if chunks[0].height >= 18 {
+        let sections = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(8), Constraint::Length(7)])
+            .split(chunks[0]);
+        render_table(frame, sections[0], &snapshot);
+        render_hook_section(frame, sections[1], snapshot.hook_health.as_ref());
+    } else {
+        render_table(frame, chunks[0], &snapshot);
+    }
     render_footer(frame, chunks[1]);
+}
+
+fn render_hook_section(frame: &mut Frame, area: Rect, health: Option<&HookHealth>) {
+    let block = Block::default()
+        .title(Line::from(vec![
+            Span::styled(" ◇ ", Style::default().fg(CORNFLOWER_BLUE)),
+            Span::styled(
+                "Hooks",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ainb-hooks", Style::default().fg(MUTED_GRAY)),
+        ]))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(SUBDUED_BORDER))
+        .style(Style::default().bg(PANEL_BG));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = match health {
+        None => vec![Line::from(Span::styled(
+            "collecting hook health…",
+            Style::default().fg(MUTED_GRAY),
+        ))],
+        Some(health) => {
+            let installed = health.installed_version.as_deref().unwrap_or("not installed");
+            let version_style = if health.version_current {
+                Style::default().fg(HEALTHY_GREEN)
+            } else {
+                Style::default().fg(GOLD)
+            };
+            let agent_line = health
+                .agents
+                .iter()
+                .map(|agent| {
+                    format!(
+                        "{} {}",
+                        agent.agent,
+                        if agent.wiring_ready { "✓" } else { "✗" }
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("   ");
+            let issue = health.issues.first().map_or_else(
+                || "✓ wiring healthy".to_string(),
+                |issue| {
+                    format!(
+                        "! {}: {} — {}",
+                        issue.component, issue.message, issue.repair
+                    )
+                },
+            );
+            vec![
+                Line::from(vec![
+                    Span::styled("version ", Style::default().fg(MUTED_GRAY)),
+                    Span::styled(
+                        format!("{installed} → {}", health.bundled_version),
+                        version_style,
+                    ),
+                ]),
+                Line::from(Span::styled(
+                    format!(
+                        "script {}  ·  ainb binary {}",
+                        if health.script_ready { "✓" } else { "✗" },
+                        if health.hook_binary_ready {
+                            "✓"
+                        } else {
+                            "✗"
+                        },
+                    ),
+                    Style::default().fg(if health.script_ready && health.hook_binary_ready {
+                        HEALTHY_GREEN
+                    } else {
+                        STOPPED_RED
+                    }),
+                )),
+                Line::from(Span::styled(agent_line, Style::default().fg(SOFT_WHITE))),
+                Line::from(Span::styled(
+                    format!(
+                        "notifyd {}  ·  approval broker {}",
+                        if health.notify_socket_live {
+                            "running"
+                        } else {
+                            "idle"
+                        },
+                        if health.approve_socket_live {
+                            "running"
+                        } else {
+                            "idle"
+                        },
+                    ),
+                    Style::default().fg(MUTED_GRAY),
+                )),
+                Line::from(Span::styled(
+                    issue,
+                    Style::default().fg(if health.issues.is_empty() {
+                        HEALTHY_GREEN
+                    } else {
+                        GOLD
+                    }),
+                )),
+            ]
+        }
+    };
+    frame.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(PANEL_BG)),
+        inner,
+    );
 }
 
 fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
@@ -258,7 +388,9 @@ fn render_footer(frame: &mut Frame, area: Rect) {
 mod tests {
     use super::*;
     use crate::fleet::daemons::probe::DaemonKind;
+    use ainb_plugin_notifyd::{HookAgentHealth, HookHealth, HookHealthIssue};
     use ratatui::backend::TestBackend;
+    use std::path::PathBuf;
 
     fn status(
         kind: DaemonKind,
@@ -297,6 +429,58 @@ mod tests {
         let shared = Arc::new(Mutex::new(Snapshot {
             rows,
             collected_at_ms: now_ms(),
+            hook_health: None,
+        }));
+        DaemonsState {
+            shared: Some(shared),
+        }
+    }
+
+    fn hook_health() -> HookHealth {
+        HookHealth {
+            bundled_version: "0.4.5".to_string(),
+            installed_version: Some("0.4.4".to_string()),
+            version_current: false,
+            script_path: PathBuf::from("/tmp/notify.sh"),
+            script_ready: true,
+            hook_binary: Some(PathBuf::from("/usr/local/bin/ainb")),
+            hook_binary_ready: true,
+            agents: vec![
+                HookAgentHealth {
+                    agent: "claude".to_string(),
+                    installed: true,
+                    wiring_ready: true,
+                    detail: "marketplace install recorded".to_string(),
+                },
+                HookAgentHealth {
+                    agent: "codex".to_string(),
+                    installed: true,
+                    wiring_ready: true,
+                    detail: "hooks.json points at shared hook".to_string(),
+                },
+                HookAgentHealth {
+                    agent: "copilot".to_string(),
+                    installed: false,
+                    wiring_ready: false,
+                    detail: "not installed".to_string(),
+                },
+            ],
+            notify_socket_live: true,
+            approve_socket_live: false,
+            last_event: None,
+            issues: vec![HookHealthIssue {
+                component: "version".to_string(),
+                message: "installed 0.4.4; ainb bundles 0.4.5".to_string(),
+                repair: "ainb fleet runtime install".to_string(),
+            }],
+        }
+    }
+
+    fn seeded_state_with_hook(rows: Vec<DaemonStatus>, hook_health: HookHealth) -> DaemonsState {
+        let shared = Arc::new(Mutex::new(Snapshot {
+            rows,
+            collected_at_ms: now_ms(),
+            hook_health: Some(hook_health),
         }));
         DaemonsState {
             shared: Some(shared),
@@ -377,6 +561,30 @@ mod tests {
             !out.contains("ATC"),
             "render must not collect beyond the seed"
         );
+    }
+
+    #[test]
+    fn renders_hook_version_state_and_repair_command_on_tall_screen() {
+        let mut state = seeded_state_with_hook(
+            vec![status(
+                DaemonKind::Notifyd,
+                DaemonState::Running,
+                true,
+                Some("socket+db"),
+            )],
+            hook_health(),
+        );
+        let out = render_to_string(&mut state, 120, 24);
+        assert!(out.contains("Hooks"), "hook section missing: {out}");
+        assert!(
+            out.contains("0.4.4 → 0.4.5"),
+            "version state missing: {out}"
+        );
+        assert!(
+            out.contains("ainb fleet runtime install"),
+            "repair missing: {out}"
+        );
+        assert!(out.contains("claude ✓"), "agent wiring missing: {out}");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -100,7 +100,7 @@ where
 /// Keep in sync with the safety-tag's CLI_COMMANDS list — adding a
 /// new top-level command means adding it here AND wiring an arm in
 /// ainb-cli's Command enum.
-const SKILL_MANAGER_CLI_COMMANDS: &[&str] = &["source", "search", "skill", "doctor"];
+const SKILL_MANAGER_CLI_COMMANDS: &[&str] = &["source", "search", "skill"];
 
 fn is_skill_manager_cli_invocation() -> bool {
     std::env::args()

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5762,12 +5762,17 @@ async fn clear_closed_claude_picker_card(
     }
 }
 
-/// Claude's own AskUserQuestion widget always exposes this fixed interaction
+/// Claude's own AskUserQuestion widget exposes a distinctive interaction
 /// footer while it owns terminal input. Native-picker reconciliation only
 /// clears a card after that footer disappears, never while the picker remains
-/// active.
+/// active. Claude Code changed its navigation hint from arrow glyphs to
+/// `Tab/Arrow keys`; both forms describe the same still-blocking picker.
 fn claude_native_picker_is_visible(pane: &str) -> bool {
-    pane.contains("Enter to select · ↑/↓ to navigate · Esc to cancel")
+    pane.lines().any(|line| {
+        line.contains("Enter to select")
+            && line.contains("Esc to cancel")
+            && (line.contains("↑/↓ to navigate") || line.contains("Tab/Arrow keys to navigate"))
+    })
 }
 
 fn fleet_delivery_uses_native_picker(request: &serde_json::Value) -> bool {
@@ -13071,6 +13076,9 @@ mod tests {
     fn native_claude_picker_footer_controls_reconcile_clearance() {
         assert!(claude_native_picker_is_visible(
             "Release proof?\nEnter to select · ↑/↓ to navigate · Esc to cancel"
+        ));
+        assert!(claude_native_picker_is_visible(
+            "Release proof?\nEnter to select · Tab/Arrow keys to navigate · Esc to cancel"
         ));
         assert!(!claude_native_picker_is_visible(
             "User answered Claude's questions: Release proof? → East"

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -4739,6 +4739,9 @@ mod tests {
         );
 
         row.current_request_fingerprint = Some("after".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Proceed with release?", "options": ["Yes"]}]
+        }));
         row.version += 1;
         let closed = apply(&delivered, FleetEvent::Snapshot(vec![row])).state;
         assert!(matches!(closed.mode, FleetMode::Browse));
@@ -4838,6 +4841,9 @@ mod tests {
 
         row.version += 1;
         row.current_request_fingerprint = Some("after".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{"id": "q", "question": "Proceed with release?", "options": ["Yes"]}]
+        }));
         state.set_sessions(vec![row]);
         assert!(matches!(state.mode, FleetMode::Browse));
         assert_eq!(

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -946,17 +946,32 @@ impl FleetPaneState {
         let before = queue.answers.len();
         let mut resumed = false;
         let mut superseded = false;
-        queue.answers.retain(|answer| {
+        let mut retained = Vec::with_capacity(before);
+        for mut answer in std::mem::take(&mut queue.answers) {
             let Some(row) = self.roster.iter().find(|row| row.session_key == answer.session_key)
             else {
-                return false;
+                continue;
             };
-            let same_request = row.version == answer.expected_version
-                && row.current_request_fingerprint.as_deref()
-                    == Some(answer.request_fingerprint.as_str());
-            if same_request {
-                return true;
+
+            // Fleet can re-observe an unchanged Claude AskUserQuestion with a
+            // new provider fingerprint/version. That is transport churn, not a
+            // different human question. Preserve already-picked options and
+            // refresh exact action routing from the authoritative row.
+            if let Some(latest) = answer_state_from_row(row) {
+                if latest.questions == answer.questions {
+                    answer.expected_version = latest.expected_version;
+                    answer.request_fingerprint = latest.request_fingerprint;
+                    answer.request_identity = latest.request_identity;
+                    retained.push(answer);
+                    continue;
+                }
+            } else if row.attention_state.eq_ignore_ascii_case("ASK") {
+                // Enrichment can temporarily omit the request body. Keep the
+                // draft until the next snapshot supplies its exact route.
+                retained.push(answer);
+                continue;
             }
+
             if answer.delivery == AnswerDelivery::AwaitingSessionResume
                 && !row.attention_state.eq_ignore_ascii_case("ASK")
             {
@@ -964,8 +979,8 @@ impl FleetPaneState {
             } else {
                 superseded = true;
             }
-            false
-        });
+        }
+        queue.answers = retained;
         if queue.answers.is_empty() {
             self.mode = FleetMode::Browse;
             self.feedback = Some(if resumed {
@@ -3177,7 +3192,7 @@ fn available_action_labels(session: &FleetSessionRow) -> Vec<&'static str> {
         actions.push("i Interrupt");
     }
     if session.capabilities.contains("stop") {
-        actions.push("s Stop");
+        actions.push("S Stop");
     }
     // Uppercase, always. Restart is bound to `R`; the conditional suppression
     // that used to live here existed only to stop two meanings of `r` being
@@ -5718,6 +5733,44 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn interview_queue_survives_unrelated_fleet_version_refreshes() {
+        let mut row = session("claude:version-refresh", "claude", "IDLE", "ASK", "managed");
+        row.current_request_fingerprint = Some("stable-interview".into());
+        row.current_request = Some(serde_json::json!({
+            "questions": [{
+                "id": "surface", "question": "Surface?", "multiSelect": true, "options": ["Fleet"]
+            }]
+        }));
+        let mut state = FleetPaneState::default();
+        state.set_sessions(vec![row.clone()]);
+        state = apply(&state, FleetEvent::Key(FleetKey::Enter)).state;
+        state = apply(&state, FleetEvent::Key(FleetKey::Space)).state;
+
+        // A re-observation can rotate opaque provider routing while leaving
+        // the actual AskUserQuestion unchanged. Preserve selections and submit
+        // against the new exact route/version.
+        row.version = 2;
+        row.current_request_fingerprint = Some("refreshed-interview".into());
+        state.set_sessions(vec![row]);
+        assert!(state.is_modal_open(), "snapshot closed unchanged interview queue");
+
+        let submitted = apply(&state, FleetEvent::Key(FleetKey::Char('s')));
+        let Some(FleetIntent::Execute {
+            expected_version,
+            action: FleetAction::StructuredAnswer {
+                request_fingerprint,
+                ..
+            },
+            ..
+        }) = submitted.intent
+        else {
+            panic!("fresh structured answer intent expected");
+        };
+        assert_eq!(expected_version, 2);
+        assert_eq!(request_fingerprint, "refreshed-interview");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -797,6 +797,252 @@ pub fn status(paths: &Paths) -> Result<Vec<StatusRow>> {
     Ok(rows)
 }
 
+/// One installed agent's hook wiring state.
+#[derive(Debug, Clone, Serialize)]
+pub struct HookAgentHealth {
+    /// Agent name (`claude`, `codex`, or `copilot`).
+    pub agent: String,
+    /// Whether the persistent install record lists this agent.
+    pub installed: bool,
+    /// Whether the agent's on-disk wiring still points at the canonical hook.
+    /// Claude's marketplace registration is performed by its CLI and has no
+    /// stable local config file to inspect, so its recorded installation is the
+    /// available local proof.
+    pub wiring_ready: bool,
+    /// Short explanation suitable for a status surface.
+    pub detail: String,
+}
+
+/// One actionable hook-health problem.
+#[derive(Debug, Clone, Serialize)]
+pub struct HookHealthIssue {
+    /// Component with the problem, for example `hook script` or `Codex`.
+    pub component: String,
+    /// Plain-language description of what was detected.
+    pub message: String,
+    /// Exact safe repair command.
+    pub repair: String,
+}
+
+/// Complete local health report for the shared `ainb-hooks` runtime.
+///
+/// This deliberately checks the files that make a hook executable, rather
+/// than trusting a historical install record alone. It does not spawn agent
+/// CLIs: callers may run it repeatedly from a TUI background collector.
+#[derive(Debug, Clone, Serialize)]
+pub struct HookHealth {
+    /// Plugin version embedded in the running `ainb` binary.
+    pub bundled_version: String,
+    /// Version recorded when hooks were last installed, if any.
+    pub installed_version: Option<String>,
+    /// Whether installed hooks are at least as new as this binary's hooks.
+    pub version_current: bool,
+    /// Canonical extracted hook script location.
+    pub script_path: PathBuf,
+    /// Whether the canonical hook script exists and is executable.
+    pub script_ready: bool,
+    /// Actual `ainb` executable named by the extracted hook binary pointer.
+    pub hook_binary: Option<PathBuf>,
+    /// Whether the hook binary pointer resolves to an executable file.
+    pub hook_binary_ready: bool,
+    /// Per-agent installation and wiring state.
+    pub agents: Vec<HookAgentHealth>,
+    /// Whether notifyd's delivery socket accepted a connection now.
+    pub notify_socket_live: bool,
+    /// Whether approval broker's socket accepted a connection now.
+    pub approve_socket_live: bool,
+    /// Most-recent persisted hook event, when one exists.
+    pub last_event: Option<String>,
+    /// Problems that need action. Idle sockets are reported above, not as a
+    /// failure: notifyd intentionally starts lazily on the first hook event.
+    pub issues: Vec<HookHealthIssue>,
+}
+
+/// Inspect local hook wiring without changing it.
+#[must_use]
+pub fn hook_health(paths: &Paths) -> HookHealth {
+    let bundled_version = embedded_plugin_version();
+    let record = InstallRecord::load(paths);
+    let (record, record_error) = match record {
+        Ok(record) => (record, None),
+        Err(error) => (InstallRecord::default(), Some(error.to_string())),
+    };
+    let script_path = canonical_hook_script(paths);
+    let script_ready = is_executable(&script_path);
+    let hook_binary = std::fs::read_to_string(canonical_hook_bin(paths)).ok().and_then(|text| {
+        let target = text.trim();
+        (!target.is_empty()).then(|| PathBuf::from(target))
+    });
+    let hook_binary_ready = hook_binary.as_deref().is_some_and(is_executable);
+    let installed_any = !record.agents.is_empty();
+    let version_current = record
+        .plugin_version
+        .as_deref()
+        .is_some_and(|installed| parse_semver(installed) >= parse_semver(&bundled_version));
+
+    let agents = Agent::ALL
+        .iter()
+        .map(|agent| agent_health(*agent, &record, &script_path))
+        .collect::<Vec<_>>();
+
+    let mut issues = Vec::new();
+    if let Some(error) = record_error {
+        issues.push(HookHealthIssue {
+            component: "install record".to_string(),
+            message: format!("cannot read install.json: {error}"),
+            repair: "ainb fleet runtime install".to_string(),
+        });
+    } else if !installed_any {
+        issues.push(HookHealthIssue {
+            component: "hooks".to_string(),
+            message: "not installed for any agent".to_string(),
+            repair: "ainb fleet runtime install".to_string(),
+        });
+    } else {
+        if !version_current {
+            let installed = record.plugin_version.as_deref().unwrap_or("unknown");
+            issues.push(HookHealthIssue {
+                component: "version".to_string(),
+                message: format!("installed {installed}; ainb bundles {bundled_version}"),
+                repair: "ainb fleet runtime install".to_string(),
+            });
+        }
+        if !script_ready {
+            issues.push(HookHealthIssue {
+                component: "hook script".to_string(),
+                message: format!("{} is missing or not executable", script_path.display()),
+                repair: "ainb fleet runtime install".to_string(),
+            });
+        }
+        if !hook_binary_ready {
+            issues.push(HookHealthIssue {
+                component: "hook binary".to_string(),
+                message: hook_binary.as_ref().map_or_else(
+                    || "ainb-bin pointer is missing or empty".to_string(),
+                    |target| format!("{} is missing or not executable", target.display()),
+                ),
+                repair: "ainb fleet runtime install".to_string(),
+            });
+        }
+        for agent in agents.iter().filter(|agent| agent.installed && !agent.wiring_ready) {
+            issues.push(HookHealthIssue {
+                component: agent.agent.clone(),
+                message: agent.detail.clone(),
+                repair: "ainb fleet runtime install".to_string(),
+            });
+        }
+    }
+
+    HookHealth {
+        bundled_version,
+        installed_version: record.plugin_version,
+        version_current,
+        script_path,
+        script_ready,
+        hook_binary,
+        hook_binary_ready,
+        agents,
+        notify_socket_live: socket_live(&paths.socket),
+        approve_socket_live: socket_live(&paths.approve_socket),
+        last_event: latest_event(paths),
+        issues,
+    }
+}
+
+fn agent_health(agent: Agent, record: &InstallRecord, script: &Path) -> HookAgentHealth {
+    let installed = record.agents.contains(&agent);
+    let (wiring_ready, detail) = match agent {
+        // Claude owns marketplace state. Its CLI confirms registration during
+        // install, but does not expose a stable config file that this fast,
+        // local-only probe could safely inspect every two seconds.
+        Agent::Claude => (
+            installed,
+            if installed {
+                "marketplace install recorded".to_string()
+            } else {
+                "not installed".to_string()
+            },
+        ),
+        Agent::Codex => {
+            config_references_script(record.codex_hooks_json.as_deref(), script, "hooks.json")
+        }
+        Agent::Copilot => {
+            config_references_script(record.copilot_hooks_json.as_deref(), script, "drop-in")
+        }
+        Agent::Unknown => (false, "unknown agent".to_string()),
+    };
+    HookAgentHealth {
+        agent: agent.name().to_string(),
+        installed,
+        wiring_ready,
+        detail,
+    }
+}
+
+fn config_references_script(
+    config: Option<&Path>,
+    script: &Path,
+    config_name: &str,
+) -> (bool, String) {
+    let Some(config) = config else {
+        return (false, format!("{config_name} path is not recorded"));
+    };
+    let Ok(text) = std::fs::read_to_string(config) else {
+        return (
+            false,
+            format!("{} is missing or unreadable", config.display()),
+        );
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&strip_line_comments(&text)) else {
+        return (false, format!("{} is not valid JSON", config.display()));
+    };
+    let expected = script.to_string_lossy();
+    if json_has_hook_command(&value, &expected) {
+        (true, format!("{} points at shared hook", config.display()))
+    } else {
+        (
+            false,
+            format!("{} does not point at shared hook", config.display()),
+        )
+    }
+}
+
+fn json_has_hook_command(value: &serde_json::Value, expected: &str) -> bool {
+    match value {
+        serde_json::Value::Object(object) => {
+            object
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|command| command.contains(expected))
+                || object.values().any(|value| json_has_hook_command(value, expected))
+        }
+        serde_json::Value::Array(values) => {
+            values.iter().any(|value| json_has_hook_command(value, expected))
+        }
+        _ => false,
+    }
+}
+
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+        && std::fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+fn socket_live(path: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(path).is_ok()
+}
+
+fn latest_event(paths: &Paths) -> Option<String> {
+    paths.db.exists().then_some(())?;
+    crate::store::Store::open(&paths.db)
+        .ok()?
+        .latest()
+        .ok()?
+        .map(|row| format!("{} ({})", row.raw_event, row.agent))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1225,6 +1471,27 @@ mod tests {
             assert!(!r.installed);
             assert!(!r.socket_ok);
         }
+    }
+
+    #[test]
+    fn hook_health_checks_version_script_binary_and_agent_wiring() {
+        let dir = fake_home();
+        let p = paths_under_home(dir.path());
+        install_under_home(&p, dir.path(), &[Agent::Codex]).unwrap();
+
+        let health = hook_health(&p);
+        assert!(health.version_current);
+        assert!(health.script_ready);
+        assert!(health.hook_binary_ready);
+        let codex = health.agents.iter().find(|agent| agent.agent == "codex").unwrap();
+        assert!(codex.installed);
+        assert!(codex.wiring_ready, "{}", codex.detail);
+        assert!(health.issues.is_empty(), "{:?}", health.issues);
+
+        std::fs::remove_file(canonical_hook_bin(&p)).unwrap();
+        let broken = hook_health(&p);
+        assert!(!broken.hook_binary_ready);
+        assert!(broken.issues.iter().any(|issue| issue.component == "hook binary"));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -43,9 +43,9 @@ pub use broker::{BrokerState, Decision, DecisionKind, PendingInfo};
 pub use envelope::{Envelope, EnvelopeError};
 pub use fallback::FallbackFile;
 pub use install::{
-    Agent, ClaudeRegister, InstallPrompt, InstallRecord, InstallReport, StatusRow, dismiss_prompt,
-    embedded_plugin_version, install as install_for, install_under_home, prompt_state, status,
-    uninstall,
+    Agent, ClaudeRegister, HookAgentHealth, HookHealth, HookHealthIssue, InstallPrompt,
+    InstallRecord, InstallReport, StatusRow, dismiss_prompt, embedded_plugin_version, hook_health,
+    install as install_for, install_under_home, prompt_state, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
 pub use osnotify::{AlertKind, classify_attention};

--- a/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
@@ -162,6 +162,55 @@ fn atc_hook_prefers_ainb_bin_over_path() {
     assert!(!calls.contains("path "), "calls: {calls}");
 }
 
+#[test]
+fn atc_hook_falls_back_to_path_when_installed_binary_is_missing() {
+    let script = hook_script();
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let ainb_home = home.join(".agents-in-a-box");
+    let hooks = ainb_home.join("hooks");
+    let missing_bin = dir.path().join("removed-worktree/target/debug/ainb");
+    let path_dir = dir.path().join("path-bin");
+    let path_bin = path_dir.join("ainb");
+    let capture = dir.path().join("captured-bin");
+    fs::create_dir_all(&hooks).unwrap();
+    fs::create_dir(&path_dir).unwrap();
+    fs::write(hooks.join("ainb-bin"), format!("{}\\n", missing_bin.display())).unwrap();
+    fs::write(
+        &path_bin,
+        "#!/usr/bin/env bash\nprintf 'path %s\\n' \"$*\" >> \"$AINB_HOOK_CAPTURE\"\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&path_bin).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path_bin, permissions).unwrap();
+
+    let original_path = std::env::var("PATH").unwrap();
+    let out = Command::new("bash")
+        .arg(&script)
+        .env("HOME", &home)
+        .env("AINB_HANGAR_HOME", &ainb_home)
+        .env("AINB_AGENT", "claude")
+        .env("AINB_MANAGED", "atc")
+        .env("AINB_HOOK_CAPTURE", &capture)
+        .env("AINB_NOTIFY_DISABLE_LAZY_SPAWN", "1")
+        .env("PATH", format!("{}:{original_path}", path_dir.display()))
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(
+                br#"{"hook_event_name":"Stop","session_id":"sess-stale-bin","cwd":"/tmp"}"#,
+            )?;
+            child.wait()
+        })
+        .expect("running hook");
+
+    assert!(out.success(), "hook failed: {out}");
+    let calls = fs::read_to_string(capture).unwrap();
+    assert!(calls.contains("path fleet atc hook"), "calls: {calls}");
+}
+
 #[tokio::test]
 async fn hook_script_into_real_daemon_persists_supported_agents() {
     // Skip if the bash script is missing — useful when running from

--- a/docs/man/ainb.1
+++ b/docs/man/ainb.1
@@ -123,8 +123,7 @@ Subcommands: list, add, remove, use
 First\-time setup and prerequisite checking
 .TP
 .B ainb doctor
-Health\-check the manifest, lockfile, deployed files, and configured
-sources. Exits non\-zero when any problem is found
+Health\-check skills, dependencies, hooks, and daemons
 .TP
 .B ainb reflect
 Reflect plugin lifecycle: bootstrap installer + dependency check

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -658,20 +658,21 @@ EXAMPLES:
 
 ## `ainb doctor`
 
-Health-check the manifest, lockfile, deployed files, and configured sources. Exits non-zero when any problem is found
+Health-check skills, dependencies, hooks, and daemons
 
 ```console
 $ ainb doctor --help
-Health-check the manifest, lockfile, deployed files, and configured sources. Exits non-zero when any problem is found
+Health-check skills, dependencies, hooks, and daemons
 
 Usage: ainb doctor [OPTIONS]
 
 Options:
-      --offline  Skip the source-reachability check (avoid hitting the network / re-running fetchers)
-  -h, --help     Print help
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --offline          Skip skill-source reachability checks. Runtime checks stay local
+  -h, --help             Print help
 
 EXAMPLES:
-  ainb doctor                      Health-check skill manifest/lockfile/deployed files
+  ainb doctor                      Health-check skills, dependencies, hooks, and daemons
   ainb doctor --offline            Skip source-reachability network checks
 ```
 

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ainb-hooks",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc. stall_guard.py additionally blocks turn-end when a session would idle on in-flight work with no wake armed, so ATC-managed sessions do not silently park on a running CI job.",
   "author": {
     "name": "Agents-in-a-Box"

--- a/plugins/ainb-hooks/hooks/notify.sh
+++ b/plugins/ainb-hooks/hooks/notify.sh
@@ -151,6 +151,12 @@ AINB_HOOK_BIN="${AINB_BIN:-}"
 if [ -z "${AINB_HOOK_BIN}" ] && [ -r "${AINB_DIR}/hooks/ainb-bin" ]; then
   IFS= read -r AINB_HOOK_BIN < "${AINB_DIR}/hooks/ainb-bin" || true
 fi
+# A dev build can disappear after `cargo clean` or its worktree is removed.
+# Do not let that stale installer record disable durable Fleet events forever:
+# fall through to the executable available on the hook's PATH.
+if [ -n "${AINB_HOOK_BIN}" ] && [ ! -x "${AINB_HOOK_BIN}" ]; then
+  AINB_HOOK_BIN=""
+fi
 if [ -z "${AINB_HOOK_BIN}" ]; then
   AINB_HOOK_BIN="$(command -v ainb 2>/dev/null || true)"
 fi


### PR DESCRIPTION
- **fix: restore Claude Fleet interview delivery**
- **fix: version Claude hook update**
- **feat: expose hook health in doctor and daemon view**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `ainb doctor` with combined checks for skills, dependencies, hooks, and daemons, including offline and JSON output options.
  * Added detailed hook health information to the daemon screen, including wiring, executables, sockets, and repair guidance.
* **Bug Fixes**
  * Preserved structured-interview drafts during refreshes when questions remain unchanged.
  * Improved hook binary fallback when configured paths are unavailable.
  * Added compatibility for an additional Claude Code picker footer.
  * Changed the Fleet stop shortcut to uppercase `S`; lowercase `s` submits interviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->