### PR TITLE
fix(fleet): native interviews are read-only from remote surfaces

### DIFF
--- a/ainb-tui/config/tmux.conf
+++ b/ainb-tui/config/tmux.conf
@@ -257,4 +257,12 @@ run '~/.tmux/plugins/tpm/tpm'
 # shows TMUX and TERM but no TMUX_PANE), so it is passed explicitly via format
 # expansion, which run-shell DOES perform. Without this the pane-aware lookup
 # never fires and prefix+A refuses whenever more than one interview is held.
-bind-key A run-shell 'TMUX_PANE=#{pane_id} ainb fleet interview release'
+#
+# The binary is resolved through the hook pointer rather than by name. A tmux
+# server outlives upgrades and is often started before the shell profile that
+# puts ainb on PATH, so a bare `ainb` here resolves against the SERVER's stale
+# environment and dies with 127. `hooks/ainb-bin` is the same indirection the
+# Claude hooks already use and always names the live binary; `command -v ainb`
+# is the fallback when that file is absent. AINB_HOME relocates the state dir
+# for tests and sandboxes and defaults to ~/.agents-in-a-box.
+bind-key A run-shell 'TMUX_PANE=#{pane_id} "$(cat "${AINB_HOME:-$HOME/.agents-in-a-box}/hooks/ainb-bin" 2>/dev/null || command -v ainb)" fleet interview release'

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -86,6 +86,14 @@ const PERMISSION_DENIED: i32 = -32000;
 /// Soft cap on one request body. Snapshot requests are tiny.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 
+/// Why a `mirrored` interview cannot be answered from a remote surface.
+///
+/// Shown verbatim to the operator, so it names the fix rather than the fault:
+/// the question is answerable, just not from here while the surface is native.
+pub const MIRRORED_IS_READ_ONLY: &str =
+    "this interview is showing in Claude's own picker — answer it in the session, \
+     or set `ainb fleet interview surface fleet` to hold the next one for Fleet";
+
 /// Cross-process, crash-safe ownership of one operation against one Hangar DB.
 ///
 /// The lock file sits beside `hangar.db`, so duplicate daemons using the same
@@ -3995,7 +4003,6 @@ async fn execute_fleet_action(
                         pool,
                         events,
                         &session,
-                        params.expected_version,
                         request_fingerprint,
                         answers,
                     )
@@ -4390,9 +4397,8 @@ async fn kill_tmux_session_exact(session_name: &str) -> Result<(), String> {
 #[cfg(test)]
 mod fleet_launch_tests {
     use super::{
-        MirroredClaudePickerStep, managed_codex_tmux_args, managed_codex_tmux_name,
-        mirrored_claude_picker_steps, normalize_picker_text, squeeze_picker_text,
-        verify_claude_picker_question, verify_picker_pane,
+        managed_codex_tmux_args, managed_codex_tmux_name, normalize_picker_text,
+        verify_picker_pane,
     };
     use std::ffi::{OsStr, OsString};
     use std::path::Path;
@@ -4521,164 +4527,10 @@ mod fleet_launch_tests {
         assert!(error.contains("newer picker"));
     }
 
-    #[test]
-    fn mirrored_claude_picker_routes_multi_question_answers_and_submit() {
-        let questions = vec![
-            serde_json::json!({
-                "id": "region",
-                "question": "Deploy to which region?",
-                "options": [{"label": "Europe"}, {"label": "United States"}]
-            }),
-            serde_json::json!({
-                "id": "checks",
-                "question": "Which checks should run?",
-                "multiSelect": true,
-                "options": [{"label": "Lint"}, {"label": "Test"}, {"label": "Tripwire"}]
-            }),
-        ];
-        let answers = vec![
-            ainb_hangar_proto::fleet::FleetQuestionAnswer {
-                question_id: "region".to_string(),
-                selected_options: vec!["United States".to_string()],
-                text: None,
-            },
-            ainb_hangar_proto::fleet::FleetQuestionAnswer {
-                question_id: "checks".to_string(),
-                selected_options: vec!["Test".to_string(), "Tripwire".to_string()],
-                text: None,
-            },
-        ];
-        assert_eq!(
-            mirrored_claude_picker_steps(&questions, &answers),
-            Ok(vec![
-                MirroredClaudePickerStep::QuestionKey {
-                    question: questions[0].clone(),
-                    key: "Down".to_string()
-                },
-                MirroredClaudePickerStep::QuestionKey {
-                    question: questions[0].clone(),
-                    key: "Enter".to_string()
-                },
-                MirroredClaudePickerStep::QuestionKey {
-                    question: questions[1].clone(),
-                    key: "Down".to_string()
-                },
-                MirroredClaudePickerStep::QuestionKey {
-                    question: questions[1].clone(),
-                    key: "Space".to_string()
-                },
-                MirroredClaudePickerStep::QuestionKey {
-                    question: questions[1].clone(),
-                    key: "Down".to_string()
-                },
-                MirroredClaudePickerStep::QuestionKey {
-                    question: questions[1].clone(),
-                    key: "Space".to_string()
-                },
-                MirroredClaudePickerStep::QuestionKey {
-                    question: questions[1].clone(),
-                    key: "Tab".to_string()
-                },
-                MirroredClaudePickerStep::Submit { answers },
-            ])
-        );
-    }
 
-    #[test]
-    fn mirrored_claude_picker_single_select_stops_after_option_enter() {
-        let question = serde_json::json!({
-            "id": "choice",
-            "question": "Choose silver or indigo",
-            "options": [{"label": "silver"}, {"label": "indigo"}],
-        });
-        let answers = vec![ainb_hangar_proto::fleet::FleetQuestionAnswer {
-            question_id: "choice".to_string(),
-            selected_options: vec!["indigo".to_string()],
-            text: None,
-        }];
-        assert_eq!(
-            mirrored_claude_picker_steps(&[question.clone()], &answers),
-            Ok(vec![
-                MirroredClaudePickerStep::QuestionKey {
-                    question,
-                    key: "Down".to_string(),
-                },
-                MirroredClaudePickerStep::QuestionKey {
-                    question: serde_json::json!({
-                        "id": "choice",
-                        "question": "Choose silver or indigo",
-                        "options": [{"label": "silver"}, {"label": "indigo"}],
-                    }),
-                    key: "Enter".to_string(),
-                },
-            ])
-        );
-    }
 
-    #[test]
-    fn mirrored_claude_picker_confirms_multi_select_with_tab_never_enter() {
-        // REGRESSION. `Enter` on a Claude multi-select row is a TOGGLE: measured on
-        // 2.1.233 the confirming Enter un-ticked the option the preceding `Space`
-        // had ticked, so the picker never reached the review screen and the answer
-        // landed half-applied. Only `Tab` advances a multi-select question.
-        let question = serde_json::json!({
-            "id": "checks",
-            "question": "Which checks should run?",
-            "multiSelect": true,
-            "options": [{"label": "Lint"}, {"label": "Test"}],
-        });
-        let answers = vec![ainb_hangar_proto::fleet::FleetQuestionAnswer {
-            question_id: "checks".to_string(),
-            selected_options: vec!["Lint".to_string()],
-            text: None,
-        }];
-        let steps = mirrored_claude_picker_steps(&[question], &answers).expect("steps");
-        let keys: Vec<&str> = steps
-            .iter()
-            .filter_map(|step| match step {
-                MirroredClaudePickerStep::QuestionKey { key, .. } => Some(key.as_str()),
-                MirroredClaudePickerStep::Submit { .. } => None,
-            })
-            .collect();
-        assert_eq!(keys, vec!["Space", "Tab"], "got {keys:?}");
-        assert!(
-            matches!(steps.last(), Some(MirroredClaudePickerStep::Submit { .. })),
-            "a multi-select question still has to reach the review screen"
-        );
-    }
 
-    #[test]
-    fn picker_verification_survives_a_hard_wrapped_option_label() {
-        // REGRESSION. The picker box hard-wraps a run of non-space characters that
-        // is longer than its content width, with NO space at the break. Collapsing
-        // whitespace to a single space therefore INVENTED a separator the label
-        // never had and the exact substring match missed, rejecting the answer
-        // before a single key was sent.
-        let long = "hardwrapmidtokenalphabetagammadeltaepsilonzetaetathetaiotakappa";
-        let (head, tail) = long.split_at(long.len() - 1);
-        let question = serde_json::json!({
-            "question": "Which reflow tolerance should the renderer adopt?",
-            "options": [{"label": "softreflow"}, {"label": long}],
-        });
-        let pane = format!(
-            "Which reflow tolerance should the renderer adopt?\n\n\
-             \u{276f} 1. softreflow\n     soft reflow\n  2. {head}\n     {tail}\n     hard wrap\n\n\
-             Enter to select \u{b7} \u{2191}/\u{2193} to navigate \u{b7} Esc to cancel\n"
-        );
-        assert_eq!(verify_claude_picker_question(&question, &pane), Ok(()));
-    }
 
-    #[test]
-    fn squeeze_drops_whitespace_while_normalize_keeps_one_space() {
-        // The mirrored route needs a wrap-tolerant form; the `verify_picker_pane`
-        // route needs the single-space separator its offset reconstruction in
-        // `has_later_picker_candidate` and its whitespace-split option-marker
-        // check are both written against. Two contracts, two functions.
-        assert_eq!(squeeze_picker_text("abc\n  d"), squeeze_picker_text("abcd"));
-        assert_eq!(squeeze_picker_text(" \u{2502} a b \u{2502} "), "ab");
-        assert_eq!(normalize_picker_text("abc\n  d"), "abc d");
-        assert_eq!(normalize_picker_text(" \u{2502} a b \u{2502} "), "a b");
-    }
 
     #[test]
     fn verified_picker_rejects_a_newer_picker_whose_prompt_has_no_question_mark() {
@@ -4698,24 +4550,6 @@ mod fleet_launch_tests {
         assert!(error.contains("newer picker"), "got: {error}");
     }
 
-    #[test]
-    fn mirrored_claude_picker_rejects_unverified_text_route() {
-        let questions = vec![serde_json::json!({
-            "id": "region",
-            "question": "Deploy to which region?",
-            "options": [{"label": "Europe"}]
-        })];
-        let answers = vec![ainb_hangar_proto::fleet::FleetQuestionAnswer {
-            question_id: "region".to_string(),
-            selected_options: vec![],
-            text: Some("Custom region".to_string()),
-        }];
-        assert!(
-            mirrored_claude_picker_steps(&questions, &answers)
-                .unwrap_err()
-                .contains("free-text")
-        );
-    }
 }
 
 async fn claude_broker_decide(
@@ -5197,7 +5031,6 @@ async fn execute_claude_structured(
     pool: &SqlitePool,
     events: &EventSink,
     session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
-    expected_version: i64,
     request_fingerprint: &str,
     answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
 ) -> (
@@ -5223,17 +5056,19 @@ async fn execute_claude_structured(
             Some("stored Claude question payload is invalid".to_string()),
         );
     };
-    if request.get("fleet_delivery").and_then(serde_json::Value::as_str) == Some("mirrored") {
-        return execute_claude_mirrored_picker(
-            pool,
-            events,
-            session,
-            expected_version,
-            request_fingerprint,
-            questions,
-            answers,
-        )
-        .await;
+    // `mirrored` means the interview was NOT held: the surface is `native`, so
+    // Claude already drew its own picker and owns that pane's stdin. The only
+    // way to answer from here would be to type blind arrow keys at a vendor TUI
+    // and screen-scrape to check they landed — a guess about a layout that is
+    // not a contract and changed four times in one week, whose failure mode is
+    // answering the WRONG question. Remote answering is the held (`fleet`) lane,
+    // which delivers exact JSON. Native stays read-only: the surfaces show the
+    // question and deep-link into the session so it is answered where it is.
+    if fleet_delivery_uses_native_picker(&request) {
+        return (
+            ActionReceiptStatus::Failed,
+            Some(MIRRORED_IS_READ_ONLY.to_string()),
+        );
     }
     let mut mapped = Vec::with_capacity(answers.len());
     for answer in answers {
@@ -5307,294 +5142,11 @@ async fn execute_claude_structured(
     }
 }
 
-/// Submit one mirrored Claude interview through its visible native picker.
-///
-/// Every key is checked against the exact request and live native screen before
-/// delivery. Free-text controls stay unavailable until their input state has
-/// equivalent verification coverage.
-async fn execute_claude_mirrored_picker(
-    pool: &SqlitePool,
-    events: &EventSink,
-    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
-    expected_version: i64,
-    request_fingerprint: &str,
-    questions: &[serde_json::Value],
-    answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
-) -> (
-    ainb_hangar_proto::fleet::ActionReceiptStatus,
-    Option<String>,
-) {
-    use ainb_hangar_proto::fleet::ActionReceiptStatus;
 
-    let steps = match mirrored_claude_picker_steps(questions, answers) {
-        Ok(steps) => steps,
-        Err(detail) => return (ActionReceiptStatus::Rejected, Some(detail)),
-    };
-    for (index, step) in steps.into_iter().enumerate() {
-        if index > 0 {
-            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-        }
-        let (status, detail) = verified_tmux_picker_for_mirrored_step(
-            pool,
-            session,
-            expected_version,
-            request_fingerprint,
-            &step,
-        )
-        .await;
-        if status != ActionReceiptStatus::Delivered {
-            let detail = detail.unwrap_or_else(|| "mirrored Claude picker step failed".to_string());
-            if index == 0 && detail == "Claude native picker is no longer active" {
-                return reconcile_claude_structured(
-                    pool,
-                    events,
-                    session,
-                    request_fingerprint,
-                    expected_version,
-                )
-                .await;
-            }
-            let detail = if index == 0 {
-                detail
-            } else {
-                format!("{detail}; native picker already advanced {index} key(s)")
-            };
-            return (status, Some(detail));
-        }
-    }
-    (
-        ActionReceiptStatus::Delivered,
-        Some("mirrored Claude native picker".to_string()),
-    )
-}
 
-#[derive(Debug, PartialEq, Eq)]
-enum MirroredClaudePickerStep {
-    QuestionKey {
-        question: serde_json::Value,
-        key: String,
-    },
-    Submit {
-        answers: Vec<ainb_hangar_proto::fleet::FleetQuestionAnswer>,
-    },
-}
 
-fn mirrored_claude_picker_steps(
-    questions: &[serde_json::Value],
-    answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
-) -> Result<Vec<MirroredClaudePickerStep>, String> {
-    if questions.len() != answers.len() || questions.is_empty() {
-        return Err("mirrored Claude answers do not cover every question".to_string());
-    }
-    let mut steps = Vec::new();
-    for (index, question) in questions.iter().enumerate() {
-        let question_id = question
-            .get("id")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string)
-            .unwrap_or_else(|| index.to_string());
-        let answer = answers
-            .iter()
-            .find(|answer| answer.question_id == question_id)
-            .ok_or_else(|| "mirrored Claude question is stale".to_string())?;
-        if answer.text.as_deref().is_some_and(|text| !text.trim().is_empty()) {
-            return Err("mirrored Claude free-text answer is not available yet".to_string());
-        }
-        let options = question
-            .get("options")
-            .and_then(serde_json::Value::as_array)
-            .ok_or_else(|| "mirrored Claude options are absent".to_string())?;
-        let mut selected = answer
-            .selected_options
-            .iter()
-            .map(|label| {
-                options
-                    .iter()
-                    .position(|option| {
-                        option.get("label").and_then(serde_json::Value::as_str) == Some(label)
-                    })
-                    .ok_or_else(|| "mirrored Claude option is stale".to_string())
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        selected.sort_unstable();
-        selected.dedup();
-        if selected.len() != answer.selected_options.len() || selected.is_empty() {
-            return Err("mirrored Claude requires listed options".to_string());
-        }
-        let multi_select = question
-            .get("multiSelect")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-        if !multi_select && selected.len() != 1 {
-            return Err("mirrored Claude single-select requires one option".to_string());
-        }
-        let mut cursor = 0;
-        for selected_index in selected {
-            for _ in cursor..selected_index {
-                steps.push(MirroredClaudePickerStep::QuestionKey {
-                    question: question.clone(),
-                    key: "Down".to_string(),
-                });
-            }
-            steps.push(MirroredClaudePickerStep::QuestionKey {
-                question: question.clone(),
-                key: if multi_select { "Space" } else { "Enter" }.to_string(),
-            });
-            cursor = selected_index;
-        }
-        if multi_select {
-            // TAB, NOT ENTER. Claude Code's multi-select rows are checkboxes and
-            // `Enter` on one is a TOGGLE, not a confirm: measured on 2.1.233, the
-            // confirming Enter un-ticked the option the preceding `Space` had just
-            // ticked, the picker stayed on the same question, and the `Submit` step
-            // below then failed its `Review your answers` guard with the answer
-            // half-applied and the picker still owning the pane. `Tab` is what
-            // advances a multi-select question to the next tab (or, on the last
-            // question, to the review screen the `Submit` step expects).
-            //
-            // Single-select keeps `Enter`, which both selects and advances there.
-            steps.push(MirroredClaudePickerStep::QuestionKey {
-                question: question.clone(),
-                key: "Tab".to_string(),
-            });
-        }
-    }
-    if questions.len() == 1
-        && !questions[0]
-            .get("multiSelect")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false)
-    {
-        return Ok(steps);
-    }
-    steps.push(MirroredClaudePickerStep::Submit {
-        answers: answers.to_vec(),
-    });
-    Ok(steps)
-}
 
-async fn verified_tmux_picker_for_mirrored_step(
-    pool: &SqlitePool,
-    session: &ainb_hangar_store::repo::fleet::FleetSessionRow,
-    expected_version: i64,
-    request_fingerprint: &str,
-    step: &MirroredClaudePickerStep,
-) -> (
-    ainb_hangar_proto::fleet::ActionReceiptStatus,
-    Option<String>,
-) {
-    use ainb_hangar_proto::fleet::ActionReceiptStatus;
-    let (Some(target), Some(fingerprint)) = (
-        session.tmux_target.as_deref(),
-        session.process_start_fingerprint.as_deref(),
-    ) else {
-        return (
-            ActionReceiptStatus::Unknown,
-            Some(DETAIL_TMUX_IDENTITY_UNKNOWN.to_string()),
-        );
-    };
-    let discovered = match ainb_fleet_core::discover::discover_all_tmux_panes().await {
-        Ok(discovered) => discovered,
-        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
-    };
-    if !discovered.iter().any(|candidate| {
-        candidate.exact_tmux_target.as_deref() == Some(target)
-            && candidate.process_start_fingerprint.as_deref() == Some(fingerprint)
-            && candidate.provider.as_str() == session.provider
-    }) {
-        return (
-            ActionReceiptStatus::Failed,
-            Some("tmux provider or process identity changed".to_string()),
-        );
-    }
-    let pane = match ainb_fleet_core::read::capture_pane(target, 0).await {
-        Ok(pane) => pane,
-        Err(error) => return (ActionReceiptStatus::Failed, Some(error.to_string())),
-    };
-    let verified = match step {
-        MirroredClaudePickerStep::QuestionKey { question, .. } => {
-            verify_claude_picker_question(question, &pane)
-        }
-        MirroredClaudePickerStep::Submit { answers } => verify_claude_picker_submit(answers, &pane),
-    };
-    if let Err(detail) = verified {
-        return (ActionReceiptStatus::Failed, Some(detail));
-    }
-    if let Err(error) = ainb_hangar_store::repo::fleet::FleetRepo::validate_action_target(
-        pool,
-        &session.session_key,
-        expected_version,
-        Some(request_fingerprint),
-    )
-    .await
-    {
-        return (ActionReceiptStatus::Failed, Some(error.to_string()));
-    }
-    let key = match step {
-        MirroredClaudePickerStep::QuestionKey { key, .. } => key,
-        MirroredClaudePickerStep::Submit { .. } => "Enter",
-    };
-    match ainb_fleet_core::send::tmux_send_picker_key(target, key).await {
-        Ok(()) => (
-            ActionReceiptStatus::Delivered,
-            Some(format!("mirrored tmux picker ({target})")),
-        ),
-        Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
-    }
-}
 
-fn verify_claude_picker_question(question: &serde_json::Value, pane: &str) -> Result<(), String> {
-    if !claude_native_picker_is_visible(pane) {
-        return Err("Claude native picker is no longer active".to_string());
-    }
-    let prompt = question
-        .get("question")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| "mirrored Claude question text is absent".to_string())?;
-    let visible = squeeze_picker_text(pane);
-    let start = visible
-        .rfind(&squeeze_picker_text(prompt))
-        .ok_or_else(|| "visible picker prompt does not match current question".to_string())?;
-    let mut cursor = start + squeeze_picker_text(prompt).len();
-    for option in question
-        .get("options")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| "mirrored Claude options are absent".to_string())?
-    {
-        let label = option
-            .get("label")
-            .and_then(serde_json::Value::as_str)
-            .ok_or_else(|| "mirrored Claude option label is absent".to_string())?;
-        let label = squeeze_picker_text(label);
-        let offset = visible[cursor..].find(&label).ok_or_else(|| {
-            "visible picker option order does not match current question".to_string()
-        })?;
-        cursor += offset + label.len();
-    }
-    Ok(())
-}
-
-fn verify_claude_picker_submit(
-    answers: &[ainb_hangar_proto::fleet::FleetQuestionAnswer],
-    pane: &str,
-) -> Result<(), String> {
-    let visible = squeeze_picker_text(pane);
-    if !visible.contains(&squeeze_picker_text(CLAUDE_PICKER_REVIEW_HEADING))
-        || !visible.contains(&squeeze_picker_text(CLAUDE_PICKER_SUBMIT_ACTION))
-    {
-        return Err("Claude native picker is not ready to submit".to_string());
-    }
-    for answer in answers {
-        for selected in &answer.selected_options {
-            if !visible.contains(&squeeze_picker_text(selected)) {
-                return Err(
-                    "Claude native picker review does not match selected answer".to_string()
-                );
-            }
-        }
-    }
-    Ok(())
-}
 
 /// One-line render of a delivered interview answer for the attention row's audit
 /// `answer` column: what the control centre shows as "answered by fleet: …".
@@ -5953,10 +5505,6 @@ fn fleet_delivery_uses_native_picker(request: &serde_json::Value) -> bool {
     )
 }
 
-// Observed in Claude Code 2.1.226, exercised by the mirrored-picker live test.
-const CLAUDE_PICKER_REVIEW_HEADING: &str = "Review your answers";
-const CLAUDE_PICKER_SUBMIT_ACTION: &str = "Submit answers";
-
 /// The approve broker socket this daemon delivers answers and permission
 /// decisions on.
 ///
@@ -6235,8 +5783,12 @@ fn picker_question_evidence(
 /// whole-pane rendering of this function by adding exactly one character
 /// between lines, and [`is_numbered_picker_token`] splits a normalized line on
 /// whitespace to find a `1.` / `2)` option marker. Both silently mis-behave if
-/// this joins with anything else. The wrap-tolerant form the mirrored Claude
-/// picker needs is [`squeeze_picker_text`], deliberately a separate function.
+/// this joins with anything else.
+///
+/// Scope note: this is only used to answer "is a picker on screen at all", for
+/// deciding whether a release put one back. It deliberately does NOT try to
+/// match option labels in order — that is what the deleted mirrored-answer path
+/// did, and matching a vendor TUI's wrapped layout is what made it unreliable.
 fn normalize_picker_text(value: &str) -> String {
     value
         .chars()
@@ -6271,30 +5823,6 @@ fn normalize_picker_text(value: &str) -> String {
         .join(" ")
 }
 
-/// [`normalize_picker_text`] with every separator removed, for the mirrored
-/// Claude picker's substring matching only.
-///
-/// Claude Code's picker box hard-wraps a run of non-space characters longer
-/// than its content width, so a 115-character single-token option label renders
-/// as `...phichipsiomeg` on one row and `a` on the next with NO space between
-/// them. Collapsing to a single space INSERTS a separator the label never had,
-/// the exact substring match in [`verify_claude_picker_question`] misses, and
-/// the answer is rejected before a single key is sent (measured:
-/// `visible picker option order does not match current question`, zero keys
-/// delivered).
-///
-/// Scoped to the mirrored route on purpose. The `verify_picker_pane` route
-/// shares the wrap fragility, but its stale-picker guard reads normalized line
-/// offsets and whitespace-split option markers, so widening this there is a
-/// separate change with its own measurements — not a free rename.
-///
-/// The cost, stated rather than hidden: with separators gone, one option's
-/// suffix concatenated with the next row could in principle match another
-/// option's label. The surrounding checks still pin the picker to the right
-/// question and screen.
-fn squeeze_picker_text(value: &str) -> String {
-    normalize_picker_text(value).split_whitespace().collect()
-}
 
 /// Mint an ACP session: the `fleet_session` + `fleet_acp_session` PAIR under one
 /// `session_key`, in ONE transaction, with NO process spawn.
@@ -13414,6 +12942,32 @@ mod tests {
         assert!(!fleet_delivery_uses_native_picker(&serde_json::json!({
             "fleet_delivery": "fleet"
         })));
+    }
+
+    /// Both native-picker deliveries are READ-ONLY from a remote surface.
+    ///
+    /// This is the gate that replaced the mirrored send-keys path. It matters
+    /// that `native_claude` is covered as well as `mirrored`: an answer for
+    /// either would otherwise fall through to the broker lane and wait on a
+    /// waiter that was never registered, reporting "no longer waiting" instead
+    /// of saying the question is answerable in the session.
+    #[test]
+    fn native_picker_deliveries_are_never_answerable_from_a_remote_surface() {
+        for delivery in ["mirrored", "native_claude"] {
+            assert!(
+                fleet_delivery_uses_native_picker(&serde_json::json!({
+                    "fleet_delivery": delivery,
+                })),
+                "{delivery} must be treated as read-only"
+            );
+        }
+        // A held interview carries no native-picker stamp, so it stays
+        // answerable over the broker as exact JSON.
+        assert!(!fleet_delivery_uses_native_picker(&serde_json::json!({})));
+        assert!(
+            MIRRORED_IS_READ_ONLY.contains("answer it in the session"),
+            "the refusal must tell the operator where the question CAN be answered"
+        );
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -90,8 +90,7 @@ const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 ///
 /// Shown verbatim to the operator, so it names the fix rather than the fault:
 /// the question is answerable, just not from here while the surface is native.
-pub const MIRRORED_IS_READ_ONLY: &str =
-    "this interview is showing in Claude's own picker — answer it in the session, \
+pub const MIRRORED_IS_READ_ONLY: &str = "this interview is showing in Claude's own picker — answer it in the session, \
      or set `ainb fleet interview surface fleet` to hold the next one for Fleet";
 
 /// Cross-process, crash-safe ownership of one operation against one Hangar DB.
@@ -3999,14 +3998,8 @@ async fn execute_fleet_action(
                     answers,
                     ..
                 } if session.provider == "claude" => {
-                    execute_claude_structured(
-                        pool,
-                        events,
-                        &session,
-                        request_fingerprint,
-                        answers,
-                    )
-                    .await
+                    execute_claude_structured(pool, events, &session, request_fingerprint, answers)
+                        .await
                 }
                 ControlAction::DismissStructured {
                     request_fingerprint,
@@ -4397,8 +4390,7 @@ async fn kill_tmux_session_exact(session_name: &str) -> Result<(), String> {
 #[cfg(test)]
 mod fleet_launch_tests {
     use super::{
-        managed_codex_tmux_args, managed_codex_tmux_name, normalize_picker_text,
-        verify_picker_pane,
+        managed_codex_tmux_args, managed_codex_tmux_name, normalize_picker_text, verify_picker_pane,
     };
     use std::ffi::{OsStr, OsString};
     use std::path::Path;
@@ -4527,11 +4519,6 @@ mod fleet_launch_tests {
         assert!(error.contains("newer picker"));
     }
 
-
-
-
-
-
     #[test]
     fn verified_picker_rejects_a_newer_picker_whose_prompt_has_no_question_mark() {
         // Guards the separator contract from the other side. Both pre-existing
@@ -4549,7 +4536,6 @@ mod fleet_launch_tests {
         let error = verify_picker_pane("claude", &picker_request(), pane).unwrap_err();
         assert!(error.contains("newer picker"), "got: {error}");
     }
-
 }
 
 async fn claude_broker_decide(
@@ -5141,12 +5127,6 @@ async fn execute_claude_structured(
         Err(error) => (ActionReceiptStatus::Failed, Some(error.to_string())),
     }
 }
-
-
-
-
-
-
 
 /// One-line render of a delivered interview answer for the attention row's audit
 /// `answer` column: what the control centre shows as "answered by fleet: …".
@@ -5822,7 +5802,6 @@ fn normalize_picker_text(value: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
 }
-
 
 /// Mint an ACP session: the `fleet_session` + `fleet_acp_session` PAIR under one
 /// `session_key`, in ONE transaction, with NO process spawn.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet.rs
@@ -1328,7 +1328,7 @@ pub(crate) fn reduce_browse_key(state: &mut FleetPaneState, key: FleetKey) -> Op
                 .selected_key
                 .as_deref()
                 .and_then(|key| state.roster.iter().find(|row| row.session_key == key))
-                .is_some_and(native_claude_picker);
+                .is_some_and(read_only_picker);
             if let Some(intent) = release_structured_intent(state) {
                 return Some(intent);
             }
@@ -1500,8 +1500,9 @@ fn release_structured_intent(state: &mut FleetPaneState) -> Option<FleetIntent> 
         .selected_key
         .as_deref()
         .and_then(|key| state.roster.iter().find(|row| row.session_key == key))?;
-    if native_claude_picker(row) {
-        state.feedback = Some("Claude native picker route is unavailable".into());
+    if read_only_picker(row) {
+        state.feedback =
+            Some("answer in the session — or `ainb fleet interview surface fleet` to hold".into());
         return None;
     }
     if !row.provider.eq_ignore_ascii_case("claude")
@@ -1530,7 +1531,7 @@ fn begin_structured_answer(state: &mut FleetPaneState) {
         .roster
         .iter()
         .find(|row| row.session_key == selected_key)
-        .is_some_and(native_claude_picker)
+        .is_some_and(read_only_picker)
     {
         state.feedback = Some("Claude picker active, answer in the Claude session".into());
         return;
@@ -1547,12 +1548,19 @@ fn begin_structured_answer(state: &mut FleetPaneState) {
     state.mode = FleetMode::Answer(AnswerQueue { answers, active });
 }
 
-fn native_claude_picker(row: &FleetSessionRow) -> bool {
+/// Claude drew its own picker for this row, so the interview is READ-ONLY here.
+///
+/// Covers both native-picker stamps. `mirrored` used to be answerable from
+/// Fleet by replaying blind keystrokes into the pane and screen-scraping to
+/// confirm they landed; that depended on a vendor TUI layout which is not a
+/// contract, and its failure mode was answering the wrong question. The daemon
+/// now refuses both, so the UI must not offer to answer either.
+fn read_only_picker(row: &FleetSessionRow) -> bool {
     row.current_request
         .as_ref()
         .and_then(|request| request.get("fleet_delivery"))
         .and_then(serde_json::Value::as_str)
-        .is_some_and(|route| route == "native_claude")
+        .is_some_and(|route| matches!(route, "native_claude" | "mirrored"))
 }
 
 fn answer_state_from_row(row: &FleetSessionRow) -> Option<AnswerState> {
@@ -3012,7 +3020,7 @@ fn render_detail(
     if session.is_actionable() {
         put_str(buffer, left, y, "NEEDS YOU", GOLD, right);
         y = y.saturating_add(1);
-        if native_claude_picker(session) {
+        if read_only_picker(session) {
             put_str(buffer, left, y, "CLAUDE PICKER ACTIVE", VIOLET, right);
             y = y.saturating_add(1);
             put_str(
@@ -3162,7 +3170,7 @@ fn available_action_labels(session: &FleetSessionRow) -> Vec<&'static str> {
         && session.is_managed()
         && session.capabilities.contains("structured_answer")
     {
-        if native_claude_picker(session) {
+        if read_only_picker(session) {
             actions.push("→ Open Claude");
         } else {
             actions.push("Enter Answer");
@@ -5362,7 +5370,25 @@ mod tests {
         assert!(native_reduced.intent.is_none());
         assert_eq!(
             native_reduced.state.feedback.as_deref(),
-            Some("Claude native picker route is unavailable")
+            Some("answer in the session — or `ainb fleet interview surface fleet` to hold")
+        );
+
+        // `mirrored` is the SAME situation: the interview was never held, so
+        // Claude owns that pane's stdin. It used to be answerable here by
+        // replaying keystrokes; the daemon now refuses, so the pane must not
+        // open an answer queue for it either.
+        let mut mirrored = session("claude:mirrored", "claude", "IDLE", "ASK", "managed");
+        mirrored.current_request_fingerprint = Some("mirrored-fp".into());
+        mirrored.current_request = Some(serde_json::json!({
+            "fleet_delivery": "mirrored",
+            "questions": [{"id": "q", "question": "Ship?", "options": ["Yes"]}]
+        }));
+        let mut mirrored_state = FleetPaneState::default();
+        mirrored_state.set_sessions(vec![mirrored]);
+        let mirrored_reduced = apply(&mirrored_state, FleetEvent::Key(FleetKey::Char('c')));
+        assert!(
+            mirrored_reduced.intent.is_none(),
+            "a mirrored interview must not produce an answer intent"
         );
 
         let mut ordinary_state = FleetPaneState::default();

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -527,7 +527,7 @@ private struct FleetNotchDetail: View {
                 }
             } else if let deck, let question = deck.questions[safe: clampedIndex(deck)] {
                 if deck.mirroredPicker {
-                    Text("Claude picker is also open. Submit here to select the same answer there. Text answers unavailable.")
+                    Text("Showing in Claude's own picker — answer it in the session. Open session, or hold the next one for Fleet with `ainb fleet interview surface fleet`.")
                         .font(.caption.weight(.medium))
                         .foregroundStyle(FleetNotchPalette.mint)
                 }
@@ -597,7 +597,23 @@ private struct FleetNotchDetail: View {
         Text(question.header).font(.subheadline.weight(.semibold))
         Text(question.text).font(.caption).fixedSize(horizontal: false, vertical: true)
 
-        if question.options.isEmpty {
+        if deck.mirroredPicker {
+            // Read-only: Claude owns this pane's stdin and already drew the
+            // picker, so there is nothing to select here. Options are still
+            // listed — the point of the card is to let you READ the question
+            // from another surface and decide whether to go answer it.
+            ForEach(question.options, id: \.self) { option in
+                HStack(spacing: 6) {
+                    Image(systemName: question.multiSelect ? "square" : "circle")
+                        .font(.caption)
+                        .foregroundStyle(FleetNotchPalette.muted)
+                    Text(option).font(.caption).foregroundStyle(FleetNotchPalette.muted)
+                    Spacer()
+                }
+                .padding(6)
+                .background(FleetNotchPalette.canvas, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            }
+        } else if question.options.isEmpty {
             TextField("Type answer", text: textBinding(deck: deck, question: question), axis: .vertical)
                 .textFieldStyle(.roundedBorder)
                 .lineLimit(2...5)
@@ -644,14 +660,21 @@ private struct FleetNotchDetail: View {
                     .font(.caption)
                     .help("Attach to this session in a terminal window")
             }
-            if session.capabilities.structuredDismiss {
+            if session.capabilities.structuredDismiss && !deck.mirroredPicker {
                 Button("Reject", role: .destructive) { rejectConfirmation = true }
                     .font(.caption)
             }
-            Button("Submit") { submit(deck) }
-                .buttonStyle(.borderedProminent)
-                .font(.caption)
-                .disabled(!complete(deck) || (deck.mirroredPicker && hasTextAnswer(deck)) || store.pendingIntentID != nil)
+            // No Submit for a mirrored deck. The only transport back into a
+            // native picker is blind keystrokes verified by screen-scraping a
+            // vendor TUI, which fails whenever that TUI is relaid out, and
+            // whose failure mode is answering the wrong question. Offering a
+            // button that cannot honour the click is worse than not offering it.
+            if !deck.mirroredPicker {
+                Button("Submit") { submit(deck) }
+                    .buttonStyle(.borderedProminent)
+                    .font(.caption)
+                    .disabled(!complete(deck) || store.pendingIntentID != nil)
+            }
         }
     }
 

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -317,7 +317,7 @@ struct FleetAnswerQueue: View {
             Text(question.header).font(.title3.weight(.semibold))
             Text(question.text).font(.body).fixedSize(horizontal: false, vertical: true)
             if deck.mirroredPicker {
-                Text("Claude picker is also open. Submit here to select the same answer there. Text answers unavailable.")
+                Text("Showing in Claude's own picker — answer it in the session. Hold the next one for Fleet with `ainb fleet interview surface fleet`.")
                     .font(.callout.weight(.medium))
                     .foregroundStyle(FleetPalette.mint)
             }
@@ -327,7 +327,20 @@ struct FleetAnswerQueue: View {
                     .foregroundStyle(FleetPalette.mint)
             }
 
-            if question.options.isEmpty {
+            if deck.readOnlyPicker {
+                // Listed but not selectable: the question is answered in the
+                // session that owns the picker, not from here.
+                ForEach(question.options, id: \.self) { option in
+                    HStack {
+                        Image(systemName: question.multiSelect ? "square" : "circle")
+                        Text(option)
+                        Spacer()
+                    }
+                    .padding(10)
+                    .background(FleetPalette.control, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                    .opacity(0.65)
+                }
+            } else if question.options.isEmpty {
                 TextField("Type answer", text: textBinding(deck: deck, question: question), axis: .vertical)
                     .textFieldStyle(.roundedBorder)
                     .lineLimit(3...8)
@@ -370,9 +383,13 @@ struct FleetAnswerQueue: View {
                     }
                     .disabled(store.pendingIntentID != nil)
                 }
-                Button("Submit all answers") { submit(deck) }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(deck.nativePicker || !complete(deck) || (deck.mirroredPicker && hasTextAnswer(deck)) || store.pendingIntentID != nil)
+                // Hidden, not just disabled, for a read-only deck: the daemon
+                // refuses these answers, so the button could never honour a click.
+                if !deck.readOnlyPicker {
+                    Button("Submit all answers") { submit(deck) }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!complete(deck) || store.pendingIntentID != nil)
+                }
             }
 
             if let notice = store.controlNotice {
@@ -466,6 +483,15 @@ struct FleetInterviewDeck {
     let questions: [FleetInterviewQuestion]
     let nativePicker: Bool
     let mirroredPicker: Bool
+
+    /// Claude drew its own picker, so this deck can be READ here but not
+    /// answered here.
+    ///
+    /// Both stamps mean the same thing operationally — the interview was never
+    /// held, Claude owns that pane's stdin, and the daemon refuses answers for
+    /// either. They are kept as separate fields because they still describe
+    /// different origins, but every UI decision keys off this.
+    var readOnlyPicker: Bool { nativePicker || mirroredPicker }
 
     init?(session: FleetSession) {
         guard session.attention == .ask,


### PR DESCRIPTION
`/interview` in a native session showed an answerable card in Fleet and the
macOS app, and pressing Submit failed with:

```
Interview failed: visible picker option order does not match current question
```

`prefix + A` separately died with `returned 127`.

## What was wrong

A `native_claude` / `mirrored` interview was never held — Claude drew its own
picker and owns that pane's stdin. The only transport back into it was
replaying blind arrow keys and screen-scraping `capture-pane` to confirm they
landed. That guard has to match a vendor TUI's wrapped, two-column layout,
which is not a contract and was relaid out four times in one week. The error
above is the guard refusing to send keys into a question it could not line up
with — failing safe, but the button should never have been offered.

## What changed

- **Daemon** refuses answers for both native-picker stamps, which makes the
  whole screen-scrape lane unreachable; it is deleted (~480 lines with tests).
  The gate reuses `fleet_delivery_uses_native_picker` so `native_claude` is
  covered too, instead of falling through to a broker waiter that was never
  registered.
- **macOS app** hides Submit for a read-only deck rather than disabling it,
  lists options non-selectably, and keeps **Open session** so the card routes
  into the session.
- **Fleet TUI** applies the same guard; it previously covered `native_claude`
  but not `mirrored`.
- **tmux binding** resolves the binary via `hooks/ainb-bin` (with `command -v`
  fallback, `AINB_HOME`-aware) instead of a bare `ainb` — the cause of the 127.

`normalize_picker_text` and friends stay: `claude_native_picker_is_visible`
still answers "is a picker on screen", which is how a release confirms it put
one back, and that check survived every layout change the label matcher failed.

## Behaviour

| surface | native (default) | fleet |
|---|---|---|
| terminal | picker, answer here | held |
| Fleet / macOS | read-only + Open session | answerable, exact JSON |

## Verification

- `cargo test --workspace` — 3901 passed, 1 failed
- The one failure is `tripwire_daemons_opens_and_renders`, **proven
  pre-existing**: it fails identically on the clean base with these changes
  stashed.
- macOS app `BUILD SUCCEEDED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only handling for native and mirrored Claude interview pickers.
  * Displayed guidance directing users to answer directly in Claude or hold the interview in Fleet.
  * Hid answer fields and submission controls when interviews cannot be answered in Fleet.
  * Preserved existing answer and release controls for standard interviews.
  * Added support for relocating the application state directory through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->