### PR TITLE
ci: cancel superseded runs, bound every job, stop the command-count churn

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - ".github/workflows/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     name: Lint workflow files

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   actionlint:
     name: Lint workflow files
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,14 @@ on:
   # is how an operator asks for it without labelling a PR.
   workflow_dispatch:
 
+# Superseded pushes used to run to completion: four pushes to one branch in
+# half an hour queued four full runs, and the last one spent 190 minutes
+# waiting for a runner rather than working. Group per ref and cancel only on
+# pull_request — a push to main must still get its own complete run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   WORKING_DIR: ainb-tui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   changes:
     name: Detect relevant changes
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -87,6 +88,7 @@ jobs:
     if: >-
       always() && (github.event_name != 'pull_request' ||
       needs.changes.outputs.relevant != 'false')
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,6 +121,7 @@ jobs:
     if: >-
       always() && (github.event_name != 'pull_request' ||
       needs.changes.outputs.relevant != 'false')
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -168,6 +171,10 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     needs: changes
+    # 40 against a 28.7min p95. A macOS leg once sat here for 97 minutes with
+    # the nextest step never recording a completion, and with no budget set
+    # nothing would have killed it before GitHub's 360min default.
+    timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -319,6 +326,7 @@ jobs:
     if: >-
       always() && (github.event_name != 'pull_request' ||
       needs.changes.outputs.relevant != 'false')
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -360,6 +368,7 @@ jobs:
   ainb-hooks:
     name: ainb-hooks (${{ matrix.os }})
     needs: changes
+    timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -455,6 +464,7 @@ jobs:
   fleet-send-tmux:
     name: fleet send integrity (${{ matrix.os }})
     needs: changes
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -514,6 +524,7 @@ jobs:
   hangar-e2e:
     name: hangar-e2e (${{ matrix.os }})
     needs: changes
+    timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -657,6 +668,7 @@ jobs:
     if: >-
       always() && (github.event_name != 'pull_request' ||
       needs.changes.outputs.acp != 'false')
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -677,6 +689,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   recordings:
     name: Recording artifacts are not empty
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -716,6 +729,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       vars.AINB_CHAT_BUS_SMOKE == '1' ||
       contains(github.event.pull_request.labels.*.name, 'chat-bus-smoke')
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -744,6 +758,7 @@ jobs:
     if: >-
       always() && (github.event_name != 'pull_request' ||
       needs.changes.outputs.relevant != 'false')
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,6 +55,7 @@ jobs:
 
   deploy:
     needs: build
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/fleet-macos-contract.yml
+++ b/.github/workflows/fleet-macos-contract.yml
@@ -50,6 +50,7 @@ concurrency:
 jobs:
   contract:
     name: Fixture daemon and Fleet macOS
+    timeout-minutes: 45
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -14,6 +14,10 @@ on:
       - "docs/**"
       - ".github/workflows/pages-build-check.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build site

--- a/.github/workflows/pages-build-check.yml
+++ b/.github/workflows/pages-build-check.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     name: Build site
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   prepare:
     name: Prepare Release
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -225,6 +226,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     needs: prepare
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -313,6 +315,7 @@ jobs:
   release:
     name: Create Release
     needs: [prepare, build]
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -444,6 +447,7 @@ jobs:
   homebrew:
     name: Update Homebrew Tap
     needs: [prepare, build, release]
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/toolkit-validation.yml'
   pull_request:
 
+# Superseded pushes used to run to completion: four pushes to one branch in
+# half an hour queued four full runs, and the last one spent 190 minutes
+# waiting for a runner rather than working. Group per ref and cancel only on
+# pull_request — a push to main must still get its own complete run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # The pinned ainb-toolkit ref this build of ainb consumes. Keep in lockstep
 # with release.yml's AINB_TOOLKIT_REF.
 env:

--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -43,6 +43,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────────
   changes:
     name: Detect relevant changes
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -62,6 +63,7 @@ jobs:
     if: >-
       always() && (github.event_name != 'pull_request' ||
       needs.changes.outputs.relevant != 'false')
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -109,6 +111,7 @@ jobs:
     if: >-
       always() && (github.event_name != 'pull_request' ||
       needs.changes.outputs.relevant != 'false')
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -3176,15 +3176,14 @@ mod tests {
 
     #[test]
     fn built_ins_registers_all_commands() {
-        let r = CommandRegistry::built_ins();
-        let names = r.names();
-        // main's 30 (built-ins + doctor + reflect + claudecode + codex + tmux +
-        // otel + abtop + witr + learnings + plugin stub + fleet + mcp +
-        // notifyd + hangar) + headroom + rtk + the web dashboard + the daemon
-        // lifecycle surface + signed self-updates = 36. The TUI is NOT in the registry, main.rs
-        // handles `tui` / no-subcommand inline.
-        assert_eq!(names.len(), 36, "expected 36 entries, got {names:?}");
-        for required in [
+        // The registry's exact surface. Adding or removing a command MUST update
+        // this list, and the list is the ONLY place that needs it, because the
+        // count comes from `expected.len()`. A separate hardcoded total is how
+        // this test kept reddening CI on both runners every time a command
+        // landed, for no signal the set comparison does not already give.
+        // The TUI is NOT in the registry; main.rs handles `tui` /
+        // no-subcommand inline.
+        let mut expected = vec![
             "daemon",
             "run",
             "list",
@@ -3221,12 +3220,13 @@ mod tests {
             "headroom",
             "rtk",
             "update",
-        ] {
-            assert!(
-                names.contains(&required),
-                "missing required command: {required}"
-            );
-        }
+        ];
+        expected.sort_unstable();
+
+        let mut names = CommandRegistry::built_ins().names();
+        names.sort_unstable();
+
+        assert_eq!(names, expected);
     }
 
     #[test]


### PR DESCRIPTION
Three independent CI fixes, each a separate commit. They come out of an audit of 496 recent CI runs and 68 failed jobs; the full write-up lives in `research/2026-08-26_19-36-56_ci-slowness-and-flakiness.md` (untracked, local).

### `concurrency:` on four workflows

None of `ci.yml`, `toolkit-validation.yml`, `actionlint.yml`, `pages-build-check.yml` had a concurrency group, so superseded pushes ran to completion. Four pushes to one branch inside half an hour queued four full runs, and the last one spent 190 minutes waiting for a runner rather than working (run 31119091905: `Cargo Machete` queued 191min, `hangar-e2e` 168min, exec times all normal). The same pileup is what starves the shared `macos-latest` pool when several branches build at once: on 2026-08-24, ten runs from five sources fired inside 23 minutes and every one of them had a macOS job as its worst-queued (42-69min), while ubuntu jobs in the same runs queued under 2 minutes.

`ci.yml` and `toolkit-validation.yml` also fire on push, so they cancel only on `pull_request`. A push to main must still get its own complete run. The two PR-only workflows cancel unconditionally.

### `timeout-minutes` on all 24 jobs

There was no budget anywhere in `.github/`, so every job inherited GitHub's 360-minute default. That is not hypothetical: job 97129546726 (`Test (macos-latest)`, run 32613236690) ran 97.6 minutes against its own 23.6-minute median, with the nextest step recording a start and no completion. Nothing would have killed it for another four hours, on a 10x-billed runner.

Budgets are measured p95 exec plus headroom, not guesses: `test` 40 (p95 28.7), `hangar-e2e` 45 (p95 30.7), `contracts` 30 (p95 18.1), `ainb-hooks` 20 (p95 5.2), release build 60 (the macOS targets run ~23). Cheap jobs get 10-15, still an order of magnitude over what they use.

### Derive the command count from the required list

`built_ins_registers_all_commands` asserted a hardcoded `36` next to a 36-entry list of the commands it also required by name. Both had to be bumped together, and forgetting the literal reddened both Test legs, six jobs in the sampled window, with `expected 35 entries ... left: 36 right: 35`. A real failure carrying no information the name check did not already have.

It now compares sorted sets. The list is the single source of truth, the count falls out of its length, and a divergence prints which command appeared or vanished instead of a pair of integers.

### Verification

- `actionlint -shellcheck=` clean across all seven workflows
- every job's `timeout-minutes` asserted to land under the right job key via a YAML parse
- `cargo fmt --all --check` clean, `scripts/check-no-probes.sh` clean
- `built_ins_registers_all_commands` passes, and was confirmed to **fail** when one entry was removed from the list, so the assertion is live rather than vacuous

The concurrency groups and job budgets only take effect on a real `pull_request` event, so this PR is itself their first exercise.