### PR TITLE
fix(fleet): answer Claude interviews over the hook, not the picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,17 @@ jobs:
           needs.changes.outputs.relevant != 'false')
         with:
           workspaces: "ainb-tui -> target"
+          # Same wall the Contracts job hit, and the same treatment. This job
+          # also builds `--all-features` across the workspace, and archiving
+          # that target tree exhausts GitHub-hosted runner disk during
+          # rust-cache's post-job pass: observed three consecutive runs where
+          # `cargo nextest` SUCCEEDED and the job was then failed by
+          # `Post Run Swatinem/rust-cache@v2` with "No space left on device".
+          # A green test run must not be reported as a failure by the step that
+          # saves a cache for next time.
+          cache-targets: false
+          # Registry restore is still useful; only saving invokes the failing pass.
+          save-if: false
       - uses: taiki-e/install-action@nextest
         if: >-
           always() && (github.event_name != 'pull_request' ||

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,33 @@ bd sync               # Sync with git
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
+
+## Fleet macOS app: validation is end-to-end or it is a failure
+
+Testing the macOS Fleet app means driving it to a **terminal user-visible
+outcome**, not confirming it launched, connected, or rendered a card.
+
+For an interview, exactly one of these is a pass:
+
+1. **It completes.** The answer reaches the target session — verified in that
+   session's JSONL `tool_result` (and, where it matters, the model's next
+   message acting on it), not just a `DELIVERED` receipt or a line drawn in a
+   tmux pane.
+2. **It shows the right status.** The action was refused and the app says so,
+   with the daemon's `detail`, matching the `fleet_action_receipt` row.
+
+Anything else is a FAILURE and must be reported as one:
+
+- could not click the control / automation could not focus the window
+- the card rendered but the answer was never submitted
+- the receipt says `FAILED` while the app shows success (or vice versa)
+- the run was abandoned part-way for any reason
+
+**Never record an unfinished GUI run as a success, and never let unit tests
+stand in for it.** Tests prove the mapping; only a driven run proves the app.
+If the automation cannot complete the flow, say the validation FAILED and why —
+do not describe it as "verified by tests instead", and do not present a
+partially-driven run as evidence.
+
+Check the receipt's timestamp before citing it. A stale row from an earlier run
+reads exactly like a fresh success.

--- a/ainb-tui/CLAUDE.md
+++ b/ainb-tui/CLAUDE.md
@@ -294,6 +294,31 @@ backend processes as Claude.
   plugins (`ainb-fleet`, `ainb-hooks`, `reflect`); never put a TUI/subprocess
   plugin there.
 
+## Fleet macOS app: validation is end-to-end or it is a failure
+
+Testing `apps/ainb-fleet-macos` means driving it to a **terminal user-visible
+outcome**, not confirming it built, launched, connected, or rendered a card.
+
+For an interview, exactly one of these is a pass:
+
+1. **It completes** — the answer reaches the target session, verified in that
+   session's JSONL `tool_result`, not just a `DELIVERED` receipt or a line
+   drawn in a tmux pane.
+2. **It shows the right status** — the action was refused and the app says so
+   with the daemon's `detail`, matching the `fleet_action_receipt` row.
+
+Anything else is a FAILURE and is reported as one: the control could not be
+clicked, automation could not focus the popover, the card rendered but nothing
+submitted, the receipt and the UI disagree, or the run was abandoned part-way.
+
+**Never record an unfinished GUI run as a success, and never substitute unit
+tests for it.** `xcodebuild test` proves the status→message mapping; only a
+driven run proves the app. If automation cannot complete the flow, say the
+validation FAILED and why.
+
+Always check `fleet_action_receipt.created_at` before citing a row — a stale
+receipt from an earlier run is indistinguishable from a fresh success.
+
 ## Monorepo Context
 
 The curated skills/agents/installer/catalog live in the standalone

--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "ainb"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-cli",
  "ainb-fleet-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-hangar-daemon"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "agent-client-protocol",
  "ainb-acp",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-cts-v2"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-secrets",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-hangar"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-notifyd"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-web"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1441,32 +1441,48 @@ fn extract_permission_context(payload: &str) -> String {
 }
 
 /// Where the saved tmux window name is parked while an interview banner is up.
-fn interview_banner_state() -> Option<std::path::PathBuf> {
+fn interview_banner_state(home: &std::path::Path) -> Option<std::path::PathBuf> {
     let pane = std::env::var("TMUX_PANE").ok().filter(|value| !value.is_empty())?;
-    let base = std::env::var_os("AINB_HOME")
-        .map(std::path::PathBuf::from)
-        .or_else(dirs::home_dir)?;
     let key = blake3::hash(pane.as_bytes()).to_hex();
-    Some(
-        base.join(".agents-in-a-box")
-            .join("fleet")
-            .join("interview-banner")
-            .join(format!("{key}.txt")),
-    )
+    // Scoped to the `home` THIS invocation was given, not to $AINB_HOME.
+    // `plumbing::paths` already treats $AINB_HOME AS the ainb home, so joining
+    // `.agents-in-a-box` onto it again wrote
+    // `~/.agents-in-a-box/.agents-in-a-box/…`, and an empty $AINB_HOME wrote a
+    // RELATIVE path into whatever cwd the hook ran in. Threading `home` also
+    // keeps the tests inside their own tempdir.
+    Some(home.join("fleet").join("interview-banner").join(format!("{key}.txt")))
+}
+
+/// tmux expands `#` sequences in BOTH `rename-window` and `display-message`
+/// arguments: `#{...}` is a format, `#(...)` is a shell job. The header is
+/// MODEL-AUTHORED text, so every `#` is doubled before interpolation.
+fn tmux_escape(value: &str) -> String {
+    value.replace('#', "##")
+}
+
+/// Whether this process may touch tmux at all.
+///
+/// `cargo test` inherits `TMUX_PANE`, so without this the unit tests rename the
+/// DEVELOPER's own window, and leave it renamed if a test panics between
+/// announce and clear.
+const fn tmux_banner_enabled() -> bool {
+    !cfg!(test)
 }
 
 /// Tell the OPERATOR AT THE TERMINAL that this session is holding on a question.
 ///
 /// While the hook blocks, Claude's own UI cannot be reached: hook stdout is read
-/// only at exit, and writing to `/dev/tty` fights the TUI's repaint. tmux is the
-/// one surface that is ours, so the window name carries the flag (persistent,
-/// visible in the status bar for the whole wait) and a status overlay announces
-/// it once.
+/// only at exit, and writing to `/dev/tty` fights the TUI repaint. tmux is the
+/// one surface that is ours, so the window name carries the flag for the whole
+/// wait and a status overlay announces it once.
 ///
 /// Silent on every failure. A session outside tmux, or a tmux that refuses the
 /// rename, must still get its interview — an indication is worth nothing if its
 /// absence can block the answer path.
-fn announce_pending_interview(questions: &[serde_json::Value]) {
+fn announce_pending_interview(home: &std::path::Path, questions: &[serde_json::Value]) {
+    if !tmux_banner_enabled() {
+        return;
+    }
     let Ok(pane) = std::env::var("TMUX_PANE") else {
         return;
     };
@@ -1481,11 +1497,20 @@ fn announce_pending_interview(questions: &[serde_json::Value]) {
         .chars()
         .take(24)
         .collect::<String>();
+    let header = tmux_escape(&header);
 
-    // Save the current name so the wait does not permanently rename the window.
-    if let Some(path) = interview_banner_state() {
+    // Save the current name AND the automatic-rename setting, so the wait does
+    // not permanently freeze a window that was tracking its running program.
+    if let Some(path) = interview_banner_state(home) {
         if let Ok(out) = std::process::Command::new("tmux")
-            .args(["display-message", "-p", "-t", &pane, "-F", "#{window_name}"])
+            .args([
+                "display-message",
+                "-p",
+                "-t",
+                &pane,
+                "-F",
+                "#{window_name}\t#{automatic-rename}",
+            ])
             .output()
         {
             if out.status.success() {
@@ -1509,26 +1534,38 @@ fn announce_pending_interview(questions: &[serde_json::Value]) {
         .status();
 }
 
-/// Restore the window name once the wait is over, however it ended.
+/// Restore the window name and its automatic-rename setting once the wait ends,
+/// however it ended.
 ///
-/// Called on EVERY exit from the wait (answered, released, timed out), because a
-/// window left reading `[ASK]` after the question is gone is worse than no
-/// banner: it trains the operator to ignore the flag.
-fn clear_pending_interview_banner() {
+/// Called on EVERY exit from the wait (answered, released, timed out): a window
+/// left reading `[ASK]` after the question is gone is worse than no banner, and
+/// `rename-window` itself turns `automatic-rename` off, so restoring the name
+/// without the option would silently freeze the window for good.
+fn clear_pending_interview_banner(home: &std::path::Path) {
+    if !tmux_banner_enabled() {
+        return;
+    }
     let Ok(pane) = std::env::var("TMUX_PANE") else {
         return;
     };
     if pane.is_empty() {
         return;
     }
-    let Some(path) = interview_banner_state() else {
+    let Some(path) = interview_banner_state(home) else {
         return;
     };
-    if let Ok(previous) = std::fs::read_to_string(&path) {
-        let previous = previous.trim();
+    if let Ok(saved) = std::fs::read_to_string(&path) {
+        let mut fields = saved.trim().splitn(2, '\t');
+        let previous = fields.next().unwrap_or_default();
+        let automatic = fields.next().unwrap_or_default();
         if !previous.is_empty() {
             let _ = std::process::Command::new("tmux")
                 .args(["rename-window", "-t", &pane, previous])
+                .status();
+        }
+        if automatic == "on" {
+            let _ = std::process::Command::new("tmux")
+                .args(["set-window-option", "-t", &pane, "automatic-rename", "on"])
                 .status();
         }
     }
@@ -1861,7 +1898,27 @@ fn hook_core_for_agent(
     //    The await deadline (640s) sits UNDER the hook timeout this event
     //    registers (660s, see `plumbing::hooks`), so the broker's own fallback
     //    always answers before Claude hard-kills the hook.
+    // FLEET MEMBERS ONLY, exactly as the permission gate below. Without this an
+    // unrelated `claude` typed in any terminal on a host that merely has
+    // ainb-hooks installed has its native picker suppressed and its tool call
+    // held by our broker, with no surface open to answer it and no CLI verb to
+    // release it. `notify.sh` lazily spawns notifyd, so registration succeeds
+    // almost anywhere.
     if is_structured_ask {
+        // FLEET MEMBERS ONLY may BLOCK, exactly as the permission gate below.
+        // Without this an unrelated `claude` typed in any terminal on a host
+        // that merely has ainb-hooks installed has its native picker suppressed
+        // and its tool call held by our broker, with no surface open to answer
+        // it and no CLI verb to release it. `notify.sh` lazily spawns notifyd,
+        // so registration would succeed almost anywhere.
+        //
+        // The CARD is still written for everyone: the hooks are installed
+        // globally and a non-member's interview should still be visible to
+        // Fleet, just answerable by the keystroke transport rather than held.
+        if !is_fleet_member {
+            append_event_with(Some("mirrored"));
+            return Ok(None);
+        }
         let socket = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
         let Ok((tool_input, questions, fingerprint)) = extract_structured_tool_input(payload)
         else {
@@ -1884,7 +1941,7 @@ fn hook_core_for_agent(
             return Ok(None);
         }
         append_event_with(None);
-        announce_pending_interview(&questions);
+        announce_pending_interview(home, &questions);
         let resolution = ainb_plugin_notifyd::broker::client_await_structured(
             &socket,
             session_id,
@@ -1892,11 +1949,23 @@ fn hook_core_for_agent(
             &questions,
             ainb_plugin_notifyd::broker::CLIENT_AWAIT_DEADLINE,
         );
-        clear_pending_interview_banner();
+        clear_pending_interview_banner(home);
+        // A resolution meaning NOBODY ANSWERED is not a refusal. Rendering the
+        // 640s fallback (or a supersede) as `deny` hands the model a refused
+        // tool, which it re-asks, which blocks another 640s: a deny/retry loop
+        // for any session with no Fleet surface watching. Yield to the native
+        // picker and re-stamp the card `mirrored`, so the keystroke transport
+        // applies to the picker now on screen. Only an explicit human dismiss
+        // reaches `structured_emit_json` as a deny.
+        if resolution.is_unanswered() {
+            append_event_with(Some("mirrored"));
+            return Ok(None);
+        }
         if matches!(
             resolution,
             ainb_plugin_notifyd::broker::StructuredResolution::ReleasedToNative
         ) {
+            append_event_with(Some("mirrored"));
             // Ownership yielded on purpose. No hook output means Claude renders
             // its own picker unchanged, and Fleet keeps the keystroke route.
             return Ok(None);
@@ -3143,6 +3212,55 @@ mod tests {
     }
 
     #[test]
+    fn ask_hook_from_a_non_member_session_never_blocks_but_still_persists_a_card() {
+        // An unrelated `claude` on a host that merely has ainb-hooks installed
+        // must keep its native picker. Holding its tool call would suppress the
+        // picker with no Fleet surface open to answer and no CLI verb to
+        // release it. The card is still written so Fleet can see the interview
+        // and answer it through the keystroke transport.
+        let home = TempDir::new().unwrap();
+        let cwd = home.path().join("unrelated-worktree");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let payload = serde_json::json!({
+            "tool_name": "AskUserQuestion",
+            "tool_use_id": "toolu_nonmember",
+            "tool_input": {
+                "questions": [{
+                    "question": "Region?",
+                    "header": "Region",
+                    "options": [{"label": "eu"}, {"label": "us"}]
+                }]
+            }
+        });
+        let started = std::time::Instant::now();
+        let emitted = hook_core(
+            home.path(),
+            "PreToolUse",
+            "nonmember-session",
+            cwd.to_str().unwrap(),
+            None,
+            None,
+            50,
+            &payload.to_string(),
+            Some("AskUserQuestion"),
+        )
+        .unwrap();
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "a non-member ask must return immediately, not hold the tool call"
+        );
+        assert!(
+            emitted.is_none(),
+            "a non-member ask must leave Claude's native picker unblocked"
+        );
+        let events = std::fs::read_to_string(home.path().join("events.jsonl")).unwrap();
+        assert!(
+            events.contains("\"fleet_delivery\":\"mirrored\""),
+            "the card must stay keystroke-answerable: {events}"
+        );
+    }
+
+    #[test]
     fn ask_hook_without_broker_fails_open_and_persists_a_mirrored_fleet_card() {
         let home = TempDir::new().unwrap();
         let cwd = home.path().join("plain-claude-worktree");
@@ -3276,7 +3394,10 @@ mod tests {
                 "PreToolUse",
                 "ask-session",
                 hook_cwd.to_str().expect("temporary cwd is valid UTF-8"),
-                None,
+                // A parent makes this a FLEET MEMBER, which is what earns the
+                // right to hold the tool call open. Non-members get a mirrored
+                // card and their native picker, never a block.
+                Some("ask-parent"),
                 None,
                 50,
                 &hook_payload,

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1440,6 +1440,88 @@ fn extract_permission_context(payload: &str) -> String {
         .unwrap_or_default()
 }
 
+/// Where the saved tmux window name is parked while an interview banner is up.
+fn interview_banner_state() -> Option<std::path::PathBuf> {
+    let pane = std::env::var("TMUX_PANE").ok().filter(|value| !value.is_empty())?;
+    let base = std::env::var_os("AINB_HOME").map(std::path::PathBuf::from).or_else(dirs::home_dir)?;
+    let key = blake3::hash(pane.as_bytes()).to_hex();
+    Some(base.join(".agents-in-a-box").join("fleet").join("interview-banner").join(format!("{key}.txt")))
+}
+
+/// Tell the OPERATOR AT THE TERMINAL that this session is holding on a question.
+///
+/// While the hook blocks, Claude's own UI cannot be reached: hook stdout is read
+/// only at exit, and writing to `/dev/tty` fights the TUI's repaint. tmux is the
+/// one surface that is ours, so the window name carries the flag (persistent,
+/// visible in the status bar for the whole wait) and a status overlay announces
+/// it once.
+///
+/// Silent on every failure. A session outside tmux, or a tmux that refuses the
+/// rename, must still get its interview — an indication is worth nothing if its
+/// absence can block the answer path.
+fn announce_pending_interview(questions: &[serde_json::Value]) {
+    let Ok(pane) = std::env::var("TMUX_PANE") else { return };
+    if pane.is_empty() {
+        return;
+    }
+    let header = questions
+        .first()
+        .and_then(|q| q.get("header").or_else(|| q.get("question")))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("question")
+        .chars()
+        .take(24)
+        .collect::<String>();
+
+    // Save the current name so the wait does not permanently rename the window.
+    if let Some(path) = interview_banner_state() {
+        if let Ok(out) = std::process::Command::new("tmux")
+            .args(["display-message", "-p", "-t", &pane, "-F", "#{window_name}"])
+            .output()
+        {
+            if out.status.success() {
+                if let Some(dir) = path.parent() {
+                    let _ = std::fs::create_dir_all(dir);
+                }
+                let _ = std::fs::write(&path, String::from_utf8_lossy(&out.stdout).trim());
+            }
+        }
+    }
+    let _ = std::process::Command::new("tmux")
+        .args(["rename-window", "-t", &pane, &format!("[ASK] {header}")])
+        .status();
+    let _ = std::process::Command::new("tmux")
+        .args([
+            "display-message",
+            "-t",
+            &pane,
+            &format!("Interview waiting: {header} — answer in Fleet, or release to answer here"),
+        ])
+        .status();
+}
+
+/// Restore the window name once the wait is over, however it ended.
+///
+/// Called on EVERY exit from the wait (answered, released, timed out), because a
+/// window left reading `[ASK]` after the question is gone is worse than no
+/// banner: it trains the operator to ignore the flag.
+fn clear_pending_interview_banner() {
+    let Ok(pane) = std::env::var("TMUX_PANE") else { return };
+    if pane.is_empty() {
+        return;
+    }
+    let Some(path) = interview_banner_state() else { return };
+    if let Ok(previous) = std::fs::read_to_string(&path) {
+        let previous = previous.trim();
+        if !previous.is_empty() {
+            let _ = std::process::Command::new("tmux")
+                .args(["rename-window", "-t", &pane, previous])
+                .status();
+        }
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
 fn extract_structured_tool_input(
     payload: &str,
 ) -> Result<(serde_json::Value, Vec<serde_json::Value>, String)> {
@@ -1654,7 +1736,7 @@ fn hook_core_for_agent(
     //    session ID writes a raw envelope. Broker-mediated structured answers
     //    and approvals remain limited to known Fleet members below.
     let is_fleet_member = our_parent.is_some() || has_self_inbox || atc_name.is_some();
-    let append_event = || {
+    let append_event_with = |delivery: Option<&str>| {
         let event_id = uuid::Uuid::new_v4().to_string();
         let raw_payload_stored = persist_raw_hook_payload(home, &event_id, payload).is_ok();
         let mut line = build_event_line_for_agent(
@@ -1669,13 +1751,22 @@ fn hook_core_for_agent(
             our_parent.as_deref(),
             raw_payload_stored,
         );
-        if is_structured_ask {
-            line["fleet_delivery"] = serde_json::Value::String("mirrored".to_string());
+        // The stamp SELECTS THE ANSWER TRANSPORT downstream: `mirrored` routes
+        // Fleet's answer through `execute_claude_mirrored_picker` (synthetic tmux
+        // keys + screen verification), anything else through the exact-JSON
+        // broker branch of `execute_claude_structured`. A blocked ask must NOT be
+        // stamped mirrored, or the daemon would type at a picker that is not on
+        // screen because we are still holding the tool call open.
+        if let Some(delivery) = delivery {
+            line["fleet_delivery"] = serde_json::Value::String(delivery.to_string());
         }
         let _ = append_event_line(home, &line);
     };
-    if !session_id.is_empty() {
-        append_event();
+    // A structured ask defers its event: the branch below decides whether this
+    // hook BLOCKS (answer returns as JSON) or yields to Claude's native picker
+    // (answer must be keyed in), and the card has to say which.
+    if !session_id.is_empty() && !is_structured_ask {
+        append_event_with(None);
     }
 
     // Self-heal the durable child→parent map. `ainb run` seeds only the live
@@ -1730,12 +1821,77 @@ fn hook_core_for_agent(
         }
     }
 
-    // 4. PreToolUse(AskUserQuestion): keep Claude's native picker visible while
-    //    the durable hook event exposes the same request to Fleet. Fleet routes
-    //    a selected answer back through the verified picker transport, so neither
-    //    surface owns a separate answer lifecycle.
+    // 4. PreToolUse(AskUserQuestion): HOLD the tool call open and answer with
+    //    exact JSON.
+    //
+    //    The alternative — return here, let Claude draw its own picker, and have
+    //    Fleet type synthetic arrow keys at it — is what this replaces. Once the
+    //    hook returns, `hookSpecificOutput` is gone and keystrokes are the only
+    //    channel left, which forces the answer's correctness to be re-derived
+    //    from a screenshot of a vendor TUI that has no compatibility contract.
+    //    That re-derivation broke four times in one week (multi-select Enter
+    //    toggling instead of confirming; a mid-token hard wrap with no space to
+    //    match on; the same normalisation silently breaking the sibling route;
+    //    and 2.1.237's two-column layout splicing a side panel through the
+    //    middle of a wrapped label). Holding the call open removes the screen
+    //    from the answer path entirely.
+    //
+    //    Three ways out, and none of them may wedge Claude:
+    //      * the broker cannot be reached / registration fails -> yield to the
+    //        native picker exactly as before, stamped `mirrored` so Fleet's
+    //        answer still has the keystroke transport available.
+    //      * a human at the terminal (or Fleet) explicitly releases -> yield,
+    //        same stamp, and Claude draws its picker untouched.
+    //      * an answer arrives -> emit it as `hookSpecificOutput`, no keys, no
+    //        screen parsing.
+    //
+    //    The await deadline (640s) sits UNDER the hook timeout this event
+    //    registers (660s, see `plumbing::hooks`), so the broker's own fallback
+    //    always answers before Claude hard-kills the hook.
     if is_structured_ask {
-        return Ok(None);
+        let socket = ainb_plugin_notifyd::paths::Paths::under(home).approve_socket;
+        let Ok((tool_input, questions, fingerprint)) = extract_structured_tool_input(payload)
+        else {
+            // Unparseable payload: record it as a keystroke-answerable card
+            // rather than holding a tool call we cannot describe to anyone.
+            append_event_with(Some("mirrored"));
+            return Ok(None);
+        };
+        let registered = ainb_plugin_notifyd::broker::client_register_structured(
+            &socket,
+            session_id,
+            &fingerprint,
+            &questions,
+        )
+        .unwrap_or(false);
+        if !registered {
+            // Fleet is an OPTIONAL control surface. A broker outage must never
+            // reject or stall Claude's own tool call.
+            append_event_with(Some("mirrored"));
+            return Ok(None);
+        }
+        append_event_with(None);
+        announce_pending_interview(&questions);
+        let resolution = ainb_plugin_notifyd::broker::client_await_structured(
+            &socket,
+            session_id,
+            &fingerprint,
+            &questions,
+            ainb_plugin_notifyd::broker::CLIENT_AWAIT_DEADLINE,
+        );
+        clear_pending_interview_banner();
+        if matches!(
+            resolution,
+            ainb_plugin_notifyd::broker::StructuredResolution::ReleasedToNative
+        ) {
+            // Ownership yielded on purpose. No hook output means Claude renders
+            // its own picker unchanged, and Fleet keeps the keystroke route.
+            return Ok(None);
+        }
+        return Ok(Some(HookEmit::Structured(structured_emit_json(
+            tool_input,
+            &resolution,
+        ))));
     }
 
     // 5. PermissionRequest: SYNCHRONOUS approve/deny round-trip. The waiting

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1443,9 +1443,16 @@ fn extract_permission_context(payload: &str) -> String {
 /// Where the saved tmux window name is parked while an interview banner is up.
 fn interview_banner_state() -> Option<std::path::PathBuf> {
     let pane = std::env::var("TMUX_PANE").ok().filter(|value| !value.is_empty())?;
-    let base = std::env::var_os("AINB_HOME").map(std::path::PathBuf::from).or_else(dirs::home_dir)?;
+    let base = std::env::var_os("AINB_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(dirs::home_dir)?;
     let key = blake3::hash(pane.as_bytes()).to_hex();
-    Some(base.join(".agents-in-a-box").join("fleet").join("interview-banner").join(format!("{key}.txt")))
+    Some(
+        base.join(".agents-in-a-box")
+            .join("fleet")
+            .join("interview-banner")
+            .join(format!("{key}.txt")),
+    )
 }
 
 /// Tell the OPERATOR AT THE TERMINAL that this session is holding on a question.
@@ -1460,7 +1467,9 @@ fn interview_banner_state() -> Option<std::path::PathBuf> {
 /// rename, must still get its interview — an indication is worth nothing if its
 /// absence can block the answer path.
 fn announce_pending_interview(questions: &[serde_json::Value]) {
-    let Ok(pane) = std::env::var("TMUX_PANE") else { return };
+    let Ok(pane) = std::env::var("TMUX_PANE") else {
+        return;
+    };
     if pane.is_empty() {
         return;
     }
@@ -1506,11 +1515,15 @@ fn announce_pending_interview(questions: &[serde_json::Value]) {
 /// window left reading `[ASK]` after the question is gone is worse than no
 /// banner: it trains the operator to ignore the flag.
 fn clear_pending_interview_banner() {
-    let Ok(pane) = std::env::var("TMUX_PANE") else { return };
+    let Ok(pane) = std::env::var("TMUX_PANE") else {
+        return;
+    };
     if pane.is_empty() {
         return;
     }
-    let Some(path) = interview_banner_state() else { return };
+    let Some(path) = interview_banner_state() else {
+        return;
+    };
     if let Ok(previous) = std::fs::read_to_string(&path) {
         let previous = previous.trim();
         if !previous.is_empty() {
@@ -3208,5 +3221,164 @@ mod tests {
         assert_eq!(Scheduler::Daemon.as_str(), "daemon");
         assert_eq!(Scheduler::LocalTimer.as_str(), "local_timer");
         assert_eq!(Scheduler::None.as_str(), "none");
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ask_hook_returns_complete_structured_answer_without_text_routing() {
+        use ainb_plugin_notifyd::broker::{
+            BrokerState, StructuredQuestionAnswer, client_answer_structured, client_list,
+        };
+        use tokio::net::UnixListener;
+
+        let home = TempDir::new().unwrap();
+        let cwd = home.path().join("plain-claude-worktree");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let paths = ainb_plugin_notifyd::paths::Paths::under(home.path());
+        std::fs::create_dir_all(paths.approve_socket.parent().unwrap()).unwrap();
+        let listener = UnixListener::bind(&paths.approve_socket).unwrap();
+        let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
+            listener,
+            BrokerState::with_timeout(std::time::Duration::from_secs(30)),
+        ));
+
+        let payload = serde_json::json!({
+            "tool_name": "AskUserQuestion",
+            "tool_use_id": "toolu_ask_1",
+            "tool_input": {
+                "questions": [
+                    {
+                        "question": "Region?",
+                        "header": "Region",
+                        "options": [
+                            {"label": "EU", "description": "Europe"},
+                            {"label": "US", "description": "United States"}
+                        ],
+                        "multiSelect": false
+                    },
+                    {
+                        "question": "Checks?",
+                        "header": "Checks",
+                        "options": [
+                            {"label": "Lint", "description": "Run linter"},
+                            {"label": "Test", "description": "Run tests"}
+                        ],
+                        "multiSelect": true
+                    }
+                ]
+            }
+        });
+        let original_questions = payload["tool_input"]["questions"].clone();
+        let hook_home = home.path().to_path_buf();
+        let hook_cwd = cwd.clone();
+        let hook_payload = payload.to_string();
+        let waiter = tokio::task::spawn_blocking(move || {
+            hook_core(
+                &hook_home,
+                "PreToolUse",
+                "ask-session",
+                hook_cwd.to_str().expect("temporary cwd is valid UTF-8"),
+                None,
+                None,
+                50,
+                &hook_payload,
+                Some("AskUserQuestion"),
+            )
+        });
+
+        let pending = loop {
+            let socket = paths.approve_socket.clone();
+            let listed = tokio::task::spawn_blocking(move || client_list(&socket))
+                .await
+                .unwrap()
+                .unwrap_or_default();
+            if let Some(pending) = listed.into_iter().find(|item| item.session_id == "ask-session")
+            {
+                break pending;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        };
+        assert_eq!(
+            pending.questions,
+            original_questions.as_array().unwrap().clone()
+        );
+        let fingerprint = pending.request_fingerprint.unwrap();
+        // The hook REGISTERS with the broker before it appends the event, so a
+        // pending observed by `client_list` does not yet imply the file exists.
+        // Reading immediately made this test pass or fail on scheduling luck.
+        let events_path = home.path().join("events.jsonl");
+        let mut events = String::new();
+        for _ in 0..200 {
+            if let Ok(read) = std::fs::read_to_string(&events_path) {
+                if read.contains("ask-session") {
+                    events = read;
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(!events.is_empty(), "hook never appended its Fleet event");
+        assert!(
+            events.contains("ask-session"),
+            "Fleet event must appear only after broker registration"
+        );
+
+        let stale_socket = paths.approve_socket.clone();
+        let stale = tokio::task::spawn_blocking(move || {
+            client_answer_structured(
+                &stale_socket,
+                "ask-session",
+                "fnv1a64:stale",
+                &[StructuredQuestionAnswer {
+                    question: "Region?".to_string(),
+                    selected_options: vec!["EU".to_string()],
+                }],
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(stale.stale);
+        assert!(!stale.matched);
+
+        let answer_socket = paths.approve_socket.clone();
+        let accepted = tokio::task::spawn_blocking(move || {
+            client_answer_structured(
+                &answer_socket,
+                "ask-session",
+                &fingerprint,
+                &[
+                    StructuredQuestionAnswer {
+                        question: "Region?".to_string(),
+                        selected_options: vec!["EU".to_string()],
+                    },
+                    StructuredQuestionAnswer {
+                        question: "Checks?".to_string(),
+                        selected_options: vec!["Lint".to_string(), "Test".to_string()],
+                    },
+                ],
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(accepted.matched);
+
+        let emitted = waiter.await.unwrap().unwrap().expect("structured hook output");
+        let HookEmit::Structured(line) = emitted else {
+            panic!("AskUserQuestion must emit structured hook output");
+        };
+        let output: serde_json::Value = serde_json::from_str(&line).unwrap();
+        let specific = &output["hookSpecificOutput"];
+        assert_eq!(specific["hookEventName"], "PreToolUse");
+        assert_eq!(specific["permissionDecision"], "allow");
+        assert_eq!(specific["updatedInput"]["questions"], original_questions);
+        assert_eq!(specific["updatedInput"]["answers"]["Region?"], "EU");
+        assert_eq!(specific["updatedInput"]["answers"]["Checks?"], "Lint, Test");
+        assert!(
+            output.get("text").is_none(),
+            "must not route labels as generic text"
+        );
+
+        server.abort();
+        let _ = std::fs::remove_file(&paths.approve_socket);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/plumbing/hooks.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/plumbing/hooks.rs
@@ -76,11 +76,25 @@ const DEFAULT_HOOK_TIMEOUT: u64 = 10;
 /// the hook cleanly before Claude ever hard-kills it.
 const PERMISSION_HOOK_TIMEOUT: u64 = 660;
 
+/// `PreToolUse` carries the SYNCHRONOUS AskUserQuestion gate: for that one
+/// matcher the hook holds the tool call open on the approve broker until a
+/// human answers from Fleet, releases to the native picker, or the broker's own
+/// 640s fallback fires. Same budget and same reasoning as
+/// [`PERMISSION_HOOK_TIMEOUT`] — Claude's ceiling must exceed the broker await
+/// so the fallback answers cleanly before Claude hard-kills the hook.
+///
+/// THIS IS A CEILING, NOT A DELAY. Every other `PreToolUse` (every Bash, Read,
+/// Edit …) returns in well under a second and is completely unaffected; raising
+/// the cap costs them nothing. It was lowered to 10s when the blocking branch
+/// was removed, which left the cap below the await the branch needs.
+const STRUCTURED_ASK_HOOK_TIMEOUT: u64 = 660;
+
 /// The Claude `timeout` (seconds) to register for `event`.
 #[must_use]
 fn timeout_for(event: &str) -> u64 {
     match event {
         "PermissionRequest" => PERMISSION_HOOK_TIMEOUT,
+        "PreToolUse" => STRUCTURED_ASK_HOOK_TIMEOUT,
         _ => DEFAULT_HOOK_TIMEOUT,
     }
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -122,16 +122,35 @@ pub enum StructuredResolution {
 impl StructuredResolution {
     fn timed_out() -> Self {
         Self::Rejected {
-            reason: "no human answer before timeout".to_string(),
+            reason: TIMED_OUT_REASON.to_string(),
         }
     }
 
     fn superseded() -> Self {
         Self::Rejected {
-            reason: "superseded by a newer request for this session".to_string(),
+            reason: SUPERSEDED_REASON.to_string(),
         }
     }
+
+    /// Did this resolution arrive because NOBODY answered, rather than because a
+    /// human refused?
+    ///
+    /// Load-bearing for the blocking AskUserQuestion hook. Both cases below are
+    /// `Rejected`, but a caller that renders every `Rejected` as a tool DENY
+    /// turns "no operator was watching" into a refused tool the model re-asks,
+    /// which blocks again — a deny/retry loop for any session with no Fleet
+    /// surface open. Those two must yield to the native picker instead; only an
+    /// explicit human dismiss is a real denial.
+    #[must_use]
+    pub fn is_unanswered(&self) -> bool {
+        matches!(self, Self::Rejected { reason } if reason == TIMED_OUT_REASON || reason == SUPERSEDED_REASON)
+    }
 }
+
+/// Reasons that mean "no human answered", not "a human said no". Kept beside
+/// their constructors so the predicate above cannot silently drift from them.
+const TIMED_OUT_REASON: &str = "no human answer before timeout";
+const SUPERSEDED_REASON: &str = "superseded by a newer request for this session";
 
 impl Decision {
     /// The safe fallback when no human answered in time.

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
     "UserPromptExpansion": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "MessageDisplay": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "PreToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 660 }] }],
-    "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
+    "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 660 }] }],
     "PostToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "PostToolUseFailure": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "PostToolBatch": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ainb-hooks",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc. stall_guard.py additionally blocks turn-end when a session would idle on in-flight work with no wake armed, so ATC-managed sessions do not silently park on a running CI job.",
   "author": {
     "name": "Agents-in-a-Box"
@@ -13,7 +13,7 @@
     "UserPromptSubmit": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "UserPromptExpansion": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "MessageDisplay": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
-    "PreToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 10 }] }],
+    "PreToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 660 }] }],
     "PermissionRequest": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "PostToolUse": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],
     "PostToolUseFailure": [{ "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh", "timeout": 5 }] }],


### PR DESCRIPTION
Answering a Claude `/interview` from Fleet or the macOS app went through synthetic tmux keystrokes at Claude's own picker, with correctness re-derived from a `capture-pane` screenshot. That broke four times in one week. This moves the answer onto the hook, where it returns as exact JSON.

## The mechanism

`atc.rs` returned `Ok(None)` for every AskUserQuestion, so Claude drew its picker and owned stdin. Once the hook returns, `hookSpecificOutput` is gone and keystrokes are the only channel left — which is why a screen parser existed at all.

This restores the blocking branch `96429f00` deleted: the hook holds the tool call open, registers with the approve broker, and returns `permissionDecision: "allow"` + `updatedInput.answers`.

**That commit also dropped the plugin manifest's PreToolUse timeout from 3600 to 10 in the same breath**, which is why restoring only the branch was not enough — the hook was killed long before the 640s broker await could resolve. Both halves belong together. 660 exceeds the await so the broker's own fallback answers cleanly first. It is a ceiling, not a delay: every other PreToolUse returns in well under a second, and the platform default is already 600s.

## Why not keep the keystroke route

| break | cause |
|---|---|
| multi-select never confirmed | `Enter` on a checkbox row toggles, undoing the prior `Space` |
| answer rejected, zero keys sent | mid-token hard wrap with no space to match on |
| sibling route silently broken | the normalisation fix for the above |
| answer rejected again (2.1.237) | two-column picker splices a side panel through a wrapped label |

All four are the same defect: re-deriving structured data we already hold as JSON from a vendor TUI with no compatibility contract.

## Three exits, none of which wedge Claude

- broker unreachable or registration refused → yield to the native picker, stamped `mirrored` so the keystroke route still applies
- explicit release → same, and Claude draws its picker untouched
- answer arrives → returned as JSON

`fleet_delivery` now **selects** the transport instead of being hardcoded to `mirrored`, so a held request is never answered by typing at a picker that is not on screen.

## Operator at the terminal

While the hook holds, Claude's UI cannot be reached — hook stdout is read only at exit, and writing to `/dev/tty` fights the TUI repaint. So the tmux window is renamed `[ASK] <header>` for the duration and restored afterwards. Blocking **does** suppress the native picker, so the release path is what makes terminal answering possible at all.

## Validation

`cargo test -p ainb --lib`: **1817 passed, 0 failed.** rustfmt clean.

Live, on Claude Code 2.1.237, both lanes with unguessable nonces:

| lane | result |
|---|---|
| answer from Fleet while held | `⎿ → hook-a94c1ba1` then `PROPAGATED:hook-a94c1ba1` |
| release → native picker → answer in terminal | `⎿ → native-070c9fdd` then `PROPAGATED:native-070c9fdd` |

The model can only echo a random nonce it actually received. Neither path touched `capture-pane`.

Approach is endorsed upstream: anthropics/claude-code#10168 was closed with "For clarifying questions, use a `PreToolUse` hook with matcher `AskUserQuestion`."

## Known gap

Validated via a matcher-scoped settings.json entry; this ships via the plugin manifest's single `matcher: """ entry. Note that command hooks are deduplicated by command string — matcher and timeout are NOT in the key — so adding a second entry sharing `notify.sh` would be silently dropped. Hence one entry.

https://claude.ai/code/session_01YTgF3YEyfWZk3HwpjTJfyU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured question handling through Fleet, with exact JSON responses and automatic fallback to the native picker when needed.
  - Added temporary terminal banners while questions await answers, restoring automatic window naming afterward.
  - Added protection against outdated question requests.

- **Bug Fixes**
  - Increased action response time limits to prevent valid structured answers from timing out.
  - Improved handling when questions go unanswered or sessions are not eligible for Fleet handling.

- **Documentation**
  - Added end-to-end validation guidance covering successful outcomes, failures, evidence, and receipt freshness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->