### PR TITLE
feat(site): cut the docsite over to ainb.app

### DIFF
--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -6,14 +6,13 @@ import starlightImageZoom from 'starlight-image-zoom';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://stevengonsalvez.github.io',
-  base: '/agents-in-a-box',
+  site: 'https://ainb.app',
   trailingSlash: 'never',
   // Old recall page moved under the dedicated reflect-memory section.
-  // NB: static meta-refresh redirects don't get `base` prepended automatically,
-  // so the destination is written with the `/agents-in-a-box` base explicitly.
+  // The site is served from the apex domain, so there is no base path to
+  // prepend here any more.
   redirects: {
-    '/knowledge/recall-by-example': '/agents-in-a-box/knowledge/reflect-memory/recall',
+    '/knowledge/recall-by-example': '/knowledge/reflect-memory/recall',
   },
   // Docs live in the repo-root `docs/` tree (outside this site dir), so MDX
   // there can't resolve `@astrojs/starlight/components` from its own folder.

--- a/website/site/public/CNAME
+++ b/website/site/public/CNAME
@@ -1,0 +1,1 @@
+ainb.app


### PR DESCRIPTION
Re-applies the revert from #760, now that DNS is actually live.

```
dig +short A ainb.app @dns1.registrar-servers.com
185.199.108.153  185.199.109.153  185.199.110.153  185.199.111.153
```

Confirmed identical from 1.1.1.1 and 8.8.8.8. The Namecheap URL-forward record that was hijacking the apex (and resolving it to `162.255.119.219`) has been removed, and the Pages custom domain is set (`cname: ainb.app`, cert provisioning).

Restores the CNAME file and the apex `site`/`base` config. **The CNAME has to ship inside the published artifact** or the next deploy clears the custom-domain setting, which is why this needs to land now rather than later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the website to use the custom domain `ainb.app`.
  * Adjusted page redirects to work with the new domain structure.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->