### PR TITLE
Revert the ainb.app CNAME until DNS is live

### DIFF
--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -6,13 +6,14 @@ import starlightImageZoom from 'starlight-image-zoom';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://ainb.app',
+  site: 'https://stevengonsalvez.github.io',
+  base: '/agents-in-a-box',
   trailingSlash: 'never',
   // Old recall page moved under the dedicated reflect-memory section.
-  // The site is served from the apex domain, so there is no base path to
-  // prepend here any more.
+  // NB: static meta-refresh redirects don't get `base` prepended automatically,
+  // so the destination is written with the `/agents-in-a-box` base explicitly.
   redirects: {
-    '/knowledge/recall-by-example': '/knowledge/reflect-memory/recall',
+    '/knowledge/recall-by-example': '/agents-in-a-box/knowledge/reflect-memory/recall',
   },
   // Docs live in the repo-root `docs/` tree (outside this site dir), so MDX
   // there can't resolve `@astrojs/starlight/components` from its own folder.

--- a/website/site/public/CNAME
+++ b/website/site/public/CNAME
@@ -1,1 +1,0 @@
-ainb.app


### PR DESCRIPTION
Temporary revert of `0658bb70`.

`ainb.app` still resolves to Namecheap parking (`162.255.119.219`). Shipping the CNAME hands GitHub Pages a custom domain that does not answer, so the current docsite would redirect to a dead host, and dropping `base` would 404 every asset on the github.io URL in the meantime.

Re-applied as soon as the apex A records point at GitHub and the Pages cname is set. Everything else from #759 stays.