### PR TITLE
fix(daemons): never self-exec a cargo test binary as a daemon

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8680,6 +8680,17 @@ fn open_daemon_stderr_log(log_dir: &std::path::Path) -> Result<std::fs::File> {
 /// recording its EXACT pid. When `announce` is true the outcome is printed
 /// (the `hangar daemon start` CLI verb); the TUI autostart passes `false`.
 pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
+    // `resolve_daemon_launch` self-execs `(current_exe, ["hangar","daemon","run"])`
+    // on both of its fallback paths. Under `cargo test` that exe is the TEST
+    // binary, and libtest reads the argv as name filters, so the "daemon" is a
+    // detached re-run of every test matching `hangar`/`daemon`/`run`. See
+    // `crate::self_exec_guard` and issue #715.
+    if crate::self_exec_guard::running_under_cargo_test() {
+        anyhow::bail!(
+            "refusing to start the hangar daemon from a cargo test binary \
+             (current_exe is a test harness, not `ainb`)"
+        );
+    }
     let pid_path = daemon_pid_path()?;
 
     // Already running? Bail out cleanly rather than spawning a duplicate.
@@ -9130,6 +9141,13 @@ fn restart_daemon(announce: bool) -> Result<()> {
 /// the home was contested a moment ago and is free now, which is a race to
 /// re-run, not a failure to report.
 fn respawn_once(bin: &std::path::Path, args: &[&str]) -> Result<Option<u32>> {
+    // Same rule as `start_daemon_if_stopped`: never detach a test harness.
+    if crate::self_exec_guard::running_under_cargo_test() {
+        anyhow::bail!(
+            "refusing to respawn the hangar daemon from a cargo test binary \
+             (current_exe is a test harness, not `ainb`)"
+        );
+    }
     let mut command = std::process::Command::new(bin);
     command
         .args(args)

--- a/ainb-tui/crates/ainb-core/src/lib.rs
+++ b/ainb-tui/crates/ainb-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod perf;
 pub mod plugins;
 pub mod providers;
 pub mod rtk;
+pub mod self_exec_guard;
 pub mod setup;
 pub mod tmux;
 pub mod usage_cache;

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -52,6 +52,7 @@ mod perf;
 mod plugins;
 mod providers;
 mod rtk;
+mod self_exec_guard;
 mod setup;
 mod tmux;
 mod usage_cache;

--- a/ainb-tui/crates/ainb-core/src/mcp_pool/client.rs
+++ b/ainb-tui/crates/ainb-core/src/mcp_pool/client.rs
@@ -7,6 +7,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::time::Duration;
 
 use super::paths;
+use crate::self_exec_guard::running_under_cargo_test;
 
 /// True when the daemon's control socket answers within ~500ms.
 pub fn daemon_alive() -> bool {
@@ -108,6 +109,23 @@ pub fn ensure_daemon() -> Result<()> {
         return Ok(());
     }
 
+    // A cargo test binary must never be re-executed as the daemon. `cargo test`
+    // runs `target/<profile>/deps/<crate>-<hash>`, so `current_exe()` here is the
+    // TEST binary, and libtest reads the `mcp daemon` argv as two name FILTERS
+    // rather than a subcommand: the child re-runs every test matching `mcp` or
+    // `daemon`, each of which can reach this function and detach another copy.
+    // With `process_group(0)` below shielding each one from the test runner's
+    // signals, that recursion is unbounded. Observed 2026-08-23: 135 orphans
+    // (see issue #715). Erroring is the correct outcome — every caller already
+    // treats a failed ensure as "fall back to per-session stdio".
+    if running_under_cargo_test() {
+        anyhow::bail!(
+            "refusing to spawn the MCP daemon from a cargo test binary \
+             (current_exe is a test harness, not `ainb`); \
+             start a real daemon first if a test needs one"
+        );
+    }
+
     let exe = std::env::current_exe().context("current_exe")?;
     let log_path = paths::daemon_log()?;
     if let Some(dir) = log_path.parent() {
@@ -157,4 +175,28 @@ pub fn restart_daemon() -> Result<()> {
         }
     }
     ensure_daemon()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The behavioural guarantee issue #715 is about: this very process IS a
+    /// cargo test binary, so `ensure_daemon` must refuse rather than detach a
+    /// copy of the test harness. Guarded on the probe agreeing we are under
+    /// cargo, so a non-cargo invocation of the test binary does not fail here.
+    #[test]
+    fn ensure_daemon_refuses_to_self_exec_the_test_harness() {
+        if !running_under_cargo_test() {
+            return;
+        }
+        if daemon_alive() {
+            return; // A real daemon is up; ensure short-circuits before the guard.
+        }
+        let err = ensure_daemon().expect_err("must refuse to spawn from a test binary");
+        assert!(
+            err.to_string().contains("cargo test binary"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/self_exec_guard.rs
+++ b/ainb-tui/crates/ainb-core/src/self_exec_guard.rs
@@ -1,0 +1,113 @@
+// ABOUTME: One rule, shared by every place that would re-execute THIS binary as
+// a long-lived daemon: never do it from a cargo test harness (issue #715).
+
+//! Refuse to self-exec a cargo test binary as a daemon.
+//!
+//! Several daemons are started by re-executing `current_exe()` with a
+//! subcommand — `mcp daemon`, `hangar daemon run`, `notifyd run`. That is
+//! correct for a real `ainb`, and catastrophic under `cargo test`, where
+//! `current_exe()` is the TEST binary:
+//!
+//! * libtest reads the trailing argv as **name filters**, not a subcommand, so
+//!   `<test-bin> mcp daemon` re-runs every test matching `mcp` or `daemon`
+//!   instead of erroring out.
+//! * Any of those re-run tests can reach the same spawn again, so the recursion
+//!   is unbounded.
+//! * The spawns use `process_group(0)`, so each copy is detached from the test
+//!   runner and outlives it.
+//!
+//! Observed 2026-08-23: 135 orphaned test binaries, which wedged the worktree's
+//! `target/debug/deps` badly enough that `readdir` on it never returned.
+
+/// Is this process a cargo-built **test** binary rather than a real `ainb`?
+///
+/// Thin IO wrapper over [`is_cargo_test_exe`]; see it for why both halves of
+/// the check are required.
+pub fn running_under_cargo_test() -> bool {
+    let cargo_env =
+        std::env::var_os("CARGO").is_some() || std::env::var_os("CARGO_MANIFEST_DIR").is_some();
+    let exe = std::env::current_exe().ok();
+    is_cargo_test_exe(cargo_env, exe.as_deref())
+}
+
+/// Pure predicate behind [`running_under_cargo_test`], split out so the rule is
+/// testable without faking the process environment.
+///
+/// BOTH halves are load-bearing, and each alone gives a wrong answer:
+///
+/// * `cargo` runs test binaries with `CARGO` / `CARGO_MANIFEST_DIR` set — but it
+///   sets those for `cargo run` too, and a `cargo run` of the real binary
+///   (`target/<profile>/ainb`) is a perfectly good daemon host. The env alone
+///   would block a legitimate spawn.
+/// * Test binaries live in `target/<profile>/deps/` — but so does the real bin
+///   ARTIFACT (`deps/ainb-<hash>`, hard-linked up to `target/<profile>/ainb`).
+///   The path alone would block someone running that artifact directly.
+///
+/// Only the conjunction — cargo is driving *and* the exe is the `deps/` copy —
+/// identifies the test-harness case.
+pub fn is_cargo_test_exe(cargo_env: bool, exe: Option<&std::path::Path>) -> bool {
+    cargo_env && exe.and_then(std::path::Path::parent).is_some_and(|dir| dir.ends_with("deps"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn cargo_driven_deps_binary_is_a_test_binary() {
+        assert!(is_cargo_test_exe(
+            true,
+            Some(Path::new("/w/target/debug/deps/ainb-39a2b8"))
+        ));
+        assert!(is_cargo_test_exe(
+            true,
+            Some(Path::new("/w/target/release/deps/ainb-6b08f1"))
+        ));
+    }
+
+    /// `cargo run` sets the same env but executes the profile-root binary.
+    #[test]
+    fn cargo_run_of_the_real_binary_is_not_a_test_binary() {
+        assert!(!is_cargo_test_exe(
+            true,
+            Some(Path::new("/w/target/debug/ainb"))
+        ));
+    }
+
+    /// Running the `deps/` artifact by hand is a legitimate daemon host.
+    #[test]
+    fn deps_artifact_without_cargo_is_not_a_test_binary() {
+        assert!(!is_cargo_test_exe(
+            false,
+            Some(Path::new("/w/target/debug/deps/ainb-39a2b8"))
+        ));
+    }
+
+    #[test]
+    fn installed_binary_is_not_a_test_binary() {
+        assert!(!is_cargo_test_exe(
+            false,
+            Some(Path::new("/opt/homebrew/bin/ainb"))
+        ));
+        assert!(!is_cargo_test_exe(
+            true,
+            Some(Path::new("/opt/homebrew/bin/ainb"))
+        ));
+    }
+
+    #[test]
+    fn unresolvable_exe_is_not_a_test_binary() {
+        assert!(!is_cargo_test_exe(true, None));
+    }
+
+    /// This very process is a cargo test binary, so the live probe must say so.
+    /// Skipped when the binary is invoked outside cargo (env absent).
+    #[test]
+    fn live_probe_agrees_when_cargo_is_driving() {
+        if std::env::var_os("CARGO").is_none() && std::env::var_os("CARGO_MANIFEST_DIR").is_none() {
+            return;
+        }
+        assert!(running_under_cargo_test());
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/procs.rs
@@ -452,6 +452,33 @@ fn respawn_args_for(exe_name: &str) -> Vec<&'static str> {
     }
 }
 
+/// Is this process a cargo-built **test** binary rather than a real daemon host?
+///
+/// Thin IO wrapper over [`is_cargo_test_exe`]; see that function for why both
+/// halves of the check are needed.
+fn running_under_cargo_test() -> bool {
+    let cargo_env =
+        std::env::var_os("CARGO").is_some() || std::env::var_os("CARGO_MANIFEST_DIR").is_some();
+    let exe = std::env::current_exe().ok();
+    is_cargo_test_exe(cargo_env, exe.as_deref())
+}
+
+/// Pure predicate behind [`running_under_cargo_test`], split out so the rule is
+/// testable without faking the process environment.
+///
+/// BOTH halves are load-bearing, and each one alone is wrong:
+///
+/// * `cargo` runs test binaries with `CARGO` / `CARGO_MANIFEST_DIR` set, but it
+///   sets those for `cargo run` too — and a `cargo run` of the real binary
+///   (`target/<profile>/ainb`) is a legitimate daemon host.
+/// * Test binaries live in `target/<profile>/deps/`, but so does the real bin
+///   ARTIFACT (`deps/ainb-<hash>`, hard-linked up to `target/<profile>/ainb`).
+///
+/// Only the conjunction identifies the test-harness case.
+fn is_cargo_test_exe(cargo_env: bool, exe: Option<&Path>) -> bool {
+    cargo_env && exe.and_then(Path::parent).is_some_and(|dir| dir.ends_with("deps"))
+}
+
 /// Detach-spawn a fresh daemon: null stdio + its own process group so a
 /// closing tmux pane or terminal SIGHUP can't take it down — the Rust
 /// equivalent of the hook script's `nohup ainb notifyd </dev/null
@@ -460,6 +487,21 @@ fn spawn_detached() -> anyhow::Result<u32> {
     use anyhow::Context;
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
+
+    // Never re-exec a cargo test binary as the daemon. Under `cargo test`,
+    // `daemon_respawn_argv`'s `current_exe()` is the TEST harness, and libtest
+    // reads the `notifyd run` argv as two name FILTERS, not a subcommand — so
+    // the child re-runs every test matching `notifyd` or `run` (`run` matches a
+    // great many), and any of those reaching this path detaches another copy.
+    // `process_group(0)` below then shields each one from the test runner.
+    // Observed 2026-08-23 alongside the MCP variant: 135 orphans total, issue
+    // #715.
+    if running_under_cargo_test() {
+        anyhow::bail!(
+            "refusing to spawn the notifyd daemon from a cargo test binary \
+             (current_exe is a test harness, not `ainb`)"
+        );
+    }
 
     let (exe, args) = daemon_respawn_argv();
     let child = Command::new(&exe)
@@ -734,6 +776,60 @@ mod tests {
             class,
             binary_drift: false,
         }
+    }
+
+    #[test]
+    fn cargo_driven_deps_binary_is_a_test_binary() {
+        assert!(is_cargo_test_exe(
+            true,
+            Some(Path::new("/w/target/debug/deps/ainb-39a2b8"))
+        ));
+        assert!(is_cargo_test_exe(
+            true,
+            Some(Path::new("/w/target/release/deps/ainb-6b08f1"))
+        ));
+    }
+
+    /// `cargo run` sets the same env but executes the profile-root binary.
+    #[test]
+    fn cargo_run_of_the_real_binary_is_not_a_test_binary() {
+        assert!(!is_cargo_test_exe(
+            true,
+            Some(Path::new("/w/target/debug/ainb"))
+        ));
+    }
+
+    /// Running the `deps/` artifact by hand is a legitimate daemon host.
+    #[test]
+    fn deps_artifact_without_cargo_is_not_a_test_binary() {
+        assert!(!is_cargo_test_exe(
+            false,
+            Some(Path::new("/w/target/debug/deps/ainb-39a2b8"))
+        ));
+        assert!(!is_cargo_test_exe(
+            false,
+            Some(Path::new("/opt/homebrew/bin/ainb"))
+        ));
+    }
+
+    #[test]
+    fn unresolvable_exe_is_not_a_test_binary() {
+        assert!(!is_cargo_test_exe(true, None));
+    }
+
+    /// The behavioural guarantee issue #715 is about: this very process IS a
+    /// cargo test binary, so the detach-spawn must refuse rather than fork a
+    /// copy of the test harness.
+    #[test]
+    fn spawn_detached_refuses_to_self_exec_the_test_harness() {
+        if !running_under_cargo_test() {
+            return;
+        }
+        let err = spawn_detached().expect_err("must refuse to spawn from a test binary");
+        assert!(
+            err.to_string().contains("cargo test binary"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #715.

## The bug is not a missing reap

`ensure_daemon` (MCP), `spawn_detached` (notifyd) and `start_daemon_if_stopped` /
`respawn_once` (hangar) all start a daemon by re-executing `current_exe()` with a
subcommand. Under `cargo test`, `current_exe()` is the **test harness**, and
libtest reads the trailing argv as **name filters, not a subcommand** — so
`<test-bin> mcp daemon` does not fail, it re-runs every test whose name contains
`mcp` or `daemon`.

Verified directly, with a throwaway crate rather than by reading the docs:

```
$ <test-binary> mcp daemon --nocapture
running 2 tests
RAN test_daemon_thing
RAN test_mcp_thing
test result: ok. 2 passed; 0 failed; ... 1 filtered out
```

Any of those re-run tests can reach the same spawn again, and every spawn uses
`process_group(0)`, so each copy detaches from the test runner. The recursion is
unbounded. `notifyd run` and `hangar daemon run` are worse than the MCP case,
because `run` matches a great many test names.

One run left **135 orphaned test binaries**. They wedged that worktree's
`target/debug/deps` badly enough that `readdir` on it never returned, which is
what made every later `cargo check` there hang with zero output.

No amount of teardown-side reaping fixes this. The spawn is not merely unreaped,
it is **never correct** — a test binary cannot be a daemon. So the fix refuses it.

## The fix

One shared predicate in `ainb-core/src/self_exec_guard.rs`, applied at all four
self-exec sites. Both halves of the check are load-bearing:

* `CARGO` / `CARGO_MANIFEST_DIR` present at runtime — but `cargo run` sets those
  too, and a `cargo run` of `target/<profile>/ainb` is a legitimate daemon host,
  so the env alone would block a valid spawn.
* the exe's parent directory is `deps/` — but the real bin **artifact** also
  lives there (`deps/ainb-<hash>`, hard-linked up to `target/<profile>/ainb`), so
  the path alone would block running that artifact directly.

Only the conjunction identifies the test harness. Erroring is the correct
outcome: every caller already treats a failed ensure as "fall back to
per-session stdio".

`ainb-plugin-notifyd` keeps its own copy of the predicate rather than taking a
new dependency edge — it shares only the IO-free `ainb-hangar-core` with
`ainb-core`, which is the wrong home for a process-spawn rule.

## Verification

Run locally on macOS 26.4.1 / arm64, cargo 1.96.0.

**Guard tests — 12 pass**, including three behavioural ones that execute in the
real condition (the test process *is* a cargo test binary) and assert the live
`ensure_daemon()` / `spawn_detached()` refuse rather than spawn. `daemon_alive()`
was false at the time (no `~/.ainb` control socket, no live daemon), so those
tests genuinely reached the guard instead of short-circuiting on an
already-running daemon.

**Orphan count — the thing the issue is about:**

```
cargo test --workspace --no-fail-fast     # 600 test binaries executed

BASELINE orphans:                    0
peak concurrent test binaries:       1
peak daemon-signature processes:     0     (mcp daemon | notifyd run | hangar daemon)
ORPHANS AFTER FULL SUITE (by pid):   0
```

Counted by pid — every process whose executable path starts with this worktree's
`target/debug/deps/` — not inferred.

## What this run does NOT prove — read before merging

**1. It is a post-fix measurement, not a before/after A/B.** I deliberately did
not run the unguarded code to reproduce the 135-orphan leak for comparison.
Doing so risks poisoning a second worktree with processes that, as #715
documents, survive `SIGKILL` across three verified passes and can only be
reclaimed by a reboot. The mechanism is instead proven independently, by the
libtest-filter reproduction above.

**2. The suite was not green.** 11 of 600 test binaries failed. My guard's error
string appears **zero times** in the entire suite log, and every failure is
environmental:

| Failing binary | Why |
|---|---|
| `tripwire_abtop`, `tripwire_daemons_opens_and_renders`, `tripwire_fleet_approve_roundtrip`, `tripwire_fleet_chat_screen`, `tripwire_fleet_panel_opens_and_answers`, `tripwire_interactive_pane`, `tripwire_witr`, `tripwire_daemon_single_instance`, `tripwire_task_happy_path_claude_provider` | tmux-driven TUI tripwires. `ci.yml` excludes these from the main job (`-E 'not binary(/^tripwire_/)'`) and notes they SKIP on macOS, where `can_run_tripwire()` is false. Failures are `can't find session` / render assertions on a loaded host. |
| `real_plugin_axes` | Self-disqualifies: *"scratch hangar home … must not be inside the live hangar home `/Users/stevengonsalvez/.agents-in-a-box`"*. This worktree lives under `~/.agents-in-a-box/worktrees/`, so the test refuses to run from here at all. |
| `real_witr_smoke` | `witr --pid <self>` returned `Timeout`. The host is carrying the 135 wedged processes from #715 at load ~7. |

I did not re-run these against the parent commit to prove they are pre-existing,
for the same reason as (1) — that requires executing the unguarded code. Treat
"environmental" as an inference from the failure text and the CI config, not as
a measured before/after.

**3. The guard is only as good as its four call sites.** Any future daemon that
self-execs `current_exe()` must call `running_under_cargo_test()` too. The four
current sites are the ones that produced the observed argv (`mcp daemon`,
`notifyd run`, `hangar daemon run`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented test runs from unintentionally launching or respawning detached background daemons.
  * Added safeguards against recursive daemon startup when running under Cargo’s test harness.
  * Tests now fall back to session-based operation when a daemon cannot be started.
  * Added coverage for daemon prevention across test, development, installed, and unresolved executable scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->