### PR TITLE
DIAGNOSTIC DO NOT MERGE: measure the rust-lld SIGBUS in Test (ubuntu-latest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,11 @@ jobs:
         if: >-
           always() && (github.event_name != 'pull_request' ||
           needs.changes.outputs.relevant != 'false')
+        with:
+          # This action installs with rustup's MINIMAL profile, which omits
+          # clippy. The span-guard gate below needs it, and a missing component
+          # would red the job with `no such command: clippy`.
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         if: >-
           always() && (github.event_name != 'pull_request' ||
@@ -519,6 +524,30 @@ jobs:
           always() && (github.event_name != 'pull_request' ||
           needs.changes.outputs.relevant != 'false')
         run: cargo xtask ci-lint
+        working-directory: ${{ env.WORKING_DIR }}
+      # NOT a workspace clippy gate. `xtask/src/ci_lint.rs` documents why one
+      # does not exist: the workspace carries heavy pre-existing clippy debt and
+      # `-D warnings` would red CI for unrelated reasons. This denies exactly ONE
+      # lint and leaves every other finding a warning.
+      #
+      # The lint is `await_holding_invalid_type`, configured in `ainb-tui/
+      # clippy.toml` to reject a `tracing` `Entered` span guard held across an
+      # `.await`. `Entered` is `Send` (unlike `EnteredSpan`), so the mistake
+      # compiles; the guard is then dropped on whichever worker resumed the task,
+      # the entering worker keeps the span id on its stack forever, and the next
+      # contextual span opened there clones a closed span. That returns a slot to
+      # the subscriber registry's pool with a live ref count, and the next
+      # `new_span` ANYWHERE trips its refcount assertion, killing whatever task
+      # opened it. That is what made `rpc_acp` fail intermittently on this job:
+      # the victim was an RPC connection handler, so the test saw a closed socket
+      # thousands of lines away from the cause.
+      - name: No tracing span guard held across an await
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: >
+          cargo clippy -p ainb-hangar-daemon -p ainb-acp --lib
+          -- -D clippy::await_holding_invalid_type
         working-directory: ${{ env.WORKING_DIR }}
       - name: Run all hangar tripwires
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,11 +223,67 @@ jobs:
       # (the database layer, 74 files) and ainb-plugin-hangar (46) had never
       # run here. `--lib --tests` widened WHICH targets are built; this
       # widens WHICH crates they are built from.
+      # ══ DIAGNOSTIC ONLY, DO NOT MERGE ══════════════════════════════════════
+      # Measures the `rust-lld` SIGBUS that fails `real_plugin_axes` in THIS job
+      # and only this job (the same test passes in `contracts`, same run, same
+      # image). The nextest command below is UNCHANGED: these steps only
+      # observe. Sampling every 5s, not in a tight loop, so the probe does not
+      # perturb what it measures.
+      - name: Baseline and start resource sampler
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: |
+          echo "nproc=$(nproc)"
+          free -m
+          df -h /
+          df -i /
+          swapon --show || echo "(no swap)"
+          mount | grep -E ' / | /home| /mnt' || true
+          ( while true; do
+              printf '%s avail_kb=%s iavail=%s mem_used_mb=%s mem_free_mb=%s\n' \
+                "$(date +%T)" \
+                "$(df --output=avail / | tail -1 | tr -d ' ')" \
+                "$(df --output=iavail / | tail -1 | tr -d ' ')" \
+                "$(free -m | awk '/Mem:/{print $3}')" \
+                "$(free -m | awk '/Mem:/{print $4}')"
+              sleep 5
+            done ) > /tmp/resource-sample.log 2>&1 &
+          echo $! > /tmp/sampler.pid
+
       - run: "cargo nextest run --workspace --lib --tests --all-features --no-fail-fast -E 'not binary(/^tripwire_/)'"
         if: >-
           always() && (github.event_name != 'pull_request' ||
           needs.changes.outputs.relevant != 'false')
         working-directory: ${{ env.WORKING_DIR }}
+
+      # ══ DIAGNOSTIC ONLY, DO NOT MERGE ══════════════════════════════════════
+      # `always()` so the numbers land on the green path too: a passing run is
+      # the control for how close a failing one actually got to the ceiling.
+      - name: Post-mortem resource report
+        if: always()
+        run: |
+          if [ -f /tmp/sampler.pid ]; then kill "$(cat /tmp/sampler.pid)" 2>/dev/null || true; fi
+          echo "===== MINIMUM free disk observed during the run ====="
+          awk '{for(i=1;i<=NF;i++){split($i,kv,"=");
+                if(kv[1]=="avail_kb"){if(m==""||kv[2]<m){m=kv[2];line=$0}}}}
+               END{printf "min avail = %.1f GB\n  at %s\n", m/1048576, line}' \
+            /tmp/resource-sample.log 2>/dev/null || echo "(no samples)"
+          echo "===== MINIMUM free memory observed ====="
+          awk '{for(i=1;i<=NF;i++){split($i,kv,"=");
+                if(kv[1]=="mem_free_mb"){if(m==""||kv[2]<m){m=kv[2];line=$0}}}}
+               END{printf "min free = %s MB\n  at %s\n", m, line}' \
+            /tmp/resource-sample.log 2>/dev/null || echo "(no samples)"
+          echo "===== last 40 samples ====="
+          tail -40 /tmp/resource-sample.log 2>/dev/null || true
+          echo "===== final state ====="
+          df -h /; df -i /; free -m
+          echo "===== target tree size ====="
+          du -sh ainb-tui/target 2>/dev/null || true
+          du -sh ainb-tui/target/debug 2>/dev/null || true
+          du -sh ainb-tui/target/debug/deps 2>/dev/null || true
+          echo "===== kernel ring buffer (OOM kill? ext4 error? mmap fault?) ====="
+          sudo dmesg | tail -120 || echo "(dmesg unavailable)"
 
   # ────────────────────────────────────────────────────────────────────────────
   # Contracts: deterministic golden/mutation gates, own job, no rerun-to-green

--- a/ainb-tui/clippy.toml
+++ b/ainb-tui/clippy.toml
@@ -1,0 +1,11 @@
+# `span.enter()` returns `Entered`, which (unlike `EnteredSpan`) is `Send` in
+# tracing 0.1. Holding one across an `.await` therefore COMPILES inside a spawned
+# task, and then the guard is dropped on whichever worker resumed the task. The
+# worker that entered keeps the span id on its thread-local stack forever; the
+# next contextual span opened there clones an already-closed span, which returns
+# a `DataInner` slot to the registry's pool with a live ref count and trips
+# `tracing-subscriber`'s `sharded.rs` refcount assertion in an unrelated task.
+#
+# Use `tracing::Instrument` on the future instead. This lint makes the mistake a
+# build failure rather than an intermittent CI panic.
+await-holding-invalid-types = ["tracing::span::Entered"]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -91,6 +91,7 @@ use ainb_hangar_store::repo::fleet_provider_event::{
 };
 use sqlx::SqlitePool;
 use tokio::sync::{Semaphore, mpsc, oneshot};
+use tracing::Instrument as _;
 
 // ------------------------------------------------------------ detail taxonomy
 
@@ -959,8 +960,30 @@ impl AcpPool {
             mode = %config.permission_mode,
             provider_version = tracing::field::Empty,
         );
-        let _entered = span.enter();
+        self.spawn_provider_process(provider, config, span.clone())
+            .instrument(span)
+            .await
+    }
 
+    /// The spawn itself, running INSIDE the caller's `acp.spawn` span.
+    ///
+    /// It is a separate function so the span can be attached with `.instrument`
+    /// rather than `span.enter()`. `Entered` is `Send` in tracing 0.1 (unlike
+    /// `EnteredSpan`), so holding one across an `.await` compiles, and then the
+    /// guard is dropped on whichever worker resumed the task. The worker that
+    /// ENTERED keeps the span id on its thread-local stack forever, and the next
+    /// contextual span opened on that worker clones an already-closed span. That
+    /// leaves a `DataInner` slot back in the registry's pool with a non-zero ref
+    /// count, and the next `new_span` anywhere in the process trips
+    /// `tracing-subscriber`'s `sharded.rs` refcount assertion, killing whatever
+    /// task happened to open that span, which in the daemon is usually an RPC
+    /// connection handler.
+    async fn spawn_provider_process(
+        self: &Arc<Self>,
+        provider: &str,
+        config: AdapterConfig,
+        span: tracing::Span,
+    ) -> Result<Arc<ProviderProcess>, AcpError> {
         let (update_tx, update_rx) = mpsc::unbounded_channel();
         let (permission_tx, permission_rx) = mpsc::unbounded_channel();
         if let Ok(mut spawning) = self.spawning.lock() {
@@ -1617,8 +1640,21 @@ impl SessionActor {
             message_id = %job.message_id,
             outcome = tracing::field::Empty,
         );
-        let _entered = span.enter();
+        self.start_turn_inner(job, turn_tx, span.clone()).instrument(span).await;
+    }
 
+    /// The turn itself, running INSIDE the caller's `acp.turn` span.
+    ///
+    /// Split out for the same reason as [`AcpPool::spawn_provider_process`]: the
+    /// span is attached with `.instrument`, never with `span.enter()`, because an
+    /// `Entered` guard held across an `.await` is dropped on whichever worker
+    /// resumed the task and corrupts the registry's span-refcount pool.
+    async fn start_turn_inner(
+        &mut self,
+        job: PromptJob,
+        turn_tx: mpsc::Sender<TurnResult>,
+        span: tracing::Span,
+    ) {
         let process = match self.attach_with_one_requeue(&job.message_id).await {
             Ok(process) => process,
             Err(refusal) => {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -1411,16 +1411,31 @@ async fn daemon_health_reports_the_acp_pool_and_the_spans_carry_their_fields() {
         let row = acp["sessions"]
             .as_array()
             .and_then(|rows| rows.iter().find(|row| row["session_key"] == *session_key));
+        // `in_flight` belongs in the WAIT, not only in the assertions below.
+        // `health()` reads the process rows under the providers lock, drops it,
+        // then awaits the sessions lock to read `turn_open`, so a snapshot is
+        // two reads with a yield between them. `start_turn` increments
+        // `in_flight_used` BEFORE it stamps `turn_started_at`, so a snapshot
+        // taken across that gap pairs a stale `in_flight: 0` with a fresh
+        // `turn_open: true` and fails an assertion about a surface that is
+        // working. Wait for the coherent snapshot instead, which is what this
+        // loop already exists to do.
+        let in_flight = acp["processes"]
+            .as_array()
+            .and_then(|rows| rows.first())
+            .and_then(|process| process["in_flight"].as_u64())
+            .unwrap_or(0);
         if let Some(row) = row {
             if row["turn_open"] == serde_json::json!(true)
                 && row["queue_depth"].as_u64().unwrap_or(0) >= 1
+                && in_flight >= 1
             {
                 break (acp["processes"].clone(), row.clone());
             }
         }
         assert!(
             Instant::now() < deadline,
-            "the pool never reported an open turn with a queued prompt: {health}"
+            "the pool never reported an open turn with a queued prompt in flight: {health}"
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     };


### PR DESCRIPTION
**Draft, diagnostic only, never to be merged.** Opened to run CI, nothing else. Close it once the numbers are read.

Branched off `f/diagnose-rpc-acp` (PR #738) because that tree reproduces the crash 2/2, so this run has the best chance of catching a failure. That means the diff shown against `main` also contains #738's three commits; the only thing added here is the last commit, `bee4cd86`.

## What is being measured

`ainb-plugin-cts-v2::real_plugin_axes` fails `Test (ubuntu-latest)` with:

```
error: linking with `cc` failed: exit status: 1
  = note: PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/
          Stack dump without symbol names:
          2  libc.so.6      0x00007fd5da245330          <- signal trampoline
          3  libc.so.6      0x00007fd5da388d06          <- FAULTING (memcpy)
          4  libLLVM.so.22.1-rust-1.96.0-stable
          6  libLLVM.so...  llvm::parallelFor(...) + 192
          7  rust-lld
          collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
error: could not compile `ainb-plugin-abtop` (bin "ainb-plugin-abtop")
```

## Established

- **Reproducible, not a flake.** 4/4: `main` @ `2622783a`, the git2 dependabot branch, and both attempts on #738 (two independent runner allocations).
- **Always `ainb-plugin-abtop`**, which is #6 of 6 in `IN_TREE_PLUGINS`. It is implicated for being last, not for its content: 1356 LOC, no `build.rs`, one 1.4 KB `include_str!`.
- **The same test passes in `Contracts`.** Same run, same commit, same `ubuntu-24.04` image, same `--all-features`: `real_plugin_axes ... PASS [97.846s]`. So the defect is not in abtop, the test, or `resolve_binary`.
- The two jobs differ in concurrent load (8989 tests vs 54) and in the `Reclaim runner disk` step, which `Contracts` has and `Test` does not.
- `Contracts` gained that step after a **same-class failure**: its comment records `No space left on device` while linking `ainb-plugin-hangar`, surfacing only as `exit status: 101`.
- `Test` has its own documented ENOSPC history: the `rust-cache` comment records three runs where nextest succeeded and the post-job save failed with `No space left on device`.
- Ruled out by measurement: inodes (131,673 files in a full `--all-features` target tree vs ext4's ~9.5 M) and anything abtop-specific.

## Not established

Whether the trigger is **disk** or **memory/load**. That is the whole point of this run. A local repro is not available: `real_plugin_axes` only fails under this job's load, and emulating x86_64 Linux for a 25 GB Rust build is not viable.

## What was added

The nextest command is byte-identical to `main` (verified by parsing both YAML files and comparing the step). The added steps only observe:

- a baseline (`nproc`, `free -m`, `df -h`, `df -i`, `swapon`, `mount`)
- a **5 second** sampler of free disk / inodes / memory, deliberately not a tight loop so the probe does not perturb the measurement
- a post-mortem reporting the **minimum** observed disk and memory, the last 40 samples, final `df`/`free`, target tree size, and `dmesg` so an OOM kill or ext4 error is distinguishable from a full filesystem

`if: always()` on the post-mortem, so a green run is the control for how close a red one got.

Parsed-YAML diff against `main` confirms only `test` and `hangar-e2e` differ; `hangar-e2e` is #738's clippy gate, inherited from the base branch.