### PR TITLE
fix: stop config.toml saves destroying sections, and read it from one path

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
 ]

--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 # =============================================================================
 [authentication]
 # Active CLI provider for agent sessions
-# Options: "claude" | "codex" | "gemini"
+# Options: "claude" | "codex" | "gemini" | "copilot"
 cli_provider = "claude"
 
 # Claude-specific authentication provider
@@ -105,35 +105,88 @@ show_container_status = true
 # Show git changes in session list (+added, -removed, ~modified)
 show_git_status = true
 
+# Show the session menu bar (also toggled live with Shift+M)
+show_session_menu_bar = true
+
+# Which sessions the list shows by default
+# Options: "all" | "active_only" | "stopped_only"
+session_filter = "all"
+
+# Sidebar geometry. Normally written by the TUI as you drag/collapse a pane
+# rather than set by hand; listed here so the keys are discoverable.
+# home_sidebar_width = 40
+# sessions_sidebar_width = 40
+# sessions_sidebar_collapsed = false
+# skill_manager_sources_width = 32
+
+# First-run wizard decisions. "unset" means "ask again next launch"; the TUI
+# writes "declined" or "installed" once you answer, so hand-editing these back
+# to "unset" is how you make the wizard offer them again.
+# Options: "unset" | "declined" | "installed"
+# statusline_decision = "unset"
+# tmux_decision = "unset"
+
 # =============================================================================
 # Container Templates (Advanced)
 # =============================================================================
 # Define custom container templates for different development environments.
 # These override or extend the built-in templates: claude-dev, node, python, rust
 #
+# `image_source` is a tagged enum. `type` is one of:
+#   { type = "Image",        name = "node:20-slim" }
+#   { type = "Dockerfile",   path = "./Dockerfile", build_args = {} }
+#   { type = "ClaudeDocker", base_image = "…", build_args = {} }
+# The tag values are case-sensitive.
+#
 # Example: Custom Node.js template with additional packages
+# --8<-- parse
 # [container_templates.my-node]
-# image_source = { type = "prebuilt", image = "node:20-slim" }
-# working_directory = "/workspace"
+# name = "my-node"
+# description = "Node 20 with extra tooling"
+# required_env = []
+# default_mcp_servers = []
+#
+# [container_templates.my-node.config]
+# image_source = { type = "Image", name = "node:20-slim" }
+# working_dir = "/workspace"
 # system_packages = ["git", "curl", "vim"]
+# npm_packages = []
+# python_packages = []
 # environment = { NODE_ENV = "development" }
-# memory_limit = "4g"
+# ports = [3000]
+# memory_limit = 4096   # megabytes, an integer — NOT a Docker-style "4g" string
 # cpu_limit = 2.0
+# mount_ssh = true
+# mount_git_config = true
+# -->8--
 
 # =============================================================================
 # MCP Servers (Advanced)
 # =============================================================================
 # Configure Model Context Protocol (MCP) servers for enhanced AI capabilities.
 #
+# Both `installation` and `definition` are tagged enums; `type` is
+# case-sensitive.
+#   installation: { type = "Npm", package = "…", version = "…" }
+#                 { type = "Python", package = "…", version = "…" }
+#                 { type = "Git", url = "…", branch = "…", install_command = "…" }
+#                 { type = "PreInstalled" }
+#                 { type = "Custom", script = "…" }
+#   definition:   { type = "Command", command = "…", args = [], env = {} }
+#                 { type = "Json", config = { … } }
+#
 # Example: Context7 documentation server
+# --8<-- parse
 # [mcp_servers.context7]
 # name = "context7"
-# command = "npx"
-# args = ["-y", "@context7/mcp-server"]
-# environment = {}
-# init_strategy = "lazy"  # Options: "lazy", "eager", "none"
+# description = "Up-to-date library documentation"
+# required_env = []
+# enabled_by_default = true
 # shared = true           # Pool this server across sessions (default: true).
 #                         # Set false for stateful servers (browser/db bridges).
+# installation = { type = "Npm", package = "@context7/mcp-server", version = "latest" }
+# definition = { type = "Command", command = "npx", args = ["-y", "@context7/mcp-server"], env = {} }
+# -->8--
 
 # =============================================================================
 # MCP Pool (shared MCP server processes for host/tmux sessions)
@@ -259,3 +312,68 @@ show_git_status = true
 # Optional: channel to reply in when the inbound message carries none.
 # channel_id = "123456789012345678"
 # default_target = "conductor"
+
+# =============================================================================
+# Usage analytics (the Analytics/burndown screen)
+# =============================================================================
+# Written by the burndown plugin (`ainb burndown plan set …`) as well as read
+# by it — hand-edit if you prefer, but note both this file and that command
+# target the same path.
+#
+# --8<-- parse
+# [usage.plan]
+# id = "claude-max"        # "claude-pro" | "claude-max" | "claude-max5x"
+#                          # | "cursor-pro" | "custom" | "none"
+# monthly_usd = 200.0
+# provider = "claude"      # "all" | "claude" | "codex" | "cursor"
+# reset_day = 1            # day of month the allowance resets
+# set_at = "2026-01-01T00:00:00Z"
+#
+# [usage.currency]
+# code = "GBP"
+# symbol = "£"
+# usd_rate = 0.79          # multiply USD figures by this for display
+#
+# # Map a model id reported by an agent onto one ainb knows the rate for.
+# [usage.model_aliases]
+# cursor-auto = "claude-sonnet-4-5"
+# -->8--
+
+# =============================================================================
+# Fleet
+# =============================================================================
+# --8<-- parse
+# [fleet]
+# # Terminal the macOS Fleet app opens when you jump to a session.
+# # Options: "warp" | "iterm" | "ghostty" | "terminal" (default: "warp")
+# terminal = "warp"
+#
+# # Budget caps for `ainb fleet cost`, in USD. Unset means no cap.
+# [fleet.cost]
+# session_usd = 5.0
+# group_usd = 25.0
+#
+# # Per-session and per-group overrides of the caps above.
+# [fleet.cost.session_overrides]
+# "my-long-running-session" = 20.0
+#
+# [fleet.cost.group_overrides]
+# "release-swarm" = 100.0
+#
+# # Which surface answers Claude interviews.
+# # Options: "native" | "fleet" (default: "native")
+# [fleet.interview]
+# surface = "native"
+# -->8--
+
+# =============================================================================
+# Presets
+# =============================================================================
+# Where the single presets.toml lives. Relative paths resolve against this
+# file's directory, so the default lands on ~/.agents-in-a-box/presets.toml.
+# `~` is NOT expanded — use an absolute path or a relative one.
+#
+# --8<-- parse
+# [presets]
+# file = "../presets.toml"
+# -->8--

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -780,6 +780,22 @@ fn worth_persisting_repo_defaults(
     !prompt_text.is_empty() || defaults.per_repo.contains_key(repo_label)
 }
 
+/// Whether a secret row should render as configured.
+///
+/// A `keychain:` reference counts on the strength of being set. Whether the
+/// secret actually retrieves is a question for whoever needs its value, not for
+/// a status dot drawn on the event loop.
+fn secret_reference_is_set(reference: &str) -> bool {
+    let trimmed = reference.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.starts_with("keychain:") {
+        return true;
+    }
+    !crate::fleet::bridge::secrets::resolve_secret(reference).trim().is_empty()
+}
+
 impl EventHandler {
     fn persist_sessions_pane_preferences(state: &mut AppState) {
         state.app_config.ui_preferences.sessions_sidebar_width =
@@ -7195,12 +7211,18 @@ impl EventHandler {
                                         Some(crate::app::state::ConfigValue::Secret(
                                             crate::app::state::SecretValue {
                                                 reference: text.clone(),
-                                                resolved:
-                                                    !crate::fleet::bridge::secrets::resolve_secret(
-                                                        text,
-                                                    )
-                                                    .trim()
-                                                    .is_empty(),
+                                                // A `keychain:` reference is
+                                                // taken at face value, exactly
+                                                // as `ConfigRow::to_value`
+                                                // does. Resolving it here means
+                                                // a keyring read plus a
+                                                // `security` shell-out, each
+                                                // bounded at 5s, on the event
+                                                // loop — up to ~10s of frozen
+                                                // TUI against a locked
+                                                // keychain, just for a status
+                                                // dot.
+                                                resolved: secret_reference_is_set(text),
                                             },
                                         ))
                                     }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3756,11 +3756,17 @@ impl EventHandler {
     /// value another process has since changed.
     fn persist_config_screen(state: &mut AppState) -> anyhow::Result<usize> {
         let pending = state.config_screen_state.pending_edits().len();
-        let external = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
+        let applied = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
         state.app_config.save()?;
-        crate::config::AppConfig::save_external_keys(&external)?;
+        crate::config::AppConfig::save_external_keys(&applied.external)?;
+        // Cleared even for the rejected rows: leaving them dirty made one
+        // unwritable value re-fail every later save for the rest of the session.
         state.config_screen_state.mark_saved();
-        Ok(pending)
+        for (key, why) in &applied.rejected {
+            tracing::warn!(key, error = %why, "settings edit rejected");
+            state.add_error_notification(format!("{key}: {why}"));
+        }
+        Ok(pending.saturating_sub(applied.rejected.len()))
     }
 
     /// Store a credential literal in the OS keychain and point the row at it.
@@ -6695,6 +6701,14 @@ impl EventHandler {
             } // AINB 2.0: Config screen events
             AppEvent::ConfigBack => {
                 tracing::info!("Navigating back from Config to HomeScreen");
+                // One write on the way out, and only when a node actually
+                // toggled — a user who just looked around leaves the file alone.
+                if let Some(ids) = state.config_screen_state.take_expansion_to_persist() {
+                    state.app_config.ui_preferences.config_tree_expanded = ids.clone();
+                    if let Err(e) = crate::config::AppConfig::save_tree_expansion(&ids) {
+                        tracing::warn!(error = %e, "could not persist config tree expansion");
+                    }
+                }
                 state.current_screen = screen_ids::HOME.to_string();
             }
             AppEvent::ConfigNextCategory => {
@@ -6738,22 +6752,10 @@ impl EventHandler {
                 tracing::debug!("Config focus switched to Settings pane");
             }
             AppEvent::ConfigToggleExpand => {
-                // Opening or closing a section is worth remembering: the tree
-                // is ~40 nodes deep across every category, and re-drilling to
-                // the same one on every launch is the reason the old flat list
-                // felt navigable and a tree would not.
-                if let Some(ids) = state.config_screen_state.toggle_expanded() {
-                    state.app_config.ui_preferences.config_tree_expanded = ids.clone();
-                    // Deliberately NOT `app_config.save()`: that serializes the
-                    // whole snapshot taken at startup, so a navigational
-                    // keystroke would revert anything `ainb config set` or
-                    // another process changed since — and widen the window for
-                    // two writers to collide over one file. This touches the one
-                    // key that actually changed.
-                    if let Err(e) = crate::config::AppConfig::save_tree_expansion(&ids) {
-                        tracing::warn!(error = %e, "could not persist config tree expansion");
-                    }
-                }
+                // In-memory only. Persisting here meant a read-parse-write of
+                // config.toml inside the event loop on every keypress; the flush
+                // happens once, on ConfigBack.
+                state.config_screen_state.toggle_expanded();
             }
             AppEvent::ConfigSearchStart => {
                 state.config_screen_state.start_search();
@@ -7244,6 +7246,12 @@ impl EventHandler {
             }
             AppEvent::ConfigPopupCancel => {
                 tracing::debug!("Config popup cancelled");
+                // A Ctrl+K prompt that is escaped must not leave the row armed:
+                // the next ordinary edit of that same row would be routed into
+                // the keychain, storing the typed "$MY_TOKEN" as a secret and
+                // rewriting the row to a `keychain:` ref — silently discarding
+                // the env reference the user actually asked for.
+                state.config_screen_state.keychain_target = None;
                 state.config_popup_state.close();
             }
             AppEvent::ConfigPopupInputChar(c) => {

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3788,15 +3788,28 @@ impl EventHandler {
             return Ok(0);
         }
         state.app_config.save()?;
-        crate::config::AppConfig::save_external_keys(&applied.external)?;
-        // Cleared even for the rejected rows: leaving them dirty made one
-        // unwritable value re-fail every later save for the rest of the session.
+        // Collected, not propagated — the same rule the modelled rows already
+        // follow. An external value the registry rejects (a `0` in a
+        // `min: 1` row, say) used to fail the whole save with `?`, so
+        // `mark_saved()` never ran, the row stayed dirty, and every later save
+        // in that session re-hit the same error. One bad row must not wedge
+        // the screen.
+        let mut rejected = applied.rejected.clone();
+        if let Err(err) = crate::config::AppConfig::save_external_keys(&applied.external) {
+            let keys = applied
+                .external
+                .iter()
+                .map(|(key, _)| key.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            rejected.push((keys, err.to_string()));
+        }
         state.config_screen_state.mark_saved();
-        for (key, why) in &applied.rejected {
+        for (key, why) in &rejected {
             tracing::warn!(key, error = %why, "settings edit rejected");
             state.add_error_notification(format!("{key}: {why}"));
         }
-        Ok(pending.saturating_sub(applied.rejected.len()))
+        Ok(pending.saturating_sub(rejected.len()))
     }
 
     /// Store a credential literal in the OS keychain and point the row at it.
@@ -3808,7 +3821,7 @@ impl EventHandler {
     /// storing an empty secret.
     fn store_secret_in_keychain(state: &mut AppState, row_key: &str, literal: &str) {
         let literal = literal.trim();
-        let Some(row) = state.config_screen_state.current_setting().cloned() else {
+        let Some(row) = crate::config::registry::row(row_key).cloned() else {
             return;
         };
         if literal.is_empty() {

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -5,7 +5,7 @@
 use crate::app::{
     AppState,
     screens::ids as screen_ids,
-    state::{AsyncAction, AuthMethod, ConfigPane},
+    state::{AsyncAction, AuthMethod, ConfigPane, ConfigScreenState},
 };
 use crate::cli::statusline_install::{InstallOutcome, StatuslineStatus, install_statusline};
 use crate::credentials;
@@ -456,22 +456,28 @@ pub enum AppEvent {
     InboxRefresh,               // Inbox: force-refresh from store (r)
     // AINB 2.0: Agent selection events
     // AINB 2.0: Config screen events
-    ConfigBack,            // Return to home screen (Esc)
-    ConfigNextCategory,    // Navigate to next category
-    ConfigPrevCategory,    // Navigate to previous category
-    ConfigNextSetting,     // Navigate to next setting
-    ConfigPrevSetting,     // Navigate to previous setting
-    ConfigSwitchPane,      // Toggle focus between category and settings pane (Tab)
-    ConfigNavigateUp,      // Navigate up within current focused pane
-    ConfigNavigateDown,    // Navigate down within current focused pane
-    ConfigFocusCategories, // Switch focus to categories pane (Left)
-    ConfigFocusSettings,   // Switch focus to settings pane (Right)
-    ConfigEditSetting,     // Start editing current setting (Enter)
-    ConfigSaveEdit,        // Save current edit (Enter while editing)
-    ConfigCancelEdit,      // Cancel current edit (Esc while editing)
-    ConfigEditChar(char),  // Input character while editing
-    ConfigEditBackspace,   // Backspace while editing
-    ConfigSaveAll,         // Save all settings (S)
+    ConfigBack,             // Return to home screen (Esc)
+    ConfigNextCategory,     // Navigate to next category
+    ConfigPrevCategory,     // Navigate to previous category
+    ConfigNextSetting,      // Navigate to next setting
+    ConfigPrevSetting,      // Navigate to previous setting
+    ConfigSwitchPane,       // Toggle focus between category and settings pane (Tab)
+    ConfigNavigateUp,       // Navigate up within current focused pane
+    ConfigNavigateDown,     // Navigate down within current focused pane
+    ConfigFocusCategories,  // Switch focus to categories pane (Left)
+    ConfigFocusSettings,    // Switch focus to settings pane (Right)
+    ConfigEditSetting,      // Start editing current setting (Enter)
+    ConfigSaveEdit,         // Save current edit (Enter while editing)
+    ConfigCancelEdit,       // Cancel current edit (Esc while editing)
+    ConfigEditChar(char),   // Input character while editing
+    ConfigEditBackspace,    // Backspace while editing
+    ConfigSaveAll,          // Save all settings (S)
+    ConfigToggleExpand,     // Open/close the selected section in the tree (Enter/Space)
+    ConfigSearchStart,      // Open the `/` filter over every row
+    ConfigSearchChar(char), // Type into the `/` filter
+    ConfigSearchBackspace,  // Backspace in the `/` filter
+    ConfigSearchCancel,     // Close the `/` filter (Esc)
+    ConfigSecretToKeychain, // Store a credential literal in the OS keychain (Ctrl+K)
     // API Key configuration
     ConfigApiKeyStart,  // Start API key input mode (when on API Key Status)
     ConfigApiKeySave,   // Save the entered API key to keychain
@@ -3330,28 +3336,54 @@ impl EventHandler {
                 KeyCode::Char(c) => Some(AppEvent::ConfigEditChar(c)),
                 _ => None,
             }
+        } else if config_state.is_searching() {
+            // `/` filter box: every printable key narrows the match list, so
+            // the vim nav letters have to come from the arrow keys here.
+            match key_event.code {
+                KeyCode::Esc => Some(AppEvent::ConfigSearchCancel),
+                KeyCode::Up => Some(AppEvent::ConfigPrevSetting),
+                KeyCode::Down => Some(AppEvent::ConfigNextSetting),
+                KeyCode::Enter => Some(AppEvent::ConfigEditSetting),
+                KeyCode::Backspace => Some(AppEvent::ConfigSearchBackspace),
+                KeyCode::Char('k') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                    Some(AppEvent::ConfigSecretToKeychain)
+                }
+                KeyCode::Char(c) => Some(AppEvent::ConfigSearchChar(c)),
+                _ => None,
+            }
         } else {
-            // Navigation mode - check if we're on auth settings
-            let is_auth_category = config_state.selected_category == 0; // Authentication category
-            let on_claude_auth = is_auth_category && config_state.selected_setting == 0; // Claude Authentication
+            // Navigation mode. The Claude-auth row opens its own popup rather
+            // than the generic choice widget, because picking "API key" there
+            // also prompts for the key and stores it in the OS keychain.
+            // Matched by KEY: the old `selected_category == 0 &&
+            // selected_setting == 0` index match pointed at whatever row
+            // happened to sort first.
+            let on_claude_auth = config_state
+                .current_setting()
+                .is_some_and(|row| row.key == ConfigScreenState::CLAUDE_PROVIDER_KEY);
+            let on_categories = config_state.focused_pane == ConfigPane::Categories;
 
             match key_event.code {
                 KeyCode::Esc => Some(AppEvent::ConfigBack),
                 KeyCode::Tab => Some(AppEvent::ConfigSwitchPane),
+                KeyCode::Char('/') => Some(AppEvent::ConfigSearchStart),
+                // Ctrl+K before the bare `k` nav arm, which would otherwise
+                // swallow it.
+                KeyCode::Char('k') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                    Some(AppEvent::ConfigSecretToKeychain)
+                }
                 // Up/Down navigate within the current focused pane
                 KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::ConfigNavigateUp),
                 KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::ConfigNavigateDown),
                 // Left/Right switch focus between panes
                 KeyCode::Left | KeyCode::Char('h') => Some(AppEvent::ConfigFocusCategories),
                 KeyCode::Right | KeyCode::Char('l') => Some(AppEvent::ConfigFocusSettings),
-                KeyCode::Enter => {
-                    if on_claude_auth {
-                        // Open the auth provider popup
-                        Some(AppEvent::AuthProviderPopupOpen)
-                    } else {
-                        Some(AppEvent::ConfigEditSetting)
-                    }
-                }
+                // Space opens/closes a section from either pane, so the tree is
+                // reachable without giving up Enter-to-edit.
+                KeyCode::Char(' ') => Some(AppEvent::ConfigToggleExpand),
+                KeyCode::Enter if on_categories => Some(AppEvent::ConfigToggleExpand),
+                KeyCode::Enter if on_claude_auth => Some(AppEvent::AuthProviderPopupOpen),
+                KeyCode::Enter => Some(AppEvent::ConfigEditSetting),
                 KeyCode::Char('s' | 'S') => Some(AppEvent::ConfigSaveAll),
                 _ => None,
             }
@@ -3711,6 +3743,73 @@ impl EventHandler {
             }
         }
         Ok(session_name.to_string())
+    }
+
+    /// Write every pending settings-screen edit, returning how many landed.
+    ///
+    /// One path for both the auto-persist on a popup confirm and the explicit
+    /// `S` save-all, so they cannot drift. The order matters: `apply_to_app_config`
+    /// folds the edits into the live config and hands back the ones whose section
+    /// `AppConfig` does not model, `save()` writes the modelled part (overlaying
+    /// the file so unknown sections survive), then `save_external_keys` writes the
+    /// rest. On success the edits are cleared, so a later save cannot rewrite a
+    /// value another process has since changed.
+    fn persist_config_screen(state: &mut AppState) -> anyhow::Result<usize> {
+        let pending = state.config_screen_state.pending_edits().len();
+        let external = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
+        state.app_config.save()?;
+        crate::config::AppConfig::save_external_keys(&external)?;
+        state.config_screen_state.mark_saved();
+        Ok(pending)
+    }
+
+    /// Store a credential literal in the OS keychain and point the row at it.
+    ///
+    /// The literal is written under a service name derived from the row's key
+    /// and NEVER written to `config.toml`: the row is left holding
+    /// `keychain:<service>`, which the existing bridge secret resolver already
+    /// understands. An empty literal is treated as "clear this row" rather than
+    /// storing an empty secret.
+    fn store_secret_in_keychain(state: &mut AppState, row_key: &str, literal: &str) {
+        let literal = literal.trim();
+        let Some(row) = state.config_screen_state.current_setting().cloned() else {
+            return;
+        };
+        if literal.is_empty() {
+            state.config_screen_state.set_row_value(
+                row_key,
+                crate::app::state::ConfigValue::Secret(crate::app::state::SecretValue::default()),
+            );
+        } else {
+            let service = crate::config::screen_model::keychain_service(row_key);
+            match crate::credentials::store_keychain_secret(&service, literal) {
+                Ok(()) => {
+                    state.config_screen_state.set_row_value(
+                        row_key,
+                        crate::app::state::ConfigValue::Secret(crate::app::state::SecretValue {
+                            reference: format!("keychain:{service}"),
+                            resolved: true,
+                        }),
+                    );
+                    state.add_success_notification(format!(
+                        "{} stored in the keychain as '{service}'",
+                        row.label
+                    ));
+                }
+                Err(e) => {
+                    // Loud on both channels: the notification can scroll away,
+                    // and "the secret silently did not get stored" is the worst
+                    // possible outcome for this flow.
+                    tracing::error!(service, error = %e, "keychain write failed");
+                    state.add_error_notification(format!("Keychain write failed: {e}"));
+                    return;
+                }
+            }
+        }
+        match Self::persist_config_screen(state) {
+            Ok(_) => {}
+            Err(e) => state.add_error_notification(format!("Failed to save setting: {e}")),
+        }
     }
 
     pub fn process_event(event: AppEvent, state: &mut AppState) {
@@ -6599,46 +6698,16 @@ impl EventHandler {
                 state.current_screen = screen_ids::HOME.to_string();
             }
             AppEvent::ConfigNextCategory => {
-                let num_categories = state.config_screen_state.categories.len();
-                if num_categories > 0 {
-                    state.config_screen_state.selected_category =
-                        (state.config_screen_state.selected_category + 1) % num_categories;
-                    state.config_screen_state.selected_setting = 0;
-                }
+                state.config_screen_state.select_next_category();
             }
             AppEvent::ConfigPrevCategory => {
-                let num_categories = state.config_screen_state.categories.len();
-                if num_categories > 0 {
-                    state.config_screen_state.selected_category = state
-                        .config_screen_state
-                        .selected_category
-                        .checked_sub(1)
-                        .unwrap_or(num_categories - 1);
-                    state.config_screen_state.selected_setting = 0;
-                }
+                state.config_screen_state.select_prev_category();
             }
             AppEvent::ConfigNextSetting => {
-                let current_category = &state.config_screen_state.categories
-                    [state.config_screen_state.selected_category];
-                if let Some(settings) = state.config_screen_state.settings.get(current_category) {
-                    if !settings.is_empty() {
-                        state.config_screen_state.selected_setting =
-                            (state.config_screen_state.selected_setting + 1) % settings.len();
-                    }
-                }
+                state.config_screen_state.select_next_setting();
             }
             AppEvent::ConfigPrevSetting => {
-                let current_category = &state.config_screen_state.categories
-                    [state.config_screen_state.selected_category];
-                if let Some(settings) = state.config_screen_state.settings.get(current_category) {
-                    if !settings.is_empty() {
-                        state.config_screen_state.selected_setting = state
-                            .config_screen_state
-                            .selected_setting
-                            .checked_sub(1)
-                            .unwrap_or(settings.len() - 1);
-                    }
-                }
+                state.config_screen_state.select_prev_setting();
             }
             AppEvent::ConfigSwitchPane => {
                 // Toggle focus between categories and settings panes
@@ -6652,67 +6721,14 @@ impl EventHandler {
                     state.config_screen_state.focused_pane
                 );
             }
-            AppEvent::ConfigNavigateUp => {
-                // Navigate up within the currently focused pane
-                match state.config_screen_state.focused_pane {
-                    ConfigPane::Categories => {
-                        // Navigate to previous category
-                        let num_categories = state.config_screen_state.categories.len();
-                        if num_categories > 0 {
-                            state.config_screen_state.selected_category = state
-                                .config_screen_state
-                                .selected_category
-                                .checked_sub(1)
-                                .unwrap_or(num_categories - 1);
-                            state.config_screen_state.selected_setting = 0;
-                        }
-                    }
-                    ConfigPane::Settings => {
-                        // Navigate to previous setting
-                        let current_category = &state.config_screen_state.categories
-                            [state.config_screen_state.selected_category];
-                        if let Some(settings) =
-                            state.config_screen_state.settings.get(current_category)
-                        {
-                            if !settings.is_empty() {
-                                state.config_screen_state.selected_setting = state
-                                    .config_screen_state
-                                    .selected_setting
-                                    .checked_sub(1)
-                                    .unwrap_or(settings.len() - 1);
-                            }
-                        }
-                    }
-                }
-            }
-            AppEvent::ConfigNavigateDown => {
-                // Navigate down within the currently focused pane
-                match state.config_screen_state.focused_pane {
-                    ConfigPane::Categories => {
-                        // Navigate to next category
-                        let num_categories = state.config_screen_state.categories.len();
-                        if num_categories > 0 {
-                            state.config_screen_state.selected_category =
-                                (state.config_screen_state.selected_category + 1) % num_categories;
-                            state.config_screen_state.selected_setting = 0;
-                        }
-                    }
-                    ConfigPane::Settings => {
-                        // Navigate to next setting
-                        let current_category = &state.config_screen_state.categories
-                            [state.config_screen_state.selected_category];
-                        if let Some(settings) =
-                            state.config_screen_state.settings.get(current_category)
-                        {
-                            if !settings.is_empty() {
-                                state.config_screen_state.selected_setting =
-                                    (state.config_screen_state.selected_setting + 1)
-                                        % settings.len();
-                            }
-                        }
-                    }
-                }
-            }
+            AppEvent::ConfigNavigateUp => match state.config_screen_state.focused_pane {
+                ConfigPane::Categories => state.config_screen_state.select_prev_category(),
+                ConfigPane::Settings => state.config_screen_state.select_prev_setting(),
+            },
+            AppEvent::ConfigNavigateDown => match state.config_screen_state.focused_pane {
+                ConfigPane::Categories => state.config_screen_state.select_next_category(),
+                ConfigPane::Settings => state.config_screen_state.select_next_setting(),
+            },
             AppEvent::ConfigFocusCategories => {
                 state.config_screen_state.focused_pane = ConfigPane::Categories;
                 tracing::debug!("Config focus switched to Categories pane");
@@ -6721,13 +6737,46 @@ impl EventHandler {
                 state.config_screen_state.focused_pane = ConfigPane::Settings;
                 tracing::debug!("Config focus switched to Settings pane");
             }
+            AppEvent::ConfigToggleExpand => {
+                // Opening or closing a section is worth remembering: the tree
+                // is ~40 nodes deep across every category, and re-drilling to
+                // the same one on every launch is the reason the old flat list
+                // felt navigable and a tree would not.
+                if let Some(ids) = state.config_screen_state.toggle_expanded() {
+                    state.app_config.ui_preferences.config_tree_expanded = ids.clone();
+                    // Deliberately NOT `app_config.save()`: that serializes the
+                    // whole snapshot taken at startup, so a navigational
+                    // keystroke would revert anything `ainb config set` or
+                    // another process changed since — and widen the window for
+                    // two writers to collide over one file. This touches the one
+                    // key that actually changed.
+                    if let Err(e) = crate::config::AppConfig::save_tree_expansion(&ids) {
+                        tracing::warn!(error = %e, "could not persist config tree expansion");
+                    }
+                }
+            }
+            AppEvent::ConfigSearchStart => {
+                state.config_screen_state.start_search();
+            }
+            AppEvent::ConfigSearchChar(c) => {
+                state.config_screen_state.push_search_char(c);
+            }
+            AppEvent::ConfigSearchBackspace => {
+                state.config_screen_state.pop_search_char();
+            }
+            AppEvent::ConfigSearchCancel => {
+                state.config_screen_state.clear_search();
+            }
             AppEvent::ConfigEditSetting => {
-                let current_category = state.config_screen_state.categories
-                    [state.config_screen_state.selected_category];
-                if let Some(settings) = state.config_screen_state.settings.get(&current_category) {
-                    if let Some(setting) = settings.get(state.config_screen_state.selected_setting)
+                let selected = state.config_screen_state.current_setting().cloned();
+                if let Some(setting) = selected {
+                    // A row core cannot persist says so instead of opening an
+                    // editor that would throw the value away.
+                    if let Some(reason) =
+                        crate::config::screen_model::read_only_reason(&setting.key)
                     {
-                        // Open popup based on setting type
+                        state.add_info_notification(format!("{}: {reason}", setting.label));
+                    } else {
                         let title = setting.label.clone();
                         let description = setting.description.clone();
                         let key = setting.key.clone();
@@ -6750,9 +6799,19 @@ impl EventHandler {
                                     text,
                                 );
                             }
-                            crate::app::state::ConfigValue::Secret(_) => {
-                                // For secrets, show empty input (don't reveal existing value)
-                                state.config_popup_state.open_text(&title, &description, &key, "");
+                            crate::app::state::ConfigValue::Secret(secret) => {
+                                // Editing a secret edits the REFERENCE
+                                // ($ENV_VAR or keychain:<service>), never a
+                                // plaintext value: a literal typed here would
+                                // land in config.toml. Ctrl+K is the path that
+                                // takes a literal, and it writes it to the
+                                // keychain instead.
+                                state.config_popup_state.open_text(
+                                    &title,
+                                    "reference: $ENV_VAR or keychain:<service> — Ctrl+K stores a literal in the keychain",
+                                    &key,
+                                    &secret.reference,
+                                );
                             }
                             crate::app::state::ConfigValue::Bool(value) => {
                                 state.config_popup_state.open_boolean(
@@ -6775,46 +6834,63 @@ impl EventHandler {
                     }
                 }
             }
-            AppEvent::ConfigSaveEdit => {
-                let current_category = state.config_screen_state.categories
-                    [state.config_screen_state.selected_category];
-                if let Some(settings) =
-                    state.config_screen_state.settings.get_mut(&current_category)
-                {
-                    if let Some(setting) =
-                        settings.get_mut(state.config_screen_state.selected_setting)
-                    {
-                        let new_value = state.config_screen_state.edit_buffer.clone();
-                        // Update the value based on the type
-                        setting.value = match &setting.value {
-                            crate::app::state::ConfigValue::Text(_) => {
-                                crate::app::state::ConfigValue::Text(new_value)
-                            }
-                            crate::app::state::ConfigValue::Secret(_) => {
-                                crate::app::state::ConfigValue::Secret(new_value)
-                            }
-                            crate::app::state::ConfigValue::Bool(_) => {
-                                crate::app::state::ConfigValue::Bool(
-                                    new_value.to_lowercase() == "true",
-                                )
-                            }
-                            crate::app::state::ConfigValue::Number(_) => {
-                                crate::app::state::ConfigValue::Number(
-                                    new_value.parse().unwrap_or(0),
-                                )
-                            }
-                            crate::app::state::ConfigValue::Choice(options, _) => {
-                                // Try to find the index of the entered value
-                                let idx = options.iter().position(|o| o == &new_value).unwrap_or(0);
-                                crate::app::state::ConfigValue::Choice(options.clone(), idx)
-                            }
+            AppEvent::ConfigSecretToKeychain => {
+                let selected = state.config_screen_state.current_setting().cloned();
+                match selected.as_ref().map(|setting| (&setting.value, setting)) {
+                    Some((crate::app::state::ConfigValue::Secret(secret), setting)) => {
+                        // Pre-fill with an existing literal so migrating one out
+                        // of config.toml is a confirm away — and so the user is
+                        // shown what is about to move, never a silent rewrite.
+                        let prefill = if secret.is_reference() {
+                            ""
+                        } else {
+                            secret.reference.as_str()
                         };
-                        tracing::info!(
-                            "Saved setting: {} = {}",
-                            setting.label,
-                            setting.value.display()
+                        let service = crate::config::screen_model::keychain_service(&setting.key);
+                        state.config_screen_state.keychain_target = Some(setting.key.clone());
+                        state.config_popup_state.open_text(
+                            &format!("{} → keychain", setting.label),
+                            &format!(
+                                "stored under '{service}'; config.toml keeps only the reference"
+                            ),
+                            &setting.key,
+                            prefill,
                         );
                     }
+                    _ => state.add_info_notification(
+                        "Ctrl+K stores a credential in the keychain; this row is not one"
+                            .to_string(),
+                    ),
+                }
+            }
+            AppEvent::ConfigSaveEdit => {
+                let new_value = state.config_screen_state.edit_buffer.clone();
+                if let Some(setting) = state.config_screen_state.current_setting().cloned() {
+                    let updated = match &setting.value {
+                        crate::app::state::ConfigValue::Text(_) => {
+                            crate::app::state::ConfigValue::Text(new_value)
+                        }
+                        crate::app::state::ConfigValue::Secret(secret) => {
+                            crate::app::state::ConfigValue::Secret(crate::app::state::SecretValue {
+                                reference: new_value,
+                                resolved: secret.resolved,
+                            })
+                        }
+                        crate::app::state::ConfigValue::Bool(_) => {
+                            crate::app::state::ConfigValue::Bool(
+                                new_value.eq_ignore_ascii_case("true"),
+                            )
+                        }
+                        crate::app::state::ConfigValue::Number(_) => {
+                            crate::app::state::ConfigValue::Number(new_value.parse().unwrap_or(0))
+                        }
+                        crate::app::state::ConfigValue::Choice(options, _) => {
+                            let idx = options.iter().position(|o| o == &new_value).unwrap_or(0);
+                            crate::app::state::ConfigValue::Choice(options.clone(), idx)
+                        }
+                    };
+                    tracing::info!("Saved setting: {} = {}", setting.label, updated.display());
+                    state.config_screen_state.set_row_value(&setting.key, updated);
                 }
                 state.config_screen_state.editing = false;
                 state.config_screen_state.edit_buffer.clear();
@@ -6832,16 +6908,10 @@ impl EventHandler {
             }
             AppEvent::ConfigSaveAll => {
                 tracing::info!("Saving all settings to config file");
-
-                // Apply ConfigScreenState settings to AppConfig
-                state.config_screen_state.apply_to_app_config(&mut state.app_config);
-
-                // Save to disk
-                match state.app_config.save() {
-                    Ok(()) => {
-                        state.add_success_notification("Settings saved to config.toml".to_string());
-                        tracing::info!("Settings saved to ~/.agents-in-a-box/config/config.toml");
-                    }
+                match Self::persist_config_screen(state) {
+                    Ok(0) => state.add_info_notification("No changes to save".to_string()),
+                    Ok(n) => state
+                        .add_success_notification(format!("Saved {n} setting(s) to config.toml")),
                     Err(e) => {
                         state.add_error_notification(format!("Failed to save settings: {}", e));
                         tracing::error!("Failed to save config: {}", e);
@@ -7086,74 +7156,87 @@ impl EventHandler {
 
                 if let Some(value) = state.config_popup_state.get_value() {
                     let setting_key = state.config_popup_state.setting_key.clone();
-                    let current_category = state.config_screen_state.categories
-                        [state.config_screen_state.selected_category];
 
-                    // Update the setting value
-                    if let Some(settings) =
-                        state.config_screen_state.settings.get_mut(&current_category)
-                    {
-                        if let Some(setting) = settings.iter_mut().find(|s| s.key == setting_key) {
-                            match value {
-                                ConfigPopupValue::Choice(text, idx) => {
-                                    if let crate::app::state::ConfigValue::Choice(opts, _) =
-                                        &setting.value
-                                    {
-                                        setting.value = crate::app::state::ConfigValue::Choice(
-                                            opts.clone(),
-                                            idx,
-                                        );
+                    // Ctrl+K flow: the popup collected a plaintext credential.
+                    // It goes to the OS keychain and the row keeps only the
+                    // reference, so the literal never reaches config.toml.
+                    let keychain_row = state
+                        .config_screen_state
+                        .keychain_target
+                        .take()
+                        .filter(|k| *k == setting_key);
+                    if let Some(row_key) = keychain_row {
+                        if let ConfigPopupValue::Text(literal) = &value {
+                            Self::store_secret_in_keychain(state, &row_key, literal);
+                        }
+                        state.config_popup_state.close();
+                    } else {
+                        let updated = match &value {
+                            ConfigPopupValue::Choice(_, idx) => state
+                                .config_screen_state
+                                .current_setting()
+                                .and_then(|row| match &row.value {
+                                    crate::app::state::ConfigValue::Choice(options, _) => {
+                                        Some(crate::app::state::ConfigValue::Choice(
+                                            options.clone(),
+                                            *idx,
+                                        ))
                                     }
-                                    tracing::info!(
-                                        "Config setting {} changed to: {}",
-                                        setting_key,
-                                        text
-                                    );
-                                }
-                                ConfigPopupValue::Text(text) => {
-                                    setting.value =
-                                        crate::app::state::ConfigValue::Text(text.clone());
-                                    tracing::info!(
-                                        "Config setting {} changed to: {}",
-                                        setting_key,
-                                        text
-                                    );
-                                }
-                                ConfigPopupValue::Boolean(b) => {
-                                    setting.value = crate::app::state::ConfigValue::Bool(b);
-                                    tracing::info!(
-                                        "Config setting {} changed to: {}",
-                                        setting_key,
-                                        b
-                                    );
-                                }
-                                ConfigPopupValue::Number(n) => {
-                                    setting.value = crate::app::state::ConfigValue::Number(n);
-                                    tracing::info!(
-                                        "Config setting {} changed to: {}",
-                                        setting_key,
-                                        n
-                                    );
+                                    _ => None,
+                                }),
+                            ConfigPopupValue::Text(text) => {
+                                // A secret row edits its reference, so the text has
+                                // to go back as a reference, not as a plain value.
+                                match state.config_screen_state.current_setting().map(|r| &r.value)
+                                {
+                                    Some(crate::app::state::ConfigValue::Secret(_)) => {
+                                        Some(crate::app::state::ConfigValue::Secret(
+                                            crate::app::state::SecretValue {
+                                                reference: text.clone(),
+                                                resolved:
+                                                    !crate::fleet::bridge::secrets::resolve_secret(
+                                                        text,
+                                                    )
+                                                    .trim()
+                                                    .is_empty(),
+                                            },
+                                        ))
+                                    }
+                                    _ => Some(crate::app::state::ConfigValue::Text(text.clone())),
                                 }
                             }
-                        }
-                    }
+                            ConfigPopupValue::Boolean(b) => {
+                                Some(crate::app::state::ConfigValue::Bool(*b))
+                            }
+                            ConfigPopupValue::Number(n) => {
+                                Some(crate::app::state::ConfigValue::Number(*n))
+                            }
+                        };
 
-                    // Auto-persist: apply the edited settings to the live
-                    // config and write config.toml immediately, so the change
-                    // *becomes* the config (and survives a reopen/restart)
-                    // without the user having to remember `S` save-all. `S`
-                    // remains as an explicit save-all; `Esc` still cancels the
-                    // single edit before it reaches here.
-                    state.config_screen_state.apply_to_app_config(&mut state.app_config);
-                    match state.app_config.save() {
-                        Ok(()) => {
-                            state.add_success_notification(
-                                "Setting saved to config.toml".to_string(),
+                        if let Some(updated) = updated {
+                            tracing::info!(
+                                "Config setting {} changed to: {}",
+                                setting_key,
+                                updated.display()
                             );
+                            state.config_screen_state.set_row_value(&setting_key, updated);
                         }
-                        Err(e) => {
-                            state.add_error_notification(format!("Failed to save setting: {}", e));
+
+                        // Auto-persist: write config.toml immediately, so the change
+                        // *becomes* the config (and survives a reopen/restart)
+                        // without the user having to remember `S` save-all. `S`
+                        // remains as an explicit save-all; `Esc` still cancels the
+                        // single edit before it reaches here.
+                        match Self::persist_config_screen(state) {
+                            Ok(_) => {
+                                state.add_success_notification(
+                                    "Setting saved to config.toml".to_string(),
+                                );
+                            }
+                            Err(e) => {
+                                state
+                                    .add_error_notification(format!("Failed to save setting: {e}"));
+                            }
                         }
                     }
                 }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3772,7 +3772,21 @@ impl EventHandler {
     /// value another process has since changed.
     fn persist_config_screen(state: &mut AppState) -> anyhow::Result<usize> {
         let pending = state.config_screen_state.pending_edits().len();
+        let dirty_before = !state.config_screen_state.dirty.is_empty();
         let applied = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
+        // Nothing to write: return before touching the file. `save()` renders
+        // the whole AppConfig from the snapshot loaded at startup, so pressing
+        // `S` with no edits would revert anything `ainb config set` or another
+        // process wrote since — and then report "No changes to save". Exactly
+        // the hazard `save_tree_expansion` exists to avoid.
+        // Keyed off `dirty`, not `pending`: `pending_edits()` deliberately
+        // excludes plugin rows and read-only rows, so a plugin-only edit has
+        // `pending == 0` while still having work to do. `dirty` is the honest
+        // "did the user change anything" signal.
+        if !dirty_before && applied.external.is_empty() {
+            state.config_screen_state.mark_saved();
+            return Ok(0);
+        }
         state.app_config.save()?;
         crate::config::AppConfig::save_external_keys(&applied.external)?;
         // Cleared even for the rejected rows: leaving them dirty made one
@@ -6959,16 +6973,12 @@ impl EventHandler {
                         // Update auth status to show API key configured
                         let masked = credentials::get_anthropic_api_key_masked();
                         let status = format!("API Key ({})", masked);
-                        let auth_category = crate::app::state::ConfigCategory::Authentication;
-                        if let Some(settings) =
-                            state.config_screen_state.settings.get_mut(&auth_category)
-                        {
-                            if let Some(status_setting) =
-                                settings.iter_mut().find(|s| s.key == "claude_auth")
-                            {
-                                status_setting.value = crate::app::state::ConfigValue::Text(status);
-                            }
-                        }
+                        // Reseed from the live config: this row is a registry Choice,
+                        // keyed by its dotted path, not the deleted `claude_auth` key.
+                        state.config_screen_state.reseed_row(
+                            crate::app::state::ConfigScreenState::CLAUDE_PROVIDER_KEY,
+                            &state.app_config,
+                        );
                     }
                     Err(e) => {
                         state.add_error_notification(format!("Failed to save API key: {}", e));
@@ -6990,18 +7000,12 @@ impl EventHandler {
                         tracing::info!("API key successfully deleted from keychain");
 
                         // Update auth status to show system auth
-                        let auth_category = crate::app::state::ConfigCategory::Authentication;
-                        if let Some(settings) =
-                            state.config_screen_state.settings.get_mut(&auth_category)
-                        {
-                            if let Some(status_setting) =
-                                settings.iter_mut().find(|s| s.key == "claude_auth")
-                            {
-                                status_setting.value = crate::app::state::ConfigValue::Text(
-                                    "System Auth (Pro/Max Plan)".to_string(),
-                                );
-                            }
-                        }
+                        // Reseed from the live config: this row is a registry Choice,
+                        // keyed by its dotted path, not the deleted `claude_auth` key.
+                        state.config_screen_state.reseed_row(
+                            crate::app::state::ConfigScreenState::CLAUDE_PROVIDER_KEY,
+                            &state.app_config,
+                        );
                     }
                     Err(e) => {
                         state.add_error_notification(format!("Failed to delete API key: {}", e));
@@ -7044,17 +7048,12 @@ impl EventHandler {
                             // Update config screen status
                             let masked = credentials::get_anthropic_api_key_masked();
                             let status = format!("API Key ({})", masked);
-                            let auth_category = crate::app::state::ConfigCategory::Authentication;
-                            if let Some(settings) =
-                                state.config_screen_state.settings.get_mut(&auth_category)
-                            {
-                                if let Some(status_setting) =
-                                    settings.iter_mut().find(|s| s.key == "claude_auth")
-                                {
-                                    status_setting.value =
-                                        crate::app::state::ConfigValue::Text(status);
-                                }
-                            }
+                            // Reseed from the live config: this row is a registry Choice,
+                            // keyed by its dotted path, not the deleted `claude_auth` key.
+                            state.config_screen_state.reseed_row(
+                                crate::app::state::ConfigScreenState::CLAUDE_PROVIDER_KEY,
+                                &state.app_config,
+                            );
 
                             // Persist auth provider to config.toml
                             state.app_config.authentication.claude_provider =
@@ -7092,18 +7091,12 @@ impl EventHandler {
                             let _ = credentials::delete_anthropic_api_key();
 
                             // Update config screen status
-                            let auth_category = crate::app::state::ConfigCategory::Authentication;
-                            if let Some(settings) =
-                                state.config_screen_state.settings.get_mut(&auth_category)
-                            {
-                                if let Some(status_setting) =
-                                    settings.iter_mut().find(|s| s.key == "claude_auth")
-                                {
-                                    status_setting.value = crate::app::state::ConfigValue::Text(
-                                        "System Auth (Pro/Max Plan)".to_string(),
-                                    );
-                                }
-                            }
+                            // Reseed from the live config: this row is a registry Choice,
+                            // keyed by its dotted path, not the deleted `claude_auth` key.
+                            state.config_screen_state.reseed_row(
+                                crate::app::state::ConfigScreenState::CLAUDE_PROVIDER_KEY,
+                                &state.app_config,
+                            );
 
                             // Persist auth provider to config.toml
                             state.app_config.authentication.claude_provider =
@@ -7137,18 +7130,12 @@ impl EventHandler {
                         state.auth_provider_popup_state.refresh_providers();
 
                         // Update config screen
-                        let auth_category = crate::app::state::ConfigCategory::Authentication;
-                        if let Some(settings) =
-                            state.config_screen_state.settings.get_mut(&auth_category)
-                        {
-                            if let Some(status_setting) =
-                                settings.iter_mut().find(|s| s.key == "claude_auth")
-                            {
-                                status_setting.value = crate::app::state::ConfigValue::Text(
-                                    "System Auth (Pro/Max Plan)".to_string(),
-                                );
-                            }
-                        }
+                        // Reseed from the live config: this row is a registry Choice,
+                        // keyed by its dotted path, not the deleted `claude_auth` key.
+                        state.config_screen_state.reseed_row(
+                            crate::app::state::ConfigScreenState::CLAUDE_PROVIDER_KEY,
+                            &state.app_config,
+                        );
 
                         // Persist switch to system auth in config.toml
                         state.app_config.authentication.claude_provider =

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1605,7 +1605,6 @@ pub enum ConfigCategory {
     Plugins,
     McpPool,
     Appearance,
-    Analytics,
     General,
     ContainerTemplates,
     McpServers,
@@ -1627,7 +1626,6 @@ impl ConfigCategory {
             ConfigCategory::Plugins,
             ConfigCategory::McpPool,
             ConfigCategory::Appearance,
-            ConfigCategory::Analytics,
             ConfigCategory::General,
             ConfigCategory::ContainerTemplates,
             ConfigCategory::McpServers,
@@ -1649,7 +1647,6 @@ impl ConfigCategory {
             ConfigCategory::Plugins => "Plugins",
             ConfigCategory::McpPool => "MCP Pool",
             ConfigCategory::Appearance => "Appearance",
-            ConfigCategory::Analytics => "Analytics",
             ConfigCategory::General => "General",
             ConfigCategory::ContainerTemplates => "Container Templates",
             ConfigCategory::McpServers => "MCP Servers",
@@ -1671,7 +1668,6 @@ impl ConfigCategory {
             ConfigCategory::Plugins => "🔌",
             ConfigCategory::McpPool => "🧬",
             ConfigCategory::Appearance => "🎨",
-            ConfigCategory::Analytics => "📊",
             ConfigCategory::General => "⚙️",
             ConfigCategory::ContainerTemplates => "📦",
             ConfigCategory::McpServers => "🛰️",
@@ -1693,7 +1689,6 @@ impl ConfigCategory {
             ConfigCategory::Plugins => "Installed plugins, enable/disable",
             ConfigCategory::McpPool => "Shared MCP servers: one process across sessions",
             ConfigCategory::Appearance => "Theme, colors, status indicators",
-            ConfigCategory::Analytics => "Usage tracking, cost alerts",
             ConfigCategory::General => "Default template, presets file",
             ConfigCategory::ContainerTemplates => "Per-template image, resources, mounts",
             ConfigCategory::McpServers => "Per-server install and launch definitions",
@@ -1883,6 +1878,18 @@ pub enum ConfigPane {
 
 // Editor detection and mapping now uses the centralized crate::editors module
 
+/// What one pass of [`ConfigScreenState::apply_to_app_config`] produced.
+#[derive(Debug, Clone, Default)]
+pub struct AppliedEdits {
+    /// Edits whose section `AppConfig` does not model, for
+    /// [`AppConfig::save_external_keys`](crate::config::AppConfig::save_external_keys).
+    pub external: Vec<(String, String)>,
+    /// `(key, why)` for edits the registry refused. Reported to the user and
+    /// then dropped, so a value that can never be written cannot wedge every
+    /// subsequent save.
+    pub rejected: Vec<(String, String)>,
+}
+
 /// The settings screen: a section tree on the left, the rows of the selected
 /// section on the right.
 ///
@@ -1929,6 +1936,13 @@ pub struct ConfigScreenState {
     /// `[fleet.bridge.telegram]` section the user never created. Tracking the
     /// edits themselves cannot invent a value.
     pub dirty: BTreeSet<String>,
+    /// Whether the tree expansion changed since the screen opened.
+    ///
+    /// Expanding a section is a navigation keystroke; writing config.toml on
+    /// each one puts a read-parse-serialize-write in the event loop and gives a
+    /// user who is just looking around a modified file. The write happens once,
+    /// on the way out.
+    pub expansion_dirty: bool,
     /// The secret row a Ctrl+K prompt is collecting a literal for.
     ///
     /// Set for exactly one popup round-trip: the popup's confirm writes the
@@ -1991,6 +2005,7 @@ impl ConfigScreenState {
             visible_rows: Vec::new(),
             search: None,
             dirty: BTreeSet::new(),
+            expansion_dirty: false,
             keychain_target: None,
             editing: false,
             edit_buffer: String::new(),
@@ -2160,18 +2175,33 @@ impl ConfigScreenState {
         }
     }
 
-    /// Open or close the selected tree node. Returns the expansion ids to
-    /// persist, or `None` when the node has no children to toggle.
-    pub fn toggle_expanded(&mut self) -> Option<Vec<String>> {
-        let node = self.current_node()?;
+    /// Open or close the selected tree node.
+    ///
+    /// Records that the expansion changed; the write itself waits for
+    /// [`take_expansion_to_persist`](Self::take_expansion_to_persist) on screen
+    /// exit. Returns whether anything toggled.
+    pub fn toggle_expanded(&mut self) -> bool {
+        let Some(node) = self.current_node() else {
+            return false;
+        };
         if !node.has_children {
-            return None;
+            return false;
         }
         let id = node.id();
         if !self.expanded.remove(&id) {
             self.expanded.insert(id);
         }
+        self.expansion_dirty = true;
         self.refresh();
+        true
+    }
+
+    /// The expansion ids to write, once, if any node was toggled since the last
+    /// call. `None` means the file must be left alone.
+    pub fn take_expansion_to_persist(&mut self) -> Option<Vec<String>> {
+        if !std::mem::take(&mut self.expansion_dirty) {
+            return None;
+        }
         Some(self.expanded.iter().cloned().collect())
     }
 
@@ -2288,24 +2318,26 @@ impl ConfigScreenState {
     /// lines of per-field match arms whose only job was to name, for a second
     /// time, where each row lived — and which was missing an arm for every row
     /// that silently discarded its edit.
-    pub fn apply_to_app_config(
-        &self,
-        config: &mut AppConfig,
-    ) -> anyhow::Result<Vec<(String, String)>> {
+    pub fn apply_to_app_config(&self, config: &mut AppConfig) -> anyhow::Result<AppliedEdits> {
         let mut root = toml::Value::try_from(&*config)
             .map_err(|e| anyhow::anyhow!("config does not serialize to TOML: {e}"))?;
 
-        let mut external = Vec::new();
+        let mut applied = AppliedEdits::default();
         for (key, raw) in self.pending_edits() {
             if registry::is_external(&key) && !key.starts_with("fleet.bridge.") {
                 // `[skills]` / `[session_reader]` are parsed off this file by
                 // other crates and have no `AppConfig` field to land in.
                 // `[fleet.bridge]` DOES round-trip, as an opaque passthrough.
-                external.push((key, raw));
+                applied.external.push((key, raw));
                 continue;
             }
-            registry::set_validated(&mut root, &key, &raw)
-                .map_err(|e| anyhow::anyhow!("setting '{key}': {e}"))?;
+            // Collected, not propagated. Failing the whole save on the first
+            // bad row left that row in `dirty`, so every later auto-persist hit
+            // the same error — one out-of-range number blocked every unrelated
+            // edit for the rest of the session.
+            if let Err(e) = registry::set_validated(&mut root, &key, &raw) {
+                applied.rejected.push((key, e.to_string()));
+            }
         }
 
         *config = root
@@ -2318,7 +2350,7 @@ impl ConfigScreenState {
         self.apply_plugin_rows(config);
         self.apply_plugin_toggle_rows(config);
 
-        Ok(external)
+        Ok(applied)
     }
 
     /// Forget the pending edits after they have been written, so a later save
@@ -2389,7 +2421,17 @@ impl ConfigScreenState {
         // not yet run, dropping the lists would leave the category empty and
         // the section would vanish from the tree entirely.
         let show_toggles = !manifests.is_empty() && plugins_cfg.enabled.is_empty();
+        let dirty = self.dirty.clone();
         let rows = self.settings.entry(ConfigCategory::Plugins).or_default();
+
+        // Discovery finishes asynchronously, so this can land between an edit
+        // and its save. Anything the user has already touched keeps the value
+        // they typed; everything else is rebuilt from the manifests.
+        let edited: HashMap<String, ConfigValue> = rows
+            .iter()
+            .filter(|row| dirty.contains(&row.key))
+            .map(|row| (row.key.clone(), row.value.clone()))
+            .collect();
 
         // Drop everything this method owns so repeated calls are idempotent.
         rows.retain(|row| {
@@ -2397,7 +2439,10 @@ impl ConfigScreenState {
                 && Self::parse_plugin_toggle_key(&row.key).is_none()
         });
         if show_toggles {
-            rows.retain(|row| row.key != "plugins.enabled" && row.key != "plugins.disabled");
+            rows.retain(|row| {
+                (row.key != "plugins.enabled" && row.key != "plugins.disabled")
+                    || dirty.contains(&row.key)
+            });
         }
 
         for manifest in manifests {
@@ -2426,12 +2471,20 @@ impl ConfigScreenState {
                 let saved_str = saved.and_then(|t| t.get(&field.key)).map(toml_scalar_to_string);
                 let value = config_value_for_field(field, saved_str.as_deref());
 
+                let key = Self::plugin_row_key(plugin, &field.key);
                 rows.push(ConfigSetting {
-                    key: Self::plugin_row_key(plugin, &field.key),
                     label: field.label.clone(),
-                    value,
+                    value: edited.get(&key).cloned().unwrap_or(value),
                     description: format!("{} · plugin: {}", field.label, plugin),
+                    key,
                 });
+            }
+        }
+
+        // Same for the enable toggles.
+        for row in rows.iter_mut() {
+            if let Some(value) = edited.get(&row.key) {
+                row.value = value.clone();
             }
         }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2247,6 +2247,35 @@ impl ConfigScreenState {
     /// so a popup confirm does not have to know which category or node it came
     /// from — the filter pane shows rows from categories other than the
     /// selected one, and the old category-scoped lookup silently missed them.
+    /// Reseed one row's widget from the live config, WITHOUT marking it dirty.
+    ///
+    /// For a value that changed outside the settings screen — the auth flow
+    /// writes `authentication.claude_provider` through its own popup and
+    /// keychain path, then the row has to catch up. Those call sites used to
+    /// look the row up by the hand-written key `"claude_auth"`, which the
+    /// registry rewrite deleted, so the `find` silently never matched and the
+    /// row kept showing the old provider until restart. They also wrote a
+    /// `Text` status into what the registry declares a `Choice`.
+    pub fn reseed_row(&mut self, key: &str, config: &AppConfig) {
+        let Some(row) = crate::config::registry::row(key) else {
+            return;
+        };
+        let Ok(as_toml) = toml::Value::try_from(config) else {
+            return;
+        };
+        let current = crate::config::registry::navigate_toml(&as_toml, key).ok();
+        let value = row.to_value(current);
+        for rows in self.settings.values_mut() {
+            if let Some(existing) = rows.iter_mut().find(|r| r.key == key) {
+                existing.value = value;
+                // Deliberately not dirty: the value is already on disk, and
+                // marking it would write it back from this snapshot.
+                self.dirty.remove(key);
+                return;
+            }
+        }
+    }
+
     pub fn set_row_value(&mut self, key: &str, value: ConfigValue) {
         for rows in self.settings.values_mut() {
             if let Some(row) = rows.iter_mut().find(|row| row.key == key) {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1588,6 +1588,13 @@ impl AgentProvider {
 // Configuration Screen State
 // ============================================================================
 
+/// A section of the settings screen.
+///
+/// Every [`ConfigRow`](crate::config::ConfigRow) files under one of these, so
+/// the list has to cover the whole TOML schema, not just the sections the
+/// hand-written rows below happen to reach. The screen renders the subset that
+/// actually has rows today; `CONFIG_REGISTRY` is the source of truth for the
+/// rest, and wiring it in is what removes that gap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConfigCategory {
     Authentication,
@@ -1597,9 +1604,16 @@ pub enum ConfigCategory {
     Editor,
     Plugins,
     McpPool,
-    Permissions,
     Appearance,
     Analytics,
+    General,
+    ContainerTemplates,
+    McpServers,
+    Fleet,
+    Usage,
+    Skills,
+    SessionReader,
+    Presets,
 }
 
 impl ConfigCategory {
@@ -1612,9 +1626,16 @@ impl ConfigCategory {
             ConfigCategory::Editor,
             ConfigCategory::Plugins,
             ConfigCategory::McpPool,
-            ConfigCategory::Permissions,
             ConfigCategory::Appearance,
             ConfigCategory::Analytics,
+            ConfigCategory::General,
+            ConfigCategory::ContainerTemplates,
+            ConfigCategory::McpServers,
+            ConfigCategory::Fleet,
+            ConfigCategory::Usage,
+            ConfigCategory::Skills,
+            ConfigCategory::SessionReader,
+            ConfigCategory::Presets,
         ]
     }
 
@@ -1627,9 +1648,16 @@ impl ConfigCategory {
             ConfigCategory::Editor => "Editor",
             ConfigCategory::Plugins => "Plugins",
             ConfigCategory::McpPool => "MCP Pool",
-            ConfigCategory::Permissions => "Permissions",
             ConfigCategory::Appearance => "Appearance",
             ConfigCategory::Analytics => "Analytics",
+            ConfigCategory::General => "General",
+            ConfigCategory::ContainerTemplates => "Container Templates",
+            ConfigCategory::McpServers => "MCP Servers",
+            ConfigCategory::Fleet => "Fleet",
+            ConfigCategory::Usage => "Usage",
+            ConfigCategory::Skills => "Skills",
+            ConfigCategory::SessionReader => "Session Reader",
+            ConfigCategory::Presets => "Presets",
         }
     }
 
@@ -1642,9 +1670,16 @@ impl ConfigCategory {
             ConfigCategory::Editor => "📝",
             ConfigCategory::Plugins => "🔌",
             ConfigCategory::McpPool => "🧬",
-            ConfigCategory::Permissions => "🛡️",
             ConfigCategory::Appearance => "🎨",
             ConfigCategory::Analytics => "📊",
+            ConfigCategory::General => "⚙️",
+            ConfigCategory::ContainerTemplates => "📦",
+            ConfigCategory::McpServers => "🛰️",
+            ConfigCategory::Fleet => "🚁",
+            ConfigCategory::Usage => "💰",
+            ConfigCategory::Skills => "🎓",
+            ConfigCategory::SessionReader => "📖",
+            ConfigCategory::Presets => "🗂️",
         }
     }
 
@@ -1657,9 +1692,16 @@ impl ConfigCategory {
             ConfigCategory::Editor => "Preferred code editor for sessions",
             ConfigCategory::Plugins => "Installed plugins, enable/disable",
             ConfigCategory::McpPool => "Shared MCP servers: one process across sessions",
-            ConfigCategory::Permissions => "File write, shell, git approval",
             ConfigCategory::Appearance => "Theme, colors, status indicators",
             ConfigCategory::Analytics => "Usage tracking, cost alerts",
+            ConfigCategory::General => "Default template, presets file",
+            ConfigCategory::ContainerTemplates => "Per-template image, resources, mounts",
+            ConfigCategory::McpServers => "Per-server install and launch definitions",
+            ConfigCategory::Fleet => "Cost caps, interview surface, phone bridge",
+            ConfigCategory::Usage => "Plan, currency, model aliases",
+            ConfigCategory::Skills => "Catalog release, API key",
+            ConfigCategory::SessionReader => "Incremental scan window",
+            ConfigCategory::Presets => "Where presets.toml lives",
         }
     }
 }
@@ -1913,31 +1955,6 @@ impl Default for ConfigScreenState {
             ],
         );
 
-        // Permissions
-        settings.insert(
-            ConfigCategory::Permissions,
-            vec![
-                ConfigSetting {
-                    key: "allow_file_write".to_string(),
-                    label: "Allow File Write".to_string(),
-                    value: ConfigValue::Bool(true),
-                    description: "Allow agents to write files".to_string(),
-                },
-                ConfigSetting {
-                    key: "allow_shell".to_string(),
-                    label: "Allow Shell Commands".to_string(),
-                    value: ConfigValue::Bool(true),
-                    description: "Allow agents to run shell commands".to_string(),
-                },
-                ConfigSetting {
-                    key: "allow_git".to_string(),
-                    label: "Allow Git Operations".to_string(),
-                    value: ConfigValue::Bool(true),
-                    description: "Allow agents to perform git operations".to_string(),
-                },
-            ],
-        );
-
         // Editor
         // Detect available editors for the editor preference setting
         let available_editors = editors::get_editor_options();
@@ -2042,7 +2059,14 @@ impl Default for ConfigScreenState {
         Self {
             selected_category: 0,
             selected_setting: 0,
-            categories: ConfigCategory::all(),
+            // Only the categories that have hand-written rows today. The
+            // registry knows about more (container templates, fleet, usage,
+            // …) but nothing renders them yet, and an empty category is worse
+            // than an absent one.
+            categories: ConfigCategory::all()
+                .into_iter()
+                .filter(|category| settings.contains_key(category))
+                .collect(),
             settings,
             editing: false,
             edit_buffer: String::new(),
@@ -2490,18 +2514,6 @@ impl ConfigScreenState {
                         if let ConfigValue::Bool(show) = &setting.value {
                             config.ui_preferences.show_git_status = *show;
                         }
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        // Apply Permissions settings
-        if let Some(settings) = self.settings.get(&ConfigCategory::Permissions) {
-            for setting in settings {
-                match setting.key.as_str() {
-                    "allow_file_write" | "allow_shell" | "allow_git" => {
-                        // These would be added to AppConfig in future
                     }
                     _ => {}
                 }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11,14 +11,14 @@ use crate::claude::{ClaudeApiClient, ClaudeMessage};
 // boss-mode @-trigger; removed along with the prompt textarea.
 use crate::components::home_screen_v2::HomeScreenV2State;
 use crate::components::live_logs_stream::LogEntry;
-use crate::config::{AppConfig, SessionLabelStore};
+use crate::config::screen_model::{self, ConfigTreeNode};
+use crate::config::{AppConfig, SessionLabelStore, registry};
 use crate::credentials;
 use crate::docker::LogStreamingCoordinator;
-use crate::editors;
 // Phase 6 (new-session redesign): ParsedRepo / RemoteBranch / legacy
 // `RepoSource` import retired with the legacy remote-clone flow.
 use crate::models::{Session, SessionAgentType, Workspace, is_default_model};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -1714,10 +1714,57 @@ pub struct ConfigSetting {
     pub description: String,
 }
 
+/// A credential row: the *reference* config.toml stores, plus whether that
+/// reference currently resolves to a non-empty secret.
+///
+/// The screen never renders the plaintext of a credential, and never renders a
+/// literal's characters either — only a status and the source it came from. The
+/// resolved value is deliberately not kept: nothing on this screen needs it, and
+/// not holding it is the cheapest way to guarantee it cannot be painted.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SecretValue {
+    /// Exactly what config.toml holds: empty, a literal, `$ENV_VAR`, or
+    /// `keychain:<service>`.
+    pub reference: String,
+    /// Whether `reference` resolved when the row was built. Resolving a
+    /// `keychain:` reference shells out to `/usr/bin/security`, so this is
+    /// evaluated once at build time and never per frame.
+    pub resolved: bool,
+}
+
+impl SecretValue {
+    /// True when the reference points somewhere else (env var / keychain)
+    /// rather than being the secret itself.
+    #[must_use]
+    pub fn is_reference(&self) -> bool {
+        self.reference.starts_with('$') || self.reference.starts_with("keychain:")
+    }
+
+    /// `unset` / `resolved (source)` / `unresolved (source)` / `literal …`.
+    #[must_use]
+    pub fn status_line(&self) -> String {
+        if self.reference.trim().is_empty() {
+            return "unset".to_string();
+        }
+        if self.is_reference() {
+            let status = if self.resolved {
+                "resolved"
+            } else {
+                "unresolved"
+            };
+            return format!("{status}  ({})", self.reference);
+        }
+        // A literal already in the user's config keeps working; we say so
+        // rather than rewriting it behind their back.
+        "literal  (in config.toml)".to_string()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ConfigValue {
     Text(String),
-    Secret(String), // Masked display
+    /// A credential. Rendered as status + source, never as the value.
+    Secret(SecretValue),
     Bool(bool),
     Choice(Vec<String>, usize), // Options and selected index
     Number(i64),
@@ -1727,14 +1774,22 @@ impl ConfigValue {
     pub fn display(&self) -> String {
         match self {
             ConfigValue::Text(s) => s.clone(),
-            ConfigValue::Secret(s) => {
-                if s.is_empty() {
-                    "Not configured".to_string()
-                } else {
-                    format!("{}••••••••", &s[..std::cmp::min(8, s.len())])
-                }
-            }
+            ConfigValue::Secret(secret) => secret.status_line(),
             ConfigValue::Bool(b) => if *b { "✓ Enabled" } else { "✗ Disabled" }.to_string(),
+            ConfigValue::Choice(options, idx) => options.get(*idx).cloned().unwrap_or_default(),
+            ConfigValue::Number(n) => n.to_string(),
+        }
+    }
+
+    /// The raw string this widget would persist: the inverse of
+    /// [`ConfigRow::to_value`](crate::config::ConfigRow::to_value), and what
+    /// [`registry::set_validated`](crate::config::registry::set_validated)
+    /// parses back into a typed TOML value.
+    pub fn raw(&self) -> String {
+        match self {
+            ConfigValue::Text(s) => s.clone(),
+            ConfigValue::Secret(secret) => secret.reference.clone(),
+            ConfigValue::Bool(b) => b.to_string(),
             ConfigValue::Choice(options, idx) => options.get(*idx).cloned().unwrap_or_default(),
             ConfigValue::Number(n) => n.to_string(),
         }
@@ -1808,7 +1863,8 @@ fn config_value_for_field(
 /// `[[config]]` schema today, but is handled for totality.)
 fn config_value_to_toml(value: &ConfigValue) -> toml::Value {
     match value {
-        ConfigValue::Text(s) | ConfigValue::Secret(s) => toml::Value::String(s.clone()),
+        ConfigValue::Text(s) => toml::Value::String(s.clone()),
+        ConfigValue::Secret(secret) => toml::Value::String(secret.reference.clone()),
         ConfigValue::Bool(b) => toml::Value::Boolean(*b),
         ConfigValue::Number(n) => toml::Value::Integer(*n),
         ConfigValue::Choice(options, idx) => {
@@ -1827,12 +1883,58 @@ pub enum ConfigPane {
 
 // Editor detection and mapping now uses the centralized crate::editors module
 
+/// The settings screen: a section tree on the left, the rows of the selected
+/// section on the right.
+///
+/// Every row comes from [`CONFIG_REGISTRY`](crate::config::CONFIG_REGISTRY),
+/// seeded from the loaded config, so "a TOML key exists" and "a menu row
+/// exists" are the same statement. The screen used to carry its own list of
+/// ~24 hand-written rows with a hand-written persist branch per row; ten of
+/// those rows accepted an edit and dropped it, and every new schema field
+/// needed both lists touched to become reachable. Now the registry is the only
+/// list, and a save routes every edit through
+/// [`registry::set_validated`](crate::config::registry::set_validated).
 #[derive(Debug, Clone)]
 pub struct ConfigScreenState {
-    pub selected_category: usize,
+    /// Index into [`visible_nodes`](Self::visible_nodes) — the tree row the
+    /// left pane has selected.
+    pub selected_node: usize,
+    /// Index into [`visible_rows`](Self::visible_rows).
     pub selected_setting: usize,
+    /// Categories that have at least one row, in [`ConfigCategory::all`] order.
     pub categories: Vec<ConfigCategory>,
-    pub settings: std::collections::HashMap<ConfigCategory, Vec<ConfigSetting>>,
+    /// Rows per category, in registry order. Plugin rows are appended to
+    /// [`ConfigCategory::Plugins`] by [`Self::apply_plugin_manifests`].
+    pub settings: HashMap<ConfigCategory, Vec<ConfigSetting>>,
+    /// The whole tree in pre-order: category roots plus a node per TOML
+    /// sub-table under them.
+    pub tree: Vec<ConfigTreeNode>,
+    /// Indices into [`tree`](Self::tree) that are currently on screen, i.e.
+    /// with every collapsed subtree skipped.
+    pub visible_nodes: Vec<usize>,
+    /// `ConfigTreeNode::id`s of the expanded nodes, persisted in
+    /// `ui_preferences.config_tree_expanded`.
+    pub expanded: BTreeSet<String>,
+    /// `(category, row index)` of every row the right pane shows: the selected
+    /// node's subtree, or the `/` filter's matches.
+    pub visible_rows: Vec<(ConfigCategory, usize)>,
+    /// The active `/` filter. `Some("")` is an open, empty filter box.
+    pub search: Option<String>,
+    /// Keys the user has actually edited this session, and therefore the only
+    /// keys a save writes.
+    ///
+    /// Deliberately not "every row that differs from the file": a row for an
+    /// absent optional leaf seeds as an empty/false widget, so a diff against
+    /// the file would materialise `require_mention_in_groups = false` into a
+    /// `[fleet.bridge.telegram]` section the user never created. Tracking the
+    /// edits themselves cannot invent a value.
+    pub dirty: BTreeSet<String>,
+    /// The secret row a Ctrl+K prompt is collecting a literal for.
+    ///
+    /// Set for exactly one popup round-trip: the popup's confirm writes the
+    /// literal to the OS keychain and stores only `keychain:<service>` in the
+    /// row, so the plaintext never reaches `config.toml` or the row's value.
+    pub keychain_target: Option<String>,
     pub editing: bool,
     pub edit_buffer: String,
     /// True when entering API key (special handling - saves to keychain)
@@ -1843,236 +1945,7 @@ pub struct ConfigScreenState {
 
 impl Default for ConfigScreenState {
     fn default() -> Self {
-        let mut settings = std::collections::HashMap::new();
-
-        // Authentication settings
-        // Determine current auth status for display
-        let auth_status = match credentials::get_anthropic_api_key() {
-            Ok(Some(key)) => {
-                let masked = if key.len() > 12 {
-                    format!("{}••••••••", &key[..12])
-                } else {
-                    "••••••••".to_string()
-                };
-                format!("API Key ({})", masked)
-            }
-            _ => "System Auth (Pro/Max Plan)".to_string(),
-        };
-
-        settings.insert(
-            ConfigCategory::Authentication,
-            vec![
-                ConfigSetting {
-                    key: "claude_auth".to_string(),
-                    label: "Claude Authentication".to_string(),
-                    value: ConfigValue::Text(auth_status),
-                    description: "Press Enter to configure authentication provider".to_string(),
-                },
-                ConfigSetting {
-                    key: "github_auth".to_string(),
-                    label: "GitHub Credentials".to_string(),
-                    value: ConfigValue::Text("System Default".to_string()),
-                    description: "Uses git credential helper. PAT support coming soon.".to_string(),
-                },
-            ],
-        );
-
-        // Workspace settings
-        settings.insert(
-            ConfigCategory::Workspace,
-            vec![
-                ConfigSetting {
-                    key: "default_workspace".to_string(),
-                    label: "Default Workspace".to_string(),
-                    value: ConfigValue::Text("~/projects".to_string()),
-                    description: "Default directory for new sessions".to_string(),
-                },
-                ConfigSetting {
-                    key: "branch_prefix".to_string(),
-                    label: "Branch Prefix".to_string(),
-                    value: ConfigValue::Text("agents/".to_string()),
-                    description: "Prefix for auto-created branch names".to_string(),
-                },
-                ConfigSetting {
-                    key: "exclude_paths".to_string(),
-                    label: "Exclude Paths".to_string(),
-                    value: ConfigValue::Text("node_modules, .git, target".to_string()),
-                    description: "Patterns to exclude from repo scanning (comma-separated)"
-                        .to_string(),
-                },
-                ConfigSetting {
-                    key: "max_repositories".to_string(),
-                    label: "Max Repositories".to_string(),
-                    value: ConfigValue::Number(500),
-                    description: "Maximum repositories to show in search results".to_string(),
-                },
-            ],
-        );
-
-        // Docker settings
-        settings.insert(
-            ConfigCategory::Docker,
-            vec![
-                ConfigSetting {
-                    key: "docker_host".to_string(),
-                    label: "Docker Host".to_string(),
-                    value: ConfigValue::Text("Auto-detect".to_string()),
-                    description: "Docker daemon connection (auto-detect, unix socket, or TCP)"
-                        .to_string(),
-                },
-                ConfigSetting {
-                    key: "docker_timeout".to_string(),
-                    label: "Connection Timeout".to_string(),
-                    value: ConfigValue::Number(60),
-                    description: "Docker connection timeout in seconds".to_string(),
-                },
-            ],
-        );
-
-        // Agent defaults
-        settings.insert(
-            ConfigCategory::AgentDefaults,
-            vec![
-                ConfigSetting {
-                    key: "default_model".to_string(),
-                    label: "Default Model".to_string(),
-                    value: ConfigValue::Choice(
-                        vec![
-                            "Opus 4.5".to_string(),
-                            "Sonnet 4.5".to_string(),
-                            "Haiku 4.5".to_string(),
-                        ],
-                        1, // Sonnet default
-                    ),
-                    description: "Default Claude model for new sessions".to_string(),
-                },
-                ConfigSetting {
-                    key: "auto_approve".to_string(),
-                    label: "Auto-Approve Actions".to_string(),
-                    value: ConfigValue::Bool(false),
-                    description: "Automatically approve file writes and commands".to_string(),
-                },
-            ],
-        );
-
-        // Editor
-        // Detect available editors for the editor preference setting
-        let available_editors = editors::get_editor_options();
-        let editor_names: Vec<String> =
-            available_editors.iter().map(|(name, _)| name.clone()).collect();
-        let default_editor_index =
-            available_editors.iter().position(|(_, avail)| *avail).unwrap_or(0);
-
-        settings.insert(
-            ConfigCategory::Editor,
-            vec![ConfigSetting {
-                key: "preferred_editor".to_string(),
-                label: "Preferred Editor".to_string(),
-                value: ConfigValue::Choice(editor_names, default_editor_index),
-                description: "Editor for opening sessions (o key)".to_string(),
-            }],
-        );
-
-        // Appearance
-        settings.insert(
-            ConfigCategory::Appearance,
-            vec![
-                ConfigSetting {
-                    key: "theme".to_string(),
-                    label: "Theme".to_string(),
-                    value: ConfigValue::Choice(
-                        vec![
-                            "Dark".to_string(),
-                            "Light".to_string(),
-                            "System".to_string(),
-                        ],
-                        0,
-                    ),
-                    description: "Color theme for the TUI".to_string(),
-                },
-                ConfigSetting {
-                    key: "show_container_status".to_string(),
-                    label: "Show Container Status".to_string(),
-                    value: ConfigValue::Bool(true),
-                    description: "Show container mode icons in session list".to_string(),
-                },
-                ConfigSetting {
-                    key: "show_git_status".to_string(),
-                    label: "Show Git Status".to_string(),
-                    value: ConfigValue::Bool(true),
-                    description: "Show git changes in session list".to_string(),
-                },
-            ],
-        );
-
-        // Plugins (empty for now)
-        settings.insert(
-            ConfigCategory::Plugins,
-            vec![ConfigSetting {
-                key: "installed_plugins".to_string(),
-                label: "Installed Plugins".to_string(),
-                value: ConfigValue::Text("None installed".to_string()),
-                description: "Manage installed plugins from the Catalog".to_string(),
-            }],
-        );
-
-        // MCP Pool (per-server `shared.*` toggles appended in from_app_config)
-        settings.insert(
-            ConfigCategory::McpPool,
-            vec![
-                ConfigSetting {
-                    key: "pool_enabled".to_string(),
-                    label: "Shared MCP Pool".to_string(),
-                    value: ConfigValue::Bool(true),
-                    description: "One MCP server process shared across all host sessions"
-                        .to_string(),
-                },
-                ConfigSetting {
-                    key: "idle_grace_secs".to_string(),
-                    label: "Idle Grace (seconds)".to_string(),
-                    value: ConfigValue::Number(300),
-                    description: "Reap a pooled server this long after its last session detaches"
-                        .to_string(),
-                },
-            ],
-        );
-
-        // Analytics
-        settings.insert(
-            ConfigCategory::Analytics,
-            vec![
-                ConfigSetting {
-                    key: "track_usage".to_string(),
-                    label: "Track Usage".to_string(),
-                    value: ConfigValue::Bool(true),
-                    description: "Track session duration and token usage".to_string(),
-                },
-                ConfigSetting {
-                    key: "cost_alerts".to_string(),
-                    label: "Cost Alerts".to_string(),
-                    value: ConfigValue::Bool(false),
-                    description: "Alert when spending exceeds threshold".to_string(),
-                },
-            ],
-        );
-
-        Self {
-            selected_category: 0,
-            selected_setting: 0,
-            // Only the categories that have hand-written rows today. The
-            // registry knows about more (container templates, fleet, usage,
-            // …) but nothing renders them yet, and an empty category is worse
-            // than an absent one.
-            categories: ConfigCategory::all()
-                .into_iter()
-                .filter(|category| settings.contains_key(category))
-                .collect(),
-            settings,
-            editing: false,
-            edit_buffer: String::new(),
-            api_key_input_mode: false,
-            focused_pane: ConfigPane::Categories,
-        }
+        Self::from_app_config(&AppConfig::default())
     }
 }
 
@@ -2081,288 +1954,389 @@ impl ConfigScreenState {
         Self::default()
     }
 
-    pub fn current_category(&self) -> Option<&ConfigCategory> {
-        self.categories.get(self.selected_category)
+    /// The registry row key whose edit opens the auth-provider popup instead of
+    /// the generic choice popup.
+    ///
+    /// Choosing "API key" there also prompts for the key and stores it in the
+    /// OS keychain, which a plain choice widget cannot do. Matched by KEY, not
+    /// by pane index — the old index match broke the moment the row order
+    /// changed.
+    pub const CLAUDE_PROVIDER_KEY: &'static str = "authentication.claude_provider";
+
+    /// Build the screen from a loaded config.
+    ///
+    /// The seed is the serialized `config` plus the top-level sections
+    /// `AppConfig` does not model (`[skills]`, `[session_reader]`), read off the
+    /// user config file so their rows show what is actually on disk rather than
+    /// blank. A missing or unparseable file just means those rows seed empty.
+    pub fn from_app_config(config: &AppConfig) -> Self {
+        let seed = seed_value(config);
+        let settings = screen_model::build_rows(&seed);
+        let categories: Vec<ConfigCategory> = ConfigCategory::all()
+            .into_iter()
+            .filter(|category| settings.get(category).is_some_and(|rows| !rows.is_empty()))
+            .collect();
+        let tree = screen_model::build_tree(&categories, &settings);
+        let expanded: BTreeSet<String> =
+            config.ui_preferences.config_tree_expanded.iter().cloned().collect();
+
+        let mut state = Self {
+            selected_node: 0,
+            selected_setting: 0,
+            categories,
+            settings,
+            tree,
+            visible_nodes: Vec::new(),
+            expanded,
+            visible_rows: Vec::new(),
+            search: None,
+            dirty: BTreeSet::new(),
+            keychain_target: None,
+            editing: false,
+            edit_buffer: String::new(),
+            api_key_input_mode: false,
+            focused_pane: ConfigPane::Categories,
+        };
+        state.refresh();
+        state
     }
 
+    // --- derived view state -------------------------------------------------
+
+    /// Recompute the two flattened lists the panes render. Cheap (a walk over
+    /// ~40 tree nodes and ~250 rows) and called only when something that
+    /// changes them changes, never per frame.
+    pub fn refresh(&mut self) {
+        self.refresh_visible_nodes();
+        self.refresh_visible_rows();
+    }
+
+    fn refresh_visible_nodes(&mut self) {
+        let mut visible = Vec::new();
+        let mut skip_deeper_than: Option<usize> = None;
+        for (index, node) in self.tree.iter().enumerate() {
+            if let Some(depth) = skip_deeper_than {
+                if node.depth > depth {
+                    continue;
+                }
+                skip_deeper_than = None;
+            }
+            visible.push(index);
+            if node.has_children && !self.expanded.contains(&node.id()) {
+                skip_deeper_than = Some(node.depth);
+            }
+        }
+        self.visible_nodes = visible;
+        if self.selected_node >= self.visible_nodes.len() {
+            self.selected_node = self.visible_nodes.len().saturating_sub(1);
+        }
+    }
+
+    fn refresh_visible_rows(&mut self) {
+        self.visible_rows = match self.search.as_deref() {
+            Some(query) if !query.trim().is_empty() => self.search_matches(query.trim()),
+            _ => self
+                .current_node()
+                .and_then(|node| {
+                    let category = node.category;
+                    let rows = node.rows.clone();
+                    self.settings
+                        .get(&category)
+                        .map(|_| rows.into_iter().map(|index| (category, index)).collect())
+                })
+                .unwrap_or_default(),
+        };
+        if self.selected_setting >= self.visible_rows.len() {
+            self.selected_setting = self.visible_rows.len().saturating_sub(1);
+        }
+    }
+
+    /// Rows matching the `/` filter, across every category.
+    ///
+    /// Ranked so a row whose key or label CONTAINS the query comes before one
+    /// that merely has it as a subsequence: typing `theme` should land on
+    /// `ui_preferences.theme`, not on the first row whose help text happens to
+    /// spell t-h-e-m-e.
+    fn search_matches(&self, query: &str) -> Vec<(ConfigCategory, usize)> {
+        let lowered = query.to_lowercase();
+        let mut exact = Vec::new();
+        let mut loose = Vec::new();
+        for category in &self.categories {
+            let Some(rows) = self.settings.get(category) else {
+                continue;
+            };
+            for (index, row) in rows.iter().enumerate() {
+                let key = row.key.to_lowercase();
+                let label = row.label.to_lowercase();
+                if key.contains(&lowered) || label.contains(&lowered) {
+                    exact.push((*category, index));
+                } else if screen_model::fuzzy_matches(&row.key, query)
+                    || screen_model::fuzzy_matches(&row.label, query)
+                    || screen_model::fuzzy_matches(&row.description, query)
+                {
+                    loose.push((*category, index));
+                }
+            }
+        }
+        exact.extend(loose);
+        exact
+    }
+
+    /// The tree node the left pane has selected.
+    #[must_use]
+    pub fn current_node(&self) -> Option<&ConfigTreeNode> {
+        self.visible_nodes
+            .get(self.selected_node)
+            .and_then(|index| self.tree.get(*index))
+    }
+
+    /// The category the right pane's title names.
+    #[must_use]
+    pub fn current_category(&self) -> Option<ConfigCategory> {
+        if self.is_searching() {
+            return None;
+        }
+        self.current_node().map(|node| node.category)
+    }
+
+    /// The rows the right pane shows, in display order.
+    #[must_use]
     pub fn current_settings(&self) -> Vec<&ConfigSetting> {
-        self.current_category()
-            .and_then(|cat| self.settings.get(cat))
-            .map(|s| s.iter().collect())
-            .unwrap_or_default()
+        self.visible_rows
+            .iter()
+            .filter_map(|(category, index)| self.settings.get(category)?.get(*index))
+            .collect()
     }
 
+    #[must_use]
     pub fn current_setting(&self) -> Option<&ConfigSetting> {
-        self.current_settings().get(self.selected_setting).copied()
+        let (category, index) = *self.visible_rows.get(self.selected_setting)?;
+        self.settings.get(&category)?.get(index)
     }
+
+    /// Why the selected row cannot be edited, or `None`.
+    #[must_use]
+    pub fn current_read_only_reason(&self) -> Option<&'static str> {
+        screen_model::read_only_reason(&self.current_setting()?.key)
+    }
+
+    /// True while the `/` filter box is open.
+    #[must_use]
+    pub fn is_searching(&self) -> bool {
+        self.search.is_some()
+    }
+
+    // --- navigation ---------------------------------------------------------
 
     pub fn select_next_category(&mut self) {
-        if !self.categories.is_empty() {
-            self.selected_category = (self.selected_category + 1) % self.categories.len();
-            self.selected_setting = 0;
+        if self.visible_nodes.is_empty() {
+            return;
         }
+        self.selected_node = (self.selected_node + 1) % self.visible_nodes.len();
+        self.selected_setting = 0;
+        self.refresh_visible_rows();
     }
 
     pub fn select_prev_category(&mut self) {
-        if !self.categories.is_empty() {
-            self.selected_category = if self.selected_category == 0 {
-                self.categories.len() - 1
-            } else {
-                self.selected_category - 1
-            };
-            self.selected_setting = 0;
+        if self.visible_nodes.is_empty() {
+            return;
         }
+        self.selected_node =
+            self.selected_node.checked_sub(1).unwrap_or(self.visible_nodes.len() - 1);
+        self.selected_setting = 0;
+        self.refresh_visible_rows();
     }
 
     pub fn select_next_setting(&mut self) {
-        let settings_count = self.current_settings().len();
-        if settings_count > 0 {
-            self.selected_setting = (self.selected_setting + 1) % settings_count;
+        if !self.visible_rows.is_empty() {
+            self.selected_setting = (self.selected_setting + 1) % self.visible_rows.len();
         }
     }
 
     pub fn select_prev_setting(&mut self) {
-        let settings_count = self.current_settings().len();
-        if settings_count > 0 {
-            self.selected_setting = if self.selected_setting == 0 {
-                settings_count - 1
-            } else {
-                self.selected_setting - 1
-            };
+        if !self.visible_rows.is_empty() {
+            self.selected_setting =
+                self.selected_setting.checked_sub(1).unwrap_or(self.visible_rows.len() - 1);
         }
     }
 
+    /// Open or close the selected tree node. Returns the expansion ids to
+    /// persist, or `None` when the node has no children to toggle.
+    pub fn toggle_expanded(&mut self) -> Option<Vec<String>> {
+        let node = self.current_node()?;
+        if !node.has_children {
+            return None;
+        }
+        let id = node.id();
+        if !self.expanded.remove(&id) {
+            self.expanded.insert(id);
+        }
+        self.refresh();
+        Some(self.expanded.iter().cloned().collect())
+    }
+
+    // --- search -------------------------------------------------------------
+
+    /// Open the `/` filter box.
+    pub fn start_search(&mut self) {
+        self.search = Some(String::new());
+        self.selected_setting = 0;
+        self.focused_pane = ConfigPane::Settings;
+        self.refresh_visible_rows();
+    }
+
+    pub fn push_search_char(&mut self, c: char) {
+        if let Some(query) = self.search.as_mut() {
+            query.push(c);
+            self.selected_setting = 0;
+            self.refresh_visible_rows();
+        }
+    }
+
+    pub fn pop_search_char(&mut self) {
+        if let Some(query) = self.search.as_mut() {
+            query.pop();
+            self.selected_setting = 0;
+            self.refresh_visible_rows();
+        }
+    }
+
+    /// Close the filter box and go back to the selected section.
+    pub fn clear_search(&mut self) {
+        self.search = None;
+        self.selected_setting = 0;
+        self.focused_pane = ConfigPane::Categories;
+        self.refresh_visible_rows();
+    }
+
+    // --- editing ------------------------------------------------------------
+
+    /// Overwrite a row's widget value and mark it for the next save.
+    ///
+    /// Keyed by the row's dotted path, which is unique across the whole screen,
+    /// so a popup confirm does not have to know which category or node it came
+    /// from — the filter pane shows rows from categories other than the
+    /// selected one, and the old category-scoped lookup silently missed them.
+    pub fn set_row_value(&mut self, key: &str, value: ConfigValue) {
+        for rows in self.settings.values_mut() {
+            if let Some(row) = rows.iter_mut().find(|row| row.key == key) {
+                row.value = value;
+                self.dirty.insert(key.to_string());
+                return;
+            }
+        }
+    }
+
+    /// Cycle the selected row's value in place (booleans and choices only).
     pub fn toggle_current_setting(&mut self) {
-        if let Some(category) = self.current_category().cloned() {
-            if let Some(settings) = self.settings.get_mut(&category) {
-                if let Some(setting) = settings.get_mut(self.selected_setting) {
-                    match &mut setting.value {
-                        ConfigValue::Bool(ref mut b) => *b = !*b,
-                        ConfigValue::Choice(options, ref mut idx) => {
-                            *idx = (*idx + 1) % options.len();
-                        }
-                        _ => {}
-                    }
-                }
-            }
+        let Some(key) = self.current_setting().map(|row| row.key.clone()) else {
+            return;
+        };
+        if screen_model::read_only_reason(&key).is_some() {
+            return;
         }
+        let Some(current) = self.current_setting().map(|row| row.value.clone()) else {
+            return;
+        };
+        let next = match current {
+            ConfigValue::Bool(b) => ConfigValue::Bool(!b),
+            ConfigValue::Choice(options, idx) if !options.is_empty() => {
+                let next = (idx + 1) % options.len();
+                ConfigValue::Choice(options, next)
+            }
+            _ => return,
+        };
+        self.set_row_value(&key, next);
     }
 
-    /// Create ConfigScreenState from AppConfig (loads persisted settings)
-    pub fn from_app_config(config: &AppConfig) -> Self {
-        let mut state = Self::default();
+    // --- persistence --------------------------------------------------------
 
-        // Update Authentication settings from config
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::Authentication) {
-            for setting in settings.iter_mut() {
-                if setting.key == "claude_auth" {
-                    // Build status text based on provider and API key presence
-                    use crate::config::ClaudeAuthProvider;
-                    let status = match &config.authentication.claude_provider {
-                        ClaudeAuthProvider::ApiKey => {
-                            let masked = credentials::get_anthropic_api_key_masked();
-                            if masked == "Not configured" {
-                                "API Key (Not configured)".to_string()
-                            } else {
-                                format!("API Key ({})", masked)
-                            }
-                        }
-                        ClaudeAuthProvider::SystemAuth => "System Auth (Pro/Max Plan)".to_string(),
-                        ClaudeAuthProvider::AmazonBedrock => {
-                            "Amazon Bedrock [Coming Soon]".to_string()
-                        }
-                        ClaudeAuthProvider::GoogleVertex => {
-                            "Google Vertex [Coming Soon]".to_string()
-                        }
-                        ClaudeAuthProvider::AzureFoundry => {
-                            "Azure Foundry [Coming Soon]".to_string()
-                        }
-                        ClaudeAuthProvider::GlmZai => "GLM on ZAI [Coming Soon]".to_string(),
-                        ClaudeAuthProvider::LlmGateway => "LLM Gateway [Coming Soon]".to_string(),
-                    };
-                    setting.value = ConfigValue::Text(status);
+    /// Every edit the user has made, as `(dotted key, raw value)`.
+    ///
+    /// Read-only rows are filtered out rather than trusted not to be dirty: the
+    /// screen refuses those edits at the keypress, and this is the second lock
+    /// on the same door.
+    #[must_use]
+    pub fn pending_edits(&self) -> Vec<(String, String)> {
+        let mut edits = Vec::new();
+        for category in &self.categories {
+            let Some(rows) = self.settings.get(category) else {
+                continue;
+            };
+            for row in rows {
+                if !self.dirty.contains(&row.key) {
+                    continue;
                 }
+                if Self::parse_plugin_row_key(&row.key).is_some()
+                    || Self::parse_plugin_toggle_key(&row.key).is_some()
+                    || screen_model::read_only_reason(&row.key).is_some()
+                {
+                    continue;
+                }
+                edits.push((row.key.clone(), row.value.raw()));
             }
         }
+        edits
+    }
 
-        // Update Workspace settings from config
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::Workspace) {
-            for setting in settings.iter_mut() {
-                match setting.key.as_str() {
-                    "default_workspace" => {
-                        // Use first scan path or default
-                        let path = config
-                            .workspace_defaults
-                            .workspace_scan_paths
-                            .first()
-                            .map(|p| p.display().to_string())
-                            .unwrap_or_else(|| "~/projects".to_string());
-                        setting.value = ConfigValue::Text(path);
-                    }
-                    "branch_prefix" => {
-                        setting.value =
-                            ConfigValue::Text(config.workspace_defaults.branch_prefix.clone());
-                    }
-                    "exclude_paths" => {
-                        let paths = config.workspace_defaults.exclude_paths.join(", ");
-                        setting.value = ConfigValue::Text(if paths.is_empty() {
-                            "node_modules, .git, target".to_string()
-                        } else {
-                            paths
-                        });
-                    }
-                    "max_repositories" => {
-                        setting.value =
-                            ConfigValue::Number(config.workspace_defaults.max_repositories as i64);
-                    }
-                    _ => {}
-                }
+    /// Fold every edit into `config`, returning the ones whose section
+    /// `AppConfig` does not model so the caller can hand them to
+    /// [`AppConfig::save_external_keys`].
+    ///
+    /// The whole persist path is: serialize `config` to TOML, write each edit
+    /// through the registry's validator, deserialize back. That replaced ~200
+    /// lines of per-field match arms whose only job was to name, for a second
+    /// time, where each row lived — and which was missing an arm for every row
+    /// that silently discarded its edit.
+    pub fn apply_to_app_config(
+        &self,
+        config: &mut AppConfig,
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        let mut root = toml::Value::try_from(&*config)
+            .map_err(|e| anyhow::anyhow!("config does not serialize to TOML: {e}"))?;
+
+        let mut external = Vec::new();
+        for (key, raw) in self.pending_edits() {
+            if registry::is_external(&key) && !key.starts_with("fleet.bridge.") {
+                // `[skills]` / `[session_reader]` are parsed off this file by
+                // other crates and have no `AppConfig` field to land in.
+                // `[fleet.bridge]` DOES round-trip, as an opaque passthrough.
+                external.push((key, raw));
+                continue;
             }
+            registry::set_validated(&mut root, &key, &raw)
+                .map_err(|e| anyhow::anyhow!("setting '{key}': {e}"))?;
         }
 
-        // Update Docker settings from config
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::Docker) {
-            for setting in settings.iter_mut() {
-                match setting.key.as_str() {
-                    "docker_host" => {
-                        let host_display =
-                            config.docker.host.clone().unwrap_or_else(|| "Auto-detect".to_string());
-                        setting.value = ConfigValue::Text(host_display);
-                    }
-                    "docker_timeout" => {
-                        setting.value = ConfigValue::Number(config.docker.timeout as i64);
-                    }
-                    _ => {}
-                }
-            }
-        }
+        *config = root
+            .try_into()
+            .map_err(|e| anyhow::anyhow!("edited config does not deserialize: {e}"))?;
 
-        // Update Agent Defaults from config
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::AgentDefaults) {
-            for setting in settings.iter_mut() {
-                match setting.key.as_str() {
-                    "auto_approve" => {
-                        // Will be added to AppConfig
-                        setting.value = ConfigValue::Bool(false);
-                    }
-                    _ => {}
-                }
-            }
-        }
+        // Plugin rows keep their own path: their schema lives in the plugin
+        // manifest, not the registry, and `plugins.*` is an opaque leaf the
+        // registry validator deliberately refuses.
+        self.apply_plugin_rows(config);
+        self.apply_plugin_toggle_rows(config);
 
-        // Update Editor from config
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::Editor) {
-            for setting in settings.iter_mut() {
-                if setting.key == "preferred_editor" {
-                    // Load current preferred editor from config
-                    if let Some(ref preferred) = config.ui_preferences.preferred_editor {
-                        // Find the index of the preferred editor in our list
-                        if let ConfigValue::Choice(ref options, ref mut idx) = setting.value {
-                            // Map command to display name
-                            let display_name = match preferred.as_str() {
-                                "code" => "VS Code",
-                                "cursor" => "Cursor",
-                                "zed" => "Zed",
-                                "nvim" => "Neovim",
-                                "vim" => "Vim",
-                                "emacs" => "Emacs",
-                                "subl" => "Sublime Text",
-                                _ => preferred.as_str(),
-                            };
-                            if let Some(pos) = options.iter().position(|n| n == display_name) {
-                                *idx = pos;
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        Ok(external)
+    }
 
-        // Update Appearance from config
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::Appearance) {
-            for setting in settings.iter_mut() {
-                match setting.key.as_str() {
-                    "theme" => {
-                        let theme_idx = match config.ui_preferences.theme.as_str() {
-                            "dark" => 0,
-                            "light" => 1,
-                            "system" => 2,
-                            _ => 0,
-                        };
-                        setting.value = ConfigValue::Choice(
-                            vec![
-                                "Dark".to_string(),
-                                "Light".to_string(),
-                                "System".to_string(),
-                            ],
-                            theme_idx,
-                        );
-                    }
-                    "show_container_status" => {
-                        setting.value =
-                            ConfigValue::Bool(config.ui_preferences.show_container_status);
-                    }
-                    "show_git_status" => {
-                        setting.value = ConfigValue::Bool(config.ui_preferences.show_git_status);
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        // Update MCP Pool from config + append one shared-toggle per server
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::McpPool) {
-            for setting in settings.iter_mut() {
-                match setting.key.as_str() {
-                    "pool_enabled" => {
-                        setting.value = ConfigValue::Bool(config.mcp_pool.enabled);
-                    }
-                    "idle_grace_secs" => {
-                        setting.value = ConfigValue::Number(config.mcp_pool.idle_grace_secs as i64);
-                    }
-                    _ => {}
-                }
-            }
-            let mut names: Vec<&String> = config.mcp_servers.keys().collect();
-            names.sort();
-            for name in names {
-                let server = &config.mcp_servers[name];
-                settings.push(ConfigSetting {
-                    key: format!("shared.{name}"),
-                    label: format!("Share: {name}"),
-                    value: ConfigValue::Bool(server.shared),
-                    description: format!(
-                        "Pool '{name}' across sessions (disable for stateful servers)"
-                    ),
-                });
-            }
-        }
-
-        // Update Analytics from config
-        if let Some(settings) = state.settings.get_mut(&ConfigCategory::Analytics) {
-            for setting in settings.iter_mut() {
-                match setting.key.as_str() {
-                    "track_usage" => {
-                        setting.value = ConfigValue::Bool(true); // Default, not in AppConfig yet
-                    }
-                    "cost_alerts" => {
-                        setting.value = ConfigValue::Bool(false); // Default, not in AppConfig yet
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        state
+    /// Forget the pending edits after they have been written, so a later save
+    /// does not rewrite values another process may have changed since.
+    pub fn mark_saved(&mut self) {
+        self.dirty.clear();
     }
 
     /// Prefix that marks a [`ConfigCategory::Plugins`] row as a per-plugin
-    /// `[[config]]` field (vs. the static enable/disable placeholder rows).
-    /// The row key is `plugin:<plugin_name>:<field_key>` — unique across
-    /// plugins that share a field name, and reversible in
-    /// [`apply_to_app_config`](Self::apply_to_app_config) so the edit lands
-    /// under `plugins.values[plugin_name][field_key]`.
+    /// `[[config]]` field (vs. a registry row). The row key is
+    /// `plugin:<plugin_name>:<field_key>` — unique across plugins that share a
+    /// field name, and reversible in
+    /// [`apply_plugin_rows`](Self::apply_plugin_rows) so the edit lands under
+    /// `plugins.values[plugin_name][field_key]`.
     const PLUGIN_ROW_PREFIX: &'static str = "plugin:";
+
+    /// Prefix for the per-plugin enable/disable toggle rows.
+    const PLUGIN_TOGGLE_PREFIX: &'static str = "plugin-enabled:";
 
     /// Compose the Plugins-category row key for a plugin's config field.
     fn plugin_row_key(plugin: &str, field_key: &str) -> String {
@@ -2370,38 +2344,78 @@ impl ConfigScreenState {
     }
 
     /// Split a Plugins-category row key back into `(plugin_name, field_key)`,
-    /// or `None` for the static placeholder rows. The plugin name and the
-    /// field key are joined by the *first* `:` after the prefix, so plugin
-    /// names never contain `:` but field keys may.
+    /// or `None` for any other row. The plugin name and the field key are
+    /// joined by the *first* `:` after the prefix, so plugin names never
+    /// contain `:` but field keys may.
     fn parse_plugin_row_key(key: &str) -> Option<(&str, &str)> {
         let rest = key.strip_prefix(Self::PLUGIN_ROW_PREFIX)?;
         rest.split_once(':')
     }
 
-    /// Append per-plugin `[[config]]` rows to the Plugins category from the
-    /// loaded plugin manifests, keeping the existing enable/disable rows.
+    /// The plugin name behind an enable/disable toggle row, or `None`.
+    fn parse_plugin_toggle_key(key: &str) -> Option<&str> {
+        key.strip_prefix(Self::PLUGIN_TOGGLE_PREFIX)
+    }
+
+    /// Rebuild the Plugins category from the loaded plugin manifests: one
+    /// enable/disable toggle per plugin, then one row per `[[config]]` field.
     ///
-    /// One [`ConfigSetting`] is produced per [`ConfigField`], mapping the
-    /// field `kind` to the matching [`ConfigValue`] widget
-    /// (`path`/`string` → `Text`, `bool` → `Bool`, `enum` → `Choice`,
-    /// `int` → `Number`). The displayed value defaults from
-    /// `plugins.values[plugin][key]` when present, else the schema `default`.
+    /// The toggles are the "real plugin list" that replaces the old static
+    /// "Installed Plugins: None installed" placeholder — a row that reported
+    /// nothing and edited nothing. They write `plugins.disabled`, so while they
+    /// are shown the raw `plugins.enabled` / `plugins.disabled` list rows are
+    /// dropped: two rows writing one key is how they end up disagreeing.
+    ///
+    /// An allowlist (`plugins.enabled` non-empty) takes precedence over the
+    /// denylist in discovery, so a toggle there would be a lie. In that mode the
+    /// raw list rows stay and no toggles are added.
+    ///
+    /// One [`ConfigSetting`] is produced per [`ConfigField`], mapping the field
+    /// `kind` to the matching [`ConfigValue`] widget (`path`/`string` → `Text`,
+    /// `bool` → `Bool`, `enum` → `Choice`, `int` → `Number`). The displayed
+    /// value defaults from `plugins.values[plugin][key]` when present, else the
+    /// schema `default`.
     ///
     /// Idempotent: re-invoking it (e.g. after the plugin runtime finishes
-    /// discovery) rebuilds the per-plugin rows from scratch rather than
-    /// duplicating them — only the static placeholder rows are retained.
+    /// discovery) rebuilds the plugin rows from scratch rather than duplicating
+    /// them.
     pub fn apply_plugin_manifests(
         &mut self,
         manifests: &[ainb_plugin_protocol::manifest::Manifest],
         plugins_cfg: &crate::config::PluginsConfig,
     ) {
+        // Toggles only replace the raw list rows when there is something to
+        // toggle. With plugins disabled (`AINB_DISABLE_PLUGINS=1`) or discovery
+        // not yet run, dropping the lists would leave the category empty and
+        // the section would vanish from the tree entirely.
+        let show_toggles = !manifests.is_empty() && plugins_cfg.enabled.is_empty();
         let rows = self.settings.entry(ConfigCategory::Plugins).or_default();
-        // Drop any previously-appended plugin rows so repeated calls are
-        // idempotent; keep the static enable/disable placeholders.
-        rows.retain(|s| Self::parse_plugin_row_key(&s.key).is_none());
+
+        // Drop everything this method owns so repeated calls are idempotent.
+        rows.retain(|row| {
+            Self::parse_plugin_row_key(&row.key).is_none()
+                && Self::parse_plugin_toggle_key(&row.key).is_none()
+        });
+        if show_toggles {
+            rows.retain(|row| row.key != "plugins.enabled" && row.key != "plugins.disabled");
+        }
 
         for manifest in manifests {
             let plugin = manifest.plugin.name.as_str();
+
+            if show_toggles {
+                let enabled = !plugins_cfg.disabled.iter().any(|name| name == plugin);
+                rows.push(ConfigSetting {
+                    key: format!("{}{plugin}", Self::PLUGIN_TOGGLE_PREFIX),
+                    label: format!("Plugin: {plugin}"),
+                    value: ConfigValue::Bool(enabled),
+                    description: format!(
+                        "{} · load {plugin} at startup",
+                        manifest.plugin.description
+                    ),
+                });
+            }
+
             // The resolved [plugins.<name>] value table, if the user has set
             // any keys — drives the displayed default ahead of the schema's.
             let saved = plugins_cfg.values.get(plugin).and_then(toml::Value::as_table);
@@ -2420,178 +2434,26 @@ impl ConfigScreenState {
                 });
             }
         }
+
+        // The Plugins category may have gone from empty to populated (or back),
+        // which changes both panes.
+        self.rebuild_tree();
     }
 
-    /// Convert ConfigScreenState back to AppConfig for saving
-    pub fn apply_to_app_config(&self, config: &mut AppConfig) {
-        // Apply Workspace settings (extracted to keep this method under the
-        // clippy `too_many_lines` threshold).
-        self.apply_workspace_rows(config);
-
-        // Apply Docker settings
-        if let Some(settings) = self.settings.get(&ConfigCategory::Docker) {
-            for setting in settings {
-                match setting.key.as_str() {
-                    "docker_host" => {
-                        if let ConfigValue::Text(host) = &setting.value {
-                            if host == "Auto-detect" || host.is_empty() {
-                                config.docker.host = None;
-                            } else {
-                                config.docker.host = Some(host.clone());
-                            }
-                        }
-                    }
-                    "docker_timeout" => {
-                        if let ConfigValue::Number(timeout) = &setting.value {
-                            config.docker.timeout = *timeout as u64;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        // Apply MCP Pool settings
-        if let Some(settings) = self.settings.get(&ConfigCategory::McpPool) {
-            for setting in settings {
-                match setting.key.as_str() {
-                    "pool_enabled" => {
-                        if let ConfigValue::Bool(enabled) = &setting.value {
-                            config.mcp_pool.enabled = *enabled;
-                        }
-                    }
-                    "idle_grace_secs" => {
-                        if let ConfigValue::Number(secs) = &setting.value {
-                            config.mcp_pool.idle_grace_secs = (*secs).max(0) as u64;
-                        }
-                    }
-                    key => {
-                        if let (Some(name), ConfigValue::Bool(shared)) =
-                            (key.strip_prefix("shared."), &setting.value)
-                        {
-                            if let Some(server) = config.mcp_servers.get_mut(name) {
-                                server.shared = *shared;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Apply Editor settings
-        if let Some(settings) = self.settings.get(&ConfigCategory::Editor) {
-            for setting in settings {
-                if setting.key == "preferred_editor" {
-                    if let ConfigValue::Choice(options, idx) = &setting.value {
-                        if let Some(editor_name) = options.get(*idx) {
-                            // Convert display name to command
-                            if let Some(cmd) = editors::editor_name_to_command(editor_name) {
-                                config.ui_preferences.preferred_editor = Some(cmd.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Apply Appearance settings
-        if let Some(settings) = self.settings.get(&ConfigCategory::Appearance) {
-            for setting in settings {
-                match setting.key.as_str() {
-                    "theme" => {
-                        if let ConfigValue::Choice(options, idx) = &setting.value {
-                            if let Some(theme) = options.get(*idx) {
-                                config.ui_preferences.theme = theme.to_lowercase();
-                            }
-                        }
-                    }
-                    "show_container_status" => {
-                        if let ConfigValue::Bool(show) = &setting.value {
-                            config.ui_preferences.show_container_status = *show;
-                        }
-                    }
-                    "show_git_status" => {
-                        if let ConfigValue::Bool(show) = &setting.value {
-                            config.ui_preferences.show_git_status = *show;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        // Apply per-plugin [[config]] edits (extracted to keep this method under
-        // the clippy `too_many_lines` threshold).
-        self.apply_plugin_rows(config);
-    }
-
-    /// Route the Workspace-category rows (`default_workspace`, `branch_prefix`,
-    /// `exclude_paths`, `max_repositories`) back into `config.workspace_defaults`.
-    fn apply_workspace_rows(&self, config: &mut AppConfig) {
-        let Some(settings) = self.settings.get(&ConfigCategory::Workspace) else {
-            return;
-        };
-        for setting in settings {
-            match setting.key.as_str() {
-                "default_workspace" => {
-                    if let ConfigValue::Text(path) = &setting.value {
-                        let expanded = if path.starts_with("~/") {
-                            dirs::home_dir()
-                                .map(|h| h.join(&path[2..]))
-                                .unwrap_or_else(|| std::path::PathBuf::from(path))
-                        } else {
-                            std::path::PathBuf::from(path)
-                        };
-                        // "Default Workspace" is surfaced as
-                        // `workspace_scan_paths.first()` in `from_app_config`, so
-                        // it must be written back as the *primary* entry. The old
-                        // code pushed to the end, leaving `first()` pointing at the
-                        // stale path — editing the field then appeared to do
-                        // nothing on reopen.
-                        //
-                        // Rebuild as: edited path first, then every other distinct
-                        // scan dir. This replaces the old primary (index 0),
-                        // de-dups the edited path, and — crucially — preserves the
-                        // remaining scan dirs even on a no-op confirm (drop the old
-                        // primary, never the tail).
-                        let paths = &mut config.workspace_defaults.workspace_scan_paths;
-                        let tail: Vec<std::path::PathBuf> =
-                            paths.iter().skip(1).filter(|p| *p != &expanded).cloned().collect();
-                        paths.clear();
-                        paths.push(expanded);
-                        paths.extend(tail);
-                    }
-                }
-                "branch_prefix" => {
-                    if let ConfigValue::Text(prefix) = &setting.value {
-                        config.workspace_defaults.branch_prefix = prefix.clone();
-                    }
-                }
-                "exclude_paths" => {
-                    if let ConfigValue::Text(paths) = &setting.value {
-                        config.workspace_defaults.exclude_paths = paths
-                            .split(',')
-                            .map(|s| s.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect();
-                    }
-                }
-                "max_repositories" => {
-                    if let ConfigValue::Number(max) = &setting.value {
-                        config.workspace_defaults.max_repositories = *max as usize;
-                    }
-                }
-                _ => {}
-            }
-        }
+    /// Recompute `categories` + `tree` after the row set changed.
+    fn rebuild_tree(&mut self) {
+        self.categories = ConfigCategory::all()
+            .into_iter()
+            .filter(|category| self.settings.get(category).is_some_and(|rows| !rows.is_empty()))
+            .collect();
+        self.tree = screen_model::build_tree(&self.categories, &self.settings);
+        self.refresh();
     }
 
     /// Route every Plugins-category row whose key is `plugin:<name>:<field_key>`
     /// (see [`Self::plugin_row_key`]) into `config.plugins.values[<name>]
-    /// [<field_key>]` — NOT a top-level field. The static enable/disable
-    /// placeholder rows have no such prefix and are skipped. The serialized
-    /// `[plugins.<name>]` table round-trips through the existing
-    /// `AppConfig::save()` pipeline.
+    /// [<field_key>]` — NOT a top-level field. The serialized `[plugins.<name>]`
+    /// table round-trips through the existing `AppConfig::save()` pipeline.
     fn apply_plugin_rows(&self, config: &mut AppConfig) {
         let Some(settings) = self.settings.get(&ConfigCategory::Plugins) else {
             return;
@@ -2615,6 +2477,92 @@ impl ConfigScreenState {
                 table.insert(field_key.to_string(), toml_value);
             }
         }
+    }
+
+    /// Turn the per-plugin enable toggles into `plugins.disabled`.
+    ///
+    /// Rebuilt from the rows rather than diffed, so re-enabling a plugin removes
+    /// its name; sorted so config.toml diffs stay stable across saves. No-op
+    /// when there are no toggle rows (allowlist mode, or discovery has not run).
+    fn apply_plugin_toggle_rows(&self, config: &mut AppConfig) {
+        let Some(settings) = self.settings.get(&ConfigCategory::Plugins) else {
+            return;
+        };
+        let mut seen_a_toggle = false;
+        let mut disabled: Vec<String> = Vec::new();
+        for setting in settings {
+            let Some(plugin) = Self::parse_plugin_toggle_key(&setting.key) else {
+                continue;
+            };
+            seen_a_toggle = true;
+            if matches!(setting.value, ConfigValue::Bool(false)) {
+                disabled.push(plugin.to_string());
+            }
+        }
+        if !seen_a_toggle {
+            return;
+        }
+        // Keep names for plugins that aren't installed here: a shared config
+        // that disables a plugin this machine never discovered must not have
+        // that line dropped on the next save.
+        for name in &config.plugins.disabled {
+            let known = settings.iter().any(|row| {
+                Self::parse_plugin_toggle_key(&row.key).is_some_and(|plugin| plugin == name)
+            });
+            if !known && !disabled.contains(name) {
+                disabled.push(name.clone());
+            }
+        }
+        disabled.sort();
+        disabled.dedup();
+        config.plugins.disabled = disabled;
+    }
+}
+
+/// The TOML tree the settings rows read from.
+///
+/// `AppConfig` does not model the whole file: `[skills]` and
+/// `[session_reader]` are parsed straight off it by `ainb-cli` and the
+/// session-reader plugin. Their registry rows would otherwise always render
+/// blank, so they are merged in from disk here. Best effort — an unreadable or
+/// unparseable file just leaves those rows empty, exactly as if the sections
+/// were absent.
+fn seed_value(config: &AppConfig) -> toml::Value {
+    let mut seed =
+        toml::Value::try_from(config).unwrap_or_else(|_| toml::Value::Table(toml::Table::new()));
+
+    let on_disk = AppConfig::get_user_config_dir()
+        .ok()
+        .map(|dir| dir.join("config.toml"))
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .and_then(|text| text.parse::<toml::Table>().ok());
+    if let Some(on_disk) = on_disk {
+        merge_external_sections(&mut seed, &toml::Value::Table(on_disk));
+    }
+    seed
+}
+
+/// Copy each [`EXTERNAL_PREFIXES`](registry::EXTERNAL_PREFIXES) section from the
+/// on-disk file into the seed, unless the seed already has it.
+///
+/// The prefixes are DOTTED PATHS (`"fleet.bridge."`), not top-level keys, so
+/// they have to be walked rather than looked up flat: `table.get("fleet.bridge")`
+/// can never match, because TOML nests. Harmless today only because
+/// `fleet.bridge` happens to be a modelled passthrough that the seed already
+/// carries; `skills` and `session_reader` are single-segment and worked by
+/// accident.
+pub(crate) fn merge_external_sections(seed: &mut toml::Value, on_disk: &toml::Value) {
+    for prefix in registry::EXTERNAL_PREFIXES {
+        let path = prefix.trim_end_matches('.');
+        if registry::navigate_toml(seed, path).is_ok() {
+            continue;
+        }
+        let Ok(value) = registry::navigate_toml(on_disk, path) else {
+            continue;
+        };
+        // Best effort: an on-disk shape that will not graft is simply skipped,
+        // leaving those rows blank rather than failing the whole screen.
+        let _ = registry::insert_at(seed, path, value.clone());
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2476,7 +2476,13 @@ impl ConfigScreenState {
         });
         if show_toggles {
             rows.retain(|row| {
-                (row.key != "plugins.enabled" && row.key != "plugins.disabled")
+                // `plugins.disabled` always stays. Discovery filters denied
+                // plugins out entirely, so after a restart a plugin disabled
+                // from this screen has no manifest and therefore no toggle row
+                // — dropping the raw list too left no way to re-enable it.
+                // Disabling would be a one-way door.
+                row.key == "plugins.disabled"
+                    || (row.key != "plugins.enabled" && row.key != "plugins.disabled")
                     || dirty.contains(&row.key)
             });
         }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2324,10 +2324,17 @@ impl ConfigScreenState {
 
         let mut applied = AppliedEdits::default();
         for (key, raw) in self.pending_edits() {
-            if registry::is_external(&key) && !key.starts_with("fleet.bridge.") {
-                // `[skills]` / `[session_reader]` are parsed off this file by
-                // other crates and have no `AppConfig` field to land in.
-                // `[fleet.bridge]` DOES round-trip, as an opaque passthrough.
+            if registry::is_external(&key) {
+                // These go through the key-level writer rather than the struct.
+                // `[skills]` and `[session_reader]` are parsed off this file by
+                // other crates and have no `AppConfig` field to land in at all.
+                // `[fleet.bridge]` does round-trip as an opaque passthrough, but
+                // routing it through the struct made the edit a no-op: `save()`
+                // preserves `fleet.bridge` from disk to stop a stale startup
+                // snapshot clobbering a hand edit, so the value the user just
+                // typed was overwritten by the old one and the screen still
+                // reported "saved". Writing the single key they touched is both
+                // explicit and safe.
                 applied.external.push((key, raw));
                 continue;
             }
@@ -2512,6 +2519,15 @@ impl ConfigScreenState {
             return;
         };
         for setting in settings {
+            // Only rows the user actually edited. Writing every row would
+            // materialise each discovered plugin's schema defaults into
+            // config.toml the first time any unrelated setting was saved,
+            // pinning today's values so a later default change in the plugin's
+            // manifest could never take effect. This is the same reason
+            // `dirty` exists for the non-plugin rows.
+            if !self.dirty.contains(&setting.key) {
+                continue;
+            }
             let Some((plugin, field_key)) = Self::parse_plugin_row_key(&setting.key) else {
                 continue;
             };

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -1035,108 +1035,221 @@ mod tests {
         );
     }
 
-    fn set_default_workspace(screen: &mut ConfigScreenState, value: &str) {
-        let settings = screen
-            .settings
-            .get_mut(&ConfigCategory::Workspace)
-            .expect("Workspace category present");
-        let setting = settings
-            .iter_mut()
-            .find(|s| s.key == "default_workspace")
-            .expect("default_workspace setting present");
-        setting.value = ConfigValue::Text(value.to_string());
+    /// Edit a row by its dotted key, exactly as the popup confirm does.
+    fn edit(screen: &mut ConfigScreenState, key: &str, value: ConfigValue) {
+        assert!(
+            screen.settings.values().flatten().any(|s| s.key == key),
+            "no row for '{key}'; the registry and the screen have drifted"
+        );
+        screen.set_row_value(key, value);
     }
 
-    fn displayed_default_workspace(screen: &ConfigScreenState) -> String {
+    fn row_display(screen: &ConfigScreenState, key: &str) -> String {
         screen
             .settings
-            .get(&ConfigCategory::Workspace)
-            .unwrap()
-            .iter()
-            .find(|s| s.key == "default_workspace")
-            .unwrap()
+            .values()
+            .flatten()
+            .find(|s| s.key == key)
+            .unwrap_or_else(|| panic!("no row for '{key}'"))
             .value
             .display()
     }
 
+    // ========================================================================
+    // Registry-driven rows: an edit reaches AppConfig and survives a reopen
+    // ========================================================================
+    //
+    // These replace the old hand-written `default_workspace` / `branch_prefix`
+    // round-trip tests. Those covered four of the ~24 rows and were the only
+    // rows with a persist branch worth testing; the point now is that ONE path
+    // (serialize → set_validated → deserialize) covers every row, so the tests
+    // pick one row per widget kind rather than one row per hand-written arm.
+
     #[test]
-    fn default_workspace_edit_replaces_primary_and_round_trips() {
+    fn a_text_edit_round_trips_through_the_registry() {
         let mut config = AppConfig::default();
-        config.workspace_defaults.workspace_scan_paths = vec![PathBuf::from("/a/git")];
-
         let mut screen = ConfigScreenState::from_app_config(&config);
-        set_default_workspace(&mut screen, "/a/projects");
-        screen.apply_to_app_config(&mut config);
 
-        // Primary scan path is the edited value, not appended to the tail.
-        assert_eq!(
-            config.workspace_defaults.workspace_scan_paths.first(),
-            Some(&PathBuf::from("/a/projects"))
+        edit(
+            &mut screen,
+            "workspace_defaults.branch_prefix",
+            ConfigValue::Text("squad/".to_string()),
         );
-        // Reopening the screen now shows the saved value.
+        screen.apply_to_app_config(&mut config).expect("edit applies");
+
+        assert_eq!(config.workspace_defaults.branch_prefix, "squad/");
         let reopened = ConfigScreenState::from_app_config(&config);
-        assert_eq!(displayed_default_workspace(&reopened), "/a/projects");
+        assert_eq!(
+            row_display(&reopened, "workspace_defaults.branch_prefix"),
+            "squad/"
+        );
     }
 
     #[test]
-    fn default_workspace_edit_preserves_other_scan_dirs() {
+    fn a_list_edit_round_trips_as_a_comma_separated_list() {
         let mut config = AppConfig::default();
-        config.workspace_defaults.workspace_scan_paths =
-            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")];
-
         let mut screen = ConfigScreenState::from_app_config(&config);
-        set_default_workspace(&mut screen, "/a/projects");
-        screen.apply_to_app_config(&mut config);
 
-        // Old primary replaced; the secondary scan dir is kept.
+        edit(
+            &mut screen,
+            "workspace_defaults.workspace_scan_paths",
+            ConfigValue::Text("/a/projects, /a/work".to_string()),
+        );
+        screen.apply_to_app_config(&mut config).expect("edit applies");
+
         assert_eq!(
             config.workspace_defaults.workspace_scan_paths,
             vec![PathBuf::from("/a/projects"), PathBuf::from("/a/work")]
         );
-    }
-
-    #[test]
-    fn default_workspace_noop_confirm_keeps_secondary_dirs() {
-        // Opening the popup and confirming without changing the value must NOT
-        // drop other configured scan dirs (regression: a de-dup that stripped
-        // the unchanged primary then overwrote slot 0 lost the secondary).
-        let mut config = AppConfig::default();
-        config.workspace_defaults.workspace_scan_paths =
-            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")];
-
-        let mut screen = ConfigScreenState::from_app_config(&config);
-        // first() is /a/git — re-confirm it unchanged.
-        set_default_workspace(&mut screen, "/a/git");
-        screen.apply_to_app_config(&mut config);
-
+        let reopened = ConfigScreenState::from_app_config(&config);
         assert_eq!(
-            config.workspace_defaults.workspace_scan_paths,
-            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")]
+            row_display(&reopened, "workspace_defaults.workspace_scan_paths"),
+            "/a/projects, /a/work"
         );
     }
 
     #[test]
-    fn default_workspace_edit_does_not_duplicate_existing_path() {
+    fn a_number_edit_round_trips_and_is_range_checked() {
         let mut config = AppConfig::default();
-        config.workspace_defaults.workspace_scan_paths =
-            vec![PathBuf::from("/a/git"), PathBuf::from("/a/work")];
-
         let mut screen = ConfigScreenState::from_app_config(&config);
-        // Promote an already-present path to primary.
-        set_default_workspace(&mut screen, "/a/work");
-        screen.apply_to_app_config(&mut config);
+
+        edit(&mut screen, "docker.timeout", ConfigValue::Number(120));
+        screen.apply_to_app_config(&mut config).expect("edit applies");
+        assert_eq!(config.docker.timeout, 120);
+
+        // Out of the registry's declared range: the save fails loudly instead
+        // of writing a value the rest of the app would have to cope with.
+        let mut screen = ConfigScreenState::from_app_config(&config);
+        edit(&mut screen, "docker.timeout", ConfigValue::Number(0));
+        let err = screen.apply_to_app_config(&mut config).unwrap_err().to_string();
+        assert!(err.contains("docker.timeout"), "{err}");
+        assert_eq!(
+            config.docker.timeout, 120,
+            "a rejected edit changes nothing"
+        );
+    }
+
+    #[test]
+    fn an_untouched_row_is_never_written() {
+        // The screen seeds ~150 rows, most of them from serde defaults. Only
+        // the rows the user actually edited may reach config.toml — otherwise
+        // opening Settings and pressing S would materialise every default.
+        let config = AppConfig::default();
+        let screen = ConfigScreenState::from_app_config(&config);
+        assert!(
+            screen.pending_edits().is_empty(),
+            "a freshly-opened screen has pending edits: {:?}",
+            screen.pending_edits()
+        );
+    }
+
+    #[test]
+    fn a_read_only_usage_row_is_shown_but_never_written() {
+        // `[usage]` belongs to the burndown plugin (READ_ONLY_SECTIONS). The
+        // row exists so the value is visible, and is refused at both the
+        // keypress and the save.
+        let config = AppConfig::default();
+        let mut screen = ConfigScreenState::from_app_config(&config);
+        assert!(
+            screen.settings.values().flatten().any(|s| s.key == "usage.currency.code"),
+            "usage rows must still be visible"
+        );
+        // Even a forced edit (the keypress path refuses first) is filtered out.
+        screen.set_row_value("usage.currency.code", ConfigValue::Text("EUR".to_string()));
+        assert!(
+            !screen.pending_edits().iter().any(|(key, _)| key.starts_with("usage.")),
+            "a usage row must never reach a save: {:?}",
+            screen.pending_edits()
+        );
+    }
+
+    /// #11. `EXTERNAL_PREFIXES` holds DOTTED PATHS, so grafting them into the
+    /// seed has to walk the path. The old code trimmed `"fleet.bridge."` to
+    /// `"fleet.bridge"` and looked it up as a flat top-level key, which TOML can
+    /// never contain — the section was silently never carried across.
+    #[test]
+    fn external_sections_graft_at_their_dotted_path() {
+        let mut seed: toml::Value = toml::from_str("[docker]\ntimeout = 60\n").unwrap();
+        let on_disk: toml::Value = toml::from_str(
+            "[skills]\napi_key = \"sk-secret\"\n\n[fleet.bridge.telegram]\ntoken = \"keychain:t\"\n",
+        )
+        .unwrap();
+
+        crate::app::state::merge_external_sections(&mut seed, &on_disk);
 
         assert_eq!(
-            config.workspace_defaults.workspace_scan_paths.first(),
-            Some(&PathBuf::from("/a/work"))
+            crate::config::registry::navigate_toml(&seed, "skills.api_key").ok(),
+            Some(&toml::Value::String("sk-secret".to_string())),
+            "single-segment external section was dropped: {seed}"
         );
-        let dupes = config
-            .workspace_defaults
-            .workspace_scan_paths
+        assert_eq!(
+            crate::config::registry::navigate_toml(&seed, "fleet.bridge.telegram.token").ok(),
+            Some(&toml::Value::String("keychain:t".to_string())),
+            "a dotted external prefix was looked up as a flat key: {seed}"
+        );
+    }
+
+    /// The seed must not overwrite a section it already carries — the loaded
+    /// config wins over whatever is on disk.
+    #[test]
+    fn an_external_section_already_in_the_seed_is_not_overwritten() {
+        let mut seed: toml::Value =
+            toml::from_str("[skills]\napi_key = \"from-config\"\n").unwrap();
+        let on_disk: toml::Value = toml::from_str("[skills]\napi_key = \"from-disk\"\n").unwrap();
+        crate::app::state::merge_external_sections(&mut seed, &on_disk);
+        assert_eq!(
+            crate::config::registry::navigate_toml(&seed, "skills.api_key").ok(),
+            Some(&toml::Value::String("from-config".to_string()))
+        );
+    }
+
+    #[test]
+    fn the_search_filter_finds_a_row_by_its_dotted_key() {
+        // The whole reason the tree got a `/` filter: a leaf is reachable
+        // without knowing which section it lives in.
+        let mut screen = ConfigScreenState::from_app_config(&AppConfig::default());
+        screen.start_search();
+        for c in "idle_grace".chars() {
+            screen.push_search_char(c);
+        }
+        let hits: Vec<String> =
+            screen.current_settings().iter().map(|row| row.key.clone()).collect();
+        assert!(
+            hits.contains(&"mcp_pool.idle_grace_secs".to_string()),
+            "search missed the row: {hits:?}"
+        );
+
+        screen.clear_search();
+        assert!(!screen.is_searching());
+    }
+
+    #[test]
+    fn expanding_a_node_reveals_its_children() {
+        let mut screen = ConfigScreenState::from_app_config(&AppConfig::default());
+        // Select the Container Templates root, which nests per template.
+        let root = screen
+            .tree
             .iter()
-            .filter(|p| *p == &PathBuf::from("/a/work"))
-            .count();
-        assert_eq!(dupes, 1, "edited path must not be duplicated");
+            .position(|node| node.category == ConfigCategory::ContainerTemplates && node.depth == 0)
+            .expect("container templates root");
+        screen.selected_node = screen
+            .visible_nodes
+            .iter()
+            .position(|index| *index == root)
+            .expect("root visible");
+
+        let before = screen.visible_nodes.len();
+        assert!(screen.current_node().unwrap().has_children);
+        screen.toggle_expanded().expect("root expands");
+        assert!(
+            screen.visible_nodes.len() > before,
+            "expanding revealed nothing: {} -> {}",
+            before,
+            screen.visible_nodes.len()
+        );
+
+        screen.toggle_expanded().expect("root collapses");
+        assert_eq!(screen.visible_nodes.len(), before);
     }
 
     // ========================================================================
@@ -1229,10 +1342,12 @@ mod tests {
 
         let rows = screen.settings.get(&ConfigCategory::Plugins).expect("Plugins category present");
 
-        // The original enable/disable placeholder row is preserved.
+        // The static "Installed Plugins: None installed" placeholder is gone,
+        // replaced by a real per-plugin enable toggle.
         assert!(
-            rows.iter().any(|s| s.key == "installed_plugins"),
-            "existing enable/disable placeholder row must be kept"
+            rows.iter().any(|s| s.key == "plugin-enabled:learnings"),
+            "expected a real enable toggle for the loaded plugin, got: {:?}",
+            rows.iter().map(|s| &s.key).collect::<Vec<_>>()
         );
 
         // learnings_dir: path → Text, value from plugins.values (override wins).
@@ -1279,6 +1394,54 @@ mod tests {
     }
 
     #[test]
+    fn a_plugin_toggle_writes_the_denylist() {
+        // The "real plugin list" that replaced the static "Installed Plugins:
+        // None installed" placeholder. Turning a plugin off must land in
+        // `plugins.disabled`; turning it back on must remove it, which a
+        // diff-free rebuild gets right and an append would not.
+        let manifest = manifest_with_config("learnings", vec![]);
+        let cfg = PluginsConfig::default();
+
+        let mut screen = ConfigScreenState::default();
+        screen.apply_plugin_manifests(std::slice::from_ref(&manifest), &cfg);
+        screen.set_row_value("plugin-enabled:learnings", ConfigValue::Bool(false));
+
+        let mut app = AppConfig::default();
+        screen.apply_to_app_config(&mut app).expect("edits apply");
+        assert_eq!(app.plugins.disabled, vec!["learnings".to_string()]);
+
+        // Re-enable: the name comes back out of the denylist.
+        screen.set_row_value("plugin-enabled:learnings", ConfigValue::Bool(true));
+        screen.apply_to_app_config(&mut app).expect("edits apply");
+        assert!(
+            app.plugins.disabled.is_empty(),
+            "re-enabling left the plugin disabled: {:?}",
+            app.plugins.disabled
+        );
+    }
+
+    #[test]
+    fn a_plugin_disabled_elsewhere_is_not_dropped_by_a_toggle_save() {
+        // A shared config can disable a plugin this machine never discovered.
+        // Rebuilding `plugins.disabled` from the visible toggles alone would
+        // silently re-enable it on the next save.
+        let manifest = manifest_with_config("learnings", vec![]);
+        let cfg = PluginsConfig::default();
+
+        let mut screen = ConfigScreenState::default();
+        screen.apply_plugin_manifests(std::slice::from_ref(&manifest), &cfg);
+        screen.set_row_value("plugin-enabled:learnings", ConfigValue::Bool(false));
+
+        let mut app = AppConfig::default();
+        app.plugins.disabled = vec!["not-installed-here".to_string()];
+        screen.apply_to_app_config(&mut app).expect("edits apply");
+        assert_eq!(
+            app.plugins.disabled,
+            vec!["learnings".to_string(), "not-installed-here".to_string()]
+        );
+    }
+
+    #[test]
     fn test_apply_routes_plugin_edit_to_values() {
         // Editing a Plugins-category row then apply_to_app_config writes into
         // app_config.plugins.values[plugin][key] — NOT a top-level config field
@@ -1307,7 +1470,7 @@ mod tests {
         }
 
         let mut app = AppConfig::default();
-        screen.apply_to_app_config(&mut app);
+        screen.apply_to_app_config(&mut app).expect("edits apply");
 
         // The edit landed under plugins.values[learnings][learnings_dir],
         // not at any top-level config field.
@@ -1713,15 +1876,15 @@ mod mcp_pool_config_screen_tests {
     use crate::app::state::{ConfigCategory, ConfigScreenState, ConfigValue};
     use crate::config::AppConfig;
 
+    /// Edit a row by its dotted key, as the popup confirm does. The per-server
+    /// `shared` rows now file under McpServers rather than McpPool, so the
+    /// lookup has to span categories.
     fn set_bool(screen: &mut ConfigScreenState, key: &str, value: bool) {
-        let setting = screen
-            .settings
-            .get_mut(&ConfigCategory::McpPool)
-            .unwrap()
-            .iter_mut()
-            .find(|s| s.key == key)
-            .unwrap_or_else(|| panic!("missing setting {key}"));
-        setting.value = ConfigValue::Bool(value);
+        assert!(
+            screen.settings.values().flatten().any(|s| s.key == key),
+            "missing setting {key}"
+        );
+        screen.set_row_value(key, ConfigValue::Bool(value));
     }
 
     #[test]
@@ -1734,19 +1897,19 @@ mod mcp_pool_config_screen_tests {
 
         // Loaded values reflect config.
         let settings = screen.settings.get(&ConfigCategory::McpPool).unwrap();
-        let grace = settings.iter().find(|s| s.key == "idle_grace_secs").unwrap();
+        let grace = settings.iter().find(|s| s.key == "mcp_pool.idle_grace_secs").unwrap();
         assert_eq!(grace.value.display(), "120");
         // Per-server toggles exist for the built-in defaults.
         assert!(
-            settings.iter().any(|s| s.key == "shared.context7"),
+            settings.iter().any(|s| s.key == "mcp_servers.context7.shared"),
             "expected per-server toggle, got: {:?}",
             settings.iter().map(|s| &s.key).collect::<Vec<_>>()
         );
 
         // Edit: disable pool + opt context7 out of sharing.
-        set_bool(&mut screen, "pool_enabled", false);
-        set_bool(&mut screen, "shared.context7", false);
-        screen.apply_to_app_config(&mut config);
+        set_bool(&mut screen, "mcp_pool.enabled", false);
+        set_bool(&mut screen, "mcp_servers.context7.shared", false);
+        screen.apply_to_app_config(&mut config).expect("edits apply");
 
         assert!(!config.mcp_pool.enabled);
         assert!(!config.mcp_servers["context7"].shared);
@@ -1758,9 +1921,9 @@ mod mcp_pool_config_screen_tests {
         // Reopen → edited values shown.
         let reopened = ConfigScreenState::from_app_config(&config);
         let settings = reopened.settings.get(&ConfigCategory::McpPool).unwrap();
-        let enabled = settings.iter().find(|s| s.key == "pool_enabled").unwrap();
+        let enabled = settings.iter().find(|s| s.key == "mcp_pool.enabled").unwrap();
         assert_eq!(enabled.value.display(), "✗ Disabled");
-        let ctx = settings.iter().find(|s| s.key == "shared.context7").unwrap();
+        let ctx = settings.iter().find(|s| s.key == "mcp_servers.context7.shared").unwrap();
         assert_eq!(ctx.value.display(), "✗ Disabled");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -1607,6 +1607,37 @@ mod tests {
     }
 
     #[test]
+    fn untouched_plugin_rows_are_not_written_into_config() {
+        // Saving an unrelated setting must not materialise every discovered
+        // plugin's schema defaults into config.toml. Doing so pins today's
+        // defaults, so a later change in the plugin's manifest can never take
+        // effect for anyone who ever opened the settings screen.
+        let manifest = manifest_with_config(
+            "learnings",
+            vec![field(
+                "learnings_dir",
+                ConfigKind::Path,
+                "~/.learnings",
+                &[],
+            )],
+        );
+        let cfg = PluginsConfig::default();
+
+        let mut screen = ConfigScreenState::default();
+        screen.apply_plugin_manifests(std::slice::from_ref(&manifest), &cfg);
+
+        // Nothing edited: the row exists and shows its default, but is clean.
+        let mut app = AppConfig::default();
+        screen.apply_to_app_config(&mut app).expect("edits apply");
+
+        assert!(
+            app.plugins.values.get("learnings").is_none(),
+            "an untouched plugin row was written into config.toml: {:?}",
+            app.plugins.values
+        );
+    }
+
+    #[test]
     fn test_apply_routes_plugin_edit_to_values() {
         // Editing a Plugins-category row then apply_to_app_config writes into
         // app_config.plugins.values[plugin][key] — NOT a top-level config field
@@ -1628,11 +1659,12 @@ mod tests {
         // Simulate the popup-confirm edit: mutate the row value in place,
         // exactly as ConfigPopupConfirm does (matched by key).
         let row_key = plugin_row_key("learnings", "learnings_dir");
-        {
-            let rows = screen.settings.get_mut(&ConfigCategory::Plugins).unwrap();
-            let row = rows.iter_mut().find(|s| s.key == row_key).expect("row present");
-            row.value = ConfigValue::Text("/tmp/edited-kb".to_string());
-        }
+        // Through `set_row_value`, exactly as ConfigPopupConfirm does. Mutating
+        // the row in place instead would leave it out of `dirty`, and only
+        // dirty rows are written — an untouched plugin row must NOT be
+        // materialised into config.toml just because some other setting was
+        // saved.
+        screen.set_row_value(&row_key, ConfigValue::Text("/tmp/edited-kb".to_string()));
 
         let mut app = AppConfig::default();
         screen.apply_to_app_config(&mut app).expect("edits apply");

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -1117,12 +1117,19 @@ mod tests {
         screen.apply_to_app_config(&mut config).expect("edit applies");
         assert_eq!(config.docker.timeout, 120);
 
-        // Out of the registry's declared range: the save fails loudly instead
-        // of writing a value the rest of the app would have to cope with.
+        // Out of the registry's declared range: the row is REPORTED and
+        // skipped rather than written, and the pass still succeeds so one bad
+        // value cannot block every other row (see
+        // `a_rejected_edit_does_not_block_the_others`).
         let mut screen = ConfigScreenState::from_app_config(&config);
         edit(&mut screen, "docker.timeout", ConfigValue::Number(0));
-        let err = screen.apply_to_app_config(&mut config).unwrap_err().to_string();
-        assert!(err.contains("docker.timeout"), "{err}");
+        let applied = screen.apply_to_app_config(&mut config).expect("the pass succeeds");
+        assert_eq!(applied.rejected.len(), 1, "{:?}", applied.rejected);
+        assert!(
+            applied.rejected[0].1.contains("between 1 and 3600"),
+            "{:?}",
+            applied.rejected
+        );
         assert_eq!(
             config.docker.timeout, 120,
             "a rejected edit changes nothing"
@@ -1203,6 +1210,101 @@ mod tests {
         );
     }
 
+    /// #2b. Expanding a node must not write anything until the screen is left,
+    /// and a screen the user only browsed must leave the file alone entirely.
+    #[test]
+    fn expansion_is_flushed_once_on_exit_and_never_when_untouched() {
+        let mut screen = ConfigScreenState::from_app_config(&AppConfig::default());
+        assert!(
+            screen.take_expansion_to_persist().is_none(),
+            "a freshly opened screen wants to write the config"
+        );
+
+        let root = screen
+            .tree
+            .iter()
+            .position(|node| node.category == ConfigCategory::ContainerTemplates && node.depth == 0)
+            .expect("container templates root");
+        screen.selected_node = screen
+            .visible_nodes
+            .iter()
+            .position(|index| *index == root)
+            .expect("root visible");
+
+        assert!(screen.toggle_expanded());
+        assert!(screen.toggle_expanded(), "collapse it again");
+
+        let flushed = screen
+            .take_expansion_to_persist()
+            .expect("a toggled tree must be persisted on exit");
+        assert!(flushed.is_empty(), "expanded then collapsed: {flushed:?}");
+        assert!(
+            screen.take_expansion_to_persist().is_none(),
+            "the flush must happen once, not on every exit"
+        );
+    }
+
+    /// #4. A Ctrl+K prompt that is escaped must disarm the row.
+    ///
+    /// Left armed, the NEXT ordinary edit of that same row is routed into the
+    /// keychain: typing `$TELEGRAM_BOT_TOKEN` stores that literal string as a
+    /// secret and rewrites the row to a `keychain:` ref, discarding the env
+    /// reference the user asked for. Drives the real event so the fix cannot be
+    /// "the state has a method nobody calls".
+    #[test]
+    fn cancelling_a_keychain_prompt_disarms_the_row() {
+        let mut state = crate::app::state::AppState::new();
+        state.config_screen_state.keychain_target = Some("fleet.bridge.telegram.token".to_string());
+
+        crate::app::EventHandler::process_event(
+            crate::app::events::AppEvent::ConfigPopupCancel,
+            &mut state,
+        );
+
+        assert_eq!(
+            state.config_screen_state.keychain_target, None,
+            "an escaped Ctrl+K prompt left the row armed; the next edit of it \
+             would be stored in the keychain"
+        );
+    }
+
+    /// #8. One unwritable row must not wedge every later save. The registry
+    /// refuses an out-of-range number; the other edit in the same pass has to
+    /// land anyway, and the bad key must not stay pending.
+    #[test]
+    fn a_rejected_edit_does_not_block_the_others() {
+        let mut config = AppConfig::default();
+        let mut screen = ConfigScreenState::from_app_config(&config);
+
+        edit(&mut screen, "docker.timeout", ConfigValue::Number(0)); // below the range
+        edit(
+            &mut screen,
+            "workspace_defaults.branch_prefix",
+            ConfigValue::Text("squad/".to_string()),
+        );
+
+        let applied = screen.apply_to_app_config(&mut config).expect("the pass itself succeeds");
+        assert_eq!(applied.rejected.len(), 1, "{:?}", applied.rejected);
+        assert!(
+            applied.rejected[0].0 == "docker.timeout",
+            "{:?}",
+            applied.rejected
+        );
+        assert_eq!(
+            config.workspace_defaults.branch_prefix, "squad/",
+            "the good edit was blocked by the bad one"
+        );
+
+        // And once saved, the bad key is gone from `dirty` rather than
+        // re-failing on every subsequent auto-persist.
+        screen.mark_saved();
+        assert!(
+            screen.pending_edits().is_empty(),
+            "a rejected edit stayed pending: {:?}",
+            screen.pending_edits()
+        );
+    }
+
     #[test]
     fn the_search_filter_finds_a_row_by_its_dotted_key() {
         // The whole reason the tree got a `/` filter: a leaf is reachable
@@ -1240,7 +1342,7 @@ mod tests {
 
         let before = screen.visible_nodes.len();
         assert!(screen.current_node().unwrap().has_children);
-        screen.toggle_expanded().expect("root expands");
+        assert!(screen.toggle_expanded(), "root expands");
         assert!(
             screen.visible_nodes.len() > before,
             "expanding revealed nothing: {} -> {}",
@@ -1248,7 +1350,7 @@ mod tests {
             screen.visible_nodes.len()
         );
 
-        screen.toggle_expanded().expect("root collapses");
+        assert!(screen.toggle_expanded(), "root collapses");
         assert_eq!(screen.visible_nodes.len(), before);
     }
 
@@ -1391,6 +1493,69 @@ mod tests {
             .find(|s| s.key == plugin_row_key("learnings", "limit"))
             .expect("limit row present");
         assert!(matches!(limit.value, ConfigValue::Number(20)));
+    }
+
+    /// The same race for a per-plugin `[[config]]` row, which is what
+    /// `tripwire_config_plugins` flaked on: discovery landing between the edit
+    /// and its save rebuilt the row from the saved config and threw the typed
+    /// value away.
+    #[test]
+    fn discovery_does_not_drop_an_edited_plugin_field() {
+        let manifest = manifest_with_config(
+            "learnings",
+            vec![field(
+                "learnings_dir",
+                ConfigKind::Path,
+                "~/.learnings",
+                &[],
+            )],
+        );
+        let cfg = plugins_values("learnings", &[("learnings_dir", "/tmp/seed")]);
+
+        let mut screen = ConfigScreenState::default();
+        screen.apply_plugin_manifests(std::slice::from_ref(&manifest), &cfg);
+
+        let row_key = plugin_row_key("learnings", "learnings_dir");
+        screen.set_row_value(&row_key, ConfigValue::Text("/tmp/edited".to_string()));
+
+        // Discovery re-runs (a second plugin finished loading).
+        screen.apply_plugin_manifests(std::slice::from_ref(&manifest), &cfg);
+
+        let row = screen
+            .settings
+            .get(&ConfigCategory::Plugins)
+            .and_then(|rows| rows.iter().find(|row| row.key == row_key))
+            .expect("row rebuilt");
+        assert!(
+            matches!(row.value, ConfigValue::Text(ref t) if t == "/tmp/edited"),
+            "discovery reverted an in-flight edit to {:?}",
+            row.value
+        );
+    }
+
+    /// Plugin discovery finishes after the screen is built, so it can land
+    /// between an edit of `plugins.disabled` and that edit's save. Replacing
+    /// the list rows with toggles at that moment used to take the pending value
+    /// with them.
+    #[test]
+    fn discovery_does_not_drop_an_edited_plugin_list_row() {
+        let mut screen = ConfigScreenState::default();
+        screen.set_row_value(
+            "plugins.disabled",
+            ConfigValue::Text("burndown, witr".to_string()),
+        );
+
+        let manifest = manifest_with_config("learnings", vec![]);
+        screen.apply_plugin_manifests(std::slice::from_ref(&manifest), &PluginsConfig::default());
+
+        assert!(
+            screen
+                .pending_edits()
+                .iter()
+                .any(|(key, raw)| key == "plugins.disabled" && raw == "burndown, witr"),
+            "discovery discarded a pending edit: {:?}",
+            screen.pending_edits()
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -998,6 +998,43 @@ mod tests {
     use crate::app::state::{ConfigCategory, ConfigScreenState, ConfigValue};
     use crate::config::AppConfig;
 
+    // ========================================================================
+    // Config screen category list
+    // ========================================================================
+
+    /// The screen renders only the categories that have rows. `ConfigCategory`
+    /// now covers the whole TOML schema (registry.rs), so without this filter
+    /// opening Settings would show eight empty sections.
+    #[test]
+    fn config_screen_lists_only_categories_that_have_rows() {
+        let screen = ConfigScreenState::default();
+        for category in &screen.categories {
+            let rows = screen
+                .settings
+                .get(category)
+                .unwrap_or_else(|| panic!("category {category:?} is listed but has no settings"));
+            assert!(
+                !rows.is_empty(),
+                "category {category:?} is listed but has no rows"
+            );
+        }
+    }
+
+    /// The tmux tripwire (`tripwire_config_plugins`) steps down exactly five
+    /// times to reach Plugins. Renumbering the category list silently breaks a
+    /// test that lives in another file, so pin the order here where it is cheap
+    /// to see.
+    #[test]
+    fn plugins_is_the_sixth_category() {
+        let screen = ConfigScreenState::default();
+        assert_eq!(
+            screen.categories.get(5),
+            Some(&ConfigCategory::Plugins),
+            "categories: {:?}",
+            screen.categories
+        );
+    }
+
     fn set_default_workspace(screen: &mut ConfigScreenState, value: &str) {
         let settings = screen
             .settings

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -1607,6 +1607,36 @@ mod tests {
     }
 
     #[test]
+    fn a_save_with_no_edits_applies_nothing() {
+        // Pressing `S` with nothing edited must not write. `save()` renders the
+        // whole AppConfig from the snapshot taken at startup, so a no-op save
+        // would revert anything `ainb config set` or another process wrote
+        // since — while reporting "No changes to save".
+        let manifest = manifest_with_config(
+            "learnings",
+            vec![field(
+                "learnings_dir",
+                ConfigKind::Path,
+                "~/.learnings",
+                &[],
+            )],
+        );
+        let cfg = PluginsConfig::default();
+        let mut screen = ConfigScreenState::default();
+        screen.apply_plugin_manifests(std::slice::from_ref(&manifest), &cfg);
+
+        assert!(screen.pending_edits().is_empty(), "nothing was edited");
+
+        let mut app = AppConfig::default();
+        let applied = screen.apply_to_app_config(&mut app).expect("applies");
+        assert!(
+            applied.external.is_empty(),
+            "a clean screen produced external writes: {:?}",
+            applied.external
+        );
+    }
+
+    #[test]
     fn untouched_plugin_rows_are_not_written_into_config() {
         // Saving an unrelated setting must not materialise every discovered
         // plugin's schema defaults into config.toml. Doing so pins today's

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -127,6 +127,15 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
     } else {
         existing.parse::<toml::Value>().context("Failed to parse user config")?
     };
+    // `[usage]` is owned by the burndown plugin. Its rows are registered and
+    // validated, so without this the value passes every check and then dies
+    // three calls later on "is in a section ainb-core must not write" — a
+    // correct refusal with nothing actionable in it.
+    if crate::config::is_burndown_owned(key) {
+        anyhow::bail!(
+            "'{key}' is owned by the burndown plugin — set it with `ainb burndown plan set`"
+        );
+    }
     set_validated(&mut probe, key, value)?;
 
     // An emptied optional key is a REMOVAL, not a value: `set_validated` drops
@@ -145,6 +154,7 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
     // `config/example.config.toml`, which is ~320 lines of comments explaining
     // the keys. `ainb config set docker.timeout 90` must change one line, not
     // strip the manual.
+    let cleared = validated.is_none();
     match validated {
         Some(value) => {
             crate::config::write_keys_into(&config_path, &[(key.to_string(), value)])
@@ -156,7 +166,10 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
         }
     }
 
-    if value.is_empty() {
+    // Keyed off what actually happened: only an OPTIONAL_KEYS row is removed
+    // when emptied. `skills.api_key = ""` stores an empty string, and calling
+    // that "Cleared" would be a lie.
+    if cleared {
         println!("Cleared {key}");
     } else {
         println!("Set {key} = {value}");

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -17,6 +17,7 @@ use std::process::Command;
 
 use super::OutputFormat;
 use crate::config::AppConfig;
+use crate::config::registry::{navigate_toml, set_validated};
 
 /// JSON output for the `path` subcommand
 #[derive(Debug, Serialize)]
@@ -123,7 +124,10 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
         toml::Value::Table(toml::map::Map::new())
     };
 
-    set_toml_value(&mut root, key, value)?;
+    // Validated against CONFIG_REGISTRY: a mistyped key or an out-of-range
+    // value fails here rather than landing in the file and being dropped by the
+    // next load, which is how a `set` could look like it worked and do nothing.
+    set_validated(&mut root, key, value)?;
 
     let content = toml::to_string_pretty(&root).context("Failed to serialize config")?;
     fs::write(&config_path, &content).context("Failed to write user config")?;
@@ -238,90 +242,6 @@ fn cmd_edit() -> Result<()> {
     Ok(())
 }
 
-// --- TOML navigation helpers ---
-
-/// Navigate a TOML value tree using dot-notation keys
-fn navigate_toml<'a>(value: &'a toml::Value, key: &str) -> Result<&'a toml::Value> {
-    let parts = parse_dot_key(key);
-    if parts.is_empty() {
-        return Err(anyhow!("Empty key"));
-    }
-
-    let mut current = value;
-    for (i, part) in parts.iter().enumerate() {
-        if let toml::Value::Table(table) = current {
-            current = table.get(part.as_str()).ok_or_else(|| {
-                let path = parts[..=i].join(".");
-                anyhow!("Key '{path}' not found in configuration")
-            })?;
-        } else {
-            let path = parts[..i].join(".");
-            return Err(anyhow!("Cannot index into non-table value at '{path}'"));
-        }
-    }
-
-    Ok(current)
-}
-
-/// Set a value in a TOML tree using dot-notation keys
-fn set_toml_value(root: &mut toml::Value, key: &str, raw_value: &str) -> Result<()> {
-    let parts = parse_dot_key(key);
-    if parts.is_empty() {
-        return Err(anyhow!("Empty key"));
-    }
-
-    // Navigate to parent, creating intermediate tables as needed
-    let mut current = root;
-    for part in &parts[..parts.len() - 1] {
-        current = current
-            .as_table_mut()
-            .ok_or_else(|| anyhow!("Cannot set key in non-table value"))?
-            .entry(part)
-            .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
-    }
-
-    let table = current
-        .as_table_mut()
-        .ok_or_else(|| anyhow!("Cannot set key in non-table value"))?;
-
-    let leaf_key = &parts[parts.len() - 1];
-    let parsed = parse_toml_scalar(raw_value);
-    table.insert(leaf_key.clone(), parsed);
-
-    Ok(())
-}
-
-/// Parse a dot-notation key into parts
-fn parse_dot_key(key: &str) -> Vec<String> {
-    key.split('.').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect()
-}
-
-/// Parse a raw string value into the most appropriate TOML scalar
-fn parse_toml_scalar(raw: &str) -> toml::Value {
-    // Try boolean
-    if raw.eq_ignore_ascii_case("true") {
-        return toml::Value::Boolean(true);
-    }
-    if raw.eq_ignore_ascii_case("false") {
-        return toml::Value::Boolean(false);
-    }
-
-    // Try integer
-    if let Ok(i) = raw.parse::<i64>() {
-        return toml::Value::Integer(i);
-    }
-
-    // Try float (only if it contains a dot to avoid int-like strings)
-    if raw.contains('.') {
-        if let Ok(f) = raw.parse::<f64>() {
-            return toml::Value::Float(f);
-        }
-    }
-
-    // Default to string
-    toml::Value::String(raw.to_string())
-}
-
 /// Print a TOML value in human-readable text format
 fn print_toml_value(value: &toml::Value) {
     match value {
@@ -362,6 +282,9 @@ fn toml_to_json(value: &toml::Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The dotted-path helpers now live next to the registry that validates
+    // against them; these tests still pin their behaviour from the CLI side.
+    use crate::config::registry::{parse_dot_key, parse_toml_scalar, set_toml_value};
 
     // --- parse_dot_key tests ---
 
@@ -440,6 +363,36 @@ mod tests {
         assert_eq!(
             parse_toml_scalar("agents/"),
             toml::Value::String("agents/".to_string())
+        );
+    }
+
+    // --- `set` validation (the write path cmd_set takes) ---
+
+    #[test]
+    fn set_refuses_a_mistyped_key() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        let err = set_validated(&mut root, "docker.timout", "30").unwrap_err().to_string();
+        assert!(err.contains("Unknown config key"), "{err}");
+        assert!(
+            root.as_table().expect("table").is_empty(),
+            "nothing was written"
+        );
+    }
+
+    #[test]
+    fn set_refuses_an_out_of_range_value() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        let err = set_validated(&mut root, "docker.timeout", "0").unwrap_err().to_string();
+        assert!(err.contains("between 1 and 3600"), "{err}");
+    }
+
+    #[test]
+    fn set_writes_a_known_key() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        set_validated(&mut root, "docker.timeout", "120").unwrap();
+        assert_eq!(
+            navigate_toml(&root, "docker.timeout").unwrap(),
+            &toml::Value::Integer(120)
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -117,11 +117,13 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
     let config_path = config_dir.join("config.toml");
 
     // Load existing user config or start with empty table
-    let mut root = if config_path.exists() {
-        let content = fs::read_to_string(&config_path).context("Failed to read user config")?;
-        content.parse::<toml::Value>().context("Failed to parse user config")?
-    } else {
+    // `read_existing` maps only "not there" to empty: a present-but-unreadable
+    // file must abort rather than be replaced by a fresh one.
+    let existing = crate::config::read_existing(&config_path)?;
+    let mut root = if existing.trim().is_empty() {
         toml::Value::Table(toml::map::Map::new())
+    } else {
+        existing.parse::<toml::Value>().context("Failed to parse user config")?
     };
 
     // Validated against CONFIG_REGISTRY: a mistyped key or an out-of-range
@@ -130,7 +132,10 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
     set_validated(&mut root, key, value)?;
 
     let content = toml::to_string_pretty(&root).context("Failed to serialize config")?;
-    fs::write(&config_path, &content).context("Failed to write user config")?;
+    // Atomic, like every other writer of this file: a truncated config.toml is
+    // not cosmetic here — the next load sees a syntax error and every consumer
+    // (bridge tokens, skills key, [usage]) falls back to defaults.
+    crate::config::write_atomic(&config_path, &content).context("Failed to write user config")?;
 
     println!("Set {key} = {value}");
     println!("Saved to {}", config_path.display());
@@ -222,7 +227,8 @@ fn cmd_edit() -> Result<()> {
         let default_config = AppConfig::default();
         let content = toml::to_string_pretty(&default_config)
             .context("Failed to serialize default config")?;
-        fs::write(&config_path, &content).context("Failed to create default config file")?;
+        crate::config::write_atomic(&config_path, &content)
+            .context("Failed to create default config file")?;
         println!("Created default config at {}", config_path.display());
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -128,7 +128,16 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
         existing.parse::<toml::Value>().context("Failed to parse user config")?
     };
     set_validated(&mut probe, key, value)?;
-    let validated = crate::config::registry::navigate_toml(&probe, key)?.clone();
+
+    // An emptied optional key is a REMOVAL, not a value: `set_validated` drops
+    // it from `probe` rather than storing `""`, because `Some("")` is not the
+    // same as unset (an empty `docker.host` means "connect to nothing", not
+    // "autodetect"). Looking it up unconditionally then failed with "Key not
+    // found" and wrote nothing, so there was no way to clear one at all.
+    let validated = match crate::config::registry::navigate_toml(&probe, key) {
+        Ok(value) => Some(value.clone()),
+        Err(_) => None,
+    };
 
     // Write through the shared key-level writer, which edits the document in
     // place. Serializing `probe` instead would be a whole-file rewrite that
@@ -136,10 +145,22 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
     // `config/example.config.toml`, which is ~320 lines of comments explaining
     // the keys. `ainb config set docker.timeout 90` must change one line, not
     // strip the manual.
-    crate::config::write_keys_into(&config_path, &[(key.to_string(), validated)])
-        .context("Failed to write user config")?;
+    match validated {
+        Some(value) => {
+            crate::config::write_keys_into(&config_path, &[(key.to_string(), value)])
+                .context("Failed to write user config")?;
+        }
+        None => {
+            crate::config::remove_key_from(&config_path, key)
+                .context("Failed to write user config")?;
+        }
+    }
 
-    println!("Set {key} = {value}");
+    if value.is_empty() {
+        println!("Cleared {key}");
+    } else {
+        println!("Set {key} = {value}");
+    }
     println!("Saved to {}", config_path.display());
 
     Ok(())

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -116,26 +116,28 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
     fs::create_dir_all(&config_dir)?;
     let config_path = config_dir.join("config.toml");
 
-    // Load existing user config or start with empty table
+    // Validate against CONFIG_REGISTRY first: a mistyped key or an out-of-range
+    // value fails here rather than landing in the file and being dropped by the
+    // next load, which is how a `set` could look like it worked and do nothing.
     // `read_existing` maps only "not there" to empty: a present-but-unreadable
     // file must abort rather than be replaced by a fresh one.
     let existing = crate::config::read_existing(&config_path)?;
-    let mut root = if existing.trim().is_empty() {
+    let mut probe = if existing.trim().is_empty() {
         toml::Value::Table(toml::map::Map::new())
     } else {
         existing.parse::<toml::Value>().context("Failed to parse user config")?
     };
+    set_validated(&mut probe, key, value)?;
+    let validated = crate::config::registry::navigate_toml(&probe, key)?.clone();
 
-    // Validated against CONFIG_REGISTRY: a mistyped key or an out-of-range
-    // value fails here rather than landing in the file and being dropped by the
-    // next load, which is how a `set` could look like it worked and do nothing.
-    set_validated(&mut root, key, value)?;
-
-    let content = toml::to_string_pretty(&root).context("Failed to serialize config")?;
-    // Atomic, like every other writer of this file: a truncated config.toml is
-    // not cosmetic here — the next load sees a syntax error and every consumer
-    // (bridge tokens, skills key, [usage]) falls back to defaults.
-    crate::config::write_atomic(&config_path, &content).context("Failed to write user config")?;
+    // Write through the shared key-level writer, which edits the document in
+    // place. Serializing `probe` instead would be a whole-file rewrite that
+    // deletes every comment — and this file is meant to be started from
+    // `config/example.config.toml`, which is ~320 lines of comments explaining
+    // the keys. `ainb config set docker.timeout 90` must change one line, not
+    // strip the manual.
+    crate::config::write_keys_into(&config_path, &[(key.to_string(), validated)])
+        .context("Failed to write user config")?;
 
     println!("Set {key} = {value}");
     println!("Saved to {}", config_path.display());

--- a/ainb-tui/crates/ainb-core/src/components/config_screen.rs
+++ b/ainb-tui/crates/ainb-core/src/components/config_screen.rs
@@ -1,24 +1,64 @@
 // ABOUTME: Configuration screen component with split-pane layout for AINB 2.0
 
+//! Settings screen: a collapsible section tree on the left, the rows of the
+//! selected section on the right.
+//!
+//! The row source is `CONFIG_REGISTRY`, so this pane now paints ~150 rows
+//! instead of ~24. Two consequences shape the rendering: the right pane must
+//! scroll (a category no longer fits on a screen), and a row is ONE line with
+//! its help shown only under the selection, rather than the old four-line block
+//! per row that fit six settings in a full-height pane.
+
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, List, ListItem, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph},
 };
 
-use crate::app::state::{AppState, ConfigPane};
+use crate::app::state::{AppState, ConfigPane, ConfigSetting, ConfigValue};
+use crate::config::screen_model;
 
 // Color palette from TUI style guide
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
 const GOLD: Color = Color::Rgb(255, 215, 0);
 const SELECTION_GREEN: Color = Color::Rgb(100, 200, 100);
+const WARNING_ORANGE: Color = Color::Rgb(255, 165, 0);
 const DARK_BG: Color = Color::Rgb(25, 25, 35);
 const PANEL_BG: Color = Color::Rgb(30, 30, 40);
 const LIST_HIGHLIGHT_BG: Color = Color::Rgb(40, 40, 60);
 const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
+
+/// Tree glyphs, matching the style guide's `▼`/`▶` pair. Two columns wide
+/// including the trailing space, so a leaf node's blank gutter lines up with an
+/// expandable sibling's arrow.
+const EXPANDED: &str = "▾ ";
+const COLLAPSED: &str = "▸ ";
+const LEAF: &str = "  ";
+
+/// Column the `label : value` separator lines up on, so a pane of rows reads as
+/// a table rather than a ragged list.
+const VALUE_COLUMN: usize = 26;
+
+/// Wider column for `/` results, which print the full dotted key instead of the
+/// label — `mcp_pool.daemon_idle_grace_secs` is 31 characters and truncating it
+/// to a label's width would hide the very thing the filter is for.
+const SEARCH_KEY_COLUMN: usize = 38;
+
+/// Blank a pane's interior before painting it.
+///
+/// `Paragraph` and `List` set the STYLE of their whole area but only write
+/// symbols for the cells they have content for. Every pane on this screen
+/// changes length as you move — the title swaps between a hint and a live
+/// filter, rows scroll, the tree expands — so without this the tail of a longer
+/// previous frame stays on screen ("Usage" repainting as "Usags  s"). Cheap: a
+/// few thousand cells once per frame.
+fn blank(frame: &mut Frame, area: Rect) {
+    frame.render_widget(Clear, area);
+}
 
 pub struct ConfigScreenComponent;
 
@@ -34,11 +74,15 @@ impl ConfigScreenComponent {
         let container = Block::default().style(Style::default().bg(DARK_BG));
         frame.render_widget(container, area);
 
-        // Main layout: Title, Content (split), Help bar
+        // The `/` filter lives in the title bar rather than in a box of its
+        // own. A box would push the panes down three rows as it opens, and a
+        // vertical shift leaves stale cells behind on every tree row whose
+        // label follows a multi-cell emoji — "Usage" repainted as "Usags  s".
+        // A layout that never moves cannot desync.
         let main_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // Title bar
+                Constraint::Length(3), // Title bar (doubles as the filter box)
                 Constraint::Min(0),    // Content area
                 Constraint::Length(2), // Help bar
             ])
@@ -49,41 +93,82 @@ impl ConfigScreenComponent {
         self.render_help_bar(frame, main_layout[2], state);
     }
 
-    fn render_title(&self, frame: &mut Frame, area: Rect, _state: &AppState) {
-        let agent_name = "Configuration".to_string();
+    /// The title bar: the screen's name and row count normally, the live `/`
+    /// filter and its match count while one is open.
+    fn render_title(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        let config_state = &state.config_screen_state;
+        let searching = config_state.is_searching();
 
         let title_block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(CORNFLOWER_BLUE))
+            .border_style(Style::default().fg(if searching {
+                SELECTION_GREEN
+            } else {
+                CORNFLOWER_BLUE
+            }))
             .style(Style::default().bg(PANEL_BG));
 
         let inner = title_block.inner(area);
         frame.render_widget(title_block, area);
+        blank(frame, inner);
 
-        let title_text = Paragraph::new(Line::from(vec![
-            Span::styled("  ", Style::default()),
-            Span::styled(
-                "Configuration",
-                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("                                        ", Style::default()),
-            Span::styled("[", Style::default().fg(MUTED_GRAY)),
-            Span::styled(&agent_name, Style::default().fg(CORNFLOWER_BLUE)),
-            Span::styled("]", Style::default().fg(MUTED_GRAY)),
-        ]))
-        .alignment(Alignment::Left)
-        .style(Style::default().bg(PANEL_BG));
+        let spans = if searching {
+            let query = config_state.search.clone().unwrap_or_default();
+            let matches = config_state.visible_rows.len();
+            vec![
+                Span::styled(" 🔍 ", Style::default().fg(GOLD)),
+                Span::styled(
+                    "Search ",
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(query, Style::default().fg(SOFT_WHITE)),
+                Span::styled("█", Style::default().fg(SELECTION_GREEN)),
+                Span::styled(
+                    format!(
+                        "  ({matches} match{})",
+                        if matches == 1 { "" } else { "es" }
+                    ),
+                    Style::default().fg(CORNFLOWER_BLUE),
+                ),
+            ]
+        } else {
+            let row_count: usize = config_state.settings.values().map(Vec::len).sum();
+            vec![
+                // Deliberately no emoji: `⚙️` carries a variation selector, and
+                // ratatui measures that as one column while the terminal draws
+                // two. Every later cell on the line is then off by one, so the
+                // tail of a longer previous title survives a repaint by a
+                // character. The panel titles below use plain (width-2) emoji
+                // and are fine.
+                Span::styled("  ", Style::default()),
+                Span::styled(
+                    "Configuration",
+                    Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("  ({row_count} settings)"),
+                    Style::default().fg(CORNFLOWER_BLUE),
+                ),
+                Span::styled("   press ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("/", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(" to search every setting", Style::default().fg(MUTED_GRAY)),
+            ]
+        };
+
+        let title_text = Paragraph::new(Line::from(spans))
+            .alignment(Alignment::Left)
+            .style(Style::default().bg(PANEL_BG));
 
         frame.render_widget(title_text, inner);
     }
 
     fn render_content(&self, frame: &mut Frame, area: Rect, state: &AppState) {
-        // Split into categories (left) and settings (right)
+        // Split into the section tree (left) and its rows (right)
         let content_layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
-                Constraint::Percentage(30), // Categories panel
+                Constraint::Percentage(30), // Tree panel
                 Constraint::Percentage(70), // Settings panel
             ])
             .split(area);
@@ -92,11 +177,13 @@ impl ConfigScreenComponent {
         self.render_settings(frame, content_layout[1], state);
     }
 
+    /// The section tree. Depth 0 nodes are categories (icon + label); deeper
+    /// nodes are the TOML sub-tables under them, indented two columns per level.
     fn render_categories(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         let config_state = &state.config_screen_state;
-        let is_focused = config_state.focused_pane == ConfigPane::Categories;
+        let is_focused =
+            config_state.focused_pane == ConfigPane::Categories && !config_state.is_searching();
 
-        // Use GOLD border when focused, CORNFLOWER_BLUE when not
         let border_color = if is_focused { GOLD } else { CORNFLOWER_BLUE };
         let title_style = if is_focused {
             Style::default().fg(GOLD).add_modifier(Modifier::BOLD)
@@ -111,14 +198,23 @@ impl ConfigScreenComponent {
             .border_style(Style::default().fg(border_color))
             .style(Style::default().bg(PANEL_BG));
 
+        let inner = block.inner(area);
+        let visible_height = inner.height as usize;
+        let offset = scroll_offset(
+            config_state.selected_node,
+            config_state.visible_nodes.len(),
+            visible_height,
+        );
+
         let items: Vec<ListItem> = config_state
-            .categories
+            .visible_nodes
             .iter()
             .enumerate()
-            .map(|(i, cat)| {
-                let is_selected = i == config_state.selected_category;
-                let icon = cat.icon();
-                let label = cat.label();
+            .skip(offset)
+            .take(visible_height)
+            .filter_map(|(position, node_index)| {
+                let node = config_state.tree.get(*node_index)?;
+                let is_selected = position == config_state.selected_node;
 
                 let style = if is_selected {
                     Style::default()
@@ -129,40 +225,75 @@ impl ConfigScreenComponent {
                     Style::default().fg(SOFT_WHITE)
                 };
 
-                let indicator = if is_selected { " " } else { "  " };
+                let mut spans = vec![Span::styled(
+                    if is_selected { "▶" } else { " " },
+                    Style::default().fg(SELECTION_GREEN),
+                )];
+                spans.push(Span::raw(" ".repeat(node.depth * 2)));
+                spans.push(Span::styled(
+                    if !node.has_children {
+                        LEAF
+                    } else if config_state.expanded.contains(&node.id()) {
+                        EXPANDED
+                    } else {
+                        COLLAPSED
+                    },
+                    Style::default().fg(CORNFLOWER_BLUE),
+                ));
+                if node.depth == 0 {
+                    spans.push(Span::styled(
+                        format!("{} ", node.category.icon()),
+                        Style::default().fg(GOLD),
+                    ));
+                }
+                spans.push(Span::styled(node.label.as_str(), style));
 
-                ListItem::new(Line::from(vec![
-                    Span::styled(indicator, Style::default().fg(SELECTION_GREEN)),
-                    Span::styled(icon, Style::default().fg(GOLD)),
-                    Span::styled(" ", Style::default()),
-                    Span::styled(label, style),
-                ]))
+                let base_style = if is_selected {
+                    Style::default().bg(LIST_HIGHLIGHT_BG)
+                } else {
+                    Style::default()
+                };
+                Some(ListItem::new(Line::from(spans)).style(base_style))
             })
             .collect();
 
-        let list = List::new(items).block(block).style(Style::default().bg(PANEL_BG));
-
-        frame.render_widget(list, area);
+        frame.render_widget(block, area);
+        blank(frame, inner);
+        frame.render_widget(List::new(items).style(Style::default().bg(PANEL_BG)), inner);
     }
 
+    /// The rows of the selected section (or the `/` filter's matches).
+    ///
+    /// One line per row so a 60-row section is navigable; the selected row gets
+    /// a second line carrying its help text.
     fn render_settings(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         let config_state = &state.config_screen_state;
-        let current_category = &config_state.categories[config_state.selected_category];
-        let is_focused = config_state.focused_pane == ConfigPane::Settings;
+        let is_focused =
+            config_state.focused_pane == ConfigPane::Settings || config_state.is_searching();
+        let rows = config_state.current_settings();
 
-        // Use GOLD border when focused, CORNFLOWER_BLUE when not
         let border_color = if is_focused { GOLD } else { CORNFLOWER_BLUE };
         let title_style = if is_focused {
             Style::default().fg(GOLD).add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(MUTED_GRAY)
         };
+        let title = match (config_state.is_searching(), config_state.current_node()) {
+            (true, _) => " Matches ".to_string(),
+            (false, Some(node)) => format!(" {} ", node.label),
+            (false, None) => " Settings ".to_string(),
+        };
 
         let block = Block::default()
-            .title(Span::styled(
-                format!(" {} Settings ", current_category.label()),
-                title_style,
-            ))
+            .title(Span::styled(title, title_style))
+            .title_bottom(Line::from(vec![Span::styled(
+                format!(
+                    " {}/{} ",
+                    (config_state.selected_setting + 1).min(rows.len()),
+                    rows.len()
+                ),
+                Style::default().fg(MUTED_GRAY),
+            )]))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(border_color))
@@ -170,124 +301,95 @@ impl ConfigScreenComponent {
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
+        blank(frame, inner);
 
-        // Get settings for current category
-        if let Some(settings) = config_state.settings.get(current_category) {
-            let settings_layout = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints(settings.iter().map(|_| Constraint::Length(4)).collect::<Vec<_>>())
-                .split(inner);
+        if rows.is_empty() {
+            let empty = Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "  ✨ No settings match",
+                    Style::default().fg(MUTED_GRAY),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "  Esc clears the filter",
+                    Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+                )),
+            ])
+            .style(Style::default().bg(PANEL_BG));
+            frame.render_widget(empty, inner);
+            return;
+        }
 
-            for (i, setting) in settings.iter().enumerate() {
-                if i >= settings_layout.len() {
-                    break;
-                }
-                self.render_setting(
-                    frame,
-                    settings_layout[i],
-                    setting,
-                    i == config_state.selected_setting,
-                    config_state.editing && i == config_state.selected_setting,
-                    &config_state.edit_buffer,
-                );
+        // Build the line list, then window it. Only the selected row expands, so
+        // the list is `rows.len() + 1` lines at most and this stays cheap even
+        // at the full ~150-row search result.
+        let width = inner.width as usize;
+        let mut lines: Vec<Line> = Vec::with_capacity(rows.len() + 1);
+        let mut selected_line = 0usize;
+        for (index, setting) in rows.iter().enumerate() {
+            let is_selected = index == config_state.selected_setting;
+            if is_selected {
+                selected_line = lines.len();
+            }
+            lines.push(row_line(
+                setting,
+                is_selected,
+                config_state.is_searching(),
+                width,
+            ));
+            if is_selected {
+                lines.push(help_line(setting, width));
             }
         }
-    }
 
-    fn render_setting(
-        &self,
-        frame: &mut Frame,
-        area: Rect,
-        setting: &crate::app::state::ConfigSetting,
-        is_selected: bool,
-        is_editing: bool,
-        edit_buffer: &str,
-    ) {
-        let layout = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(1), // Label + value
-                Constraint::Length(1), // Separator
-                Constraint::Length(1), // Description
-                Constraint::Length(1), // Padding
-            ])
-            .split(area);
+        let height = inner.height as usize;
+        // Keep both the selected row AND its help line on screen.
+        let offset = scroll_offset(selected_line + 1, lines.len(), height);
+        let windowed: Vec<Line> = lines.into_iter().skip(offset).take(height).collect();
 
-        // Selection indicator
-        let indicator = if is_selected { "" } else { " " };
-        let indicator_style = if is_selected {
-            Style::default().fg(SELECTION_GREEN)
-        } else {
-            Style::default().fg(MUTED_GRAY)
-        };
-
-        // Value display
-        let value_display = if is_editing {
-            format!("{}|", edit_buffer)
-        } else {
-            setting.value.display()
-        };
-
-        let value_style = if is_editing {
-            Style::default().fg(GOLD).add_modifier(Modifier::UNDERLINED)
-        } else {
-            Style::default().fg(SOFT_WHITE)
-        };
-
-        // Label + Value line
-        let label_line = Paragraph::new(Line::from(vec![
-            Span::styled(format!("{} ", indicator), indicator_style),
-            Span::styled(
-                &setting.label,
-                if is_selected {
-                    Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(SOFT_WHITE)
-                },
-            ),
-            Span::styled(": ", Style::default().fg(MUTED_GRAY)),
-            Span::styled(value_display, value_style),
-        ]));
-        frame.render_widget(label_line, layout[0]);
-
-        // Separator
-        let separator = Paragraph::new(Line::from(vec![Span::styled(
-            "  ────────────────────────────────────────────────",
-            Style::default().fg(MUTED_GRAY),
-        )]));
-        frame.render_widget(separator, layout[1]);
-
-        // Description
-        let desc = Paragraph::new(Line::from(vec![
-            Span::styled("  ", Style::default()),
-            Span::styled("", Style::default().fg(CORNFLOWER_BLUE)),
-            Span::styled(" ", Style::default()),
-            Span::styled(&setting.description, Style::default().fg(MUTED_GRAY)),
-        ]));
-        frame.render_widget(desc, layout[2]);
+        frame.render_widget(
+            Paragraph::new(windowed).style(Style::default().bg(PANEL_BG)),
+            inner,
+        );
     }
 
     fn render_help_bar(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         let config_state = &state.config_screen_state;
 
-        let help_items = if config_state.editing {
+        let on_secret = matches!(
+            config_state.current_setting().map(|row| &row.value),
+            Some(ConfigValue::Secret(_))
+        );
+
+        let help_items: Vec<(&str, &str)> = if config_state.is_searching() {
+            vec![
+                ("type", "filter"),
+                ("↑↓", "navigate"),
+                ("Enter", "edit"),
+                ("Esc", "clear filter"),
+            ]
+        } else if config_state.editing {
             vec![("Enter", "save"), ("Esc", "cancel")]
         } else {
-            vec![
+            let mut items = vec![
+                ("/", "search"),
                 ("↑↓", "navigate"),
                 ("←→/Tab", "switch pane"),
+                ("Space", "expand"),
                 ("Enter", "edit"),
-                ("S", "save all"),
-                ("Esc", "back"),
-            ]
+            ];
+            if on_secret {
+                items.push(("^K", "to keychain"));
+            }
+            items.push(("S", "save all"));
+            items.push(("Esc", "back"));
+            items
         };
 
-        let mut spans = Vec::new();
-        spans.push(Span::styled("  ", Style::default()));
-
+        let mut spans = vec![Span::styled("  ", Style::default())];
         for (i, (key, desc)) in help_items.iter().enumerate() {
             if i > 0 {
-                spans.push(Span::styled(" | ", Style::default().fg(MUTED_GRAY)));
+                spans.push(Span::styled(" │ ", Style::default().fg(SUBDUED_BORDER)));
             }
             spans.push(Span::styled(
                 *key,
@@ -298,13 +400,151 @@ impl ConfigScreenComponent {
         }
 
         let help_bar = Paragraph::new(Line::from(spans)).style(Style::default().bg(DARK_BG));
-
         frame.render_widget(help_bar, area);
     }
+}
+
+/// `▶ Label ..... : value`, or the full dotted key while filtering.
+///
+/// Search results show the key rather than the label so a row found by typing
+/// `double_click` is identifiable without knowing which section it came from —
+/// which is the whole point of a flat filter over a tree.
+fn row_line<'a>(
+    setting: &'a ConfigSetting,
+    is_selected: bool,
+    searching: bool,
+    width: usize,
+) -> Line<'a> {
+    let name = if searching {
+        setting.key.as_str()
+    } else {
+        setting.label.as_str()
+    };
+    let read_only = screen_model::read_only_reason(&setting.key).is_some();
+
+    let name_style = match (is_selected, read_only) {
+        (true, _) => Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+        (false, true) => Style::default().fg(MUTED_GRAY),
+        (false, false) => Style::default().fg(SOFT_WHITE),
+    };
+    let value_style = match (read_only, &setting.value) {
+        (true, _) => Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        (false, ConfigValue::Secret(secret)) if !secret.resolved => {
+            Style::default().fg(WARNING_ORANGE)
+        }
+        (false, ConfigValue::Secret(_)) => Style::default().fg(SELECTION_GREEN),
+        (false, _) => Style::default().fg(SOFT_WHITE),
+    };
+
+    let column = if searching {
+        SEARCH_KEY_COLUMN
+    } else {
+        VALUE_COLUMN
+    };
+    let padded = pad_to(name, column.min(width.saturating_sub(12)));
+    let mut spans = vec![
+        Span::styled(
+            if is_selected { "▶ " } else { "  " },
+            Style::default().fg(SELECTION_GREEN),
+        ),
+        Span::styled(padded, name_style),
+        Span::styled(" : ", Style::default().fg(MUTED_GRAY)),
+        Span::styled(setting.value.display(), value_style),
+    ];
+    if read_only {
+        spans.push(Span::styled(
+            "  [read-only]",
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        ));
+    }
+
+    let line = Line::from(spans);
+    if is_selected {
+        line.style(Style::default().bg(LIST_HIGHLIGHT_BG))
+    } else {
+        line
+    }
+}
+
+/// The selected row's help, plus its dotted key so the user can reach the same
+/// setting from `ainb config set`.
+fn help_line<'a>(setting: &'a ConfigSetting, width: usize) -> Line<'a> {
+    let reason = screen_model::read_only_reason(&setting.key);
+    let text = reason.map_or_else(|| setting.description.clone(), |why| why.to_string());
+    Line::from(vec![
+        Span::styled("    ", Style::default()),
+        Span::styled("└─ ", Style::default().fg(SUBDUED_BORDER)),
+        Span::styled(
+            truncate(&text, width.saturating_sub(8)),
+            Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+        ),
+    ])
+}
+
+/// First line index to render so `selected` (1-based) sits inside a `height`
+/// tall window. Returns 0 when everything fits.
+fn scroll_offset(selected: usize, total: usize, height: usize) -> usize {
+    if height == 0 || total <= height {
+        return 0;
+    }
+    let selected = selected.min(total.saturating_sub(1));
+    if selected < height {
+        0
+    } else {
+        (selected + 1).saturating_sub(height).min(total - height)
+    }
+}
+
+fn pad_to(text: &str, width: usize) -> String {
+    let len = text.chars().count();
+    if len >= width {
+        return truncate(text, width);
+    }
+    format!("{text}{}", " ".repeat(width - len))
+}
+
+/// Character-safe truncation: byte slicing a label with a `→` in it panics.
+fn truncate(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(width.saturating_sub(1)).collect();
+    out.push('…');
+    out
 }
 
 impl Default for ConfigScreenComponent {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrolling_keeps_the_selection_in_view() {
+        assert_eq!(scroll_offset(1, 5, 10), 0, "everything fits");
+        assert_eq!(scroll_offset(3, 100, 10), 0, "near the top");
+        assert_eq!(scroll_offset(50, 100, 10), 41);
+        assert_eq!(scroll_offset(99, 100, 10), 90, "clamped at the end");
+        assert_eq!(scroll_offset(5, 100, 0), 0, "zero-height pane");
+    }
+
+    #[test]
+    fn truncation_is_character_safe() {
+        assert_eq!(truncate("token → keychain", 8), "token →…");
+        assert_eq!(truncate("short", 20), "short");
+        assert_eq!(truncate("anything", 0), "");
+    }
+
+    #[test]
+    fn padding_lines_values_up() {
+        assert_eq!(pad_to("Theme", 8), "Theme   ");
+        assert_eq!(pad_to("A very long label indeed", 8), "A very …");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -1025,7 +1025,14 @@ pub(crate) fn read_existing(path: &Path) -> Result<String> {
 
 pub(crate) fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
     let tmp = temp_path(path);
-    fs::write(&tmp, contents)?;
+    // Every failure below removes the temp file. The name is per-process and
+    // random, so unlike the old fixed `config.toml.tmp` nothing would ever
+    // overwrite a leftover — an aborted write would leave one in the config
+    // directory forever.
+    if let Err(err) = fs::write(&tmp, contents) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
     // Carry the target's permissions onto the replacement. `fs::write` used to
     // truncate in place and keep them; a temp file is created fresh under the
     // umask, so without this a `chmod 600 config.toml` is silently reverted to
@@ -1036,9 +1043,16 @@ pub(crate) fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
     {
         use std::os::unix::fs::PermissionsExt;
         let mode = fs::metadata(path).map(|m| m.permissions().mode() & 0o777).unwrap_or(0o600);
-        fs::set_permissions(&tmp, fs::Permissions::from_mode(mode))?;
+        if let Err(err) = fs::set_permissions(&tmp, fs::Permissions::from_mode(mode)) {
+            let _ = fs::remove_file(&tmp);
+            return Err(err);
+        }
     }
-    fs::rename(&tmp, path)
+    if let Err(err) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(())
 }
 
 /// Write exactly these dotted keys into a config file, leaving every other byte
@@ -1075,6 +1089,19 @@ pub(crate) fn remove_key_from(path: &Path, key: &str) -> Result<()> {
     remove_document_key(&mut doc, key);
     write_atomic(path, &doc.to_string())?;
     Ok(())
+}
+
+/// Whether `key` lives in a section the burndown plugin owns.
+///
+/// Core reads `[usage]` but must never write it: the plugin does its own
+/// load-modify-save against the same file, so a write from here would revert a
+/// plan set from another shell.
+#[must_use]
+pub(crate) fn is_burndown_owned(key: &str) -> bool {
+    let section = key.split('.').next().unwrap_or_default();
+    NEVER_WRITE_PATHS
+        .iter()
+        .any(|p| *p == section || key.starts_with(&format!("{p}.")))
 }
 
 pub(crate) fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> Result<()> {
@@ -1252,16 +1279,20 @@ fn to_edit_value(value: &toml::Value) -> toml_edit::Value {
 /// without resolving `HOME` — a test that calls the writer directly writes to
 /// the developer's real config.
 fn external_edit_value(key: &str, raw: &str) -> Result<toml::Value> {
-    // `fleet.bridge.*` matches `is_external` (its tokens are parsed by
-    // `fleet::bridge::config`, not by serde), but `[fleet]` IS modelled as an
-    // opaque passthrough — so `AppConfig::save` owns it and would revert
-    // anything written here on the next save.
-    if !registry::is_external(key) || key.starts_with("fleet.bridge.") {
+    // `fleet.bridge.*` belongs here. Its tokens are parsed by
+    // `fleet::bridge::config`, not by serde, and while `[fleet]` IS modelled as
+    // an opaque passthrough, `save()` deliberately preserves `fleet.bridge`
+    // from disk — so routing a bridge edit through the struct made it a no-op.
+    // The key-level write is the one path that actually lands it.
+    if !registry::is_external(key) {
         anyhow::bail!("'{key}' is not an externally-owned config key — AppConfig::save owns it");
     }
     let section = key.split('.').next().unwrap_or_default();
-    if READ_ONLY_SECTIONS.contains(&section) {
-        anyhow::bail!("'{key}' is in a read-only section");
+    if NEVER_WRITE_PATHS
+        .iter()
+        .any(|path| *path == section || key.starts_with(&format!("{path}.")))
+    {
+        anyhow::bail!("'{key}' is in a section ainb-core must not write");
     }
     registry::validate(key, raw)
 }
@@ -1359,9 +1390,25 @@ fn migrate_stray_user_config(canonical: &Path) {
     // Rewriting it would strip the comments and layout of a file users are
     // explicitly pointed at hand-editing.
     if carried > 0 {
-        let Ok(rendered) = toml::to_string_pretty(&merged) else {
-            return;
+        // Through `toml_edit`, like every other writer of this file: the
+        // population this migration touches is exactly the people who copied
+        // the ~320-line commented `example.config.toml`, and rendering the
+        // merged table would delete all of it on first launch, silently.
+        let mut doc = match fs::read_to_string(canonical)
+            .unwrap_or_default()
+            .parse::<toml_edit::DocumentMut>()
+        {
+            Ok(doc) => doc,
+            Err(_) => return,
         };
+        let mut leaves = Vec::new();
+        flatten_leaves(&merged, String::new(), &mut leaves);
+        for (key, value) in &leaves {
+            if set_document_key(&mut doc, key, value).is_err() {
+                return;
+            }
+        }
+        let rendered = doc.to_string();
         if canonical.parent().is_some_and(|d| fs::create_dir_all(d).is_err()) {
             return;
         }
@@ -2271,23 +2318,24 @@ theme = \"dark\"   # keep it dark
         );
     }
 
-    /// #10. `fleet.bridge.*` matches `is_external` but `[fleet]` IS modelled
-    /// (as an opaque passthrough), so the next `AppConfig::save()` reverts
-    /// anything written here. The second writer must refuse it outright.
+    /// `fleet.bridge.*` goes THROUGH the key-level writer, and the genuinely
+    /// modelled keys stay out of it.
+    ///
+    /// This assertion used to be the exact opposite. The reasoning was that
+    /// `[fleet]` is modelled, so `save()` owns it — but `save()` deliberately
+    /// preserves `fleet.bridge` from disk, so routing an edit through the
+    /// struct meant it was overwritten by the value already there. The
+    /// key-level write is the only path that lands it.
     #[test]
-    fn the_external_writer_refuses_a_modelled_bridge_key() {
-        // Guard only — calling `save_external_keys` here would write to the
-        // developer's REAL config.toml, which is how this test first ran.
-        let err = external_edit_value("fleet.bridge.telegram.token", "keychain:x")
-            .expect_err("fleet.bridge is modelled; save() owns it");
+    fn the_external_writer_accepts_bridge_keys_and_refuses_modelled_ones() {
         assert!(
-            err.to_string().contains("fleet.bridge.telegram.token"),
-            "unexpected error: {err}"
+            external_edit_value("fleet.bridge.telegram.token", "keychain:x").is_ok(),
+            "a bridge edit must reach the file"
         );
         // The genuinely external sections still go through.
         assert!(external_edit_value("skills.catalog_release", "v1.2.3").is_ok());
         assert!(external_edit_value("session_reader.incremental_window_days", "7").is_ok());
-        // And a modelled key is refused just as firmly.
+        // A modelled key belongs to `save()`, not here.
         assert!(external_edit_value("docker.timeout", "60").is_err());
     }
 
@@ -2481,6 +2529,43 @@ theme = \"dark\"   # keep it dark
             root.join("config.toml.migrated").exists(),
             "stray file's contents were destroyed rather than kept"
         );
+    }
+
+    /// A `fleet.bridge.*` edit must actually reach the file.
+    ///
+    /// This is the row class the whole PR exists to protect, and it was broken
+    /// twice in a row: first routed through the struct, where `save()`'s
+    /// preservation of `fleet.bridge` silently overwrote it, then routed to the
+    /// key-level writer which still refused the prefix. Both times the screen
+    /// reported "Setting saved to config.toml" and nothing changed.
+    #[test]
+    fn a_bridge_edit_is_accepted_by_the_external_writer() {
+        let value = external_edit_value("fleet.bridge.telegram.token", "keychain:ainb-telegram")
+            .expect("a bridge edit must be an accepted external write");
+        assert_eq!(value.as_str(), Some("keychain:ainb-telegram"));
+    }
+
+    /// The counterpart: `[usage]` belongs to the burndown plugin, and core must
+    /// keep refusing it.
+    #[test]
+    fn a_usage_edit_is_refused_by_the_external_writer() {
+        // Refused at the `is_external` gate, before the ownership check even
+        // runs — `[usage]` is not an externally-owned section, it is a modelled
+        // one core reads and the burndown plugin writes.
+        assert!(
+            external_edit_value("usage.currency.code", "GBP").is_err(),
+            "core must not write a section the burndown plugin owns"
+        );
+    }
+
+    /// And it must be refused with something actionable, not a bare failure
+    /// three calls downstream.
+    #[test]
+    fn burndown_owned_keys_are_recognised() {
+        assert!(is_burndown_owned("usage.currency.code"));
+        assert!(is_burndown_owned("usage"));
+        assert!(!is_burndown_owned("fleet.bridge.telegram.token"));
+        assert!(!is_burndown_owned("docker.timeout"));
     }
 
     /// A map key containing a dot must survive a save.

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -1024,6 +1024,13 @@ pub(crate) fn read_existing(path: &Path) -> Result<String> {
 }
 
 pub(crate) fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    // Follow a symlink to its target before writing. `rename` REPLACES a
+    // symlink with a regular file, so a config.toml symlinked into a dotfiles
+    // repo would silently stop being the tracked file after the first save,
+    // and the mode carry-over below (which follows the link) would give no
+    // hint that it had happened.
+    let resolved = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let path = resolved.as_path();
     let tmp = temp_path(path);
     // Every failure below removes the temp file. The name is per-process and
     // random, so unlike the old fixed `config.toml.tmp` nothing would ever
@@ -1182,8 +1189,40 @@ fn flatten_document_leaves(table: &toml_edit::Table, prefix: String, out: &mut V
         } else {
             format!("{prefix}.{segment}")
         };
-        match item.as_table() {
-            Some(inner) if !inner.is_empty() => flatten_document_leaves(inner, path, out),
+        // `as_table_like`, not `as_table`: an inline table
+        // (`installation = { type = "Npm", … }`, which is exactly how
+        // `example.config.toml` documents `[mcp_servers.*]`) is an
+        // `Item::Value`, so `as_table()` says no. The `toml` side descends into
+        // it either way, so treating it as a leaf here made the prune pass
+        // remove it and the set pass re-emit it as `[section.sub]` headers,
+        // destroying the line and its comments on the first save.
+        match item.as_table_like() {
+            Some(inner) if !inner.is_empty() => {
+                flatten_document_leaves_like(inner, path, out);
+            }
+            _ => out.push(path),
+        }
+    }
+}
+
+/// [`flatten_document_leaves`] over anything table-like, including an inline
+/// table.
+fn flatten_document_leaves_like(
+    table: &dyn toml_edit::TableLike,
+    prefix: String,
+    out: &mut Vec<String>,
+) {
+    for (key, item) in table.iter() {
+        let segment = registry::quote_key_segment(key);
+        let path = if prefix.is_empty() {
+            segment
+        } else {
+            format!("{prefix}.{segment}")
+        };
+        match item.as_table_like() {
+            Some(inner) if !inner.is_empty() => {
+                flatten_document_leaves_like(inner, path, out);
+            }
             _ => out.push(path),
         }
     }
@@ -2566,6 +2605,52 @@ theme = \"dark\"   # keep it dark
         assert!(is_burndown_owned("usage"));
         assert!(!is_burndown_owned("fleet.bridge.telegram.token"));
         assert!(!is_burndown_owned("docker.timeout"));
+    }
+
+    /// An inline table must survive a save intact.
+    ///
+    /// `example.config.toml` documents `[mcp_servers.*]` with inline
+    /// `installation = { type = "Npm", … }` / `definition = { … }` values. An
+    /// inline table is an `Item::Value`, so `as_table()` says no: the document
+    /// walk called it a leaf while the `toml` walk descended into it, the
+    /// prune pass then removed it and the set pass re-emitted it as
+    /// `[section.sub]` headers — destroying the line and its comment.
+    #[test]
+    fn save_keeps_an_inline_table_and_its_comment() {
+        let existing = "\
+# my mcp servers
+[mcp_servers.context7]
+name = \"context7\"
+description = \"docs\"
+required_env = []
+enabled_by_default = true
+shared = true
+installation = { type = \"Npm\", package = \"@context7/mcp-server\", version = \"latest\" }  # inline
+definition = { type = \"Command\", command = \"npx\", args = [\"-y\"], env = {} }
+
+[docker]
+timeout = 60
+";
+        let config: AppConfig = toml::from_str(existing).expect("parses");
+        let saved = config.overlay_onto_existing(existing).expect("overlays");
+
+        assert!(
+            saved.contains("installation = {"),
+            "the inline table was expanded into headers:\n{saved}"
+        );
+        assert!(
+            saved.contains("# inline"),
+            "the inline comment was lost:\n{saved}"
+        );
+        assert!(
+            saved.contains("# my mcp servers"),
+            "the section comment was lost:\n{saved}"
+        );
+        assert!(
+            !saved.contains("[mcp_servers.context7.installation]"),
+            "the inline table was re-emitted as a header:\n{saved}"
+        );
+        toml::from_str::<AppConfig>(&saved).expect("saved config no longer deserializes");
     }
 
     /// A map key containing a dot must survive a save.

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -19,6 +19,7 @@ pub mod mcp_init;
 pub mod onboarding;
 pub mod presets;
 pub mod registry;
+pub mod screen_model;
 pub mod session_defaults;
 pub mod ssh_display_names;
 
@@ -823,6 +824,16 @@ pub struct UiPreferences {
     /// default; `Declined` suppresses the prompt entirely.
     #[serde(default)]
     pub tmux_decision: TmuxDecision,
+
+    /// Which nodes of the Settings screen's category tree are expanded,
+    /// as `"<category label>|<dotted path>"` ids.
+    ///
+    /// Persisted UI state rather than a preference — it sits here beside the
+    /// sidebar widths for the same reason they do: the screen is unusable if
+    /// every section re-collapses on restart, and there is nowhere else that
+    /// survives a restart. Registered `Hidden` in the config registry.
+    #[serde(default)]
+    pub config_tree_expanded: Vec<String>,
 }
 
 /// The user's recorded decision on the Claude Code statusline wiring.
@@ -868,6 +879,7 @@ impl Default for UiPreferences {
             skill_manager_sources_width: None,
             statusline_decision: StatuslineDecision::default(),
             tmux_decision: TmuxDecision::default(),
+            config_tree_expanded: Vec::new(),
         }
     }
 }
@@ -956,10 +968,111 @@ const READ_ONLY_SECTIONS: &[&str] = &["usage"];
 /// skills API key and burndown's `[usage]` — so a partial write is not a
 /// cosmetic problem: the next load sees a syntax error and every consumer falls
 /// back to defaults. The burndown plugin already writes this way; core matches.
-fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
-    let tmp = path.with_extension("toml.tmp");
-    fs::write(&tmp, contents)?;
-    fs::rename(&tmp, path)
+/// A temp filename no other writer can be using.
+///
+/// The old fixed `config.toml.tmp` is the SAME path `ainb-plugin-burndown`
+/// computes for its own atomic save. Now that both write one config.toml, two
+/// concurrent saves could each write that file and then rename the other's
+/// half-written copy over the real config. Process id plus a random word makes
+/// a collision impossible between processes and between threads.
+fn temp_path(path: &Path) -> PathBuf {
+    path.with_extension(format!(
+        "toml.{}.{:08x}.tmp",
+        std::process::id(),
+        rand::random::<u32>()
+    ))
+}
+
+/// Read a config file, mapping ONLY "it is not there" to empty.
+///
+/// `read_to_string(..).unwrap_or_default()` treats a permission error, an I/O
+/// error or a directory in the file's place as an empty file — and the caller
+/// then overwrites it, because `rename` needs permission on the DIRECTORY, not
+/// the file. `[skills]`, `[session_reader]` and `[fleet.bridge]` all live in
+/// that file and would go with it.
+pub(crate) fn read_existing(path: &Path) -> Result<String> {
+    match fs::read_to_string(path) {
+        Ok(text) => Ok(text),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(err) => Err(anyhow::Error::new(err).context(format!(
+            "refusing to save over {} — it exists but could not be read",
+            path.display()
+        ))),
+    }
+}
+
+pub(crate) fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    let tmp = temp_path(path);
+    if let Err(err) = fs::write(&tmp, contents) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    if let Err(err) = fs::rename(&tmp, path) {
+        // A unique temp name is only an improvement if it does not accumulate.
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// Write exactly these dotted keys into a config file, leaving every other byte
+/// of it alone.
+///
+/// The narrow counterpart to [`AppConfig::save`], for the cases where
+/// serializing the whole struct would be wrong: a key the struct does not model
+/// (`[skills]`), or a key whose in-memory snapshot is stale and would revert
+/// another writer. Same safety discipline as `save` — refuses a file it cannot
+/// read or parse, refuses [`READ_ONLY_SECTIONS`], writes atomically.
+///
+/// Path-explicit so it is testable without redirecting `HOME`.
+fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> Result<()> {
+    if edits.is_empty() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let existing = read_existing(path)?;
+    let mut root = if existing.trim().is_empty() {
+        toml::Value::Table(toml::Table::new())
+    } else {
+        toml::Value::Table(existing.parse::<toml::Table>().context(
+            "refusing to save over a config.toml that does not parse — fix the syntax error first",
+        )?)
+    };
+
+    for (key, value) in edits {
+        let section = key.split('.').next().unwrap_or_default();
+        if READ_ONLY_SECTIONS.contains(&section) {
+            anyhow::bail!("'{key}' is in a read-only section");
+        }
+        registry::insert_at(&mut root, key, value.clone())?;
+    }
+
+    write_atomic(path, &toml::to_string_pretty(&root)?)?;
+    Ok(())
+}
+
+/// The TOML value an external edit writes, or an error naming why the key is
+/// not one this writer owns.
+///
+/// Split out from [`AppConfig::save_external_keys`] so the guard can be tested
+/// without resolving `HOME` — a test that calls the writer directly writes to
+/// the developer's real config.
+fn external_edit_value(key: &str, raw: &str) -> Result<toml::Value> {
+    // `fleet.bridge.*` matches `is_external` (its tokens are parsed by
+    // `fleet::bridge::config`, not by serde), but `[fleet]` IS modelled as an
+    // opaque passthrough — so `AppConfig::save` owns it and would revert
+    // anything written here on the next save.
+    if !registry::is_external(key) || key.starts_with("fleet.bridge.") {
+        anyhow::bail!("'{key}' is not an externally-owned config key — AppConfig::save owns it");
+    }
+    let section = key.split('.').next().unwrap_or_default();
+    if READ_ONLY_SECTIONS.contains(&section) {
+        anyhow::bail!("'{key}' is in a read-only section");
+    }
+    registry::validate(key, raw)
 }
 
 /// Fold a stray `~/.agents-in-a-box/config.toml` into the real user config at
@@ -980,6 +1093,31 @@ fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
 /// were. In particular a canonical file that does not parse aborts the
 /// migration rather than being replaced by the stray one — overwriting a config
 /// we failed to understand is the data loss this whole change exists to stop.
+/// Copy the keys of `higher` that `lower` does not already have, descending
+/// into tables both sides define. Returns how many leaves were carried across,
+/// so the caller can leave the file untouched when the answer is zero.
+fn merge_missing_keys(lower: &mut toml::Table, higher: toml::Table) -> usize {
+    let mut carried = 0;
+    for (key, value) in higher {
+        match lower.entry(key) {
+            toml::map::Entry::Vacant(slot) => {
+                slot.insert(value);
+                carried += 1;
+            }
+            toml::map::Entry::Occupied(mut slot) => {
+                // Two tables merge; anything else means the canonical file has
+                // a real value here and canonical wins.
+                if let (Some(existing), toml::Value::Table(incoming)) =
+                    (slot.get_mut().as_table_mut(), value)
+                {
+                    carried += merge_missing_keys(existing, incoming);
+                }
+            }
+        }
+    }
+    carried
+}
+
 fn migrate_stray_user_config(canonical: &Path) {
     let Some(stray) = canonical.parent().and_then(Path::parent).map(|d| d.join("config.toml"))
     else {
@@ -1019,13 +1157,12 @@ fn migrate_stray_user_config(canonical: &Path) {
     };
 
     // Canonical wins: only keys the real config never set are carried over.
-    let mut carried = 0usize;
-    for (key, value) in stray_table {
-        if let toml::map::Entry::Vacant(slot) = merged.entry(key) {
-            slot.insert(value);
-            carried += 1;
-        }
-    }
+    // Recursively, because a top-level-only merge loses everything under a
+    // section the canonical file has so much as touched — a canonical
+    // `[fleet.cost]` occupies the `fleet` key, and the stray's
+    // `[fleet.bridge.telegram] token` is then silently dropped. Losing bridge
+    // tokens is the whole reason this migration exists.
+    let carried = merge_missing_keys(&mut merged, stray_table);
 
     // Nothing to carry across: leave the canonical file byte-for-byte alone.
     // Rewriting it would strip the comments and layout of a file users are
@@ -1129,9 +1266,21 @@ impl AppConfig {
         let mut table = if existing.trim().is_empty() {
             toml::Table::new()
         } else {
-            existing.parse::<toml::Table>().context(
+            let table = existing.parse::<toml::Table>().context(
                 "refusing to save over a config.toml that does not parse — fix the syntax error first",
-            )?
+            )?;
+            // Second gate, and the one that matters in practice. A file can
+            // tokenize perfectly and still fail serde (`timeout = "60"`, a
+            // `Vec<String>` holding an int). `AppConfig::load` returns Err on
+            // such a file, and several callers `unwrap_or_default()` and then
+            // save — so without this, a DEFAULT config gets overlaid and every
+            // modelled section on disk is replaced with defaults. Same wipe the
+            // syntax gate above exists to stop, one layer down.
+            let _: AppConfig = toml::Value::Table(table.clone()).try_into().context(
+                "refusing to save over a config.toml that parses but does not load into ainb's \
+                 schema — saving would replace every section it models with defaults",
+            )?;
+            table
         };
         let toml::Value::Table(ours) = toml::Value::try_from(self)? else {
             anyhow::bail!("AppConfig did not serialize to a TOML table");
@@ -1151,7 +1300,7 @@ impl AppConfig {
         fs::create_dir_all(&config_dir)?;
 
         let config_path = config_dir.join("config.toml");
-        let existing = fs::read_to_string(&config_path).unwrap_or_default();
+        let existing = read_existing(&config_path)?;
         let content = self.overlay_onto_existing(&existing)?;
 
         match write_atomic(&config_path, &content) {
@@ -1176,6 +1325,51 @@ impl AppConfig {
                 Err(e.into())
             }
         }
+    }
+
+    /// Write registry keys that live in this file but NOT in `AppConfig`'s
+    /// serde shape — `[skills]` (owned by `ainb-cli`) and `[session_reader]`
+    /// (owned by the session-reader plugin). See
+    /// [`EXTERNAL_PREFIXES`](registry::EXTERNAL_PREFIXES).
+    ///
+    /// [`save`](Self::save) cannot carry these: it serializes `self`, and
+    /// `self` has no field for them, so an edit made in the settings screen
+    /// would be accepted and then silently dropped — the exact failure mode the
+    /// config registry exists to remove. This is a *second* writer over the
+    /// same file rather than a way around `save`: it starts from the on-disk
+    /// table (so every unmodelled section survives byte-for-byte), refuses a
+    /// file that does not parse, validates each value through the registry, and
+    /// writes atomically, exactly as `save` does.
+    ///
+    /// Refuses [`READ_ONLY_SECTIONS`] and any key that is not external, so it
+    /// can never become a back door around either guard.
+    pub fn save_external_keys(edits: &[(String, String)]) -> Result<()> {
+        if edits.is_empty() {
+            return Ok(());
+        }
+        let mut prepared = Vec::with_capacity(edits.len());
+        for (key, raw) in edits {
+            prepared.push((key.clone(), external_edit_value(key, raw)?));
+        }
+        let config_path = Self::get_user_config_dir()?.join("config.toml");
+        write_keys_into(&config_path, &prepared)
+    }
+
+    /// Persist the settings screen's tree expansion, and nothing else.
+    ///
+    /// Deliberately NOT `save()`: expanding a section is a navigational
+    /// keystroke, and `save()` writes the whole in-memory `AppConfig`, which is
+    /// the snapshot taken at startup. Navigating would then revert anything
+    /// `ainb config set` or another process had changed since — and multiply the
+    /// window for two writers to collide.
+    pub fn save_tree_expansion(ids: &[String]) -> Result<()> {
+        let value =
+            toml::Value::Array(ids.iter().map(|id| toml::Value::String(id.clone())).collect());
+        let config_path = Self::get_user_config_dir()?.join("config.toml");
+        write_keys_into(
+            &config_path,
+            &[("ui_preferences.config_tree_expanded".to_string(), value)],
+        )
     }
 
     /// Get configuration file paths in order of precedence
@@ -1498,6 +1692,211 @@ impl ProjectConfig {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    // ================================================================
+    // Review findings #2 #3 #4 #5 #10: what a save is allowed to destroy
+    // ================================================================
+
+    /// #2. A file that TOKENIZES but does not load into `AppConfig` must abort
+    /// the save.
+    ///
+    /// `AppConfig::load()` returns Err on such a file, and three callers
+    /// (`cli/tmux_install.rs`, `app/state.rs`, `cli/run.rs`) `unwrap_or_default()`
+    /// and then save — so a DEFAULT config gets overlaid onto the real file and
+    /// every modelled section is replaced with defaults. The syntax gate does
+    /// not catch it because the syntax is fine.
+    #[test]
+    fn saving_over_a_config_that_parses_but_does_not_load_is_refused() {
+        // `timeout` is a u64; a quoted number is valid TOML and invalid schema.
+        let on_disk = "[docker]\ntimeout = \"60\"\n\n[skills]\napi_key = \"sk-secret\"\n";
+        assert!(
+            toml::from_str::<AppConfig>(on_disk).is_err(),
+            "fixture must be a file that parses but does not load"
+        );
+        assert!(
+            on_disk.parse::<toml::Table>().is_ok(),
+            "fixture must tokenize"
+        );
+
+        let err = AppConfig::default()
+            .overlay_onto_existing(on_disk)
+            .expect_err("a config that does not load must not be overlaid");
+        assert!(
+            err.to_string().contains("does not load"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// #3. Two writers must not share a temp path. `write_atomic` used a fixed
+    /// `config.toml.tmp`, which `ainb-plugin-burndown` computes identically —
+    /// so a concurrent burndown save and TUI save could rename each other's
+    /// half-written temp over the real config.
+    #[test]
+    fn atomic_writes_do_not_share_a_temp_path() {
+        let path = Path::new("/tmp/config.toml");
+        let a = temp_path(path);
+        let b = temp_path(path);
+        assert_ne!(a, b, "two writes reused one temp path: {a:?}");
+        assert!(
+            !a.ends_with("config.toml.tmp"),
+            "temp path is the fixed name burndown also computes: {a:?}"
+        );
+        assert!(
+            a.file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains(&std::process::id().to_string()),
+            "temp path does not identify the writing process: {a:?}"
+        );
+    }
+
+    /// #4. Only "not there" may be treated as empty. An unreadable-but-present
+    /// file read as `""` is overwritten wholesale, destroying `[skills]`,
+    /// `[session_reader]` and `[fleet.bridge]` — the rename needs only
+    /// directory permission, so the write succeeds.
+    #[test]
+    fn an_unreadable_config_is_not_treated_as_empty() {
+        let tmp = TempDir::new().expect("tempdir");
+
+        // A directory in the file's place: present, and not readable as text.
+        let as_dir = tmp.path().join("config.toml");
+        fs::create_dir(&as_dir).expect("mkdir");
+        let err = read_existing(&as_dir).expect_err("an unreadable path must not read as empty");
+        assert!(err.to_string().contains("could not be read"), "{err}");
+
+        // Absent is still empty.
+        assert_eq!(read_existing(&tmp.path().join("absent.toml")).unwrap(), "");
+    }
+
+    /// #5. The stray-config migration merged only TOP-LEVEL keys, so a
+    /// canonical file with any `[fleet]` content already occupied the `fleet`
+    /// key and the stray's `[fleet.bridge.telegram]` tokens were never carried
+    /// across — the precise data loss this change exists to stop.
+    #[test]
+    fn migrate_carries_a_nested_stray_section_into_an_occupied_parent() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path().join(".agents-in-a-box");
+        let canonical = root.join("config").join("config.toml");
+        fs::create_dir_all(canonical.parent().unwrap()).expect("mkdir");
+
+        fs::write(&canonical, "[fleet.cost]\nsession_usd = 5.0\n").expect("write canonical");
+        fs::write(
+            root.join("config.toml"),
+            "[fleet.bridge.telegram]\ntoken = \"keychain:ainb-telegram\"\n",
+        )
+        .expect("write stray");
+
+        migrate_stray_user_config(&canonical);
+
+        let merged: toml::Value =
+            toml::from_str(&fs::read_to_string(&canonical).expect("read")).expect("parse");
+        assert_eq!(
+            registry::navigate_toml(&merged, "fleet.bridge.telegram.token").ok(),
+            Some(&toml::Value::String("keychain:ainb-telegram".to_string())),
+            "the stray bridge token was dropped because `fleet` was already occupied: {merged}"
+        );
+        assert_eq!(
+            registry::navigate_toml(&merged, "fleet.cost.session_usd").ok(),
+            Some(&toml::Value::Float(5.0)),
+            "the canonical value must still win"
+        );
+    }
+
+    /// #9. A navigational keystroke must not rewrite the whole file.
+    ///
+    /// `ConfigToggleExpand` used to call `AppConfig::save()`, which serializes
+    /// the in-memory snapshot taken at startup — so expanding a tree node
+    /// reverted anything `ainb config set` or another process had changed since.
+    /// The targeted writer touches one key and leaves every other byte.
+    #[test]
+    fn a_targeted_write_leaves_every_other_section_alone() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("config.toml");
+        // Stands in for "another writer changed this since we loaded".
+        fs::write(
+            &path,
+            "[docker]\ntimeout = 120\n\n[skills]\napi_key = \"sk-secret\"\n",
+        )
+        .expect("seed");
+
+        write_keys_into(
+            &path,
+            &[(
+                "ui_preferences.config_tree_expanded".to_string(),
+                toml::Value::Array(vec![toml::Value::String("Fleet|fleet".to_string())]),
+            )],
+        )
+        .expect("targeted write");
+
+        let after: toml::Value =
+            toml::from_str(&fs::read_to_string(&path).expect("read")).expect("parse");
+        assert_eq!(
+            registry::navigate_toml(&after, "docker.timeout").ok(),
+            Some(&toml::Value::Integer(120)),
+            "a tree keystroke reverted another writer's value: {after}"
+        );
+        assert_eq!(
+            registry::navigate_toml(&after, "skills.api_key").ok(),
+            Some(&toml::Value::String("sk-secret".to_string()))
+        );
+        assert_eq!(
+            registry::navigate_toml(&after, "ui_preferences.config_tree_expanded").ok(),
+            Some(&toml::Value::Array(vec![toml::Value::String(
+                "Fleet|fleet".to_string()
+            )]))
+        );
+    }
+
+    /// A targeted write is still refused on a file it cannot parse, and on a
+    /// read-only section — the narrow writer is not a way around either guard.
+    #[test]
+    fn a_targeted_write_keeps_the_same_guards() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, "this is not valid toml\n").expect("seed");
+        assert!(
+            write_keys_into(
+                &path,
+                &[("docker.timeout".to_string(), toml::Value::Integer(1))]
+            )
+            .is_err(),
+            "wrote over a config.toml that does not parse"
+        );
+
+        let ok_path = tmp.path().join("ok.toml");
+        fs::write(&ok_path, "[usage]\n").expect("seed");
+        assert!(
+            write_keys_into(
+                &ok_path,
+                &[(
+                    "usage.currency.code".to_string(),
+                    toml::Value::String("EUR".into())
+                )]
+            )
+            .is_err(),
+            "wrote into a read-only section"
+        );
+    }
+
+    /// #10. `fleet.bridge.*` matches `is_external` but `[fleet]` IS modelled
+    /// (as an opaque passthrough), so the next `AppConfig::save()` reverts
+    /// anything written here. The second writer must refuse it outright.
+    #[test]
+    fn the_external_writer_refuses_a_modelled_bridge_key() {
+        // Guard only — calling `save_external_keys` here would write to the
+        // developer's REAL config.toml, which is how this test first ran.
+        let err = external_edit_value("fleet.bridge.telegram.token", "keychain:x")
+            .expect_err("fleet.bridge is modelled; save() owns it");
+        assert!(
+            err.to_string().contains("fleet.bridge.telegram.token"),
+            "unexpected error: {err}"
+        );
+        // The genuinely external sections still go through.
+        assert!(external_edit_value("skills.catalog_release", "v1.2.3").is_ok());
+        assert!(external_edit_value("session_reader.incremental_window_days", "7").is_ok());
+        // And a modelled key is refused just as firmly.
+        assert!(external_edit_value("docker.timeout", "60").is_err());
+    }
 
     /// A canonical config with a syntax error must abort the migration, not be
     /// replaced by the stray file. Treating an unparseable file as empty would
@@ -2259,6 +2658,7 @@ mod old_config_tests {
                 skill_manager_sources_width: None,
                 statusline_decision: StatuslineDecision::default(),
                 tmux_decision: TmuxDecision::default(),
+                config_tree_expanded: Vec::new(),
             },
             docker: DockerConfig {
                 host: None,
@@ -2306,6 +2706,7 @@ mod old_config_tests {
                 skill_manager_sources_width: None,
                 statusline_decision: StatuslineDecision::default(),
                 tmux_decision: TmuxDecision::default(),
+                config_tree_expanded: Vec::new(),
             },
             docker: DockerConfig {
                 host: None,

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -464,6 +464,17 @@ pub struct FleetConfig {
     /// `Option` for the same presence reason as [`InterviewConfig::surface`].
     #[serde(default)]
     pub terminal: Option<String>,
+    /// `[fleet.bridge]` carried verbatim, never interpreted here.
+    ///
+    /// The phone bridge parses this table itself, off the same file, with its
+    /// own resolver (`fleet::bridge::config`) — it holds bot tokens, so
+    /// `ainb-core` deliberately does not model its shape. It still has to be a
+    /// field: `save()` preserves unmodelled *top-level* sections, but `fleet`
+    /// IS modelled, so anything nested under it that has no field here would be
+    /// dropped on the next save. That is exactly how the bridge's Telegram,
+    /// Slack and Discord tokens used to get wiped by any settings save.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bridge: Option<toml::Value>,
 }
 
 fn default_fleet_terminal() -> &'static str {
@@ -476,6 +487,7 @@ impl Default for FleetConfig {
             cost: CostBudgetConfig::default(),
             interview: InterviewConfig::default(),
             terminal: None,
+            bridge: None,
         }
     }
 }
@@ -960,13 +972,39 @@ impl AppConfig {
         Ok(config)
     }
 
+    /// Overlay the sections this struct models onto whatever is already on
+    /// disk, leaving every other top-level section untouched.
+    ///
+    /// `AppConfig` does not model the whole file. `[skills]` (catalog release +
+    /// API key) and `[session_reader]` are parsed straight off the same path by
+    /// other crates, and nothing here has a field for them. A plain
+    /// `to_string_pretty(self)` write therefore erased them on every settings
+    /// save. Overlaying key-by-key keeps them, and keeps any section a future
+    /// crate adds, without `ainb-core` needing to know what they are.
+    ///
+    /// Deliberately shallow: a modelled section (`[fleet]`, `[mcp_servers]`, …)
+    /// is replaced wholesale so that *removing* an entry from it actually
+    /// sticks. Unmodelled tables nested under a modelled section need a
+    /// passthrough field instead — see [`FleetConfig::bridge`].
+    fn overlay_onto_existing(&self, existing: &str) -> Result<String> {
+        let mut table = existing.parse::<toml::Table>().unwrap_or_default();
+        let toml::Value::Table(ours) = toml::Value::try_from(self)? else {
+            anyhow::bail!("AppConfig did not serialize to a TOML table");
+        };
+        for (key, value) in ours {
+            table.insert(key, value);
+        }
+        Ok(toml::to_string_pretty(&table)?)
+    }
+
     /// Save configuration to user config directory
     pub fn save(&self) -> Result<()> {
         let config_dir = Self::get_user_config_dir()?;
         fs::create_dir_all(&config_dir)?;
 
         let config_path = config_dir.join("config.toml");
-        let content = toml::to_string_pretty(self)?;
+        let existing = fs::read_to_string(&config_path).unwrap_or_default();
+        let content = self.overlay_onto_existing(&existing)?;
 
         match fs::write(&config_path, &content) {
             Ok(()) => {
@@ -1143,6 +1181,9 @@ impl AppConfig {
         if other.fleet.terminal.is_some() {
             self.fleet.terminal.clone_from(&other.fleet.terminal);
         }
+        if other.fleet.bridge.is_some() {
+            self.fleet.bridge.clone_from(&other.fleet.bridge);
+        }
 
         // Pool settings: trust the loaded layer whenever it differs from the
         // defaults. `enabled = false` must survive (it IS the default-diverging
@@ -1309,6 +1350,109 @@ impl ProjectConfig {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// The overlay serializes a `toml::Table`, not the struct, so field
+    /// declaration order no longer protects us: TOML requires every top-level
+    /// scalar before the first table, and a sorted map interleaves them
+    /// (`authentication` sorts before `version`). Prove a fully-populated
+    /// config still renders to something that parses back.
+    #[test]
+    fn overlay_output_is_valid_toml_for_a_full_config() {
+        let mut config = AppConfig::default();
+        config.load_builtin_templates();
+
+        let rendered = config
+            .overlay_onto_existing("[skills]\napi_key = \"sk-secret\"\n")
+            .expect("overlay must not fail on a fully-populated config");
+
+        let reparsed: AppConfig = toml::from_str(&rendered).expect("overlay emitted invalid TOML");
+        assert_eq!(reparsed.version, config.version);
+        assert_eq!(
+            reparsed.default_container_template,
+            config.default_container_template
+        );
+        assert_eq!(
+            reparsed.container_templates.len(),
+            config.container_templates.len()
+        );
+
+        let table: toml::Table = rendered.parse().expect("valid TOML");
+        assert_eq!(table["skills"]["api_key"].as_str(), Some("sk-secret"));
+    }
+
+    /// Saving must not eat the sections `AppConfig` does not model.
+    ///
+    /// `[skills]` and `[session_reader]` are read off this same file by
+    /// `ainb-cli` and the session-reader plugin; `[fleet.bridge]` holds the
+    /// phone bridge's bot tokens. Before the overlay write, every settings save
+    /// replaced the file wholesale and silently destroyed all three.
+    #[test]
+    fn save_preserves_sections_app_config_does_not_model() {
+        let existing = r#"
+[skills]
+catalog_release = "v1.5.0"
+api_key = "sk-secret"
+
+[session_reader]
+incremental_window_days = 90
+
+[fleet.bridge.telegram]
+token = "keychain:ainb-telegram"
+user_id = 123456789
+
+[ui_preferences]
+theme = "dark"
+"#;
+        // Round-trip through load so `[fleet.bridge]` reaches the struct the
+        // way a real save does, then write back over the same content.
+        let loaded: AppConfig = toml::from_str(existing).expect("parses");
+        let saved = loaded.overlay_onto_existing(existing).expect("overlays");
+        let reparsed: toml::Table = saved.parse().expect("still valid TOML");
+
+        assert_eq!(
+            reparsed["skills"]["catalog_release"].as_str(),
+            Some("v1.5.0"),
+            "[skills] was dropped by save"
+        );
+        assert_eq!(
+            reparsed["skills"]["api_key"].as_str(),
+            Some("sk-secret"),
+            "the skills API key was dropped by save"
+        );
+        assert_eq!(
+            reparsed["session_reader"]["incremental_window_days"].as_integer(),
+            Some(90),
+            "[session_reader] was dropped by save"
+        );
+        assert_eq!(
+            reparsed["fleet"]["bridge"]["telegram"]["token"].as_str(),
+            Some("keychain:ainb-telegram"),
+            "[fleet.bridge] was dropped by save — bridge tokens are gone"
+        );
+    }
+
+    /// The flip side of the overlay: a modelled section is replaced wholesale,
+    /// so deleting an entry from it actually sticks instead of being resurrected
+    /// from the previous file contents.
+    #[test]
+    fn save_replaces_modelled_sections_wholesale() {
+        let existing = r#"
+[ui_preferences]
+theme = "light"
+show_git_status = false
+"#;
+        let mut config: AppConfig = toml::from_str(existing).expect("parses");
+        config.ui_preferences.show_git_status = true;
+
+        let saved = config.overlay_onto_existing(existing).expect("overlays");
+        let reparsed: toml::Table = saved.parse().expect("still valid TOML");
+
+        assert_eq!(
+            reparsed["ui_preferences"]["show_git_status"].as_bool(),
+            Some(true),
+            "a modelled field kept its stale on-disk value"
+        );
+    }
 
     #[test]
     fn test_default_config() {

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -937,9 +937,67 @@ fn merge_plugin_value_table(lower: &mut toml::Value, higher: toml::Value) {
     }
 }
 
+/// Fold a stray `~/.agents-in-a-box/config.toml` into the real user config at
+/// `~/.agents-in-a-box/config/config.toml`, then move it aside.
+///
+/// The burndown and session-reader plugins used to read and write the file one
+/// directory up from the one everything else uses, so a user's `[usage]` plan
+/// could end up in a file `ainb-core` never opened. Both plugins now agree on
+/// the `config/` path; this carries the old file's contents across once, taking
+/// the canonical file's value wherever both set the same key.
+///
+/// Best effort by design: any failure here leaves both files untouched rather
+/// than blocking startup.
+fn migrate_stray_user_config(canonical: &Path) {
+    let Some(stray) = canonical.parent().and_then(Path::parent).map(|d| d.join("config.toml"))
+    else {
+        return;
+    };
+    if !stray.exists() || stray == canonical {
+        return;
+    }
+
+    let Ok(stray_table) = fs::read_to_string(&stray).and_then(|s| {
+        s.parse::<toml::Table>()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    }) else {
+        return;
+    };
+
+    let mut merged = fs::read_to_string(canonical)
+        .ok()
+        .and_then(|s| s.parse::<toml::Table>().ok())
+        .unwrap_or_default();
+    // Canonical wins: only keys the real config never set are carried over.
+    for (key, value) in stray_table {
+        merged.entry(key).or_insert(value);
+    }
+
+    let Ok(rendered) = toml::to_string_pretty(&merged) else {
+        return;
+    };
+    if canonical.parent().is_some_and(|d| fs::create_dir_all(d).is_err()) {
+        return;
+    }
+    if fs::write(canonical, rendered).is_err() {
+        return;
+    }
+    // Keep the old file's contents around rather than deleting them outright.
+    let _ = fs::rename(&stray, stray.with_extension("toml.migrated"));
+    tracing::info!(
+        stray = %stray.display(),
+        canonical = %canonical.display(),
+        "merged stray config.toml into the user config"
+    );
+}
+
 impl AppConfig {
     /// Load configuration from default locations
     pub fn load() -> Result<Self> {
+        if let Ok(dir) = Self::get_user_config_dir() {
+            migrate_stray_user_config(&dir.join("config.toml"));
+        }
+
         // Try loading from multiple locations in order of precedence
         let config_paths = Self::get_config_paths();
 
@@ -1042,7 +1100,7 @@ impl AppConfig {
             paths.push(cwd.join(".ainb").join("config.toml"));
         }
 
-        // 2. User config (~/.agents-in-a-box/config.toml)
+        // 2. User config (~/.agents-in-a-box/config/config.toml)
         if let Ok(config_dir) = Self::get_user_config_dir() {
             paths.push(config_dir.join("config.toml"));
         }
@@ -1378,6 +1436,47 @@ mod tests {
 
         let table: toml::Table = rendered.parse().expect("valid TOML");
         assert_eq!(table["skills"]["api_key"].as_str(), Some("sk-secret"));
+    }
+
+    /// A user who set `[usage]` while the plugins still read the file one
+    /// directory up must not lose it. The stray file is folded in and moved
+    /// aside, and the canonical file wins wherever both set the same key.
+    #[test]
+    fn migrate_folds_stray_config_in_and_moves_it_aside() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path().join(".agents-in-a-box");
+        let canonical = root.join("config").join("config.toml");
+        fs::create_dir_all(canonical.parent().unwrap()).expect("mkdir");
+
+        fs::write(
+            root.join("config.toml"),
+            "[usage.currency]\ncode = \"GBP\"\n\n[ui_preferences]\ntheme = \"light\"\n",
+        )
+        .expect("write stray");
+        fs::write(&canonical, "[ui_preferences]\ntheme = \"dark\"\n").expect("write canonical");
+
+        migrate_stray_user_config(&canonical);
+
+        let merged: toml::Table =
+            fs::read_to_string(&canonical).expect("read").parse().expect("valid TOML");
+        assert_eq!(
+            merged["usage"]["currency"]["code"].as_str(),
+            Some("GBP"),
+            "the stray file's [usage] was not carried across"
+        );
+        assert_eq!(
+            merged["ui_preferences"]["theme"].as_str(),
+            Some("dark"),
+            "the stray file overwrote a key the canonical config already set"
+        );
+        assert!(
+            !root.join("config.toml").exists(),
+            "stray file was left in place"
+        );
+        assert!(
+            root.join("config.toml.migrated").exists(),
+            "stray file's contents were destroyed rather than kept"
+        );
     }
 
     /// Saving must not eat the sections `AppConfig` does not model.

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -937,6 +937,29 @@ fn merge_plugin_value_table(lower: &mut toml::Value, higher: toml::Value) {
     }
 }
 
+/// Sections `ainb-core` reads but must never write back.
+///
+/// `[usage]` is owned by the burndown plugin, which does its own
+/// load-modify-save against this same file. Now that both agree on one path, a
+/// long-lived TUI overwriting `[usage]` from the snapshot it loaded at startup
+/// would silently revert a plan set from another shell mid-session. Core has no
+/// UI for `[usage]` and never assigns to it, so the honest contract is
+/// read-only.
+const READ_ONLY_SECTIONS: &[&str] = &["usage"];
+
+/// Write `contents` to `path` atomically, so a crash or a full disk cannot
+/// leave a truncated file behind.
+///
+/// This file now carries three writers' data — the bridge's bot tokens, the
+/// skills API key and burndown's `[usage]` — so a partial write is not a
+/// cosmetic problem: the next load sees a syntax error and every consumer falls
+/// back to defaults. The burndown plugin already writes this way; core matches.
+fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    let tmp = path.with_extension("toml.tmp");
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, path)
+}
+
 /// Fold a stray `~/.agents-in-a-box/config.toml` into the real user config at
 /// `~/.agents-in-a-box/config/config.toml`, then move it aside.
 ///
@@ -946,8 +969,15 @@ fn merge_plugin_value_table(lower: &mut toml::Value, higher: toml::Value) {
 /// the `config/` path; this carries the old file's contents across once, taking
 /// the canonical file's value wherever both set the same key.
 ///
-/// Best effort by design: any failure here leaves both files untouched rather
-/// than blocking startup.
+/// Deliberately NOT called from [`AppConfig::load`]: that runs in daemons, in
+/// plugin startup and inside the TUI event loop, and a filesystem write as a
+/// side effect of a read races every other process doing the same. Call it once
+/// from a binary's startup instead — see [`AppConfig::migrate_legacy_paths`].
+///
+/// Best effort by design: every failure path leaves BOTH files exactly as they
+/// were. In particular a canonical file that does not parse aborts the
+/// migration rather than being replaced by the stray one — overwriting a config
+/// we failed to understand is the data loss this whole change exists to stop.
 fn migrate_stray_user_config(canonical: &Path) {
     let Some(stray) = canonical.parent().and_then(Path::parent).map(|d| d.join("config.toml"))
     else {
@@ -964,40 +994,85 @@ fn migrate_stray_user_config(canonical: &Path) {
         return;
     };
 
-    let mut merged = fs::read_to_string(canonical)
-        .ok()
-        .and_then(|s| s.parse::<toml::Table>().ok())
-        .unwrap_or_default();
+    // An unreadable or unparseable canonical file must abort the migration.
+    // Treating it as empty would write the stray file's contents over a config
+    // whose real contents we could not read.
+    let mut merged = match fs::read_to_string(canonical) {
+        Ok(text) => match text.parse::<toml::Table>() {
+            Ok(table) => table,
+            Err(err) => {
+                tracing::warn!(
+                    path = %canonical.display(),
+                    %err,
+                    "user config does not parse; leaving it alone instead of migrating over it"
+                );
+                return;
+            }
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => toml::Table::new(),
+        Err(err) => {
+            tracing::warn!(path = %canonical.display(), %err, "cannot read user config; skipping migration");
+            return;
+        }
+    };
+
     // Canonical wins: only keys the real config never set are carried over.
+    let mut carried = 0usize;
     for (key, value) in stray_table {
-        merged.entry(key).or_insert(value);
+        if let toml::map::Entry::Vacant(slot) = merged.entry(key) {
+            slot.insert(value);
+            carried += 1;
+        }
     }
 
-    let Ok(rendered) = toml::to_string_pretty(&merged) else {
-        return;
-    };
-    if canonical.parent().is_some_and(|d| fs::create_dir_all(d).is_err()) {
-        return;
+    // Nothing to carry across: leave the canonical file byte-for-byte alone.
+    // Rewriting it would strip the comments and layout of a file users are
+    // explicitly pointed at hand-editing.
+    if carried > 0 {
+        let Ok(rendered) = toml::to_string_pretty(&merged) else {
+            return;
+        };
+        if canonical.parent().is_some_and(|d| fs::create_dir_all(d).is_err()) {
+            return;
+        }
+        if let Err(err) = write_atomic(canonical, &rendered) {
+            tracing::warn!(path = %canonical.display(), %err, "failed to write merged user config");
+            return;
+        }
     }
-    if fs::write(canonical, rendered).is_err() {
-        return;
+
+    // Keep the old file's contents rather than deleting them, and never clobber
+    // an earlier backup — in the worst case it is the only surviving copy.
+    let mut backup = stray.with_extension("toml.migrated");
+    let mut n = 1;
+    while backup.exists() {
+        backup = stray.with_extension(format!("toml.migrated.{n}"));
+        n += 1;
     }
-    // Keep the old file's contents around rather than deleting them outright.
-    let _ = fs::rename(&stray, stray.with_extension("toml.migrated"));
+    let _ = fs::rename(&stray, &backup);
     tracing::info!(
         stray = %stray.display(),
         canonical = %canonical.display(),
+        backup = %backup.display(),
+        carried,
         "merged stray config.toml into the user config"
     );
 }
-
 impl AppConfig {
-    /// Load configuration from default locations
-    pub fn load() -> Result<Self> {
+    /// One-shot cleanup of config files left behind by older builds.
+    ///
+    /// Call this ONCE from a binary's startup, before the first
+    /// [`AppConfig::load`]. It is deliberately separate from `load()`, which
+    /// runs in daemons, plugin startup and the TUI event loop where a
+    /// filesystem write as a side effect of a read would race other processes.
+    pub fn migrate_legacy_paths() {
         if let Ok(dir) = Self::get_user_config_dir() {
             migrate_stray_user_config(&dir.join("config.toml"));
         }
+    }
 
+    /// Load configuration from default locations
+    pub fn load() -> Result<Self> {
         // Try loading from multiple locations in order of precedence
         let config_paths = Self::get_config_paths();
 
@@ -1045,11 +1120,24 @@ impl AppConfig {
     /// sticks. Unmodelled tables nested under a modelled section need a
     /// passthrough field instead — see [`FleetConfig::bridge`].
     fn overlay_onto_existing(&self, existing: &str) -> Result<String> {
-        let mut table = existing.parse::<toml::Table>().unwrap_or_default();
+        // A file we cannot parse must abort the save, never be treated as
+        // empty. `AppConfig::load()` falls back to defaults on a parse error,
+        // so defaulting here would let one bad keystroke in a hand-edited file
+        // turn the next settings save into a wipe of every section on disk.
+        let mut table = if existing.trim().is_empty() {
+            toml::Table::new()
+        } else {
+            existing.parse::<toml::Table>().context(
+                "refusing to save over a config.toml that does not parse — fix the syntax error first",
+            )?
+        };
         let toml::Value::Table(ours) = toml::Value::try_from(self)? else {
             anyhow::bail!("AppConfig did not serialize to a TOML table");
         };
         for (key, value) in ours {
+            if READ_ONLY_SECTIONS.contains(&key.as_str()) && table.contains_key(&key) {
+                continue;
+            }
             table.insert(key, value);
         }
         Ok(toml::to_string_pretty(&table)?)
@@ -1064,7 +1152,7 @@ impl AppConfig {
         let existing = fs::read_to_string(&config_path).unwrap_or_default();
         let content = self.overlay_onto_existing(&existing)?;
 
-        match fs::write(&config_path, &content) {
+        match write_atomic(&config_path, &content) {
             Ok(()) => {
                 // Audit log the successful config save
                 audit::audit_config_saved(
@@ -1408,6 +1496,128 @@ impl ProjectConfig {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// A canonical config with a syntax error must abort the migration, not be
+    /// replaced by the stray file. Treating an unparseable file as empty would
+    /// destroy exactly the sections this change exists to protect.
+    #[test]
+    fn migrate_leaves_an_unparseable_canonical_config_alone() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path().join(".agents-in-a-box");
+        let canonical = root.join("config").join("config.toml");
+        fs::create_dir_all(canonical.parent().unwrap()).expect("mkdir");
+
+        let broken = "[skills]\napi_key = \"sk-secret\"\nthis is not valid toml\n";
+        fs::write(&canonical, broken).expect("write canonical");
+        fs::write(
+            root.join("config.toml"),
+            "[usage.currency]\ncode = \"GBP\"\n",
+        )
+        .expect("write stray");
+
+        migrate_stray_user_config(&canonical);
+
+        assert_eq!(
+            fs::read_to_string(&canonical).expect("read"),
+            broken,
+            "an unparseable canonical config was overwritten by the stray file"
+        );
+        assert!(
+            root.join("config.toml").exists(),
+            "the stray file was consumed even though the migration could not run"
+        );
+    }
+
+    /// A stray file that carries nothing across must leave the canonical file
+    /// byte-for-byte alone — users hand-edit it, and a round-trip through the
+    /// serializer strips every comment.
+    #[test]
+    fn migrate_does_not_reformat_when_nothing_is_carried_across() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path().join(".agents-in-a-box");
+        let canonical = root.join("config").join("config.toml");
+        fs::create_dir_all(canonical.parent().unwrap()).expect("mkdir");
+
+        let commented = "# my notes\n[ui_preferences]\ntheme = \"dark\"\n";
+        fs::write(&canonical, commented).expect("write canonical");
+        fs::write(
+            root.join("config.toml"),
+            "[ui_preferences]\ntheme = \"light\"\n",
+        )
+        .expect("write stray");
+
+        migrate_stray_user_config(&canonical);
+
+        assert_eq!(
+            fs::read_to_string(&canonical).expect("read"),
+            commented,
+            "the canonical file was reformatted despite nothing being carried across"
+        );
+        assert!(
+            root.join("config.toml.migrated").exists(),
+            "stray was not moved aside"
+        );
+    }
+
+    /// The backup is sometimes the only surviving copy, so a second migration
+    /// must not clobber the first one's backup.
+    #[test]
+    fn migrate_never_overwrites_an_existing_backup() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path().join(".agents-in-a-box");
+        let canonical = root.join("config").join("config.toml");
+        fs::create_dir_all(canonical.parent().unwrap()).expect("mkdir");
+        fs::write(&canonical, "").expect("write canonical");
+        fs::write(root.join("config.toml.migrated"), "first backup\n").expect("write backup");
+        fs::write(root.join("config.toml"), "[docker]\ntimeout = 90\n").expect("write stray");
+
+        migrate_stray_user_config(&canonical);
+
+        assert_eq!(
+            fs::read_to_string(root.join("config.toml.migrated")).expect("read"),
+            "first backup\n",
+            "the earlier backup was destroyed"
+        );
+        assert!(
+            root.join("config.toml.migrated.1").exists(),
+            "the new backup did not fall back to a free name"
+        );
+    }
+
+    /// Saving over a file we cannot parse must fail loudly. `AppConfig::load()`
+    /// falls back to defaults on a parse error, so silently treating the file as
+    /// empty would turn the next settings save into a wipe of everything on disk.
+    #[test]
+    fn save_refuses_to_overlay_an_unparseable_file() {
+        let config = AppConfig::default();
+        let err = config
+            .overlay_onto_existing("[skills]\napi_key = \"sk\"\nnot valid toml\n")
+            .expect_err("overlaying an unparseable file must fail");
+        assert!(
+            err.to_string().contains("does not parse"),
+            "error should say the file is unparseable, got: {err}"
+        );
+    }
+
+    /// `[usage]` is owned by the burndown plugin, which load-modify-saves the
+    /// same file. A long-lived TUI must not revert a plan set from another
+    /// shell mid-session.
+    #[test]
+    fn save_does_not_rewrite_usage_owned_by_the_burndown_plugin() {
+        // What the TUI loaded at startup: no plan.
+        let config = AppConfig::default();
+        // What another process wrote to the file since then.
+        let on_disk = "[usage.currency]\ncode = \"GBP\"\nsymbol = \"£\"\nusd_rate = 0.79\n";
+
+        let saved = config.overlay_onto_existing(on_disk).expect("overlays");
+        let reparsed: toml::Table = saved.parse().expect("valid TOML");
+
+        assert_eq!(
+            reparsed["usage"]["currency"]["code"].as_str(),
+            Some("GBP"),
+            "a settings save reverted [usage] to the snapshot loaded at startup"
+        );
+    }
 
     /// The overlay serializes a `toml::Table`, not the struct, so field
     /// declaration order no longer protects us: TOML requires every top-level

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -18,6 +18,7 @@ pub mod mcp;
 pub mod mcp_init;
 pub mod onboarding;
 pub mod presets;
+pub mod registry;
 pub mod session_defaults;
 pub mod ssh_display_names;
 
@@ -30,6 +31,7 @@ pub use mcp::{McpInitStrategy, McpInstallation, McpServerConfig, McpServerDefini
 pub use mcp_init::{McpInitResult, McpInitializer, apply_mcp_init_result};
 pub use onboarding::OnboardingConfig;
 pub use presets::{PermissionSet, PresetManager, RepositoryPreset, create_default_presets};
+pub use registry::{CONFIG_REGISTRY, ConfigRow, Entry as ConfigEntry, RowKind};
 pub use session_defaults::{PerRepoDefaults, SessionDefaults};
 pub use ssh_display_names::{SessionLabelStore, SshDisplayNameStore, normalize_session_label};
 

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -961,6 +961,18 @@ fn merge_plugin_value_table(lower: &mut toml::Value, higher: toml::Value) {
 /// read-only.
 const READ_ONLY_SECTIONS: &[&str] = &["usage"];
 
+/// Dotted paths `ainb-core` reads but must never write back from its own
+/// snapshot.
+///
+/// A superset of [`READ_ONLY_SECTIONS`], because the rule is not a top-level
+/// one. `[fleet.bridge]` sits INSIDE a section core does model, is carried as an
+/// opaque `toml::Value` passthrough, is never assigned by core, and is the table
+/// `fleet::bridge::config::SETUP_SKELETON` explicitly tells users to hand-edit.
+/// Without this, a settings save writes the startup snapshot back over a bot
+/// token edited while the TUI was open — the data loss this whole change exists
+/// to stop, one section further in than `[usage]`.
+const READ_ONLY_PATHS: &[&str] = &["usage", "fleet.bridge"];
+
 /// Write `contents` to `path` atomically, so a crash or a full disk cannot
 /// leave a truncated file behind.
 ///
@@ -1025,7 +1037,7 @@ pub(crate) fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
 /// read or parse, refuses [`READ_ONLY_SECTIONS`], writes atomically.
 ///
 /// Path-explicit so it is testable without redirecting `HOME`.
-fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> Result<()> {
+pub(crate) fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> Result<()> {
     if edits.is_empty() {
         return Ok(());
     }
@@ -1034,24 +1046,155 @@ fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> Result<()> {
     }
 
     let existing = read_existing(path)?;
-    let mut root = if existing.trim().is_empty() {
-        toml::Value::Table(toml::Table::new())
-    } else {
-        toml::Value::Table(existing.parse::<toml::Table>().context(
-            "refusing to save over a config.toml that does not parse — fix the syntax error first",
-        )?)
-    };
+    // `toml_edit`, not `toml`: this file is the one users are told to copy from
+    // `config/example.config.toml`, which is almost entirely comments. A
+    // round-trip through `to_string_pretty` deletes every comment and reflows
+    // every line — and this writer runs on a settings edit, not on an explicit
+    // "rewrite my config". `config/presets.rs` uses toml_edit for the same
+    // reason.
+    let mut doc = existing.parse::<toml_edit::DocumentMut>().context(
+        "refusing to save over a config.toml that does not parse — fix the syntax error first",
+    )?;
 
     for (key, value) in edits {
         let section = key.split('.').next().unwrap_or_default();
-        if READ_ONLY_SECTIONS.contains(&section) {
-            anyhow::bail!("'{key}' is in a read-only section");
+        if READ_ONLY_PATHS
+            .iter()
+            .any(|path| *path == section || key.starts_with(&format!("{path}.")))
+        {
+            anyhow::bail!("'{key}' is in a section ainb-core must not write");
         }
-        registry::insert_at(&mut root, key, value.clone())?;
+        set_document_key(&mut doc, key, value)?;
     }
 
-    write_atomic(path, &toml::to_string_pretty(&root)?)?;
+    write_atomic(path, &doc.to_string())?;
     Ok(())
+}
+
+/// Set one dotted key in a `toml_edit` document, creating the parent tables it
+/// needs and leaving every other byte of the document untouched.
+/// Every scalar/array leaf in `table`, as dotted paths.
+///
+/// A leaf is anything that is not a table: writing those individually is what
+/// lets a save edit values in place instead of replacing whole sections and
+/// flattening them into inline tables.
+fn flatten_leaves(
+    table: &toml::map::Map<String, toml::Value>,
+    prefix: String,
+    out: &mut Vec<(String, toml::Value)>,
+) {
+    for (key, value) in table {
+        let path = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        match value {
+            // An empty table is a leaf: it still has to be written, or a
+            // section that exists only to be present would vanish.
+            toml::Value::Table(inner) if !inner.is_empty() => {
+                flatten_leaves(inner, path, out);
+            }
+            other => out.push((path, other.clone())),
+        }
+    }
+}
+
+/// The same walk over a `toml_edit` document, used to find leaves on disk that
+/// our snapshot no longer has.
+fn flatten_document_leaves(table: &toml_edit::Table, prefix: String, out: &mut Vec<String>) {
+    for (key, item) in table.iter() {
+        let path = if prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        match item.as_table() {
+            Some(inner) if !inner.is_empty() => flatten_document_leaves(inner, path, out),
+            _ => out.push(path),
+        }
+    }
+}
+
+/// Remove one dotted key from the document, ignoring a path that is not there.
+fn remove_document_key(doc: &mut toml_edit::DocumentMut, key: &str) {
+    let parts = registry::parse_dot_key(key);
+    let Some((leaf, parents)) = parts.split_last() else {
+        return;
+    };
+    let mut table: &mut dyn toml_edit::TableLike = doc.as_table_mut();
+    for part in parents {
+        match table.get_mut(part).and_then(toml_edit::Item::as_table_like_mut) {
+            Some(next) => table = next,
+            None => return,
+        }
+    }
+    table.remove(leaf);
+}
+
+fn set_document_key(
+    doc: &mut toml_edit::DocumentMut,
+    key: &str,
+    value: &toml::Value,
+) -> Result<()> {
+    let parts = registry::parse_dot_key(key);
+    let Some((leaf, parents)) = parts.split_last() else {
+        anyhow::bail!("empty config key");
+    };
+
+    let mut table: &mut dyn toml_edit::TableLike = doc.as_table_mut();
+    for part in parents {
+        if table.get(part).is_none() {
+            let mut created = toml_edit::Table::new();
+            // Implicit: a parent that only exists to hold a sub-table does not
+            // print an empty `[header]` of its own.
+            created.set_implicit(true);
+            table.insert(part, toml_edit::Item::Table(created));
+        }
+        table = table
+            .get_mut(part)
+            .and_then(toml_edit::Item::as_table_like_mut)
+            .ok_or_else(|| anyhow::anyhow!("cannot set '{key}': '{part}' is not a table"))?;
+    }
+
+    match table.get_mut(leaf) {
+        Some(item) => {
+            let mut next = to_edit_value(value);
+            // Carry the old value's decor across. That decor holds the
+            // whitespace AND the trailing `# comment` on the same line, so
+            // replacing the item without it silently deletes the note the user
+            // wrote next to the setting they just changed.
+            if let Some(previous) = item.as_value() {
+                *next.decor_mut() = previous.decor().clone();
+            }
+            *item = toml_edit::Item::Value(next);
+        }
+        None => {
+            table.insert(leaf, toml_edit::Item::Value(to_edit_value(value)));
+        }
+    }
+    Ok(())
+}
+
+/// Convert a `toml::Value` into the `toml_edit` value the document stores.
+fn to_edit_value(value: &toml::Value) -> toml_edit::Value {
+    match value {
+        toml::Value::String(s) => s.as_str().into(),
+        toml::Value::Integer(i) => (*i).into(),
+        toml::Value::Float(f) => (*f).into(),
+        toml::Value::Boolean(b) => (*b).into(),
+        toml::Value::Datetime(dt) => dt.to_string().into(),
+        toml::Value::Array(items) => {
+            items.iter().map(to_edit_value).collect::<toml_edit::Array>().into()
+        }
+        toml::Value::Table(entries) => {
+            let mut inline = toml_edit::InlineTable::new();
+            for (key, entry) in entries {
+                inline.insert(key, to_edit_value(entry));
+            }
+            inline.into()
+        }
+    }
 }
 
 /// The TOML value an external edit writes, or an error naming why the key is
@@ -1222,17 +1365,9 @@ impl AppConfig {
             if path.exists() {
                 let content = fs::read_to_string(&path)
                     .with_context(|| format!("Failed to read config from {}", path.display()))?;
-
-                let usage_present = content
-                    .parse::<toml::Value>()
-                    .ok()
-                    .and_then(|value| value.as_table().cloned())
-                    .is_some_and(|table| table.contains_key("usage"));
-
-                let file_config: AppConfig = toml::from_str(&content)
+                config
+                    .merge_file_contents(&content)
                     .with_context(|| format!("Failed to parse config from {}", path.display()))?;
-
-                config.merge_loaded(file_config, usage_present);
             }
         }
 
@@ -1242,6 +1377,25 @@ impl AppConfig {
         }
 
         Ok(config)
+    }
+
+    /// Merge one config file's contents into `self`, exactly as [`load`](Self::load)
+    /// does for each path it finds.
+    ///
+    /// Split out so a test can round-trip a real file through the loader
+    /// without depending on `HOME` or the current directory — the field-by-field
+    /// `merge_loaded` below is where a newly-added key gets silently dropped,
+    /// and only a test that goes through this path catches it.
+    pub(crate) fn merge_file_contents(&mut self, content: &str) -> Result<()> {
+        let usage_present = content
+            .parse::<toml::Value>()
+            .ok()
+            .and_then(|value| value.as_table().cloned())
+            .is_some_and(|table| table.contains_key("usage"));
+
+        let file_config: AppConfig = toml::from_str(content)?;
+        self.merge_loaded(file_config, usage_present);
+        Ok(())
     }
 
     /// Overlay the sections this struct models onto whatever is already on
@@ -1285,13 +1439,75 @@ impl AppConfig {
         let toml::Value::Table(ours) = toml::Value::try_from(self)? else {
             anyhow::bail!("AppConfig did not serialize to a TOML table");
         };
+
+        // Snapshot the read-only paths BEFORE merging: a modelled section is
+        // replaced wholesale, so `[fleet]` takes `[fleet.bridge]` with it and
+        // "skip this key" is not enough for a path more than one level deep.
+        let on_disk = toml::Value::Table(table.clone());
+        let preserved: Vec<(&str, toml::Value)> = READ_ONLY_PATHS
+            .iter()
+            .filter_map(|path| {
+                registry::navigate_toml(&on_disk, path).ok().map(|value| (*path, value.clone()))
+            })
+            .collect();
+
         for (key, value) in ours {
-            if READ_ONLY_SECTIONS.contains(&key.as_str()) && table.contains_key(&key) {
-                continue;
-            }
             table.insert(key, value);
         }
-        Ok(toml::to_string_pretty(&table)?)
+
+        let mut root = toml::Value::Table(table);
+        for (path, value) in preserved {
+            // What is on disk wins for these paths. Absent on disk means core
+            // writes its snapshot, which is what `[usage]` already did.
+            registry::insert_at(&mut root, path, value)?;
+        }
+
+        // Render through `toml_edit`, not `toml::to_string_pretty`, so the
+        // file keeps its comments. Users are told to start from
+        // `config/example.config.toml`, which is ~320 lines of comments
+        // explaining what every key does; a settings save that silently
+        // deleted all of them would leave a file strictly less useful than the
+        // one it replaced.
+        //
+        // Setting LEAVES rather than whole sections is what makes that work: a
+        // top-level `doc["docker"] = <table>` writes `docker = { timeout = 60 }`
+        // as an inline value, flattening the `[docker]` header and taking every
+        // comment attached to it. Walking to leaves edits values in place and
+        // leaves the document's shape alone.
+        let toml::Value::Table(root_table) = root else {
+            anyhow::bail!("config did not render to a TOML table");
+        };
+        let mut doc = existing.parse::<toml_edit::DocumentMut>().unwrap_or_default();
+
+        let mut ours_leaves = Vec::new();
+        flatten_leaves(&root_table, String::new(), &mut ours_leaves);
+
+        // Wholesale replacement of a modelled section has to keep working, or
+        // removing an entry from `[mcp_servers]` would never stick. Leaf-wise
+        // writing cannot express a deletion, so prune first: drop any leaf the
+        // document has under a section we model that our snapshot no longer
+        // carries. Read-only paths are exempt — they are not ours to prune.
+        let ours_keys: std::collections::HashSet<&str> =
+            ours_leaves.iter().map(|(k, _)| k.as_str()).collect();
+        let mut doc_leaves = Vec::new();
+        flatten_document_leaves(doc.as_table(), String::new(), &mut doc_leaves);
+        for key in doc_leaves {
+            let section = key.split('.').next().unwrap_or_default();
+            let is_read_only = READ_ONLY_PATHS
+                .iter()
+                .any(|path| *path == section || key.starts_with(&format!("{path}.")));
+            if is_read_only || !root_table.contains_key(section) {
+                continue;
+            }
+            if !ours_keys.contains(key.as_str()) {
+                remove_document_key(&mut doc, &key);
+            }
+        }
+
+        for (key, value) in &ours_leaves {
+            set_document_key(&mut doc, key, value)?;
+        }
+        Ok(doc.to_string())
     }
 
     /// Save configuration to user config directory
@@ -1468,6 +1684,13 @@ impl AppConfig {
         // Old configs keep the default (true) values
         if other.ui_preferences.preferred_editor.is_some() {
             self.ui_preferences.preferred_editor = other.ui_preferences.preferred_editor;
+        }
+        // A field with no arm here is not merely "not merged": `load()` returns
+        // the default for it, and the next `save()` then overlays that default
+        // back over the file. An unlisted key is silently destroyed, not just
+        // ignored. Covered by `loading_restores_the_config_tree_expansion`.
+        if !other.ui_preferences.config_tree_expanded.is_empty() {
+            self.ui_preferences.config_tree_expanded = other.ui_preferences.config_tree_expanded;
         }
         if other.ui_preferences.home_sidebar_width.is_some() {
             self.ui_preferences.home_sidebar_width = other.ui_preferences.home_sidebar_width;
@@ -1802,6 +2025,128 @@ mod tests {
         );
     }
 
+    // ================================================================
+    // Review round 3, findings #1 #2 #3
+    // ================================================================
+
+    /// #1. A key `merge_loaded` has no arm for is dropped by every load, and
+    /// the next save then writes the empty value back over what was stored.
+    ///
+    /// Goes through `merge_file_contents`, which is exactly what `load()` runs
+    /// per file — a test built on a hand-made struct never touches `merge_loaded`
+    /// and so never sees this.
+    #[test]
+    fn loading_restores_the_config_tree_expansion() {
+        let on_disk =
+            "[ui_preferences]\nconfig_tree_expanded = [\"Fleet|fleet\", \"MCP Pool|mcp_pool\"]\n";
+
+        let mut config = AppConfig::default();
+        config.merge_file_contents(on_disk).expect("loads");
+
+        assert_eq!(
+            config.ui_preferences.config_tree_expanded,
+            vec!["Fleet|fleet".to_string(), "MCP Pool|mcp_pool".to_string()],
+            "the loader dropped the expansion state"
+        );
+
+        // And the round trip back to disk must not erase it.
+        let written = config.overlay_onto_existing(on_disk).expect("overlay");
+        let reread: toml::Value = toml::from_str(&written).expect("parse");
+        assert_eq!(
+            registry::navigate_toml(&reread, "ui_preferences.config_tree_expanded").ok(),
+            Some(&toml::Value::Array(vec![
+                toml::Value::String("Fleet|fleet".to_string()),
+                toml::Value::String("MCP Pool|mcp_pool".to_string()),
+            ])),
+            "saving after a load erased the expansion state:\n{written}"
+        );
+    }
+
+    /// #2. Persisting a setting must not reformat the file.
+    ///
+    /// `config/example.config.toml` is almost entirely comments and users are
+    /// told to copy it. A targeted write that round-trips through
+    /// `to_string_pretty` deletes every one of them — on a navigation keypress,
+    /// with no save and no confirmation.
+    #[test]
+    fn a_targeted_write_preserves_comments_and_layout() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("config.toml");
+        let hand_written = "\
+# ainb configuration
+# Copied from config/example.config.toml — every line below is load-bearing.
+
+[docker]
+# Connection timeout in seconds
+timeout   = 60
+
+[ui_preferences]
+theme = \"dark\"   # keep it dark
+";
+        fs::write(&path, hand_written).expect("seed");
+
+        write_keys_into(
+            &path,
+            &[(
+                "ui_preferences.config_tree_expanded".to_string(),
+                toml::Value::Array(vec![toml::Value::String("Fleet|fleet".to_string())]),
+            )],
+        )
+        .expect("targeted write");
+
+        let after = fs::read_to_string(&path).expect("read");
+        for comment in [
+            "# ainb configuration",
+            "# Copied from config/example.config.toml",
+            "# Connection timeout in seconds",
+            "# keep it dark",
+        ] {
+            assert!(
+                after.contains(comment),
+                "a settings write deleted {comment:?}:\n---\n{after}\n---"
+            );
+        }
+        assert!(
+            after.contains("timeout   = 60"),
+            "hand-written spacing was reflowed:\n---\n{after}\n---"
+        );
+        assert!(
+            after.contains("config_tree_expanded = [\"Fleet|fleet\"]"),
+            "the value was not written:\n---\n{after}\n---"
+        );
+    }
+
+    /// #3. `[fleet.bridge]` is hand-edited (see `SETUP_SKELETON`) and never
+    /// assigned by core, so a settings save must not write it back from the
+    /// snapshot it loaded at startup — that reverts a token edited while the
+    /// TUI was open. `[usage]` already has this guard; the bridge is the data
+    /// this PR exists to protect and had none.
+    #[test]
+    fn a_save_does_not_revert_a_hand_edited_bridge_token() {
+        // What the TUI loaded at startup.
+        let mut snapshot = AppConfig::default();
+        snapshot.fleet.bridge =
+            Some(toml::from_str("[telegram]\ntoken = \"keychain:stale\"\n").expect("stale bridge"));
+
+        // What is on disk now — the user hand-edited the token meanwhile.
+        let on_disk =
+            "[fleet.bridge.telegram]\ntoken = \"keychain:freshly-edited\"\nuser_id = 42\n";
+
+        let written = snapshot.overlay_onto_existing(on_disk).expect("overlay");
+        let after: toml::Value = toml::from_str(&written).expect("parse");
+
+        assert_eq!(
+            registry::navigate_toml(&after, "fleet.bridge.telegram.token").ok(),
+            Some(&toml::Value::String("keychain:freshly-edited".to_string())),
+            "a settings save reverted a hand-edited bridge token:\n{written}"
+        );
+        assert_eq!(
+            registry::navigate_toml(&after, "fleet.bridge.telegram.user_id").ok(),
+            Some(&toml::Value::Integer(42)),
+            "a settings save dropped a hand-added bridge key:\n{written}"
+        );
+    }
+
     /// #9. A navigational keystroke must not rewrite the whole file.
     ///
     /// `ConfigToggleExpand` used to call `AppConfig::save()`, which serializes
@@ -2087,6 +2432,48 @@ mod tests {
         assert!(
             root.join("config.toml.migrated").exists(),
             "stray file's contents were destroyed rather than kept"
+        );
+    }
+
+    /// A settings save must not strip the file's comments.
+    ///
+    /// Users are told to start from `config/example.config.toml`, which is
+    /// ~320 lines of comments explaining what every key does. Rendering the
+    /// save through `toml::to_string_pretty` deleted all of them, so the first
+    /// time anyone changed a setting the file they were left with was strictly
+    /// less useful than the one they copied.
+    #[test]
+    fn save_keeps_the_comments_in_a_hand_written_config() {
+        let existing = "\
+# The theme the TUI paints with.
+# Options: \"dark\" | \"light\"
+[ui_preferences]
+theme = \"dark\"   # trailing note
+
+# How long to wait on the Docker daemon.
+[docker]
+timeout = 60
+";
+        let mut config: AppConfig = toml::from_str(existing).expect("parses");
+        config.ui_preferences.theme = "light".to_string();
+
+        let saved = config.overlay_onto_existing(existing).expect("overlays");
+
+        assert!(
+            saved.contains("# The theme the TUI paints with."),
+            "a leading comment was stripped by save:\n{saved}"
+        );
+        assert!(
+            saved.contains("# How long to wait on the Docker daemon."),
+            "a section comment was stripped by save:\n{saved}"
+        );
+        assert!(
+            saved.contains("# trailing note"),
+            "a trailing comment was stripped by save:\n{saved}"
+        );
+        assert!(
+            saved.contains("theme = \"light\""),
+            "the edited value did not reach the file:\n{saved}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -973,6 +973,16 @@ const READ_ONLY_SECTIONS: &[&str] = &["usage"];
 /// to stop, one section further in than `[usage]`.
 const READ_ONLY_PATHS: &[&str] = &["usage", "fleet.bridge"];
 
+/// Paths `write_keys_into` refuses even for an explicit, key-level edit.
+///
+/// Narrower than [`READ_ONLY_PATHS`] on purpose. That list stops the *wholesale*
+/// overlay clobbering a section from a startup snapshot, which is a staleness
+/// problem, not an ownership one. `[fleet.bridge]` needs that protection but is
+/// still ours to change when the user actually edits one of its rows — writing
+/// the single key they touched is precisely the safe operation. `[usage]` is
+/// different: the burndown plugin owns it, so core must not write it at all.
+const NEVER_WRITE_PATHS: &[&str] = &["usage"];
+
 /// Write `contents` to `path` atomically, so a crash or a full disk cannot
 /// leave a truncated file behind.
 ///
@@ -1015,16 +1025,20 @@ pub(crate) fn read_existing(path: &Path) -> Result<String> {
 
 pub(crate) fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
     let tmp = temp_path(path);
-    if let Err(err) = fs::write(&tmp, contents) {
-        let _ = fs::remove_file(&tmp);
-        return Err(err);
+    fs::write(&tmp, contents)?;
+    // Carry the target's permissions onto the replacement. `fs::write` used to
+    // truncate in place and keep them; a temp file is created fresh under the
+    // umask, so without this a `chmod 600 config.toml` is silently reverted to
+    // world-readable on the next save. This file holds bot tokens and an API
+    // key, so that is a real downgrade, and the temp file itself sits in the
+    // same directory before the rename.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(path).map(|m| m.permissions().mode() & 0o777).unwrap_or(0o600);
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(mode))?;
     }
-    if let Err(err) = fs::rename(&tmp, path) {
-        // A unique temp name is only an improvement if it does not accumulate.
-        let _ = fs::remove_file(&tmp);
-        return Err(err);
-    }
-    Ok(())
+    fs::rename(&tmp, path)
 }
 
 /// Write exactly these dotted keys into a config file, leaving every other byte
@@ -1037,6 +1051,32 @@ pub(crate) fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
 /// read or parse, refuses [`READ_ONLY_SECTIONS`], writes atomically.
 ///
 /// Path-explicit so it is testable without redirecting `HOME`.
+/// Remove one dotted key from a config file, preserving everything else.
+///
+/// The counterpart to [`write_keys_into`] for an optional key being cleared.
+/// Storing `""` is not the same as unset: an empty `docker.host` means "connect
+/// to nothing" where an absent one means "autodetect", so clearing has to
+/// delete the key rather than blank it.
+pub(crate) fn remove_key_from(path: &Path, key: &str) -> Result<()> {
+    let existing = read_existing(path)?;
+    if existing.trim().is_empty() {
+        return Ok(());
+    }
+    let section = key.split('.').next().unwrap_or_default();
+    if NEVER_WRITE_PATHS
+        .iter()
+        .any(|p| *p == section || key.starts_with(&format!("{p}.")))
+    {
+        anyhow::bail!("'{key}' is in a section ainb-core must not write");
+    }
+    let mut doc = existing.parse::<toml_edit::DocumentMut>().context(
+        "refusing to save over a config.toml that does not parse — fix the syntax error first",
+    )?;
+    remove_document_key(&mut doc, key);
+    write_atomic(path, &doc.to_string())?;
+    Ok(())
+}
+
 pub(crate) fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> Result<()> {
     if edits.is_empty() {
         return Ok(());
@@ -1058,7 +1098,7 @@ pub(crate) fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> R
 
     for (key, value) in edits {
         let section = key.split('.').next().unwrap_or_default();
-        if READ_ONLY_PATHS
+        if NEVER_WRITE_PATHS
             .iter()
             .any(|path| *path == section || key.starts_with(&format!("{path}.")))
         {
@@ -1071,8 +1111,6 @@ pub(crate) fn write_keys_into(path: &Path, edits: &[(String, toml::Value)]) -> R
     Ok(())
 }
 
-/// Set one dotted key in a `toml_edit` document, creating the parent tables it
-/// needs and leaving every other byte of the document untouched.
 /// Every scalar/array leaf in `table`, as dotted paths.
 ///
 /// A leaf is anything that is not a table: writing those individually is what
@@ -1084,10 +1122,14 @@ fn flatten_leaves(
     out: &mut Vec<(String, toml::Value)>,
 ) {
     for (key, value) in table {
+        // Quote a segment that is not a bare TOML key. A model id like
+        // `gpt-4.1` splits back into two segments otherwise, inventing a
+        // nested table and corrupting the file.
+        let segment = registry::quote_key_segment(key.as_ref());
         let path = if prefix.is_empty() {
-            key.clone()
+            segment
         } else {
-            format!("{prefix}.{key}")
+            format!("{prefix}.{segment}")
         };
         match value {
             // An empty table is a leaf: it still has to be written, or a
@@ -1104,10 +1146,14 @@ fn flatten_leaves(
 /// our snapshot no longer has.
 fn flatten_document_leaves(table: &toml_edit::Table, prefix: String, out: &mut Vec<String>) {
     for (key, item) in table.iter() {
+        // Quote a segment that is not a bare TOML key. A model id like
+        // `gpt-4.1` splits back into two segments otherwise, inventing a
+        // nested table and corrupting the file.
+        let segment = registry::quote_key_segment(key.as_ref());
         let path = if prefix.is_empty() {
-            key.to_string()
+            segment
         } else {
-            format!("{prefix}.{key}")
+            format!("{prefix}.{segment}")
         };
         match item.as_table() {
             Some(inner) if !inner.is_empty() => flatten_document_leaves(inner, path, out),
@@ -1132,6 +1178,8 @@ fn remove_document_key(doc: &mut toml_edit::DocumentMut, key: &str) {
     table.remove(leaf);
 }
 
+/// Set one dotted key in a `toml_edit` document, creating the parent tables it
+/// needs and leaving every other byte of the document untouched.
 fn set_document_key(
     doc: &mut toml_edit::DocumentMut,
     key: &str,
@@ -1218,24 +1266,6 @@ fn external_edit_value(key: &str, raw: &str) -> Result<toml::Value> {
     registry::validate(key, raw)
 }
 
-/// Fold a stray `~/.agents-in-a-box/config.toml` into the real user config at
-/// `~/.agents-in-a-box/config/config.toml`, then move it aside.
-///
-/// The burndown and session-reader plugins used to read and write the file one
-/// directory up from the one everything else uses, so a user's `[usage]` plan
-/// could end up in a file `ainb-core` never opened. Both plugins now agree on
-/// the `config/` path; this carries the old file's contents across once, taking
-/// the canonical file's value wherever both set the same key.
-///
-/// Deliberately NOT called from [`AppConfig::load`]: that runs in daemons, in
-/// plugin startup and inside the TUI event loop, and a filesystem write as a
-/// side effect of a read races every other process doing the same. Call it once
-/// from a binary's startup instead — see [`AppConfig::migrate_legacy_paths`].
-///
-/// Best effort by design: every failure path leaves BOTH files exactly as they
-/// were. In particular a canonical file that does not parse aborts the
-/// migration rather than being replaced by the stray one — overwriting a config
-/// we failed to understand is the data loss this whole change exists to stop.
 /// Copy the keys of `higher` that `lower` does not already have, descending
 /// into tables both sides define. Returns how many leaves were carried across,
 /// so the caller can leave the file untouched when the answer is zero.
@@ -1261,6 +1291,24 @@ fn merge_missing_keys(lower: &mut toml::Table, higher: toml::Table) -> usize {
     carried
 }
 
+/// Fold a stray `~/.agents-in-a-box/config.toml` into the real user config at
+/// `~/.agents-in-a-box/config/config.toml`, then move it aside.
+///
+/// The burndown and session-reader plugins used to read and write the file one
+/// directory up from the one everything else uses, so a user's `[usage]` plan
+/// could end up in a file `ainb-core` never opened. Both plugins now agree on
+/// the `config/` path; this carries the old file's contents across once, taking
+/// the canonical file's value wherever both set the same key.
+///
+/// Deliberately NOT called from [`AppConfig::load`]: that runs in daemons, in
+/// plugin startup and inside the TUI event loop, and a filesystem write as a
+/// side effect of a read races every other process doing the same. Call it once
+/// from a binary's startup instead — see [`AppConfig::migrate_legacy_paths`].
+///
+/// Best effort by design: every failure path leaves BOTH files exactly as they
+/// were. In particular a canonical file that does not parse aborts the
+/// migration rather than being replaced by the stray one — overwriting a config
+/// we failed to understand is the data loss this whole change exists to stop.
 fn migrate_stray_user_config(canonical: &Path) {
     let Some(stray) = canonical.parent().and_then(Path::parent).map(|d| d.join("config.toml"))
     else {
@@ -2433,6 +2481,39 @@ theme = \"dark\"   # keep it dark
             root.join("config.toml.migrated").exists(),
             "stray file's contents were destroyed rather than kept"
         );
+    }
+
+    /// A map key containing a dot must survive a save.
+    ///
+    /// Model ids routinely have dots, and `[usage.model_aliases]` is keyed by
+    /// them. Flattening `gpt-4.1` into a dotted path and splitting it again
+    /// invented a `[usage.model_aliases.gpt-4]` table with a `1` inside,
+    /// alongside the untouched original — after which the file no longer
+    /// deserialized and every consumer silently fell back to defaults.
+    #[test]
+    fn save_keeps_a_map_key_that_contains_a_dot() {
+        let existing = "\
+[usage.model_aliases]
+\"gpt-4.1\" = \"claude-sonnet-4-5\"
+
+[docker]
+timeout = 60
+";
+        let config: AppConfig = toml::from_str(existing).expect("parses");
+        let saved = config.overlay_onto_existing(existing).expect("overlays");
+
+        let reparsed: toml::Table = saved.parse().expect("still valid TOML");
+        assert_eq!(
+            reparsed["usage"]["model_aliases"]["gpt-4.1"].as_str(),
+            Some("claude-sonnet-4-5"),
+            "the dotted map key did not survive the save:\n{saved}"
+        );
+        assert!(
+            reparsed["usage"]["model_aliases"].get("gpt-4").is_none(),
+            "the dotted key was split into a nested table:\n{saved}"
+        );
+        // The whole point: it must still load.
+        toml::from_str::<AppConfig>(&saved).expect("saved config no longer deserializes");
     }
 
     /// A settings save must not strip the file's comments.

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -1,0 +1,2027 @@
+// ABOUTME: One table describing every user-facing configuration leaf.
+// Pairs each dotted TOML path with its widget, help text and validation, so the
+// settings screen and `ainb config set` stop disagreeing about what exists.
+
+//! The configuration registry.
+//!
+//! The settings screen used to carry a hand-written list of rows. Nothing tied
+//! that list to the actual serde schema, so the two drifted: the schema grew to
+//! ~95 leaves while the screen reached 12 of them, and ten rows edited state
+//! that no persist branch ever read back.
+//!
+//! This module is the single place a leaf is declared. Every path in the
+//! serialized [`AppConfig`](crate::config::AppConfig) is either a
+//! [`Entry::Row`] (a real preference, with a label, one line of help and a
+//! [`RowKind`] that drives both the widget and the validator) or an
+//! [`Entry::Hidden`] (persisted UI/wizard state that is not a preference, with
+//! a written reason). `every_leaf_has_an_entry` in this file's test module
+//! fails the build when a new schema field has neither, so "a TOML key exists"
+//! now implies "a menu row exists".
+//!
+//! The shape deliberately mirrors the plugin `[[config]]` contract
+//! (`ainb_plugin_protocol::manifest::ConfigField`) that already round-trips
+//! plugin settings end to end. It is a core-local type rather than a reuse
+//! because rows need help text and numeric ranges, and because the plugin wire
+//! surface is frozen by a conformance gate that a core-side need should never
+//! force a version bump on.
+//!
+//! ## Map keys
+//!
+//! `[container_templates.<name>]`, `[mcp_servers.<name>]` and
+//! `[plugins.<name>]` are keyed by user-chosen names. Those segments normalise
+//! to a literal `*` in registry keys ("mcp_servers.*.shared"), so one entry
+//! covers every instance. [`registry_key`] performs that normalisation for a
+//! concrete path.
+
+use anyhow::{Result, anyhow, bail};
+
+use crate::app::state::{ConfigCategory, ConfigSetting, ConfigValue};
+
+/// The value type of a configuration leaf: selects the widget the settings
+/// screen renders, and the validator `ainb config set` applies.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RowKind {
+    /// Free-form string (text input).
+    Text,
+    /// A credential. Rendered masked; the value in config.toml may be a
+    /// literal, an env ref (`$VAR`) or a keychain ref (`keychain:<service>`).
+    Secret,
+    /// Boolean toggle.
+    Bool,
+    /// Integer within an inclusive range.
+    Number { min: i64, max: i64 },
+    /// Floating point within an inclusive range (money, rates, CPU shares).
+    Float { min: f64, max: f64 },
+    /// One of an enumerated set. The strings are the *serialized* forms, not
+    /// display names, so they can be written straight back into config.toml.
+    Choice(&'static [&'static str]),
+    /// Array of scalars, edited as a comma-separated list.
+    List,
+    /// A structured value (array of tables, or a nested JSON blob) with no
+    /// scalar rendering. Displayed read-only; `ainb config set` refuses it and
+    /// points at `ainb config edit`.
+    Opaque,
+}
+
+/// One editable configuration leaf.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ConfigRow {
+    /// Dotted TOML path, with map keys normalised to `*`.
+    pub key: &'static str,
+    /// Which settings category the row files under.
+    pub category: ConfigCategory,
+    /// Short human label.
+    pub label: &'static str,
+    /// One line of help; becomes [`ConfigSetting::description`].
+    pub help: &'static str,
+    /// Value type: widget + validation.
+    pub kind: RowKind,
+}
+
+/// A registry entry: either a user-facing row or a deliberately hidden leaf.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Entry {
+    /// A real preference. Rendered, editable, validated.
+    Row(ConfigRow),
+    /// Internal state, not a user preference. `why` is documentation for the
+    /// next reader and is asserted non-empty by the tests, because an unexplained
+    /// hidden leaf is how a real setting quietly disappears.
+    Hidden {
+        key: &'static str,
+        why: &'static str,
+    },
+}
+
+impl Entry {
+    /// The dotted key this entry claims.
+    #[must_use]
+    pub fn key(&self) -> &'static str {
+        match self {
+            Entry::Row(row) => row.key,
+            Entry::Hidden { key, .. } => key,
+        }
+    }
+
+    /// The row, when this entry is one.
+    #[must_use]
+    pub fn as_row(&self) -> Option<&ConfigRow> {
+        match self {
+            Entry::Row(row) => Some(row),
+            Entry::Hidden { .. } => None,
+        }
+    }
+}
+
+use ConfigCategory as C;
+
+/// Every configuration leaf ainb understands.
+///
+/// Ordered by section so the file reads like the TOML it describes. Adding a
+/// field to the schema without adding an entry here fails
+/// `every_leaf_has_an_entry`.
+pub static CONFIG_REGISTRY: &[Entry] = &[
+    // ── General ────────────────────────────────────────────────────────────
+    Entry::Hidden {
+        key: "version",
+        why: "stamped from CARGO_PKG_VERSION on save; a migration marker, not a preference",
+    },
+    Entry::Row(ConfigRow {
+        key: "default_container_template",
+        category: C::General,
+        label: "Default Container Template",
+        help: "Container template used when a session does not name one",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "presets.file",
+        category: C::Presets,
+        label: "Presets File",
+        help: "Path to presets.toml, relative to the config dir or absolute",
+        kind: RowKind::Text,
+    }),
+    // ── Authentication / agent defaults ────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "authentication.cli_provider",
+        category: C::AgentDefaults,
+        label: "Agent CLI",
+        help: "Which agent CLI new sessions launch",
+        kind: RowKind::Choice(&["claude", "codex", "gemini", "copilot"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "authentication.claude_provider",
+        category: C::Authentication,
+        label: "Claude Authentication",
+        help: "How Claude authenticates: subscription, API key, or a cloud gateway",
+        kind: RowKind::Choice(&[
+            "system_auth",
+            "api_key",
+            "amazon_bedrock",
+            "google_vertex",
+            "azure_foundry",
+            "glm_zai",
+            "llm_gateway",
+        ]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "authentication.default_model",
+        category: C::AgentDefaults,
+        label: "Default Model",
+        help: "Model alias passed to the agent CLI (e.g. sonnet, opus)",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "authentication.github_method",
+        category: C::Authentication,
+        label: "GitHub Auth Method",
+        help: "How git operations authenticate to GitHub (unset = inherit the gh CLI)",
+        kind: RowKind::Text,
+    }),
+    // ── Container templates ────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.name",
+        category: C::ContainerTemplates,
+        label: "Template Name",
+        help: "Identifier used to select this template",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.description",
+        category: C::ContainerTemplates,
+        label: "Template Description",
+        help: "One line shown in the template picker",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.image_source.type",
+        category: C::ContainerTemplates,
+        label: "Image Source",
+        help: "Prebuilt Image, a local Dockerfile, or the bundled ClaudeDocker build",
+        kind: RowKind::Choice(&["Image", "Dockerfile", "ClaudeDocker"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.image_source.name",
+        category: C::ContainerTemplates,
+        label: "Image Name",
+        help: "Registry image reference, when the source is a prebuilt Image",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.image_source.path",
+        category: C::ContainerTemplates,
+        label: "Dockerfile Path",
+        help: "Dockerfile to build, when the source is a Dockerfile",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.image_source.base_image",
+        category: C::ContainerTemplates,
+        label: "Base Image Override",
+        help: "Base image for the ClaudeDocker build (unset = the bundled default)",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.image_source.build_args.*",
+        category: C::ContainerTemplates,
+        label: "Build Arg",
+        help: "Docker build argument passed at image build time",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.working_dir",
+        category: C::ContainerTemplates,
+        label: "Working Directory",
+        help: "Directory the repository mounts to inside the container",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.command",
+        category: C::ContainerTemplates,
+        label: "Command",
+        help: "Container command argv (unset = the image default)",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.entrypoint",
+        category: C::ContainerTemplates,
+        label: "Entrypoint",
+        help: "Container entrypoint argv (unset = the image default)",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.environment.*",
+        category: C::ContainerTemplates,
+        label: "Environment Variable",
+        help: "Environment variable exported inside the container",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.user",
+        category: C::ContainerTemplates,
+        label: "Run As User",
+        help: "User the container process runs as (unset = the image default)",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.memory_limit",
+        category: C::ContainerTemplates,
+        label: "Memory Limit (MB)",
+        help: "Hard memory ceiling in megabytes",
+        kind: RowKind::Number {
+            min: 64,
+            max: 1_048_576,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.cpu_limit",
+        category: C::ContainerTemplates,
+        label: "CPU Limit",
+        help: "CPU shares; 0.5 is half a core",
+        kind: RowKind::Float {
+            min: 0.1,
+            max: 1024.0,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.system_packages",
+        category: C::ContainerTemplates,
+        label: "System Packages",
+        help: "apt packages installed into the image",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.npm_packages",
+        category: C::ContainerTemplates,
+        label: "NPM Packages",
+        help: "npm packages installed globally in the image",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.python_packages",
+        category: C::ContainerTemplates,
+        label: "Python Packages",
+        help: "pip packages installed into the image",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.ports",
+        category: C::ContainerTemplates,
+        label: "Exposed Ports",
+        help: "Container ports published to the host",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.volumes",
+        category: C::ContainerTemplates,
+        label: "Volume Mounts",
+        help: "Extra host→container mounts; edit with `ainb config edit`",
+        kind: RowKind::Opaque,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.mount_ssh",
+        category: C::ContainerTemplates,
+        label: "Mount SSH Keys",
+        help: "Bind ~/.ssh into the container so git over SSH works",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.config.mount_git_config",
+        category: C::ContainerTemplates,
+        label: "Mount Git Config",
+        help: "Bind ~/.gitconfig so commits carry your identity",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.required_env",
+        category: C::ContainerTemplates,
+        label: "Required Env Vars",
+        help: "Variables that must be present on the host before the template runs",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "container_templates.*.default_mcp_servers",
+        category: C::ContainerTemplates,
+        label: "Default MCP Servers",
+        help: "MCP servers installed into containers built from this template",
+        kind: RowKind::List,
+    }),
+    // ── MCP servers ────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.name",
+        category: C::McpServers,
+        label: "Server Name",
+        help: "Name the MCP server registers under in .mcp.json",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.description",
+        category: C::McpServers,
+        label: "Server Description",
+        help: "One line shown in the MCP server list",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.installation.type",
+        category: C::McpServers,
+        label: "Install Method",
+        help: "How the server binary is obtained before first launch",
+        kind: RowKind::Choice(&["Npm", "Python", "Git", "PreInstalled", "Custom"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.installation.package",
+        category: C::McpServers,
+        label: "Package",
+        help: "npm or pip package name, for package installs",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.installation.version",
+        category: C::McpServers,
+        label: "Package Version",
+        help: "Pinned package version (unset = latest)",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.installation.url",
+        category: C::McpServers,
+        label: "Repository URL",
+        help: "Git remote to clone, for git installs",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.installation.branch",
+        category: C::McpServers,
+        label: "Repository Branch",
+        help: "Branch to check out, for git installs (unset = the default branch)",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.installation.install_command",
+        category: C::McpServers,
+        label: "Install Command",
+        help: "Command run inside the clone to build the server",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.installation.script",
+        category: C::McpServers,
+        label: "Install Script",
+        help: "Shell script run to install a custom server",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.definition.type",
+        category: C::McpServers,
+        label: "Launch Kind",
+        help: "Command: spawn an argv. Json: hand the agent a raw server block",
+        kind: RowKind::Choice(&["Command", "Json"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.definition.command",
+        category: C::McpServers,
+        label: "Launch Command",
+        help: "Executable that starts the server",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.definition.args",
+        category: C::McpServers,
+        label: "Launch Arguments",
+        help: "Arguments appended to the launch command",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.definition.env.*",
+        category: C::McpServers,
+        label: "Launch Environment",
+        help: "Environment variable set for the server process",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.definition.config",
+        category: C::McpServers,
+        label: "Raw Server Block",
+        help: "Verbatim JSON server definition; edit with `ainb config edit`",
+        kind: RowKind::Opaque,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.required_env",
+        category: C::McpServers,
+        label: "Required Env Vars",
+        help: "Host variables that must be set before this server can start",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.enabled_by_default",
+        category: C::McpServers,
+        label: "Enabled By Default",
+        help: "Add this server to new sessions without being asked",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_servers.*.shared",
+        category: C::McpPool,
+        label: "Share Across Sessions",
+        help: "Pool one process across sessions; turn off for stateful servers",
+        kind: RowKind::Bool,
+    }),
+    // ── Workspace ──────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "workspace_defaults.branch_prefix",
+        category: C::Workspace,
+        label: "Branch Prefix",
+        help: "Prefix applied to branches created for new sessions",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "workspace_defaults.exclude_paths",
+        category: C::Workspace,
+        label: "Exclude Paths",
+        help: "Substrings that exclude a directory from repository scanning",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "workspace_defaults.workspace_scan_paths",
+        category: C::Workspace,
+        label: "Scan Paths",
+        help: "Extra directories scanned for git repositories, on top of the defaults",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "workspace_defaults.max_repositories",
+        category: C::Workspace,
+        label: "Max Repositories",
+        help: "Cap on repositories listed in workspace search results",
+        kind: RowKind::Number {
+            min: 1,
+            max: 100_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "workspace_defaults.worktree_collision_behavior",
+        category: C::Workspace,
+        label: "Worktree Collision",
+        help: "When a worktree path already exists: rename automatically, or fail",
+        kind: RowKind::Choice(&["auto_rename", "error"]),
+    }),
+    // ── UI preferences ─────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "ui_preferences.theme",
+        category: C::Appearance,
+        label: "Theme",
+        help: "Colour theme for the TUI",
+        kind: RowKind::Choice(&["dark", "light"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui_preferences.show_container_status",
+        category: C::Appearance,
+        label: "Show Container Status",
+        help: "Render container mode icons in the session list",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui_preferences.show_git_status",
+        category: C::Appearance,
+        label: "Show Git Status",
+        help: "Render per-session git change counts in the session list",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui_preferences.show_session_menu_bar",
+        category: C::Appearance,
+        label: "Show Session Menu Bar",
+        help: "Keep the Sessions keymap legend expanded (⇧M toggles it live)",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui_preferences.preferred_editor",
+        category: C::Editor,
+        label: "Preferred Editor",
+        help: "Editor command used to open a session's worktree",
+        kind: RowKind::Text,
+    }),
+    Entry::Hidden {
+        key: "ui_preferences.session_filter",
+        why: "the live Sessions status filter, cycled with a keypress and persisted so it survives a restart",
+    },
+    Entry::Hidden {
+        key: "ui_preferences.home_sidebar_width",
+        why: "written by the divider drag on the Home screen; a layout artefact, not a preference to type",
+    },
+    Entry::Hidden {
+        key: "ui_preferences.sessions_sidebar_width",
+        why: "written by the divider drag on the Sessions screen",
+    },
+    Entry::Hidden {
+        key: "ui_preferences.sessions_sidebar_collapsed",
+        why: "written when the Sessions sidebar is collapsed with a keypress",
+    },
+    Entry::Hidden {
+        key: "ui_preferences.skill_manager_sources_width",
+        why: "written by the divider drag on the Skill Manager screen",
+    },
+    Entry::Hidden {
+        key: "ui_preferences.statusline_decision",
+        why: "records whether the statusline prompt was answered; the wizard owns it, re-asking is the only way to change it",
+    },
+    Entry::Hidden {
+        key: "ui_preferences.tmux_decision",
+        why: "records whether the tmux.conf prompt was answered; owned by `ainb init` for the same reason",
+    },
+    // ── Docker ─────────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "docker.host",
+        category: C::Docker,
+        label: "Docker Host",
+        help: "Docker endpoint, e.g. unix:///var/run/docker.sock (unset = autodetect)",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "docker.timeout",
+        category: C::Docker,
+        label: "Connection Timeout",
+        help: "Seconds to wait on a Docker API call before giving up",
+        kind: RowKind::Number { min: 1, max: 3600 },
+    }),
+    // ── Usage ──────────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "usage.plan.id",
+        category: C::Usage,
+        label: "Subscription Plan",
+        help: "Which subscription the burndown gauge measures against",
+        kind: RowKind::Choice(&[
+            "claude-pro",
+            "claude-max",
+            "claude-max5x",
+            "cursor-pro",
+            "custom",
+            "none",
+        ]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage.plan.monthly_usd",
+        category: C::Usage,
+        label: "Plan Monthly Cost",
+        help: "Monthly plan price in USD; the denominator of the burndown gauge",
+        kind: RowKind::Float {
+            min: 0.0,
+            max: 1_000_000.0,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage.plan.provider",
+        category: C::Usage,
+        label: "Plan Provider",
+        help: "Which provider's spend counts against this plan",
+        kind: RowKind::Choice(&["all", "claude", "codex", "cursor"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage.plan.reset_day",
+        category: C::Usage,
+        label: "Billing Reset Day",
+        help: "Day of month the plan's usage window restarts",
+        kind: RowKind::Number { min: 1, max: 31 },
+    }),
+    Entry::Hidden {
+        key: "usage.plan.set_at",
+        why: "timestamp stamped when the plan was chosen; a provenance record, editing it changes nothing",
+    },
+    Entry::Row(ConfigRow {
+        key: "usage.currency.code",
+        category: C::Usage,
+        label: "Currency Code",
+        help: "ISO code costs are displayed in, e.g. GBP",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage.currency.symbol",
+        category: C::Usage,
+        label: "Currency Symbol",
+        help: "Symbol prefixed to displayed costs",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage.currency.usd_rate",
+        category: C::Usage,
+        label: "USD Exchange Rate",
+        help: "Multiplier applied to USD costs before display",
+        kind: RowKind::Float {
+            min: 0.000_001,
+            max: 10_000.0,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage.model_aliases.*",
+        category: C::Usage,
+        label: "Model Alias",
+        help: "Maps a raw model id in usage data onto a friendlier display name",
+        kind: RowKind::Text,
+    }),
+    // ── Plugins ────────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "plugins.enabled",
+        category: C::Plugins,
+        label: "Enabled Plugins",
+        help: "Allowlist: when non-empty ONLY these plugins load",
+        kind: RowKind::List,
+    }),
+    Entry::Row(ConfigRow {
+        key: "plugins.disabled",
+        category: C::Plugins,
+        label: "Disabled Plugins",
+        help: "Denylist: these plugins are skipped (ignored when an allowlist is set)",
+        kind: RowKind::List,
+    }),
+    Entry::Hidden {
+        key: "plugins.*",
+        why: "per-plugin values whose schema is the plugin's own [[config]] manifest; the screen renders those rows from the manifest, so duplicating them here would drift",
+    },
+    // ── Fleet ──────────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "fleet.cost.session_usd",
+        category: C::Fleet,
+        label: "Session Budget (USD)",
+        help: "Alert when any one session's lifetime spend crosses this",
+        kind: RowKind::Float {
+            min: 0.0,
+            max: 1_000_000.0,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.cost.group_usd",
+        category: C::Fleet,
+        label: "Group Budget (USD)",
+        help: "Alert when any one workspace group's lifetime spend crosses this",
+        kind: RowKind::Float {
+            min: 0.0,
+            max: 1_000_000.0,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.cost.session_overrides.*",
+        category: C::Fleet,
+        label: "Session Budget Override",
+        help: "Per-session USD ceiling, overriding the blanket session budget",
+        kind: RowKind::Float {
+            min: 0.0,
+            max: 1_000_000.0,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.cost.group_overrides.*",
+        category: C::Fleet,
+        label: "Group Budget Override",
+        help: "Per-group USD ceiling, overriding the blanket group budget",
+        kind: RowKind::Float {
+            min: 0.0,
+            max: 1_000_000.0,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.interview.surface",
+        category: C::Fleet,
+        label: "Interview Surface",
+        help: "native: Claude draws its own picker. fleet: hold the call for a remote answer",
+        kind: RowKind::Choice(&["native", "fleet"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.terminal",
+        category: C::Fleet,
+        label: "Jump-To Terminal",
+        help: "Terminal the macOS Fleet app opens when you jump to a session",
+        kind: RowKind::Choice(&["warp", "iterm", "ghostty", "terminal"]),
+    }),
+    // ── Fleet bridge ───────────────────────────────────────────────────────
+    // Parsed by `fleet::bridge::config` off the same file; `ainb-core` carries
+    // it as an opaque passthrough, so these rows are declared by hand and are
+    // exempt from the schema walk (see EXTERNAL_PREFIXES).
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.outbound_enabled",
+        category: C::Fleet,
+        label: "Bridge Outbound Push",
+        help: "Let the bridge message your phone when a session needs attention",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.outbound_poll_secs",
+        category: C::Fleet,
+        label: "Bridge Poll Interval",
+        help: "Seconds between attention-inbox polls by the outbound worker",
+        kind: RowKind::Number { min: 1, max: 3600 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.response_timeout",
+        category: C::Fleet,
+        label: "Bridge Response Timeout",
+        help: "Default seconds a channel waits for a session to answer",
+        kind: RowKind::Number {
+            min: 1,
+            max: 86_400,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.telegram.token",
+        category: C::Fleet,
+        label: "Telegram Bot Token",
+        help: "Literal, $ENV_VAR ref, or keychain:<service> ref",
+        kind: RowKind::Secret,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.telegram.user_id",
+        category: C::Fleet,
+        label: "Telegram User ID",
+        help: "The only Telegram account allowed to drive the bridge; a number or a $ENV ref",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.telegram.default_target",
+        category: C::Fleet,
+        label: "Telegram Default Target",
+        help: "Session a bare message routes to when none is named",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.telegram.require_mention_in_groups",
+        category: C::Fleet,
+        label: "Telegram Require Mention",
+        help: "In group chats, only act on messages that mention the bot",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.telegram.response_timeout",
+        category: C::Fleet,
+        label: "Telegram Response Timeout",
+        help: "Seconds this channel waits for an answer, overriding the shared default",
+        kind: RowKind::Number {
+            min: 1,
+            max: 86_400,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.slack.bot_token",
+        category: C::Fleet,
+        label: "Slack Bot Token",
+        help: "xoxb- token. Literal, $ENV_VAR ref, or keychain:<service> ref",
+        kind: RowKind::Secret,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.slack.app_token",
+        category: C::Fleet,
+        label: "Slack App Token",
+        help: "xapp- socket-mode token. Literal, $ENV_VAR ref, or keychain:<service> ref",
+        kind: RowKind::Secret,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.slack.user_id",
+        category: C::Fleet,
+        label: "Slack User ID",
+        help: "The only Slack account allowed to drive the bridge",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.slack.default_target",
+        category: C::Fleet,
+        label: "Slack Default Target",
+        help: "Session a bare message routes to when none is named",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.slack.listen_mode",
+        category: C::Fleet,
+        label: "Slack Listen Mode",
+        help: "mentions: only @-mentions and DMs. all: every message in joined channels",
+        kind: RowKind::Choice(&["mentions", "all"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.slack.response_timeout",
+        category: C::Fleet,
+        label: "Slack Response Timeout",
+        help: "Seconds this channel waits for an answer, overriding the shared default",
+        kind: RowKind::Number {
+            min: 1,
+            max: 86_400,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.discord.token",
+        category: C::Fleet,
+        label: "Discord Bot Token",
+        help: "Literal, $ENV_VAR ref, or keychain:<service> ref",
+        kind: RowKind::Secret,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.discord.user_id",
+        category: C::Fleet,
+        label: "Discord User ID",
+        help: "The only Discord account allowed to drive the bridge",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.discord.default_target",
+        category: C::Fleet,
+        label: "Discord Default Target",
+        help: "Session a bare message routes to when none is named",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.discord.channel_id",
+        category: C::Fleet,
+        label: "Discord Channel ID",
+        help: "Channel the bridge listens on and pushes into",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.bridge.discord.response_timeout",
+        category: C::Fleet,
+        label: "Discord Response Timeout",
+        help: "Seconds this channel waits for an answer, overriding the shared default",
+        kind: RowKind::Number {
+            min: 1,
+            max: 86_400,
+        },
+    }),
+    // ── MCP pool ───────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "mcp_pool.enabled",
+        category: C::McpPool,
+        label: "Shared MCP Pool",
+        help: "Share one MCP server process across host sessions instead of one each",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_pool.idle_grace_secs",
+        category: C::McpPool,
+        label: "Idle Grace",
+        help: "Seconds a pooled server survives after its last session detaches",
+        kind: RowKind::Number {
+            min: 0,
+            max: 86_400,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_pool.monitor_refresh_secs",
+        category: C::McpPool,
+        label: "Monitor Refresh",
+        help: "Auto-refresh cadence for the pool overlay while open; 0 = manual only",
+        kind: RowKind::Number { min: 0, max: 3600 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "mcp_pool.daemon_idle_grace_secs",
+        category: C::McpPool,
+        label: "Daemon Idle Grace",
+        help: "Seconds the pool daemon lingers with zero clients; 0 = never self-exit",
+        kind: RowKind::Number {
+            min: 0,
+            max: 604_800,
+        },
+    }),
+    // ── Sections owned by other crates ─────────────────────────────────────
+    // Same file, different parser. See EXTERNAL_PREFIXES.
+    Entry::Row(ConfigRow {
+        key: "skills.catalog_release",
+        category: C::Skills,
+        label: "Catalog Release",
+        help: "Release tag of the curated skills catalog to fetch (default: latest)",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "skills.api_key",
+        category: C::Skills,
+        label: "Skills API Key",
+        help: "skills.sh API key. Literal, $ENV_VAR ref, or keychain:<service> ref",
+        kind: RowKind::Secret,
+    }),
+    Entry::Row(ConfigRow {
+        key: "session_reader.incremental_window_days",
+        category: C::SessionReader,
+        label: "Incremental Window",
+        help: "Days of session history re-aggregated on each scan; older files use the cached aggregate",
+        kind: RowKind::Number {
+            min: 1,
+            max: 36_500,
+        },
+    }),
+];
+
+/// Top-level prefixes that live in `config.toml` but not in
+/// [`AppConfig`](crate::config::AppConfig)'s serde shape.
+///
+/// `[fleet.bridge]` is carried as an opaque `toml::Value` passthrough (its
+/// tokens are parsed by `fleet::bridge::config`), and `[skills]` /
+/// `[session_reader]` are parsed off the same file by `ainb-cli` and the
+/// session-reader plugin. Their leaves are registered by hand above and are
+/// skipped by the schema walk in both directions: nothing here can prove they
+/// exist, so nothing here should claim they don't.
+pub const EXTERNAL_PREFIXES: &[&str] = &["fleet.bridge.", "skills.", "session_reader."];
+
+/// Registry paths whose direct children are user-chosen map keys rather than
+/// schema field names. The child segment normalises to `*`.
+const MAP_PARENTS: &[&str] = &[
+    "container_templates",
+    "container_templates.*.config.environment",
+    "container_templates.*.config.image_source.build_args",
+    "mcp_servers",
+    "mcp_servers.*.definition.env",
+    "usage.model_aliases",
+    "fleet.cost.session_overrides",
+    "fleet.cost.group_overrides",
+    "plugins",
+];
+
+/// Registry paths that are leaves even though they serialize as a table: the
+/// structure below them is not ours to describe.
+const OPAQUE_ROOTS: &[&str] = &["plugins.*", "mcp_servers.*.definition.config"];
+
+/// `[plugins]` mixes real fields with the flattened per-plugin value map, so
+/// the map-key rule has to skip these two names.
+const PLUGIN_FIELDS: &[&str] = &["enabled", "disabled"];
+
+fn is_map_parent(path: &str) -> bool {
+    MAP_PARENTS.contains(&path)
+}
+
+fn is_opaque_root(path: &str) -> bool {
+    OPAQUE_ROOTS.contains(&path)
+}
+
+/// True when `key` belongs to a section this registry describes but the schema
+/// walk cannot see. See [`EXTERNAL_PREFIXES`].
+#[must_use]
+pub fn is_external(key: &str) -> bool {
+    EXTERNAL_PREFIXES.iter().any(|prefix| key.starts_with(prefix))
+}
+
+/// Normalise a concrete dotted path into the key the registry uses: map keys
+/// collapse to `*`, and descent stops at an opaque root.
+///
+/// `mcp_servers.context7.shared` → `mcp_servers.*.shared`;
+/// `plugins.learnings.learnings_dir` → `plugins.*`.
+#[must_use]
+pub fn registry_key(concrete: &str) -> String {
+    let mut path = String::new();
+    for segment in parse_dot_key(concrete) {
+        if is_opaque_root(&path) {
+            return path;
+        }
+        path = child_key(&path, &segment);
+    }
+    path
+}
+
+/// Extend a registry path by one segment, collapsing a map key to `*`.
+/// Shared by [`registry_key`] and the schema walk in the tests, so a concrete
+/// path and a walked path can never normalise differently.
+fn child_key(path: &str, segment: &str) -> String {
+    let normalised =
+        if is_map_parent(path) && !(path == "plugins" && PLUGIN_FIELDS.contains(&segment)) {
+            "*"
+        } else {
+            segment
+        };
+    if path.is_empty() {
+        normalised.to_string()
+    } else {
+        format!("{path}.{normalised}")
+    }
+}
+
+/// Look up the entry for a concrete or already-normalised dotted path.
+#[must_use]
+pub fn entry(key: &str) -> Option<&'static Entry> {
+    let normalised = registry_key(key);
+    CONFIG_REGISTRY.iter().find(|entry| entry.key() == normalised)
+}
+
+/// Look up the *row* for a dotted path. Hidden leaves return `None`.
+#[must_use]
+pub fn row(key: &str) -> Option<&'static ConfigRow> {
+    entry(key).and_then(Entry::as_row)
+}
+
+/// Every user-facing row, in registry order.
+pub fn rows() -> impl Iterator<Item = &'static ConfigRow> {
+    CONFIG_REGISTRY.iter().filter_map(Entry::as_row)
+}
+
+// --- Dotted-path navigation -------------------------------------------------
+//
+// Lifted out of `cli/config_cmd.rs` so the CLI, the settings screen and the
+// registry's own validation all read and write a leaf the same way.
+
+/// Split a dot-notation key into its segments, dropping empties.
+#[must_use]
+pub fn parse_dot_key(key: &str) -> Vec<String> {
+    key.split('.').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect()
+}
+
+/// Navigate a TOML value tree using dot-notation keys.
+pub fn navigate_toml<'a>(value: &'a toml::Value, key: &str) -> Result<&'a toml::Value> {
+    let parts = parse_dot_key(key);
+    if parts.is_empty() {
+        return Err(anyhow!("Empty key"));
+    }
+
+    let mut current = value;
+    for (i, part) in parts.iter().enumerate() {
+        if let toml::Value::Table(table) = current {
+            current = table.get(part.as_str()).ok_or_else(|| {
+                let path = parts[..=i].join(".");
+                anyhow!("Key '{path}' not found in configuration")
+            })?;
+        } else {
+            let path = parts[..i].join(".");
+            return Err(anyhow!("Cannot index into non-table value at '{path}'"));
+        }
+    }
+
+    Ok(current)
+}
+
+/// Set a value in a TOML tree using dot-notation keys, creating intermediate
+/// tables. Performs no validation; prefer [`set_validated`].
+pub fn set_toml_value(root: &mut toml::Value, key: &str, raw_value: &str) -> Result<()> {
+    insert_at(root, key, parse_toml_scalar(raw_value))
+}
+
+/// Insert an already-built value at a dotted path, creating intermediate tables.
+fn insert_at(root: &mut toml::Value, key: &str, value: toml::Value) -> Result<()> {
+    let parts = parse_dot_key(key);
+    if parts.is_empty() {
+        return Err(anyhow!("Empty key"));
+    }
+
+    let mut current = root;
+    for part in &parts[..parts.len() - 1] {
+        current = current
+            .as_table_mut()
+            .ok_or_else(|| anyhow!("Cannot set key in non-table value"))?
+            .entry(part)
+            .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    }
+
+    let table = current
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("Cannot set key in non-table value"))?;
+
+    table.insert(parts[parts.len() - 1].clone(), value);
+    Ok(())
+}
+
+/// Parse a raw string into the most appropriate TOML scalar.
+#[must_use]
+pub fn parse_toml_scalar(raw: &str) -> toml::Value {
+    if raw.eq_ignore_ascii_case("true") {
+        return toml::Value::Boolean(true);
+    }
+    if raw.eq_ignore_ascii_case("false") {
+        return toml::Value::Boolean(false);
+    }
+    if let Ok(i) = raw.parse::<i64>() {
+        return toml::Value::Integer(i);
+    }
+    if raw.contains('.') {
+        if let Ok(f) = raw.parse::<f64>() {
+            return toml::Value::Float(f);
+        }
+    }
+    toml::Value::String(raw.to_string())
+}
+
+// --- Validation -------------------------------------------------------------
+
+/// Validate a raw string against the registry entry for `key`, returning the
+/// TOML value to store.
+///
+/// `ainb config set` used to write any dotted path it was handed, so a typo
+/// landed silently in config.toml and was dropped on the next load, and an
+/// out-of-range number was only noticed when something downstream misbehaved.
+/// Both now fail here, before anything is written.
+///
+/// Hidden leaves are accepted with plain scalar parsing: they are real schema
+/// keys owned by a wizard or the layout code, so refusing them outright would
+/// remove an escape hatch, but there is no user-facing type to check them
+/// against.
+pub fn validate(key: &str, raw: &str) -> Result<toml::Value> {
+    let normalised = registry_key(key);
+    let Some(found) = entry(&normalised) else {
+        let hint = suggestions(&normalised);
+        bail!("Unknown config key '{key}'.{hint}");
+    };
+
+    let Some(row) = found.as_row() else {
+        // Hidden leaf: internal state, no declared widget to validate against.
+        return Ok(parse_toml_scalar(raw));
+    };
+
+    match row.kind {
+        RowKind::Text | RowKind::Secret => Ok(toml::Value::String(raw.to_string())),
+        RowKind::Bool => match raw.trim().to_ascii_lowercase().as_str() {
+            "true" => Ok(toml::Value::Boolean(true)),
+            "false" => Ok(toml::Value::Boolean(false)),
+            other => bail!("'{key}' is a true/false setting, got '{other}'"),
+        },
+        RowKind::Number { min, max } => {
+            let n: i64 = raw
+                .trim()
+                .parse()
+                .map_err(|_| anyhow!("'{key}' takes a whole number, got '{raw}'"))?;
+            if n < min || n > max {
+                bail!("'{key}' must be between {min} and {max}, got {n}");
+            }
+            Ok(toml::Value::Integer(n))
+        }
+        RowKind::Float { min, max } => {
+            let f: f64 =
+                raw.trim().parse().map_err(|_| anyhow!("'{key}' takes a number, got '{raw}'"))?;
+            if !f.is_finite() || f < min || f > max {
+                bail!("'{key}' must be between {min} and {max}, got {raw}");
+            }
+            Ok(toml::Value::Float(f))
+        }
+        RowKind::Choice(options) => {
+            let value = raw.trim();
+            if options.contains(&value) {
+                Ok(toml::Value::String(value.to_string()))
+            } else {
+                bail!(
+                    "'{key}' must be one of: {}. Got '{value}'",
+                    options.join(", ")
+                );
+            }
+        }
+        RowKind::List => {
+            let items: Vec<toml::Value> = raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(parse_toml_scalar)
+                .collect();
+            Ok(toml::Value::Array(items))
+        }
+        RowKind::Opaque => bail!(
+            "'{key}' holds a structured value that cannot be set from the command line; use `ainb config edit`"
+        ),
+    }
+}
+
+/// Validate `raw` against the registry, then write it into `root` at `key`.
+pub fn set_validated(root: &mut toml::Value, key: &str, raw: &str) -> Result<()> {
+    let value = validate(key, raw)?;
+    insert_at(root, key, value)
+}
+
+/// " Did you mean …" tail for an unknown key, or a pointer at `ainb config
+/// show` when nothing looks close. Cheap linear scan over ~120 entries.
+fn suggestions(key: &str) -> String {
+    let leaf = key.rsplit('.').next().unwrap_or(key);
+    let head = key.split('.').next().unwrap_or(key);
+    let mut hits: Vec<&str> = CONFIG_REGISTRY
+        .iter()
+        .map(Entry::key)
+        .filter(|candidate| {
+            candidate.rsplit('.').next() == Some(leaf) || candidate.starts_with(head)
+        })
+        .take(4)
+        .collect();
+    hits.dedup();
+    if hits.is_empty() {
+        " Run `ainb config show` to see the keys that exist.".to_string()
+    } else {
+        format!(" Did you mean: {}?", hits.join(", "))
+    }
+}
+
+// --- Settings-screen conversion ---------------------------------------------
+
+impl ConfigRow {
+    /// Build the settings row the screen renders, seeded from `current`: the
+    /// value at this row's path in the loaded config, which already carries the
+    /// serde defaults. `None` (an absent optional key) seeds an empty widget.
+    ///
+    /// Mirrors `config_value_for_field`, which does the same job for a plugin's
+    /// `[[config]]` fields.
+    #[must_use]
+    pub fn to_setting(&self, current: Option<&toml::Value>) -> ConfigSetting {
+        ConfigSetting {
+            key: self.key.to_string(),
+            label: self.label.to_string(),
+            value: self.to_value(current),
+            description: self.help.to_string(),
+        }
+    }
+
+    /// The widget value for this row, seeded from `current`.
+    ///
+    /// `Float` renders as text: [`ConfigValue`] has no float variant, and
+    /// rounding a currency rate or a CPU share into an integer would silently
+    /// corrupt it.
+    #[must_use]
+    pub fn to_value(&self, current: Option<&toml::Value>) -> ConfigValue {
+        match self.kind {
+            RowKind::Secret => ConfigValue::Secret(current.map(scalar_text).unwrap_or_default()),
+            RowKind::Bool => {
+                ConfigValue::Bool(current.and_then(toml::Value::as_bool).unwrap_or(false))
+            }
+            RowKind::Number { .. } => {
+                ConfigValue::Number(current.and_then(toml::Value::as_integer).unwrap_or(0))
+            }
+            RowKind::Choice(options) => {
+                let selected = current.map(scalar_text).unwrap_or_default();
+                let idx = options.iter().position(|o| *o == selected).unwrap_or(0);
+                ConfigValue::Choice(options.iter().map(|o| (*o).to_string()).collect(), idx)
+            }
+            RowKind::Text | RowKind::Float { .. } | RowKind::List | RowKind::Opaque => {
+                ConfigValue::Text(current.map(scalar_text).unwrap_or_default())
+            }
+        }
+    }
+}
+
+/// Render a TOML value as the plain string a text widget edits. Arrays join
+/// with ", " to match the comma-separated form [`validate`] parses back.
+#[must_use]
+pub fn scalar_text(value: &toml::Value) -> String {
+    match value {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Integer(i) => i.to_string(),
+        toml::Value::Float(f) => f.to_string(),
+        toml::Value::Boolean(b) => b.to_string(),
+        toml::Value::Datetime(dt) => dt.to_string(),
+        toml::Value::Array(items) => items.iter().map(scalar_text).collect::<Vec<_>>().join(", "),
+        toml::Value::Table(_) => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::state::SessionFilter;
+    use crate::config::container::{ImageSource, VolumeMount};
+    use crate::config::{
+        AppConfig, AuthenticationConfig, ClaudeAuthProvider, CliProvider, ContainerTemplate,
+        ContainerTemplateConfig, CostBudgetConfig, CurrencyConfig, DockerConfig, FleetConfig,
+        InterviewConfig, McpInstallation, McpPoolConfig, McpServerConfig, McpServerDefinition,
+        PluginsConfig, PresetsConfig, StatuslineDecision, TmuxDecision, UiPreferences, UsageConfig,
+        UsagePlan, UsagePlanId, UsagePlanProvider, WorkspaceDefaults, WorktreeCollisionBehavior,
+    };
+    use std::collections::{BTreeMap, HashMap};
+
+    /// A config with **every** leaf present.
+    ///
+    /// Deliberately written as exhaustive struct literals with no
+    /// `..Default::default()`: adding a field to any config struct fails to
+    /// compile here, which is the first half of the drift guard. The second
+    /// half is [`every_leaf_has_an_entry`], which needs every optional field
+    /// populated, because an absent `Option` serializes to nothing and would hide a
+    /// missing registry row.
+    ///
+    /// Enum-valued fields carry real variants rather than hand-written strings
+    /// so [`choice_options_match_serde`] checks the registry's choice lists
+    /// against serde's actual output.
+    fn fully_populated() -> AppConfig {
+        AppConfig {
+            version: "9.9.9".to_string(),
+            authentication: AuthenticationConfig {
+                cli_provider: CliProvider::Codex,
+                claude_provider: ClaudeAuthProvider::ApiKey,
+                default_model: "opus".to_string(),
+                github_method: Some("gh".to_string()),
+            },
+            default_container_template: "claude-dev".to_string(),
+            container_templates: container_templates(),
+            mcp_servers: mcp_servers(),
+            workspace_defaults: WorkspaceDefaults {
+                branch_prefix: "agents/".to_string(),
+                exclude_paths: vec!["node_modules".to_string()],
+                workspace_scan_paths: vec!["/tmp/repos".into()],
+                max_repositories: 500,
+                worktree_collision_behavior: WorktreeCollisionBehavior::Error,
+            },
+            ui_preferences: UiPreferences {
+                theme: "light".to_string(),
+                show_container_status: true,
+                show_git_status: false,
+                show_session_menu_bar: true,
+                session_filter: SessionFilter::ActiveOnly,
+                preferred_editor: Some("nvim".to_string()),
+                home_sidebar_width: Some(30),
+                sessions_sidebar_width: Some(28),
+                sessions_sidebar_collapsed: Some(true),
+                skill_manager_sources_width: Some(32),
+                statusline_decision: StatuslineDecision::Installed,
+                tmux_decision: TmuxDecision::Declined,
+            },
+            docker: DockerConfig {
+                host: Some("unix:///var/run/docker.sock".to_string()),
+                timeout: 60,
+            },
+            usage: UsageConfig {
+                plan: Some(UsagePlan {
+                    id: UsagePlanId::ClaudeMax5x,
+                    monthly_usd: 100.0,
+                    provider: UsagePlanProvider::Claude,
+                    reset_day: 14,
+                    set_at: "2026-08-28T00:00:00Z".to_string(),
+                }),
+                currency: CurrencyConfig {
+                    code: "GBP".to_string(),
+                    symbol: "£".to_string(),
+                    usd_rate: 0.78,
+                },
+                model_aliases: HashMap::from([("claude-opus-5".to_string(), "opus".to_string())]),
+            },
+            plugins: PluginsConfig {
+                enabled: vec!["learnings".to_string()],
+                disabled: vec!["burndown".to_string()],
+                values: BTreeMap::from([(
+                    "learnings".to_string(),
+                    toml::Value::Table(toml::map::Map::from_iter([(
+                        "learnings_dir".to_string(),
+                        toml::Value::String("~/kb".to_string()),
+                    )])),
+                )]),
+            },
+            presets: PresetsConfig {
+                file: "../presets.toml".to_string(),
+            },
+            fleet: FleetConfig {
+                cost: CostBudgetConfig {
+                    session_usd: Some(5.0),
+                    group_usd: Some(25.0),
+                    session_overrides: HashMap::from([("abc123".to_string(), 50.0)]),
+                    group_overrides: HashMap::from([("infra".to_string(), 100.0)]),
+                },
+                interview: InterviewConfig {
+                    surface: Some("fleet".to_string()),
+                },
+                terminal: Some("ghostty".to_string()),
+                // `[fleet.bridge]` is an opaque passthrough parsed elsewhere;
+                // its rows are hand-declared and walk-exempt. See
+                // EXTERNAL_PREFIXES.
+                bridge: None,
+            },
+            mcp_pool: McpPoolConfig {
+                enabled: true,
+                idle_grace_secs: 300,
+                monitor_refresh_secs: 2,
+                daemon_idle_grace_secs: 900,
+            },
+        }
+    }
+
+    /// One template per [`ImageSource`] variant, because a single template can only be
+    /// one of them, so the variant-specific leaves need three entries. Map keys
+    /// normalise to `*`, so they all fold into the same registry paths.
+    fn container_templates() -> HashMap<String, ContainerTemplate> {
+        let base = |image_source: ImageSource| ContainerTemplateConfig {
+            image_source,
+            working_dir: "/workspace".to_string(),
+            command: Some(vec!["bash".to_string()]),
+            entrypoint: Some(vec!["/app/start.sh".to_string()]),
+            environment: HashMap::from([("NODE_ENV".to_string(), "development".to_string())]),
+            user: Some("claude-user".to_string()),
+            memory_limit: Some(4096),
+            cpu_limit: Some(2.0),
+            system_packages: vec!["git".to_string()],
+            npm_packages: vec!["@anthropic-ai/claude-code".to_string()],
+            python_packages: vec!["uv".to_string()],
+            ports: vec![3000],
+            volumes: vec![VolumeMount {
+                host_path: "/tmp".to_string(),
+                container_path: "/tmp".to_string(),
+                read_only: true,
+            }],
+            mount_ssh: true,
+            mount_git_config: true,
+        };
+        let template = |name: &str, image_source: ImageSource| ContainerTemplate {
+            name: name.to_string(),
+            description: "test template".to_string(),
+            config: base(image_source),
+            required_env: vec!["ANTHROPIC_API_KEY".to_string()],
+            default_mcp_servers: vec!["context7".to_string()],
+        };
+        HashMap::from([
+            (
+                "image".to_string(),
+                template(
+                    "image",
+                    ImageSource::Image {
+                        name: "node:20-slim".to_string(),
+                    },
+                ),
+            ),
+            (
+                "dockerfile".to_string(),
+                template(
+                    "dockerfile",
+                    ImageSource::Dockerfile {
+                        path: "/tmp/Dockerfile".into(),
+                        build_args: HashMap::from([(
+                            "RUST_VERSION".to_string(),
+                            "1.90".to_string(),
+                        )]),
+                    },
+                ),
+            ),
+            (
+                "claude-docker".to_string(),
+                template(
+                    "claude-docker",
+                    ImageSource::ClaudeDocker {
+                        base_image: Some("debian:bookworm".to_string()),
+                        build_args: HashMap::from([("TZ".to_string(), "UTC".to_string())]),
+                    },
+                ),
+            ),
+        ])
+    }
+
+    /// One server per [`McpInstallation`] / [`McpServerDefinition`] variant, for
+    /// the same reason as [`container_templates`].
+    fn mcp_servers() -> HashMap<String, McpServerConfig> {
+        let server = |name: &str,
+                      installation: McpInstallation,
+                      definition: McpServerDefinition| McpServerConfig {
+            name: name.to_string(),
+            description: "test server".to_string(),
+            installation,
+            definition,
+            required_env: vec!["API_KEY".to_string()],
+            enabled_by_default: true,
+            shared: false,
+        };
+        HashMap::from([
+            (
+                "npm".to_string(),
+                server(
+                    "npm",
+                    McpInstallation::Npm {
+                        package: "context7".to_string(),
+                        version: Some("1.0.0".to_string()),
+                    },
+                    McpServerDefinition::Command {
+                        command: "node".to_string(),
+                        args: vec!["index.js".to_string()],
+                        env: HashMap::from([("PORT".to_string(), "3000".to_string())]),
+                    },
+                ),
+            ),
+            (
+                "python".to_string(),
+                server(
+                    "python",
+                    McpInstallation::Python {
+                        package: "mcp-server".to_string(),
+                        version: Some("2.0.0".to_string()),
+                    },
+                    McpServerDefinition::Json {
+                        config: serde_json::json!({ "type": "sse", "url": "http://localhost" }),
+                    },
+                ),
+            ),
+            (
+                "git".to_string(),
+                server(
+                    "git",
+                    McpInstallation::Git {
+                        url: "https://example.invalid/mcp.git".to_string(),
+                        branch: Some("main".to_string()),
+                        install_command: Some("just build".to_string()),
+                    },
+                    McpServerDefinition::Command {
+                        command: "./mcp".to_string(),
+                        args: vec![],
+                        env: HashMap::new(),
+                    },
+                ),
+            ),
+            (
+                "preinstalled".to_string(),
+                server(
+                    "preinstalled",
+                    McpInstallation::PreInstalled,
+                    McpServerDefinition::Command {
+                        command: "mcp".to_string(),
+                        args: vec![],
+                        env: HashMap::new(),
+                    },
+                ),
+            ),
+            (
+                "custom".to_string(),
+                server(
+                    "custom",
+                    McpInstallation::Custom {
+                        script: "curl -fsSL https://example.invalid/install.sh | sh".to_string(),
+                    },
+                    McpServerDefinition::Command {
+                        command: "mcp".to_string(),
+                        args: vec![],
+                        env: HashMap::new(),
+                    },
+                ),
+            ),
+        ])
+    }
+
+    /// Every leaf path in a serialized config, normalised to registry keys,
+    /// mapped to the values observed at that path.
+    fn schema_leaves() -> BTreeMap<String, Vec<toml::Value>> {
+        let config = fully_populated();
+        let value = toml::Value::try_from(&config).expect("config serializes to TOML");
+        let mut out = BTreeMap::new();
+        walk(&value, "", &mut out);
+        out
+    }
+
+    fn walk(value: &toml::Value, path: &str, out: &mut BTreeMap<String, Vec<toml::Value>>) {
+        if !path.is_empty() && is_opaque_root(path) {
+            out.entry(path.to_string()).or_default().push(value.clone());
+            return;
+        }
+        match value {
+            toml::Value::Table(table) => {
+                for (key, child) in table {
+                    walk(child, &child_key(path, key), out);
+                }
+            }
+            leaf => out.entry(path.to_string()).or_default().push(leaf.clone()),
+        }
+    }
+
+    #[test]
+    fn every_leaf_has_an_entry() {
+        let missing: Vec<String> = schema_leaves()
+            .keys()
+            .filter(|key| !is_external(key))
+            .filter(|key| entry(key).is_none())
+            .cloned()
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "config schema leaves with no CONFIG_REGISTRY entry:\n  {}\n\n\
+             Add an Entry::Row for each (it is a user preference) or an \
+             Entry::Hidden with a written `why` (it is internal state) in \
+             crates/ainb-core/src/config/registry.rs.",
+            missing.join("\n  ")
+        );
+    }
+
+    #[test]
+    fn every_entry_names_a_real_leaf() {
+        let leaves = schema_leaves();
+        let stale: Vec<&str> = CONFIG_REGISTRY
+            .iter()
+            .map(Entry::key)
+            .filter(|key| !is_external(key))
+            .filter(|key| !leaves.contains_key(*key))
+            .collect();
+
+        assert!(
+            stale.is_empty(),
+            "CONFIG_REGISTRY entries whose key is not in the config schema \
+             (typo, or the field was removed):\n  {}",
+            stale.join("\n  ")
+        );
+    }
+
+    #[test]
+    fn registry_keys_are_unique() {
+        let mut seen = BTreeMap::new();
+        for entry in CONFIG_REGISTRY {
+            let count: &mut usize = seen.entry(entry.key()).or_default();
+            *count += 1;
+        }
+        let dupes: Vec<&str> = seen.iter().filter(|(_, n)| **n > 1).map(|(k, _)| *k).collect();
+        assert!(dupes.is_empty(), "duplicate registry keys: {dupes:?}");
+    }
+
+    #[test]
+    fn hidden_entries_explain_themselves() {
+        for entry in CONFIG_REGISTRY {
+            if let Entry::Hidden { key, why } = entry {
+                assert!(!why.trim().is_empty(), "hidden entry '{key}' has no reason");
+            }
+        }
+    }
+
+    #[test]
+    fn rows_carry_a_label_and_one_line_of_help() {
+        for row in rows() {
+            assert!(
+                !row.label.trim().is_empty(),
+                "row '{}' has no label",
+                row.key
+            );
+            assert!(!row.help.trim().is_empty(), "row '{}' has no help", row.key);
+            assert!(
+                !row.help.contains('\n'),
+                "row '{}' help must be one line",
+                row.key
+            );
+            if let RowKind::Choice(options) = row.kind {
+                assert!(
+                    !options.is_empty(),
+                    "choice row '{}' has no options",
+                    row.key
+                );
+            }
+            if let RowKind::Number { min, max } = row.kind {
+                assert!(min <= max, "row '{}' has an inverted range", row.key);
+            }
+        }
+    }
+
+    #[test]
+    fn choice_options_match_serde() {
+        let leaves = schema_leaves();
+        for row in rows() {
+            let RowKind::Choice(options) = row.kind else {
+                continue;
+            };
+            let Some(observed) = leaves.get(row.key) else {
+                continue;
+            };
+            for value in observed {
+                let rendered = scalar_text(value);
+                assert!(
+                    options.contains(&rendered.as_str()),
+                    "'{}' serializes as '{rendered}', which is not in its choice list {options:?}",
+                    row.key
+                );
+            }
+        }
+    }
+
+    /// Each match below is exhaustive, so adding an enum variant fails to
+    /// compile here, which is the prompt to widen the matching choice list.
+    #[test]
+    fn choice_lists_cover_every_enum_variant() {
+        fn token<T: serde::Serialize>(value: &T) -> String {
+            match toml::Value::try_from(value).expect("enum serializes") {
+                toml::Value::String(s) => s,
+                other => panic!("expected a string tag, got {other}"),
+            }
+        }
+        fn assert_covered<T: serde::Serialize>(key: &str, variants: &[T]) {
+            let RowKind::Choice(options) = row(key).expect("row exists").kind else {
+                panic!("'{key}' is not a choice row");
+            };
+            for variant in variants {
+                let rendered = token(variant);
+                assert!(
+                    options.contains(&rendered.as_str()),
+                    "'{key}' choice list {options:?} is missing '{rendered}'"
+                );
+            }
+            assert_eq!(
+                options.len(),
+                variants.len(),
+                "'{key}' choice list {options:?} does not match the variant count"
+            );
+        }
+
+        let cli = [
+            CliProvider::Claude,
+            CliProvider::Codex,
+            CliProvider::Gemini,
+            CliProvider::Copilot,
+        ];
+        for variant in &cli {
+            match variant {
+                CliProvider::Claude
+                | CliProvider::Codex
+                | CliProvider::Gemini
+                | CliProvider::Copilot => {}
+            }
+        }
+        assert_covered("authentication.cli_provider", &cli);
+
+        let claude = [
+            ClaudeAuthProvider::SystemAuth,
+            ClaudeAuthProvider::ApiKey,
+            ClaudeAuthProvider::AmazonBedrock,
+            ClaudeAuthProvider::GoogleVertex,
+            ClaudeAuthProvider::AzureFoundry,
+            ClaudeAuthProvider::GlmZai,
+            ClaudeAuthProvider::LlmGateway,
+        ];
+        for variant in &claude {
+            match variant {
+                ClaudeAuthProvider::SystemAuth
+                | ClaudeAuthProvider::ApiKey
+                | ClaudeAuthProvider::AmazonBedrock
+                | ClaudeAuthProvider::GoogleVertex
+                | ClaudeAuthProvider::AzureFoundry
+                | ClaudeAuthProvider::GlmZai
+                | ClaudeAuthProvider::LlmGateway => {}
+            }
+        }
+        assert_covered("authentication.claude_provider", &claude);
+
+        let plans = [
+            UsagePlanId::ClaudePro,
+            UsagePlanId::ClaudeMax,
+            UsagePlanId::ClaudeMax5x,
+            UsagePlanId::CursorPro,
+            UsagePlanId::Custom,
+            UsagePlanId::None,
+        ];
+        for variant in &plans {
+            match variant {
+                UsagePlanId::ClaudePro
+                | UsagePlanId::ClaudeMax
+                | UsagePlanId::ClaudeMax5x
+                | UsagePlanId::CursorPro
+                | UsagePlanId::Custom
+                | UsagePlanId::None => {}
+            }
+        }
+        assert_covered("usage.plan.id", &plans);
+
+        let providers = [
+            UsagePlanProvider::All,
+            UsagePlanProvider::Claude,
+            UsagePlanProvider::Codex,
+            UsagePlanProvider::Cursor,
+        ];
+        for variant in &providers {
+            match variant {
+                UsagePlanProvider::All
+                | UsagePlanProvider::Claude
+                | UsagePlanProvider::Codex
+                | UsagePlanProvider::Cursor => {}
+            }
+        }
+        assert_covered("usage.plan.provider", &providers);
+
+        let collisions = [
+            WorktreeCollisionBehavior::AutoRename,
+            WorktreeCollisionBehavior::Error,
+        ];
+        for variant in &collisions {
+            match variant {
+                WorktreeCollisionBehavior::AutoRename | WorktreeCollisionBehavior::Error => {}
+            }
+        }
+        assert_covered(
+            "workspace_defaults.worktree_collision_behavior",
+            &collisions,
+        );
+    }
+
+    // --- key normalisation ---
+
+    #[test]
+    fn map_keys_normalise_to_a_star() {
+        assert_eq!(
+            registry_key("mcp_servers.context7.shared"),
+            "mcp_servers.*.shared"
+        );
+        assert_eq!(
+            registry_key("container_templates.node.config.environment.NODE_ENV"),
+            "container_templates.*.config.environment.*"
+        );
+        assert_eq!(
+            registry_key("usage.model_aliases.claude-opus-5"),
+            "usage.model_aliases.*"
+        );
+        assert_eq!(
+            registry_key("fleet.cost.session_overrides.abc"),
+            "fleet.cost.session_overrides.*"
+        );
+    }
+
+    #[test]
+    fn plugin_fields_survive_normalisation_but_plugin_tables_collapse() {
+        assert_eq!(registry_key("plugins.enabled"), "plugins.enabled");
+        assert_eq!(registry_key("plugins.disabled"), "plugins.disabled");
+        assert_eq!(registry_key("plugins.learnings.learnings_dir"), "plugins.*");
+    }
+
+    #[test]
+    fn lookup_accepts_concrete_paths() {
+        let shared = row("mcp_servers.context7.shared").expect("resolves through the map key");
+        assert_eq!(shared.kind, RowKind::Bool);
+        assert!(row("nope.not.a.key").is_none());
+    }
+
+    // --- validation ---
+
+    #[test]
+    fn validate_rejects_an_unknown_key_with_a_hint() {
+        let err = validate("docker.timout", "30").unwrap_err().to_string();
+        assert!(err.contains("Unknown config key 'docker.timout'"), "{err}");
+        assert!(err.contains("docker.timeout"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_an_out_of_range_number() {
+        let err = validate("usage.plan.reset_day", "40").unwrap_err().to_string();
+        assert!(err.contains("between 1 and 31"), "{err}");
+        assert_eq!(
+            validate("usage.plan.reset_day", "14").unwrap(),
+            toml::Value::Integer(14)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_non_numeric_number() {
+        let err = validate("docker.timeout", "soon").unwrap_err().to_string();
+        assert!(err.contains("whole number"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_an_unlisted_choice() {
+        let err = validate("ui_preferences.theme", "solarized").unwrap_err().to_string();
+        assert!(err.contains("dark, light"), "{err}");
+        assert_eq!(
+            validate("ui_preferences.theme", "light").unwrap(),
+            toml::Value::String("light".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_non_boolean() {
+        let err = validate("mcp_pool.enabled", "yes").unwrap_err().to_string();
+        assert!(err.contains("true/false"), "{err}");
+        assert_eq!(
+            validate("mcp_pool.enabled", "FALSE").unwrap(),
+            toml::Value::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_structured_value() {
+        let err = validate("mcp_servers.ctx.definition.config", "{}").unwrap_err().to_string();
+        assert!(err.contains("ainb config edit"), "{err}");
+    }
+
+    #[test]
+    fn validate_splits_a_list_and_keeps_scalar_types() {
+        let value = validate("container_templates.node.config.ports", "3000, 5173").unwrap();
+        assert_eq!(
+            value,
+            toml::Value::Array(vec![toml::Value::Integer(3000), toml::Value::Integer(5173)])
+        );
+    }
+
+    #[test]
+    fn validate_accepts_a_float_in_range_and_rejects_one_outside() {
+        assert_eq!(
+            validate("fleet.cost.session_usd", "5.5").unwrap(),
+            toml::Value::Float(5.5)
+        );
+        let err = validate("fleet.cost.session_usd", "-1").unwrap_err().to_string();
+        assert!(err.contains("between"), "{err}");
+    }
+
+    #[test]
+    fn validate_accepts_hidden_leaves_without_a_type() {
+        // Internal state is still a real key; refusing it would remove the
+        // only escape hatch for a wizard-owned value.
+        assert_eq!(
+            validate("ui_preferences.home_sidebar_width", "40").unwrap(),
+            toml::Value::Integer(40)
+        );
+    }
+
+    #[test]
+    fn set_validated_writes_through_a_nested_path() {
+        let mut root = toml::Value::Table(toml::map::Map::new());
+        set_validated(&mut root, "mcp_pool.idle_grace_secs", "120").unwrap();
+        assert_eq!(
+            navigate_toml(&root, "mcp_pool.idle_grace_secs").unwrap(),
+            &toml::Value::Integer(120)
+        );
+
+        // A rejected value leaves the tree untouched.
+        assert!(set_validated(&mut root, "mcp_pool.idle_grace_secs", "-5").is_err());
+        assert_eq!(
+            navigate_toml(&root, "mcp_pool.idle_grace_secs").unwrap(),
+            &toml::Value::Integer(120)
+        );
+    }
+
+    // --- settings-screen conversion ---
+
+    #[test]
+    fn to_setting_seeds_from_the_current_value() {
+        let config = toml::Value::try_from(fully_populated()).unwrap();
+        let theme = row("ui_preferences.theme").unwrap();
+        let current = navigate_toml(&config, "ui_preferences.theme").unwrap();
+        let setting = theme.to_setting(Some(current));
+
+        assert_eq!(setting.key, "ui_preferences.theme");
+        assert_eq!(setting.label, "Theme");
+        assert_eq!(setting.description, theme.help);
+        match setting.value {
+            ConfigValue::Choice(options, idx) => {
+                assert_eq!(options[idx], "light");
+            }
+            other => panic!("expected a choice widget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_setting_renders_each_kind() {
+        let config = toml::Value::try_from(fully_populated()).unwrap();
+        let value_at = |key: &str| navigate_toml(&config, key).ok().cloned();
+
+        let bool_row = row("mcp_pool.enabled").unwrap();
+        assert!(matches!(
+            bool_row.to_value(value_at("mcp_pool.enabled").as_ref()),
+            ConfigValue::Bool(true)
+        ));
+
+        let number_row = row("docker.timeout").unwrap();
+        assert!(matches!(
+            number_row.to_value(value_at("docker.timeout").as_ref()),
+            ConfigValue::Number(60)
+        ));
+
+        let list_row = row("plugins.disabled").unwrap();
+        match list_row.to_value(value_at("plugins.disabled").as_ref()) {
+            ConfigValue::Text(text) => assert_eq!(text, "burndown"),
+            other => panic!("expected text, got {other:?}"),
+        }
+
+        // Floats keep their precision rather than being rounded into an int.
+        let float_row = row("usage.currency.usd_rate").unwrap();
+        match float_row.to_value(value_at("usage.currency.usd_rate").as_ref()) {
+            ConfigValue::Text(text) => assert_eq!(text, "0.78"),
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn secret_rows_produce_a_masked_widget() {
+        for key in [
+            "fleet.bridge.telegram.token",
+            "fleet.bridge.slack.bot_token",
+            "fleet.bridge.slack.app_token",
+            "fleet.bridge.discord.token",
+            "skills.api_key",
+        ] {
+            let secret = row(key).unwrap_or_else(|| panic!("{key} is registered"));
+            assert_eq!(secret.kind, RowKind::Secret, "{key} must be a secret");
+            let value = secret.to_value(Some(&toml::Value::String("xoxb-abcdef123".to_string())));
+            match value {
+                ConfigValue::Secret(_) => {
+                    assert!(
+                        !value.display().contains("abcdef123"),
+                        "{key} leaked its value"
+                    );
+                }
+                other => panic!("expected a secret widget for {key}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn missing_value_seeds_an_empty_widget() {
+        let host = row("docker.host").unwrap();
+        assert!(matches!(host.to_value(None), ConfigValue::Text(text) if text.is_empty()));
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -1441,9 +1441,16 @@ impl ConfigRow {
             RowKind::Bool => {
                 ConfigValue::Bool(current.and_then(toml::Value::as_bool).unwrap_or(false))
             }
-            RowKind::Number { .. } => {
-                ConfigValue::Number(current.and_then(toml::Value::as_integer).unwrap_or(0))
-            }
+            RowKind::Number { .. } => match current.and_then(toml::Value::as_integer) {
+                Some(n) => ConfigValue::Number(n),
+                // An unset OPTIONAL row is blank, not `0`. Rendering `0` was a
+                // false claim about the config — `memory_limit` has a `min` of
+                // 64, so confirming the row unchanged sent `"0"` and the edit
+                // was rejected. Text also gives the row a way to be cleared,
+                // which a number widget has no way to express.
+                None if is_optional(self.key) => ConfigValue::Text(String::new()),
+                None => ConfigValue::Number(0),
+            },
             RowKind::Choice(options) => {
                 let selected = current.map(scalar_text).unwrap_or_default();
                 let idx = options.iter().position(|o| *o == selected).unwrap_or(0);

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -55,12 +55,25 @@ pub enum RowKind {
     /// One of an enumerated set. The strings are the *serialized* forms, not
     /// display names, so they can be written straight back into config.toml.
     Choice(&'static [&'static str]),
-    /// Array of scalars, edited as a comma-separated list.
-    List,
+    /// Array of scalars, edited as a comma-separated list. The element type is
+    /// explicit because it cannot be guessed: `definition.args` is a
+    /// `Vec<String>` whose elements often look like numbers (`"8931"`), while
+    /// `config.ports` is a `Vec<u16>` that must NOT be stored as strings.
+    List(ListElement),
     /// A structured value (array of tables, or a nested JSON blob) with no
     /// scalar rendering. Displayed read-only; `ainb config set` refuses it and
     /// points at `ainb config edit`.
     Opaque,
+}
+
+/// What a [`RowKind::List`] holds. The list widget edits a comma-separated
+/// string either way; this decides what each element parses back into.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ListElement {
+    /// Elements stay strings, however numeric they look.
+    Text,
+    /// Elements are whole numbers (ports, ids).
+    Integer,
 }
 
 /// One editable configuration leaf.
@@ -238,14 +251,14 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         category: C::ContainerTemplates,
         label: "Command",
         help: "Container command argv (unset = the image default)",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "container_templates.*.config.entrypoint",
         category: C::ContainerTemplates,
         label: "Entrypoint",
         help: "Container entrypoint argv (unset = the image default)",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "container_templates.*.config.environment.*",
@@ -286,28 +299,28 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         category: C::ContainerTemplates,
         label: "System Packages",
         help: "apt packages installed into the image",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "container_templates.*.config.npm_packages",
         category: C::ContainerTemplates,
         label: "NPM Packages",
         help: "npm packages installed globally in the image",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "container_templates.*.config.python_packages",
         category: C::ContainerTemplates,
         label: "Python Packages",
         help: "pip packages installed into the image",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "container_templates.*.config.ports",
         category: C::ContainerTemplates,
         label: "Exposed Ports",
         help: "Container ports published to the host",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Integer),
     }),
     Entry::Row(ConfigRow {
         key: "container_templates.*.config.volumes",
@@ -335,14 +348,14 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         category: C::ContainerTemplates,
         label: "Required Env Vars",
         help: "Variables that must be present on the host before the template runs",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "container_templates.*.default_mcp_servers",
         category: C::ContainerTemplates,
         label: "Default MCP Servers",
         help: "MCP servers installed into containers built from this template",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     // ── MCP servers ────────────────────────────────────────────────────────
     Entry::Row(ConfigRow {
@@ -427,7 +440,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         category: C::McpServers,
         label: "Launch Arguments",
         help: "Arguments appended to the launch command",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "mcp_servers.*.definition.env.*",
@@ -448,7 +461,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         category: C::McpServers,
         label: "Required Env Vars",
         help: "Host variables that must be set before this server can start",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "mcp_servers.*.enabled_by_default",
@@ -477,14 +490,14 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         category: C::Workspace,
         label: "Exclude Paths",
         help: "Substrings that exclude a directory from repository scanning",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "workspace_defaults.workspace_scan_paths",
         category: C::Workspace,
         label: "Scan Paths",
         help: "Extra directories scanned for git repositories, on top of the defaults",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "workspace_defaults.max_repositories",
@@ -566,6 +579,10 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
     Entry::Hidden {
         key: "ui_preferences.tmux_decision",
         why: "records whether the tmux.conf prompt was answered; owned by `ainb init` for the same reason",
+    },
+    Entry::Hidden {
+        key: "ui_preferences.config_tree_expanded",
+        why: "which nodes of this very screen's tree are open; written by the expand keypress, like the sidebar widths",
     },
     // ── Docker ─────────────────────────────────────────────────────────────
     Entry::Row(ConfigRow {
@@ -662,14 +679,14 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         category: C::Plugins,
         label: "Enabled Plugins",
         help: "Allowlist: when non-empty ONLY these plugins load",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Row(ConfigRow {
         key: "plugins.disabled",
         category: C::Plugins,
         label: "Disabled Plugins",
         help: "Denylist: these plugins are skipped (ignored when an allowlist is set)",
-        kind: RowKind::List,
+        kind: RowKind::List(ListElement::Text),
     }),
     Entry::Hidden {
         key: "plugins.*",
@@ -953,6 +970,45 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
 /// exist, so nothing here should claim they don't.
 pub const EXTERNAL_PREFIXES: &[&str] = &["fleet.bridge.", "skills.", "session_reader."];
 
+/// Registry keys whose schema field is an `Option`: clearing the widget must
+/// REMOVE the key rather than store an empty value.
+///
+/// Storing `""` in an `Option<String>` yields `Some("")`, not `None` —
+/// `docker.host` then becomes an empty endpoint that Docker tries to dial, and
+/// `preferred_editor` an empty command. Every other row keeps its empty value,
+/// because those fields have a serde default and removing the key would
+/// silently restore that default instead of honouring the edit.
+///
+/// Hand-written, like [`CONFIG_REGISTRY`] itself, and proved against the schema
+/// by `optional_keys_match_the_schema` — which DERIVES the true set by dropping
+/// each leaf and checking whether serde puts it back.
+pub const OPTIONAL_KEYS: &[&str] = &[
+    "authentication.github_method",
+    "container_templates.*.config.command",
+    "container_templates.*.config.cpu_limit",
+    "container_templates.*.config.entrypoint",
+    "container_templates.*.config.environment.*",
+    "container_templates.*.config.image_source.base_image",
+    "container_templates.*.config.image_source.build_args.*",
+    "container_templates.*.config.memory_limit",
+    "container_templates.*.config.user",
+    "docker.host",
+    "fleet.cost.group_overrides.*",
+    "fleet.cost.group_usd",
+    "fleet.cost.session_overrides.*",
+    "fleet.cost.session_usd",
+    "fleet.interview.surface",
+    "fleet.terminal",
+    "ui_preferences.preferred_editor",
+    "usage.model_aliases.*",
+];
+
+/// True when clearing this row's widget should remove the key.
+#[must_use]
+pub fn is_optional(key: &str) -> bool {
+    OPTIONAL_KEYS.contains(&registry_key(key).as_str())
+}
+
 /// Registry paths whose direct children are user-chosen map keys rather than
 /// schema field names. The child segment normalises to `*`.
 const MAP_PARENTS: &[&str] = &[
@@ -1083,7 +1139,11 @@ pub fn set_toml_value(root: &mut toml::Value, key: &str, raw_value: &str) -> Res
 }
 
 /// Insert an already-built value at a dotted path, creating intermediate tables.
-fn insert_at(root: &mut toml::Value, key: &str, value: toml::Value) -> Result<()> {
+///
+/// Public so a writer that has already produced a typed value (the tree-expansion
+/// array, say) does not have to render it back to a string just to have
+/// [`set_validated`] parse it again.
+pub fn insert_at(root: &mut toml::Value, key: &str, value: toml::Value) -> Result<()> {
     let parts = parse_dot_key(key);
     if parts.is_empty() {
         return Err(anyhow!("Empty key"));
@@ -1188,13 +1248,17 @@ pub fn validate(key: &str, raw: &str) -> Result<toml::Value> {
                 );
             }
         }
-        RowKind::List => {
-            let items: Vec<toml::Value> = raw
-                .split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(parse_toml_scalar)
-                .collect();
+        RowKind::List(element) => {
+            let mut items = Vec::new();
+            for item in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                items.push(match element {
+                    ListElement::Text => toml::Value::String(item.to_string()),
+                    ListElement::Integer => toml::Value::Integer(
+                        item.parse()
+                            .map_err(|_| anyhow!("'{key}' takes whole numbers, got '{item}'"))?,
+                    ),
+                });
+            }
             Ok(toml::Value::Array(items))
         }
         RowKind::Opaque => bail!(
@@ -1204,9 +1268,39 @@ pub fn validate(key: &str, raw: &str) -> Result<toml::Value> {
 }
 
 /// Validate `raw` against the registry, then write it into `root` at `key`.
+///
+/// An emptied widget on an [`OPTIONAL_KEYS`] row REMOVES the key instead of
+/// storing an empty value: `Option<String>` deserializes `""` as `Some("")`,
+/// which is how clearing `docker.host` used to leave Docker dialling an empty
+/// endpoint. Every other row keeps its empty value, because removing a key with
+/// a serde default would silently restore that default rather than honour the
+/// edit.
 pub fn set_validated(root: &mut toml::Value, key: &str, raw: &str) -> Result<()> {
+    if raw.trim().is_empty() && is_optional(key) {
+        remove_at(root, key);
+        return Ok(());
+    }
     let value = validate(key, raw)?;
     insert_at(root, key, value)
+}
+
+/// Delete the leaf at a dotted path, leaving its parent tables in place.
+/// Returns whether anything was removed.
+pub fn remove_at(root: &mut toml::Value, key: &str) -> bool {
+    let parts = parse_dot_key(key);
+    let Some((last, parents)) = parts.split_last() else {
+        return false;
+    };
+    let mut current = root;
+    for part in parents {
+        match current.as_table_mut().and_then(|table| table.get_mut(part.as_str())) {
+            Some(child) => current = child,
+            None => return false,
+        }
+    }
+    current
+        .as_table_mut()
+        .is_some_and(|table| table.remove(last.as_str()).is_some())
 }
 
 /// " Did you mean …" tail for an unknown key, or a pointer at `ainb config
@@ -1254,10 +1348,24 @@ impl ConfigRow {
     /// `Float` renders as text: [`ConfigValue`] has no float variant, and
     /// rounding a currency rate or a CPU share into an integer would silently
     /// corrupt it.
+    ///
+    /// Not pure for [`RowKind::Secret`]: a secret row's status is "does this
+    /// reference resolve?", which reads the environment and — for a
+    /// `keychain:` reference — shells out to `/usr/bin/security`. Doing it here
+    /// keeps every row seeded through one call; the screen builds rows once, so
+    /// this never runs per frame.
     #[must_use]
     pub fn to_value(&self, current: Option<&toml::Value>) -> ConfigValue {
         match self.kind {
-            RowKind::Secret => ConfigValue::Secret(current.map(scalar_text).unwrap_or_default()),
+            RowKind::Secret => {
+                let reference = current.map(scalar_text).unwrap_or_default();
+                let resolved = !reference.trim().is_empty()
+                    && !crate::fleet::bridge::secrets::resolve_secret(&reference).trim().is_empty();
+                ConfigValue::Secret(crate::app::state::SecretValue {
+                    reference,
+                    resolved,
+                })
+            }
             RowKind::Bool => {
                 ConfigValue::Bool(current.and_then(toml::Value::as_bool).unwrap_or(false))
             }
@@ -1269,7 +1377,7 @@ impl ConfigRow {
                 let idx = options.iter().position(|o| *o == selected).unwrap_or(0);
                 ConfigValue::Choice(options.iter().map(|o| (*o).to_string()).collect(), idx)
             }
-            RowKind::Text | RowKind::Float { .. } | RowKind::List | RowKind::Opaque => {
+            RowKind::Text | RowKind::Float { .. } | RowKind::List(_) | RowKind::Opaque => {
                 ConfigValue::Text(current.map(scalar_text).unwrap_or_default())
             }
         }
@@ -1349,6 +1457,7 @@ mod tests {
                 skill_manager_sources_width: Some(32),
                 statusline_decision: StatuslineDecision::Installed,
                 tmux_decision: TmuxDecision::Declined,
+                config_tree_expanded: vec!["Fleet|fleet".to_string()],
             },
             docker: DockerConfig {
                 host: Some("unix:///var/run/docker.sock".to_string()),
@@ -1424,7 +1533,7 @@ mod tests {
             system_packages: vec!["git".to_string()],
             npm_packages: vec!["@anthropic-ai/claude-code".to_string()],
             python_packages: vec!["uv".to_string()],
-            ports: vec![3000],
+            ports: vec![3000, 5173],
             volumes: vec![VolumeMount {
                 host_path: "/tmp".to_string(),
                 container_path: "/tmp".to_string(),
@@ -1501,7 +1610,12 @@ mod tests {
                     },
                     McpServerDefinition::Command {
                         command: "node".to_string(),
-                        args: vec!["index.js".to_string()],
+                        // "8931" is a STRING here (args is `Vec<String>`) and
+                        // deliberately looks like a number: a list widget that
+                        // guesses element types turns it into an integer and
+                        // the next load fails to deserialize. See
+                        // `every_row_round_trips_through_its_widget`.
+                        args: vec!["--port".to_string(), "8931".to_string()],
                         env: HashMap::from([("PORT".to_string(), "3000".to_string())]),
                     },
                 ),
@@ -2017,6 +2131,134 @@ mod tests {
                 other => panic!("expected a secret widget for {key}, got {other:?}"),
             }
         }
+    }
+
+    // --- review findings #6 / #7: what a widget's raw string writes back ---
+
+    /// Every leaf must survive the trip through its widget unchanged.
+    ///
+    /// `scalar_text` renders a value for editing and `validate` parses it back;
+    /// if those two disagree, confirming a row without touching it rewrites the
+    /// value into a different TYPE, and the next load fails to deserialize.
+    /// Found `mcp_servers.*.definition.args` (a `Vec<String>`) turning
+    /// `["--port", "8931"]` into `["--port", 8931]`.
+    #[test]
+    fn every_row_round_trips_through_its_widget() {
+        let mut broken = Vec::new();
+        for (key, observed) in schema_leaves() {
+            let Some(row) = row(&key) else { continue };
+            if matches!(row.kind, RowKind::Opaque) {
+                continue;
+            }
+            for value in observed {
+                let rendered = scalar_text(&value);
+                let Ok(parsed) = validate(&key, &rendered) else {
+                    broken.push(format!("{key}: '{rendered}' does not validate"));
+                    continue;
+                };
+                if parsed != value {
+                    broken.push(format!("{key}: {value} -> '{rendered}' -> {parsed}"));
+                }
+            }
+        }
+        assert!(
+            broken.is_empty(),
+            "these rows change their value's type on a no-op edit:\n  {}",
+            broken.join("\n  ")
+        );
+    }
+
+    /// `OPTIONAL_KEYS` must name exactly the leaves serde leaves absent.
+    ///
+    /// Derived, not trusted: drop each leaf from a fully-populated config,
+    /// deserialize, re-serialize, and see whether it comes back. A field with a
+    /// serde default reappears; an `Option` stays gone. Clearing the widget of
+    /// the latter has to REMOVE the key — storing `""` gives `Some("")`, which
+    /// is how `docker.host` ends up as an empty endpoint Docker then tries to
+    /// dial.
+    #[test]
+    fn optional_keys_match_the_schema() {
+        let full = toml::Value::try_from(fully_populated()).unwrap();
+
+        let mut derived: Vec<String> = Vec::new();
+        for (key, _) in schema_leaves() {
+            if row(&key).is_none() || is_external(&key) {
+                continue;
+            }
+            let Some(concrete) = first_concrete_path(&full, &key) else {
+                continue;
+            };
+            let mut trimmed = full.clone();
+            if !remove_at(&mut trimmed, &concrete) {
+                continue;
+            }
+            let Ok(parsed) = trimmed.try_into::<AppConfig>() else {
+                continue; // Required by the schema; not optional.
+            };
+            let reserialized = toml::Value::try_from(parsed).unwrap();
+            if navigate_toml(&reserialized, &concrete).is_err() {
+                derived.push(key);
+            }
+        }
+        derived.sort();
+        derived.dedup();
+
+        let mut declared: Vec<String> = OPTIONAL_KEYS.iter().map(|k| (*k).to_string()).collect();
+        declared.sort();
+
+        assert_eq!(
+            declared, derived,
+            "OPTIONAL_KEYS has drifted from the schema.\n  declared: {declared:?}\n  derived:  {derived:?}"
+        );
+    }
+
+    /// Resolve a registry key's `*` segments against a real config, taking the
+    /// first instance of each map.
+    fn first_concrete_path(seed: &toml::Value, key: &str) -> Option<String> {
+        let mut path = String::new();
+        let mut node = seed;
+        for segment in parse_dot_key(key) {
+            let table = node.as_table()?;
+            let name = if segment == "*" {
+                table.keys().next()?.clone()
+            } else {
+                segment.clone()
+            };
+            node = table.get(&name)?;
+            path = if path.is_empty() {
+                name
+            } else {
+                format!("{path}.{name}")
+            };
+        }
+        Some(path)
+    }
+
+    #[test]
+    fn clearing_an_optional_row_removes_the_key() {
+        let mut root: toml::Value =
+            toml::from_str("[docker]\nhost = \"tcp://1.2.3.4:2376\"\n").unwrap();
+        set_validated(&mut root, "docker.host", "").unwrap();
+        assert!(
+            navigate_toml(&root, "docker.host").is_err(),
+            "clearing an Option<String> must remove the key, not store \"\": {root}"
+        );
+        // And the config still loads, with the field back to None.
+        let parsed: AppConfig = root.try_into().unwrap();
+        assert_eq!(parsed.docker.host, None);
+    }
+
+    #[test]
+    fn clearing_a_defaulted_row_keeps_the_empty_value() {
+        // `branch_prefix` is a plain `String` with a serde default. Removing it
+        // would silently restore "agents/" instead of honouring the edit, so an
+        // empty value is stored as an empty value.
+        let mut root: toml::Value = toml::from_str("[workspace_defaults]\n").unwrap();
+        set_validated(&mut root, "workspace_defaults.branch_prefix", "").unwrap();
+        assert_eq!(
+            navigate_toml(&root, "workspace_defaults.branch_prefix").unwrap(),
+            &toml::Value::String(String::new())
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -1212,6 +1212,20 @@ pub fn validate(key: &str, raw: &str) -> Result<toml::Value> {
         return Ok(parse_toml_scalar(raw));
     };
 
+    // A key BELOW an opaque root is a user-extensible namespace, not a typo:
+    // `plugins.<name>.<field>` normalises to `plugins.*`, whose shape is the
+    // plugin's own `[[config]]` manifest and not ours to declare. Refusing it
+    // broke `ainb config set plugins.learnings.learnings_dir`, which worked
+    // before the registry existed. Setting the opaque root ITSELF is still
+    // refused below — that is the structured value `ainb config edit` is for.
+    // `registry_key` stops descending at an opaque root, so a concrete key with
+    // MORE segments than its normalised form is one that reaches inside.
+    if matches!(row.kind, RowKind::Opaque)
+        && parse_dot_key(key).len() > parse_dot_key(&normalised).len()
+    {
+        return Ok(parse_toml_scalar(raw));
+    }
+
     match row.kind {
         RowKind::Text | RowKind::Secret => Ok(toml::Value::String(raw.to_string())),
         RowKind::Bool => match raw.trim().to_ascii_lowercase().as_str() {
@@ -1349,11 +1363,9 @@ impl ConfigRow {
     /// rounding a currency rate or a CPU share into an integer would silently
     /// corrupt it.
     ///
-    /// Not pure for [`RowKind::Secret`]: a secret row's status is "does this
-    /// reference resolve?", which reads the environment and — for a
-    /// `keychain:` reference — shells out to `/usr/bin/security`. Doing it here
-    /// keeps every row seeded through one call; the screen builds rows once, so
-    /// this never runs per frame.
+    /// [`RowKind::Secret`] reads the process environment for a `$VAR`
+    /// reference, which is free. It deliberately does NOT touch the keychain —
+    /// see [`secret_value`].
     #[must_use]
     pub fn to_value(&self, current: Option<&toml::Value>) -> ConfigValue {
         match self.kind {
@@ -1740,6 +1752,22 @@ mod tests {
         );
     }
 
+    /// Every settings category must be reachable. A category with a label, an
+    /// icon and no row is a menu entry nothing can ever open — the same drift
+    /// in the other direction from `every_leaf_has_an_entry`.
+    #[test]
+    fn every_category_has_at_least_one_row() {
+        let empty: Vec<ConfigCategory> = ConfigCategory::all()
+            .into_iter()
+            .filter(|category| !rows().any(|row| row.category == *category))
+            .collect();
+        assert!(
+            empty.is_empty(),
+            "these categories have no rows and can never be opened: {empty:?}\n\
+             Give each one a row, or drop the variant."
+        );
+    }
+
     #[test]
     fn registry_keys_are_unique() {
         let mut seen = BTreeMap::new();
@@ -2004,6 +2032,26 @@ mod tests {
             validate("mcp_pool.enabled", "FALSE").unwrap(),
             toml::Value::Boolean(false)
         );
+    }
+
+    /// #7. Per-plugin keys must stay settable: their schema is the plugin's own
+    /// `[[config]]` manifest, so the registry describes the table as opaque
+    /// rather than describing its contents.
+    #[test]
+    fn a_key_below_an_opaque_root_is_settable() {
+        assert_eq!(
+            validate("plugins.learnings.learnings_dir", "~/kb").unwrap(),
+            toml::Value::String("~/kb".to_string())
+        );
+        assert_eq!(
+            validate("plugins.burndown.daily_cap", "20").unwrap(),
+            toml::Value::Integer(20)
+        );
+        // The opaque ROOT itself is still refused — that is a structured value.
+        let err = validate("mcp_servers.ctx.definition.config", "{}").unwrap_err().to_string();
+        assert!(err.contains("ainb config edit"), "{err}");
+        // And a genuinely unknown key is still a typo.
+        assert!(validate("plugins", "x").is_err());
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -1106,7 +1106,54 @@ pub fn rows() -> impl Iterator<Item = &'static ConfigRow> {
 /// Split a dot-notation key into its segments, dropping empties.
 #[must_use]
 pub fn parse_dot_key(key: &str) -> Vec<String> {
-    key.split('.').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect()
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut quoted = false;
+    let mut chars = key.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            // A quoted segment holds a key that is not bare — a model id like
+            // `gpt-4.1`, an MCP server called `my.server`. Splitting those on
+            // `.` invents nested tables and corrupts the file, so honour the
+            // quotes the same way TOML itself does.
+            '"' => quoted = !quoted,
+            '\\' if quoted => {
+                if let Some(escaped) = chars.next() {
+                    current.push(escaped);
+                }
+            }
+            '.' if !quoted => {
+                let part = current.trim().to_string();
+                if !part.is_empty() {
+                    parts.push(part);
+                }
+                current.clear();
+            }
+            other => current.push(other),
+        }
+    }
+    let last = current.trim().to_string();
+    if !last.is_empty() {
+        parts.push(last);
+    }
+    parts
+}
+
+/// Render one path segment for use in a dotted key, quoting it when it is not
+/// a bare TOML key.
+///
+/// The inverse of [`parse_dot_key`]'s quote handling: a segment containing a
+/// `.` (or a quote, or whitespace) has to go back as `"gpt-4.1"`, or the next
+/// parse splits it apart again.
+#[must_use]
+pub fn quote_key_segment(segment: &str) -> String {
+    let bare = !segment.is_empty()
+        && segment.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if bare {
+        segment.to_string()
+    } else {
+        format!("\"{}\"", segment.replace('\\', "\\\\").replace('"', "\\\""))
+    }
 }
 
 /// Navigate a TOML value tree using dot-notation keys.
@@ -1363,16 +1410,29 @@ impl ConfigRow {
     /// rounding a currency rate or a CPU share into an integer would silently
     /// corrupt it.
     ///
-    /// [`RowKind::Secret`] reads the process environment for a `$VAR`
-    /// reference, which is free. It deliberately does NOT touch the keychain —
-    /// see [`secret_value`].
+    /// [`RowKind::Secret`] resolves a `$VAR` reference against the process
+    /// environment, which is free, and deliberately does NOT touch the
+    /// keychain. `build_rows` runs before the TUI's first paint, and a
+    /// `keychain:` reference costs an in-process keyring read plus a
+    /// `/usr/bin/security` shell-out, each bounded at 5s — with the bridge's
+    /// four token rows and the skills key all set, that was up to ~50s of
+    /// blocking on startup against a locked keychain. A `keychain:` row is
+    /// reported as configured on the strength of having a reference at all;
+    /// whether the secret is actually retrievable is a question for the moment
+    /// something needs its value.
     #[must_use]
     pub fn to_value(&self, current: Option<&toml::Value>) -> ConfigValue {
         match self.kind {
             RowKind::Secret => {
                 let reference = current.map(scalar_text).unwrap_or_default();
-                let resolved = !reference.trim().is_empty()
-                    && !crate::fleet::bridge::secrets::resolve_secret(&reference).trim().is_empty();
+                let trimmed = reference.trim();
+                let resolved = if trimmed.is_empty() {
+                    false
+                } else if trimmed.starts_with("keychain:") {
+                    true
+                } else {
+                    !crate::fleet::bridge::secrets::resolve_secret(&reference).trim().is_empty()
+                };
                 ConfigValue::Secret(crate::app::state::SecretValue {
                     reference,
                     resolved,

--- a/ainb-tui/crates/ainb-core/src/config/screen_model.rs
+++ b/ainb-tui/crates/ainb-core/src/config/screen_model.rs
@@ -70,7 +70,7 @@ fn expand_from(node: &toml::Value, rest: &[String], prefix: String, out: &mut Ve
 
     let base = join_path(&prefix, &rest[..star].join("."));
     for (name, child) in table {
-        expand_from(child, &rest[star + 1..], join_path(&base, name), out);
+        expand_from(child, &rest[star + 1..], join_map_key(&base, name), out);
     }
 }
 
@@ -80,6 +80,17 @@ fn join_path(prefix: &str, tail: &str) -> String {
         (false, true) => prefix.to_string(),
         (false, false) => format!("{prefix}.{tail}"),
     }
+}
+
+/// Join a map key onto a path, quoting it when it is not a bare TOML key.
+///
+/// A server called `context7.io` would otherwise produce the row key
+/// `mcp_servers.context7.io.shared`, which re-splits into a path that does not
+/// exist: the row seeds from a default instead of disk, and toggling it writes
+/// a `mcp_servers.context7 = { io = { ... } }` table that stops the whole
+/// config deserializing. Same class as the dotted-key bug in `flatten_leaves`.
+fn join_map_key(prefix: &str, key: &str) -> String {
+    join_path(prefix, &crate::config::registry::quote_key_segment(key))
 }
 
 /// Why a registry row cannot be edited from the settings screen, or `None`

--- a/ainb-tui/crates/ainb-core/src/config/screen_model.rs
+++ b/ainb-tui/crates/ainb-core/src/config/screen_model.rs
@@ -1,0 +1,548 @@
+// ABOUTME: Turns CONFIG_REGISTRY into the rows and the section tree the
+// settings screen renders, seeded from a serialized config.
+
+//! The settings screen's model layer.
+//!
+//! [`CONFIG_REGISTRY`](super::registry::CONFIG_REGISTRY) describes the schema;
+//! this module turns that description into what a user actually sees:
+//!
+//! - [`expand_key`] resolves a registry key's `*` segments against a real
+//!   config, so `mcp_servers.*.shared` becomes one row per configured server.
+//! - [`build_rows`] seeds one [`ConfigSetting`] per concrete key, grouped by
+//!   [`ConfigCategory`].
+//! - [`build_tree`] derives the collapsible left pane from the dotted keys, so
+//!   the tree mirrors the TOML sections instead of being a second hand-written
+//!   list that can drift from the first.
+//!
+//! Nothing here reads or writes a file. The caller supplies the seed and
+//! decides what to do with the rows.
+
+use std::collections::{BTreeMap, HashMap};
+
+use crate::app::state::{ConfigCategory, ConfigSetting, ConfigValue};
+
+use super::registry::{self, parse_dot_key};
+
+/// How deep the tree may nest below a category root.
+///
+/// Container templates are the deepest real section
+/// (`container_templates.<name>.config.image_source.build_args.<arg>`); four
+/// levels reaches `image_source` and leaves the last hop as rows, which is
+/// where a list beats another expandable node.
+const MAX_TREE_DEPTH: usize = 4;
+
+/// Expand a registry key into the concrete dotted paths a config actually has.
+///
+/// A key with no `*` is returned as-is even when the leaf is absent: an unset
+/// `Option` still deserves a row, which is how you set it for the first time. A
+/// key WITH a `*` can only be expanded against real data — nothing can invent
+/// the name of an MCP server that isn't configured — so an absent or empty map
+/// yields no rows.
+#[must_use]
+pub fn expand_key(key: &str, seed: &toml::Value) -> Vec<String> {
+    if !key.contains('*') {
+        return vec![key.to_string()];
+    }
+    let segments = parse_dot_key(key);
+    let mut out = Vec::new();
+    expand_from(seed, &segments, String::new(), &mut out);
+    out
+}
+
+fn expand_from(node: &toml::Value, rest: &[String], prefix: String, out: &mut Vec<String>) {
+    let Some(star) = rest.iter().position(|segment| segment == "*") else {
+        out.push(join_path(&prefix, &rest.join(".")));
+        return;
+    };
+
+    // Walk the literal segments in front of the star; a missing one means this
+    // branch of the config simply isn't there.
+    let mut current = node;
+    for segment in &rest[..star] {
+        match current.as_table().and_then(|table| table.get(segment)) {
+            Some(child) => current = child,
+            None => return,
+        }
+    }
+    let Some(table) = current.as_table() else {
+        return;
+    };
+
+    let base = join_path(&prefix, &rest[..star].join("."));
+    for (name, child) in table {
+        expand_from(child, &rest[star + 1..], join_path(&base, name), out);
+    }
+}
+
+fn join_path(prefix: &str, tail: &str) -> String {
+    match (prefix.is_empty(), tail.is_empty()) {
+        (true, _) => tail.to_string(),
+        (false, true) => prefix.to_string(),
+        (false, false) => format!("{prefix}.{tail}"),
+    }
+}
+
+/// Why a registry row cannot be edited from the settings screen, or `None`
+/// when it can.
+///
+/// A row that accepts an edit and drops it is the failure this whole registry
+/// exists to remove, so anything core cannot actually persist says so up front
+/// instead of pretending.
+#[must_use]
+pub fn read_only_reason(key: &str) -> Option<&'static str> {
+    let normalised = registry::registry_key(key);
+    if normalised.starts_with("usage.") {
+        // `READ_ONLY_SECTIONS` in config/mod.rs: `[usage]` is owned by the
+        // burndown plugin, which does its own load-modify-save against this
+        // file. Core writing it would revert a plan set from another process.
+        return Some("read-only — [usage] is owned by the burndown plugin");
+    }
+    match registry::row(&normalised).map(|row| row.kind) {
+        Some(registry::RowKind::Opaque) => {
+            Some("read-only — structured value; edit it with `ainb config edit`")
+        }
+        _ => None,
+    }
+}
+
+/// Build one [`ConfigSetting`] per visible schema leaf, grouped by category and
+/// kept in registry order within each.
+///
+/// `seed` is a serialized config: the same tree
+/// [`registry::navigate_toml`] reads and [`registry::set_validated`] writes, so
+/// what a row displays and what a save writes can never disagree about where a
+/// value lives.
+#[must_use]
+pub fn build_rows(seed: &toml::Value) -> HashMap<ConfigCategory, Vec<ConfigSetting>> {
+    let mut grouped: HashMap<ConfigCategory, Vec<ConfigSetting>> = HashMap::new();
+    for row in registry::rows() {
+        for concrete in expand_key(row.key, seed) {
+            let current = registry::navigate_toml(seed, &concrete).ok();
+            let mut setting = row.to_setting(current);
+            // The row's identity is its CONCRETE path — `mcp_servers.ctx.shared`,
+            // not `mcp_servers.*.shared` — because that is what a save writes and
+            // what the search pane shows.
+            setting.key = concrete;
+            widen_with_detected_choices(&mut setting);
+            grouped.entry(row.category).or_default().push(setting);
+        }
+    }
+    grouped
+}
+
+/// Offer a picker where the *options* come from the machine rather than the
+/// schema.
+///
+/// `ui_preferences.preferred_editor` is a free-form command string — the
+/// registry is right to call it `Text`, because any executable is valid. But
+/// making the user type `subl` from memory is a step back from the picker of
+/// detected editors the old hand-written screen had, so the row keeps its Text
+/// semantics (a plain string is what gets written) while presenting the editors
+/// actually installed here as choices.
+///
+/// The current value is kept in the list even when it is not one of the known
+/// editors, so opening the screen can never silently retarget a custom editor.
+fn widen_with_detected_choices(setting: &mut ConfigSetting) {
+    if setting.key != "ui_preferences.preferred_editor" {
+        return;
+    }
+    let ConfigValue::Text(current) = &setting.value else {
+        return;
+    };
+    let current = current.clone();
+
+    let mut options: Vec<String> = crate::editors::get_installed_editors()
+        .into_iter()
+        .map(|(_, command)| command)
+        .collect();
+    if options.is_empty() {
+        return; // Nothing detected: a text field beats an empty picker.
+    }
+    if !current.is_empty() && !options.contains(&current) {
+        options.insert(0, current.clone());
+    }
+    let selected = options.iter().position(|option| *option == current).unwrap_or(0);
+    setting.value = ConfigValue::Choice(options, selected);
+}
+
+/// One node of the settings tree: a category root, or a TOML sub-table under
+/// it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigTreeNode {
+    pub category: ConfigCategory,
+    /// Dotted path this node covers. Empty when the category's rows are
+    /// top-level leaves (`default_container_template`).
+    pub path: String,
+    /// What the left pane prints.
+    pub label: String,
+    /// Indentation level; 0 is the category root.
+    pub depth: usize,
+    /// Whether any node below this one exists, i.e. whether it can expand.
+    pub has_children: bool,
+    /// Indices into this category's row vector for the WHOLE subtree, so
+    /// selecting a node shows everything under it.
+    pub rows: Vec<usize>,
+}
+
+impl ConfigTreeNode {
+    /// Stable identity for expansion state, persisted in
+    /// `ui_preferences.config_tree_expanded`. Uses the category's label rather
+    /// than its `Debug` form so a rename of the enum variant does not silently
+    /// collapse everyone's tree.
+    #[must_use]
+    pub fn id(&self) -> String {
+        format!("{}|{}", self.category.label(), self.path)
+    }
+}
+
+/// Derive the whole tree, in pre-order, for the given categories.
+///
+/// `categories` fixes the top-level order; `rows` is the output of
+/// [`build_rows`]. A category with no rows contributes nothing.
+#[must_use]
+pub fn build_tree(
+    categories: &[ConfigCategory],
+    rows: &HashMap<ConfigCategory, Vec<ConfigSetting>>,
+) -> Vec<ConfigTreeNode> {
+    let mut nodes = Vec::new();
+    for category in categories {
+        let Some(category_rows) = rows.get(category) else {
+            continue;
+        };
+        if category_rows.is_empty() {
+            continue;
+        }
+        push_category(*category, category_rows, &mut nodes);
+    }
+    nodes
+}
+
+/// Emit a category root plus its subtree.
+///
+/// The root's path is the longest prefix every row in the category shares, so
+/// `[mcp_pool]` (whose rows are all siblings) is one flat node while `[fleet]`
+/// (cost / interview / bridge) grows children.
+fn push_category(category: ConfigCategory, rows: &[ConfigSetting], out: &mut Vec<ConfigTreeNode>) {
+    let parents: Vec<Vec<String>> = rows.iter().map(|row| parent_segments(&row.key)).collect();
+    let root = common_prefix(&parents);
+    let all: Vec<usize> = (0..rows.len()).collect();
+
+    let root_index = out.len();
+    out.push(ConfigTreeNode {
+        category,
+        path: root.join("."),
+        label: category.label().to_string(),
+        depth: 0,
+        has_children: false,
+        rows: all.clone(),
+    });
+
+    push_children(category, rows, &parents, &root, &all, 1, out);
+    out[root_index].has_children = out.len() > root_index + 1;
+}
+
+/// Group the rows that live BELOW `prefix` by their next path segment, emitting
+/// one node per group and recursing.
+#[allow(clippy::too_many_arguments)]
+fn push_children(
+    category: ConfigCategory,
+    rows: &[ConfigSetting],
+    parents: &[Vec<String>],
+    prefix: &[String],
+    candidates: &[usize],
+    depth: usize,
+    out: &mut Vec<ConfigTreeNode>,
+) {
+    if depth > MAX_TREE_DEPTH {
+        return;
+    }
+
+    // First-seen order, not alphabetical: registry order is the order a reader
+    // of config.toml expects, and `build_rows` preserves it.
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for &index in candidates {
+        let parent = &parents[index];
+        if parent.len() <= prefix.len() {
+            continue; // A row that sits directly on `prefix`, not below it.
+        }
+        let segment = parent[prefix.len()].clone();
+        if !groups.contains_key(&segment) {
+            order.push(segment.clone());
+        }
+        groups.entry(segment).or_default().push(index);
+    }
+
+    for segment in order {
+        let members = groups.remove(&segment).unwrap_or_default();
+        let mut child_prefix = prefix.to_vec();
+        child_prefix.push(segment.clone());
+
+        let index = out.len();
+        out.push(ConfigTreeNode {
+            category,
+            path: child_prefix.join("."),
+            label: prettify(&segment),
+            depth,
+            has_children: false,
+            rows: members.clone(),
+        });
+        push_children(
+            category,
+            rows,
+            parents,
+            &child_prefix,
+            &members,
+            depth + 1,
+            out,
+        );
+        out[index].has_children = out.len() > index + 1;
+    }
+}
+
+/// The dotted path of the table a key lives in: `fleet.cost.session_usd` →
+/// `["fleet", "cost"]`.
+fn parent_segments(key: &str) -> Vec<String> {
+    let mut segments = parse_dot_key(key);
+    segments.pop();
+    segments
+}
+
+fn common_prefix(paths: &[Vec<String>]) -> Vec<String> {
+    let Some((first, rest)) = paths.split_first() else {
+        return Vec::new();
+    };
+    let mut prefix = first.clone();
+    for path in rest {
+        let shared = prefix.iter().zip(path.iter()).take_while(|(a, b)| a == b).count();
+        prefix.truncate(shared);
+    }
+    prefix
+}
+
+/// `image_source` → `Image Source`. Words split on `_` only: a user-chosen map
+/// key such as a template named `claude-docker` keeps its own spelling.
+fn prettify(segment: &str) -> String {
+    segment
+        .split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Case-insensitive subsequence match, used by the `/` filter.
+///
+/// Subsequence rather than substring so `dblclk` finds `double_click_ms`; the
+/// caller ranks exact substring hits first, so the loose matches sort below the
+/// obvious ones instead of burying them.
+#[must_use]
+pub fn fuzzy_matches(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let mut wanted = needle.chars().flat_map(char::to_lowercase).peekable();
+    for candidate in haystack.chars().flat_map(char::to_lowercase) {
+        match wanted.peek() {
+            Some(&next) if next == candidate => {
+                wanted.next();
+            }
+            Some(_) => {}
+            None => return true,
+        }
+    }
+    wanted.peek().is_none()
+}
+
+/// The keychain service a secret row stores its literal under.
+///
+/// Derived from the dotted key so it is unique per row, stable across restarts
+/// and self-describing in Keychain Access — `ainb-fleet-bridge-telegram-token`
+/// says exactly which setting it backs. The `keychain:` resolver
+/// ([`crate::fleet::bridge::secrets`]) looks an item up by service name alone,
+/// so the service IS the whole address; a shorter scheme would risk two rows
+/// colliding on one item.
+#[must_use]
+pub fn keychain_service(key: &str) -> String {
+    format!("ainb-{}", key.replace('.', "-"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AppConfig;
+
+    fn seed() -> toml::Value {
+        toml::Value::try_from(AppConfig::default()).expect("config serializes")
+    }
+
+    #[test]
+    fn a_key_without_a_star_survives_even_when_the_leaf_is_absent() {
+        let empty = toml::Value::Table(toml::map::Map::new());
+        assert_eq!(expand_key("docker.host", &empty), vec!["docker.host"]);
+    }
+
+    #[test]
+    fn a_star_expands_to_one_path_per_configured_instance() {
+        let seed: toml::Value = toml::from_str(
+            r#"
+            [mcp_servers.context7]
+            shared = true
+            [mcp_servers.playwright]
+            shared = false
+            "#,
+        )
+        .unwrap();
+        let mut keys = expand_key("mcp_servers.*.shared", &seed);
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                "mcp_servers.context7.shared",
+                "mcp_servers.playwright.shared"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_star_over_an_absent_map_yields_no_rows() {
+        let empty = toml::Value::Table(toml::map::Map::new());
+        assert!(expand_key("mcp_servers.*.shared", &empty).is_empty());
+    }
+
+    #[test]
+    fn nested_stars_expand_together() {
+        let seed: toml::Value = toml::from_str(
+            r#"
+            [container_templates.dev.config.environment]
+            NODE_ENV = "development"
+            TZ = "UTC"
+            "#,
+        )
+        .unwrap();
+        let mut keys = expand_key("container_templates.*.config.environment.*", &seed);
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                "container_templates.dev.config.environment.NODE_ENV",
+                "container_templates.dev.config.environment.TZ",
+            ]
+        );
+    }
+
+    #[test]
+    fn rows_are_seeded_from_the_config_and_keyed_by_concrete_path() {
+        let rows = build_rows(&seed());
+        let pool = rows.get(&ConfigCategory::McpPool).expect("MCP pool rows");
+        let enabled =
+            pool.iter().find(|row| row.key == "mcp_pool.enabled").expect("pool enabled row");
+        assert!(matches!(enabled.value, ConfigValue::Bool(true)));
+        assert!(!enabled.description.is_empty());
+    }
+
+    #[test]
+    fn the_opaque_plugin_value_table_never_becomes_a_row() {
+        let seed: toml::Value = toml::from_str(
+            r#"
+            [plugins.learnings]
+            learnings_dir = "/tmp/kb"
+            "#,
+        )
+        .unwrap();
+        let rows = build_rows(&seed);
+        let plugin_rows = rows.get(&ConfigCategory::Plugins).cloned().unwrap_or_default();
+        assert!(
+            plugin_rows.iter().all(|row| !row.key.starts_with("plugins.learnings")),
+            "plugin value tables must come from manifests, not the registry: {:?}",
+            plugin_rows.iter().map(|r| &r.key).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn hidden_leaves_never_become_rows() {
+        let rows = build_rows(&seed());
+        let keys: Vec<&str> = rows.values().flatten().map(|row| row.key.as_str()).collect();
+        for hidden in ["version", "ui_preferences.home_sidebar_width"] {
+            assert!(
+                !keys.contains(&hidden),
+                "hidden leaf '{hidden}' was rendered"
+            );
+        }
+    }
+
+    #[test]
+    fn a_flat_section_is_a_single_tree_node() {
+        let rows = build_rows(&seed());
+        let tree = build_tree(&[ConfigCategory::McpPool], &rows);
+        assert_eq!(tree.len(), 1, "{tree:#?}");
+        assert_eq!(tree[0].path, "mcp_pool");
+        assert!(!tree[0].has_children);
+    }
+
+    #[test]
+    fn a_nested_section_grows_children_that_mirror_the_toml() {
+        let seed: toml::Value = toml::from_str(
+            r#"
+            [fleet.cost]
+            session_usd = 5.0
+            [fleet.interview]
+            surface = "fleet"
+            [fleet.bridge.telegram]
+            token = "$TG"
+            "#,
+        )
+        .unwrap();
+        let rows = build_rows(&seed);
+        let tree = build_tree(&[ConfigCategory::Fleet], &rows);
+
+        let paths: Vec<&str> = tree.iter().map(|node| node.path.as_str()).collect();
+        assert_eq!(paths[0], "fleet", "{paths:?}");
+        assert!(paths.contains(&"fleet.cost"), "{paths:?}");
+        assert!(paths.contains(&"fleet.interview"), "{paths:?}");
+        assert!(paths.contains(&"fleet.bridge"), "{paths:?}");
+        assert!(paths.contains(&"fleet.bridge.telegram"), "{paths:?}");
+        assert!(tree[0].has_children);
+
+        // The root carries every row in the category, so selecting it is
+        // "show me the whole section".
+        let fleet_rows = rows.get(&ConfigCategory::Fleet).unwrap();
+        assert_eq!(tree[0].rows.len(), fleet_rows.len());
+
+        // A child carries only its own subtree.
+        let bridge = tree.iter().find(|node| node.path == "fleet.bridge").unwrap();
+        assert!(bridge.rows.iter().all(|&i| fleet_rows[i].key.starts_with("fleet.bridge.")));
+    }
+
+    #[test]
+    fn usage_rows_declare_themselves_read_only() {
+        assert!(read_only_reason("usage.plan.id").is_some());
+        assert!(read_only_reason("usage.currency.code").is_some());
+        assert!(read_only_reason("mcp_pool.enabled").is_none());
+    }
+
+    #[test]
+    fn structured_rows_declare_themselves_read_only() {
+        assert!(read_only_reason("mcp_servers.ctx.definition.config").is_some());
+    }
+
+    #[test]
+    fn fuzzy_matches_a_subsequence_and_rejects_a_miss() {
+        assert!(fuzzy_matches("mcp_pool.idle_grace_secs", "idlegrace"));
+        assert!(fuzzy_matches("Shared MCP Pool", "mcp"));
+        assert!(!fuzzy_matches("docker.timeout", "zzz"));
+    }
+
+    #[test]
+    fn the_keychain_service_is_derived_from_the_key() {
+        assert_eq!(
+            keychain_service("fleet.bridge.telegram.token"),
+            "ainb-fleet-bridge-telegram-token"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/config/screen_model.rs
+++ b/ainb-tui/crates/ainb-core/src/config/screen_model.rs
@@ -141,7 +141,9 @@ pub fn build_rows(seed: &toml::Value) -> HashMap<ConfigCategory, Vec<ConfigSetti
 /// actually installed here as choices.
 ///
 /// The current value is kept in the list even when it is not one of the known
-/// editors, so opening the screen can never silently retarget a custom editor.
+/// editors — including the empty value of an unset preference — so opening the
+/// screen can never silently retarget a custom editor nor invent a choice the
+/// user never made.
 fn widen_with_detected_choices(setting: &mut ConfigSetting) {
     if setting.key != "ui_preferences.preferred_editor" {
         return;
@@ -158,7 +160,12 @@ fn widen_with_detected_choices(setting: &mut ConfigSetting) {
     if options.is_empty() {
         return; // Nothing detected: a text field beats an empty picker.
     }
-    if !current.is_empty() && !options.contains(&current) {
+    // An unset preference gets an explicit empty first option rather than
+    // silently pre-selecting whichever editor was detected first. Showing
+    // `Preferred Editor : code` to someone who never chose one is a claim about
+    // their config that is not true — and confirming the row would write it.
+    // The empty option round-trips to "remove the key" (`OPTIONAL_KEYS`).
+    if !options.contains(&current) {
         options.insert(0, current.clone());
     }
     let selected = options.iter().position(|option| *option == current).unwrap_or(0);
@@ -517,6 +524,27 @@ mod tests {
         // A child carries only its own subtree.
         let bridge = tree.iter().find(|node| node.path == "fleet.bridge").unwrap();
         assert!(bridge.rows.iter().all(|&i| fleet_rows[i].key.starts_with("fleet.bridge.")));
+    }
+
+    /// #9. An unset `preferred_editor` must render as unset, not as whichever
+    /// editor happens to be installed first.
+    #[test]
+    fn an_unset_editor_preference_does_not_preselect_one() {
+        let rows = build_rows(&seed());
+        let editor = rows
+            .get(&ConfigCategory::Editor)
+            .and_then(|rows| rows.iter().find(|row| row.key == "ui_preferences.preferred_editor"))
+            .expect("editor row");
+        assert_eq!(
+            editor.value.display(),
+            "",
+            "an unset editor preference was rendered as a real choice"
+        );
+        assert_eq!(
+            editor.value.raw(),
+            "",
+            "confirming the row would write that choice"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/credentials.rs
+++ b/ainb-tui/crates/ainb-core/src/credentials.rs
@@ -66,6 +66,34 @@ pub fn store_credential(key: CredentialKey, value: &str) -> Result<()> {
     Ok(())
 }
 
+/// Account name for keychain items addressed by SERVICE alone.
+///
+/// A `keychain:<service>` reference in config.toml is resolved by
+/// [`crate::fleet::bridge::secrets`], which shells out to
+/// `security find-generic-password -s <service> -w` — service only, no account.
+/// The `keyring` crate always writes both attributes, so items written for those
+/// references need one fixed account for the lookup to be unambiguous.
+pub(crate) const REFERENCE_ACCOUNT: &str = "ainb";
+
+/// Store a secret under an arbitrary keychain SERVICE name, for a
+/// `keychain:<service>` reference held in config.toml.
+///
+/// Distinct from [`store_credential`], which files everything under one service
+/// keyed by account: those are ainb's own well-known credentials, whereas these
+/// are addressed by service because that is all the reference syntax carries.
+pub fn store_keychain_secret(service: &str, value: &str) -> Result<()> {
+    if service.trim().is_empty() {
+        anyhow::bail!("keychain service name is empty");
+    }
+    if value.is_empty() {
+        anyhow::bail!("refusing to store an empty secret");
+    }
+    let entry = Entry::new(service, REFERENCE_ACCOUNT).context("Failed to create keyring entry")?;
+    entry.set_password(value).context("Failed to store secret in keychain")?;
+    tracing::info!(service, "stored secret in keychain");
+    Ok(())
+}
+
 /// Retrieve a credential from the system keychain
 pub fn get_credential(key: CredentialKey) -> Result<Option<String>> {
     let entry = Entry::new(SERVICE_NAME, key.as_str()).context("Failed to create keyring entry")?;
@@ -251,5 +279,43 @@ mod tests {
 
         // Verify deleted
         assert!(!has_anthropic_api_key());
+    }
+}
+
+#[cfg(test)]
+mod keychain_reference_tests {
+    use super::*;
+
+    /// Round-trip a `keychain:<service>` reference: write it the way the
+    /// settings screen's Ctrl+K does, read it back the way
+    /// [`crate::fleet::bridge::secrets`] does.
+    ///
+    /// `#[ignore]` because it writes a real item to the developer's login
+    /// keychain — and because macOS has no default keychain at all when `HOME`
+    /// is redirected, which is exactly what every tripwire and CI job does, so
+    /// an always-on version would fail there for reasons unrelated to the code.
+    /// Run it deliberately:
+    ///
+    /// ```text
+    /// cargo test -p ainb --lib keychain_reference_round_trips -- --ignored
+    /// security delete-generic-password -s ainb-test-secret-round-trip
+    /// ```
+    #[test]
+    #[ignore = "writes to the real login keychain; run manually"]
+    fn keychain_reference_round_trips() {
+        let service = "ainb-test-secret-round-trip";
+        store_keychain_secret(service, "xoxb-round-trip").expect("store");
+        let resolved =
+            crate::fleet::bridge::secrets::resolve_secret(&format!("keychain:{service}"));
+        assert_eq!(resolved, "xoxb-round-trip");
+
+        let entry = Entry::new(service, REFERENCE_ACCOUNT).unwrap();
+        entry.delete_credential().expect("clean up the test item");
+    }
+
+    #[test]
+    fn an_empty_secret_is_refused_rather_than_stored() {
+        assert!(store_keychain_secret("ainb-test-never-written", "").is_err());
+        assert!(store_keychain_secret("  ", "value").is_err());
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/secrets.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/secrets.rs
@@ -82,10 +82,34 @@ fn resolve_secret_with(value: &str, env: impl Fn(&str) -> Option<String>) -> Str
 /// Same reference syntax and the same keychain item either way — this is one
 /// scheme with two readers, not two schemes.
 fn resolve_keychain(service: &str) -> String {
-    if let Some(found) = resolve_keychain_in_process(service) {
+    let owned = service.to_string();
+    // BOTH readers are bounded. `keyring::Entry::get_password` blocks on a
+    // locked keychain or an ACL prompt exactly like `security` does, so leaving
+    // the in-process read unbounded reintroduced the hang the watchdog exists
+    // to prevent — and put it on the TUI's startup path.
+    if let Some(Some(found)) = bounded(KEYCHAIN_TIMEOUT, move || {
+        resolve_keychain_in_process(&owned)
+    }) {
         return found;
     }
     resolve_keychain_via_security(service)
+}
+
+/// Run `work` on a detached thread and give up after `limit`.
+///
+/// Detached on purpose: on a timeout we stop waiting, but the thread is NOT
+/// joined — a keychain call blocked behind a user dialog would otherwise block
+/// us right back. It self-reaps when the call returns, and the send into a
+/// dropped channel is a harmless no-op.
+fn bounded<T: Send + 'static>(
+    limit: Duration,
+    work: impl FnOnce() -> T + Send + 'static,
+) -> Option<T> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(work());
+    });
+    rx.recv_timeout(limit).ok()
 }
 
 /// Step 1: the `keyring` read. `None` means "not found here, try `security`" —
@@ -108,32 +132,25 @@ fn resolve_keychain_in_process(service: &str) -> Option<String> {
 /// prompt can't hang the bridge at startup.
 fn resolve_keychain_via_security(service: &str) -> String {
     let service_owned = service.to_string();
-    let (tx, rx) = std::sync::mpsc::channel();
-    // Detached on purpose: on a timeout we stop waiting on `rx` and return, but
-    // this thread is NOT joined. It self-reaps — `security` is bounded by its own
-    // 5s wall-clock (KEYCHAIN_TIMEOUT mirrors it), so the thread finishes shortly
-    // after and `tx.send` into the dropped channel is a harmless no-op. A bounded,
-    // intentional leak, not an unbounded one.
-    std::thread::spawn(move || {
-        let out = Command::new("/usr/bin/security")
+    let output = bounded(KEYCHAIN_TIMEOUT, move || {
+        Command::new("/usr/bin/security")
             .args(["find-generic-password", "-s", &service_owned, "-w"])
-            .output();
-        let _ = tx.send(out);
+            .output()
     });
 
-    match rx.recv_timeout(KEYCHAIN_TIMEOUT) {
-        Ok(Ok(out)) if out.status.success() => {
+    match output {
+        Some(Ok(out)) if out.status.success() => {
             String::from_utf8_lossy(&out.stdout).trim().to_string()
         }
-        Ok(Ok(_)) => {
+        Some(Ok(_)) => {
             tracing::warn!(service, "keychain has no item for service");
             String::new()
         }
-        Ok(Err(e)) => {
+        Some(Err(e)) => {
             tracing::warn!(service, error = %e, "keychain lookup failed");
             String::new()
         }
-        Err(_) => {
+        None => {
             tracing::warn!(service, "keychain lookup timed out");
             String::new()
         }
@@ -143,6 +160,29 @@ fn resolve_keychain_via_security(service: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The watchdog must give up on a call that never returns. Both keychain
+    /// readers block on a locked keychain or an ACL prompt, and the settings
+    /// screen resolves secrets on a path a user is waiting on.
+    #[test]
+    fn a_blocked_lookup_gives_up_instead_of_hanging() {
+        let started = std::time::Instant::now();
+        let result = bounded(Duration::from_millis(80), || {
+            std::thread::sleep(Duration::from_secs(30));
+            "never arrives"
+        });
+        assert_eq!(result, None, "an unbounded lookup would have blocked here");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the watchdog did not fire: waited {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn a_prompt_lookup_returns_its_value() {
+        assert_eq!(bounded(Duration::from_secs(5), || 42), Some(42));
+    }
 
     #[test]
     fn plain_literal_passes_through() {

--- a/ainb-tui/crates/ainb-core/src/fleet/bridge/secrets.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/bridge/secrets.rs
@@ -64,9 +64,49 @@ fn resolve_secret_with(value: &str, env: impl Fn(&str) -> Option<String>) -> Str
     raw.to_string()
 }
 
-/// macOS keychain lookup, bounded by a watchdog so a locked-keychain prompt
-/// can't hang the bridge at startup.
+/// Keychain lookup for a `keychain:<service>` reference.
+///
+/// Two readers, in this order:
+///
+/// 1. **In-process, via `keyring`.** This is how the settings screen's
+///    "store in the keychain" action WRITES the item, and an item is readable
+///    without a prompt by the process that created it. Shelling out to
+///    `security` for something ainb just wrote fails instead: the ACL trusts
+///    the creating binary, not `/usr/bin/security`, so the read raises an
+///    authorization dialog and the watchdog below times out before the user can
+///    answer it.
+/// 2. **`/usr/bin/security`**, for items a user (or an older ainb) put there by
+///    hand. Apple-signed and stable, so an "Always Allow" against it sticks
+///    across rebuilds.
+///
+/// Same reference syntax and the same keychain item either way — this is one
+/// scheme with two readers, not two schemes.
 fn resolve_keychain(service: &str) -> String {
+    if let Some(found) = resolve_keychain_in_process(service) {
+        return found;
+    }
+    resolve_keychain_via_security(service)
+}
+
+/// Step 1: the `keyring` read. `None` means "not found here, try `security`" —
+/// including on error, because a keychain ainb cannot open in-process may still
+/// be readable by the Apple-signed helper.
+fn resolve_keychain_in_process(service: &str) -> Option<String> {
+    let entry = keyring::Entry::new(service, crate::credentials::REFERENCE_ACCOUNT).ok()?;
+    match entry.get_password() {
+        Ok(password) if !password.trim().is_empty() => Some(password.trim().to_string()),
+        Ok(_) => None,
+        Err(keyring::Error::NoEntry) => None,
+        Err(e) => {
+            tracing::debug!(service, error = %e, "in-process keychain read failed; trying security");
+            None
+        }
+    }
+}
+
+/// Step 2: `/usr/bin/security`, bounded by a watchdog so a locked-keychain
+/// prompt can't hang the bridge at startup.
+fn resolve_keychain_via_security(service: &str) -> String {
     let service_owned = service.to_string();
     let (tx, rx) = std::sync::mpsc::channel();
     // Detached on purpose: on a timeout we stop waiting on `rx` and return, but

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -122,6 +122,13 @@ async fn tokio_main() -> Result<()> {
     setup_logging();
     setup_panic_handler();
 
+    // Once per process, before anything calls AppConfig::load(). Older builds
+    // let the burndown and session-reader plugins keep a second config.toml one
+    // directory above the real one; this folds any leftover into the canonical
+    // file. Deliberately here rather than inside load(), which also runs in
+    // daemons and inside the TUI event loop.
+    config::AppConfig::migrate_legacy_paths();
+
     // Build the clap surface from the CommandRegistry. The base `ainb` command
     // (--format, after-help, etc.) lives in cli::root_clap_command(); each
     // built-in subcommand registers itself via CommandRegistry::built_ins().

--- a/ainb-tui/crates/ainb-core/tests/example_config_parses.rs
+++ b/ainb-tui/crates/ainb-core/tests/example_config_parses.rs
@@ -1,0 +1,128 @@
+// ABOUTME: Proves config/example.config.toml still describes the real schema.
+
+//! `config/example.config.toml` is the only reference most users read, and
+//! nothing used to parse it. It drifted badly: the `container_templates`
+//! example used an `image_source` tag (`"prebuilt"`) that has never existed,
+//! called `working_dir` `working_directory`, gave `memory_limit` a Docker-style
+//! `"4g"` string where the field is an integer count of megabytes, and showed
+//! `mcp_servers` entries with flat `command` / `args` / `init_strategy` keys
+//! that `McpServerConfig` does not have at all. Every one of those blocks would
+//! have failed to load.
+//!
+//! The illustrative blocks have to stay commented out — users copy this file
+//! straight to `~/.agents-in-a-box/config/config.toml`, so a live
+//! `[container_templates.my-node]` would conjure a template nobody asked for.
+//! So each one is fenced with `# --8<-- parse` / `# -->8--`; this test
+//! uncomments what is inside the fences and deserializes it as the real
+//! `AppConfig`.
+//!
+//! Adding an example? Put it inside a fence. Changing the schema? This test
+//! tells you which block in the docs you just invalidated.
+
+use ainb::config::AppConfig;
+
+const EXAMPLE: &str = include_str!("../../../config/example.config.toml");
+
+const OPEN: &str = "--8<-- parse";
+const CLOSE: &str = "-->8--";
+
+/// Strip one leading `# ` (or a bare `#`) from a commented example line.
+fn uncomment(line: &str) -> String {
+    let trimmed = line.trim_start();
+    match trimmed.strip_prefix('#') {
+        Some(rest) => rest.strip_prefix(' ').unwrap_or(rest).to_string(),
+        None => line.to_string(),
+    }
+}
+
+/// Every fenced block, uncommented, in file order.
+fn fenced_blocks(source: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current: Option<Vec<String>> = None;
+
+    for line in source.lines() {
+        if line.contains(OPEN) {
+            assert!(current.is_none(), "nested `{OPEN}` fence in example.config.toml");
+            current = Some(Vec::new());
+            continue;
+        }
+        if line.contains(CLOSE) {
+            let block = current.take().unwrap_or_else(|| {
+                panic!("`{CLOSE}` without a matching `{OPEN}` in example.config.toml")
+            });
+            blocks.push(block.join("\n"));
+            continue;
+        }
+        if let Some(buffer) = current.as_mut() {
+            buffer.push(uncomment(line));
+        }
+    }
+
+    assert!(current.is_none(), "unclosed `{OPEN}` fence in example.config.toml");
+    blocks
+}
+
+/// The uncommented part of the file — everything a user gets by copying it
+/// verbatim — must load as-is.
+#[test]
+fn live_portion_of_the_example_config_loads() {
+    let live: String = EXAMPLE
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    toml::from_str::<AppConfig>(&live)
+        .expect("the uncommented part of example.config.toml does not deserialize as AppConfig");
+}
+
+/// Each fenced example block must deserialize too, so a documented example can
+/// never describe a shape the code will reject.
+#[test]
+fn every_fenced_example_block_loads() {
+    let blocks = fenced_blocks(EXAMPLE);
+    assert!(
+        !blocks.is_empty(),
+        "no `{OPEN}` fences found — did the sentinels get renamed?"
+    );
+
+    for (i, block) in blocks.iter().enumerate() {
+        if let Err(err) = toml::from_str::<AppConfig>(block) {
+            panic!(
+                "fenced example block {} in config/example.config.toml does not \
+                 deserialize as AppConfig: {err}\n--- block ---\n{block}",
+                i + 1
+            );
+        }
+    }
+}
+
+/// The whole file, with every fenced block enabled, must ALSO load — this is
+/// what a user gets if they uncomment the examples, and it catches two blocks
+/// that parse alone but collide (a duplicate key, say).
+#[test]
+fn the_example_config_loads_with_all_examples_enabled() {
+    let mut combined = EXAMPLE
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for block in fenced_blocks(EXAMPLE) {
+        combined.push('\n');
+        combined.push_str(&block);
+    }
+
+    toml::from_str::<AppConfig>(&combined)
+        .expect("example.config.toml does not load with its example blocks enabled");
+}
+
+#[test]
+fn uncomment_strips_exactly_one_hash_and_space() {
+    assert_eq!(uncomment("# key = 1"), "key = 1");
+    assert_eq!(uncomment("#key = 1"), "key = 1");
+    assert_eq!(uncomment("#  indented = 1"), " indented = 1");
+    assert_eq!(uncomment(""), "");
+    // A trailing comment on a real line survives, so `memory_limit = 4096   #
+    // megabytes` keeps its note.
+    assert_eq!(uncomment("# a = 1   # note"), "a = 1   # note");
+}

--- a/ainb-tui/crates/ainb-core/tests/example_config_parses.rs
+++ b/ainb-tui/crates/ainb-core/tests/example_config_parses.rs
@@ -42,7 +42,10 @@ fn fenced_blocks(source: &str) -> Vec<String> {
 
     for line in source.lines() {
         if line.contains(OPEN) {
-            assert!(current.is_none(), "nested `{OPEN}` fence in example.config.toml");
+            assert!(
+                current.is_none(),
+                "nested `{OPEN}` fence in example.config.toml"
+            );
             current = Some(Vec::new());
             continue;
         }
@@ -58,7 +61,10 @@ fn fenced_blocks(source: &str) -> Vec<String> {
         }
     }
 
-    assert!(current.is_none(), "unclosed `{OPEN}` fence in example.config.toml");
+    assert!(
+        current.is_none(),
+        "unclosed `{OPEN}` fence in example.config.toml"
+    );
     blocks
 }
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_config_plugins.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_config_plugins.rs
@@ -6,7 +6,7 @@
 //! TUI-only — no CLI parity leg). It drives the real `ainb` binary in a
 //! detached tmux session and exercises the full loop end-to-end:
 //!
-//!   tmux `C` → host GoToConfig → Configuration screen
+//!   tmux `o` → host GoToConfig → Configuration screen
 //!     → `j`×5 to the Plugins category (Categories pane)
 //!     → the learnings `[[config]]` rows paint (built from the loaded
 //!       manifest by `ConfigScreenState::apply_plugin_manifests`, seeded
@@ -26,9 +26,10 @@
 //! - ALSO seeds `config.toml` with `[plugins.learnings].learnings_dir` so the
 //!   pre-edit render is deterministic AND the file already has the section the
 //!   final grep checks.
-//! - Re-presses `C` each poll on the open step (the resend pattern) — the
-//!   first `C` can land before the host's first paint and be dropped; `C` is
-//!   idempotent once on the Config screen.
+//! - Re-presses `o` each poll on the open step (the resend pattern) — the
+//!   first `o` can land before the host's first paint and be dropped; `o` is
+//!   idempotent once on the Config screen. (It was `C` until 7f402237 made the
+//!   home-screen shortcuts all-lowercase, which this test did not follow.)
 //! - Asserts EXACT unique tokens, never a substring-OR.
 
 use std::fs;
@@ -179,9 +180,9 @@ fn send_key(session: &str, key: &str) {
 /// category and assert the learnings `[[config]]` row renders. Returns the
 /// capture once the Plugins category shows the field label.
 fn open_plugins_category(session: &str) -> Option<String> {
-    // Open Settings — resend `C` until the Configuration title paints.
+    // Open Settings — resend `o` until the Configuration title paints.
     let open_deadline = Instant::now() + Duration::from_secs(30);
-    poll_capture_resending(session, "C", open_deadline, |c| c.contains(CONFIG_TITLE))?;
+    poll_capture_resending(session, "o", open_deadline, |c| c.contains(CONFIG_TITLE))?;
 
     // Focus starts on the Categories pane. Step down to Plugins (index 5 of
     // ConfigCategory::all(): Authentication, Workspace, Docker, AgentDefaults,
@@ -199,17 +200,39 @@ fn open_plugins_category(session: &str) -> Option<String> {
     })
 }
 
+/// Press `j` in the Settings pane until the SELECTED row (the one carrying the
+/// `▶` marker) contains `needle`.
+///
+/// The Plugins category now leads with one enable/disable toggle per loaded
+/// plugin, so the old "one Down past the placeholder" hop lands on a different
+/// row depending on how many plugins are staged. Stepping until the selection
+/// matches is index-free and cannot drift.
+fn step_to_selected_row(session: &str, needle: &str) -> bool {
+    for _ in 0..40 {
+        let cap = capture_pane(session);
+        let selected = cap.lines().find(|line| line.contains("▶") && line.contains(needle));
+        if selected.is_some() {
+            return true;
+        }
+        send_key(session, "j");
+        thread::sleep(Duration::from_millis(120));
+    }
+    false
+}
+
 /// Edit the learnings_dir row from the Plugins category: focus the Settings
-/// pane, move to the first plugin row (one Down past the `installed_plugins`
-/// placeholder — learnings_dir is the first manifest field), open the text
-/// popup, clear the seeded value, type [`EDITED_VALUE`], and confirm. The
-/// confirm triggers the host's apply→`AppConfig::save()` hook (cf7fe1e), so
-/// the value persists to config.toml without an explicit save-all.
+/// pane, step to the learnings_dir row, open the text popup, clear the seeded
+/// value, type [`EDITED_VALUE`], and confirm. The confirm triggers the host's
+/// apply→`AppConfig::save()` hook (cf7fe1e), so the value persists to
+/// config.toml without an explicit save-all.
 fn edit_learnings_dir_value(session: &str) {
     send_key(session, "l"); // focus Settings pane
     thread::sleep(Duration::from_millis(200));
-    send_key(session, "j"); // installed_plugins -> learnings_dir
-    thread::sleep(Duration::from_millis(200));
+    if !step_to_selected_row(session, FIELD_LABEL) {
+        let last = capture_pane(session);
+        let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
+        panic!("could not select the {FIELD_LABEL:?} row; last:\n---\n{last}\n---");
+    }
     send_key(session, "Enter"); // open the text-input popup
 
     // Wait for the popup to mount (it pre-fills with the seeded value).

--- a/ainb-tui/crates/ainb-core/tests/tripwire_config_plugins.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_config_plugins.rs
@@ -209,15 +209,27 @@ fn open_plugins_category(session: &str) -> Option<String> {
 /// matches is index-free and cannot drift.
 fn step_to_selected_row(session: &str, needle: &str) -> bool {
     for _ in 0..40 {
-        let cap = capture_pane(session);
-        let selected = cap.lines().find(|line| line.contains("▶") && line.contains(needle));
-        if selected.is_some() {
+        if selected_settings_row(&capture_pane(session)).is_some_and(|row| row.contains(needle)) {
             return true;
         }
         send_key(session, "j");
         thread::sleep(Duration::from_millis(120));
     }
     false
+}
+
+/// The selected row of the RIGHT-hand settings pane.
+///
+/// Both panes share every terminal line, so `line.contains("▶") &&
+/// line.contains(label)` is a false match whenever the left pane's selection
+/// happens to sit on the same row as the label — which depends on plugin
+/// discovery order and so flaked about one run in three. Split at the pane
+/// divider and only look right of it.
+fn selected_settings_row(capture: &str) -> Option<&str> {
+    capture
+        .lines()
+        .filter_map(|line| line.split("││").nth(1))
+        .find(|segment| segment.trim_start().starts_with('▶'))
 }
 
 /// Edit the learnings_dir row from the Plugins category: focus the Settings

--- a/ainb-tui/crates/ainb-core/tests/tripwire_config_registry_screen.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_config_registry_screen.rs
@@ -1,0 +1,365 @@
+//! Tripwire: the registry-driven Settings screen, end to end in real tmux.
+//!
+//! The settings rows now come from `CONFIG_REGISTRY` rather than a hand-written
+//! list, which is only worth anything if a user can actually reach a leaf and
+//! change it. This drives the real `ainb` binary and exercises the whole loop:
+//!
+//!   `o` → Configuration screen (row count in the title proves registry rows,
+//!         not the old ~24 hand-written ones)
+//!     → `j` down the tree to Container Templates
+//!     → `Space` expands it; per-template child nodes appear that were NOT
+//!       there before (the tree mirrors the TOML sections)
+//!     → `/` opens the filter; typing a dotted key finds a leaf in a section
+//!       the tree is not even on
+//!     → `Enter` edits the match, the new value is typed and confirmed
+//!     → the row re-renders with the new value
+//!     → `Esc` `Esc` returns to the HomeScreen (the return path, per the
+//!       tmux-ui-tripwire skill's forward+return rule)
+//!     → the seeded config.toml carries the NEW value and no longer the old one
+//!
+//! Per the tmux-ui-tripwire skill:
+//! - Skips gracefully if tmux isn't on PATH.
+//! - Runs with `AINB_DISABLE_PLUGINS=1`: this is the host's own code path, and
+//!   it must not depend on a staged plugin tree to be testable.
+//! - Seeds an isolated HOME with `onboarding.toml` (skip the first-run wizard)
+//!   and a dismissed notify-install prompt, so neither modal eats a keystroke.
+//! - Navigates by POLLING FOR THE PANE TITLE rather than counting `j` presses,
+//!   so adding a category cannot silently retarget the test at another section.
+//! - Asserts the exact rendered row (`<key> : <value>`), never a substring-OR:
+//!   `capture.contains("450")` alone would pass off any digit anywhere.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// The row the test edits, and its seeded / edited values. `idle_grace_secs`
+/// is a `Number` row with a declared range, so the edit also exercises the
+/// registry's validation on the way to disk.
+const ROW_KEY: &str = "mcp_pool.idle_grace_secs";
+const SEED_SECS: &str = "300";
+const EDITED_SECS: &str = "450";
+
+/// The Configuration screen title token (host `config_screen.rs`).
+const CONFIG_TITLE: &str = "Configuration";
+
+/// The category whose tree node must expand into per-template children.
+const TREE_CATEGORY: &str = "Container Templates";
+
+/// A child node the expansion must reveal: the `claude-dev` template's node,
+/// title-cased by the tree. Distinct from the lower-case `claude-dev` that
+/// appears as a *value* in the right-hand pane, so this token can only come
+/// from the tree.
+const TREE_CHILD: &str = "Claude-dev";
+
+/// A HomeScreen marker (mirrors the other tripwires).
+const HOME_MARKER: &str = "Stats";
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Seed an isolated HOME: skip the first-run wizard, dismiss the notify prompt,
+/// and pre-write the row this test edits so the pre-edit render is
+/// deterministic AND the file the final assertion inspects already has it.
+fn seed_isolated_home(home: &Path) -> PathBuf {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create config dir");
+
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+
+    let config_path = cfg.join("config.toml");
+    fs::write(
+        &config_path,
+        format!("[mcp_pool]\nenabled = true\nidle_grace_secs = {SEED_SECS}\n"),
+    )
+    .expect("seed config.toml");
+
+    let paths = ainb_plugin_notifyd::Paths::under(home.join(".agents-in-a-box"));
+    fs::create_dir_all(&paths.base).expect("create agents-in-a-box base");
+    ainb_plugin_notifyd::dismiss_prompt(&paths).expect("seed dismissed notify prompt");
+
+    config_path
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+/// Re-sends `key` on each iteration until `ok` holds. Only safe for idempotent
+/// keys — used here for `o` (a no-op once the screen is open).
+fn poll_capture_resending<F>(
+    session: &str,
+    key: &str,
+    deadline: Instant,
+    mut ok: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    send_key(session, key);
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+        send_key(session, key);
+    }
+    None
+}
+
+fn send_key(session: &str, key: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+}
+
+fn type_literal(session: &str, text: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, "-l", text])
+        .status()
+        .expect("tmux type literal");
+}
+
+fn kill(session: &str) {
+    let _ = Command::new("tmux").args(["kill-session", "-t", session]).status();
+}
+
+/// The rendered row for `key`, with the padding collapsed: `"<key> : <value>"`.
+/// Returns `None` when no line mentions the key.
+///
+/// Asserting on this rather than on `capture.contains(value)` is the difference
+/// between "the edit landed on this row" and "the number 450 appears somewhere
+/// on a 200-column screen".
+fn rendered_row(capture: &str, key: &str) -> Option<String> {
+    let line = capture.lines().find(|line| line.contains(key))?;
+    // Start AT the key: the same terminal row also carries the left pane's tree
+    // and both panes' borders, none of which belong to this assertion.
+    let start = line.find(key)?;
+    let segment = line[start..].trim_end_matches(['│', ' ']);
+    Some(segment.split_whitespace().collect::<Vec<_>>().join(" "))
+}
+
+/// Step the tree down until the right-hand pane's title is `label`, which is
+/// how the screen names the SELECTED node. Index-free, so inserting a category
+/// cannot silently point this test at a different section.
+fn step_to_node(session: &str, label: &str) -> Option<String> {
+    let wanted = format!("╭ {label} ");
+    for _ in 0..30 {
+        let cap = capture_pane(session);
+        if cap.contains(&wanted) {
+            return Some(cap);
+        }
+        send_key(session, "j");
+        thread::sleep(Duration::from_millis(150));
+    }
+    None
+}
+
+#[test]
+fn settings_tree_search_and_edit_reach_config_toml() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    let config_path = seed_isolated_home(home_tmp.path());
+
+    let session = format!("tripwire-config-registry-{}", std::process::id());
+    let status = Command::new("tmux")
+        .args(["new-session", "-d", "-s", &session, "-x", "200", "-y", "50"])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed");
+
+    let cmd = format!(
+        "HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+        home_tmp.path().display(),
+        ainb_bin().display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("tmux send launch cmd");
+
+    let home_deadline = Instant::now() + Duration::from_secs(45);
+    if poll_capture(&session, home_deadline, |c| {
+        c.contains(HOME_MARKER) && c.contains("[i]")
+    })
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
+    }
+
+    // 1. Open Settings. The title carries the row count, which is the cheapest
+    //    proof the rows came from the registry: the old hand-written list could
+    //    not reach three figures.
+    let open_deadline = Instant::now() + Duration::from_secs(30);
+    let Some(opened) =
+        poll_capture_resending(&session, "o", open_deadline, |c| c.contains(CONFIG_TITLE))
+    else {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("Settings never opened; last:\n---\n{last}\n---");
+    };
+    let row_count = settings_count(&opened).unwrap_or_else(|| {
+        kill(&session);
+        panic!("title did not report a row count:\n---\n{opened}\n---");
+    });
+    assert!(
+        row_count > 100,
+        "expected the registry's ~150 rows, got {row_count}; the screen is still on a \
+         hand-written list:\n---\n{opened}\n---"
+    );
+
+    // 2. The tree expands. Before pressing Space the child nodes must NOT be on
+    //    screen, or "expanding worked" would be unfalsifiable.
+    let Some(before_expand) = step_to_node(&session, TREE_CATEGORY) else {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("never reached the {TREE_CATEGORY} node; last:\n---\n{last}\n---");
+    };
+    assert!(
+        !before_expand.contains(TREE_CHILD),
+        "the tree was already expanded, so this test cannot prove Space expands \
+         it:\n---\n{before_expand}\n---"
+    );
+
+    send_key(&session, "Space");
+    let expand_deadline = Instant::now() + Duration::from_secs(15);
+    let expanded = poll_capture(&session, expand_deadline, |c| c.contains(TREE_CHILD));
+    if expanded.is_none() {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("Space did not expand {TREE_CATEGORY} into {TREE_CHILD}; last:\n---\n{last}\n---");
+    }
+
+    // 3. `/` finds a leaf in a section the tree is not on. The filter is the
+    //    whole reason a 150-row tree is usable, so it has to reach across.
+    send_key(&session, "/");
+    thread::sleep(Duration::from_millis(300));
+    type_literal(&session, "idle_grace_secs");
+    let search_deadline = Instant::now() + Duration::from_secs(15);
+    let Some(matched) = poll_capture(&session, search_deadline, |c| c.contains(ROW_KEY)) else {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("`/` search did not surface {ROW_KEY}; last:\n---\n{last}\n---");
+    };
+    assert_eq!(
+        rendered_row(&matched, ROW_KEY).as_deref(),
+        Some(format!("{ROW_KEY} : {SEED_SECS}").as_str()),
+        "the filtered row did not render its seeded value:\n---\n{matched}\n---"
+    );
+
+    // 4. Edit it. The popup pre-fills with the current value; clear and retype.
+    send_key(&session, "Enter");
+    let popup_deadline = Instant::now() + Duration::from_secs(15);
+    if poll_capture(&session, popup_deadline, |c| {
+        c.contains("Enter save | Esc cancel")
+    })
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("the edit popup never mounted; last:\n---\n{last}\n---");
+    }
+    for _ in 0..(SEED_SECS.len() + 4) {
+        send_key(&session, "BSpace");
+    }
+    type_literal(&session, EDITED_SECS);
+    thread::sleep(Duration::from_millis(200));
+    send_key(&session, "Enter");
+
+    // 5. The row re-renders with the new value — exact `key : value`, so a
+    //    stray "450" elsewhere on screen cannot pass this.
+    let edited_deadline = Instant::now() + Duration::from_secs(15);
+    let edited = poll_capture(&session, edited_deadline, |c| {
+        rendered_row(c, ROW_KEY).as_deref() == Some(format!("{ROW_KEY} : {EDITED_SECS}").as_str())
+    });
+    if edited.is_none() {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!(
+            "the edited row did not re-render as '{ROW_KEY} : {EDITED_SECS}'; \
+             last:\n---\n{last}\n---"
+        );
+    }
+
+    // 6. Return path: Esc clears the filter, Esc leaves Settings. A forward-only
+    //    test passes while the way back is broken.
+    send_key(&session, "Escape");
+    thread::sleep(Duration::from_millis(400));
+    send_key(&session, "Escape");
+    let back_deadline = Instant::now() + Duration::from_secs(15);
+    let back = poll_capture(&session, back_deadline, |c| {
+        c.contains(HOME_MARKER) && !c.contains(CONFIG_TITLE)
+    });
+    let last = capture_pane(&session);
+    kill(&session);
+    assert!(
+        back.is_some(),
+        "Esc did not return to the HomeScreen; last:\n---\n{last}\n---"
+    );
+
+    // 7. The edit is on disk, and the old value is gone — a save that appended
+    //    rather than replaced would leave both.
+    let on_disk = fs::read_to_string(&config_path).expect("read seeded config.toml");
+    assert!(
+        on_disk.contains(&format!("idle_grace_secs = {EDITED_SECS}")),
+        "config.toml did not persist the edit; contents:\n---\n{on_disk}\n---"
+    );
+    assert!(
+        !on_disk.contains(&format!("idle_grace_secs = {SEED_SECS}")),
+        "config.toml still carries the old value; contents:\n---\n{on_disk}\n---"
+    );
+}
+
+/// Parse the `(N settings)` badge out of the Configuration title bar.
+fn settings_count(capture: &str) -> Option<usize> {
+    let line = capture.lines().find(|line| line.contains(CONFIG_TITLE))?;
+    let start = line.find('(')? + 1;
+    let rest = &line[start..];
+    let end = rest.find(" settings")?;
+    rest[..end].trim().parse().ok()
+}

--- a/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-burndown/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
+toml_edit = { workspace = true }
 toml = { workspace = true }
 async-trait = "0.1"
 nucleo-matcher = "0.3"

--- a/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
@@ -150,32 +150,62 @@ impl AppConfig {
         })
     }
 
-    /// Atomic write of `~/.agents-in-a-box/config/config.toml`. Replaces only
-    /// the `[usage]` table; leaves every other table the plugin doesn't
-    /// own intact.
+    /// Atomic write of `~/.agents-in-a-box/config/config.toml`, touching only
+    /// the `[usage]` table.
+    ///
+    /// This plugin now shares the file with `ainb-core`, so two things that
+    /// used to be harmless are not:
+    ///
+    /// * Rendering through `toml::to_string_pretty` deleted every comment.
+    ///   Core edits this file through `toml_edit` specifically to keep them —
+    ///   users are told to start from `config/example.config.toml`, which is
+    ///   ~320 lines of explanation — and one `ainb burndown plan set` would
+    ///   have undone that for the whole file.
+    /// * Writing back the whole `_original` snapshot reverted anything core or
+    ///   `ainb config set` wrote between this plugin's `load()` and its
+    ///   `save()`. Re-reading here and editing in place narrows that to the
+    ///   `[usage]` table this plugin actually owns.
     pub fn save(&self) -> Result<()> {
         let path = config_path()?;
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Start from the parsed original (or an empty inline table) so
-        // we preserve [docker], [ui_preferences], etc.
-        let mut root = self
-            ._original
-            .clone()
-            .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
-        if let toml::Value::Table(ref mut table) = root {
-            let usage_value =
-                toml::Value::try_from(&self.usage).context("failed to serialise [usage] table")?;
-            table.insert("usage".to_string(), usage_value);
-        }
-        let content =
-            toml::to_string_pretty(&root).context("failed to serialise config to TOML")?;
+        // Re-read rather than trusting the snapshot from `load()`: another
+        // writer may have touched the file since.
+        let existing = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(err) => {
+                return Err(err).with_context(|| format!("failed to read {}", path.display()));
+            }
+        };
+        let mut doc = if existing.trim().is_empty() {
+            toml_edit::DocumentMut::new()
+        } else {
+            existing
+                .parse::<toml_edit::DocumentMut>()
+                .with_context(|| format!("failed to parse {}", path.display()))?
+        };
 
-        // Best-effort atomic write: tmp + rename.
-        let tmp = path.with_extension("toml.tmp");
-        std::fs::write(&tmp, content)?;
+        let usage_value =
+            toml::Value::try_from(&self.usage).context("failed to serialise [usage] table")?;
+        let rendered = toml::to_string_pretty(&toml::Value::Table(
+            [("usage".to_string(), usage_value)].into_iter().collect(),
+        ))
+        .context("failed to serialise [usage] table")?;
+        let fragment = rendered
+            .parse::<toml_edit::DocumentMut>()
+            .context("failed to re-parse the [usage] table")?;
+        if let Some(item) = fragment.get("usage") {
+            doc["usage"] = item.clone();
+        }
+
+        // Atomic, and with a per-process temp name: core writes this same
+        // directory, and a shared `config.toml.tmp` let either process rename
+        // the other's half-written file over the real one.
+        let tmp = path.with_extension(format!("toml.{}.tmp", std::process::id()));
+        std::fs::write(&tmp, doc.to_string())?;
         std::fs::rename(&tmp, &path)?;
         Ok(())
     }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
@@ -2,7 +2,7 @@
 //!
 //! ainb-core lives on the host side and the plugin can't link against it,
 //! so we define a narrow set of POD types matching the on-disk
-//! `~/.agents-in-a-box/config.toml` schema for the fields the plugin
+//! `~/.agents-in-a-box/config/config.toml` schema for the fields the plugin
 //! cares about (plan projection + currency display).
 //!
 //! Wire shape is identical to `ainb-core::config::{UsagePlan, UsagePlanId,
@@ -96,7 +96,7 @@ fn default_exchange_rate() -> f64 {
 
 /// Subset of ainb-core's `UsageConfig` the plugin reads/writes.
 ///
-/// The on-disk schema in `~/.agents-in-a-box/config.toml` lives under the
+/// The on-disk schema in `~/.agents-in-a-box/config/config.toml` lives under the
 /// `[usage]` table. The plugin only owns this slice — other top-level
 /// tables (docker, mcp, ui_preferences, etc.) are read-modify-write
 /// preserved through `toml::Value` round-tripping in [`AppConfig::save`].
@@ -123,7 +123,7 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
-    /// Read `~/.agents-in-a-box/config.toml` (if present), parsing only
+    /// Read `~/.agents-in-a-box/config/config.toml` (if present), parsing only
     /// the `[usage]` table. Other tables are retained as raw
     /// `toml::Value` so `save()` can write them back unchanged.
     pub fn load() -> Result<Self> {
@@ -150,7 +150,7 @@ impl AppConfig {
         })
     }
 
-    /// Atomic write of `~/.agents-in-a-box/config.toml`. Replaces only
+    /// Atomic write of `~/.agents-in-a-box/config/config.toml`. Replaces only
     /// the `[usage]` table; leaves every other table the plugin doesn't
     /// own intact.
     pub fn save(&self) -> Result<()> {
@@ -181,7 +181,12 @@ impl AppConfig {
     }
 }
 
+/// `~/.agents-in-a-box/config/config.toml`.
+///
+/// The `config/` segment matters: this plugin used to read and write the file
+/// one level up, so the `[usage]` plan it stored was invisible to `ainb-core`
+/// and vice versa.
 fn config_path() -> Result<PathBuf> {
     let home = dirs::home_dir().context("could not resolve home directory")?;
-    Ok(home.join(".agents-in-a-box").join("config.toml"))
+    Ok(home.join(".agents-in-a-box").join("config").join("config.toml"))
 }

--- a/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-burndown/src/config.rs
@@ -205,8 +205,32 @@ impl AppConfig {
         // directory, and a shared `config.toml.tmp` let either process rename
         // the other's half-written file over the real one.
         let tmp = path.with_extension(format!("toml.{}.tmp", std::process::id()));
-        std::fs::write(&tmp, doc.to_string())?;
-        std::fs::rename(&tmp, &path)?;
+        if let Err(err) = std::fs::write(&tmp, doc.to_string()) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(err.into());
+        }
+        // Carry the target's mode across. A temp file is created under the
+        // umask, so without this a `chmod 600` on a config holding the bridge's
+        // bot tokens and the skills API key comes back world-readable after a
+        // plan set. Core's `write_atomic` guards this for the same reason.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path)
+                .map(|m| m.permissions().mode() & 0o777)
+                .unwrap_or(0o600);
+            if let Err(err) = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(mode))
+            {
+                let _ = std::fs::remove_file(&tmp);
+                return Err(err.into());
+            }
+        }
+        // Remove the temp on failure: the name is per-process, so nothing would
+        // ever overwrite a leftover holding the full config, secrets included.
+        if let Err(err) = std::fs::rename(&tmp, &path) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(err.into());
+        }
         Ok(())
     }
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
@@ -33,7 +33,7 @@ pub enum StoreError {
 }
 
 /// Retention policy applied on every insert. Mirrors the runtime
-/// config in `~/.agents-in-a-box/config.toml [notifyd]`.
+/// config in `~/.agents-in-a-box/config/config.toml [notifyd]`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RetentionPolicy {
     /// Delete rows whose `ts` is older than this many days. `0` =

--- a/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-session-reader/src/config.rs
@@ -1,5 +1,5 @@
 //! Plugin-side config: the `[session_reader]` table of
-//! `~/.agents-in-a-box/config.toml`.
+//! `~/.agents-in-a-box/config/config.toml`.
 //!
 //! Read-only — the host owns the file; this plugin only consumes its
 //! own table (mirroring the burndown plugin's disk-read pattern, since
@@ -82,10 +82,14 @@ pub fn load_from(path: &Path) -> SessionReaderConfig {
     }
 }
 
-/// `~/.agents-in-a-box/config.toml`, resolved via `$HOME`.
+/// `~/.agents-in-a-box/config/config.toml`, resolved via `$HOME`.
+///
+/// The `config/` segment matters: this plugin used to read the file one level
+/// up, which nothing writes. `[session_reader]` set the way the docs describe
+/// therefore never reached it.
 fn default_config_path() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
-    Some(PathBuf::from(home).join(".agents-in-a-box").join("config.toml"))
+    Some(PathBuf::from(home).join(".agents-in-a-box").join("config").join("config.toml"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Two data-loss bugs in the user config, found while auditing the config surface for the settings-menu rejig (epic `agents-in-a-box-wg83`, bead `agents-in-a-box-d8j2`).

## 1. Saving config.toml destroyed sections nobody modelled

`AppConfig::save()` rewrote the whole file from the struct:

```rust
let content = toml::to_string_pretty(self)?;
fs::write(&config_path, &content)
```

`AppConfig` does not model every section in that file:

| section | who reads it | was |
|---|---|---|
| `[skills]` — catalog release, API key | `ainb-cli` catalog | destroyed |
| `[session_reader]` — incremental window | session-reader plugin | destroyed |
| `[fleet.bridge]` — Telegram/Slack/Discord **bot tokens** | phone bridge | destroyed |

All three live at `~/.agents-in-a-box/config/config.toml`, so **any** settings save from the TUI wiped them.

Fix: overlay the modelled sections onto whatever is already on disk, leaving other top-level sections untouched. `[fleet.bridge]` needed more than that — `fleet` *is* modelled, so a table nested under it with no field is still dropped — so it gets a verbatim passthrough field.

The overlay is deliberately shallow: a modelled section is replaced wholesale, so *removing* an entry from it still sticks. There is a test for that too.

## 2. The user config had two paths

`burndown` and `session-reader` read and wrote `~/.agents-in-a-box/config.toml` — one directory above the `~/.agents-in-a-box/config/config.toml` everything else uses.

Consequences: a `[usage]` plan stored by burndown was invisible to `ainb-core` and vice versa, and the `[session_reader]` window that `example.config.toml` tells you to set landed in a file the plugin never opened.

Fix: both plugins point at the canonical path. `AppConfig::load()` folds any stray file left by an older build into it once — canonical wins on conflict, and the old file is kept as `config.toml.migrated` rather than deleted.

## Verification

Each fix was negative-verified: neutralised individually, its test fails.

- `save_preserves_sections_app_config_does_not_model` fails without the overlay, and again without the `fleet.bridge` passthrough
- `save_replaces_modelled_sections_wholesale` — deletions still stick
- `overlay_output_is_valid_toml_for_a_full_config` — the overlay serializes a sorted map, not the struct, so scalar-after-table ordering is checked explicitly
- `migrate_folds_stray_config_in_and_moves_it_aside`

Green: `ainb` lib 1894, `ainb-plugin-burndown` 229, `ainb-plugin-session-reader` 122, `ainb --test behavioral` 51. Full tripwire suite not run locally; leaving that to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options for Copilot, session preferences, container templates, MCP servers, Fleet, usage, skills, session reader, and presets.
  * Redesigned Settings with collapsible categories, search, clearer controls, plugin toggles, and validation feedback.
  * Added secure keychain storage for secret configuration values.

* **Bug Fixes**
  * Preserves unsupported configuration sections and comments during saves.
  * Migrates legacy configuration files automatically and prevents stalled keychain lookups.
  * Improved CLI handling for clearing individual settings and prevents unnecessary saves.

* **Documentation**
  * Updated example configuration and configuration-path documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->