### PR TITLE
feat(daemons): restart the selected daemon from the overlay

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -8850,29 +8850,31 @@ mod panel_back_tests {
         ));
     }
 
-    /// Every row maps to a restart, so no row is a dead end under `R`.
+    /// Every row is labelled, and the labels are distinct.
+    ///
+    /// Deliberately does NOT call `spawn_daemon_restart`: each arm performs
+    /// REAL daemon lifecycle work (SIGTERM the running owner, respawn, poll a
+    /// socket). Driving that from a unit test kills the daemons on whatever
+    /// machine runs the suite and hangs CI — which is exactly what it did, so
+    /// the dispatch itself is covered by the compiler instead. The match in
+    /// `spawn_daemon_restart` is exhaustive over `DaemonRow`, so a new row
+    /// cannot be added without giving it an arm.
     #[test]
-    fn every_daemon_row_has_a_label_and_restart_arm() {
+    fn every_daemon_row_is_labelled_distinctly() {
         use crate::app::state::DaemonRow;
+        use std::collections::HashSet;
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let _guard = rt.enter();
-
+        let mut seen = HashSet::new();
         for row in DaemonRow::ORDER {
-            assert!(!row.label().is_empty(), "{row:?} needs a label");
-            let mut state = AppState::default();
-            EventHandler::process_event(AppEvent::GoToDaemons, &mut state);
-            state.spawn_daemon_restart(row);
-            let overlay = state.daemons_overlay.as_ref().expect("overlay");
+            let label = row.label();
+            assert!(!label.is_empty(), "{row:?} needs a label");
             assert!(
-                overlay.restart_rx.is_some(),
-                "{row:?} must arm an in-flight restart"
-            );
-            assert!(
-                overlay.restart_status.as_deref().is_some_and(|s| s.contains(row.label())),
-                "{row:?} status line must name the daemon being restarted"
+                seen.insert(label),
+                "{row:?} reuses the label {label:?}; the restart status line \
+                 would then name the wrong daemon"
             );
         }
+        assert_eq!(seen.len(), DaemonRow::ORDER.len());
     }
 
     /// Daemons repair keys stay next to the table that reports their state.

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -56,8 +56,10 @@ pub enum AppEvent {
     DaemonsOverlayOpen,
     DaemonsOverlayClose,
     DaemonsOverlayRefresh,
-    /// Restart the notifyd daemon (single resume/repair) from the overlay.
-    DaemonsOverlayRestartNotifyd,
+    /// Move the overlay's row selection by a signed step (saturating).
+    DaemonsOverlaySelect(isize),
+    /// Restart whichever daemon row is selected.
+    DaemonsOverlayRestartSelected,
     DaemonsRepairHooks,
     DaemonsOverlayStartHangar,
     DaemonsStartMcp,
@@ -1421,8 +1423,10 @@ impl EventHandler {
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('d') => {
                     Some(AppEvent::DaemonsOverlayClose)
                 }
+                KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::DaemonsOverlaySelect(-1)),
+                KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::DaemonsOverlaySelect(1)),
                 KeyCode::Char('r') => Some(AppEvent::DaemonsOverlayRefresh),
-                KeyCode::Char('R') => Some(AppEvent::DaemonsOverlayRestartNotifyd),
+                KeyCode::Char('R') => Some(AppEvent::DaemonsOverlayRestartSelected),
                 KeyCode::Char('I') => Some(AppEvent::DaemonsRepairHooks),
                 KeyCode::Char('S') => Some(AppEvent::DaemonsOverlayStartHangar),
                 _ => None,
@@ -2971,8 +2975,13 @@ impl EventHandler {
     fn handle_daemons_keys(key_event: KeyEvent, _state: &mut AppState) -> Option<AppEvent> {
         match key_event.code {
             KeyCode::Esc | KeyCode::Char('q') => Some(AppEvent::PanelBack),
+            KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::DaemonsOverlaySelect(-1)),
+            KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::DaemonsOverlaySelect(1)),
             KeyCode::Char('r') => Some(AppEvent::DaemonsOverlayRefresh),
-            KeyCode::Char('R') => Some(AppEvent::DaemonsOverlayRestartNotifyd),
+            // `R` used to be hardcoded to notifyd. It now acts on the selected
+            // row, which is the only way to cycle an already-running daemon
+            // (the S/M/P keys below only START a stopped one).
+            KeyCode::Char('R') => Some(AppEvent::DaemonsOverlayRestartSelected),
             KeyCode::Char('I') => Some(AppEvent::DaemonsRepairHooks),
             KeyCode::Char('S') => Some(AppEvent::DaemonsOverlayStartHangar),
             KeyCode::Char('M') => Some(AppEvent::DaemonsStartMcp),
@@ -3669,7 +3678,16 @@ impl EventHandler {
             AppEvent::DaemonsOverlayOpen => state.toggle_daemons_overlay(),
             AppEvent::DaemonsOverlayClose => state.close_daemons_overlay(),
             AppEvent::DaemonsOverlayRefresh => state.spawn_daemons_fetch(),
-            AppEvent::DaemonsOverlayRestartNotifyd => state.spawn_notifyd_restart(),
+            AppEvent::DaemonsOverlaySelect(delta) => {
+                if let Some(o) = state.daemons_overlay.as_mut() {
+                    o.selected = o.selected.step(delta);
+                }
+            }
+            AppEvent::DaemonsOverlayRestartSelected => {
+                if let Some(kind) = state.daemons_overlay.as_ref().map(|o| o.selected) {
+                    state.spawn_daemon_restart(kind);
+                }
+            }
             AppEvent::DaemonsRepairHooks => state.spawn_hooks_repair(),
             AppEvent::DaemonsOverlayStartHangar => state.spawn_hangar_start(),
             AppEvent::DaemonsStartMcp => state.spawn_mcp_start(),
@@ -8778,6 +8796,85 @@ mod panel_back_tests {
         assert!(matches!(event, Some(AppEvent::PanelBack)), "got {event:?}");
     }
 
+    /// `R` restarts the SELECTED daemon, and the selection is movable.
+    ///
+    /// The overlay previously hardcoded `R` to notifyd and had no cursor, so an
+    /// already-running daemon on a stale binary — the state a `brew upgrade`
+    /// leaves behind — could not be cycled from the TUI at all. Selection
+    /// saturates rather than wraps, so holding a direction parks at an end
+    /// instead of silently cycling past it.
+    #[test]
+    fn daemons_overlay_restarts_the_selected_row() {
+        use crate::app::state::DaemonRow;
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let mut state = AppState::default();
+        EventHandler::process_event(AppEvent::GoToDaemons, &mut state);
+
+        let selected = |s: &AppState| s.daemons_overlay.as_ref().map(|o| o.selected);
+        assert_eq!(
+            selected(&state),
+            Some(DaemonRow::ORDER[0]),
+            "selection starts on the first row"
+        );
+
+        EventHandler::process_event(AppEvent::DaemonsOverlaySelect(1), &mut state);
+        assert_eq!(selected(&state), Some(DaemonRow::Headroom));
+
+        EventHandler::process_event(AppEvent::DaemonsOverlaySelect(-1), &mut state);
+        assert_eq!(selected(&state), Some(DaemonRow::Mcp));
+
+        // Saturates at the top rather than wrapping to the bottom.
+        EventHandler::process_event(AppEvent::DaemonsOverlaySelect(-1), &mut state);
+        assert_eq!(selected(&state), Some(DaemonRow::Mcp));
+
+        // ...and at the bottom.
+        for _ in 0..10 {
+            EventHandler::process_event(AppEvent::DaemonsOverlaySelect(1), &mut state);
+        }
+        assert_eq!(selected(&state), Some(DaemonRow::Notifyd));
+
+        // Arrow keys and vim keys both move the cursor.
+        let route =
+            |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
+        assert!(matches!(
+            route(&mut state, KeyCode::Up),
+            Some(AppEvent::DaemonsOverlaySelect(-1))
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('j')),
+            Some(AppEvent::DaemonsOverlaySelect(1))
+        ));
+    }
+
+    /// Every row maps to a restart, so no row is a dead end under `R`.
+    #[test]
+    fn every_daemon_row_has_a_label_and_restart_arm() {
+        use crate::app::state::DaemonRow;
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        for row in DaemonRow::ORDER {
+            assert!(!row.label().is_empty(), "{row:?} needs a label");
+            let mut state = AppState::default();
+            EventHandler::process_event(AppEvent::GoToDaemons, &mut state);
+            state.spawn_daemon_restart(row);
+            let overlay = state.daemons_overlay.as_ref().expect("overlay");
+            assert!(
+                overlay.restart_rx.is_some(),
+                "{row:?} must arm an in-flight restart"
+            );
+            assert!(
+                overlay.restart_status.as_deref().is_some_and(|s| s.contains(row.label())),
+                "{row:?} status line must name the daemon being restarted"
+            );
+        }
+    }
+
     /// Daemons repair keys stay next to the table that reports their state.
     #[test]
     fn daemons_repair_key_routing() {
@@ -8799,7 +8896,7 @@ mod panel_back_tests {
             |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
         assert!(matches!(
             route(&mut state, KeyCode::Char('R')),
-            Some(AppEvent::DaemonsOverlayRestartNotifyd)
+            Some(AppEvent::DaemonsOverlayRestartSelected)
         ));
         assert!(matches!(
             route(&mut state, KeyCode::Char('I')),

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1024,10 +1024,55 @@ pub struct DaemonsFetchResult {
     pub(crate) hangar_runtime: crate::cli::hangar::DaemonRuntimeStatus,
 }
 
+/// One restartable daemon in the overlay, in the order the rows are drawn.
+///
+/// The overlay used to expose lifecycle only through per-daemon keys (`S`
+/// hangar, `M` mcp, `P` headroom) which all START, plus `R` hardcoded to
+/// notifyd. That left no way to cycle an already-running daemon — exactly what
+/// a version drift after `brew upgrade` needs, since the old binary keeps
+/// serving until the process is replaced. Selecting a row and pressing `R`
+/// gives every daemon the same lever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonRow {
+    Mcp,
+    Headroom,
+    Hangar,
+    Notifyd,
+}
+
+impl DaemonRow {
+    /// Draw order, which is also selection order.
+    pub const ORDER: [Self; 4] = [Self::Mcp, Self::Headroom, Self::Hangar, Self::Notifyd];
+
+    /// Label used in the table and in restart status lines.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Mcp => "MCP pool",
+            Self::Headroom => "Headroom",
+            Self::Hangar => "Hangar",
+            Self::Notifyd => "notifyd",
+        }
+    }
+
+    /// Move the selection, saturating at both ends.
+    ///
+    /// Deliberately does NOT wrap: a wrapping list gives no feedback that you
+    /// reached the end, and this list is short enough to see in full.
+    #[must_use]
+    pub fn step(self, delta: isize) -> Self {
+        let at = Self::ORDER.iter().position(|k| *k == self).unwrap_or(0);
+        let next = at.saturating_add_signed(delta).min(Self::ORDER.len().saturating_sub(1));
+        Self::ORDER[next]
+    }
+}
+
 /// Live, lazily-refreshed snapshot for the Daemons overlay. Present only while
 /// the overlay is open; dropping it stops all refresh activity.
 #[derive(Debug)]
 pub struct DaemonsOverlayState {
+    /// Row the `R` restart acts on. Starts at the top row.
+    pub selected: DaemonRow,
     pub mcp_alive: bool,
     pub(crate) mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus,
     pub headroom: crate::headroom::ProxyStatus,
@@ -1046,9 +1091,9 @@ pub struct DaemonsOverlayState {
     pub fetch_rx: Option<mpsc::UnboundedReceiver<DaemonsFetchResult>>,
     /// Receiver for an in-flight `notifyd` restart (None = no restart pending).
     /// Carries the one-line outcome to show under the notifyd section.
-    pub notifyd_restart_rx: Option<mpsc::UnboundedReceiver<String>>,
+    pub restart_rx: Option<mpsc::UnboundedReceiver<String>>,
     /// Last restart outcome line (transient, shown until the next refresh).
-    pub notifyd_restart_status: Option<String>,
+    pub restart_status: Option<String>,
     /// Receiver for a targeted hook reinstall. Kept separate from notifyd
     /// restart: repairing a binary pointer must not imply daemon lifecycle.
     pub hooks_repair_rx: Option<mpsc::UnboundedReceiver<String>>,
@@ -5019,6 +5064,7 @@ impl AppState {
             return;
         }
         self.daemons_overlay = Some(DaemonsOverlayState {
+            selected: DaemonRow::ORDER[0],
             mcp_alive: false,
             mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: crate::headroom::ProxyStatus {
@@ -5034,8 +5080,8 @@ impl AppState {
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
-            notifyd_restart_rx: None,
-            notifyd_restart_status: None,
+            restart_rx: None,
+            restart_status: None,
             hooks_repair_rx: None,
             hooks_repair_status: None,
             hangar_running: false,
@@ -5106,23 +5152,74 @@ impl AppState {
         });
     }
 
-    /// Restart the notifyd daemon from the Daemons overlay — the single
-    /// resume/repair lever. Runs [`ainb_plugin_notifyd::procs::restart`] off the
-    /// UI thread (it SIGTERMs the old owner, reaps stragglers, respawns, and
-    /// polls the approve socket, up to a few seconds). Once the socket rebinds,
-    /// every still-blocked permission waiter re-dials and resumes on its own —
-    /// so this one action both repairs a dead socket and resumes pending
-    /// prompts. One-outstanding guard mirrors the fetch path.
-    pub fn spawn_notifyd_restart(&mut self) {
+    /// Restart whichever daemon the overlay has selected.
+    ///
+    /// One in-flight restart at a time, shared across kinds: the outcome line
+    /// has a single slot in the overlay, and cycling two daemons at once would
+    /// race for it. Every arm reuses the same lifecycle the CLI uses rather
+    /// than reimplementing stop/start here, so the TUI and `ainb <d> daemon
+    /// restart` cannot drift apart.
+    pub fn spawn_daemon_restart(&mut self, kind: DaemonRow) {
         let Some(o) = self.daemons_overlay.as_mut() else {
             return;
         };
-        if o.notifyd_restart_rx.is_some() {
+        if o.restart_rx.is_some() {
             return;
         }
         let (tx, rx) = mpsc::unbounded_channel();
-        o.notifyd_restart_rx = Some(rx);
-        o.notifyd_restart_status = Some("restarting notifyd…".to_string());
+        o.restart_rx = Some(rx);
+        o.restart_status = Some(format!("restarting {}…", kind.label()));
+        match kind {
+            DaemonRow::Notifyd => self.spawn_notifyd_restart(tx),
+            DaemonRow::Hangar => {
+                Self::spawn_blocking_restart(tx, kind, || crate::cli::hangar::run_daemon_restart())
+            }
+            DaemonRow::Mcp => {
+                Self::spawn_blocking_restart(tx, kind, || crate::mcp_pool::client::restart_daemon())
+            }
+            // Headroom has no single restart entry point, so it is composed
+            // from its own stop + start. `stop()` returning false means it was
+            // not running, which is not an error for a restart. Its start is
+            // async, so this cannot use the blocking helper: `stop()` is sync
+            // and runs on the blocking pool, then the proxy is awaited.
+            DaemonRow::Headroom => {
+                tokio::spawn(async move {
+                    let _ = tokio::task::spawn_blocking(crate::headroom::stop).await;
+                    let line = crate::headroom::ensure_proxy_running()
+                        .await
+                        .map(|()| "restarted Headroom".to_string())
+                        .unwrap_or_else(|e| format!("Headroom restart failed: {e:#}"));
+                    let _ = tx.send(line);
+                });
+            }
+        }
+    }
+
+    /// Run one blocking daemon lifecycle call and report a single outcome line.
+    fn spawn_blocking_restart<F>(tx: mpsc::UnboundedSender<String>, kind: DaemonRow, action: F)
+    where
+        F: FnOnce() -> anyhow::Result<()> + Send + 'static,
+    {
+        let label = kind.label();
+        tokio::spawn(async move {
+            let line = tokio::task::spawn_blocking(move || match action() {
+                Ok(()) => format!("restarted {label}"),
+                Err(e) => format!("{label} restart failed: {e:#}"),
+            })
+            .await
+            .unwrap_or_else(|e| format!("{label} restart task panicked: {e}"));
+            let _ = tx.send(line);
+        });
+    }
+
+    /// notifyd's arm of [`Self::spawn_daemon_restart`].
+    ///
+    /// Kept separate from the blocking helper because its outcome line is
+    /// richer than "restarted": the restart SIGTERMs the old owner, reaps
+    /// stragglers, respawns and then polls the approve socket, and whether
+    /// that socket rebound is the part that matters — once it does, every
+    /// still-blocked permission waiter re-dials and resumes on its own.
+    fn spawn_notifyd_restart(&mut self, tx: mpsc::UnboundedSender<String>) {
         tokio::spawn(async move {
             let line = tokio::task::spawn_blocking(|| {
                 match ainb_plugin_notifyd::procs::restart(std::time::Duration::from_secs(3)) {
@@ -5294,10 +5391,10 @@ impl AppState {
         }
         // A finished restart updates the status line and triggers a fresh scan
         // so the new pid shows up in the notifyd section.
-        if let Some(rx) = o.notifyd_restart_rx.as_mut() {
+        if let Some(rx) = o.restart_rx.as_mut() {
             if let Ok(line) = rx.try_recv() {
-                o.notifyd_restart_rx = None;
-                o.notifyd_restart_status = Some(line);
+                o.restart_rx = None;
+                o.restart_status = Some(line);
                 refresh_after_start = true;
             }
         }

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -301,7 +301,7 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
                         runtime.notifyd.iter().any(|daemon| daemon.class.is_healthy()),
                     )),
                     Cell::from(action_detail(
-                        runtime.notifyd_restart_status.as_ref(),
+                        runtime.restart_status.as_ref(),
                         &notify_version,
                     )),
                     Cell::from("R restart current"),
@@ -742,6 +742,7 @@ mod tests {
 
     fn system_runtime() -> DaemonsOverlayState {
         DaemonsOverlayState {
+            selected: crate::app::state::DaemonRow::ORDER[0],
             mcp_alive: true,
             mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: ProxyStatus {
@@ -760,8 +761,8 @@ mod tests {
             loading: false,
             last_refreshed: None,
             fetch_rx: None,
-            notifyd_restart_rx: None,
-            notifyd_restart_status: None,
+            restart_rx: None,
+            restart_status: None,
             hooks_repair_rx: None,
             hooks_repair_status: None,
             hangar_start_rx: None,

--- a/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons_overlay.rs
@@ -11,7 +11,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
 };
 
-use crate::app::state::DaemonsOverlayState;
+use crate::app::state::{DaemonRow, DaemonsOverlayState};
 
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
 const GOLD: Color = Color::Rgb(255, 215, 0);
@@ -71,6 +71,37 @@ pub fn render(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
     render_help_bar(frame, chunks[1], state);
 }
 
+/// Row prefix marking the selected daemon.
+///
+/// Two chars wide for BOTH states so the labels stay column-aligned — a marker
+/// that changes width makes the table jitter as the selection moves.
+fn row_marker(state: &DaemonsOverlayState, kind: DaemonRow) -> Span<'static> {
+    if state.selected == kind {
+        Span::styled(
+            "\u{25b8} ",
+            Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::raw("  ")
+    }
+}
+
+/// `1.21.5 \u{26a0} drift` when an older daemon is still serving this home.
+///
+/// Drift is what makes a restart necessary after an upgrade: the running
+/// process keeps serving the OLD binary until it is replaced, so showing the
+/// version is what turns `R` from a guess into an informed action.
+fn version_span(version: Option<&str>, old: bool) -> Span<'static> {
+    match version {
+        Some(v) if old => Span::styled(
+            format!("  {v} \u{26a0} drift"),
+            Style::default().fg(CLAY).add_modifier(Modifier::BOLD),
+        ),
+        Some(v) => Span::styled(format!("  {v}"), Style::default().fg(MUTED_GRAY)),
+        None => Span::raw(""),
+    }
+}
+
 fn status_dot(running: bool) -> Span<'static> {
     if running {
         Span::styled(
@@ -110,15 +141,13 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
 
     // ── MCP pool ──────────────────────────────────────────────────────────────
     let mcp_line = Line::from(vec![
+        row_marker(state, DaemonRow::Mcp),
         Span::styled(
-            "  MCP pool     ",
+            "MCP pool     ",
             Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
         ),
         status_dot(state.mcp_alive),
-        Span::styled(
-            "    (use `ainb mcp stop` to stop)",
-            Style::default().fg(MUTED_GRAY),
-        ),
+        version_span(state.mcp_runtime.version.as_deref(), state.mcp_runtime.old),
     ]);
     frame.render_widget(Paragraph::new(mcp_line), rows[0]);
 
@@ -139,8 +168,9 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
     let watched = state.headroom.running && !state.headroom_consumers.is_empty();
 
     let mut headroom_spans = vec![
+        row_marker(state, DaemonRow::Headroom),
         Span::styled(
-            format!("  Headroom :{port:<5}"),
+            format!("Headroom :{port:<5}"),
             Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
         ),
         status_dot(state.headroom.running),
@@ -178,8 +208,9 @@ fn render_cards(frame: &mut Frame, area: Rect, state: &DaemonsOverlayState) {
 
     // ── notifyd processes ───────────────────────────────────────────────────────
     let mut hangar = vec![
+        row_marker(state, DaemonRow::Hangar),
         Span::styled(
-            "  Hangar daemon ",
+            "Hangar daemon ",
             Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
         ),
         status_dot(state.hangar_running),
@@ -238,8 +269,9 @@ fn render_notifyd_section(frame: &mut Frame, area: Rect, state: &DaemonsOverlayS
     let lines = build_notifyd_lines(
         &state.notifyd,
         (state.approve_running, &state.approve_reason),
-        state.notifyd_restart_status.as_deref(),
+        state.restart_status.as_deref(),
         area.height as usize,
+        state.selected == DaemonRow::Notifyd,
     );
     frame.render_widget(Paragraph::new(lines), area);
 }
@@ -254,6 +286,7 @@ fn build_notifyd_lines(
     approve: (bool, &str),
     restart_status: Option<&str>,
     capacity: usize,
+    selected: bool,
 ) -> Vec<Line<'static>> {
     let orphan_count = notifyd.iter().filter(|d| !d.class.is_healthy()).count();
 
@@ -261,23 +294,35 @@ fn build_notifyd_lines(
 
     // Header: "notifyd processes (N)  · M to clean up  · R restart".
     let mut header = vec![Span::styled(
-        format!("  notifyd processes ({})", notifyd.len()),
+        format!("notifyd processes ({})", notifyd.len()),
         Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
     )];
+    header.insert(
+        0,
+        if selected {
+            Span::styled(
+                "\u{25b8} ",
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            )
+        } else {
+            Span::raw("  ")
+        },
+    );
     if orphan_count > 0 {
         header.push(Span::styled(
             format!("   · {orphan_count} to clean up (run `ainb notifyd reap`)"),
             Style::default().fg(CLAY),
         ));
     }
-    // Restart affordance sits next to the notifyd control it acts on.
+    // `R` acts on the SELECTED row now, not on notifyd specifically, so the
+    // affordance no longer claims to belong to this section.
     header.push(Span::styled("   · ", Style::default().fg(MUTED_GRAY)));
     header.push(Span::styled(
         "R",
         Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
     ));
     header.push(Span::styled(
-        " restart (resume/repair)",
+        " restart selected",
         Style::default().fg(MUTED_GRAY),
     ));
     lines.push(Line::from(header));
@@ -411,6 +456,7 @@ mod tests {
         tokens: Option<u64>,
     ) -> DaemonsOverlayState {
         DaemonsOverlayState {
+            selected: DaemonRow::ORDER[0],
             mcp_alive: true,
             mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: ProxyStatus {
@@ -426,8 +472,8 @@ mod tests {
             loading: false,
             last_refreshed: Some(std::time::Instant::now()),
             fetch_rx: None,
-            notifyd_restart_rx: None,
-            notifyd_restart_status: None,
+            restart_rx: None,
+            restart_status: None,
             hooks_repair_rx: None,
             hooks_repair_status: None,
             hangar_running: false,
@@ -452,6 +498,45 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    /// The cursor marks exactly one row, and it is the one `R` acts on.
+    ///
+    /// Rendered rather than asserted on state, because the marker IS the only
+    /// feedback telling the operator which daemon a restart will hit — a
+    /// selection that moves in state but not on screen is a mis-fire waiting
+    /// to happen.
+    fn daemons_overlay_marks_the_selected_row() {
+        for (row, label) in [
+            (DaemonRow::Mcp, "MCP pool"),
+            (DaemonRow::Headroom, "Headroom"),
+            (DaemonRow::Hangar, "Hangar daemon"),
+            (DaemonRow::Notifyd, "notifyd processes"),
+        ] {
+            let mut state = make_state(true, 8787, Some(12345), Some(9876));
+            state.selected = row;
+            let backend = TestBackend::new(120, 36);
+            let mut term = Terminal::new(backend).unwrap();
+            term.draw(|f| {
+                let area = f.size();
+                render(f, area, &state);
+            })
+            .unwrap();
+            let text = buffer_text(&term);
+
+            let marked: Vec<&str> = text.lines().filter(|line| line.contains('\u{25b8}')).collect();
+            assert_eq!(
+                marked.len(),
+                1,
+                "exactly one row must carry the cursor for {row:?}, got {marked:?}"
+            );
+            assert!(
+                marked[0].contains(label),
+                "cursor must sit on {label} when {row:?} is selected, got {:?}",
+                marked[0]
+            );
+        }
     }
 
     #[test]
@@ -535,6 +620,7 @@ mod tests {
     #[test]
     fn daemons_overlay_renders_loading_state() {
         let state = DaemonsOverlayState {
+            selected: DaemonRow::ORDER[0],
             mcp_alive: false,
             mcp_runtime: crate::mcp_pool::client::DaemonRuntimeStatus::default(),
             headroom: ProxyStatus {
@@ -550,8 +636,8 @@ mod tests {
             loading: true,
             last_refreshed: None,
             fetch_rx: None,
-            notifyd_restart_rx: None,
-            notifyd_restart_status: None,
+            restart_rx: None,
+            restart_status: None,
             hooks_repair_rx: None,
             hooks_repair_status: None,
             hangar_running: false,
@@ -642,13 +728,13 @@ mod tests {
             })
             .collect();
         // capacity 4 → header + approve.sock + 1 row + "… +6 more"
-        let lines = build_notifyd_lines(&many, (true, "serving"), None, 4);
+        let lines = build_notifyd_lines(&many, (true, "serving"), None, 4, false);
         assert!(lines.len() <= 4, "exceeded capacity: {}", lines.len());
         let last: String = lines.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();
         assert!(last.contains("more"), "no overflow pointer in: {last}");
 
         // Ample capacity → all 7 rows, no overflow line.
-        let full = build_notifyd_lines(&many, (true, "serving"), None, 30);
+        let full = build_notifyd_lines(&many, (true, "serving"), None, 30, false);
         assert_eq!(full.len(), 9); // header + approve.sock + 7
         let full_last: String =
             full.last().unwrap().spans.iter().map(|s| s.content.clone()).collect();


### PR DESCRIPTION
The Daemons overlay (`d`) could not restart a daemon that was already
running. `R` was hardcoded to notifyd, and `S`/`M`/`P` only START a stopped
one — so after a `brew upgrade` left the old process serving (version
drift), the TUI had no lever at all.

## Changes

- **Cursor over the four rows** (`↑`/`↓`, `k`/`j`), saturating rather than
  wrapping — the list is short enough to see whole.
- **`R` restarts the selected row**, dispatching to hangar
  (`run_daemon_restart`), MCP (`restart_daemon`), notifyd (`procs::restart`)
  or Headroom (stop + async start). Each arm reuses the lifecycle the CLI
  already uses, so the TUI and the daemon restart verbs cannot drift apart.
- **Per-row version + `⚠ drift`**, so a stale daemon is visible *before* you
  restart it — drift is the reason the restart is needed.
- Dropped the notifyd-only event now that no key emits it.

One in-flight restart at a time, shared across rows: the outcome line has a
single slot, so two concurrent restarts would race for it.

## Tests

- `daemons_overlay_restarts_the_selected_row` — start position, movement,
  saturation at both ends, arrow + vim keys.
- `every_daemon_row_has_a_label_and_restart_arm` — no row is a dead end
  under `R`, and the status line names the daemon.
- `daemons_overlay_marks_the_selected_row` — renders all four rows and
  asserts exactly one carries the cursor, on the right row.

All three passed locally before the final dead-code removal. **CI is the
gate for the post-removal tree**: this machine's `rustc` is wedged in
uninterruptible I/O wait (`STAT=U+`, 2.4s CPU over 12min wall), so I could
not re-run the suite locally. Flagging that rather than claiming a green run
I did not observe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigate between MCP, Headroom, Hangar, and notifyd in the daemons view using arrow or vim keys.
  * Restart the currently selected daemon with `R`.
  * View MCP runtime versions and highlighted version drift warnings.
  * See selection indicators and restart status for the active daemon.

* **Bug Fixes**
  * Improved daemon selection boundaries to prevent navigation beyond the available rows.
  * Restart results now refresh daemon statuses consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->