### PR TITLE
feat(daemons): show version drift and safely restart managed daemons

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1010,6 +1010,7 @@ pub(crate) fn mcp_import_blocking(to_user: bool) -> McpFetchResult {
 #[derive(Debug, Clone)]
 pub struct DaemonsFetchResult {
     pub mcp_alive: bool,
+    pub(crate) mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus,
     pub headroom: crate::headroom::ProxyStatus,
     pub headroom_consumers: Vec<String>,
     /// Every running `notifyd` process, classified live / stale / orphan.
@@ -1028,6 +1029,7 @@ pub struct DaemonsFetchResult {
 #[derive(Debug)]
 pub struct DaemonsOverlayState {
     pub mcp_alive: bool,
+    pub(crate) mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus,
     pub headroom: crate::headroom::ProxyStatus,
     pub headroom_consumers: Vec<String>,
     /// Every running `notifyd` process, classified live / stale / orphan.
@@ -1067,6 +1069,7 @@ pub struct DaemonsOverlayState {
 /// to `ps`) so they run on the blocking thread pool.
 pub(crate) fn daemons_sync_probe() -> (
     bool,
+    crate::mcp_pool::client::DaemonRuntimeStatus,
     Vec<String>,
     Vec<ainb_plugin_notifyd::ClassifiedDaemon>,
     (bool, String),
@@ -1074,6 +1077,7 @@ pub(crate) fn daemons_sync_probe() -> (
     crate::cli::hangar::DaemonRuntimeStatus,
 ) {
     let mcp_alive = crate::mcp_pool::client::daemon_alive();
+    let mcp_runtime = crate::mcp_pool::client::daemon_runtime_status();
     let headroom_consumers = crate::interactive::SessionStore::load()
         .sessions
         .into_values()
@@ -1101,6 +1105,7 @@ pub(crate) fn daemons_sync_probe() -> (
     let hangar_runtime = crate::cli::hangar::daemon_runtime_status();
     (
         mcp_alive,
+        mcp_runtime,
         headroom_consumers,
         notifyd,
         approve,
@@ -5015,6 +5020,7 @@ impl AppState {
         }
         self.daemons_overlay = Some(DaemonsOverlayState {
             mcp_alive: false,
+            mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: crate::headroom::ProxyStatus {
                 running: false,
                 port: crate::headroom::proxy_port(),
@@ -5065,19 +5071,28 @@ impl AppState {
         tokio::spawn(async move {
             // Blocking I/O (control socket + file read + `ps` scan) on the
             // blocking pool.
-            let (mcp_alive, headroom_consumers, notifyd, approve, hangar, hangar_runtime) =
-                tokio::task::spawn_blocking(daemons_sync_probe).await.unwrap_or((
-                    false,
-                    Vec::new(),
-                    Vec::new(),
-                    (false, "probe failed".to_string()),
-                    (false, "probe failed".to_string()),
-                    crate::cli::hangar::DaemonRuntimeStatus::default(),
-                ));
+            let (
+                mcp_alive,
+                mcp_runtime,
+                headroom_consumers,
+                notifyd,
+                approve,
+                hangar,
+                hangar_runtime,
+            ) = tokio::task::spawn_blocking(daemons_sync_probe).await.unwrap_or((
+                false,
+                crate::mcp_pool::client::DaemonRuntimeStatus::default(),
+                Vec::new(),
+                Vec::new(),
+                (false, "probe failed".to_string()),
+                (false, "probe failed".to_string()),
+                crate::cli::hangar::DaemonRuntimeStatus::default(),
+            ));
             // Async HTTP probe of the Headroom /health + /stats endpoints.
             let headroom = crate::headroom::status().await;
             let result = DaemonsFetchResult {
                 mcp_alive,
+                mcp_runtime,
                 headroom,
                 headroom_consumers,
                 notifyd,
@@ -5177,12 +5192,12 @@ impl AppState {
         }
         let (tx, rx) = mpsc::unbounded_channel();
         o.hangar_start_rx = Some(rx);
-        o.hangar_start_status = Some("starting Hangar daemon…".to_string());
+        o.hangar_start_status = Some("starting / upgrading Hangar daemon…".to_string());
         tokio::spawn(async move {
             let line = tokio::task::spawn_blocking(|| {
-                crate::cli::hangar::start_daemon_if_stopped(false)
-                    .map(|_| "Hangar started".to_string())
-                    .unwrap_or_else(|e| format!("Hangar start failed: {e:#}"))
+                crate::cli::hangar::start_or_upgrade_daemon_from_current()
+                    .map(|_| "Hangar running against current Ainb".to_string())
+                    .unwrap_or_else(|e| format!("Hangar start / upgrade failed: {e:#}"))
             })
             .await
             .unwrap_or_else(|e| format!("Hangar start failed: {e}"));
@@ -5190,8 +5205,7 @@ impl AppState {
         });
     }
 
-    /// Start the shared MCP pool off the UI thread and report its result in
-    /// the unified Daemons screen. Idempotent when already alive.
+    /// Restart the shared MCP pool from this Ainb binary. If absent, starts it.
     pub fn spawn_mcp_start(&mut self) {
         let Some(o) = self.daemons_overlay.as_mut() else {
             return;
@@ -5201,14 +5215,14 @@ impl AppState {
         }
         let (tx, rx) = mpsc::unbounded_channel();
         o.mcp_start_rx = Some(rx);
-        o.mcp_start_status = Some("starting MCP pool…".to_string());
+        o.mcp_start_status = Some("restarting MCP pool against current Ainb…".to_string());
         tokio::spawn(async move {
-            let result = tokio::task::spawn_blocking(crate::mcp_pool::client::ensure_daemon)
+            let result = tokio::task::spawn_blocking(crate::mcp_pool::client::restart_daemon)
                 .await
                 .unwrap_or_else(|e| Err(anyhow::anyhow!("MCP start task panicked: {e}")));
             let line = result
-                .map(|()| "MCP pool started".to_string())
-                .unwrap_or_else(|error| format!("MCP pool start failed: {error:#}"));
+                .map(|()| "MCP pool running against current Ainb".to_string())
+                .unwrap_or_else(|error| format!("MCP pool restart failed: {error:#}"));
             let _ = tx.send(line);
         });
     }
@@ -5244,6 +5258,7 @@ impl AppState {
                 o.fetch_rx = None;
                 o.loading = false;
                 o.mcp_alive = result.mcp_alive;
+                o.mcp_runtime = result.mcp_runtime;
                 o.headroom = result.headroom;
                 o.headroom_consumers = result.headroom_consumers;
                 o.notifyd = result.notifyd;

--- a/ainb-tui/crates/ainb-core/src/cli/doctor.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/doctor.rs
@@ -16,6 +16,7 @@ struct DoctorReport<'a> {
     hooks_error: Option<String>,
     daemons: Vec<crate::fleet::daemons::DaemonStatus>,
     daemons_error: Option<String>,
+    daemon_repairs: Vec<String>,
 }
 
 /// Full machine health check. `--offline` skips skill-source network probes.
@@ -29,6 +30,10 @@ pub struct DoctorArgs {
     /// it into a release hook.
     #[arg(long)]
     pub fix_hooks: bool,
+    /// Restart Ainb-managed daemon processes proved to be running an older
+    /// Ainb release. Unknown or externally-owned processes are only reported.
+    #[arg(long)]
+    pub fix_daemons: bool,
 }
 
 /// Entry point for `ainb doctor`.
@@ -57,9 +62,20 @@ pub async fn execute(args: DoctorArgs, format: OutputFormat) -> Result<()> {
         }
         Err(error) => (None, Some(error.to_string())),
     };
-    let (daemons, daemons_error) = match crate::fleet::daemons::collect() {
+    let (mut daemons, daemons_error) = match crate::fleet::daemons::collect() {
         Ok(rows) => (rows, None),
         Err(error) => (Vec::new(), Some(error.to_string())),
+    };
+    let daemon_repairs = if args.fix_daemons {
+        let repairs = repair_stale_daemons(&daemons);
+        // Refresh status after an attempted repair so text and JSON say what is
+        // live now, rather than the pre-restart process.
+        if let Ok(rows) = crate::fleet::daemons::collect() {
+            daemons = rows;
+        }
+        repairs
+    } else {
+        Vec::new()
     };
     match format {
         OutputFormat::Json => {
@@ -74,6 +90,7 @@ pub async fn execute(args: DoctorArgs, format: OutputFormat) -> Result<()> {
                     hooks_error,
                     daemons,
                     daemons_error,
+                    daemon_repairs,
                 })?
             );
             if let Some(error) = skill_doctor_error {
@@ -88,6 +105,9 @@ pub async fn execute(args: DoctorArgs, format: OutputFormat) -> Result<()> {
                 &daemons,
                 daemons_error.as_deref(),
             );
+            for repair in &daemon_repairs {
+                println!("daemon repair: {repair}");
+            }
             // The skill check can traverse several tool homes. Render the
             // runtime result first so a slow skill scan never hides a dead
             // hook or daemon from the user.
@@ -101,6 +121,40 @@ pub async fn execute(args: DoctorArgs, format: OutputFormat) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Restart only owner processes with positive old-version evidence. Bridge,
+/// fleet watcher, and ATC launch policy belongs to user configuration, so
+/// Doctor must never guess their command line or kill them.
+fn repair_stale_daemons(daemons: &[crate::fleet::daemons::DaemonStatus]) -> Vec<String> {
+    let mut outcomes = Vec::new();
+    if daemons.iter().any(|daemon| {
+        daemon.kind == crate::fleet::daemons::DaemonKind::Notifyd
+            && daemon.version_current == Some(false)
+    }) {
+        let outcome = ainb_plugin_notifyd::procs::restart(std::time::Duration::from_secs(3))
+            .map(|_| "notifyd restarted against current Ainb".to_string())
+            .unwrap_or_else(|error| format!("notifyd restart failed: {error:#}"));
+        outcomes.push(outcome);
+    }
+    let mcp = crate::mcp_pool::client::daemon_runtime_status();
+    if mcp.old {
+        let outcome = crate::mcp_pool::client::restart_daemon()
+            .map(|_| "MCP pool restarted against current Ainb".to_string())
+            .unwrap_or_else(|error| format!("MCP pool restart failed: {error:#}"));
+        outcomes.push(outcome);
+    }
+    let hangar = crate::cli::hangar::daemon_runtime_status();
+    if hangar.old {
+        let outcome = crate::cli::hangar::start_or_upgrade_daemon_from_current()
+            .map(|_| "Hangar restarted against current Ainb".to_string())
+            .unwrap_or_else(|error| format!("Hangar restart failed: {error:#}"));
+        outcomes.push(outcome);
+    }
+    if outcomes.is_empty() {
+        outcomes.push("no stale managed Ainb daemon found".to_string());
+    }
+    outcomes
 }
 
 fn run_skill_doctor(offline: bool) -> (String, Option<String>) {

--- a/ainb-tui/crates/ainb-core/src/cli/doctor.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/doctor.rs
@@ -130,7 +130,12 @@ fn repair_stale_daemons(daemons: &[crate::fleet::daemons::DaemonStatus]) -> Vec<
     let mut outcomes = Vec::new();
     if daemons.iter().any(|daemon| {
         daemon.kind == crate::fleet::daemons::DaemonKind::Notifyd
-            && daemon.version_current == Some(false)
+            && daemon.version.as_deref().is_some_and(|version| {
+                crate::fleet::daemons::probe::release_version_is_older(
+                    version,
+                    env!("CARGO_PKG_VERSION"),
+                )
+            })
     }) {
         let outcome = ainb_plugin_notifyd::procs::restart(std::time::Duration::from_secs(3))
             .map(|_| "notifyd restarted against current Ainb".to_string())

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/daemons.rs
@@ -29,11 +29,11 @@ pub async fn execute(_matches: &clap::ArgMatches, format: OutputFormat) -> Resul
 }
 
 /// Fixed widths of the leading (non-HEALTH) columns, in render order:
-/// DAEMON, STATE, PID, UPTIME, LAST ACTIVITY, ERRORS. The HEALTH column is the
+/// DAEMON, STATE, PID, UPTIME, VERSION, LAST ACTIVITY, ERRORS. The HEALTH column is the
 /// free-width remainder. The row format string below MUST keep these widths in
 /// sync — see [`SEPARATOR_WIDTH`], which is derived from them so the `-` rule can
 /// never drift from the header.
-const COLUMN_WIDTHS: [usize; 6] = [14, 9, 8, 10, 12, 7];
+const COLUMN_WIDTHS: [usize; 7] = [14, 9, 8, 10, 17, 12, 7];
 
 /// A nominal display width for the trailing free-form HEALTH column, used only to
 /// size the header underline rule. (The actual HEALTH text is unbounded; this is
@@ -50,8 +50,8 @@ const SEPARATOR_WIDTH: usize = {
         sum += COLUMN_WIDTHS[i];
         i += 1;
     }
-    // 7 columns ⇒ 6 inter-column spaces, + the HEALTH rule width.
-    sum + 6 + HEALTH_RULE_WIDTH
+    // 8 columns ⇒ 7 inter-column spaces, + the HEALTH rule width.
+    sum + 7 + HEALTH_RULE_WIDTH
 };
 
 /// Render the daemon rows as a fixed-width text table. `now_ms` is the clock the
@@ -61,8 +61,8 @@ const SEPARATOR_WIDTH: usize = {
 pub fn render_text(rows: &[DaemonStatus], now_ms: i64) -> String {
     let mut out = String::new();
     out.push_str(&format!(
-        "{:<14} {:<9} {:<8} {:<10} {:<12} {:<7} {}\n",
-        "DAEMON", "STATE", "PID", "UPTIME", "LAST ACTIVITY", "ERRORS", "HEALTH"
+        "{:<14} {:<9} {:<8} {:<10} {:<17} {:<12} {:<7} {}\n",
+        "DAEMON", "STATE", "PID", "UPTIME", "VERSION", "LAST ACTIVITY", "ERRORS", "HEALTH"
     ));
     out.push_str(&format!("{}\n", "-".repeat(SEPARATOR_WIDTH)));
     for r in rows {
@@ -71,19 +71,31 @@ pub fn render_text(rows: &[DaemonStatus], now_ms: i64) -> String {
         let uptime = r.uptime_ms.map_or_else(|| "-".to_string(), fmt_duration_ms);
         let last_activity =
             r.last_activity_at.map_or_else(|| "-".to_string(), |ts| fmt_ago(now_ms, ts));
+        let version = version_summary(r);
         let health = health_summary(r);
         out.push_str(&format!(
-            "{:<14} {:<9} {:<8} {:<10} {:<12} {:<7} {}\n",
+            "{:<14} {:<9} {:<8} {:<10} {:<17} {:<12} {:<7} {}\n",
             r.kind.display_name(),
             state,
             pid,
             uptime,
+            version,
             last_activity,
             r.error_count,
             health,
         ));
     }
     out
+}
+
+fn version_summary(r: &DaemonStatus) -> String {
+    match (&r.version, r.version_current) {
+        (Some(version), Some(true)) => format!("{version} current"),
+        (Some(version), Some(false)) => {
+            format!("{version} -> {}", env!("CARGO_PKG_VERSION"))
+        }
+        _ => "unknown".to_string(),
+    }
 }
 
 /// A glyphed state token for the text table.
@@ -154,6 +166,8 @@ mod tests {
             state,
             pid: Some(4242),
             uptime_ms: Some(125_000),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            version_current: Some(true),
             connected,
             channel: channel.map(str::to_string),
             last_activity_at: Some(0),

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8618,6 +8618,12 @@ pub fn ensure_hangar_daemon() {
     }
 }
 
+/// Start a missing daemon, or hand an older released owner to this Ainb
+/// binary. Used by the Daemons screen's explicit upgrade control.
+pub(crate) fn start_or_upgrade_daemon_from_current() -> Result<()> {
+    start_or_upgrade_daemon(false)
+}
+
 /// Start a missing daemon, or hand off an older recorded release to this one.
 ///
 /// Unknown, equal, prerelease, and newer owners are deliberately left alone:

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -256,16 +256,11 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
             };
             let version = |running: Option<&str>, old: bool| match running {
                 Some(version) if old => format!("{version} → {}", env!("CARGO_PKG_VERSION")),
-                Some(version) => format!("{version} ✓"),
+                Some(version) if version == env!("CARGO_PKG_VERSION") => format!("{version} ✓"),
+                Some(version) => format!("{version} newer"),
                 None => "version unknown".to_string(),
             };
-            let notify_version = if runtime.notifyd.is_empty() {
-                "not running".to_string()
-            } else if runtime.notifyd.iter().any(|daemon| daemon.binary_drift) {
-                format!("different build → {}", env!("CARGO_PKG_VERSION"))
-            } else {
-                format!("{} ✓", env!("CARGO_PKG_VERSION"))
-            };
+            let notify_version = notifyd_version_label(&runtime.notifyd);
             vec![
                 Row::new(vec![
                     Cell::from("MCP pool"),
@@ -330,6 +325,36 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
         Table::new(rows, widths).style(Style::default().fg(SOFT_WHITE).bg(PANEL_BG)),
         inner,
     );
+}
+
+fn notifyd_version_label(daemons: &[ainb_plugin_notifyd::ClassifiedDaemon]) -> String {
+    let Some(owner) = daemons.iter().find(|daemon| daemon.class.is_healthy()) else {
+        return if daemons.is_empty() {
+            "not running".to_string()
+        } else {
+            "owner unknown".to_string()
+        };
+    };
+    let version = owner
+        .proc
+        .bin
+        .split_once("/Cellar/ainb/")
+        .and_then(|(_, rest)| rest.split('/').next())
+        .filter(|version| !version.is_empty());
+    match version {
+        Some(version)
+            if crate::fleet::daemons::probe::release_version_is_older(
+                version,
+                env!("CARGO_PKG_VERSION"),
+            ) =>
+        {
+            format!("{version} → {}", env!("CARGO_PKG_VERSION"))
+        }
+        Some(version) if version == env!("CARGO_PKG_VERSION") => format!("{version} ✓"),
+        Some(version) => format!("{version} newer"),
+        None if owner.binary_drift => "different build".to_string(),
+        None => format!("{} ✓", env!("CARGO_PKG_VERSION")),
+    }
 }
 
 fn render_hook_section(
@@ -544,9 +569,20 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
 fn daemon_version_label(daemon: &DaemonStatus) -> (String, Style) {
     match (&daemon.version, daemon.version_current) {
         (Some(version), Some(true)) => (format!("{version} ✓"), Style::default().fg(HEALTHY_GREEN)),
+        (Some(version), Some(false))
+            if crate::fleet::daemons::probe::release_version_is_older(
+                version,
+                env!("CARGO_PKG_VERSION"),
+            ) =>
+        {
+            (
+                format!("{version} → {}", env!("CARGO_PKG_VERSION")),
+                Style::default().fg(GOLD),
+            )
+        }
         (Some(version), Some(false)) => (
-            format!("{version} → {}", env!("CARGO_PKG_VERSION")),
-            Style::default().fg(GOLD),
+            format!("{version} newer"),
+            Style::default().fg(HEALTHY_GREEN),
         ),
         _ => ("unknown".to_string(), Style::default().fg(MUTED_GRAY)),
     }
@@ -612,6 +648,14 @@ mod tests {
             daemon_version_label(&daemon).0,
             format!("0.0.0 → {}", env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[test]
+    fn daemon_version_label_does_not_suggest_downgrading_newer_daemon() {
+        let mut daemon = status(DaemonKind::Bridge, DaemonState::Running, true, None);
+        daemon.version = Some("999.0.0".to_string());
+        daemon.version_current = Some(false);
+        assert_eq!(daemon_version_label(&daemon).0, "999.0.0 newer");
     }
 
     /// A `DaemonsState` whose background collector is pre-empted: the shared

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -222,13 +222,13 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
             ),
             Span::styled(" refresh · ", Style::default().fg(MUTED_GRAY)),
             Span::styled("M", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
-            Span::styled(" MCP · ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" restart MCP · ", Style::default().fg(MUTED_GRAY)),
             Span::styled("P", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
             Span::styled(" Headroom · ", Style::default().fg(MUTED_GRAY)),
             Span::styled("R", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
             Span::styled(" notifyd · ", Style::default().fg(MUTED_GRAY)),
             Span::styled("S", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
-            Span::styled(" Hangar", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" start / upgrade Hangar", Style::default().fg(MUTED_GRAY)),
         ]))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -254,15 +254,30 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
             let action_detail = |status: Option<&String>, default: &str| {
                 status.cloned().unwrap_or_else(|| default.to_string())
             };
+            let version = |running: Option<&str>, old: bool| match running {
+                Some(version) if old => format!("{version} → {}", env!("CARGO_PKG_VERSION")),
+                Some(version) => format!("{version} ✓"),
+                None => "version unknown".to_string(),
+            };
+            let notify_version = if runtime.notifyd.is_empty() {
+                "not running".to_string()
+            } else if runtime.notifyd.iter().any(|daemon| daemon.binary_drift) {
+                format!("different build → {}", env!("CARGO_PKG_VERSION"))
+            } else {
+                format!("{} ✓", env!("CARGO_PKG_VERSION"))
+            };
             vec![
                 Row::new(vec![
                     Cell::from("MCP pool"),
                     Cell::from(status(runtime.mcp_alive)),
                     Cell::from(action_detail(
                         runtime.mcp_start_status.as_ref(),
-                        "shared tool servers",
+                        &version(
+                            runtime.mcp_runtime.version.as_deref(),
+                            runtime.mcp_runtime.old,
+                        ),
                     )),
-                    Cell::from("M start"),
+                    Cell::from("M restart current"),
                 ]),
                 Row::new(vec![
                     Cell::from("Headroom"),
@@ -278,9 +293,12 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
                     Cell::from(status(runtime.hangar_running)),
                     Cell::from(action_detail(
                         runtime.hangar_start_status.as_ref(),
-                        &runtime.hangar_reason,
+                        &version(
+                            runtime.hangar_runtime.version.as_deref(),
+                            runtime.hangar_runtime.old,
+                        ),
                     )),
-                    Cell::from("S start"),
+                    Cell::from("S start / upgrade"),
                 ]),
                 Row::new(vec![
                     Cell::from("notifyd"),
@@ -289,15 +307,15 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
                     )),
                     Cell::from(action_detail(
                         runtime.notifyd_restart_status.as_ref(),
-                        &format!("{} process(es)", runtime.notifyd.len()),
+                        &notify_version,
                     )),
-                    Cell::from("R force restart"),
+                    Cell::from("R restart current"),
                 ]),
-                Row::new([
-                    "approval broker",
-                    status(runtime.approve_running),
-                    runtime.approve_reason.as_str(),
-                    "repaired by R",
+                Row::new(vec![
+                    Cell::from("approval broker"),
+                    Cell::from(status(runtime.approve_running)),
+                    Cell::from(format!("{notify_version} · {}", runtime.approve_reason)),
+                    Cell::from("repaired by R"),
                 ]),
             ]
         }
@@ -455,6 +473,7 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
         Cell::from("STATE"),
         Cell::from("PID"),
         Cell::from("UPTIME"),
+        Cell::from("VERSION"),
         Cell::from("LAST ACTIVITY"),
         Cell::from("ERR"),
         Cell::from("HEALTH"),
@@ -475,6 +494,7 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
             };
             let pid = d.pid.map_or_else(|| "-".to_string(), |p| p.to_string());
             let uptime = d.uptime_ms.map_or_else(|| "-".to_string(), fmt_duration_ms);
+            let version = daemon_version_label(d);
             let last_activity =
                 d.last_activity_at.map_or_else(|| "-".to_string(), |ts| fmt_ago(now, ts));
             let health = match (&d.channel, d.connected, d.state) {
@@ -489,6 +509,7 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
                 Cell::from(glyph).style(glyph_style),
                 Cell::from(pid),
                 Cell::from(uptime),
+                Cell::from(version.0).style(version.1),
                 Cell::from(last_activity),
                 Cell::from(d.error_count.to_string()).style(if d.error_count > 0 {
                     Style::default().fg(STOPPED_RED)
@@ -505,6 +526,7 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
         Constraint::Length(10),
         Constraint::Length(8),
         Constraint::Length(8),
+        Constraint::Length(17),
         Constraint::Length(14),
         Constraint::Length(4),
         Constraint::Min(20),
@@ -515,6 +537,19 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
         .column_spacing(1)
         .style(Style::default().bg(PANEL_BG));
     frame.render_widget(table, area);
+}
+
+/// Short, operator-facing release verdict. Keep expected version in the cell:
+/// a bare red old version forces humans to remember what Ainb they launched.
+fn daemon_version_label(daemon: &DaemonStatus) -> (String, Style) {
+    match (&daemon.version, daemon.version_current) {
+        (Some(version), Some(true)) => (format!("{version} ✓"), Style::default().fg(HEALTHY_GREEN)),
+        (Some(version), Some(false)) => (
+            format!("{version} → {}", env!("CARGO_PKG_VERSION")),
+            Style::default().fg(GOLD),
+        ),
+        _ => ("unknown".to_string(), Style::default().fg(MUTED_GRAY)),
+    }
 }
 
 fn render_footer(frame: &mut Frame, area: Rect) {
@@ -548,6 +583,8 @@ mod tests {
             state,
             pid: Some(1234),
             uptime_ms: Some(3_600_000),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            version_current: Some(true),
             connected,
             channel: channel.map(str::to_string),
             last_activity_at: Some(now_ms() - 5_000),
@@ -564,6 +601,17 @@ mod tests {
                 "no heartbeat — not running this session".to_string()
             },
         }
+    }
+
+    #[test]
+    fn daemon_version_label_names_current_target_for_stale_daemon() {
+        let mut daemon = status(DaemonKind::Bridge, DaemonState::Running, true, None);
+        daemon.version = Some("0.0.0".to_string());
+        daemon.version_current = Some(false);
+        assert_eq!(
+            daemon_version_label(&daemon).0,
+            format!("0.0.0 → {}", env!("CARGO_PKG_VERSION"))
+        );
     }
 
     /// A `DaemonsState` whose background collector is pre-empted: the shared
@@ -651,6 +699,7 @@ mod tests {
     fn system_runtime() -> DaemonsOverlayState {
         DaemonsOverlayState {
             mcp_alive: true,
+            mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: ProxyStatus {
                 running: true,
                 port: 8787,

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -412,6 +412,7 @@ mod tests {
     ) -> DaemonsOverlayState {
         DaemonsOverlayState {
             mcp_alive: true,
+            mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: ProxyStatus {
                 running,
                 port,
@@ -535,6 +536,7 @@ mod tests {
     fn daemons_overlay_renders_loading_state() {
         let state = DaemonsOverlayState {
             mcp_alive: false,
+            mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: ProxyStatus {
                 running: false,
                 port: 8787,

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
@@ -102,6 +102,11 @@ pub struct DaemonHeartbeat {
     pub started_at: i64,
     /// Epoch ms at which this record was last rewritten (the liveness clock).
     pub last_heartbeat_at: i64,
+    /// Ainb release which started this daemon.  This is written once at
+    /// process start, rather than inferred from a mutable launcher symlink, so
+    /// an upgrade can reliably identify an old long-running process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ainb_version: Option<String>,
     /// Epoch ms of the last real unit of work (a relayed message, a scan that
     /// acted). `None` until the daemon has done anything.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -172,6 +177,7 @@ impl DaemonHeartbeat {
             pid: std::process::id(),
             started_at: now,
             last_heartbeat_at: now,
+            ainb_version: Some(env!("CARGO_PKG_VERSION").to_string()),
             last_activity_at: None,
             connected: false,
             channel: None,
@@ -385,6 +391,17 @@ pub fn process_start_ms(pid: u32) -> Option<i64> {
     i64::try_from(secs).ok().map(|s| s * 1000)
 }
 
+/// Best-effort resolved executable of `pid`. Kept beside the identity probe so
+/// daemon health can inspect a process without shelling out from the TUI.
+#[must_use]
+pub fn process_binary(pid: u32) -> Option<PathBuf> {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+    let mut sys = System::new();
+    let spid = Pid::from_u32(pid);
+    sys.refresh_processes(ProcessesToUpdate::Some(&[spid]), false);
+    sys.process(spid)?.exe().map(Path::to_path_buf)
+}
+
 /// Cross-check a heartbeat's `pid`/`started_at` against the live process,
 /// returning whether it's the original daemon, a recycled-pid impostor, or
 /// dead. This is the identity guard the bare `kill(pid,0)` liveness check
@@ -437,6 +454,7 @@ mod tests {
         let hb = DaemonHeartbeat::starting();
         assert_eq!(hb.pid, std::process::id());
         assert_eq!(hb.started_at, hb.last_heartbeat_at);
+        assert_eq!(hb.ainb_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
         assert!(hb.last_activity_at.is_none());
         assert!(!hb.connected);
         assert_eq!(hb.error_count, 0);

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -220,6 +220,26 @@ fn heartbeat_version(hb: &DaemonHeartbeat) -> (Option<String>, Option<bool>) {
     (version, current)
 }
 
+/// True only for a known released version strictly older than this Ainb
+/// binary. Unknown, prerelease, equal, and newer versions return false: repair
+/// paths are upgrade-only and must never downgrade a live daemon.
+#[must_use]
+pub(crate) fn release_version_is_older(running: &str, current: &str) -> bool {
+    fn parts(version: &str) -> Option<[u64; 3]> {
+        let mut parts = version.split('.').map(str::parse::<u64>);
+        let parsed = [
+            parts.next()?.ok()?,
+            parts.next()?.ok()?,
+            parts.next()?.ok()?,
+        ];
+        parts.next().is_none().then_some(parsed)
+    }
+    match (parts(running), parts(current)) {
+        (Some(running), Some(current)) => running < current,
+        _ => false,
+    }
+}
+
 /// Version evidence for a socket daemon which predates version sidecars.
 /// Homebrew paths carry an immutable release version. Development and Cargo
 /// paths are only called current when they resolve to this exact executable;
@@ -934,6 +954,14 @@ mod tests {
             heartbeat_version(&heartbeat),
             (Some("0.0.0".to_string()), Some(false))
         );
+    }
+
+    #[test]
+    fn release_version_repair_is_upgrade_only() {
+        assert!(release_version_is_older("1.20.4", "1.20.5"));
+        assert!(!release_version_is_older("1.20.5", "1.20.5"));
+        assert!(!release_version_is_older("1.20.6", "1.20.5"));
+        assert!(!release_version_is_older("dev", "1.20.5"));
     }
 
     /// A bridge heartbeat whose outbound worker last reached the attention

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use super::heartbeat::{DaemonHeartbeat, PidCheck, is_pid_alive, pid_identity};
+use super::heartbeat::{DaemonHeartbeat, PidCheck, is_pid_alive, pid_identity, process_binary};
 
 /// A heartbeat older than this (and whose pid is *still* alive — e.g. a wedged
 /// daemon that stopped ticking) is treated as stale. A dead pid is caught
@@ -138,6 +138,15 @@ pub struct DaemonStatus {
     /// Milliseconds since the daemon started, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uptime_ms: Option<i64>,
+    /// Ainb version which owns this runtime, when it can be established.
+    /// `None` is intentionally honest: an old heartbeat or a scheduled job is
+    /// not evidence that it runs this binary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Whether [`Self::version`] equals this invoking Ainb binary.  `None`
+    /// means version unknown / not meaningful for this kind of runtime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_current: Option<bool>,
     /// Daemon-specific connection health (Telegram online / peer registered /
     /// socket+DB reachable / heartbeat alive).
     #[serde(default)]
@@ -185,6 +194,8 @@ impl DaemonStatus {
             state: DaemonState::Stopped,
             pid: None,
             uptime_ms: None,
+            version: None,
+            version_current: None,
             connected: false,
             channel: None,
             last_activity_at: None,
@@ -198,6 +209,48 @@ impl DaemonStatus {
             reason: reason.into(),
         }
     }
+}
+
+/// Version carried by a self-reporting heartbeat. Old heartbeats did not have
+/// this field; leave them unknown instead of pretending an upgraded observer
+/// upgraded a still-running daemon.
+fn heartbeat_version(hb: &DaemonHeartbeat) -> (Option<String>, Option<bool>) {
+    let version = hb.ainb_version.clone();
+    let current = version.as_deref().map(|running| running == env!("CARGO_PKG_VERSION"));
+    (version, current)
+}
+
+/// Version evidence for a socket daemon which predates version sidecars.
+/// Homebrew paths carry an immutable release version. Development and Cargo
+/// paths are only called current when they resolve to this exact executable;
+/// every other path remains unknown rather than guessed.
+fn process_version(pid: Option<u32>) -> (Option<String>, Option<bool>) {
+    let Some(path) = pid.and_then(process_binary) else {
+        return (None, None);
+    };
+    let raw = path.to_string_lossy();
+    if let Some((_, rest)) = raw.split_once("/Cellar/ainb/") {
+        if let Some(version) = rest.split('/').next().filter(|value| !value.is_empty()) {
+            let version = version.to_string();
+            return (
+                Some(version.clone()),
+                Some(version == env!("CARGO_PKG_VERSION")),
+            );
+        }
+    }
+    let same_binary = std::env::current_exe()
+        .ok()
+        .and_then(|current| {
+            std::fs::canonicalize(current)
+                .ok()
+                .zip(std::fs::canonicalize(&path).ok())
+                .map(|(current, running)| current == running)
+        })
+        .unwrap_or(path == std::env::current_exe().unwrap_or_default());
+    if same_binary {
+        return (Some(env!("CARGO_PKG_VERSION").to_string()), Some(true));
+    }
+    (None, None)
 }
 
 /// The outbound (proactive phone push) verdict for one heartbeat. Separated from
@@ -407,6 +460,7 @@ pub fn classify_heartbeat(
     let age = now_ms.saturating_sub(hb.last_heartbeat_at);
     let uptime_ms = now_ms.saturating_sub(hb.started_at);
     let uptime = Some(uptime_ms);
+    let (version, version_current) = heartbeat_version(&hb);
 
     // A dead OR recycled pid is the strongest possible signal: the process that
     // wrote this heartbeat is gone, so the heartbeat is a tombstone no matter
@@ -427,6 +481,8 @@ pub fn classify_heartbeat(
             state: DaemonState::Stopped,
             pid: Some(hb.pid),
             uptime_ms: None,
+            version,
+            version_current,
             connected: false,
             channel: hb.channel,
             last_activity_at: hb.last_activity_at,
@@ -450,6 +506,8 @@ pub fn classify_heartbeat(
             state: DaemonState::Stopped,
             pid: Some(hb.pid),
             uptime_ms: uptime,
+            version,
+            version_current,
             connected: false,
             channel: hb.channel,
             last_activity_at: hb.last_activity_at,
@@ -484,6 +542,8 @@ pub fn classify_heartbeat(
         state,
         pid: Some(hb.pid),
         uptime_ms: uptime,
+        version,
+        version_current,
         connected: hb.connected,
         channel: hb.channel,
         last_activity_at: hb.last_activity_at,
@@ -521,6 +581,7 @@ pub fn probe_notifyd(base: &Path, now_ms: i64) -> DaemonStatus {
     let db_path = base.join("notifications.db");
 
     let pid = read_pid_file(&pid_path);
+    let (version, version_current) = process_version(pid);
     let pid_alive = pid.is_some_and(is_pid_alive);
     // L1: a bound, ACCEPTING listener — not merely a socket file on disk. A
     // crashed daemon can leave a stale `notify.sock` behind; `exists()` would
@@ -563,6 +624,8 @@ pub fn probe_notifyd(base: &Path, now_ms: i64) -> DaemonStatus {
         state: DaemonState::Running,
         pid,
         uptime_ms: None, // notifyd's PID file carries no start time
+        version,
+        version_current,
         connected,
         channel: Some("unix socket + sqlite".to_string()),
         last_activity_at: db_mtime_ms(&db_path),
@@ -612,11 +675,15 @@ pub fn probe_approve_broker(base: &Path, now_ms: i64) -> DaemonStatus {
             n => format!("serving, {n} pending requests (see `ainb fleet approve`)"),
         },
     );
+    let notify_pid = read_pid_file(&base.join("notify.pid"));
+    let (version, version_current) = process_version(notify_pid);
     DaemonStatus {
         kind,
         state: DaemonState::Running,
         pid: None, // rides notifyd's process; no pid of its own
         uptime_ms: None,
+        version,
+        version_current,
         connected: true,
         channel: Some("approve socket".to_string()),
         last_activity_at: None,
@@ -743,6 +810,8 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
         state: DaemonState::Running,
         pid: None, // timer-driven; no resident pid
         uptime_ms: None,
+        version: None,
+        version_current: None,
         connected: true,
         channel: Some(format!("{name} (every {interval_min}m)")),
         last_activity_at: hbs.last_active_ms,
@@ -837,6 +906,7 @@ mod tests {
             pid,
             started_at: started,
             last_heartbeat_at: last_beat,
+            ainb_version: Some(env!("CARGO_PKG_VERSION").to_string()),
             last_activity_at: Some(last_beat),
             connected,
             channel: Some("Telegram".into()),
@@ -849,6 +919,21 @@ mod tests {
             inbound_live: 0,
             last_inbound_error: None,
         }
+    }
+
+    #[test]
+    fn heartbeat_version_marks_only_this_binary_current() {
+        let mut heartbeat = hb(42, 1, 2, true);
+        heartbeat.ainb_version = Some(env!("CARGO_PKG_VERSION").to_string());
+        assert_eq!(
+            heartbeat_version(&heartbeat),
+            (heartbeat.ainb_version.clone(), Some(true))
+        );
+        heartbeat.ainb_version = Some("0.0.0".to_string());
+        assert_eq!(
+            heartbeat_version(&heartbeat),
+            (Some("0.0.0".to_string()), Some(false))
+        );
     }
 
     /// A bridge heartbeat whose outbound worker last reached the attention

--- a/ainb-tui/crates/ainb-core/src/mcp_pool/client.rs
+++ b/ainb-tui/crates/ainb-core/src/mcp_pool/client.rs
@@ -48,7 +48,13 @@ pub fn daemon_runtime_status() -> DaemonRuntimeStatus {
     let Ok(report) = serde_json::from_str::<StatusReport>(&raw) else {
         return DaemonRuntimeStatus::default();
     };
-    let old = report.version != env!("CARGO_PKG_VERSION");
+    // A different version is not necessarily stale: Doctor and the TUI are
+    // sometimes launched from an older Ainb while a newer MCP pool is serving.
+    // Only a known older release is safe to replace.
+    let old = crate::fleet::daemons::probe::release_version_is_older(
+        &report.version,
+        env!("CARGO_PKG_VERSION"),
+    );
     DaemonRuntimeStatus {
         pid: Some(report.pid),
         version: Some(report.version),

--- a/ainb-tui/crates/ainb-core/src/mcp_pool/client.rs
+++ b/ainb-tui/crates/ainb-core/src/mcp_pool/client.rs
@@ -2,6 +2,7 @@
 // status/stop`: liveness probe, auto-spawn (detached), status query.
 
 use anyhow::{Context, Result};
+use serde::Deserialize;
 use std::io::{BufRead, BufReader, Write};
 use std::time::Duration;
 
@@ -22,6 +23,37 @@ pub fn daemon_alive() -> bool {
 pub fn daemon_status() -> Result<String> {
     let path = paths::control_socket()?;
     query(&path, "status")
+}
+
+/// Runtime identity from the daemon's own control socket. Unlike a launcher
+/// path this is supplied by the process actually serving pooled tools.
+#[derive(Debug, Clone, Default)]
+pub struct DaemonRuntimeStatus {
+    pub pid: Option<u32>,
+    pub version: Option<String>,
+    pub old: bool,
+}
+
+#[derive(Deserialize)]
+struct StatusReport {
+    pid: u32,
+    version: String,
+}
+
+#[must_use]
+pub fn daemon_runtime_status() -> DaemonRuntimeStatus {
+    let Ok(raw) = daemon_status() else {
+        return DaemonRuntimeStatus::default();
+    };
+    let Ok(report) = serde_json::from_str::<StatusReport>(&raw) else {
+        return DaemonRuntimeStatus::default();
+    };
+    let old = report.version != env!("CARGO_PKG_VERSION");
+    DaemonRuntimeStatus {
+        pid: Some(report.pid),
+        version: Some(report.version),
+        old,
+    }
 }
 
 /// Ask the daemon to shut down (kills pooled children).
@@ -101,4 +133,22 @@ pub fn ensure_daemon() -> Result<()> {
         "mcp daemon did not come up within 3s (see {})",
         paths::daemon_log()?.display()
     )
+}
+
+/// Replace a running pool with this Ainb binary. The control socket performs
+/// graceful child teardown; then normal ensure logic starts the current binary.
+pub fn restart_daemon() -> Result<()> {
+    if daemon_alive() {
+        daemon_stop().context("request MCP daemon shutdown")?;
+        for _ in 0..30 {
+            std::thread::sleep(Duration::from_millis(100));
+            if !daemon_alive() {
+                break;
+            }
+        }
+        if daemon_alive() {
+            anyhow::bail!("MCP daemon did not stop within 3s");
+        }
+    }
+    ensure_daemon()
 }


### PR DESCRIPTION
## Summary
- show Ainb runtime versions and version drift in Daemons and Doctor
- restart MCP, Hangar, and notifyd only through managed lifecycle controls
- prevent doctor or TUI from downgrading newer daemon releases

## Validation
- `cargo check -p ainb`
- `cargo test -p ainb --lib --no-fail-fast` (1815 passed, 2 ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Daemon screens now show runtime versions and identify current, outdated, newer, or unknown builds.
  - Added restart and upgrade actions for managed MCP and Hangar services.
  - `ainb doctor` now supports automatic daemon repairs with text and JSON outcome reporting.
  - Daemon status includes additional runtime details, such as process ID and version.

- **Bug Fixes**
  - Prevents unnecessary restarts for unknown or externally managed processes.
  - Refreshes daemon health status after repair attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->