### PR TITLE
docs: fix the Edit-page 404, the broken links, and every orphan page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,14 +10,18 @@ If you're looking for a specific topic, start here:
 | Section | What's in it |
 |---|---|
 | [Product](#product) | What agents-in-a-box is, value, high-level architecture |
-| [TUI](#tui) | The `ainb` terminal app + CLI |
-| [Toolkit](#toolkit) | Portable skills, agents, workflows (ainb-toolkit external repo) |
+| [TUI](#tui) | The `ainb` terminal app |
+| [CLI](#cli) | Every subcommand, every flag |
+| [Fleet](#fleet) | Running many agents at once: attention, the chat bridge, ATC, cost |
+| [Hangar](#hangar) | The managed-agents control plane |
+| [Skill manager](#skill-manager) | Install, sync and promote units across tool homes |
+| [Toolkit](#toolkit) | Portable skills, agents, workflows (external repo) |
 | [Plugins](#plugins) | v2 subprocess plugin system |
 | [Observability](#observability) | Usage/cost, live processes, causality, telemetry |
 | [Knowledge](#knowledge) | `reflect` / `recall` GraphRAG + QMD |
 | [Contributing](#contributing) | Build, test, ship |
-| [Reference](#reference) | Architecture, glossary, deep dives |
-| [Plans](#plans) | Active implementation plans + their research |
+| [Reference](#reference) | Architecture, glossary, repositories |
+| [Internal](#internal) | Plans, specs and research, not published to the site |
 
 ---
 
@@ -29,29 +33,82 @@ If you're looking for a specific topic, start here:
 
 ## TUI
 
-The `ainb` terminal app and its CLI.
+The `ainb` terminal app.
 
 - [Overview](tui/overview.md)
 - [Install](tui/install.md)
-- [First session quickstart](tui/quickstart.md)
+- [First session quickstart](tui/quickstart.md) — start here
+- [Starting a new session](tui/start-session.md)
 - [Attaching to sessions](tui/attach.md) — full-screen and in-pane tmux attach
-- [CLI reference](tui/cli.md) — every subcommand, every flag
+- [Code review (diff)](tui/code-review.md)
+- [Shared MCP pool](tui/mcp-pool.mdx)
+- [Token optimisation — Headroom & RTK](tui/token-optimization.mdx)
+- [Daemons overlay](tui/daemons.mdx)
+- [Inbox & notifications](tui/inbox-notifications.md)
+- [Browser dashboard (`ainb web`)](tui/web.md)
 - [Keyboard shortcuts](tui/keyboard-shortcuts.md)
 - [Architecture](tui/architecture.md)
 - [FAQ](tui/faq.md)
 
+## CLI
+
+- [Full CLI reference](tui/cli.md) — generated from `--help`, drift-checked in CI
+
+## Fleet
+
+Running more than one agent at a time.
+
+- [Chat bridge](fleet-bridge.md) — drive the fleet from Telegram, Slack or Discord
+- [ATC](atc-plumbing.md) — the always-on watcher and its session-lifecycle plumbing
+- [Fleet cost rollups](tui/fleet-cost.md) — spend across every session, with budget alerts
+
+## Hangar
+
+The managed-agents control plane: boards, tasks, squads, autopilots.
+
+- [Architecture & features](hangar/architecture.md)
+
+> The rest of `hangar/` is the build record — the original proposal, phase
+> plans, verification goals and the Multica research that produced them. It is
+> kept for provenance and is not published to the site. See
+> [hangar/README.md](hangar/README.md).
+
+## Skill manager
+
+Install, sync and promote skills, agents and commands across your tool homes.
+
+- [Guide](skill-manager/guide.mdx) — start here
+- [Discovery & import](skill-manager/discovery.md) — adopt what is already on disk
+- [Catalog browse](skill-manager/browse.md)
+- [Sync](skill-manager/sync.md) — reconcile home and repo
+- [Drift check](skill-manager/check.md)
+- [Usage tracking](skill-manager/usage.md)
+- [Promote](skill-manager/promote.md) — turn a local unit into a git-backed source
+- [Sandbox testing](skill-manager/sandbox-testing.md)
+
 ## Toolkit
 
-Portable AI-coding agent toolkit. Skills, agents, workflows — deployed to 9 AI tools. The canonical source is the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo; ainb consumes it as a pinned external source.
+Portable AI-coding agent toolkit. Skills, agents and workflows deployed to 9 AI
+tools. The canonical source is the standalone
+[`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit)
+repo; ainb consumes it as a pinned external source.
 
 - [Overview](toolkit/overview.md)
 - [Skills (94)](toolkit/skills.md)
 - [Agents (16)](toolkit/agents.md)
 - [Bootstrap engine](toolkit/bootstrap.md)
 
+Claude Code plugins that ship alongside it:
+
+- [Overview](toolkit/plugins/overview.md) — how these differ from ainb plugins
+- [`reflect`](toolkit/plugins/reflect.md) — learning capture and recall
+- [`ainb-fleet`](toolkit/plugins/ainb-fleet.md) — the fleet orchestration skills
+- [`ainb-hooks`](toolkit/plugins/ainb-hooks.md) — lifecycle events into Hangar and the Inbox
+
 ## Plugins
 
-> **Read this first if you're confused: [plugins/README.md](plugins/README.md)** — the word "plugin" means two different things in this repo. The index disambiguates.
+> **Read this first if the word is confusing: [plugins/README.md](plugins/README.md).**
+> "Plugin" means two different things in this repo, and that page disambiguates.
 
 The v2 subprocess plugin system for the ainb TUI:
 
@@ -61,15 +118,24 @@ The v2 subprocess plugin system for the ainb TUI:
 - [Wire spec v2](plugins/spec-v2.md) — the JSON-RPC contract
 - [Changelog](plugins/changelog.md)
 
+In-tree plugins:
+
+- [burndown](plugins/burndown.md) — the analytics screen and `ainb usage`
+- [session-reader](plugins/session-reader.md) — the silent backend behind burndown's numbers
+- [witr](plugins/witr.md) — process-causality tracing
+- [learnings](plugins/learnings.md) — browse and search the knowledge base
+- [abtop](plugins/abtop.md) — live agent-process monitor
+
 ## Observability
 
-See what your agents are doing, spending, and running.
+See what your agents are doing, spending and running.
 
 - [Overview](observability/overview.md) — which tool answers which question
-- [Usage analytics (burndown)](plugins/burndown.md) — spend by day / project / model
+- [Usage analytics (burndown)](plugins/burndown.md) — spend by day, project and model
+- [Fleet cost rollups](tui/fleet-cost.md) — spend across the whole fleet
 - [abtop](plugins/abtop.md) — live agent-process monitor
 - [witr](plugins/witr.md) — process-causality tracing
-- [OpenTelemetry → Grafana Cloud](reference/otel-grafana.md) — ship metrics/logs/traces off-box, with example dashboards
+- [OpenTelemetry to Grafana Cloud](reference/otel-grafana.md) — ship metrics, logs and traces off-box
 
 ## Knowledge
 
@@ -77,6 +143,15 @@ The two-tier learning capture and retrieval system.
 
 - [How reflection works](knowledge/overview.md)
 - [`reflect` CLI reference](knowledge/reflect-cli.md)
+- [Hooks & platform](knowledge/hooks-and-platform.md) — Claude, Codex and Copilot wiring
+
+Reflect memory, in depth:
+
+- [Problem & fit](knowledge/reflect-memory/problem-and-fit.md)
+- [The construct](knowledge/reflect-memory/construct.md)
+- [Recall reference](knowledge/reflect-memory/recall.md)
+- [Why build, not adopt](knowledge/reflect-memory/comparison.md)
+- [Memory browser (`reflect serve`)](knowledge/reflect-memory/serve.md)
 
 ## Contributing
 
@@ -89,16 +164,27 @@ The two-tier learning capture and retrieval system.
 
 - [Architecture deep-dive](reference/architecture.md)
 - [Glossary](reference/glossary.md)
+- [Repositories](reference/repositories.md) — which repo holds what
 
-## Plans
+## Internal
 
-Committed implementation plans for in-flight work. Research lives in GitHub
-Discussions; visual explainers on the explainer site.
+Written for whoever is building the thing, not for a reader of the site, so
+these are excluded from the site build. They stay in the repo for provenance.
+
+| Directory | What it holds |
+|---|---|
+| `plans/` | Dated implementation plans for in-flight work |
+| `contracts/` | Implementer specs, e.g. the macOS fleet daemon contract |
+| `explorations/` | Comparative research notes |
+| `solutions/` | Troubleshooting and postmortem notes |
+| `hangar/` | The Hangar build record, except `hangar/architecture.md` |
+
+Current plans:
 
 - [Buzz port part 1 — daemon chat bus + ACP adapter](plans/2026-07-31-buzz-port-01-chat-bus-acp.md)
-- [Buzz port part 2 — fleet chat + copilot (macOS + TUI)](plans/2026-07-31-buzz-port-02-fleet-chat-copilot.md) · [spec](plans/2026-07-31-buzz-port-02-fleet-chat-copilot-spec.md)
-- Research: [porting block/buzz into ainb (discussion #570)](https://github.com/stevengonsalvez/agents-in-a-box/discussions/570) — includes the ACP resume/steering spike as a comment
-- Explainer: [buzz → ainb port research](https://explainers.stevengonsalvez.com/buzz-acp-port/) (committed copy under `explainers/`)
+- [Buzz port part 2 — fleet chat + copilot](plans/2026-07-31-buzz-port-02-fleet-chat-copilot.md) · [spec](plans/2026-07-31-buzz-port-02-fleet-chat-copilot-spec.md)
+- Research: [porting block/buzz into ainb (discussion #570)](https://github.com/stevengonsalvez/agents-in-a-box/discussions/570)
+- Explainer: [buzz to ainb port research](https://explainers.stevengonsalvez.com/buzz-acp-port/)
 
 ---
 
@@ -128,7 +214,7 @@ provenance.
 
 - Markdown is the source format. Astro Starlight renders to HTML at build time.
 - Code blocks: always tag the language for syntax highlighting.
-- Cross-link other docs with relative paths (`[…](../plugins/spec-v2.md)`).
+- Cross-link other docs with relative paths, resolved from the linking file (`[…](plugins/spec-v2.md)` from here, `[…](../plugins/spec-v2.md)` from inside `tui/`).
 - Heading style: `#` once per file (title), then `##` and below for sections.
 - Frontmatter (Starlight-style) only on files that override the title or sidebar position:
 

--- a/docs/assets/diagrams/reflect.svg
+++ b/docs/assets/diagrams/reflect.svg
@@ -43,7 +43,7 @@
   </defs>
   <rect width="960.0" height="700.0" fill="#ffffff"/>
   <text x="480.0" y="56" text-anchor="middle" class="title">reflect — Claude Code plugin</text>
-  <text x="480.0" y="82" text-anchor="middle" class="subtitle">Lifecycle hooks capture corrections &amp; inject prior learnings · v3.6.0</text>
+  <text x="480.0" y="82" text-anchor="middle" class="subtitle">Lifecycle hooks capture corrections &amp; inject prior learnings · v5.2.5</text>
   <path d="M 135.0,300.0 L 135.0,138.0 L 300.0,138.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
   <path d="M 210.0,345.0 L 230.4,345.0 L 279.6,268.0 L 300.0,268.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
   <path d="M 210.0,345.0 L 230.4,345.0 L 279.6,398.0 L 300.0,398.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>

--- a/docs/hangar/README.md
+++ b/docs/hangar/README.md
@@ -2,7 +2,21 @@
 
 ainb's managed-agents control plane — where the box opens and agents launch.
 
-Hangar is the proposed evolution of ainb from a local CLI/TUI into a managed-agents platform: assign tasks to agents, track lifecycle, compound skills, surface progress in real time. It's the ainb-flavored answer to what Multica does for Claude Code.
+Hangar took ainb from a local CLI/TUI to a managed-agents platform: assign tasks to agents,
+track lifecycle, compound skills, surface progress in real time.
+
+**Status: shipped.** All 35 `agents-in-a-box-e38` child beads are closed. The live surface is
+39 RPC methods, 13 TUI screens, 16 CLI noun-groups and 23 migrations
+(see [`proofs/multica-comparison.md`](proofs/multica-comparison.md) for the reconciliation).
+
+Most of this directory is the build record: the plan, the phase docs and the research that
+produced it. Read those as history. The pages that describe what Hangar *does today* are
+[`architecture.md`](architecture.md), [`tui-keybindings.md`](tui-keybindings.md) and
+[`pull-pipeline.md`](pull-pipeline.md).
+
+> Two numbers below are pre-e38 estimates, kept because they record what was believed at the
+> time: the "~45% already exists" reuse figure and the "~16 weeks across 8 phases" build
+> estimate. `architecture.md`'s "17 RPC methods / 35 features" is the same vintage.
 
 ## Contents
 
@@ -40,7 +54,7 @@ docs/hangar/
 0. Using the shipped TUI? `tui-keybindings.md` documents every screen's keys,
    including the [task-failure taxonomy](tui-keybindings.md#task-failures)
    (what each `failure_reason` means and whether a retry helps).
-1. Start with `hangar-plan.html` — the synthesized proposal with inline diagrams.
+1. `hangar-plan.html` is the original synthesized proposal, with inline diagrams. Historical.
 2. Drill into individual reports under `research/` for evidence and citations.
 3. The diagrams in `diagrams/` are also usable standalone.
 

--- a/docs/hangar/architecture.md
+++ b/docs/hangar/architecture.md
@@ -7,15 +7,20 @@ Hangar gives `ainb` a **managed-agent control plane**: file work as *issues*, as
 
 It is deliberately **loosely coupled**. A standalone `ainb-hangar-daemon` owns the data plane (SQLite, the task FSM, the cron scheduler, the agent runner). The TUI is a **plugin** (`hangar-tui`) that the host `ainb` binary loads and that talks to the daemon over a unix-socket JSON-RPC contract. The plugin holds *zero* domain logic — it subscribes, pulls snapshots, renders, and forwards key intents. So the control plane keeps running (autopilots fire, tasks dispatch) whether or not a TUI is attached.
 
-| | |
-|---|---|
-| **Crates** | 4 Rust crates + 1 plugin |
-| **TUI screens** | 9 |
-| **CLI noun-groups** | 10 (`ainb hangar …`) |
-| **JSON-RPC methods** | 17 |
-| **Migrations** | 0001–0010 (16 tables) |
-| **Features** | 35 — 22 e2e-tripwired, 12 acceptance-only, 0 untested |
-| **Build phases** | P0–P9 |
+| | | How to re-derive |
+|---|---|---|
+| **Crates** | 7 Rust crates + 1 plugin | `ls -d ainb-tui/crates/ainb-hangar-*` |
+| **CLI noun-groups** | 18 (`ainb hangar …`) | `HangarCommand` in `cli/hangar/mod.rs` |
+| **JSON-RPC methods** | 144 | `ALL_METHODS` in `ainb-hangar-proto/src/methods.rs` |
+| **Migrations** | 0001–0092 | `ls ainb-hangar-store/migrations/` |
+| **Build phases** | P0–P9 (complete) | `docs/hangar/phases/` |
+
+> These were last checked on 2026-08-26 and each carries the command that
+> produces it, because the previous set (4 crates, 17 RPC methods, migrations
+> 0001–0010) was a pre-e38 snapshot that stayed on the page long after the
+> code moved. The reconciliation in
+> [`proofs/multica-comparison.md`](proofs/multica-comparison.md) is itself
+> now behind: it records 39 RPC methods and 23 migrations.
 
 ## System architecture
 

--- a/docs/knowledge/reflect-cli.md
+++ b/docs/knowledge/reflect-cli.md
@@ -11,7 +11,7 @@ There are **two** independent versions and they are easy to confuse:
 | Component | Package / manifest | Version | Source of truth |
 |---|---|---|---|
 | `reflect` **CLI** | Python package `reflect-kb` | `0.3.0` | [`pyproject.toml`](https://github.com/stevengonsalvez/ainb-reflect-memory/blob/main/pyproject.toml) (ainb-reflect-memory root) |
-| `reflect` **plugin** (Claude Code wiring) | [`plugin/`](https://github.com/stevengonsalvez/ainb-reflect-memory/tree/main/plugin) | `3.6.0` | [`plugin/.claude-plugin/plugin.json`](https://github.com/stevengonsalvez/ainb-reflect-memory/blob/main/plugin/.claude-plugin/plugin.json) |
+| `reflect` **plugin** (Claude Code wiring) | [`plugin/`](https://github.com/stevengonsalvez/ainb-reflect-memory/tree/main/plugin) | `5.2.5` | [`plugin/.claude-plugin/plugin.json`](https://github.com/stevengonsalvez/ainb-reflect-memory/blob/main/plugin/.claude-plugin/plugin.json) |
 
 `reflect --version` reports the CLI version (`0.3.x`). The plugin version describes the harness wiring (hooks, skills, adapters) and is documented separately in the plugin architecture docs.
 
@@ -67,7 +67,7 @@ The CLI is the data layer; it knows nothing about Claude Code. Knowledge content
 
 ## Plugin: skills, adapters and hooks
 
-The `reflect` plugin (version `3.6.0`) wires the CLI into the agent harness. It ships:
+The `reflect` plugin (version `5.2.5`) wires the CLI into the agent harness. It ships:
 
 **Six colon-namespaced skills** ([`plugin/skills/`](https://github.com/stevengonsalvez/ainb-reflect-memory/tree/main/plugin/skills)):
 

--- a/docs/plugins/changelog.md
+++ b/docs/plugins/changelog.md
@@ -15,7 +15,7 @@ Tracks how the plugin contract (`./spec-v2.md`) evolves.
 
 Subprocess plugin contract. Plugins are native executables exchanging JSON-RPC 2.0 over LSP-style Content-Length framed stdio. Replaces the v1 wasm contract entirely.
 
-Surface area (full reference in [v2.md](./v2.md)):
+Surface area (full reference in [v2.md](./spec-v2.md)):
 
 - **Six host → plugin methods**: `plugin/init`, `plugin/shutdown`, `plugin/render`, `plugin/handle_event`, `plugin/handle_key`, `plugin/cli_dispatch`.
 - **Eight plugin → host methods**: `host/snapshot/get`, `host/snapshot/publish`, `host/snapshot/subscribe`, `host/action/invoke`, `host/log`, `host/fs/read_dir`, `host/fs/read_file`, `host/network/fetch`.

--- a/docs/plugins/spec-v2.md
+++ b/docs/plugins/spec-v2.md
@@ -4,7 +4,7 @@ title: "ainb plugin contract — v2 (subprocess)"
 
 **Status:** stable.
 **Host versions covered:** `2.x.y` (additive minor bumps stay in v2).
-**Successor:** tracked in [CHANGELOG.md](./CHANGELOG.md). A new contract version (`v3`) ships only when an existing signature changes incompatibly.
+**Successor:** tracked in [CHANGELOG.md](./changelog.md). A new contract version (`v3`) ships only when an existing signature changes incompatibly.
 
 A plugin **conforms to v2** if it satisfies every MUST clause below. The `ainb-plugin-cts-v2` crate is the executable form of this document; a plugin author runs it via `cargo test` to get a per-axis pass/fail report.
 

--- a/docs/toolkit/plugins/overview.md
+++ b/docs/toolkit/plugins/overview.md
@@ -3,7 +3,7 @@ title: "Claude Code plugins"
 description: "The host-agent plugins this repo ships or documents: reflect, ainb-fleet, ainb-hooks, caveman-stats, and illustration."
 ---
 
-These are **host-agent plugins** — bundles of skills, hooks, and commands that Claude Code, Codex, or Copilot load. They are a different system from [ainb v2 plugins](../../plugins/overview.md), which are subprocess plugins for the **ainb TUI**. If you're unsure which you want, read the [plugins disambiguation](../../plugins/readme.md) first.
+These are **host-agent plugins** — bundles of skills, hooks, and commands that Claude Code, Codex, or Copilot load. They are a different system from [ainb v2 plugins](../../plugins/overview.md), which are subprocess plugins for the **ainb TUI**. If you're unsure which you want, read the [plugins disambiguation](../../plugins/README.md) first.
 
 The repo publishes the in-tree Claude Code plugins through `.claude-plugin/marketplace.json` at the repo root; the source lives under `plugins/<name>/`. Add the marketplace, then install:
 

--- a/docs/toolkit/plugins/reflect.md
+++ b/docs/toolkit/plugins/reflect.md
@@ -3,7 +3,7 @@ title: "reflect"
 description: "Claude Code plugin for agent self-improvement: captures corrections as learnings, indexes them, and auto-recalls the relevant ones into every new session."
 ---
 
-`reflect` is a **Claude Code plugin** — it is loaded by Claude Code (Anthropic's plugin system: skills + hooks + commands), not by the ainb TUI. It captures the corrections and design decisions you make in a session as structured learnings, indexes them into a hybrid GraphRAG + BM25 knowledge base, and auto-injects the most relevant prior learnings into every new session. Philosophy: *correct once, never again; recall everything next time.* Current version: **3.6.0**.
+`reflect` is a **Claude Code plugin** — it is loaded by Claude Code (Anthropic's plugin system: skills + hooks + commands), not by the ainb TUI. It captures the corrections and design decisions you make in a session as structured learnings, indexes them into a hybrid GraphRAG + BM25 knowledge base, and auto-injects the most relevant prior learnings into every new session. Philosophy: *correct once, never again; recall everything next time.* Current version: **5.2.5** (the ref pinned in `.claude-plugin/marketplace.json`).
 
 ## How it works
 

--- a/docs/tui/daemons.mdx
+++ b/docs/tui/daemons.mdx
@@ -9,11 +9,11 @@ ainb runs a few background daemons on your behalf — the shared MCP server pool
 
 ![ainb TUI Daemons overlay showing the shared MCP pool row as down and the Headroom proxy on port 8787 as up with a saved-tokens count and a watched marker, plus the consuming-sessions line; r refreshes and esc closes](../assets/screenshots/daemons-overlay.gif)
 
-*The overlay lists each daemon with a live status dot, and for the Headroom proxy: its port (`:8787`), the tokens it has saved so far (the same figure as the [Savings tab](token-optimization.md) and `ainb usage savings`), and which sessions are routed through it. `r` refreshes; `R` restarts notifyd; `Esc` closes.*
+*The overlay lists each daemon with a live status dot, and for the Headroom proxy: its port (`:8787`), the tokens it has saved so far (the same figure as the [Savings tab](token-optimization.mdx) and `ainb usage savings`), and which sessions are routed through it. `r` refreshes; `R` restarts notifyd; `Esc` closes.*
 
 ## What's on it
 
-- **MCP pool** — the shared `ainb mcp daemon` that spawns each MCP server once behind a unix socket. See [Shared MCP pool](mcp-pool.md).
+- **MCP pool** — the shared `ainb mcp daemon` that spawns each MCP server once behind a unix socket. See [Shared MCP pool](mcp-pool.mdx).
 - **Headroom proxy** — the ainb-managed compression proxy. Its row carries the live saved-token count and a **`watched`** marker when the in-loop watchdog is keeping it alive for a routed session.
 - **notifyd processes** — every running `ainb-notifyd` process, one line each, with its pid and health class. Orphaned or wedged strays are counted with a `· N to clean up (run \`ainb notifyd reap\`)` hint. notifyd owns the [Inbox](inbox-notifications.md) socket **and** the **approve socket** (`~/.agents-in-a-box/approve.sock`) that the synchronous permission round-trip blocks on.
 
@@ -57,6 +57,6 @@ ainb notifyd reap      # kill orphan/wedged notifyd strays, sparing the live own
 ## See also
 
 - [Inbox & notifications](inbox-notifications.md) — the daemon behind the notifyd rows, and the permission approve/deny round-trip.
-- [Token optimisation — Headroom & RTK](token-optimization.md) — the proxy this overlay watches.
-- [Shared MCP pool](mcp-pool.md) — the other daemon on this screen.
+- [Token optimisation — Headroom & RTK](token-optimization.mdx) — the proxy this overlay watches.
+- [Shared MCP pool](mcp-pool.mdx) — the other daemon on this screen.
 - [Keyboard shortcuts](keyboard-shortcuts.md).

--- a/docs/tui/inbox-notifications.md
+++ b/docs/tui/inbox-notifications.md
@@ -96,7 +96,7 @@ The waiting side is built to survive every failure mode without silently green-l
 
 - **Timeout ladder** — the broker holds an AWAIT for up to 600 s; the waiting hook re-dials until 640 s; Claude's own hook timeout is registered at 660 s. Each layer answers before the one above kills it, and an unanswered wait falls back to **deny** — never auto-approve.
 - **Dead or restarted socket** — the blocked hook re-dials `approve.sock` every 500 ms until its deadline. If notifyd dies mid-wait, the prompt isn't lost: the moment a fresh daemon binds the socket, every still-waiting hook re-registers itself.
-- **Single resume/repair command** — `ainb notifyd restart` (CLI) or **`R`** in the [Daemons overlay](daemons.md) stops the owner, reaps strays, respawns, and waits for `approve.sock` to bind. Because of the re-dial loop, that one command repairs the socket *and* resumes every pending prompt.
+- **Single resume/repair command** — `ainb notifyd restart` (CLI) or **`R`** in the [Daemons overlay](daemons.mdx) stops the owner, reaps strays, respawns, and waits for `approve.sock` to bind. Because of the re-dial loop, that one command repairs the socket *and* resumes every pending prompt.
 - **Observability** — the approve broker is a first-class row in `ainb fleet daemons`, with the live pending-waiter count in its health reason (`serving — 2 pending requests`), and notifyd's processes are listed in the `d` overlay.
 
 ## Host resources it touches

--- a/docs/tui/overview.md
+++ b/docs/tui/overview.md
@@ -26,8 +26,8 @@ From the home screen, single keys jump to each screen (see [Keyboard shortcuts](
 | Sessions | `s` | List, attach, restart, and delete agent sessions |
 | Agents | `a` | Pick a provider/agent before spawning a session |
 | Recovery | `R` | Find and resume orphaned sessions / broken worktrees |
-| Stats | `i` | Usage analytics: Daily, Weekly, Project, Burndown, Optimize, [Savings](token-optimization.md) (`[`/`]` switch tabs) |
-| Daemons | `d` | Read-only [Daemons overlay](daemons.md): shared MCP pool + Headroom proxy |
+| Stats | `i` | Usage analytics: Daily, Weekly, Project, Burndown, Optimize, [Savings](token-optimization.mdx) (`[`/`]` switch tabs) |
+| Daemons | `d` | Read-only [Daemons overlay](daemons.mdx): shared MCP pool + Headroom proxy |
 | Skills | `k` | Browse available skills |
 | Inbox | `I` | ainb-hooks notification inbox |
 | Config | `C` | View configuration |

--- a/docs/tui/token-optimization.mdx
+++ b/docs/tui/token-optimization.mdx
@@ -60,7 +60,7 @@ Open the usage screen with `i`, then press `]` to cycle the outer tabs to **Savi
 *The Savings card pulls `savings.total_tokens` straight from the live proxy's `/stats`: `● Headroom 907K live`. RTK shows installed/not-installed and its own saved total. The **caveman** row is a modelled estimate (`×0.74`, labelled `est`) and is never counted as real. **NET (measured)** = Headroom + RTK only.*
 
 <Aside type="tip">
-The same figures are available headlessly with `ainb usage savings`, and the Headroom proxy's live saved-token count also appears on the [Daemons overlay](daemons.md) (`d`).
+The same figures are available headlessly with `ainb usage savings`, and the Headroom proxy's live saved-token count also appears on the [Daemons overlay](daemons.mdx) (`d`).
 </Aside>
 
 ## CLI surfaces
@@ -108,6 +108,6 @@ Token optimisation is best-effort: it must never break a session. Every failure 
 
 ## See also
 
-- [Daemons overlay](daemons.md) — the `d` screen showing the live Headroom proxy + watchdog.
-- [Shared MCP pool](mcp-pool.md) — the other ainb-managed background daemon.
+- [Daemons overlay](daemons.mdx) — the `d` screen showing the live Headroom proxy + watchdog.
+- [Shared MCP pool](mcp-pool.mdx) — the other ainb-managed background daemon.
 - [Keyboard shortcuts](keyboard-shortcuts.md).

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -86,12 +86,14 @@ export default defineConfig({
             { label: 'Install', slug: 'tui/install' },
             { label: 'Quickstart', slug: 'tui/quickstart' },
             { label: 'Starting a new session', slug: 'tui/start-session' },
+            { label: 'Attaching to a session', slug: 'tui/attach' },
             { label: 'Code Review (diff)', slug: 'tui/code-review' },
             { label: 'Shared MCP pool', slug: 'tui/mcp-pool' },
             { label: 'Token optimisation (Headroom · RTK)', slug: 'tui/token-optimization' },
             { label: 'Daemons overlay', slug: 'tui/daemons' },
             { label: 'Keyboard shortcuts', slug: 'tui/keyboard-shortcuts' },
             { label: 'Inbox & notifications', slug: 'tui/inbox-notifications' },
+            { label: 'Browser dashboard (ainb web)', slug: 'tui/web' },
             { label: 'Architecture', slug: 'tui/architecture' },
             { label: 'FAQ', slug: 'tui/faq' },
           ],
@@ -100,6 +102,14 @@ export default defineConfig({
           label: 'CLI',
           items: [
             { label: 'Full CLI reference', slug: 'tui/cli' },
+          ],
+        },
+        {
+          label: 'Fleet',
+          items: [
+            { label: 'Chat bridge (Telegram · Slack · Discord)', slug: 'fleet-bridge' },
+            { label: 'ATC — the always-on watcher', slug: 'atc-plumbing' },
+            { label: 'Fleet cost rollups', slug: 'tui/fleet-cost' },
           ],
         },
         {
@@ -178,12 +188,20 @@ export default defineConfig({
             { label: 'Building', slug: 'contributing/building' },
             { label: 'CI / CD', slug: 'contributing/ci-cd' },
             { label: 'Release process', slug: 'contributing/release-process' },
+            { label: 'Verifying on a loaded box', slug: 'contributing/verifying-on-a-loaded-box' },
           ],
         },
         {
           label: 'Hangar',
           items: [
             { label: 'Architecture & features', slug: 'hangar/architecture' },
+          ],
+        },
+        {
+          label: 'Observability',
+          items: [
+            { label: 'Overview', slug: 'observability/overview' },
+            { label: 'OpenTelemetry to Grafana', slug: 'reference/otel-grafana' },
           ],
         },
         {

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -47,7 +47,14 @@ export default defineConfig({
       plugins: [starlightImageZoom()],
       customCss: ['./src/styles/tokens.css', './src/styles/crt.css', './src/styles/reflect-viz.css'],
       editLink: {
-        baseUrl: 'https://github.com/stevengonsalvez/agents-in-a-box/edit/main/',
+        // Starlight builds this as `new URL(baseUrl + entry.filePath)`. The docs
+        // collection is loaded from `../../docs`, so `entry.filePath` carries a
+        // leading `../../`, and `new URL()` resolves it by popping two segments.
+        // Pointing the base at this site's own directory gives it two segments
+        // it can afford to lose: `../../` eats `website/site/` and lands on
+        // `edit/main/docs/...`. Without the suffix it ate `edit/main/` instead,
+        // and every "Edit page" link 404'd.
+        baseUrl: 'https://github.com/stevengonsalvez/agents-in-a-box/edit/main/website/site/',
       },
       lastUpdated: true,
       pagination: true,

--- a/website/site/src/content.config.ts
+++ b/website/site/src/content.config.ts
@@ -22,6 +22,12 @@ export const collections = {
         // breaking every time automation drops a new file in one of them.
         '!explorations/**',
         '!solutions/**',
+        // Implementer specs and dated build plans. Same reasoning as above:
+        // written for whoever is building the thing, not for a reader of the
+        // site. They were building as pages with no sidebar entry, i.e.
+        // reachable only by guessing the URL.
+        '!contracts/**',
+        '!plans/**',
         // hangar/architecture.md is the one exception: a real, human-authored
         // site page (see astro.config.mjs sidebar entry for slug
         // 'hangar/architecture'). A plain '!hangar/**' plus a later


### PR DESCRIPTION
Cleanup pass over the docsite now that it is live on ainb.app.

### Edit page 404 on all 73 pages

Starlight synthesises the URL as `new URL(baseUrl + entry.filePath)` (`utils/routing/data.ts:107-108`). The docs collection loads from `../../docs`, so `entry.filePath` carries a leading `../../` and `new URL()` resolved it by popping two segments — eating `edit/main/`:

```
edit/main/ + ../../docs/product/value.md
  -> github.com/stevengonsalvez/agents-in-a-box/docs/product/value.md   404
```

Pointing the base at the site's own directory gives the `../../` two segments it can afford to lose. Verified across .md and .mdx; zero links in the build still miss the segment.

### 13 broken relative links

Three name/case errors (`./v2.md`, `./CHANGELOG.md`, `readme.md`). The other ten pointed at `.md` where the file is `.mdx` — `daemons`, `mcp-pool` and `token-optimization` were converted and every inbound link was left behind, so the three newest TUI feature pages were unreachable from the pages referencing them.

### Orphan pages

Thirteen pages built into real URLs with no sidebar entry. Eight were genuine user docs and now have a route in — including the chat bridge, ATC and fleet cost, none of which had an entry point anywhere. `contracts/` and `plans/` are implementer specs and are now excluded from the build like `explorations/` and `solutions/`.

**Every page the site builds is now reachable from the sidebar.**

### Hangar said it was still proposed

The index called it "the proposed evolution of ainb" while the reconciliation two directories away records all 35 e38 beads closed. `architecture.md` carried a pre-e38 snapshot (4 crates, 17 RPC methods, migrations 0001-0010); live is 7 crates, 18 CLI noun-groups, 144 methods in `ALL_METHODS`, 92 migrations. Every row now carries the command that re-derives it — and notes that `proofs/multica-comparison.md` has itself fallen behind.

### Also

- Docs index listed 37 of 115 files; now mirrors the sidebar, with an Internal section explaining the exclusions.
- `reflect` was documented as 3.6.0 in three places and a diagram; the marketplace pins v5.2.5.

### Sweep

```
broken relative links      0
built-but-unreachable      0
stale counts               0
old-domain references      0
```