### PR TITLE
feat: add signed self-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,6 +327,40 @@ jobs:
         with:
           path: artifacts
 
+      - name: Sign release manifest
+        env:
+          AINB_RELEASE_SIGNING_KEY: ${{ secrets.AINB_RELEASE_SIGNING_KEY }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AINB_RELEASE_SIGNING_KEY}" ]; then
+            echo "AINB_RELEASE_SIGNING_KEY is required to publish a release"
+            exit 1
+          fi
+
+          mac_sha=$(sha256sum artifacts/aarch64-apple-darwin/*.tar.gz | awk '{print $1}')
+          intel_sha=$(sha256sum artifacts/x86_64-apple-darwin/*.tar.gz | awk '{print $1}')
+          linux_sha=$(sha256sum artifacts/x86_64-unknown-linux-gnu/*.tar.gz | awk '{print $1}')
+          if [ -z "${mac_sha}" ] || [ -z "${intel_sha}" ] || [ -z "${linux_sha}" ]; then
+            echo "release archives missing while assembling signed manifest"
+            exit 1
+          fi
+
+          cat > artifacts/release-manifest.json <<EOF
+          {"version":"${VERSION}","assets":[
+            {"target":"aarch64-apple-darwin","archive":"ainb-${VERSION}-aarch64-apple-darwin.tar.gz","sha256":"${mac_sha}"},
+            {"target":"x86_64-apple-darwin","archive":"ainb-${VERSION}-x86_64-apple-darwin.tar.gz","sha256":"${intel_sha}"},
+            {"target":"x86_64-unknown-linux-gnu","archive":"ainb-${VERSION}-x86_64-unknown-linux-gnu.tar.gz","sha256":"${linux_sha}"}
+          ]}
+          EOF
+
+          key_path="${RUNNER_TEMP}/ainb-release-signing-key.pem"
+          printf '%s' "${AINB_RELEASE_SIGNING_KEY}" > "${key_path}"
+          chmod 600 "${key_path}"
+          openssl pkeyutl -sign -rawin -inkey "${key_path}" \
+            -in artifacts/release-manifest.json -out "${RUNNER_TEMP}/release-manifest.sig"
+          base64 "${RUNNER_TEMP}/release-manifest.sig" | tr -d '\n' > artifacts/release-manifest.sig
+
       # Publish the curated skill catalog index as a release asset. The curated
       # skills live in the standalone stevengonsalvez/ainb-toolkit repo (Option
       # B), so we clone the PINNED ainb-toolkit ref and run the xtask against

--- a/README.md
+++ b/README.md
@@ -220,6 +220,26 @@ brew install ainb
 
 The tap lives at [`stevengonsalvez/homebrew-agents-in-a-box`](https://github.com/stevengonsalvez/homebrew-agents-in-a-box) and is auto-updated by the release workflow on every tagged release — `brew upgrade ainb` always pulls the latest.
 
+### Updates
+
+ainb installs a short-lived daily OS timer on first TUI launch. The timer checks
+the latest signed stable release even while ainb is closed, then records the
+result and sends one native notification per version. It never installs a
+release without an explicit command.
+
+```bash
+ainb update check             # verify signed release metadata now
+ainb update status            # show cached result
+ainb update --yes             # install latest signed stable release
+ainb update schedule status   # inspect daily checker
+ainb update schedule disable  # opt out of background checks
+```
+
+The Daemons screen lists this as `release checker`. Homebrew updates through
+`brew upgrade ainb`; Cargo updates from the exact signed release tag; curl
+installs download, checksum, stage, and atomically replace only canonical
+ainb install paths.
+
 <details>
 <summary><b>Other install methods</b></summary>
 

--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "ansi-to-tui",
  "anyhow",
  "arboard",
+ "base64 0.22.1",
  "bincode",
  "blake3",
  "bollard",
@@ -154,6 +155,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "dirs",
+ "ed25519-dalek",
  "fs2",
  "futures-util",
  "git2",
@@ -174,9 +176,11 @@ dependencies = [
  "rexpect",
  "rpassword",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "shell-escape",
  "similar",
  "sqlx",
@@ -1796,6 +1800,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2125,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
 name = "ed25519-compact"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2142,20 @@ checksum = "5c24599140dc39d7a81e4476e7573d41bbc18e07c803900298e522a5fbcfbfb6"
 dependencies = [
  "ct-codecs",
  "getrandom 0.4.3",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2282,6 +2337,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"

--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -77,6 +77,10 @@ sysinfo = { workspace = true }
 arboard = { workspace = true }
 keyring = { workspace = true }
 regex = { workspace = true }
+semver = "1.0"
+base64 = "0.22"
+ed25519-dalek = "2.1"
+sha2 = "0.10"
 lazy_static = { workspace = true }
 which = { workspace = true }
 url = { workspace = true }

--- a/ainb-tui/crates/ainb-core/src/cli/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/daemon.rs
@@ -77,7 +77,7 @@ impl Action {
 }
 
 /// Every controllable daemon, in the order the Daemons table lists them.
-pub const CONTROLLABLE: [DaemonKind; 8] = [
+pub const CONTROLLABLE: [DaemonKind; 9] = [
     DaemonKind::Bridge,
     DaemonKind::Notifyd,
     DaemonKind::ApproveBroker,
@@ -86,6 +86,7 @@ pub const CONTROLLABLE: [DaemonKind; 8] = [
     DaemonKind::McpPool,
     DaemonKind::HangarDaemon,
     DaemonKind::HeadroomProxy,
+    DaemonKind::ReleaseChecker,
 ];
 
 /// Resolve a daemon by its stable CLI id.
@@ -137,6 +138,20 @@ pub async fn control(kind: DaemonKind, action: Action) -> Result<String> {
         DaemonKind::Atc => atc(action),
         DaemonKind::Bridge => bridge(action),
         DaemonKind::FleetDaemon => fleet_daemon(action),
+        DaemonKind::ReleaseChecker => release_checker(action),
+    }
+}
+
+fn release_checker(action: Action) -> Result<String> {
+    match action {
+        Action::Start | Action::Restart => {
+            crate::cli::update::ensure_schedule().context("enable daily release checker")?;
+            Ok("daily release checker enabled".to_string())
+        }
+        Action::Stop => {
+            crate::cli::update::disable_schedule().context("disable daily release checker")?;
+            Ok("daily release checker disabled".to_string())
+        }
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/daemon.rs
@@ -152,6 +152,7 @@ fn release_checker(action: Action) -> Result<String> {
             crate::cli::update::disable_schedule().context("disable daily release checker")?;
             Ok("daily release checker disabled".to_string())
         }
+        Action::Pair => bail!("`pair` is not a lifecycle verb for this daemon"),
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/mod.rs
@@ -36,6 +36,7 @@ pub mod status;
 pub mod statusline;
 pub mod statusline_install;
 pub mod tmux_install;
+pub mod update;
 pub mod usage;
 pub mod util;
 

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -3181,9 +3181,9 @@ mod tests {
         // main's 30 (built-ins + doctor + reflect + claudecode + codex + tmux +
         // otel + abtop + witr + learnings + plugin stub + fleet + mcp +
         // notifyd + hangar) + headroom + rtk + the web dashboard + the daemon
-        // lifecycle surface = 35. The TUI is NOT in the registry, main.rs
+        // lifecycle surface + signed self-updates = 36. The TUI is NOT in the registry, main.rs
         // handles `tui` / no-subcommand inline.
-        assert_eq!(names.len(), 35, "expected 35 entries, got {names:?}");
+        assert_eq!(names.len(), 36, "expected 36 entries, got {names:?}");
         for required in [
             "daemon",
             "run",
@@ -3220,6 +3220,7 @@ mod tests {
             "hangar",
             "headroom",
             "rtk",
+            "update",
         ] {
             assert!(
                 names.contains(&required),

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -120,6 +120,7 @@ impl CommandRegistry {
         r.register(NotifydCommand); // ainb-hooks daemon: status/restart/install
         r.register(HangarCommand); // Hangar control plane (issue / task / beads / daemon)
         r.register(RtkCommand); // RTK token-killer: install/uninstall/status
+        r.register(UpdateCommand); // signed stable release checker + updater
         r
     }
 
@@ -2867,6 +2868,58 @@ impl CliCommand for HeadroomCommand {
     fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
         let matches = matches.clone();
         Box::pin(async move { crate::cli::headroom::execute(&matches, ctx.format).await })
+    }
+}
+
+/// `ainb update` — signed stable release check, install, and scheduler controls.
+pub struct UpdateCommand;
+impl CliCommand for UpdateCommand {
+    fn name(&self) -> &'static str {
+        "update"
+    }
+
+    fn build(&self, app: Command) -> Command {
+        let check = Command::new("check")
+            .about("Check GitHub for the latest stable ainb release")
+            .arg(
+                clap::Arg::new("scheduled")
+                    .long("scheduled")
+                    .hide(true)
+                    .action(clap::ArgAction::SetTrue),
+            );
+        let schedule = Command::new("schedule")
+            .about("Enable, disable, or inspect daily release checks")
+            .subcommand_required(true)
+            .arg_required_else_help(true)
+            .subcommand(Command::new("enable").about("Install the daily OS timer"))
+            .subcommand(Command::new("disable").about("Remove the daily OS timer"))
+            .subcommand(Command::new("status").about("Show timer installation state"));
+        app.subcommand(
+            Command::new(self.name())
+                .about("Update ainb to the latest signed stable release")
+                .arg(
+                    clap::Arg::new("yes")
+                        .long("yes")
+                        .short('y')
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Install without ainb's confirmation prompt"),
+                )
+                .subcommand(check)
+                .subcommand(Command::new("status").about("Show cached update state"))
+                .subcommand(schedule)
+                .after_help(
+                    "EXAMPLES:\n  \
+                     ainb update                    Check and install after confirmation\n  \
+                     ainb update --yes              Install without confirmation\n  \
+                     ainb update check              Refresh latest stable release state\n  \
+                     ainb update schedule enable    Enable the daily background check",
+                ),
+        )
+    }
+
+    fn run(&self, matches: &ArgMatches, ctx: CliContext) -> BoxFuture<'static, Result<()>> {
+        let matches = matches.clone();
+        Box::pin(async move { crate::cli::update::execute(&matches, ctx.format).await })
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -146,7 +146,11 @@ impl CommandRegistry {
     }
 
     pub fn find(&self, name: &str) -> Option<&dyn CliCommand> {
-        self.entries.iter().find(|c| c.name() == name).map(|c| &**c as &dyn CliCommand)
+        let canonical_name = if name == "upgrade" { "update" } else { name };
+        self.entries
+            .iter()
+            .find(|c| c.name() == canonical_name)
+            .map(|c| &**c as &dyn CliCommand)
     }
 
     /// Build the root `clap::Command` by folding every registered impl's
@@ -2897,6 +2901,7 @@ impl CliCommand for UpdateCommand {
         app.subcommand(
             Command::new(self.name())
                 .about("Update ainb to the latest signed stable release")
+                .visible_alias("upgrade")
                 .arg(
                     clap::Arg::new("yes")
                         .long("yes")

--- a/ainb-tui/crates/ainb-core/src/cli/update.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/update.rs
@@ -40,6 +40,26 @@ pub struct ReleaseAsset {
     pub sha256: String,
 }
 
+impl ReleaseAsset {
+    fn validate(&self) -> Result<()> {
+        let archive_is_file_name = std::path::Path::new(&self.archive)
+            .file_name()
+            .is_some_and(|name| name == self.archive.as_str());
+        if !archive_is_file_name
+            || !self
+                .archive
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+        {
+            bail!("release archive name is unsafe: {}", self.archive);
+        }
+        if self.sha256.len() != 64 || !self.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            bail!("release archive checksum is invalid for {}", self.archive);
+        }
+        Ok(())
+    }
+}
+
 impl ReleaseManifest {
     /// Small constructor retained for integration tests and fixture builders.
     #[must_use]
@@ -95,6 +115,9 @@ pub fn verify_manifest_with_key(
     let manifest: ReleaseManifest =
         serde_json::from_slice(bytes).context("decoding signed release manifest")?;
     manifest.stable_version()?;
+    for asset in &manifest.assets {
+        asset.validate()?;
+    }
     Ok(manifest)
 }
 
@@ -501,9 +524,19 @@ async fn apply_direct_release(manifest: &ReleaseManifest) -> Result<()> {
     make_executable(&replacement)?;
     re_sign_macos_binary(&replacement)?;
     verify_candidate_binary(&replacement)?;
-    std::fs::rename(&replacement, &destination)
-        .with_context(|| format!("replacing {}", destination.display()))?;
-    replace_direct_plugins(temp.path(), parent)?;
+    let mut plugins = DirectPluginSwap::stage(temp.path(), parent)?;
+    if let Some(swap) = plugins.as_mut() {
+        swap.activate()?;
+    }
+    if let Err(error) = std::fs::rename(&replacement, &destination) {
+        if let Some(swap) = plugins.as_mut() {
+            swap.rollback().context("rolling back bundled plugins")?;
+        }
+        return Err(error).with_context(|| format!("replacing {}", destination.display()));
+    }
+    if let Some(swap) = plugins {
+        swap.commit()?;
+    }
     Ok(())
 }
 
@@ -556,43 +589,74 @@ fn re_sign_macos_binary(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn replace_direct_plugins(staging_root: &Path, install_dir: &Path) -> Result<()> {
-    let staged = staging_root.join("plugins");
-    if !staged.is_dir() {
-        return Ok(());
-    }
-    let next = install_dir.join(".ainb-plugins-next");
-    if next.exists() {
-        std::fs::remove_dir_all(&next).with_context(|| format!("clearing {}", next.display()))?;
-    }
-    let copy = Command::new("cp")
-        .args(["-R"])
-        .arg(&staged)
-        .arg(&next)
-        .status()
-        .context("staging bundled plugins")?;
-    if !copy.success() {
-        bail!("staging bundled plugins exited {copy}");
-    }
-    let current = install_dir.join("plugins");
-    let backup = install_dir.join(".ainb-plugins-previous");
-    if backup.exists() {
-        std::fs::remove_dir_all(&backup)
-            .with_context(|| format!("clearing {}", backup.display()))?;
-    }
-    if current.exists() {
-        std::fs::rename(&current, &backup).context("backing up bundled plugins")?;
-    }
-    if let Err(error) = std::fs::rename(&next, &current) {
-        if backup.exists() {
-            let _ = std::fs::rename(&backup, &current);
+struct DirectPluginSwap {
+    current: PathBuf,
+    next: PathBuf,
+    backup: PathBuf,
+}
+
+impl DirectPluginSwap {
+    fn stage(staging_root: &Path, install_dir: &Path) -> Result<Option<Self>> {
+        let staged = staging_root.join("plugins");
+        if !staged.is_dir() {
+            return Ok(None);
         }
-        return Err(error).context("activating bundled plugins");
+        let next = install_dir.join(".ainb-plugins-next");
+        if next.exists() {
+            std::fs::remove_dir_all(&next)
+                .with_context(|| format!("clearing {}", next.display()))?;
+        }
+        let copy = Command::new("cp")
+            .args(["-R"])
+            .arg(&staged)
+            .arg(&next)
+            .status()
+            .context("staging bundled plugins")?;
+        if !copy.success() {
+            bail!("staging bundled plugins exited {copy}");
+        }
+        Ok(Some(Self {
+            current: install_dir.join("plugins"),
+            next,
+            backup: install_dir.join(".ainb-plugins-previous"),
+        }))
     }
-    if backup.exists() {
-        std::fs::remove_dir_all(&backup).context("removing previous bundled plugins")?;
+
+    fn activate(&mut self) -> Result<()> {
+        if self.backup.exists() {
+            std::fs::remove_dir_all(&self.backup)
+                .with_context(|| format!("clearing {}", self.backup.display()))?;
+        }
+        if self.current.exists() {
+            std::fs::rename(&self.current, &self.backup).context("backing up bundled plugins")?;
+        }
+        if let Err(error) = std::fs::rename(&self.next, &self.current) {
+            if self.backup.exists() {
+                let _ = std::fs::rename(&self.backup, &self.current);
+            }
+            return Err(error).context("activating bundled plugins");
+        }
+        Ok(())
     }
-    Ok(())
+
+    fn rollback(&mut self) -> Result<()> {
+        if self.current.exists() {
+            std::fs::remove_dir_all(&self.current)
+                .with_context(|| format!("removing replacement {}", self.current.display()))?;
+        }
+        if self.backup.exists() {
+            std::fs::rename(&self.backup, &self.current).context("restoring bundled plugins")?;
+        }
+        Ok(())
+    }
+
+    fn commit(self) -> Result<()> {
+        if self.backup.exists() {
+            std::fs::remove_dir_all(&self.backup)
+                .with_context(|| format!("removing previous {}", self.backup.display()))?;
+        }
+        Ok(())
+    }
 }
 
 fn canonical_eq(left: &Path, right: &Path) -> bool {
@@ -700,4 +764,34 @@ pub fn disable_schedule() -> Result<()> {
 #[must_use]
 pub fn cached_state() -> Option<ReleaseState> {
     state_path().ok().and_then(|path| ReleaseState::load_from(&path).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_swap_rolls_back_when_binary_activation_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let staging = temp.path().join("staging");
+        let install = temp.path().join("install");
+        std::fs::create_dir_all(staging.join("plugins")).unwrap();
+        std::fs::create_dir_all(install.join("plugins")).unwrap();
+        std::fs::write(staging.join("plugins/new-plugin"), "new").unwrap();
+        std::fs::write(install.join("plugins/old-plugin"), "old").unwrap();
+
+        let mut swap = DirectPluginSwap::stage(&staging, &install).unwrap().unwrap();
+        swap.activate().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(install.join("plugins/new-plugin")).unwrap(),
+            "new"
+        );
+
+        swap.rollback().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(install.join("plugins/old-plugin")).unwrap(),
+            "old"
+        );
+        assert!(!install.join("plugins/new-plugin").exists());
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/update.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/update.rs
@@ -1,0 +1,703 @@
+//! Release discovery and self-update state.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use ainb_plugin_notifyd::osnotify::Transport;
+use anyhow::{Context, Result, bail};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::cli::OutputFormat;
+
+const RELEASE_DOWNLOAD_ROOT: &str =
+    "https://github.com/stevengonsalvez/agents-in-a-box/releases/latest/download";
+const RELEASE_SIGNING_PUBLIC_KEY_B64: &str = "2diG6eoKmUWKOk3XULwefjwKb5IIYTZA4xmNNA8Z6uk=";
+const LAUNCHD_LABEL: &str = "com.agentsinabox.release-check";
+const SYSTEMD_STEM: &str = "com.agentsinabox.release-check";
+
+/// Signed release metadata fetched from the current stable GitHub release.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseManifest {
+    /// Stable semantic version without a leading `v`.
+    pub version: String,
+    /// Immutable archive metadata for each supported target.
+    #[serde(default)]
+    pub assets: Vec<ReleaseAsset>,
+}
+
+/// One signed release archive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseAsset {
+    /// Rust target triple for the archive.
+    pub target: String,
+    /// Release asset file name.
+    pub archive: String,
+    /// SHA-256 of the archive, lowercase hexadecimal.
+    pub sha256: String,
+}
+
+impl ReleaseManifest {
+    /// Small constructor retained for integration tests and fixture builders.
+    #[must_use]
+    pub fn for_test(version: &str) -> Self {
+        Self {
+            version: version.to_string(),
+            assets: Vec::new(),
+        }
+    }
+
+    fn stable_version(&self) -> Result<Version> {
+        let version = Version::parse(self.version.trim_start_matches('v'))
+            .with_context(|| format!("invalid release version `{}`", self.version))?;
+        if !version.pre.is_empty() {
+            bail!("prerelease `{version}` is not eligible for stable updates");
+        }
+        Ok(version)
+    }
+
+    fn asset_for_current_platform(&self) -> Result<&ReleaseAsset> {
+        let target = current_target()?;
+        self.assets
+            .iter()
+            .find(|asset| asset.target == target)
+            .with_context(|| format!("release {} has no archive for {target}", self.version))
+    }
+}
+
+/// Verify a detached base64 Ed25519 signature and decode its JSON manifest.
+pub fn verify_manifest(bytes: &[u8], signature_b64: &str) -> Result<ReleaseManifest> {
+    verify_manifest_with_key(bytes, signature_b64, RELEASE_SIGNING_PUBLIC_KEY_B64)
+}
+
+/// Test seam for verifying a manifest under an explicit encoded public key.
+pub fn verify_manifest_with_key(
+    bytes: &[u8],
+    signature_b64: &str,
+    public_key_b64: &str,
+) -> Result<ReleaseManifest> {
+    let key_bytes = STANDARD
+        .decode(public_key_b64.trim())
+        .context("decoding Ed25519 release public key")?;
+    let key_bytes: [u8; 32] = key_bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("release public key must be 32 bytes"))?;
+    let key = VerifyingKey::from_bytes(&key_bytes).context("parsing Ed25519 release public key")?;
+    let signature_bytes =
+        STANDARD.decode(signature_b64.trim()).context("decoding release signature")?;
+    let signature =
+        Signature::from_slice(&signature_bytes).context("parsing Ed25519 release signature")?;
+    key.verify(bytes, &signature)
+        .context("release manifest signature does not match")?;
+    let manifest: ReleaseManifest =
+        serde_json::from_slice(bytes).context("decoding signed release manifest")?;
+    manifest.stable_version()?;
+    Ok(manifest)
+}
+
+/// Release availability relative to the running Ainb binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateAvailability {
+    /// A strictly newer stable release is available.
+    Available,
+    /// The running release equals or exceeds the latest stable release.
+    CurrentOrNewer,
+}
+
+/// Durable result of the last successful release check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseState {
+    /// Epoch milliseconds of the successful check.
+    pub checked_at_ms: i64,
+    /// Latest stable version returned by the release source.
+    pub latest_version: String,
+    /// Availability relative to the running binary.
+    pub availability: UpdateAvailability,
+    /// Latest version when an update may safely be installed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_version: Option<String>,
+}
+
+impl ReleaseState {
+    /// Derive durable availability from the running version and release manifest.
+    pub fn from_manifest(
+        local_version: &str,
+        manifest: &ReleaseManifest,
+        checked_at_ms: i64,
+    ) -> Result<Self> {
+        let local = Version::parse(local_version.trim_start_matches('v'))
+            .with_context(|| format!("invalid local version `{local_version}`"))?;
+        let latest = manifest.stable_version()?;
+        let availability = if latest > local {
+            UpdateAvailability::Available
+        } else {
+            UpdateAvailability::CurrentOrNewer
+        };
+        Ok(Self {
+            checked_at_ms,
+            latest_version: latest.to_string(),
+            available_version: (availability == UpdateAvailability::Available)
+                .then(|| latest.to_string()),
+            availability,
+        })
+    }
+
+    /// Persist this complete release-check result without exposing torn JSON to readers.
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        crate::fleet::plumbing::atomic::write_atomic_json(path, self)
+    }
+
+    /// Read one previously persisted release-check result.
+    pub fn load_from(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("reading update state {}", path.display()))?;
+        serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing update state {}", path.display()))
+    }
+}
+
+/// OS timer definition for the daily, short-lived release checker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UpdateSchedule {
+    interval_secs: u64,
+}
+
+impl UpdateSchedule {
+    /// Daily release check cadence.
+    #[must_use]
+    pub const fn daily() -> Self {
+        Self {
+            interval_secs: 24 * 60 * 60,
+        }
+    }
+
+    /// Render the macOS LaunchAgent job. The shell resolves `ainb` at each run.
+    #[must_use]
+    pub fn launchd_plist(self, ainb_bin: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.agentsinabox.release-check</string>
+  <key>ProgramArguments</key><array>
+    <string>/bin/sh</string><string>-c</string><string>exec {ainb_bin} update check --scheduled</string>
+  </array>
+  <key>StartInterval</key><integer>{}</integer>
+  <key>RunAtLoad</key><true/>
+  <key>EnvironmentVariables</key><dict><key>PATH</key><string>{}</string></dict>
+</dict></plist>
+"#,
+            self.interval_secs,
+            crate::fleet::unit_program::unit_path_env(),
+        )
+    }
+
+    /// Render the Linux systemd user timer. Persistent catch-up handles sleep.
+    #[must_use]
+    pub fn systemd_timer(self) -> String {
+        format!(
+            "[Unit]\nDescription=ainb release check timer\n\n[Timer]\nOnUnitActiveSec={}\nPersistent=true\nUnit=com.agentsinabox.release-check.service\n\n[Install]\nWantedBy=timers.target\n",
+            self.interval_secs
+        )
+    }
+
+    /// Render the Linux systemd user oneshot service.
+    #[must_use]
+    pub fn systemd_service(self, ainb_bin: &str) -> String {
+        format!(
+            "[Unit]\nDescription=ainb release check\n\n[Service]\nType=oneshot\nEnvironment=\"PATH={}\"\nExecStart=/bin/sh -c 'exec {} update check --scheduled'\n",
+            crate::fleet::unit_program::unit_path_env(),
+            ainb_bin,
+        )
+    }
+}
+
+/// Dispatch `ainb update` and its release-check scheduler controls.
+pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
+    match matches.subcommand() {
+        Some(("check", sub)) => check_command(sub.get_flag("scheduled"), format).await,
+        Some(("status", _)) => status_command(format),
+        Some(("schedule", sub)) => schedule_command(sub),
+        None => apply_command(matches.get_flag("yes")).await,
+        _ => unreachable!("clap constrains update subcommands"),
+    }
+}
+
+async fn check_command(scheduled: bool, format: OutputFormat) -> Result<()> {
+    let state = fetch_release_state().await?;
+    state.save_to(&state_path()?)?;
+    if scheduled {
+        notify_once_for_available(&state)?;
+    }
+    render_state(&state, format);
+    Ok(())
+}
+
+fn status_command(format: OutputFormat) -> Result<()> {
+    let path = state_path()?;
+    match ReleaseState::load_from(&path) {
+        Ok(state) => render_state(&state, format),
+        Err(e)
+            if e.downcast_ref::<std::io::Error>()
+                .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound) =>
+        {
+            match format {
+                OutputFormat::Json => println!(
+                    r#"{{"checked":false,"scheduler_enabled":{}}}"#,
+                    schedule_is_enabled()
+                ),
+                _ => println!("No release check yet. Run `ainb update check`."),
+            }
+        }
+        Err(e) => return Err(e),
+    }
+    Ok(())
+}
+
+fn schedule_command(matches: &clap::ArgMatches) -> Result<()> {
+    match matches.subcommand() {
+        Some(("enable", _)) => enable_schedule(),
+        Some(("disable", _)) => disable_schedule(),
+        Some(("status", _)) => {
+            println!(
+                "release checker: {}",
+                if schedule_is_enabled() {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            );
+            Ok(())
+        }
+        _ => unreachable!("clap constrains schedule subcommands"),
+    }
+}
+
+async fn apply_command(yes: bool) -> Result<()> {
+    let manifest = fetch_release_manifest().await?;
+    let state = ReleaseState::from_manifest(
+        env!("CARGO_PKG_VERSION"),
+        &manifest,
+        chrono::Utc::now().timestamp_millis(),
+    )?;
+    state.save_to(&state_path()?)?;
+    if state.availability != UpdateAvailability::Available {
+        println!("ainb {} is current.", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+    let version = state.available_version.as_deref().expect("available version");
+    if !yes {
+        bail!("ainb {version} is available. Re-run with `ainb update --yes` to install it.");
+    }
+    let owner = InstallOwner::detect()?;
+    owner.apply(&manifest).await?;
+    println!("ainb update started for {version}; restart ainb to use it.");
+    Ok(())
+}
+
+async fn fetch_release_state() -> Result<ReleaseState> {
+    let manifest = fetch_release_manifest().await?;
+    ReleaseState::from_manifest(
+        env!("CARGO_PKG_VERSION"),
+        &manifest,
+        chrono::Utc::now().timestamp_millis(),
+    )
+}
+
+async fn fetch_release_manifest() -> Result<ReleaseManifest> {
+    let client = reqwest::Client::builder()
+        .user_agent(format!("ainb/{} update-check", env!("CARGO_PKG_VERSION")))
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .context("building GitHub release client")?;
+    let manifest_url = format!("{RELEASE_DOWNLOAD_ROOT}/release-manifest.json");
+    let signature_url = format!("{RELEASE_DOWNLOAD_ROOT}/release-manifest.sig");
+    let manifest_bytes = client
+        .get(manifest_url)
+        .send()
+        .await
+        .context("downloading signed release manifest")?
+        .error_for_status()
+        .context("signed release manifest request failed")?
+        .bytes()
+        .await
+        .context("reading signed release manifest")?;
+    let signature = client
+        .get(signature_url)
+        .send()
+        .await
+        .context("downloading release manifest signature")?
+        .error_for_status()
+        .context("release manifest signature request failed")?
+        .text()
+        .await
+        .context("reading release manifest signature")?;
+    verify_manifest(&manifest_bytes, &signature)
+}
+
+fn state_path() -> Result<PathBuf> {
+    Ok(crate::fleet::plumbing::paths::ainb_home()?.join("update-state.json"))
+}
+
+fn notified_version_path() -> Result<PathBuf> {
+    Ok(crate::fleet::plumbing::paths::ainb_home()?.join("update-notified-version"))
+}
+
+fn notify_once_for_available(state: &ReleaseState) -> Result<()> {
+    let Some(version) = state.available_version.as_deref() else {
+        return Ok(());
+    };
+    let path = notified_version_path()?;
+    if std::fs::read_to_string(&path).ok().as_deref().map(str::trim) == Some(version) {
+        return Ok(());
+    }
+    ainb_plugin_notifyd::osnotify::NativeTransport.emit(
+        "ainb update available",
+        &format!("ainb {version} is ready. Run ainb update --yes, then restart."),
+    );
+    crate::fleet::plumbing::atomic::write_atomic(&path, version.as_bytes())
+}
+
+fn render_state(state: &ReleaseState, format: OutputFormat) {
+    match format {
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string(state).expect("serializable update state")
+        ),
+        _ => match state.availability {
+            UpdateAvailability::Available => println!(
+                "ainb {} available (running {})",
+                state.available_version.as_deref().unwrap_or(&state.latest_version),
+                env!("CARGO_PKG_VERSION")
+            ),
+            UpdateAvailability::CurrentOrNewer => {
+                println!("ainb {} is current.", env!("CARGO_PKG_VERSION"))
+            }
+        },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallOwner {
+    Homebrew,
+    Cargo,
+    Direct,
+}
+
+impl InstallOwner {
+    fn detect() -> Result<Self> {
+        let exe = std::env::current_exe().context("resolving ainb executable")?;
+        if Command::new("brew")
+            .args(["list", "--versions", "ainb"])
+            .output()
+            .ok()
+            .is_some_and(|out| out.status.success())
+        {
+            return Ok(Self::Homebrew);
+        }
+        if exe.parent().is_some_and(|parent| parent.ends_with(".cargo/bin")) {
+            return Ok(Self::Cargo);
+        }
+        let home = dirs::home_dir();
+        let direct = [
+            PathBuf::from("/usr/local/bin/ainb"),
+            home.unwrap_or_default().join(".local/bin/ainb"),
+        ];
+        if direct.iter().any(|path| canonical_eq(path, &exe)) {
+            return Ok(Self::Direct);
+        }
+        bail!(
+            "ainb installation is unmanaged; reinstall with the curl installer or use your package manager"
+        )
+    }
+
+    async fn apply(self, manifest: &ReleaseManifest) -> Result<()> {
+        if self == Self::Direct {
+            return apply_direct_release(manifest).await;
+        }
+        let version = manifest.stable_version()?.to_string();
+        let mut command = match self {
+            Self::Homebrew => {
+                let mut c = Command::new("brew");
+                c.args(["upgrade", "ainb"]);
+                c
+            }
+            Self::Cargo => {
+                let mut c = Command::new("cargo");
+                c.args([
+                    "install",
+                    "--git",
+                    "https://github.com/stevengonsalvez/agents-in-a-box",
+                    "--tag",
+                    &format!("v{version}"),
+                    "--locked",
+                    "--force",
+                    "ainb",
+                ]);
+                c
+            }
+            Self::Direct => unreachable!("handled above"),
+        };
+        let status = command.status().context("running ainb installer")?;
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("ainb update command exited {status}")
+        }
+    }
+}
+
+async fn apply_direct_release(manifest: &ReleaseManifest) -> Result<()> {
+    let asset = manifest.asset_for_current_platform()?;
+    let url = format!(
+        "https://github.com/stevengonsalvez/agents-in-a-box/releases/download/v{}/{}",
+        manifest.stable_version()?,
+        asset.archive,
+    );
+    let bytes = reqwest::Client::builder()
+        .user_agent(format!("ainb/{} updater", env!("CARGO_PKG_VERSION")))
+        .timeout(std::time::Duration::from_secs(90))
+        .build()
+        .context("building archive download client")?
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("downloading {}", asset.archive))?
+        .error_for_status()
+        .with_context(|| format!("release archive request failed for {}", asset.archive))?
+        .bytes()
+        .await
+        .context("reading release archive")?;
+    let actual_sha = format!("{:x}", Sha256::digest(&bytes));
+    if !actual_sha.eq_ignore_ascii_case(asset.sha256.trim()) {
+        bail!("release archive checksum mismatch for {}", asset.archive);
+    }
+
+    let temp = tempfile::tempdir().context("creating release staging directory")?;
+    let archive = temp.path().join(&asset.archive);
+    std::fs::write(&archive, &bytes).context("staging verified release archive")?;
+    let unpack = Command::new("tar")
+        .args(["-xzf"])
+        .arg(&archive)
+        .arg("-C")
+        .arg(temp.path())
+        .status()
+        .context("extracting verified release archive")?;
+    if !unpack.success() {
+        bail!("extracting verified release archive exited {unpack}");
+    }
+
+    let staged_binary = temp.path().join("ainb");
+    verify_candidate_binary(&staged_binary)?;
+    let destination = std::env::current_exe().context("resolving installed ainb binary")?;
+    let parent = destination.parent().context("resolving ainb install directory")?;
+    let replacement = parent.join(".ainb-update-next");
+    std::fs::copy(&staged_binary, &replacement)
+        .with_context(|| format!("staging replacement at {}", replacement.display()))?;
+    make_executable(&replacement)?;
+    re_sign_macos_binary(&replacement)?;
+    verify_candidate_binary(&replacement)?;
+    std::fs::rename(&replacement, &destination)
+        .with_context(|| format!("replacing {}", destination.display()))?;
+    replace_direct_plugins(temp.path(), parent)?;
+    Ok(())
+}
+
+fn current_target() -> Result<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
+        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
+        (os, arch) => bail!("no signed ainb release archive for {arch}-{os}"),
+    }
+}
+
+fn verify_candidate_binary(path: &Path) -> Result<()> {
+    if !path.is_file() {
+        bail!("verified release archive did not contain ainb binary");
+    }
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("running candidate {}", path.display()))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!("candidate ainb binary failed its version check")
+    }
+}
+
+fn make_executable(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
+
+fn re_sign_macos_binary(path: &Path) -> Result<()> {
+    if cfg!(target_os = "macos") {
+        let status = Command::new("codesign")
+            .args(["--force", "--sign", "-"])
+            .arg(path)
+            .status()
+            .context("ad-hoc signing replacement ainb binary")?;
+        if !status.success() {
+            bail!("codesign replacement binary exited {status}");
+        }
+    }
+    Ok(())
+}
+
+fn replace_direct_plugins(staging_root: &Path, install_dir: &Path) -> Result<()> {
+    let staged = staging_root.join("plugins");
+    if !staged.is_dir() {
+        return Ok(());
+    }
+    let next = install_dir.join(".ainb-plugins-next");
+    if next.exists() {
+        std::fs::remove_dir_all(&next).with_context(|| format!("clearing {}", next.display()))?;
+    }
+    let copy = Command::new("cp")
+        .args(["-R"])
+        .arg(&staged)
+        .arg(&next)
+        .status()
+        .context("staging bundled plugins")?;
+    if !copy.success() {
+        bail!("staging bundled plugins exited {copy}");
+    }
+    let current = install_dir.join("plugins");
+    let backup = install_dir.join(".ainb-plugins-previous");
+    if backup.exists() {
+        std::fs::remove_dir_all(&backup)
+            .with_context(|| format!("clearing {}", backup.display()))?;
+    }
+    if current.exists() {
+        std::fs::rename(&current, &backup).context("backing up bundled plugins")?;
+    }
+    if let Err(error) = std::fs::rename(&next, &current) {
+        if backup.exists() {
+            let _ = std::fs::rename(&backup, &current);
+        }
+        return Err(error).context("activating bundled plugins");
+    }
+    if backup.exists() {
+        std::fs::remove_dir_all(&backup).context("removing previous bundled plugins")?;
+    }
+    Ok(())
+}
+
+fn canonical_eq(left: &Path, right: &Path) -> bool {
+    std::fs::canonicalize(left).ok() == std::fs::canonicalize(right).ok()
+}
+
+fn launchd_path() -> Option<PathBuf> {
+    dirs::home_dir()
+        .map(|home| home.join("Library/LaunchAgents").join(format!("{LAUNCHD_LABEL}.plist")))
+}
+
+fn systemd_paths() -> Option<(PathBuf, PathBuf)> {
+    dirs::home_dir().map(|home| {
+        let dir = home.join(".config/systemd/user");
+        (
+            dir.join(format!("{SYSTEMD_STEM}.service")),
+            dir.join(format!("{SYSTEMD_STEM}.timer")),
+        )
+    })
+}
+
+/// Whether the operating-system daily release checker is installed.
+#[must_use]
+pub fn schedule_is_enabled() -> bool {
+    if cfg!(target_os = "macos") {
+        launchd_path().is_some_and(|path| path.exists())
+    } else {
+        systemd_paths().is_some_and(|(_, timer)| timer.exists())
+    }
+}
+
+/// Install the daily release checker if it is not already installed.
+pub fn ensure_schedule() -> Result<()> {
+    if schedule_is_enabled() {
+        return Ok(());
+    }
+    let schedule = UpdateSchedule::daily();
+    if cfg!(target_os = "macos") {
+        let path = launchd_path().context("resolving LaunchAgents path")?;
+        crate::fleet::plumbing::atomic::write_atomic(
+            &path,
+            schedule.launchd_plist("ainb").as_bytes(),
+        )?;
+        let _ = Command::new("launchctl").args(["unload", &path.display().to_string()]).output();
+        let _ = Command::new("launchctl").args(["load", &path.display().to_string()]).output();
+    } else {
+        let (service, timer) = systemd_paths().context("resolving systemd user directory")?;
+        crate::fleet::plumbing::atomic::write_atomic(
+            &service,
+            schedule.systemd_service("ainb").as_bytes(),
+        )?;
+        crate::fleet::plumbing::atomic::write_atomic(&timer, schedule.systemd_timer().as_bytes())?;
+        let _ = Command::new("systemctl").args(["--user", "daemon-reload"]).output();
+        let _ = Command::new("systemctl")
+            .args([
+                "--user",
+                "enable",
+                "--now",
+                &format!("{SYSTEMD_STEM}.timer"),
+            ])
+            .output();
+        let _ = Command::new("systemctl")
+            .args(["--user", "start", &format!("{SYSTEMD_STEM}.service")])
+            .output();
+    }
+    Ok(())
+}
+
+fn enable_schedule() -> Result<()> {
+    ensure_schedule()?;
+    println!("Daily ainb release check enabled.");
+    Ok(())
+}
+
+/// Remove the daily release checker and its OS registration.
+pub fn disable_schedule() -> Result<()> {
+    if cfg!(target_os = "macos") {
+        if let Some(path) = launchd_path().filter(|path| path.exists()) {
+            let _ =
+                Command::new("launchctl").args(["unload", &path.display().to_string()]).output();
+            std::fs::remove_file(path).context("removing release-check LaunchAgent")?;
+        }
+    } else if let Some((service, timer)) = systemd_paths() {
+        let _ = Command::new("systemctl")
+            .args([
+                "--user",
+                "disable",
+                "--now",
+                &format!("{SYSTEMD_STEM}.timer"),
+            ])
+            .output();
+        for path in [timer, service] {
+            if path.exists() {
+                std::fs::remove_file(&path)
+                    .with_context(|| format!("removing {}", path.display()))?;
+            }
+        }
+        let _ = Command::new("systemctl").args(["--user", "daemon-reload"]).output();
+    }
+    println!("Daily ainb release check disabled.");
+    Ok(())
+}
+
+/// Read the last verified update result when one exists.
+#[must_use]
+pub fn cached_state() -> Option<ReleaseState> {
+    state_path().ok().and_then(|path| ReleaseState::load_from(&path).ok())
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -70,6 +70,8 @@ pub enum DaemonKind {
     HangarDaemon,
     /// Headroom context proxy (`headroom proxy`), when ainb manages one.
     HeadroomProxy,
+    /// Daily short-lived signed release checker.
+    ReleaseChecker,
 }
 
 impl DaemonKind {
@@ -85,6 +87,7 @@ impl DaemonKind {
             Self::McpPool => "mcp-pool",
             Self::HangarDaemon => "hangar-daemon",
             Self::HeadroomProxy => "headroom-proxy",
+            Self::ReleaseChecker => "release-checker",
         }
     }
 
@@ -100,6 +103,7 @@ impl DaemonKind {
             Self::McpPool => "mcp pool",
             Self::HangarDaemon => "hangar daemon",
             Self::HeadroomProxy => "headroom proxy",
+            Self::ReleaseChecker => "release checker",
         }
     }
 }
@@ -1031,6 +1035,42 @@ pub fn probe_headroom_proxy() -> DaemonStatus {
     }
 }
 
+/// Probe the daily OS release-check registration.
+///
+/// This row deliberately models a scheduled oneshot, not a long-running
+/// process. `Running` means the supervisor owns a daily job; the last verified
+/// check time remains visible as daemon activity.
+#[must_use]
+pub fn probe_release_checker() -> DaemonStatus {
+    let kind = DaemonKind::ReleaseChecker;
+    if !crate::cli::update::schedule_is_enabled() {
+        return DaemonStatus::stopped(kind, "daily release check is disabled".to_string());
+    }
+    let cached = crate::cli::update::cached_state();
+    DaemonStatus {
+        connected: true,
+        channel: Some(if cfg!(target_os = "macos") {
+            "launchd daily timer".to_string()
+        } else {
+            "systemd user timer".to_string()
+        }),
+        last_activity_at: cached.as_ref().map(|state| state.checked_at_ms),
+        reason: cached
+            .as_ref()
+            .map(|state| match state.availability {
+                crate::cli::update::UpdateAvailability::Available => format!(
+                    "daily signed check enabled, ainb {} available",
+                    state.available_version.as_deref().unwrap_or(&state.latest_version)
+                ),
+                crate::cli::update::UpdateAvailability::CurrentOrNewer => {
+                    "daily signed check enabled, current".to_string()
+                }
+            })
+            .unwrap_or_else(|| "daily signed check enabled, awaiting first check".to_string()),
+        ..DaemonStatus::running(kind)
+    }
+}
+
 /// Append the CAUSE to a bridge row that is not running, when the bridge could
 /// not have started at all.
 ///
@@ -1091,6 +1131,7 @@ pub fn collect_socket_daemons() -> Vec<DaemonStatus> {
         probe_mcp_pool(),
         probe_hangar_daemon(),
         probe_headroom_proxy(),
+        probe_release_checker(),
     ]
 }
 
@@ -2195,6 +2236,7 @@ mod tests {
                 DaemonKind::McpPool,
                 DaemonKind::HangarDaemon,
                 DaemonKind::HeadroomProxy,
+                DaemonKind::ReleaseChecker,
             ]
         );
     }
@@ -2212,6 +2254,7 @@ mod tests {
             DaemonKind::McpPool,
             DaemonKind::HangarDaemon,
             DaemonKind::HeadroomProxy,
+            DaemonKind::ReleaseChecker,
         ];
         let ids: std::collections::HashSet<&str> = kinds.iter().map(|k| k.id()).collect();
         assert_eq!(ids.len(), kinds.len(), "daemon ids must be unique");

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -179,6 +179,9 @@ async fn tokio_main() -> Result<()> {
                 // binary. Without it an upgraded ainb kept talking to the
                 // pre-upgrade notifyd until someone restarted it by hand.
                 fleet::daemons::ensure_daemons_current();
+                if let Err(error) = cli::update::ensure_schedule() {
+                    tracing::warn!(error = %error, "failed to install daily release checker");
+                }
             }
 
             // Best-effort: drop shipped default presets into
@@ -201,6 +204,13 @@ async fn tokio_main() -> Result<()> {
 
             let mut app_state = App::new();
             app_state.init().await;
+            if let Some(state) = cli::update::cached_state() {
+                if let Some(version) = state.available_version {
+                    app_state.state.add_info_notification(format!(
+                        "ainb {version} available. Run `ainb update --yes`, then restart."
+                    ));
+                }
+            }
 
             // Migrate legacy local-path favorites to their remote indicator. A
             // star is always a remote pointer now; local-path entries from

--- a/ainb-tui/crates/ainb-core/tests/update_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/update_cli.rs
@@ -4,15 +4,21 @@ use ainb::cli::{registry::CommandRegistry, root_clap_command};
 
 #[test]
 fn update_cli_exposes_apply_check_status_and_schedule() {
-    let app = CommandRegistry::built_ins().build_clap(root_clap_command());
+    let registry = CommandRegistry::built_ins();
+    let app = registry.build_clap(root_clap_command());
 
     for argv in [
         vec!["ainb", "update"],
         vec!["ainb", "update", "--yes"],
+        vec!["ainb", "upgrade", "--yes"],
         vec!["ainb", "update", "check", "--scheduled"],
         vec!["ainb", "update", "status", "--format", "json"],
         vec!["ainb", "update", "schedule", "enable"],
     ] {
         app.clone().try_get_matches_from(argv).unwrap();
     }
+
+    assert!(registry.find("upgrade").is_some());
+    let alias_matches = app.clone().try_get_matches_from(["ainb", "upgrade", "--yes"]).unwrap();
+    assert_eq!(alias_matches.subcommand_name(), Some("update"));
 }

--- a/ainb-tui/crates/ainb-core/tests/update_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/update_cli.rs
@@ -1,0 +1,18 @@
+//! Public clap surface for `ainb update`.
+
+use ainb::cli::{registry::CommandRegistry, root_clap_command};
+
+#[test]
+fn update_cli_exposes_apply_check_status_and_schedule() {
+    let app = CommandRegistry::built_ins().build_clap(root_clap_command());
+
+    for argv in [
+        vec!["ainb", "update"],
+        vec!["ainb", "update", "--yes"],
+        vec!["ainb", "update", "check", "--scheduled"],
+        vec!["ainb", "update", "status", "--format", "json"],
+        vec!["ainb", "update", "schedule", "enable"],
+    ] {
+        app.clone().try_get_matches_from(argv).unwrap();
+    }
+}

--- a/ainb-tui/crates/ainb-core/tests/update_domain.rs
+++ b/ainb-tui/crates/ainb-core/tests/update_domain.rs
@@ -1,0 +1,86 @@
+//! Domain behavior for signed Ainb releases and daily update schedules.
+
+use ainb::cli::update::{
+    ReleaseManifest, ReleaseState, UpdateAvailability, UpdateSchedule, verify_manifest_with_key,
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use ed25519_dalek::{Signer, SigningKey};
+
+#[test]
+fn stable_manifest_newer_than_local_is_available() {
+    let manifest = ReleaseManifest::for_test("1.23.0");
+    let state = ReleaseState::from_manifest("1.22.5", &manifest, 1_700_000_000_000).unwrap();
+
+    assert_eq!(state.availability, UpdateAvailability::Available);
+    assert_eq!(state.available_version.as_deref(), Some("1.23.0"));
+}
+
+#[test]
+fn prerelease_manifest_is_rejected() {
+    let manifest = ReleaseManifest::for_test("1.23.0-beta.1");
+
+    assert!(ReleaseState::from_manifest("1.22.5", &manifest, 1_700_000_000_000).is_err());
+}
+
+#[test]
+fn signed_manifest_requires_the_matching_ed25519_public_key() {
+    let signing_key = SigningKey::from_bytes(&[7; 32]);
+    let bytes = br#"{"version":"1.23.0","assets":[]}"#;
+    let signature = signing_key.sign(bytes);
+    let verified = verify_manifest_with_key(
+        bytes,
+        &STANDARD.encode(signature.to_bytes()),
+        &STANDARD.encode(signing_key.verifying_key().as_bytes()),
+    )
+    .unwrap();
+
+    assert_eq!(verified.version, "1.23.0");
+    assert!(
+        verify_manifest_with_key(
+            bytes,
+            &STANDARD.encode(signature.to_bytes()),
+            &STANDARD.encode([8; 32])
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn local_newer_than_manifest_never_downgrades() {
+    let manifest = ReleaseManifest::for_test("1.22.5");
+    let state = ReleaseState::from_manifest("1.23.0", &manifest, 1_700_000_000_000).unwrap();
+
+    assert_eq!(state.availability, UpdateAvailability::CurrentOrNewer);
+    assert!(state.available_version.is_none());
+}
+
+#[test]
+fn update_state_round_trips_from_its_own_atomic_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = ReleaseManifest::for_test("1.23.0");
+    let state = ReleaseState::from_manifest("1.22.5", &manifest, 1_700_000_000_000).unwrap();
+    let path = temp.path().join("update-state.json");
+
+    state.save_to(&path).unwrap();
+
+    assert_eq!(ReleaseState::load_from(&path).unwrap(), state);
+}
+
+#[test]
+fn macos_schedule_runs_background_check_daily() {
+    let plist = UpdateSchedule::daily().launchd_plist("ainb");
+
+    assert!(plist.contains("<integer>86400</integer>"));
+    assert!(plist.contains("ainb update check --scheduled"));
+    assert!(plist.contains("<key>RunAtLoad</key>"));
+}
+
+#[test]
+fn linux_schedule_is_persistent_daily_timer() {
+    let timer = UpdateSchedule::daily().systemd_timer();
+    let service = UpdateSchedule::daily().systemd_service("ainb");
+
+    assert!(timer.contains("OnUnitActiveSec=86400"));
+    assert!(timer.contains("Persistent=true"));
+    assert!(service.contains("ainb update check --scheduled"));
+}

--- a/ainb-tui/crates/ainb-core/tests/update_domain.rs
+++ b/ainb-tui/crates/ainb-core/tests/update_domain.rs
@@ -46,6 +46,22 @@ fn signed_manifest_requires_the_matching_ed25519_public_key() {
 }
 
 #[test]
+fn signed_manifest_rejects_unsafe_asset_metadata() {
+    let signing_key = SigningKey::from_bytes(&[9; 32]);
+    let bytes = br#"{"version":"1.23.0","assets":[{"target":"x86_64-unknown-linux-gnu","archive":"../ainb.tar.gz","sha256":"0000000000000000000000000000000000000000000000000000000000000000"}]}"#;
+    let signature = signing_key.sign(bytes);
+
+    assert!(
+        verify_manifest_with_key(
+            bytes,
+            &STANDARD.encode(signature.to_bytes()),
+            &STANDARD.encode(signing_key.verifying_key().as_bytes()),
+        )
+        .is_err()
+    );
+}
+
+#[test]
 fn local_newer_than_manifest_never_downgrades() {
     let manifest = ReleaseManifest::for_test("1.22.5");
     let state = ReleaseState::from_manifest("1.23.0", &manifest, 1_700_000_000_000).unwrap();

--- a/docs/man/ainb.1
+++ b/docs/man/ainb.1
@@ -205,7 +205,7 @@ Subcommands: status, stop
 Start, stop, or restart any ainb daemon
 .br
 Subcommands: list, bridge, notifyd, approve\-broker, atc, fleet\-daemon,
-mcp\-pool, hangar\-daemon, headroom\-proxy
+mcp\-pool, hangar\-daemon, headroom\-proxy, release\-checker
 .TP
 .B ainb mcp
 Shared MCP server pool: daemon / proxy / status / stop / import / install
@@ -230,6 +230,11 @@ RTK (Rust Token Killer): compress CLI output in Claude Code via PreToolUse
 hook
 .br
 Subcommands: status, install, uninstall
+.TP
+.B ainb update
+Update ainb to the latest signed stable release
+.br
+Subcommands: check, status, schedule
 .TP
 .B ainb skill
 Install / remove units across one or more target tools

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -3143,16 +3143,17 @@ Start, stop, or restart any ainb daemon
 Usage: ainb daemon [OPTIONS] <COMMAND>
 
 Commands:
-  list            List every controllable daemon
-  bridge          phone bridge
-  notifyd         notifyd
-  approve-broker  approve broker
-  atc             ATC
-  fleet-daemon    fleet daemon
-  mcp-pool        mcp pool
-  hangar-daemon   hangar daemon
-  headroom-proxy  headroom proxy
-  help            Print this message or the help of the given subcommand(s)
+  list             List every controllable daemon
+  bridge           phone bridge
+  notifyd          notifyd
+  approve-broker   approve broker
+  atc              ATC
+  fleet-daemon     fleet daemon
+  mcp-pool         mcp pool
+  hangar-daemon    hangar daemon
+  headroom-proxy   headroom proxy
+  release-checker  release checker
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -3718,6 +3719,72 @@ $ ainb daemon headroom-proxy stop --help
 Take it down
 
 Usage: ainb daemon headroom-proxy stop [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb daemon release-checker`
+
+release checker
+
+```console
+$ ainb daemon release-checker --help
+release checker
+
+Usage: ainb daemon release-checker [OPTIONS] <COMMAND>
+
+Commands:
+  start    Bring it up
+  restart  Take it down and bring it back up
+  stop     Take it down
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb daemon release-checker start`
+
+Bring it up
+
+```console
+$ ainb daemon release-checker start --help
+Bring it up
+
+Usage: ainb daemon release-checker start [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb daemon release-checker restart`
+
+Take it down and bring it back up
+
+```console
+$ ainb daemon release-checker restart --help
+Take it down and bring it back up
+
+Usage: ainb daemon release-checker restart [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb daemon release-checker stop`
+
+Take it down
+
+```console
+$ ainb daemon release-checker stop --help
+Take it down
+
+Usage: ainb daemon release-checker stop [OPTIONS]
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -6768,6 +6835,130 @@ $ ainb rtk uninstall --help
 Remove the Claude Code hook from ~/.claude/settings.json (rtk init -g --uninstall). Leaves the rtk binary installed.
 
 Usage: ainb rtk uninstall [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+## `ainb update`
+
+Update ainb to the latest signed stable release
+
+```console
+$ ainb update --help
+Update ainb to the latest signed stable release
+
+Usage: ainb update [OPTIONS] [COMMAND]
+
+Commands:
+  check     Check GitHub for the latest stable ainb release
+  status    Show cached update state
+  schedule  Enable, disable, or inspect daily release checks
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -y, --yes              Install without ainb's confirmation prompt
+  -h, --help             Print help
+
+EXAMPLES:
+  ainb update                    Check and install after confirmation
+  ainb update --yes              Install without confirmation
+  ainb update check              Refresh latest stable release state
+  ainb update schedule enable    Enable the daily background check
+```
+
+### `ainb update check`
+
+Check GitHub for the latest stable ainb release
+
+```console
+$ ainb update check --help
+Check GitHub for the latest stable ainb release
+
+Usage: ainb update check [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb update status`
+
+Show cached update state
+
+```console
+$ ainb update status --help
+Show cached update state
+
+Usage: ainb update status [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb update schedule`
+
+Enable, disable, or inspect daily release checks
+
+```console
+$ ainb update schedule --help
+Enable, disable, or inspect daily release checks
+
+Usage: ainb update schedule [OPTIONS] <COMMAND>
+
+Commands:
+  enable   Install the daily OS timer
+  disable  Remove the daily OS timer
+  status   Show timer installation state
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb update schedule enable`
+
+Install the daily OS timer
+
+```console
+$ ainb update schedule enable --help
+Install the daily OS timer
+
+Usage: ainb update schedule enable [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb update schedule disable`
+
+Remove the daily OS timer
+
+```console
+$ ainb update schedule disable --help
+Remove the daily OS timer
+
+Usage: ainb update schedule disable [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb update schedule status`
+
+Show timer installation state
+
+```console
+$ ainb update schedule status --help
+Show timer installation state
+
+Usage: ainb update schedule status [OPTIONS]
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]


### PR DESCRIPTION
## Summary
- add signed stable release manifest verification and direct updater
- schedule daily launchd/systemd release checks and expose Daemons row
- add `ainb update` plus `ainb upgrade` alias

## Validation
- cargo test -p ainb --test update_domain --test update_cli --quiet
- cargo test -p ainb cli::daemon::tests --lib --quiet
- cargo build -p ainb
- actionlint .github/workflows/release.yml