### PR TITLE
feat(fleet): native interviews by default, flippable to fleet

### DIFF
--- a/ainb-tui/config/tmux.conf
+++ b/ainb-tui/config/tmux.conf
@@ -246,3 +246,11 @@ set -g @yank_selection 'clipboard'
 
 # Initialize TPM (KEEP AT BOTTOM)
 run '~/.tmux/plugins/tpm/tpm'
+
+# ─── Claude interviews ────────────────────────────────────────────────────────
+# When an interview is held for Fleet, this window lights up and is renamed
+# [ASK>FLEET] <header>. The held pane CANNOT free itself — while the hook holds
+# the tool call Claude owns stdin, so nothing typed in the session reaches us.
+# The release therefore has to arrive from outside the app, which is what a
+# prefix binding is. `A` because tmux already binds `i` (display-message).
+bind-key A run-shell 'ainb fleet interview release'

--- a/ainb-tui/config/tmux.conf
+++ b/ainb-tui/config/tmux.conf
@@ -253,4 +253,8 @@ run '~/.tmux/plugins/tpm/tpm'
 # the tool call Claude owns stdin, so nothing typed in the session reaches us.
 # The release therefore has to arrive from outside the app, which is what a
 # prefix binding is. `A` because tmux already binds `i` (display-message).
-bind-key A run-shell 'ainb fleet interview release'
+# TMUX_PANE is NOT exported into run-shell jobs (verified: `run-shell 'env'`
+# shows TMUX and TERM but no TMUX_PANE), so it is passed explicitly via format
+# expansion, which run-shell DOES perform. Without this the pane-aware lookup
+# never fires and prefix+A refuses whenever more than one interview is held.
+bind-key A run-shell 'TMUX_PANE=#{pane_id} ainb fleet interview release'

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1441,6 +1441,109 @@ fn extract_permission_context(payload: &str) -> String {
 }
 
 /// Where the saved tmux window name is parked while an interview banner is up.
+/// Which surface owns the next interview for a session.
+///
+/// DEFAULT IS NATIVE, deliberately. Holding the tool call is the powerful mode
+/// but it suppresses Claude's own picker, so a session whose operator is at the
+/// terminal would stare at a banner instead of a question. Native costs nothing
+/// and never strands anyone; Fleet-hold is opted into per session (or globally)
+/// by whoever actually wants to answer from another surface.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum InterviewSurface {
+    /// Claude draws its own picker immediately; Fleet gets a mirrored card.
+    Native,
+    /// The hook holds the tool call so Fleet/macOS can answer as exact JSON.
+    Fleet,
+}
+
+impl InterviewSurface {
+    /// Parse a stored token. Anything unrecognised is NATIVE: a corrupt or
+    /// half-written file must never silently start holding tool calls.
+    fn parse(raw: &str) -> Self {
+        match raw.trim() {
+            "fleet" => Self::Fleet,
+            _ => Self::Native,
+        }
+    }
+
+    /// The token written to disk.
+    #[must_use]
+    pub const fn token(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Fleet => "fleet",
+        }
+    }
+}
+
+/// Directory holding the surface preference: one file per session id, plus a
+/// `default` file for the global setting.
+#[must_use]
+pub fn interview_surface_dir(home: &std::path::Path) -> std::path::PathBuf {
+    home.join("fleet").join("interview-surface")
+}
+
+/// Resolve the surface for `session_id`: per-session override, else the global
+/// default, else [`InterviewSurface::Native`].
+///
+/// Two small file reads, no TOML parse — this runs on EVERY `AskUserQuestion`
+/// and must not become a cost on the hook path.
+#[must_use]
+pub fn interview_surface(home: &std::path::Path, session_id: &str) -> InterviewSurface {
+    let dir = interview_surface_dir(home);
+    if !session_id.is_empty() {
+        if let Ok(raw) = std::fs::read_to_string(dir.join(sanitize_surface_key(session_id))) {
+            return InterviewSurface::parse(&raw);
+        }
+    }
+    // The GLOBAL default lives in config.toml (`[fleet.interview] surface`), not
+    // a hidden state file, so it sits visible beside every other setting. Only
+    // the per-session override above stays runtime state: it is ephemeral and
+    // keyed by uuid, which does not belong in a config file.
+    crate::config::AppConfig::load().map_or(InterviewSurface::Native, |config| {
+        InterviewSurface::parse(&config.fleet.interview.surface)
+    })
+}
+
+/// Persist the surface for a session id, or for the global default when
+/// `session_id` is `None`.
+///
+/// # Errors
+/// Returns an [`std::io::Error`] if the directory or file cannot be written.
+pub fn set_interview_surface(
+    home: &std::path::Path,
+    session_id: Option<&str>,
+    surface: InterviewSurface,
+) -> std::io::Result<()> {
+    let Some(session_id) = session_id else {
+        // Global default: persist into config.toml so `ainb fleet interview
+        // surface fleet` is visible in the same file the user already edits.
+        let mut config = crate::config::AppConfig::load()
+            .map_err(|e| std::io::Error::other(format!("loading config: {e}")))?;
+        config.fleet.interview.surface = surface.token().to_string();
+        return config.save().map_err(|e| std::io::Error::other(format!("saving config: {e}")));
+    };
+    let dir = interview_surface_dir(home);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join(sanitize_surface_key(session_id)), surface.token())
+}
+
+/// A session id is used as a FILE NAME here, so anything that could escape the
+/// directory or collide is replaced. Ids are UUID-shaped in practice; this is a
+/// guard, not a transformation anyone should depend on.
+fn sanitize_surface_key(session_id: &str) -> String {
+    session_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 fn interview_banner_state(home: &std::path::Path) -> Option<std::path::PathBuf> {
     let pane = std::env::var("TMUX_PANE").ok().filter(|value| !value.is_empty())?;
     let key = blake3::hash(pane.as_bytes()).to_hex();
@@ -1479,7 +1582,25 @@ const fn tmux_banner_enabled() -> bool {
 /// Silent on every failure. A session outside tmux, or a tmux that refuses the
 /// rename, must still get its interview — an indication is worth nothing if its
 /// absence can block the answer path.
-fn announce_pending_interview(home: &std::path::Path, questions: &[serde_json::Value]) {
+/// The provider session id whose interview is being held in THIS tmux pane.
+///
+/// `prefix + A` runs inside the held pane and must release that pane's own
+/// interview, not "the only one held" — with two held at once the latter frees
+/// somebody else's question into a terminal nobody is watching. The hook is the
+/// only party that knows both facts at once, so it records the pairing here.
+#[must_use]
+pub fn pane_held_session(home: &std::path::Path) -> Option<String> {
+    let path = interview_banner_state(home)?.with_extension("session");
+    let id = std::fs::read_to_string(path).ok()?;
+    let id = id.trim();
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+fn announce_pending_interview(
+    home: &std::path::Path,
+    session_id: &str,
+    questions: &[serde_json::Value],
+) {
     if !tmux_banner_enabled() {
         return;
     }
@@ -1509,7 +1630,7 @@ fn announce_pending_interview(home: &std::path::Path, questions: &[serde_json::V
                 "-t",
                 &pane,
                 "-F",
-                "#{window_name}\t#{automatic-rename}",
+                "#{window_name}\t#{automatic-rename}\t#{window-status-style}",
             ])
             .output()
         {
@@ -1518,11 +1639,31 @@ fn announce_pending_interview(home: &std::path::Path, questions: &[serde_json::V
                     let _ = std::fs::create_dir_all(dir);
                 }
                 let _ = std::fs::write(&path, String::from_utf8_lossy(&out.stdout).trim());
+                let _ = std::fs::write(path.with_extension("session"), session_id);
             }
         }
     }
+    // Name the SURFACE, not just the fact of a question: this banner only ever
+    // appears while the hook is holding for Fleet, and "[ASK]" alone left the
+    // operator guessing whether to answer here or somewhere else.
     let _ = std::process::Command::new("tmux")
-        .args(["rename-window", "-t", &pane, &format!("[ASK] {header}")])
+        .args([
+            "rename-window",
+            "-t",
+            &pane,
+            &format!("[ASK>FLEET] {header}"),
+        ])
+        .status();
+    // Light the window up in the status bar. A rename alone is easy to scan
+    // past in a bar full of windows; a colour change is not.
+    let _ = std::process::Command::new("tmux")
+        .args([
+            "set-window-option",
+            "-t",
+            &pane,
+            "window-status-style",
+            "fg=black,bg=yellow,bold",
+        ])
         .status();
     let _ = std::process::Command::new("tmux")
         .args([
@@ -1555,9 +1696,10 @@ fn clear_pending_interview_banner(home: &std::path::Path) {
         return;
     };
     if let Ok(saved) = std::fs::read_to_string(&path) {
-        let mut fields = saved.trim().splitn(2, '\t');
+        let mut fields = saved.trim().splitn(3, '\t');
         let previous = fields.next().unwrap_or_default();
         let automatic = fields.next().unwrap_or_default();
+        let style = fields.next().unwrap_or_default();
         if !previous.is_empty() {
             let _ = std::process::Command::new("tmux")
                 .args(["rename-window", "-t", &pane, previous])
@@ -1568,7 +1710,32 @@ fn clear_pending_interview_banner(home: &std::path::Path) {
                 .args(["set-window-option", "-t", &pane, "automatic-rename", "on"])
                 .status();
         }
+        // Put the status style back. An empty capture means the window had no
+        // explicit style, so the option is UNSET rather than set to "" — the
+        // latter would pin an empty style and stop it inheriting the theme.
+        let _ = if style.is_empty() {
+            std::process::Command::new("tmux")
+                .args([
+                    "set-window-option",
+                    "-t",
+                    &pane,
+                    "-u",
+                    "window-status-style",
+                ])
+                .status()
+        } else {
+            std::process::Command::new("tmux")
+                .args([
+                    "set-window-option",
+                    "-t",
+                    &pane,
+                    "window-status-style",
+                    style,
+                ])
+                .status()
+        };
     }
+    let _ = std::fs::remove_file(path.with_extension("session"));
     let _ = std::fs::remove_file(&path);
 }
 
@@ -1915,7 +2082,11 @@ fn hook_core_for_agent(
         // The CARD is still written for everyone: the hooks are installed
         // globally and a non-member's interview should still be visible to
         // Fleet, just answerable by the keystroke transport rather than held.
-        if !is_fleet_member {
+        // NATIVE IS THE DEFAULT. Holding is opt-in per session (or globally)
+        // via `ainb fleet interview surface`, and only ever for fleet members.
+        // A non-member, or a session left on the default, keeps Claude's own
+        // picker and gets a mirrored card so Fleet can still see and answer it.
+        if !is_fleet_member || interview_surface(home, session_id) != InterviewSurface::Fleet {
             append_event_with(Some("mirrored"));
             return Ok(None);
         }
@@ -1941,7 +2112,7 @@ fn hook_core_for_agent(
             return Ok(None);
         }
         append_event_with(None);
-        announce_pending_interview(home, &questions);
+        announce_pending_interview(home, session_id, &questions);
         let resolution = ainb_plugin_notifyd::broker::client_await_structured(
             &socket,
             session_id,
@@ -3212,6 +3383,50 @@ mod tests {
     }
 
     #[test]
+    fn native_is_the_configured_default_surface() {
+        // Pinned WITHOUT touching the filesystem. `interview_surface` falls back
+        // to the real `AppConfig::load()`, so asserting the default through it
+        // reads the developer's own config.toml and fails on any machine that
+        // has opted into fleet — which is exactly how this test first broke.
+        assert_eq!(crate::config::InterviewConfig::default().surface, "native");
+    }
+
+    #[test]
+    fn a_per_session_surface_overrides_whatever_the_global_default_is() {
+        let home = TempDir::new().unwrap();
+        let global = super::interview_surface(home.path(), "");
+        super::set_interview_surface(home.path(), Some("sess-a"), super::InterviewSurface::Fleet)
+            .unwrap();
+        assert_eq!(
+            super::interview_surface(home.path(), "sess-a"),
+            super::InterviewSurface::Fleet
+        );
+        // Per-session, not global: a sibling session still follows the default.
+        assert_eq!(super::interview_surface(home.path(), "sess-b"), global);
+        // And it flips back.
+        super::set_interview_surface(home.path(), Some("sess-a"), super::InterviewSurface::Native)
+            .unwrap();
+        assert_eq!(
+            super::interview_surface(home.path(), "sess-a"),
+            super::InterviewSurface::Native
+        );
+    }
+
+    #[test]
+    fn unrecognised_surface_token_reads_as_native() {
+        // A truncated or hand-edited value must never silently start holding
+        // tool calls.
+        let home = TempDir::new().unwrap();
+        let dir = super::interview_surface_dir(home.path());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("sess-c"), "flee").unwrap();
+        assert_eq!(
+            super::interview_surface(home.path(), "sess-c"),
+            super::InterviewSurface::Native
+        );
+    }
+
+    #[test]
     fn ask_hook_from_a_non_member_session_never_blocks_but_still_persists_a_card() {
         // An unrelated `claude` on a host that merely has ainb-hooks installed
         // must keep its native picker. Holding its tool call would suppress the
@@ -3385,6 +3600,14 @@ mod tests {
             }
         });
         let original_questions = payload["tool_input"]["questions"].clone();
+        // Native is the DEFAULT, so this session has to opt into fleet-hold or
+        // the hook returns immediately and there is nothing to answer.
+        super::set_interview_surface(
+            home.path(),
+            Some("ask-session"),
+            super::InterviewSurface::Fleet,
+        )
+        .unwrap();
         let hook_home = home.path().to_path_buf();
         let hook_cwd = cwd.clone();
         let hook_payload = payload.to_string();

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc.rs
@@ -1501,7 +1501,7 @@ pub fn interview_surface(home: &std::path::Path, session_id: &str) -> InterviewS
     // the per-session override above stays runtime state: it is ephemeral and
     // keyed by uuid, which does not belong in a config file.
     crate::config::AppConfig::load().map_or(InterviewSurface::Native, |config| {
-        InterviewSurface::parse(&config.fleet.interview.surface)
+        InterviewSurface::parse(config.fleet.interview.surface_token())
     })
 }
 
@@ -1520,7 +1520,7 @@ pub fn set_interview_surface(
         // surface fleet` is visible in the same file the user already edits.
         let mut config = crate::config::AppConfig::load()
             .map_err(|e| std::io::Error::other(format!("loading config: {e}")))?;
-        config.fleet.interview.surface = surface.token().to_string();
+        config.fleet.interview.surface = Some(surface.token().to_string());
         return config.save().map_err(|e| std::io::Error::other(format!("saving config: {e}")));
     };
     let dir = interview_surface_dir(home);
@@ -1623,23 +1623,48 @@ fn announce_pending_interview(
     // Save the current name AND the automatic-rename setting, so the wait does
     // not permanently freeze a window that was tracking its running program.
     if let Some(path) = interview_banner_state(home) {
-        if let Ok(out) = std::process::Command::new("tmux")
-            .args([
-                "display-message",
-                "-p",
-                "-t",
-                &pane,
-                "-F",
-                "#{window_name}\t#{automatic-rename}\t#{window-status-style}",
-            ])
-            .output()
-        {
-            if out.status.success() {
-                if let Some(dir) = path.parent() {
-                    let _ = std::fs::create_dir_all(dir);
+        // NEVER overwrite an existing record. A hook that died without clearing
+        // (pane closed, session interrupted, hook killed) leaves the banner in
+        // place; capturing it again would record "[ASK>FLEET] …" and the yellow
+        // style AS the previous state, and the next clear would restore those
+        // permanently.
+        if !path.exists() {
+            if let Ok(out) = std::process::Command::new("tmux")
+                .args([
+                    "display-message",
+                    "-p",
+                    "-t",
+                    &pane,
+                    "-F",
+                    "#{window_name}\t#{automatic-rename}",
+                ])
+                .output()
+            {
+                if out.status.success() {
+                    if let Some(dir) = path.parent() {
+                        let _ = std::fs::create_dir_all(dir);
+                    }
+                    // `#{window-status-style}` reports the EFFECTIVE (inherited)
+                    // value, not "set at window scope", so restoring from it would
+                    // pin an explicit window-level style and stop the window
+                    // following later theme changes. `show-window-options` prints
+                    // nothing when the option is unset, which is the distinction.
+                    let style = std::process::Command::new("tmux")
+                        .args(["show-window-options", "-t", &pane, "window-status-style"])
+                        .output()
+                        .ok()
+                        .filter(|o| o.status.success())
+                        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                        .unwrap_or_default();
+                    let style = style
+                        .split_once(' ')
+                        .map_or(String::new(), |(_, value)| value.trim().to_string());
+                    let _ = std::fs::write(
+                        &path,
+                        format!("{}\t{}", String::from_utf8_lossy(&out.stdout).trim(), style),
+                    );
+                    let _ = std::fs::write(path.with_extension("session"), session_id);
                 }
-                let _ = std::fs::write(&path, String::from_utf8_lossy(&out.stdout).trim());
-                let _ = std::fs::write(path.with_extension("session"), session_id);
             }
         }
     }
@@ -1705,7 +1730,7 @@ fn clear_pending_interview_banner(home: &std::path::Path) {
                 .args(["rename-window", "-t", &pane, previous])
                 .status();
         }
-        if automatic == "on" {
+        if automatic == "1" {
             let _ = std::process::Command::new("tmux")
                 .args(["set-window-option", "-t", &pane, "automatic-rename", "on"])
                 .status();
@@ -3388,7 +3413,13 @@ mod tests {
         // to the real `AppConfig::load()`, so asserting the default through it
         // reads the developer's own config.toml and fails on any machine that
         // has opted into fleet — which is exactly how this test first broke.
-        assert_eq!(crate::config::InterviewConfig::default().surface, "native");
+        // Absent, not "native": the merge needs to tell "unset" from "set to
+        // native", and the default is applied by surface_token().
+        assert_eq!(crate::config::InterviewConfig::default().surface, None);
+        assert_eq!(
+            crate::config::InterviewConfig::default().surface_token(),
+            "native"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/interview.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/interview.rs
@@ -19,8 +19,6 @@ use ainb_plugin_notifyd::broker::{client_list, client_release_structured};
 #[derive(serde::Serialize)]
 struct HeldRow {
     session_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    workspace: Option<String>,
     request_fingerprint: String,
     waiting_secs: u64,
     surface: String,
@@ -46,24 +44,39 @@ fn socket(home: &Path) -> std::path::PathBuf {
     ainb_plugin_notifyd::paths::Paths::under(home).approve_socket
 }
 
-fn held(home: &Path) -> Vec<HeldRow> {
+fn held(home: &Path) -> Result<Vec<HeldRow>> {
     let sock = socket(home);
-    client_list(&sock)
-        .unwrap_or_default()
+    // A broker we cannot reach is NOT "nothing is held" — a hook may be parked
+    // right now. Saying "no interviews are being held open" to someone whose
+    // session is blocked is the same lie as reporting a failed delivery as
+    // delivered, so this fails loudly like its sibling `approve` verb does.
+    Ok(client_list(&sock)
+        .with_context(|| {
+            format!(
+                "approve broker unreachable at {} (repair with `ainb notifyd restart`)",
+                sock.display()
+            )
+        })?
         .into_iter()
         .filter(|p| p.tool == "AskUserQuestion")
         .map(|p| HeldRow {
             surface: interview_surface(home, &p.session_id).token().to_string(),
             session_id: p.session_id,
-            workspace: None,
             request_fingerprint: p.request_fingerprint.unwrap_or_default(),
             waiting_secs: p.waiting_ms / 1000,
         })
-        .collect()
+        .collect())
+}
+
+/// Strip control characters. These strings arrive off the socket from whoever
+/// registered the request, and are printed straight to a terminal — the sibling
+/// `approve` verb sanitises the same class of value for the same reason.
+fn sanitize(value: &str) -> String {
+    value.chars().map(|c| if c.is_control() { ' ' } else { c }).collect()
 }
 
 fn list(home: &Path, format: OutputFormat) -> Result<()> {
-    let rows = held(home);
+    let rows = held(home)?;
     if matches!(format, OutputFormat::Json) {
         println!("{}", serde_json::to_string_pretty(&rows)?);
         return Ok(());
@@ -76,17 +89,13 @@ fn list(home: &Path, format: OutputFormat) -> Result<()> {
         );
         return Ok(());
     }
-    println!(
-        "{:<38} {:<26} {:>8}  {}",
-        "SESSION", "WORKSPACE", "WAITING", "FINGERPRINT"
-    );
+    println!("{:<38} {:>8}  {}", "SESSION", "WAITING", "FINGERPRINT");
     for r in &rows {
         println!(
-            "{:<38} {:<26} {:>7}s  {}",
-            r.session_id,
-            r.workspace.as_deref().unwrap_or("-"),
+            "{:<38} {:>7}s  {}",
+            sanitize(&r.session_id),
             r.waiting_secs,
-            r.request_fingerprint
+            sanitize(&r.request_fingerprint)
         );
     }
     println!("\nrelease to the terminal: ainb fleet interview release <session>");
@@ -94,10 +103,7 @@ fn list(home: &Path, format: OutputFormat) -> Result<()> {
 }
 
 fn release(home: &Path, session: Option<&str>) -> Result<()> {
-    let rows = held(home);
-    // With no argument, release the ONLY held interview. Guessing between
-    // several would be worse than refusing: the wrong pick silently hands
-    // somebody else's question back to a terminal nobody is watching.
+    let rows = held(home)?;
     let pane_session = crate::cli::fleet::atc::pane_held_session(home);
     let row = match session {
         Some(id) => rows.iter().find(|r| r.session_id == id).with_context(|| {
@@ -107,12 +113,19 @@ fn release(home: &Path, session: Option<&str>) -> Result<()> {
         // own session is the only sane target: releasing "the only held one"
         // would hand somebody else's question back to a terminal nobody is
         // watching the moment two are held at once.
-        None => match pane_session.and_then(|id| rows.iter().find(|r| r.session_id == id)) {
-            Some(row) => row,
-            None if rows.len() == 1 => &rows[0],
+        None => match pane_session {
+            // Inside a tmux pane the pane's OWN interview is the only safe
+            // target. Falling back to "the only held one" here would release
+            // somebody else's question into a terminal nobody is watching,
+            // which is exactly what the pane-aware lookup exists to prevent.
+            Some(id) => rows
+                .iter()
+                .find(|r| r.session_id == id)
+                .with_context(|| "this pane is not holding an interview".to_string())?,
             None if rows.is_empty() => anyhow::bail!("no interviews are being held open"),
+            None if rows.len() == 1 => &rows[0],
             None => anyhow::bail!(
-                "this pane is not holding an interview, and {} others are; name one \
+                "{} interviews are held and this is not a tmux pane; name one \
                  (see `ainb fleet interview list`)",
                 rows.len()
             ),
@@ -128,7 +141,7 @@ fn release(home: &Path, session: Option<&str>) -> Result<()> {
     } else {
         println!(
             "{} was not holding that request any more (already answered or released)",
-            row.session_id
+            sanitize(&row.session_id)
         );
     }
     Ok(())

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/interview.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/interview.rs
@@ -1,0 +1,159 @@
+// ABOUTME: `ainb fleet interview list|release|surface` — the non-GUI lever for
+// Claude's AskUserQuestion surface.
+//
+// Releasing a held interview previously required a key in the Hangar Fleet
+// screen, which is useless in the one case that matters: the pane you need to
+// unblock IS your terminal, and while the hook holds the tool call Claude owns
+// its stdin, so nothing typed inside the session can free it. The release has
+// to arrive from outside the pane — this verb, or a tmux binding that calls it.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::cli::OutputFormat;
+use crate::cli::fleet::atc::{InterviewSurface, interview_surface, set_interview_surface};
+use ainb_plugin_notifyd::broker::{client_list, client_release_structured};
+
+/// One interview currently held open by a blocked hook.
+#[derive(serde::Serialize)]
+struct HeldRow {
+    session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace: Option<String>,
+    request_fingerprint: String,
+    waiting_secs: u64,
+    surface: String,
+}
+
+pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    let home = crate::fleet::plumbing::paths::ainb_home().context("resolving ainb home")?;
+    match matches.subcommand() {
+        Some(("list", _)) => list(&home, format),
+        Some(("release", sub)) => {
+            release(&home, sub.get_one::<String>("session").map(String::as_str))
+        }
+        Some(("surface", sub)) => surface(
+            &home,
+            sub.get_one::<String>("mode").map(String::as_str),
+            sub.get_one::<String>("session").map(String::as_str),
+        ),
+        _ => Ok(()),
+    }
+}
+
+fn socket(home: &Path) -> std::path::PathBuf {
+    ainb_plugin_notifyd::paths::Paths::under(home).approve_socket
+}
+
+fn held(home: &Path) -> Vec<HeldRow> {
+    let sock = socket(home);
+    client_list(&sock)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|p| p.tool == "AskUserQuestion")
+        .map(|p| HeldRow {
+            surface: interview_surface(home, &p.session_id).token().to_string(),
+            session_id: p.session_id,
+            workspace: None,
+            request_fingerprint: p.request_fingerprint.unwrap_or_default(),
+            waiting_secs: p.waiting_ms / 1000,
+        })
+        .collect()
+}
+
+fn list(home: &Path, format: OutputFormat) -> Result<()> {
+    let rows = held(home);
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+    if rows.is_empty() {
+        println!("no interviews are being held open");
+        println!(
+            "(default surface: {} — set with `ainb fleet interview surface native|fleet`)",
+            interview_surface(home, "").token()
+        );
+        return Ok(());
+    }
+    println!(
+        "{:<38} {:<26} {:>8}  {}",
+        "SESSION", "WORKSPACE", "WAITING", "FINGERPRINT"
+    );
+    for r in &rows {
+        println!(
+            "{:<38} {:<26} {:>7}s  {}",
+            r.session_id,
+            r.workspace.as_deref().unwrap_or("-"),
+            r.waiting_secs,
+            r.request_fingerprint
+        );
+    }
+    println!("\nrelease to the terminal: ainb fleet interview release <session>");
+    Ok(())
+}
+
+fn release(home: &Path, session: Option<&str>) -> Result<()> {
+    let rows = held(home);
+    // With no argument, release the ONLY held interview. Guessing between
+    // several would be worse than refusing: the wrong pick silently hands
+    // somebody else's question back to a terminal nobody is watching.
+    let pane_session = crate::cli::fleet::atc::pane_held_session(home);
+    let row = match session {
+        Some(id) => rows.iter().find(|r| r.session_id == id).with_context(|| {
+            format!("session {id} is not holding an interview (see `ainb fleet interview list`)")
+        })?,
+        // Bound to `prefix + A`, this runs INSIDE the held pane, so the pane's
+        // own session is the only sane target: releasing "the only held one"
+        // would hand somebody else's question back to a terminal nobody is
+        // watching the moment two are held at once.
+        None => match pane_session.and_then(|id| rows.iter().find(|r| r.session_id == id)) {
+            Some(row) => row,
+            None if rows.len() == 1 => &rows[0],
+            None if rows.is_empty() => anyhow::bail!("no interviews are being held open"),
+            None => anyhow::bail!(
+                "this pane is not holding an interview, and {} others are; name one \
+                 (see `ainb fleet interview list`)",
+                rows.len()
+            ),
+        },
+    };
+    let ack = client_release_structured(&socket(home), &row.session_id, &row.request_fingerprint)
+        .context("releasing the held interview")?;
+    if ack.matched {
+        println!(
+            "released {} — Claude's picker is now in its terminal",
+            row.session_id
+        );
+    } else {
+        println!(
+            "{} was not holding that request any more (already answered or released)",
+            row.session_id
+        );
+    }
+    Ok(())
+}
+
+fn surface(home: &Path, mode: Option<&str>, session: Option<&str>) -> Result<()> {
+    let Some(mode) = mode else {
+        match session {
+            Some(id) => println!("{id}: {}", interview_surface(home, id).token()),
+            None => println!("default: {}", interview_surface(home, "").token()),
+        }
+        return Ok(());
+    };
+    let target = if mode == "fleet" {
+        InterviewSurface::Fleet
+    } else {
+        InterviewSurface::Native
+    };
+    set_interview_surface(home, session, target)?;
+    match session {
+        Some(id) => println!("{id}: {}", target.token()),
+        None => println!(
+            "default: {} (persisted to config.toml under [fleet.interview])",
+            target.token()
+        ),
+    }
+    Ok(())
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/mod.rs
@@ -20,8 +20,10 @@ pub mod cost;
 pub mod daemon;
 pub mod daemons;
 pub mod enrich_cache;
+pub mod interview;
 pub mod msg;
 pub mod needs;
+pub mod open_terminal;
 pub mod runtime;
 pub mod sequence;
 pub mod standup;
@@ -36,6 +38,8 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
             )
             .await
         }
+        Some(("interview", sub)) => interview::execute(sub, format).await,
+        Some(("open-terminal", sub)) => open_terminal::execute(sub),
         Some(("deny", sub)) => {
             approve::execute(sub, format, ainb_plugin_notifyd::broker::DecisionKind::Deny).await
         }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/open_terminal.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/open_terminal.rs
@@ -1,0 +1,82 @@
+// ABOUTME: `ainb fleet open-terminal <tmux-target>` — attach to a session in a
+// real terminal window.
+//
+// The macOS Fleet app can be deeplinked INTO (`ainbfleet://session/<key>`) but
+// had no way to send you OUT to the session, so a read-only interview card named
+// a pane you then had to find yourself. The terminal choice lives in Rust
+// (`[fleet] terminal` in config.toml) rather than in Swift so there is one
+// source of truth and the app stays a one-line `Process` call.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+
+/// Map the configured token to a macOS application name.
+///
+/// Unknown tokens fall back to Terminal.app rather than failing: the point of
+/// the button is to land you somewhere, and a typo in config should not make it
+/// silently do nothing.
+fn terminal_app(token: &str) -> &'static str {
+    match token.trim().to_ascii_lowercase().as_str() {
+        "warp" => "Warp",
+        "iterm" | "iterm2" => "iTerm",
+        "ghostty" => "Ghostty",
+        _ => "Terminal",
+    }
+}
+
+pub fn execute(matches: &clap::ArgMatches) -> Result<()> {
+    let target = matches.get_one::<String>("target").context("a tmux target is required")?;
+    // tmux targets are shell-interpolated into the script below, so anything
+    // that is not a plausible target is refused rather than escaped: these
+    // strings arrive from a UI and a session name is never exotic.
+    if target.is_empty()
+        || !target
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '@' | '%'))
+    {
+        anyhow::bail!("refusing to open an implausible tmux target: {target}");
+    }
+    let config = crate::config::AppConfig::load().unwrap_or_default();
+    let app = terminal_app(&config.fleet.terminal);
+
+    // A `.command` file is the one launch shape every macOS terminal honours:
+    // `open -a <App> <file>` opens a window running it. Passing the command as
+    // argv differs per terminal, and AppleScript needs automation permission we
+    // would rather not require.
+    let dir = std::env::temp_dir().join("ainb-open-terminal");
+    std::fs::create_dir_all(&dir).context("creating the launcher directory")?;
+    let script = dir.join(format!("attach-{}.command", sanitize(target)));
+    {
+        let mut file = std::fs::File::create(&script).context("writing the launcher")?;
+        writeln!(file, "#!/bin/bash")?;
+        // `-A` attaches if the session exists and creates it otherwise, which is
+        // wrong here: a typo would spawn an empty session that looks like the
+        // real one. Plain attach fails loudly instead.
+        writeln!(file, "exec tmux attach -t {target}")?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .context("making the launcher executable")?;
+    }
+    let status = std::process::Command::new("open")
+        .arg("-a")
+        .arg(app)
+        .arg(&script)
+        .status()
+        .context("launching the terminal")?;
+    if !status.success() {
+        anyhow::bail!("{app} refused to open (is it installed?)");
+    }
+    println!("opened {target} in {app}");
+    Ok(())
+}
+
+fn sanitize(target: &str) -> String {
+    target
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/open_terminal.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/open_terminal.rs
@@ -26,6 +26,11 @@ fn terminal_app(token: &str) -> &'static str {
 }
 
 pub fn execute(matches: &clap::ArgMatches) -> Result<()> {
+    // `open -a` is macOS-only, and this verb is registered on every platform.
+    // Say so, rather than failing with a generic "launching the terminal".
+    if !cfg!(target_os = "macos") {
+        anyhow::bail!("`fleet open-terminal` is macOS-only; attach with `tmux attach -t <target>`");
+    }
     let target = matches.get_one::<String>("target").context("a tmux target is required")?;
     // tmux targets are shell-interpolated into the script below, so anything
     // that is not a plausible target is refused rather than escaped: these
@@ -38,7 +43,7 @@ pub fn execute(matches: &clap::ArgMatches) -> Result<()> {
         anyhow::bail!("refusing to open an implausible tmux target: {target}");
     }
     let config = crate::config::AppConfig::load().unwrap_or_default();
-    let app = terminal_app(&config.fleet.terminal);
+    let app = terminal_app(config.fleet.terminal_token());
 
     // A `.command` file is the one launch shape every macOS terminal honours:
     // `open -a <App> <file>` opens a window running it. Passing the command as

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -2503,6 +2503,49 @@ impl CliCommand for FleetCommand {
             "Deny a session's pending permission request \
              (no arg: list every waiter with worktree, tool, input and age)",
         ));
+        // `interview` is the non-GUI lever for the AskUserQuestion surface.
+        // Releasing a held interview used to require a key in the Hangar Fleet
+        // screen, which is useless precisely when the thing you need to unblock
+        // IS your terminal.
+        let interview = Command::new("interview")
+            .about("Claude interviews: which surface answers them, and release a held one")
+            .subcommand_required(true)
+            .subcommand(
+                Command::new("list")
+                    .about("Interviews currently held open, with their fingerprints"),
+            )
+            .subcommand(
+                Command::new("release")
+                    .about("Hand a held interview back to Claude's own picker in the terminal")
+                    .arg(
+                        clap::Arg::new("session")
+                            .help("Provider session id (see `ainb fleet interview list`)")
+                            .required(false),
+                    ),
+            )
+            .subcommand(
+                Command::new("surface")
+                    .about("Where interviews are answered (config.toml [fleet.interview]). Default: native")
+                    .arg(
+                        clap::Arg::new("mode")
+                            .help("native = picker shows immediately; fleet = hold for Fleet/macOS")
+                            .value_parser(["native", "fleet"])
+                            .required(false),
+                    )
+                    .arg(
+                        clap::Arg::new("session")
+                            .long("session")
+                            .help("Apply to one session id instead of the global default")
+                            .required(false),
+                    ),
+            );
+        let open_terminal = Command::new("open-terminal")
+            .about("Attach to a session in a real terminal window (terminal from config.toml [fleet] terminal)")
+            .arg(
+                clap::Arg::new("target")
+                    .help("tmux target, e.g. tmux_myrepo--f-thing--abcd1234_f_thing")
+                    .required(true),
+            );
         let atc = build_atc_command();
         let bridge = Command::new("bridge")
             .about(
@@ -2527,6 +2570,8 @@ impl CliCommand for FleetCommand {
                 .arg_required_else_help(true)
                 .subcommand(approve)
                 .subcommand(deny)
+                .subcommand(interview)
+                .subcommand(open_terminal)
                 .subcommand(standup)
                 .subcommand(broadcast)
                 .subcommand(msg)
@@ -3028,7 +3073,7 @@ mod tests {
     }
 
     #[test]
-    fn fleet_exposes_twenty_one_subcommands_including_the_chat_bus_verbs() {
+    fn fleet_exposes_twenty_three_subcommands_including_the_interview_levers() {
         // The `fleet` namespace surface. Adding/removing a fleet subcommand MUST
         // update this count + list — it is the registry guard the daemons-
         // observability feature wired through. `daemon` (the watcher) and
@@ -3060,8 +3105,10 @@ mod tests {
                 "daemons",
                 "deny",
                 "enrich-cache",
+                "interview",
                 "msg",
                 "needs",
+                "open-terminal",
                 "runtime",
                 "sequence",
                 "standup",
@@ -3071,8 +3118,8 @@ mod tests {
         );
         assert_eq!(
             names.len(),
-            21,
-            "expected 21 fleet subcommands, got {names:?}"
+            23,
+            "expected 23 fleet subcommands, got {names:?}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -448,11 +448,72 @@ pub struct PluginsConfig {
 /// Currently only carries cost budget caps; reserved as the home for
 /// future fleet-wide knobs so they share one `[fleet]` table in
 /// `config.toml`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FleetConfig {
     /// Budget caps for `ainb fleet cost`. See [`CostBudgetConfig`].
     #[serde(default)]
     pub cost: CostBudgetConfig,
+    /// Which surface answers Claude interviews. See [`InterviewConfig`].
+    #[serde(default)]
+    pub interview: InterviewConfig,
+    /// Terminal the macOS Fleet app opens when you jump to a session.
+    ///
+    /// `warp` | `iterm` | `ghostty` | `terminal`. Defaults to `warp`; the macOS
+    /// default handler would almost always be Terminal.app, which lands you in
+    /// the wrong terminal.
+    #[serde(default = "default_fleet_terminal")]
+    pub terminal: String,
+}
+
+fn default_fleet_terminal() -> String {
+    "warp".to_string()
+}
+
+impl Default for FleetConfig {
+    fn default() -> Self {
+        Self {
+            cost: CostBudgetConfig::default(),
+            interview: InterviewConfig::default(),
+            terminal: default_fleet_terminal(),
+        }
+    }
+}
+
+/// Where an `AskUserQuestion` is answered.
+///
+/// `native` (the DEFAULT) lets Claude draw its own picker immediately and
+/// mirrors a read-only card into Fleet. `fleet` makes the PreToolUse hook HOLD
+/// the tool call so Fleet or the macOS app can answer it as exact JSON, with no
+/// synthetic keystrokes — at the cost of suppressing the terminal picker until
+/// someone answers or releases it.
+///
+/// Native is the default deliberately: holding is the more powerful mode but it
+/// strands an operator who is sitting at the terminal, so it is opted into
+/// rather than inherited.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [fleet.interview]
+/// surface = "native"   # or "fleet" to hold for remote answering
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InterviewConfig {
+    /// `"native"` or `"fleet"`. Unrecognised values read as `"native"`, so a
+    /// typo can never silently start holding tool calls.
+    #[serde(default = "default_interview_surface")]
+    pub surface: String,
+}
+
+fn default_interview_surface() -> String {
+    "native".to_string()
+}
+
+impl Default for InterviewConfig {
+    fn default() -> Self {
+        Self {
+            surface: default_interview_surface(),
+        }
+    }
 }
 
 /// Spend ceilings consumed by `ainb fleet cost`.
@@ -1051,6 +1112,16 @@ impl AppConfig {
         // intact.
         if !other.fleet.cost.is_empty() {
             self.fleet.cost = other.fleet.cost;
+        }
+        // `merge_loaded` is a hand-written field-by-field merge, so a struct
+        // field that is not named here is silently DROPPED no matter what the
+        // file says. An unset section deserializes to the default, so only a
+        // non-default value counts as "the file set this".
+        if other.fleet.interview != InterviewConfig::default() {
+            self.fleet.interview = other.fleet.interview.clone();
+        }
+        if other.fleet.terminal != default_fleet_terminal() {
+            self.fleet.terminal.clone_from(&other.fleet.terminal);
         }
 
         // Pool settings: trust the loaded layer whenever it differs from the

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -461,12 +461,13 @@ pub struct FleetConfig {
     /// `warp` | `iterm` | `ghostty` | `terminal`. Defaults to `warp`; the macOS
     /// default handler would almost always be Terminal.app, which lands you in
     /// the wrong terminal.
-    #[serde(default = "default_fleet_terminal")]
-    pub terminal: String,
+    /// `Option` for the same presence reason as [`InterviewConfig::surface`].
+    #[serde(default)]
+    pub terminal: Option<String>,
 }
 
-fn default_fleet_terminal() -> String {
-    "warp".to_string()
+fn default_fleet_terminal() -> &'static str {
+    "warp"
 }
 
 impl Default for FleetConfig {
@@ -474,7 +475,7 @@ impl Default for FleetConfig {
         Self {
             cost: CostBudgetConfig::default(),
             interview: InterviewConfig::default(),
-            terminal: default_fleet_terminal(),
+            terminal: None,
         }
     }
 }
@@ -500,8 +501,13 @@ impl Default for FleetConfig {
 pub struct InterviewConfig {
     /// `"native"` or `"fleet"`. Unrecognised values read as `"native"`, so a
     /// typo can never silently start holding tool calls.
-    #[serde(default = "default_interview_surface")]
-    pub surface: String,
+    ///
+    /// `Option` so the merge can tell "this layer said native" from "this layer
+    /// said nothing". Comparing against the default cannot: a project config
+    /// explicitly setting `native` would be indistinguishable from an absent
+    /// section and would lose to a user config saying `fleet`.
+    #[serde(default)]
+    pub surface: Option<String>,
 }
 
 fn default_interview_surface() -> String {
@@ -510,9 +516,23 @@ fn default_interview_surface() -> String {
 
 impl Default for InterviewConfig {
     fn default() -> Self {
-        Self {
-            surface: default_interview_surface(),
-        }
+        Self { surface: None }
+    }
+}
+
+impl FleetConfig {
+    /// The effective terminal token, applying the `warp` default.
+    #[must_use]
+    pub fn terminal_token(&self) -> &str {
+        self.terminal.as_deref().unwrap_or(default_fleet_terminal())
+    }
+}
+
+impl InterviewConfig {
+    /// The effective surface token, applying the `native` default.
+    #[must_use]
+    pub fn surface_token(&self) -> &str {
+        self.surface.as_deref().unwrap_or("native")
     }
 }
 
@@ -1117,10 +1137,10 @@ impl AppConfig {
         // field that is not named here is silently DROPPED no matter what the
         // file says. An unset section deserializes to the default, so only a
         // non-default value counts as "the file set this".
-        if other.fleet.interview != InterviewConfig::default() {
+        if other.fleet.interview.surface.is_some() {
             self.fleet.interview = other.fleet.interview.clone();
         }
-        if other.fleet.terminal != default_fleet_terminal() {
+        if other.fleet.terminal.is_some() {
             self.fleet.terminal.clone_from(&other.fleet.terminal);
         }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -635,6 +635,15 @@ private struct FleetNotchDetail: View {
                     .disabled(questionIndex + 1 >= deck.questions.count)
             }
             Spacer()
+            // The app can be deeplinked INTO (ainbfleet://session/<key>) but had
+            // no way to send you OUT, so a card named a pane you then had to go
+            // find. `ainb fleet open-terminal` owns the terminal choice, from
+            // config.toml [fleet] terminal, so this stays a one-line call.
+            if let target = session.tmuxTarget, !target.isEmpty {
+                Button("Open session") { openSession(target) }
+                    .font(.caption)
+                    .help("Attach to this session in a terminal window")
+            }
             if session.capabilities.structuredDismiss {
                 Button("Reject", role: .destructive) { rejectConfirmation = true }
                     .font(.caption)
@@ -643,6 +652,30 @@ private struct FleetNotchDetail: View {
                 .buttonStyle(.borderedProminent)
                 .font(.caption)
                 .disabled(!complete(deck) || (deck.mirroredPicker && hasTextAnswer(deck)) || store.pendingIntentID != nil)
+        }
+    }
+
+    /// Attach to a session in a real terminal window.
+    ///
+    /// Shells out rather than reimplementing the launch: which terminal to use
+    /// is a setting (`[fleet] terminal`), and duplicating that resolution in
+    /// Swift would let the two drift. Failure is surfaced in `controlNotice`
+    /// for the same reason a failed delivery is — a button that silently does
+    /// nothing is worse than one that says why.
+    private func openSession(_ tmuxTarget: String) {
+        let candidates = ["/opt/homebrew/bin/ainb", "/usr/local/bin/ainb"]
+        guard let binary = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) })
+        else {
+            store.reportControlNotice("Open session failed: ainb not found on this machine.")
+            return
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = ["fleet", "open-terminal", tmuxTarget]
+        do {
+            try process.run()
+        } catch {
+            store.reportControlNotice("Open session failed: \(error.localizedDescription)")
         }
     }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -672,6 +672,27 @@ private struct FleetNotchDetail: View {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: binary)
         process.arguments = ["fleet", "open-terminal", tmuxTarget]
+        let errors = Pipe()
+        process.standardError = errors
+        // `run()` throws only when the LAUNCH fails. A non-zero exit — the
+        // configured terminal not being installed, or a refused target — would
+        // otherwise leave the button doing visibly nothing, which is the exact
+        // defect this function's own doc says it exists to prevent.
+        process.terminationHandler = { finished in
+            guard finished.terminationStatus != 0 else { return }
+            let detail = String(
+                data: errors.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            Task { @MainActor in
+                self.store.reportControlNotice(
+                    detail.isEmpty
+                        ? "Open session failed (exit \(finished.terminationStatus))."
+                        : "Open session failed: \(detail)"
+                )
+            }
+        }
         do {
             try process.run()
         } catch {

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -1088,6 +1088,15 @@ final class FleetStore: ObservableObject {
         }
     }
 
+    /// Surface a message from a caller that is not itself a store action.
+    ///
+    /// `controlNotice` stays `private(set)` so the store keeps ownership of what
+    /// the operator is told; this is the one narrow door, used by side actions
+    /// like "Open session" whose failure must not be silent.
+    func reportControlNotice(_ message: String) {
+        controlNotice = message
+    }
+
     private func record(_ receipt: FleetActionReceipt) {
         record([receipt])
     }

--- a/docs/man/ainb.1
+++ b/docs/man/ainb.1
@@ -189,9 +189,9 @@ watch, tail
 Fleet orchestration: standup / broadcast / sequence / needs / cost / runtime
 / daemon / daemons / atc / bridge
 .br
-Subcommands: approve, deny, standup, broadcast, msg, acp, transcript,
-channel, copilot, confirm, activity, sequence, needs, archived, cost,
-daemon, daemons, runtime, atc, bridge, enrich\-cache
+Subcommands: approve, deny, interview, open\-terminal, standup, broadcast,
+msg, acp, transcript, channel, copilot, confirm, activity, sequence, needs,
+archived, cost, daemon, daemons, runtime, atc, bridge, enrich\-cache
 .TP
 .B ainb headroom
 Manage the ainb\-managed Headroom compression proxy

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2018,28 +2018,30 @@ Fleet orchestration: standup / broadcast / sequence / needs / cost / runtime / d
 Usage: ainb fleet [OPTIONS] <COMMAND>
 
 Commands:
-  approve       Approve a session's pending permission request (no arg: list every waiter with worktree, tool, input and age)
-  deny          Deny a session's pending permission request (no arg: list every waiter with worktree, tool, input and age)
-  standup       Live fleet status: every claude session across ainb + peers + bg jobs
-  broadcast     Send one prompt to selected sessions (peers-first, tmux fallback)
-  msg           Chat bus: persisted messages with per-recipient delivery receipts
-  acp           ACP sessions: daemon-owned headless agents that answer on the chat bus
-  transcript    Page or follow one session's full execution transcript
-  channel       Chat channels: a named scope with a recipient set
-  copilot       The fleet copilot session's per-session adapter config
-  confirm       Guardrail confirm cards: copilot tool calls held for a human
-  activity      The append-only copilot activity feed
-  sequence      Ordered prompts with ack between steps
-  needs         Center control panel — sessions blocked on input / errors / idle / waiting
-  archived      Sessions the daemon retired out of the live roster (still browsable)
-  cost          Per-session / model / day / group spend rollups + budget caps
-  daemon        Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
-  daemons       Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
-  runtime       Install the standalone Fleet daemon and provider hooks
-  atc           Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
-  bridge        Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
-  enrich-cache  Content-addressed enrich cache (the producer's write path)
-  help          Print this message or the help of the given subcommand(s)
+  approve        Approve a session's pending permission request (no arg: list every waiter with worktree, tool, input and age)
+  deny           Deny a session's pending permission request (no arg: list every waiter with worktree, tool, input and age)
+  interview      Claude interviews: which surface answers them, and release a held one
+  open-terminal  Attach to a session in a real terminal window (terminal from config.toml [fleet] terminal)
+  standup        Live fleet status: every claude session across ainb + peers + bg jobs
+  broadcast      Send one prompt to selected sessions (peers-first, tmux fallback)
+  msg            Chat bus: persisted messages with per-recipient delivery receipts
+  acp            ACP sessions: daemon-owned headless agents that answer on the chat bus
+  transcript     Page or follow one session's full execution transcript
+  channel        Chat channels: a named scope with a recipient set
+  copilot        The fleet copilot session's per-session adapter config
+  confirm        Guardrail confirm cards: copilot tool calls held for a human
+  activity       The append-only copilot activity feed
+  sequence       Ordered prompts with ack between steps
+  needs          Center control panel — sessions blocked on input / errors / idle / waiting
+  archived       Sessions the daemon retired out of the live roster (still browsable)
+  cost           Per-session / model / day / group spend rollups + budget caps
+  daemon         Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
+  daemons        Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
+  runtime        Install the standalone Fleet daemon and provider hooks
+  atc            Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
+  bridge         Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
+  enrich-cache   Content-addressed enrich cache (the producer's write path)
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -2097,6 +2099,97 @@ Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
       --reason <reason>  Optional reason relayed to the agent with the decision [default: ""]
       --full             When listing, print the complete tool input and cwd, not a preview
+  -h, --help             Print help
+```
+
+### `ainb fleet interview`
+
+Claude interviews: which surface answers them, and release a held one
+
+```console
+$ ainb fleet interview --help
+Claude interviews: which surface answers them, and release a held one
+
+Usage: ainb fleet interview [OPTIONS] <COMMAND>
+
+Commands:
+  list     Interviews currently held open, with their fingerprints
+  release  Hand a held interview back to Claude's own picker in the terminal
+  surface  Where interviews are answered (config.toml [fleet.interview]). Default: native
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet interview list`
+
+Interviews currently held open, with their fingerprints
+
+```console
+$ ainb fleet interview list --help
+Interviews currently held open, with their fingerprints
+
+Usage: ainb fleet interview list [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet interview release`
+
+Hand a held interview back to Claude's own picker in the terminal
+
+```console
+$ ainb fleet interview release --help
+Hand a held interview back to Claude's own picker in the terminal
+
+Usage: ainb fleet interview release [OPTIONS] [session]
+
+Arguments:
+  [session]  Provider session id (see `ainb fleet interview list`)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb fleet interview surface`
+
+Where interviews are answered (config.toml [fleet.interview]). Default: native
+
+```console
+$ ainb fleet interview surface --help
+Where interviews are answered (config.toml [fleet.interview]). Default: native
+
+Usage: ainb fleet interview surface [OPTIONS] [mode]
+
+Arguments:
+  [mode]  native = picker shows immediately; fleet = hold for Fleet/macOS [possible values: native, fleet]
+
+Options:
+      --format <format>    Output format [default: text] [possible values: text, json, csv, markdown]
+      --session <session>  Apply to one session id instead of the global default
+  -h, --help               Print help
+```
+
+### `ainb fleet open-terminal`
+
+Attach to a session in a real terminal window (terminal from config.toml [fleet] terminal)
+
+```console
+$ ainb fleet open-terminal --help
+Attach to a session in a real terminal window (terminal from config.toml [fleet] terminal)
+
+Usage: ainb fleet open-terminal [OPTIONS] <target>
+
+Arguments:
+  <target>  tmux target, e.g. tmux_myrepo--f-thing--abcd1234_f_thing
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
   -h, --help             Print help
 ```
 


### PR DESCRIPTION
Follow-on to #699. That shipped hold-for-fleet as the DEFAULT, which suppressed Claude's own picker for every fleet session. Wrong default: holding is the powerful mode but it strands an operator sitting at the terminal. Native is now the default; fleet-hold is opted into.

```
  /interview fires
        |
   surface = native  (DEFAULT)      surface = fleet  (opt-in)
        |                                 |
   picker prints immediately         hook HOLDS <=640s
   fleet/macOS: card + Open session  picker suppressed
                                     window lit [ASK>FLEET] <header>
                                          |
                                     answer in fleet  -> exact JSON
                                     prefix + A       -> picker returns here
```

## Settings live in config.toml

```toml
[fleet]
terminal = "warp"      # warp | iterm | ghostty | terminal

[fleet.interview]
surface = "native"     # or "fleet"
```

Per-session overrides stay runtime state — ephemeral, keyed by uuid, does not belong in a config file.

## New levers

| command | does |
|---|---|
| `ainb fleet interview list` | what is held, with fingerprints |
| `ainb fleet interview release` | hand it back to the terminal |
| `ainb fleet interview surface` | native \| fleet, global or `--session` |
| `ainb fleet open-terminal` | attach to a session in a real terminal |
| `prefix + A` (tmux) | release THIS pane's interview |
| macOS **Open session** | same, from the card |

The release matters because **a held pane cannot free itself**: while the hook holds the tool call Claude owns stdin, so nothing typed inside the session reaches us. It has to arrive from outside. `A` because tmux already binds `i` to display-message. Release resolves the PANE's own session — releasing "the only held one" would free somebody else's question into a terminal nobody is watching once two are held.

## Banner

Now names the surface and lights up: `[ASK>FLEET] <header>` with a yellow window-status-style, since a rename alone is easy to scan past in a bar full of windows. Name, style and automatic-rename are all restored on release.

## Trap fixed twice

`AppConfig::merge_loaded` is a hand-written field-by-field merge, so a new config field is read from the file and then **silently dropped** unless named there. `surface = "fleet"` persisted correctly and always read back `native` until the merge line landed. Both new fields are merged.

## Validation

`cargo test -p ainb --lib`: **1821 passed**. `xcodebuild test`: **149 passed**. rustfmt clean.

Live, on Claude Code 2.1.237:

| behaviour | result |
|---|---|
| default native | picker instant, no hold, window `claude` |
| flip to fleet | picker suppressed, `[ASK>FLEET] Ban`, window lit yellow |
| `prefix + A` release | picker returns, name/style/auto-rename restored |
| answer after release | `⎿ → p-d02368` then `PROPAGATED:p-d02368` |
| macOS Open session | wrote `exec tmux attach -t tmux_surftest`, launched Warp |

Note: a tmux prefix binding cannot be triggered by `send-keys` (the client handles the prefix), so the binding was verified by running its exact command with a real pane id.

https://claude.ai/code/session_01YTgF3YEyfWZk3HwpjTJfyU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls for viewing, releasing, and configuring Fleet interviews as native Claude prompts or Fleet-held sessions.
  * Added session-specific and global interview-surface settings.
  * Added `fleet open-terminal` to launch sessions in the configured macOS terminal.
  * Added an “Open session” button to interview details when a terminal target is available.
  * Added a tmux shortcut for releasing held interviews.
* **Bug Fixes**
  * Improved handling of unavailable or invalid interview release requests.
  * Restored tmux window and status settings after Fleet-held interviews.
* **Documentation**
  * Updated Fleet command documentation with the new interview and terminal controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->