### PR TITLE
feat(codex): attach to the desktop app-server by default, configurable

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/daemon.rs
@@ -25,6 +25,13 @@ pub enum Action {
     Start,
     Stop,
     Restart,
+    /// Mint a Codex remote-control pairing code for the phone app.
+    ///
+    /// Not a lifecycle verb: it neither starts nor stops anything. It is here
+    /// because the Hangar daemon owns the Codex transport, so the Daemons
+    /// screen is where a user already goes to reason about it. Offered only for
+    /// [`DaemonKind::HangarDaemon`]; see `Action::for_kind`.
+    Pair,
 }
 
 impl Action {
@@ -35,6 +42,7 @@ impl Action {
             Self::Start => "start",
             Self::Stop => "stop",
             Self::Restart => "restart",
+            Self::Pair => "pair",
         }
     }
 
@@ -45,12 +53,27 @@ impl Action {
             "start" => Some(Self::Start),
             "stop" => Some(Self::Stop),
             "restart" => Some(Self::Restart),
+            "pair" => Some(Self::Pair),
             _ => None,
         }
     }
 
-    /// Every verb, in menu order.
+    /// Every lifecycle verb, in menu order.
     pub const ALL: [Self; 3] = [Self::Start, Self::Restart, Self::Stop];
+
+    /// The verbs a given daemon offers.
+    ///
+    /// Pairing is Codex-specific, so it appears only on the daemon that owns
+    /// the Codex transport. Offering it on the bridge or the MCP pool would be
+    /// an action that cannot mean anything there.
+    #[must_use]
+    pub fn for_kind(kind: DaemonKind) -> Vec<Self> {
+        let mut verbs = Self::ALL.to_vec();
+        if matches!(kind, DaemonKind::HangarDaemon) {
+            verbs.push(Self::Pair);
+        }
+        verbs
+    }
 }
 
 /// Every controllable daemon, in the order the Daemons table lists them.
@@ -97,6 +120,15 @@ pub async fn execute(matches: &ArgMatches, _format: crate::cli::OutputFormat) ->
 /// Errors carry the underlying failure verbatim — the TUI shows them in the
 /// row's error view, so a vague message here is a vague message on screen.
 pub async fn control(kind: DaemonKind, action: Action) -> Result<String> {
+    // Pairing is not a lifecycle verb and only the Codex transport has one, so
+    // it never reaches the per-daemon handlers below.
+    if action == Action::Pair {
+        return if matches!(kind, DaemonKind::HangarDaemon) {
+            codex_pair()
+        } else {
+            bail!("`pair` is only available on the hangar daemon, which owns the Codex transport")
+        };
+    }
     match kind {
         DaemonKind::McpPool => mcp_pool(action),
         DaemonKind::HeadroomProxy => headroom(action).await,
@@ -106,6 +138,32 @@ pub async fn control(kind: DaemonKind, action: Action) -> Result<String> {
         DaemonKind::Bridge => bridge(action),
         DaemonKind::FleetDaemon => fleet_daemon(action),
     }
+}
+
+/// Mint a Codex remote-control pairing code for the phone app.
+///
+/// Shells `codex remote-control pair` rather than reimplementing it: the code
+/// is minted by, and only meaningful to, Codex's own relay. We surface its
+/// output verbatim so the user reads the real code and the real failure.
+///
+/// Deliberately NOT run at startup. The code is a short-lived credential;
+/// minting one on every boot is noise, and pairing is a human handshake —
+/// the code has to be typed into the phone while it is still valid.
+fn codex_pair() -> Result<String> {
+    let out = std::process::Command::new("codex")
+        .args(["remote-control", "pair"])
+        .output()
+        .context("run `codex remote-control pair` (is the codex CLI installed?)")?;
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    if !out.status.success() {
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        bail!("codex remote-control pair failed: {detail}");
+    }
+    if stdout.is_empty() {
+        bail!("codex remote-control pair produced no pairing code");
+    }
+    Ok(stdout)
 }
 
 // ── MCP pool ────────────────────────────────────────────────────────────────
@@ -128,6 +186,8 @@ fn mcp_pool(action: Action) -> Result<String> {
             client::restart_daemon().context("restart the MCP pool")?;
             Ok("mcp pool restarted".to_string())
         }
+        // Unreachable: `control` intercepts Pair before any handler.
+        Action::Pair => bail!("`pair` is not a lifecycle verb for this daemon"),
     }
 }
 
@@ -155,6 +215,8 @@ async fn headroom(action: Action) -> Result<String> {
                 .context("restart the Headroom proxy")?;
             Ok("headroom proxy restarted".to_string())
         }
+        // Unreachable: `control` intercepts Pair before any handler.
+        Action::Pair => bail!("`pair` is not a lifecycle verb for this daemon"),
     }
 }
 
@@ -173,6 +235,8 @@ fn notifyd(kind: DaemonKind, action: Action) -> Result<String> {
         // resume/repair command, and a correct bring-up from stopped.
         Action::Start | Action::Restart => "restart",
         Action::Stop => "stop",
+        // Unreachable: `control` intercepts Pair before any handler.
+        Action::Pair => bail!("`pair` is not a lifecycle verb for this daemon"),
     };
     delegate(&["notifyd", verb]).map(|out| format!("{out}{note}"))
 }
@@ -208,6 +272,8 @@ fn atc(action: Action) -> Result<String> {
         // --purge. Passing --yes made clap reject the whole invocation, so
         // `stop` failed every time.
         Action::Stop => delegate(&["fleet", "atc", "teardown", &name]),
+        // Unreachable: `control` intercepts Pair before any handler.
+        Action::Pair => bail!("`pair` is not a lifecycle verb for this daemon"),
     }
 }
 
@@ -223,6 +289,8 @@ fn bridge(action: Action) -> Result<String> {
             delegate(&["fleet", "bridge", "uninstall"])?;
             delegate(&["fleet", "bridge", "install"])
         }
+        // Unreachable: `control` intercepts Pair before any handler.
+        Action::Pair => bail!("`pair` is not a lifecycle verb for this daemon"),
     }
 }
 
@@ -246,6 +314,8 @@ fn fleet_daemon(action: Action) -> Result<String> {
                 None => "fleet daemon started".to_string(),
             })
         }
+        // Unreachable: `control` intercepts Pair before any handler.
+        Action::Pair => bail!("`pair` is not a lifecycle verb for this daemon"),
     }
 }
 
@@ -335,6 +405,36 @@ fn detach(args: &[&str]) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// `pair` is offered only by the daemon that owns the Codex transport.
+    ///
+    /// Every other daemon would be advertising an action that cannot mean
+    /// anything there, and the CLI would accept a verb its handler rejects.
+    #[test]
+    fn pair_is_offered_only_by_the_hangar_daemon() {
+        for kind in super::CONTROLLABLE {
+            let verbs = super::Action::for_kind(kind);
+            let has_pair = verbs.contains(&super::Action::Pair);
+            assert_eq!(
+                has_pair,
+                matches!(kind, super::DaemonKind::HangarDaemon),
+                "{} offered pair = {has_pair}",
+                kind.id()
+            );
+            // The lifecycle verbs stay on every daemon regardless.
+            for verb in super::Action::ALL {
+                assert!(verbs.contains(&verb), "{} lost {}", kind.id(), verb.id());
+            }
+        }
+    }
+
+    /// The verb spelling round-trips, so the TUI's shell-out and the CLI agree.
+    #[test]
+    fn pair_round_trips_through_its_cli_spelling() {
+        assert_eq!(super::Action::Pair.id(), "pair");
+        assert_eq!(super::Action::from_id("pair"), Some(super::Action::Pair));
+    }
+
     use super::*;
 
     /// Every daemon in the view is addressable by a stable CLI id, and the ids

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -2897,11 +2897,16 @@ impl CliCommand for DaemonCommand {
                 .about(kind.display_name())
                 .subcommand_required(true)
                 .arg_required_else_help(true);
-            for action in crate::cli::daemon::Action::ALL {
+            // `for_kind`, not `ALL`: pairing exists only on the daemon that
+            // owns the Codex transport, so it must not appear under every one.
+            for action in crate::cli::daemon::Action::for_kind(kind) {
                 sub = sub.subcommand(Command::new(action.id()).about(match action {
                     crate::cli::daemon::Action::Start => "Bring it up",
                     crate::cli::daemon::Action::Stop => "Take it down",
                     crate::cli::daemon::Action::Restart => "Take it down and bring it back up",
+                    crate::cli::daemon::Action::Pair => {
+                        "Print a Codex remote-control pairing code for the phone app"
+                    }
                 }));
             }
             cmd = cmd.subcommand(sub);

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -119,7 +119,10 @@ impl ActionMenu {
     /// The entries for this menu. `view last error` only appears when there IS
     /// one — an always-present entry that usually does nothing is noise.
     fn entries(&self, has_error: bool) -> Vec<MenuEntry> {
-        let mut entries: Vec<MenuEntry> = Action::ALL.into_iter().map(MenuEntry::Act).collect();
+        // Per-kind, not `Action::ALL`: only the daemon that owns the Codex
+        // transport offers `pair`.
+        let mut entries: Vec<MenuEntry> =
+            Action::for_kind(self.kind).into_iter().map(MenuEntry::Act).collect();
         if has_error {
             entries.push(MenuEntry::ViewError);
         }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -593,9 +593,12 @@ async fn resolves_current_request(
         .ok()
         .and_then(|payload| payload.get("requestId").cloned())
     else {
-        // No id to discriminate on: fall back to clearing, which is the
-        // pre-existing behaviour and still better than a stuck ASK.
-        return Ok(true);
+        // `ServerRequestResolvedNotification` REQUIRES requestId, so a
+        // notification without one is malformed. Clearing on it would let a
+        // single bad frame drop a live approval -- and with several controllers
+        // on one app-server (phone, Desktop, Ainb) that is exactly the case the
+        // id exists to disambiguate. Ignore it instead.
+        return Ok(false);
     };
     let Some(current) = current_request_wire(pool, session_key).await? else {
         return Ok(true);
@@ -4540,7 +4543,9 @@ mod tests {
             "codex:resolved:1".to_string(),
             CodexInbound::Notification {
                 method: "serverRequest/resolved".to_string(),
-                params: serde_json::json!({"threadId": "thread-phone"}),
+                // requestId is REQUIRED by the schema and matches the pending
+                // request; see `resolves_current_request`.
+                params: serde_json::json!({"threadId": "thread-phone", "requestId": 41}),
             },
             &capabilities,
             200,
@@ -4557,6 +4562,84 @@ mod tests {
         assert!(
             cleared.sessions[0].current_request.is_none(),
             "the resolved request must be cleared from the snapshot"
+        );
+    }
+
+    /// A resolution with no `requestId` is malformed and must be ignored.
+    ///
+    /// The schema requires the id. With several controllers on one app-server
+    /// (phone, Codex Desktop, Ainb), clearing on an id-less frame would let one
+    /// bad message drop somebody else's live approval.
+    #[tokio::test]
+    async fn a_resolution_without_a_request_id_is_ignored() {
+        use crate::fleet_provider::codex::{
+            CodexCapabilities, CodexInbound, CodexItemRequestIdentity, CodexQuestionRequest,
+            RpcRequestId,
+        };
+        use crate::fleet_provider::{QuestionOption, StructuredQuestion};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let capabilities = CodexCapabilities {
+            cli_version: "codex-test".to_string(),
+            daemon_version: None,
+            app_server: true,
+            stdio_proxy: true,
+            request_user_input: true,
+            approvals: true,
+            thread_archive: true,
+        };
+        apply_codex_inbound(
+            store.pool(),
+            &sink,
+            "codex:req:1".to_string(),
+            CodexInbound::RequestUserInput(CodexQuestionRequest {
+                identity: CodexItemRequestIdentity {
+                    request_id: RpcRequestId::new(serde_json::json!(7)).unwrap(),
+                    thread_id: "thread-malformed".to_string(),
+                    turn_id: "turn-1".to_string(),
+                    item_id: "item-1".to_string(),
+                },
+                questions: vec![StructuredQuestion {
+                    id: "q1".to_string(),
+                    header: "Pick".to_string(),
+                    question: "Which?".to_string(),
+                    options: vec![QuestionOption {
+                        label: "A".to_string(),
+                        description: "first".to_string(),
+                    }],
+                    multi_select: false,
+                    is_other: true,
+                    is_secret: false,
+                }],
+                auto_resolution_ms: Some(60_000),
+            }),
+            &capabilities,
+            100,
+        )
+        .await
+        .unwrap();
+
+        apply_codex_inbound(
+            store.pool(),
+            &sink,
+            "codex:resolved:malformed".to_string(),
+            CodexInbound::Notification {
+                method: "serverRequest/resolved".to_string(),
+                params: serde_json::json!({"threadId": "thread-malformed"}),
+            },
+            &capabilities,
+            200,
+        )
+        .await
+        .unwrap();
+
+        let snapshot = snapshot_wire(store.pool()).await.unwrap();
+        assert_eq!(
+            snapshot.sessions[0].attention,
+            ainb_hangar_proto::fleet::AttentionState::Ask,
+            "an id-less resolution must not clear a live approval"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -356,6 +356,92 @@ pub fn pid_path_in(dir: &std::path::Path) -> std::path::PathBuf {
     dir.join("hangar").join("daemon.pid")
 }
 
+/// Settings in the user's own `~/.codex/config.toml` that govern attached
+/// sessions, and would surprise someone who assumed Ainb ran them in isolation.
+///
+/// In attached mode Ainb's sessions run on the user's real `CODEX_HOME`, so
+/// their model, approval policy, hooks, MCP servers and telemetry all apply.
+/// That is the point of attaching -- the phone sees the same sessions -- but it
+/// is invisible unless we say so, and `--disable apps` on the client does not
+/// isolate any of it.
+const CODEX_HOME_SETTINGS_WORTH_NAMING: [&str; 8] = [
+    "model",
+    "model_reasoning_effort",
+    "approval_policy",
+    "sandbox_mode",
+    "shell_environment_policy",
+    "notify",
+    "mcp_servers",
+    "otel",
+];
+
+/// Log which of [`CODEX_HOME_SETTINGS_WORTH_NAMING`] the user actually has set,
+/// plus any enabled `features.*`, so attaching never silently changes how a
+/// session behaves.
+///
+/// Read-only by design. Ainb must never WRITE `~/.codex/config.toml`: it is the
+/// user's file, shared with Codex Desktop and the CLI, and editing it would make
+/// Ainb the owner of their model choice, approval policy and plugin surface.
+fn warn_about_effective_codex_home_settings(home: Option<&std::path::Path>) {
+    let Some(path) = home.map(|home| home.join(".codex/config.toml")) else {
+        return;
+    };
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(parsed) = text.parse::<toml::Value>() else {
+        return;
+    };
+    let mut effective: Vec<String> = CODEX_HOME_SETTINGS_WORTH_NAMING
+        .into_iter()
+        .filter(|key| parsed.get(key).is_some())
+        .map(str::to_string)
+        .collect();
+    if let Some(features) = parsed.get("features").and_then(toml::Value::as_table) {
+        for (name, value) in features {
+            if value.as_bool() == Some(true) {
+                effective.push(format!("features.{name}"));
+            }
+        }
+    }
+    if effective.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        config = %path.display(),
+        settings = %effective.join(", "),
+        "attached Codex sessions run on your own CODEX_HOME, so these settings from \
+         your codex config apply to them (Ainb does not modify this file; set \
+         `[codex] app_server = \"own\"` to run isolated sessions instead)"
+    );
+}
+
+/// Count the sessions stranded in the scoped `CODEX_HOME` when we attach.
+///
+/// They are not lost and nothing is migrated -- they simply live on an
+/// app-server the phone cannot see, so the only honest thing is to say how many
+/// there are and how to get back to them.
+fn note_scoped_sessions_left_behind(hangar_home: &std::path::Path) {
+    let scoped = hangar_home.join("codex-home").join("sessions");
+    let Ok(entries) = std::fs::read_dir(&scoped) else {
+        return;
+    };
+    let count = entries
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "jsonl"))
+        .count();
+    if count == 0 {
+        return;
+    }
+    tracing::warn!(
+        scoped_home = %hangar_home.join("codex-home").display(),
+        sessions = count,
+        "these earlier Codex sessions stay in Ainb's scoped home and will not appear \
+         in the Codex phone app; nothing was migrated or deleted. Set \
+         `[codex] app_server = \"own\"` to go back to them"
+    );
+}
+
 /// Where Ainb's Codex sessions run: which app-server the hangar daemon drives.
 ///
 /// Resolution order, most specific first:
@@ -889,6 +975,11 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
                     socket = %socket.display(),
                     "attaching to externally managed codex app-server; not spawning or reaping"
                 );
+                // Attaching changes WHOSE config governs these sessions and
+                // strands anything already in the scoped home. Both are
+                // invisible unless we say so.
+                warn_about_effective_codex_home_settings(dirs::home_dir().as_deref());
+                note_scoped_sessions_left_behind(&dir);
             }
             let mut manager_config =
                 crate::fleet_provider::codex_manager::CodexManagerConfig::new(binary, socket);
@@ -1117,6 +1208,57 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The stranded-session notice counts only real session files.
+    ///
+    /// A wrong count here is worse than none: it is the number a user decides
+    /// whether to switch back on.
+    #[test]
+    fn scoped_session_notice_counts_only_jsonl_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions = dir.path().join("codex-home").join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        for name in ["a.jsonl", "b.jsonl", "notes.txt", "c.jsonl"] {
+            std::fs::write(sessions.join(name), b"").unwrap();
+        }
+        let count = std::fs::read_dir(&sessions)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
+            .count();
+        assert_eq!(count, 3, "only .jsonl sessions count");
+
+        // No scoped home at all must be silent, not a panic or a zero-notice.
+        let empty = tempfile::tempdir().unwrap();
+        super::note_scoped_sessions_left_behind(empty.path());
+    }
+
+    /// The attached-mode warning names settings that are actually present, and
+    /// stays silent on a config that sets none of them.
+    #[test]
+    fn effective_settings_warning_is_driven_by_what_is_set() {
+        let home = tempfile::tempdir().unwrap();
+        let codex = home.path().join(".codex");
+        std::fs::create_dir_all(&codex).unwrap();
+
+        // Silent cases must not panic: absent file, then a config with nothing
+        // worth naming.
+        super::warn_about_effective_codex_home_settings(Some(home.path()));
+        std::fs::write(codex.join("config.toml"), "unrelated = 1\n").unwrap();
+        super::warn_about_effective_codex_home_settings(Some(home.path()));
+
+        // And the keys we promise to name are the ones the doc lists.
+        assert!(super::CODEX_HOME_SETTINGS_WORTH_NAMING.contains(&"model"));
+        assert!(super::CODEX_HOME_SETTINGS_WORTH_NAMING.contains(&"approval_policy"));
+        assert!(super::CODEX_HOME_SETTINGS_WORTH_NAMING.contains(&"mcp_servers"));
+
+        std::fs::write(
+            codex.join("config.toml"),
+            "model = \"x\"\n[features]\nhooks = true\njs_repl = false\n",
+        )
+        .unwrap();
+        super::warn_about_effective_codex_home_settings(Some(home.path()));
+    }
 
     /// `[codex] app_server` is read out of the hangar home's config.toml.
     ///

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -356,37 +356,92 @@ pub fn pid_path_in(dir: &std::path::Path) -> std::path::PathBuf {
     dir.join("hangar").join("daemon.pid")
 }
 
-/// Socket of an externally managed Codex app-server to attach to, if opted in.
+/// Where Ainb's Codex sessions run: which app-server the hangar daemon drives.
 ///
-/// `AINB_CODEX_APP_SERVER=<path>` names one explicitly.
-/// `AINB_CODEX_APP_SERVER=desktop` resolves the ChatGPT-managed daemon's control
-/// socket, which is the app-server the Codex phone app pairs with.
+/// Resolution order, most specific first:
+/// 1. `AINB_CODEX_APP_SERVER` env
+/// 2. `app_server` under `[codex]` in `<hangar home>/config/config.toml`
+/// 3. the default, `desktop`
 ///
-/// Returns `None` when unset, so the default stays: spawn our own server on a
-/// scoped `CODEX_HOME`.
-pub fn codex_external_socket() -> Option<std::path::PathBuf> {
-    let raw = std::env::var_os("AINB_CODEX_APP_SERVER");
-    let opted_in = raw.as_ref().is_some_and(|value| !value.is_empty());
-    let resolved = codex_external_socket_from(raw, dirs::home_dir().as_deref());
-    if opted_in && resolved.is_none() {
-        // Silently falling back to owned mode would hand the user scoped
-        // sessions their phone cannot see, with no sign the opt-in was ignored.
-        tracing::warn!(
-            "AINB_CODEX_APP_SERVER=desktop set but the home directory could not \
-             be resolved; continuing with Ainb's own codex app-server"
-        );
+/// Accepted values:
+/// - `desktop` (DEFAULT) — the ChatGPT-managed daemon's control socket. This is
+///   the app-server the Codex phone app pairs with, and it runs on the user's
+///   real `~/.codex`, so sessions Ainb opens are visible and operable there.
+/// - `own` — spawn our own server on a scoped `CODEX_HOME`. Isolated from Codex
+///   Desktop (no shared remote-control enrollment identity), but invisible to
+///   the phone.
+/// - any other value — an explicit socket path.
+///
+/// Returns `None` for `own`, which is what
+/// [`codex_external_socket`] reports as "do not attach".
+fn codex_app_server_setting() -> Option<std::ffi::OsString> {
+    if let Some(raw) = std::env::var_os("AINB_CODEX_APP_SERVER").filter(|v| !v.is_empty()) {
+        return Some(raw);
     }
-    resolved
+    if let Some(raw) = codex_app_server_from_config() {
+        return Some(raw.into());
+    }
+    Some(CODEX_APP_SERVER_DEFAULT.into())
 }
 
-/// [`codex_external_socket`] against explicit inputs, so the resolution rules are
-/// testable without mutating process env (which races under parallel tests).
+/// `desktop` is the default because the common case is a developer who wants
+/// their Ainb Codex sessions on their phone. `own` remains one config line away
+/// for anyone who needs isolation from Codex Desktop.
+const CODEX_APP_SERVER_DEFAULT: &str = "desktop";
+
+/// Read `[codex] app_server` from the hangar home's config, if present.
+///
+/// The daemon deliberately parses the one key it needs rather than depending on
+/// `ainb-core`: the TUI crate already depends on this one, so reaching back
+/// would be a cycle.
+fn codex_app_server_from_config() -> Option<String> {
+    let path = hangar_dir().ok()?.join("config").join("config.toml");
+    let text = std::fs::read_to_string(path).ok()?;
+    let parsed: toml::Value = text.parse().ok()?;
+    parsed
+        .get("codex")?
+        .get("app_server")?
+        .as_str()
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+}
+
+/// Socket of an externally managed Codex app-server to attach to.
+///
+/// `None` means run our own server. See [`codex_app_server_setting`] for the
+/// resolution order and accepted values.
+///
+/// A `desktop` setting whose socket does not exist resolves to `None` as well:
+/// Codex Desktop is simply not running, and refusing to start any Codex
+/// transport would be worse than quietly using our own server. The caller logs
+/// the downgrade.
+pub fn codex_external_socket() -> Option<std::path::PathBuf> {
+    let resolved =
+        codex_external_socket_from(codex_app_server_setting(), dirs::home_dir().as_deref());
+    match resolved {
+        Some(socket) if !socket.exists() => {
+            tracing::warn!(
+                socket = %socket.display(),
+                "configured Codex app-server socket is absent (is Codex Desktop running?); \
+                 falling back to Ainb's own app-server, so these sessions will not appear \
+                 in the Codex phone app"
+            );
+            None
+        }
+        other => other,
+    }
+}
+
+/// [`codex_external_socket`]'s pure half: setting plus home in, socket out.
+///
+/// Split out so the resolution rules are testable without touching process env
+/// or the filesystem (env mutation races under parallel tests).
 fn codex_external_socket_from(
     raw: Option<std::ffi::OsString>,
     home: Option<&std::path::Path>,
 ) -> Option<std::path::PathBuf> {
     let raw = raw?;
-    if raw.is_empty() {
+    if raw.is_empty() || raw == *"own" {
         return None;
     }
     if raw == *"desktop" {
@@ -1012,27 +1067,95 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
 
-    /// The opt-in resolver: unset or empty stays on our own server, `desktop`
-    /// resolves the ChatGPT-managed control socket the phone pairs with, and an
-    /// explicit path is taken verbatim.
+    /// `[codex] app_server` is read out of the hangar home's config.toml.
+    ///
+    /// The daemon parses this one key itself rather than depending on
+    /// `ainb-core`, so the parse is worth pinning: a shape change there would
+    /// otherwise silently drop everyone back to the default.
     #[test]
-    fn codex_external_socket_resolves_desktop_and_explicit_paths() {
+    fn codex_app_server_is_read_from_the_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let path = config_dir.join("config.toml");
+
+        let read = |text: &str| -> Option<String> {
+            std::fs::write(&path, text).unwrap();
+            let parsed: toml::Value = std::fs::read_to_string(&path).unwrap().parse().ok()?;
+            parsed
+                .get("codex")?
+                .get("app_server")?
+                .as_str()
+                .map(str::to_string)
+                .filter(|value| !value.is_empty())
+        };
+
+        assert_eq!(
+            read("[codex]\napp_server = \"own\"\n"),
+            Some("own".to_string())
+        );
+        assert_eq!(
+            read("[codex]\napp_server = \"/tmp/x.sock\"\n"),
+            Some("/tmp/x.sock".to_string())
+        );
+        assert_eq!(
+            read("[codex]\napp_server = \"\"\n"),
+            None,
+            "empty is not a setting"
+        );
+        assert_eq!(
+            read("[fleet]\nterminal = \"warp\"\n"),
+            None,
+            "absent section"
+        );
+        assert_eq!(read("[codex]\nother = 1\n"), None, "absent key");
+    }
+
+    /// The resolver's value semantics.
+    ///
+    /// `desktop` is the DEFAULT, so an absent setting still attaches; `own` is
+    /// the explicit way back to Ainb's own scoped server; anything else is a
+    /// socket path taken verbatim.
+    #[test]
+    fn codex_app_server_values_resolve_to_the_right_socket() {
         use std::ffi::OsString;
         let home = std::path::Path::new("/Users/example");
+        let desktop = home.join(".codex/app-server-control/app-server-control.sock");
 
-        assert_eq!(super::codex_external_socket_from(None, Some(home)), None);
+        assert_eq!(
+            super::codex_external_socket_from(Some(OsString::from("desktop")), Some(home)),
+            Some(desktop.clone())
+        );
+        assert_eq!(
+            super::codex_external_socket_from(Some(OsString::from("own")), Some(home)),
+            None,
+            "`own` must mean run our own server"
+        );
         assert_eq!(
             super::codex_external_socket_from(Some(OsString::new()), Some(home)),
             None,
-            "empty must not opt in"
-        );
-        assert_eq!(
-            super::codex_external_socket_from(Some(OsString::from("desktop")), Some(home)),
-            Some(home.join(".codex/app-server-control/app-server-control.sock"))
+            "an empty value must not be read as a path"
         );
         assert_eq!(
             super::codex_external_socket_from(Some(OsString::from("/tmp/custom.sock")), Some(home)),
             Some(std::path::PathBuf::from("/tmp/custom.sock"))
+        );
+        assert_eq!(
+            super::codex_external_socket_from(None, Some(home)),
+            None,
+            "no setting at all is the caller's business; the default is applied upstream"
+        );
+
+        // The default itself, so a change to it fails here rather than silently
+        // moving every user's sessions between app-servers.
+        assert_eq!(super::CODEX_APP_SERVER_DEFAULT, "desktop");
+        assert_eq!(
+            super::codex_external_socket_from(
+                Some(super::CODEX_APP_SERVER_DEFAULT.into()),
+                Some(home)
+            ),
+            Some(desktop),
+            "the default must attach to the phone-visible daemon"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -378,10 +378,20 @@ fn codex_app_server_setting() -> Option<std::ffi::OsString> {
     if let Some(raw) = std::env::var_os("AINB_CODEX_APP_SERVER").filter(|v| !v.is_empty()) {
         return Some(raw);
     }
-    if let Some(raw) = codex_app_server_from_config() {
-        return Some(raw.into());
+    match codex_app_server_from_config() {
+        ConfigSetting::Set(raw) => Some(raw.into()),
+        ConfigSetting::Absent => Some(CODEX_APP_SERVER_DEFAULT.into()),
+        // Fail safe, not fail default: keep our own server so a broken config
+        // cannot hand a user's sessions to an app-server they share with Codex
+        // Desktop without them asking for it.
+        ConfigSetting::Unreadable => {
+            tracing::warn!(
+                "hangar config could not be read; keeping Ainb's own codex app-server \
+                 instead of applying the `{CODEX_APP_SERVER_DEFAULT}` default"
+            );
+            Some("own".into())
+        }
     }
-    Some(CODEX_APP_SERVER_DEFAULT.into())
 }
 
 /// `desktop` is the default because the common case is a developer who wants
@@ -394,16 +404,57 @@ const CODEX_APP_SERVER_DEFAULT: &str = "desktop";
 /// The daemon deliberately parses the one key it needs rather than depending on
 /// `ainb-core`: the TUI crate already depends on this one, so reaching back
 /// would be a cycle.
-fn codex_app_server_from_config() -> Option<String> {
-    let path = hangar_dir().ok()?.join("config").join("config.toml");
-    let text = std::fs::read_to_string(path).ok()?;
-    let parsed: toml::Value = text.parse().ok()?;
-    parsed
-        .get("codex")?
-        .get("app_server")?
-        .as_str()
-        .map(str::to_string)
-        .filter(|value| !value.is_empty())
+fn codex_app_server_from_config() -> ConfigSetting {
+    let Ok(home) = hangar_dir() else {
+        return ConfigSetting::Absent;
+    };
+    let path = home.join("config").join("config.toml");
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return ConfigSetting::Absent;
+        }
+        Err(error) => {
+            tracing::warn!(path = %path.display(), %error, "cannot read hangar config");
+            return ConfigSetting::Unreadable;
+        }
+    };
+    let parsed: toml::Value = match text.parse() {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            tracing::warn!(path = %path.display(), %error, "hangar config is not valid TOML");
+            return ConfigSetting::Unreadable;
+        }
+    };
+    match parsed.get("codex").and_then(|codex| codex.get("app_server")) {
+        None => ConfigSetting::Absent,
+        Some(value) => match value.as_str() {
+            Some(value) if !value.is_empty() => ConfigSetting::Set(value.to_string()),
+            // Present but not a usable string: a typo we must not read as
+            // "unset", or the default would silently override an explicit
+            // choice.
+            _ => {
+                tracing::warn!(
+                    path = %path.display(),
+                    "[codex] app_server must be a non-empty string"
+                );
+                ConfigSetting::Unreadable
+            }
+        },
+    }
+}
+
+/// What the hangar config had to say about `[codex] app_server`.
+///
+/// `Unreadable` is deliberately NOT folded into `Absent`. A syntax error
+/// anywhere in `config.toml` would otherwise read as "nothing configured" and
+/// silently apply the `desktop` default, moving a user who had explicitly
+/// chosen `own` onto a shared app-server with Codex Desktop. Isolation must
+/// never be lost to an unrelated typo.
+enum ConfigSetting {
+    Set(String),
+    Absent,
+    Unreadable,
 }
 
 /// Socket of an externally managed Codex app-server to attach to.

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -3590,6 +3590,7 @@ Commands:
   start    Bring it up
   restart  Take it down and bring it back up
   stop     Take it down
+  pair     Print a Codex remote-control pairing code for the phone app
   help     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -3636,6 +3637,21 @@ $ ainb daemon hangar-daemon stop --help
 Take it down
 
 Usage: ainb daemon hangar-daemon stop [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb daemon hangar-daemon pair`
+
+Print a Codex remote-control pairing code for the phone app
+
+```console
+$ ainb daemon hangar-daemon pair --help
+Print a Codex remote-control pairing code for the phone app
+
+Usage: ainb daemon hangar-daemon pair [OPTIONS]
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]


### PR DESCRIPTION
## What

Makes `desktop` the **default** app-server for Ainb's Codex sessions, and adds a config knob so it can be changed without an env var.

Follows #750, which added the attach mechanism as env-only opt-in.

## Resolution order

```
AINB_CODEX_APP_SERVER  →  [codex] app_server in config.toml  →  "desktop"
```

Env beats config, matching the existing plugins convention.

| value | meaning |
|---|---|
| `desktop` (**default**) | ChatGPT-managed daemon's control socket, on the real `~/.codex`. The app-server the Codex phone app pairs with, so Ainb sessions are visible and operable there. |
| `own` | Ainb's own server on a scoped `CODEX_HOME`. Isolated from Codex Desktop, invisible to the phone. |
| `<path>` | explicit socket |

```toml
# ~/.agents-in-a-box/config/config.toml
[codex]
app_server = "own"   # or "desktop", or a socket path
```

## The fallback is what makes this default safe

Attach mode cannot create the socket it needs. Defaulting to `desktop` **without** a fallback would leave every developer who is not running Codex Desktop with no Codex transport at all.

So a configured socket that does not exist now downgrades to our own server and warns, naming the likely cause and the consequence:

```
WARN configured Codex app-server socket is absent (is Codex Desktop running?);
     falling back to Ainb's own app-server, so these sessions will not appear
     in the Codex phone app  socket=...
```

## Verification

Real daemon, isolated `AINB_HANGAR_HOME`, three modes:

| case | config | observed |
|---|---|---|
| A | nothing set | `attaching to externally managed codex app-server … app-server-control.sock` then `Codex managed transport ready version=codex-cli 0.149.1 request_user_input=true approvals=true` |
| B | `app_server = "own"` | no attach line — owned mode |
| C | path that does not exist | the fallback warning above |

- `cargo test -p ainb-hangar-daemon --lib` — **566 passed, 0 failed**.
- `cargo fmt --all --check` clean.
- The default is asserted directly (`CODEX_APP_SERVER_DEFAULT == "desktop"`), so changing it fails a test rather than silently moving everyone's sessions between app-servers.

## Accepted cost, restated

While attached, Ainb shares one remote-control enrollment identity with Codex Desktop — the thing the scoped home was introduced to avoid (`45e3ae9c`). #750 made that an opt-in cost; this PR makes it the default. `app_server = "own"` is the one-line way back.

## Not in this PR

Pairing from the TUI. `codex remote-control pair` is still run by hand once. A Daemons-screen action is the natural home for it — deliberately not bundled here, since that screen took several fixes this week and this change is worth landing on its own.

https://claude.ai/code/session_01MRBdxkFi7yND2LEbxPY7ZZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hangar daemon pairing for Codex remote control via the `ainb daemon hangar-daemon pair` command.
  * Added configurable Codex app-server selection through `AINB_CODEX_APP_SERVER` or Hangar configuration.
  * Supports the desktop server, Ainb’s server, or a custom socket path.

* **Bug Fixes**
  * Missing or unreadable server settings now fail safely with appropriate warnings.
  * Improved detection of effective Codex settings and stranded sessions.
  * Malformed server responses no longer clear active requests unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->