### PR TITLE
fix(daemons): stop reporting stopped daemons as crashed, and stop the daemon racing ATC

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
@@ -29,10 +29,8 @@ const SCAN_INTERVAL_SECS: u64 = 5;
 /// host running many sessions.
 fn atc_holding_the_fleet() -> Option<String> {
     let home = crate::fleet::plumbing::paths::ainb_home().ok()?;
-    let status = crate::fleet::daemons::probe::probe_atc(
-        &home,
-        crate::fleet::daemons::heartbeat::now_ms(),
-    );
+    let status =
+        crate::fleet::daemons::probe::probe_atc(&home, crate::fleet::daemons::heartbeat::now_ms());
     if status.state != crate::fleet::daemons::probe::DaemonState::Running {
         return None;
     }

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
@@ -15,8 +15,43 @@ use crate::fleet::types::Signal;
 
 const SCAN_INTERVAL_SECS: u64 = 5;
 
+/// Refuse to start when a LIVE ATC already supervises this fleet.
+///
+/// Both watchers auto-`continue` on API errors by sending keys to the same
+/// panes, and each de-dups only within its own process, so two of them send
+/// twice. Worse, ATC's per-session retry cap becomes meaningless while an
+/// uncapped daemon keeps hammering.
+///
+/// Liveness comes from `probe_atc`, NOT from a pidfile: an ATC that is merely
+/// provisioned, disabled, or whose last heartbeat is stale is not supervising
+/// anything, and refusing on a stale record would block a legitimate start.
+/// The instance name is reported because a bare refusal is unactionable on a
+/// host running many sessions.
+fn atc_holding_the_fleet() -> Option<String> {
+    let home = crate::fleet::plumbing::paths::ainb_home().ok()?;
+    let status = crate::fleet::daemons::probe::probe_atc(
+        &home,
+        crate::fleet::daemons::heartbeat::now_ms(),
+    );
+    if status.state != crate::fleet::daemons::probe::DaemonState::Running {
+        return None;
+    }
+    // `probe_atc` puts the winning instance name in the channel label.
+    Some(status.channel.unwrap_or_else(|| "unnamed".to_string()))
+}
+
 pub async fn execute(matches: &clap::ArgMatches, _format: OutputFormat) -> Result<()> {
     let verbose = matches.get_flag("verbose");
+
+    if !matches.get_flag("force-race") {
+        if let Some(owner) = atc_holding_the_fleet() {
+            anyhow::bail!(
+                "ATC '{owner}' is supervising this fleet; running the daemon alongside it \
+                 sends every auto-continue twice and defeats ATC's per-session retry cap.\n\
+                 Use ATC, or pass --force-race to run both deliberately."
+            );
+        }
+    }
 
     // Heartbeat: the fleet daemon had no observability either. Record a startup
     // record and refresh it every scan so the Daemons surface can show it

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -2453,11 +2453,32 @@ impl CliCommand for FleetCommand {
                     .help("Reporting window passed to the burndown plugin"),
             );
         let daemon = Command::new("daemon")
-            .about("Watcher: registers as ainb-fleet-cp peer, auto-continues API errors")
+            .about(
+                "DEPRECATED, superseded by `ainb fleet atc`: auto-continues API errors \
+                 without ATC's per-session retry cap",
+            )
+            .long_about(
+                "Watcher that scans every session's pane and auto-continues the ones \
+                 hitting API errors.\n\n\
+                 DEPRECATED: `ainb fleet atc` does the same job and adds a per-session \
+                 retry cap with escalation, which this daemon has never had, so a session \
+                 that keeps failing is retried forever here instead of being escalated to \
+                 you. Prefer `ainb fleet atc setup <name>`.\n\n\
+                 It refuses to start while a live ATC supervises the fleet, because both \
+                 send the same auto-continue to the same pane and each de-dups only within \
+                 its own process. Kept for unmanaged one-off recovery; use --force-race to \
+                 run both deliberately.",
+            )
             .arg(
                 clap::Arg::new("verbose")
                     .long("verbose")
                     .short('v')
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("force-race")
+                    .long("force-race")
+                    .help("Start even when a live ATC supervises the fleet (both will act)")
                     .action(clap::ArgAction::SetTrue),
             );
         let daemons = Command::new("daemons").about(

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
@@ -58,7 +58,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::fleet::plumbing::atomic::write_atomic_json;
@@ -320,7 +320,33 @@ impl DaemonHeartbeat {
         self.write_in(&crate::fleet::plumbing::paths::ainb_home()?, name)
     }
 
-    /// Read `<name>`'s heartbeat file under `home`, if present and parseable.
+    /// Delete `<name>`'s heartbeat under `home`, marking a CLEAN stop.
+    ///
+    /// The absence of a heartbeat is what distinguishes "stopped on purpose"
+    /// from "crashed": nothing used to remove these files, so a record outlived
+    /// its process forever and every deliberately-stopped daemon reported
+    /// `stale heartbeat, pid not alive (crashed)`.
+    ///
+    /// A stop that never runs (SIGKILL, power loss) leaves the record behind
+    /// and therefore still reads as a crash. That is correct: from the outside
+    /// a killed daemon and a crashed one are the same event.
+    ///
+    /// Missing file is success, so a double stop is not an error.
+    pub fn clear_in(home: &Path, name: &str) -> Result<()> {
+        let path = heartbeat_path_in(home, name);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("clearing heartbeat {}", path.display())),
+        }
+    }
+
+    /// Delete `<name>`'s heartbeat under the default ainb home.
+    pub fn clear(name: &str) -> Result<()> {
+        Self::clear_in(&crate::fleet::plumbing::paths::ainb_home()?, name)
+    }
+
+    /// Read `<name>`'s heartbeat under `home`, if present and parseable.
     #[must_use]
     pub fn read_in(home: &Path, name: &str) -> Option<Self> {
         let text = std::fs::read_to_string(heartbeat_path_in(home, name)).ok()?;
@@ -407,6 +433,54 @@ pub fn process_binary(pid: u32) -> Option<PathBuf> {
 /// dead. This is the identity guard the bare `kill(pid,0)` liveness check
 /// lacked.
 #[must_use]
+/// Delete heartbeats whose process is provably gone, returning the names swept.
+///
+/// `clear_in` only helps daemons stopped AFTER it ships. Records orphaned
+/// before that (the stopping process is long gone, so nothing will ever come
+/// back for them) would report `crashed` forever. This sweep collects them.
+///
+/// ONLY `Dead` and `Recycled` are swept. `Matched` means the process is alive
+/// and owns the record; `Recycled` means the pid was reused by an unrelated
+/// process, so the record is stale in a different way but equally orphaned.
+/// A running daemon's heartbeat is never touched.
+///
+/// Best-effort per entry: one unreadable file must not abort the sweep.
+pub fn sweep_orphaned_in(home: &Path) -> Vec<String> {
+    let dir = daemons_dir_in(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut swept = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(name) = path.file_stem().and_then(|s| s.to_str()).map(str::to_string) else {
+            continue;
+        };
+        let Some(hb) = DaemonHeartbeat::read_in(home, &name) else {
+            continue;
+        };
+        if matches!(
+            pid_identity(hb.pid, hb.started_at),
+            PidCheck::Dead | PidCheck::Recycled
+        ) && DaemonHeartbeat::clear_in(home, &name).is_ok()
+        {
+            swept.push(name);
+        }
+    }
+    swept.sort();
+    swept
+}
+
+/// Sweep orphaned heartbeats under the default ainb home.
+pub fn sweep_orphaned() -> Vec<String> {
+    crate::fleet::plumbing::paths::ainb_home()
+        .map(|home| sweep_orphaned_in(&home))
+        .unwrap_or_default()
+}
+
 pub fn pid_identity(pid: u32, started_at_ms: i64) -> PidCheck {
     classify_pid_identity(started_at_ms, process_start_ms(pid))
 }
@@ -760,6 +834,73 @@ mod tests {
         hb.write_in(home.path(), "bridge").unwrap();
         let back = DaemonHeartbeat::read_in(home.path(), "bridge").unwrap();
         assert_eq!(back, hb);
+    }
+
+    /// A CLEAN stop and a CRASH must stay distinguishable.
+    ///
+    /// This is the whole reason for clearing the record instead of hiding the
+    /// row: if both cases looked alike, the fix would be row-hiding with extra
+    /// steps. Clean stop removes the record so the daemon reads as stopped; a
+    /// process that died without clearing leaves it, and still reads as dead.
+    #[test]
+    fn a_clean_stop_and_a_crash_do_not_look_alike() {
+        let home = TempDir::new().unwrap();
+
+        // Clean stop: the daemon cleared its own record on the way out.
+        DaemonHeartbeat::starting().write_in(home.path(), "fleet-daemon").unwrap();
+        DaemonHeartbeat::clear_in(home.path(), "fleet-daemon").unwrap();
+        assert!(
+            DaemonHeartbeat::read_in(home.path(), "fleet-daemon").is_none(),
+            "a clean stop must leave no record, so the row reads stopped, not crashed"
+        );
+
+        // Crash (or SIGKILL): nothing ran on the way out, so the record stays
+        // and its pid is dead. pid 1 is alive but did not start when this
+        // record claims, so identity does not match: exactly the crash shape.
+        let mut crashed = DaemonHeartbeat::starting();
+        crashed.pid = 1;
+        crashed.started_at = 0;
+        crashed.write_in(home.path(), "notifyd").unwrap();
+        let back = DaemonHeartbeat::read_in(home.path(), "notifyd")
+            .expect("a crash leaves the record behind");
+        assert!(
+            matches!(
+                pid_identity(back.pid, back.started_at),
+                PidCheck::Dead | PidCheck::Recycled
+            ),
+            "a crashed daemon's record must still classify as not-alive"
+        );
+    }
+
+    /// The sweep collects records orphaned BEFORE the clear-on-stop shipped.
+    ///
+    /// Without it, an already-dead pid keeps reporting `crashed` forever: the
+    /// process that would have cleaned up is long gone.
+    #[test]
+    fn the_sweep_takes_orphans_and_spares_the_living() {
+        let home = TempDir::new().unwrap();
+
+        // Orphan: dead pid identity, nobody left to clean it.
+        let mut orphan = DaemonHeartbeat::starting();
+        orphan.pid = 1;
+        orphan.started_at = 0;
+        orphan.write_in(home.path(), "fleet-daemon").unwrap();
+
+        // Living: this very process, so identity matches.
+        let mut alive = DaemonHeartbeat::starting();
+        alive.pid = std::process::id();
+        alive.started_at = process_start_ms(std::process::id()).unwrap_or(now_ms());
+        alive.write_in(home.path(), "atc").unwrap();
+
+        let swept = sweep_orphaned_in(home.path());
+        assert!(
+            swept.contains(&"fleet-daemon".to_string()),
+            "the orphaned record must be swept, got {swept:?}"
+        );
+        assert!(
+            DaemonHeartbeat::read_in(home.path(), "atc").is_some(),
+            "a LIVE daemon's heartbeat must never be swept"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/heartbeat.rs
@@ -836,6 +836,17 @@ mod tests {
         assert_eq!(back, hb);
     }
 
+    /// A pid that cannot own a live process on any supported platform.
+    ///
+    /// pid 1 is NOT safe here: on Linux it is init and reads far from a zero
+    /// `started_at`, so it classifies dead, but on macOS launchd's start time
+    /// is not readable the same way and the comparison landed inside
+    /// `PID_IDENTITY_TOLERANCE_MS`, classifying the record as MATCHED. Both new
+    /// tests then failed on macOS only. A pid above the platform maximum has no
+    /// process to read, so `process_start_ms` returns `None` and the verdict is
+    /// `Dead` everywhere.
+    const ABSENT_PID: u32 = u32::MAX;
+
     /// A CLEAN stop and a CRASH must stay distinguishable.
     ///
     /// This is the whole reason for clearing the record instead of hiding the
@@ -858,7 +869,7 @@ mod tests {
         // and its pid is dead. pid 1 is alive but did not start when this
         // record claims, so identity does not match: exactly the crash shape.
         let mut crashed = DaemonHeartbeat::starting();
-        crashed.pid = 1;
+        crashed.pid = ABSENT_PID;
         crashed.started_at = 0;
         crashed.write_in(home.path(), "notifyd").unwrap();
         let back = DaemonHeartbeat::read_in(home.path(), "notifyd")
@@ -882,21 +893,31 @@ mod tests {
 
         // Orphan: dead pid identity, nobody left to clean it.
         let mut orphan = DaemonHeartbeat::starting();
-        orphan.pid = 1;
+        orphan.pid = ABSENT_PID;
         orphan.started_at = 0;
         orphan.write_in(home.path(), "fleet-daemon").unwrap();
 
-        // Living: this very process, so identity matches.
-        let mut alive = DaemonHeartbeat::starting();
-        alive.pid = std::process::id();
-        alive.started_at = process_start_ms(std::process::id()).unwrap_or(now_ms());
-        alive.write_in(home.path(), "atc").unwrap();
+        // Living: this very process, recorded with the start time the probe
+        // itself reports, so identity matches exactly rather than within a
+        // tolerance. If the platform cannot read our own start time there is no
+        // honest way to build a "live" record, so that half is skipped rather
+        // than faked with `now_ms()`, which would read as recycled and be swept.
+        let live_start = process_start_ms(std::process::id());
+        if let Some(start) = live_start {
+            let mut alive = DaemonHeartbeat::starting();
+            alive.pid = std::process::id();
+            alive.started_at = start;
+            alive.write_in(home.path(), "atc").unwrap();
+        }
 
         let swept = sweep_orphaned_in(home.path());
         assert!(
             swept.contains(&"fleet-daemon".to_string()),
             "the orphaned record must be swept, got {swept:?}"
         );
+        if live_start.is_none() {
+            return;
+        }
         assert!(
             DaemonHeartbeat::read_in(home.path(), "atc").is_some(),
             "a LIVE daemon's heartbeat must never be swept"

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/mod.rs
@@ -28,3 +28,42 @@ pub mod probe;
 
 pub use heartbeat::{DaemonHeartbeat, is_pid_alive};
 pub use probe::{DaemonKind, DaemonState, DaemonStatus, collect, collect_in};
+
+/// Bring long-running daemons onto THIS binary at launch, and clear the
+/// heartbeats of ones that are already gone.
+///
+/// Mirrors `ensure_hangar_daemon`, which has always upgraded an older released
+/// hangar daemon on TUI start. notifyd never got the same treatment, so after a
+/// `brew upgrade` the old process kept serving until someone noticed the drift
+/// column and restarted it by hand.
+///
+/// Only the LIVE OWNER is considered, and only when its binary differs from
+/// this one. Stale owners and orphans are a reap concern, not an upgrade
+/// concern, and restarting on anything less than a real drift would cycle a
+/// healthy daemon on every launch.
+///
+/// Deliberately does NOT touch a daemon whose binary matches: a dev build
+/// another worktree is deliberately running reports its own path, and cycling
+/// it would break that session.
+///
+/// Best-effort and quiet, like the hangar equivalent: the TUI owns the
+/// terminal, and a failed upgrade must never stop it launching.
+pub fn ensure_daemons_current() {
+    for name in heartbeat::sweep_orphaned() {
+        tracing::info!(daemon = %name, "cleared heartbeat for a daemon that is no longer running");
+    }
+
+    let drifted = ainb_plugin_notifyd::procs::scan().into_iter().any(|d| {
+        matches!(d.class, ainb_plugin_notifyd::DaemonClass::LiveOwner) && d.binary_drift
+    });
+    if !drifted {
+        return;
+    }
+    match ainb_plugin_notifyd::procs::restart(std::time::Duration::from_secs(3)) {
+        Ok(out) => tracing::info!(
+            socket_bound = out.socket_bound,
+            "notifyd restarted onto this binary after an upgrade"
+        ),
+        Err(e) => tracing::warn!(error = %e, "notifyd upgrade failed (TUI continues)"),
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/mod.rs
@@ -53,9 +53,9 @@ pub fn ensure_daemons_current() {
         tracing::info!(daemon = %name, "cleared heartbeat for a daemon that is no longer running");
     }
 
-    let drifted = ainb_plugin_notifyd::procs::scan().into_iter().any(|d| {
-        matches!(d.class, ainb_plugin_notifyd::DaemonClass::LiveOwner) && d.binary_drift
-    });
+    let drifted = ainb_plugin_notifyd::procs::scan()
+        .into_iter()
+        .any(|d| matches!(d.class, ainb_plugin_notifyd::DaemonClass::LiveOwner) && d.binary_drift);
     if !drifted {
         return;
     }

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -173,6 +173,11 @@ async fn tokio_main() -> Result<()> {
                 // the daemon) instead of an offline panel. Idempotent + non-fatal — a
                 // spawn failure is logged and the TUI still launches.
                 cli::hangar::ensure_hangar_daemon();
+                // Same contract for the rest: clear heartbeats left by daemons
+                // that are already gone, and hand a drifted notifyd to this
+                // binary. Without it an upgraded ainb kept talking to the
+                // pre-upgrade notifyd until someone restarted it by hand.
+                fleet::daemons::ensure_daemons_current();
             }
 
             // Best-effort: drop shipped default presets into

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -2035,7 +2035,7 @@ Commands:
   needs          Center control panel — sessions blocked on input / errors / idle / waiting
   archived       Sessions the daemon retired out of the live roster (still browsable)
   cost           Per-session / model / day / group spend rollups + budget caps
-  daemon         Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
+  daemon         DEPRECATED, superseded by `ainb fleet atc`: auto-continues API errors without ATC's per-session retry cap
   daemons        Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
   runtime        Install the standalone Fleet daemon and provider hooks
   atc            Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
@@ -2681,18 +2681,33 @@ Options:
 
 ### `ainb fleet daemon`
 
-Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
+Watcher that scans every session's pane and auto-continues the ones hitting API errors.
 
 ```console
 $ ainb fleet daemon --help
-Watcher: registers as ainb-fleet-cp peer, auto-continues API errors
+Watcher that scans every session's pane and auto-continues the ones hitting API errors.
+
+DEPRECATED: `ainb fleet atc` does the same job and adds a per-session retry cap with escalation, which this daemon has never had, so a session that keeps failing is retried forever here instead of being escalated to you. Prefer `ainb fleet atc setup <name>`.
+
+It refuses to start while a live ATC supervises the fleet, because both send the same auto-continue to the same pane and each de-dups only within its own process. Kept for unmanaged one-off recovery; use --force-race to run both deliberately.
 
 Usage: ainb fleet daemon [OPTIONS]
 
 Options:
-      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
-  -v, --verbose          
-  -h, --help             Print help
+      --format <format>
+          Output format
+          
+          [default: text]
+          [possible values: text, json, csv, markdown]
+
+  -v, --verbose
+          
+
+      --force-race
+          Start even when a live ATC supervises the fleet (both will act)
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 ### `ainb fleet daemons`

--- a/plugins/ainb-fleet/skills/daemon/SKILL.md
+++ b/plugins/ainb-fleet/skills/daemon/SKILL.md
@@ -21,6 +21,18 @@ allowed-tools:
 
 # ainb fleet:daemon
 
+> **DEPRECATED. Use [`/ainb-fleet:atc`](../atc/SKILL.md).** `ainb fleet daemon`
+> now REFUSES to start while a live ATC supervises the fleet, because both send
+> the same auto-`continue` to the same pane and each de-dups only inside its own
+> process, so the pane gets it twice. Pass `--force-race` to run both anyway.
+>
+> The difference that matters is the **retry cap**: ATC gives up on a session
+> after a bounded number of attempts and escalates to you. This daemon has no
+> cap, so a session that keeps failing is retried forever, and running it beside
+> ATC makes ATC's cap meaningless.
+>
+> Kept for unmanaged one-off recovery, not removed.
+
 > **Superseded by [`/ainb-fleet:atc`](../atc/SKILL.md) for managed fleets.** ATC
 > absorbs this daemon's job — its ERR playbook does the same auto-`continue`, but
 > **with a per-session retry cap + escalate-on-exhaustion** that this daemon


### PR DESCRIPTION
Four related changes to daemon lifecycle. All four came out of one screen:
`d` showed `fleet daemon ○ stopped 54868 stale heartbeat, pid not alive
(crashed)` for a daemon nobody had crashed.

## 1. A clean stop no longer looks like a crash

**Nothing ever removed a heartbeat file.** A record outlived its process
forever, so the pid was genuinely dead and the "crashed" verdict was correct
given the evidence, and the evidence was never cleared. Same root cause behind
`ainb doctor`, `ainb fleet daemons` and the Daemons screen all showing corpses.

- `clear_in` removes the record on a clean stop.
- Absence now means stopped on purpose; presence with a dead pid still means
  crashed.
- **A SIGKILL'd daemon still reads as crashed.** The cleanup never runs, so the
  record stays. That is correct (from outside, killed and crashed are the same
  event) but flagging it rather than leaving it as a surprise.

## 2. Existing corpses get swept

`clear_in` only helps daemons stopped *after* it ships. pid 54868's record is
already orphaned and the process that would clean it is long gone, so without a
sweep the bug stays on screen after the fix lands. `sweep_orphaned_in` collects
records whose pid is `Dead` or `Recycled`; a live daemon's heartbeat is never
touched.

## 3. `ainb fleet daemon` refuses to race a live ATC

Both auto-`continue` on API errors by sending keys to the same panes, and each
de-dups only inside its own process, so two of them send twice. Worse, ATC's
per-session retry cap is meaningless while an uncapped daemon keeps hammering.
Nothing enforced the documented rule.

- Liveness from `probe_atc`, **not a pidfile** — an ATC that is provisioned,
  disabled, or stale is not supervising anything, and refusing on a stale
  record would block a legitimate start.
- The refusal **names the instance**; a bare refusal is unactionable on a host
  running many sessions.
- `--force-race` is a real, documented override. A guard with no escape hatch
  gets worked around by deleting the guard.
- **Deprecated, not removed.** Help text and skill doc point at ATC and explain
  the retry-cap difference. Removing a working tool others may depend on is a
  separate call to make on evidence.

## 4. notifyd comes onto the current binary at launch

`ensure_hangar_daemon` has always upgraded an older released hangar daemon on
TUI start; notifyd never got the same treatment, so after `brew upgrade` the
pre-upgrade process kept serving until someone noticed the drift column. This
mirrors that contract rather than inventing one, keyed off notifyd's existing
`binary_drift` flag. Only the LIVE OWNER is considered, and a daemon whose
binary matches is left alone, so a dev build another worktree runs deliberately
is not cycled out from under it.

## Tests

`a_clean_stop_and_a_crash_do_not_look_alike` asserts **both** directions: a
clean stop leaves no record, and a process that died without clearing still
classifies as not-alive. If those two were indistinguishable this would just be
row-hiding with extra steps. `the_sweep_takes_orphans_and_spares_the_living`
covers the sweep, including that a live daemon is never swept.

## Verification honesty

`cargo fmt --check` is clean. **The compile did not finish locally** — the
build wedged at 834 lines with no exit marker and was killed along with two
stalled poll loops, so I have **no local compile or test result** for this
branch and am not claiming one. CI is the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically cleans up stale daemon records and refreshes the fleet notification service after upgrades.
  * Daemon startup now detects active ATC supervision and provides guidance when concurrent operation is unsafe.
  * Added `--force-race` to intentionally run alongside a live ATC.

* **Bug Fixes**
  * Improved heartbeat cleanup for cleanly stopped and orphaned daemons.
  * Added clearer context for heartbeat filesystem errors.

* **Documentation**
  * Marked `ainb fleet daemon` as deprecated for managed fleets and recommended `ainb fleet atc` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->