### PR TITLE
fix(hangar): stop entering acp spans across await points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,11 @@ jobs:
         if: >-
           always() && (github.event_name != 'pull_request' ||
           needs.changes.outputs.relevant != 'false')
+        with:
+          # This action installs with rustup's MINIMAL profile, which omits
+          # clippy. The span-guard gate below needs it, and a missing component
+          # would red the job with `no such command: clippy`.
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         if: >-
           always() && (github.event_name != 'pull_request' ||
@@ -519,6 +524,30 @@ jobs:
           always() && (github.event_name != 'pull_request' ||
           needs.changes.outputs.relevant != 'false')
         run: cargo xtask ci-lint
+        working-directory: ${{ env.WORKING_DIR }}
+      # NOT a workspace clippy gate. `xtask/src/ci_lint.rs` documents why one
+      # does not exist: the workspace carries heavy pre-existing clippy debt and
+      # `-D warnings` would red CI for unrelated reasons. This denies exactly ONE
+      # lint and leaves every other finding a warning.
+      #
+      # The lint is `await_holding_invalid_type`, configured in `ainb-tui/
+      # clippy.toml` to reject a `tracing` `Entered` span guard held across an
+      # `.await`. `Entered` is `Send` (unlike `EnteredSpan`), so the mistake
+      # compiles; the guard is then dropped on whichever worker resumed the task,
+      # the entering worker keeps the span id on its stack forever, and the next
+      # contextual span opened there clones a closed span. That returns a slot to
+      # the subscriber registry's pool with a live ref count, and the next
+      # `new_span` ANYWHERE trips its refcount assertion, killing whatever task
+      # opened it. That is what made `rpc_acp` fail intermittently on this job:
+      # the victim was an RPC connection handler, so the test saw a closed socket
+      # thousands of lines away from the cause.
+      - name: No tracing span guard held across an await
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: >
+          cargo clippy -p ainb-hangar-daemon -p ainb-acp --lib
+          -- -D clippy::await_holding_invalid_type
         working-directory: ${{ env.WORKING_DIR }}
       - name: Run all hangar tripwires
         if: >-

--- a/ainb-tui/clippy.toml
+++ b/ainb-tui/clippy.toml
@@ -1,0 +1,11 @@
+# `span.enter()` returns `Entered`, which (unlike `EnteredSpan`) is `Send` in
+# tracing 0.1. Holding one across an `.await` therefore COMPILES inside a spawned
+# task, and then the guard is dropped on whichever worker resumed the task. The
+# worker that entered keeps the span id on its thread-local stack forever; the
+# next contextual span opened there clones an already-closed span, which returns
+# a `DataInner` slot to the registry's pool with a live ref count and trips
+# `tracing-subscriber`'s `sharded.rs` refcount assertion in an unrelated task.
+#
+# Use `tracing::Instrument` on the future instead. This lint makes the mistake a
+# build failure rather than an intermittent CI panic.
+await-holding-invalid-types = ["tracing::span::Entered"]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -91,6 +91,7 @@ use ainb_hangar_store::repo::fleet_provider_event::{
 };
 use sqlx::SqlitePool;
 use tokio::sync::{Semaphore, mpsc, oneshot};
+use tracing::Instrument as _;
 
 // ------------------------------------------------------------ detail taxonomy
 
@@ -959,8 +960,30 @@ impl AcpPool {
             mode = %config.permission_mode,
             provider_version = tracing::field::Empty,
         );
-        let _entered = span.enter();
+        self.spawn_provider_process(provider, config, span.clone())
+            .instrument(span)
+            .await
+    }
 
+    /// The spawn itself, running INSIDE the caller's `acp.spawn` span.
+    ///
+    /// It is a separate function so the span can be attached with `.instrument`
+    /// rather than `span.enter()`. `Entered` is `Send` in tracing 0.1 (unlike
+    /// `EnteredSpan`), so holding one across an `.await` compiles, and then the
+    /// guard is dropped on whichever worker resumed the task. The worker that
+    /// ENTERED keeps the span id on its thread-local stack forever, and the next
+    /// contextual span opened on that worker clones an already-closed span. That
+    /// leaves a `DataInner` slot back in the registry's pool with a non-zero ref
+    /// count, and the next `new_span` anywhere in the process trips
+    /// `tracing-subscriber`'s `sharded.rs` refcount assertion, killing whatever
+    /// task happened to open that span, which in the daemon is usually an RPC
+    /// connection handler.
+    async fn spawn_provider_process(
+        self: &Arc<Self>,
+        provider: &str,
+        config: AdapterConfig,
+        span: tracing::Span,
+    ) -> Result<Arc<ProviderProcess>, AcpError> {
         let (update_tx, update_rx) = mpsc::unbounded_channel();
         let (permission_tx, permission_rx) = mpsc::unbounded_channel();
         if let Ok(mut spawning) = self.spawning.lock() {
@@ -1617,8 +1640,21 @@ impl SessionActor {
             message_id = %job.message_id,
             outcome = tracing::field::Empty,
         );
-        let _entered = span.enter();
+        self.start_turn_inner(job, turn_tx, span.clone()).instrument(span).await;
+    }
 
+    /// The turn itself, running INSIDE the caller's `acp.turn` span.
+    ///
+    /// Split out for the same reason as [`AcpPool::spawn_provider_process`]: the
+    /// span is attached with `.instrument`, never with `span.enter()`, because an
+    /// `Entered` guard held across an `.await` is dropped on whichever worker
+    /// resumed the task and corrupts the registry's span-refcount pool.
+    async fn start_turn_inner(
+        &mut self,
+        job: PromptJob,
+        turn_tx: mpsc::Sender<TurnResult>,
+        span: tracing::Span,
+    ) {
         let process = match self.attach_with_one_requeue(&job.message_id).await {
             Ok(process) => process,
             Err(refusal) => {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -1411,16 +1411,31 @@ async fn daemon_health_reports_the_acp_pool_and_the_spans_carry_their_fields() {
         let row = acp["sessions"]
             .as_array()
             .and_then(|rows| rows.iter().find(|row| row["session_key"] == *session_key));
+        // `in_flight` belongs in the WAIT, not only in the assertions below.
+        // `health()` reads the process rows under the providers lock, drops it,
+        // then awaits the sessions lock to read `turn_open`, so a snapshot is
+        // two reads with a yield between them. `start_turn` increments
+        // `in_flight_used` BEFORE it stamps `turn_started_at`, so a snapshot
+        // taken across that gap pairs a stale `in_flight: 0` with a fresh
+        // `turn_open: true` and fails an assertion about a surface that is
+        // working. Wait for the coherent snapshot instead, which is what this
+        // loop already exists to do.
+        let in_flight = acp["processes"]
+            .as_array()
+            .and_then(|rows| rows.first())
+            .and_then(|process| process["in_flight"].as_u64())
+            .unwrap_or(0);
         if let Some(row) = row {
             if row["turn_open"] == serde_json::json!(true)
                 && row["queue_depth"].as_u64().unwrap_or(0) >= 1
+                && in_flight >= 1
             {
                 break (acp["processes"].clone(), row.clone());
             }
         }
         assert!(
             Instant::now() < deadline,
-            "the pool never reported an open turn with a queued prompt: {health}"
+            "the pool never reported an open turn with a queued prompt in flight: {health}"
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     };


### PR DESCRIPTION
`hangar-e2e (ubuntu-latest)` has been failing intermittently on `ainb-hangar-daemon::rpc_acp` since at least 2026-08-19. It was twice attributed to runner infra and once to a dependency bump; neither holds.

## It is not the dep bumps, and it is not infra

Tree `6be49e9d` ran twice. Run 32759728390 (`revert/rust-dep-bumps`) went **green**. Run 32765447474 (the merge of that PR onto `main`) went **red**. Byte-identical source, same runner image. That is nondeterminism, and `681f53ff` being a pure revert neither introduced nor fixed it.

Observed rate, last 150 CI runs (2026-08-10 → 08-24): **5 `rpc_acp` failures on ubuntu**. Treat that as a **lower bound on an unknown rate**, not a measurement: it counts only runs whose logs were still retained and whose failure reached the visible tail, and `scripts/hangar/run_acceptance_tests.sh` prints just `tail -25` of a failing target, so the registry panic is sometimes cut out of the log entirely.

> **Corrected 2026-08-25.** An earlier version of this line asserted the failures were ubuntu-only. That was wrong, and wrong in a way that invites a bad safety conclusion, so the phrasing has been removed rather than quoted here: leaving the false claim in the text means a search or a skim surfaces it out of context.
>
> **This bug is platform-agnostic.** Two macOS occurrences landed on 2026-08-25, both on trees without this fix, both carrying the registry signature `assertion left == right failed / left: 1 / right: 0`:
>
> | where | run | site | symptom |
> |---|---|---|---|
> | PR #743, `hangar-e2e (macos-latest)` | 32791223210 | `rpc_acp.rs:294` | `no permission was ever raised for acp:...` |
> | **main** @ `b543978e`, `hangar-e2e (macos-latest)` | 32795157214 | `rpc_acp.rs:437` | `connection closed while awaiting frame` |
>
> The first is a third distinct symptom: the task killed was the `SessionActor` that raises the permission, so no attention row was ever written. The second is the original symptom; `:437` is `assert!(read > 0, ...)`, the same assert that read as `:426` before commit `34e9a742` shifted it down 11 lines.
>
> The second one carries a further finding. `b543978e` **already contained** `34e9a742`, "install the span capture before any serve task spawns", which moves `span_log()` into `Harness::start` so the registry cannot be swapped mid-run. macOS failed anyway. So that fix does **not** subsume this one: it removes one contributor, and the `.enter()`-across-await path panics without it. The standalone repro below agrees, having installed the subscriber once up front, with no swap, and panicked regardless. Both changes were needed.
>
> The absence of macOS failures in the 150-run sample was sample size, not a property, and is consistent with the standalone repro below firing **on macOS**. Do not use this document to rule out that platform.

### Is this class swept, or just these two sites?

**Swept.** `cargo clippy --workspace --all-targets -- -D clippy::await_holding_invalid_type` exits **0**: every crate, every target, libs and bins and tests and benches, zero hits. `grep -rn "\.entered()"` across `crates/` returns nothing, so the `EnteredSpan` variant (`!Send`, so it cannot cross an await in a spawned task but can inside a `LocalSet`) has no sites to worry about either.

That is a compiler-level check over coroutine interior types, not a text search, so it also covers what a grep would miss: `Span::enter(&span)` in call position, a helper returning `Entered`, and re-exports.

Two limits, stated rather than glossed:

1. It only sees code that compiles under the current feature resolution. `--all-targets` is not `--all-features`, so a site behind an off-by-default feature is unlinted.
2. **The gate this PR ships is narrower than the audit that backs this claim.** CI runs the lint over `-p ainb-hangar-daemon -p ainb-acp --lib`; the sweep above was `--workspace --all-targets`. As shipped, a future regression in, say, `ainb-fleet-core` would not be caught. Widening the CI gate to match the audit costs a full clippy pass and has not been done.

## Bug 1: a span guard held across an await

`span.enter()` returns `Entered`. Unlike `EnteredSpan` it has no `PhantomNotSend`, so it is `Send` and holding one across an `.await` compiles inside a spawned task. `acp_pool.rs` did exactly that in two places.

```
┌──────────────────────────────┐
│ let _entered = span.enter(); │  task then awaits
└───────────────┬──────────────┘
                ▼ resumes on ANOTHER worker
┌──────────────────────────────┐
│ exit(id) lands on worker B   │  B never entered it, no-op
│ worker A keeps the id        │  stranded on A's span stack
└───────────────┬──────────────┘
                ▼ span closes, slot recycled
┌──────────────────────────────┐
│ next contextual span on A    │  clone_span(stale) -> sharded.rs:317
│ slot returns to pool refs==1 │  next new_span -> sharded.rs:265
└──────────────────────────────┘
```

The victim is whatever task next opens a span, which in the daemon is usually an RPC connection handler. Its socket drops and the test reports `connection closed while awaiting frame` at `rpc_acp.rs:426`, with no visible relationship to the cause. `run_acceptance_tests.sh` prints only the last 25 lines of a failing target, which is why the `sharded.rs` panic is sometimes absent from the log entirely.

Reproduced standalone on a 4-worker runtime with a `fmt` + `Registry` subscriber:

| shape | result |
|---|---|
| `span.enter()` across `.await` | `sharded.rs:317` then `sharded.rs:265`, `left: 1 right: 0` |
| same load via `.instrument()` | 2000 rounds x 32 tasks, zero panics |

`[profile.release]` sets no `debug-assertions`, so shipped builds never panic here. The span tree is still wrong and the refcount still drifts, silently.

## Bug 2: a torn health snapshot

Separate flake, no tracing involvement, same test binary. `AcpPool::health()` reads the process rows under the providers lock, drops it, then awaits the sessions lock to read `turn_open`. `start_turn` increments `in_flight_used` before it stamps `turn_started_at`, so a snapshot taken across that gap pairs a stale `in_flight: 0` with a fresh `turn_open: true`. The poll loop already existed to wait for a coherent snapshot; it just was not waiting on `in_flight`.

Seen in run 32746893843 (`rpc_acp.rs:1460`, no `sharded.rs` line) and once locally in twelve serial runs.

## Guard

`ainb-tui/clippy.toml` lists `tracing::span::Entered` under `await-holding-invalid-types`, and `hangar-e2e` runs `cargo clippy` denying **only** `clippy::await_holding_invalid_type`. Not a workspace `-D warnings` gate: `xtask/src/ci_lint.rs` documents why that does not exist, and every other clippy finding stays a warning. `dtolnay/rust-toolchain` installs the minimal profile, so the job's toolchain gains the `clippy` component.

Gate verified both directions: exit 0 on this tree, exit 101 with the guard reintroduced.

## Verification

- `rpc_acp` 20/20 serial on macOS. Caveat: macOS was also 20/20 **before** the fix, so this is a regression check, not proof. The proof is the standalone A/B above and the lint. (The 2026-08-25 macOS CI occurrence noted above shows the local macOS run was luck, not immunity.)
- `acp_pool` 42 passed, `ainb-acp --lib` 19 passed.
- `cargo fmt --all --check`, `cargo xtask ci-lint` clean.
- The only remaining `span.enter()` sites (`run_loop.rs:2830`, `it_otlp_export_when_endpoint_set.rs:115`) have no await in scope, which the lint confirms.

Linux CI on this PR is the real test.

https://claude.ai/code/session_01V1xTJr7wwNkksFN7K4w3mL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background operation tracing during asynchronous processing.
  * Prevented inconsistent health-status snapshots while work is in progress.

* **Tests**
  * Expanded health monitoring checks to verify in-flight operations are reported consistently.
  * Added automated safeguards against unsafe asynchronous tracing patterns.
  * Improved build validation by checking available system storage before running resource-intensive tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



