### PR TITLE
fix: snap error-context slice to char boundaries

### DIFF
--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -2227,7 +2227,9 @@ mod tests {
     #[test]
     fn shared_remote_codex_failures_show_a_short_next_action() {
         assert_eq!(
-            format_codex_remote_control_failure("Codex app-server WebSocket handshake failed: invalid token"),
+            format_codex_remote_control_failure(
+                "Codex app-server WebSocket handshake failed: invalid token"
+            ),
             "Codex bridge conflict. Restart Ainb, then retry."
         );
         assert_eq!(
@@ -2235,7 +2237,9 @@ mod tests {
             "Codex bridge starting. Retry session in 5 seconds."
         );
         assert_eq!(
-            format_codex_remote_control_failure("installed Codex cannot generate app-server schema"),
+            format_codex_remote_control_failure(
+                "installed Codex cannot generate app-server schema"
+            ),
             "Codex unavailable. Update Codex, then retry."
         );
         assert_eq!(

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/read/errors.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/read/errors.rs
@@ -89,11 +89,16 @@ mod tests {
 
     #[test]
     fn multibyte_context_does_not_panic() {
-        // 40 and 100 box-drawing chars = 120 and 300 bytes, so both the -80 and
-        // the +200 context offsets land inside a 3-byte '─'. Pre-fix this panicked
-        // with "byte index N is not a char boundary" and killed the fleet daemon.
+        // Byte layout, chosen so BOTH snapping loops are exercised:
+        //   0..120    40 '─' (3 bytes each)
+        //   120..144  "API Error: fetch failed!" (24 ASCII bytes; match is 120..129)
+        //   144..444  100 '─'
+        // start = 120 - 80  = 40  -> 40 % 3 == 1 within the leading run  -> mid-codepoint
+        // end   = 129 + 200 = 329 -> (329 - 144) % 3 == 2 in the trailing run -> mid-codepoint
+        // The trailing '!' is load-bearing: drop it and both offsets land on
+        // multiples of 3, so the `end` loop never runs and the test goes blind.
         let text = format!(
-            "{}API Error: fetch failed{}",
+            "{}API Error: fetch failed!{}",
             "─".repeat(40),
             "─".repeat(100)
         );

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/read/errors.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/read/errors.rs
@@ -51,8 +51,17 @@ pub fn detect_error_signals(text: &str, at_ms: i64) -> Vec<Signal> {
     let mut out = Vec::new();
     for p in API_ERROR_PATTERNS.iter() {
         if let Some(m) = p.re.find(text) {
-            let start = m.start().saturating_sub(80);
-            let end = (m.end() + 200).min(text.len());
+            // Pane text is full of box-drawing chars and emoji, so the ±context
+            // offsets land mid-codepoint constantly. Slicing there panics and
+            // takes the whole daemon down, so snap outward to char boundaries.
+            let mut start = m.start().saturating_sub(80);
+            let mut end = (m.end() + 200).min(text.len());
+            while !text.is_char_boundary(start) {
+                start -= 1;
+            }
+            while !text.is_char_boundary(end) {
+                end += 1;
+            }
             out.push(Signal::ApiError {
                 at: at_ms,
                 pattern: p.name.to_string(),
@@ -76,6 +85,27 @@ mod tests {
                 |s| matches!(s, Signal::ApiError { pattern, .. } if pattern == "rate_limited")
             )
         );
+    }
+
+    #[test]
+    fn multibyte_context_does_not_panic() {
+        // 40 and 100 box-drawing chars = 120 and 300 bytes, so both the -80 and
+        // the +200 context offsets land inside a 3-byte '─'. Pre-fix this panicked
+        // with "byte index N is not a char boundary" and killed the fleet daemon.
+        let text = format!(
+            "{}API Error: fetch failed{}",
+            "─".repeat(40),
+            "─".repeat(100)
+        );
+        let signals = detect_error_signals(&text, 0);
+        let raw = signals
+            .iter()
+            .find_map(|s| match s {
+                Signal::ApiError { pattern, raw, .. } if pattern == "fetch_failed" => Some(raw),
+                _ => None,
+            })
+            .expect("fetch_failed signal");
+        assert!(raw.contains("API Error"));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/read/tmux_pane.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/read/tmux_pane.rs
@@ -67,11 +67,30 @@ pub fn detect_signals_from_pane(pane: &str, at_ms: i64) -> Vec<Signal> {
     let mut out = Vec::new();
     // AskUserQuestion UI has a recognisable header band; refine as samples accrue.
     if pane.contains('?') && pane.contains('│') && pane.contains('┌') && pane.contains('└') {
-        let snippet_start = pane.len().saturating_sub(400);
+        // This branch only fires on panes that DO contain box-drawing chars, so a
+        // raw byte offset lands mid-codepoint most of the time. Snap outward.
+        let mut snippet_start = pane.len().saturating_sub(400);
+        while !pane.is_char_boundary(snippet_start) {
+            snippet_start -= 1;
+        }
         out.push(Signal::AskUserQuestion {
             at: at_ms,
             raw: pane[snippet_start..].to_string(),
         });
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn box_drawn_pane_snippet_does_not_panic() {
+        // 10 ASCII+box bytes of header then 200 '─' = 610 bytes, so len()-400 = 210
+        // lands 200 bytes into the 3-byte run, i.e. mid-codepoint.
+        let pane = format!("┌?│└{}", "─".repeat(200));
+        let signals = detect_signals_from_pane(&pane, 0);
+        assert!(signals.iter().any(|s| matches!(s, Signal::AskUserQuestion { .. })));
+    }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -1233,37 +1233,29 @@ fn legacy_proxy_daemon_pairs(ps_output: &str, live_socket: &Path) -> Vec<(u32, u
 /// A PID is reusable after the first process exits, so the start fingerprint is
 /// required before both TERM and KILL. The fresh process-table check also proves
 /// the legacy parent-child topology still targets this exact home.
-async fn legacy_proxy_daemon_is_current(
-    candidate: &LegacyProxyDaemon,
-    live_socket: &Path,
-) -> bool {
-    process_identity(candidate.pid)
-        .await
-        .is_some_and(|identity| identity.process_start_fingerprint == candidate.process_start_fingerprint)
-        && process_identity(candidate.proxy_pid).await.is_some_and(|identity| {
-            identity.process_start_fingerprint == candidate.proxy_start_fingerprint
-        })
-        && ps_process_table()
-            .await
-            .is_some_and(|ps_output| {
-                legacy_proxy_daemon_pairs(&ps_output, live_socket)
-                    .contains(&(candidate.pid, candidate.proxy_pid))
-            })
+async fn legacy_proxy_daemon_is_current(candidate: &LegacyProxyDaemon, live_socket: &Path) -> bool {
+    process_identity(candidate.pid).await.is_some_and(|identity| {
+        identity.process_start_fingerprint == candidate.process_start_fingerprint
+    }) && process_identity(candidate.proxy_pid).await.is_some_and(|identity| {
+        identity.process_start_fingerprint == candidate.proxy_start_fingerprint
+    }) && ps_process_table().await.is_some_and(|ps_output| {
+        legacy_proxy_daemon_pairs(&ps_output, live_socket)
+            .contains(&(candidate.pid, candidate.proxy_pid))
+    })
 }
 
 /// Confirm the proxy child remains the exact same process after its parent exits.
 async fn legacy_proxy_child_is_current(candidate: &LegacyProxyDaemon, live_socket: &Path) -> bool {
-    process_identity(candidate.proxy_pid)
-        .await
-        .is_some_and(|identity| identity.process_start_fingerprint == candidate.proxy_start_fingerprint)
-        && ps_process_table().await.is_some_and(|ps_output| {
-            ps_output.lines().filter_map(parse_ps_row).any(|row| {
-                row.pid == candidate.proxy_pid
-                    && is_codex_app_server(row.args)
-                    && codex_proxy_socket(row.args)
-                        .is_some_and(|socket| socket == live_socket.to_string_lossy())
-            })
+    process_identity(candidate.proxy_pid).await.is_some_and(|identity| {
+        identity.process_start_fingerprint == candidate.proxy_start_fingerprint
+    }) && ps_process_table().await.is_some_and(|ps_output| {
+        ps_output.lines().filter_map(parse_ps_row).any(|row| {
+            row.pid == candidate.proxy_pid
+                && is_codex_app_server(row.args)
+                && codex_proxy_socket(row.args)
+                    .is_some_and(|socket| socket == live_socket.to_string_lossy())
         })
+    })
 }
 
 /// From ppid==1 orphan candidates, drop our own pid and the pid(s) listening on our

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -187,13 +187,12 @@ mod migration_tests {
         apply_migrations(&pool).await.unwrap();
 
         for version in [87_i64, 89, 90] {
-            let present: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?",
-            )
-            .bind(version)
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+            let present: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?")
+                    .bind(version)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
             assert_eq!(present, 1, "migration {version} was not recorded");
         }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -5761,15 +5761,19 @@ mod tests {
         row.version = 2;
         row.current_request_fingerprint = Some("refreshed-interview".into());
         state.set_sessions(vec![row]);
-        assert!(state.is_modal_open(), "snapshot closed unchanged interview queue");
+        assert!(
+            state.is_modal_open(),
+            "snapshot closed unchanged interview queue"
+        );
 
         let submitted = apply(&state, FleetEvent::Key(FleetKey::Char('s')));
         let Some(FleetIntent::Execute {
             expected_version,
-            action: FleetAction::StructuredAnswer {
-                request_fingerprint,
-                ..
-            },
+            action:
+                FleetAction::StructuredAnswer {
+                    request_fingerprint,
+                    ..
+                },
             ..
         }) = submitted.intent
         else {

--- a/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
@@ -175,7 +175,11 @@ fn atc_hook_falls_back_to_path_when_installed_binary_is_missing() {
     let capture = dir.path().join("captured-bin");
     fs::create_dir_all(&hooks).unwrap();
     fs::create_dir(&path_dir).unwrap();
-    fs::write(hooks.join("ainb-bin"), format!("{}\\n", missing_bin.display())).unwrap();
+    fs::write(
+        hooks.join("ainb-bin"),
+        format!("{}\\n", missing_bin.display()),
+    )
+    .unwrap();
     fs::write(
         &path_bin,
         "#!/usr/bin/env bash\nprintf 'path %s\\n' \"$*\" >> \"$AINB_HOOK_CAPTURE\"\n",


### PR DESCRIPTION
## Problem

`detect_error_signals` slices pane text at raw byte offsets:

```rust
let start = m.start().saturating_sub(80);
let end = (m.end() + 200).min(text.len());
raw: text[start..end].to_string(),
```

Only `text.len()` is respected, never a codepoint boundary. Any API error whose surrounding ±context contains a box-drawing char or emoji panics the process:

```
panicked at crates/ainb-fleet-core/src/fleet/read/errors.rs:59:26:
end byte index 4004 is not a char boundary; it is inside '─' (bytes 4003..4006 of string)
```

Observed live: `ainb fleet daemon` died ~1s after every start on a fleet where one session pane held an API error inside a box-drawn frame. Consequence is not cosmetic, the daemon is the ATC heartbeat driver, so a provisioned ATC instance silently stops beating and never auto-continues anything.

Platform-independent: it is plain `str` slicing semantics, so macOS (Intel + Apple Silicon) and Linux are all affected.

## Fix

Snap both offsets outward to char boundaries before slicing. Widening never truncates the match, and `text.len()` is always a boundary so the loops terminate.

## Test

`multibyte_context_does_not_panic` pads the match with 3-byte `─` on both sides so the -80 and +200 offsets both land mid-codepoint. Verified it fails on pre-fix code (`start byte index 40 is not a char boundary`) and passes after.

```
test fleet::read::errors::tests::multibyte_context_does_not_panic ... ok
test fleet::read::errors::tests::matches_rate_limited ... ok
test fleet::read::errors::tests::no_false_positive_on_clean_text ... ok
```