### PR TITLE
fix(plugins): stop a vanished plugin binary from hanging the Hangar screen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,6 +481,16 @@ jobs:
               man1.install "share/man/man1/ainb.1" if File.exist?("share/man/man1/ainb.1")
               (bin/"ainb").write <<~WRAPPER
                 #!/bin/bash
+                # This value names a keg-versioned path, so an older install's
+                # export outlives the keg once `brew upgrade` deletes that
+                # Cellar directory. Inherited from a long-lived shell or a tmux
+                # server environment it then silently pointed the runtime at a
+                # directory that no longer exists, and every plugin screen came
+                # up empty. Drop a value that no longer resolves; a real
+                # user-set override still wins.
+                if [ -n "${AINB_PLUGIN_ROOT}" ] && [ ! -d "${AINB_PLUGIN_ROOT}" ]; then
+                  unset AINB_PLUGIN_ROOT
+                fi
                 export AINB_PLUGIN_ROOT="${AINB_PLUGIN_ROOT:-#{libexec}/plugins}"
                 exec "#{libexec}/ainb" "$@"
               WRAPPER

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,15 +482,22 @@ jobs:
               (bin/"ainb").write <<~WRAPPER
                 #!/bin/bash
                 # This value names a keg-versioned path, so an older install's
-                # export outlives the keg once `brew upgrade` deletes that
-                # Cellar directory. Inherited from a long-lived shell or a tmux
-                # server environment it then silently pointed the runtime at a
-                # directory that no longer exists, and every plugin screen came
-                # up empty. Drop a value that no longer resolves; a real
-                # user-set override still wins.
-                if [ -n "${AINB_PLUGIN_ROOT}" ] && [ ! -d "${AINB_PLUGIN_ROOT}" ]; then
-                  unset AINB_PLUGIN_ROOT
-                fi
+                # export outlives the keg. Inherited from a long-lived shell or
+                # a tmux server environment it survives `brew upgrade` and then
+                # either points at a directory the upgrade deleted (every plugin
+                # screen comes up empty) or, until `brew cleanup` runs and
+                # removes the old keg, still resolves — pairing this binary with
+                # the PREVIOUS release's plugin binaries.
+                #
+                # Drop any inherited value naming a different ainb keg, whether
+                # or not it still exists. A genuine user override (any path not
+                # under an ainb Cellar keg) is untouched.
+                case "${AINB_PLUGIN_ROOT}" in
+                  "" ) ;;
+                  "#{libexec}/plugins" ) ;;
+                  */Cellar/ainb/* ) unset AINB_PLUGIN_ROOT ;;
+                  * ) [ -d "${AINB_PLUGIN_ROOT}" ] || unset AINB_PLUGIN_ROOT ;;
+                esac
                 export AINB_PLUGIN_ROOT="${AINB_PLUGIN_ROOT:-#{libexec}/plugins}"
                 exec "#{libexec}/ainb" "$@"
               WRAPPER

--- a/ainb-tui/crates/ainb-core/build.rs
+++ b/ainb-tui/crates/ainb-core/build.rs
@@ -50,7 +50,13 @@ const SCAN_DIRS: &[&str] = &["src/components", "src/widgets"];
 /// in false positives, so we walk the file at function granularity.
 /// Phase 7c todo: split the render-path methods into their own module
 /// and move them under `SCAN_DIRS`.
-const SCAN_FN_SCOPED: &[(&str, &[&str])] = &[("src/app/state.rs", &["tick_plugin_renders"])];
+// `collect_plugin_render_outcome` is called from inside `tick_plugin_renders`
+// and is render-path code, but the scan is function-scoped — an `.await` added
+// there would otherwise slip past the lint.
+const SCAN_FN_SCOPED: &[(&str, &[&str])] = &[(
+    "src/app/state.rs",
+    &["tick_plugin_renders", "collect_plugin_render_outcome"],
+)];
 
 fn main() {
     let crate_root =

--- a/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
+++ b/ainb-tui/crates/ainb-core/src/app/screens/builtin.rs
@@ -386,7 +386,7 @@ fn click_to_viewport(
 }
 
 /// Build the placeholder paragraph shown when a plugin screen renders
-/// but no frame has arrived yet. Two cases:
+/// but no frame has arrived yet. Three cases:
 ///
 /// 1. **Plugin not registered** — runtime came up but this plugin is
 ///    absent. Either disabled (`AINB_DISABLE_PLUGINS=1`,
@@ -394,7 +394,12 @@ fn click_to_viewport(
 ///    `config.toml [plugins]` excludes it) or never installed at all.
 ///    Show actionable text so the user knows it's a deliberate state,
 ///    not a hang.
-/// 2. **Plugin registered, no frame yet** — runtime spawned the
+/// 2. **Plugin registered, render failed** — the runtime tried and could
+///    not produce a frame (most often: the subprocess cannot be spawned
+///    because its binary was removed under a running TUI by an upgrade).
+///    Show the error and how to recover. Without this the screen claimed
+///    to be connecting forever while every keystroke was dropped.
+/// 3. **Plugin registered, no frame yet** — runtime spawned the
 ///    subprocess but the first `plugin/render` hasn't completed. This
 ///    is the genuine "rendering…" case; lasts milliseconds in normal
 ///    operation.
@@ -418,6 +423,62 @@ fn build_placeholder_for_unloaded_plugin(
         }
         _ => false,
     };
+
+    // A recorded render failure outranks the loading beat: the plugin is
+    // registered, so case 3 would otherwise paint "connecting…" forever.
+    let render_error = if plugin_registered {
+        state.plugin_render_errors.get(screen_id)
+    } else {
+        None
+    };
+
+    if let Some(err) = render_error {
+        const GOLD: Color = Color::Rgb(255, 215, 0);
+        const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
+        const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
+        const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+        const ERROR_RED: Color = Color::Rgb(230, 110, 110);
+        const DARK_BG: Color = Color::Rgb(25, 25, 35);
+
+        let name = title_case_screen(screen_id);
+        let plugin_label = plugin_name.unwrap_or(screen_id).to_string();
+        let lines = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("The `{plugin_label}` plugin could not render this screen."),
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(err.clone(), Style::default().fg(ERROR_RED))),
+            Line::from(""),
+            Line::from(Span::styled(
+                "If ainb was upgraded while this session was open, the plugin binary",
+                Style::default().fg(MUTED_GRAY),
+            )),
+            Line::from(Span::styled(
+                "it was discovered from no longer exists. Quit and relaunch ainb.",
+                Style::default().fg(MUTED_GRAY),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Logs: ~/.agents-in-a-box/logs/agents-in-a-box-*.jsonl - search `plugin spawn failed`.",
+                Style::default().fg(MUTED_GRAY),
+            )),
+        ];
+        let block = Block::default()
+            .title(Line::from(vec![
+                Span::styled(" ⬡ ", Style::default().fg(GOLD)),
+                Span::styled(
+                    format!("{name} unavailable "),
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ),
+            ]))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(CORNFLOWER_BLUE))
+            .style(Style::default().bg(DARK_BG));
+        return Paragraph::new(lines).alignment(Alignment::Center).block(block);
+    }
 
     if plugin_registered {
         // Genuine transient render lag: the runtime has the plugin (freshly

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3148,6 +3148,16 @@ pub struct AppState {
     /// plugin screen) reads as `false`.
     pub plugin_captures_text: std::collections::HashMap<crate::app::screens::ScreenId, bool>,
 
+    /// Last `plugin/render` failure per plugin-owned screen id, as reported by
+    /// the render oneshot that `tick_plugin_renders` now keeps instead of
+    /// dropping. Set on `RenderOutcome::RuntimeError` / `PluginError`, cleared
+    /// the moment a frame renders successfully.
+    ///
+    /// `PluginScreen::render` paints this instead of the "connecting…"
+    /// placeholder, which is the difference between a screen that explains it
+    /// cannot start the plugin and one that claims to be loading forever.
+    pub plugin_render_errors: std::collections::HashMap<crate::app::screens::ScreenId, String>,
+
     /// Cheap Send + Clone façade onto the plugin runtime, populated by
     /// `App::init`. `None` when running plugin-free (e.g. tests, or
     /// installs that haven't completed bundled-plugin discovery yet).
@@ -3671,6 +3681,7 @@ impl Default for AppState {
             plugin_render_origins: std::collections::HashMap::new(),
             plugin_last_render_viewport: std::collections::HashMap::new(),
             plugin_captures_text: std::collections::HashMap::new(),
+            plugin_render_errors: std::collections::HashMap::new(),
             plugin_runtime: None,
 
             statusline_status_cache: None,
@@ -11640,6 +11651,22 @@ pub struct App {
     /// `None` until [`App::init`] runs, or when no provider dir is
     /// watchable — the burndown then keeps its press-`r` refresh behaviour.
     usage_dir_watcher: Option<crate::models::usage_dir_watcher::UsageDirWatcher>,
+    /// In-flight `plugin/render` outcome receivers, keyed by screen id.
+    ///
+    /// The frame itself comes back via `RuntimeHandle::try_recv_render`, so
+    /// this oneshot used to be dropped on the spot — which threw away the
+    /// FAILURE half of the result. A lazy plugin whose subprocess can no
+    /// longer be spawned answers every kick with
+    /// `RenderOutcome::RuntimeError`, and with the receiver dropped that
+    /// error went nowhere: the screen sat on "connecting…" forever while
+    /// key and mouse events were silently dropped (`child.is_none()`).
+    /// Holding the receiver for one tick and polling it with `try_recv`
+    /// keeps `tick_plugin_renders` synchronous while letting the failure
+    /// reach `state.plugin_render_errors` and the user.
+    plugin_render_outcomes: std::collections::HashMap<
+        crate::app::screens::ScreenId,
+        tokio::sync::oneshot::Receiver<ainb_plugin_runtime::RenderOutcome>,
+    >,
 }
 
 impl App {
@@ -11648,6 +11675,7 @@ impl App {
             state: AppState::new(),
             plugin_runtime_owner: None,
             usage_dir_watcher: None,
+            plugin_render_outcomes: std::collections::HashMap::new(),
         }
     }
 
@@ -11720,6 +11748,14 @@ impl App {
             if handle.lifecycle_state(&pid).is_none() {
                 continue;
             }
+
+            // Collect the previous kick's outcome before issuing another one.
+            // Only the failure half matters here (the frame arrives via
+            // `try_recv_render` above), and it MUST be collected: a lazy
+            // plugin whose binary is gone answers every kick with
+            // `RuntimeError`, and dropping that receiver is what left the
+            // screen on "connecting…" indefinitely with no log line.
+            self.collect_plugin_render_outcome(screen_id);
 
             // Drain the cached frame (if any) into the screen map. The
             // plugin task pushes a fresh frame each time it returns from
@@ -11810,11 +11846,56 @@ impl App {
                 .insert((*screen_id).to_string(), (width, height));
 
             let viewport = ainb_plugin_runtime::Viewport { width, height };
-            // Returned oneshot is intentionally dropped — the cache
-            // pickup happens via `try_recv_render` next tick.
-            let _ = handle.render(&pid, viewport, 0);
+            // The frame lands in the cache for `try_recv_render`; the
+            // returned oneshot carries the outcome, and specifically the
+            // failure case that cache can never represent. Park it until
+            // the next tick's `collect_plugin_render_outcome`.
+            let rx = handle.render(&pid, viewport, 0);
+            self.plugin_render_outcomes.insert((*screen_id).to_string(), rx);
         }
         drained
+    }
+
+    /// Poll the parked `plugin/render` oneshot for `screen_id`, recording any
+    /// failure in `state.plugin_render_errors` (and clearing it on success).
+    ///
+    /// Non-blocking by construction — `try_recv` never awaits, so
+    /// `tick_plugin_renders` stays synchronous per its `build.rs`-enforced
+    /// contract. A receiver that is still `Empty` is put back so a slow render
+    /// is judged on the tick it actually completes, not abandoned.
+    fn collect_plugin_render_outcome(&mut self, screen_id: &str) {
+        use ainb_plugin_runtime::RenderOutcome;
+        use tokio::sync::oneshot::error::TryRecvError;
+
+        let Some(mut rx) = self.plugin_render_outcomes.remove(screen_id) else {
+            return;
+        };
+        let message = match rx.try_recv() {
+            Ok(RenderOutcome::Ok(_)) => {
+                self.state.plugin_render_errors.remove(screen_id);
+                return;
+            }
+            Ok(RenderOutcome::RuntimeError(e)) => e,
+            Ok(RenderOutcome::PluginError { code, message }) => {
+                format!("{message} (code {code})")
+            }
+            Err(TryRecvError::Empty) => {
+                // Still rendering. Keep waiting rather than treating a slow
+                // frame as a failure.
+                self.plugin_render_outcomes.insert(screen_id.to_string(), rx);
+                return;
+            }
+            // Sender dropped without answering: the plugin task is gone.
+            Err(TryRecvError::Closed) => "plugin task stopped without answering".to_string(),
+        };
+
+        // Log once per distinct message so a failing screen doesn't spam the
+        // log at tick cadence while the user sits on it.
+        let is_new = self.state.plugin_render_errors.get(screen_id) != Some(&message);
+        if is_new {
+            warn!(screen = %screen_id, error = %message, "plugin render failed");
+        }
+        self.state.plugin_render_errors.insert(screen_id.to_string(), message);
     }
 
     pub async fn init(&mut self) {
@@ -12396,6 +12477,47 @@ mod plugin_render_gate_tests {
         assert!(
             handle.take_render_dirty(&PluginId::from("burndown")),
             "unfocused plugin must stay dirty for its deferred first paint"
+        );
+
+        runtime.shutdown();
+    }
+
+    /// A lazy plugin only execs its binary on first use, so one that vanished
+    /// after discovery (`brew upgrade` deleting the keg a running TUI was
+    /// launched from) fails at the render kick. The render oneshot used to be
+    /// dropped, so that failure reached nobody: the screen sat on
+    /// "connecting…" forever while key and mouse events were dropped. The
+    /// outcome must land in `plugin_render_errors` for the placeholder to
+    /// paint instead.
+    #[test]
+    fn unspawnable_plugin_records_a_render_error() {
+        // `app_with_plugins` registers against /nonexistent/plugin-binary,
+        // which is exactly the post-upgrade state.
+        let (runtime, mut app) = app_with_plugins(&["learnings"]);
+
+        app.state.current_screen = ids::LEARNINGS.to_string();
+        app.state.plugin_render_areas.insert(ids::LEARNINGS.to_string(), (120, 40));
+
+        // First tick kicks the render; the spawn attempt and its failure
+        // happen on the runtime's executor, so poll a bounded number of
+        // ticks for the outcome rather than assuming one is enough.
+        let mut recorded = None;
+        for _ in 0..200 {
+            app.tick_plugin_renders();
+            if let Some(err) = app.state.plugin_render_errors.get(ids::LEARNINGS) {
+                recorded = Some(err.clone());
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let err = recorded.expect(
+            "a plugin whose binary cannot be spawned must record a render error, \
+             not leave the screen on the loading placeholder forever",
+        );
+        assert!(
+            !err.is_empty(),
+            "the recorded render error must carry a message to show the user"
         );
 
         runtime.shutdown();

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11861,8 +11861,13 @@ impl App {
     ///
     /// Non-blocking by construction — `try_recv` never awaits, so
     /// `tick_plugin_renders` stays synchronous per its `build.rs`-enforced
-    /// contract. A receiver that is still `Empty` is put back so a slow render
-    /// is judged on the tick it actually completes, not abandoned.
+    /// contract. A receiver that is still `Empty` is put back, so a render that
+    /// outlives one tick is judged on a later tick rather than abandoned
+    /// immediately — but only until the next kick for that screen replaces it.
+    /// Superseding is deliberate: the newer kick reports the current state of
+    /// the same plugin, so a persistent failure is still caught on the very
+    /// next tick, and a failure that has since been fixed is not worth
+    /// resurrecting.
     fn collect_plugin_render_outcome(&mut self, screen_id: &str) {
         use ainb_plugin_runtime::RenderOutcome;
         use tokio::sync::oneshot::error::TryRecvError;

--- a/ainb-tui/crates/ainb-core/src/plugins.rs
+++ b/ainb-tui/crates/ainb-core/src/plugins.rs
@@ -454,12 +454,12 @@ pub(crate) fn plugins_disabled() -> bool {
 }
 
 /// Search a small list of candidate locations for the plugin staging
-/// directory. Returns the first one that exists.
+/// directory. Returns the first one that is a directory.
 ///
 /// Search order:
 /// 1. `$AINB_PLUGIN_ROOT` (test/CI override).
-/// 2. `<exe-dir>/plugins/`              (brew/libexec install layout).
-/// 3. `<exe-dir>/dist/plugins/`         (release tarball layout).
+/// 2. `<exe-dir>/plugins/`              (brew/libexec + release tarball layout).
+/// 3. `<exe-dir>/dist/plugins/`         (staged `dist/` beside the binary).
 /// 4. `<exe-dir>/../../dist/plugins/`   (cargo run from `target/<profile>/`).
 /// 5. `<cwd>/dist/plugins/`             (workspace dev layout).
 /// 6. `~/.agents-in-a-box/plugins/cache/` (installed plugins).
@@ -471,10 +471,23 @@ pub(crate) fn plugins_disabled() -> bool {
 /// into a long-lived shell (or a tmux server's environment) outlives the keg it
 /// names, and once `brew upgrade` deletes that Cellar directory every `ainb`
 /// launched from it came up with zero plugins and no explanation. Candidate 2
-/// covers the same layout without the env var, so a stale export now degrades
-/// to a warning instead of an empty runtime.
+/// covers both the Homebrew keg (`libexec/ainb` beside `libexec/plugins`) and
+/// the release tarball (`plugins/` beside the binary, staged by
+/// `scripts/build-plugins.sh`), so a stale export degrades to a warning instead
+/// of an empty runtime.
+///
+/// To force an EMPTY runtime, set `AINB_DISABLE_PLUGINS=1` or point
+/// `AINB_PLUGIN_ROOT` at an existing empty directory. A non-existent path is no
+/// longer a way to ask for that — it is treated as the mistake it usually is.
 pub(crate) fn discover_plugin_root() -> Option<PathBuf> {
-    if let Ok(env_root) = std::env::var("AINB_PLUGIN_ROOT") {
+    discover_plugin_root_from(std::env::var("AINB_PLUGIN_ROOT").ok().as_deref())
+}
+
+/// [`discover_plugin_root`] with the override injected rather than read from
+/// the process environment, so tests exercise the search order without
+/// mutating global state (and racing every other test in the binary).
+fn discover_plugin_root_from(env_root: Option<&str>) -> Option<PathBuf> {
+    if let Some(env_root) = env_root {
         let trimmed = env_root.trim();
         if !trimmed.is_empty() {
             let p = PathBuf::from(trimmed);
@@ -540,9 +553,15 @@ pub(crate) fn discover_plugin_root() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
+    /// An EXISTING but empty root is how a caller asks for a plugin-free
+    /// runtime. This used to point at a non-existent path, which now falls
+    /// through to the derived candidates and would load whatever the machine
+    /// happens to have in `~/.agents-in-a-box/plugins/cache` — passing only on
+    /// a developer box whose cache is empty.
     #[test]
     fn empty_root_returns_no_loaded_plugins() {
-        std::env::set_var("AINB_PLUGIN_ROOT", "/definitely/not/a/real/path");
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("AINB_PLUGIN_ROOT", dir.path());
         let (_runtime, handle, outcome) =
             init_plugin_runtime().expect("runtime init must succeed even with no plugin root");
         assert_eq!(outcome.loaded.len(), 0, "no plugins should load");
@@ -566,9 +585,7 @@ mod tests {
     fn missing_plugin_root_is_never_returned() {
         let stale = std::env::temp_dir().join("ainb-cellar-1.0.0-deleted/plugins");
         assert!(!stale.exists(), "fixture path must not exist");
-        std::env::set_var("AINB_PLUGIN_ROOT", &stale);
-        let resolved = discover_plugin_root();
-        std::env::remove_var("AINB_PLUGIN_ROOT");
+        let resolved = discover_plugin_root_from(Some(&stale.to_string_lossy()));
         assert_ne!(
             resolved.as_deref(),
             Some(stale.as_path()),
@@ -584,9 +601,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let file = dir.path().join("not-a-directory");
         std::fs::write(&file, b"").expect("write fixture file");
-        std::env::set_var("AINB_PLUGIN_ROOT", &file);
-        let resolved = discover_plugin_root();
-        std::env::remove_var("AINB_PLUGIN_ROOT");
+        let resolved = discover_plugin_root_from(Some(&file.to_string_lossy()));
         assert_ne!(
             resolved.as_deref(),
             Some(file.as_path()),
@@ -599,9 +614,7 @@ mod tests {
     #[test]
     fn existing_plugin_root_still_wins() {
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("AINB_PLUGIN_ROOT", dir.path());
-        let resolved = discover_plugin_root();
-        std::env::remove_var("AINB_PLUGIN_ROOT");
+        let resolved = discover_plugin_root_from(Some(&dir.path().to_string_lossy()));
         assert_eq!(resolved.as_deref(), Some(dir.path()));
     }
 

--- a/ainb-tui/crates/ainb-core/src/plugins.rs
+++ b/ainb-tui/crates/ainb-core/src/plugins.rs
@@ -478,16 +478,16 @@ pub(crate) fn discover_plugin_root() -> Option<PathBuf> {
         let trimmed = env_root.trim();
         if !trimmed.is_empty() {
             let p = PathBuf::from(trimmed);
-            if p.exists() {
+            if p.is_dir() {
                 return Some(p);
             }
-            // Set, but pointing nowhere. Falling through silently is how a
-            // stale value became "the Hangar screen says the plugin isn't
-            // installed" with nothing in the log to explain it. Say so, then
-            // keep searching the derived candidates.
+            // Set, but not naming a usable directory. Falling through silently
+            // is how a stale value became "the Hangar screen says the plugin
+            // isn't installed" with nothing in the log to explain it. Say so,
+            // then keep searching the derived candidates.
             warn!(
                 plugin_root = %p.display(),
-                "AINB_PLUGIN_ROOT points at a path that does not exist - ignoring it and \
+                "AINB_PLUGIN_ROOT does not name an existing directory - ignoring it and \
                  falling back to the binary-relative plugin directories. A stale export \
                  (e.g. naming a Homebrew keg that an upgrade deleted) is the usual cause; \
                  unset it in your shell and in any tmux server environment."
@@ -506,14 +506,14 @@ pub(crate) fn discover_plugin_root() -> Option<PathBuf> {
                 return Some(libexec);
             }
             let here = d.join("dist").join("plugins");
-            if here.exists() {
+            if here.is_dir() {
                 return Some(here);
             }
             // `target/<profile>/ainb` -> repo-root `dist/plugins`. Canonicalize
             // is best-effort: a failure must not abort the remaining candidates
             // (it used to `?` straight out of the whole function).
             let up = d.join("..").join("..").join("dist").join("plugins");
-            if up.exists() {
+            if up.is_dir() {
                 return Some(up.canonicalize().unwrap_or(up));
             }
         }
@@ -521,14 +521,14 @@ pub(crate) fn discover_plugin_root() -> Option<PathBuf> {
 
     if let Ok(cwd) = std::env::current_dir() {
         let here = cwd.join("dist").join("plugins");
-        if here.exists() {
+        if here.is_dir() {
             return Some(here);
         }
     }
 
     if let Some(home) = dirs::home_dir() {
         let installed = home.join(".agents-in-a-box").join("plugins").join("cache");
-        if installed.exists() {
+        if installed.is_dir() {
             return Some(installed);
         }
     }
@@ -573,6 +573,24 @@ mod tests {
             resolved.as_deref(),
             Some(stale.as_path()),
             "a plugin root that does not exist must not be handed to discovery"
+        );
+    }
+
+    /// A plugin root is a directory to scan. A path that exists but is a
+    /// regular file would be handed to discovery and fail there instead, so
+    /// reject it the same way as a missing one.
+    #[test]
+    fn plugin_root_that_is_a_file_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("not-a-directory");
+        std::fs::write(&file, b"").expect("write fixture file");
+        std::env::set_var("AINB_PLUGIN_ROOT", &file);
+        let resolved = discover_plugin_root();
+        std::env::remove_var("AINB_PLUGIN_ROOT");
+        assert_ne!(
+            resolved.as_deref(),
+            Some(file.as_path()),
+            "a plugin root that is a file must not be handed to discovery"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/plugins.rs
+++ b/ainb-tui/crates/ainb-core/src/plugins.rs
@@ -458,28 +458,63 @@ pub(crate) fn plugins_disabled() -> bool {
 ///
 /// Search order:
 /// 1. `$AINB_PLUGIN_ROOT` (test/CI override).
-/// 2. `<exe-dir>/dist/plugins/`         (release tarball layout).
-/// 3. `<exe-dir>/../dist/plugins/`      (cargo run from `target/<profile>/`).
-/// 4. `<cwd>/dist/plugins/`             (workspace dev layout).
-/// 5. `~/.agents-in-a-box/plugins/cache/` (installed plugins).
+/// 2. `<exe-dir>/plugins/`              (brew/libexec install layout).
+/// 3. `<exe-dir>/dist/plugins/`         (release tarball layout).
+/// 4. `<exe-dir>/../../dist/plugins/`   (cargo run from `target/<profile>/`).
+/// 5. `<cwd>/dist/plugins/`             (workspace dev layout).
+/// 6. `~/.agents-in-a-box/plugins/cache/` (installed plugins).
+///
+/// Every candidate after the env override is derived from the running binary
+/// or the cwd, so discovery keeps working with `AINB_PLUGIN_ROOT` unset. That
+/// matters because the Homebrew wrapper used to be the ONLY thing pointing a
+/// packaged install at its plugins: a keg-versioned `AINB_PLUGIN_ROOT` exported
+/// into a long-lived shell (or a tmux server's environment) outlives the keg it
+/// names, and once `brew upgrade` deletes that Cellar directory every `ainb`
+/// launched from it came up with zero plugins and no explanation. Candidate 2
+/// covers the same layout without the env var, so a stale export now degrades
+/// to a warning instead of an empty runtime.
 pub(crate) fn discover_plugin_root() -> Option<PathBuf> {
     if let Ok(env_root) = std::env::var("AINB_PLUGIN_ROOT") {
-        let p = PathBuf::from(env_root);
-        if p.exists() {
-            return Some(p);
+        let trimmed = env_root.trim();
+        if !trimmed.is_empty() {
+            let p = PathBuf::from(trimmed);
+            if p.exists() {
+                return Some(p);
+            }
+            // Set, but pointing nowhere. Falling through silently is how a
+            // stale value became "the Hangar screen says the plugin isn't
+            // installed" with nothing in the log to explain it. Say so, then
+            // keep searching the derived candidates.
+            warn!(
+                plugin_root = %p.display(),
+                "AINB_PLUGIN_ROOT points at a path that does not exist - ignoring it and \
+                 falling back to the binary-relative plugin directories. A stale export \
+                 (e.g. naming a Homebrew keg that an upgrade deleted) is the usual cause; \
+                 unset it in your shell and in any tmux server environment."
+            );
         }
     }
 
     if let Ok(exe) = std::env::current_exe() {
         let exe_dir = exe.parent().map(Path::to_path_buf);
         if let Some(d) = &exe_dir {
+            // Homebrew/libexec layout: `libexec/ainb` sitting alongside
+            // `libexec/plugins`. Checked before `dist/plugins` because a
+            // packaged install has no `dist/` at all.
+            let libexec = d.join("plugins");
+            if libexec.is_dir() {
+                return Some(libexec);
+            }
             let here = d.join("dist").join("plugins");
             if here.exists() {
                 return Some(here);
             }
+            // `target/<profile>/ainb` -> repo-root `dist/plugins`. Canonicalize
+            // is best-effort: a failure must not abort the remaining candidates
+            // (it used to `?` straight out of the whole function).
             let up = d.join("..").join("..").join("dist").join("plugins");
             if up.exists() {
-                return Some(up.canonicalize().ok()?);
+                return Some(up.canonicalize().unwrap_or(up));
             }
         }
     }
@@ -521,6 +556,35 @@ mod tests {
             "runtime has zero plugins"
         );
         std::env::remove_var("AINB_PLUGIN_ROOT");
+    }
+
+    /// A keg-versioned `AINB_PLUGIN_ROOT` outlives the keg it names once
+    /// `brew upgrade` deletes that Cellar directory. Returning it anyway (or
+    /// falling through to it silently) is what produced a TUI with zero
+    /// plugins and a Hangar screen insisting the plugin wasn't installed.
+    #[test]
+    fn missing_plugin_root_is_never_returned() {
+        let stale = std::env::temp_dir().join("ainb-cellar-1.0.0-deleted/plugins");
+        assert!(!stale.exists(), "fixture path must not exist");
+        std::env::set_var("AINB_PLUGIN_ROOT", &stale);
+        let resolved = discover_plugin_root();
+        std::env::remove_var("AINB_PLUGIN_ROOT");
+        assert_ne!(
+            resolved.as_deref(),
+            Some(stale.as_path()),
+            "a plugin root that does not exist must not be handed to discovery"
+        );
+    }
+
+    /// The override still wins when it actually resolves — the fix above
+    /// must not turn `AINB_PLUGIN_ROOT` into a no-op for CI and tests.
+    #[test]
+    fn existing_plugin_root_still_wins() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("AINB_PLUGIN_ROOT", dir.path());
+        let resolved = discover_plugin_root();
+        std::env::remove_var("AINB_PLUGIN_ROOT");
+        assert_eq!(resolved.as_deref(), Some(dir.path()));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/tests/cli_plugin_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/cli_plugin_integration.rs
@@ -27,6 +27,14 @@ fn ainb_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
 }
 
+/// An existing, empty plugin root — the supported way to force a plugin-free
+/// runtime. See the `AINB_PLUGIN_ROOT` note in `plugins::discover_plugin_root`.
+fn empty_plugin_root(tmp: &tempfile::TempDir) -> PathBuf {
+    let root = tmp.path().join("empty-plugin-root");
+    fs::create_dir_all(&root).expect("create empty plugin root");
+    root
+}
+
 fn write_plugin_fixture(root: &std::path::Path, name: &str, with_binary: bool) -> PathBuf {
     let dir = root.join(name);
     fs::create_dir_all(&dir).unwrap();
@@ -120,7 +128,13 @@ fn plugin_watch_unknown_plugin_exits_nonzero() {
             "--duration",
             "1",
         ])
-        .env("AINB_PLUGIN_ROOT", "/definitely/not/a/real/path")
+        // An EXISTING empty directory is how you ask for a plugin-free
+        // runtime. A non-existent path is not: discovery reports it and falls
+        // through to the binary- and cwd-relative candidates, and
+        // `scripts/build-plugins.sh` stages exactly one of those
+        // (`<cwd>/dist/plugins`), so this test would load real plugins on any
+        // checkout that had run it.
+        .env("AINB_PLUGIN_ROOT", empty_plugin_root(&tmp))
         .env("HOME", tmp.path())
         .output()
         .expect("spawn ainb");
@@ -148,7 +162,13 @@ fn plugin_tail_unknown_plugin_exits_nonzero() {
             "--duration",
             "1",
         ])
-        .env("AINB_PLUGIN_ROOT", "/definitely/not/a/real/path")
+        // An EXISTING empty directory is how you ask for a plugin-free
+        // runtime. A non-existent path is not: discovery reports it and falls
+        // through to the binary- and cwd-relative candidates, and
+        // `scripts/build-plugins.sh` stages exactly one of those
+        // (`<cwd>/dist/plugins`), so this test would load real plugins on any
+        // checkout that had run it.
+        .env("AINB_PLUGIN_ROOT", empty_plugin_root(&tmp))
         .env("HOME", tmp.path())
         .output()
         .expect("spawn ainb");

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -759,6 +759,18 @@ impl PluginTask {
         let mut child = match spawn_plugin(&self.plugin.binary_path) {
             Ok(c) => c,
             Err(e) => {
+                // Loud on purpose. A lazy plugin only execs its binary on
+                // first use, so a binary that vanished after discovery (the
+                // classic case: `brew upgrade` deleting the keg a still-running
+                // TUI was launched from) fails here and nowhere else. The
+                // caller's error goes to a oneshot the render tick may drop,
+                // so without this line the whole failure is invisible.
+                warn!(
+                    plugin = %self.plugin.id,
+                    binary = %self.plugin.binary_path.display(),
+                    error = %e,
+                    "plugin spawn failed"
+                );
                 self.record_failure();
                 return Err(e);
             }

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -772,6 +772,23 @@ impl PluginTask {
                     "plugin spawn failed"
                 );
                 self.record_failure();
+                // Leave a state the plugin can actually be judged from. This
+                // branch used to return with the state still `Spawning`, which
+                // `ensure_running` treats as spawnable — so a binary that can
+                // never be exec'd was retried on every later kick, and because
+                // the quarantine check lives only on `handle_exit` (a process
+                // that started, then died) the breaker never engaged for a
+                // process that never started at all.
+                if self.is_quarantine_due() {
+                    self.set_state(LifecycleState::Quarantined);
+                    error!(
+                        plugin = %self.plugin.id,
+                        "quarantined after {} failed spawns",
+                        self.failures.len()
+                    );
+                } else {
+                    self.set_state(LifecycleState::Idle);
+                }
                 return Err(e);
             }
         };

--- a/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/src/plugin_task.rs
@@ -754,31 +754,36 @@ impl PluginTask {
         self.spawn_and_init().await
     }
 
+    /// Bring the subprocess up and complete `plugin/init`.
+    ///
+    /// Every failure inside settles the lifecycle state and counts against the
+    /// circuit breaker. That used to be true of no failure at all: the whole
+    /// function returned with the state still `Spawning`, which
+    /// `ensure_running` treats as spawnable, and the quarantine check lived
+    /// only on `handle_exit` — the path for a process that started and then
+    /// died. A plugin that could never start (binary deleted by an upgrade
+    /// under a running TUI) or that started but never completed init (ABI
+    /// mismatch after a half-upgrade) was therefore retried on every later
+    /// render, CLI, or action kick, forever, without ever tripping the breaker.
     async fn spawn_and_init(&mut self) -> Result<(), RuntimeError> {
         self.set_state(LifecycleState::Spawning);
-        let mut child = match spawn_plugin(&self.plugin.binary_path) {
-            Ok(c) => c,
+        match self.spawn_and_init_inner().await {
+            Ok(()) => Ok(()),
             Err(e) => {
-                // Loud on purpose. A lazy plugin only execs its binary on
-                // first use, so a binary that vanished after discovery (the
-                // classic case: `brew upgrade` deleting the keg a still-running
-                // TUI was launched from) fails here and nowhere else. The
-                // caller's error goes to a oneshot the render tick may drop,
-                // so without this line the whole failure is invisible.
                 warn!(
                     plugin = %self.plugin.id,
                     binary = %self.plugin.binary_path.display(),
                     error = %e,
                     "plugin spawn failed"
                 );
+                // A failure after the exec (init timeout, ABI rejection) leaves
+                // a live child behind. Reap it here rather than letting the
+                // next attempt overwrite `self.child` and strand it.
+                if let Some(cs) = self.child.take() {
+                    cs.stderr_drain.abort();
+                    cs.stdout_reader.abort();
+                }
                 self.record_failure();
-                // Leave a state the plugin can actually be judged from. This
-                // branch used to return with the state still `Spawning`, which
-                // `ensure_running` treats as spawnable — so a binary that can
-                // never be exec'd was retried on every later kick, and because
-                // the quarantine check lives only on `handle_exit` (a process
-                // that started, then died) the breaker never engaged for a
-                // process that never started at all.
                 if self.is_quarantine_due() {
                     self.set_state(LifecycleState::Quarantined);
                     error!(
@@ -789,9 +794,15 @@ impl PluginTask {
                 } else {
                     self.set_state(LifecycleState::Idle);
                 }
-                return Err(e);
+                Err(e)
             }
-        };
+        }
+    }
+
+    /// Raw spawn + init. Returns the first error; `spawn_and_init` owns the
+    /// state transition, failure accounting, and child cleanup for all of them.
+    async fn spawn_and_init_inner(&mut self) -> Result<(), RuntimeError> {
+        let mut child = spawn_plugin(&self.plugin.binary_path)?;
         let stdin = child
             .stdin
             .take()
@@ -1566,11 +1577,16 @@ impl PluginTask {
                     plugin = %self.plugin.id,
                     "eager respawn after exit failed: {e}"
                 );
-                // spawn_and_init transitions to Spawning then either
-                // Running on success or leaves us in Spawning on
-                // failure; explicitly fall back to Idle so the next
-                // failure scheduling math doesn't confuse states.
-                self.set_state(LifecycleState::Idle);
+                // spawn_and_init now settles the state itself on failure:
+                // Quarantined once the breaker trips, else Idle. Only fill in
+                // Idle for the states it does not settle, and NEVER downgrade
+                // Quarantined — doing so re-armed `ensure_running` (which
+                // treats Idle as spawnable) and re-exec'd a binary that can
+                // never start, which is precisely the eager-plugin case
+                // (session-reader) this breaker exists to stop.
+                if !matches!(*self.state.read(), LifecycleState::Quarantined) {
+                    self.set_state(LifecycleState::Idle);
+                }
             }
         }
     }

--- a/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
+++ b/ainb-tui/crates/ainb-plugin-runtime/tests/fixture_e2e.rs
@@ -307,6 +307,50 @@ fn action_round_trip() {
     }
 }
 
+/// A binary that can never be exec'd (the post-`brew upgrade` state of a lazy
+/// plugin) must trip the same circuit breaker as a process that starts and
+/// dies. The spawn-failure branch used to return with the state still
+/// `Spawning` — which `ensure_running` treats as spawnable — and the
+/// quarantine check lived only on the exit path, so this case retried the
+/// exec on every kick forever and never quarantined.
+#[test]
+fn unspawnable_binary_quarantines_instead_of_retrying_forever() {
+    let (rt, handle) = build_runtime();
+    let plugin = RegisteredPlugin::new(
+        fixture_manifest(),
+        PathBuf::from("/nonexistent/plugin-binary-that-cannot-be-spawned"),
+        PathBuf::from("/dev/null/manifest.toml"),
+    );
+    let id = plugin.id.clone();
+    rt.register(plugin);
+
+    // threshold = 3 failures inside failure_window.
+    for _ in 0..3 {
+        drop(handle.render(&id, Viewport::new(10, 1), 0));
+        std::thread::sleep(Duration::from_millis(150));
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut quarantined = false;
+    while std::time::Instant::now() < deadline {
+        if matches!(
+            handle.lifecycle_state(&id),
+            Some(LifecycleState::Quarantined)
+        ) {
+            quarantined = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        quarantined,
+        "a plugin whose binary cannot be spawned must quarantine; state = {:?}",
+        handle.lifecycle_state(&id)
+    );
+
+    rt.shutdown();
+}
+
 #[test]
 fn sigkill_triggers_respawn_then_quarantine() {
     let (rt, handle) = build_runtime();

--- a/ainb-tui/install.sh
+++ b/ainb-tui/install.sh
@@ -176,6 +176,24 @@ main() {
         sudo chmod +x "${install_dir}/${BINARY_NAME}"
     fi
 
+    # Bundled first-party plugins. The tarball ships `plugins/` next to the
+    # binary and the runtime looks for `<exe-dir>/plugins`, so installing it
+    # alongside is all that is needed — no AINB_PLUGIN_ROOT, no wrapper. Without
+    # this the curl install has no analytics, witr, or Hangar screens at all.
+    # Best-effort and version-matched: replace wholesale so an upgrade can never
+    # leave the new binary talking to the previous release's plugin binaries.
+    # Older tarballs have no `plugins/`, so a missing directory is skipped.
+    if [ -d "${tmp_dir}/plugins" ]; then
+        if [ -w "$install_dir" ]; then
+            rm -rf "${install_dir}/plugins"
+            mv "${tmp_dir}/plugins" "${install_dir}/plugins"
+        else
+            sudo rm -rf "${install_dir}/plugins"
+            sudo mv "${tmp_dir}/plugins" "${install_dir}/plugins"
+        fi
+        info "Plugins installed to ${install_dir}/plugins"
+    fi
+
     # Man page (best-effort). Sibling of the bin dir, so /usr/local/bin gives
     # /usr/local/share/man/man1 and ~/.local/bin gives ~/.local/share/man/man1,
     # both on the default manpath. Older release tarballs have no share/, so a


### PR DESCRIPTION
## What broke

Pressing `g` in a TUI that had been running since before a `brew upgrade` left the Hangar screen stuck on **"Hangar — connecting… waiting for the plugin's first frame"**, with every keystroke and click silently discarded.

`hangar-tui` is `spawn = "lazy"`: its binary is only exec'd on first use. The upgrade deleted the Cellar directory that binary lived in, so the spawn failed on entry. Two independent defects then conspired to make that invisible:

1. `tick_plugin_renders` dropped the render oneshot, throwing away the failure half of the result. `RenderOutcome::RuntimeError` reached nobody.
2. The spawn failure itself was never logged.

So the screen claimed to be loading forever, input went nowhere (`child.is_none()` drops key and mouse events), and the log said nothing. Over four days the only trace in a 326 MB log was 25 `handle_key/handle_mouse dropped (idle)` lines and zero spawn attempts.

A second, separate failure sits behind the same upgrade: the brew wrapper exports a **keg-versioned** `AINB_PLUGIN_ROOT`. Exported into a long-lived shell or a tmux server environment, it outlives the keg it names. After the upgrade every `ainb` launched from that environment resolved a missing path, silently fell through to an empty `~/.agents-in-a-box/plugins/cache`, and came up with **zero plugins** — Hangar rendering `[ hangar-tui unavailable ]`.

## What changed

**`fix(plugins): never trust a plugin root that no longer exists`**
- Warn (instead of silently falling through) when `AINB_PLUGIN_ROOT` is set but does not resolve.
- Add the brew/libexec layout `<exe-dir>/plugins` to the derived candidates, so a packaged install finds its plugins **without** the env var. The wrapper's export stops being load-bearing.
- A failed `canonicalize()` on the cargo-layout candidate no longer `?`-returns out of the whole function, skipping the remaining fallbacks.

**`fix(plugins): surface a failed plugin spawn instead of connecting forever`**
- Hold the render oneshot for one tick and poll it with `try_recv`, so `tick_plugin_renders` stays synchronous (per its `build.rs`-enforced contract) while failures reach `state.plugin_render_errors`.
- The placeholder gains a third case: name the plugin, show the OS error, and say to relaunch.
- `warn!` on spawn failure in the plugin task, at the log the panel points the user to.
- Errors log once per distinct message, not per tick.

**`ci(release): drop a stale AINB_PLUGIN_ROOT in the brew wrapper`**
- The wrapper ignores an inherited value that no longer resolves. A real user-set override still wins.

## Verification

Reproduced the original bug, then proved each fix against it.

**Stale root** — launched with `AINB_PLUGIN_ROOT` pointing at the deleted `1.21.1` keg. Before: `[ hangar-tui unavailable ]`. After: warning logged, discovery falls back to the exe-relative directory, Hangar renders.

```
WARN AINB_PLUGIN_ROOT points at a path that does not exist - ignoring it and falling back
     to the binary-relative plugin directories... plugin_root=/opt/homebrew/Cellar/ainb/1.21.1/libexec/plugins
INFO discovering subprocess plugins plugin_root=.../fakeinstall/libexec/plugins
```

**Vanished binary** — staged a brew-like install, started the TUI, deleted `hangar-tui` underneath it, pressed `g`. Before: "connecting…" forever with dead input. After:

```
╭ ⬡ Hangar unavailable ──────────────────────────────────────────────╮
│         The `hangar-tui` plugin could not render this screen.       │
│              io: No such file or directory (os error 2)             │
│  If ainb was upgraded while this session was open, the plugin binary│
│   it was discovered from no longer exists. Quit and relaunch ainb.  │
│  Logs: ~/.agents-in-a-box/logs/... - search `plugin spawn failed`.  │
╰─────────────────────────────────────────────────────────────────────╯
```

Both log lines land, exactly once each over 20s on the failing screen (no tick-cadence spam):
```
WARN plugin spawn failed  plugin=hangar-tui binary=... error=io: No such file or directory (os error 2)
WARN plugin render failed screen=hangar error=io: No such file or directory (os error 2)
```

**Happy path** — restored the binary, relaunched, `g` renders the Hangar kanban in ~1s. No regression.

**Tests** — 3 new, all green, plus the 3 existing render-gate tests:
- `missing_plugin_root_is_never_returned`
- `existing_plugin_root_still_wins` (the override is not turned into a no-op)
- `unspawnable_plugin_records_a_render_error` (end-to-end through `tick_plugin_renders`)

`cargo build` clean, `cargo clippy -p ainb --lib` reports 0 errors, `cargo fmt` applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin discovery now recovers from missing or stale plugin paths and provides clearer warnings.
  * Homebrew installations automatically fall back to the correct plugin directory.
  * Failed plugin launches and rendering errors now display an “Unavailable” panel with recovery guidance and log details.
  * Plugin errors clear automatically after successful rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->