### PR TITLE
feat: add durable session labels

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -104,6 +104,10 @@ pub enum AppEvent {
         x: u16,
         y: u16,
     },
+    MouseRightClick {
+        x: u16,
+        y: u16,
+    },
     MouseDragStart {
         x: u16,
         y: u16,
@@ -218,6 +222,16 @@ pub enum AppEvent {
     SshSessionRenameBackspace,  // Backspace in SSH rename
     SshSessionConfirmRename,    // Confirm SSH rename (Enter)
     SshSessionCancelRename,     // Cancel SSH rename (Escape)
+    // Durable session label events (managed and SSH sessions)
+    SessionLabelStartRename,
+    SessionLabelRenameChar(char),
+    SessionLabelRenameBackspace,
+    SessionLabelConfirmRename,
+    SessionLabelCancelRename,
+    SessionContextNext,
+    SessionContextPrev,
+    SessionContextActivate,
+    SessionContextCancel,
     // AINB 2.0: Home screen events
     HomeScreenSelectTile,    // Select current tile (Enter)
     HomeScreenNavigateUp,    // Navigate up in tile grid
@@ -897,6 +911,22 @@ impl EventHandler {
             return None;
         }
         match event {
+            AppEvent::MouseRightClick { x, y } => {
+                if state.current_screen == screen_ids::SESSION_LIST && !state.help_visible {
+                    if let Some(crate::app::state::SessionListRowTarget::Attachable(target)) =
+                        state.session_list_row_at_mouse(x, y)
+                    {
+                        if matches!(
+                            target,
+                            crate::app::state::AttachableRef::WorkspaceSession { .. }
+                                | crate::app::state::AttachableRef::SshSession { .. }
+                        ) {
+                            state.open_session_context_menu(target);
+                        }
+                    }
+                }
+                None
+            }
             AppEvent::MouseClick { x, y } => {
                 if state.current_screen == screen_ids::FLEET_PANEL
                     && state.fleet_panel_state.canonical_modal_open()
@@ -1472,6 +1502,27 @@ impl EventHandler {
                 KeyCode::Char(c) => return Some(AppEvent::SshSessionRenameChar(c)),
                 _ => return None,
             }
+        }
+
+        // Durable session-label popup captures input everywhere it is opened.
+        if state.session_label_rename_mode {
+            match key_event.code {
+                KeyCode::Enter => return Some(AppEvent::SessionLabelConfirmRename),
+                KeyCode::Esc => return Some(AppEvent::SessionLabelCancelRename),
+                KeyCode::Backspace => return Some(AppEvent::SessionLabelRenameBackspace),
+                KeyCode::Char(c) => return Some(AppEvent::SessionLabelRenameChar(c)),
+                _ => return None,
+            }
+        }
+
+        if state.session_context_menu.is_some() {
+            return match key_event.code {
+                KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::SessionContextPrev),
+                KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::SessionContextNext),
+                KeyCode::Enter => Some(AppEvent::SessionContextActivate),
+                KeyCode::Esc => Some(AppEvent::SessionContextCancel),
+                _ => None,
+            };
         }
 
         // Handle onboarding wizard view FIRST (before any other handlers)
@@ -2145,14 +2196,14 @@ impl EventHandler {
             // so the resume affordance could own 'r'). See restart_affordance.
             KeyCode::Char('u') => Some(AppEvent::ReauthenticateCredentials),
             KeyCode::F(2) => {
-                // F2 for rename - works in "SSH Sessions" and "Other tmux" sections
-                if state.is_ssh_session_selected() {
-                    Some(AppEvent::SshSessionStartRename)
+                // Durable labels never rename Git branches or tmux sessions.
+                if state.selected_session().is_some() || state.is_ssh_session_selected() {
+                    Some(AppEvent::SessionLabelStartRename)
                 } else if state.is_other_tmux_selected() {
                     Some(AppEvent::OtherTmuxStartRename)
                 } else {
                     Some(AppEvent::ShowNotification(
-                        "F2 rename only works on SSH and 'Other tmux' sessions".to_string(),
+                        "F2 labels managed or SSH sessions; Other tmux keeps rename".to_string(),
                     ))
                 }
             }
@@ -3784,6 +3835,46 @@ impl EventHandler {
             AppEvent::SshSessionRenameBackspace => state.ssh_session_rename_backspace(),
             AppEvent::SshSessionCancelRename => state.cancel_ssh_session_rename(),
             AppEvent::SshSessionConfirmRename => state.confirm_ssh_session_rename(),
+            AppEvent::SessionLabelStartRename => state.start_session_label_rename(),
+            AppEvent::SessionLabelRenameChar(c) => state.session_label_rename_char(c),
+            AppEvent::SessionLabelRenameBackspace => state.session_label_rename_backspace(),
+            AppEvent::SessionLabelCancelRename => state.cancel_session_label_rename(),
+            AppEvent::SessionLabelConfirmRename => state.confirm_session_label_rename(),
+            AppEvent::SessionContextNext => state.session_context_next(1),
+            AppEvent::SessionContextPrev => state.session_context_next(-1),
+            AppEvent::SessionContextCancel => state.close_session_context_menu(),
+            AppEvent::SessionContextActivate => {
+                let event = match state.take_session_context_action() {
+                    Some(crate::app::state::SessionContextAction::Attach) => {
+                        Some(AppEvent::AttachTmuxSession)
+                    }
+                    Some(crate::app::state::SessionContextAction::Restart) => {
+                        Some(AppEvent::RestartSession)
+                    }
+                    Some(crate::app::state::SessionContextAction::EditLabel) => {
+                        Some(AppEvent::SessionLabelStartRename)
+                    }
+                    Some(crate::app::state::SessionContextAction::OpenEditor) => {
+                        Some(AppEvent::OpenInEditor)
+                    }
+                    Some(crate::app::state::SessionContextAction::OpenShell) => {
+                        Some(AppEvent::OpenQuickShell)
+                    }
+                    Some(crate::app::state::SessionContextAction::OpenGit) => {
+                        Some(AppEvent::ShowGitView)
+                    }
+                    Some(crate::app::state::SessionContextAction::QuickCommit) => {
+                        Some(AppEvent::QuickCommitStart)
+                    }
+                    Some(crate::app::state::SessionContextAction::Delete) => {
+                        Some(AppEvent::DeleteSession)
+                    }
+                    None => None,
+                };
+                if let Some(event) = event {
+                    Self::process_event(event, state);
+                }
+            }
             AppEvent::RefreshWorkspaces => {
                 // Mark for async processing to reload workspace data
                 state.pending_async_action = Some(AsyncAction::RefreshWorkspaces);
@@ -8090,6 +8181,7 @@ impl EventHandler {
             }
             // Mouse events are handled directly in the main event loop
             AppEvent::MouseClick { .. }
+            | AppEvent::MouseRightClick { .. }
             | AppEvent::MouseDragStart { .. }
             | AppEvent::MouseDragEnd { .. }
             | AppEvent::MouseDragging { .. }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11,7 +11,7 @@ use crate::claude::{ClaudeApiClient, ClaudeMessage};
 // boss-mode @-trigger; removed along with the prompt textarea.
 use crate::components::home_screen_v2::HomeScreenV2State;
 use crate::components::live_logs_stream::LogEntry;
-use crate::config::{AppConfig, SshDisplayNameStore};
+use crate::config::{AppConfig, SessionLabelStore};
 use crate::credentials;
 use crate::docker::LogStreamingCoordinator;
 use crate::editors;
@@ -46,6 +46,26 @@ pub enum AttachableRef {
     OtherTmux {
         other_idx: usize,
     },
+}
+
+/// Actions available from a session row's context menu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionContextAction {
+    Attach,
+    Restart,
+    EditLabel,
+    OpenEditor,
+    OpenShell,
+    OpenGit,
+    QuickCommit,
+    Delete,
+}
+
+/// Ephemeral state for the keyboard-accessible right-click context menu.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionContextMenu {
+    pub target: AttachableRef,
+    pub selected: usize,
 }
 
 /// Text editor with cursor support for boss mode prompts
@@ -3053,8 +3073,13 @@ pub struct AppState {
     pub ssh_session_rename_mode: bool,
     /// Buffer for the new display name being typed during rename
     pub ssh_session_rename_buffer: String,
-    /// Persistent store for SSH session display names
-    pub ssh_display_name_store: SshDisplayNameStore,
+    /// Persistent store for durable session labels.
+    pub session_label_store: SessionLabelStore,
+    /// Durable-label text popup state for managed and SSH sessions.
+    pub session_label_rename_mode: bool,
+    pub session_label_rename_buffer: String,
+    pub session_label_rename_target: Option<AttachableRef>,
+    pub session_context_menu: Option<SessionContextMenu>,
 
     // AINB 2.0: Home screen and agent selection
     pub home_screen_state: HomeScreenState,
@@ -3312,8 +3337,12 @@ async fn load_workspaces_async() -> anyhow::Result<Vec<Workspace>> {
         .map(|(i, w)| (canonical_key(&w.path), i))
         .collect();
 
+    let session_label_store = SessionLabelStore::load();
     for interactive_session in interactive_sessions {
-        let session = interactive_session.to_session_model();
+        let mut session = interactive_session.to_session_model();
+        if let Some(label) = session_label_store.get(&interactive_session.tmux_session_name) {
+            session.display_name = Some(label.clone());
+        }
         let workspace_path = interactive_session.source_repository.clone();
         let workspace_name = interactive_session.workspace_name.clone();
         let key = canonical_key(&workspace_path);
@@ -3639,7 +3668,11 @@ impl Default for AppState {
             selected_ssh_session_index: None,
             ssh_session_rename_mode: false,
             ssh_session_rename_buffer: String::new(),
-            ssh_display_name_store: SshDisplayNameStore::load(),
+            session_label_store: SessionLabelStore::load(),
+            session_label_rename_mode: false,
+            session_label_rename_buffer: String::new(),
+            session_label_rename_target: None,
+            session_context_menu: None,
 
             // AINB 2.0: Home screen and agent selection
             home_screen_state: HomeScreenState::default(),
@@ -5717,7 +5750,12 @@ impl AppState {
                 // Convert to Session models and add to workspaces
                 for interactive_session in sessions {
                     live_tmux_names.insert(interactive_session.tmux_session_name.clone());
-                    let session = interactive_session.to_session_model();
+                    let mut session = interactive_session.to_session_model();
+                    if let Some(label) =
+                        self.session_label_store.get(&interactive_session.tmux_session_name)
+                    {
+                        session.display_name = Some(label.clone());
+                    }
 
                     // Find or create workspace for this session.
                     // Use source_repository (the original git repo) not worktree_path parent.
@@ -5976,7 +6014,7 @@ impl AppState {
                     }
 
                     // Restore display_name from persistent store
-                    if let Some(preserved_name) = self.ssh_display_name_store.get(&name) {
+                    if let Some(preserved_name) = self.session_label_store.get(&name) {
                         ssh_session.display_name = Some(preserved_name.clone());
                     }
 
@@ -7118,9 +7156,9 @@ impl AppState {
 
                 // Persist to disk
                 if let Some(key) = tmux_name {
-                    self.ssh_display_name_store.set(key, session.display_name.clone());
-                    if let Err(e) = self.ssh_display_name_store.save() {
-                        warn!("Failed to save SSH display names: {}", e);
+                    self.session_label_store.set(key, session.display_name.clone());
+                    if let Err(e) = self.session_label_store.save() {
+                        warn!("Failed to save session labels: {}", e);
                     }
                 }
             }
@@ -7128,6 +7166,148 @@ impl AppState {
 
         self.ssh_session_rename_mode = false;
         self.ssh_session_rename_buffer.clear();
+    }
+
+    /// Open durable-label editing for the selected managed or SSH session.
+    pub fn start_session_label_rename(&mut self) {
+        let target = if let (Some(workspace_idx), Some(session_idx)) =
+            (self.selected_workspace_index, self.selected_session_index)
+        {
+            Some(AttachableRef::WorkspaceSession {
+                workspace_idx,
+                session_idx,
+            })
+        } else {
+            self.selected_ssh_session_index
+                .map(|ssh_idx| AttachableRef::SshSession { ssh_idx })
+        };
+        let Some(target) = target else {
+            return;
+        };
+
+        let current = match target {
+            AttachableRef::WorkspaceSession {
+                workspace_idx,
+                session_idx,
+            } => self
+                .workspaces
+                .get(workspace_idx)
+                .and_then(|workspace| workspace.sessions.get(session_idx))
+                .and_then(|session| session.display_name.clone()),
+            AttachableRef::SshSession { ssh_idx } => {
+                self.ssh_sessions.get(ssh_idx).and_then(|session| session.display_name.clone())
+            }
+            _ => None,
+        };
+        self.session_label_rename_target = Some(target);
+        self.session_label_rename_buffer = current.unwrap_or_default();
+        self.session_label_rename_mode = true;
+    }
+
+    pub fn cancel_session_label_rename(&mut self) {
+        self.session_label_rename_mode = false;
+        self.session_label_rename_buffer.clear();
+        self.session_label_rename_target = None;
+    }
+
+    pub fn session_label_rename_char(&mut self, c: char) {
+        if self.session_label_rename_mode {
+            self.session_label_rename_buffer.push(c);
+        }
+    }
+
+    pub fn session_label_rename_backspace(&mut self) {
+        if self.session_label_rename_mode {
+            self.session_label_rename_buffer.pop();
+        }
+    }
+
+    /// Validate, persist, and immediately render a durable session label.
+    pub fn confirm_session_label_rename(&mut self) {
+        let Some(target) = self.session_label_rename_target else {
+            return self.cancel_session_label_rename();
+        };
+        let label = match crate::config::normalize_session_label(&self.session_label_rename_buffer)
+        {
+            Ok(label) => label,
+            Err(error) => {
+                self.add_error_notification(error);
+                return;
+            }
+        };
+
+        let tmux_name = match target {
+            AttachableRef::WorkspaceSession {
+                workspace_idx,
+                session_idx,
+            } => self
+                .workspaces
+                .get_mut(workspace_idx)
+                .and_then(|workspace| workspace.sessions.get_mut(session_idx)),
+            AttachableRef::SshSession { ssh_idx } => self.ssh_sessions.get_mut(ssh_idx),
+            _ => None,
+        }
+        .and_then(|session| {
+            session.display_name = label.clone();
+            session.tmux_session_name.clone()
+        });
+
+        if let Some(tmux_name) = tmux_name {
+            self.session_label_store.set(tmux_name, label);
+            if let Err(error) = self.session_label_store.save() {
+                self.add_error_notification(format!("Failed to save session label: {error}"));
+                return;
+            }
+        }
+        self.cancel_session_label_rename();
+    }
+
+    pub fn open_session_context_menu(&mut self, target: AttachableRef) {
+        self.select_attachable(target);
+        self.session_context_menu = Some(SessionContextMenu {
+            target,
+            selected: 0,
+        });
+    }
+
+    pub fn close_session_context_menu(&mut self) {
+        self.session_context_menu = None;
+    }
+
+    pub fn session_context_actions(&self) -> &'static [SessionContextAction] {
+        const MANAGED: &[SessionContextAction] = &[
+            SessionContextAction::Attach,
+            SessionContextAction::Restart,
+            SessionContextAction::EditLabel,
+            SessionContextAction::OpenEditor,
+            SessionContextAction::OpenShell,
+            SessionContextAction::OpenGit,
+            SessionContextAction::QuickCommit,
+            SessionContextAction::Delete,
+        ];
+        const SSH: &[SessionContextAction] = &[
+            SessionContextAction::Attach,
+            SessionContextAction::EditLabel,
+            SessionContextAction::Delete,
+        ];
+        match self.session_context_menu.map(|menu| menu.target) {
+            Some(AttachableRef::SshSession { .. }) => SSH,
+            _ => MANAGED,
+        }
+    }
+
+    pub fn session_context_next(&mut self, delta: isize) {
+        let len = self.session_context_actions().len();
+        if let Some(menu) = self.session_context_menu.as_mut() {
+            menu.selected = (menu.selected as isize + delta).rem_euclid(len as isize) as usize;
+        }
+    }
+
+    pub fn take_session_context_action(&mut self) -> Option<SessionContextAction> {
+        let selected = self.session_context_menu?.selected;
+        let action = self.session_context_actions().get(selected).copied();
+        self.close_session_context_menu();
+        action
     }
 
     pub fn toggle_claude_chat(&mut self) {
@@ -8939,7 +9119,12 @@ impl AppState {
                 }
 
                 // Convert to Session model and add to workspaces
-                let session = interactive_session.to_session_model();
+                let mut session = interactive_session.to_session_model();
+                if let Some(label) =
+                    self.session_label_store.get(&interactive_session.tmux_session_name)
+                {
+                    session.display_name = Some(label.clone());
+                }
 
                 // Find or create workspace for this repo
                 if let Some((ws_idx, workspace)) =

--- a/ainb-tui/crates/ainb-core/src/cli/label.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/label.rs
@@ -1,0 +1,56 @@
+// ABOUTME: CLI command for durable session labels.
+// Labels are stored separately from mutable Git and tmux metadata.
+
+use anyhow::{Result, anyhow};
+
+use super::LabelArgs;
+use crate::cli::util::find_session;
+use crate::config::{SessionLabelStore, normalize_session_label};
+
+/// Execute `ainb label SESSION --set TEXT` or `--clear`.
+pub fn execute(args: LabelArgs) -> Result<()> {
+    let tmux_name = resolve_tmux_name(&args.session)?;
+    let label = if args.clear {
+        None
+    } else {
+        Some(
+            normalize_session_label(
+                args.set.as_deref().ok_or_else(|| anyhow!("use --set TEXT or --clear"))?,
+            )
+            .map_err(anyhow::Error::msg)?
+            .ok_or_else(|| anyhow!("Session label cannot be blank. Use --clear instead."))?,
+        )
+    };
+
+    let mut labels = SessionLabelStore::load();
+    labels.set(tmux_name.clone(), label.clone());
+    labels.save()?;
+
+    match label {
+        Some(label) => println!("Session label set: {tmux_name} -> {label}"),
+        None => println!("Session label cleared: {tmux_name}"),
+    }
+    Ok(())
+}
+
+fn resolve_tmux_name(session: &str) -> Result<String> {
+    // SSH sessions do not have managed-session metadata. Their tmux names are
+    // already exact durable identifiers and deliberately remain unmapped.
+    if session.starts_with("ssh-") {
+        return Ok(session.to_string());
+    }
+    Ok(find_session(session)?.tmux_session_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_label_targets_keep_the_exact_tmux_name() {
+        assert_eq!(
+            resolve_tmux_name("ssh-prod-22").expect("ssh name"),
+            "ssh-prod-22"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/cli/list.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/list.rs
@@ -4,6 +4,7 @@
 // Shows: session ID, workspace, status (Claude running, idle, stopped), tmux session name
 
 use super::{ListArgs, OutputFormat};
+use crate::config::SessionLabelStore;
 use crate::interactive::session_manager::{SessionMetadata, SessionStore};
 use crate::tmux::ClaudeProcessDetector;
 use anyhow::Result;
@@ -39,6 +40,7 @@ pub struct SessionInfo {
     pub session_id: String,
     pub tmux_session_name: String,
     pub workspace_name: String,
+    pub display_name: Option<String>,
     pub worktree_path: String,
     pub created_at: DateTime<Utc>,
     pub is_running: bool,
@@ -62,6 +64,7 @@ impl SessionInfo {
             session_id: metadata.session_id.to_string(),
             tmux_session_name: metadata.tmux_session_name.clone(),
             workspace_name: metadata.display_workspace_name(),
+            display_name: None,
             worktree_path: metadata.worktree_path.display().to_string(),
             created_at: metadata.created_at,
             is_running,
@@ -98,6 +101,7 @@ pub async fn execute(args: ListArgs, format: OutputFormat) -> Result<()> {
 #[allow(clippy::unused_async)] // Async for consistency with other CLI commands
 pub async fn list_sessions(args: &ListArgs) -> Result<Vec<SessionInfo>> {
     let store = SessionStore::load();
+    let labels = SessionLabelStore::load();
     let detector = ClaudeProcessDetector::new();
 
     let mut sessions = Vec::new();
@@ -108,7 +112,8 @@ pub async fn list_sessions(args: &ListArgs) -> Result<Vec<SessionInfo>> {
             .get_session_health(&metadata.tmux_session_name)
             .unwrap_or((false, false));
 
-        let info = SessionInfo::from_metadata(metadata, is_running, claude_active);
+        let mut info = SessionInfo::from_metadata(metadata, is_running, claude_active);
+        info.display_name = labels.get(&metadata.tmux_session_name).cloned();
 
         // Apply filters
         if args.running && !is_running {
@@ -146,8 +151,8 @@ fn output_text(sessions: &[SessionInfo]) {
 
     // Print header
     println!(
-        "{:<36} {:<25} {:<10} TMUX SESSION",
-        "ID", "WORKSPACE", "STATUS"
+        "{:<36} {:<22} {:<22} {:<10} TMUX SESSION",
+        "ID", "WORKSPACE", "SESSION LABEL", "STATUS"
     );
     let separator = "-".repeat(100);
     println!("{separator}");
@@ -157,9 +162,10 @@ fn output_text(sessions: &[SessionInfo]) {
         let status = session.status();
         let workspace = truncate(&session.workspace_name, 25);
         println!(
-            "{:<36} {:<25} {:<10} {}",
+            "{:<36} {:<22} {:<22} {:<10} {}",
             session.session_id,
             workspace,
+            truncate(session.display_name.as_deref().unwrap_or(""), 22),
             status.icon(),
             session.tmux_session_name
         );

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -20,6 +20,7 @@ pub mod git_cmd;
 pub mod hangar;
 pub mod headroom;
 pub mod init;
+pub mod label;
 pub mod list;
 pub mod logs;
 pub mod mcp;
@@ -210,6 +211,26 @@ pub struct ListArgs {
     /// Show only sessions for a specific workspace
     #[arg(long)]
     pub workspace: Option<String>,
+}
+
+/// Set or clear a durable session label.
+#[derive(clap::Args)]
+#[command(group(
+    clap::ArgGroup::new("label_action")
+        .required(true)
+        .args(["set", "clear"])
+))]
+pub struct LabelArgs {
+    /// Session ID, workspace name, or exact SSH tmux session name
+    pub session: String,
+
+    /// Set a durable human label
+    #[arg(long, conflicts_with = "clear")]
+    pub set: Option<String>,
+
+    /// Remove the durable label
+    #[arg(long, conflicts_with = "set")]
+    pub clear: bool,
 }
 
 /// View session output/logs. Description set in `cli/registry.rs`.

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -3118,13 +3118,14 @@ mod tests {
         // main's 30 (built-ins + doctor + reflect + claudecode + codex + tmux +
         // otel + abtop + witr + learnings + plugin stub + fleet + mcp +
         // notifyd + hangar) + headroom + rtk + the web dashboard + the daemon
-        // lifecycle surface = 34. The TUI is NOT in the registry — main.rs
+        // lifecycle surface = 35. The TUI is NOT in the registry, main.rs
         // handles `tui` / no-subcommand inline.
-        assert_eq!(names.len(), 34, "expected 34 entries, got {names:?}");
+        assert_eq!(names.len(), 35, "expected 35 entries, got {names:?}");
         for required in [
             "daemon",
             "run",
             "list",
+            "label",
             "logs",
             "attach",
             "status",

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -87,6 +87,7 @@ impl CommandRegistry {
         let mut r = Self::new();
         r.register(RunCommand);
         r.register(ListCommand);
+        r.register(LabelCommand);
         r.register(LogsCommand);
         r.register(AttachCommand);
         r.register(StatusCommand);
@@ -223,6 +224,30 @@ impl CliCommand for ListCommand {
     fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
         match crate::cli::ListArgs::from_arg_matches(matches) {
             Ok(args) => Box::pin(async move { crate::cli::list::execute(args, ctx.format).await }),
+            Err(e) => boxed_err(e),
+        }
+    }
+}
+
+pub struct LabelCommand;
+impl CliCommand for LabelCommand {
+    fn name(&self) -> &'static str {
+        "label"
+    }
+    fn build(&self, app: Command) -> Command {
+        app.subcommand(
+            <crate::cli::LabelArgs as clap::Args>::augment_args(Command::new(self.name()))
+                .about("Set or clear a durable session label")
+                .after_help(
+                    "EXAMPLES:\n  \
+                     ainb label my-project --set \"RPC flake\"\n  \
+                     ainb label my-project --clear",
+                ),
+        )
+    }
+    fn run(&self, matches: &ArgMatches, _ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        match crate::cli::LabelArgs::from_arg_matches(matches) {
+            Ok(args) => Box::pin(async move { crate::cli::label::execute(args) }),
             Err(e) => boxed_err(e),
         }
     }
@@ -3238,6 +3263,25 @@ mod tests {
         let args = crate::cli::RunArgs::from_arg_matches(sub).expect("args extract");
         assert!(args.worktree);
         assert_eq!(args.repo.as_deref(), Some(std::path::Path::new(".")));
+    }
+
+    #[test]
+    fn label_command_parses_set_and_clear() {
+        let app = CommandRegistry::built_ins().build_clap(root());
+        let matches = app
+            .try_get_matches_from(["ainb", "label", "abc123", "--set", "RPC flake"])
+            .expect("label set parses");
+        let (_, sub) = matches.subcommand().expect("label subcommand");
+        let args = crate::cli::LabelArgs::from_arg_matches(sub).expect("label args");
+        assert_eq!(args.session, "abc123");
+        assert_eq!(args.set.as_deref(), Some("RPC flake"));
+        assert!(!args.clear);
+
+        let app = CommandRegistry::built_ins().build_clap(root());
+        assert!(
+            app.try_get_matches_from(["ainb", "label", "abc123", "--set", "x", "--clear"])
+                .is_err()
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/logs_viewer.rs
+++ b/ainb-tui/crates/ainb-core/src/components/logs_viewer.rs
@@ -51,7 +51,10 @@ impl LogsViewerComponent {
         // Build spans with colored status
         let info_spans = vec![
             Span::styled(" ", Style::default()),
-            Span::styled(&session.name, Style::default().fg(Color::White)),
+            Span::styled(
+                session.display_name.as_deref().unwrap_or(&session.name),
+                Style::default().fg(Color::White),
+            ),
             Span::styled(" │ ", Style::default().fg(Color::DarkGray)),
             Span::styled(
                 format!("{} {}", session.status.indicator(), status_text),

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -6,7 +6,7 @@ use ratatui::{
     prelude::*,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, List, ListItem, ListState},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
 
 // Premium color palette (TUI Style Guide)
@@ -43,9 +43,11 @@ use ainb_plugin_notifyd::AlertKind;
 
 use crate::app::{
     AppState,
-    state::{AttachableRef, SessionListRowTarget},
+    state::{AttachableRef, SessionContextAction, SessionListRowTarget},
 };
-use crate::models::{SessionAgentType, SessionMode, SessionStatus, ShellSessionStatus, Workspace};
+use crate::models::{
+    Session, SessionAgentType, SessionMode, SessionStatus, ShellSessionStatus, Workspace,
+};
 
 /// Width of the leading badge slot rendered before every list row.
 /// Two characters: a digit (or space) and a trailing space separator.
@@ -195,7 +197,10 @@ impl SessionListComponent {
                     .style(Style::default().bg(DARK_BG))
                     .title(Line::from(title_spans))
                     .title_bottom(
-                        if state.ssh_session_rename_mode || state.other_tmux_rename_mode {
+                        if state.ssh_session_rename_mode
+                            || state.other_tmux_rename_mode
+                            || state.session_label_rename_mode
+                        {
                             // Rename mode help (SSH or Other tmux)
                             Line::from(vec![
                                 Span::styled(
@@ -286,6 +291,77 @@ impl SessionListComponent {
             .highlight_symbol("▶ ");
 
         frame.render_stateful_widget(list, area, &mut self.list_state);
+
+        if state.session_label_rename_mode {
+            let width = area.width.min(54);
+            let height = 7;
+            let popup = Rect::new(
+                area.x + area.width.saturating_sub(width) / 2,
+                area.y + area.height.saturating_sub(height) / 2,
+                width,
+                height,
+            );
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(" Session label ")
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(GOLD))
+                .style(Style::default().bg(DARK_BG));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+            let text = format!(
+                "Durable name, Git branch unchanged\n\n{}|\n\nEnter save   Esc cancel   blank clears",
+                state.session_label_rename_buffer
+            );
+            frame.render_widget(
+                Paragraph::new(text).style(Style::default().fg(SOFT_WHITE).bg(DARK_BG)),
+                inner,
+            );
+        }
+
+        if let Some(menu) = state.session_context_menu {
+            let actions = state.session_context_actions();
+            let width = area.width.min(30);
+            let height = (actions.len() as u16 + 3).min(area.height);
+            let popup = Rect::new(
+                area.x + area.width.saturating_sub(width) / 2,
+                area.y + area.height.saturating_sub(height) / 2,
+                width,
+                height,
+            );
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(" Session actions ")
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(GOLD))
+                .style(Style::default().bg(DARK_BG));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+            let lines: Vec<Line> = actions
+                .iter()
+                .enumerate()
+                .map(|(index, action)| {
+                    let selected = index == menu.selected;
+                    Line::styled(
+                        format!(
+                            "{} {}",
+                            if selected { "▶" } else { " " },
+                            context_action_label(*action)
+                        ),
+                        Style::default()
+                            .fg(if selected {
+                                SELECTION_GREEN
+                            } else {
+                                SOFT_WHITE
+                            })
+                            .bg(if selected { LIST_HIGHLIGHT_BG } else { DARK_BG }),
+                    )
+                })
+                .collect();
+            frame.render_widget(Paragraph::new(lines), inner);
+        }
     }
 
     fn build_list_items_static(state: &AppState) -> Vec<ListItem<'static>> {
@@ -492,7 +568,7 @@ impl SessionListComponent {
                         Span::styled(pill_r, Style::default().fg(agent_color).bg(row_bg)),
                         Span::raw(" "),
                         Span::styled(
-                            session.branch_name.clone(),
+                            session_list_name(session),
                             Style::default().fg(branch_color).add_modifier(
                                 if is_selected_session {
                                     Modifier::BOLD
@@ -900,6 +976,28 @@ fn workspace_running_count(workspace: &Workspace) -> usize {
     workspace.running_sessions().len()
 }
 
+/// User label followed by the current Git branch, or only the branch when unlabeled.
+fn session_list_name(session: &Session) -> String {
+    session
+        .display_name
+        .as_ref()
+        .map(|label| format!("{label} · {}", session.branch_name))
+        .unwrap_or_else(|| session.branch_name.clone())
+}
+
+fn context_action_label(action: SessionContextAction) -> &'static str {
+    match action {
+        SessionContextAction::Attach => "Attach",
+        SessionContextAction::Restart => "Restart",
+        SessionContextAction::EditLabel => "Rename session label",
+        SessionContextAction::OpenEditor => "Open editor",
+        SessionContextAction::OpenShell => "Open shell",
+        SessionContextAction::OpenGit => "Git",
+        SessionContextAction::QuickCommit => "Quick commit",
+        SessionContextAction::Delete => "Delete",
+    }
+}
+
 /// Multi-select ballot toggle shared by the workspace-session and
 /// other-tmux rows: ☑ (green, marked) / ☐ (muted, unmarked).
 fn ballot_checkbox(checked: bool) -> Span<'static> {
@@ -963,5 +1061,14 @@ mod tests {
                 }
             ))
         );
+    }
+
+    #[test]
+    fn durable_label_keeps_live_branch_visible() {
+        let mut session = Session::new("workspace".to_string(), "/tmp/workspace".to_string());
+        session.branch_name = "fix/rpc-acp-flake".to_string();
+        session.display_name = Some("RPC flake".to_string());
+
+        assert_eq!(session_list_name(&session), "RPC flake · fix/rpc-acp-flake");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/tmux_preview.rs
+++ b/ainb-tui/crates/ainb-core/src/components/tmux_preview.rs
@@ -142,8 +142,14 @@ impl TmuxPreviewPane {
         is_focused: bool,
     ) {
         let title = match self.preview_mode {
-            PreviewMode::Normal => format!("Session Preview: {}", session.name),
-            PreviewMode::Scroll => format!("Session Preview: {} [SCROLL MODE]", session.name),
+            PreviewMode::Normal => format!(
+                "Session Preview: {}",
+                session.display_name.as_deref().unwrap_or(&session.name)
+            ),
+            PreviewMode::Scroll => format!(
+                "Session Preview: {} [SCROLL MODE]",
+                session.display_name.as_deref().unwrap_or(&session.name)
+            ),
         };
 
         // Grey when unfocused; green when focused (gold while in scroll mode).

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -31,7 +31,7 @@ pub use mcp_init::{McpInitResult, McpInitializer, apply_mcp_init_result};
 pub use onboarding::OnboardingConfig;
 pub use presets::{PermissionSet, PresetManager, RepositoryPreset, create_default_presets};
 pub use session_defaults::{PerRepoDefaults, SessionDefaults};
-pub use ssh_display_names::SshDisplayNameStore;
+pub use ssh_display_names::{SessionLabelStore, SshDisplayNameStore, normalize_session_label};
 
 /// Authentication provider for Claude API
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]

--- a/ainb-tui/crates/ainb-core/src/config/ssh_display_names.rs
+++ b/ainb-tui/crates/ainb-core/src/config/ssh_display_names.rs
@@ -1,30 +1,56 @@
-// ABOUTME: Persistent storage for SSH session display names
-// Stores custom display names in ~/.agents-in-a-box/ssh_display_names.json
+// ABOUTME: Persistent storage for durable session labels
+// Stores custom labels by stable tmux session name.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-/// Store for SSH session display names
-/// Maps tmux_session_name -> custom display_name
+/// Normalize a durable session label before it reaches disk or the UI.
+///
+/// Blank input clears a label. Control characters are rejected because labels
+/// render inside terminal rows, and 64 characters keeps every layout usable.
+pub fn normalize_session_label(raw: &str) -> Result<Option<String>, String> {
+    let label = raw.trim();
+    if label.is_empty() {
+        return Ok(None);
+    }
+    if label.chars().any(char::is_control) {
+        return Err("Session label cannot contain control characters".to_string());
+    }
+    if label.chars().count() > 64 {
+        return Err("Session label must be 64 characters or fewer".to_string());
+    }
+    Ok(Some(label.to_string()))
+}
+
+/// Store for durable session labels.
+/// Maps tmux session name to a human-provided label, independent from Git.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub struct SshDisplayNameStore {
+pub struct SessionLabelStore {
     /// Map of tmux_session_name -> display_name
     #[serde(flatten)]
     names: HashMap<String, String>,
 }
 
-impl SshDisplayNameStore {
+impl SessionLabelStore {
     /// Get the storage file path
     fn storage_path() -> Option<PathBuf> {
-        dirs::home_dir().map(|h| h.join(".agents-in-a-box").join("ssh_display_names.json"))
+        std::env::var_os("AINB_HOME")
+            .map(PathBuf::from)
+            .or_else(dirs::home_dir)
+            .map(|base| base.join(".agents-in-a-box").join("session-labels.json"))
+    }
+
+    fn legacy_storage_path() -> Option<PathBuf> {
+        dirs::home_dir().map(|home| home.join(".agents-in-a-box").join("ssh_display_names.json"))
     }
 
     /// Load from disk (returns empty store if file doesn't exist)
     pub fn load() -> Self {
         Self::storage_path()
             .and_then(|path| fs::read_to_string(path).ok())
+            .or_else(|| Self::legacy_storage_path().and_then(|path| fs::read_to_string(path).ok()))
             .and_then(|content| serde_json::from_str(&content).ok())
             .unwrap_or_default()
     }
@@ -60,14 +86,27 @@ impl SshDisplayNameStore {
     }
 }
 
+/// Compatibility alias for code that still refers to SSH display names.
+pub type SshDisplayNameStore = SessionLabelStore;
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+
+    #[test]
+    fn session_labels_trim_clear_and_reject_unsafe_values() {
+        assert_eq!(
+            normalize_session_label("  RPC flake  ").expect("valid label"),
+            Some("RPC flake".to_string())
+        );
+        assert_eq!(normalize_session_label("   ").expect("blank clears"), None);
+        assert!(normalize_session_label("two\nlines").is_err());
+        assert!(normalize_session_label(&"x".repeat(65)).is_err());
+    }
 
     #[test]
     fn test_store_get_set() {
-        let mut store = SshDisplayNameStore::default();
+        let mut store = SessionLabelStore::default();
 
         // Initially empty
         assert!(store.get("ssh-test-22").is_none());
@@ -83,12 +122,12 @@ mod tests {
 
     #[test]
     fn test_store_serialization() {
-        let mut store = SshDisplayNameStore::default();
+        let mut store = SessionLabelStore::default();
         store.set("ssh-prod-22".to_string(), Some("Production".to_string()));
         store.set("ssh-staging-22".to_string(), Some("Staging".to_string()));
 
         let json = serde_json::to_string(&store).unwrap();
-        let loaded: SshDisplayNameStore = serde_json::from_str(&json).unwrap();
+        let loaded: SessionLabelStore = serde_json::from_str(&json).unwrap();
 
         assert_eq!(loaded.get("ssh-prod-22"), Some(&"Production".to_string()));
         assert_eq!(loaded.get("ssh-staging-22"), Some(&"Staging".to_string()));

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -820,6 +820,17 @@ async fn run_tui_loop(
                                 EventHandler::process_event(app_event, &mut app.state);
                             }
                         }
+                        MouseEventKind::Down(MouseButton::Right) => {
+                            if let Some(app_event) = EventHandler::handle_mouse_event(
+                                AppEvent::MouseRightClick {
+                                    x: mouse_event.column,
+                                    y: mouse_event.row,
+                                },
+                                &mut app.state,
+                            ) {
+                                EventHandler::process_event(app_event, &mut app.state);
+                            }
+                        }
                         MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => {
                             // Handle mouse scroll based on current view
                             use crate::app::screens::ids as screen_ids;

--- a/docs/man/ainb.1
+++ b/docs/man/ainb.1
@@ -84,6 +84,9 @@ Spawn a new AI coding session
 .B ainb list
 List all sessions (running + idle)
 .TP
+.B ainb label
+Set or clear a durable session label
+.TP
 .B ainb logs
 View session output/logs
 .TP

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -112,6 +112,17 @@ checkout you point at: it shares that branch, index and working tree with your
 editor and with every other session started there. Prefer --worktree.
 ```
 
+### Durable session labels
+
+Labels are separate from Git branches and tmux names. They stay attached when
+the agent changes branches. Use `F2` or right-click a managed or SSH session in
+the TUI, or run:
+
+```text
+ainb label my-project --set "RPC flake"
+ainb label my-project --clear
+```
+
 ## `ainb list`
 
 List all sessions (running + idle)

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -112,17 +112,6 @@ checkout you point at: it shares that branch, index and working tree with your
 editor and with every other session started there. Prefer --worktree.
 ```
 
-### Durable session labels
-
-Labels are separate from Git branches and tmux names. They stay attached when
-the agent changes branches. Use `F2` or right-click a managed or SSH session in
-the TUI, or run:
-
-```text
-ainb label my-project --set "RPC flake"
-ainb label my-project --clear
-```
-
 ## `ainb list`
 
 List all sessions (running + idle)
@@ -144,6 +133,30 @@ EXAMPLES:
   ainb list --running              Only running sessions
   ainb list --workspace my-proj    Sessions for one workspace
   ainb list --format json          Machine-readable output
+```
+
+## `ainb label`
+
+Set or clear a durable session label
+
+```console
+$ ainb label --help
+Set or clear a durable session label
+
+Usage: ainb label [OPTIONS] <--set <SET>|--clear> <SESSION>
+
+Arguments:
+  <SESSION>  Session ID, workspace name, or exact SSH tmux session name
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+      --set <SET>        Set a durable human label
+      --clear            Remove the durable label
+  -h, --help             Print help
+
+EXAMPLES:
+  ainb label my-project --set "RPC flake"
+  ainb label my-project --clear
 ```
 
 ## `ainb logs`

--- a/docs/tui/faq.md
+++ b/docs/tui/faq.md
@@ -145,7 +145,7 @@ Press `x` from the session list to clean up:
 | `x` | Cleanup orphaned sessions |
 | `$` | Open shell in workspace |
 | `o` | Open in editor |
-| `F2` | Rename "Other" tmux session |
+| `F2` | Edit durable Session label for managed or SSH session. Rename Other tmux sessions. |
 | `g` | Git view |
 | `l` | Logs view |
 | `c` | Config |


### PR DESCRIPTION
## Summary
- add durable labels independent from live Git branches
- provide F2 and right-click session actions for managed and SSH sessions
- add CLI label set and clear commands

## Verification
- cargo check -p ainb
- focused session-label tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable session labels for managed and SSH sessions.
  - Rename labels with F2, including validation and persistence.
  - Added right-click context menus for session actions such as attach, restart, edit, Git, quick commit, and delete.
  - Added `label` CLI commands to set or clear labels.
  - Session labels now appear in lists, previews, logs, and JSON output.

- **Documentation**
  - Documented durable labels, CLI usage, and updated F2 behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->