### PR TITLE
fix(hangar): install the span capture before any serve task spawns

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -165,6 +165,17 @@ struct Harness {
 
 impl Harness {
     async fn start(script: &[(&str, &str)], tune: impl FnOnce(&mut PoolConfig)) -> Self {
+        // Install the span capture BEFORE anything spawns, not lazily from the
+        // one test that asserts on spans. `serve` tasks from earlier tests are
+        // never aborted -- they outlive POOL_LOCK and keep spans open -- so a
+        // later `set_global_default` swaps the registry underneath them. Those
+        // spans then CLOSE against a registry that never saw them opened, and
+        // tracing-subscriber's sharded registry panics `left == right` on a
+        // tokio worker, killing the daemon runtime. The socket dies and every
+        // in-flight test fails with "connection closed while awaiting frame".
+        // Installing here means the first harness wins the OnceLock and every
+        // span in the binary opens and closes against that same registry.
+        span_log();
         let guard = POOL_LOCK.lock().await;
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open_in(dir.path()).await.expect("store");


### PR DESCRIPTION
Fixes the `hangar-e2e (ubuntu-latest)` failure that has left `main` red since 15:56 today.

## What was failing

Two tests in `crates/ainb-hangar-daemon/tests/rpc_acp.rs`, on main at `681f53ff`:

```
daemon_health_reports_the_acp_pool_and_the_spans_carry_their_fields  FAILED
two_parked_permissions_are_both_answerable_over_the_wire            FAILED
test result: FAILED. 9 passed; 2 failed
thread 'tokio-rt-worker' panicked at tracing-subscriber-0.3.23/src/registry/sharded.rs
  assertion `left == right` failed
```

## It is not the dependency bumps

Worth stating, since the red appeared right after a git2 / opentelemetry_sdk bump and its revert. Main's Rust inputs at `681f53ff` are **byte-identical** to `8bbe332a`, where `hangar-e2e (ubuntu-latest)` was green — `Cargo.lock`, `ainb-tui/Cargo.toml` and `crates/ainb-hangar-daemon/Cargo.toml` all hash the same. Same inputs, different verdict: a race, not a regression.

## Mechanism

`span_log()` installed the global subscriber **lazily**, via `set_global_default`, from the single test that asserts on spans (line 1356).

1. Every test spawns `tokio::spawn(rpc::serve(...))` in `Harness::start`. Those tasks are never aborted — they outlive `POOL_LOCK` and keep spans open past the end of the test that created them.
2. The span-asserting test then swaps in a new registry underneath those live spans.
3. Those spans CLOSE against a registry that never saw them open → `sharded.rs` `assertion left == right failed`, panicking a tokio worker.
4. The panic takes down the daemon runtime, the socket closes, and whichever test is mid-frame dies at `rpc_acp.rs:426` on `assert!(read > 0, "connection closed while awaiting frame")`.

That is why the two failures look unrelated, why the span test is always one of them, and why it is intermittent — it depends purely on interleaving.

## Fix

Call `span_log()` at the top of `Harness::start`, before anything spawns. The first harness wins the `OnceLock`; every span in the binary then opens and closes against that one registry. Nothing can open a span earlier — they all originate from harness-spawned work.

One line plus the comment explaining why it cannot be moved back.

## Verification

Against the race, not the symptom — 6 consecutive local runs of the full suite:

```
run 1: ok. 11 passed; 0 failed
run 2: ok. 11 passed; 0 failed
run 3: ok. 11 passed; 0 failed
run 4: ok. 11 passed; 0 failed
run 5: ok. 11 passed; 0 failed
```
(plus the initial run, 11/11)

A green local run alone would not prove much for a race; the CI `hangar-e2e` legs on this PR are the real gate.

https://claude.ai/code/session_015TMAU2cLaimQdBMzxjshxr