### PR TITLE
fix(tui): show build version on home

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/home_screen_v2.rs
+++ b/ainb-tui/crates/ainb-core/src/components/home_screen_v2.rs
@@ -27,6 +27,7 @@ const PANEL_BG: Color = Color::Rgb(30, 30, 40);
 const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
 const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
+const DISPLAY_VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
 const SIDEBAR_EDGE_HIT_SLOP: u16 = 1;
 pub const SIDEBAR_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
 
@@ -522,7 +523,7 @@ impl HomeScreenV2Component {
                 Style::default().fg(MUTED_GRAY),
             ),
             Span::styled("                    ", Style::default()),
-            Span::styled("v2.0.0", Style::default().fg(MUTED_GRAY)),
+            Span::styled(DISPLAY_VERSION, Style::default().fg(MUTED_GRAY)),
         ]))
         .style(Style::default().bg(PANEL_BG));
 
@@ -561,7 +562,7 @@ impl HomeScreenV2Component {
                 Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
             ),
             Span::styled(" - Agents in a Box", Style::default().fg(SOFT_WHITE)),
-            Span::styled("  v2.0.0", Style::default().fg(MUTED_GRAY)),
+            Span::styled(format!("  {DISPLAY_VERSION}"), Style::default().fg(MUTED_GRAY)),
         ]))
         .style(Style::default().bg(PANEL_BG));
 
@@ -682,6 +683,31 @@ impl Default for HomeScreenV2Component {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn render_to_string(width: u16, height: u16) -> String {
+        let component = HomeScreenV2Component::new();
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        let mut state = HomeScreenV2State::new();
+
+        terminal
+            .draw(|frame| component.render(frame, frame.area(), &mut state, &[]))
+            .unwrap();
+
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn headers_render_the_package_version() {
+        assert!(render_to_string(120, 40).contains(DISPLAY_VERSION));
+        assert!(render_to_string(80, 24).contains(DISPLAY_VERSION));
+    }
 
     #[test]
     fn test_layout_mode_detection() {

--- a/ainb-tui/crates/ainb-core/src/components/home_screen_v2.rs
+++ b/ainb-tui/crates/ainb-core/src/components/home_screen_v2.rs
@@ -562,7 +562,10 @@ impl HomeScreenV2Component {
                 Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
             ),
             Span::styled(" - Agents in a Box", Style::default().fg(SOFT_WHITE)),
-            Span::styled(format!("  {DISPLAY_VERSION}"), Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("  {DISPLAY_VERSION}"),
+                Style::default().fg(MUTED_GRAY),
+            ),
         ]))
         .style(Style::default().bg(PANEL_BG));
 
@@ -694,13 +697,7 @@ mod tests {
             .draw(|frame| component.render(frame, frame.area(), &mut state, &[]))
             .unwrap();
 
-        terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect()
+        terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect()
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- render the compiled package version in full and compact home headers
- replace stale v2.0.0 copy

## Validation
- cargo test -p ainb headers_render_the_package_version --lib
- cargo fmt -p ainb --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Home screen headers now display the application’s current package version automatically instead of a fixed version.
  * Version information appears consistently in both full-size and compact layouts.
  * The displayed version updates automatically with each application release.

* **Tests**
  * Added coverage to verify version display across supported home screen layouts and screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->