### PR TITLE
fix(daemons): four correctness fixes from the post-merge review of #708

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5192,7 +5192,11 @@ impl AppState {
         match kind {
             DaemonRow::Notifyd => self.spawn_notifyd_restart(tx),
             DaemonRow::Hangar => {
-                Self::spawn_blocking_restart(tx, kind, || crate::cli::hangar::run_daemon_restart())
+                // Quiet: this runs while the TUI holds the alternate screen, so
+                // the announcing variant's stdout lands on top of the frame.
+                Self::spawn_blocking_restart(tx, kind, || {
+                    crate::cli::hangar::run_daemon_restart_quiet()
+                })
             }
             DaemonRow::Mcp => {
                 Self::spawn_blocking_restart(tx, kind, || crate::mcp_pool::client::restart_daemon())

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -9103,6 +9103,16 @@ pub(crate) fn run_daemon_restart() -> Result<()> {
     restart_daemon(true)
 }
 
+/// Restart the daemon without printing anything.
+///
+/// The TUI owns the alternate screen in raw mode, so a `println!` from a
+/// background thread does not scroll — it smears over whatever the renderer
+/// last painted, and nothing repaints it away. Every other daemon the Daemons
+/// screen restarts is already silent; this is the Hangar equivalent.
+pub(crate) fn run_daemon_restart_quiet() -> Result<()> {
+    restart_daemon(false)
+}
+
 fn restart_daemon(announce: bool) -> Result<()> {
     if let Err(e) = stop_daemon(announce) {
         if announce {

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -27,7 +27,7 @@ const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
 const GOLD: Color = Color::Rgb(255, 215, 0);
 const HEALTHY_GREEN: Color = Color::Rgb(100, 200, 100);
 /// Cursor colour, per the TUI style guide. Same RGB as HEALTHY_GREEN but kept
-/// separate: one means "this daemon is up", the other means "R acts on this
+/// separate: one means "this daemon is up", the other means "Enter acts on this
 /// row", and they must be free to diverge.
 const SELECTION_GREEN: Color = Color::Rgb(100, 200, 100);
 const STOPPED_RED: Color = Color::Rgb(220, 100, 100);
@@ -850,7 +850,7 @@ fn render_table(frame: &mut Frame, area: Rect, snapshot: &Snapshot, state: &Daem
             };
             Row::new(vec![
                 Cell::from(if selected { "▶" } else { "" })
-                    .style(Style::default().fg(HEALTHY_GREEN)),
+                    .style(Style::default().fg(SELECTION_GREEN)),
                 Cell::from(d.kind.display_name()).style(if selected {
                     Style::default().fg(HEALTHY_GREEN).add_modifier(Modifier::BOLD)
                 } else {

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/mod.rs
@@ -269,6 +269,43 @@ pub fn config_problem() -> Option<String> {
     load_config(None).err().map(|e| format!("{e:#}"))
 }
 
+/// [`config_problem`], memoised on the config file's identity.
+///
+/// The Daemons collector asks this every couple of seconds for as long as a
+/// bridge row is down, and the answer is not cheap: parsing resolves the
+/// configured secrets, and a `keychain:<service>` ref shells out to
+/// `/usr/bin/security`. Uncached, a stopped bridge with a keychain token means
+/// a `security` subprocess every 2s — repeated unlock prompts, and a 5s stall
+/// each time the keychain is locked.
+///
+/// The verdict only changes when the file does, so key the cache on its path,
+/// mtime and length. A config that cannot be stat'd re-reads every time, which
+/// is the safe direction: it is the case where the answer is "missing", and
+/// that is the cheap branch anyway.
+pub fn config_problem_cached() -> Option<String> {
+    use std::sync::Mutex;
+    type Stamp = (std::path::PathBuf, Option<std::time::SystemTime>, u64);
+    static CACHE: Mutex<Option<(Stamp, Option<String>)>> = Mutex::new(None);
+
+    let path = crate::fleet::bridge::config::default_config_path();
+    let meta = std::fs::metadata(&path).ok();
+    let stamp: Stamp = (
+        path,
+        meta.as_ref().and_then(|m| m.modified().ok()),
+        meta.as_ref().map_or(0, std::fs::Metadata::len),
+    );
+
+    let mut cache = CACHE.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some((cached_stamp, verdict)) = cache.as_ref() {
+        if *cached_stamp == stamp {
+            return verdict.clone();
+        }
+    }
+    let verdict = config_problem();
+    *cache = Some((stamp, verdict.clone()));
+    verdict
+}
+
 /// Uninstall the bridge service. Returns the removed unit path, if any.
 pub fn uninstall() -> Result<Option<std::path::PathBuf>> {
     service::uninstall()

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/service.rs
@@ -150,6 +150,16 @@ fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
 
+/// Whether an install should `launchctl unload` before (maybe) reloading.
+///
+/// Split out so the rule is testable without launchctl. The dangerous case is
+/// `activate == false` over an unchanged unit: that is a healthy bridge being
+/// stopped because the INSTALLING shell could not resolve a secret the daemon
+/// resolves in its own environment.
+const fn should_unload(activate: bool, definition_unchanged: bool) -> bool {
+    activate || !definition_unchanged
+}
+
 fn install_launchd(paths: &ServicePaths, activate: bool) -> Result<PathBuf> {
     let plist_path = launchd_plist_path()?;
     if let Some(parent) = plist_path.parent() {
@@ -158,14 +168,26 @@ fn install_launchd(paths: &ServicePaths, activate: bool) -> Result<PathBuf> {
     if let Some(parent) = paths.log_path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    std::fs::write(&plist_path, build_plist(paths))
+    let definition = build_plist(paths);
+    let unchanged = std::fs::read_to_string(&plist_path).is_ok_and(|on_disk| on_disk == definition);
+    std::fs::write(&plist_path, &definition)
         .with_context(|| format!("writing {}", plist_path.display()))?;
-    // Idempotent reload: unload (ignore errors), then load. The unload runs
-    // even when we will not re-load, so a previously-good unit does not keep
-    // running against a definition that has since gone stale.
-    let _ = std::process::Command::new("launchctl")
-        .args(["unload", &plist_path.to_string_lossy()])
-        .output();
+
+    // Never take down a bridge we are not going to bring back up, unless the
+    // definition it is running actually changed.
+    //
+    // `activate` is decided partly by whether the config's secrets resolve — in
+    // the INSTALLING shell. Re-running install over an unchanged unit from a
+    // shell without `$TELEGRAM_BOT_TOKEN` exported, or with the keychain
+    // locked, therefore used to unload a perfectly healthy bridge and then
+    // decline to reload it, reporting "installed but NOT started". The
+    // stale-definition case the unconditional unload existed for is still
+    // covered: a changed definition is still unloaded.
+    if should_unload(activate, unchanged) {
+        let _ = std::process::Command::new("launchctl")
+            .args(["unload", &plist_path.to_string_lossy()])
+            .output();
+    }
     if activate {
         let _ = std::process::Command::new("launchctl")
             .args(["load", &plist_path.to_string_lossy()])
@@ -259,6 +281,35 @@ fn install_systemd(paths: &ServicePaths, activate: bool) -> Result<PathBuf> {
             .output();
     }
     Ok(unit_path)
+}
+
+#[cfg(test)]
+mod unload_rule_tests {
+    use super::should_unload;
+
+    /// The regression: re-installing over an unchanged unit from a shell that
+    /// cannot see the secret must NOT take the running bridge down. `install`
+    /// decides `activate` partly from whether the config's secrets resolve in
+    /// the caller's environment, so this path is reached by simply running
+    /// `ainb fleet bridge install` over SSH without the token exported.
+    #[test]
+    fn an_unchanged_unit_is_never_unloaded_when_it_will_not_be_reloaded() {
+        assert!(!should_unload(false, true));
+    }
+
+    /// A changed definition still gets unloaded even when we will not reload,
+    /// so a previously-good unit does not keep running against a stale one.
+    #[test]
+    fn a_changed_definition_is_unloaded_even_without_activation() {
+        assert!(should_unload(false, false));
+    }
+
+    /// Activation always reloads, so it always unloads first.
+    #[test]
+    fn activation_always_cycles_the_unit() {
+        assert!(should_unload(true, true));
+        assert!(should_unload(true, false));
+    }
 }
 
 fn teardown_systemd() -> Result<Option<PathBuf>> {

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -1042,13 +1042,23 @@ pub fn probe_headroom_proxy() -> DaemonStatus {
 /// used — the full setup skeleton belongs in `bridge status`, not a table cell.
 ///
 /// Pure over `problem` so the annotation is testable without a config file.
+/// Which bridge rows a config problem may be appended to.
+///
+/// `Degraded` is deliberately excluded even though it is not `Running`: that
+/// state means the process IS alive but half its job is not happening. Telling
+/// the operator a live daemon "cannot start" is simply false, and it fires for
+/// real — a daemon launched with a baked-in `AINB_CONFIG_PATH` reads a config
+/// this process cannot see, so the row would read "running (connected), but …
+/// — cannot start: no bridge config".
+fn annotatable_bridge_row(row: &DaemonStatus) -> bool {
+    row.kind == DaemonKind::Bridge
+        && matches!(row.state, DaemonState::Stopped | DaemonState::Unknown)
+}
+
 pub fn annotate_bridge_config(rows: &mut [DaemonStatus], problem: Option<&str>) {
     let Some(problem) = problem else { return };
     let head = problem.lines().next().unwrap_or(problem).trim();
-    for row in rows
-        .iter_mut()
-        .filter(|r| r.kind == DaemonKind::Bridge && r.state != DaemonState::Running)
-    {
+    for row in rows.iter_mut().filter(|r| annotatable_bridge_row(r)) {
         row.reason = format!("{} — cannot start: {head}", row.reason);
     }
 }
@@ -1095,13 +1105,14 @@ pub fn collect() -> anyhow::Result<Vec<DaemonStatus>> {
         .unwrap_or_else(|_| ainb_home.clone());
     let mut rows = collect_in(&ainb_home, &notifyd_base, super::heartbeat::now_ms());
     rows.extend(collect_socket_daemons());
-    // Only pay for the config read when a bridge row is actually down — this
-    // runs on the TUI's refresh loop.
-    if rows
-        .iter()
-        .any(|r| r.kind == DaemonKind::Bridge && r.state != DaemonState::Running)
-    {
-        annotate_bridge_config(&mut rows, crate::fleet::bridge::config_problem().as_deref());
+    // Only pay for the config read when a bridge row is actually down, and take
+    // the memoised verdict — this runs on the TUI's refresh loop every couple of
+    // seconds, and an uncached read shells out to the keychain each time.
+    if rows.iter().any(|r| annotatable_bridge_row(r)) {
+        annotate_bridge_config(
+            &mut rows,
+            crate::fleet::bridge::config_problem_cached().as_deref(),
+        );
     }
     Ok(rows)
 }
@@ -2145,6 +2156,36 @@ mod tests {
     /// shows up. MCP pool, the Hangar daemon and the Headroom proxy used to be
     /// real processes with no row here — visible only as ad-hoc lines in a
     /// separate panel, with no way to act on them.
+    /// A `Degraded` bridge is ALIVE — half its job is not happening, but the
+    /// process is up. Appending "cannot start" to it is simply false, and it
+    /// fires for real: a daemon launched with a baked-in `AINB_CONFIG_PATH`
+    /// reads a config this process cannot see.
+    #[test]
+    fn a_degraded_bridge_is_never_told_it_cannot_start() {
+        let mut rows = vec![DaemonStatus {
+            state: DaemonState::Degraded,
+            reason: "running (connected), but a push did not reach the human".to_string(),
+            ..DaemonStatus::stopped(DaemonKind::Bridge, String::new())
+        }];
+        annotate_bridge_config(&mut rows, Some("no bridge config: it does not exist"));
+        assert!(
+            !rows[0].reason.contains("cannot start"),
+            "a live daemon must not be told it cannot start, got {:?}",
+            rows[0].reason
+        );
+    }
+
+    /// A stopped bridge DOES get the cause appended — that is the whole point.
+    #[test]
+    fn a_stopped_bridge_gets_the_config_cause() {
+        let mut rows = vec![DaemonStatus::stopped(
+            DaemonKind::Bridge,
+            "no heartbeat".to_string(),
+        )];
+        annotate_bridge_config(&mut rows, Some("no bridge config: it does not exist"));
+        assert!(rows[0].reason.contains("cannot start: no bridge config"));
+    }
+
     #[test]
     fn the_socket_probed_daemons_complete_the_roster() {
         let kinds: Vec<DaemonKind> = collect_socket_daemons().iter().map(|r| r.kind).collect();


### PR DESCRIPTION
Follow-up to #708. That PR was reviewed before it merged `origin/main`, and the merge resolution — plus the parallel daemons work main landed in #707/#709/#711 — went unreviewed. A `/review` over `a385b492..53331a33` found eight issues; this fixes the four that affect a user.

## The Hangar restart printed over the TUI

The Daemons screen restarted the Hangar daemon through the **announcing** CLI entry point, so its `println!` went to stdout from a background thread while the TUI held the alternate screen in raw mode. That output does not scroll — it smears over the last painted frame and nothing repaints it away. Every other daemon the screen restarts was already silent.

## `bridge install` could stop a working bridge

`install()` decides whether to activate partly from whether the config's secrets resolve — **in the installing shell**. The launchd path unloaded unconditionally and only reloaded when activating. So re-running `ainb fleet bridge install` over an unchanged unit from a shell without `$TELEGRAM_BOT_TOKEN` exported, or with the keychain locked, stopped a healthy bridge and left it stopped, reporting "installed but NOT started".

Now it unloads only when it will reload, or when the definition actually changed — which still covers the stale-unit case the unconditional unload existed for. systemd was never affected: `daemon-reload` does not stop a running unit.

## A keychain lookup every two seconds

The Daemons collector calls `config_problem()` on every pass while a bridge row is down, and parsing **resolves the configured secrets** — a `keychain:<service>` ref shells out to `/usr/bin/security`. A stopped bridge with a keychain token meant a `security` subprocess every 2s, repeated unlock prompts, and a 5s stall each time the keychain was locked. `ainb doctor` doubled it, calling `collect()` twice.

The verdict only changes when the config file does, so it is memoised on the file's path, mtime and length.

## A live daemon told it "cannot start"

The config-cause annotation matched every non-`Running` row, which includes `Degraded` — a state that means the process **is** alive with half its job failing. It fires concretely when the daemon runs with a baked-in `AINB_CONFIG_PATH` the TUI process cannot see, producing `"running (connected), but a proactive push did not reach the human — cannot start: no bridge config"`. Now limited to `Stopped`/`Unknown`.

## Also

`SELECTION_GREEN` was added with a comment explaining why it must stay separate from `HEALTHY_GREEN`, then never used — the cursor still painted `HEALTHY_GREEN`, so the two could not actually diverge.

## Not fixed here

The review also found that **`daemons_overlay` is unreachable**: `AppEvent::DaemonsOverlayOpen` has no producer, the overlay is only created by `GoToDaemons` (which sets `current_screen = DAEMONS`), and `layout.rs` skips rendering it on that screen. Its two cosmetic findings — a help bar still reading `R restart notifyd`, and the shared `restart_status` rendering under the notifyd header regardless of which row was restarted — are invisible for that reason. Deleting the component is a separate, larger change and is left out deliberately rather than mixed in here.

## Verification

`cargo test -p ainb --lib`: 1861 passed, 0 failed. New tests pin the unload rule (an unchanged unit is never unloaded when it will not be reloaded) and that a `Degraded` bridge is never told it cannot start, while a `Stopped` one still gets the cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented daemon restart messages from disrupting the terminal interface.
  * Improved bridge status annotations so active but degraded bridges are not incorrectly marked with configuration errors.
  * Avoided unnecessary bridge interruptions when configuration and activation settings are unchanged.
  * Ensured outdated bridge configurations are refreshed when needed.

* **UI Improvements**
  * Updated daemon selection guidance and refined the selected-row highlight color.

* **Performance**
  * Reduced repeated bridge configuration checks for faster status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->