### PR TITLE
fix: clean failed Codex launches

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -520,6 +520,8 @@ mod tests {
         let unquoted = pane_command.replace(['\'', '"'], "");
         for fragment in [
             "codex",
+            "-c",
+            "check_for_update_on_startup=false",
             "--remote",
             "unix:///tmp/ainb-idle-restart.sock",
             "resume",

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -18,7 +18,7 @@ use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{
     ModelSource, SessionMetadata, SessionStore, claim_codex_remote_thread,
-    ensure_codex_remote_thread,
+    ensure_codex_remote_thread, rollback_failed_interactive_launch,
 };
 use crate::models::session::{SessionAgentType, is_default_model};
 use crate::tmux::TmuxSession;
@@ -42,6 +42,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
     let work_dir: PathBuf;
     let branch_name: String;
+    let worktree_manager: Option<WorktreeManager>;
     let session_id = Uuid::new_v4();
     // Set when the session ends up running directly in the user's checkout.
     // Kept so the warning can be REPEATED in the post-creation summary: with
@@ -52,8 +53,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
     // Step 3: Create worktree if requested
     if args.worktree || args.create_branch.is_some() {
-        let worktree_manager =
-            WorktreeManager::new().context("Failed to initialize worktree manager")?;
+        let manager = WorktreeManager::new().context("Failed to initialize worktree manager")?;
 
         let branch = args
             .create_branch
@@ -62,15 +62,17 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
         info!("Creating worktree for branch: {}", branch);
 
-        let worktree_info = worktree_manager
+        let worktree_info = manager
             .create_worktree(session_id, &repo_path, &branch, None)
             .context("Failed to create worktree")?;
 
         work_dir = worktree_info.path;
         branch_name = branch;
+        worktree_manager = Some(manager);
 
         println!("Created worktree at: {}", work_dir.display());
     } else {
+        worktree_manager = None;
         work_dir = repo_path.clone();
         branch_name =
             crate::git::current_branch_at(&repo_path).unwrap_or_else(|| "main".to_string());
@@ -107,17 +109,24 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
     // Step 6: Allocate the daemon-owned remote thread before tmux starts.
     let codex_remote = if provider == CliProvider::Codex {
-        Some(
-            ensure_codex_remote_thread(
-                session_id,
-                &work_dir,
-                model.as_deref(),
-                args.dangerously_skip_permissions,
-                false,
-                None,
-            )
-            .await?,
+        match ensure_codex_remote_thread(
+            session_id,
+            &work_dir,
+            model.as_deref(),
+            args.dangerously_skip_permissions,
+            false,
+            None,
         )
+        .await
+        {
+            Ok(remote) => Some(remote),
+            Err(error) => {
+                rollback_failed_interactive_launch(session_id, None, worktree_manager.as_ref())
+                    .await;
+                return Err(error)
+                    .context("Codex failed to start; AINB ran failed-session cleanup");
+            }
+        }
     } else {
         None
     };
@@ -159,22 +168,41 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
     // Step 7: Create tmux session
     let mut tmux = TmuxSession::new(session_name.clone(), claude_cmd.clone()).with_env(session_env);
-    tmux.start(&work_dir).await.context("Failed to start tmux session")?;
+    if let Err(error) = tmux.start(&work_dir).await {
+        rollback_failed_interactive_launch(
+            session_id,
+            Some(tmux.name()),
+            worktree_manager.as_ref(),
+        )
+        .await;
+        return Err(error).context("Failed to start tmux session");
+    }
 
     let tmux_name = tmux.name().to_string();
     info!("Started tmux session: {}", tmux_name);
 
     let codex_remote = match codex_remote {
-        Some(remote) if remote.thread_id.is_none() => Some(
-            claim_codex_remote_thread(
-                session_id,
-                &work_dir,
-                model.as_deref(),
-                args.dangerously_skip_permissions,
-                false,
-            )
-            .await?,
-        ),
+        Some(remote) if remote.thread_id.is_none() => match claim_codex_remote_thread(
+            session_id,
+            &work_dir,
+            model.as_deref(),
+            args.dangerously_skip_permissions,
+            false,
+        )
+        .await
+        {
+            Ok(remote) => Some(remote),
+            Err(error) => {
+                rollback_failed_interactive_launch(
+                    session_id,
+                    Some(&tmux_name),
+                    worktree_manager.as_ref(),
+                )
+                .await;
+                return Err(error)
+                    .context("Codex failed to start; AINB ran failed-session cleanup");
+            }
+        },
         remote => remote,
     };
 
@@ -218,8 +246,11 @@ pub async fn execute(args: RunArgs) -> Result<()> {
 
     // Locked RMW (pu4): another `ainb run`/`kill` or a daemon register racing
     // this write must not lost-update the store.
-    SessionStore::mutate(|store| store.upsert(metadata))
-        .context("Failed to save session metadata")?;
+    if let Err(error) = SessionStore::mutate(|store| store.upsert(metadata)) {
+        rollback_failed_interactive_launch(session_id, Some(&tmux_name), worktree_manager.as_ref())
+            .await;
+        return Err(error).context("Failed to save session metadata");
+    }
 
     info!("Saved session metadata for TUI discovery");
 
@@ -513,6 +544,8 @@ fn remote_codex_command(
 ) -> String {
     let mut parts = vec![
         "codex".to_string(),
+        "-c".to_string(),
+        "check_for_update_on_startup=false".to_string(),
         "--disable".to_string(),
         "apps".to_string(),
         "--remote".to_string(),
@@ -793,7 +826,7 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
+            "codex -c check_for_update_on_startup=false --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
         );
         assert!(!command.contains("--last"));
     }
@@ -811,7 +844,7 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
+            "codex -c check_for_update_on_startup=false --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -18,7 +18,7 @@ use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{
     ModelSource, SessionMetadata, SessionStore, claim_codex_remote_thread,
-    ensure_codex_remote_thread, rollback_failed_interactive_launch,
+    discard_codex_remote_thread, ensure_codex_remote_thread, rollback_failed_interactive_launch,
 };
 use crate::models::session::{SessionAgentType, is_default_model};
 use crate::tmux::TmuxSession;
@@ -228,6 +228,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         CliProvider::Copilot => SessionAgentType::Copilot,
     };
 
+    let codex_thread_id = codex_remote.and_then(|remote| remote.thread_id);
     let metadata = SessionMetadata {
         session_id,
         tmux_session_name: tmux_name.clone(),
@@ -241,7 +242,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         model: model.clone(),
         model_source: ModelSource::Raw,
         codex_model: None,
-        codex_thread_id: codex_remote.and_then(|remote| remote.thread_id),
+        codex_thread_id: codex_thread_id.clone(),
     };
 
     // Locked RMW (pu4): another `ainb run`/`kill` or a daemon register racing
@@ -249,6 +250,11 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     if let Err(error) = SessionStore::mutate(|store| store.upsert(metadata)) {
         rollback_failed_interactive_launch(session_id, Some(&tmux_name), worktree_manager.as_ref())
             .await;
+        if codex_thread_id.is_some() {
+            if let Err(cleanup_error) = discard_codex_remote_thread(session_id).await {
+                warn!("Failed to discard claimed Codex thread for {session_id}: {cleanup_error:#}");
+            }
+        }
         return Err(error).context("Failed to save session metadata");
     }
 

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -225,7 +225,7 @@ impl WorktreeManager {
         }
 
         // Remove the session symlink if it exists
-        if session_path.exists() {
+        if session_path.is_symlink() || session_path.exists() {
             std::fs::remove_file(&session_path)?;
         }
 

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -199,6 +199,19 @@ pub(crate) async fn claim_codex_remote_thread(
     }
 }
 
+/// Archive and forget a remote thread created by a failed fresh launch.
+pub(crate) async fn discard_codex_remote_thread(session_id: Uuid) -> anyhow::Result<()> {
+    let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
+        .map_err(|error| anyhow::anyhow!("connect to Ainb Codex runtime: {error}"))?;
+    client
+        .codex_session_discard(ainb_hangar_proto::fleet::CodexSessionDiscardParams {
+            session_id: session_id.to_string(),
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("discard failed Codex thread: {error}"))?;
+    Ok(())
+}
+
 /// Roll back resources created before a fresh Interactive session is registered.
 pub(crate) async fn rollback_failed_interactive_launch(
     session_id: Uuid,
@@ -206,7 +219,8 @@ pub(crate) async fn rollback_failed_interactive_launch(
     worktree_manager: Option<&WorktreeManager>,
 ) {
     if let Some(tmux_name) = exact_tmux_name {
-        match Command::new("tmux").args(["kill-session", "-t", tmux_name]).output().await {
+        let exact_target = format!("={tmux_name}");
+        match Command::new("tmux").args(["kill-session", "-t", &exact_target]).output().await {
             Ok(output) if output.status.success() => {
                 info!("Rolled back failed launch tmux session: {tmux_name}");
             }
@@ -2386,8 +2400,9 @@ mod tests {
         impl Drop for ExactTmuxCleanup {
             fn drop(&mut self) {
                 for name in &self.0 {
+                    let exact_target = format!("={name}");
                     let _ = std::process::Command::new("tmux")
-                        .args(["kill-session", "-t", name])
+                        .args(["kill-session", "-t", &exact_target])
                         .output();
                 }
             }
@@ -2396,8 +2411,13 @@ mod tests {
         let session_id = Uuid::new_v4();
         let failed_tmux = format!("ainb-failed-launch-{session_id}");
         let sibling_tmux = format!("ainb-sibling-launch-{}", Uuid::new_v4());
-        let _tmux_cleanup = ExactTmuxCleanup(vec![failed_tmux.clone(), sibling_tmux.clone()]);
-        for name in [&failed_tmux, &sibling_tmux] {
+        let prefix_tmux = format!("{failed_tmux}-still-running");
+        let _tmux_cleanup = ExactTmuxCleanup(vec![
+            failed_tmux.clone(),
+            sibling_tmux.clone(),
+            prefix_tmux.clone(),
+        ]);
+        for name in [&failed_tmux, &sibling_tmux, &prefix_tmux] {
             assert!(
                 std::process::Command::new("tmux")
                     .args(["new-session", "-d", "-s", name])
@@ -2445,7 +2465,7 @@ mod tests {
         assert!(std::fs::symlink_metadata(&session_link).is_err());
         assert!(
             !std::process::Command::new("tmux")
-                .args(["has-session", "-t", &failed_tmux])
+                .args(["has-session", "-t", &format!("={failed_tmux}")])
                 .output()
                 .expect("check failed tmux")
                 .status
@@ -2453,9 +2473,27 @@ mod tests {
         );
         assert!(
             std::process::Command::new("tmux")
-                .args(["has-session", "-t", &sibling_tmux])
+                .args(["has-session", "-t", &format!("={sibling_tmux}")])
                 .output()
                 .expect("check sibling tmux")
+                .status
+                .success()
+        );
+        assert!(
+            std::process::Command::new("tmux")
+                .args(["has-session", "-t", &format!("={prefix_tmux}")])
+                .output()
+                .expect("check prefix tmux")
+                .status
+                .success()
+        );
+
+        rollback_failed_interactive_launch(session_id, Some(&failed_tmux), None).await;
+        assert!(
+            std::process::Command::new("tmux")
+                .args(["has-session", "-t", &format!("={prefix_tmux}")])
+                .output()
+                .expect("check prefix tmux after missing exact target")
                 .status
                 .success()
         );

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -193,11 +193,47 @@ pub(crate) async fn claim_codex_remote_thread(
             return Ok(remote);
         }
         if tokio::time::Instant::now() >= deadline {
-            anyhow::bail!(
-                "Codex started but did not publish a remote thread within 10 seconds; keep the pane open and retry"
-            );
+            anyhow::bail!("Codex started but did not publish a remote thread within 10 seconds");
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// Roll back resources created before a fresh Interactive session is registered.
+pub(crate) async fn rollback_failed_interactive_launch(
+    session_id: Uuid,
+    exact_tmux_name: Option<&str>,
+    worktree_manager: Option<&WorktreeManager>,
+) {
+    if let Some(tmux_name) = exact_tmux_name {
+        match Command::new("tmux").args(["kill-session", "-t", tmux_name]).output().await {
+            Ok(output) if output.status.success() => {
+                info!("Rolled back failed launch tmux session: {tmux_name}");
+            }
+            Ok(output) => warn!(
+                "Failed to roll back tmux session '{}': {}",
+                tmux_name,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+            Err(error) => warn!("Failed to run tmux cleanup for '{tmux_name}': {error}"),
+        }
+    }
+
+    if let Some(worktree_manager) = worktree_manager {
+        match worktree_manager.remove_worktree(session_id) {
+            Ok(()) => info!("Rolled back failed launch worktree: {session_id}"),
+            Err(crate::git::WorktreeError::NotFound(_)) => {}
+            Err(error) => warn!("Failed to roll back worktree for {session_id}: {error}"),
+        }
+    }
+
+    if let Err(error) = SessionStore::mutate(|store| {
+        if let Some(tmux_name) = exact_tmux_name {
+            store.remove_by_tmux_name(tmux_name);
+        }
+        store.remove_by_session_id(session_id);
+    }) {
+        warn!("Failed to purge failed launch metadata for {session_id}: {error}");
     }
 }
 
@@ -577,17 +613,29 @@ impl InteractiveSessionManager {
         }
 
         let codex_remote = if agent_type == SessionAgentType::Codex {
-            Some(
-                ensure_codex_remote_thread(
-                    session_id,
-                    &worktree_info.path,
-                    model.as_deref(),
-                    skip_permissions,
-                    headroom_enabled,
-                    None,
-                )
-                .await?,
+            match ensure_codex_remote_thread(
+                session_id,
+                &worktree_info.path,
+                model.as_deref(),
+                skip_permissions,
+                headroom_enabled,
+                None,
             )
+            .await
+            {
+                Ok(remote) => Some(remote),
+                Err(error) => {
+                    rollback_failed_interactive_launch(
+                        session_id,
+                        None,
+                        Some(&self.worktree_manager),
+                    )
+                    .await;
+                    return Err(error
+                        .context("Codex failed to start; AINB ran failed-session cleanup")
+                        .into());
+                }
+            }
         } else {
             None
         };
@@ -598,7 +646,15 @@ impl InteractiveSessionManager {
 
         // Step 3: Start tmux session
         info!("Starting tmux session: {}", tmux_session_name);
-        self.start_tmux_session(&tmux_session_name, &worktree_info.path).await?;
+        if let Err(error) = self.start_tmux_session(&tmux_session_name, &worktree_info.path).await {
+            rollback_failed_interactive_launch(
+                session_id,
+                Some(&tmux_session_name),
+                Some(&self.worktree_manager),
+            )
+            .await;
+            return Err(error);
+        }
 
         // Step 4: Start CLI in tmux session (for AI agent types)
         match agent_type {
@@ -610,18 +666,28 @@ impl InteractiveSessionManager {
                     "Starting {:?} CLI in tmux session (model={:?}, skip_permissions={})",
                     agent_type, model, skip_permissions
                 );
-                self.start_cli_in_tmux(
-                    &tmux_session_name,
-                    &worktree_info.path,
-                    skip_permissions,
-                    model.clone(),
-                    agent_type,
-                    None,
-                    false, // resume_requested — fresh launch
-                    headroom_enabled,
-                    codex_remote.as_ref(),
-                )
-                .await?;
+                if let Err(error) = self
+                    .start_cli_in_tmux(
+                        &tmux_session_name,
+                        &worktree_info.path,
+                        skip_permissions,
+                        model.clone(),
+                        agent_type,
+                        None,
+                        false, // resume_requested: fresh launch
+                        headroom_enabled,
+                        codex_remote.as_ref(),
+                    )
+                    .await
+                {
+                    rollback_failed_interactive_launch(
+                        session_id,
+                        Some(&tmux_session_name),
+                        Some(&self.worktree_manager),
+                    )
+                    .await;
+                    return Err(error);
+                }
             }
             _ => {
                 info!("Skipping CLI for agent type: {:?}", agent_type);
@@ -629,16 +695,28 @@ impl InteractiveSessionManager {
         }
 
         let codex_remote = match codex_remote {
-            Some(remote) if remote.thread_id.is_none() => Some(
-                claim_codex_remote_thread(
-                    session_id,
-                    &worktree_info.path,
-                    model.as_deref(),
-                    skip_permissions,
-                    headroom_enabled,
-                )
-                .await?,
-            ),
+            Some(remote) if remote.thread_id.is_none() => match claim_codex_remote_thread(
+                session_id,
+                &worktree_info.path,
+                model.as_deref(),
+                skip_permissions,
+                headroom_enabled,
+            )
+            .await
+            {
+                Ok(remote) => Some(remote),
+                Err(error) => {
+                    rollback_failed_interactive_launch(
+                        session_id,
+                        Some(&tmux_session_name),
+                        Some(&self.worktree_manager),
+                    )
+                    .await;
+                    return Err(error
+                        .context("Codex failed to start; AINB ran failed-session cleanup")
+                        .into());
+                }
+            },
             remote => remote,
         };
 
@@ -779,17 +857,29 @@ impl InteractiveSessionManager {
         }
 
         let codex_remote = if agent_type == SessionAgentType::Codex {
-            Some(
-                ensure_codex_remote_thread(
-                    session_id,
-                    &existing_worktree_path,
-                    model.as_deref(),
-                    skip_permissions,
-                    headroom_enabled,
-                    None,
-                )
-                .await?,
+            match ensure_codex_remote_thread(
+                session_id,
+                &existing_worktree_path,
+                model.as_deref(),
+                skip_permissions,
+                headroom_enabled,
+                None,
             )
+            .await
+            {
+                Ok(remote) => Some(remote),
+                Err(error) => {
+                    rollback_failed_interactive_launch(
+                        session_id,
+                        None,
+                        Some(&self.worktree_manager),
+                    )
+                    .await;
+                    return Err(error
+                        .context("Codex failed to start; AINB ran failed-session cleanup")
+                        .into());
+                }
+            }
         } else {
             None
         };
@@ -800,7 +890,17 @@ impl InteractiveSessionManager {
 
         // Step 2: Start tmux session
         info!("Starting tmux session: {}", tmux_session_name);
-        self.start_tmux_session(&tmux_session_name, &existing_worktree_path).await?;
+        if let Err(error) =
+            self.start_tmux_session(&tmux_session_name, &existing_worktree_path).await
+        {
+            rollback_failed_interactive_launch(
+                session_id,
+                Some(&tmux_session_name),
+                Some(&self.worktree_manager),
+            )
+            .await;
+            return Err(error);
+        }
 
         // Step 3: Start CLI in tmux session (for AI agent types)
         match agent_type {
@@ -812,18 +912,28 @@ impl InteractiveSessionManager {
                     "Starting {:?} CLI in tmux session (model={:?}, skip_permissions={})",
                     agent_type, model, skip_permissions
                 );
-                self.start_cli_in_tmux(
-                    &tmux_session_name,
-                    &existing_worktree_path,
-                    skip_permissions,
-                    model.clone(),
-                    agent_type,
-                    None,
-                    false, // resume_requested — fresh launch
-                    headroom_enabled,
-                    codex_remote.as_ref(),
-                )
-                .await?;
+                if let Err(error) = self
+                    .start_cli_in_tmux(
+                        &tmux_session_name,
+                        &existing_worktree_path,
+                        skip_permissions,
+                        model.clone(),
+                        agent_type,
+                        None,
+                        false, // resume_requested: fresh launch
+                        headroom_enabled,
+                        codex_remote.as_ref(),
+                    )
+                    .await
+                {
+                    rollback_failed_interactive_launch(
+                        session_id,
+                        Some(&tmux_session_name),
+                        Some(&self.worktree_manager),
+                    )
+                    .await;
+                    return Err(error);
+                }
             }
             _ => {
                 info!("Skipping CLI for agent type: {:?}", agent_type);
@@ -831,16 +941,28 @@ impl InteractiveSessionManager {
         }
 
         let codex_remote = match codex_remote {
-            Some(remote) if remote.thread_id.is_none() => Some(
-                claim_codex_remote_thread(
-                    session_id,
-                    &existing_worktree_path,
-                    model.as_deref(),
-                    skip_permissions,
-                    headroom_enabled,
-                )
-                .await?,
-            ),
+            Some(remote) if remote.thread_id.is_none() => match claim_codex_remote_thread(
+                session_id,
+                &existing_worktree_path,
+                model.as_deref(),
+                skip_permissions,
+                headroom_enabled,
+            )
+            .await
+            {
+                Ok(remote) => Some(remote),
+                Err(error) => {
+                    rollback_failed_interactive_launch(
+                        session_id,
+                        Some(&tmux_session_name),
+                        Some(&self.worktree_manager),
+                    )
+                    .await;
+                    return Err(error
+                        .context("Codex failed to start; AINB ran failed-session cleanup")
+                        .into());
+                }
+            },
             remote => remote,
         };
 
@@ -1757,11 +1879,16 @@ impl InteractiveSessionManager {
         has_history: bool,
     ) -> Vec<String> {
         let mut cmd_parts = vec![provider.command().to_string()];
+        if agent_type == SessionAgentType::Codex {
+            cmd_parts.extend([
+                "-c".to_string(),
+                "check_for_update_on_startup=false".to_string(),
+            ]);
+        }
 
-        // Codex resume is a subcommand form — `codex resume --last [opts]` — so
-        // the `resume --last` tokens must come right after the binary, BEFORE
-        // any --model / skip-permissions flags (codex accepts those as options
-        // of the `resume` subcommand). `--last` continues the most recent
+        // Codex resume is a subcommand form. Global config overrides precede
+        // `resume --last`; model and permission flags follow it as resume
+        // subcommand options. `--last` continues the most recent
         // session in the current cwd (worktrees are 1-session-per-dir, so that
         // is "the last session"). Codex owns the cwd filtering.
         let codex_resume = agent_type == SessionAgentType::Codex && resume_requested;
@@ -1909,6 +2036,8 @@ impl InteractiveSessionManager {
             }
             let mut command = vec![
                 provider.command().to_string(),
+                "-c".to_string(),
+                "check_for_update_on_startup=false".to_string(),
                 "--disable".to_string(),
                 "apps".to_string(),
                 "--remote".to_string(),
@@ -2223,6 +2352,117 @@ fn wire_rtk_project_hook_with_cmd(worktree: &std::path::Path, cmd: &str) -> anyh
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_launch_rollback_removes_only_exact_owned_resources() {
+        if !Command::new("tmux")
+            .arg("-V")
+            .output()
+            .await
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        let _env = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().expect("temp home");
+        let prior_home = std::env::var_os("AINB_HOME");
+        std::env::set_var("AINB_HOME", home.path());
+
+        struct RestoreHome(Option<std::ffi::OsString>);
+        impl Drop for RestoreHome {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(home) => std::env::set_var("AINB_HOME", home),
+                    None => std::env::remove_var("AINB_HOME"),
+                }
+            }
+        }
+        let _restore_home = RestoreHome(prior_home);
+
+        struct ExactTmuxCleanup(Vec<String>);
+        impl Drop for ExactTmuxCleanup {
+            fn drop(&mut self) {
+                for name in &self.0 {
+                    let _ = std::process::Command::new("tmux")
+                        .args(["kill-session", "-t", name])
+                        .output();
+                }
+            }
+        }
+
+        let session_id = Uuid::new_v4();
+        let failed_tmux = format!("ainb-failed-launch-{session_id}");
+        let sibling_tmux = format!("ainb-sibling-launch-{}", Uuid::new_v4());
+        let _tmux_cleanup = ExactTmuxCleanup(vec![failed_tmux.clone(), sibling_tmux.clone()]);
+        for name in [&failed_tmux, &sibling_tmux] {
+            assert!(
+                std::process::Command::new("tmux")
+                    .args(["new-session", "-d", "-s", name])
+                    .status()
+                    .expect("create tmux session")
+                    .success()
+            );
+        }
+
+        let worktree_manager = WorktreeManager::new().expect("worktree manager");
+        let worktree = worktree_manager.base_dir().join("by-name").join("failed-launch");
+        std::fs::create_dir_all(&worktree).expect("create worktree");
+        let session_link =
+            worktree_manager.base_dir().join("by-session").join(session_id.to_string());
+        std::os::unix::fs::symlink(&worktree, &session_link).expect("link worktree");
+
+        let sibling_id = Uuid::new_v4();
+        let mut store = SessionStore::default();
+        for (id, name, path) in [
+            (session_id, failed_tmux.clone(), worktree.clone()),
+            (sibling_id, sibling_tmux.clone(), PathBuf::from("/keep")),
+        ] {
+            store.upsert(SessionMetadata {
+                session_id: id,
+                tmux_session_name: name,
+                worktree_path: path,
+                workspace_name: "test".to_string(),
+                created_at: Utc::now(),
+                agent_type: SessionAgentType::Codex,
+                headroom_enabled: false,
+                rtk_enabled: false,
+                skip_permissions: Some(false),
+                model: None,
+                model_source: ModelSource::Raw,
+                codex_model: None,
+                codex_thread_id: None,
+            });
+        }
+        store.save().expect("seed store");
+
+        rollback_failed_interactive_launch(session_id, Some(&failed_tmux), Some(&worktree_manager))
+            .await;
+
+        assert!(!worktree.exists());
+        assert!(std::fs::symlink_metadata(&session_link).is_err());
+        assert!(
+            !std::process::Command::new("tmux")
+                .args(["has-session", "-t", &failed_tmux])
+                .output()
+                .expect("check failed tmux")
+                .status
+                .success()
+        );
+        assert!(
+            std::process::Command::new("tmux")
+                .args(["has-session", "-t", &sibling_tmux])
+                .output()
+                .expect("check sibling tmux")
+                .status
+                .success()
+        );
+        let store = SessionStore::load();
+        assert!(store.find_by_tmux_name(&failed_tmux).is_none());
+        assert!(store.find_by_tmux_name(&sibling_tmux).is_some());
+    }
 
     #[test]
     fn shared_remote_codex_failures_show_a_short_next_action() {
@@ -3290,7 +3530,7 @@ mod tests {
 
     #[test]
     fn codex_resume_is_subcommand_before_flags() {
-        // `resume --last` must come right after the binary, before flags.
+        // Global config precedes the resume subcommand; resume flags follow it.
         let p = parts(
             CliProvider::Codex,
             SessionAgentType::Codex,
@@ -3303,6 +3543,8 @@ mod tests {
             p,
             vec![
                 "codex",
+                "-c",
+                "check_for_update_on_startup=false",
                 "resume",
                 "--last",
                 "--dangerously-bypass-approvals-and-sandbox",
@@ -3324,6 +3566,8 @@ mod tests {
             p,
             vec![
                 "codex",
+                "-c",
+                "check_for_update_on_startup=false",
                 "resume",
                 "--last",
                 "--model",
@@ -3345,7 +3589,12 @@ mod tests {
         );
         assert_eq!(
             p,
-            vec!["codex", "--dangerously-bypass-approvals-and-sandbox"]
+            vec![
+                "codex",
+                "-c",
+                "check_for_update_on_startup=false",
+                "--dangerously-bypass-approvals-and-sandbox",
+            ]
         );
     }
 

--- a/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
+++ b/ainb-tui/crates/ainb-core/tests/resume_command_tmux.rs
@@ -250,7 +250,7 @@ async fn codex_resume_launches_resume_last() {
     kill(&name);
 
     assert!(
-        cmd.contains("codex resume --last"),
+        cmd.contains("check_for_update_on_startup=false resume --last"),
         "codex resume must be `resume --last`, got: {cmd}"
     );
     assert!(

--- a/ainb-tui/crates/ainb-hangar-client/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-client/src/lib.rs
@@ -327,6 +327,20 @@ impl DaemonClient {
         })
     }
 
+    /// Discard one failed Interactive Codex launch and archive its remote thread.
+    pub async fn codex_session_discard(
+        &self,
+        params: ainb_hangar_proto::fleet::CodexSessionDiscardParams,
+    ) -> Result<ainb_hangar_proto::fleet::CodexSessionDiscardResult, DaemonError> {
+        let value = serde_json::to_value(params).map_err(|source| {
+            DaemonError::Decode(format!("encoding Codex discard params: {source}"))
+        })?;
+        let result = self.call(ainb_hangar_proto::methods::CODEX_SESSION_DISCARD, value).await?;
+        serde_json::from_value(result).map_err(|source| {
+            DaemonError::Decode(format!("decoding Codex discard result: {source}"))
+        })
+    }
+
     /// Rebuild one stale Claude interview through the live daemon.
     pub async fn fleet_reproject_claude_interview(
         &self,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex.rs
@@ -190,6 +190,8 @@ pub fn managed_tui_command(
     additional_args: impl IntoIterator<Item = OsString>,
 ) -> CommandSpec {
     let mut args = vec![
+        "-c".into(),
+        "check_for_update_on_startup=false".into(),
         "--disable".into(),
         "apps".into(),
         "--remote".into(),
@@ -897,6 +899,8 @@ mod tests {
             )
             .args,
             vec![
+                OsString::from("-c"),
+                OsString::from("check_for_update_on_startup=false"),
                 OsString::from("--disable"),
                 OsString::from("apps"),
                 OsString::from("--remote"),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -30,7 +30,10 @@ use tokio::sync::RwLock;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep};
-use tokio_tungstenite::{WebSocketStream, client_async, tungstenite::Message};
+use tokio_tungstenite::{
+    WebSocketStream, client_async_with_config,
+    tungstenite::{Message, protocol::WebSocketConfig},
+};
 
 #[cfg(test)]
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
@@ -45,6 +48,15 @@ use super::{ApprovalDecision, ProviderError, ProviderReceipt, QuestionAnswer};
 use crate::events::EventSink;
 
 const INITIALIZE_ID: u64 = 1;
+const CODEX_WEBSOCKET_MAX_MESSAGE_SIZE: usize = 64 << 20;
+
+fn codex_websocket_config() -> WebSocketConfig {
+    WebSocketConfig {
+        max_message_size: Some(CODEX_WEBSOCKET_MAX_MESSAGE_SIZE),
+        max_frame_size: Some(CODEX_WEBSOCKET_MAX_MESSAGE_SIZE),
+        ..WebSocketConfig::default()
+    }
+}
 
 static ACTIVE_MANAGER: OnceLock<RwLock<Option<CodexManagerHandle>>> = OnceLock::new();
 
@@ -723,7 +735,13 @@ pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, Pr
             )));
         }
     };
-    let websocket = match client_async("ws://localhost/", socket).await {
+    let websocket = match client_async_with_config(
+        "ws://localhost/",
+        socket,
+        Some(codex_websocket_config()),
+    )
+    .await
+    {
         Ok((websocket, _)) => websocket,
         Err(error) => {
             if let Some(server) = server.as_mut() {
@@ -2350,6 +2368,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("app-server.sock");
         let listener = UnixListener::bind(&socket_path).unwrap();
+        let payload_size = (16 << 20) + 1;
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let mut websocket = accept_async(stream).await.unwrap();
@@ -2363,20 +2382,36 @@ mod tests {
             );
             websocket
                 .send(Message::Text(
-                    json!({ "jsonrpc": "2.0", "id": 1, "result": {} }).to_string(),
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": { "payload": "x".repeat(payload_size) },
+                    })
+                    .to_string(),
                 ))
                 .await
                 .unwrap();
         });
 
         let socket = UnixStream::connect(&socket_path).await.unwrap();
-        let (websocket, _) = client_async("ws://localhost/", socket).await.unwrap();
+        let (websocket, _) = client_async_with_config(
+            "ws://localhost/",
+            socket,
+            Some(codex_websocket_config()),
+        )
+        .await
+        .unwrap();
         let mut transport = WebSocketTransport { websocket };
         transport
             .write_message(&json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize" }))
             .await
             .unwrap();
-        assert_eq!(transport.read_message().await.unwrap()["id"], 1);
+        let response = transport.read_message().await.unwrap();
+        assert_eq!(response["id"], 1);
+        assert_eq!(
+            response["result"]["payload"].as_str().unwrap().len(),
+            payload_size
+        );
         server.await.unwrap();
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -735,26 +735,23 @@ pub async fn spawn(config: CodexManagerConfig) -> Result<ManagedCodexManager, Pr
             )));
         }
     };
-    let websocket = match client_async_with_config(
-        "ws://localhost/",
-        socket,
-        Some(codex_websocket_config()),
-    )
-    .await
-    {
-        Ok((websocket, _)) => websocket,
-        Err(error) => {
-            if let Some(server) = server.as_mut() {
-                stop_child(server).await;
+    let websocket =
+        match client_async_with_config("ws://localhost/", socket, Some(codex_websocket_config()))
+            .await
+        {
+            Ok((websocket, _)) => websocket,
+            Err(error) => {
+                if let Some(server) = server.as_mut() {
+                    stop_child(server).await;
+                }
+                if owns_server {
+                    remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
+                }
+                return Err(ProviderError::Transport(format!(
+                    "Codex app-server WebSocket handshake failed: {error}"
+                )));
             }
-            if owns_server {
-                remove_owned_socket(Some(&config.socket_path), Some(&owner_marker_path)).await;
-            }
-            return Err(ProviderError::Transport(format!(
-                "Codex app-server WebSocket handshake failed: {error}"
-            )));
-        }
-    };
+        };
     let cleanup: Box<dyn ProcessCleanup> = Box::new(ServerCleanup {
         server,
         owned_socket_path: owns_server.then(|| config.socket_path.clone()),
@@ -2394,13 +2391,10 @@ mod tests {
         });
 
         let socket = UnixStream::connect(&socket_path).await.unwrap();
-        let (websocket, _) = client_async_with_config(
-            "ws://localhost/",
-            socket,
-            Some(codex_websocket_config()),
-        )
-        .await
-        .unwrap();
+        let (websocket, _) =
+            client_async_with_config("ws://localhost/", socket, Some(codex_websocket_config()))
+                .await
+                .unwrap();
         let mut transport = WebSocketTransport { websocket };
         transport
             .write_message(&json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize" }))

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs
@@ -2365,7 +2365,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let socket_path = dir.path().join("app-server.sock");
         let listener = UnixListener::bind(&socket_path).unwrap();
-        let payload_size = (16 << 20) + 1;
+        // Match the production frame that exceeded tungstenite's 16 MiB
+        // default, so a lower cap cannot pass this regression silently.
+        let payload_size = 55_822_540;
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let mut websocket = accept_async(stream).await.unwrap();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3438,46 +3438,66 @@ async fn handle_codex_session_discard(
     pool: &SqlitePool,
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
-    use ainb_hangar_proto::fleet::{CodexSessionDiscardParams, CodexSessionDiscardResult};
+    use ainb_hangar_proto::fleet::CodexSessionDiscardParams;
 
     let params: CodexSessionDiscardParams = parse_params(req, "{ session_id }")?;
     if params.session_id.trim().is_empty() {
         return Err(invalid_params("session_id must not be empty"));
     }
 
+    let result =
+        discard_interactive_codex_thread(pool, &params.session_id, |thread_id| async move {
+            let manager = crate::fleet_provider::codex_manager::wait_for_active_handle(
+                std::time::Duration::from_secs(15),
+            )
+            .await
+            .ok_or_else(|| internal("Ainb Codex remote control unavailable during cleanup"))?;
+            manager
+                .thread_archive(&thread_id)
+                .await
+                .map_err(|error| internal(&format!("archive failed Codex thread: {error}")))?;
+            Ok(())
+        })
+        .await?;
+    to_value(&result)
+}
+
+async fn discard_interactive_codex_thread<F, Fut>(
+    pool: &SqlitePool,
+    session_id: &str,
+    archive: F,
+) -> Result<ainb_hangar_proto::fleet::CodexSessionDiscardResult, RpcError>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: std::future::Future<Output = Result<(), RpcError>>,
+{
+    use ainb_hangar_proto::fleet::CodexSessionDiscardResult;
+
     let thread_id: Option<Option<String>> =
         sqlx::query_scalar("SELECT thread_id FROM interactive_codex_thread WHERE session_id = ?")
-            .bind(&params.session_id)
+            .bind(session_id)
             .fetch_optional(pool)
             .await
             .map_err(|error| internal(&format!("read Interactive Codex thread: {error}")))?;
 
     let Some(thread_id) = thread_id else {
-        return to_value(&CodexSessionDiscardResult {
+        return Ok(CodexSessionDiscardResult {
             discarded: false,
             archived: false,
         });
     };
 
-    if let Some(thread_id) = thread_id.as_deref() {
-        let manager = crate::fleet_provider::codex_manager::wait_for_active_handle(
-            std::time::Duration::from_secs(15),
-        )
-        .await
-        .ok_or_else(|| internal("Ainb Codex remote control unavailable during cleanup"))?;
-        manager
-            .thread_archive(thread_id)
-            .await
-            .map_err(|error| internal(&format!("archive failed Codex thread: {error}")))?;
+    if let Some(thread_id) = thread_id.clone() {
+        archive(thread_id).await?;
     }
 
     sqlx::query("DELETE FROM interactive_codex_thread WHERE session_id = ?")
-        .bind(&params.session_id)
+        .bind(session_id)
         .execute(pool)
         .await
         .map_err(|error| internal(&format!("discard Interactive Codex thread: {error}")))?;
 
-    to_value(&CodexSessionDiscardResult {
+    Ok(CodexSessionDiscardResult {
         discarded: true,
         archived: thread_id.is_some(),
     })
@@ -13195,6 +13215,40 @@ mod tests {
 
         assert!(result.discarded);
         assert!(!result.archived);
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM interactive_codex_thread WHERE session_id = 'failed-session'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn codex_session_discard_archives_claimed_thread_before_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        sqlx::query(
+            "INSERT INTO interactive_codex_thread (session_id, thread_id, cwd) \
+             VALUES ('failed-session', 'thread-1', '/tmp')",
+        )
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+        let result = discard_interactive_codex_thread(
+            store.pool(),
+            "failed-session",
+            |thread_id| async move {
+                assert_eq!(thread_id, "thread-1");
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.discarded);
+        assert!(result.archived);
         let remaining: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM interactive_codex_thread WHERE session_id = 'failed-session'",
         )

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1260,6 +1260,7 @@ async fn handle(
         methods::FLEET_RECEIPT_GET => handle_fleet_receipt_get(pool, req).await,
         methods::FLEET_START => handle_fleet_start(pool, req, events).await,
         methods::CODEX_SESSION_ENSURE => handle_codex_session_ensure(pool, req).await,
+        methods::CODEX_SESSION_DISCARD => handle_codex_session_discard(pool, req).await,
         methods::FLEET_TIMELINE => handle_fleet_timeline(pool, req).await,
         methods::FLEET_ACP_SESSION_CREATE => {
             handle_fleet_acp_session_create(pool, req, events).await
@@ -3428,6 +3429,57 @@ async fn handle_codex_session_ensure(
     to_value(&CodexSessionEnsureResult {
         thread_id,
         endpoint: format!("unix://{}", manager.socket_path().display()),
+    })
+}
+
+/// Remove one failed Interactive Codex launch after archiving any claimed
+/// remote thread. The row stays recoverable when archival fails.
+async fn handle_codex_session_discard(
+    pool: &SqlitePool,
+    req: &RpcRequest,
+) -> Result<serde_json::Value, RpcError> {
+    use ainb_hangar_proto::fleet::{CodexSessionDiscardParams, CodexSessionDiscardResult};
+
+    let params: CodexSessionDiscardParams = parse_params(req, "{ session_id }")?;
+    if params.session_id.trim().is_empty() {
+        return Err(invalid_params("session_id must not be empty"));
+    }
+
+    let thread_id: Option<Option<String>> =
+        sqlx::query_scalar("SELECT thread_id FROM interactive_codex_thread WHERE session_id = ?")
+            .bind(&params.session_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|error| internal(&format!("read Interactive Codex thread: {error}")))?;
+
+    let Some(thread_id) = thread_id else {
+        return to_value(&CodexSessionDiscardResult {
+            discarded: false,
+            archived: false,
+        });
+    };
+
+    if let Some(thread_id) = thread_id.as_deref() {
+        let manager = crate::fleet_provider::codex_manager::wait_for_active_handle(
+            std::time::Duration::from_secs(15),
+        )
+        .await
+        .ok_or_else(|| internal("Ainb Codex remote control unavailable during cleanup"))?;
+        manager
+            .thread_archive(thread_id)
+            .await
+            .map_err(|error| internal(&format!("archive failed Codex thread: {error}")))?;
+    }
+
+    sqlx::query("DELETE FROM interactive_codex_thread WHERE session_id = ?")
+        .bind(&params.session_id)
+        .execute(pool)
+        .await
+        .map_err(|error| internal(&format!("discard Interactive Codex thread: {error}")))?;
+
+    to_value(&CodexSessionDiscardResult {
+        discarded: true,
+        archived: thread_id.is_some(),
     })
 }
 
@@ -13115,6 +13167,41 @@ mod tests {
         assert_eq!(codex_started_thread_id(&non_tui, &cwd), None);
         let fork = payload.replace("\"forkedFromId\":null", "\"forkedFromId\":\"parent\"");
         assert_eq!(codex_started_thread_id(&fork, &cwd), None);
+    }
+
+    #[tokio::test]
+    async fn codex_session_discard_removes_pending_reservation() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        sqlx::query(
+            "INSERT INTO interactive_codex_thread (session_id, thread_id, cwd) \
+             VALUES ('failed-session', NULL, '/tmp')",
+        )
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+        let result = handle_codex_session_discard(
+            store.pool(),
+            &req(
+                methods::CODEX_SESSION_DISCARD,
+                serde_json::json!({ "session_id": "failed-session" }),
+            ),
+        )
+        .await
+        .unwrap();
+        let result: ainb_hangar_proto::fleet::CodexSessionDiscardResult =
+            serde_json::from_value(result).unwrap();
+
+        assert!(result.discarded);
+        assert!(!result.archived);
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM interactive_codex_thread WHERE session_id = 'failed-session'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(remaining, 0);
     }
     use ainb_hangar_store::Store;
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4356,9 +4356,8 @@ mod fleet_launch_tests {
                 "/repo",
                 "--",
                 "codex",
-                // Fleet-managed Codex launches run with apps disabled
-                // (`managed_tui_command`). The flags sit ahead of `--remote`
-                // because they are global, not subcommand, options.
+                "-c",
+                "check_for_update_on_startup=false",
                 "--disable",
                 "apps",
                 "--remote",

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -13236,11 +13236,20 @@ mod tests {
         .await
         .unwrap();
 
+        let archive_pool = store.pool().clone();
         let result = discard_interactive_codex_thread(
             store.pool(),
             "failed-session",
-            |thread_id| async move {
+            move |thread_id| async move {
                 assert_eq!(thread_id, "thread-1");
+                let remaining: i64 = sqlx::query_scalar(
+                    "SELECT COUNT(*) FROM interactive_codex_thread \
+                     WHERE session_id = 'failed-session'",
+                )
+                .fetch_one(&archive_pool)
+                .await
+                .unwrap();
+                assert_eq!(remaining, 1, "row deleted before remote archive");
                 Ok(())
             },
         )

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3433,7 +3433,7 @@ async fn handle_codex_session_ensure(
 }
 
 /// Remove one failed Interactive Codex launch after archiving any claimed
-/// remote thread. The row stays recoverable when archival fails.
+/// remote thread.
 async fn handle_codex_session_discard(
     pool: &SqlitePool,
     req: &RpcRequest,
@@ -3452,11 +3452,11 @@ async fn handle_codex_session_discard(
             )
             .await
             .ok_or_else(|| internal("Ainb Codex remote control unavailable during cleanup"))?;
-            manager
-                .thread_archive(&thread_id)
-                .await
-                .map_err(|error| internal(&format!("archive failed Codex thread: {error}")))?;
-            Ok(())
+            match manager.thread_archive(&thread_id).await {
+                Ok(_) => Ok(true),
+                Err(error) if error.to_string().contains("no rollout found") => Ok(false),
+                Err(error) => Err(internal(&format!("archive failed Codex thread: {error}"))),
+            }
         })
         .await?;
     to_value(&result)
@@ -3469,7 +3469,7 @@ async fn discard_interactive_codex_thread<F, Fut>(
 ) -> Result<ainb_hangar_proto::fleet::CodexSessionDiscardResult, RpcError>
 where
     F: FnOnce(String) -> Fut,
-    Fut: std::future::Future<Output = Result<(), RpcError>>,
+    Fut: std::future::Future<Output = Result<bool, RpcError>>,
 {
     use ainb_hangar_proto::fleet::CodexSessionDiscardResult;
 
@@ -3487,9 +3487,10 @@ where
         });
     };
 
-    if let Some(thread_id) = thread_id.clone() {
-        archive(thread_id).await?;
-    }
+    let archived = match thread_id {
+        Some(thread_id) => archive(thread_id).await?,
+        None => false,
+    };
 
     sqlx::query("DELETE FROM interactive_codex_thread WHERE session_id = ?")
         .bind(session_id)
@@ -3499,7 +3500,7 @@ where
 
     Ok(CodexSessionDiscardResult {
         discarded: true,
-        archived: thread_id.is_some(),
+        archived,
     })
 }
 
@@ -13250,7 +13251,7 @@ mod tests {
                 .await
                 .unwrap();
                 assert_eq!(remaining, 1, "row deleted before remote archive");
-                Ok(())
+                Ok(true)
             },
         )
         .await
@@ -13258,6 +13259,40 @@ mod tests {
 
         assert!(result.discarded);
         assert!(result.archived);
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM interactive_codex_thread WHERE session_id = 'failed-session'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn codex_session_discard_removes_unmaterialized_claimed_thread() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.unwrap();
+        sqlx::query(
+            "INSERT INTO interactive_codex_thread (session_id, thread_id, cwd) \
+             VALUES ('failed-session', 'thread-without-rollout', '/tmp')",
+        )
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+        let result = discard_interactive_codex_thread(
+            store.pool(),
+            "failed-session",
+            |thread_id| async move {
+                assert_eq!(thread_id, "thread-without-rollout");
+                Ok(false)
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.discarded);
+        assert!(!result.archived);
         let remaining: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM interactive_codex_thread WHERE session_id = 'failed-session'",
         )

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -1352,6 +1352,22 @@ pub struct CodexSessionEnsureResult {
     pub endpoint: String,
 }
 
+/// Parameters for `codex/session_discard`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexSessionDiscardParams {
+    /// Failed Interactive session identity whose reservation is discarded.
+    pub session_id: String,
+}
+
+/// Result for `codex/session_discard`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexSessionDiscardResult {
+    /// Whether a daemon reservation was removed.
+    pub discarded: bool,
+    /// Whether its claimed remote thread was archived.
+    pub archived: bool,
+}
+
 /// Parameters for `fleet/broadcast`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetBroadcastParams {

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -411,6 +411,8 @@ pub const FLEET_START: &str = "fleet/start";
 /// Ensure one Interactive Codex session has an exact thread on Ainb's shared
 /// Codex app-server.
 pub const CODEX_SESSION_ENSURE: &str = "codex/session_ensure";
+/// Discard one failed Interactive Codex launch and archive its remote thread.
+pub const CODEX_SESSION_DISCARD: &str = "codex/session_discard";
 /// Read bounded, payload-free Fleet revision timeline entries.
 pub const FLEET_TIMELINE: &str = "fleet/timeline";
 /// Read a bounded daemon-owned Fleet usage summary.
@@ -1842,6 +1844,9 @@ pub const ALL_METHODS: &[&str] = &[
     FLEET_CONFIRM_ANSWER,
     FLEET_ACTIVITY_LIST,
     FLEET_COPILOT_GATE,
+    // Failed Interactive Codex launch cleanup is appended to preserve the
+    // existing wire catalogue order.
+    CODEX_SESSION_DISCARD,
 ];
 
 #[cfg(test)]
@@ -2156,6 +2161,7 @@ mod tests {
             FLEET_CONFIRM_ANSWER,
             FLEET_ACTIVITY_LIST,
             FLEET_COPILOT_GATE,
+            CODEX_SESSION_DISCARD,
         ];
         for m in declared {
             assert!(


### PR DESCRIPTION
## Summary
- raise Codex remote-control WebSocket frame allowance above observed snapshot size
- suppress Codex startup update picker for managed TUI launches
- rollback exact tmux, worktree, symlink, and metadata after failed managed starts

## Tests
- cargo check --manifest-path ainb-tui/crates/ainb-core/Cargo.toml --lib
- cargo check --manifest-path ainb-tui/crates/ainb-hangar-daemon/Cargo.toml --lib
- cargo test --manifest-path ainb-tui/crates/ainb-core/Cargo.toml --lib codex_ -- --nocapture
- cargo test --manifest-path ainb-tui/crates/ainb-core/Cargo.toml --lib failed_launch_rollback_removes_only_exact_owned_resources -- --nocapture
- cargo test --manifest-path ainb-tui/crates/ainb-hangar-daemon/Cargo.toml managed_codex_launch_runs_remote_tui_in_exact_tmux_session -- --nocapture
- rustfmt --edition 2021 --check on changed Rust files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed Codex session launches now clean up temporary sessions, worktrees, reservations, and remote threads.
  * Broken worktree links are removed reliably during cleanup.
  * Codex startup update checks are disabled for managed and resumed sessions, preventing unexpected prompts.
  * Improved handling of large Codex WebSocket messages.
* **Reliability**
  * Added recovery support when startup, thread allocation, metadata persistence, or remote connections fail.
  * Failed remote sessions can now be discarded and archived safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->