### PR TITLE
fix(bridge): make the phone bridge fail honestly instead of silently

### DIFF
--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -209,3 +209,53 @@ show_git_status = true
 # [session_reader]
 # Trailing recent-window size in days (default 30, minimum 1).
 # incremental_window_days = 30
+
+# ── Phone bridge (`ainb fleet bridge`) ────────────────────────────────
+# Two-way relay between a chat app and the fleet. Read ONLY from this
+# file (`~/.agents-in-a-box/config/config.toml`, or $AINB_CONFIG_PATH) —
+# the bridge does not use the layered search, so a project-level
+# `.ainb/config.toml` is invisible to it.
+#
+# Configure at least ONE channel, or `ainb fleet bridge run` exits and
+# `ainb fleet bridge install` writes the service without starting it.
+#
+# Every secret takes a literal, an env ref ("$TELEGRAM_BOT_TOKEN"), or a
+# keychain ref ("keychain:<service>"). It is resolved in-process and is
+# never written into the launchd/systemd unit.
+#
+# [fleet.bridge]
+# Seconds to wait for a session's reply before giving up (shared default
+# for every channel below; each may override it).
+# response_timeout = 300
+#
+# Proactive push of the fleet's open asks to the phone (default true),
+# and how often the attention inbox is polled (default 15s).
+# outbound_enabled = true
+# outbound_poll_secs = 15
+#
+# [fleet.bridge.telegram]
+# Required: token, user_id.
+# token = "$TELEGRAM_BOT_TOKEN"
+# user_id = 123456789
+# Optional: session to prefer when a message carries no target prefix,
+# and whether group messages must @mention the bot (default true).
+# default_target = "conductor"
+# require_mention_in_groups = true
+#
+# [fleet.bridge.slack]
+# Required: bot_token (xoxb-…), app_token (xapp-…), user_id.
+# bot_token = "$SLACK_BOT_TOKEN"
+# app_token = "$SLACK_APP_TOKEN"
+# user_id = "U0123ABC"
+# Optional: "mentions" (default) acts only on @mentions and DMs; "all"
+# acts on every message in channels the bot is in.
+# listen_mode = "mentions"
+# default_target = "conductor"
+#
+# [fleet.bridge.discord]
+# Required: token, user_id (snowflake, as a string).
+# token = "$DISCORD_BOT_TOKEN"
+# user_id = "123456789012345678"
+# Optional: channel to reply in when the inbound message carries none.
+# channel_id = "123456789012345678"
+# default_target = "conductor"

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/bridge.rs
@@ -13,18 +13,21 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
     match matches.subcommand() {
         Some(("run", _)) | None => crate::fleet::bridge::run().await,
         Some(("install", _)) => {
-            let path = crate::fleet::bridge::install()?;
-            emit(
-                format,
-                &format!("phone bridge installed: {}", path.display()),
-            );
             // Writing the unit is not the same as being able to start it. Say
             // so at install time rather than leaving the operator to discover
             // a dead bridge from `status` they had no reason to run.
+            let path = crate::fleet::bridge::install()?;
+            let blocker = crate::fleet::bridge::install_would_be_unrunnable();
+            let state = if blocker.is_some() {
+                "installed but NOT started"
+            } else {
+                "installed"
+            };
+            emit(format, &format!("phone bridge {state}: {}", path.display()));
             // stderr, not `emit`: in --format json the result must stay a
             // single document on stdout, and a warning is not the result.
             // Matches how `fleet atc setup` surfaces the same condition.
-            if let Some(warning) = crate::fleet::bridge::install_would_be_unrunnable() {
+            if let Some(warning) = blocker {
                 eprintln!("warning: {warning}");
             }
             Ok(())

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/config.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/config.rs
@@ -184,6 +184,48 @@ pub fn default_config_path() -> PathBuf {
     p
 }
 
+/// What a usable `[fleet.bridge]` table has to contain, as a paste-able
+/// skeleton. Every secret is a NAME or a placeholder ref — this string must
+/// never gain a real token value, it is printed to terminals and logs.
+pub const SETUP_SKELETON: &str = "\
+configure at least ONE channel. Required keys per channel:\n\
+\x20 [fleet.bridge.telegram]  token, user_id\n\
+\x20 [fleet.bridge.slack]     bot_token, app_token, user_id\n\
+\x20 [fleet.bridge.discord]   token, user_id\n\
+\n\
+Optional, all channels: default_target, response_timeout (default 300s).\n\
+Optional, [fleet.bridge]: outbound_enabled (default true), outbound_poll_secs\n\
+(default 15s), response_timeout (shared default for every channel).\n\
+\n\
+Every secret key takes a literal, an env ref (\"$TELEGRAM_BOT_TOKEN\"), or a\n\
+keychain ref (\"keychain:<service>\"); it is resolved in-process and is never\n\
+written into the launchd/systemd unit.\n\
+\n\
+Telegram example:\n\
+\n\
+\x20 [fleet.bridge]\n\
+\x20 response_timeout = 300\n\
+\n\
+\x20 [fleet.bridge.telegram]\n\
+\x20 token = \"$TELEGRAM_BOT_TOKEN\"\n\
+\x20 user_id = 123456789\n\
+\n\
+Then re-run `ainb fleet bridge install` — it validates this config and refuses\n\
+to start a service that cannot run.";
+
+/// Which file the bridge reads, spelled out. The bridge does NOT use ainb's
+/// layered config search: a project-level `.ainb/config.toml` is invisible to
+/// it, which is its own dead end when the table is "obviously there".
+#[must_use]
+pub fn config_source_note(path: &Path) -> String {
+    let via = if std::env::var_os("AINB_CONFIG_PATH").is_some() {
+        " (from $AINB_CONFIG_PATH)"
+    } else {
+        " (the user config; project-level .ainb/config.toml is NOT read by the bridge)"
+    };
+    format!("{}{via}", path.display())
+}
+
 /// Coerce a TOML scalar seconds value (`response_timeout`,
 /// `outbound_poll_secs`) into a positive `u64`. The caller attaches the key name
 /// via `.context(...)`, so the messages here stay key-neutral.
@@ -333,7 +375,7 @@ pub fn parse_config(toml_text: &str) -> Result<BridgeConfig> {
     let bridge = root
         .fleet
         .and_then(|f| f.bridge)
-        .ok_or_else(|| anyhow!("config has no [fleet.bridge] table"))?;
+        .ok_or_else(|| anyhow!("config has no [fleet.bridge] table\n\n{SETUP_SKELETON}"))?;
 
     let shared_timeout = coerce_timeout(bridge.response_timeout.as_ref(), RESPONSE_TIMEOUT)
         .context("[fleet.bridge] `response_timeout`")?;
@@ -343,10 +385,7 @@ pub fn parse_config(toml_text: &str) -> Result<BridgeConfig> {
     let discord = bridge.discord.map(|d| parse_discord(d, shared_timeout)).transpose()?;
 
     if telegram.is_none() && slack.is_none() && discord.is_none() {
-        bail!(
-            "[fleet.bridge] has no channel — configure at least one of \
-             [fleet.bridge.telegram], [fleet.bridge.slack], or [fleet.bridge.discord]"
-        );
+        bail!("[fleet.bridge] has no channel\n\n{SETUP_SKELETON}");
     }
     let outbound_enabled = bridge.outbound_enabled.unwrap_or(true);
     let outbound_poll_secs = coerce_timeout(bridge.outbound_poll_secs.as_ref(), OUTBOUND_POLL_SECS)
@@ -372,11 +411,16 @@ pub fn load_config(path: Option<&Path>) -> Result<BridgeConfig> {
         }
     };
     if !cfg_path.exists() {
-        bail!("config file not found: {}", cfg_path.display());
+        bail!(
+            "no bridge config: {} does not exist\n\n{SETUP_SKELETON}",
+            config_source_note(cfg_path)
+        );
     }
     let text = std::fs::read_to_string(cfg_path)
         .with_context(|| format!("failed to read {}", cfg_path.display()))?;
-    parse_config(&text)
+    // `{e:#}` flattens the whole context chain into the one message, so the
+    // file name leads and no `Caused by:` tail is needed to read the fix.
+    parse_config(&text).map_err(|e| anyhow!("{}: {e:#}", config_source_note(cfg_path)))
 }
 
 #[cfg(test)]
@@ -517,12 +561,21 @@ mod tests {
     fn missing_bridge_table_errors() {
         let err = parse_config("[fleet]\n").unwrap_err();
         assert!(err.to_string().contains("no [fleet.bridge] table"));
+        // A dead end is the bug: the message has to carry the fix.
+        let msg = err.to_string();
+        assert!(msg.contains("[fleet.bridge.telegram]"), "{msg}");
+        assert!(msg.contains("token, user_id"), "{msg}");
+        assert!(msg.contains("ainb fleet bridge install"), "{msg}");
     }
 
     #[test]
     fn no_channel_errors() {
         let err = parse_config("[fleet.bridge]\nresponse_timeout = 60\n").unwrap_err();
-        assert!(err.to_string().contains("at least one"));
+        let msg = err.to_string();
+        assert!(msg.contains("[fleet.bridge] has no channel"), "{msg}");
+        // and carries the same paste-able skeleton as the missing-table case.
+        assert!(msg.contains("at least ONE channel"), "{msg}");
+        assert!(msg.contains("[fleet.bridge.discord]"), "{msg}");
     }
 
     #[test]
@@ -658,5 +711,53 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("user_id"));
+    }
+
+    #[test]
+    fn setup_skeleton_never_carries_a_secret_value() {
+        // It is printed to terminals and logs. Placeholders and key names only.
+        let lower = SETUP_SKELETON.to_lowercase();
+        assert!(!lower.contains("xoxb-"), "{SETUP_SKELETON}");
+        assert!(!lower.contains("xapp-"), "{SETUP_SKELETON}");
+        // The only token-ish strings are the documented ref forms.
+        assert!(SETUP_SKELETON.contains("$TELEGRAM_BOT_TOKEN"));
+        assert!(SETUP_SKELETON.contains("keychain:<service>"));
+    }
+
+    #[test]
+    fn load_config_names_the_missing_file_and_the_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("config.toml");
+        let err = load_config(Some(&missing)).unwrap_err().to_string();
+        assert!(err.contains(&missing.display().to_string()), "{err}");
+        assert!(err.contains("[fleet.bridge.slack]"), "{err}");
+    }
+
+    #[test]
+    fn load_config_error_leads_with_the_file_it_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[other]\nkey = 1\n").unwrap();
+        let err = load_config(Some(&path)).unwrap_err().to_string();
+        assert!(
+            err.starts_with(&path.display().to_string()),
+            "the file has to lead, got: {err}"
+        );
+        assert!(err.contains("config has no [fleet.bridge] table"), "{err}");
+    }
+
+    #[test]
+    fn load_config_flattens_the_context_chain_into_one_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[fleet.bridge.slack]\nbot_token = \"b\"\napp_token = \"a\"\nuser_id = \"U1\"\nlisten_mode = \"shouting\"\n",
+        )
+        .unwrap();
+        let err = load_config(Some(&path)).unwrap_err().to_string();
+        // `{e:#}` keeps the inner cause on the one line the operator sees.
+        assert!(err.contains("listen_mode"), "{err}");
+        assert!(err.contains(&path.display().to_string()), "{err}");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
@@ -239,16 +239,34 @@ fn build_outbound_notifier(cfg: &BridgeConfig) -> Option<outbound::Fanout> {
 }
 
 /// Install the bridge as a launchd/systemd service (idempotent).
+///
+/// The unit is always written, but it is only STARTED when the daemon could
+/// actually run: an unresolvable program OR an unusable config both mean
+/// `ainb fleet bridge run` exits immediately, and `KeepAlive` /
+/// `Restart=always` then respawn that exit forever into an unrotated log. The
+/// config half is why this host ran a service that had never once started.
 pub fn install() -> Result<std::path::PathBuf> {
-    service::install()
+    service::install(config_problem().is_none())
 }
 
-/// `Some(warning)` when the unit `install` would write names a program that
-/// does not resolve, so the CLI can say so rather than reporting a success
-/// that can never start.
+/// `Some(warning)` when the service `install` writes could not start: either
+/// the unit names a program that does not resolve, or the config the daemon
+/// reads is missing/unusable. The CLI prints this rather than reporting a
+/// success that can never run.
 #[must_use]
 pub fn install_would_be_unrunnable() -> Option<String> {
-    service::install_would_be_unrunnable()
+    service::install_would_be_unrunnable().or_else(config_problem)
+}
+
+/// `Some(explanation)` when the config `ainb fleet bridge run` would load
+/// cannot start a bridge. The explanation is the loader's own error, which
+/// already names the file it looked in and the keys it needs.
+///
+/// Secrets never reach this string: the loader reports missing/empty KEYS, and
+/// resolved values are not echoed.
+#[must_use]
+pub fn config_problem() -> Option<String> {
+    load_config(None).err().map(|e| format!("{e:#}"))
 }
 
 /// Uninstall the bridge service. Returns the removed unit path, if any.
@@ -257,8 +275,16 @@ pub fn uninstall() -> Result<Option<std::path::PathBuf>> {
 }
 
 /// Human-readable install status.
+///
+/// Install state alone was a half-truth: a correctly-installed unit whose
+/// config has no `[fleet.bridge]` table reported clean while the bridge exited
+/// 1 on every launch. The config verdict is part of the status.
 pub fn status() -> Result<String> {
-    service::status()
+    let unit = service::status()?;
+    Ok(match config_problem() {
+        Some(problem) => format!("{unit}\n  config: UNUSABLE — {problem}"),
+        None => format!("{unit}\n  config: ok"),
+    })
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
@@ -285,9 +285,13 @@ fn teardown_systemd() -> Result<Option<PathBuf>> {
 /// wrapper means the scheduler spawns successfully and `exec ainb` exits 127,
 /// so `KeepAlive` / `Restart=always` respawn it forever into an unrotated log.
 /// Writing it inactive leaves the operator a unit to reload once PATH is fixed.
-pub fn install() -> Result<PathBuf> {
+///
+/// `config_ok` is the same judgement about the OTHER way the daemon exits
+/// immediately — an unusable `[fleet.bridge]` — decided by the caller, which
+/// owns the config loader. Either blocker leaves the unit written but stopped.
+pub fn install(config_ok: bool) -> Result<PathBuf> {
     let paths = resolve_paths()?;
-    let activate = unit_would_be_unrunnable(&paths).is_none();
+    let activate = config_ok && unit_would_be_unrunnable(&paths).is_none();
     if cfg!(target_os = "macos") {
         install_launchd(&paths, activate)
     } else {

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -2028,10 +2028,14 @@ mod tests {
         ];
         annotate_bridge_config(
             &mut rows,
-            Some("/home/u/config.toml: config has no [fleet.bridge] table\n\nconfigure at least ONE channel"),
+            Some(
+                "/home/u/config.toml: config has no [fleet.bridge] table\n\nconfigure at least ONE channel",
+            ),
         );
         assert!(
-            rows[0].reason.contains("cannot start: /home/u/config.toml: config has no [fleet.bridge] table"),
+            rows[0]
+                .reason
+                .contains("cannot start: /home/u/config.toml: config has no [fleet.bridge] table"),
             "{}",
             rows[0].reason
         );

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -885,6 +885,28 @@ fn db_mtime_ms(path: &Path) -> Option<i64> {
     i64::try_from(dur.as_millis()).ok()
 }
 
+/// Append the CAUSE to a bridge row that is not running, when the bridge could
+/// not have started at all.
+///
+/// "stale heartbeat — pid 89585 not alive (crashed)" is a true row and a dead
+/// end: it never says the crash was `ainb fleet bridge run` exiting 1 on a
+/// config with no `[fleet.bridge]` table. This is the surface an operator
+/// actually reads (`ainb doctor`, `ainb fleet daemons`, the TUI Daemons
+/// screen), so the cause belongs on it. Only the first line of the problem is
+/// used — the full setup skeleton belongs in `bridge status`, not a table cell.
+///
+/// Pure over `problem` so the annotation is testable without a config file.
+pub fn annotate_bridge_config(rows: &mut [DaemonStatus], problem: Option<&str>) {
+    let Some(problem) = problem else { return };
+    let head = problem.lines().next().unwrap_or(problem).trim();
+    for row in rows
+        .iter_mut()
+        .filter(|r| r.kind == DaemonKind::Bridge && r.state != DaemonState::Running)
+    {
+        row.reason = format!("{} — cannot start: {head}", row.reason);
+    }
+}
+
 /// Aggregate every daemon under an explicit ainb home + notifyd base. The
 /// test seam — every path is injected so a test isolates to a tempdir.
 ///
@@ -909,11 +931,16 @@ pub fn collect() -> anyhow::Result<Vec<DaemonStatus>> {
     let notifyd_base = ainb_plugin_notifyd::Paths::from_home()
         .map(|p| p.base)
         .unwrap_or_else(|_| ainb_home.clone());
-    Ok(collect_in(
-        &ainb_home,
-        &notifyd_base,
-        super::heartbeat::now_ms(),
-    ))
+    let mut rows = collect_in(&ainb_home, &notifyd_base, super::heartbeat::now_ms());
+    // Only pay for the config read when a bridge row is actually down — this
+    // runs on the TUI's refresh loop.
+    if rows
+        .iter()
+        .any(|r| r.kind == DaemonKind::Bridge && r.state != DaemonState::Running)
+    {
+        annotate_bridge_config(&mut rows, crate::fleet::bridge::config_problem().as_deref());
+    }
+    Ok(rows)
 }
 
 #[cfg(test)]
@@ -1991,5 +2018,43 @@ mod tests {
         sorted.sort_unstable();
         sorted.dedup();
         assert_eq!(sorted.len(), 4);
+    }
+
+    #[test]
+    fn stopped_bridge_row_names_the_config_cause() {
+        let mut rows = vec![
+            DaemonStatus::stopped(DaemonKind::Bridge, "stale heartbeat — pid 1 not alive"),
+            DaemonStatus::stopped(DaemonKind::Notifyd, "not running"),
+        ];
+        annotate_bridge_config(
+            &mut rows,
+            Some("/home/u/config.toml: config has no [fleet.bridge] table\n\nconfigure at least ONE channel"),
+        );
+        assert!(
+            rows[0].reason.contains("cannot start: /home/u/config.toml: config has no [fleet.bridge] table"),
+            "{}",
+            rows[0].reason
+        );
+        // Only the first line — the table cell is not the place for the skeleton.
+        assert!(!rows[0].reason.contains("configure at least ONE channel"));
+        // Other daemons are untouched.
+        assert_eq!(rows[1].reason, "not running");
+    }
+
+    #[test]
+    fn running_bridge_row_is_not_annotated() {
+        let mut rows = vec![DaemonStatus {
+            state: DaemonState::Running,
+            ..DaemonStatus::stopped(DaemonKind::Bridge, "connected")
+        }];
+        annotate_bridge_config(&mut rows, Some("some config problem"));
+        assert_eq!(rows[0].reason, "connected");
+    }
+
+    #[test]
+    fn no_config_problem_leaves_every_row_alone() {
+        let mut rows = vec![DaemonStatus::stopped(DaemonKind::Bridge, "stale heartbeat")];
+        annotate_bridge_config(&mut rows, None);
+        assert_eq!(rows[0].reason, "stale heartbeat");
     }
 }

--- a/docs/fleet-bridge.md
+++ b/docs/fleet-bridge.md
@@ -81,6 +81,12 @@ argv or written into the launchd/systemd unit:
 Config lives in ainb's `~/.agents-in-a-box/config/config.toml` (override with
 `AINB_CONFIG_PATH`). At least one channel table must be present.
 
+The bridge reads **that one file**, not ainb's layered config search: a
+project-level `.ainb/config.toml` or `/etc/agents-in-a-box/config.toml` is
+invisible to it. Without a usable `[fleet.bridge]`, `ainb fleet bridge run`
+exits naming the file it read and the keys it needs, and `install` writes the
+service without starting it (see below).
+
 ```toml
 [fleet.bridge]
 response_timeout = 300              # optional shared default (seconds)
@@ -146,9 +152,17 @@ ainb fleet bridge run
 # Install as a launchd (macOS) / systemd-user (Linux) service. The unit's
 # ProgramArguments/ExecStart is `ainb fleet bridge run` — no token on the command
 # line; the daemon reads it from config at startup. Idempotent.
+#
+# Install validates before it starts: if `ainb` does not resolve on the unit's
+# PATH, or the config cannot start a bridge, the unit is WRITTEN but NOT
+# started, and the blocker is printed on stderr. Otherwise KeepAlive /
+# Restart=always would respawn an instant-exit process forever. Fix the
+# blocker, re-run install.
 ainb fleet bridge install
 
 # Status / teardown:
+# `status` reports BOTH halves: the unit (installed / program resolves) and the
+# config (`ok` / `UNUSABLE — <why>`).
 ainb fleet bridge status
 ainb fleet bridge uninstall
 ```


### PR DESCRIPTION
The phone bridge on this host ran an installed launchd service that had never once started. `ainb fleet bridge run` exited 1 with:

```
Error: config has no [fleet.bridge] table
```

which names neither the file it read nor a single key to write in it. Nothing else surfaced the cause: `bridge status` reported the unit only, and the daemons row said `stale heartbeat — pid 89585 not alive (crashed)`. The bridge was down for days and the first symptom was a phone push that never arrived.

## What `[fleet.bridge]` actually requires

Read from **one** file: `$AINB_CONFIG_PATH`, else `~/.agents-in-a-box/config/config.toml`. The bridge does not use ainb's layered config search, so a project-level `.ainb/config.toml` is invisible to it.

At least one channel table, each with:

| table | required | optional |
|---|---|---|
| `[fleet.bridge.telegram]` | `token`, `user_id` | `default_target`, `require_mention_in_groups`, `response_timeout` |
| `[fleet.bridge.slack]` | `bot_token`, `app_token`, `user_id` | `default_target`, `listen_mode`, `response_timeout` |
| `[fleet.bridge.discord]` | `token`, `user_id` | `default_target`, `channel_id`, `response_timeout` |

`[fleet.bridge]` itself is optional: `response_timeout` (300s), `outbound_enabled` (true), `outbound_poll_secs` (15s). Every secret key takes a literal, `"$ENV_VAR"`, or `"keychain:<service>"`, resolved in-process and never written into the unit.

## Changes

- **The error names the file and the keys.** Every load failure leads with the path it read; the missing-table and no-channel cases carry a paste-able skeleton. Key names and placeholder refs only, never a resolved value.
- **`install` no longer starts a service that cannot run.** It already refused to start a unit whose program does not resolve (`KeepAlive` / `Restart=always` respawn an instant-exit process forever). An unusable config is the same failure with a different exit code and was unchecked. The unit is written either way; when it cannot run it is left stopped and the blocker goes to stderr, and stdout says `installed but NOT started`.
- **`bridge status` reports both halves** — the unit and `config: ok` / `config: UNUSABLE — <why>`.
- **A stopped bridge row names the cause.** `ainb doctor`, `ainb fleet daemons` and the TUI Daemons screen all render `fleet::daemons::collect`; a down bridge row now appends `— cannot start: <first line>`. The config read is skipped while the bridge is running, so the TUI refresh loop does not pay for it.
- **Docs**: `example.config.toml` claimed to list every option and never mentioned the bridge; it now carries the commented template.

## Not redone

The Cellar-pinned program path (item 4 of the brief) is already fixed on main by #608: `resolve_paths` no longer freezes `current_exe()`, the unit runs `/bin/sh -c 'exec ainb …'`, and `status` / `install` both check that the program resolves. No change needed.

## Verification

```
$ AINB_CONFIG_PATH=<tmp>/empty-config.toml ainb fleet bridge run
Error: <tmp>/empty-config.toml (from $AINB_CONFIG_PATH): config has no [fleet.bridge] table

configure at least ONE channel. Required keys per channel:
  [fleet.bridge.telegram]  token, user_id
  [fleet.bridge.slack]     bot_token, app_token, user_id
  [fleet.bridge.discord]   token, user_id
  …
Then re-run `ainb fleet bridge install` — it validates this config and refuses
to start a service that cannot run.

$ ainb fleet bridge status
launchd: installed (…/com.agentsinabox.phone-bridge.plist)
  config: UNUSABLE — …/config.toml (the user config; project-level .ainb/config.toml is NOT read by the bridge): config has no [fleet.bridge] table
```

`cargo test -p ainb --lib -- fleet::bridge fleet::daemons` → 278 passed, 0 failed. Clippy clean (no new diagnostics).

## Still to do by hand

No credentials were written and no daemon was touched. The user's config has no `[fleet.bridge*]` table at all, so a channel block plus its token still has to be added by hand, then `ainb fleet bridge install` re-run — which will now start the service, or say why it will not.

https://claude.ai/code/session_015TMAU2cLaimQdBMzxjshxr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided bridge configuration examples and clearer setup instructions.
  * Bridge status now reports both service and configuration health.
  * Stopped bridge entries display relevant configuration issues.

* **Bug Fixes**
  * Services no longer start when the executable or configuration is invalid.
  * Installation output clearly distinguishes started services from installed-but-stopped services.
  * Configuration errors now include actionable source and setup details.

* **Documentation**
  * Clarified configuration requirements, validation behavior, and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->