### PR TITLE
fix(fleet-macos): report refused actions as refused, not delivered

### DIFF
--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		A1000000000000000000003C /* FleetQuickSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003D /* FleetQuickSwitcher.swift */; };
 		A1000000000000000000003E /* FleetSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003F /* FleetSettingsView.swift */; };
 		A10000000000000000000040 /* FleetRosterPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000043 /* FleetRosterPresentationTests.swift */; };
+		A10000000000000000000097 /* FleetReceiptNoticeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000098 /* FleetReceiptNoticeTests.swift */; };
 		A10000000000000000000045 /* FleetFixtureDaemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000049 /* FleetFixtureDaemon.swift */; };
 		A1000000000000000000005A /* FleetFixtureDaemonFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005B /* FleetFixtureDaemonFallbackTests.swift */; };
 		A1000000000000000000005C /* FleetFixtureDaemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000049 /* FleetFixtureDaemon.swift */; };
@@ -86,6 +87,7 @@
 		A1000000000000000000003D /* FleetQuickSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetRoster/FleetQuickSwitcher.swift; sourceTree = SOURCE_ROOT; };
 		A1000000000000000000003F /* FleetSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Settings/FleetSettingsView.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000043 /* FleetRosterPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetRosterPresentationTests.swift; sourceTree = "<group>"; };
+		A10000000000000000000098 /* FleetReceiptNoticeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetReceiptNoticeTests.swift; sourceTree = "<group>"; };
 		A10000000000000000000049 /* FleetFixtureDaemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/Support/FleetFixtureDaemon.swift; sourceTree = SOURCE_ROOT; };
 		A1000000000000000000005B /* FleetFixtureDaemonFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests/FleetRPCTests/FleetFixtureDaemonFallbackTests.swift; sourceTree = SOURCE_ROOT; };
 		A1000000000000000000004A /* FleetUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/Support/FleetUITestCase.swift; sourceTree = SOURCE_ROOT; };
@@ -218,6 +220,7 @@
 				A1000000000000000000002D /* FleetConnectionTests.swift */,
 				A1000000000000000000002E /* FleetDaemonContractTests.swift */,
 				A10000000000000000000043 /* FleetRosterPresentationTests.swift */,
+				A10000000000000000000098 /* FleetReceiptNoticeTests.swift */,
 				A1000000000000000000005B /* FleetFixtureDaemonFallbackTests.swift */,
 				A100000000000000000000114 /* FleetChatPresentationTests.swift */,
 			);
@@ -416,6 +419,7 @@
 				A1000000000000000000001C /* FleetConnectionTests.swift in Sources */,
 				A1000000000000000000001D /* FleetDaemonContractTests.swift in Sources */,
 				A10000000000000000000040 /* FleetRosterPresentationTests.swift in Sources */,
+				A10000000000000000000097 /* FleetReceiptNoticeTests.swift in Sources */,
 				A1000000000000000000005C /* FleetFixtureDaemon.swift in Sources */,
 				A1000000000000000000005A /* FleetFixtureDaemonFallbackTests.swift in Sources */,
 				A100000000000000000000115 /* FleetChatPresentationTests.swift in Sources */,

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -323,6 +323,7 @@ final class FleetStore: ObservableObject {
                     action: action.wireAction(prompt: trimmedPrompt)
                 ))
                 self.record(result.receipt)
+                self.controlNotice = Self.controlNotice(for: result.receipt, failurePrefix: "Action")
                 await self.refreshAuthoritativeState(using: connection)
             } catch {
                 self.controlNotice = "Action refused: \(String(describing: error))"
@@ -467,6 +468,7 @@ final class FleetStore: ObservableObject {
                 ))
                 self.lastStart = result
                 self.record(result.receipt)
+                self.controlNotice = Self.controlNotice(for: result.receipt, failurePrefix: "Start")
                 await self.refreshAuthoritativeState(using: connection)
             } catch {
                 self.controlNotice = "Start refused: \(String(describing: error))"
@@ -501,6 +503,7 @@ final class FleetStore: ObservableObject {
                     idempotencyKey: intentID
                 ))
                 self.record(result.receipts)
+                self.controlNotice = Self.broadcastNotice(for: result.receipts)
                 await self.refreshAuthoritativeState(using: connection)
             } catch {
                 self.controlNotice = "Broadcast refused: \(String(describing: error))"
@@ -1052,10 +1055,28 @@ final class FleetStore: ObservableObject {
     /// `detail` is surfaced verbatim because it is the only place the reason
     /// exists; without it the operator sees "failed" and has to go read the
     /// database to learn what happened.
+    /// The one success wording, named so the refresh path can recognise it as
+    /// safe to overwrite.
+    nonisolated static let deliveredNotice = "Delivered. Confirming Fleet state."
+
+    /// Operator-facing notice for a fan-out, where "some landed" is the case
+    /// that matters and a bare success string would hide it.
+    nonisolated static func broadcastNotice(for receipts: [FleetActionReceipt]) -> String {
+        guard !receipts.isEmpty else { return "Broadcast reached no sessions." }
+        let failed = receipts.filter { $0.status != .delivered }
+        if failed.isEmpty {
+            return "Delivered to \(receipts.count) session\(receipts.count == 1 ? "" : "s")."
+        }
+        let reason = failed.compactMap { $0.detail?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
+        let head = "Broadcast: \(receipts.count - failed.count)/\(receipts.count) delivered, \(failed.count) failed"
+        return reason.map { "\(head): \($0)" } ?? "\(head)."
+    }
+
     nonisolated static func controlNotice(for receipt: FleetActionReceipt, failurePrefix: String) -> String {
         switch receipt.status {
         case .delivered:
-            return "Delivered. Confirming Fleet state."
+            return deliveredNotice
         case .pending:
             return "\(failurePrefix) accepted, awaiting delivery."
         case .failed, .rejected, .unknown:
@@ -1085,7 +1106,14 @@ final class FleetStore: ObservableObject {
             let snapshot = try await connection.snapshot()
             apply(FleetProjectionReducer.snapshot(snapshot, from: projection))
         } catch {
-            controlNotice = "Fleet refresh refused: \(String(describing: error))"
+            // A refresh complaint must NOT overwrite a delivery failure we just
+            // set: the receipt's reason is the only record of WHY the action was
+            // refused, and replacing it with a read error tells the operator the
+            // action landed and only the follow-up snapshot failed — the exact
+            // inversion this file was changed to stop.
+            if controlNotice == nil || controlNotice == Self.deliveredNotice {
+                controlNotice = "Fleet refresh refused: \(String(describing: error))"
+            }
         }
         guard canReadReceipts else { return }
         do {

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -434,7 +434,7 @@ final class FleetStore: ObservableObject {
                     action: action
                 ))
                 self.record(result.receipt)
-                self.controlNotice = "Delivered. Confirming Fleet state."
+                self.controlNotice = Self.controlNotice(for: result.receipt, failurePrefix: failurePrefix)
                 await self.refreshAuthoritativeState(using: connection)
             } catch {
                 self.controlNotice = "\(failurePrefix) refused: \(String(describing: error))"
@@ -1037,6 +1037,34 @@ final class FleetStore: ObservableObject {
 
     private func handle(_ error: Error) {
         becomeStale(reason: error.localizedDescription)
+    }
+
+    /// Operator-facing notice for a receipt the daemon actually returned.
+    ///
+    /// A `FLEET_ACTION` that round-trips is NOT the same as one that landed: the
+    /// daemon answers a rejected or undeliverable action with a perfectly
+    /// successful RPC carrying a non-`delivered` status and a `detail` saying
+    /// why. Reporting "Delivered." for every non-throwing call is how a picker
+    /// that refused the answer, sent zero keys and left the target session
+    /// sitting on its question still read as success on this surface — the
+    /// failure was real, loud in the receipt, and invisible here.
+    ///
+    /// `detail` is surfaced verbatim because it is the only place the reason
+    /// exists; without it the operator sees "failed" and has to go read the
+    /// database to learn what happened.
+    nonisolated static func controlNotice(for receipt: FleetActionReceipt, failurePrefix: String) -> String {
+        switch receipt.status {
+        case .delivered:
+            return "Delivered. Confirming Fleet state."
+        case .pending:
+            return "\(failurePrefix) accepted, awaiting delivery."
+        case .failed, .rejected, .unknown:
+            let reason = receipt.detail?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let outcome = receipt.status.operatorToken
+            return reason.isEmpty
+                ? "\(failurePrefix) \(outcome)."
+                : "\(failurePrefix) \(outcome): \(reason)"
+        }
     }
 
     private func record(_ receipt: FleetActionReceipt) {

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -494,6 +494,23 @@ struct FleetActionParams: Codable, Equatable {
 
 enum ActionReceiptStatus: String, Codable, Equatable, CaseIterable { case pending = "PENDING", delivered = "DELIVERED", failed = "FAILED", unknown = "UNKNOWN", rejected = "REJECTED" }
 
+extension ActionReceiptStatus {
+    /// The ONE operator-facing word for a status on this surface.
+    ///
+    /// Mirrors `receipt_status_token` on the daemon side, and is exhaustive on
+    /// purpose: a new variant must be a compile error here rather than silently
+    /// rendering as whichever arm was written last.
+    var operatorToken: String {
+        switch self {
+        case .pending: return "pending"
+        case .delivered: return "delivered"
+        case .failed: return "failed"
+        case .rejected: return "rejected"
+        case .unknown: return "could not be confirmed"
+        }
+    }
+}
+
 struct FleetActionReceipt: Codable, Equatable {
     let requestID: String
     let sessionKey: String

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -497,9 +497,14 @@ enum ActionReceiptStatus: String, Codable, Equatable, CaseIterable { case pendin
 extension ActionReceiptStatus {
     /// The ONE operator-facing word for a status on this surface.
     ///
-    /// Mirrors `receipt_status_token` on the daemon side, and is exhaustive on
-    /// purpose: a new variant must be a compile error here rather than silently
-    /// rendering as whichever arm was written last.
+    /// DELIBERATELY PROSE, not the wire token. `receipt_status_token` on the
+    /// daemon side returns the uppercase wire words (`FAILED`, `REJECTED`, …)
+    /// for logs and CLI output; this reads inside an English sentence, so it is
+    /// lowercase and renders `.unknown` as a phrase. The divergence is intended
+    /// — do not "fix" it by aligning to the Rust strings.
+    ///
+    /// Exhaustive on purpose: a new variant must be a compile error here rather
+    /// than silently rendering as whichever arm was written last.
     var operatorToken: String {
         switch self {
         case .pending: return "pending"

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetReceiptNoticeTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetReceiptNoticeTests.swift
@@ -45,6 +45,34 @@ final class FleetReceiptNoticeTests: XCTestCase {
         XCTAssertEqual(notice, "Interview failed.")
     }
 
+    func testBroadcastWhereEveryLegFailedIsNotReportedAsClean() {
+        let notice = FleetStore.broadcastNotice(for: [
+            receipt(.failed, detail: "no live tmux session"),
+            receipt(.failed, detail: "no live tmux session"),
+        ])
+        XCTAssertFalse(notice.hasPrefix("Delivered"), "a total fan-out failure must not read as delivered: \(notice)")
+        XCTAssertTrue(notice.contains("0/2 delivered"), notice)
+        XCTAssertTrue(notice.contains("no live tmux session"), notice)
+    }
+
+    func testPartialBroadcastReportsBothHalves() {
+        let notice = FleetStore.broadcastNotice(for: [
+            receipt(.delivered, detail: nil),
+            receipt(.failed, detail: "pane died"),
+        ])
+        XCTAssertTrue(notice.contains("1/2 delivered"), notice)
+        XCTAssertTrue(notice.contains("1 failed"), notice)
+    }
+
+    func testFullyDeliveredBroadcastReadsAsDelivered() {
+        let notice = FleetStore.broadcastNotice(for: [receipt(.delivered, detail: nil), receipt(.delivered, detail: nil)])
+        XCTAssertEqual(notice, "Delivered to 2 sessions.")
+    }
+
+    func testEmptyBroadcastDoesNotClaimDelivery() {
+        XCTAssertEqual(FleetStore.broadcastNotice(for: []), "Broadcast reached no sessions.")
+    }
+
     private func receipt(_ status: ActionReceiptStatus, detail: String?) -> FleetActionReceipt {
         FleetActionReceipt(
             requestID: "req-1",

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetReceiptNoticeTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetReceiptNoticeTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import AINBFleet
+
+/// REGRESSION. A `fleet/action` that round-trips is not an action that landed.
+/// The daemon answers a refused action with a successful RPC carrying a
+/// non-delivered status plus a `detail`; the surface used to report
+/// "Delivered. Confirming Fleet state." for every non-throwing call, so a
+/// mirrored picker that refused the answer, sent ZERO keys and left the target
+/// session sitting on its question still read as success here.
+final class FleetReceiptNoticeTests: XCTestCase {
+    func testFailedReceiptIsNotReportedAsDelivered() {
+        let notice = FleetStore.controlNotice(
+            for: receipt(.failed, detail: "visible picker option order does not match current question"),
+            failurePrefix: "Interview"
+        )
+        XCTAssertFalse(notice.contains("Delivered"), "a FAILED receipt must never read as delivered: \(notice)")
+        XCTAssertTrue(notice.contains("failed"), notice)
+        XCTAssertTrue(
+            notice.contains("visible picker option order does not match current question"),
+            "the daemon's reason is the only place the cause exists, so it must be surfaced: \(notice)"
+        )
+    }
+
+    func testRejectedAndUnknownAlsoSurfaceAsNotDelivered() {
+        for status in [ActionReceiptStatus.rejected, .unknown] {
+            let notice = FleetStore.controlNotice(for: receipt(status, detail: "nope"), failurePrefix: "Approval")
+            XCTAssertFalse(notice.contains("Delivered"), "\(status) must not read as delivered: \(notice)")
+            XCTAssertTrue(notice.hasPrefix("Approval "), notice)
+        }
+    }
+
+    func testDeliveredKeepsTheConfirmingWording() {
+        let notice = FleetStore.controlNotice(for: receipt(.delivered, detail: nil), failurePrefix: "Interview")
+        XCTAssertEqual(notice, "Delivered. Confirming Fleet state.")
+    }
+
+    func testPendingIsNeitherDeliveredNorAFailure() {
+        let notice = FleetStore.controlNotice(for: receipt(.pending, detail: nil), failurePrefix: "Interview")
+        XCTAssertFalse(notice.contains("Delivered"), notice)
+        XCTAssertTrue(notice.contains("awaiting delivery"), notice)
+    }
+
+    func testMissingDetailStillProducesAReadableNotice() {
+        let notice = FleetStore.controlNotice(for: receipt(.failed, detail: "   "), failurePrefix: "Interview")
+        XCTAssertEqual(notice, "Interview failed.")
+    }
+
+    private func receipt(_ status: ActionReceiptStatus, detail: String?) -> FleetActionReceipt {
+        FleetActionReceipt(
+            requestID: "req-1",
+            sessionKey: "claude:abc",
+            actionKind: "structured_answer",
+            actionFingerprint: "fnv1a64:0",
+            expectedVersion: 1,
+            idempotencyKey: nil,
+            status: status,
+            detail: detail,
+            sessionVersion: 1,
+            createdAt: 0,
+            updatedAt: 0
+        )
+    }
+}


### PR DESCRIPTION
The macOS Fleet app reported "Delivered. Confirming Fleet state." for every action whose RPC did not throw. A refused action is a **successful RPC carrying a non-`DELIVERED` receipt** and a `detail` explaining why, so it took the success path.

Live example that prompted this: a mirrored interview answered from the app reported submitted, while the receipt read

```
status = FAILED
detail = visible picker option order does not match current question
```

Zero keys were sent and the target Claude session sat on its question. The failure was real, loud in `fleet_action_receipt`, and invisible on the surface that caused it.

## Changes

Commit 1 — the shared structured path (`performStructured`), which serves interview answers, interview rejection, open-picker and approvals. Branch on `receipt.status`, surface `detail` verbatim since it is the only place the reason exists.

Commit 2 — the sibling paths, found by review, on higher-traffic surfaces:

| path | was | now |
|---|---|---|
| `perform` (send prompt / interrupt) | no notice at all — silence reads as success | reports the refusal |
| `broadcast` | no notice — all-legs-failed looked clean | `0/2 delivered, 2 failed: <reason>` |
| `start` | bare `REJECTED` token, `detail` dropped | reports the reason |
| `refreshAuthoritativeState` | clobbered the delivery reason with a read error | only overwrites nil or the success wording |

`operatorToken` is exhaustive so a new status variant is a compile error rather than a silently mislabelled one. Its doc previously claimed to mirror `receipt_status_token`; it does not (daemon returns uppercase wire words for logs, this reads inside a sentence) and now says the divergence is intended.

## Validation

`xcodebuild test` on the same invocation CI uses: **145/145 pass**, including 9 new tests asserting a FAILED receipt never renders as delivered, that the daemon's reason reaches the operator, and that a fully-failed fan-out is not reported as clean.

## Not in scope

`ci/check-swift-boundary.sh` fails on a clean tree (`rc=1`, one violation in `FleetDesktopController.swift:1047` about transcript-derived data). Pre-existing, unrelated to these files, and referenced by no workflow.

https://claude.ai/code/session_01YTgF3YEyfWZk3HwpjTJfyU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator notices now reflect the actual receipt status of fleet actions and broadcasts.
  * Added clearer messaging for delivered, pending, failed, rejected, unknown, partial, and empty broadcast outcomes.
  * Receipt details are included when available.

* **Bug Fixes**
  * Authoritative refresh errors no longer overwrite meaningful delivery-status notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->