### PR TITLE
fix(daemons): make the R outcome visible on the screen that owns it

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3694,20 +3694,24 @@ impl EventHandler {
             AppEvent::DaemonsRestartSelected => {
                 let rows = state.daemons_state.snapshot().rows;
                 match state.daemons_state.selected_kind(&rows) {
-                    None => {}
+                    None => state.daemons_state.set_restart_outcome("no daemon selected"),
                     Some(kind) => {
                         match crate::components::daemons::DaemonsState::restart_support(kind) {
                             // Only notifyd has an in-process restart; the broker
                             // rides its runtime. Anything else says why, so the key
                             // never silently no-ops or hits a different daemon.
                             Ok(_) => {
-                                state.spawn_daemon_restart(crate::app::state::DaemonRow::Notifyd)
+                                state.daemons_state.set_restart_outcome(format!(
+                                    "restarting {}…",
+                                    kind.display_name()
+                                ));
+                                state.spawn_daemon_restart(crate::app::state::DaemonRow::Notifyd);
                             }
-                            Err(why) => {
-                                if let Some(o) = state.daemons_overlay.as_mut() {
-                                    o.restart_status = Some(why);
-                                }
-                            }
+                            // The outcome goes to the SCREEN's own state: the
+                            // first cut wrote it to the overlay's, which this
+                            // screen never renders, so a correct refusal was
+                            // invisible and R read as a dead key.
+                            Err(why) => state.daemons_state.set_restart_outcome(why),
                         }
                     }
                 }

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -950,7 +950,7 @@ mod tests {
                 text.contains(kind.display_name()),
                 "{kind:?}: the refusal must name the daemon on screen"
             );
-            let tail = why.split("; ").next_back().unwrap_or(&why);
+            let tail = why.rsplit("; ").next().unwrap_or(&why);
             assert!(
                 text.contains(tail.trim()),
                 "{kind:?}: refusal text {tail:?} never rendered; R would look like a dead key"

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -76,6 +76,13 @@ pub struct DaemonsState {
     /// meaningful even before the first snapshot arrives, and
     /// [`Self::selected_kind`] is the single place that turns it into a target.
     selected: usize,
+    /// What the last `R` did, or why it could not act.
+    ///
+    /// Owned by THIS screen. The first cut wrote it to
+    /// `DaemonsOverlayState::restart_status`, a field this screen does not own
+    /// and never renders, so a correct refusal was invisible and `R` read as a
+    /// dead key on every row that cannot be restarted.
+    restart_outcome: Option<String>,
 }
 
 impl DaemonsState {
@@ -114,10 +121,21 @@ impl DaemonsState {
             // Same runtime as notifyd: restarting that rebinds this socket.
             DaemonKind::ApproveBroker => Ok(DaemonKind::Notifyd),
             DaemonKind::Bridge | DaemonKind::Atc | DaemonKind::FleetDaemon => Err(format!(
-                "{} has no restart from the TUI — use its own CLI verb",
+                "{} has no TUI restart; use its own CLI verb",
                 kind.display_name()
             )),
         }
+    }
+
+    /// The line describing the last `R`, for the renderer.
+    #[must_use]
+    pub fn restart_outcome(&self) -> Option<&str> {
+        self.restart_outcome.as_deref()
+    }
+
+    /// Record what `R` did, or why it refused.
+    pub fn set_restart_outcome(&mut self, line: impl Into<String>) {
+        self.restart_outcome = Some(line.into());
     }
 
     /// Move the cursor, saturating at both ends.
@@ -279,7 +297,7 @@ pub fn render(
     } else {
         render_table(frame, chunks[0], &snapshot, cursor);
     }
-    render_footer(frame, chunks[1]);
+    render_footer(frame, chunks[1], state.restart_outcome());
 }
 
 fn render_system_services(frame: &mut Frame, area: Rect, runtime: Option<&DaemonsOverlayState>) {
@@ -675,14 +693,24 @@ fn daemon_version_label(daemon: &DaemonStatus) -> (String, Style) {
     }
 }
 
-fn render_footer(frame: &mut Frame, area: Rect) {
-    let footer = Paragraph::new(Line::from(vec![
+/// `outcome` is the last `R` result. It renders in the footer because the
+/// footer is drawn on EVERY layout branch: a message shown only in the tall
+/// layout would be missing exactly when the terminal is small.
+fn render_footer(frame: &mut Frame, area: Rect, outcome: Option<&str>) {
+    let mut spans = vec![
         Span::styled("read-only • live", Style::default().fg(MUTED_GRAY)),
         Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)),
         Span::styled("q/Esc", Style::default().fg(CORNFLOWER_BLUE)),
         Span::styled(" back", Style::default().fg(MUTED_GRAY)),
-    ]))
-    .style(Style::default().bg(PANEL_BG));
+    ];
+    if let Some(line) = outcome {
+        spans.push(Span::styled("  │  ", Style::default().fg(SUBDUED_BORDER)));
+        spans.push(Span::styled(
+            line.to_string(),
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ));
+    }
+    let footer = Paragraph::new(Line::from(spans)).style(Style::default().bg(PANEL_BG));
     frame.render_widget(footer, area);
 }
 
@@ -758,6 +786,7 @@ mod tests {
         DaemonsState {
             shared: Some(shared),
             selected: 0,
+            restart_outcome: None,
         }
     }
 
@@ -811,6 +840,7 @@ mod tests {
         DaemonsState {
             shared: Some(shared),
             selected: 0,
+            restart_outcome: None,
         }
     }
 
@@ -895,6 +925,54 @@ mod tests {
                 target.display_name()
             );
         }
+    }
+
+    /// Every refusal REACHES THE SCREEN, asserted from the drawn buffer.
+    ///
+    /// Deliberately renders instead of checking `restart_support`'s return
+    /// value. That return value was already correct in the shipped build and
+    /// the message still never appeared, because it was written to a field this
+    /// screen does not own. Asserting the wrong layer is what shipped an
+    /// unreachable cursor and then an invisible refusal, so this reads the
+    /// pixels. It covers EVERY non-restartable row rather than a sample: a row
+    /// whose refusal silently fails to render is a dead key on that row.
+    #[test]
+    fn every_refusal_is_visible_on_the_rendered_screen() {
+        for kind in [DaemonKind::Bridge, DaemonKind::Atc, DaemonKind::FleetDaemon] {
+            let why = DaemonsState::restart_support(kind)
+                .expect_err("this row has no restart entry point");
+
+            let mut state = seeded_state(vec![status(kind, DaemonState::Running, true, None)]);
+            state.set_restart_outcome(why.clone());
+
+            let text = render_to_string(&mut state, None, 200, 40);
+            assert!(
+                text.contains(kind.display_name()),
+                "{kind:?}: the refusal must name the daemon on screen"
+            );
+            let tail = why.split("; ").next_back().unwrap_or(&why);
+            assert!(
+                text.contains(tail.trim()),
+                "{kind:?}: refusal text {tail:?} never rendered; R would look like a dead key"
+            );
+        }
+    }
+
+    /// A successful restart is announced too, so `R` is never silent.
+    #[test]
+    fn a_restartable_row_announces_that_it_is_restarting() {
+        let mut state = seeded_state(vec![status(
+            DaemonKind::Notifyd,
+            DaemonState::Running,
+            true,
+            Some("unix socket"),
+        )]);
+        state.set_restart_outcome("restarting notifyd…");
+        let text = render_to_string(&mut state, None, 200, 40);
+        assert!(
+            text.contains("restarting notifyd"),
+            "a restart must report itself on screen"
+        );
     }
 
     /// `R` refuses daemons it cannot restart instead of silently no-opping or


### PR DESCRIPTION
## The bug

1.21.8 refuses correctly when `R` lands on a daemon with no restart path, and
**restarts nothing wrong** — I verified that live: parked on ATC, pressed `R`,
notifyd's pid was unchanged.

But it said nothing. The message went to `DaemonsOverlayState::restart_status`,
a field the Daemons **screen** does not own and never renders. So on bridge,
ATC and fleet daemon, `R` behaved perfectly and looked like a dead key.

## Fix

- The screen gets its own `restart_outcome`.
- It renders in the **footer**, which is drawn on every layout branch, so the
  message cannot vanish on a short terminal.
- A successful restart announces itself too (`restarting notifyd…`), so `R` is
  never silent on any row.

## Tests assert the pixels, not the return value

`restart_support` already returned the right error in the shipped build and the
message still never appeared. Asserting the wrong layer is what shipped an
unreachable cursor (#711) and then this invisible refusal, so:

- `every_refusal_is_visible_on_the_rendered_screen` renders and searches the
  **drawn buffer** for both the daemon's name and the reason text, for **every**
  non-restartable row — Bridge, ATC, FleetDaemon — not a sample. A row whose
  refusal fails to render is a dead key on that row, and this fails if so.
- `a_restartable_row_announces_that_it_is_restarting` covers the success path.

## What is reachable

Press `d`, move with `↑`/`↓`, press `R`. Verified live on 1.21.8: cursor renders
and moves, `approve broker` is no longer truncated, and `R` on a non-restartable
row leaves other daemons untouched. This PR adds the missing feedback line.

## Verification honesty

Formatting is verified (`cargo fmt --check` clean). **The test build did not run
locally** — Rust builds on this machine die silently (`rustc` wedged in
uninterruptible I/O wait; `cargo check` emits zero output in 9 minutes). CI is
the gate for compilation and the assertions above. Not claiming a local green run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon restart actions now show clear status messages, including when a restart is in progress, succeeds, is unsupported, or cannot proceed because no daemon is selected.
  * Restart results now remain visible in the Daemons screen footer across layouts.
  * Improved feedback helps clarify the outcome of daemon management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->