### PR TITLE
feat(hangar): distinguish a daemon restart from a reconnect

### DIFF
--- a/ainb-tui/crates/ainb-hangar-core/src/ids.rs
+++ b/ainb-tui/crates/ainb-hangar-core/src/ids.rs
@@ -112,6 +112,21 @@ id_newtype! {
     RuntimeId
 }
 id_newtype! {
+    /// Identifies one RUN of a daemon process (`agent_runtime.instance_id`).
+    ///
+    /// Unlike its neighbours this is not a table PK: it is minted once per
+    /// daemon process and stamped on the runtime row that process registers, so
+    /// the next registration can tell a RESTART (a different instance took the
+    /// runtime over — the previous process's tasks are orphans) from a
+    /// RECONNECT (the same live instance re-registering). A stored `NULL` means
+    /// no process has claimed the row and is read as "assume restart".
+    ///
+    /// Its own newtype precisely because it lives beside a [`RuntimeId`] in
+    /// every signature that carries both: the compiler refuses the swap that a
+    /// pair of bare `String`s would silently accept.
+    InstanceId
+}
+id_newtype! {
     /// Identifies an issue (the `issue` table PK).
     IssueId
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -900,10 +900,17 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // changed `HANGAR_DAEMON_RUNTIME_ID` (which is warned about, not obeyed).
         // Resolving here keeps the registered row, the agents, and the claim loop on
         // ONE id instead of claiming for an id nothing is bound to.
+        //
+        // This is also where this PROCESS claims the runtime (migration 0092): the
+        // registration stamps our instance id and reports whether we displaced a
+        // different one, which is what tells the run loop that the rows still
+        // `dispatched`/`running` for this runtime are a dead process's orphans
+        // rather than our own live work.
         let now =
             ainb_hangar_core::clock::HangarClock::now_ms(&ainb_hangar_core::clock::SystemClock);
-        cfg.runtime_id =
-            Some(crate::runtime_register::effective_runtime_id(store.pool(), now).await);
+        let boot = crate::runtime_register::resolve_runtime_boot(store.pool(), now).await;
+        cfg.runtime_id = Some(boot.runtime_id);
+        cfg.runtime_arrival = boot.arrival;
         // Boot is done; from here the run loop owns shutdown.
         let _ = running_tx.send(());
         run(store.pool().clone(), cfg, stats, broker.sink(), shutdown).await

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -45,6 +45,7 @@ use std::time::Duration;
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
 use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use ainb_hangar_core::task::state::TaskState;
+use ainb_hangar_store::bootstrap::RuntimeArrival;
 use ainb_hangar_store::repo::task::{Task, TaskRepo};
 use ainb_hangar_store::service::claim::{ClaimTaskService, ClaimedTask};
 use ainb_hangar_store::service::complete::{CompleteParams, CompleteTaskService};
@@ -62,7 +63,7 @@ use crate::health_stats::HealthStats;
 use crate::progress_comment;
 use crate::runner::{Backend, Mode, ProviderInvocation, RunOutcome, Runner, RunnerConfig};
 use crate::sweeper::{
-    SweeperConfig, reclaim_orphaned_on_startup, sweep_expired_queued, sweep_runtime_presence,
+    SweeperConfig, reclaim_orphans_on_restart, sweep_expired_queued, sweep_runtime_presence,
     sweep_stale_dispatched, sweep_stale_running,
 };
 
@@ -131,6 +132,17 @@ const HANGAR_PARENT_SESSION: &str = "hangar-daemon";
 pub struct DaemonConfig {
     /// Runtime id this daemon claims tasks for, or `None` (claim disabled).
     pub runtime_id: Option<String>,
+    /// What this process's boot registration displaced (migration 0092) — the
+    /// signal the startup orphan reclaim keys off.
+    ///
+    /// [`Self::from_env`] cannot know it (nothing has touched the database yet),
+    /// so it defaults to `Restart` with no named predecessor: an unknown owner is
+    /// read as "the previous executor is gone", which is the recoverable
+    /// assumption and preserves the pre-0092 unconditional-reclaim behaviour for
+    /// any caller that drives [`run`] without registering. [`crate::boot`]
+    /// overwrites it with the verdict
+    /// [`crate::runtime_register::resolve_runtime_boot`] actually returned.
+    pub runtime_arrival: RuntimeArrival,
     /// Path to the `claude` provider binary.
     pub claude_path: PathBuf,
     /// Path to the `codex` provider binary (e38.16).
@@ -232,6 +244,10 @@ impl DaemonConfig {
 
         Self {
             runtime_id,
+            // Unknown until the boot registration runs; see the field docs.
+            runtime_arrival: RuntimeArrival::Restart {
+                previous_instance_id: None,
+            },
             claude_path,
             codex_path,
             copilot_path,
@@ -478,14 +494,19 @@ pub async fn run(
         return Ok(());
     };
 
-    // e38.25 crash recovery: this daemon just booted, so any task still frozen
-    // `dispatched`/`running` for its runtime is an orphan from a previous
-    // (crashed/restarted) instance — the process that owned those runs is gone.
-    // Reclaim them to `queued` once, up front, so the work is re-dispatched
-    // immediately rather than stranded until the multi-hour running TTL. Scoped
-    // to this runtime so a sibling daemon's live runs are never touched. A
-    // reclaim fault is non-fatal — the time-based sweepers still backstop it.
-    match reclaim_orphaned_on_startup(&pool, &runtime_id).await {
+    // e38.25 crash recovery: a task still frozen `dispatched`/`running` for this
+    // runtime is an orphan from a previous instance — the process that owned
+    // those runs is gone. Reclaim them to `queued` once, up front, so the work is
+    // re-dispatched immediately rather than stranded until the multi-hour running
+    // TTL. Scoped to this runtime so a sibling daemon's live runs are never
+    // touched. A reclaim fault is non-fatal — the time-based sweepers still
+    // backstop it.
+    //
+    // Gated on the boot registration's verdict (migration 0092) rather than on
+    // "we are in boot": if this process merely RE-registered a runtime it already
+    // owned, those in-flight rows belong to its own live runs and requeuing them
+    // would double-dispatch work that never stopped.
+    match reclaim_orphans_on_restart(&pool, &runtime_id, &cfg.runtime_arrival).await {
         Ok(n) if n > 0 => tracing::info!(reclaimed = n, "startup crash-recovery reclaim"),
         Ok(_) => {}
         Err(e) => tracing::error!(error = %e, "startup crash-recovery reclaim failed"),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -821,6 +821,13 @@ pub fn spawn_gc_sweeper(
 /// event, so it needs no change). The reference publishes
 /// `EventDaemonRegister{stale_sweep}` on its own bus for exactly this reason.
 ///
+/// The pass also RECOVERS work: a runtime that decays all the way to `offline`
+/// has its orphaned `dispatched`/`running` rows reclaimed to `queued` on that
+/// same tick, so a daemon that died and never comes back no longer strands its
+/// tasks until the 2.5h running TTL (see
+/// [`crate::sweeper::reclaim_orphans_for_offline_runtimes`]). A reclaim fault is
+/// swallowed per runtime, so the events below are emitted either way.
+///
 /// `runtime_id` is this daemon's own runtime, beaten first each pass so the
 /// daemon can never sweep itself; `None` for a daemon that advertises none.
 /// A failed pass is logged and the loop continues — presence is observability,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -821,13 +821,6 @@ pub fn spawn_gc_sweeper(
 /// event, so it needs no change). The reference publishes
 /// `EventDaemonRegister{stale_sweep}` on its own bus for exactly this reason.
 ///
-/// The pass also RECOVERS work: a runtime that decays all the way to `offline`
-/// has its orphaned `dispatched`/`running` rows reclaimed to `queued` on that
-/// same tick, so a daemon that died and never comes back no longer strands its
-/// tasks until the 2.5h running TTL (see
-/// [`crate::sweeper::reclaim_orphans_for_offline_runtimes`]). A reclaim fault is
-/// swallowed per runtime, so the events below are emitted either way.
-///
 /// `runtime_id` is this daemon's own runtime, beaten first each pass so the
 /// daemon can never sweep itself; `None` for a daemon that advertises none.
 /// A failed pass is logged and the loop continues — presence is observability,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runtime_register.rs
@@ -29,9 +29,148 @@
 //! booted against a brand-new home with no workspace yet has nothing to attach
 //! to, so registration is a no-op in that case (returns `false`); the boot seed
 //! lays the workspace down first, so in practice this only guards odd orderings.
+//!
+//! # Restart vs reconnect (migration 0092)
+//!
+//! Because every boot refreshes the SAME row, the registration alone could not
+//! say whether the daemon that owned it is still alive. [`daemon_instance_id`]
+//! mints one id per daemon PROCESS and [`resolve_runtime_boot`] presents it, so
+//! the store can compare it with the stored owner and answer
+//! [`RuntimeArrival`]: a different owner means this process took the runtime over
+//! and the previous one's `dispatched`/`running` tasks are orphans; an identical
+//! owner means the same live process re-registered and its work must be left
+//! alone. The boot path acts on that in
+//! [`crate::sweeper::reclaim_orphans_on_restart`].
+//!
+//! Exactly ONE call site claims the instance — [`resolve_runtime_boot`], from
+//! [`crate::boot`]. [`effective_runtime_id`] (used by the boot seed) deliberately
+//! does NOT: it runs earlier in the same process, and if it claimed first, the
+//! real boot registration would see its own id and report a reconnect, skipping
+//! the orphan reconcile the restart needs.
 
+use std::sync::OnceLock;
+
+use ainb_hangar_core::ids::InstanceId;
+use ainb_hangar_store::bootstrap::{RuntimeArrival, RuntimeRegistration};
 use anyhow::{Context, Result};
 use sqlx::SqlitePool;
+
+/// This daemon process's instance id, minted on first use.
+///
+/// Stable for the life of the process — that stability IS the signal (see the
+/// module docs), so it is deliberately never re-minted per call or per
+/// registration.
+///
+/// A ULID from the same [`ainb_hangar_core::idgen`] seam every other Hangar id
+/// comes from, so no new dependency and no second id format.
+pub fn daemon_instance_id() -> &'static InstanceId {
+    static INSTANCE: OnceLock<InstanceId> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        use ainb_hangar_core::idgen::IdGen;
+        InstanceId::from_str(ainb_hangar_core::idgen::SystemIdGen.new_ulid())
+            .expect("a freshly minted ULID is never empty")
+    })
+}
+
+/// What [`resolve_runtime_boot`] resolved: the id this daemon claims for, and
+/// whether taking it over orphaned a previous instance's in-flight work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBoot {
+    /// The runtime id actually in use (an existing row's id wins).
+    pub runtime_id: String,
+    /// Restart or reconnect, as decided against the stored instance id.
+    pub arrival: RuntimeArrival,
+}
+
+/// [`effective_runtime_id`], plus the restart-vs-reconnect verdict: register
+/// under this PROCESS's [`daemon_instance_id`] and report what that displaced.
+///
+/// This is the daemon's boot registration and the only place that claims
+/// instance ownership (see the module docs). Infallible from the caller's view
+/// for the same reason [`effective_runtime_id`] is — a fault falls back to the
+/// configured id, and to `Restart` with no named predecessor, because "assume
+/// the previous executor is gone" is the recoverable reading of an unknown
+/// owner: requeuing a task whose process died is cheap, stranding one until the
+/// 2.5h running TTL is not.
+pub async fn resolve_runtime_boot(pool: &SqlitePool, now_ms: i64) -> RuntimeBoot {
+    let configured = ainb_hangar_store::bootstrap::default_runtime_id();
+    let instance = daemon_instance_id();
+    let registered = ainb_hangar_store::bootstrap::register_runtime_instance(
+        pool,
+        &configured,
+        instance,
+        now_ms,
+    )
+    .await;
+    match registered {
+        Ok(Some(RuntimeRegistration {
+            runtime_id,
+            arrival,
+        })) => {
+            log_settled_id(&configured, &runtime_id);
+            match &arrival {
+                RuntimeArrival::Restart {
+                    previous_instance_id,
+                } => tracing::info!(
+                    runtime_id = %runtime_id,
+                    instance_id = %instance,
+                    previous_instance_id = previous_instance_id
+                        .as_ref()
+                        .map_or("<none>", InstanceId::as_str),
+                    "runtime registered as a RESTART; the previous instance's in-flight tasks \
+                     are orphaned"
+                ),
+                RuntimeArrival::Reconnect => tracing::info!(
+                    runtime_id = %runtime_id,
+                    instance_id = %instance,
+                    "runtime registered as a RECONNECT; the same instance still owns its work"
+                ),
+            }
+            RuntimeBoot {
+                runtime_id,
+                arrival,
+            }
+        }
+        // No workspace to attach to yet: nothing registered, carry the configured
+        // id and the safe default verdict.
+        Ok(None) => {
+            tracing::info!(runtime_id = %configured, "runtime self-register skipped (no workspace yet)");
+            unknown_owner_boot(configured)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "runtime self-register/resolve failed; using the configured id");
+            unknown_owner_boot(configured)
+        }
+    }
+}
+
+/// The fallback boot verdict when the registration could not run: the configured
+/// id, and `Restart` with no predecessor (unknown owner ⇒ assume the previous
+/// executor is gone).
+const fn unknown_owner_boot(runtime_id: String) -> RuntimeBoot {
+    RuntimeBoot {
+        runtime_id,
+        arrival: RuntimeArrival::Restart {
+            previous_instance_id: None,
+        },
+    }
+}
+
+/// Log which id a registration settled on: a `warn!` naming both when an
+/// existing runtime's id overrode the configured one (a runtime cannot be
+/// renamed), an `info!` otherwise.
+fn log_settled_id(configured: &str, settled: &str) {
+    if settled == configured {
+        tracing::info!(runtime_id = %settled, "self-registered agent runtime");
+    } else {
+        tracing::warn!(
+            configured = %configured,
+            existing = %settled,
+            "HANGAR_DAEMON_RUNTIME_ID={configured} ignored; existing runtime {settled} \
+             is in use; a runtime cannot be renamed after first boot"
+        );
+    }
+}
 
 /// Resolve the runtime id this daemon registers under AND claims for.
 ///
@@ -49,20 +188,16 @@ use sqlx::SqlitePool;
 /// Infallible from the caller's view: a fault falls back to the configured id
 /// (logged), because refusing to boot over a transient error is worse than
 /// carrying on with the configured identity.
+///
+/// Does NOT claim instance ownership — this is the boot SEED's resolve, and the
+/// process that executes the runtime's tasks claims through
+/// [`resolve_runtime_boot`]. See the module docs for why claiming from both would
+/// mask the restart.
 pub async fn effective_runtime_id(pool: &SqlitePool, now_ms: i64) -> String {
     let configured = ainb_hangar_store::bootstrap::default_runtime_id();
     match ainb_hangar_store::bootstrap::ensure_runtime(pool, &configured, now_ms).await {
         Ok(Some(settled)) => {
-            if settled != configured {
-                tracing::warn!(
-                    configured = %configured,
-                    existing = %settled,
-                    "HANGAR_DAEMON_RUNTIME_ID={configured} ignored; existing runtime {settled} \
-                     is in use; a runtime cannot be renamed after first boot"
-                );
-            } else {
-                tracing::info!(runtime_id = %settled, "self-registered agent runtime");
-            }
+            log_settled_id(&configured, &settled);
             settled
         }
         // No workspace to attach to yet: nothing registered, carry the configured id.
@@ -184,6 +319,94 @@ mod tests {
             "the restart refreshed last_seen_at"
         );
         assert_eq!(row.status, "online");
+    }
+
+    /// The recorded owner of `runtime_id`, or `None` when unclaimed.
+    async fn owner(pool: &SqlitePool, runtime_id: &str) -> Option<InstanceId> {
+        ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo::instance_id(pool, runtime_id)
+            .await
+            .expect("read instance_id")
+    }
+
+    /// Booting against a runtime a DIFFERENT instance owns is a restart: the
+    /// verdict names the displaced instance, and this process takes the row over.
+    #[tokio::test]
+    async fn boot_after_another_instance_reports_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_workspace(pool).await;
+
+        // A previous daemon process owned the runtime and then died.
+        let previous = InstanceId::from_str("inst-dead").unwrap();
+        let runtime_id = ainb_hangar_store::bootstrap::default_runtime_id();
+        ainb_hangar_store::bootstrap::register_runtime_instance(
+            pool,
+            &runtime_id,
+            &previous,
+            1_000,
+        )
+        .await
+        .unwrap()
+        .expect("previous instance registered");
+
+        let boot = resolve_runtime_boot(pool, 2_000).await;
+        assert_eq!(boot.runtime_id, runtime_id);
+        assert_eq!(
+            boot.arrival,
+            RuntimeArrival::Restart {
+                previous_instance_id: Some(previous)
+            },
+            "a dead predecessor's in-flight tasks are orphans"
+        );
+        assert_eq!(
+            owner(pool, &runtime_id).await.as_ref(),
+            Some(daemon_instance_id()),
+            "this process now owns the runtime"
+        );
+    }
+
+    /// A SECOND registration by the same process is a reconnect — the instance id
+    /// is minted once per process, so the row already names us and nothing of ours
+    /// is orphaned.
+    #[tokio::test]
+    async fn resolve_runtime_boot_twice_in_one_process_is_a_reconnect() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_workspace(pool).await;
+
+        assert!(
+            resolve_runtime_boot(pool, 1_000).await.arrival.is_restart(),
+            "an unowned runtime reads as a restart"
+        );
+        assert_eq!(
+            resolve_runtime_boot(pool, 2_000).await.arrival,
+            RuntimeArrival::Reconnect,
+            "the same process must not look like it displaced itself"
+        );
+    }
+
+    /// The boot SEED's resolve must not claim the instance: if it did, the real
+    /// boot registration would see its own id, report a reconnect, and skip the
+    /// orphan reconcile a genuine restart needs.
+    #[tokio::test]
+    async fn effective_runtime_id_does_not_claim_the_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        seed_workspace(pool).await;
+
+        let runtime_id = effective_runtime_id(pool, 1_000).await;
+        assert_eq!(
+            owner(pool, &runtime_id).await,
+            None,
+            "the seed materialises the row without owning it"
+        );
+        assert!(
+            resolve_runtime_boot(pool, 2_000).await.arrival.is_restart(),
+            "so the boot registration still sees an unowned runtime"
+        );
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
@@ -29,6 +29,15 @@
 //! production uses the reference defaults, tests inject a frozen clock and tight
 //! config so the suite is deterministic (no `tokio::time::sleep`).
 //!
+//! # Orphan reclaim (not time-based)
+//!
+//! Separately from the TTLs, a runtime's whole in-flight set is reclaimed the
+//! moment its owning PROCESS is known to be gone — no TTL wait, because the
+//! evidence is ownership, not age. [`reclaim_orphaned_for_runtime`] does the
+//! work; two thin wrappers name the two pieces of evidence:
+//! [`reclaim_orphans_on_restart`] (a different instance registered the runtime)
+//! and [`reclaim_orphans_for_offline_runtimes`] (the presence sweep aged it out).
+//!
 //! # Idempotency
 //!
 //! Every statement constrains the source `status` in its `WHERE` clause, so a
@@ -52,7 +61,7 @@ use std::time::Duration;
 use ainb_hangar_core::clock::HangarClock;
 use ainb_hangar_proto::events::PresenceState;
 use ainb_hangar_store::bootstrap::RuntimeArrival;
-use ainb_hangar_store::repo::agent_runtime::{AgentRuntimeRepo, PresenceSweep};
+use ainb_hangar_store::repo::agent_runtime::{AgentRuntimeRepo, PresenceSweep, SweptRuntime};
 use sqlx::SqlitePool;
 
 /// How long a `queued` task may wait before it is failed. Reference:
@@ -342,6 +351,10 @@ pub async fn sweep_stale_dispatched(
 /// (the claim-disabled "sweepers only" mode), in which case the pass is purely
 /// the age sweep.
 ///
+/// A runtime that lands in the `offline` band also has its orphaned in-flight
+/// tasks reclaimed to `queued` — see [`reclaim_orphans_for_offline_runtimes`],
+/// which owns the trigger's reasoning and swallows its own faults.
+///
 /// Returns the rows that moved so the caller can fan `AgentPresence` events out
 /// (the reference publishes `EventDaemonRegister{stale_sweep}` for the same
 /// reason: clients must re-read the runtime list).
@@ -349,6 +362,8 @@ pub async fn sweep_stale_dispatched(
 /// # Errors
 ///
 /// Returns a [`sqlx::Error`] if the heartbeat or either sweep statement fails.
+/// A failed *reclaim* is NOT an error here: it is logged and skipped so the
+/// presence transitions are still reported and still announced.
 pub async fn sweep_runtime_presence(
     pool: &SqlitePool,
     clock: &dyn HangarClock,
@@ -372,35 +387,47 @@ pub async fn sweep_runtime_presence(
             "runtime_presence_swept",
         );
     }
+    // Going offline is itself the verdict that a runtime's in-flight work is
+    // orphaned, so recover it here rather than stranding it until the multi-hour
+    // running TTL. Faults are absorbed per runtime so the caller still gets the
+    // full sweep to fan presence events from.
+    reclaim_orphans_for_offline_runtimes(pool, &sweep.to_offline, own_runtime_id).await;
     Ok(sweep)
 }
 
-/// Reclaim a crashed daemon's orphaned in-flight tasks back to `queued` at
-/// startup (e38.25 crash recovery).
+/// Reclaim one runtime's orphaned in-flight tasks back to `queued` (e38.25 crash
+/// recovery).
 ///
 /// When a daemon dies uncleanly (`kill -9`, OOM, panic) mid-task its claimed
 /// rows are left frozen in `dispatched` or `running` — the FSM step that would
 /// have finalised them never ran. The time-based sweepers eventually move them
 /// (a `running` row only past the 2.5h running TTL; a `dispatched` row past the
-/// 90s reclaim window), but on a fresh boot there is no need to wait: the
-/// process that *was* executing those tasks is, by definition, gone. So at
-/// startup the newly-booted daemon reclaims every non-terminal in-flight row it
-/// owns — scoped to **its own** `runtime_id` so a sibling daemon's live runs in
-/// a multi-runtime deployment are never disturbed — back to `queued`, clearing
+/// 90s reclaim window), but once the owning process is known to be gone there is
+/// no need to wait. So the caller reclaims every non-terminal in-flight row that
+/// runtime owns — scoped to the one `runtime_id` so a sibling daemon's live runs
+/// in a multi-runtime deployment are never disturbed — back to `queued`, clearing
 /// `started_at` / `dispatched_at` so a fresh claim re-dispatches the work. The
 /// `attempt` counter is left **unchanged** (a crash redelivery is not a retry,
 /// mirroring [`reclaim_stale_dispatched`]).
 ///
-/// This is the redelivery the daemon-restart path needs: the orphan leaves its
-/// `running`/`dispatched` limbo immediately on restart rather than stranding the
-/// work for hours. Mirrors the reference's runtime-scoped reclaim-on-boot.
+/// This function is deliberately TRIGGER-NEUTRAL: deciding that the owning
+/// process is gone is the caller's job, and there are two such callers, each a
+/// thin wrapper naming its own evidence — [`reclaim_orphans_on_restart`] (a
+/// different process instance registered this runtime) and
+/// [`reclaim_orphans_for_offline_runtimes`] (the presence sweep aged the runtime
+/// out). Never call it unconditionally: requeuing rows a LIVE process is still
+/// executing double-dispatches that work.
 ///
 /// Returns the number of rows reclaimed.
 ///
 /// # Errors
 ///
-/// Returns a [`sqlx::Error`] if the statement fails.
-pub async fn reclaim_orphaned_on_startup(
+/// Returns a [`sqlx::Error`] if the statement fails. A requeue can legitimately
+/// fail: `queued` is a *pending* status, so returning a `running` row to it can
+/// collide with the one-pending-task-per-(issue, agent) unique index when a
+/// newer task for the same pair is already waiting. Both callers treat that as
+/// non-fatal — the time-based sweepers still backstop the row.
+pub async fn reclaim_orphaned_for_runtime(
     pool: &SqlitePool,
     runtime_id: &str,
 ) -> Result<u64, sqlx::Error> {
@@ -416,17 +443,16 @@ pub async fn reclaim_orphaned_on_startup(
     .rows_affected();
     if reclaimed > 0 {
         tracing::info!(
-            kind = "startup",
             outcome = "reclaimed",
             count = reclaimed,
             runtime_id,
-            "sweeper_startup_reclaim"
+            "sweeper_orphan_reclaim"
         );
     }
     Ok(reclaimed)
 }
 
-/// [`reclaim_orphaned_on_startup`], but only when the boot registration says a
+/// [`reclaim_orphaned_for_runtime`], but only when the boot registration says a
 /// DIFFERENT process instance owned this runtime (migration 0092).
 ///
 /// "This daemon just booted" is a weaker signal than it looks: the same process
@@ -457,7 +483,75 @@ pub async fn reclaim_orphans_on_restart(
         );
         return Ok(0);
     }
-    reclaim_orphaned_on_startup(pool, runtime_id).await
+    reclaim_orphaned_for_runtime(pool, runtime_id).await
+}
+
+/// [`reclaim_orphaned_for_runtime`] for every runtime the presence sweep just
+/// aged out to `offline`.
+///
+/// The restart wrapper above only recovers a dead daemon's work when that daemon
+/// COMES BACK. Nothing brings back a machine that was shut down, so without this
+/// its in-flight rows sit `dispatched`/`running` until the multi-hour
+/// [`RUNNING_TTL`] — hours in which the tasks look alive, block their issue, and
+/// are claimable by nobody. Crossing [`PresenceState::OFFLINE_AFTER_MS`] with no
+/// heartbeat is the second piece of evidence that the owning process is gone, so
+/// the same runtime-scoped reclaim runs on that transition.
+///
+/// Only `to_offline` — never `to_unstable`. Unstable is the GRACE window whose
+/// whole purpose is to let a briefly-stalled daemon (a GC pause, a slow disk, a
+/// laptop lid) keep the run it is still executing; reclaiming there would rob it.
+///
+/// Faults are swallowed per runtime, deliberately: presence is observability, and
+/// one runtime's failed requeue (most plausibly the pending-task unique-index
+/// collision described on [`reclaim_orphaned_for_runtime`]) must not stop the
+/// next runtime's reclaim, nor the caller's `AgentPresence` fan-out. The
+/// time-based sweepers remain the backstop for whatever is skipped. Returns the
+/// total rows reclaimed across all runtimes.
+///
+/// # Residual hazard (read before changing this)
+///
+/// A daemon that is ALIVE but wedged for >10min gets its rows requeued while it
+/// may still be executing them; if it later un-wedges, that work can run twice.
+/// The 10-minute threshold IS the mitigation — it is 20 missed 30s beats.
+///
+/// `agent_runtime.instance_id` (migration 0092) does NOT help here, despite
+/// being the right tool for the restart wrapper: the offline row's `instance_id`
+/// is still the WEDGED process's own id, because nothing else has registered.
+/// A dead daemon and a wedged one are byte-identical in the schema — same
+/// instance, stale `last_seen_at` — so gating on the instance would reject both
+/// or accept both. Closing this properly needs a fencing token (stamp the owning
+/// instance on the task row at dispatch and make the terminal write conditional
+/// on it), which is a schema change and out of scope here.
+pub async fn reclaim_orphans_for_offline_runtimes(
+    pool: &SqlitePool,
+    to_offline: &[SweptRuntime],
+    own_runtime_id: Option<&str>,
+) -> u64 {
+    let mut total = 0;
+    for rt in to_offline {
+        // Defensive: `sweep_runtime_presence` beats for our own runtime before it
+        // sweeps, so our id cannot legitimately appear here. A backwards clock
+        // jump or a process paused past the grace window could in principle
+        // produce it, and self-reclaiming would requeue OUR OWN live runs — the
+        // exact double-dispatch the restart wrapper's reconnect check exists to
+        // prevent. Cheaper to guard than to reason about.
+        if own_runtime_id == Some(rt.id.as_str()) {
+            tracing::warn!(
+                runtime_id = %rt.id,
+                "presence sweep aged out our own runtime; skipping self-reclaim"
+            );
+            continue;
+        }
+        match reclaim_orphaned_for_runtime(pool, &rt.id).await {
+            Ok(n) => total += n,
+            Err(e) => tracing::error!(
+                error = %e,
+                runtime_id = %rt.id,
+                "offline orphan reclaim failed"
+            ),
+        }
+    }
+    total
 }
 
 /// Fail up to `batch_size` rows in `from_status` whose `age_column` is older

--- a/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
@@ -51,6 +51,7 @@ use std::time::Duration;
 
 use ainb_hangar_core::clock::HangarClock;
 use ainb_hangar_proto::events::PresenceState;
+use ainb_hangar_store::bootstrap::RuntimeArrival;
 use ainb_hangar_store::repo::agent_runtime::{AgentRuntimeRepo, PresenceSweep};
 use sqlx::SqlitePool;
 
@@ -423,6 +424,40 @@ pub async fn reclaim_orphaned_on_startup(
         );
     }
     Ok(reclaimed)
+}
+
+/// [`reclaim_orphaned_on_startup`], but only when the boot registration says a
+/// DIFFERENT process instance owned this runtime (migration 0092).
+///
+/// "This daemon just booted" is a weaker signal than it looks: the same process
+/// can register a runtime more than once, and a reclaim on a
+/// [`RuntimeArrival::Reconnect`] would requeue tasks that are still executing
+/// under a live process — the exact corruption the unconditional reclaim risks
+/// once anything re-registers. Keying off the arrival makes the reconcile follow
+/// the ownership change that actually orphans work, rather than the boot that
+/// usually accompanies it.
+///
+/// Returns the number of rows reclaimed (`0` on a reconnect, without touching
+/// the database).
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the reclaim statement fails.
+pub async fn reclaim_orphans_on_restart(
+    pool: &SqlitePool,
+    runtime_id: &str,
+    arrival: &RuntimeArrival,
+) -> Result<u64, sqlx::Error> {
+    if !arrival.is_restart() {
+        tracing::info!(
+            kind = "startup",
+            outcome = "skipped",
+            runtime_id,
+            "same instance reconnected; its in-flight tasks are live, not orphans"
+        );
+        return Ok(0);
+    }
+    reclaim_orphaned_on_startup(pool, runtime_id).await
 }
 
 /// Fail up to `batch_size` rows in `from_status` whose `age_column` is older

--- a/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/sweeper.rs
@@ -29,15 +29,6 @@
 //! production uses the reference defaults, tests inject a frozen clock and tight
 //! config so the suite is deterministic (no `tokio::time::sleep`).
 //!
-//! # Orphan reclaim (not time-based)
-//!
-//! Separately from the TTLs, a runtime's whole in-flight set is reclaimed the
-//! moment its owning PROCESS is known to be gone — no TTL wait, because the
-//! evidence is ownership, not age. [`reclaim_orphaned_for_runtime`] does the
-//! work; two thin wrappers name the two pieces of evidence:
-//! [`reclaim_orphans_on_restart`] (a different instance registered the runtime)
-//! and [`reclaim_orphans_for_offline_runtimes`] (the presence sweep aged it out).
-//!
 //! # Idempotency
 //!
 //! Every statement constrains the source `status` in its `WHERE` clause, so a
@@ -61,7 +52,7 @@ use std::time::Duration;
 use ainb_hangar_core::clock::HangarClock;
 use ainb_hangar_proto::events::PresenceState;
 use ainb_hangar_store::bootstrap::RuntimeArrival;
-use ainb_hangar_store::repo::agent_runtime::{AgentRuntimeRepo, PresenceSweep, SweptRuntime};
+use ainb_hangar_store::repo::agent_runtime::{AgentRuntimeRepo, PresenceSweep};
 use sqlx::SqlitePool;
 
 /// How long a `queued` task may wait before it is failed. Reference:
@@ -351,10 +342,6 @@ pub async fn sweep_stale_dispatched(
 /// (the claim-disabled "sweepers only" mode), in which case the pass is purely
 /// the age sweep.
 ///
-/// A runtime that lands in the `offline` band also has its orphaned in-flight
-/// tasks reclaimed to `queued` — see [`reclaim_orphans_for_offline_runtimes`],
-/// which owns the trigger's reasoning and swallows its own faults.
-///
 /// Returns the rows that moved so the caller can fan `AgentPresence` events out
 /// (the reference publishes `EventDaemonRegister{stale_sweep}` for the same
 /// reason: clients must re-read the runtime list).
@@ -362,8 +349,6 @@ pub async fn sweep_stale_dispatched(
 /// # Errors
 ///
 /// Returns a [`sqlx::Error`] if the heartbeat or either sweep statement fails.
-/// A failed *reclaim* is NOT an error here: it is logged and skipped so the
-/// presence transitions are still reported and still announced.
 pub async fn sweep_runtime_presence(
     pool: &SqlitePool,
     clock: &dyn HangarClock,
@@ -387,47 +372,35 @@ pub async fn sweep_runtime_presence(
             "runtime_presence_swept",
         );
     }
-    // Going offline is itself the verdict that a runtime's in-flight work is
-    // orphaned, so recover it here rather than stranding it until the multi-hour
-    // running TTL. Faults are absorbed per runtime so the caller still gets the
-    // full sweep to fan presence events from.
-    reclaim_orphans_for_offline_runtimes(pool, &sweep.to_offline, own_runtime_id).await;
     Ok(sweep)
 }
 
-/// Reclaim one runtime's orphaned in-flight tasks back to `queued` (e38.25 crash
-/// recovery).
+/// Reclaim a crashed daemon's orphaned in-flight tasks back to `queued` at
+/// startup (e38.25 crash recovery).
 ///
 /// When a daemon dies uncleanly (`kill -9`, OOM, panic) mid-task its claimed
 /// rows are left frozen in `dispatched` or `running` — the FSM step that would
 /// have finalised them never ran. The time-based sweepers eventually move them
 /// (a `running` row only past the 2.5h running TTL; a `dispatched` row past the
-/// 90s reclaim window), but once the owning process is known to be gone there is
-/// no need to wait. So the caller reclaims every non-terminal in-flight row that
-/// runtime owns — scoped to the one `runtime_id` so a sibling daemon's live runs
-/// in a multi-runtime deployment are never disturbed — back to `queued`, clearing
+/// 90s reclaim window), but on a fresh boot there is no need to wait: the
+/// process that *was* executing those tasks is, by definition, gone. So at
+/// startup the newly-booted daemon reclaims every non-terminal in-flight row it
+/// owns — scoped to **its own** `runtime_id` so a sibling daemon's live runs in
+/// a multi-runtime deployment are never disturbed — back to `queued`, clearing
 /// `started_at` / `dispatched_at` so a fresh claim re-dispatches the work. The
 /// `attempt` counter is left **unchanged** (a crash redelivery is not a retry,
 /// mirroring [`reclaim_stale_dispatched`]).
 ///
-/// This function is deliberately TRIGGER-NEUTRAL: deciding that the owning
-/// process is gone is the caller's job, and there are two such callers, each a
-/// thin wrapper naming its own evidence — [`reclaim_orphans_on_restart`] (a
-/// different process instance registered this runtime) and
-/// [`reclaim_orphans_for_offline_runtimes`] (the presence sweep aged the runtime
-/// out). Never call it unconditionally: requeuing rows a LIVE process is still
-/// executing double-dispatches that work.
+/// This is the redelivery the daemon-restart path needs: the orphan leaves its
+/// `running`/`dispatched` limbo immediately on restart rather than stranding the
+/// work for hours. Mirrors the reference's runtime-scoped reclaim-on-boot.
 ///
 /// Returns the number of rows reclaimed.
 ///
 /// # Errors
 ///
-/// Returns a [`sqlx::Error`] if the statement fails. A requeue can legitimately
-/// fail: `queued` is a *pending* status, so returning a `running` row to it can
-/// collide with the one-pending-task-per-(issue, agent) unique index when a
-/// newer task for the same pair is already waiting. Both callers treat that as
-/// non-fatal — the time-based sweepers still backstop the row.
-pub async fn reclaim_orphaned_for_runtime(
+/// Returns a [`sqlx::Error`] if the statement fails.
+pub async fn reclaim_orphaned_on_startup(
     pool: &SqlitePool,
     runtime_id: &str,
 ) -> Result<u64, sqlx::Error> {
@@ -443,16 +416,17 @@ pub async fn reclaim_orphaned_for_runtime(
     .rows_affected();
     if reclaimed > 0 {
         tracing::info!(
+            kind = "startup",
             outcome = "reclaimed",
             count = reclaimed,
             runtime_id,
-            "sweeper_orphan_reclaim"
+            "sweeper_startup_reclaim"
         );
     }
     Ok(reclaimed)
 }
 
-/// [`reclaim_orphaned_for_runtime`], but only when the boot registration says a
+/// [`reclaim_orphaned_on_startup`], but only when the boot registration says a
 /// DIFFERENT process instance owned this runtime (migration 0092).
 ///
 /// "This daemon just booted" is a weaker signal than it looks: the same process
@@ -483,75 +457,7 @@ pub async fn reclaim_orphans_on_restart(
         );
         return Ok(0);
     }
-    reclaim_orphaned_for_runtime(pool, runtime_id).await
-}
-
-/// [`reclaim_orphaned_for_runtime`] for every runtime the presence sweep just
-/// aged out to `offline`.
-///
-/// The restart wrapper above only recovers a dead daemon's work when that daemon
-/// COMES BACK. Nothing brings back a machine that was shut down, so without this
-/// its in-flight rows sit `dispatched`/`running` until the multi-hour
-/// [`RUNNING_TTL`] — hours in which the tasks look alive, block their issue, and
-/// are claimable by nobody. Crossing [`PresenceState::OFFLINE_AFTER_MS`] with no
-/// heartbeat is the second piece of evidence that the owning process is gone, so
-/// the same runtime-scoped reclaim runs on that transition.
-///
-/// Only `to_offline` — never `to_unstable`. Unstable is the GRACE window whose
-/// whole purpose is to let a briefly-stalled daemon (a GC pause, a slow disk, a
-/// laptop lid) keep the run it is still executing; reclaiming there would rob it.
-///
-/// Faults are swallowed per runtime, deliberately: presence is observability, and
-/// one runtime's failed requeue (most plausibly the pending-task unique-index
-/// collision described on [`reclaim_orphaned_for_runtime`]) must not stop the
-/// next runtime's reclaim, nor the caller's `AgentPresence` fan-out. The
-/// time-based sweepers remain the backstop for whatever is skipped. Returns the
-/// total rows reclaimed across all runtimes.
-///
-/// # Residual hazard (read before changing this)
-///
-/// A daemon that is ALIVE but wedged for >10min gets its rows requeued while it
-/// may still be executing them; if it later un-wedges, that work can run twice.
-/// The 10-minute threshold IS the mitigation — it is 20 missed 30s beats.
-///
-/// `agent_runtime.instance_id` (migration 0092) does NOT help here, despite
-/// being the right tool for the restart wrapper: the offline row's `instance_id`
-/// is still the WEDGED process's own id, because nothing else has registered.
-/// A dead daemon and a wedged one are byte-identical in the schema — same
-/// instance, stale `last_seen_at` — so gating on the instance would reject both
-/// or accept both. Closing this properly needs a fencing token (stamp the owning
-/// instance on the task row at dispatch and make the terminal write conditional
-/// on it), which is a schema change and out of scope here.
-pub async fn reclaim_orphans_for_offline_runtimes(
-    pool: &SqlitePool,
-    to_offline: &[SweptRuntime],
-    own_runtime_id: Option<&str>,
-) -> u64 {
-    let mut total = 0;
-    for rt in to_offline {
-        // Defensive: `sweep_runtime_presence` beats for our own runtime before it
-        // sweeps, so our id cannot legitimately appear here. A backwards clock
-        // jump or a process paused past the grace window could in principle
-        // produce it, and self-reclaiming would requeue OUR OWN live runs — the
-        // exact double-dispatch the restart wrapper's reconnect check exists to
-        // prevent. Cheaper to guard than to reason about.
-        if own_runtime_id == Some(rt.id.as_str()) {
-            tracing::warn!(
-                runtime_id = %rt.id,
-                "presence sweep aged out our own runtime; skipping self-reclaim"
-            );
-            continue;
-        }
-        match reclaim_orphaned_for_runtime(pool, &rt.id).await {
-            Ok(n) => total += n,
-            Err(e) => tracing::error!(
-                error = %e,
-                runtime_id = %rt.id,
-                "offline orphan reclaim failed"
-            ),
-        }
-    }
-    total
+    reclaim_orphaned_on_startup(pool, runtime_id).await
 }
 
 /// Fail up to `batch_size` rows in `from_status` whose `age_column` is older

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
@@ -20,10 +20,11 @@
 use ainb_hangar_core::clock::FixedClock;
 use ainb_hangar_daemon::sweeper::{
     DISPATCHED_TTL, QUEUED_TTL, RECLAIM_WINDOW, RUNNING_TTL, SweeperConfig,
-    reclaim_orphaned_on_startup, reclaim_stale_dispatched, sweep_expired_queued,
-    sweep_stale_dispatched, sweep_stale_running,
+    reclaim_orphaned_on_startup, reclaim_orphans_on_restart, reclaim_stale_dispatched,
+    sweep_expired_queued, sweep_stale_dispatched, sweep_stale_running,
 };
 use ainb_hangar_store::Store;
+use ainb_hangar_store::bootstrap::RuntimeArrival;
 use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
 use sqlx::{Row, SqlitePool};
 
@@ -678,4 +679,59 @@ async fn startup_reclaim_is_runtime_scoped_and_skips_terminal() {
         sib_disp, "dispatched",
         "sibling runtime's live dispatched row untouched"
     );
+}
+
+/// A RESTART reconciles the orphans: a task left `running` by the instance this
+/// boot displaced goes back to `queued` immediately, without waiting out the
+/// 2.5h running TTL.
+#[tokio::test]
+async fn restart_arrival_reclaims_the_displaced_instances_orphans() {
+    let (_dir, store) = open_seeded().await;
+    seed_task(store.pool(), "r1", "queued", BASE_MS, None).await;
+    sqlx::query("UPDATE agent_task_queue SET status='running', started_at=? WHERE id='r1'")
+        .bind(BASE_MS)
+        .execute(store.pool())
+        .await
+        .expect("force running");
+
+    let arrival = RuntimeArrival::Restart {
+        previous_instance_id: Some(
+            ainb_hangar_core::ids::InstanceId::from_str("inst-dead").unwrap(),
+        ),
+    };
+    let reclaimed = reclaim_orphans_on_restart(store.pool(), "rt-1", &arrival)
+        .await
+        .expect("reclaim ok");
+    assert_eq!(reclaimed, 1, "the dead instance's orphan is reclaimed");
+
+    let (status, reason, attempt, _) = read_task(store.pool(), "r1").await;
+    assert_eq!(status, "queued", "orphan returned to queued");
+    assert_eq!(reason, None, "a crash redelivery is not a failure");
+    assert_eq!(attempt, 1, "attempt unchanged (redelivery, not retry)");
+}
+
+/// A RECONNECT touches NOTHING: the same instance still owns those rows, so its
+/// in-flight work is live, not orphaned, and requeuing it would double-dispatch
+/// a run that never stopped.
+#[tokio::test]
+async fn reconnect_arrival_leaves_the_live_instances_work_alone() {
+    let (_dir, store) = open_seeded().await;
+    seed_task(store.pool(), "r1", "queued", BASE_MS, None).await;
+    sqlx::query("UPDATE agent_task_queue SET status='running', started_at=? WHERE id='r1'")
+        .bind(BASE_MS)
+        .execute(store.pool())
+        .await
+        .expect("force running");
+    seed_task(store.pool(), "d1", "dispatched", BASE_MS, Some(BASE_MS)).await;
+
+    let reclaimed = reclaim_orphans_on_restart(store.pool(), "rt-1", &RuntimeArrival::Reconnect)
+        .await
+        .expect("reclaim ok");
+    assert_eq!(reclaimed, 0, "a reconnect reclaims nothing");
+
+    let (running, _, _, _) = read_task(store.pool(), "r1").await;
+    assert_eq!(running, "running", "the live run keeps executing");
+    let (dispatched, _, _, dispatched_at) = read_task(store.pool(), "d1").await;
+    assert_eq!(dispatched, "dispatched", "the live dispatch is untouched");
+    assert_eq!(dispatched_at, Some(BASE_MS), "…with its claim stamp intact");
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
@@ -18,13 +18,17 @@
 #![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 
 use ainb_hangar_core::clock::FixedClock;
+use ainb_hangar_daemon::events::EventBroker;
 use ainb_hangar_daemon::sweeper::{
     DISPATCHED_TTL, QUEUED_TTL, RECLAIM_WINDOW, RUNNING_TTL, SweeperConfig,
-    reclaim_orphaned_on_startup, reclaim_orphans_on_restart, reclaim_stale_dispatched,
-    sweep_expired_queued, sweep_stale_dispatched, sweep_stale_running,
+    reclaim_orphaned_for_runtime, reclaim_orphans_for_offline_runtimes, reclaim_orphans_on_restart,
+    reclaim_stale_dispatched, sweep_expired_queued, sweep_runtime_presence, sweep_stale_dispatched,
+    sweep_stale_running,
 };
+use ainb_hangar_proto::events::{HangarEvent, PresenceState};
 use ainb_hangar_store::Store;
 use ainb_hangar_store::bootstrap::RuntimeArrival;
+use ainb_hangar_store::repo::agent_runtime::SweptRuntime;
 use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
 use sqlx::{Row, SqlitePool};
 
@@ -601,7 +605,7 @@ async fn startup_reclaims_own_running_orphan_to_queued() {
         .await
         .expect("force running");
 
-    let reclaimed = reclaim_orphaned_on_startup(store.pool(), "rt-1").await.expect("reclaim ok");
+    let reclaimed = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await.expect("reclaim ok");
     assert_eq!(reclaimed, 1, "the running orphan is reclaimed");
 
     let (status, reason, attempt, _) = read_task(store.pool(), "r1").await;
@@ -628,7 +632,7 @@ async fn startup_reclaims_own_dispatched_orphan_to_queued() {
     let (_dir, store) = open_seeded().await;
     seed_task(store.pool(), "d1", "dispatched", BASE_MS, Some(BASE_MS)).await;
 
-    let reclaimed = reclaim_orphaned_on_startup(store.pool(), "rt-1").await.expect("reclaim ok");
+    let reclaimed = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await.expect("reclaim ok");
     assert_eq!(reclaimed, 1, "the dispatched orphan is reclaimed");
 
     let (status, _, _, dispatched_at) = read_task(store.pool(), "d1").await;
@@ -659,7 +663,7 @@ async fn startup_reclaim_is_runtime_scoped_and_skips_terminal() {
     seed_task_rt2(store.pool(), "sib-run", "running").await;
     seed_task_rt2(store.pool(), "sib-disp", "dispatched").await;
 
-    let reclaimed = reclaim_orphaned_on_startup(store.pool(), "rt-1").await.expect("reclaim ok");
+    let reclaimed = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await.expect("reclaim ok");
     assert_eq!(
         reclaimed, 1,
         "only this runtime's single in-flight orphan is reclaimed"
@@ -734,4 +738,308 @@ async fn reconnect_arrival_leaves_the_live_instances_work_alone() {
     let (dispatched, _, _, dispatched_at) = read_task(store.pool(), "d1").await;
     assert_eq!(dispatched, "dispatched", "the live dispatch is untouched");
     assert_eq!(dispatched_at, Some(BASE_MS), "…with its claim stamp intact");
+}
+
+// ---- presence-driven offline reclaim --------------------------------------
+//
+// The startup reclaim above only fires when the dead daemon comes BACK. These
+// pin the other trigger: the presence sweep declaring a runtime `offline` is
+// itself the signal that its in-flight work is orphaned, so the tasks are
+// recoverable without that daemon ever returning.
+
+/// Stamp a runtime's heartbeat directly so the presence sweep can age it.
+async fn beat(pool: &SqlitePool, runtime_id: &str, at_ms: i64) {
+    sqlx::query("UPDATE agent_runtime SET last_seen_at = ?, status = 'online' WHERE id = ?")
+        .bind(at_ms)
+        .bind(runtime_id)
+        .execute(pool)
+        .await
+        .expect("stamp heartbeat");
+}
+
+/// Insert a task on an explicit runtime/agent/issue in `status`, stamping
+/// `started_at` for a `running` row.
+async fn seed_task_on(
+    pool: &SqlitePool,
+    id: &str,
+    runtime_id: &str,
+    agent_id: &str,
+    issue_id: Option<&str>,
+    status: &str,
+) {
+    sqlx::query(
+        "INSERT INTO agent_task_queue \
+         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, started_at) \
+         VALUES (?, 'ws-1', ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(id)
+    .bind(runtime_id)
+    .bind(agent_id)
+    .bind(issue_id)
+    .bind(status)
+    .bind(BASE_MS)
+    .bind((status == "running").then_some(BASE_MS))
+    .execute(pool)
+    .await
+    .expect("insert task");
+}
+
+/// A runtime that decays to `offline` has its in-flight rows returned to
+/// `queued` on that same pass — the 2.5h running TTL is no longer the recovery
+/// path for a daemon that simply died.
+#[tokio::test]
+async fn offline_presence_reclaims_that_runtimes_inflight_tasks() {
+    let (_dir, store) = open_seeded().await;
+    beat(store.pool(), "rt-1", BASE_MS).await;
+    seed_task_on(store.pool(), "run-1", "rt-1", "agent-1", None, "running").await;
+    seed_task_on(
+        store.pool(),
+        "disp-1",
+        "rt-1",
+        "agent-1",
+        None,
+        "dispatched",
+    )
+    .await;
+
+    let past_offline = BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1;
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(past_offline), None)
+        .await
+        .expect("sweep ok");
+    assert_eq!(
+        sweep.to_offline.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        vec!["rt-1"],
+        "the dead runtime went offline on this pass",
+    );
+
+    let (run_status, reason, attempt, _) = read_task(store.pool(), "run-1").await;
+    assert_eq!(run_status, "queued", "the orphaned run is recoverable now");
+    assert_eq!(reason, None, "a presence redelivery is not a failure");
+    assert_eq!(attempt, 1, "attempt unchanged (redelivery, not retry)");
+    let (disp_status, ..) = read_task(store.pool(), "disp-1").await;
+    assert_eq!(disp_status, "queued", "the orphaned dispatch too");
+
+    let started_at: Option<i64> =
+        sqlx::query("SELECT started_at FROM agent_task_queue WHERE id='run-1'")
+            .fetch_one(store.pool())
+            .await
+            .expect("read started_at")
+            .try_get("started_at")
+            .unwrap();
+    assert_eq!(
+        started_at, None,
+        "started_at cleared so a fresh claim re-runs it"
+    );
+}
+
+/// `unstable` is the GRACE window, not a verdict: a runtime that merely missed a
+/// few beats keeps its live work. Reclaiming here would rob a briefly-stalled
+/// daemon of a run that never stopped.
+#[tokio::test]
+async fn unstable_presence_leaves_the_inflight_work_alone() {
+    let (_dir, store) = open_seeded().await;
+    beat(store.pool(), "rt-1", BASE_MS).await;
+    seed_task_on(store.pool(), "run-1", "rt-1", "agent-1", None, "running").await;
+
+    let inside_grace = BASE_MS + PresenceState::UNSTABLE_AFTER_MS + 1;
+    assert!(
+        inside_grace - BASE_MS <= PresenceState::OFFLINE_AFTER_MS,
+        "the fixture must sit strictly inside the grace window",
+    );
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(inside_grace), None)
+        .await
+        .expect("sweep ok");
+    assert_eq!(
+        sweep.to_unstable.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        vec!["rt-1"],
+        "the runtime went unstable, not offline",
+    );
+    assert!(sweep.to_offline.is_empty(), "still inside the grace window");
+
+    let (status, ..) = read_task(store.pool(), "run-1").await;
+    assert_eq!(status, "running", "an unstable runtime keeps its live run");
+}
+
+/// The reclaim follows the offline verdict per runtime: a sibling still beating
+/// keeps every one of its in-flight rows.
+#[tokio::test]
+async fn offline_reclaim_is_scoped_to_the_runtime_that_went_offline() {
+    let (_dir, store) = open_seeded().await;
+    seed_second_runtime(store.pool()).await;
+    let past_offline = BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1;
+    beat(store.pool(), "rt-1", BASE_MS).await;
+    beat(store.pool(), "rt-2", past_offline).await;
+
+    seed_task_on(store.pool(), "dead-run", "rt-1", "agent-1", None, "running").await;
+    seed_task_on(store.pool(), "live-run", "rt-2", "agent-2", None, "running").await;
+
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(past_offline), None)
+        .await
+        .expect("sweep ok");
+    assert_eq!(
+        sweep.to_offline.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        vec!["rt-1"],
+        "only the stale runtime went offline",
+    );
+
+    let (dead, ..) = read_task(store.pool(), "dead-run").await;
+    assert_eq!(dead, "queued", "the offline runtime's orphan is reclaimed");
+    let (live, ..) = read_task(store.pool(), "live-run").await;
+    assert_eq!(live, "running", "the beating sibling's run is untouched");
+}
+
+/// A reclaim that FAILS (here: requeuing would collide with the
+/// one-pending-task-per-(issue, agent) unique index) is logged and skipped — the
+/// pass still reclaims the next offline runtime and still reports both
+/// transitions so the presence events are emitted.
+#[tokio::test]
+async fn a_failed_reclaim_does_not_abort_the_presence_pass() {
+    let (_dir, store) = open_seeded().await;
+    seed_second_runtime(store.pool()).await;
+    sqlx::query(
+        "INSERT INTO issue (id, workspace_id, title, creator_type, creator_id, created_at) \
+         VALUES ('iss-1', 'ws-1', 'I', 'member', 'user-1', ?)",
+    )
+    .bind(BASE_MS)
+    .execute(store.pool())
+    .await
+    .expect("insert issue");
+
+    // rt-1: requeuing `poison` would make a SECOND pending row on (iss-1, agent-1).
+    seed_task_on(
+        store.pool(),
+        "blocker",
+        "rt-1",
+        "agent-1",
+        Some("iss-1"),
+        "queued",
+    )
+    .await;
+    seed_task_on(
+        store.pool(),
+        "poison",
+        "rt-1",
+        "agent-1",
+        Some("iss-1"),
+        "running",
+    )
+    .await;
+    // rt-2: an ordinary orphan that must still be reclaimed.
+    seed_task_on(store.pool(), "sib-run", "rt-2", "agent-2", None, "running").await;
+
+    beat(store.pool(), "rt-1", BASE_MS).await;
+    beat(store.pool(), "rt-2", BASE_MS).await;
+
+    let past_offline = BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1;
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(past_offline), None)
+        .await
+        .expect("a reclaim fault never fails the presence pass");
+    let mut offline: Vec<&str> = sweep.to_offline.iter().map(|r| r.id.as_str()).collect();
+    offline.sort_unstable();
+    assert_eq!(
+        offline,
+        vec!["rt-1", "rt-2"],
+        "both transitions are still reported, so both fan out events",
+    );
+
+    let (poison, ..) = read_task(store.pool(), "poison").await;
+    assert_eq!(poison, "running", "the conflicting reclaim was rejected");
+    let (sib, ..) = read_task(store.pool(), "sib-run").await;
+    assert_eq!(
+        sib, "queued",
+        "the fault did not stop the next runtime's reclaim",
+    );
+
+    // The fault is a REAL error the pass swallowed, not an inert no-match: the
+    // same reclaim run directly surfaces the constraint violation.
+    let direct = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await;
+    assert!(
+        direct.is_err(),
+        "requeuing `poison` must violate the pending-task index, got {direct:?}",
+    );
+}
+
+/// The sweeping daemon beats for itself first, so its own runtime cannot reach
+/// the offline band — its live work is never requeued under it.
+#[tokio::test]
+async fn the_sweeping_daemon_never_reclaims_its_own_work() {
+    let (_dir, store) = open_seeded().await;
+    beat(store.pool(), "rt-1", BASE_MS).await;
+    seed_task_on(store.pool(), "own-run", "rt-1", "agent-1", None, "running").await;
+
+    let far_future = BASE_MS + 24 * 60 * 60 * 1_000;
+    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(far_future), Some("rt-1"))
+        .await
+        .expect("sweep ok");
+    assert!(
+        sweep.is_empty(),
+        "our own runtime beat before the sweep saw it"
+    );
+
+    let (status, ..) = read_task(store.pool(), "own-run").await;
+    assert_eq!(status, "running", "our own live run keeps executing");
+}
+
+/// The defensive half of the same rule: handed its OWN runtime in the offline
+/// set — only reachable via a backwards clock jump or a process paused past the
+/// grace window — the reclaim still skips it. The second call proves the skip is
+/// the guard doing work, not an inert loop.
+#[tokio::test]
+async fn the_offline_reclaim_never_touches_our_own_runtime() {
+    let (_dir, store) = open_seeded().await;
+    seed_task_on(store.pool(), "own-run", "rt-1", "agent-1", None, "running").await;
+    let offline = vec![SweptRuntime {
+        id: "rt-1".to_string(),
+        workspace_id: "ws-1".to_string(),
+    }];
+
+    let skipped = reclaim_orphans_for_offline_runtimes(store.pool(), &offline, Some("rt-1")).await;
+    assert_eq!(skipped, 0, "we never requeue our own live work");
+    let (status, ..) = read_task(store.pool(), "own-run").await;
+    assert_eq!(status, "running", "the run is left executing");
+
+    let reclaimed =
+        reclaim_orphans_for_offline_runtimes(store.pool(), &offline, Some("rt-other")).await;
+    assert_eq!(
+        reclaimed, 1,
+        "the identical input reclaims when the runtime is not ours",
+    );
+}
+
+/// End-to-end through the SCHEDULED loop, not the bare function: the daemon's
+/// real presence task ticks, declares the runtime offline, and the orphan is
+/// `queued` by the time the `AgentPresence` event lands. Pins the wiring a
+/// function-level test cannot see.
+#[tokio::test]
+async fn the_presence_loop_reclaims_and_still_announces() {
+    let (_dir, store) = open_seeded().await;
+    beat(store.pool(), "rt-1", BASE_MS).await;
+    seed_task_on(store.pool(), "orphan", "rt-1", "agent-1", None, "running").await;
+
+    let broker = EventBroker::new();
+    let mut rx = broker.subscribe();
+    let handle = ainb_hangar_daemon::run_loop::spawn_runtime_presence(
+        store.pool().clone(),
+        None,
+        std::time::Duration::from_millis(20),
+        std::sync::Arc::new(FixedClock(BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1)),
+        broker.sink(),
+    );
+    let scoped = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+        .await
+        .expect("an AgentPresence event within the budget")
+        .expect("event channel open");
+    handle.abort();
+
+    match scoped.event {
+        HangarEvent::AgentPresence { state, .. } => {
+            assert_eq!(state, PresenceState::Offline, "the loop announced offline");
+        }
+        other => panic!("expected AgentPresence, got {other:?}"),
+    }
+    let (status, ..) = read_task(store.pool(), "orphan").await;
+    assert_eq!(
+        status, "queued",
+        "the same tick recovered the dead runtime's work",
+    );
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/sweeper_ttls.rs
@@ -18,17 +18,13 @@
 #![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 
 use ainb_hangar_core::clock::FixedClock;
-use ainb_hangar_daemon::events::EventBroker;
 use ainb_hangar_daemon::sweeper::{
     DISPATCHED_TTL, QUEUED_TTL, RECLAIM_WINDOW, RUNNING_TTL, SweeperConfig,
-    reclaim_orphaned_for_runtime, reclaim_orphans_for_offline_runtimes, reclaim_orphans_on_restart,
-    reclaim_stale_dispatched, sweep_expired_queued, sweep_runtime_presence, sweep_stale_dispatched,
-    sweep_stale_running,
+    reclaim_orphaned_on_startup, reclaim_orphans_on_restart, reclaim_stale_dispatched,
+    sweep_expired_queued, sweep_stale_dispatched, sweep_stale_running,
 };
-use ainb_hangar_proto::events::{HangarEvent, PresenceState};
 use ainb_hangar_store::Store;
 use ainb_hangar_store::bootstrap::RuntimeArrival;
-use ainb_hangar_store::repo::agent_runtime::SweptRuntime;
 use ainb_hangar_store::repo::task::{NewTask, TaskRepo};
 use sqlx::{Row, SqlitePool};
 
@@ -605,7 +601,7 @@ async fn startup_reclaims_own_running_orphan_to_queued() {
         .await
         .expect("force running");
 
-    let reclaimed = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await.expect("reclaim ok");
+    let reclaimed = reclaim_orphaned_on_startup(store.pool(), "rt-1").await.expect("reclaim ok");
     assert_eq!(reclaimed, 1, "the running orphan is reclaimed");
 
     let (status, reason, attempt, _) = read_task(store.pool(), "r1").await;
@@ -632,7 +628,7 @@ async fn startup_reclaims_own_dispatched_orphan_to_queued() {
     let (_dir, store) = open_seeded().await;
     seed_task(store.pool(), "d1", "dispatched", BASE_MS, Some(BASE_MS)).await;
 
-    let reclaimed = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await.expect("reclaim ok");
+    let reclaimed = reclaim_orphaned_on_startup(store.pool(), "rt-1").await.expect("reclaim ok");
     assert_eq!(reclaimed, 1, "the dispatched orphan is reclaimed");
 
     let (status, _, _, dispatched_at) = read_task(store.pool(), "d1").await;
@@ -663,7 +659,7 @@ async fn startup_reclaim_is_runtime_scoped_and_skips_terminal() {
     seed_task_rt2(store.pool(), "sib-run", "running").await;
     seed_task_rt2(store.pool(), "sib-disp", "dispatched").await;
 
-    let reclaimed = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await.expect("reclaim ok");
+    let reclaimed = reclaim_orphaned_on_startup(store.pool(), "rt-1").await.expect("reclaim ok");
     assert_eq!(
         reclaimed, 1,
         "only this runtime's single in-flight orphan is reclaimed"
@@ -738,308 +734,4 @@ async fn reconnect_arrival_leaves_the_live_instances_work_alone() {
     let (dispatched, _, _, dispatched_at) = read_task(store.pool(), "d1").await;
     assert_eq!(dispatched, "dispatched", "the live dispatch is untouched");
     assert_eq!(dispatched_at, Some(BASE_MS), "…with its claim stamp intact");
-}
-
-// ---- presence-driven offline reclaim --------------------------------------
-//
-// The startup reclaim above only fires when the dead daemon comes BACK. These
-// pin the other trigger: the presence sweep declaring a runtime `offline` is
-// itself the signal that its in-flight work is orphaned, so the tasks are
-// recoverable without that daemon ever returning.
-
-/// Stamp a runtime's heartbeat directly so the presence sweep can age it.
-async fn beat(pool: &SqlitePool, runtime_id: &str, at_ms: i64) {
-    sqlx::query("UPDATE agent_runtime SET last_seen_at = ?, status = 'online' WHERE id = ?")
-        .bind(at_ms)
-        .bind(runtime_id)
-        .execute(pool)
-        .await
-        .expect("stamp heartbeat");
-}
-
-/// Insert a task on an explicit runtime/agent/issue in `status`, stamping
-/// `started_at` for a `running` row.
-async fn seed_task_on(
-    pool: &SqlitePool,
-    id: &str,
-    runtime_id: &str,
-    agent_id: &str,
-    issue_id: Option<&str>,
-    status: &str,
-) {
-    sqlx::query(
-        "INSERT INTO agent_task_queue \
-         (id, workspace_id, runtime_id, agent_id, issue_id, status, created_at, started_at) \
-         VALUES (?, 'ws-1', ?, ?, ?, ?, ?, ?)",
-    )
-    .bind(id)
-    .bind(runtime_id)
-    .bind(agent_id)
-    .bind(issue_id)
-    .bind(status)
-    .bind(BASE_MS)
-    .bind((status == "running").then_some(BASE_MS))
-    .execute(pool)
-    .await
-    .expect("insert task");
-}
-
-/// A runtime that decays to `offline` has its in-flight rows returned to
-/// `queued` on that same pass — the 2.5h running TTL is no longer the recovery
-/// path for a daemon that simply died.
-#[tokio::test]
-async fn offline_presence_reclaims_that_runtimes_inflight_tasks() {
-    let (_dir, store) = open_seeded().await;
-    beat(store.pool(), "rt-1", BASE_MS).await;
-    seed_task_on(store.pool(), "run-1", "rt-1", "agent-1", None, "running").await;
-    seed_task_on(
-        store.pool(),
-        "disp-1",
-        "rt-1",
-        "agent-1",
-        None,
-        "dispatched",
-    )
-    .await;
-
-    let past_offline = BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1;
-    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(past_offline), None)
-        .await
-        .expect("sweep ok");
-    assert_eq!(
-        sweep.to_offline.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
-        vec!["rt-1"],
-        "the dead runtime went offline on this pass",
-    );
-
-    let (run_status, reason, attempt, _) = read_task(store.pool(), "run-1").await;
-    assert_eq!(run_status, "queued", "the orphaned run is recoverable now");
-    assert_eq!(reason, None, "a presence redelivery is not a failure");
-    assert_eq!(attempt, 1, "attempt unchanged (redelivery, not retry)");
-    let (disp_status, ..) = read_task(store.pool(), "disp-1").await;
-    assert_eq!(disp_status, "queued", "the orphaned dispatch too");
-
-    let started_at: Option<i64> =
-        sqlx::query("SELECT started_at FROM agent_task_queue WHERE id='run-1'")
-            .fetch_one(store.pool())
-            .await
-            .expect("read started_at")
-            .try_get("started_at")
-            .unwrap();
-    assert_eq!(
-        started_at, None,
-        "started_at cleared so a fresh claim re-runs it"
-    );
-}
-
-/// `unstable` is the GRACE window, not a verdict: a runtime that merely missed a
-/// few beats keeps its live work. Reclaiming here would rob a briefly-stalled
-/// daemon of a run that never stopped.
-#[tokio::test]
-async fn unstable_presence_leaves_the_inflight_work_alone() {
-    let (_dir, store) = open_seeded().await;
-    beat(store.pool(), "rt-1", BASE_MS).await;
-    seed_task_on(store.pool(), "run-1", "rt-1", "agent-1", None, "running").await;
-
-    let inside_grace = BASE_MS + PresenceState::UNSTABLE_AFTER_MS + 1;
-    assert!(
-        inside_grace - BASE_MS <= PresenceState::OFFLINE_AFTER_MS,
-        "the fixture must sit strictly inside the grace window",
-    );
-    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(inside_grace), None)
-        .await
-        .expect("sweep ok");
-    assert_eq!(
-        sweep.to_unstable.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
-        vec!["rt-1"],
-        "the runtime went unstable, not offline",
-    );
-    assert!(sweep.to_offline.is_empty(), "still inside the grace window");
-
-    let (status, ..) = read_task(store.pool(), "run-1").await;
-    assert_eq!(status, "running", "an unstable runtime keeps its live run");
-}
-
-/// The reclaim follows the offline verdict per runtime: a sibling still beating
-/// keeps every one of its in-flight rows.
-#[tokio::test]
-async fn offline_reclaim_is_scoped_to_the_runtime_that_went_offline() {
-    let (_dir, store) = open_seeded().await;
-    seed_second_runtime(store.pool()).await;
-    let past_offline = BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1;
-    beat(store.pool(), "rt-1", BASE_MS).await;
-    beat(store.pool(), "rt-2", past_offline).await;
-
-    seed_task_on(store.pool(), "dead-run", "rt-1", "agent-1", None, "running").await;
-    seed_task_on(store.pool(), "live-run", "rt-2", "agent-2", None, "running").await;
-
-    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(past_offline), None)
-        .await
-        .expect("sweep ok");
-    assert_eq!(
-        sweep.to_offline.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
-        vec!["rt-1"],
-        "only the stale runtime went offline",
-    );
-
-    let (dead, ..) = read_task(store.pool(), "dead-run").await;
-    assert_eq!(dead, "queued", "the offline runtime's orphan is reclaimed");
-    let (live, ..) = read_task(store.pool(), "live-run").await;
-    assert_eq!(live, "running", "the beating sibling's run is untouched");
-}
-
-/// A reclaim that FAILS (here: requeuing would collide with the
-/// one-pending-task-per-(issue, agent) unique index) is logged and skipped — the
-/// pass still reclaims the next offline runtime and still reports both
-/// transitions so the presence events are emitted.
-#[tokio::test]
-async fn a_failed_reclaim_does_not_abort_the_presence_pass() {
-    let (_dir, store) = open_seeded().await;
-    seed_second_runtime(store.pool()).await;
-    sqlx::query(
-        "INSERT INTO issue (id, workspace_id, title, creator_type, creator_id, created_at) \
-         VALUES ('iss-1', 'ws-1', 'I', 'member', 'user-1', ?)",
-    )
-    .bind(BASE_MS)
-    .execute(store.pool())
-    .await
-    .expect("insert issue");
-
-    // rt-1: requeuing `poison` would make a SECOND pending row on (iss-1, agent-1).
-    seed_task_on(
-        store.pool(),
-        "blocker",
-        "rt-1",
-        "agent-1",
-        Some("iss-1"),
-        "queued",
-    )
-    .await;
-    seed_task_on(
-        store.pool(),
-        "poison",
-        "rt-1",
-        "agent-1",
-        Some("iss-1"),
-        "running",
-    )
-    .await;
-    // rt-2: an ordinary orphan that must still be reclaimed.
-    seed_task_on(store.pool(), "sib-run", "rt-2", "agent-2", None, "running").await;
-
-    beat(store.pool(), "rt-1", BASE_MS).await;
-    beat(store.pool(), "rt-2", BASE_MS).await;
-
-    let past_offline = BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1;
-    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(past_offline), None)
-        .await
-        .expect("a reclaim fault never fails the presence pass");
-    let mut offline: Vec<&str> = sweep.to_offline.iter().map(|r| r.id.as_str()).collect();
-    offline.sort_unstable();
-    assert_eq!(
-        offline,
-        vec!["rt-1", "rt-2"],
-        "both transitions are still reported, so both fan out events",
-    );
-
-    let (poison, ..) = read_task(store.pool(), "poison").await;
-    assert_eq!(poison, "running", "the conflicting reclaim was rejected");
-    let (sib, ..) = read_task(store.pool(), "sib-run").await;
-    assert_eq!(
-        sib, "queued",
-        "the fault did not stop the next runtime's reclaim",
-    );
-
-    // The fault is a REAL error the pass swallowed, not an inert no-match: the
-    // same reclaim run directly surfaces the constraint violation.
-    let direct = reclaim_orphaned_for_runtime(store.pool(), "rt-1").await;
-    assert!(
-        direct.is_err(),
-        "requeuing `poison` must violate the pending-task index, got {direct:?}",
-    );
-}
-
-/// The sweeping daemon beats for itself first, so its own runtime cannot reach
-/// the offline band — its live work is never requeued under it.
-#[tokio::test]
-async fn the_sweeping_daemon_never_reclaims_its_own_work() {
-    let (_dir, store) = open_seeded().await;
-    beat(store.pool(), "rt-1", BASE_MS).await;
-    seed_task_on(store.pool(), "own-run", "rt-1", "agent-1", None, "running").await;
-
-    let far_future = BASE_MS + 24 * 60 * 60 * 1_000;
-    let sweep = sweep_runtime_presence(store.pool(), &FixedClock(far_future), Some("rt-1"))
-        .await
-        .expect("sweep ok");
-    assert!(
-        sweep.is_empty(),
-        "our own runtime beat before the sweep saw it"
-    );
-
-    let (status, ..) = read_task(store.pool(), "own-run").await;
-    assert_eq!(status, "running", "our own live run keeps executing");
-}
-
-/// The defensive half of the same rule: handed its OWN runtime in the offline
-/// set — only reachable via a backwards clock jump or a process paused past the
-/// grace window — the reclaim still skips it. The second call proves the skip is
-/// the guard doing work, not an inert loop.
-#[tokio::test]
-async fn the_offline_reclaim_never_touches_our_own_runtime() {
-    let (_dir, store) = open_seeded().await;
-    seed_task_on(store.pool(), "own-run", "rt-1", "agent-1", None, "running").await;
-    let offline = vec![SweptRuntime {
-        id: "rt-1".to_string(),
-        workspace_id: "ws-1".to_string(),
-    }];
-
-    let skipped = reclaim_orphans_for_offline_runtimes(store.pool(), &offline, Some("rt-1")).await;
-    assert_eq!(skipped, 0, "we never requeue our own live work");
-    let (status, ..) = read_task(store.pool(), "own-run").await;
-    assert_eq!(status, "running", "the run is left executing");
-
-    let reclaimed =
-        reclaim_orphans_for_offline_runtimes(store.pool(), &offline, Some("rt-other")).await;
-    assert_eq!(
-        reclaimed, 1,
-        "the identical input reclaims when the runtime is not ours",
-    );
-}
-
-/// End-to-end through the SCHEDULED loop, not the bare function: the daemon's
-/// real presence task ticks, declares the runtime offline, and the orphan is
-/// `queued` by the time the `AgentPresence` event lands. Pins the wiring a
-/// function-level test cannot see.
-#[tokio::test]
-async fn the_presence_loop_reclaims_and_still_announces() {
-    let (_dir, store) = open_seeded().await;
-    beat(store.pool(), "rt-1", BASE_MS).await;
-    seed_task_on(store.pool(), "orphan", "rt-1", "agent-1", None, "running").await;
-
-    let broker = EventBroker::new();
-    let mut rx = broker.subscribe();
-    let handle = ainb_hangar_daemon::run_loop::spawn_runtime_presence(
-        store.pool().clone(),
-        None,
-        std::time::Duration::from_millis(20),
-        std::sync::Arc::new(FixedClock(BASE_MS + PresenceState::OFFLINE_AFTER_MS + 1)),
-        broker.sink(),
-    );
-    let scoped = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
-        .await
-        .expect("an AgentPresence event within the budget")
-        .expect("event channel open");
-    handle.abort();
-
-    match scoped.event {
-        HangarEvent::AgentPresence { state, .. } => {
-            assert_eq!(state, PresenceState::Offline, "the loop announced offline");
-        }
-        other => panic!("expected AgentPresence, got {other:?}"),
-    }
-    let (status, ..) = read_task(store.pool(), "orphan").await;
-    assert_eq!(
-        status, "queued",
-        "the same tick recovered the dead runtime's work",
-    );
 }

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0092_agent_runtime_instance_id.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0092_agent_runtime_instance_id.sql
@@ -1,0 +1,37 @@
+-- Hangar v1 schema, migration 0092: which daemon PROCESS currently owns a
+-- runtime registration.
+--
+-- `agent_runtime` is keyed on (workspace_id, daemon_id, provider) and every boot
+-- upserts THAT row, refreshing `status`/`last_seen_at`. So the row could not
+-- distinguish "the same daemon is still alive" from "the daemon died and came
+-- back with every child process dead" — both look like an online runtime with a
+-- fresh heartbeat. The second case orphans work: tasks the dead process owned
+-- stay `running`/`dispatched` with nothing executing them.
+--
+-- `instance_id` is a ULID minted ONCE per daemon process and presented at
+-- registration. Comparing the presented value with the stored one turns that
+-- ambiguity into a decision: a DIFFERENT value means a new process took the
+-- runtime over (a RESTART — the previous instance's in-flight tasks are orphans
+-- and get requeued), an IDENTICAL value means the same live process
+-- re-registered (a RECONNECT — its work is still running and must not be
+-- touched).
+--
+-- NULLABLE, with no backfill and no default. NULL means NO PROCESS HAS CLAIMED
+-- THIS ROW: every row that predates this migration, plus rows written by the
+-- non-daemon callers (`ainb hangar agent create`, the `hangar/agent_create` RPC)
+-- which materialise the runtime FK without owning a process. NULL is therefore
+-- read as "unknown owner ⇒ assume RESTART", the safe default: requeuing a task
+-- whose executor is gone is recoverable, leaving one stranded until the 2.5h
+-- running TTL is not.
+--
+-- Deliberately NOT a lease. This column answers "who owns it now", not "is that
+-- owner still alive" — heartbeat leases / grace windows are a separate concern
+-- and stay out of this migration.
+--
+-- Growth: one nullable TEXT column on a table with one row per
+-- (workspace, daemon, provider) — single digits on a real home. `ALTER TABLE ADD
+-- COLUMN` with no default is a metadata-only change (no table rewrite), and no
+-- index is added: the value is read on the row the unique tuple already selects
+-- and is never itself a predicate.
+
+ALTER TABLE agent_runtime ADD COLUMN instance_id TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -32,6 +32,7 @@ use sqlx::SqlitePool;
 
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
 use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
+use ainb_hangar_core::ids::InstanceId;
 
 use crate::repo::agent::{Agent, AgentRepo};
 
@@ -217,6 +218,16 @@ pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx:
 /// race where a concurrent daemon registered a different id between the read and
 /// the insert would otherwise FK-fail the caller's insert).
 ///
+/// **This path never claims `instance_id`** (migration 0092). It exists for the
+/// callers that only need the runtime FK to be materialised — `ainb hangar agent
+/// create`, the `hangar/agent_create` RPC, the boot seed — none of which is the
+/// process that EXECUTES that runtime's tasks. Overwriting the owner from here
+/// would make a live daemon look displaced and get its running work requeued out
+/// from under it. A daemon claiming ownership calls
+/// [`register_runtime_instance`] instead; on the insert branch here the column is
+/// simply left NULL ("no process owns this row"), which the next real
+/// registration reads as a restart.
+///
 /// # Errors
 ///
 /// Returns a [`sqlx::Error`] if the workspace lookup or the upsert fails. It never
@@ -256,6 +267,143 @@ pub async fn ensure_runtime(
     .fetch_one(pool)
     .await?;
     Ok(Some(settled))
+}
+
+/// What a runtime registration means for the work that runtime already owns.
+///
+/// The whole point of `agent_runtime.instance_id` (migration 0092): the upsert
+/// alone cannot tell "the same daemon is still alive" from "the daemon died and
+/// came back", because both write the same row with a fresh heartbeat. Comparing
+/// the PRESENTED instance id with the STORED one does, and this is that answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeArrival {
+    /// A different process instance now owns the runtime, so whatever the
+    /// previous owner left `dispatched`/`running` is an orphan: the process that
+    /// was executing it is gone.
+    ///
+    /// `previous_instance_id` is the displaced owner, or `None` when the row had
+    /// none — either a brand-new registration (nothing to reconcile) or a row
+    /// written before 0092 / by a non-daemon caller (unknown owner, which is read
+    /// as a restart because that is the recoverable assumption).
+    Restart {
+        /// The instance this registration displaced; `None` when unknown.
+        previous_instance_id: Option<InstanceId>,
+    },
+    /// The SAME live instance re-registering. Its in-flight tasks are genuinely
+    /// running and must NOT be reconciled.
+    Reconnect,
+}
+
+impl RuntimeArrival {
+    /// Whether this arrival means the previous owner's in-flight work is orphaned.
+    #[must_use]
+    pub const fn is_restart(&self) -> bool {
+        matches!(self, Self::Restart { .. })
+    }
+}
+
+/// The outcome of [`register_runtime_instance`]: the id the row settled on, plus
+/// what this registration means for that runtime's in-flight work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeRegistration {
+    /// The runtime id the row ACTUALLY settled on — the pre-existing one when a
+    /// runtime is already registered (a runtime cannot be renamed; see
+    /// [`ensure_runtime`]).
+    pub runtime_id: String,
+    /// Restart or reconnect, decided against the previously stored instance id.
+    pub arrival: RuntimeArrival,
+}
+
+/// Take the write lock at `BEGIN` rather than on first write.
+///
+/// [`register_runtime_instance`] reads the stored instance id and then overwrites
+/// it, which a deferred transaction would serve from a read snapshot and then
+/// fail to upgrade with `SQLITE_BUSY_SNAPSHOT` (which `busy_timeout` does not
+/// retry). `BEGIN IMMEDIATE` has no snapshot to invalidate, so ordinary
+/// contention is covered by `busy_timeout`. Same reasoning as
+/// [`crate::repo::fleet`]'s writer.
+const IMMEDIATE_TRANSACTION: &str = "BEGIN IMMEDIATE";
+
+/// [`ensure_runtime`], plus: stamp `instance_id` with the presented daemon
+/// process instance and report whether that was a RESTART or a RECONNECT.
+///
+/// This is the daemon-boot entry point. Every invariant of [`ensure_runtime`]
+/// still holds — same conflict target, the `id` is never rewritten, an existing
+/// runtime's id wins — and additionally the row records WHICH process owns it,
+/// which is the fact a plain upsert cannot carry (see [`RuntimeArrival`]).
+///
+/// Read-then-write in ONE [`IMMEDIATE_TRANSACTION`], not one statement: `SQLite`
+/// `RETURNING` reports the row AFTER the update, so an upsert cannot hand back
+/// the instance id it just overwrote, and the pre-update value is precisely what
+/// the decision needs. The transaction is what makes the read and the overwrite
+/// atomic, so two racing daemons cannot both read the same predecessor and both
+/// conclude they displaced it.
+///
+/// Returns `Ok(None)` when there is no workspace to attach to yet (the same
+/// benign no-op as [`ensure_runtime`]).
+///
+/// # Errors
+///
+/// Returns a [`sqlx::Error`] if the workspace lookup, the read, or the upsert
+/// fails. See [`ensure_runtime`] for the (production-unreachable) PK-collision
+/// case.
+pub async fn register_runtime_instance(
+    pool: &SqlitePool,
+    runtime_id: &str,
+    instance_id: &InstanceId,
+    now_ms: i64,
+) -> Result<Option<RuntimeRegistration>, sqlx::Error> {
+    let Some(workspace_id) = find_default_workspace(pool).await? else {
+        return Ok(None);
+    };
+    let mut tx = pool.begin_with(IMMEDIATE_TRANSACTION).await?;
+    // `Option<Option<String>>`: the outer `None` is "no row for this tuple yet"
+    // (a first registration), the inner `None` is "a row with no owner" (pre-0092,
+    // or written by a non-daemon caller). Both are unknown predecessors.
+    let stored: Option<Option<String>> = sqlx::query_scalar(
+        "SELECT instance_id FROM agent_runtime \
+         WHERE workspace_id = ? AND daemon_id = ? AND provider = ?",
+    )
+    .bind(&workspace_id)
+    .bind(SELF_DAEMON_ID)
+    .bind(DEFAULT_PROVIDER)
+    .fetch_optional(&mut *tx)
+    .await?;
+    // An empty stored value cannot be a real instance (`InstanceId` forbids it),
+    // so it degrades to "unknown owner" rather than comparing as a distinct one.
+    let previous = stored.flatten().and_then(|s| InstanceId::from_str(s).ok());
+    let arrival = if previous.as_ref() == Some(instance_id) {
+        RuntimeArrival::Reconnect
+    } else {
+        RuntimeArrival::Restart {
+            previous_instance_id: previous,
+        }
+    };
+
+    let settled: String = sqlx::query_scalar(
+        "INSERT INTO agent_runtime \
+         (id, workspace_id, daemon_id, provider, runtime_mode, last_seen_at, status, instance_id) \
+         VALUES (?, ?, ?, ?, ?, ?, 'online', ?) \
+         ON CONFLICT(workspace_id, daemon_id, provider) DO UPDATE SET \
+           status = 'online', \
+           last_seen_at = excluded.last_seen_at, \
+           instance_id = excluded.instance_id \
+         RETURNING id",
+    )
+    .bind(runtime_id)
+    .bind(&workspace_id)
+    .bind(SELF_DAEMON_ID)
+    .bind(DEFAULT_PROVIDER)
+    .bind(SELF_RUNTIME_MODE)
+    .bind(now_ms)
+    .bind(instance_id.as_str())
+    .fetch_one(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(Some(RuntimeRegistration {
+        runtime_id: settled,
+        arrival,
+    }))
 }
 
 /// Create one agent from scratch, filling every FK behind the scenes.
@@ -629,6 +777,246 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "the agent's runtime FK still resolves (never orphaned)"
+        );
+    }
+
+    /// Mint a distinct test instance id (the shape a daemon presents at boot).
+    fn instance(id: &str) -> InstanceId {
+        InstanceId::from_str(id).expect("non-empty test instance id")
+    }
+
+    /// The recorded owner of `runtime_id`, or `None` when unclaimed.
+    async fn owner(pool: &SqlitePool, runtime_id: &str) -> Option<InstanceId> {
+        crate::repo::agent_runtime::AgentRuntimeRepo::instance_id(pool, runtime_id)
+            .await
+            .expect("read instance_id")
+    }
+
+    /// A daemon claiming a runtime NO process owns is a RESTART: an unknown
+    /// predecessor is read as "the previous executor is gone", the recoverable
+    /// assumption. The presented instance is recorded so the NEXT boot can tell.
+    #[tokio::test]
+    async fn first_instance_to_claim_an_unowned_runtime_reports_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        ensure_default_workspace(pool).await.unwrap();
+
+        let reg = register_runtime_instance(pool, "default", &instance("inst-a"), 1_000)
+            .await
+            .unwrap()
+            .expect("a workspace exists, so the runtime registers");
+        assert_eq!(reg.runtime_id, "default");
+        assert_eq!(
+            reg.arrival,
+            RuntimeArrival::Restart {
+                previous_instance_id: None
+            },
+            "an unowned runtime has no predecessor to name"
+        );
+        assert_eq!(
+            owner(pool, "default").await.as_ref().map(InstanceId::as_str),
+            Some("inst-a"),
+            "the presented instance is recorded on the row"
+        );
+    }
+
+    /// The SAME instance re-registering is a RECONNECT — its in-flight work is
+    /// genuinely running, so nothing may be reconciled.
+    #[tokio::test]
+    async fn same_instance_re_registering_reports_reconnect() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        ensure_default_workspace(pool).await.unwrap();
+
+        register_runtime_instance(pool, "default", &instance("inst-a"), 1_000)
+            .await
+            .unwrap();
+        let again = register_runtime_instance(pool, "default", &instance("inst-a"), 2_000)
+            .await
+            .unwrap()
+            .expect("registered");
+        assert_eq!(
+            again.arrival,
+            RuntimeArrival::Reconnect,
+            "the same instance did not displace anyone"
+        );
+        assert!(!again.arrival.is_restart());
+
+        let row = crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "default")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.last_seen_at,
+            Some(2_000),
+            "…but the heartbeat refreshed"
+        );
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "a re-registration upserts, never duplicates");
+    }
+
+    /// A DIFFERENT instance taking the runtime over is a RESTART that NAMES the
+    /// instance it displaced — the fact a bare upsert could not carry, and the
+    /// signal the daemon's orphan reconcile keys off.
+    #[tokio::test]
+    async fn a_new_instance_taking_over_reports_restart_naming_the_previous() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        ensure_default_workspace(pool).await.unwrap();
+
+        register_runtime_instance(pool, "default", &instance("inst-a"), 1_000)
+            .await
+            .unwrap();
+        let reg = register_runtime_instance(pool, "default", &instance("inst-b"), 2_000)
+            .await
+            .unwrap()
+            .expect("registered");
+        assert_eq!(
+            reg.arrival,
+            RuntimeArrival::Restart {
+                previous_instance_id: Some(instance("inst-a"))
+            },
+            "the new instance displaced inst-a"
+        );
+        assert!(reg.arrival.is_restart());
+        assert_eq!(
+            owner(pool, "default").await.as_ref().map(InstanceId::as_str),
+            Some("inst-b"),
+            "ownership moved to the new instance"
+        );
+    }
+
+    /// The instance-less path (CLI `agent create` / the boot seed) refreshes the
+    /// row WITHOUT claiming it. Clobbering the owner from there would make the
+    /// live daemon look displaced on its next registration and requeue its
+    /// running work out from under it.
+    #[tokio::test]
+    async fn ensure_runtime_refreshes_without_claiming_the_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = ensure_default_workspace(pool).await.unwrap();
+
+        register_runtime_instance(pool, "default", &instance("inst-a"), 1_000)
+            .await
+            .unwrap();
+        // The CLI create path: ensures the runtime FK, then binds it.
+        create_agent(pool, &ws, "cli-made", "claude", None).await.unwrap();
+        assert_eq!(
+            ensure_runtime(pool, "default", 3_000).await.unwrap().as_deref(),
+            Some("default")
+        );
+
+        assert_eq!(
+            owner(pool, "default").await.as_ref().map(InstanceId::as_str),
+            Some("inst-a"),
+            "a non-daemon caller never takes ownership"
+        );
+        // …and the live daemon's next registration is still a plain reconnect.
+        let reg = register_runtime_instance(pool, "default", &instance("inst-a"), 4_000)
+            .await
+            .unwrap()
+            .expect("registered");
+        assert_eq!(
+            reg.arrival,
+            RuntimeArrival::Reconnect,
+            "the CLI touch must not read as a restart"
+        );
+    }
+
+    /// A row materialised by the instance-less path carries no owner, so the
+    /// first real daemon registration reads it as a restart (unknown ⇒ assume the
+    /// executor is gone) rather than as its own reconnect.
+    #[tokio::test]
+    async fn a_runtime_created_without_an_instance_is_unowned() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        ensure_default_workspace(pool).await.unwrap();
+
+        ensure_runtime(pool, "default", 1_000).await.unwrap();
+        assert_eq!(owner(pool, "default").await, None, "no process owns it");
+
+        let reg = register_runtime_instance(pool, "default", &instance("inst-a"), 2_000)
+            .await
+            .unwrap()
+            .expect("registered");
+        assert_eq!(
+            reg.arrival,
+            RuntimeArrival::Restart {
+                previous_instance_id: None
+            }
+        );
+    }
+
+    /// No workspace ⇒ the same benign no-op [`ensure_runtime`] gives: nothing is
+    /// registered and nothing is claimed.
+    #[tokio::test]
+    async fn register_runtime_instance_is_a_noop_without_a_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+
+        assert_eq!(
+            register_runtime_instance(pool, "default", &instance("inst-a"), 1_000)
+                .await
+                .unwrap(),
+            None,
+            "no workspace ⇒ no-op"
+        );
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_runtime")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "no row written without a workspace");
+    }
+
+    /// A runtime still cannot be renamed: a boot with a DIFFERENT configured id
+    /// settles on the EXISTING row and stamps its instance there — the ownership
+    /// and the claim id stay on one row, never split across two.
+    #[tokio::test]
+    async fn register_runtime_instance_claims_the_existing_row_when_the_id_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let pool = store.pool();
+        let ws = ensure_default_workspace(pool).await.unwrap();
+
+        register_runtime_instance(pool, "runtime-a", &instance("inst-a"), 1_000)
+            .await
+            .unwrap();
+        create_agent(pool, &ws, "bound", "claude", None).await.unwrap();
+
+        let reg = register_runtime_instance(pool, "runtime-b", &instance("inst-b"), 2_000)
+            .await
+            .unwrap()
+            .expect("registered");
+        assert_eq!(
+            reg.runtime_id, "runtime-a",
+            "the existing id wins (a runtime cannot be renamed)"
+        );
+        assert_eq!(
+            reg.arrival,
+            RuntimeArrival::Restart {
+                previous_instance_id: Some(instance("inst-a"))
+            }
+        );
+        assert_eq!(
+            owner(pool, "runtime-a").await.as_ref().map(InstanceId::as_str),
+            Some("inst-b"),
+            "the new instance owns the row that actually exists"
+        );
+        assert!(
+            crate::repo::agent_runtime::AgentRuntimeRepo::get(pool, "runtime-b")
+                .await
+                .unwrap()
+                .is_none(),
+            "the refused id never became a row"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent_runtime.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent_runtime.rs
@@ -6,6 +6,7 @@
 //! row per `(workspace_id, daemon_id, provider)` via a unique index, so
 //! re-registering the same tuple is a conflict rather than a duplicate.
 
+use ainb_hangar_core::ids::InstanceId;
 use sqlx::SqlitePool;
 
 /// A registered provider runtime (one daemon advertising one provider).
@@ -125,6 +126,31 @@ impl AgentRuntimeRepo {
         .bind(workspace_id)
         .fetch_all(pool)
         .await
+    }
+
+    /// The daemon process instance that currently owns `id`, or `None` when the
+    /// row carries no owner (pre-migration-0092, or materialised by a non-daemon
+    /// caller) or does not exist.
+    ///
+    /// Deliberately a narrow scalar read rather than a field on [`AgentRuntime`]:
+    /// ownership is consumed only by the registration decision
+    /// ([`crate::bootstrap::register_runtime_instance`]) and by the tests that
+    /// pin it — the roster, the presence sweep, and the wire snapshots have no
+    /// use for it, so it stays off the row type they all share.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the query fails.
+    pub async fn instance_id(
+        pool: &SqlitePool,
+        id: &str,
+    ) -> Result<Option<InstanceId>, sqlx::Error> {
+        let stored: Option<Option<String>> =
+            sqlx::query_scalar("SELECT instance_id FROM agent_runtime WHERE id = ?")
+                .bind(id)
+                .fetch_optional(pool)
+                .await?;
+        Ok(stored.flatten().and_then(|s| InstanceId::from_str(s).ok()))
     }
 
     /// Refresh one runtime's heartbeat: stamp `last_seen_at = now_ms` and return

--- a/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/migration_upgrade_full_chain.rs
@@ -713,6 +713,23 @@ async fn assert_added_columns_read_defaults(pool: &SqlitePool) {
         "0045 task.squad_id defaults NULL"
     );
 
+    // 0092 agent_runtime.instance_id defaults NULL on a pre-existing registration:
+    // no daemon PROCESS has claimed that row, which the boot path reads as
+    // "unknown owner ⇒ assume restart" (the safe default — an upgraded home
+    // requeues its orphans on the first boot rather than trusting a runtime it
+    // has never seen an instance id for).
+    assert_eq!(
+        sqlx::query_scalar::<_, Option<String>>(
+            "SELECT instance_id FROM agent_runtime WHERE id = ?"
+        )
+        .bind("rt-1")
+        .fetch_one(pool)
+        .await
+        .expect("agent_runtime 0092 instance_id column"),
+        None,
+        "0092 agent_runtime.instance_id defaults NULL (no process owns a legacy row)"
+    );
+
     // 0032 workspace.default_agent defaults NULL on prior rows.
     assert_eq!(
         sqlx::query_scalar::<_, Option<String>>("SELECT default_agent FROM workspace WHERE id = ?")

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -670,6 +670,7 @@ Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
       --offline          Skip skill-source reachability checks. Runtime checks stay local
       --fix-hooks        Repair installed notification hooks: stable binary launcher, extracted scripts, and agent wiring. Reports a broken dev target without changing it into a release hook
+      --fix-daemons      Restart Ainb-managed daemon processes proved to be running an older Ainb release. Unknown or externally-owned processes are only reported
   -h, --help             Print help
 
 EXAMPLES:


### PR DESCRIPTION
Adopts an ownership pattern from [get-bb/bb](https://github.com/get-bb/bb) (no bb code — prior art only), plus an unrelated red-CI fix that was blocking main.

## What this does

`agent_runtime` is keyed on `(workspace_id, daemon_id, provider)` and every boot upserts **that same row**, refreshing only `status` and `last_seen_at`. The row can say *a* daemon is online; it cannot say **which process**. Two very different situations are indistinguishable:

| situation | its `running` tasks are | correct action |
|---|---|---|
| same daemon alive, re-registering | genuinely executing | **leave alone** |
| daemon crashed, new process took over | orphans — executor is dead | **requeue** |

Get it backwards and you double-dispatch: two agents on one worktree, same task.

Migration 0092 adds a nullable `instance_id` — a ULID minted once per daemon process and stamped at registration. Reading the stored value before overwriting it turns the ambiguity into a verdict (`RuntimeArrival::Restart` / `Reconnect`), and the existing startup orphan reclaim now gates on **ownership** rather than on "we reached `run()`".

## Be clear about the scope

**No user-visible behaviour change today.** `run()` has exactly one call site, so "we booted" already implied "new process", and the pre-existing startup reclaim was already correct. What this buys:

1. The system can represent a fact it previously could not — which process owns a runtime.
2. It closes a latent trap. The old reclaim was correct *by accident of call-site count*. Add a second entry point, an in-process restart, or a supervisor retry, and the old code silently requeues work that is still executing.
3. It is the prerequisite for recovering a dead runtime's work.

## What was tried and reverted

This branch briefly carried an offline-presence reclaim (reclaim a runtime's orphans when the presence sweep aged it into the `offline` band). **Reverted in 8a33ca42** — review established it cannot work:

- **Unreachable.** Production has exactly one `agent_runtime` row (both registration paths hardcode the same `(SELF_DAEMON_ID, "claude", default-workspace)` tuple; no CLI verb adds more), and the daemon *is* the sweeper — it heartbeats its own row at the top of every pass, so that row can never age into the offline band. When the daemon is dead, nothing sweeps at all. `to_offline` is always empty.
- **Regressive if it did fire.** The reclaim leaves `runtime_id` pointing at the dead runtime, and a row returned to `queued` is then aged by `sweep_expired_queued` from `created_at` against the 2h `QUEUED_TTL` — failing a long-running task *sooner* than the 2.5h `RUNNING_TTL` it had.

Recovering a dead runtime's work needs a sweeper that outlives the daemon. There is no such process today, and picking one (CLI on startup? a service-manager timer? next daemon boot — which is already the startup reclaim) is a design decision, not an implementation detail.

## Known pre-existing bug, not fixed here

`reclaim_orphaned_on_startup` is one unfiltered `UPDATE ... WHERE runtime_id=? AND status IN ('dispatched','running')`. SQLite statement atomicity means a UNIQUE violation on **any** row rolls back the whole statement, so one conflicting row strands **every other orphan** on that runtime until its TTL. The conflict is reachable: `idx_one_pending_task_per_issue_agent` covers `('queued','dispatched')`, so a `running` task plus a `queued` task for the same (issue, agent) is legal until the reclaim tries to make both pending. Fix is a `NOT EXISTS` guard in the `WHERE` so a poisoned row is skipped rather than the batch. Filed as follow-up rather than smuggled in here.

## Also included

`docs(tui): regenerate CLI reference for --fix-daemons` — `--fix-daemons` landed on `ainb doctor` in #693 without regenerating the reference, so the **CLI reference freshness** job has been red on main since that merge. One generated line; `gen-man.sh` produced no change. Unrelated to the hangar work, but it unblocks main.

## Decisions worth reviewing

- **`BEGIN IMMEDIATE`, not one statement.** SQLite `RETURNING` reports the row *after* the update, so an upsert cannot hand back the instance id it just overwrote — and the pre-update value is what the decision needs. A deferred transaction would read from a snapshot then fail to upgrade with `SQLITE_BUSY_SNAPSHOT`, which `busy_timeout` does not retry.
- **Non-daemon callers deliberately do not claim ownership.** `ainb hangar agent create` and the `hangar/agent_create` RPC materialise the runtime FK but do not execute tasks. If they stamped `instance_id`, a live daemon would look displaced and lose its running work. `ensure_runtime` leaves the column NULL.
- **NULL reads as restart.** Requeuing a task whose executor is gone is recoverable; stranding one is not.
- **`InstanceId` is its own newtype** beside `RuntimeId`, so the compiler refuses the swap two bare `String`s would accept.

## Verification

Run independently of the implementing agent, on the final tree:

| Gate | Result |
|---|---|
| `cargo test -p ainb-hangar-store -p ainb-hangar-daemon --no-fail-fast` | **1883 passed, 0 failed**, exit 0 |
| `migration_upgrade_full_chain` (contract) | 4 passed, green first time |
| `cargo fmt --check` | clean |
| clippy | no new warnings inside any added hunk |
| `cargo build -p ainb` after rebase onto current main | builds |

Two tmux tripwires (`tripwire_daemon_concurrent_runs`, `tripwire_daemon_single_instance::sigterm_during_boot_is_answered_and_releases_the_home`) failed under parallel cargo load and were investigated rather than rerun-to-green. Both pass in isolation, and the sigterm one was matched against base: HEAD alone 7/7 (3.62s), base alone 7/7 (3.51s) — identical. `--no-fail-fast` matters here: the default stops at the first failing binary, which makes a partial tally look like a full one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime instance tracking to distinguish daemon restarts from reconnects.
  - Preserved active runtime sessions during reconnects.
  - Added the `--fix-daemons` option to `ainb doctor` for restarting outdated managed daemons.

- **Bug Fixes**
  - Reconnects no longer reclaim active or dispatched tasks.
  - Tasks from restarted runtimes are automatically recovered for continued processing.
  - Runtime registration now preserves established runtime identifiers and ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->