### PR TITLE
fix(new-session): Esc from Configure no longer fabricates a phantom recent

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -741,6 +741,25 @@ mod picker_local_paths_tests {
 
 pub struct EventHandler;
 
+/// Whether Esc-ing out of Configure should write this repo into
+/// `SessionDefaults::per_repo` at all.
+///
+/// Only when there is something to preserve: a typed prompt, or an entry that
+/// already exists (whose stale prompt may need clearing). Backing out of a
+/// repo that was never launched must NOT fabricate a ⌚ recent — that is how
+/// typo'd owner/repo entries ended up pinned to the top of the picker
+/// (Stevie 2026-07-05: `sdfads/ssdaf`).
+///
+/// Pulled out of the event arm so the rule is testable without driving the
+/// whole new-session flow.
+fn worth_persisting_repo_defaults(
+    prompt_text: &str,
+    defaults: &crate::config::session_defaults::SessionDefaults,
+    repo_label: &str,
+) -> bool {
+    !prompt_text.is_empty() || defaults.per_repo.contains_key(repo_label)
+}
+
 impl EventHandler {
     fn persist_sessions_pane_preferences(state: &mut AppState) {
         state.app_config.ui_preferences.sessions_sidebar_width =
@@ -3886,15 +3905,7 @@ impl EventHandler {
                 if !repo_label.is_empty() {
                     let path = SessionDefaults::default_path();
                     let mut defaults = SessionDefaults::load_from(&path);
-                    // Only touch per_repo when there is something to preserve:
-                    // a typed prompt, or an entry that already exists (whose
-                    // stale prompt may need clearing). Esc-ing straight out of
-                    // a never-launched repo must NOT fabricate a ⌚ recent —
-                    // that's how typo'd owner/repo entries ended up pinned to
-                    // the top of the picker (Stevie 2026-07-05: sdfads/ssdaf).
-                    let worth_persisting =
-                        !prompt_text.is_empty() || defaults.per_repo.contains_key(&repo_label);
-                    if worth_persisting {
+                    if worth_persisting_repo_defaults(&prompt_text, &defaults, &repo_label) {
                         let entry = defaults.per_repo.entry(repo_label.clone()).or_default();
                         entry.last_prompt = if prompt_text.is_empty() {
                             None
@@ -10226,5 +10237,37 @@ mod fleet_offline_action_tests {
                 .feedback()
                 .is_some_and(|message| message.contains("high-risk action disabled"))
         );
+    }
+}
+
+#[cfg(test)]
+mod configure_back_persist_tests {
+    use super::worth_persisting_repo_defaults;
+    use crate::config::session_defaults::SessionDefaults;
+
+    #[test]
+    fn esc_out_of_a_never_launched_repo_does_not_fabricate_a_recent() {
+        let defaults = SessionDefaults::default();
+        assert!(
+            !worth_persisting_repo_defaults("", &defaults, "sdfads/ssdaf"),
+            "a typo'd repo with no prompt must not be written into per_repo"
+        );
+    }
+
+    #[test]
+    fn a_typed_prompt_is_always_persisted() {
+        let defaults = SessionDefaults::default();
+        assert!(worth_persisting_repo_defaults(
+            "fix the thing",
+            &defaults,
+            "owner/repo"
+        ));
+    }
+
+    #[test]
+    fn an_existing_entry_is_still_updated_so_a_stale_prompt_can_be_cleared() {
+        let mut defaults = SessionDefaults::default();
+        defaults.per_repo.insert("owner/repo".to_string(), Default::default());
+        assert!(worth_persisting_repo_defaults("", &defaults, "owner/repo"));
     }
 }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3886,23 +3886,36 @@ impl EventHandler {
                 if !repo_label.is_empty() {
                     let path = SessionDefaults::default_path();
                     let mut defaults = SessionDefaults::load_from(&path);
-                    let entry = defaults.per_repo.entry(repo_label.clone()).or_default();
-                    entry.last_prompt = if prompt_text.is_empty() {
-                        None
-                    } else {
-                        Some(prompt_text)
-                    };
-                    if let Err(err) = defaults.save_to(&path) {
-                        tracing::warn!(error = %err, "ConfigureBack: persist failed");
-                    }
-                    // Refresh PickRepo's in-memory snapshot so a later Enter
-                    // on PickRepo doesn't clobber the prompt we just wrote.
-                    // The picker carries its own `defaults` copy from open
-                    // time; mutations elsewhere are invisible to it.
-                    if let Some(pick) =
-                        state.new_session_state.as_mut().and_then(|ns| ns.pick_repo_state.as_mut())
-                    {
-                        pick.defaults = defaults;
+                    // Only touch per_repo when there is something to preserve:
+                    // a typed prompt, or an entry that already exists (whose
+                    // stale prompt may need clearing). Esc-ing straight out of
+                    // a never-launched repo must NOT fabricate a ⌚ recent —
+                    // that's how typo'd owner/repo entries ended up pinned to
+                    // the top of the picker (Stevie 2026-07-05: sdfads/ssdaf).
+                    let worth_persisting =
+                        !prompt_text.is_empty() || defaults.per_repo.contains_key(&repo_label);
+                    if worth_persisting {
+                        let entry = defaults.per_repo.entry(repo_label.clone()).or_default();
+                        entry.last_prompt = if prompt_text.is_empty() {
+                            None
+                        } else {
+                            Some(prompt_text)
+                        };
+                        if let Err(err) = defaults.save_to(&path) {
+                            tracing::warn!(error = %err, "ConfigureBack: persist failed");
+                        }
+                        // Refresh PickRepo's in-memory snapshot so a later
+                        // Enter on PickRepo doesn't clobber the prompt we just
+                        // wrote. The picker carries its own `defaults` copy
+                        // from open time; mutations elsewhere are invisible
+                        // to it.
+                        if let Some(pick) = state
+                            .new_session_state
+                            .as_mut()
+                            .and_then(|ns| ns.pick_repo_state.as_mut())
+                        {
+                            pick.defaults = defaults;
+                        }
                     }
                 }
                 if let Some(ns) = state.new_session_state.as_mut() {


### PR DESCRIPTION
Carries #390 forward onto current main, with the test it was missing. #390 itself is closed as stale — it sat as a draft for seven weeks and was 2413 commits behind — but **the bug it fixes is still live on main**, so the fix is re-raised here rather than dropped.

## The bug

`AppEvent::ConfigureBack` (Esc out of Configure) unconditionally did:

```rust
let entry = defaults.per_repo.entry(repo_label.clone()).or_default();
```

`or_default()` creates the entry whether or not there is anything to store. Backing out of a repo you never launched writes it into `SessionDefaults::per_repo`, and it then shows up pinned at the top of the picker as a ⌚ recent. That's how typo'd entries like `sdfads/ssdaf` got stuck there.

Verified still present on `origin/main` before raising this: the unguarded `entry(...).or_default()` is at `app/events.rs:3890`, and no phantom/fabricate guard exists anywhere in the file.

## The fix

Persist only when there is something to preserve — a typed prompt, or an entry that already exists (whose stale prompt may need clearing):

```rust
fn worth_persisting_repo_defaults(prompt_text, defaults, repo_label) -> bool {
    !prompt_text.is_empty() || defaults.per_repo.contains_key(repo_label)
}
```

Commit 1 is @stevengonsalvez's original `c18490c7`, cherry-picked unchanged onto main (authorship preserved).

## What's new here

Commit 2 pulls the guard out of the event arm and pins it with tests. As shipped it was an inline boolean inside a match arm, unreachable without driving the whole new-session flow — which is plausibly why the original never left draft.

| case | expected |
|---|---|
| never-launched repo, no prompt | not written to `per_repo` |
| typed prompt | always written |
| existing entry, empty prompt | still written, so the stale prompt clears |

```
running 3 tests
test app::events::configure_back_persist_tests::esc_out_of_a_never_launched_repo_does_not_fabricate_a_recent ... ok
test app::events::configure_back_persist_tests::a_typed_prompt_is_always_persisted ... ok
test app::events::configure_back_persist_tests::an_existing_entry_is_still_updated_so_a_stale_prompt_can_be_cleared ... ok

test result: ok. 3 passed; 0 failed
```

`cargo check -p ainb --lib` clean, `cargo fmt --all` clean.

https://claude.ai/code/session_015TMAU2cLaimQdBMzxjshxr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cancelled repository configuration from creating unnecessary settings when no values were entered.
  * Preserved existing repository settings while clearing outdated prompts appropriately.
  * Ensured repository defaults refresh correctly after configuration changes.

* **Tests**
  * Added coverage for empty input, entered values, and existing repository settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->