### PR TITLE
docs: correct every published count, rewrite the Why section, prepare ainb.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ agents-in-a-box/
 │   └── reference/              #   Architecture deep-dive, glossary
 │
 ├── website/                    # Website source (Astro + Starlight)
-│   └── BRIEF.md                #   Design instruction for stevengonsalvez.github.io
+│   └── BRIEF.md                #   Original design brief (historical)      
 │
 └── .github/workflows/
     ├── ci.yml                  #   Rust CI (fmt, clippy, test, deny, machete)
@@ -635,7 +635,7 @@ and `.agents/goals/ainb-skill-manager-v1.2-rollup-plan.md`.
 
 ## Links
 
-- [Website](https://stevengonsalvez.github.io/agents-in-a-box/)
+- [Website](https://ainb.app/)
 - [Releases](https://github.com/stevengonsalvez/agents-in-a-box/releases)
 - [Homebrew Tap](https://github.com/stevengonsalvez/homebrew-agents-in-a-box)
 - [Issues](https://github.com/stevengonsalvez/agents-in-a-box/issues)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 </p>
 
 <p align="center">
-  <code>115 Rust Modules</code> · <code>91 Skills</code> · <code>37 Agents</code> · <code>9 AI Tools</code> · <code>Knowledge Graph</code>
+  <code>34 Rust Crates</code> · <code>94 Skills</code> · <code>16 Agents</code> · <code>9 AI Tools</code> · <code>Knowledge Graph</code>
 </p>
 
 ---
@@ -55,7 +55,7 @@ separate, standalone repo — `ainb` consumes it as a pinned external source.
 |---|---|
 | **stevengonsalvez/agents-in-a-box** (this repo) | The `ainb` TUI/CLI unit manager (Rust workspace), the v2 plugin system, and the docs. |
 | **[stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory)** | `reflect` — the long-term memory engine (GraphRAG + QMD) + its Claude Code plugin, extracted from this monorepo. Engine install: `uv tool install --upgrade 'git+https://github.com/stevengonsalvez/ainb-reflect-memory.git[graph]'`. |
-| **[stevengonsalvez/ainb-toolkit](https://github.com/stevengonsalvez/ainb-toolkit)** | The canonical home for the 91 curated skills, 37 agents, workflows, utilities, the `external-dependencies.yaml` manifest, the `bootstrap.js` legacy installer, and the generated `catalog.yaml`. `ainb` browses + installs from it; the release CI pins a tag of it to generate the curated `catalog-index.json`. |
+| **[stevengonsalvez/ainb-toolkit](https://github.com/stevengonsalvez/ainb-toolkit)** | The canonical home for the 94 curated skills, 16 agents, workflows, utilities, the `external-dependencies.yaml` manifest, the `bootstrap.js` legacy installer, and the generated `catalog.yaml`. `ainb` browses + installs from it; the release CI pins a tag of it to generate the curated `catalog-index.json`. |
 
 <p align="center">
   <img src="docs/assets/screenshots/dashboard-session.png" alt="ainb TUI — live session dashboard with multi-workspace sidebar" width="900">
@@ -75,8 +75,8 @@ separate, standalone repo — `ainb` consumes it as a pinned external source.
 
 | Component | What it does | Scale |
 |-----------|-------------|-------|
-| **[ainb TUI](#ainb--terminal-ui)** | Rust terminal app for managing Claude Code sessions | 115 modules |
-| **[Toolkit](#toolkit)** | Portable skills, agents, and workflows for AI coding tools | 91 skills, 37 agents |
+| **[ainb TUI](#ainb--terminal-ui)** | Rust terminal app for managing Claude Code sessions | 34 crates |
+| **[Toolkit](#toolkit)** | Portable skills, agents, and workflows for AI coding tools | 94 skills, 16 agents |
 | **[Knowledge System](#knowledge-system)** | GraphRAG + QMD learning capture and retrieval | [Architecture docs](docs/knowledge/overview.md) |
 
 ---
@@ -87,9 +87,9 @@ Most AI coding setups are a loose collection of dotfiles. This project treats th
 
 - **One toolkit, many tools** — Write a skill once, deploy it to Claude Code, Codex, Gemini, Cursor, Copilot, Amazon Q, Cline, Roo, or Clawdhub
 - **Session isolation** — Each coding session gets its own git worktree and tmux session. No cross-contamination
-- **Agents that compose** — 37 specialized agents (backend-developer, security-agent, architecture-reviewer, etc.) that can be orchestrated into swarms
+- **Agents that compose** — 16 specialized agents (backend-developer, security-agent, code-reviewer, deep-reasoner, etc.) plus swarm skills to coordinate them across sessions
 - **Memory that persists** — A two-tier knowledge system (GraphRAG + QMD) that captures learnings and retrieves them across sessions and projects
-- **Production Rust** — The TUI isn't a shell script. It's 115 modules of typed, tested, async Rust with clippy pedantic/nursery lints
+- **Production Rust** — The TUI isn't a shell script. It's a 34-crate workspace of typed, tested, async Rust with clippy pedantic/nursery lints
 
 ---
 
@@ -136,7 +136,7 @@ A Rust-based terminal application for managing AI coding sessions with git workt
 - **Usage analytics** — Built-in token + session tracking by day, week, provider, and project. Know where your budget went — then cut it with [The Token Optimisation Playbook](https://stevengonsalvez.com/blog/token-optimisation-playbook)
 - **Easy onboarding** — First-run setup wizard checks dependencies, configures auth, and gets you creating sessions in minutes
 - **Live log streaming** — Real-time viewer with level filtering and search across all running sessions
-- **Scriptable CLI** — 30+ commands (every TUI action, plus headless `witr`, `learnings search`, `diff-review --format json`, …) with `--format json` output for every piece of state. **[📘 Full CLI reference →](docs/tui/cli.md)** — a generated, multi-hierarchy man page covering every subcommand.
+- **Scriptable CLI** — 40 commands (every TUI action, plus headless `witr`, `learnings search`, `diff-review --format json`, …), with `--format json` on session state, config, git, usage, fleet, and most daemons. **[📘 Full CLI reference →](docs/tui/cli.md)** — a generated, multi-hierarchy man page covering every subcommand.
 
 ### Feature Showcase
 
@@ -200,7 +200,7 @@ ainb config set authentication.default_model opus
 ainb completion zsh > ~/.zsh/completions/_ainb
 ```
 
-**20 top-level commands** — `tui`, `run`, `list`, `logs`, `attach`, `status`, `kill`, `auth`, `recover`, `config`, `git`, `favorites`, `init`, `presets`, `usage`, `claudecode`, `completion`, `plugin`, `fleet`, `help` — with nested subcommands for recover / config / git / favorites / presets / plugin / fleet.
+**40 top-level commands** — `tui`, `run`, `list`, `label`, `logs`, `attach`, `status`, `kill`, `auth`, `recover`, `config`, `git`, `favorites`, `init`, `doctor`, `reflect`, `presets`, `usage`, `statusline`, `claudecode`, `codex`, `tmux`, `otel`, `completion`, `abtop`, `web`, `witr`, `learnings`, `plugin`, `fleet`, `headroom`, `daemon`, `mcp`, `notifyd`, `hangar`, `rtk`, `diff-review`, `skill`, `source`, `search` — with nested subcommands for recover / config / git / favorites / presets / plugin / fleet / hangar / mcp / daemon / usage / skill / source.
 
 **[📘 Full CLI reference → docs/tui/cli.md](docs/tui/cli.md)**
 
@@ -351,87 +351,85 @@ A portable AI coding agent toolkit: skills, agents, workflows, and configuration
 | **Cursor** | Project root | Project directory |
 | **Cline** | Project root | Project directory |
 | **Roo** | Project root | Project directory |
-| **Clawdhub** | Project root | Project directory |
+| **Claude Desktop** | `~/Library/Application Support/Claude/` | Home directory — MCP servers only |
 
-### Skills (91)
+### Skills (94)
 
 Skills are reusable capabilities that any supported AI tool can invoke.
 
 <details>
-<summary><b>Workflow & Planning</b></summary>
+<summary><b>Workflow & Planning</b> (14)</summary>
 
-`plan` · `plan-tdd` · `plan-gh` · `implement` · `validate` · `workflow` · `brainstorm` · `critique` · `discuss` · `expose` · `interview`
+`plan` · `plan-tdd` · `plan-gh` · `implement` · `validate` · `workflow` · `brainstorm` · `critique` · `discuss` · `expose` · `interview` · `make-a-goal` · `show-me` · `enhance-prompt`
 </details>
 
 <details>
-<summary><b>Code Quality & Testing</b></summary>
+<summary><b>Code Quality & Testing</b> (11)</summary>
 
-`commit` · `find-missing-tests` · `webapp-testing` · `security-audit` · `security-scan` · `simplify`
+`commit` · `find-missing-tests` · `webapp-testing` · `security-audit` · `security-scan` · `test-driven-development` · `expect-test` · `browser-verify` · `mobile-e2e-mcp` · `test-ainb` · `agentmail`
 </details>
 
 <details>
-<summary><b>DevOps & Infrastructure</b></summary>
+<summary><b>DevOps & Infrastructure</b> (9)</summary>
 
-`start-local` · `start-ios` · `start-android` · `spawn-agent` · `tmux-monitor` · `tmux-status` · `expose` · `debug-bridge`
+`start-local` · `start-ios` · `start-android` · `spawn-agent` · `tmux-monitor` · `tmux-status` · `tmux-message` · `debug-bridge` · `coding-agent`
 </details>
 
 <details>
-<summary><b>Knowledge & Learning</b></summary>
+<summary><b>Knowledge & Learning</b> (6)</summary>
 
-`reflect` · `research` · `research-cache` · `instincts` · `compound-docs` · `prime`
+`research` · `research-cache` · `instincts` · `prime` · `notebooklm` · `explain-to-me`
 </details>
 
 <details>
-<summary><b>Session Management</b></summary>
+<summary><b>Session Management</b> (9)</summary>
 
-`health-check` · `session-info` · `session-metrics` · `session-summary` · `handover` · `recover-sessions` · `plugins`
+`health-check` · `session-info` · `session-metrics` · `session-summary` · `handover` · `recover-sessions` · `plugins` · `standup` · `token-usage`
 </details>
 
 <details>
-<summary><b>Swarm Orchestration</b></summary>
+<summary><b>Swarm Orchestration</b> (8)</summary>
 
-`swarm-create` · `swarm-join` · `swarm-inbox` · `swarm-status` · `swarm-shutdown` · `swarm-orchestration` · `swarm-agent-troubleshooting`
+`swarm-create` · `swarm-join` · `swarm-inbox` · `swarm-status` · `swarm-shutdown` · `swarm-orchestration` · `swarm-agent-troubleshooting` · `swarm-attach-watchdog`
 
 > Sizing guidance: [Progressive subagents](https://stevengonsalvez.com/tools-tips/progressive-subagents) — score the work before you spawn eight agents.
 </details>
 
 <details>
-<summary><b>GitHub & Issues</b></summary>
+<summary><b>GitHub & Issues</b> (8)</summary>
 
-`gh-issue` · `make-github-issues` · `do-issues` · `merge-agent-work` · `list-agent-worktrees` · `attach-agent-worktree` · `cleanup-agent-worktree`
+`gh-issue` · `make-github-issues` · `do-issues` · `merge-agent-work` · `list-agent-worktrees` · `attach-agent-worktree` · `cleanup-agent-worktree` · `git-history-surgery`
 </details>
 
 <details>
-<summary><b>Design & Frontend</b></summary>
+<summary><b>Design & Frontend</b> (12)</summary>
 
-`ui-ux-pro-max` · `frontend-design` · `frontend-slides` · `tui-style-guide` · `tui-screen` · `liquid-glass` · `remotion-best-practices`
+`ui-ux-pro-max` · `frontend-design` · `frontend-slides` · `tui-style-guide` · `liquid-glass` · `remotion` · `remotion-best-practices` · `design-md` · `react-components` · `shadcn-ui` · `stitch-design` · `stitch-loop`
 </details>
 
 <details>
-<summary><b>Research & Analysis</b></summary>
+<summary><b>Research & Analysis</b> (8)</summary>
 
-`crypto-research` · `oracle` · `notebooklm` · `sentry-cli` · `ats-resume-matcher` · `resume-formatter` · `retro-pdf`
+`crypto-research` · `oracle` · `sentry-cli` · `ats-resume-matcher` · `resume-formatter` · `retro-pdf` · `scrapling-official` · `posthog-replay-analysis`
 </details>
 
 <details>
-<summary><b>Agent Architecture</b></summary>
+<summary><b>Agent Architecture</b> (9)</summary>
 
-`skill-creator` · `agent-ops` · `autonomous-loops` · `cost-aware-pipeline` · `media-processing` · `nano-banana-pro` · `sync-learnings`
+`skill-creator` · `agent-ops` · `autonomous-loops` · `cost-aware-pipeline` · `media-processing` · `nano-banana-pro` · `sync-learnings` · `claude-langfuse` · `langfuse-setup`
 </details>
 
-### Agents (37)
+### Agents (16)
 
 Specialized AI agents organized by domain. Each agent has a defined persona, tool access, and area of expertise.
 
 | Category | Agents |
 |----------|--------|
-| **Universal** | `backend-developer` · `frontend-developer` · `superstar-engineer` |
-| **Orchestrators** | `tech-lead-orchestrator` · `project-analyst` · `team-configurator` |
-| **Engineering** | `api-architect` · `architecture-reviewer` · `code-archaeologist` · `code-reviewer` · `dev-cleanup-wizard` · `devops-automator` · `documentation-specialist` · `gatekeeper` · `integration-tests` · `lead-orchestrator` · `migration` · `performance-optimizer` · `planner` · `playwright-test-validator` · `property-mutation` · `release-manager` · `security-agent` · `service-codegen` · `solution-architect` · `tailwind-css-expert` · `test-writer-fixer` |
-| **Design** | `ui-designer` |
-| **Swarm** | `swarm-leader` · `swarm-worker` |
-| **Meta** | `agentmaker` · `reflect` |
-| **Root** | `distinguished-engineer` · `web-search-researcher` |
+| **Universal** (5) | `backend-developer` · `deep-reasoner` · `fast-worker` · `frontend-developer` · `superstar-engineer` |
+| **Engineering** (6) | `code-archaeologist` · `code-reviewer` · `documentation-specialist` · `performance-optimizer` · `security-agent` · `test-engineer` |
+| **Swarm** (2) | `leader` · `worker` |
+| **Meta** (1) | `agentmaker` |
+| **Root** (2) | `distinguished-engineer` · `web-search-researcher` |
 
 ---
 
@@ -469,7 +467,7 @@ agents-in-a-box/
 │   │   ├── ainb-plugin-burndown/       #   v2 analytics plugin
 │   │   ├── ainb-plugin-notifyd/        #   v2 notifications plugin
 │   │   ├── ainb-plugin-session-reader/ #   v2 data-backend plugin
-│   │   ├── ainb-plugin-cts-v2/         #   Conformance test suite (14 axes)
+│   │   ├── ainb-plugin-cts-v2/         #   Conformance test suite (21 axes)
 │   │   └── ainb-plugin-testkit/        #   Plugin author test harness
 │   ├── config/                 #   Homebrew formula & packaging
 │   └── install.sh              #   One-liner installer
@@ -482,7 +480,7 @@ agents-in-a-box/
 │   ├── ainb-fleet/             #   Backs the `ainb fleet` CLI (standup/broadcast/sequence/needs/daemon)
 │   └── ainb-hooks/             #   ainb lifecycle hooks
 │
-# The portable toolkit (91 skills, 37 agents, workflows, utilities,
+# The portable toolkit (94 skills, 16 agents, workflows, utilities,
 # bootstrap.js, external-dependencies.yaml, catalog.yaml) lives in a
 # SEPARATE repo: github.com/stevengonsalvez/ainb-toolkit — flattened at
 # its repo root. `ainb` consumes it as a pinned external source.

--- a/README.md
+++ b/README.md
@@ -83,13 +83,86 @@ separate, standalone repo — `ainb` consumes it as a pinned external source.
 
 ## Why agents-in-a-box?
 
-Most AI coding setups are a loose collection of dotfiles. This project treats the problem as an engineering system:
+> ### Run a fleet. Lose nothing.
+>
+> Every agent gets its own worktree, its own tmux session, and a line item on your bill.
 
-- **One toolkit, many tools** — Write a skill once, deploy it to Claude Code, Codex, Gemini, Cursor, Copilot, Amazon Q, Cline, Roo, or Clawdhub
-- **Session isolation** — Each coding session gets its own git worktree and tmux session. No cross-contamination
-- **Agents that compose** — 16 specialized agents (backend-developer, security-agent, code-reviewer, deep-reasoner, etc.) plus swarm skills to coordinate them across sessions
-- **Memory that persists** — A two-tier knowledge system (GraphRAG + QMD) that captures learnings and retrieves them across sessions and projects
-- **Production Rust** — The TUI isn't a shell script. It's a 34-crate workspace of typed, tested, async Rust with clippy pedantic/nursery lints
+One agent is a chat window. Five agents is an operations problem, and that is the
+part nothing else solves. Here is every part of it.
+
+### Your agents stop fighting each other
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| Two agents, one branch | Index lock races, half-committed files, work silently overwritten | One git worktree and one branch per session, cleaned up when the session is killed cleanly |
+| Laptop sleeps, SSH drops | Session gone, context gone, start the conversation again | tmux-backed. Reattach and keep typing where you left off |
+| A crash leaves sessions behind | Hunt through `tmux ls` and guess which pane was what | `ainb recover` finds the orphans and resumes them |
+
+### You stop babysitting them
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| Which agent needs me *right now* | Cycle through every pane in turn, repeatedly | Press `f`. The Fleet panel lists exactly who is blocked |
+| An agent asked a question 20 minutes ago | Scroll back through output to find it | Answer it from the Fleet panel without attaching |
+| Nobody is watching while you are away | You are the event loop | ATC wakes on a timer and works the queue for you |
+
+### Work queues up without you
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| Every task starts with you typing | You are the scheduler | Hangar boards hold tasks agents pull from |
+| One agent per job, in sequence | Long jobs serialise behind you | Squads fan a job out across several agents |
+| Recurring work | A cron job you maintain by hand | Autopilots fire on a schedule and report back |
+
+### You see what they actually changed
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| Approving diffs on autopilot | Side effects land that you never read | Hunk-by-hunk review with syntax highlighting before you trust it |
+| Reviewing means opening the whole TUI | Context switch just to read a diff | `ainb diff-review` runs headless and emits JSON |
+
+### The bill stops surprising you
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| Spend is invisible until the invoice | The provider console shows one total | Burndown by day, week, project, model and provider |
+| Which repo burned the budget? | No per-repo or per-branch split anywhere | Per-project attribution, down to the worktree |
+| Long runs blow the context window | The conversation resets and you start over | Headroom compresses context across opted-in sessions |
+
+### You stop repeating yourself
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| Re-explaining the codebase every session | Every session starts cold | Learnings captured as you work, searchable next time |
+| The same rule copied into four tools' configs | One copy gets updated, the rest quietly go stale | Write a skill once, deploy it to 9 tools from one source |
+
+### The plumbing stops leaking
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| One MCP server per session | N processes, N startups, N times the memory | One pooled server shared across every session |
+| Approvals and errors scattered across panes | You miss the one that mattered | One Inbox collects every notification from every agent |
+| Background processes die quietly | `ps aux`, grep, guess, restart by hand | The Daemons screen shows health and restarts in place |
+
+### It reaches further than your terminal
+
+| The problem | Without ainb | With ainb |
+|---|---|---|
+| You are away from your desk | Agents stall until you get back | Bridge the fleet to Telegram, Slack or Discord |
+| You want a glance without a terminal | Terminal or nothing | `ainb web` serves a read-only dashboard |
+| What did that process actually touch? | Guesswork | `witr` traces process causality |
+| Which agent is genuinely busy? | Open every pane and look | `abtop`, which is top for AI agents |
+
+### What it won't do
+
+Straight answers, so you find out here rather than twenty minutes in:
+
+- **Worktrees isolate git state, not your environment.** Two agents still share port 3000, your database, and `node_modules`. If they need different services running, you still have to arrange that.
+- **tmux is required**, not optional. Same for `git`.
+- **No native Windows.** It uses PTY and POSIX file modes. WSL2 works.
+- **`ainb otel` is a setup wizard for Grafana Alloy**, wiring up Claude Code's own telemetry. ainb does not emit telemetry of its own.
+- **Memory starts empty.** The learnings browser is only as useful as what `reflect` has written into it.
+- **ATC and headroom are opt-in** and need extra setup: a hook plugin and an external binary respectively.
 
 ---
 

--- a/ainb-tui/crates/ainb-core/src/docs.rs
+++ b/ainb-tui/crates/ainb-core/src/docs.rs
@@ -1,25 +1,35 @@
-// ABOUTME: Canonical docsite (GitHub Pages) links surfaced in the TUI/CLI so
-// users can jump from a tool to the page that shows what it does. Rendered as
-// plain full URLs — modern terminals auto-linkify them (Cmd/Ctrl-click) and the
-// text stays mouse-selectable; never truncate them.
+// ABOUTME: Canonical docsite links surfaced in the TUI/CLI so users can jump
+// from a tool to the page that shows what it does. Rendered as plain full URLs
+// — modern terminals auto-linkify them (Cmd/Ctrl-click) and the text stays
+// mouse-selectable; never truncate them.
+//
+// The origin lives in exactly one place, `doc_url!`. It used to be pasted into
+// every const, which is how the old GitHub Pages URL ended up duplicated across
+// this file and two plugin crates. Change it here and everything follows.
+
+/// Build a docsite URL from a path relative to the site root.
+macro_rules! doc_url {
+    ($path:literal) => {
+        concat!("https://ainb.app/", $path)
+    };
+}
 
 /// Docsite root.
-pub const SITE: &str = "https://stevengonsalvez.github.io/agents-in-a-box/";
+pub const SITE: &str = doc_url!("");
 /// OpenTelemetry → Grafana Cloud guide (with example dashboards).
-pub const OTEL: &str = "https://stevengonsalvez.github.io/agents-in-a-box/reference/otel-grafana/";
+pub const OTEL: &str = doc_url!("reference/otel-grafana/");
 /// witr process-causality plugin.
-pub const WITR: &str = "https://stevengonsalvez.github.io/agents-in-a-box/plugins/witr/";
+pub const WITR: &str = doc_url!("plugins/witr/");
 /// abtop agent-process monitor plugin.
-pub const ABTOP: &str = "https://stevengonsalvez.github.io/agents-in-a-box/plugins/abtop/";
+pub const ABTOP: &str = doc_url!("plugins/abtop/");
 /// burndown usage/cost analytics plugin.
-pub const BURNDOWN: &str = "https://stevengonsalvez.github.io/agents-in-a-box/plugins/burndown/";
+pub const BURNDOWN: &str = doc_url!("plugins/burndown/");
 /// Token-optimization tools (rtk + headroom).
-pub const TOKEN_OPT: &str =
-    "https://stevengonsalvez.github.io/agents-in-a-box/tui/token-optimization/";
+pub const TOKEN_OPT: &str = doc_url!("tui/token-optimization/");
 /// reflect long-term memory.
-pub const REFLECT: &str = "https://stevengonsalvez.github.io/agents-in-a-box/knowledge/overview/";
+pub const REFLECT: &str = doc_url!("knowledge/overview/");
 /// ainb-toolkit (skills + agents).
-pub const TOOLKIT: &str = "https://stevengonsalvez.github.io/agents-in-a-box/toolkit/overview/";
+pub const TOOLKIT: &str = doc_url!("toolkit/overview/");
 
 // Official vendor auth guides, surfaced on the onboarding Authentication step.
 /// Claude Code authentication guide.

--- a/ainb-tui/crates/ainb-core/src/setup/catalog.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/catalog.rs
@@ -520,7 +520,7 @@ pub fn catalog() -> Vec<Topic> {
             deps: vec![dep(
                 "toolkit",
                 "ainb-toolkit",
-                "91 skills / 37 agents for claude/codex/copilot",
+                "94 skills / 16 agents for claude/codex/copilot",
                 Recommended,
                 Custom("toolkit-deployed"),
                 Toolkit,

--- a/ainb-tui/crates/ainb-core/tests/tripwire_deps_installer.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_deps_installer.rs
@@ -138,7 +138,9 @@ fn deps_installer_cursor_docs_and_install_affordance() {
     let mut saw_install = false;
     for _ in 0..30 {
         let c = capture(&session);
-        if c.contains("stevengonsalvez.github.io/agents-in-a-box/") {
+        // Compare against the shipped const, not a pasted literal, so a
+        // domain change can never leave this assertion behind.
+        if c.contains(ainb::docs::SITE) {
             saw_docs = true;
         }
         if c.contains("press i to install") {

--- a/ainb-tui/crates/ainb-plugin-abtop/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-abtop/src/plugin.rs
@@ -198,8 +198,9 @@ impl AbtopPlugin {
             // stays copyable, and it never truncates.
             let hint = format!(
                 "abtop not found on PATH. Install: {}  (or `cargo install abtop`)\n\
-                 What it does + screenshots: https://stevengonsalvez.github.io/agents-in-a-box/plugins/abtop/\n",
+                 What it does + screenshots: {}\n",
                 platform_install_command(),
+                crate::render::empty::DOCSITE_URL,
             );
             return CliOutput {
                 stdout: hint.into_bytes(),

--- a/ainb-tui/crates/ainb-plugin-abtop/src/render/empty.rs
+++ b/ainb-tui/crates/ainb-plugin-abtop/src/render/empty.rs
@@ -54,7 +54,7 @@ const REPO_URL: &str = "https://github.com/graykode/abtop";
 /// ainb docsite page for the abtop plugin — shows what it looks like inside
 /// ainb (screenshots). Full bare URL so terminals auto-linkify it and it stays
 /// copyable; left-aligned painting keeps it from truncating at >=80 cols.
-const DOCSITE_URL: &str = "https://stevengonsalvez.github.io/agents-in-a-box/plugins/abtop/";
+pub(crate) const DOCSITE_URL: &str = "https://ainb.app/plugins/abtop/";
 
 /// One install-command hint, resolved for the current platform.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ainb-tui/crates/ainb-plugin-cts-v2/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/src/lib.rs
@@ -1,10 +1,13 @@
 //! Conformance Test Suite v2 for the ainb plugin JSON-RPC subprocess ABI.
 //!
-//! 14 core axes covering manifest round-trip, framing, method dispatch,
-//! capability gating, render determinism, snapshot pub/sub, action
-//! timeout, log filtering, fs path guard, graceful shutdown, crash
-//! recovery, quarantine, and CLI dispatch capture — plus the
-//! `read_paths`/`[config]`, mouse-forwarding, and redraw-hint canaries.
+//! 18 numbered axes (`a01`-`a18`) covering manifest round-trip, framing,
+//! method dispatch, capability gating, render determinism, snapshot
+//! get-after-publish, snapshot subscribe, action timeout, log filtering,
+//! fs path guard, graceful shutdown, crash recovery, quarantine, CLI
+//! dispatch capture, event-stream subscribe, managed-subprocess spawn,
+//! unix-socket dial, and secret-store get — plus the
+//! `read_paths`/`[config]`, mouse-forwarding, and redraw-hint canaries,
+//! for 21 in total. Keep this list in sync with `tests/canaries/`.
 //!
 //! Each axis consists of:
 //! - A canary plugin binary under `tests/canaries/<axis>/main.rs`

--- a/ainb-tui/crates/ainb-plugin-witr/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-witr/src/plugin.rs
@@ -232,7 +232,10 @@ impl WitrPlugin {
         let Some(path) = self.witr_path.clone() else {
             // Full docsite URL on its own line: terminals auto-linkify it, it
             // stays copyable, and it never truncates.
-            let docs = "What it does + screenshots: https://stevengonsalvez.github.io/agents-in-a-box/plugins/witr/";
+            let docs = format!(
+                "What it does + screenshots: {}",
+                crate::render::empty::DOCSITE_URL
+            );
             let hint = match &self.lifecycle {
                 Lifecycle::Outdated {
                     found_version,

--- a/ainb-tui/crates/ainb-plugin-witr/src/render/empty.rs
+++ b/ainb-tui/crates/ainb-plugin-witr/src/render/empty.rs
@@ -65,7 +65,7 @@ const README_URL: &str = "https://github.com/pranshuparmar/witr#installation";
 /// ainb docsite page for the witr plugin — shows what it looks like inside ainb
 /// (screenshots). Full bare URL so terminals auto-linkify it and it stays
 /// copyable; left-aligned painting keeps it from truncating at >=80 cols.
-const DOCSITE_URL: &str = "https://stevengonsalvez.github.io/agents-in-a-box/plugins/witr/";
+pub(crate) const DOCSITE_URL: &str = "https://ainb.app/plugins/witr/";
 
 /// Resolve an [`InstallHint`] for the current build target.
 ///

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,8 @@ The `ainb` terminal app and its CLI.
 Portable AI-coding agent toolkit. Skills, agents, workflows — deployed to 9 AI tools. The canonical source is the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo; ainb consumes it as a pinned external source.
 
 - [Overview](toolkit/overview.md)
-- [Skills (86)](toolkit/skills.md)
-- [Agents (37)](toolkit/agents.md)
+- [Skills (94)](toolkit/skills.md)
+- [Agents (16)](toolkit/agents.md)
 - [Bootstrap engine](toolkit/bootstrap.md)
 
 ## Plugins

--- a/docs/assets/diagrams/ecosystem-architecture.svg
+++ b/docs/assets/diagrams/ecosystem-architecture.svg
@@ -68,13 +68,13 @@
   <text x="1066.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">process</text>
   <text x="1066.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">causality</text>
   <rect x="684" y="386" width="432" height="44" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="900.0" y="411" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="600">SDK + conformance: protocol - sdk-rust - testkit - cts-v2 (14 axes)</text>
+  <text x="900.0" y="411" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="600">SDK + conformance: protocol - sdk-rust - testkit - cts-v2 (21 axes)</text>
   <rect x="1200" y="100" width="480" height="350" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
   <text x="1224" y="132" fill="#141413" font-size="16.5" font-weight="700">3 - Toolkit - write once, deploy to 9+ tools</text>
   <text x="1224" y="151" fill="#6B655B" font-size="11.5">ainb-toolkit (external repo) — github.com/stevengonsalvez/ainb-toolkit</text>
   <rect x="1224" y="156" width="432" height="64" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
   <text x="1440.0" y="183" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">ainb-toolkit: skills/ agents/ …</text>
-  <text x="1440.0" y="203" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">91 skills - 37 agents - 22 hooks - workflows - knowledge</text>
+  <text x="1440.0" y="203" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">94 skills - 16 agents - 16 hooks - workflows - knowledge</text>
   <path d="M 1340,220 V 248" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
   <rect x="1224" y="252" width="300" height="70" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
   <text x="1374" y="276" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">bootstrap.js</text>

--- a/docs/contributing/ci-cd.md
+++ b/docs/contributing/ci-cd.md
@@ -35,7 +35,7 @@ Jobs:
 
 ## `deploy-pages.yml` — docs site to GitHub Pages
 
-Runs on push to `main` touching `website/site/**`, `docs/**`, or the workflow itself (also `workflow_dispatch`). Builds the Astro + Starlight site under `website/site` with Node 22 and `npm ci` + `npm run build`, then deploys to GitHub Pages (`https://stevengonsalvez.github.io/agents-in-a-box/`). Uses a `pages` concurrency group so an in-flight deploy finishes while queued runs are cancelled.
+Runs on push to `main` touching `website/site/**`, `docs/**`, or the workflow itself (also `workflow_dispatch`). Builds the Astro + Starlight site under `website/site` with Node 22 and `npm ci` + `npm run build`, then deploys to GitHub Pages, served at the custom domain `https://ainb.app/` via `website/site/public/CNAME`. Uses a `pages` concurrency group so an in-flight deploy finishes while queued runs are cancelled.
 
 ## See also
 

--- a/docs/plugins/changelog.md
+++ b/docs/plugins/changelog.md
@@ -26,7 +26,7 @@ Surface area (full reference in [v2.md](./v2.md)):
 - **Chunked publishes**: `WIRE_VERSION` + `chunk_index` + `is_final` ordering contract; subscribers MUST drop follow-on chunks that arrived without chunk 0.
 - **Priority key channel** (2026-05-15): host runtime drains `plugin/handle_key` notifications ahead of `plugin/handle_event` to prevent FIFO starvation during chunked publishes.
 
-`ainb-plugin-cts-v2` ships with 14 conformance axes. In-tree dogfood plugins: `burndown` (analytics screen + `ainb usage` CLI), `session-reader` (chunked usage_data publisher), and `witr` (`ainb witr` CLI + `/witr` slash wrapping the external `witr` binary via `spawn_subprocess`; its process-causality screen is a host-embedded `witr -i` TTY). See [Plugins → In-tree plugins](./overview.md#reference-plugins) for per-plugin pages.
+`ainb-plugin-cts-v2` ships with 21 conformance axes. In-tree dogfood plugins: `burndown` (analytics screen + `ainb usage` CLI), `session-reader` (chunked usage_data publisher), and `witr` (`ainb witr` CLI + `/witr` slash wrapping the external `witr` binary via `spawn_subprocess`; its process-causality screen is a host-embedded `witr -i` TTY). See [Plugins → In-tree plugins](./overview.md#reference-plugins) for per-plugin pages.
 
 ## v1 — historical, removed 2026-05-15
 

--- a/docs/plugins/spec-v2.md
+++ b/docs/plugins/spec-v2.md
@@ -289,7 +289,7 @@ Denied capability → `RpcError { code: -32001, message: "capability denied: <ca
 
 ## 10. Conformance test suite
 
-`ainb-plugin-cts-v2` covers 14 axes: manifest round-trip, framing, method dispatch, capability gating, render determinism, snapshot pub/sub, action timeout, log filtering, fs path guard, graceful shutdown, crash recovery, quarantine, CLI dispatch capture, chunked publish ordering. Each axis has a canary plugin at `crates/ainb-plugin-cts-v2/tests/canaries/<axis>/` and a host-side `#[test]` in `tests/axes.rs`.
+`ainb-plugin-cts-v2` covers 21 axes: manifest round-trip, framing, method dispatch, capability gating, render determinism, snapshot get-after-publish, snapshot subscribe, action timeout, log filtering, fs path guard, graceful shutdown, crash recovery, quarantine, CLI dispatch capture, event-stream subscribe, managed-subprocess spawn, unix-socket dial, secret-store get, mouse forwarding, read_paths config, redraw hint. Each axis has a canary plugin at `crates/ainb-plugin-cts-v2/tests/canaries/<axis>/` and a host-side `#[test]` in `tests/axes.rs`.
 
 Plugins MUST pass every axis their manifest's capability + provides surface implies. Axes for surface a plugin doesn't expose are skipped.
 

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -22,7 +22,7 @@ Solid arrows are data/control flow, dashed arrows are writes and feedback, clay 
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                            ainb TUI host                                │
 │                                                                         │
-│   Rust · ratatui · tokio · 115 modules · Unix-only                      │
+│   Rust · ratatui · tokio · 34 crates · Unix-only                        │
 │                                                                         │
 │   ┌──────────────┐  ┌──────────────┐  ┌─────────────────────────────┐  │
 │   │   tmux/PTY   │  │  git/worktree│  │  plugin runtime (v2 ABI)    │  │
@@ -57,8 +57,8 @@ Solid arrows are data/control flow, dashed arrows are writes and feedback, clay 
    │   https://github.com/stevengonsalvez/ainb-toolkit                  │
    │                                                                     │
    │   Source of truth (flattened layout):                               │
-   │   ├── skills/      86 skills                                        │
-   │   ├── agents/      37 agents (universal, engineering, orchestrator) │
+   │   ├── skills/      94 skills                                        │
+   │   ├── agents/      16 agents (universal, engineering, swarm, meta)  │
    │   ├── workflows/   structured delivery workflows                    │
    │   └── utilities/   shared hooks, config, output styles              │
    │                                                                     │

--- a/docs/product/value.md
+++ b/docs/product/value.md
@@ -38,7 +38,7 @@ Every TUI operation is also a CLI subcommand. `--format json` on every command. 
 
 ### A portable toolkit that follows you across tools
 
-86 skills (plan, implement, validate, reflect, swarm-create, …) and 37 specialised agents (backend-developer, code-reviewer, security-agent, …). Write them once; deploy to Claude Code, Codex, Copilot, Gemini, Amazon Q, Cursor, Cline, Roo, Hermes, nanoclaw, Clawdhub. One source, 11 targets. The toolkit lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo; ainb's skill manager syncs from it as a pinned external source.
+94 skills (plan, implement, validate, commit, swarm-create, …) and 16 specialised agents (backend-developer, code-reviewer, security-agent, deep-reasoner, …). Write them once; deploy to Claude Code, Codex, Copilot, Gemini, Amazon Q, Cursor, Cline, Roo, and Claude Desktop. One source, 9 targets. The toolkit lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo; ainb's skill manager syncs from it as a pinned external source.
 
 ### A plugin system you can actually use
 

--- a/docs/product/what-is-ainb.md
+++ b/docs/product/what-is-ainb.md
@@ -7,7 +7,7 @@ A terminal-native ecosystem for managing AI coding agents. Three components shar
 | # | Component | What it is |
 |---|---|---|
 | 1 | **`ainb` TUI + CLI** | Rust terminal app for spawning and supervising AI coding sessions. Each session gets its own git worktree and tmux session. Multi-provider: Claude Code, Codex, Gemini, Copilot, Kiro, raw shell, SSH. |
-| 2 | **ainb-toolkit** | Portable skills + agents + workflows that deploy to 11 different AI coding tools from a single source. 86 skills, 37 agents. Lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo; ainb consumes it as a pinned external source. |
+| 2 | **ainb-toolkit** | Portable skills + agents + workflows that deploy to 9 different AI coding tools from a single source. 94 skills, 16 agents. Lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo; ainb consumes it as a pinned external source. |
 | 3 | **Plugins (v2 ABI)** | Native-binary plugins for the TUI host. Capability-gated, JSON-RPC over stdio. Own screens, CLIs, statusline segments. Two reference plugins ship in-tree (`burndown`, `session-reader`). |
 | 4 | **`reflect-kb`** | Knowledge capture and retrieval library. Two-tier: QMD for fast vector search + nano-graphrag for cross-project entity-relation queries. Installed as the `reflect` CLI. |
 
@@ -42,7 +42,7 @@ If you've ever had two Claude Code sessions stomp on each other's branches, lost
    ┌─────────────────────────────────────────────────────────────┐
    │                       ainb TUI host                          │
    │                                                              │
-   │   Rust · ratatui · tokio · 115 modules · Unix-only           │
+   │   Rust · ratatui · tokio · 34 crates · Unix-only             │
    │                                                              │
    │   tmux ←─ session persistence                                │
    │   git  ←─ worktree-per-session isolation                     │

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -52,11 +52,11 @@ Definitions for the terms that recur across the agents-in-a-box docs. Where a te
 
 **Wire version** — the schema version of a snapshot/event type. Plugin types crates (e.g. `ainb-plugin-types-sessions`) carry a `pub const WIRE_VERSION: u32` (currently `3`); subscribers must check `event.version == WIRE_VERSION` and reject mismatches gracefully rather than panicking.
 
-**CTS (Conformance Test Suite)** — the executable form of the plugin spec. `ainb-plugin-cts-v2` covers **14 axes** (manifest round-trip, framing, method dispatch, capability gating, render determinism, snapshot pub/sub, action timeout, log filtering, fs path guard, graceful shutdown, crash recovery, quarantine, CLI dispatch capture, chunked publish ordering). A plugin author runs it via `cargo test` for a per-axis pass/fail report.
+**CTS (Conformance Test Suite)** — the executable form of the plugin spec. `ainb-plugin-cts-v2` covers **21 axes** (manifest round-trip, framing, method dispatch, capability gating, render determinism, snapshot get-after-publish, snapshot subscribe, action timeout, log filtering, fs path guard, graceful shutdown, crash recovery, quarantine, CLI dispatch capture, event-stream subscribe, managed-subprocess spawn, unix-socket dial, secret-store get, mouse forwarding, read_paths config, redraw hint). A plugin author runs it via `cargo test` for a per-axis pass/fail report.
 
 **Canary** — a minimal plugin written to exercise exactly one CTS axis, living at `crates/ainb-plugin-cts-v2/tests/canaries/<axis>/`.
 
-**`cts-v2`** — the `ainb-plugin-cts-v2` crate: the host-side conformance test runner (14 axes) plus its canary plugins.
+**`cts-v2`** — the `ainb-plugin-cts-v2` crate: the host-side conformance test runner (21 axes) plus its canary plugins.
 
 **`testkit`** — the `ainb-plugin-testkit` crate: an in-process test harness for plugin authors. A plugin author hands their `Plugin` impl to testkit to exercise it without spawning a real subprocess.
 

--- a/docs/toolkit/agents.md
+++ b/docs/toolkit/agents.md
@@ -1,36 +1,29 @@
 ---
-title: "Agents (37)"
+title: "Agents (16)"
 ---
 
-37 specialised AI agents organised by domain.
+16 specialised AI agents organised by domain. Each has a defined persona, tool
+access, and area of expertise.
 
 ## By category
 
-37 agents across 6 nested categories plus 2 root-level agents.
+16 agents across 4 nested categories plus 2 root-level agents.
 
-### Universal (3)
+### Universal (5)
 
-`backend-developer` `frontend-developer` `superstar-engineer`
+`backend-developer` `deep-reasoner` `fast-worker` `frontend-developer` `superstar-engineer`
 
-### Orchestrators (3)
+### Engineering (6)
 
-`tech-lead-orchestrator` `project-analyst` `team-configurator`
-
-### Engineering (24)
-
-`api-architect` `architecture-reviewer` `code-archaeologist` `code-reviewer` `dev-cleanup-wizard` `devops-automator` `documentation-specialist` `focused-repository-analyzer` `gatekeeper` `integration-tests` `lead-orchestrator` `migration` `performance-optimizer` `planner` `playwright-test-validator` `property-mutation` `release-manager` `security-agent` `service-codegen` `solution-architect` `supabase-security-reviewer` `tailwind-css-expert` `test-analyser` `test-writer-fixer`
-
-### Design (1)
-
-`ui-designer`
+`code-archaeologist` `code-reviewer` `documentation-specialist` `performance-optimizer` `security-agent` `test-engineer`
 
 ### Swarm (2)
 
-`worker` `leader`
+`leader` `worker`
 
-### Meta (2)
+### Meta (1)
 
-`agentmaker` `reflect`
+`agentmaker`
 
 ### Root (2)
 

--- a/docs/toolkit/skills.md
+++ b/docs/toolkit/skills.md
@@ -1,8 +1,8 @@
 ---
-title: "Skills (91)"
+title: "Skills (94)"
 ---
 
-All 91 skills grouped by purpose. Each links to its SKILL.md source.
+All 94 skills grouped by purpose. Each links to its SKILL.md source.
 
 ## Planning & Workflow (14)
 
@@ -12,17 +12,17 @@ All 91 skills grouped by purpose. Each links to its SKILL.md source.
 
 `coding-agent` `spawn-agent` `attach-agent-worktree` `list-agent-worktrees` `cleanup-agent-worktree` `merge-agent-work` `do-issues` `gh-issue` `make-github-issues` `find-missing-tests` `commit` `sync-learnings`
 
-## Multi-agent / Swarm (7)
+## Multi-agent / Swarm (8)
 
-`swarm-create` `swarm-join` `swarm-status` `swarm-inbox` `swarm-shutdown` `swarm-orchestration` `swarm-agent-troubleshooting`
+`swarm-create` `swarm-join` `swarm-status` `swarm-inbox` `swarm-shutdown` `swarm-orchestration` `swarm-agent-troubleshooting` `swarm-attach-watchdog`
 
-## Session & Learning (8)
+## Session & Learning (7)
 
-`session-info` `session-metrics` `session-summary` `health-check` `instincts` `reflect` `compound-docs` `research-cache`
+`session-info` `session-metrics` `session-summary` `health-check` `instincts` `research-cache` `standup`
 
-## Testing (5)
+## Testing (7)
 
-`expect-test` `webapp-testing` `browser-verify` `test-driven-development` `mobile-e2e-mcp`
+`expect-test` `webapp-testing` `browser-verify` `test-driven-development` `mobile-e2e-mcp` `test-ainb` `agentmail`
 
 ## Design & UI (13)
 
@@ -44,13 +44,13 @@ All 91 skills grouped by purpose. Each links to its SKILL.md source.
 
 `resume-formatter` `ats-resume-matcher` `retro-pdf` `skill-creator` `token-usage`
 
-## Meta / autonomous patterns (5)
+## Meta / autonomous patterns (4)
 
-`autonomous-loops` `agent-ops` `cost-aware-pipeline` `scrapling-official` `fireworks-tech-graph`
+`autonomous-loops` `agent-ops` `cost-aware-pipeline` `scrapling-official`
 
 ## Recently added (7)
 
-Not yet folded into the grouped lists above: `claude-langfuse` `explain-to-me` `git-history-surgery` `langfuse-setup` `make-a-goal` `standup` `tmux-message`
+Not yet folded into the grouped lists above: `claude-langfuse` `explain-to-me` `git-history-surgery` `langfuse-setup` `make-a-goal` `show-me` `tmux-message`
 
 ## See also
 

--- a/website/BRIEF.md
+++ b/website/BRIEF.md
@@ -1,7 +1,8 @@
 # agents-in-a-box — website design brief
 
 > **For Claude design** (or any human/AI designer briefed off this doc).
-> **Output expected:** a complete visual + interaction design for `stevengonsalvez.github.io/agents-in-a-box`. See §12 for deliverable shape.
+> **Output expected:** a complete visual + interaction design for the ainb site. See §12 for deliverable shape.
+> **Superseded:** this brief is historical. The shipped site has grown well past it, and the site now lives at `ainb.app`, not GitHub Pages' default URL.
 > **Status:** locked via interview 2026-05-18. Treat decisions in §0 as fixed unless explicitly renegotiated.
 
 ---
@@ -19,7 +20,7 @@
 | Logo | **ASCII block art** (existing `AGENTS / IN A / BOX` lockup) |
 | Tone | **Hacker-honest blunt.** Drop articles, drop fluff. |
 | Primary CTA | **Copyable install command** (`brew install ainb`) |
-| Domain | `stevengonsalvez.github.io/agents-in-a-box` (GitHub Pages) |
+| Domain | `ainb.app` (GitHub Pages + CNAME) — *changed 2026-08-26, was `stevengonsalvez.github.io/agents-in-a-box`* |
 | Palette | **Pure TUI** — `#191923` bg, `#6495ED` border, `#FFD700` gold, `#DCDCE6` text |
 | Reference | **charm.sh** — match polish, deviate via pure-ASCII identity |
 | Flourishes | Scanlines + blinking cursor + boot sequence + vim keybinds + ASCII dividers (all behind `prefers-reduced-motion` opt-in) |

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -6,14 +6,13 @@ import starlightImageZoom from 'starlight-image-zoom';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://stevengonsalvez.github.io',
-  base: '/agents-in-a-box',
+  site: 'https://ainb.app',
   trailingSlash: 'never',
   // Old recall page moved under the dedicated reflect-memory section.
-  // NB: static meta-refresh redirects don't get `base` prepended automatically,
-  // so the destination is written with the `/agents-in-a-box` base explicitly.
+  // The site is served from the apex domain, so there is no base path to
+  // prepend here any more.
   redirects: {
-    '/knowledge/recall-by-example': '/agents-in-a-box/knowledge/reflect-memory/recall',
+    '/knowledge/recall-by-example': '/knowledge/reflect-memory/recall',
   },
   // Docs live in the repo-root `docs/` tree (outside this site dir), so MDX
   // there can't resolve `@astrojs/starlight/components` from its own folder.

--- a/website/site/public/CNAME
+++ b/website/site/public/CNAME
@@ -1,0 +1,1 @@
+ainb.app

--- a/website/site/src/pages/index.astro
+++ b/website/site/src/pages/index.astro
@@ -16,11 +16,11 @@ const docs = (path: string) => `${BASE}/${path.replace(/^\//, '')}`;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0F0F18" />
-    <meta name="description" content="Run agents. Worktree per session. No bullshit. Terminal-native ecosystem for managing AI coding agents — Claude · Codex · Gemini · Copilot." />
+    <meta name="description" content="Run a fleet. Lose nothing. Every agent gets its own worktree, its own tmux session, and a line item on your bill. Claude · Codex · Gemini · Copilot." />
     <meta property="og:title" content="agents-in-a-box" />
-    <meta property="og:description" content="Run agents. Worktree per session. No bullshit." />
+    <meta property="og:description" content="Run a fleet. Lose nothing. Every agent gets its own worktree, its own tmux session, and a line item on your bill." />
     <meta property="og:type" content="website" />
-    <title>agents-in-a-box — run agents, worktree per session, no bullshit</title>
+    <title>agents-in-a-box · run a fleet, lose nothing</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -55,7 +55,11 @@ const docs = (path: string) => `${BASE}/${path.replace(/^\//, '')}`;
             IN  A  BOX</pre>
 
         <p class="hero__tag">
-          Run agents. Worktree per session. No&nbsp;bullshit.
+          Run a fleet. Lose&nbsp;nothing.
+        </p>
+        <p class="hero__sub">
+          Every agent gets its own worktree, its own tmux session,
+          and a line item on your&nbsp;bill.
         </p>
 
         <div class="install">
@@ -72,31 +76,31 @@ const docs = (path: string) => `${BASE}/${path.replace(/^\//, '')}`;
       <!-- THREE-COL VALUE PROP -->
       <section class="row3">
         <a class="card" href={docs('tui/overview')}>
-          <h3>TUI</h3>
+          <h3>ONE SCREEN</h3>
           <div class="card__body">
-            <span>34 crates</span>
-            <span>4 providers</span>
-            <span>tmux-bound</span>
+            <span>see who is blocked</span>
+            <span>answer without attaching</span>
+            <span>survives sleep</span>
           </div>
-          <span class="card__cta">docs →</span>
+          <span class="card__cta">docs &rarr;</span>
         </a>
         <a class="card" href={docs('toolkit/overview')}>
-          <h3>TOOLKIT</h3>
+          <h3>ONE SOURCE</h3>
           <div class="card__body">
-            <span>94 skills</span>
-            <span>9 tools</span>
-            <span>16 agents</span>
+            <span>write a skill once</span>
+            <span>deploy to 9 tools</span>
+            <span>no config drift</span>
           </div>
-          <span class="card__cta">docs →</span>
+          <span class="card__cta">docs &rarr;</span>
         </a>
-        <a class="card" href={docs('plugins/overview')}>
-          <h3>PLUGINS</h3>
+        <a class="card" href={docs('plugins/burndown')}>
+          <h3>ONE BILL</h3>
           <div class="card__body">
-            <span>v2 ABI</span>
-            <span>JSON-RPC</span>
-            <span>cap-gated</span>
+            <span>spend per project</span>
+            <span>per model, per day</span>
+            <span>before the invoice</span>
           </div>
-          <span class="card__cta">docs →</span>
+          <span class="card__cta">docs &rarr;</span>
         </a>
       </section>
 
@@ -378,8 +382,17 @@ cli_namespaces = ["usage"]</code></pre>
       .hero__tag {
         font-family: var(--ainb-font-display);
         font-size: clamp(1.2rem, 2.5vw, 1.6rem);
-        margin: 2.5rem 0 2rem;
+        margin: 2.5rem 0 0.75rem;
         color: var(--ainb-text-primary);
+      }
+
+      .hero__sub {
+        font-size: clamp(0.9rem, 1.6vw, 1.05rem);
+        line-height: 1.6;
+        max-width: 46ch;
+        margin: 0 auto 2rem;
+        color: var(--ainb-text-muted);
+        text-wrap: balance;
       }
 
       .install {

--- a/website/site/src/pages/index.astro
+++ b/website/site/src/pages/index.astro
@@ -74,7 +74,7 @@ const docs = (path: string) => `${BASE}/${path.replace(/^\//, '')}`;
         <a class="card" href={docs('tui/overview')}>
           <h3>TUI</h3>
           <div class="card__body">
-            <span>115 modules</span>
+            <span>34 crates</span>
             <span>4 providers</span>
             <span>tmux-bound</span>
           </div>
@@ -83,9 +83,9 @@ const docs = (path: string) => `${BASE}/${path.replace(/^\//, '')}`;
         <a class="card" href={docs('toolkit/overview')}>
           <h3>TOOLKIT</h3>
           <div class="card__body">
-            <span>86 skills</span>
+            <span>94 skills</span>
             <span>9 tools</span>
-            <span>37 agents</span>
+            <span>16 agents</span>
           </div>
           <span class="card__cta">docs →</span>
         </a>
@@ -181,7 +181,7 @@ cli_namespaces = ["usage"]</code></pre>
    └──────────┘
 
    ┌────────────────────────────────────┐
-   │  Toolkit (86 skills · 37 agents)   │
+   │  Toolkit (94 skills · 16 agents)   │
    │  Deploys to 9 AI coding tools      │
    └────────────────────────────────────┘
 
@@ -210,19 +210,19 @@ cli_namespaces = ["usage"]</code></pre>
       <!-- STATS -->
       <section class="stats">
         <div class="stats__item">
-          <span class="stats__num ainb-stat">115</span>
-          <span class="stats__lbl">modules</span>
+          <span class="stats__num ainb-stat">34</span>
+          <span class="stats__lbl">crates</span>
         </div>
         <div class="stats__item">
-          <span class="stats__num ainb-stat">86</span>
+          <span class="stats__num ainb-stat">94</span>
           <span class="stats__lbl">skills</span>
         </div>
         <div class="stats__item">
-          <span class="stats__num ainb-stat">37</span>
+          <span class="stats__num ainb-stat">16</span>
           <span class="stats__lbl">agents</span>
         </div>
         <div class="stats__item">
-          <span class="stats__num ainb-stat">2</span>
+          <span class="stats__num ainb-stat">6</span>
           <span class="stats__lbl">plugins</span>
         </div>
       </section>


### PR DESCRIPTION
## What this is

Three things, 24 commits, one file per commit.

### 1. Every published number was wrong

Verified against the toolkit's own auto-generated `catalog.yaml` and the code.

| Claim | Was | Now |
|---|---|---|
| Agents | 37 | **16** |
| Skills | 91 / 86 | **94** |
| Rust "modules" | 115 | **34 crates** |
| CLI commands | 20 | **40** |
| Conformance axes | 14 | **21** |
| Toolkit hooks | 22 | **16** |

`37 agents` was on the README, the docs and the landing page. The README's agent table listed 24 engineering agents that no longer exist while omitting `deep-reasoner`, `fast-worker` and `test-engineer`. The setup wizard was also telling every new user 91/37.

Other corrections found on the way:
- `value.md` listed Hermes, nanoclaw and Clawdhub as deploy targets. None has a tool adapter.
- The Supported AI Tools table listed Clawdhub; the ninth adapter is Claude Desktop, and it accepts MCP servers only.
- The `--format json` claim ("every piece of state") is false: 19 of 40 commands honour the global flag.

### 2. The Why section

Was five bullets describing architecture. Now eight themed tables, 22 rows, `Problem | Without ainb | With ainb`, covering Fleet, Hangar, ATC, cost attribution, the bridge and the web dashboard, none of which the README previously mentioned.

Adds a **What it won't do** block: worktrees isolate git state but not ports or dependencies, tmux is mandatory, no native Windows, `ainb otel` configures Grafana Alloy rather than emitting telemetry of its own.

Landing page cards go from `34 crates / 4 providers / tmux-bound` to ONE SCREEN / ONE SOURCE / ONE BILL.

### 3. ainb.app groundwork

The docsite origin was pasted into 8 consts in `docs.rs`, duplicated in both plugin crates, and pinned by a literal in a tripwire assertion. 13 copies. Now one `doc_url!` macro, one `pub(crate)` const per plugin, and the test asserts against `ainb::docs::SITE`.

**The `feat(site): serve the docsite from ainb.app` commit is reverted immediately after merge** and re-applied once DNS is live. Landing the CNAME while `ainb.app` still points at Namecheap parking would redirect the current docsite to a dead domain and 404 every asset.

## Verification

- `cargo fmt --check` clean, `cargo clippy --all-targets` exit 0
- `cargo check` passes on all touched crates
- Site builds: 73 pages, root-relative hrefs, CNAME lands in `dist`

## Known issue, pre-existing, not fixed here

Every "Edit this page" link on the docsite 404s. `editLink.baseUrl` is configured but `edit/main` appears zero times in the build. Confirmed pre-existing by rebuilding against the original config.