### PR TITLE
fix(hangar): never credit a cargo test binary as the home's daemon

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "ainb"
-version = "1.22.2"
+version = "1.22.3"
 dependencies = [
  "ainb-cli",
  "ainb-fleet-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-hangar-daemon"
-version = "1.22.2"
+version = "1.22.3"
 dependencies = [
  "agent-client-protocol",
  "ainb-acp",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-cts-v2"
-version = "1.22.2"
+version = "1.22.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-secrets",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-hangar"
-version = "1.22.2"
+version = "1.22.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-notifyd"
-version = "1.22.2"
+version = "1.22.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-web"
-version = "1.22.2"
+version = "1.22.3"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8027,8 +8027,40 @@ fn pid_owns_a_home(pid: u32, socket: &std::path::Path) -> bool {
     }
     i32::try_from(pid).is_ok_and(|pid| {
         ainb_hangar_daemon::single_instance::process_argv(pid)
-            .is_some_and(|args| ainb_hangar_daemon::single_instance::is_hangar_daemon_args(&args))
+            .is_some_and(|args| argv_credits_a_daemon(&args))
     })
+}
+
+/// The argv half of [`pid_owns_a_home`], as a pure function so the boot-window
+/// fallback's exact credit rule is testable without spawning a process.
+///
+/// A recognised daemon shape counts, EXCEPT from a `cargo test` binary.
+fn argv_credits_a_daemon(args: &str) -> bool {
+    !is_cargo_test_binary(args) && ainb_hangar_daemon::single_instance::is_hangar_daemon_args(args)
+}
+
+/// Is this argv a `cargo test` binary (`.../target/<profile>/deps/<name>-<hash>`)?
+///
+/// A test binary that self-exec'd as `... hangar daemon run` (#715) writes the
+/// REAL `daemon.pid` but never binds the socket. The argv fallback above would
+/// then credit it as this home's daemon on shape alone, autostart would decline
+/// to start anything, and every socket client would get ECONNREFUSED for as
+/// long as that pid lived -- a home wedged with ZERO daemons, which is exactly
+/// what the fallback exists to avoid.
+///
+/// Deliberately NOT applied to `single_instance::holder_is_live_daemon`: that
+/// caller has the opposite asymmetry (a false negative there steals a live
+/// holder's lock and puts two daemons on one home) and already respects an
+/// in-process `boot()` inside a test binary via `shares_our_command_line`.
+fn is_cargo_test_binary(args: &str) -> bool {
+    let Some(argv0) = args.split_whitespace().next() else {
+        return false;
+    };
+    let path = std::path::Path::new(argv0);
+    path.parent()
+        .and_then(std::path::Path::file_name)
+        .is_some_and(|dir| dir == "deps")
+        && path.components().any(|part| part.as_os_str() == "target")
 }
 
 /// Is `pid` a live process? `kill(pid, 0)` succeeds iff it exists (and we may
@@ -10858,6 +10890,50 @@ mod tests {
             None,
             "a live non-daemon in the lock must not be read as the home's owner"
         );
+    }
+
+    /// A self-exec'd cargo TEST binary must not be credited as this home's daemon.
+    ///
+    /// The incident: a test run left `.../target/debug/deps/ainb-<hash> hangar
+    /// daemon run` detached against the user's REAL home and writing its
+    /// `daemon.pid`. It matched the argv fallback on shape, so
+    /// `ensure_hangar_daemon` read the home as already served and started
+    /// nothing, while the socket it never bound sat orphaned. Every Codex
+    /// resume then failed with ECONNREFUSED, surfaced to the user as "Codex
+    /// remote control unavailable".
+    ///
+    /// Asserted on `argv_credits_a_daemon` rather than end to end: this test
+    /// binary's own argv does not contain the `hangar daemon run` token window,
+    /// so seeding our pid would pass with or without the guard.
+    #[test]
+    fn a_cargo_test_binary_is_never_credited_as_this_homes_daemon() {
+        let test_binary = "/w/ainb-tui/target/debug/deps/ainb-39a2b880848dbfd5 hangar daemon run";
+
+        // Shape recognition alone still says "daemon". That is the trap.
+        assert!(
+            ainb_hangar_daemon::single_instance::is_hangar_daemon_args(test_binary),
+            "argv shape matches, which is why the extra guard exists"
+        );
+        assert!(
+            !argv_credits_a_daemon(test_binary),
+            "a target/**/deps/ binary must never be credited as the home's daemon"
+        );
+
+        // The shapes that must keep counting, or autostart would spawn a second
+        // daemon on top of a live one.
+        for live in [
+            "/opt/homebrew/bin/ainb hangar daemon run",
+            "/w/ainb-tui/target/debug/ainb hangar daemon run",
+            "/opt/homebrew/bin/ainb-hangar-daemon",
+        ] {
+            assert!(argv_credits_a_daemon(live), "must still credit: {live}");
+        }
+
+        // And the ordinary CLI verbs stay uncredited.
+        assert!(!argv_credits_a_daemon(
+            "/opt/homebrew/bin/ainb hangar daemon status"
+        ));
+        assert!(!argv_credits_a_daemon(""));
     }
 
     /// The skew helper flags a differing recorded version, and stays quiet for


### PR DESCRIPTION
## Symptom

Resuming a stopped Codex session failed every time with:

```
Resume failed: Codex remote control unavailable. Check Hangar logs, then retry.
```

The real error is one layer down, in the ainb log:

```
WARN ainb::interactive::session_manager
  error: "connect /Users/.../.agents-in-a-box/hangar.sock: Connection refused (os error 61)"
```

`ECONNREFUSED` on a unix socket means the socket file exists but nothing is listening.

## Root cause

```
┌──────────────────────┐   ┌────────────────────────┐   ┌─────────────────────┐
│ daemon.pid = a cargo │──▶│ pid_owns_a_home()      │──▶│ "daemon is running" │
│ TEST binary, alive   │   │ no socket proof, but   │   │ autostart skipped   │
└──────────────────────┘   │ argv has hangar/daemon │   └──────────┬──────────┘
                           │ /run → credited TRUE   │              │
                           └────────────────────────┘              ▼
                                                        ┌─────────────────────┐
                                                        │ hangar.sock orphan  │
                                                        │ every client ECONN- │
                                                        │ REFUSED, forever    │
                                                        └─────────────────────┘
```

On the affected machine `~/.agents-in-a-box/hangar/daemon.pid` named a live
`.../ainb-tui/target/debug/deps/ainb-<hash> hangar daemon run` — a cargo test binary that had
self-exec'd a daemon (the #715 class) against the user's **real** hangar home, written the pid
file, and never bound the socket.

`pid_owns_a_home` (`cli/hangar/mod.rs`) takes socket ownership as proof, then falls back to argv
shape for the legitimate boot window before the socket is bound. `is_hangar_daemon_args` matches
the token window `["hangar","daemon","run"]` anywhere in argv and ignores argv0, so the test binary
matched. `start_or_upgrade_daemon` saw `Some(pid)` and started nothing. The `running_under_cargo_test()`
guard refuses to *start* a daemon from a test binary but nothing refused to *credit* one, and the
argv fallback has no time bound, so the home stayed wedged with zero daemons.

## Fix

Reject a `target/**/deps/` argv0 in the client's credit rule only, via a small pure
`argv_credits_a_daemon`.

Deliberately **not** applied to `single_instance::holder_is_live_daemon`. The two callers have
opposite safety asymmetries:

| caller | wrong answer that hurts | so it should be |
|---|---|---|
| `holder_is_live_daemon` (daemon) | false negative → steals a live holder's lock → two daemons on one home | generous |
| `pid_owns_a_home` (client) | false positive → zero daemons, home wedged | strict |

The daemon side already covers an in-process `boot()` inside a test binary through
`shares_our_command_line`, so it needs no change.

## Verification

- `cargo test -p ainb --lib cli::hangar::tests` — 90/90.
- `cargo test -p ainb-hangar-daemon --lib single_instance` — 12/12.
- `cargo fmt --all --check` clean.
- The new test is **proven load-bearing**: removing the guard fails it with
  `a target/**/deps/ binary must never be credited as the home's daemon`. A first draft asserted
  end to end by seeding our own pid; that passed with the guard removed, because this test binary's
  argv has no `hangar daemon run` token window. The committed test asserts on the pure credit
  function instead, and the doc comment records why.

## Not fixed here

The other half is that a test run spawned ~110 detached `mcp daemon` / `notifyd run` /
`hangar daemon run` processes into the developer's real `~/.agents-in-a-box/` home (no test-home
override; `HOME` was the real one). That leak deserves its own change; this PR makes such a leak
unable to wedge the home.

https://claude.ai/code/session_01MRBdxkFi7yND2LEbxPY7ZZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon detection to avoid incorrectly identifying detached test processes as the active daemon.
  * Preserved recognition of valid daemon launches and standard command-line operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->