### PR TITLE
feat(daemons): install hooks from the TUI, and stamp daemon identity under load

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5267,7 +5267,8 @@ impl AppState {
         });
     }
 
-    /// Reinstall only already-installed hooks against this running binary.
+    /// Reinstall installed hooks against this running binary, or perform the
+    /// first install for every agent when no hooks are installed yet.
     /// This is the repair action for stale package-manager paths and damaged
     /// wiring; it deliberately does not start/restart any daemon.
     pub fn spawn_hooks_repair(&mut self) {
@@ -5279,14 +5280,14 @@ impl AppState {
         }
         let (tx, rx) = mpsc::unbounded_channel();
         o.hooks_repair_rx = Some(rx);
-        o.hooks_repair_status = Some("repairing hooks…".to_string());
+        o.hooks_repair_status = Some("installing hooks…".to_string());
         tokio::spawn(async move {
             let line = tokio::task::spawn_blocking(|| {
                 let result = ainb_plugin_notifyd::Paths::from_home()
-                    .and_then(|paths| ainb_plugin_notifyd::repair_hooks(&paths));
+                    .and_then(|paths| ainb_plugin_notifyd::repair_or_install_hooks(&paths));
                 match result {
                     Ok(report) => format!(
-                        "hooks repaired for {}",
+                        "hooks installed for {}",
                         report
                             .record
                             .agents

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8805,11 +8805,15 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     // version over it would silence the very skew warning `status` exists to
     // print. Best-effort: a write failure must not fail the start (the skew
     // check just degrades to "unknown").
-    // Only when OUR child is the daemon now serving. `exited.is_none()` is not
-    // that test: a child still alive at the probe may be a slow starter that
-    // goes on to lose the lock, and stamping our version over the incumbent's
-    // silences the very skew warning `status` exists to print.
-    if owner == Some(child.id()) {
+    // Only when OUR child is the daemon this start recorded. That is the child
+    // holding the lock at the probe, OR the no-owner fallback above: with no
+    // lock on disk there is no incumbent whose stamp we could clobber, and the
+    // pid file we just wrote names the child, so the stamp must match it. A
+    // probe that merely finds the child still alive is NOT enough when someone
+    // ELSE holds the lock: a slow starter can go on to lose the race, and
+    // stamping our version over the incumbent's silences the very skew warning
+    // `status` exists to print.
+    if owner == Some(child.id()) || (owner.is_none() && exited.is_none()) {
         if let Ok(vpath) = daemon_version_path() {
             std::fs::write(&vpath, format!("{}\n", env!("CARGO_PKG_VERSION"))).ok();
         }

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -661,7 +661,7 @@ fn render_hook_section(
                 "  I",
                 Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" repair", Style::default().fg(MUTED_GRAY)),
+            Span::styled(" install / repair", Style::default().fg(MUTED_GRAY)),
         ]))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -1287,8 +1287,8 @@ mod tests {
         );
         assert!(out.contains("Hooks"), "hook section missing: {out}");
         assert!(
-            out.contains("I repair"),
-            "hook repair action missing: {out}"
+            out.contains("I install / repair"),
+            "hook install/repair action missing: {out}"
         );
         assert!(out.contains("release"), "hook mode missing: {out}");
         assert!(

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -553,6 +553,18 @@ pub fn repair_hooks(paths: &Paths) -> Result<InstallReport> {
     install(paths, &record.agents)
 }
 
+/// Repair installed hooks, or perform the first install for every agent when
+/// nothing is installed yet. This backs the TUI's repair keypress: unlike the
+/// diagnostic CLI path above, a keypress on the Daemons screen is explicit
+/// operator intent, so an empty record means "install", not "refuse".
+pub fn repair_or_install_hooks(paths: &Paths) -> Result<InstallReport> {
+    let record = InstallRecord::load(paths)?;
+    if record.agents.is_empty() {
+        return install(paths, Agent::ALL);
+    }
+    install(paths, &record.agents)
+}
+
 /// Install variant that takes an explicit `$HOME` root. Lets tests
 /// stay isolated without mutating the process-wide environment.
 pub fn install_under_home(paths: &Paths, home: &Path, agents: &[Agent]) -> Result<InstallRecord> {

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -46,7 +46,7 @@ pub use install::{
     Agent, ClaudeRegister, HookAgentHealth, HookBinaryMode, HookHealth, HookHealthIssue,
     InstallPrompt, InstallRecord, InstallReport, StatusRow, auto_repair_hook_binary,
     dismiss_prompt, embedded_plugin_version, hook_health, install as install_for,
-    install_under_home, prompt_state, repair_hooks, status, uninstall,
+    install_under_home, prompt_state, repair_hooks, repair_or_install_hooks, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
 pub use osnotify::{AlertKind, classify_attention};


### PR DESCRIPTION
Salvages the two commits from #700 that are still live, rebuilt on current `main`.

#700 went CONFLICTING when the Daemons-screen rewrite (#708) landed underneath it, and the conflicts sit almost entirely in the parts that rewrite made obsolete. Rather than hand-resolve code that is now deleted, this cherry-picks the half that still matters. Both commits keep their original authorship and apply cleanly.

## `I` was a dead key on a fresh machine

`repair_hooks` refuses an empty install record, so a host with no hooks installed got `hook repair failed: hooks are not installed; run ainb notifyd install --all` — CLI homework from a screen whose whole point is that you can act on the red rows.

`I` now installs for all agents when the record is empty and repairs recorded agents otherwise (`repair_or_install_hooks` in `ainb-plugin-notifyd`). The CLI diagnostic path keeps its deliberate refusal. Section label becomes `I install / repair`.

## `hangar daemon start` skipped its identity stamp under load

`start` only wrote `daemon.binary`/version when its 400ms probe saw the child already holding the ownership lock. A slow starter on a loaded machine skipped the stamp forever, which flaked the lifecycle round-trip test with `NotFound`. With no lock on disk there is no incumbent to clobber and the recorded pid names the child, so it stamps on that fallback too.

## Deliberately dropped from #700

| dropped | why |
|---|---|
| `B` starts the phone bridge | Superseded — `Enter` on the bridge row offers start/restart/stop via `ainb daemon bridge start` |
| Footer drops `read-only` | Superseded — the rewritten footer never had it |
| `chore: sync Cargo.lock to 1.21.3` | Stale — the release workflow has since moved to 1.22.0 |

Closes #700.

## Verification

`cargo test -p ainb --lib`: 1863 passed, 0 failed. `cargo test -p ainb-plugin-notifyd`: green. `components::daemons`: 28 passed, including the footer test that asserts the new `I install / repair` label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hooks can now be installed when none are present, as well as repaired when already configured.
  * The Hooks interface now clearly identifies the available “install / repair” action.

* **Bug Fixes**
  * Improved daemon startup tracking so version information is recorded reliably during slow starts.
  * Preserved version-mismatch warnings when another daemon instance owns the lock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->