### PR TITLE
fix(codex): unify the managed launch argv across both spawn paths

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -134,6 +134,12 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     let claude_cmd = codex_remote
         .as_ref()
         .map(|remote| {
+            // Pre-launch, at the launch site rather than inside the builder:
+            // `-C` into a directory Codex has not seen shows a blocking trust
+            // modal, and under `--remote` no flag suppresses it. Kept out of
+            // `remote_codex_command` so that stays pure and its tests never
+            // write to the user's Codex config.
+            crate::interactive::session_manager::trust_codex_project_dir(&work_dir);
             remote_codex_command(
                 remote,
                 &work_dir,
@@ -542,37 +548,31 @@ fn build_agent_command(args: &RunArgs) -> String {
         .join(" ")
 }
 
+/// Shell-ready argv for a managed Codex session. PURE: builds a string and
+/// nothing else, so tests can call it without touching the user's Codex config.
+///
+/// Delegates to [`crate::interactive::session_manager::codex_remote_command`]
+/// so this path and the TUI's cannot drift. They HAD drifted: this builder was
+/// missing `--dangerously-bypass-hook-trust` and the retiring-model
+/// substitution, so `ainb run --tool codex` still hit the hooks-need-review and
+/// deprecation modals the TUI path had already been fixed for.
 fn remote_codex_command(
     remote: &ainb_hangar_proto::fleet::CodexSessionEnsureResult,
     cwd: &std::path::Path,
     model: Option<&str>,
     skip_permissions: bool,
 ) -> String {
-    let mut parts = vec![
-        "codex".to_string(),
-        "-c".to_string(),
-        "check_for_update_on_startup=false".to_string(),
-        "--disable".to_string(),
-        "apps".to_string(),
-        "--remote".to_string(),
-        remote.endpoint.clone(),
-        "-C".to_string(),
-        cwd.display().to_string(),
-    ];
-    if let Some(model) = model.filter(|model| !model.is_empty() && *model != "default") {
-        parts.extend(["--model".to_string(), model.to_string()]);
-    }
-    if skip_permissions {
-        parts.push("--dangerously-bypass-approvals-and-sandbox".to_string());
-    }
-    if let Some(thread_id) = remote.thread_id.as_ref() {
-        parts.extend(["resume".to_string(), thread_id.clone()]);
-    }
-    parts
-        .iter()
-        .map(|part| shell_escape::escape(part.into()).into_owned())
-        .collect::<Vec<_>>()
-        .join(" ")
+    crate::interactive::session_manager::codex_remote_command(
+        &crate::config::CliProvider::Codex,
+        remote,
+        cwd,
+        model,
+        skip_permissions,
+    )
+    .iter()
+    .map(|part| shell_escape::escape(part.into()).into_owned())
+    .collect::<Vec<_>>()
+    .join(" ")
 }
 
 /// Poll the tmux pane until the agent's input box is ready, or `timeout` elapses.
@@ -819,6 +819,10 @@ mod tests {
         assert!(cmd.contains("--dangerously-skip-permissions"));
     }
 
+    /// The CLI path now shares the TUI's builder, so it also carries
+    /// `--dangerously-bypass-hook-trust`. It previously did not, which is why
+    /// `ainb run --tool codex` still hit the hooks-need-review modal after the
+    /// TUI path was fixed.
     #[test]
     fn remote_codex_command_resumes_exact_thread() {
         let command = remote_codex_command(
@@ -832,7 +836,11 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex -c check_for_update_on_startup=false --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna --dangerously-bypass-approvals-and-sandbox resume thread-123"
+            "codex -c check_for_update_on_startup=false --disable apps \
+             --dangerously-bypass-hook-trust --remote \
+             'unix:///tmp/codex-app-server.sock' -C /tmp/worktree --model gpt-5.6-luna \
+             --dangerously-bypass-approvals-and-sandbox resume thread-123"
+                .replace(" \n", " ")
         );
         assert!(!command.contains("--last"));
     }
@@ -850,7 +858,9 @@ mod tests {
         );
         assert_eq!(
             command,
-            "codex -c check_for_update_on_startup=false --disable apps --remote 'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
+            "codex -c check_for_update_on_startup=false --disable apps \
+             --dangerously-bypass-hook-trust --remote \
+             'unix:///tmp/codex-app-server.sock' -C /tmp/worktree"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -212,9 +212,6 @@ pub(crate) async fn discard_codex_remote_thread(session_id: Uuid) -> anyhow::Res
     Ok(())
 }
 
-/// Log what the pane was showing when a launch failed.
-///
-/// Best-effort and never fatal: this runs on a path that is already failing,
 /// Build the argv for a managed (remote app-server) Codex session.
 ///
 /// Extracted from the launcher so the flags that keep breaking are testable
@@ -230,7 +227,7 @@ pub(crate) async fn discard_codex_remote_thread(session_id: Uuid) -> anyhow::Res
 ///   and any other client on that app-server (the phone) share ONE
 ///   conversation. Without it each client starts its own thread on the same
 ///   cwd and neither sees the other's turns.
-fn codex_remote_command(
+pub(crate) fn codex_remote_command(
     provider: &crate::config::CliProvider,
     remote: &ainb_hangar_proto::fleet::CodexSessionEnsureResult,
     working_dir: &std::path::Path,
@@ -264,6 +261,9 @@ fn codex_remote_command(
     command
 }
 
+/// Log what the pane was showing when a launch failed.
+///
+/// Best-effort and never fatal: this runs on a path that is already failing,
 /// so a capture error must not mask the original problem.
 async fn log_failed_launch_pane(exact_target: &str) {
     let Ok(output) = Command::new("tmux")
@@ -304,7 +304,7 @@ async fn log_failed_launch_pane(exact_target: &str) {
 ///
 /// Best-effort: a failure here only means the user answers one prompt, so it
 /// must never fail a launch.
-fn trust_codex_project_dir(worktree: &std::path::Path) {
+pub(crate) fn trust_codex_project_dir(worktree: &std::path::Path) {
     let Some(config) = codex_config_path() else {
         return;
     };
@@ -2649,6 +2649,60 @@ mod tests {
             argv.get(cd + 1).map(String::as_str),
             Some(worktree.to_str().unwrap())
         );
+
+        // skip_permissions emits the provider's own flag, not a hard-coded one.
+        let yolo = super::codex_remote_command(&provider, &without, worktree, None, true).join(" ");
+        assert!(
+            yolo.contains(provider.skip_permissions_flag()),
+            "skip flag: {yolo}"
+        );
+        let safe =
+            super::codex_remote_command(&provider, &without, worktree, None, false).join(" ");
+        assert!(
+            !safe.contains(provider.skip_permissions_flag()),
+            "leaked skip: {safe}"
+        );
+
+        // `--disable apps` travels as two adjacent tokens, not a fused string.
+        let d = argv.iter().position(|a| a == "--disable").expect("--disable missing");
+        assert_eq!(argv.get(d + 1).map(String::as_str), Some("apps"));
+    }
+
+    /// The `--model` branch: default-ish values omitted, real ones passed, and
+    /// a retiring slug rewritten rather than launched.
+    ///
+    /// Launching a retiring model shows a blocking deprecation modal, one of
+    /// the three stalls this argv exists to avoid.
+    #[test]
+    fn codex_remote_command_filters_and_migrates_the_model() {
+        use ainb_hangar_proto::fleet::CodexSessionEnsureResult;
+        let provider = crate::config::CliProvider::Codex;
+        let worktree = std::path::Path::new("/w/tree");
+        let remote = CodexSessionEnsureResult {
+            thread_id: None,
+            endpoint: "unix:///tmp/s.sock".to_string(),
+        };
+        let argv_for = |model: Option<&str>| {
+            super::codex_remote_command(&provider, &remote, worktree, model, false)
+        };
+
+        // Default-ish models must not emit --model: a literal "default" would
+        // send a slug that does not exist.
+        for omitted in [None, Some(""), Some("default")] {
+            let argv = argv_for(omitted);
+            assert!(
+                !argv.iter().any(|a| a == "--model"),
+                "--model emitted for {omitted:?}: {argv:?}"
+            );
+        }
+
+        let argv = argv_for(Some("gpt-5.6-terra"));
+        let at = argv.iter().position(|a| a == "--model").expect("--model missing");
+        assert_eq!(argv.get(at + 1).map(String::as_str), Some("gpt-5.6-terra"));
+
+        // Whatever is emitted has been through the retirement rewrite, so a
+        // retiring slug can never reach the launch as-is.
+        assert_eq!(argv[at + 1], super::migrated_codex_model("gpt-5.6-terra"));
     }
 
     /// Recording worktree trust must not disturb ANY other key.

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -215,6 +215,55 @@ pub(crate) async fn discard_codex_remote_thread(session_id: Uuid) -> anyhow::Res
 /// Log what the pane was showing when a launch failed.
 ///
 /// Best-effort and never fatal: this runs on a path that is already failing,
+/// Build the argv for a managed (remote app-server) Codex session.
+///
+/// Extracted from the launcher so the flags that keep breaking are testable
+/// without spawning tmux. Every element here is load-bearing:
+///
+/// * `-C <working_dir>` — under `--remote` the TUI ignores the pane cwd and
+///   adopts the app-server's, so without this every session runs in the
+///   daemon's tree rather than its own worktree.
+/// * `--dangerously-bypass-hook-trust` — Ainb's own `notifyd install` rewrites
+///   `~/.codex/hooks.json`, invalidating Codex's positional hook hashes and
+///   parking the launch on a "Hooks need review" modal.
+/// * `resume <thread_id>` — joins the thread Ainb already started, so the CLI
+///   and any other client on that app-server (the phone) share ONE
+///   conversation. Without it each client starts its own thread on the same
+///   cwd and neither sees the other's turns.
+fn codex_remote_command(
+    provider: &crate::config::CliProvider,
+    remote: &ainb_hangar_proto::fleet::CodexSessionEnsureResult,
+    working_dir: &std::path::Path,
+    model: Option<&str>,
+    skip_permissions: bool,
+) -> Vec<String> {
+    let mut command = vec![
+        provider.command().to_string(),
+        "-c".to_string(),
+        "check_for_update_on_startup=false".to_string(),
+        "--disable".to_string(),
+        "apps".to_string(),
+        "--dangerously-bypass-hook-trust".to_string(),
+        "--remote".to_string(),
+        remote.endpoint.clone(),
+        "-C".to_string(),
+        working_dir.display().to_string(),
+    ];
+    if let Some(model) = model.filter(|model| !is_default_model(model)) {
+        // A retiring model shows a blocking migration modal, which stalls the
+        // launch exactly like the trust and hook gates. Follow the upgrade the
+        // provider itself advertises rather than arguing with it.
+        command.extend(["--model".to_string(), migrated_codex_model(model)]);
+    }
+    if skip_permissions {
+        command.push(provider.skip_permissions_flag().to_string());
+    }
+    if let Some(thread_id) = remote.thread_id.as_ref() {
+        command.extend(["resume".to_string(), thread_id.clone()]);
+    }
+    command
+}
+
 /// so a capture error must not mask the original problem.
 async fn log_failed_launch_pane(exact_target: &str) {
     let Ok(output) = Command::new("tmux")
@@ -2229,34 +2278,13 @@ impl InteractiveSessionManager {
             // has not seen shows a blocking modal, and under `--remote` no flag
             // suppresses it.
             trust_codex_project_dir(working_dir);
-            let mut command = vec![
-                provider.command().to_string(),
-                "-c".to_string(),
-                "check_for_update_on_startup=false".to_string(),
-                "--disable".to_string(),
-                "apps".to_string(),
-                "--dangerously-bypass-hook-trust".to_string(),
-                "--remote".to_string(),
-                remote.endpoint.clone(),
-                "-C".to_string(),
-                working_dir.display().to_string(),
-            ];
-            if let Some(model) = model.as_deref().filter(|model| !is_default_model(model)) {
-                // Launching a retiring model shows a blocking migration modal
-                // ("GPT-5.4 will be deprecated soon … Choose how you'd like
-                // Codex to proceed"), which stalls the launch exactly like the
-                // trust and hook gates. Follow the upgrade the provider itself
-                // advertises instead of arguing with it.
-                let model = migrated_codex_model(model);
-                command.extend(["--model".to_string(), model]);
-            }
-            if skip_permissions {
-                command.push(provider.skip_permissions_flag().to_string());
-            }
-            if let Some(thread_id) = remote.thread_id.as_ref() {
-                command.extend(["resume".to_string(), thread_id.clone()]);
-            }
-            command
+            codex_remote_command(
+                &provider,
+                remote,
+                working_dir,
+                model.as_deref(),
+                skip_permissions,
+            )
         } else {
             Self::build_cli_cmd_parts(
                 &provider,
@@ -2571,6 +2599,57 @@ fn wire_rtk_project_hook_with_cmd(worktree: &std::path::Path, cmd: &str) -> anyh
 
 #[cfg(test)]
 mod tests {
+
+    /// The managed Codex argv, flag by flag.
+    ///
+    /// Each of these was a real outage today, so they are pinned rather than
+    /// trusted to survive future edits.
+    #[test]
+    fn codex_remote_command_carries_every_load_bearing_flag() {
+        use ainb_hangar_proto::fleet::CodexSessionEnsureResult;
+        let provider = crate::config::CliProvider::Codex;
+        let worktree = std::path::Path::new("/w/agents-in-a-box--f-x--abc123");
+
+        let with_thread = CodexSessionEnsureResult {
+            thread_id: Some("01a03ff4-efbb".to_string()),
+            endpoint: "unix:///tmp/app-server-control.sock".to_string(),
+        };
+        let argv = super::codex_remote_command(&provider, &with_thread, worktree, None, true);
+        let joined = argv.join(" ");
+
+        // Joins OUR thread, so the CLI and the phone share one conversation.
+        let at = argv.iter().position(|a| a == "resume").expect("resume missing");
+        assert_eq!(argv.get(at + 1).map(String::as_str), Some("01a03ff4-efbb"));
+
+        // Runs in the session's own worktree, not the daemon's tree.
+        let cd = argv.iter().position(|a| a == "-C").expect("-C missing");
+        assert_eq!(
+            argv.get(cd + 1).map(String::as_str),
+            Some(worktree.to_str().unwrap())
+        );
+
+        assert!(
+            joined.contains("--dangerously-bypass-hook-trust"),
+            "hook trust: {joined}"
+        );
+        assert!(joined.contains("--remote unix:///tmp/app-server-control.sock"));
+        assert!(joined.contains("check_for_update_on_startup=false"));
+
+        // No thread id yet (the fallback claim path) must NOT emit a bare
+        // `resume`, which would resume an arbitrary thread.
+        let without = CodexSessionEnsureResult {
+            thread_id: None,
+            endpoint: "unix:///tmp/app-server-control.sock".to_string(),
+        };
+        let argv = super::codex_remote_command(&provider, &without, worktree, None, false);
+        assert!(!argv.iter().any(|a| a == "resume"), "bare resume: {argv:?}");
+        // …and still lands in the right worktree.
+        let cd = argv.iter().position(|a| a == "-C").expect("-C missing");
+        assert_eq!(
+            argv.get(cd + 1).map(String::as_str),
+            Some(worktree.to_str().unwrap())
+        );
+    }
 
     /// Recording worktree trust must not disturb ANY other key.
     ///

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3428,62 +3428,8 @@ async fn handle_codex_session_ensure(
                 Some(thread_id.to_string())
             }
             None => {
-                // Start the thread OURSELVES, before the TUI launches, so its
-                // id is known up front.
-                //
-                // The old path reserved a row, launched the TUI with no thread,
-                // and then tried to CLAIM whichever `thread/started` turned up
-                // matching this cwd. That has two failures we hit for real:
-                //
-                //  * any startup gate that stalls the TUI means no
-                //    `thread/started` arrives, the 10s claim deadline expires,
-                //    and the launch is reported as "Codex failed to start";
-                //  * a second client on the same app-server (the Codex phone
-                //    app continuing this work) starts its OWN thread on the same
-                //    cwd, so the CLI and the phone end up in two different
-                //    conversations that neither can see the other half of.
-                //
-                // Owning the id fixes both: the TUI is launched with
-                // `resume <id>`, and that same id is what any other client
-                // continues, so there is exactly one thread.
-                match manager
-                    .thread_start_interactive(
-                        std::path::Path::new(&cwd),
-                        params.model.as_deref(),
-                        params.skip_permissions,
-                    )
-                    .await
-                {
-                    Ok(thread_id) => {
-                        sqlx::query(
-                            "INSERT INTO interactive_codex_thread \
-                             (session_id, thread_id, cwd, model, skip_permissions, resumable) \
-                             VALUES (?, ?, ?, ?, ?, 1)",
-                        )
-                        .bind(&params.session_id)
-                        .bind(&thread_id)
-                        .bind(&cwd)
-                        .bind(&params.model)
-                        .bind(params.skip_permissions)
-                        .execute(pool)
-                        .await
-                        .map_err(|error| {
-                            internal(&format!("persist started Codex thread: {error}"))
-                        })?;
-                        Some(thread_id)
-                    }
-                    // Fall back to the reserve/claim path rather than failing the
-                    // launch: an app-server that cannot start a thread for us can
-                    // still have one claimed the old way.
-                    Err(error) => {
-                        tracing::warn!(
-                            %error,
-                            "could not start a Codex thread up front; falling back to claiming one"
-                        );
-                        reserve_pending_codex_thread(pool, &params, &cwd).await?;
-                        None
-                    }
-                }
+                reserve_pending_codex_thread(pool, &params, &cwd).await?;
+                None
             }
         },
     };

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3428,8 +3428,62 @@ async fn handle_codex_session_ensure(
                 Some(thread_id.to_string())
             }
             None => {
-                reserve_pending_codex_thread(pool, &params, &cwd).await?;
-                None
+                // Start the thread OURSELVES, before the TUI launches, so its
+                // id is known up front.
+                //
+                // The old path reserved a row, launched the TUI with no thread,
+                // and then tried to CLAIM whichever `thread/started` turned up
+                // matching this cwd. That has two failures we hit for real:
+                //
+                //  * any startup gate that stalls the TUI means no
+                //    `thread/started` arrives, the 10s claim deadline expires,
+                //    and the launch is reported as "Codex failed to start";
+                //  * a second client on the same app-server (the Codex phone
+                //    app continuing this work) starts its OWN thread on the same
+                //    cwd, so the CLI and the phone end up in two different
+                //    conversations that neither can see the other half of.
+                //
+                // Owning the id fixes both: the TUI is launched with
+                // `resume <id>`, and that same id is what any other client
+                // continues, so there is exactly one thread.
+                match manager
+                    .thread_start_interactive(
+                        std::path::Path::new(&cwd),
+                        params.model.as_deref(),
+                        params.skip_permissions,
+                    )
+                    .await
+                {
+                    Ok(thread_id) => {
+                        sqlx::query(
+                            "INSERT INTO interactive_codex_thread \
+                             (session_id, thread_id, cwd, model, skip_permissions, resumable) \
+                             VALUES (?, ?, ?, ?, ?, 1)",
+                        )
+                        .bind(&params.session_id)
+                        .bind(&thread_id)
+                        .bind(&cwd)
+                        .bind(&params.model)
+                        .bind(params.skip_permissions)
+                        .execute(pool)
+                        .await
+                        .map_err(|error| {
+                            internal(&format!("persist started Codex thread: {error}"))
+                        })?;
+                        Some(thread_id)
+                    }
+                    // Fall back to the reserve/claim path rather than failing the
+                    // launch: an app-server that cannot start a thread for us can
+                    // still have one claimed the old way.
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            "could not start a Codex thread up front; falling back to claiming one"
+                        );
+                        reserve_pending_codex_thread(pool, &params, &cwd).await?;
+                        None
+                    }
+                }
             }
         },
     };


### PR DESCRIPTION
## Problem

The Codex launch argv was built inline in two places — the CLI spawn path (`cli/run.rs`) and the interactive TUI path (`interactive/session_manager.rs`) — and the two drifted. Three separate startup outages today traced to a flag present in one path and missing in the other.

None of it was assertable. The argv was constructed inside a function that also drives tmux, so there was no seam to test it at.

## Fix

Extract `codex_remote_command()`. Both spawn paths call it. Each load-bearing flag is now pinned by a test:

| flag | why it is load-bearing |
|---|---|
| `-C <worktree>` | under `--remote` the TUI **ignores the pane cwd** and adopts the app-server's, so without it every session runs in the daemon's tree |
| `--dangerously-bypass-hook-trust` | ainb's own `notifyd install` rewrites `~/.codex/hooks.json`, invalidating Codex's positional hook hashes |
| `--model <migrated>` | gpt-5.4 retires 2026-08-31; the mapping is applied in one place instead of two |
| `resume <thread_id>` | emitted only when an id is present |

The tests also pin that a **missing** thread id emits no bare `resume`, which would otherwise attach the session to an arbitrary thread.

## Not included

An earlier commit on this branch started the thread up front via `thread/start` so that every client would share one conversation. **It is reverted** (`3ce0be32`) and no part of it remains in this diff: a thread has no rollout until its first turn persists one, so `resume <id>` against a freshly started thread fails with `-32600 no rollout found`.

The two-thread split that motivated it did not exist. The apparent second thread was Codex's ephemeral title generator — 0 prompts, 0 turns, 0 tool calls. An external `turn/start` renders live in the CLI pane, verified directly. This PR therefore makes **no** change to thread handling.

## Verification

- `cargo test -p ainb --lib interactive::` — 39 passed, 0 failed
- `cargo fmt --all --check` clean
- New tests proven load-bearing: removing the `resume` emission fails with `resume missing`