### PR TITLE
ci: reclaim runner disk before the Test job's all-features build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,49 @@ jobs:
         if: >-
           always() && (github.event_name != 'pull_request' ||
           needs.changes.outputs.relevant != 'false')
+      # Linux only: these paths and `df --output` are GNU/Linux, and the macOS
+      # leg of this matrix has never hit the wall.
+      #
+      # MEASURED, 2026-08-24, run 32785104108: this job's target tree peaks at
+      # 85G and the runner offers 86G free after the image. A ~1G margin, which
+      # is why it failed roughly one run in three rather than every time, and
+      # why it always died on `ainb-plugin-abtop`: that is the LAST of the six
+      # nested plugin builds `real_plugin_axes` runs, so it links at peak
+      # accumulation. At the failure the filesystem was 145G/145G, 8.8M free.
+      #
+      # It does NOT present as a disk error. `rust-lld` sizes the output with
+      # ftruncate, mmaps it, and only faults when a page is written to a
+      # filesystem that can no longer allocate blocks, so ENOSPC arrives as
+      # `ld terminated with signal 7 [Bus error]` under an LLVM crash report.
+      # That cost two days of it being read as a flake, then as infra.
+      #
+      # The Contracts job hit the same wall and took the same treatment; this
+      # reclaim frees 20G (59G used here against 39G there, same image), taking
+      # the margin from ~1G to ~21G.
+      - name: Reclaim runner disk
+        if: >-
+          runner.os == 'Linux' && always() &&
+          (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+                      /usr/local/.ghcup /usr/local/share/boost
+          df -h /
+      # Fail FAST and legibly if the headroom ever goes away again, rather than
+      # 20 minutes later as a linker crash nobody can attribute.
+      - name: Assert disk headroom for the --all-features build
+        if: >-
+          runner.os == 'Linux' && always() &&
+          (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: |
+          avail=$(df --output=avail / | tail -1)
+          need=94371840   # 90G in 1K blocks; the tree measured 85G
+          if [ "$avail" -lt "$need" ]; then
+            echo "::error::only $((avail/1048576))G free, this job's build needs ~85G. Reclaim more before it links, because rust-lld reports exhaustion as SIGBUS, not as a disk error."
+            exit 1
+          fi
+          echo "$((avail/1048576))G free, need ~85G"
       - uses: dtolnay/rust-toolchain@stable
         if: >-
           always() && (github.event_name != 'pull_request' ||


### PR DESCRIPTION
`Test (ubuntu-latest)` fails reproducibly with a linker crash while building `ainb-plugin-abtop`. It is disk exhaustion, measured, not a flake and not a code defect. This adds the reclaim step `Contracts` already has, plus a pre-flight assertion so a recurrence is legible.

## The measurement

Instrumented run **32785104108** (diagnostic branch, now redundant). The nextest command was byte-identical to main; the added steps only observed.

| | |
|---|---|
| baseline | `/dev/root 145G, 59G used, 86G avail, 41%` |
| final | `/dev/root 145G, 145G used, **8.8M avail, 100%**` |
| min free during run | **41,068 kB = 40 MB** |
| target tree at failure | **85 G** (`ainb-tui/target/debug/deps`) |
| min free memory | 155 MB, but `available` 15,004 MB; swap 154 MB of 3 G |
| inodes | 18,396,241 free of 19,529,728. Never moved. |
| dmesg | no OOM kill, no ext4 error |

Free space fell monotonically over the final three minutes and the link died at the bottom of the slide:

```
22:49:15  avail_kb=1490736
22:50:16  avail_kb=718556
22:50:31  avail_kb=363108
22:50:41  avail_kb=174640
22:50:46  avail_kb=41068     <- 40 MB, then SIGBUS
```

**86 G available against 85 G needed.** Every symptom falls out of that one number.

## Why it looked like anything but disk

```
= note: PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/
        Stack dump without symbol names:
        2  libc.so.6      0x00007fd5da245330        <- signal trampoline
        3  libc.so.6      0x00007fd5da388d06        <- FAULTING (memcpy)
        4  libLLVM.so.22.1-rust-1.96.0-stable
        6  libLLVM.so...  llvm::parallelFor(...) + 192
        7  rust-lld
        collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
error: could not compile `ainb-plugin-abtop` (bin "ainb-plugin-abtop")
```

`rust-lld` sizes the output with `ftruncate`, `mmap`s it, and faults only when a page is written to a filesystem that can no longer allocate blocks. LLVM has no clean ENOSPC path there, so a full disk arrives as a compiler-bug report and SIGBUS. It was read as a flake, then as runner infra, before being measured.

## Why one run in three, why always abtop, why Contracts passes

All three follow from the ~1 G margin:

- **~1-in-3, not random.** 86 G against 85 G. Any small variation in the dep set tips it. Observed on `main` @ `2622783a`, on the git2 dependabot branch, and twice on #738's tree across two independent runner allocations.
- **Always `ainb-plugin-abtop`.** It is #6 of 6 in `IN_TREE_PLUGINS`, so it links at peak accumulation. Whichever were last would crash. abtop itself is 1356 lines with no `build.rs` and one 1.4 KB `include_str!` — nothing special about it.
- **`Contracts` passes.** Same run, same commit, same `ubuntu-24.04` image, same `--all-features`: `real_plugin_axes ... PASS [97.846s]`, building the same binary. It already reclaims this disk. 59 G used here against 39 G there is a **measured 20 G difference**, so it runs with ~21 G of headroom instead of ~1 G.

## The change

Two steps on the `test` job only, both `runner.os == 'Linux'` gated because the paths and `df --output` are GNU and the macOS leg has never hit this:

1. `Reclaim runner disk` — the same Android/dotnet/GHC/boost removal `Contracts` uses. Frees 20 G, taking the margin from ~1 G to ~21 G.
2. `Assert disk headroom` — fails fast with a readable `::error::` if free space drops under 90 G, instead of surfacing 20 minutes later as a linker crash.

Parsed-YAML diff against `main` confirms only `test` differs; every other job is byte-identical.

## Known limit

The assertion measures headroom **at start**. It cannot see the build's own footprint growing. When the tree grows past the post-reclaim ~106 G, the check will still pass and the job will exhaust mid-build and SIGBUS again. Guarding that needs a failure-only post-mortem (`df -h` plus `du -sh ainb-tui/target`), which is not in this PR pending a decision.

## Unblocks

#738 (the `rpc_acp` tracing fix) is blocked only by this failure. It needs `main` merged in once this lands.