### PR TITLE
fix(ainb-hooks): keep Codex SessionEnd under the 3s cap

### DIFF
--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -1559,6 +1559,28 @@ mod tests {
     }
 
     #[test]
+    fn codex_template_respects_codex_hook_timeout_caps() {
+        // Codex hard-clamps the SessionEnd hook to 3s and surfaces the clamp
+        // as an error item on every session start. Anything above the cap is a
+        // user-visible startup error, not a silent adjustment.
+        let template: serde_json::Value = serde_json::from_str(CODEX_HOOKS_TEMPLATE).unwrap();
+        let caps = [("SessionEnd", 3u64)];
+        for (event, cap) in caps {
+            let entries = template["hooks"][event].as_array().expect("event entries");
+            for entry in entries {
+                for hook in entry["hooks"].as_array().expect("hook list") {
+                    let timeout = hook["timeout"].as_u64().expect("timeout");
+                    assert!(
+                        timeout <= cap,
+                        "{event} hook timeout {timeout}s exceeds Codex's {cap}s cap; \
+                         Codex clamps it and prints a startup error"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn claude_manifest_registers_every_documented_hook() {
         let manifest: serde_json::Value = serde_json::from_str(CLAUDE_PLUGIN_JSON).unwrap();
         let hooks = manifest["hooks"].as_object().expect("hooks object");

--- a/plugins/ainb-hooks/.claude-plugin/plugin.json
+++ b/plugins/ainb-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ainb-hooks",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Emit every safely observable Claude Code lifecycle event into Hangar's durable provider log. User-facing events still reach ainb-notifyd over its Unix socket. The same notify.sh powers ATC structured control when installed with AINB_MANAGED=atc. stall_guard.py additionally blocks turn-end when a session would idle on in-flight work with no wake armed, so ATC-managed sessions do not silently park on a running CI job.",
   "author": {
     "name": "Agents-in-a-Box"

--- a/plugins/ainb-hooks/README.md
+++ b/plugins/ainb-hooks/README.md
@@ -132,6 +132,12 @@ enabling it, and everything looks fine until you notice turns are not being
 blocked. This was diagnosed by wiring a probe wrapper in place of the guard and
 watching it never get invoked while three sibling `Stop` hooks ran.
 
+Trust covers the hook entry itself, so editing an entry (a bare `timeout`
+change included) invalidates it and needs one more approval. Codex caps the
+`SessionEnd` hook at 3s and prints a `clamping SessionEnd hook timeout to 3s`
+error item at the top of every session for anything higher, which is why the
+template pins that one event to 3.
+
 After `ainb-notifyd install --codex`, start `codex` once and approve the
 startup hooks review (`tui/src/startup_hooks_review.rs`, shown when "hooks are
 new or changed"). That writes the `trusted_hash` entries.

--- a/plugins/ainb-hooks/codex/hooks.json
+++ b/plugins/ainb-hooks/codex/hooks.json
@@ -1,11 +1,11 @@
 {
-  "//": "ainb-hooks managed block, merged into ~/.codex/hooks.json by `ainb-notifyd install --codex`. Do not edit by hand. Every Codex CLI lifecycle hook is captured into Hangar's durable provider log. The notification daemon still routes only user-facing events to OS surfaces.",
+  "//": "ainb-hooks managed block, merged into ~/.codex/hooks.json by `ainb-notifyd install --codex`. Do not edit by hand. Every Codex CLI lifecycle hook is captured into Hangar's durable provider log. The notification daemon still routes only user-facing events to OS surfaces. SessionEnd is capped at 3s: Codex hard-clamps that hook and prints a startup error for anything longer.",
   "hooks": {
     "SessionStart": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
     ],
     "SessionEnd": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }
+      { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 3 }] }
     ],
     "UserPromptSubmit": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "AINB_AGENT=codex __AINB_HOOK_SCRIPT__", "timeout": 5 }] }


### PR DESCRIPTION
## Problem

Every Codex session started under ainb opened with an error item before the first turn:

```
{"type":"item.completed","item":{"id":"item_0","type":"error",
 "message":"clamping SessionEnd hook timeout to 3s in /Users/.../codex-home/hooks.json"}}
```

Codex hard-clamps the `SessionEnd` hook to 3s and surfaces the clamp as a user-visible error, not a silent adjustment. `plugins/ainb-hooks/codex/hooks.json` shipped `"timeout": 5` for that event, so `ainb-notifyd install --codex` wrote an over-cap value into both `~/.codex/hooks.json` and ainb's `codex-home`.

`SessionEnd` is the only event Codex caps this way — the clamp string appears exactly once in the codex 0.147.0 binary, and no other hook event has an equivalent.

## Fix

- Drop the `SessionEnd` timeout to 3 in the Codex hooks template, and record the cap in the template's `"//"` note.
- Pin it with `codex_template_respects_codex_hook_timeout_caps`, a table-driven test over per-event caps so the template cannot drift back over the limit.

## Verification

- `cargo test -p ainb-plugin-notifyd --lib install::` — 28/28 green.
- New test proven to catch the regression: reverting the template to `"timeout": 5` fails it with `SessionEnd hook timeout 5s exceeds Codex's 3s cap`.
- Live `codex exec` under ainb's `CODEX_HOME` after repairing the installed file: the clamp error is gone; only the unrelated codex-side skills-context-budget notice remains.
- `rustfmt --check` clean.

## Note for existing installs

Already-installed `~/.codex/hooks.json` keeps the old 5s value until `ainb-notifyd install --codex` runs again on a build carrying this change (the installer replaces `_ainb_managed` entries, so no manual edit is needed).

https://claude.ai/code/session_01MRBdxkFi7yND2LEbxPY7ZZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Codex session-end hook timeout to comply with Codex’s three-second limit.
  * Prevented startup warnings caused by unsupported timeout values.

* **Tests**
  * Added coverage to verify that all embedded session-end hook timeouts remain within the supported limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->