### PR TITLE
feat(daemons): put the restart cursor on the screen `d` actually opens

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -8835,7 +8835,6 @@ mod panel_back_tests {
     #[test]
     fn daemons_overlay_restarts_the_selected_row() {
         use crate::app::state::DaemonRow;
-        use crossterm::event::{KeyCode, KeyEvent};
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let _guard = rt.enter();
@@ -8866,17 +8865,11 @@ mod panel_back_tests {
         }
         assert_eq!(selected(&state), Some(DaemonRow::Notifyd));
 
-        // Arrow keys and vim keys both move the cursor.
-        let route =
-            |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
-        assert!(matches!(
-            route(&mut state, KeyCode::Up),
-            Some(AppEvent::DaemonsOverlaySelect(-1))
-        ));
-        assert!(matches!(
-            route(&mut state, KeyCode::Char('j')),
-            Some(AppEvent::DaemonsOverlaySelect(1))
-        ));
+        // Key routing is NOT asserted here: `GoToDaemons` opens the Daemons
+        // SCREEN, whose arrows drive that screen's cursor, not this overlay's.
+        // `daemons_screen_keys_drive_the_screen_cursor_not_the_overlay` owns
+        // that contract — conflating the two is what shipped a cursor nobody
+        // could reach.
     }
 
     /// Every row is labelled, and the labels are distinct.

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -58,8 +58,12 @@ pub enum AppEvent {
     DaemonsOverlayRefresh,
     /// Move the overlay's row selection by a signed step (saturating).
     DaemonsOverlaySelect(isize),
-    /// Restart whichever daemon row is selected.
+    /// Restart whichever daemon row is selected in the overlay.
     DaemonsOverlayRestartSelected,
+    /// Move the Daemons SCREEN cursor by a signed step (saturating).
+    DaemonsSelect(isize),
+    /// Restart the daemon the Daemons screen cursor is on.
+    DaemonsRestartSelected,
     DaemonsRepairHooks,
     DaemonsOverlayStartHangar,
     DaemonsStartMcp,
@@ -2975,13 +2979,13 @@ impl EventHandler {
     fn handle_daemons_keys(key_event: KeyEvent, _state: &mut AppState) -> Option<AppEvent> {
         match key_event.code {
             KeyCode::Esc | KeyCode::Char('q') => Some(AppEvent::PanelBack),
-            KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::DaemonsOverlaySelect(-1)),
-            KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::DaemonsOverlaySelect(1)),
+            KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::DaemonsSelect(-1)),
+            KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::DaemonsSelect(1)),
             KeyCode::Char('r') => Some(AppEvent::DaemonsOverlayRefresh),
-            // `R` used to be hardcoded to notifyd. It now acts on the selected
-            // row, which is the only way to cycle an already-running daemon
-            // (the S/M/P keys below only START a stopped one).
-            KeyCode::Char('R') => Some(AppEvent::DaemonsOverlayRestartSelected),
+            // Acts on the row the cursor is drawn on — see
+            // `DaemonsState::selected_kind`, which is the single authority for
+            // both the highlight and this target.
+            KeyCode::Char('R') => Some(AppEvent::DaemonsRestartSelected),
             KeyCode::Char('I') => Some(AppEvent::DaemonsRepairHooks),
             KeyCode::Char('S') => Some(AppEvent::DaemonsOverlayStartHangar),
             KeyCode::Char('M') => Some(AppEvent::DaemonsStartMcp),
@@ -3681,6 +3685,27 @@ impl EventHandler {
             AppEvent::DaemonsOverlaySelect(delta) => {
                 if let Some(o) = state.daemons_overlay.as_mut() {
                     o.selected = o.selected.step(delta);
+                }
+            }
+            AppEvent::DaemonsSelect(delta) => {
+                let rows = state.daemons_state.snapshot().rows;
+                state.daemons_state.move_selection(delta, rows.len());
+            }
+            AppEvent::DaemonsRestartSelected => {
+                let rows = state.daemons_state.snapshot().rows;
+                match state.daemons_state.selected_kind(&rows) {
+                    None => {}
+                    Some(kind) => match crate::components::daemons::DaemonsState::restart_support(kind) {
+                        // Only notifyd has an in-process restart; the broker
+                        // rides its runtime. Anything else says why, so the key
+                        // never silently no-ops or hits a different daemon.
+                        Ok(_) => state.spawn_daemon_restart(crate::app::state::DaemonRow::Notifyd),
+                        Err(why) => {
+                            if let Some(o) = state.daemons_overlay.as_mut() {
+                                o.restart_status = Some(why);
+                            }
+                        }
+                    },
                 }
             }
             AppEvent::DaemonsOverlayRestartSelected => {
@@ -8877,6 +8902,42 @@ mod panel_back_tests {
         assert_eq!(seen.len(), DaemonRow::ORDER.len());
     }
 
+    /// `d` reaches the Daemons SCREEN, and its keys drive that screen's cursor.
+    ///
+    /// Pinned because a previous change wired the cursor into the Daemons
+    /// OVERLAY — a different component — so `R` restarted a row nobody could
+    /// see highlighted while the screen's help still advertised notifyd. The
+    /// keys the operator actually presses must map to the surface they are
+    /// looking at.
+    #[test]
+    fn daemons_screen_keys_drive_the_screen_cursor_not_the_overlay() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let mut state = AppState::default();
+        EventHandler::process_event(AppEvent::GoToDaemons, &mut state);
+
+        let route =
+            |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
+        assert!(
+            matches!(
+                route(&mut state, KeyCode::Char('R')),
+                Some(AppEvent::DaemonsRestartSelected)
+            ),
+            "R must restart the row the screen highlights"
+        );
+        assert!(matches!(
+            route(&mut state, KeyCode::Down),
+            Some(AppEvent::DaemonsSelect(1))
+        ));
+        assert!(matches!(
+            route(&mut state, KeyCode::Char('k')),
+            Some(AppEvent::DaemonsSelect(-1))
+        ));
+    }
+
     /// Daemons repair keys stay next to the table that reports their state.
     #[test]
     fn daemons_repair_key_routing() {
@@ -8898,7 +8959,7 @@ mod panel_back_tests {
             |s: &mut AppState, code| EventHandler::handle_key_event(KeyEvent::from(code), s);
         assert!(matches!(
             route(&mut state, KeyCode::Char('R')),
-            Some(AppEvent::DaemonsOverlayRestartSelected)
+            Some(AppEvent::DaemonsRestartSelected)
         ));
         assert!(matches!(
             route(&mut state, KeyCode::Char('I')),

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3695,17 +3695,21 @@ impl EventHandler {
                 let rows = state.daemons_state.snapshot().rows;
                 match state.daemons_state.selected_kind(&rows) {
                     None => {}
-                    Some(kind) => match crate::components::daemons::DaemonsState::restart_support(kind) {
-                        // Only notifyd has an in-process restart; the broker
-                        // rides its runtime. Anything else says why, so the key
-                        // never silently no-ops or hits a different daemon.
-                        Ok(_) => state.spawn_daemon_restart(crate::app::state::DaemonRow::Notifyd),
-                        Err(why) => {
-                            if let Some(o) = state.daemons_overlay.as_mut() {
-                                o.restart_status = Some(why);
+                    Some(kind) => {
+                        match crate::components::daemons::DaemonsState::restart_support(kind) {
+                            // Only notifyd has an in-process restart; the broker
+                            // rides its runtime. Anything else says why, so the key
+                            // never silently no-ops or hits a different daemon.
+                            Ok(_) => {
+                                state.spawn_daemon_restart(crate::app::state::DaemonRow::Notifyd)
+                            }
+                            Err(why) => {
+                                if let Some(o) = state.daemons_overlay.as_mut() {
+                                    o.restart_status = Some(why);
+                                }
                             }
                         }
-                    },
+                    }
                 }
             }
             AppEvent::DaemonsOverlayRestartSelected => {

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -18,13 +18,17 @@ use ratatui::{
 use crate::app::state::DaemonsOverlayState;
 use crate::cli::fleet::daemons::{fmt_ago, fmt_duration_ms};
 use crate::fleet::daemons::heartbeat::now_ms;
-use crate::fleet::daemons::probe::{DaemonState, DaemonStatus};
+use crate::fleet::daemons::probe::{DaemonKind, DaemonState, DaemonStatus};
 use ainb_plugin_notifyd::{HookHealth, Paths};
 
 // Palette shared with the rest of ainb-tui (see components/layout.rs).
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
 const GOLD: Color = Color::Rgb(255, 215, 0);
 const HEALTHY_GREEN: Color = Color::Rgb(100, 200, 100);
+/// Cursor colour, per the TUI style guide. Same RGB as HEALTHY_GREEN but kept
+/// separate: one means "this daemon is up", the other means "R acts on this
+/// row", and they must be free to diverge.
+const SELECTION_GREEN: Color = Color::Rgb(100, 200, 100);
 const STOPPED_RED: Color = Color::Rgb(220, 100, 100);
 const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
@@ -65,6 +69,66 @@ pub struct DaemonsState {
     /// The snapshot the background collector publishes into. `None` until the
     /// first render lazily spawns the collector.
     shared: Option<Arc<Mutex<Snapshot>>>,
+    /// Cursor into the rendered rows. `R` restarts THIS row and nothing else.
+    ///
+    /// Stored as an index rather than a [`DaemonKind`] because the row list is
+    /// whatever the collector last published: an index keeps the cursor
+    /// meaningful even before the first snapshot arrives, and
+    /// [`Self::selected_kind`] is the single place that turns it into a target.
+    selected: usize,
+}
+
+impl DaemonsState {
+    /// The daemon the cursor is on, or `None` when there are no rows.
+    ///
+    /// THE authority for both the highlight and the restart target. Render and
+    /// key handling must both go through it — if one of them ever computed the
+    /// row independently, `R` could restart a daemon other than the one the
+    /// operator can see highlighted, which is the exact failure this indirection
+    /// exists to make impossible.
+    #[must_use]
+    pub fn selected_kind(&self, rows: &[DaemonStatus]) -> Option<DaemonKind> {
+        rows.get(self.selected_index(rows)).map(|d| d.kind)
+    }
+
+    /// The cursor clamped to the current row count.
+    ///
+    /// The collector republishes the row list, so a cursor parked past the end
+    /// (rows disappeared between renders) must not silently point at nothing.
+    #[must_use]
+    pub fn selected_index(&self, rows: &[DaemonStatus]) -> usize {
+        self.selected.min(rows.len().saturating_sub(1))
+    }
+
+    /// Whether `R` can act on a daemon kind, and why not when it cannot.
+    ///
+    /// Only notifyd has an in-process restart. The approve broker is served on
+    /// notifyd's runtime, so restarting notifyd restarts it too. The bridge,
+    /// ATC and the fleet daemon expose no restart entry point, and `R` says so
+    /// rather than doing nothing — a key that silently no-ops reads as broken,
+    /// and a key that falls back to "some other daemon" would be dangerous.
+    #[must_use]
+    pub fn restart_support(kind: DaemonKind) -> Result<DaemonKind, String> {
+        match kind {
+            DaemonKind::Notifyd => Ok(DaemonKind::Notifyd),
+            // Same runtime as notifyd: restarting that rebinds this socket.
+            DaemonKind::ApproveBroker => Ok(DaemonKind::Notifyd),
+            DaemonKind::Bridge | DaemonKind::Atc | DaemonKind::FleetDaemon => Err(format!(
+                "{} has no restart from the TUI — use its own CLI verb",
+                kind.display_name()
+            )),
+        }
+    }
+
+    /// Move the cursor, saturating at both ends.
+    pub fn move_selection(&mut self, delta: isize, row_count: usize) {
+        if row_count == 0 {
+            self.selected = 0;
+            return;
+        }
+        let at = self.selected.min(row_count - 1);
+        self.selected = at.saturating_add_signed(delta).min(row_count - 1);
+    }
 }
 
 impl DaemonsState {
@@ -96,7 +160,7 @@ impl DaemonsState {
 
     /// Read the latest published snapshot. Off the render path this is a pure
     /// memory read under a microsecond lock.
-    fn snapshot(&mut self) -> Snapshot {
+    pub fn snapshot(&mut self) -> Snapshot {
         let shared = self.shared();
         let guard = shared.lock().unwrap_or_else(|p| p.into_inner());
         Snapshot {
@@ -166,6 +230,13 @@ pub fn render(
                 "  runtime health",
                 Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
             ),
+            Span::styled(
+                "  \u{2191}\u{2193}",
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" select \u{b7} ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("R", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+            Span::styled(" restart selected", Style::default().fg(MUTED_GRAY)),
         ]))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -225,8 +296,6 @@ fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&Daemon
             Span::styled(" restart MCP · ", Style::default().fg(MUTED_GRAY)),
             Span::styled("P", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
             Span::styled(" Headroom · ", Style::default().fg(MUTED_GRAY)),
-            Span::styled("R", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
-            Span::styled(" notifyd · ", Style::default().fg(MUTED_GRAY)),
             Span::styled("S", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
             Span::styled(" start / upgrade Hangar", Style::default().fg(MUTED_GRAY)),
         ]))
@@ -505,10 +574,14 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
     ])
     .style(Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD));
 
+    // The highlight comes from the SAME call the restart target does, so the
+    // marked row and the row `R` acts on cannot drift apart.
+    let cursor = state.selected_index(&snapshot.rows);
     let rows: Vec<Row> = snapshot
         .rows
         .iter()
-        .map(|d| {
+        .enumerate()
+        .map(|(index, d)| {
             let (glyph, glyph_style) = match d.state {
                 DaemonState::Running => ("● running", Style::default().fg(HEALTHY_GREEN)),
                 // Amber, not green: the process is up but one half of its job is
@@ -528,9 +601,17 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
                 }
                 _ => d.reason.clone(),
             };
+            let marker = if index == cursor { "\u{25b6} " } else { "  " };
             Row::new(vec![
-                Cell::from(d.kind.display_name())
-                    .style(Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)),
+                Cell::from(format!("{marker}{}", d.kind.display_name())).style(
+                    if index == cursor {
+                        Style::default()
+                            .fg(SELECTION_GREEN)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)
+                    },
+                ),
                 Cell::from(glyph).style(glyph_style),
                 Cell::from(pid),
                 Cell::from(uptime),
@@ -670,6 +751,7 @@ mod tests {
         }));
         DaemonsState {
             shared: Some(shared),
+            selected: 0,
         }
     }
 
@@ -722,6 +804,7 @@ mod tests {
         }));
         DaemonsState {
             shared: Some(shared),
+            selected: 0,
         }
     }
 
@@ -738,6 +821,120 @@ mod tests {
         terminal.draw(|f| render(f, f.area(), state, runtime)).unwrap();
         let buf = terminal.backend().buffer().clone();
         buf.content().iter().map(|c| c.symbol()).collect::<String>()
+    }
+
+    /// Render and return the buffer as LINES, so a test can ask which row the
+    /// cursor is drawn on rather than only whether a glyph exists somewhere.
+    fn render_to_lines(
+        state: &mut DaemonsState,
+        runtime: Option<&DaemonsOverlayState>,
+        w: u16,
+        h: u16,
+    ) -> Vec<String> {
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, f.area(), state, runtime)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        (0..h)
+            .map(|y| {
+                (0..w)
+                    .map(|x| buf.cell((x, y)).map_or(" ", |c| c.symbol()).to_string())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    /// The row the cursor is DRAWN on is the row `R` restarts — always.
+    ///
+    /// This is the safety property, so it is asserted against the rendered
+    /// buffer rather than against state: it reads back which line carries the
+    /// cursor glyph and requires that line to name the same daemon that
+    /// `selected_kind` hands the restart. If render and dispatch ever compute
+    /// the row separately and disagree — the highlighted daemon differing from
+    /// the restarted one — this fails.
+    #[test]
+    fn the_highlighted_row_is_the_row_restart_targets() {
+        let rows = vec![
+            status(DaemonKind::Bridge, DaemonState::Stopped, false, None),
+            status(DaemonKind::Notifyd, DaemonState::Running, true, Some(1)),
+            status(DaemonKind::ApproveBroker, DaemonState::Running, true, None),
+            status(DaemonKind::Atc, DaemonState::Running, true, None),
+        ];
+        let mut state = seeded_state(rows.clone());
+
+        for want in 0..rows.len() {
+            // Drive the cursor the way the key handler does, from wherever it is.
+            state.selected = 0;
+            state.move_selection(want as isize, rows.len());
+
+            let target = state
+                .selected_kind(&rows)
+                .expect("a populated table always has a selected row");
+
+            let lines = render_to_lines(&mut state, None, 160, 30);
+            let marked: Vec<&String> =
+                lines.iter().filter(|l| l.contains('\u{25b6}')).collect();
+            assert_eq!(
+                marked.len(),
+                1,
+                "exactly one row may carry the cursor, got {marked:?}"
+            );
+            assert!(
+                marked[0].contains(target.display_name()),
+                "cursor is drawn on {:?} but restart would target {:?}",
+                marked[0].trim(),
+                target.display_name()
+            );
+        }
+    }
+
+    /// `R` refuses daemons it cannot restart instead of silently no-opping or
+    /// falling back to a different daemon.
+    #[test]
+    fn restart_support_never_redirects_to_an_unrelated_daemon() {
+        assert_eq!(
+            DaemonsState::restart_support(DaemonKind::Notifyd),
+            Ok(DaemonKind::Notifyd)
+        );
+        // The broker shares notifyd's runtime, so this redirect is the one
+        // legitimate case — and it is the ONLY one.
+        assert_eq!(
+            DaemonsState::restart_support(DaemonKind::ApproveBroker),
+            Ok(DaemonKind::Notifyd)
+        );
+        for kind in [DaemonKind::Bridge, DaemonKind::Atc, DaemonKind::FleetDaemon] {
+            let err = DaemonsState::restart_support(kind)
+                .expect_err("{kind:?} has no restart entry point");
+            assert!(
+                err.contains(kind.display_name()),
+                "the refusal must name the daemon the cursor is on, got {err:?}"
+            );
+        }
+    }
+
+    /// The cursor saturates rather than wrapping, and survives an empty table.
+    #[test]
+    fn cursor_saturates_and_tolerates_an_empty_table() {
+        let rows = vec![
+            status(DaemonKind::Bridge, DaemonState::Stopped, false, None),
+            status(DaemonKind::Notifyd, DaemonState::Running, true, Some(1)),
+        ];
+        let mut state = seeded_state(rows.clone());
+
+        state.move_selection(-1, rows.len());
+        assert_eq!(state.selected_index(&rows), 0, "saturates at the top");
+
+        state.move_selection(50, rows.len());
+        assert_eq!(
+            state.selected_index(&rows),
+            rows.len() - 1,
+            "saturates at the bottom"
+        );
+
+        // A cursor parked past the end must not point at nothing when the
+        // collector republishes a shorter list.
+        assert_eq!(state.selected_kind(&[]), None);
+        assert_eq!(state.selected_index(&[]), 0);
     }
 
     fn system_runtime() -> DaemonsOverlayState {

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -857,7 +857,12 @@ mod tests {
     fn the_highlighted_row_is_the_row_restart_targets() {
         let rows = vec![
             status(DaemonKind::Bridge, DaemonState::Stopped, false, None),
-            status(DaemonKind::Notifyd, DaemonState::Running, true, Some(1)),
+            status(
+                DaemonKind::Notifyd,
+                DaemonState::Running,
+                true,
+                Some("unix socket"),
+            ),
             status(DaemonKind::ApproveBroker, DaemonState::Running, true, None),
             status(DaemonKind::Atc, DaemonState::Running, true, None),
         ];
@@ -916,7 +921,12 @@ mod tests {
     fn cursor_saturates_and_tolerates_an_empty_table() {
         let rows = vec![
             status(DaemonKind::Bridge, DaemonState::Stopped, false, None),
-            status(DaemonKind::Notifyd, DaemonState::Running, true, Some(1)),
+            status(
+                DaemonKind::Notifyd,
+                DaemonState::Running,
+                true,
+                Some("unix socket"),
+            ),
         ];
         let mut state = seeded_state(rows.clone());
 

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -605,9 +605,7 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
             Row::new(vec![
                 Cell::from(format!("{marker}{}", d.kind.display_name())).style(
                     if index == cursor {
-                        Style::default()
-                            .fg(SELECTION_GREEN)
-                            .add_modifier(Modifier::BOLD)
+                        Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
                     } else {
                         Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)
                     },
@@ -867,13 +865,11 @@ mod tests {
             state.selected = 0;
             state.move_selection(want as isize, rows.len());
 
-            let target = state
-                .selected_kind(&rows)
-                .expect("a populated table always has a selected row");
+            let target =
+                state.selected_kind(&rows).expect("a populated table always has a selected row");
 
             let lines = render_to_lines(&mut state, None, 160, 30);
-            let marked: Vec<&String> =
-                lines.iter().filter(|l| l.contains('\u{25b6}')).collect();
+            let marked: Vec<&String> = lines.iter().filter(|l| l.contains('\u{25b6}')).collect();
             assert_eq!(
                 marked.len(),
                 1,

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -218,6 +218,9 @@ pub fn render(
     runtime: Option<&DaemonsOverlayState>,
 ) {
     let snapshot = state.snapshot();
+    // Resolved ONCE here and handed to the table, so the highlighted row and
+    // the row `R` restarts come from the same call.
+    let cursor = state.selected_index(&snapshot.rows);
 
     let outer = Block::default()
         .title(Line::from(vec![
@@ -263,7 +266,7 @@ pub fn render(
                 Constraint::Length(7),
             ])
             .split(chunks[0]);
-        render_table(frame, sections[0], &snapshot);
+        render_table(frame, sections[0], &snapshot, cursor);
         render_system_services(frame, sections[1], runtime);
         render_hook_section(frame, sections[2], snapshot.hook_health.as_ref(), runtime);
     } else if chunks[0].height >= 18 {
@@ -271,10 +274,10 @@ pub fn render(
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(8), Constraint::Length(7)])
             .split(chunks[0]);
-        render_table(frame, sections[0], &snapshot);
+        render_table(frame, sections[0], &snapshot, cursor);
         render_hook_section(frame, sections[1], snapshot.hook_health.as_ref(), runtime);
     } else {
-        render_table(frame, chunks[0], &snapshot);
+        render_table(frame, chunks[0], &snapshot, cursor);
     }
     render_footer(frame, chunks[1]);
 }
@@ -555,7 +558,10 @@ fn render_hook_section(
     );
 }
 
-fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
+/// `cursor` is the row index the caller resolved via
+/// [`DaemonsState::selected_index`]. Passed in rather than re-derived here so
+/// the highlight and the restart target come from one call, not two.
+fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot, cursor: usize) {
     let now = if snapshot.collected_at_ms > 0 {
         snapshot.collected_at_ms
     } else {
@@ -574,9 +580,6 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot) {
     ])
     .style(Style::default().fg(MUTED_GRAY).add_modifier(Modifier::BOLD));
 
-    // The highlight comes from the SAME call the restart target does, so the
-    // marked row and the row `R` acts on cannot drift apart.
-    let cursor = state.selected_index(&snapshot.rows);
     let rows: Vec<Row> = snapshot
         .rows
         .iter()

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -569,6 +569,7 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot, cursor: usiz
     };
 
     let header = Row::new(vec![
+        Cell::from(""),
         Cell::from("DAEMON"),
         Cell::from("STATE"),
         Cell::from("PID"),
@@ -604,15 +605,15 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot, cursor: usiz
                 }
                 _ => d.reason.clone(),
             };
-            let marker = if index == cursor { "\u{25b6} " } else { "  " };
+            let selected = index == cursor;
             Row::new(vec![
-                Cell::from(format!("{marker}{}", d.kind.display_name())).style(
-                    if index == cursor {
-                        Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)
-                    },
-                ),
+                Cell::from(if selected { "\u{25b6}" } else { "" })
+                    .style(Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)),
+                Cell::from(d.kind.display_name()).style(if selected {
+                    Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD)
+                }),
                 Cell::from(glyph).style(glyph_style),
                 Cell::from(pid),
                 Cell::from(uptime),
@@ -628,7 +629,11 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot, cursor: usiz
         })
         .collect();
 
+    // The cursor lives in its OWN gutter column rather than being prefixed onto
+    // the name: "approve broker" is exactly the 14 columns DAEMON allows, so a
+    // 2-char marker inside that cell truncated the daemon's name.
     let widths = [
+        Constraint::Length(2),
         Constraint::Length(14),
         Constraint::Length(10),
         Constraint::Length(8),


### PR DESCRIPTION
## What this fixes

v1.21.7 shipped row selection + `R`-restarts-selected into
`components/daemons_overlay.rs`. But **`d` opens `components/daemons.rs`** — a
different component, listing a different daemon set (phone bridge, notifyd,
approve broker, ATC, fleet daemon). The feature was unreachable from the
keybinding, and on that screen `R` restarted a row with **no visible cursor**,
while its help still read "R notifyd". That is a regression currently in
1.21.7.

## What is reachable after this PR

Press `d` → the Daemons table. There:

| key | effect |
|---|---|
| `↑`/`↓`, `k`/`j` | move the cursor (saturates, no wrap) |
| `R` | restart the daemon the cursor is drawn on |

The table header advertises exactly those keys. The System services panel no
longer claims `R` is notifyd's.

## The safety property

`DaemonsState::selected_kind()` is the single authority. Render draws the
marker at `selected_index()`; the restart target comes from the same call.
There is no second path that could pick a different row.

`R` also cannot redirect to a daemon you are not pointing at: only notifyd has
an in-process restart, the approve broker legitimately maps to it (same
runtime), and Bridge/ATC/FleetDaemon return an error naming themselves — `R`
refuses out loud rather than no-opping or hitting a neighbour.

## Tests

- `the_highlighted_row_is_the_row_restart_targets` — renders at every cursor
  position, reads the line carrying the cursor **out of the buffer**, and
  requires it to name the same daemon `selected_kind` hands the restart. It
  fails if render and dispatch ever diverge, including when each is
  individually plausible but out of sync.
- `restart_support_never_redirects_to_an_unrelated_daemon` — broker→notifyd is
  the only permitted redirect; the rest must refuse and name themselves.
- `cursor_saturates_and_tolerates_an_empty_table`.
- `daemons_screen_keys_drive_the_screen_cursor_not_the_overlay` — pins the
  exact regression this PR fixes.

## Verification honesty

`cargo check -p ainb --lib` passes locally. The **test build did not complete
on this machine** — Rust builds here keep dying silently (`rustc` wedged in
uninterruptible I/O wait earlier in the session). So CI is the gate for both
test compilation and the assertions above; I am not claiming a local green run.