### PR TITLE
fix(release): resolve lockfile online

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Update Cargo.lock version
         working-directory: ${{ env.WORKING_DIR }}
-        run: cargo update --workspace --offline
+        run: cargo update --workspace
 
       - name: Update CHANGELOG.md
         working-directory: ${{ env.WORKING_DIR }}


### PR DESCRIPTION
## Summary\n- allow Cargo to resolve the lockfile on fresh GitHub runners\n- unblocks release preparation before platform builds\n\n## Validation\n- workflow diff reviewed\n- failed release run 33076636638 reproduced the missing offline index dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process by allowing dependency updates to access the network when refreshing lockfile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->