### PR TITLE
feat(tui): Daemons screen toggles: install hooks, start bridge

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "ainb"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-cli",
  "ainb-fleet-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-hangar-daemon"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "agent-client-protocol",
  "ainb-acp",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-cts-v2"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-secrets",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-hangar"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-notifyd"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-web"
-version = "1.20.5"
+version = "1.21.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -62,6 +62,8 @@ pub enum AppEvent {
     DaemonsOverlayStartHangar,
     DaemonsStartMcp,
     DaemonsStartHeadroom,
+    /// Detach-spawn the phone bridge daemon from the Daemons screen.
+    DaemonsStartBridge,
     RefreshWorkspaces,  // Manual refresh of workspace data
     CycleSessionFilter, // Cycle Interactive session filter (Shift+F): All → ActiveOnly → StoppedOnly
     ToggleClaudeChat,   // Toggle Claude chat visibility
@@ -2977,6 +2979,7 @@ impl EventHandler {
             KeyCode::Char('S') => Some(AppEvent::DaemonsOverlayStartHangar),
             KeyCode::Char('M') => Some(AppEvent::DaemonsStartMcp),
             KeyCode::Char('P') => Some(AppEvent::DaemonsStartHeadroom),
+            KeyCode::Char('B') => Some(AppEvent::DaemonsStartBridge),
             _ => None,
         }
     }
@@ -3672,6 +3675,7 @@ impl EventHandler {
             AppEvent::DaemonsOverlayRestartNotifyd => state.spawn_notifyd_restart(),
             AppEvent::DaemonsRepairHooks => state.spawn_hooks_repair(),
             AppEvent::DaemonsOverlayStartHangar => state.spawn_hangar_start(),
+            AppEvent::DaemonsStartBridge => state.spawn_bridge_start(),
             AppEvent::DaemonsStartMcp => state.spawn_mcp_start(),
             AppEvent::DaemonsStartHeadroom => state.spawn_headroom_start(),
             AppEvent::ToggleClaudeChat => state.toggle_claude_chat(),
@@ -8816,6 +8820,10 @@ mod panel_back_tests {
         assert!(matches!(
             route(&mut state, KeyCode::Char('P')),
             Some(AppEvent::DaemonsStartHeadroom)
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('B')),
+            Some(AppEvent::DaemonsStartBridge)
         ));
     }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1062,6 +1062,9 @@ pub struct DaemonsOverlayState {
     /// Headroom start result, shown in the unified Daemons table.
     pub headroom_start_rx: Option<mpsc::UnboundedReceiver<String>>,
     pub headroom_start_status: Option<String>,
+    /// Phone bridge start result, shown in the Daemons footer.
+    pub bridge_start_rx: Option<mpsc::UnboundedReceiver<String>>,
+    pub bridge_start_status: Option<String>,
 }
 
 /// Blocking portion of the daemons fetch: MCP alive probe + SessionStore read
@@ -5047,6 +5050,8 @@ impl AppState {
             mcp_start_status: None,
             headroom_start_rx: None,
             headroom_start_status: None,
+            bridge_start_rx: None,
+            bridge_start_status: None,
         });
         self.spawn_daemons_fetch();
     }
@@ -5175,11 +5180,66 @@ impl AppState {
                             .collect::<Vec<_>>()
                             .join(", ")
                     ),
-                    Err(error) => format!("hook repair failed: {error:#}"),
+                    Err(error) => format!("hook install failed: {error:#}"),
                 }
             })
             .await
-            .unwrap_or_else(|error| format!("hook repair task panicked: {error}"));
+            .unwrap_or_else(|error| format!("hook install task panicked: {error}"));
+            let _ = tx.send(line);
+        });
+    }
+
+    /// Detach-spawn the phone bridge (`ainb fleet bridge run`) from the Daemons
+    /// screen. Null stdio + its own process group so it outlives the TUI. The
+    /// heartbeat the bridge writes shows up in the top table within a couple of
+    /// collect intervals; this status line only reports the spawn itself.
+    pub fn spawn_bridge_start(&mut self) {
+        let Some(o) = self.daemons_overlay.as_mut() else {
+            return;
+        };
+        if o.bridge_start_rx.is_some() {
+            return;
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        o.bridge_start_rx = Some(rx);
+        o.bridge_start_status = Some("starting phone bridge…".to_string());
+        tokio::spawn(async move {
+            let line = tokio::task::spawn_blocking(|| {
+                use std::os::unix::process::CommandExt;
+                use std::process::Stdio;
+                // Refuse up front when the bridge provably cannot run (no
+                // channel configured, the same check `bridge run` bails on)
+                // instead of spawning a child that dies silently into null
+                // stdio.
+                match crate::fleet::bridge::config::load_config(None) {
+                    Ok(cfg) if !cfg.any_channel() => {
+                        return "bridge not started: no channel configured; add \
+                                [fleet.bridge.telegram], [fleet.bridge.slack], or \
+                                [fleet.bridge.discord] to config.toml"
+                            .to_string();
+                    }
+                    Err(error) => return format!("bridge not started: {error:#}"),
+                    Ok(_) => {}
+                }
+                let exe =
+                    std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("ainb"));
+                match std::process::Command::new(&exe)
+                    .args(["fleet", "bridge", "run"])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .process_group(0)
+                    .spawn()
+                {
+                    Ok(child) => format!(
+                        "bridge starting (pid {}), watch the phone bridge row",
+                        child.id()
+                    ),
+                    Err(error) => format!("bridge start failed: {error:#}"),
+                }
+            })
+            .await
+            .unwrap_or_else(|error| format!("bridge start task panicked: {error}"));
             let _ = tx.send(line);
         });
     }
@@ -5290,6 +5350,13 @@ impl AppState {
             if let Ok(line) = rx.try_recv() {
                 o.headroom_start_rx = None;
                 o.headroom_start_status = Some(line);
+                refresh_after_start = true;
+            }
+        }
+        if let Some(rx) = o.bridge_start_rx.as_mut() {
+            if let Ok(line) = rx.try_recv() {
+                o.bridge_start_rx = None;
+                o.bridge_start_status = Some(line);
                 refresh_after_start = true;
             }
         }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5146,7 +5146,8 @@ impl AppState {
         });
     }
 
-    /// Reinstall only already-installed hooks against this running binary.
+    /// Reinstall installed hooks against this running binary, or perform the
+    /// first install for every agent when no hooks are installed yet.
     /// This is the repair action for stale package-manager paths and damaged
     /// wiring; it deliberately does not start/restart any daemon.
     pub fn spawn_hooks_repair(&mut self) {
@@ -5158,14 +5159,14 @@ impl AppState {
         }
         let (tx, rx) = mpsc::unbounded_channel();
         o.hooks_repair_rx = Some(rx);
-        o.hooks_repair_status = Some("repairing hooks…".to_string());
+        o.hooks_repair_status = Some("installing hooks…".to_string());
         tokio::spawn(async move {
             let line = tokio::task::spawn_blocking(|| {
                 let result = ainb_plugin_notifyd::Paths::from_home()
-                    .and_then(|paths| ainb_plugin_notifyd::repair_hooks(&paths));
+                    .and_then(|paths| ainb_plugin_notifyd::repair_or_install_hooks(&paths));
                 match result {
                     Ok(report) => format!(
-                        "hooks repaired for {}",
+                        "hooks installed for {}",
                         report
                             .record
                             .agents

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8794,11 +8794,15 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     // version over it would silence the very skew warning `status` exists to
     // print. Best-effort: a write failure must not fail the start (the skew
     // check just degrades to "unknown").
-    // Only when OUR child is the daemon now serving. `exited.is_none()` is not
-    // that test: a child still alive at the probe may be a slow starter that
-    // goes on to lose the lock, and stamping our version over the incumbent's
-    // silences the very skew warning `status` exists to print.
-    if owner == Some(child.id()) {
+    // Only when OUR child is the daemon this start recorded. That is the child
+    // holding the lock at the probe, OR the no-owner fallback above: with no
+    // lock on disk there is no incumbent whose stamp we could clobber, and the
+    // pid file we just wrote names the child, so the stamp must match it. A
+    // probe that merely finds the child still alive is NOT enough when someone
+    // ELSE holds the lock: a slow starter can go on to lose the race, and
+    // stamping our version over the incumbent's silences the very skew warning
+    // `status` exists to print.
+    if owner == Some(child.id()) || (owner.is_none() && exited.is_none()) {
         if let Ok(vpath) = daemon_version_path() {
             std::fs::write(&vpath, format!("{}\n", env!("CARGO_PKG_VERSION"))).ok();
         }

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -375,7 +375,7 @@ fn render_hook_section(
                 "  I",
                 Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" repair", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" install / repair", Style::default().fg(MUTED_GRAY)),
         ]))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -858,8 +858,8 @@ mod tests {
         );
         assert!(out.contains("Hooks"), "hook section missing: {out}");
         assert!(
-            out.contains("I repair"),
-            "hook repair action missing: {out}"
+            out.contains("I install / repair"),
+            "hook install/repair action missing: {out}"
         );
         assert!(out.contains("release"), "hook mode missing: {out}");
         assert!(

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -205,7 +205,7 @@ pub fn render(
     } else {
         render_table(frame, chunks[0], &snapshot);
     }
-    render_footer(frame, chunks[1]);
+    render_footer(frame, chunks[1], runtime);
 }
 
 fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&DaemonsOverlayState>) {
@@ -588,14 +588,25 @@ fn daemon_version_label(daemon: &DaemonStatus) -> (String, Style) {
     }
 }
 
-fn render_footer(frame: &mut Frame, area: Rect) {
-    let footer = Paragraph::new(Line::from(vec![
-        Span::styled("read-only • live", Style::default().fg(MUTED_GRAY)),
+fn render_footer(frame: &mut Frame, area: Rect, runtime: Option<&DaemonsOverlayState>) {
+    let mut spans = vec![
+        Span::styled("live", Style::default().fg(MUTED_GRAY)),
+        Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)),
+        Span::styled("B", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+        Span::styled(" start bridge", Style::default().fg(MUTED_GRAY)),
         Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)),
         Span::styled("q/Esc", Style::default().fg(CORNFLOWER_BLUE)),
         Span::styled(" back", Style::default().fg(MUTED_GRAY)),
-    ]))
-    .style(Style::default().bg(PANEL_BG));
+    ];
+    // Outcome of the last B press (spawn / refusal), until the next refresh.
+    if let Some(status) = runtime.and_then(|runtime| runtime.bridge_start_status.as_deref()) {
+        spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
+        spans.push(Span::styled(
+            format!("B {status}"),
+            Style::default().fg(GOLD),
+        ));
+    }
+    let footer = Paragraph::new(Line::from(spans)).style(Style::default().bg(PANEL_BG));
     frame.render_widget(footer, area);
 }
 
@@ -770,6 +781,8 @@ mod tests {
             mcp_start_status: None,
             headroom_start_rx: None,
             headroom_start_status: None,
+            bridge_start_rx: None,
+            bridge_start_status: None,
         }
     }
 
@@ -887,6 +900,26 @@ mod tests {
             "repair missing: {out}"
         );
         assert!(out.contains("claude ✓"), "agent wiring missing: {out}");
+    }
+
+    #[test]
+    fn footer_names_bridge_start_key_and_last_outcome() {
+        let mut state = seeded_state(Vec::new());
+        let mut runtime = system_runtime();
+        runtime.bridge_start_status = Some("bridge starting (pid 4242)".to_string());
+        let out = render_to_string(&mut state, Some(&runtime), 120, 24);
+        assert!(
+            out.contains("B start bridge"),
+            "bridge key hint missing: {out}"
+        );
+        assert!(
+            out.contains("B bridge starting (pid 4242)"),
+            "bridge start status missing: {out}"
+        );
+        assert!(
+            !out.contains("read-only"),
+            "stale read-only label still rendered"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -439,6 +439,8 @@ mod tests {
             mcp_start_status: None,
             headroom_start_rx: None,
             headroom_start_status: None,
+            bridge_start_rx: None,
+            bridge_start_status: None,
         }
     }
 
@@ -563,6 +565,8 @@ mod tests {
             mcp_start_status: None,
             headroom_start_rx: None,
             headroom_start_status: None,
+            bridge_start_rx: None,
+            bridge_start_status: None,
         };
         let backend = TestBackend::new(120, 30);
         let mut term = Terminal::new(backend).unwrap();

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -553,6 +553,18 @@ pub fn repair_hooks(paths: &Paths) -> Result<InstallReport> {
     install(paths, &record.agents)
 }
 
+/// Repair installed hooks, or perform the first install for every agent when
+/// nothing is installed yet. This backs the TUI's repair keypress: unlike the
+/// diagnostic CLI path above, a keypress on the Daemons screen is explicit
+/// operator intent, so an empty record means "install", not "refuse".
+pub fn repair_or_install_hooks(paths: &Paths) -> Result<InstallReport> {
+    let record = InstallRecord::load(paths)?;
+    if record.agents.is_empty() {
+        return install(paths, Agent::ALL);
+    }
+    install(paths, &record.agents)
+}
+
 /// Install variant that takes an explicit `$HOME` root. Lets tests
 /// stay isolated without mutating the process-wide environment.
 pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Result<InstallRecord> {

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -46,7 +46,7 @@ pub use install::{
     Agent, ClaudeRegister, HookAgentHealth, HookBinaryMode, HookHealth, HookHealthIssue,
     InstallPrompt, InstallRecord, InstallReport, StatusRow, auto_repair_hook_binary,
     dismiss_prompt, embedded_plugin_version, hook_health, install as install_for,
-    install_under_home, prompt_state, repair_hooks, status, uninstall,
+    install_under_home, prompt_state, repair_hooks, repair_or_install_hooks, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
 pub use osnotify::{AlertKind, classify_attention};


### PR DESCRIPTION
## Why

The Daemons screen showed red rows with no way to act on two of them:

- **`I` repair was a dead key on a fresh machine**: `repair_hooks` refuses an empty install record, so a host with no hooks got `hook repair failed: hooks are not installed; run ainb notifyd install --all` and CLI homework.
- **A crashed phone bridge had no start path in the TUI** (dead since a June crash on the reporting host, nothing restarts it).
- The footer still claimed `read-only • live` while the screen carries six action keys.

## What

- `I` now performs the first install for all agents when the install record is empty, and repairs (reinstalls recorded agents) otherwise. New `repair_or_install_hooks` in ainb-plugin-notifyd; the CLI diagnostic path keeps its deliberate refusal. Section title becomes `I install / repair`.
- New `B` key detach-spawns `ainb fleet bridge run` (own process group, null stdio, current exe). Configs with no bridge channel are refused up front with the same message `bridge run` bails with, so the child can never die silently into null stdio. Spawn outcome lands in the footer; the heartbeat shows in the top table within a collect interval.
- Footer drops the stale `read-only` label and names the `B` key.
- Cargo.lock synced to the 1.21.3 workspace version bump (missed in the release commit).

## Tests

- `components::daemons`: 18 pass, incl. new footer test (key hint + outcome line + no `read-only`).
- `daemons_repair_key_routing` extended with the `B` route.
- `ainb-plugin-notifyd` install suite: 27 pass.

## Also in this PR (per review of the CI red)

- `fix(hangar)`: `daemon start` only stamped `daemon.binary`/version when its 400ms probe saw the child already holding the lock; a slow starter skipped the stamp forever, flaking the lifecycle round-trip test with NotFound. Start now stamps on the no-owner fallback too (no incumbent to clobber, pid file names the child). Lifecycle suite: 4 pass locally.
