### PR TITLE
feat!: retire gpt-5.4 from the Codex model picker

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "ainb-hangar-sandbox",
  "ainb-hangar-secrets",
  "ainb-hangar-store",
+ "ainb-model-rates",
  "ainb-plugin-hangar",
  "ainb-plugin-notifyd",
  "ainb-plugin-session-reader",

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -1002,7 +1002,7 @@ mod tests {
             create_branch: None,
             worktree: false,
             tool: Tool::Codex,
-            model: Some("gpt-5.4".to_string()),
+            model: Some("gpt-5.6-terra".to_string()),
             prompt: None,
             attach: false,
             dangerously_skip_permissions: false,
@@ -1014,8 +1014,8 @@ mod tests {
         let cmd = build_agent_command(&args);
         assert!(cmd.starts_with("codex"));
         assert!(
-            cmd.contains("--model gpt-5.4"),
-            "Codex with explicit gpt-5.4 must emit --model, got: {cmd}"
+            cmd.contains("--model gpt-5.6-terra"),
+            "Codex with explicit gpt-5.6-terra must emit --model, got: {cmd}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -97,7 +97,11 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     });
 
     // Step 5: Keep model opaque. Provider CLI owns model validation/catalog.
-    let model = requested_model(args.model.as_deref());
+    // Resolved HERE, above step 6, not inside `build_agent_command`: the Codex
+    // remote thread is allocated from this value first, so a retired id
+    // substituted only at argv-build time would already have gone out on the
+    // app-server `newThread` and aborted the run before argv existed.
+    let model = launch_model(&args);
 
     // Step 5.5: Wire shared MCP pool (Claude only; never blocks creation).
     // Ensures the pool daemon is up and merge-writes the worktree's
@@ -493,6 +497,27 @@ fn requested_model(model: Option<&str>) -> Option<String> {
     (!is_default_model(model)).then(|| model.to_string())
 }
 
+/// The model id a launch should actually use: the requested one, with a
+/// RETIRED Codex id swapped for its replacement.
+///
+/// Retired ids reach here from persisted sessions and saved presets as opaque
+/// strings, and launching one shows Codex's blocking migration modal, so the
+/// session never starts.
+///
+/// NOT pure for Codex: `migrated_codex_model` reads `<CODEX_HOME>/
+/// models_cache.json` to prefer the replacement the provider itself
+/// advertises. Callers that must stay hermetic (`remote_codex_command` and its
+/// tests) take the model as an argument instead of calling this.
+fn launch_model(args: &RunArgs) -> Option<String> {
+    let model = requested_model(args.model.as_deref())?;
+    if args.tool.to_cli_provider() == CliProvider::Codex {
+        return Some(crate::interactive::session_manager::migrated_codex_model(
+            &model,
+        ));
+    }
+    Some(model)
+}
+
 /// Validate that the selected provider's CLI binary is installed and on PATH
 fn validate_provider_installed(provider: &CliProvider) -> Result<()> {
     let cmd = provider.command();
@@ -526,7 +551,7 @@ fn build_agent_command(args: &RunArgs) -> String {
 
     match provider {
         CliProvider::Claude | CliProvider::Codex => {
-            if let Some(model) = requested_model(args.model.as_deref()) {
+            if let Some(model) = launch_model(args) {
                 cmd_parts.push("--model".to_string());
                 cmd_parts.push(model);
             }
@@ -1016,6 +1041,42 @@ mod tests {
         assert!(
             cmd.contains("--model gpt-5.6-terra"),
             "Codex with explicit gpt-5.6-terra must emit --model, got: {cmd}"
+        );
+    }
+
+    /// A retired id must not reach the wire. Persisted sessions and saved
+    /// presets both arrive here as opaque strings, so `ainb run --model
+    /// gpt-5.4` after 2026-08-31 would otherwise launch into Codex's blocking
+    /// migration modal and never start.
+    ///
+    /// Asserted as "not the retired id" rather than "exactly terra": the
+    /// substitution prefers Codex's own `models_cache.json` when the machine
+    /// has one, and this test must not depend on that file's contents.
+    #[test]
+    fn test_build_codex_command_substitutes_a_retired_model() {
+        let args = RunArgs {
+            remote_repo: None,
+            repo: None,
+            create_branch: None,
+            worktree: false,
+            tool: Tool::Codex,
+            model: Some("gpt-5.4".to_string()),
+            prompt: None,
+            attach: false,
+            dangerously_skip_permissions: false,
+            name: None,
+            interactive: false,
+            parent: None,
+        };
+
+        let cmd = build_agent_command(&args);
+        assert!(
+            cmd.contains("--model"),
+            "the flag must still be emitted, got: {cmd}"
+        );
+        assert!(
+            !cmd.contains("gpt-5.4"),
+            "gpt-5.4 retired 2026-08-31 and must not reach the wire, got: {cmd}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -370,41 +370,55 @@ fn write_atomic_config(path: &std::path::Path, contents: &str) -> std::io::Resul
 /// Codex owns this data and updates it server-side; we read it rather than
 /// hard-coding a mapping that would go stale.
 ///
-/// Returns the input unchanged when the cache is absent, unreadable, or has no
-/// upgrade for this model. Never fails a launch on its own.
-fn migrated_codex_model(model: &str) -> String {
-    let Some(cache) = codex_models_cache_path() else {
-        return model.to_string();
-    };
-    let Ok(text) = std::fs::read_to_string(&cache) else {
-        return model.to_string();
-    };
-    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) else {
-        return model.to_string();
-    };
-    let replacement = parsed
-        .get("models")
-        .and_then(|models| models.as_array())
-        .and_then(|models| {
-            models
-                .iter()
-                .find(|entry| entry.get("slug").and_then(|s| s.as_str()) == Some(model))
-        })
-        .and_then(|entry| entry.get("upgrade"))
-        .filter(|upgrade| !upgrade.is_null())
-        .and_then(|upgrade| upgrade.get("model"))
-        .and_then(|model| model.as_str());
-    match replacement {
-        Some(replacement) if replacement != model => {
+/// When the cache cannot answer - absent on a fresh machine, unreadable, or
+/// pruned of the entry once a model is fully gone - this falls back to
+/// [`ainb_model_rates::retired_codex_replacement`], the small dated table of ids
+/// known to be dead. Returns the input unchanged only when neither source has
+/// anything to say. Never fails a launch on its own.
+pub(crate) fn migrated_codex_model(model: &str) -> String {
+    if let Some((replacement, source)) = codex_cache_upgrade(model) {
+        warn!(
+            "Codex is retiring '{model}'; launching '{replacement}' instead \
+             (per {source})"
+        );
+        return replacement;
+    }
+
+    // The cache had nothing to say. It can be absent (fresh machine),
+    // unreadable, stale, or pruned of the entry once the model is fully gone,
+    // so fall back to the small dated table of ids we know are dead. Warn
+    // either way: the user pinned a model and is not getting it, and for
+    // gpt-5.4-mini the replacement costs more.
+    match ainb_model_rates::retired_codex_replacement(model) {
+        Some(replacement) => {
             warn!(
-                "Codex is retiring '{model}'; launching '{replacement}' instead \
-                 (per {})",
-                cache.display()
+                "'{model}' is retired and the Codex models cache offers no \
+                 upgrade; launching '{replacement}' instead"
             );
             replacement.to_string()
         }
-        _ => model.to_string(),
+        None => model.to_string(),
     }
+}
+
+/// The replacement `<CODEX_HOME>/models_cache.json` advertises for `model`,
+/// with the cache path that supplied it, or `None` when the cache is absent,
+/// unreadable, unparseable, or carries no upgrade for this model.
+fn codex_cache_upgrade(model: &str) -> Option<(String, String)> {
+    let cache = codex_models_cache_path()?;
+    let text = std::fs::read_to_string(&cache).ok()?;
+    let parsed = serde_json::from_str::<serde_json::Value>(&text).ok()?;
+    let replacement = parsed
+        .get("models")
+        .and_then(|models| models.as_array())?
+        .iter()
+        .find(|entry| entry.get("slug").and_then(|s| s.as_str()) == Some(model))
+        .and_then(|entry| entry.get("upgrade"))
+        .filter(|upgrade| !upgrade.is_null())
+        .and_then(|upgrade| upgrade.get("model"))
+        .and_then(|model| model.as_str())
+        .filter(|replacement| *replacement != model)?;
+    Some((replacement.to_string(), cache.display().to_string()))
 }
 
 /// `<CODEX_HOME>/models_cache.json`, honouring `CODEX_HOME`.
@@ -2123,13 +2137,23 @@ impl InteractiveSessionManager {
 
         // AINB does not own provider model catalogs. Pass any non-default raw
         // value through unchanged; provider CLI performs validation.
+        //
+        // The one exception is a RETIRED Codex id. Persisted session metadata
+        // and saved presets both reach this builder as opaque strings, so a
+        // session created before a retirement would resume straight into the
+        // provider's blocking migration modal and never start.
         if matches!(
             agent_type,
             SessionAgentType::Claude | SessionAgentType::Codex
         ) {
             if let Some(model) = model.map(str::trim).filter(|model| !is_default_model(model)) {
+                let model = if agent_type == SessionAgentType::Codex {
+                    migrated_codex_model(model)
+                } else {
+                    model.to_string()
+                };
                 cmd_parts.push("--model".to_string());
-                cmd_parts.push(model.to_string());
+                cmd_parts.push(model);
             }
         }
 

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -279,10 +279,18 @@ pub enum CodexModel {
     SystemDefault,
     /// `gpt-5.5` — 1M ctx, recommended default.
     Gpt55,
-    /// `gpt-5.4` — 1M ctx, flagship alt.
-    Gpt54,
-    /// `gpt-5.4-mini` — 200K ctx, fast/cheap.
-    Gpt54Mini,
+    /// `gpt-5.6-terra`: flagship alt. Replaced `gpt-5.4`, which retired
+    /// 2026-08-31; terra sits at the same $2.50/$15.00 tier (see
+    /// `ainb-model-rates`). The `serde(alias)` keeps session metadata written
+    /// before the swap deserializable: the variant name is persisted verbatim
+    /// in `SessionMetadata::codex_model`, so dropping the old name would fail
+    /// the whole record, not just the field.
+    #[serde(alias = "Gpt54")]
+    Gpt56Terra,
+    /// `gpt-5.6-luna`: fast/cheap. Replaced `gpt-5.4-mini` (retired
+    /// 2026-08-31). See `Gpt56Terra` for why the alias is load-bearing.
+    #[serde(alias = "Gpt54Mini")]
+    Gpt56Luna,
     /// `gpt-5.3-codex` — 200K ctx, deep SWE.
     Gpt53Codex,
 }
@@ -293,8 +301,8 @@ impl CodexModel {
         match self {
             CodexModel::SystemDefault => None,
             CodexModel::Gpt55 => Some("gpt-5.5"),
-            CodexModel::Gpt54 => Some("gpt-5.4"),
-            CodexModel::Gpt54Mini => Some("gpt-5.4-mini"),
+            CodexModel::Gpt56Terra => Some("gpt-5.6-terra"),
+            CodexModel::Gpt56Luna => Some("gpt-5.6-luna"),
             CodexModel::Gpt53Codex => Some("gpt-5.3-codex"),
         }
     }
@@ -304,8 +312,8 @@ impl CodexModel {
         match self {
             CodexModel::SystemDefault => "system default",
             CodexModel::Gpt55 => "gpt-5.5 [1M]",
-            CodexModel::Gpt54 => "gpt-5.4 [1M]",
-            CodexModel::Gpt54Mini => "gpt-5.4-mini [200K]",
+            CodexModel::Gpt56Terra => "gpt-5.6-terra",
+            CodexModel::Gpt56Luna => "gpt-5.6-luna",
             CodexModel::Gpt53Codex => "gpt-5.3-codex [200K]",
         }
     }
@@ -315,21 +323,28 @@ impl CodexModel {
         vec![
             CodexModel::SystemDefault,
             CodexModel::Gpt55,
-            CodexModel::Gpt54,
-            CodexModel::Gpt54Mini,
+            CodexModel::Gpt56Terra,
+            CodexModel::Gpt56Luna,
             CodexModel::Gpt53Codex,
         ]
     }
 
     /// Parse a TOML / preset string into a `CodexModel`. Accepts canonical IDs
     /// only (Codex CLI never had short aliases) plus `""` / `"default"` for
-    /// the SystemDefault variant. Unknown values fall back to `SystemDefault`.
+    /// the SystemDefault variant, and the two retired `gpt-5.4*` ids, which map
+    /// forward to their replacements. Unknown values fall back to
+    /// `SystemDefault`.
     pub fn parse(value: &str) -> CodexModel {
         match value.trim().to_lowercase().as_str() {
             "" | "default" => CodexModel::SystemDefault,
             "gpt-5.5" => CodexModel::Gpt55,
-            "gpt-5.4" => CodexModel::Gpt54,
-            "gpt-5.4-mini" => CodexModel::Gpt54Mini,
+            "gpt-5.6-terra" => CodexModel::Gpt56Terra,
+            "gpt-5.6-luna" => CodexModel::Gpt56Luna,
+            // Retired 2026-08-31. Mapped forward rather than left to the
+            // unknown-id arm: a preset pinned to gpt-5.4 would otherwise
+            // silently revert to the Codex CLI default with only a log line.
+            "gpt-5.4" => CodexModel::Gpt56Terra,
+            "gpt-5.4-mini" => CodexModel::Gpt56Luna,
             "gpt-5.3-codex" => CodexModel::Gpt53Codex,
             other => {
                 tracing::warn!(
@@ -826,12 +841,47 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-    use super::is_default_model;
+    use super::{CodexModel, is_default_model};
 
     #[test]
     fn default_model_sentinels_are_recognized_after_trimming() {
         assert!(is_default_model(""));
         assert!(is_default_model("  DEFAULT  "));
         assert!(!is_default_model("claude-opus-4-8"));
+    }
+
+    /// The gpt-5.4 family retired 2026-08-31. Nothing may still resolve to it.
+    #[test]
+    fn no_codex_variant_still_launches_a_retired_gpt_5_4() {
+        for model in CodexModel::all() {
+            let cli = model.cli_value().unwrap_or("");
+            assert!(
+                !cli.starts_with("gpt-5.4"),
+                "{cli} retired 2026-08-31 and must not be launchable"
+            );
+        }
+    }
+
+    /// A preset pinned to a retired id maps forward instead of silently
+    /// reverting to the Codex CLI default.
+    #[test]
+    fn retired_gpt_5_4_presets_map_forward() {
+        assert_eq!(CodexModel::parse("gpt-5.4"), CodexModel::Gpt56Terra);
+        assert_eq!(CodexModel::parse("gpt-5.4-mini"), CodexModel::Gpt56Luna);
+    }
+
+    /// `SessionMetadata::codex_model` persists the VARIANT NAME, so session
+    /// records written before the rename carry `"Gpt54"`. Without the
+    /// `serde(alias)` the whole record fails to deserialize, not just the field.
+    #[test]
+    fn legacy_variant_names_still_deserialize() {
+        assert_eq!(
+            serde_json::from_str::<CodexModel>("\"Gpt54\"").unwrap(),
+            CodexModel::Gpt56Terra
+        );
+        assert_eq!(
+            serde_json::from_str::<CodexModel>("\"Gpt54Mini\"").unwrap(),
+            CodexModel::Gpt56Luna
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -335,16 +335,25 @@ impl CodexModel {
     /// forward to their replacements. Unknown values fall back to
     /// `SystemDefault`.
     pub fn parse(value: &str) -> CodexModel {
-        match value.trim().to_lowercase().as_str() {
+        let lowered = value.trim().to_lowercase();
+        // A retired id resolves to its replacement so the Configure row names
+        // a model that still exists rather than a dead one. No warning here:
+        // `parse` runs on every frame of the Configure render, and a per-frame
+        // log line would bury the one that matters. The substitution is logged
+        // once, at the launch site, by `migrated_codex_model`.
+        //
+        // That launch site can still disagree with this row: it prefers the
+        // `upgrade` Codex publishes in `models_cache.json` and only falls back
+        // to this table. When the provider names a replacement outside
+        // `CodexModel`'s list, the row shows the table's answer and the
+        // session launches the provider's. Reading the cache here is not the
+        // fix - `parse` is a pure per-frame call and must not touch the disk.
+        let lowered = ainb_model_rates::retired_codex_replacement(&lowered).unwrap_or(&lowered);
+        match lowered {
             "" | "default" => CodexModel::SystemDefault,
             "gpt-5.5" => CodexModel::Gpt55,
             "gpt-5.6-terra" => CodexModel::Gpt56Terra,
             "gpt-5.6-luna" => CodexModel::Gpt56Luna,
-            // Retired 2026-08-31. Mapped forward rather than left to the
-            // unknown-id arm: a preset pinned to gpt-5.4 would otherwise
-            // silently revert to the Codex CLI default with only a log line.
-            "gpt-5.4" => CodexModel::Gpt56Terra,
-            "gpt-5.4-mini" => CodexModel::Gpt56Luna,
             "gpt-5.3-codex" => CodexModel::Gpt53Codex,
             other => {
                 tracing::warn!(

--- a/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
+++ b/ainb-tui/crates/ainb-hangar-daemon/Cargo.toml
@@ -83,6 +83,11 @@ ainb-plugin-notifyd = { path = "../ainb-plugin-notifyd" }
 # Fleet usage contract. Swift receives only its bounded, safe DTO.
 ainb-plugin-session-reader = { path = "../ainb-plugin-session-reader" }
 ainb-plugin-types-sessions = { path = "../ainb-plugin-types-sessions" }
+# Provider model metadata shared with ainb-core. Used here for the retired-id
+# table only: an agent record pinned to a retired Codex model would otherwise
+# dispatch `codex exec -m <dead id>` straight into the provider's blocking
+# migration modal, and a headless run has nobody to dismiss it.
+ainb-model-rates = { path = "../ainb-model-rates" }
 # e38.23 OS-level agent confinement: wraps the provider spawn in a Seatbelt
 # (macOS) / Landlock (Linux) FS sandbox so the agent subprocess can only
 # read/write the task's isolated roots. Gates the non-claude providers (e38.16).

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -1251,8 +1251,22 @@ impl Runner {
             argv.push(CODEX_JSON_FLAG.to_string());
         }
         if let Some(model) = &invocation.model {
+            // A retired id dispatches into Codex's blocking migration modal,
+            // and a headless run has nobody to dismiss it: the task hangs to
+            // its timeout. Agent records hold whatever was pinned when they
+            // were written, so the substitution belongs here, at the wire.
+            let model = match ainb_model_rates::retired_codex_replacement(model) {
+                Some(replacement) => {
+                    tracing::warn!(
+                        "agent model '{model}' is retired; dispatching \
+                         '{replacement}' instead"
+                    );
+                    replacement.to_string()
+                }
+                None => model.clone(),
+            };
             argv.push(CODEX_MODEL_FLAG.to_string());
-            argv.push(model.clone());
+            argv.push(model);
         }
         argv.extend(invocation.cli_args.iter().cloned());
         argv.push(ARG_SEPARATOR.to_string());

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -341,7 +341,7 @@ const ARG_SEPARATOR: &str = "--";
 /// sandbox + env allowlist remain the real confinement boundary.
 const COPILOT_ALLOW_ALL_TOOLS_FLAG: &str = "--allow-all-tools";
 /// The copilot model flag (`copilot --model <model>`), verified against Copilot
-/// CLI 1.0.68 (`$ copilot --model gpt-5.4`).
+/// CLI 1.0.68 (`$ copilot --model gpt-5.6-terra`).
 const COPILOT_MODEL_FLAG: &str = "--model";
 
 /// Static configuration for a [`Runner`].
@@ -1272,7 +1272,7 @@ impl Runner {
     ///
     /// Flags verified against GitHub Copilot CLI 1.0.68 (`copilot --help`):
     /// `--allow-all-tools` is "required for non-interactive mode", and `--model`
-    /// is a real flag (`$ copilot --model gpt-5.4`) — so, unlike the interactive
+    /// is a real flag (`$ copilot --model gpt-5.6-terra`) — so, unlike the interactive
     /// session launcher's stale "no model flag for these providers" rule, the
     /// agent's configured `model` IS threaded here. No subcommand is invented
     /// (copilot has none).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -300,13 +300,13 @@ fn copilot_command_carries_verified_non_interactive_flags() {
     // The agent's configured model is threaded (copilot DOES support --model).
     let invocation = ProviderInvocation {
         prompt: "do the thing".to_string(),
-        model: Some("gpt-5.4".to_string()),
+        model: Some("gpt-5.6-terra".to_string()),
         cli_args: vec!["--add-dir".to_string(), "/tmp/x".to_string()],
     };
     let (_program, argv) = runner.provider_command(Backend::Copilot, &invocation, Mode::Headless);
     let joined = argv.join(" ");
     assert!(
-        joined.contains("--model gpt-5.4"),
+        joined.contains("--model gpt-5.6-terra"),
         "model must be threaded: {argv:?}"
     );
     assert!(

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/dispatch_routing.rs
@@ -515,6 +515,51 @@ fn brief_that_names_a_subcommand_does_not_hijack_it() {
     );
 }
 
+/// An agent record pinned to a retired Codex model dispatches the replacement.
+///
+/// Headless is the case that matters: launching a retired id shows Codex's
+/// blocking migration modal, and a headless run has nobody to dismiss it, so
+/// the task burns to its timeout instead of failing fast. gpt-5.4 retired
+/// 2026-08-31 and agent records still carry it.
+#[test]
+fn a_retired_codex_model_is_replaced_before_dispatch() {
+    let tmp = TempDir::new().expect("tmp");
+    let (runner, _marker) = runner_with_all(tmp.path());
+    let inv = ProviderInvocation {
+        prompt: "do the thing".to_string(),
+        model: Some("gpt-5.4".to_string()),
+        cli_args: vec![],
+    };
+    let (_p, argv) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
+    let joined = argv.join(" ");
+    assert!(
+        joined.contains("-m gpt-5.6-terra"),
+        "retired gpt-5.4 must dispatch as its replacement: {argv:?}"
+    );
+    assert!(
+        !joined.contains("gpt-5.4"),
+        "the retired id must not reach the wire: {argv:?}"
+    );
+}
+
+/// A live model id is passed through untouched: AINB does not own the Codex
+/// catalogue, and only the dated retirement table may rewrite a pin.
+#[test]
+fn a_live_codex_model_is_dispatched_verbatim() {
+    let tmp = TempDir::new().expect("tmp");
+    let (runner, _marker) = runner_with_all(tmp.path());
+    let inv = ProviderInvocation {
+        prompt: "do the thing".to_string(),
+        model: Some("gpt-5.5".to_string()),
+        cli_args: vec![],
+    };
+    let (_p, argv) = runner.provider_command(Backend::Codex, &inv, Mode::Headless);
+    assert!(
+        argv.join(" ").contains("-m gpt-5.5"),
+        "a live model must be threaded unchanged: {argv:?}"
+    );
+}
+
 /// A value-taking flag in the agent's `cli_args` must not swallow the brief.
 ///
 /// `cli_args` are appended verbatim before the prompt, so a trailing flag that

--- a/ainb-tui/crates/ainb-model-rates/src/lib.rs
+++ b/ainb-tui/crates/ainb-model-rates/src/lib.rs
@@ -126,6 +126,9 @@ fn openai_rates(m: &str) -> Option<(f64, f64)> {
     if m.starts_with("gpt-5.5") {
         return Some((5.0, 30.0));
     }
+    // The gpt-5.4 family retired 2026-08-31. Its rates STAY: this table prices
+    // historical transcripts, and deleting a retired model's rate does not tidy
+    // anything up: it turns every past session that used it into `cost n/a`.
     if m.starts_with("gpt-5.4-nano") {
         return Some((0.2, 1.25));
     }

--- a/ainb-tui/crates/ainb-model-rates/src/lib.rs
+++ b/ainb-tui/crates/ainb-model-rates/src/lib.rs
@@ -107,6 +107,39 @@ fn anthropic_rates(m: &str) -> Option<(f64, f64)> {
     None
 }
 
+/// The replacement for a Codex model id that has been retired, or `None` for
+/// an id that is still live.
+///
+/// Lives beside the rate table because both are provider model metadata that
+/// more than one crate needs: the TUI/CLI launcher in `ainb-core` and the
+/// hangar daemon's dispatch each have to keep a retired id off the wire, and
+/// they share no crate other than this one.
+///
+/// At those launch sites this is the LAST resort, not the first. `ainb-core`
+/// prefers the `upgrade` block Codex publishes in its own `models_cache.json`,
+/// because the provider owns that data and keeps it current. This table exists
+/// for the moments the cache cannot answer: absent on a fresh machine,
+/// unreadable, or pruned of the entry once the model is fully gone - exactly
+/// when a stale pin most needs rescuing.
+///
+/// Matching is case-insensitive. The Configure picker lowercases before it
+/// asks and the CLI launch path does not, so `--model GPT-5.4` has to resolve
+/// the same as `--model gpt-5.4`.
+///
+/// Keep it small and dated. An entry earns its place only while real on-disk
+/// presets and session records still carry the retired id.
+pub fn retired_codex_replacement(model: &str) -> Option<&'static str> {
+    // Retired 2026-08-31.
+    match model.trim().to_lowercase().as_str() {
+        "gpt-5.4" => Some("gpt-5.6-terra"),
+        // Note this is a price INCREASE, $0.75/$4.50 -> $1.00/$6.00. luna is
+        // the closest surviving cheap tier, not a like-for-like swap, so the
+        // launch-site warning is what tells a cost-sensitive user it happened.
+        "gpt-5.4-mini" => Some("gpt-5.6-luna"),
+        _ => None,
+    }
+}
+
 /// OpenAI list prices, most-specific prefix first.
 fn openai_rates(m: &str) -> Option<(f64, f64)> {
     // GPT-5.6 family: three tiers at three price points. Bare `gpt-5.6`
@@ -297,5 +330,40 @@ mod tests {
     fn reasoning_tokens_bill_at_the_output_rate() {
         let with_reasoning = estimate_cost_usd("gpt-5.6-sol", 0, 0, 0, 0, 1_000_000);
         assert_eq!(with_reasoning, Some(30.0));
+    }
+
+    /// The table the Configure row, the CLI launcher and the daemon dispatch
+    /// all share. A live id must return `None` so the provider keeps owning
+    /// its own catalogue.
+    #[test]
+    fn only_retired_ids_have_a_replacement() {
+        assert_eq!(retired_codex_replacement("gpt-5.4"), Some("gpt-5.6-terra"));
+        assert_eq!(
+            retired_codex_replacement("gpt-5.4-mini"),
+            Some("gpt-5.6-luna")
+        );
+        assert_eq!(retired_codex_replacement("gpt-5.6-terra"), None);
+        assert_eq!(retired_codex_replacement("gpt-5.5"), None);
+        assert_eq!(retired_codex_replacement("anything-else"), None);
+    }
+
+    /// `ainb run --model GPT-5.4` reaches the table with the case the user
+    /// typed, while the Configure picker lowercases first. Both must resolve.
+    #[test]
+    fn retired_ids_match_regardless_of_case_and_padding() {
+        assert_eq!(retired_codex_replacement("GPT-5.4"), Some("gpt-5.6-terra"));
+        assert_eq!(
+            retired_codex_replacement("  Gpt-5.4-Mini  "),
+            Some("gpt-5.6-luna")
+        );
+    }
+
+    /// The gpt-5.4 family retired 2026-08-31 but its RATES stay: this table
+    /// prices historical transcripts, and dropping them turns every past
+    /// session that used the model into `cost n/a`.
+    #[test]
+    fn retired_models_keep_their_historical_rates() {
+        assert_eq!(input_per_million("gpt-5.4"), 2.5);
+        assert_eq!(input_per_million("gpt-5.4-mini"), 0.75);
     }
 }


### PR DESCRIPTION
## What

`gpt-5.4` retires **2026-08-31**. The Codex model picker still offered `gpt-5.4` and `gpt-5.4-mini` as selectable entries, so a user could pick one and get hard-modalled at launch after that date.

Swaps both picker entries for the gpt-5.6 family:

| was | now | why |
|---|---|---|
| `gpt-5.4 [1M]` | `gpt-5.6-terra` | identical $2.50/$15.00 rate in `ainb-model-rates` |
| `gpt-5.4-mini [200K]` | `gpt-5.6-luna` | nearest cheap/fast tier ($1/$6) |

This matches the replacement main already asserts elsewhere: `a_retiring_model_is_replaced_by_its_advertised_upgrade` in `session_manager.rs` pins `gpt-5.4 → gpt-5.6-terra` from Codex's own `models_cache.json`.

## Relationship to `migrated_codex_model()`

`session_manager::migrated_codex_model()` already substitutes a retiring slug at launch time from Codex's advertised upgrade data. That is the runtime safety net and it stays the authority. This PR fixes the layer above it: the picker should not *advertise* a dead model in the first place, and a saved preset should not depend on the cache file being present to resolve. The two compose - preset `gpt-5.4` -> `Gpt56Terra` -> `--model gpt-5.6-terra`, which `migrated_codex_model` then leaves alone.

## Decisions worth a reviewer's eye

- **Presets map forward, not to `SystemDefault`.** `CodexModel::parse("gpt-5.4")` returns `Gpt56Terra` rather than falling through to the unknown-id arm. The fallthrough would have silently reverted a user who deliberately pinned a model back to the Codex CLI default, with only a `tracing::warn` to explain it.
- **`serde(alias = "Gpt54")` is load-bearing.** `SessionMetadata::codex_model` persists the *variant name*. Without the alias, a session record written before this rename fails to deserialize as a whole record, not just that field. Covered by `legacy_variant_names_still_deserialize`.
- **Labels lose the `[ctx]` bracket.** Every other row reads `gpt-5.5 [1M]`. The gpt-5.6 context windows are not documented anywhere in this repo, and inventing a number is worse than omitting it. Happy to add them in a follow-up once someone supplies the real figures.
- **The rates table keeps its `gpt-5.4` arms**, with a comment saying why. That table prices historical transcripts; deleting a retired model's rate turns every past session that used it into `cost n/a` rather than tidying anything up. Same reasoning for the captured `session.shutdown` fixtures in the copilot parser, which are real recorded data and were left alone.

## Tests

Three new regression tests in `models/session.rs`:
- `no_codex_variant_still_launches_a_retired_gpt_5_4` - sweeps the whole `all()` ring, so this cannot regress by someone re-adding a variant
- `retired_gpt_5_4_presets_map_forward`
- `legacy_variant_names_still_deserialize`

Verified locally on this base: `cargo build --workspace` clean, `cargo test -p ainb --lib` 1892 passed / 0 failed, `dispatch_routing` 11/11, `ainb-model-rates` + `ainb-plugin-session-reader` green, `cargo fmt --all --check` clean.

## Breaking

`CodexModel::Gpt54` / `Gpt54Mini` renamed to `Gpt56Terra` / `Gpt56Luna`. On-disk data is unaffected via the serde aliases; anything naming the variants in Rust must update. No other crate in the workspace referenced them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Model Updates**
  - Replaced retired GPT-5.4 model options with GPT-5.6 Terra and GPT-5.6 Luna.
  - Existing saved sessions and retired model presets continue to work through automatic compatibility mapping.
  - Updated model examples and command validation to use GPT-5.6 Terra.

- **Reliability**
  - Automatically substitutes retired Codex models before launching interactive or headless runs, preventing migration prompts from blocking execution.

- **Cost Estimates**
  - Preserved GPT-5.4 pricing for accurate estimates in historical transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->