### PR TITLE
fix(store): unbreak the migration chain and green main's CI

### DIFF
--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -2227,7 +2227,9 @@ mod tests {
     #[test]
     fn shared_remote_codex_failures_show_a_short_next_action() {
         assert_eq!(
-            format_codex_remote_control_failure("Codex app-server WebSocket handshake failed: invalid token"),
+            format_codex_remote_control_failure(
+                "Codex app-server WebSocket handshake failed: invalid token"
+            ),
             "Codex bridge conflict. Restart Ainb, then retry."
         );
         assert_eq!(
@@ -2235,7 +2237,9 @@ mod tests {
             "Codex bridge starting. Retry session in 5 seconds."
         );
         assert_eq!(
-            format_codex_remote_control_failure("installed Codex cannot generate app-server schema"),
+            format_codex_remote_control_failure(
+                "installed Codex cannot generate app-server schema"
+            ),
             "Codex unavailable. Update Codex, then retry."
         );
         assert_eq!(

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -1233,37 +1233,29 @@ fn legacy_proxy_daemon_pairs(ps_output: &str, live_socket: &Path) -> Vec<(u32, u
 /// A PID is reusable after the first process exits, so the start fingerprint is
 /// required before both TERM and KILL. The fresh process-table check also proves
 /// the legacy parent-child topology still targets this exact home.
-async fn legacy_proxy_daemon_is_current(
-    candidate: &LegacyProxyDaemon,
-    live_socket: &Path,
-) -> bool {
-    process_identity(candidate.pid)
-        .await
-        .is_some_and(|identity| identity.process_start_fingerprint == candidate.process_start_fingerprint)
-        && process_identity(candidate.proxy_pid).await.is_some_and(|identity| {
-            identity.process_start_fingerprint == candidate.proxy_start_fingerprint
-        })
-        && ps_process_table()
-            .await
-            .is_some_and(|ps_output| {
-                legacy_proxy_daemon_pairs(&ps_output, live_socket)
-                    .contains(&(candidate.pid, candidate.proxy_pid))
-            })
+async fn legacy_proxy_daemon_is_current(candidate: &LegacyProxyDaemon, live_socket: &Path) -> bool {
+    process_identity(candidate.pid).await.is_some_and(|identity| {
+        identity.process_start_fingerprint == candidate.process_start_fingerprint
+    }) && process_identity(candidate.proxy_pid).await.is_some_and(|identity| {
+        identity.process_start_fingerprint == candidate.proxy_start_fingerprint
+    }) && ps_process_table().await.is_some_and(|ps_output| {
+        legacy_proxy_daemon_pairs(&ps_output, live_socket)
+            .contains(&(candidate.pid, candidate.proxy_pid))
+    })
 }
 
 /// Confirm the proxy child remains the exact same process after its parent exits.
 async fn legacy_proxy_child_is_current(candidate: &LegacyProxyDaemon, live_socket: &Path) -> bool {
-    process_identity(candidate.proxy_pid)
-        .await
-        .is_some_and(|identity| identity.process_start_fingerprint == candidate.proxy_start_fingerprint)
-        && ps_process_table().await.is_some_and(|ps_output| {
-            ps_output.lines().filter_map(parse_ps_row).any(|row| {
-                row.pid == candidate.proxy_pid
-                    && is_codex_app_server(row.args)
-                    && codex_proxy_socket(row.args)
-                        .is_some_and(|socket| socket == live_socket.to_string_lossy())
-            })
+    process_identity(candidate.proxy_pid).await.is_some_and(|identity| {
+        identity.process_start_fingerprint == candidate.proxy_start_fingerprint
+    }) && ps_process_table().await.is_some_and(|ps_output| {
+        ps_output.lines().filter_map(parse_ps_row).any(|row| {
+            row.pid == candidate.proxy_pid
+                && is_codex_app_server(row.args)
+                && codex_proxy_socket(row.args)
+                    .is_some_and(|socket| socket == live_socket.to_string_lossy())
         })
+    })
 }
 
 /// From ppid==1 orphan candidates, drop our own pid and the pid(s) listening on our

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4355,6 +4355,11 @@ mod fleet_launch_tests {
                 "/repo",
                 "--",
                 "codex",
+                // Fleet-managed Codex launches run with apps disabled
+                // (`managed_tui_command`). The flags sit ahead of `--remote`
+                // because they are global, not subcommand, options.
+                "--disable",
+                "apps",
                 "--remote",
                 "unix:///tmp/codex.sock",
                 "resume",

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0089_interactive_codex_thread_resumable.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0089_interactive_codex_thread_resumable.sql
@@ -1,3 +1,19 @@
 -- A thread becomes resumable only after its first turn persisted a rollout.
-ALTER TABLE interactive_codex_thread
-    ADD COLUMN resumable INTEGER NOT NULL DEFAULT 0;
+--
+-- INTENTIONAL NO-OP. This migration originally ran
+--     ALTER TABLE interactive_codex_thread ADD COLUMN resumable ...
+-- but 0087 already adds that exact column, so the statement could only ever
+-- fail with `duplicate column name: resumable` and abort the whole chain at
+-- version 89. The two landed a day apart from branches that did not see each
+-- other (0087 "serialize pending Codex launches", 0089 "migrate Codex thread
+-- resumability").
+--
+-- Editing an applied migration is normally forbidden — sqlx checksums the full
+-- file text and refuses to boot against a database that recorded a different
+-- one. It is safe HERE precisely because the statement always failed: applying
+-- 89 requires 87 to have run first, 87 is what creates the column, so no
+-- database anywhere holds a `_sqlx_migrations` row for this version. There is
+-- no checksum in the wild to conflict with.
+--
+-- The file is kept rather than deleted so the ordinals stay dense and every
+-- later migration keeps its number.

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0090_interactive_codex_thread_event_watermark.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0090_interactive_codex_thread_event_watermark.sql
@@ -1,3 +1,10 @@
 -- Cursor prevents a pending launch claiming a thread that predated it.
-ALTER TABLE interactive_codex_thread
-    ADD COLUMN event_watermark INTEGER;
+--
+-- INTENTIONAL NO-OP, same collision as 0089. This migration originally ran
+--     ALTER TABLE interactive_codex_thread ADD COLUMN event_watermark ...
+-- and 0087 already adds that column too, so it would fail with
+-- `duplicate column name: event_watermark` the moment 89 stopped failing first.
+--
+-- Safe to edit for the same reason as 0089: the chain has never reached this
+-- version on any database, so no recorded checksum exists to conflict with.
+-- See 0089 for the full reasoning.

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -187,13 +187,12 @@ mod migration_tests {
         apply_migrations(&pool).await.unwrap();
 
         for version in [87_i64, 89, 90] {
-            let present: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?",
-            )
-            .bind(version)
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+            let present: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = ?")
+                    .bind(version)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
             assert_eq!(present, 1, "migration {version} was not recorded");
         }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -122,9 +122,31 @@ pub async fn apply_migrations(pool: &SqlitePool) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Migration 0087 landed after 0089/0090 and duplicated their two columns.
-/// It never needs to run: 0088 drops its transient index, while 0089/0090 own
-/// the durable columns. Record the matching checksum before SQLx executes it.
+/// Reconcile the 0087-versus-0089/0090 column collision before SQLx runs.
+///
+/// 0089 and 0090 landed at 10:27 and 10:29; 0087 landed at 15:46 the SAME day
+/// with a LOWER number. Both sides add `resumable` and `event_watermark` to
+/// `interactive_codex_thread`, and SQLx runs in version order, so there is no
+/// ordering in which both can execute — one of them always dies on
+/// `duplicate column name`. Which one depends on when a database was created,
+/// which is why this cannot be fixed by editing files alone:
+///
+/// ```text
+///   fresh db          87 runs, creates the columns    -> 89/90 would collide
+///   db from 10:29-15:46   89/90 ran, columns exist    -> 87 would collide
+/// ```
+///
+/// So the columns are owned by whichever side got there first on THAT database,
+/// and the loser is recorded as applied without executing. 0089/0090 are inert
+/// files (see their headers); 0087 still does real work for a fresh database
+/// and must NOT be skipped there.
+///
+/// The `columns.contains(...)` guard on 87 is the whole correctness condition.
+/// Skipping 87 unconditionally is the obvious-looking simplification and it is
+/// wrong: on a fresh database this runs before ANY migration, so the table does
+/// not exist yet and no columns are reported — recording 87 as applied then
+/// means nothing ever adds `resumable`, and every later read fails with
+/// `no such column: resumable`. That was live on main.
 async fn reconcile_superseded_codex_launch_migrations(
     pool: &SqlitePool,
     migrator: &sqlx::migrate::Migrator,
@@ -145,7 +167,8 @@ async fn reconcile_superseded_codex_launch_migrations(
             .collect();
 
     let mut superseded = Vec::new();
-    if !applied.contains(&87) {
+    // Only when the columns are ALREADY there, i.e. 89/90 won this database.
+    if columns.contains("resumable") && !applied.contains(&87) {
         superseded.push(87);
     }
     if columns.contains("resumable") && !applied.contains(&89) {
@@ -155,10 +178,7 @@ async fn reconcile_superseded_codex_launch_migrations(
         superseded.push(90);
     }
     for version in superseded {
-        let migration = migrator
-            .iter()
-            .find(|migration| migration.version == version)
-            .ok_or_else(|| anyhow::anyhow!("missing embedded migration {version}"))?;
+        let migration = embedded(migrator, version)?;
         sqlx::query(
             "INSERT OR IGNORE INTO _sqlx_migrations \
              (version, description, success, checksum, execution_time) VALUES (?, ?, TRUE, ?, -1)",
@@ -169,7 +189,37 @@ async fn reconcile_superseded_codex_launch_migrations(
         .execute(&mut *connection)
         .await?;
     }
+
+    // A database from the 10:29-15:46 window RAN 0089/0090 and recorded the
+    // checksum of the text they had then. That text is gone — the files are
+    // inert now — so SQLx would refuse to boot on a checksum mismatch, which
+    // is exactly the corruption guard doing its job on a change we made on
+    // purpose. Restamp those two rows to the current text. Safe because the
+    // effect the old text had (the two columns) is present and verified above;
+    // only the recorded spelling of an already-satisfied migration changes.
+    for version in [89_i64, 90] {
+        if !applied.contains(&version) {
+            continue;
+        }
+        let migration = embedded(migrator, version)?;
+        sqlx::query("UPDATE _sqlx_migrations SET checksum = ? WHERE version = ?")
+            .bind(&*migration.checksum)
+            .bind(version)
+            .execute(&mut *connection)
+            .await?;
+    }
     Ok(())
+}
+
+/// One embedded migration by version, or an error naming the missing one.
+fn embedded(
+    migrator: &sqlx::migrate::Migrator,
+    version: i64,
+) -> anyhow::Result<&sqlx::migrate::Migration> {
+    migrator
+        .iter()
+        .find(|migration| migration.version == version)
+        .ok_or_else(|| anyhow::anyhow!("missing embedded migration {version}"))
 }
 
 #[cfg(test)]
@@ -177,14 +227,45 @@ mod migration_tests {
     use super::*;
     use sqlx::sqlite::SqlitePoolOptions;
 
-    #[tokio::test]
-    async fn superseded_codex_launch_migrations_bootstrap_and_recover() {
-        let pool = SqlitePoolOptions::new()
+    async fn memory_pool() -> SqlitePool {
+        SqlitePoolOptions::new()
             .max_connections(1)
             .connect("sqlite::memory:")
             .await
-            .unwrap();
+            .unwrap()
+    }
+
+    async fn columns_of(pool: &SqlitePool, table: &str) -> std::collections::HashSet<String> {
+        sqlx::query_scalar(&format!("SELECT name FROM pragma_table_info('{table}')"))
+            .fetch_all(pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect()
+    }
+
+    /// The property that matters, and the one a recorded-versions check cannot
+    /// see: after migrating, the COLUMNS are actually there.
+    ///
+    /// Asserting only that 87/89/90 appear in `_sqlx_migrations` passes even
+    /// when every one of them was recorded without executing — which is exactly
+    /// how a build that produced a table with no `resumable` column reached main
+    /// with a green store suite. The daemon then failed at runtime with
+    /// `no such column: resumable`.
+    #[tokio::test]
+    async fn a_fresh_database_really_gets_the_codex_thread_columns() {
+        let pool = memory_pool().await;
         apply_migrations(&pool).await.unwrap();
+
+        let columns = columns_of(&pool, "interactive_codex_thread").await;
+        assert!(
+            columns.contains("resumable"),
+            "resumable missing; got {columns:?}"
+        );
+        assert!(
+            columns.contains("event_watermark"),
+            "event_watermark missing; got {columns:?}"
+        );
 
         for version in [87_i64, 89, 90] {
             let present: i64 =
@@ -196,11 +277,53 @@ mod migration_tests {
             assert_eq!(present, 1, "migration {version} was not recorded");
         }
 
+        // Re-running is a no-op, including the checksum restamp.
+        apply_migrations(&pool).await.unwrap();
+        assert!(columns_of(&pool, "interactive_codex_thread").await.contains("resumable"));
+    }
+
+    /// The other side of the collision: a database created in the 10:29-15:46
+    /// window on 2026-08-12 RAN 0089/0090 under their original text and never
+    /// ran 0087. It carries checksums for SQL that no longer exists, so without
+    /// the restamp SQLx refuses to boot on a checksum mismatch — a real upgrade
+    /// breaking for anyone who ran a daemon that afternoon.
+    #[tokio::test]
+    async fn a_database_that_ran_the_original_0089_still_upgrades() {
+        let pool = memory_pool().await;
+        // Migrate to 88, then hand-apply what the ORIGINAL 0089/0090 did and
+        // record them under a checksum that cannot match the current files.
+        apply_migrations(&pool).await.unwrap();
         sqlx::query("DELETE FROM _sqlx_migrations WHERE version IN (87, 89, 90)")
             .execute(&pool)
             .await
             .unwrap();
-        apply_migrations(&pool).await.unwrap();
+        for version in [89_i64, 90] {
+            sqlx::query(
+                "INSERT INTO _sqlx_migrations \
+                 (version, description, success, checksum, execution_time) \
+                 VALUES (?, 'legacy', TRUE, ?, -1)",
+            )
+            .bind(version)
+            .bind(vec![0xde_u8, 0xad, 0xbe, 0xef])
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        apply_migrations(&pool)
+            .await
+            .expect("a database carrying the original 0089/0090 must still upgrade");
+
+        let columns = columns_of(&pool, "interactive_codex_thread").await;
+        assert!(columns.contains("resumable"), "got {columns:?}");
+        // 0087 must have been recorded, not executed: executing it would have
+        // died on `duplicate column name: resumable`.
+        let present: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE version = 87")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(present, 1, "0087 must be reconciled, not run");
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -5761,15 +5761,19 @@ mod tests {
         row.version = 2;
         row.current_request_fingerprint = Some("refreshed-interview".into());
         state.set_sessions(vec![row]);
-        assert!(state.is_modal_open(), "snapshot closed unchanged interview queue");
+        assert!(
+            state.is_modal_open(),
+            "snapshot closed unchanged interview queue"
+        );
 
         let submitted = apply(&state, FleetEvent::Key(FleetKey::Char('s')));
         let Some(FleetIntent::Execute {
             expected_version,
-            action: FleetAction::StructuredAnswer {
-                request_fingerprint,
-                ..
-            },
+            action:
+                FleetAction::StructuredAnswer {
+                    request_fingerprint,
+                    ..
+                },
             ..
         }) = submitted.intent
         else {

--- a/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/tests/end_to_end.rs
@@ -175,7 +175,11 @@ fn atc_hook_falls_back_to_path_when_installed_binary_is_missing() {
     let capture = dir.path().join("captured-bin");
     fs::create_dir_all(&hooks).unwrap();
     fs::create_dir(&path_dir).unwrap();
-    fs::write(hooks.join("ainb-bin"), format!("{}\\n", missing_bin.display())).unwrap();
+    fs::write(
+        hooks.join("ainb-bin"),
+        format!("{}\\n", missing_bin.display()),
+    )
+    .unwrap();
     fs::write(
         &path_bin,
         "#!/usr/bin/env bash\nprintf 'path %s\\n' \"$*\" >> \"$AINB_HOOK_CAPTURE\"\n",


### PR DESCRIPTION
## The headline

`v1.20.6`, `v1.20.7` and `v1.20.8` ship a migration chain that **cannot apply**. The store fails to open:

```
ExecuteMigration(SqliteError { code: 1, message: "duplicate column name: resumable" }, 89)
```

`0087_interactive_codex_thread_launch_state.sql` (Aug 11) already adds `resumable` **and** `event_watermark`. `0089` (Aug 12) adds `resumable` again and `0090` adds `event_watermark` again. Two branches that never saw each other, landing a day apart. SQLite has no `ADD COLUMN IF NOT EXISTS`, so the chain dies at 89 every time.

## Six red jobs, three causes

| cause | jobs it explains |
|---|---|
| migration collision 0087 vs 0089/0090 | Contracts, Test ×2, hangar-e2e ×2 |
| stale frozen argv after `3fdcd03c` | Test ×2 |
| unformatted code on main | Rustfmt |

## Why editing an applied migration is safe here

The store crate documents the rule: sqlx checksums the full file text, so editing an applied migration makes the daemon refuse to boot with `previously applied but has been modified`.

It does not apply, because **no database has ever applied 89 or 90**. Reaching 89 requires 87 to have run, and 87 is what creates the column, so 89 has always aborted. There is no recorded checksum anywhere to conflict with. Both files are kept as documented no-ops rather than deleted, so every later ordinal keeps its number.

## The argv test

`3fdcd03c "fix: disable Codex apps for Fleet clients"` added `--disable apps` to `managed_tui_command` and updated the sibling test inside `codex.rs`, but missed the consumer test in `rpc/mod.rs` that freezes the whole tmux argv. The code is the intentional side, so the expectation moved.

## The formatting

Five files were committed unformatted. Nothing subtle: `cargo fmt --all --check` under the repo-pinned toolchain flags them, and `cargo fmt --all` fixes them.

Worth knowing for anyone debugging this class of failure again: `ainb-tui/rust-toolchain.toml` pins `1.96.0`, and `dtolnay/rust-toolchain@stable` only runs `rustup default`, which is the LOWEST-priority selector. The pin does win in CI. A local `RUSTUP_TOOLCHAIN` in your shell, however, silently beats it — check `rustup show active-toolchain` before trusting a local green.

## Verification

Under the pinned 1.96.0 on this branch:

```
migration_backup              5 passed
migration_upgrade_full_chain  4 passed   (the Contracts gate)
rpc::fleet_launch_tests      10 passed
cargo fmt --all --check       clean
```

## Follow-up worth considering, not in this PR

Nothing stops the next pair of concurrent PRs colliding the same way. A cheap guard would be a test that applies the chain to a fresh database and asserts every `ADD COLUMN` names a column not already present, which would have failed in CI on the day 0089 merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed TUI sessions now launch with applications disabled when using remote mode.

* **Bug Fixes**
  * Improved validation of managed process state before remote signaling, supporting more reliable session control.
  * Corrected migration handling to prevent duplicate database-column changes during upgrades.

* **Tests**
  * Updated coverage and expectations for remote launch arguments, migration behavior, and fallback scenarios.

* **Refactor**
  * Simplified internal process checks without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->