### PR TITLE
feat: make the env-only and hardcoded config knobs settable

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -10,6 +10,26 @@
 version = "0.1.0"
 
 # =============================================================================
+# General
+# =============================================================================
+# --8<-- parse
+# [general]
+# ## Colourise fenced code blocks in agent output. NO_COLOR still wins over
+# ## this and over AGENTS_BOX_SYNTAX_HIGHLIGHT.
+# syntax_highlight = true
+#
+# ## Install skills into each tool's real config dir (~/.claude, ~/.codex, ...)
+# ## rather than ainb's managed sandbox. True is the shipped behaviour: an
+# ## installed skill has to be where the tool actually looks.
+# skill_install_real_homes = true
+#
+# ## Base directory for ainb state: <home>/.agents-in-a-box/...
+# ## Unset means your OS home directory. This does NOT move config.toml, which
+# ## is always read from the OS home.
+# home = "/Volumes/work"
+# -->8--
+
+# =============================================================================
 # Authentication
 # =============================================================================
 [authentication]
@@ -84,6 +104,15 @@ max_repositories = 500
 # Behavior when a target worktree path already exists
 # Options: "auto_rename" | "error"
 worktree_collision_behavior = "auto_rename"
+
+# How many directory levels below each scan path the scanner descends.
+# Raise it for deeply nested checkouts; every extra level multiplies the walk.
+scan_max_depth = 3
+
+# Seconds a cached repository scan stays fresh before the scanner walks the
+# disk again. The cache is also invalidated when a scan path's mtime changes,
+# so this is the ceiling on staleness rather than the only guard.
+scan_cache_ttl_secs = 3600
 
 # =============================================================================
 # UI Preferences
@@ -348,6 +377,41 @@ session_filter = "all"
 # # Options: "warp" | "iterm" | "ghostty" | "terminal" (default: "warp")
 # terminal = "warp"
 #
+# ## Minutes of quiet before a session reads IDLE. One knob for both producers
+# ## (the tmux classifier and notifyd's hook fold), so they cannot disagree.
+# ## Env: AINB_FLEET_IDLE_MIN
+# idle_min = 5
+#
+# ## How `ainb fleet send` delivers.
+# ## "tmux" send-keys first with a broker fallback (default), "tmux-only" never
+# ## touches the broker, "broker" tries the broker first.
+# ## Env: AINB_FLEET_TRANSPORT
+# transport = "tmux"
+#
+# ## Attach cost/hint enrichment to fleet rows. False still serves free cached
+# ## suggestions but runs no producer, so it spends no tokens.
+# ## Env: AINB_FLEET_ENRICH
+# enrich = true
+#
+# ## Milliseconds before a STICKY hook row (ASK/ERR/WAIT/IDLE) stops being
+# ## trusted and the reader falls back to a live scan. 0 disables the check:
+# ## those states only change on a new event, so age is a poor signal for them.
+# ## Env: AINB_FLEET_STATE_STALE_MS
+# state_stale_ms = 0
+#
+# ## Milliseconds before a HEALTHY hook row (RUNNING/DONE) stops suppressing
+# ## the live scan. Its own knob, because a daemon that stopped materializing
+# ## would otherwise mask a real need forever. Before this key existed both
+# ## windows read AINB_FLEET_STATE_STALE_MS with different hardcoded fallbacks.
+# ## Env: AINB_FLEET_HEALTHY_STATE_STALE_MS (AINB_FLEET_STATE_STALE_MS still
+# ## works as a legacy fallback).
+# healthy_state_stale_ms = 300000
+#
+# ## Seconds of pane silence before tmux discovery calls a live session
+# ## "between turns" rather than working.
+# ## Env: AINB_FLEET_TMUX_IDLE_AFTER_SECS
+# tmux_idle_after_secs = 120
+#
 # # Budget caps for `ainb fleet cost`, in USD. Unset means no cap.
 # [fleet.cost]
 # session_usd = 5.0
@@ -377,3 +441,149 @@ session_filter = "all"
 # [presets]
 # file = "../presets.toml"
 # -->8--
+
+# =============================================================================
+# UI tunables
+# =============================================================================
+# Cadences and query bounds, as opposed to [ui_preferences] above, which is
+# what the interface looks like and which the TUI writes back itself.
+#
+# --8<-- parse
+# [ui]
+# ## Milliseconds between input polls. Lower feels snappier and costs CPU;
+# ## ~30fps by default.
+# tick_rate_ms = 33
+#
+# ## Milliseconds between the heavy periodic passes (tmux previews, mascot
+# ## animation, OAuth refresh checks). Deliberately much coarser than the poll:
+# ## running these per poll starves the event loop.
+# app_tick_ms = 250
+#
+# ## Rows the attention-marker query reads per refresh, and how far back an
+# ## event may still raise a session's [?] / [!] marker.
+# session_query_limit = 500
+# session_lookback_hours = 6
+#
+# ## Rows the Inbox lists. The query runs every render, so keep it modest.
+# inbox_list_limit = 200
+#
+# ## Milliseconds in which two clicks count as one double-click.
+# double_click_ms = 300
+# -->8--
+
+# =============================================================================
+# Usage client
+# =============================================================================
+# How ainb FETCHES and caches usage data. Deliberately not [usage] above: that
+# section belongs to the burndown plugin, which writes it itself, so ainb-core
+# treats it as read-only. These four knobs are core's own.
+#
+# --8<-- parse
+# [usage_client]
+# ## Port the ainb-managed Headroom compression proxy listens on.
+# ## Env: AINB_HEADROOM_PORT
+# headroom_port = 8787
+#
+# ## Seconds `ainb usage` waits for data before giving up. The first scan of a
+# ## large ~/.claude/projects is slow; raise this against a huge archive.
+# ## Env: AINB_USAGE_TIMEOUT_SECS
+# fetch_timeout_secs = 120
+#
+# ## Seconds between Codex statusline usage refreshes.
+# ## Env: AINB_CODEX_USAGE_TTL_SECS
+# codex_ttl_secs = 60
+#
+# ## Override the usage cache database. Unset derives
+# ## <home>/.agents-in-a-box/cache/usage.db.
+# ## Env: AINB_USAGE_CACHE_DB
+# cache_db = "/tmp/usage.db"
+# -->8--
+
+# =============================================================================
+# Daemons
+# =============================================================================
+# --8<-- parse
+# [daemons]
+# ## Milliseconds without a heartbeat before a daemon whose pid is STILL alive
+# ## (a wedged daemon that stopped ticking) reads stale. A dead pid is caught
+# ## immediately regardless of this window.
+# stale_after_ms = 90000
+#
+# ## Milliseconds the bridge may go without a SUCCESSFUL attention poll before
+# ## its proactive-push half counts as broken. A different clock from the one
+# ## above: that asks "is the process alive", this asks "can it do the job".
+# attention_stale_after_ms = 45000
+#
+# [notifyd]
+# ## Seconds one (session, event) pair waits before it may raise another OS
+# ## notification. Keeps a noisy session out of Notification Center.
+# os_debounce_secs = 60
+#
+# ## Seconds an unanswered permission request waits before it is auto-DENIED.
+# ## The bottom of a timeout ladder (broker < client re-dial < Claude's hook
+# ## timeout), so values above 630 are clamped rather than trusted.
+# approval_timeout_secs = 600
+# -->8--
+
+# =============================================================================
+# Web dashboard
+# =============================================================================
+# Defaults for `ainb web`. Its CLI flags still win, because a flag is a
+# decision about one invocation and this file is a standing preference.
+#
+# The bearer token is NOT settable here. Pass `--token <secret>`; it goes to
+# the OS keychain and never into this file.
+#
+# --8<-- parse
+# [web]
+# ## host:port to bind. A non-loopback address still has to clear the bind
+# ## security check, so setting it here cannot expose anything a flag could not.
+# listen = "127.0.0.1:8420"
+#
+# ## Serve viewer-only: the live WS terminal and POST /api/answer are refused.
+# read_only = false
+#
+# ## Allow a non-loopback bind with no token. Honoured ONLY together with
+# ## read_only; the security check refuses it otherwise.
+# insecure_bind = false
+# -->8--
+
+# =============================================================================
+# ACP adapters
+# =============================================================================
+# The adapter registry the Hangar daemon spawns ACP sessions from. Naming an
+# adapter overrides the built-in entry; naming a new one adds it. Omitting the
+# section keeps the built-in `claude-agent-acp` and `codex-acp` entries.
+#
+# --8<-- parse
+# [acp.adapters.claude-agent-acp]
+# ## Executable to spawn. Unset resolves the adapter's own name on PATH.
+# command = "/opt/homebrew/bin/claude-agent-acp"
+#
+# ## The permission mode PINNED at session/new and re-asserted after every
+# ## session/load. Never leave an adapter to inherit ambient state: one was
+# ## observed picking up "bypassPermissions", which disables the whole
+# ## permission surface silently.
+# ## Options: "default" | "acceptEdits" | "bypassPermissions" | "plan"
+# permission_mode = "default"
+# -->8--
+
+# =============================================================================
+# Hangar daemon
+# =============================================================================
+# NOT part of this file. These knobs live in the Hangar daemon's `daemon_config`
+# SQLite table (~/.agents-in-a-box/hangar.db), because the daemon reads them on
+# its own tick without restarting. They are listed in the settings screen under
+# "Hangar Daemon" and are settable from either surface:
+#
+#   ainb config set hangar_daemon.autostandup.enabled true
+#   ainb hangar daemon config set autostandup.stagnant_min 30
+#
+# Writing `[hangar_daemon]` into this file does nothing at all.
+#
+#   hangar_daemon.autostandup.enabled          bool         (default false)
+#   hangar_daemon.autostandup.stagnant_min     int 1..1440  (default 15)
+#   hangar_daemon.autostandup.cooldown_min     int 1..1440  (default 60)
+#   hangar_daemon.autostandup.max_concurrent   int 1..64    (default 1)
+#   hangar_daemon.card_agent.default           claude|codex|copilot (default claude)
+#   hangar_daemon.workspace.creation_disabled  bool         (default false)

--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -22,12 +22,12 @@ version = "0.1.0"
 # ## rather than ainb's managed sandbox. True is the shipped behaviour: an
 # ## installed skill has to be where the tool actually looks.
 # skill_install_real_homes = true
-#
-# ## Base directory for ainb state: <home>/.agents-in-a-box/...
-# ## Unset means your OS home directory. This does NOT move config.toml, which
-# ## is always read from the OS home.
-# home = "/Volumes/work"
 # -->8--
+#
+# The AINB_HOME env var still relocates ainb's state directory and is unchanged.
+# It has deliberately NOT been promoted to a config key: its readers disagree
+# about whether it names the state directory itself or its parent, so a key here
+# would have to pick one and silently scatter the other's files.
 
 # =============================================================================
 # Authentication

--- a/ainb-tui/crates/ainb-acp/tests/store_writer_fake_adapter.rs
+++ b/ainb-tui/crates/ainb-acp/tests/store_writer_fake_adapter.rs
@@ -386,8 +386,20 @@ async fn a_buffered_chunk_commits_on_the_interval_without_a_second_push() {
     );
     assert_eq!(rows(&store).await.len(), 0);
 
-    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
-    let high_water = writer.tick().await.expect("tick").expect("high water");
+    // Poll rather than sleeping a fixed 80ms: on a loaded CI runner the
+    // commit interval had not elapsed by the time the assertion ran, and the
+    // test failed claiming the chunk never committed.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let high_water = loop {
+        if let Some(hw) = writer.tick().await.expect("tick") {
+            break hw;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the buffered chunk never committed within 10s"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    };
 
     assert_eq!(high_water.session_key, SESSION_KEY);
     assert_eq!(rows(&store).await.len(), 1);

--- a/ainb-tui/crates/ainb-adapters-tool/src/install_root.rs
+++ b/ainb-tui/crates/ainb-adapters-tool/src/install_root.rs
@@ -62,11 +62,40 @@ pub fn read_root_for(tool: &str) -> PathBuf {
         }
     }
 
-    if let Some(real) = real_home_for(tool) {
-        return real;
+    if use_real_homes() {
+        if let Some(real) = real_home_for(tool) {
+            return real;
+        }
     }
 
     ainb_skill_core::default_ainb_home().join("tools").join(tool)
+}
+
+/// Whether tier 2 (the tool's real config dir) is in play at all.
+///
+/// True by default, because an installed skill has to be where the tool
+/// actually looks. `general.skill_install_real_homes = false`, which the host
+/// publishes as `AINB_USE_REAL_HOMES`, routes every read and write into the
+/// managed sandbox instead, for a machine whose `~/.claude` is hand-managed and
+/// must not be touched.
+///
+/// The variable had no reader at all before: real homes became the
+/// unconditional default and the opt-in flag was left documented but dead, so
+/// setting it did nothing. It is a live gate again, defaulting to the shipped
+/// behaviour.
+///
+/// This crate reads the variable rather than config.toml because it does not
+/// depend on `ainb`; the host fills it at startup
+/// (`ainb::config::tunables::export_env_bridge`), and an exported value still
+/// wins over the file.
+fn use_real_homes() -> bool {
+    match std::env::var("AINB_USE_REAL_HOMES") {
+        Ok(raw) => !matches!(
+            raw.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        Err(_) => true,
+    }
 }
 
 /// Best-effort per-tool real-home mapping. Returns `None` when the

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3803,7 +3803,22 @@ impl EventHandler {
     /// value another process has since changed.
     fn persist_config_screen(state: &mut AppState) -> anyhow::Result<PersistOutcome> {
         let pending = state.config_screen_state.pending_edits().len();
-        let dirty_before = !state.config_screen_state.dirty.is_empty();
+        // Daemon rows are excluded: they go to SQLite, and
+        // `apply_to_app_config` deliberately skips them, so a save that touched
+        // only daemon rows changed nothing in `app_config`. Counting them here
+        // let it fall through and rewrite config.toml from the startup
+        // snapshot — the exact revert this guard exists to prevent.
+        let dirty_before = state
+            .config_screen_state
+            .dirty
+            .iter()
+            .any(|key| !key.starts_with("hangar_daemon."));
+        let plugin_written = state
+            .config_screen_state
+            .dirty
+            .iter()
+            .filter(|key| key.starts_with("plugin:") || key.starts_with("plugin-enabled:"))
+            .count();
         let mut applied = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
         // Nothing to write: return before touching the file. `save()` renders
         // the whole AppConfig from the snapshot loaded at startup, so pressing
@@ -3855,7 +3870,10 @@ impl EventHandler {
         Ok(PersistOutcome {
             // The daemon rows are counted separately: they are not in
             // config.toml, and their write has not been attempted yet.
-            written: pending.saturating_sub(rejected.len() + queued_for_daemon),
+            // `pending_edits()` deliberately skips plugin rows, but
+            // `apply_plugin_rows` DOES write them — counting only pending
+            // meant editing any plugin setting completed in total silence.
+            written: pending.saturating_sub(rejected.len() + queued_for_daemon) + plugin_written,
             queued_for_daemon,
         })
     }
@@ -10531,6 +10549,29 @@ mod hangar_daemon_persist_tests {
     use super::*;
     use crate::app::state::{AppState, ConfigValue};
 
+    /// Point HOME at a tempdir for the duration of the test.
+    ///
+    /// `AppState::default()` calls the real `AppConfig::load()`, and
+    /// `persist_config_screen` can reach `save()` — so without this these tests
+    /// wrote the developer's own `~/.agents-in-a-box/config/config.toml`,
+    /// appended real audit entries, and mutated the process-wide tunables
+    /// snapshot that other tests in this binary read. Serialised, because the
+    /// environment is process-global and cargo runs tests in parallel.
+    fn with_isolated_home<T>(body: impl FnOnce() -> T) -> T {
+        static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let previous = std::env::var_os("HOME");
+        std::env::set_var("HOME", dir.path());
+        let out = body();
+        match previous {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        out
+    }
+
     /// Two Hangar-daemon edits confirmed inside one app tick must BOTH be
     /// written.
     ///
@@ -10541,28 +10582,30 @@ mod hangar_daemon_persist_tests {
     /// `assertion `left == right` failed: left: 1, right: 2`.
     #[test]
     fn two_daemon_edits_in_one_tick_are_both_queued() {
-        let mut state = AppState::default();
+        with_isolated_home(|| {
+            let mut state = AppState::default();
 
-        state
-            .config_screen_state
-            .set_row_value("hangar_daemon.autostandup.enabled", ConfigValue::Bool(true));
-        EventHandler::persist_config_screen(&mut state).expect("first persist");
+            state
+                .config_screen_state
+                .set_row_value("hangar_daemon.autostandup.enabled", ConfigValue::Bool(true));
+            EventHandler::persist_config_screen(&mut state).expect("first persist");
 
-        state.config_screen_state.set_row_value(
-            "hangar_daemon.autostandup.stagnant_min",
-            ConfigValue::Number(30),
-        );
-        EventHandler::persist_config_screen(&mut state).expect("second persist");
+            state.config_screen_state.set_row_value(
+                "hangar_daemon.autostandup.stagnant_min",
+                ConfigValue::Number(30),
+            );
+            EventHandler::persist_config_screen(&mut state).expect("second persist");
 
-        let queued: Vec<&str> =
-            state.pending_daemon_config_edits.iter().map(|(k, _)| k.as_str()).collect();
-        assert_eq!(
-            queued.len(),
-            2,
-            "both edits must survive until the tick drains them, got {queued:?}"
-        );
-        assert!(queued.contains(&"autostandup.enabled"), "{queued:?}");
-        assert!(queued.contains(&"autostandup.stagnant_min"), "{queued:?}");
+            let queued: Vec<&str> =
+                state.pending_daemon_config_edits.iter().map(|(k, _)| k.as_str()).collect();
+            assert_eq!(
+                queued.len(),
+                2,
+                "both edits must survive until the tick drains them, got {queued:?}"
+            );
+            assert!(queued.contains(&"autostandup.enabled"), "{queued:?}");
+            assert!(queued.contains(&"autostandup.stagnant_min"), "{queued:?}");
+        });
     }
 
     /// A daemon row is NOT reported as saved to config.toml: it has not been
@@ -10570,34 +10613,38 @@ mod hangar_daemon_persist_tests {
     /// error toast on the next tick.
     #[test]
     fn a_daemon_row_is_not_reported_as_saved_to_config_toml() {
-        let mut state = AppState::default();
-        state
-            .config_screen_state
-            .set_row_value("hangar_daemon.autostandup.enabled", ConfigValue::Bool(true));
+        with_isolated_home(|| {
+            let mut state = AppState::default();
+            state
+                .config_screen_state
+                .set_row_value("hangar_daemon.autostandup.enabled", ConfigValue::Bool(true));
 
-        let outcome = EventHandler::persist_config_screen(&mut state).expect("persist");
-        assert_eq!(outcome.written, 0, "nothing reached config.toml");
-        assert_eq!(outcome.queued_for_daemon, 1);
-        let message = outcome.message().expect("a daemon edit is still a change");
-        assert!(
-            !message.contains("config.toml"),
-            "a daemon row must not claim config.toml: {message}"
-        );
-        assert!(message.contains("Hangar daemon"), "{message}");
+            let outcome = EventHandler::persist_config_screen(&mut state).expect("persist");
+            assert_eq!(outcome.written, 0, "nothing reached config.toml");
+            assert_eq!(outcome.queued_for_daemon, 1);
+            let message = outcome.message().expect("a daemon edit is still a change");
+            assert!(
+                !message.contains("config.toml"),
+                "a daemon row must not claim config.toml: {message}"
+            );
+            assert!(message.contains("Hangar daemon"), "{message}");
+        });
     }
 
     /// A config.toml row keeps its own wording, so the split does not make the
     /// ordinary case vaguer.
     #[test]
     fn a_config_toml_row_still_reports_config_toml() {
-        let outcome = PersistOutcome {
-            written: 2,
-            queued_for_daemon: 0,
-        };
-        assert_eq!(
-            outcome.message().unwrap(),
-            "Saved 2 setting(s) to config.toml"
-        );
-        assert!(PersistOutcome::default().message().is_none());
+        with_isolated_home(|| {
+            let outcome = PersistOutcome {
+                written: 2,
+                queued_for_daemon: 0,
+            };
+            assert_eq!(
+                outcome.message().unwrap(),
+                "Saved 2 setting(s) to config.toml"
+            );
+            assert!(PersistOutcome::default().message().is_none());
+        });
     }
 }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -3773,7 +3773,7 @@ impl EventHandler {
     fn persist_config_screen(state: &mut AppState) -> anyhow::Result<usize> {
         let pending = state.config_screen_state.pending_edits().len();
         let dirty_before = !state.config_screen_state.dirty.is_empty();
-        let applied = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
+        let mut applied = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
         // Nothing to write: return before touching the file. `save()` renders
         // the whole AppConfig from the snapshot loaded at startup, so pressing
         // `S` with no edits would revert anything `ainb config set` or another
@@ -3783,6 +3783,14 @@ impl EventHandler {
         // excludes plugin rows and read-only rows, so a plugin-only edit has
         // `pending == 0` while still having work to do. `dirty` is the honest
         // "did the user change anything" signal.
+        // The Hangar daemon rows land in a SQLite table, not this file, and
+        // that store is async while this pass is not. Queue them before the
+        // early return, so a save that touched only daemon rows still writes.
+        if !applied.daemon.is_empty() {
+            let edits = std::mem::take(&mut applied.daemon);
+            state.pending_async_action =
+                Some(crate::app::state::AsyncAction::HangarDaemonConfigSet(edits));
+        }
         if !dirty_before && applied.external.is_empty() {
             state.config_screen_state.mark_saved();
             return Ok(0);
@@ -4090,10 +4098,10 @@ impl EventHandler {
                 // detached `std::thread` it is not torn down mid-write at
                 // shutdown.
                 let scan_paths = state.app_config.workspace_defaults.workspace_scan_paths.clone();
-                let exclude_paths = state.app_config.workspace_defaults.exclude_paths.clone();
+                let defaults = state.app_config.workspace_defaults.clone();
                 tokio::task::spawn_blocking(move || {
                     let scanner = WorkspaceScanner::with_additional_paths(scan_paths)
-                        .with_exclude_paths(exclude_paths);
+                        .with_workspace_defaults(&defaults);
                     if let Err(err) = scanner.scan() {
                         tracing::warn!(error = %err, "pick_repo: background repo rescan failed");
                     }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -10558,8 +10558,10 @@ mod hangar_daemon_persist_tests {
     /// snapshot that other tests in this binary read. Serialised, because the
     /// environment is process-global and cargo runs tests in parallel.
     fn with_isolated_home<T>(body: impl FnOnce() -> T) -> T {
-        static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // The crate-wide lock, not a private one: sibling tests call
+        // `AppConfig::load()` and `snapshot()`, which read this same HOME.
+        let _guard =
+            crate::config::tunables::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let dir = tempfile::tempdir().expect("tempdir");
         let previous = std::env::var_os("HOME");

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -796,6 +796,37 @@ fn secret_reference_is_set(reference: &str) -> bool {
     !crate::fleet::bridge::secrets::resolve_secret(reference).trim().is_empty()
 }
 
+/// What one pass of `persist_config_screen` did.
+///
+/// Two counts, not one, because the two backends succeed at different moments:
+/// `written` is already in config.toml when this returns, while
+/// `queued_for_daemon` has not been attempted yet: it goes to the Hangar
+/// daemon's SQLite table on the next app tick, and can still fail there with
+/// its own error toast. Reporting "Setting saved to config.toml" for a daemon
+/// row was wrong twice over: wrong file, and wrong tense.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PersistOutcome {
+    /// Rows written to config.toml.
+    pub written: usize,
+    /// Rows handed to the Hangar daemon queue, not yet written.
+    pub queued_for_daemon: usize,
+}
+
+impl PersistOutcome {
+    /// The success line to show, or `None` when nothing happened at all.
+    #[must_use]
+    pub fn message(self) -> Option<String> {
+        match (self.written, self.queued_for_daemon) {
+            (0, 0) => None,
+            (0, queued) => Some(format!("Sending {queued} setting(s) to the Hangar daemon")),
+            (written, 0) => Some(format!("Saved {written} setting(s) to config.toml")),
+            (written, queued) => Some(format!(
+                "Saved {written} setting(s) to config.toml, sending {queued} to the Hangar daemon"
+            )),
+        }
+    }
+}
+
 impl EventHandler {
     fn persist_sessions_pane_preferences(state: &mut AppState) {
         state.app_config.ui_preferences.sessions_sidebar_width =
@@ -3770,7 +3801,7 @@ impl EventHandler {
     /// the file so unknown sections survive), then `save_external_keys` writes the
     /// rest. On success the edits are cleared, so a later save cannot rewrite a
     /// value another process has since changed.
-    fn persist_config_screen(state: &mut AppState) -> anyhow::Result<usize> {
+    fn persist_config_screen(state: &mut AppState) -> anyhow::Result<PersistOutcome> {
         let pending = state.config_screen_state.pending_edits().len();
         let dirty_before = !state.config_screen_state.dirty.is_empty();
         let mut applied = state.config_screen_state.apply_to_app_config(&mut state.app_config)?;
@@ -3784,16 +3815,20 @@ impl EventHandler {
         // `pending == 0` while still having work to do. `dirty` is the honest
         // "did the user change anything" signal.
         // The Hangar daemon rows land in a SQLite table, not this file, and
-        // that store is async while this pass is not. Queue them before the
-        // early return, so a save that touched only daemon rows still writes.
-        if !applied.daemon.is_empty() {
-            let edits = std::mem::take(&mut applied.daemon);
-            state.pending_async_action =
-                Some(crate::app::state::AsyncAction::HangarDaemonConfigSet(edits));
-        }
+        // that store is async while this pass is not. APPENDED to a queue, not
+        // assigned to `pending_async_action`: that slot holds one action and is
+        // drained once per app tick, so two popup confirms inside the same
+        // 250 ms tick silently threw the first edit away and toasted "saved"
+        // for both. Queue them before the early return, so a save that touched
+        // only daemon rows still writes.
+        let queued_for_daemon = applied.daemon.len();
+        state.pending_daemon_config_edits.append(&mut applied.daemon);
         if !dirty_before && applied.external.is_empty() {
             state.config_screen_state.mark_saved();
-            return Ok(0);
+            return Ok(PersistOutcome {
+                written: 0,
+                queued_for_daemon,
+            });
         }
         state.app_config.save()?;
         // Collected, not propagated — the same rule the modelled rows already
@@ -3817,7 +3852,12 @@ impl EventHandler {
             tracing::warn!(key, error = %why, "settings edit rejected");
             state.add_error_notification(format!("{key}: {why}"));
         }
-        Ok(pending.saturating_sub(rejected.len()))
+        Ok(PersistOutcome {
+            // The daemon rows are counted separately: they are not in
+            // config.toml, and their write has not been attempted yet.
+            written: pending.saturating_sub(rejected.len() + queued_for_daemon),
+            queued_for_daemon,
+        })
     }
 
     /// Store a credential literal in the OS keychain and point the row at it.
@@ -6962,9 +7002,10 @@ impl EventHandler {
             AppEvent::ConfigSaveAll => {
                 tracing::info!("Saving all settings to config file");
                 match Self::persist_config_screen(state) {
-                    Ok(0) => state.add_info_notification("No changes to save".to_string()),
-                    Ok(n) => state
-                        .add_success_notification(format!("Saved {n} setting(s) to config.toml")),
+                    Ok(outcome) => match outcome.message() {
+                        Some(message) => state.add_success_notification(message),
+                        None => state.add_info_notification("No changes to save".to_string()),
+                    },
                     Err(e) => {
                         state.add_error_notification(format!("Failed to save settings: {}", e));
                         tracing::error!("Failed to save config: {}", e);
@@ -7260,10 +7301,10 @@ impl EventHandler {
                         // remains as an explicit save-all; `Esc` still cancels the
                         // single edit before it reaches here.
                         match Self::persist_config_screen(state) {
-                            Ok(_) => {
-                                state.add_success_notification(
-                                    "Setting saved to config.toml".to_string(),
-                                );
+                            Ok(outcome) => {
+                                if let Some(message) = outcome.message() {
+                                    state.add_success_notification(message);
+                                }
                             }
                             Err(e) => {
                                 state
@@ -10482,5 +10523,81 @@ mod configure_back_persist_tests {
         let mut defaults = SessionDefaults::default();
         defaults.per_repo.insert("owner/repo".to_string(), Default::default());
         assert!(worth_persisting_repo_defaults("", &defaults, "owner/repo"));
+    }
+}
+
+#[cfg(test)]
+mod hangar_daemon_persist_tests {
+    use super::*;
+    use crate::app::state::{AppState, ConfigValue};
+
+    /// Two Hangar-daemon edits confirmed inside one app tick must BOTH be
+    /// written.
+    ///
+    /// `persist_config_screen` used to assign `pending_async_action`, a slot
+    /// that holds exactly one action and is drained once per 250 ms tick, while
+    /// persist runs on every popup confirm. So the first edit was silently
+    /// dropped and both got a success toast. Before the queue this fails with
+    /// `assertion `left == right` failed: left: 1, right: 2`.
+    #[test]
+    fn two_daemon_edits_in_one_tick_are_both_queued() {
+        let mut state = AppState::default();
+
+        state
+            .config_screen_state
+            .set_row_value("hangar_daemon.autostandup.enabled", ConfigValue::Bool(true));
+        EventHandler::persist_config_screen(&mut state).expect("first persist");
+
+        state.config_screen_state.set_row_value(
+            "hangar_daemon.autostandup.stagnant_min",
+            ConfigValue::Number(30),
+        );
+        EventHandler::persist_config_screen(&mut state).expect("second persist");
+
+        let queued: Vec<&str> =
+            state.pending_daemon_config_edits.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(
+            queued.len(),
+            2,
+            "both edits must survive until the tick drains them, got {queued:?}"
+        );
+        assert!(queued.contains(&"autostandup.enabled"), "{queued:?}");
+        assert!(queued.contains(&"autostandup.stagnant_min"), "{queued:?}");
+    }
+
+    /// A daemon row is NOT reported as saved to config.toml: it has not been
+    /// written anywhere yet, and its SQLite write can still fail with its own
+    /// error toast on the next tick.
+    #[test]
+    fn a_daemon_row_is_not_reported_as_saved_to_config_toml() {
+        let mut state = AppState::default();
+        state
+            .config_screen_state
+            .set_row_value("hangar_daemon.autostandup.enabled", ConfigValue::Bool(true));
+
+        let outcome = EventHandler::persist_config_screen(&mut state).expect("persist");
+        assert_eq!(outcome.written, 0, "nothing reached config.toml");
+        assert_eq!(outcome.queued_for_daemon, 1);
+        let message = outcome.message().expect("a daemon edit is still a change");
+        assert!(
+            !message.contains("config.toml"),
+            "a daemon row must not claim config.toml: {message}"
+        );
+        assert!(message.contains("Hangar daemon"), "{message}");
+    }
+
+    /// A config.toml row keeps its own wording, so the split does not make the
+    /// ordinary case vaguer.
+    #[test]
+    fn a_config_toml_row_still_reports_config_toml() {
+        let outcome = PersistOutcome {
+            written: 2,
+            queued_for_daemon: 0,
+        };
+        assert_eq!(
+            outcome.message().unwrap(),
+            "Saved 2 setting(s) to config.toml"
+        );
+        assert!(PersistOutcome::default().message().is_none());
     }
 }

--- a/ainb-tui/crates/ainb-core/src/app/session_loader.rs
+++ b/ainb-tui/crates/ainb-core/src/app/session_loader.rs
@@ -243,7 +243,7 @@ impl SessionLoader {
         let scanner = WorkspaceScanner::with_additional_paths(
             self.config.workspace_defaults.workspace_scan_paths.clone(),
         )
-        .with_exclude_paths(self.config.workspace_defaults.exclude_paths.clone());
+        .with_workspace_defaults(&self.config.workspace_defaults);
         let scan_result = scanner.scan()?;
 
         let max_repos = self.config.workspace_defaults.max_repositories;

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -10377,13 +10377,18 @@ impl AppState {
         // only returns rows that EXIST, so a first-time write that failed left
         // the rejected value on screen with `dirty` already cleared: the row
         // claimed the setting had landed and no later save would ever write it.
-        for (key, _) in &failures {
-            let row_key = format!("hangar_daemon.{key}");
-            self.config_screen_state.dirty.insert(row_key);
-        }
+        let failed_rows: Vec<String> =
+            failures.iter().map(|(key, _)| format!("hangar_daemon.{key}")).collect();
         // Re-read rather than trust the write: the row now shows what the
         // database holds, including for any write that just failed.
         self.load_hangar_daemon_config().await;
+        // AFTER the re-seed, not before. `seed_hangar_daemon_rows` clears
+        // `dirty` for every key it finds in the store, so marking the row for
+        // retry first meant the flag was erased on the next line for any knob
+        // that already had a row — i.e. everything except a first-ever write.
+        for row_key in failed_rows {
+            self.config_screen_state.dirty.insert(row_key);
+        }
     }
 
     pub async fn process_async_action(&mut self) -> anyhow::Result<()> {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2763,18 +2763,29 @@ fn hangar_db_path() -> Option<std::path::PathBuf> {
 /// bookkeeping) is not config and must never reach a settings row.
 async fn read_daemon_config() -> anyhow::Result<Option<Vec<(String, String)>>> {
     use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
-    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
 
     if hangar_db_path().is_none() {
         return Ok(None);
     }
-    let store = ainb_hangar_store::Store::open_default().await?;
-    let mut stored = Vec::new();
-    for descriptor in DAEMON_CONFIG_REGISTRY {
-        if let Some(value) = DaemonConfigRepo::get(store.pool(), descriptor.key).await? {
-            stored.push((descriptor.key.to_string(), value));
-        }
-    }
+    // Read-only. `Store::open_default` takes a whole-database backup and
+    // applies pending migrations, and this runs on the first app tick of every
+    // launch — so after an upgrade it migrated a running daemon's live schema
+    // out from under it, and blocked the event loop for the length of the copy.
+    // The existence guard above stops creation, not migration.
+    let Some(rows) = ainb_hangar_store::Store::read_daemon_config_read_only().await? else {
+        return Ok(None);
+    };
+    let known: std::collections::HashMap<&str, String> =
+        rows.into_iter()
+            .fold(std::collections::HashMap::new(), |mut acc, (key, value)| {
+                if let Some(descriptor) = DAEMON_CONFIG_REGISTRY.iter().find(|d| d.key == key) {
+                    acc.insert(descriptor.key, value);
+                }
+                acc
+            });
+    let mut stored: Vec<(String, String)> =
+        known.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+    stored.sort();
     Ok(Some(stored))
 }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1613,6 +1613,10 @@ pub enum ConfigCategory {
     Skills,
     SessionReader,
     Presets,
+    Daemons,
+    Web,
+    Acp,
+    HangarDaemon,
 }
 
 impl ConfigCategory {
@@ -1634,6 +1638,10 @@ impl ConfigCategory {
             ConfigCategory::Skills,
             ConfigCategory::SessionReader,
             ConfigCategory::Presets,
+            ConfigCategory::Daemons,
+            ConfigCategory::Web,
+            ConfigCategory::Acp,
+            ConfigCategory::HangarDaemon,
         ]
     }
 
@@ -1655,6 +1663,10 @@ impl ConfigCategory {
             ConfigCategory::Skills => "Skills",
             ConfigCategory::SessionReader => "Session Reader",
             ConfigCategory::Presets => "Presets",
+            ConfigCategory::Daemons => "Daemons",
+            ConfigCategory::Web => "Web Dashboard",
+            ConfigCategory::Acp => "ACP Adapters",
+            ConfigCategory::HangarDaemon => "Hangar Daemon",
         }
     }
 
@@ -1676,6 +1688,10 @@ impl ConfigCategory {
             ConfigCategory::Skills => "🎓",
             ConfigCategory::SessionReader => "📖",
             ConfigCategory::Presets => "🗂️",
+            ConfigCategory::Daemons => "🛎️",
+            ConfigCategory::Web => "🌐",
+            ConfigCategory::Acp => "🔗",
+            ConfigCategory::HangarDaemon => "🏗️",
         }
     }
 
@@ -1697,6 +1713,10 @@ impl ConfigCategory {
             ConfigCategory::Skills => "Catalog release, API key",
             ConfigCategory::SessionReader => "Incremental scan window",
             ConfigCategory::Presets => "Where presets.toml lives",
+            ConfigCategory::Daemons => "Staleness windows, notification debounce, approvals",
+            ConfigCategory::Web => "`ainb web` bind address and read-only mode",
+            ConfigCategory::Acp => "Per-adapter command and pinned permission mode",
+            ConfigCategory::HangarDaemon => "Auto-standup and lockdown (stored in the daemon DB)",
         }
     }
 }
@@ -1888,6 +1908,12 @@ pub struct AppliedEdits {
     /// then dropped, so a value that can never be written cannot wedge every
     /// subsequent save.
     pub rejected: Vec<(String, String)>,
+    /// `(daemon_config key, raw value)` for the `hangar_daemon.*` rows, whose
+    /// backend is the Hangar SQLite `daemon_config` table rather than
+    /// config.toml. Dispatched through
+    /// [`AsyncAction::HangarDaemonConfigSet`](crate::app::state::AsyncAction::HangarDaemonConfigSet),
+    /// because that store is async and this pass is not.
+    pub daemon: Vec<(String, String)>,
 }
 
 /// The settings screen: a section tree on the left, the rows of the selected
@@ -2276,6 +2302,32 @@ impl ConfigScreenState {
         }
     }
 
+    /// Overwrite the `hangar_daemon.*` rows from the daemon's stored values,
+    /// WITHOUT marking them dirty.
+    ///
+    /// `stored` is `(daemon_config key, value)`; a key absent from it keeps the
+    /// coded default the row was seeded with, which is what the daemon applies
+    /// for a key with no row. Deliberately not `set_row_value`: that marks the
+    /// row dirty, and the next save would write these values straight back into
+    /// a database that already holds them.
+    pub fn seed_hangar_daemon_rows(&mut self, stored: &[(String, String)]) {
+        for (daemon_key, value) in stored {
+            let key = format!("{}{daemon_key}", registry::HANGAR_DAEMON_PREFIX);
+            let Some(row) = registry::row(&key) else {
+                continue;
+            };
+            let seeded = row.to_value(Some(&registry::parse_toml_scalar(value)));
+            for rows in self.settings.values_mut() {
+                if let Some(existing) = rows.iter_mut().find(|r| r.key == key) {
+                    existing.value = seeded;
+                    self.dirty.remove(&key);
+                    break;
+                }
+            }
+        }
+        self.refresh_visible_rows();
+    }
+
     pub fn set_row_value(&mut self, key: &str, value: ConfigValue) {
         for rows in self.settings.values_mut() {
             if let Some(row) = rows.iter_mut().find(|row| row.key == key) {
@@ -2353,6 +2405,13 @@ impl ConfigScreenState {
 
         let mut applied = AppliedEdits::default();
         for (key, raw) in self.pending_edits() {
+            if let Some(daemon_key) = registry::hangar_daemon_key(&key) {
+                // Not config.toml at all: `save_external_keys` would happily
+                // write a `[hangar_daemon]` section that nothing ever reads,
+                // which is the silent no-op this category exists to avoid.
+                applied.daemon.push((daemon_key.to_string(), raw));
+                continue;
+            }
             if registry::is_external(&key) {
                 // These go through the key-level writer rather than the struct.
                 // `[skills]` and `[session_reader]` are parsed off this file by
@@ -2643,7 +2702,71 @@ fn seed_value(config: &AppConfig) -> toml::Value {
     if let Some(on_disk) = on_disk {
         merge_external_sections(&mut seed, &toml::Value::Table(on_disk));
     }
+    seed_hangar_daemon_defaults(&mut seed);
     seed
+}
+
+/// Plant every Hangar daemon knob's coded default under `hangar_daemon.` in the
+/// seed.
+///
+/// Without this the rows have no value to render at all and every one of them
+/// would seed as an empty widget, which claims the daemon is unconfigured. The
+/// coded default is the honest placeholder: it IS what the daemon runs when a
+/// key has no stored row. `AsyncAction::HangarDaemonConfigLoad` replaces it with
+/// the stored value shortly after startup.
+/// The Hangar SQLite database, when one exists.
+///
+/// `Store::open_default` CREATES the database and runs migrations, which is the
+/// right behaviour for the daemon and the wrong one for a settings screen
+/// painting itself: opening the TUI must not conjure a hangar.db on a machine
+/// that has never run the daemon. So the file is probed first.
+fn hangar_db_path() -> Option<std::path::PathBuf> {
+    let path = ainb_hangar_core::hangar_home()?.join("hangar.db");
+    path.exists().then_some(path)
+}
+
+/// Every stored `daemon_config` value, or `None` when there is no database yet.
+///
+/// Only the keys the registry knows: an internal-state row (the daemon's own
+/// bookkeeping) is not config and must never reach a settings row.
+async fn read_daemon_config() -> anyhow::Result<Option<Vec<(String, String)>>> {
+    use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    if hangar_db_path().is_none() {
+        return Ok(None);
+    }
+    let store = ainb_hangar_store::Store::open_default().await?;
+    let mut stored = Vec::new();
+    for descriptor in DAEMON_CONFIG_REGISTRY {
+        if let Some(value) = DaemonConfigRepo::get(store.pool(), descriptor.key).await? {
+            stored.push((descriptor.key.to_string(), value));
+        }
+    }
+    Ok(Some(stored))
+}
+
+/// Validate one `daemon_config` edit and write it.
+///
+/// Validation goes through the descriptor, not the core registry: the daemon's
+/// own registry is the authority on what its table accepts, and it is the gate
+/// the RPC handler and the CLI both use.
+async fn write_daemon_config(key: &str, raw: &str) -> anyhow::Result<()> {
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let descriptor = ainb_hangar_core::daemon_config::descriptor(key)
+        .ok_or_else(|| anyhow::anyhow!("not a daemon config key"))?;
+    let normalized = descriptor.validate(raw).map_err(|why| anyhow::anyhow!(why))?;
+    let store = ainb_hangar_store::Store::open_default().await?;
+    DaemonConfigRepo::set(store.pool(), key, &normalized).await?;
+    Ok(())
+}
+
+fn seed_hangar_daemon_defaults(seed: &mut toml::Value) {
+    for descriptor in ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY {
+        let key = format!("{}{}", registry::HANGAR_DAEMON_PREFIX, descriptor.key);
+        let _ = registry::insert_at(seed, &key, registry::parse_toml_scalar(descriptor.default));
+    }
 }
 
 /// Copy each [`EXTERNAL_PREFIXES`](registry::EXTERNAL_PREFIXES) section from the
@@ -3024,6 +3147,13 @@ pub struct AppState {
     pub new_session_state: Option<NewSessionState>,
     // Async action processing
     pub pending_async_action: Option<AsyncAction>,
+    /// Whether the Hangar daemon's stored `daemon_config` values have been read
+    /// into the settings rows yet.
+    ///
+    /// A one-shot of its own rather than a seeded `pending_async_action`: that
+    /// slot holds ONE keystroke-driven action, so pre-filling it both races the
+    /// first keystroke and makes "no action is pending" untestable.
+    pub hangar_daemon_config_loaded: bool,
     // Flag to track if user cancelled during async operation
     pub async_operation_cancelled: bool,
     // Confirmation dialog state
@@ -3592,6 +3722,14 @@ pub enum NewSessionStep {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AsyncAction {
+    /// Write `(daemon_config key, raw value)` pairs to the Hangar daemon's
+    /// `daemon_config` SQLite table.
+    ///
+    /// A SECOND write backend, so it gets its own action rather than riding on
+    /// `AppConfig::save`. A rejected value or an unreachable database raises an
+    /// error notification; it is never a silent no-op, which for a row the user
+    /// just edited is indistinguishable from success.
+    HangarDaemonConfigSet(Vec<(String, String)>),
     // Phase 6 (new-session redesign): legacy `StartNewSession`,
     // `StartWorkspaceSearch`, `NewSessionInCurrentDir`, `NewSessionNormal`,
     // `NewSessionWithRepoInput`, `ValidateRepoSource`, `CloneRemoteRepo`,
@@ -3679,6 +3817,7 @@ impl Default for AppState {
             help_visible: false,
             new_session_state: None,
             pending_async_action: None,
+            hangar_daemon_config_loaded: false,
             async_operation_cancelled: false,
             confirmation_dialog: None,
             mcp_overlay: None,
@@ -10126,7 +10265,56 @@ impl AppState {
         Ok(())
     }
 
+    /// Reseed the `Hangar Daemon` settings rows from the `daemon_config` table.
+    ///
+    /// A missing database is the normal state on a machine that has never run
+    /// the daemon, so it is silent: the rows keep their coded defaults, which is
+    /// what the daemon would apply anyway. A database that exists but cannot be
+    /// read IS reported, because then the rows are showing values that may not
+    /// be what is stored.
+    async fn load_hangar_daemon_config(&mut self) {
+        match read_daemon_config().await {
+            Ok(Some(stored)) => self.config_screen_state.seed_hangar_daemon_rows(&stored),
+            Ok(None) => {}
+            Err(error) => {
+                warn!(%error, "hangar daemon config: could not read stored values");
+                self.add_warning_notification(format!(
+                    "Hangar Daemon settings show defaults: {error}"
+                ));
+            }
+        }
+    }
+
+    /// Write edited `hangar_daemon.*` rows back to the `daemon_config` table.
+    ///
+    /// Every value passes `ConfigDescriptor::validate` first, which is the same
+    /// gate the RPC handler and the `ainb hangar daemon config set` CLI use, so
+    /// the three surfaces cannot disagree about what is legal. Each failure
+    /// raises its own error notification naming the row: a write the user asked
+    /// for that quietly did not happen is worse than one that visibly failed.
+    async fn set_hangar_daemon_config(&mut self, edits: Vec<(String, String)>) {
+        for (key, raw) in edits {
+            match write_daemon_config(&key, &raw).await {
+                Ok(()) => {}
+                Err(error) => {
+                    warn!(key, %error, "hangar daemon config write failed");
+                    self.add_error_notification(format!("hangar_daemon.{key}: {error}"));
+                }
+            }
+        }
+        // Re-read rather than trust the write: the row now shows what the
+        // database holds, including for any write that just failed.
+        self.load_hangar_daemon_config().await;
+    }
+
     pub async fn process_async_action(&mut self) -> anyhow::Result<()> {
+        // Once, on the first app tick: the `Hangar Daemon` settings rows are
+        // seeded with coded defaults synchronously (the store is async and the
+        // screen is not), and this replaces them with what is actually stored.
+        if !self.hangar_daemon_config_loaded {
+            self.hangar_daemon_config_loaded = true;
+            self.load_hangar_daemon_config().await;
+        }
         if let Some(action) = self.pending_async_action.take() {
             info!(
                 ">>> process_async_action() called with action: {:?}",
@@ -10135,6 +10323,9 @@ impl AppState {
             match action {
                 AsyncAction::CreateSessionFromConfigure(spec) => {
                     self.create_session_from_configure(spec).await;
+                }
+                AsyncAction::HangarDaemonConfigSet(edits) => {
+                    self.set_hangar_daemon_config(edits).await;
                 }
                 AsyncAction::CheckGitAuth => {
                     self.check_git_auth().await;
@@ -11244,18 +11435,20 @@ impl AppState {
         &self,
         now_ms: i64,
     ) -> Option<Vec<ainb_plugin_notifyd::NotificationRecord>> {
-        // Only events within this rolling window can mark a session.
-        const LOOKBACK_MS: i64 = 6 * 60 * 60 * 1000;
-        // Bounds query cost; ample for any realistic active fleet.
-        const QUERY_LIMIT: u32 = 500;
+        // Only events within this rolling window can mark a session, and only
+        // this many rows are read per refresh. Both bound query cost on a large
+        // notifications DB; `[ui]` raises them for a very large fleet.
+        let tunables = &crate::config::tunables::snapshot().ui;
+        let lookback_ms = i64::from(tunables.session_lookback_hours) * 60 * 60 * 1000;
+        let query_limit = tunables.session_query_limit;
 
         let db = ainb_plugin_notifyd::Paths::from_home().ok()?.db;
         if !db.exists() {
             return None;
         }
         let store = ainb_plugin_notifyd::Store::open(&db).ok()?;
-        let floor = now_ms - LOOKBACK_MS;
-        match store.recent_since(floor, QUERY_LIMIT) {
+        let floor = now_ms - lookback_ms;
+        match store.recent_since(floor, query_limit) {
             Ok(rows) => Some(rows),
             Err(e) => {
                 debug!("attention: notifications store read failed: {e}");

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2794,15 +2794,44 @@ async fn read_daemon_config() -> anyhow::Result<Option<Vec<(String, String)>>> {
 /// Validation goes through the descriptor, not the core registry: the daemon's
 /// own registry is the authority on what its table accepts, and it is the gate
 /// the RPC handler and the CLI both use.
-async fn write_daemon_config(key: &str, raw: &str) -> anyhow::Result<()> {
+async fn write_daemon_config_batch(edits: &[(String, String)]) -> Vec<(String, anyhow::Error)> {
     use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
 
-    let descriptor = ainb_hangar_core::daemon_config::descriptor(key)
-        .ok_or_else(|| anyhow::anyhow!("not a daemon config key"))?;
-    let normalized = descriptor.validate(raw).map_err(|why| anyhow::anyhow!(why))?;
-    let store = ainb_hangar_store::Store::open_default().await?;
-    DaemonConfigRepo::set(store.pool(), key, &normalized).await?;
-    Ok(())
+    let mut failures = Vec::new();
+    // Validate before opening anything: a batch of only-invalid values should
+    // not open the store at all.
+    let mut valid = Vec::with_capacity(edits.len());
+    for (key, raw) in edits {
+        match ainb_hangar_core::daemon_config::descriptor(key) {
+            Some(descriptor) => match descriptor.validate(raw) {
+                Ok(normalized) => valid.push((key.clone(), normalized)),
+                Err(why) => failures.push((key.clone(), anyhow::anyhow!(why))),
+            },
+            None => failures.push((key.clone(), anyhow::anyhow!("not a daemon config key"))),
+        }
+    }
+    if valid.is_empty() {
+        return failures;
+    }
+
+    // ONE open for the whole batch. `open_default` runs a whole-database
+    // VACUUM INTO backup plus migrations, and this runs on the UI task — doing
+    // it per key meant saving three rows paid that cost three times.
+    let store = match ainb_hangar_store::Store::open_default().await {
+        Ok(store) => store,
+        Err(error) => {
+            let message = error.to_string();
+            failures
+                .extend(valid.into_iter().map(|(key, _)| (key, anyhow::anyhow!(message.clone()))));
+            return failures;
+        }
+    };
+    for (key, normalized) in valid {
+        if let Err(error) = DaemonConfigRepo::set(store.pool(), &key, &normalized).await {
+            failures.push((key, error.into()));
+        }
+    }
+    failures
 }
 
 fn seed_hangar_daemon_defaults(seed: &mut toml::Value) {
@@ -10338,14 +10367,19 @@ impl AppState {
     /// raises its own error notification naming the row: a write the user asked
     /// for that quietly did not happen is worse than one that visibly failed.
     async fn set_hangar_daemon_config(&mut self, edits: Vec<(String, String)>) {
-        for (key, raw) in edits {
-            match write_daemon_config(&key, &raw).await {
-                Ok(()) => {}
-                Err(error) => {
-                    warn!(key, %error, "hangar daemon config write failed");
-                    self.add_error_notification(format!("hangar_daemon.{key}: {error}"));
-                }
-            }
+        let failures = write_daemon_config_batch(&edits).await;
+        for (key, error) in &failures {
+            warn!(key, %error, "hangar daemon config write failed");
+            self.add_error_notification(format!("hangar_daemon.{key}: {error}"));
+        }
+        // Put a failed row back to the value the database actually holds, and
+        // mark it dirty again so a later `S` retries it. `read_daemon_config`
+        // only returns rows that EXIST, so a first-time write that failed left
+        // the rejected value on screen with `dirty` already cleared: the row
+        // claimed the setting had landed and no later save would ever write it.
+        for (key, _) in &failures {
+            let row_key = format!("hangar_daemon.{key}");
+            self.config_screen_state.dirty.insert(row_key);
         }
         // Re-read rather than trust the write: the row now shows what the
         // database holds, including for any write that just failed.

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1911,7 +1911,7 @@ pub struct AppliedEdits {
     /// `(daemon_config key, raw value)` for the `hangar_daemon.*` rows, whose
     /// backend is the Hangar SQLite `daemon_config` table rather than
     /// config.toml. Dispatched through
-    /// [`AsyncAction::HangarDaemonConfigSet`](crate::app::state::AsyncAction::HangarDaemonConfigSet),
+    /// `pending_daemon_config_edits`,
     /// because that store is async and this pass is not.
     pub daemon: Vec<(String, String)>,
 }
@@ -2744,7 +2744,7 @@ fn seed_builtin_acp_adapters(seed: &mut toml::Value) {
 /// Without this the rows have no value to render at all and every one of them
 /// would seed as an empty widget, which claims the daemon is unconfigured. The
 /// coded default is the honest placeholder: it IS what the daemon runs when a
-/// key has no stored row. `AsyncAction::HangarDaemonConfigLoad` replaces it with
+/// key has no stored row. `load_hangar_daemon_config` replaces it with
 /// the stored value shortly after startup.
 /// The Hangar SQLite database, when one exists.
 ///
@@ -10382,10 +10382,19 @@ impl AppState {
         // Re-read rather than trust the write: the row now shows what the
         // database holds, including for any write that just failed.
         self.load_hangar_daemon_config().await;
-        // AFTER the re-seed, not before. `seed_hangar_daemon_rows` clears
-        // `dirty` for every key it finds in the store, so marking the row for
-        // retry first meant the flag was erased on the next line for any knob
-        // that already had a row — i.e. everything except a first-ever write.
+        // AFTER the re-seed, not before: `seed_hangar_daemon_rows` clears
+        // `dirty` for every key it finds in the store, so marking the row first
+        // meant the flag was erased on the next line.
+        //
+        // What this does and does not buy: the row now shows the value the
+        // database actually holds, and stays dirty so it is visibly unsaved.
+        // For a key that already had a stored row that means a later `S`
+        // rewrites the STORED value — a no-op — rather than the one the user
+        // typed, because the re-seed has already replaced it. Preserving the
+        // rejected input across a failure needs the row to carry a pending
+        // value distinct from its displayed one, which the widget has no room
+        // for today. The error notification names the row, so the failure is
+        // never silent; re-typing it is the recovery.
         for row_key in failed_rows {
             self.config_screen_state.dirty.insert(row_key);
         }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -2703,7 +2703,39 @@ fn seed_value(config: &AppConfig) -> toml::Value {
         merge_external_sections(&mut seed, &toml::Value::Table(on_disk));
     }
     seed_hangar_daemon_defaults(&mut seed);
+    seed_builtin_acp_adapters(&mut seed);
     seed
+}
+
+/// Plant the built-in ACP adapters into the seed so their rows exist.
+///
+/// `acp.adapters.*` rows are wildcards, and `AcpConfig::adapters` defaults empty
+/// with `skip_serializing_if`, so the key was absent from the seed, `expand_key`
+/// returned nothing, and the whole "ACP Adapters" category was filtered out for
+/// having zero rows. It could never render, and there was no way to reach the
+/// adapters from the screen at all.
+///
+/// The built-ins live in `PoolConfig::default()`, not in config.toml, so they
+/// have to be named here for the same reason the Hangar daemon knobs do: the
+/// row has to exist before a user can be the first person to configure it. Only
+/// planted where the user has not already declared the adapter, so a configured
+/// `command` is never overwritten by a default.
+fn seed_builtin_acp_adapters(seed: &mut toml::Value) {
+    for name in ainb_hangar_daemon::acp_pool::PoolConfig::default().adapters.keys() {
+        let base = format!("acp.adapters.{}", registry::quote_key_segment(name));
+        for (field, value) in [
+            ("command", toml::Value::String(String::new())),
+            (
+                "permission_mode",
+                toml::Value::String("default".to_string()),
+            ),
+        ] {
+            let key = format!("{base}.{field}");
+            if registry::navigate_toml(seed, &key).is_err() {
+                let _ = registry::insert_at(seed, &key, value);
+            }
+        }
+    }
 }
 
 /// Plant every Hangar daemon knob's coded default under `hangar_daemon.` in the
@@ -3147,6 +3179,15 @@ pub struct AppState {
     pub new_session_state: Option<NewSessionState>,
     // Async action processing
     pub pending_async_action: Option<AsyncAction>,
+    /// Hangar daemon `(daemon_config key, raw value)` edits waiting to be
+    /// written to the daemon's SQLite table.
+    ///
+    /// A queue of its own rather than an `AsyncAction`: that slot holds exactly
+    /// one action and is drained once per app tick, so two settings edits
+    /// confirmed inside the same 250 ms tick would silently lose the first
+    /// while toasting success for both. Appended to, drained in
+    /// `process_async_action`.
+    pub pending_daemon_config_edits: Vec<(String, String)>,
     /// Whether the Hangar daemon's stored `daemon_config` values have been read
     /// into the settings rows yet.
     ///
@@ -3722,14 +3763,6 @@ pub enum NewSessionStep {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AsyncAction {
-    /// Write `(daemon_config key, raw value)` pairs to the Hangar daemon's
-    /// `daemon_config` SQLite table.
-    ///
-    /// A SECOND write backend, so it gets its own action rather than riding on
-    /// `AppConfig::save`. A rejected value or an unreachable database raises an
-    /// error notification; it is never a silent no-op, which for a row the user
-    /// just edited is indistinguishable from success.
-    HangarDaemonConfigSet(Vec<(String, String)>),
     // Phase 6 (new-session redesign): legacy `StartNewSession`,
     // `StartWorkspaceSearch`, `NewSessionInCurrentDir`, `NewSessionNormal`,
     // `NewSessionWithRepoInput`, `ValidateRepoSource`, `CloneRemoteRepo`,
@@ -3817,6 +3850,7 @@ impl Default for AppState {
             help_visible: false,
             new_session_state: None,
             pending_async_action: None,
+            pending_daemon_config_edits: Vec::new(),
             hangar_daemon_config_loaded: false,
             async_operation_cancelled: false,
             confirmation_dialog: None,
@@ -10315,6 +10349,10 @@ impl AppState {
             self.hangar_daemon_config_loaded = true;
             self.load_hangar_daemon_config().await;
         }
+        if !self.pending_daemon_config_edits.is_empty() {
+            let edits = std::mem::take(&mut self.pending_daemon_config_edits);
+            self.set_hangar_daemon_config(edits).await;
+        }
         if let Some(action) = self.pending_async_action.take() {
             info!(
                 ">>> process_async_action() called with action: {:?}",
@@ -10323,9 +10361,6 @@ impl AppState {
             match action {
                 AsyncAction::CreateSessionFromConfigure(spec) => {
                     self.create_session_from_configure(spec).await;
-                }
-                AsyncAction::HangarDaemonConfigSet(edits) => {
-                    self.set_hangar_daemon_config(edits).await;
                 }
                 AsyncAction::CheckGitAuth => {
                     self.check_git_auth().await;
@@ -11438,9 +11473,9 @@ impl AppState {
         // Only events within this rolling window can mark a session, and only
         // this many rows are read per refresh. Both bound query cost on a large
         // notifications DB; `[ui]` raises them for a very large fleet.
-        let tunables = &crate::config::tunables::snapshot().ui;
-        let lookback_ms = i64::from(tunables.session_lookback_hours) * 60 * 60 * 1000;
-        let query_limit = tunables.session_query_limit;
+        let config = crate::config::tunables::snapshot();
+        let lookback_ms = i64::from(config.ui.session_lookback_hours) * 60 * 60 * 1000;
+        let query_limit = config.ui.session_query_limit;
 
         let db = ainb_plugin_notifyd::Paths::from_home().ok()?.db;
         if !db.exists() {
@@ -13119,5 +13154,86 @@ mod panel_close_tests {
     #[test]
     fn rejects_malformed_payload() {
         assert!(!panel_close_matches(ids::ANALYTICS, b"not-json", BURNDOWN));
+    }
+}
+
+#[cfg(test)]
+mod seeded_category_tests {
+    use super::*;
+
+    /// Categories that describe something already IN FORCE, and so must render
+    /// on a machine that has configured nothing.
+    ///
+    /// `McpServers` is deliberately absent: its rows describe user-created
+    /// servers, and having none until you add one is the honest state. The
+    /// three below are not like that. The ACP built-ins are spawning sessions
+    /// right now and the Hangar daemon knobs are governing it, but neither
+    /// lives in config.toml, so unless the seed plants them `expand_key`
+    /// returns nothing and the category is dropped for having zero rows.
+    const ALWAYS_REACHABLE: &[ConfigCategory] = &[
+        ConfigCategory::Acp,
+        ConfigCategory::HangarDaemon,
+        ConfigCategory::ContainerTemplates,
+    ];
+
+    /// A category whose subject already exists must be openable out of the box.
+    ///
+    /// `every_category_has_at_least_one_row` in the registry proves each
+    /// category has an ENTRY; it cannot prove the entry expands. Before
+    /// `seed_builtin_acp_adapters` this fails with
+    /// `these categories seed no rows and can never be opened: ["ACP Adapters"]`.
+    #[test]
+    fn categories_describing_live_things_seed_rows_out_of_the_box() {
+        let seed = seed_value(&AppConfig::default());
+        let rows = crate::config::screen_model::build_rows(&seed);
+        let empty: Vec<&str> = ALWAYS_REACHABLE
+            .iter()
+            .filter(|category| rows.get(category).is_none_or(|r| r.is_empty()))
+            .map(|category| category.label())
+            .collect();
+        assert!(
+            empty.is_empty(),
+            "these categories seed no rows and can never be opened: {empty:?}"
+        );
+    }
+
+    /// The built-in ACP adapters are reachable by name, not just as a count.
+    #[test]
+    fn the_builtin_acp_adapters_get_rows() {
+        let seed = seed_value(&AppConfig::default());
+        let rows = crate::config::screen_model::build_rows(&seed);
+        let keys: Vec<&str> = rows
+            .get(&ConfigCategory::Acp)
+            .expect("the ACP category has rows")
+            .iter()
+            .map(|row| row.key.as_str())
+            .collect();
+        for adapter in ["claude-agent-acp", "codex-acp"] {
+            assert!(
+                keys.iter().any(|key| key.contains(adapter)),
+                "no row for the built-in adapter {adapter}: {keys:?}"
+            );
+        }
+    }
+
+    /// A user-declared adapter's own values survive the seeding, which only
+    /// fills in built-ins the config has not already described.
+    #[test]
+    fn a_configured_adapter_is_not_overwritten_by_the_builtin_seed() {
+        let mut config = AppConfig::default();
+        config.acp.adapters.insert(
+            "claude-agent-acp".to_string(),
+            crate::config::AcpAdapterConfig {
+                command: Some("/opt/mine".to_string()),
+                permission_mode: "plan".to_string(),
+            },
+        );
+        let seed = seed_value(&config);
+        assert_eq!(
+            crate::config::registry::navigate_toml(&seed, "acp.adapters.claude-agent-acp.command")
+                .unwrap()
+                .as_str(),
+            Some("/opt/mine")
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/codex_statusline.rs
@@ -98,12 +98,13 @@ pub fn codex_cache_path() -> Option<PathBuf> {
     Some(dir.join("ainb").join("codex-live.json"))
 }
 
-/// Effective throttle TTL (env override → default).
+/// Effective throttle TTL: `AINB_CODEX_USAGE_TTL_SECS`, else
+/// `usage_client.codex_ttl_secs`, else [`CODEX_USAGE_TTL_SECS`].
 fn ttl_secs() -> u64 {
-    std::env::var("AINB_CODEX_USAGE_TTL_SECS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(CODEX_USAGE_TTL_SECS)
+    crate::config::tunables::resolved(
+        "AINB_CODEX_USAGE_TTL_SECS",
+        crate::config::tunables::snapshot().usage_client.codex_ttl_secs,
+    )
 }
 
 // ---- wham/usage response shape (only the fields we read) ----

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -58,8 +58,8 @@ pub enum ConfigCommands {
 /// Execute a config subcommand
 pub async fn execute(command: ConfigCommands, format: OutputFormat) -> Result<()> {
     match command {
-        ConfigCommands::Show => cmd_show(format),
-        ConfigCommands::Get { key } => cmd_get(&key, format),
+        ConfigCommands::Show => cmd_show(format).await,
+        ConfigCommands::Get { key } => cmd_get(&key, format).await,
         ConfigCommands::Set { key, value } => cmd_set(&key, &value).await,
         ConfigCommands::Reset { force } => cmd_reset(force),
         ConfigCommands::Path => cmd_path(format),
@@ -67,28 +67,87 @@ pub async fn execute(command: ConfigCommands, format: OutputFormat) -> Result<()
     }
 }
 
-/// Display the full merged configuration
-fn cmd_show(format: OutputFormat) -> Result<()> {
+/// Display the full merged configuration.
+///
+/// Includes the `hangar_daemon.*` knobs, which are NOT in config.toml: they live
+/// in the Hangar daemon's SQLite table. `show` used to be silent about them, so
+/// a key `ainb config set` accepts did not appear in the dump of "the merged
+/// config", which reads as the key not existing.
+async fn cmd_show(format: OutputFormat) -> Result<()> {
     let config = AppConfig::load().context("Failed to load configuration")?;
+    let daemon = hangar_daemon_values().await;
 
     match format {
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&config)
-                .context("Failed to serialize config as JSON")?;
-            println!("{json}");
+            let mut json =
+                serde_json::to_value(&config).context("Failed to serialize config as JSON")?;
+            if let Some(object) = json.as_object_mut() {
+                object.insert(
+                    "hangar_daemon".to_string(),
+                    serde_json::Value::Object(
+                        daemon
+                            .iter()
+                            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                            .collect(),
+                    ),
+                );
+            }
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json)
+                    .context("Failed to serialize config as JSON")?
+            );
         }
         OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
             let toml_str =
                 toml::to_string_pretty(&config).context("Failed to serialize config as TOML")?;
             println!("{toml_str}");
+            // A comment block, not a `[hangar_daemon]` table: the text form is
+            // valid TOML a user may paste back into config.toml, where these
+            // keys do nothing at all.
+            println!("# Hangar daemon knobs (stored in hangar.db, NOT in this file).");
+            println!("# Read/write with `ainb config get|set hangar_daemon.<key>`.");
+            for (key, value) in &daemon {
+                println!("#   hangar_daemon.{key} = {value}");
+            }
         }
     }
 
     Ok(())
 }
 
+/// Every Hangar daemon knob and its effective value (stored, else the coded
+/// default). Falls back to the coded defaults when the database is missing or
+/// unreadable, because `show` must never fail on an optional backend.
+async fn hangar_daemon_values() -> Vec<(String, String)> {
+    use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let store = ainb_hangar_store::Store::open_default().await.ok();
+    let mut out = Vec::with_capacity(DAEMON_CONFIG_REGISTRY.len());
+    for descriptor in DAEMON_CONFIG_REGISTRY {
+        let stored = match &store {
+            Some(store) => DaemonConfigRepo::get(store.pool(), descriptor.key).await.ok().flatten(),
+            None => None,
+        };
+        out.push((
+            descriptor.key.to_string(),
+            stored.unwrap_or_else(|| descriptor.default.to_string()),
+        ));
+    }
+    out
+}
+
 /// Get a specific config value by dot-notation key
-fn cmd_get(key: &str, format: OutputFormat) -> Result<()> {
+async fn cmd_get(key: &str, format: OutputFormat) -> Result<()> {
+    // Same routing as `cmd_set`. Without it, the very sequence
+    // `example.config.toml` prescribes ("config set hangar_daemon.x, then read
+    // it back") wrote successfully and then errored with "Key not found",
+    // which reads as the write having failed.
+    if let Some(daemon_key) = crate::config::registry::hangar_daemon_key(key) {
+        return get_hangar_daemon(key, daemon_key, format).await;
+    }
+
     let config = AppConfig::load().context("Failed to load configuration")?;
     let toml_value =
         toml::Value::try_from(&config).context("Failed to convert config to TOML value")?;
@@ -176,6 +235,11 @@ async fn cmd_set(key: &str, value: &str) -> Result<()> {
     // Keyed off what actually happened: only an OPTIONAL_KEYS row is removed
     // when emptied. `skills.api_key = ""` stores an empty string, and calling
     // that "Cleared" would be a lie.
+    // The promoted tunables read a process-wide snapshot; refresh it so a
+    // long-lived embedding of this crate does not keep serving the old value.
+    // Free in the one-shot CLI, where the process exits next.
+    crate::config::tunables::refresh_snapshot();
+
     if cleared {
         println!("Cleared {key}");
     } else {
@@ -183,6 +247,43 @@ async fn cmd_set(key: &str, value: &str) -> Result<()> {
     }
     println!("Saved to {}", config_path.display());
 
+    Ok(())
+}
+
+/// Read one knob back out of the Hangar daemon's `daemon_config` table.
+///
+/// A key with no stored row prints its coded default, which is what the daemon
+/// actually runs: reporting "not found" would be a claim about the daemon's
+/// behaviour that is not true.
+async fn get_hangar_daemon(key: &str, daemon_key: &str, format: OutputFormat) -> Result<()> {
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let descriptor = ainb_hangar_core::daemon_config::descriptor(daemon_key)
+        .ok_or_else(|| anyhow!("'{key}' is not a Hangar daemon config key"))?;
+    let store = ainb_hangar_store::Store::open_default()
+        .await
+        .context("open the Hangar database")?;
+    let stored = DaemonConfigRepo::get(store.pool(), daemon_key)
+        .await
+        .with_context(|| format!("read daemon_config `{daemon_key}`"))?;
+    let value = stored.as_deref().unwrap_or(descriptor.default);
+
+    match format {
+        OutputFormat::Json => {
+            let json = serde_json::json!({
+                "key": key,
+                "value": value,
+                "is_default": stored.is_none(),
+                "default": descriptor.default,
+                "source": "hangar daemon_config",
+            });
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json).context("serialize value as JSON")?
+            );
+        }
+        OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => println!("{value}"),
+    }
     Ok(())
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -119,11 +119,28 @@ async fn cmd_show(format: OutputFormat) -> Result<()> {
 /// Every Hangar daemon knob and its effective value (stored, else the coded
 /// default). Falls back to the coded defaults when the database is missing or
 /// unreadable, because `show` must never fail on an optional backend.
+/// Whether the Hangar database already exists.
+///
+/// Reads must not create it: `Store::open_default` would, and the settings
+/// screen guards the same way before showing daemon rows.
+fn hangar_db_exists() -> bool {
+    ainb_hangar_core::hangar_home()
+        .map(|home| home.join("hangar.db").exists())
+        .unwrap_or(false)
+}
+
 async fn hangar_daemon_values() -> Vec<(String, String)> {
     use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
     use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
 
-    let store = ainb_hangar_store::Store::open_default().await.ok();
+    // Only open an existing database. `Store::open_default` CREATES the file
+    // and runs migrations, so a read-only `ainb config show` would conjure a
+    // hangar.db on a machine that has never run the daemon — migration
+    // ownership belongs to daemon startup. Absent means "show the defaults".
+    let store = match hangar_db_exists() {
+        true => ainb_hangar_store::Store::open_default().await.ok(),
+        false => None,
+    };
     let mut out = Vec::with_capacity(DAEMON_CONFIG_REGISTRY.len());
     for descriptor in DAEMON_CONFIG_REGISTRY {
         let stored = match &store {
@@ -260,12 +277,19 @@ async fn get_hangar_daemon(key: &str, daemon_key: &str, format: OutputFormat) ->
 
     let descriptor = ainb_hangar_core::daemon_config::descriptor(daemon_key)
         .ok_or_else(|| anyhow!("'{key}' is not a Hangar daemon config key"))?;
-    let store = ainb_hangar_store::Store::open_default()
-        .await
-        .context("open the Hangar database")?;
-    let stored = DaemonConfigRepo::get(store.pool(), daemon_key)
-        .await
-        .with_context(|| format!("read daemon_config `{daemon_key}`"))?;
+    // Same rule as `hangar_daemon_values`: a read must not create the database.
+    // `Store::open_default` creates it and runs migrations, so with no daemon
+    // ever started the honest answer is the registry default.
+    let stored = if hangar_db_exists() {
+        let store = ainb_hangar_store::Store::open_default()
+            .await
+            .context("open the Hangar database")?;
+        DaemonConfigRepo::get(store.pool(), daemon_key)
+            .await
+            .with_context(|| format!("read daemon_config `{daemon_key}`"))?
+    } else {
+        None
+    };
     let value = stored.as_deref().unwrap_or(descriptor.default);
 
     match format {

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -56,12 +56,11 @@ pub enum ConfigCommands {
 }
 
 /// Execute a config subcommand
-#[allow(clippy::unused_async)]
 pub async fn execute(command: ConfigCommands, format: OutputFormat) -> Result<()> {
     match command {
         ConfigCommands::Show => cmd_show(format),
         ConfigCommands::Get { key } => cmd_get(&key, format),
-        ConfigCommands::Set { key, value } => cmd_set(&key, &value),
+        ConfigCommands::Set { key, value } => cmd_set(&key, &value).await,
         ConfigCommands::Reset { force } => cmd_reset(force),
         ConfigCommands::Path => cmd_path(format),
         ConfigCommands::Edit => cmd_edit(),
@@ -111,10 +110,18 @@ fn cmd_get(key: &str, format: OutputFormat) -> Result<()> {
 }
 
 /// Set a config value in the user-level config file
-fn cmd_set(key: &str, value: &str) -> Result<()> {
+async fn cmd_set(key: &str, value: &str) -> Result<()> {
     let config_dir = AppConfig::get_user_config_dir()?;
     fs::create_dir_all(&config_dir)?;
     let config_path = config_dir.join("config.toml");
+
+    // A `hangar_daemon.*` key is not in this file: its backend is the Hangar
+    // daemon's `daemon_config` SQLite table. Writing it here would produce a
+    // `[hangar_daemon]` section nothing ever reads, which is exactly the silent
+    // no-op the registry exists to stop.
+    if let Some(daemon_key) = crate::config::registry::hangar_daemon_key(key) {
+        return set_hangar_daemon(key, daemon_key, value).await;
+    }
 
     // Validate against CONFIG_REGISTRY first: a mistyped key or an out-of-range
     // value fails here rather than landing in the file and being dropped by the
@@ -176,6 +183,32 @@ fn cmd_set(key: &str, value: &str) -> Result<()> {
     }
     println!("Saved to {}", config_path.display());
 
+    Ok(())
+}
+
+/// Write one knob to the Hangar daemon's `daemon_config` table.
+///
+/// Validated by the daemon's OWN descriptor rather than by `CONFIG_REGISTRY`:
+/// that table is the daemon's authority on what it accepts, and it is the same
+/// gate the `hangar/daemon_config_set` RPC and `ainb hangar daemon config set`
+/// pass. `CONFIG_REGISTRY` still owns the row's label, help and search entry.
+///
+/// Opening the store creates the database if it is missing, which is correct
+/// here and only here: the user has explicitly asked for a value to be stored.
+async fn set_hangar_daemon(key: &str, daemon_key: &str, value: &str) -> Result<()> {
+    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
+
+    let descriptor = ainb_hangar_core::daemon_config::descriptor(daemon_key)
+        .ok_or_else(|| anyhow!("'{key}' is not a Hangar daemon config key"))?;
+    let normalized = descriptor.validate(value).map_err(|why| anyhow!(why))?;
+    let store = ainb_hangar_store::Store::open_default()
+        .await
+        .context("open the Hangar database")?;
+    DaemonConfigRepo::set(store.pool(), daemon_key, &normalized)
+        .await
+        .with_context(|| format!("write daemon_config `{daemon_key}`"))?;
+    println!("Set {key} = {normalized}");
+    println!("Saved to the Hangar daemon database (takes effect on its next tick)");
     Ok(())
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -119,34 +119,23 @@ async fn cmd_show(format: OutputFormat) -> Result<()> {
 /// Every Hangar daemon knob and its effective value (stored, else the coded
 /// default). Falls back to the coded defaults when the database is missing or
 /// unreadable, because `show` must never fail on an optional backend.
-/// Whether the Hangar database already exists.
-///
-/// Reads must not create it: `Store::open_default` would, and the settings
-/// screen guards the same way before showing daemon rows.
-fn hangar_db_exists() -> bool {
-    ainb_hangar_core::hangar_home()
-        .map(|home| home.join("hangar.db").exists())
-        .unwrap_or(false)
-}
 
 async fn hangar_daemon_values() -> Vec<(String, String)> {
     use ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY;
-    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
 
-    // Only open an existing database. `Store::open_default` CREATES the file
-    // and runs migrations, so a read-only `ainb config show` would conjure a
-    // hangar.db on a machine that has never run the daemon — migration
-    // ownership belongs to daemon startup. Absent means "show the defaults".
-    let store = match hangar_db_exists() {
-        true => ainb_hangar_store::Store::open_default().await.ok(),
-        false => None,
-    };
+    // Read-only: `Store::open_default` both CREATES the database and applies
+    // pending migrations, so a display command would conjure a hangar.db on a
+    // machine that never ran the daemon — and, worse, migrate a running
+    // daemon's live schema. Migration ownership belongs to daemon startup.
+    let rows = ainb_hangar_store::Store::read_daemon_config_read_only()
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let stored_by_key: std::collections::HashMap<String, String> = rows.into_iter().collect();
     let mut out = Vec::with_capacity(DAEMON_CONFIG_REGISTRY.len());
     for descriptor in DAEMON_CONFIG_REGISTRY {
-        let stored = match &store {
-            Some(store) => DaemonConfigRepo::get(store.pool(), descriptor.key).await.ok().flatten(),
-            None => None,
-        };
+        let stored = stored_by_key.get(descriptor.key).cloned();
         out.push((
             descriptor.key.to_string(),
             stored.unwrap_or_else(|| descriptor.default.to_string()),
@@ -273,23 +262,19 @@ async fn cmd_set(key: &str, value: &str) -> Result<()> {
 /// actually runs: reporting "not found" would be a claim about the daemon's
 /// behaviour that is not true.
 async fn get_hangar_daemon(key: &str, daemon_key: &str, format: OutputFormat) -> Result<()> {
-    use ainb_hangar_store::repo::daemon_config::DaemonConfigRepo;
-
     let descriptor = ainb_hangar_core::daemon_config::descriptor(daemon_key)
         .ok_or_else(|| anyhow!("'{key}' is not a Hangar daemon config key"))?;
     // Same rule as `hangar_daemon_values`: a read must not create the database.
     // `Store::open_default` creates it and runs migrations, so with no daemon
     // ever started the honest answer is the registry default.
-    let stored = if hangar_db_exists() {
-        let store = ainb_hangar_store::Store::open_default()
-            .await
-            .context("open the Hangar database")?;
-        DaemonConfigRepo::get(store.pool(), daemon_key)
-            .await
-            .with_context(|| format!("read daemon_config `{daemon_key}`"))?
-    } else {
-        None
-    };
+    // Read-only, same reason as `hangar_daemon_values`.
+    let stored = ainb_hangar_store::Store::read_daemon_config_read_only()
+        .await
+        .with_context(|| format!("read daemon_config `{daemon_key}`"))?
+        .unwrap_or_default()
+        .into_iter()
+        .find(|(key, _)| key == daemon_key)
+        .map(|(_, value)| value);
     let value = stored.as_deref().unwrap_or(descriptor.default);
 
     match format {

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/needs.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/needs.rs
@@ -19,15 +19,18 @@ use crate::fleet::types::Session;
 /// Staleness window (ms) for a hook-sourced `current_state` row before the
 /// reader falls back to a live `classify()` scan. `0` (the default) disables
 /// the age check: ASK/ERR/WAIT/IDLE are sticky states the materializer only
-/// changes on a new event, so an old row is normally still the truth. Override
-/// via `AINB_FLEET_STATE_STALE_MS` only when there is an independent reason to
-/// distrust an aged row (e.g. a known-flaky daemon).
+/// changes on a new event, so an old row is normally still the truth. Raise
+/// `fleet.state_stale_ms` (or `AINB_FLEET_STATE_STALE_MS`) only when there is
+/// an independent reason to distrust an aged row (e.g. a known-flaky daemon).
+///
+/// This is the STICKY-kind window. The RUNNING/DONE floor is a separate knob
+/// with its own default; see `fleet::read::current_state`.
 fn stale_window_ms() -> i64 {
-    std::env::var("AINB_FLEET_STATE_STALE_MS")
-        .ok()
-        .and_then(|v| v.parse::<i64>().ok())
-        .filter(|n| *n >= 0)
-        .unwrap_or(0)
+    crate::config::tunables::resolved(
+        "AINB_FLEET_STATE_STALE_MS",
+        crate::config::tunables::snapshot().fleet.state_stale_ms,
+    )
+    .max(0)
 }
 
 pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> {
@@ -51,8 +54,8 @@ pub async fn execute(matches: &clap::ArgMatches, format: OutputFormat) -> Result
     Ok(())
 }
 
-/// Enrichment is on by default. `--no-enrich` or `AINB_FLEET_ENRICH=0` turns it
-/// off — the reader still attaches free cached suggestions, but no card is
+/// Enrichment is on by default. `--no-enrich`, `fleet.enrich = false`, or
+/// `AINB_FLEET_ENRICH=0` turns it off. The reader still attaches free cached suggestions, but no card is
 /// flagged `need_enrich`, so no producer (inline or agent) runs → 0 tokens.
 pub fn enrich_enabled(matches: &clap::ArgMatches) -> bool {
     if matches
@@ -64,7 +67,10 @@ pub fn enrich_enabled(matches: &clap::ArgMatches) -> bool {
     {
         return false;
     }
-    std::env::var("AINB_FLEET_ENRICH").map(|v| v != "0").unwrap_or(true)
+    crate::config::tunables::resolved_bool(
+        "AINB_FLEET_ENRICH",
+        crate::config::tunables::snapshot().fleet.enrich,
+    )
 }
 
 /// Classify every session, reading the event-sourced `current_state` table as

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -724,16 +724,13 @@ async fn dispatch_usage_via_plugin(argv: Vec<String>) -> ! {
 /// data. Subsequent runs hit session-reader's sqlite cache and finish
 /// in well under a second.
 ///
-/// Override via the `AINB_USAGE_TIMEOUT_SECS` env var when running
-/// against very large session archives.
-const PLUGIN_DATA_WAIT_DEFAULT_SECS: u64 = 120;
-
+/// Raise `usage_client.fetch_timeout_secs` (or `AINB_USAGE_TIMEOUT_SECS`)
+/// when running against very large session archives.
 fn plugin_data_wait() -> std::time::Duration {
-    std::env::var("AINB_USAGE_TIMEOUT_SECS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(std::time::Duration::from_secs)
-        .unwrap_or_else(|| std::time::Duration::from_secs(PLUGIN_DATA_WAIT_DEFAULT_SECS))
+    std::time::Duration::from_secs(crate::config::tunables::resolved(
+        "AINB_USAGE_TIMEOUT_SECS",
+        crate::config::tunables::snapshot().usage_client.fetch_timeout_secs,
+    ))
 }
 
 /// Pause between retry attempts when burndown still reports
@@ -1645,8 +1642,10 @@ impl CliCommand for WebCommand {
                     clap::Arg::new("listen")
                         .long("listen")
                         .value_name("ADDR")
-                        .default_value("127.0.0.1:8420")
-                        .help("Address to bind (default loopback; non-loopback needs --token)"),
+                        .help(
+                            "Address to bind (default: web.listen, or 127.0.0.1:8420; \
+                             non-loopback needs --token)",
+                        ),
                 )
                 .arg(
                     clap::Arg::new("token").long("token").value_name("SECRET").help(
@@ -1686,13 +1685,25 @@ impl CliCommand for WebCommand {
     fn run(&self, matches: &ArgMatches, _ctx: CliContext) -> BoxFuture<'static, Result<()>> {
         // Extract owned values synchronously so only owned data crosses into
         // the 'static future.
+        //
+        // `[web]` supplies the defaults; the flags still win, because a flag is
+        // a decision about THIS invocation and a file is a standing preference.
+        // `--listen` therefore carries no clap default any more: with one, an
+        // unset flag was indistinguishable from an explicit loopback and the
+        // config value could never be reached. The two booleans are
+        // `SetTrue`-only, so a flag can turn them on and a file is the only way
+        // to have them on by default.
+        //
+        // The token is deliberately not configurable here: `--token` is the
+        // only way in, and it never touches config.toml.
+        let defaults = &crate::config::tunables::snapshot().web;
         let listen_raw = matches
             .get_one::<String>("listen")
             .cloned()
-            .unwrap_or_else(|| "127.0.0.1:8420".to_string());
+            .unwrap_or_else(|| defaults.listen.clone());
         let token = matches.get_one::<String>("token").cloned();
-        let insecure_bind = matches.get_flag("insecure-bind");
-        let read_only = matches.get_flag("read-only");
+        let insecure_bind = matches.get_flag("insecure-bind") || defaults.insecure_bind;
+        let read_only = matches.get_flag("read-only") || defaults.read_only;
 
         Box::pin(async move {
             use std::net::ToSocketAddrs;

--- a/ainb-tui/crates/ainb-core/src/cli/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/registry.rs
@@ -1656,6 +1656,7 @@ impl CliCommand for WebCommand {
                     clap::Arg::new("insecure-bind")
                         .long("insecure-bind")
                         .action(clap::ArgAction::SetTrue)
+                        .overrides_with("no-insecure-bind")
                         .help(
                             "Allow a non-loopback bind with no token. DANGEROUS: an \
                              unauthenticated bind exposes a control surface — the live WS \
@@ -1668,9 +1669,31 @@ impl CliCommand for WebCommand {
                     clap::Arg::new("read-only")
                         .long("read-only")
                         .action(clap::ArgAction::SetTrue)
+                        .overrides_with("no-read-only")
                         .help(
                             "Viewer-only: disable the live terminal write surface \
                              (the WS terminal is refused with 403)",
+                        ),
+                )
+                // Negations exist because `[web]` can now turn these on by
+                // default. A SetTrue flag can only ever say "on", so without
+                // these there is no way to run one invocation with the write
+                // surface enabled once `web.read_only = true` is in the file.
+                .arg(
+                    clap::Arg::new("no-read-only")
+                        .long("no-read-only")
+                        .action(clap::ArgAction::SetTrue)
+                        .overrides_with("read-only")
+                        .help("Serve the write surface for this run, overriding web.read_only"),
+                )
+                .arg(
+                    clap::Arg::new("no-insecure-bind")
+                        .long("no-insecure-bind")
+                        .action(clap::ArgAction::SetTrue)
+                        .overrides_with("insecure-bind")
+                        .help(
+                            "Refuse an unauthenticated non-loopback bind for this run, \
+                             overriding web.insecure_bind",
                         ),
                 )
                 .after_help(
@@ -1690,20 +1713,34 @@ impl CliCommand for WebCommand {
         // a decision about THIS invocation and a file is a standing preference.
         // `--listen` therefore carries no clap default any more: with one, an
         // unset flag was indistinguishable from an explicit loopback and the
-        // config value could never be reached. The two booleans are
-        // `SetTrue`-only, so a flag can turn them on and a file is the only way
-        // to have them on by default.
+        // config value could never be reached.
+        //
+        // Each boolean reads as three states, not two: an explicit `--no-x`
+        // turns it off, an explicit `--x` turns it on, and neither defers to
+        // the file. `flag || config` is what a SetTrue pair cannot express, and
+        // it made `insecure_bind` in particular a one-way door: once true in
+        // config there was no invocation that could refuse it again.
         //
         // The token is deliberately not configurable here: `--token` is the
         // only way in, and it never touches config.toml.
-        let defaults = &crate::config::tunables::snapshot().web;
+        let defaults = crate::config::tunables::snapshot();
+        let defaults = &defaults.web;
+        let flag_or = |on: &str, off: &str, from_config: bool| {
+            if matches.get_flag(off) {
+                false
+            } else if matches.get_flag(on) {
+                true
+            } else {
+                from_config
+            }
+        };
         let listen_raw = matches
             .get_one::<String>("listen")
             .cloned()
             .unwrap_or_else(|| defaults.listen.clone());
         let token = matches.get_one::<String>("token").cloned();
-        let insecure_bind = matches.get_flag("insecure-bind") || defaults.insecure_bind;
-        let read_only = matches.get_flag("read-only") || defaults.read_only;
+        let insecure_bind = flag_or("insecure-bind", "no-insecure-bind", defaults.insecure_bind);
+        let read_only = flag_or("read-only", "no-read-only", defaults.read_only);
 
         Box::pin(async move {
             use std::net::ToSocketAddrs;

--- a/ainb-tui/crates/ainb-core/src/components/home_screen_v2.rs
+++ b/ainb-tui/crates/ainb-core/src/components/home_screen_v2.rs
@@ -29,7 +29,12 @@ const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
 const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 const DISPLAY_VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
 const SIDEBAR_EDGE_HIT_SLOP: u16 = 1;
-pub const SIDEBAR_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
+/// Window in which two sidebar clicks count as a double-click, from
+/// `ui.double_click_ms`. A function rather than a const because the value is a
+/// preference now, for the same reason a slow-hands accessibility setting exists.
+pub fn sidebar_double_click_window() -> Duration {
+    Duration::from_millis(crate::config::tunables::snapshot().ui.double_click_ms)
+}
 
 /// Focus area on the home screen
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -189,7 +194,7 @@ impl HomeScreenV2State {
             .last_sidebar_click
             .map(|(last_index, last_at)| {
                 last_index == item_index
-                    && now.saturating_duration_since(last_at) <= SIDEBAR_DOUBLE_CLICK_WINDOW
+                    && now.saturating_duration_since(last_at) <= sidebar_double_click_window()
             })
             .unwrap_or(false);
         self.last_sidebar_click = Some((item_index, now));
@@ -782,7 +787,8 @@ mod tests {
         assert!(!first.double_click);
         assert_eq!(state.sidebar.selected_item(), SidebarItem::Setup);
 
-        let second = state.click_sidebar_item_at(3, 9, now + SIDEBAR_DOUBLE_CLICK_WINDOW).unwrap();
+        let second =
+            state.click_sidebar_item_at(3, 9, now + sidebar_double_click_window()).unwrap();
         assert_eq!(second.item, SidebarItem::Setup);
         assert!(second.double_click);
     }
@@ -799,7 +805,7 @@ mod tests {
                 .click_sidebar_item_at(
                     3,
                     10,
-                    now + SIDEBAR_DOUBLE_CLICK_WINDOW + Duration::from_millis(1)
+                    now + sidebar_double_click_window() + Duration::from_millis(1)
                 )
                 .unwrap()
                 .double_click

--- a/ainb-tui/crates/ainb-core/src/components/inbox.rs
+++ b/ainb-tui/crates/ainb-core/src/components/inbox.rs
@@ -157,8 +157,14 @@ impl std::fmt::Debug for InboxState {
     }
 }
 
-const POLL_TICKS: u64 = 1; // every render — cheap with WAL + LIMIT 200
-const LIST_LIMIT: u32 = 200;
+const POLL_TICKS: u64 = 1; // every render, cheap with WAL + a bounded LIMIT
+
+/// Rows the list query asks for, from `ui.inbox_list_limit`. Read per refresh
+/// rather than baked in as a const, because the query runs every render and the
+/// right bound depends on the size of the fleet in front of it.
+fn list_limit() -> u32 {
+    crate::config::tunables::snapshot().ui.inbox_list_limit
+}
 
 impl InboxState {
     /// Open the SQLite store lazily and refresh the visible rows.
@@ -183,7 +189,7 @@ impl InboxState {
                 self.show_archived,
                 self.agent_filter.as_sql(),
                 None,
-                LIST_LIMIT,
+                list_limit(),
             ) {
                 Ok(rows) => {
                     self.rows = rows;

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -577,7 +577,7 @@ fn default_fleet_transport() -> String {
     "tmux".to_string()
 }
 
-fn default_fleet_healthy_state_stale_ms() -> i64 {
+pub(crate) fn default_fleet_healthy_state_stale_ms() -> i64 {
     5 * 60_000
 }
 

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -2103,7 +2103,25 @@ impl AppConfig {
         if other.web != WebServerConfig::default() {
             self.web = other.web;
         }
-        self.acp.adapters.extend(other.acp.adapters);
+        // Per FIELD, not per entry. `HashMap::extend` replaces the whole
+        // value, so a higher layer that set only `command` reset
+        // `permission_mode` back to the default — which defeats the point of
+        // `AcpAdapterToml`'s Option fields, where an absent key means "leave
+        // the built-in alone".
+        for (name, adapter) in other.acp.adapters {
+            let entry = self.acp.adapters.entry(name).or_default();
+            if adapter.command.is_some() {
+                entry.command = adapter.command;
+            }
+            // `permission_mode` is a `String` with a serde default here, so an
+            // absent key and an explicit `"default"` are indistinguishable
+            // after deserialization. Same differs-from-default convention the
+            // rest of this merge uses; the cost is that explicitly writing the
+            // default in a higher layer cannot override a lower one.
+            if adapter.permission_mode != crate::config::tunables::default_acp_permission_mode() {
+                entry.permission_mode = adapter.permission_mode;
+            }
+        }
     }
 
     /// Load built-in container templates

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -1785,6 +1785,12 @@ impl AppConfig {
 
         match write_atomic(&config_path, &content) {
             Ok(()) => {
+                // The promoted tunables read from a process-wide snapshot, so
+                // without this a save reports success and changes nothing until
+                // the next launch: syntax highlighting stays on, the inbox keeps
+                // its old limit. Re-loads rather than installing `self`, because
+                // `load()` also merges the project and system layers.
+                tunables::refresh_snapshot();
                 // Audit log the successful config save
                 audit::audit_config_saved(
                     &config_path.display().to_string(),

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -22,6 +22,7 @@ pub mod registry;
 pub mod screen_model;
 pub mod session_defaults;
 pub mod ssh_display_names;
+pub mod tunables;
 
 pub use container::{ContainerTemplate, ContainerTemplateConfig};
 pub use favorites_store::{
@@ -35,6 +36,10 @@ pub use presets::{PermissionSet, PresetManager, RepositoryPreset, create_default
 pub use registry::{CONFIG_REGISTRY, ConfigRow, Entry as ConfigEntry, RowKind};
 pub use session_defaults::{PerRepoDefaults, SessionDefaults};
 pub use ssh_display_names::{SessionLabelStore, SshDisplayNameStore, normalize_session_label};
+pub use tunables::{
+    AcpAdapterConfig, AcpConfig, DaemonsConfig, GeneralConfig, NotifydConfig, UiConfig,
+    UsageClientConfig, WebServerConfig,
+};
 
 /// Authentication provider for Claude API
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -268,6 +273,37 @@ pub struct AppConfig {
     /// Shared MCP pool settings. See [`McpPoolConfig`].
     #[serde(default)]
     pub mcp_pool: McpPoolConfig,
+
+    /// Cross-cutting knobs with no other home. See [`GeneralConfig`].
+    #[serde(default)]
+    pub general: GeneralConfig,
+
+    /// TUI cadences and query bounds. See [`UiConfig`].
+    #[serde(default)]
+    pub ui: UiConfig,
+
+    /// Daemon-staleness windows. See [`DaemonsConfig`].
+    #[serde(default)]
+    pub daemons: DaemonsConfig,
+
+    /// How usage data is fetched and cached: core's half of usage, distinct
+    /// from the plugin-owned `[usage]`. See [`UsageClientConfig`].
+    #[serde(default)]
+    pub usage_client: UsageClientConfig,
+
+    /// Notification-daemon knobs, parsed by the daemon itself and mirrored
+    /// here so a save round-trips them. See [`NotifydConfig`].
+    #[serde(default)]
+    pub notifyd: NotifydConfig,
+
+    /// `ainb web` defaults, overridden by its CLI flags. See
+    /// [`WebServerConfig`].
+    #[serde(default)]
+    pub web: WebServerConfig,
+
+    /// The ACP adapter registry. See [`AcpConfig`].
+    #[serde(default)]
+    pub acp: AcpConfig,
 }
 
 /// Shared MCP server pool for host (tmux) sessions.
@@ -467,6 +503,55 @@ pub struct FleetConfig {
     /// `Option` for the same presence reason as [`InterviewConfig::surface`].
     #[serde(default)]
     pub terminal: Option<String>,
+    /// Minutes a session must sit quiet before it reads IDLE.
+    ///
+    /// One knob for both IDLE producers (the tmux classifier and notifyd's
+    /// hook-sourced fold), so a session cannot be idle to one and busy to the
+    /// other. Env: `AINB_FLEET_IDLE_MIN`.
+    #[serde(default = "default_fleet_idle_min")]
+    pub idle_min: u64,
+
+    /// How `ainb fleet send` delivers: `tmux` (send-keys first, broker
+    /// fallback), `tmux-only`, or `broker`. Env: `AINB_FLEET_TRANSPORT`.
+    #[serde(default = "default_fleet_transport")]
+    pub transport: String,
+
+    /// Attach cost/hint enrichment to fleet rows. Off means the reader still
+    /// serves free cached suggestions but flags nothing `need_enrich`, so no
+    /// producer runs and no tokens are spent. Env: `AINB_FLEET_ENRICH`.
+    #[serde(default = "default_true")]
+    pub enrich: bool,
+
+    /// Staleness window (ms) for a hook-sourced `current_state` row of a STICKY
+    /// kind (ASK/ERR/WAIT/IDLE) before the reader falls back to a live scan.
+    /// `0` (the default) disables the check: those kinds stay true until a new
+    /// event changes them, so age is a poor staleness signal for them.
+    ///
+    /// Distinct from [`healthy_state_stale_ms`](Self::healthy_state_stale_ms),
+    /// which is the point of splitting them. Both windows used to read the ONE
+    /// env var `AINB_FLEET_STATE_STALE_MS` with two different hardcoded
+    /// fallbacks (0 here, 300000 there), so setting it moved two unrelated
+    /// clocks at once and neither had a single knowable default.
+    /// Env: `AINB_FLEET_STATE_STALE_MS`.
+    #[serde(default)]
+    pub state_stale_ms: i64,
+
+    /// Staleness window (ms) for a hook-sourced row of a HEALTHY-suppressing
+    /// kind (RUNNING/DONE). These are the dangerous ones: a daemon that stopped
+    /// materializing leaves a stale RUNNING row that suppresses the live scan
+    /// forever, so this window has a real floor rather than being off by
+    /// default. Env: `AINB_FLEET_HEALTHY_STATE_STALE_MS`, falling back to the
+    /// legacy `AINB_FLEET_STATE_STALE_MS` so an existing override keeps working.
+    #[serde(default = "default_fleet_healthy_state_stale_ms")]
+    pub healthy_state_stale_ms: i64,
+
+    /// Seconds of pane silence after which tmux discovery calls a live session
+    /// between turns rather than working. Sized above a slow tool call so a
+    /// quiet-but-busy agent is not mislabelled.
+    /// Env: `AINB_FLEET_TMUX_IDLE_AFTER_SECS`.
+    #[serde(default = "default_fleet_tmux_idle_after_secs")]
+    pub tmux_idle_after_secs: i64,
+
     /// `[fleet.bridge]` carried verbatim, never interpreted here.
     ///
     /// The phone bridge parses this table itself, off the same file, with its
@@ -484,12 +569,34 @@ fn default_fleet_terminal() -> &'static str {
     "warp"
 }
 
+fn default_fleet_idle_min() -> u64 {
+    5
+}
+
+fn default_fleet_transport() -> String {
+    "tmux".to_string()
+}
+
+fn default_fleet_healthy_state_stale_ms() -> i64 {
+    5 * 60_000
+}
+
+fn default_fleet_tmux_idle_after_secs() -> i64 {
+    120
+}
+
 impl Default for FleetConfig {
     fn default() -> Self {
         Self {
             cost: CostBudgetConfig::default(),
             interview: InterviewConfig::default(),
             terminal: None,
+            idle_min: default_fleet_idle_min(),
+            transport: default_fleet_transport(),
+            enrich: true,
+            state_stale_ms: 0,
+            healthy_state_stale_ms: default_fleet_healthy_state_stale_ms(),
+            tmux_idle_after_secs: default_fleet_tmux_idle_after_secs(),
             bridge: None,
         }
     }
@@ -737,6 +844,19 @@ pub struct WorkspaceDefaults {
     /// Behavior when a target worktree path already exists
     #[serde(default)]
     pub worktree_collision_behavior: WorktreeCollisionBehavior,
+
+    /// How many directory levels below each scan path the repository scanner
+    /// descends. `WorkspaceScanner::with_max_depth` has always existed and was
+    /// never wired to anything, so the value was effectively frozen at 3. Deep
+    /// trees need more; every extra level multiplies the walk.
+    #[serde(default = "default_scan_max_depth")]
+    pub scan_max_depth: usize,
+
+    /// Seconds a cached repository scan stays fresh before the next scan walks
+    /// the disk again. The cache is also invalidated by a scan path's mtime, so
+    /// this is the ceiling on staleness, not the only guard.
+    #[serde(default = "default_scan_cache_ttl_secs")]
+    pub scan_cache_ttl_secs: i64,
 }
 
 impl Default for WorkspaceDefaults {
@@ -747,6 +867,8 @@ impl Default for WorkspaceDefaults {
             workspace_scan_paths: Vec::new(),
             max_repositories: default_max_repositories(),
             worktree_collision_behavior: WorktreeCollisionBehavior::default(),
+            scan_max_depth: default_scan_max_depth(),
+            scan_cache_ttl_secs: default_scan_cache_ttl_secs(),
         }
     }
 }
@@ -933,6 +1055,14 @@ fn default_docker_timeout() -> u64 {
 
 fn default_max_repositories() -> usize {
     500
+}
+
+fn default_scan_max_depth() -> usize {
+    3
+}
+
+fn default_scan_cache_ttl_secs() -> i64 {
+    3600
 }
 
 /// Merge a higher-layer per-plugin value table into the lower-layer one in
@@ -1798,6 +1928,13 @@ impl AppConfig {
             self.workspace_defaults.worktree_collision_behavior =
                 other.workspace_defaults.worktree_collision_behavior;
         }
+        if other.workspace_defaults.scan_max_depth != default_scan_max_depth() {
+            self.workspace_defaults.scan_max_depth = other.workspace_defaults.scan_max_depth;
+        }
+        if other.workspace_defaults.scan_cache_ttl_secs != default_scan_cache_ttl_secs() {
+            self.workspace_defaults.scan_cache_ttl_secs =
+                other.workspace_defaults.scan_cache_ttl_secs;
+        }
 
         // Override UI preferences
         // Check if this is an old config (empty theme indicates pre-v0.4 config)
@@ -1883,6 +2020,28 @@ impl AppConfig {
         if other.fleet.bridge.is_some() {
             self.fleet.bridge.clone_from(&other.fleet.bridge);
         }
+        // Promoted knobs: a layer counts as having set one only when it differs
+        // from the coded default. A field with no arm here is silently DROPPED
+        // on load and then overlaid back onto the file by the next save. That
+        // is the failure `loading_restores_the_config_tree_expansion` guards.
+        if other.fleet.idle_min != default_fleet_idle_min() {
+            self.fleet.idle_min = other.fleet.idle_min;
+        }
+        if other.fleet.transport != default_fleet_transport() {
+            self.fleet.transport = other.fleet.transport.clone();
+        }
+        if !other.fleet.enrich {
+            self.fleet.enrich = false;
+        }
+        if other.fleet.state_stale_ms != 0 {
+            self.fleet.state_stale_ms = other.fleet.state_stale_ms;
+        }
+        if other.fleet.healthy_state_stale_ms != default_fleet_healthy_state_stale_ms() {
+            self.fleet.healthy_state_stale_ms = other.fleet.healthy_state_stale_ms;
+        }
+        if other.fleet.tmux_idle_after_secs != default_fleet_tmux_idle_after_secs() {
+            self.fleet.tmux_idle_after_secs = other.fleet.tmux_idle_after_secs;
+        }
 
         // Pool settings: trust the loaded layer whenever it differs from the
         // defaults. `enabled = false` must survive (it IS the default-diverging
@@ -1914,6 +2073,31 @@ impl AppConfig {
                 higher_table,
             );
         }
+
+        // Promoted sections layer wholesale, like `[mcp_pool]`: a layer that
+        // omits the section deserializes to the default and changes nothing, so
+        // "differs from the default" is the only usable signal that a file set
+        // it. `[acp]` is a map and layers per adapter instead, so a project can
+        // repoint one adapter without redeclaring the registry.
+        if other.general != GeneralConfig::default() {
+            self.general = other.general;
+        }
+        if other.ui != UiConfig::default() {
+            self.ui = other.ui;
+        }
+        if other.daemons != DaemonsConfig::default() {
+            self.daemons = other.daemons;
+        }
+        if other.usage_client != UsageClientConfig::default() {
+            self.usage_client = other.usage_client;
+        }
+        if other.notifyd != NotifydConfig::default() {
+            self.notifyd = other.notifyd;
+        }
+        if other.web != WebServerConfig::default() {
+            self.web = other.web;
+        }
+        self.acp.adapters.extend(other.acp.adapters);
     }
 
     /// Load built-in container templates
@@ -1960,6 +2144,13 @@ impl Default for AppConfig {
             presets: PresetsConfig::default(),
             fleet: FleetConfig::default(),
             mcp_pool: McpPoolConfig::default(),
+            general: GeneralConfig::default(),
+            ui: UiConfig::default(),
+            daemons: DaemonsConfig::default(),
+            usage_client: UsageClientConfig::default(),
+            notifyd: NotifydConfig::default(),
+            web: WebServerConfig::default(),
+            acp: AcpConfig::default(),
         };
 
         // Load built-in templates

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -1078,7 +1078,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "usage_client.headroom_port",
         category: C::Usage,
         label: "Headroom Proxy Port",
-        help: "Port the ainb-managed Headroom compression proxy listens on",
+        help: "Port the ainb-managed Headroom compression proxy listens on (restart)",
         kind: RowKind::Number {
             min: 1,
             max: 65_535,
@@ -1108,7 +1108,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "usage_client.cache_db",
         category: C::Usage,
         label: "Usage Cache DB",
-        help: "Path to the usage cache database; blank derives it under the state dir",
+        help: "Path to the usage cache database; blank derives it under the state dir (restart)",
         kind: RowKind::Text,
     }),
     // ── Daemons ────────────────────────────────────────────────────────────

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -1169,7 +1169,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "web.insecure_bind",
         category: C::Web,
         label: "Allow Insecure Bind",
-        help: "Permit a non-loopback bind with no token; honoured only with read-only",
+        help: "DANGEROUS: serves an unauthenticated control surface to the network. Only with read-only; prefer a token",
         kind: RowKind::Bool,
     }),
     // ── ACP adapters ───────────────────────────────────────────────────────

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -146,6 +146,27 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         kind: RowKind::Text,
     }),
     Entry::Row(ConfigRow {
+        key: "general.syntax_highlight",
+        category: C::General,
+        label: "Syntax Highlighting",
+        help: "Colourise fenced code blocks in agent output (NO_COLOR still wins)",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "general.skill_install_real_homes",
+        category: C::General,
+        label: "Install Skills To Real Tool Homes",
+        help: "Write installs to ~/.claude, ~/.codex … instead of ainb's managed sandbox",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "general.home",
+        category: C::General,
+        label: "State Directory",
+        help: "Base dir for ainb state (<home>/.agents-in-a-box); blank = your home dir",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
         key: "presets.file",
         category: C::Presets,
         label: "Presets File",
@@ -516,7 +537,23 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         help: "When a worktree path already exists: rename automatically, or fail",
         kind: RowKind::Choice(&["auto_rename", "error"]),
     }),
-    // ── UI preferences ─────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "workspace_defaults.scan_max_depth",
+        category: C::Workspace,
+        label: "Scan Depth",
+        help: "Directory levels below each scan path the repo scanner descends",
+        kind: RowKind::Number { min: 1, max: 16 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "workspace_defaults.scan_cache_ttl_secs",
+        category: C::Workspace,
+        label: "Scan Cache TTL",
+        help: "Seconds a cached repository scan stays fresh before walking disk again",
+        kind: RowKind::Number {
+            min: 0,
+            max: 604_800,
+        },
+    }), // ── UI preferences ─────────────────────────────────────────────────────
     Entry::Row(ConfigRow {
         key: "ui_preferences.theme",
         category: C::Appearance,
@@ -584,6 +621,61 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "ui_preferences.config_tree_expanded",
         why: "which nodes of this very screen's tree are open; written by the expand keypress, like the sidebar widths",
     },
+    // ── UI tunables ────────────────────────────────────────────────────────
+    // `[ui]`, not `[ui_preferences]`: that section is what the interface LOOKS
+    // like and the TUI writes it back; these are cadences and query bounds a
+    // user tunes for a slow terminal or a very large fleet.
+    Entry::Row(ConfigRow {
+        key: "ui.tick_rate_ms",
+        category: C::Appearance,
+        label: "Event Poll Interval",
+        help: "Milliseconds between input polls; lower feels snappier and costs CPU",
+        kind: RowKind::Number { min: 1, max: 1000 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui.app_tick_ms",
+        category: C::Appearance,
+        label: "App Tick Interval",
+        help: "Milliseconds between heavy periodic passes (previews, animation, refreshes)",
+        kind: RowKind::Number {
+            min: 1,
+            max: 60_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui.session_query_limit",
+        category: C::Appearance,
+        label: "Attention Query Limit",
+        help: "Rows the attention-marker query reads per refresh",
+        kind: RowKind::Number {
+            min: 1,
+            max: 100_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui.session_lookback_hours",
+        category: C::Appearance,
+        label: "Attention Lookback",
+        help: "Hours back an event may still raise a session's attention marker",
+        kind: RowKind::Number { min: 1, max: 8760 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui.inbox_list_limit",
+        category: C::Appearance,
+        label: "Inbox Row Limit",
+        help: "Rows the Inbox lists; the query runs every render, so keep it modest",
+        kind: RowKind::Number {
+            min: 1,
+            max: 100_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui.double_click_ms",
+        category: C::Appearance,
+        label: "Double-Click Window",
+        help: "Milliseconds in which two clicks count as one double-click",
+        kind: RowKind::Number { min: 50, max: 2000 },
+    }),
     // ── Docker ─────────────────────────────────────────────────────────────
     Entry::Row(ConfigRow {
         key: "docker.host",
@@ -747,7 +839,60 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         help: "Terminal the macOS Fleet app opens when you jump to a session",
         kind: RowKind::Choice(&["warp", "iterm", "ghostty", "terminal"]),
     }),
-    // ── Fleet bridge ───────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "fleet.idle_min",
+        category: C::Fleet,
+        label: "Idle Threshold",
+        help: "Minutes of quiet before a session reads IDLE, for tmux and hook sources alike",
+        kind: RowKind::Number {
+            min: 1,
+            max: 10_080,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.transport",
+        category: C::Fleet,
+        label: "Send Transport",
+        help: "How `ainb fleet send` delivers: tmux first, tmux only, or the broker",
+        kind: RowKind::Choice(&["tmux", "tmux-only", "broker"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.enrich",
+        category: C::Fleet,
+        label: "Row Enrichment",
+        help: "Attach cost/hint enrichment to fleet rows; off spends no tokens",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.state_stale_ms",
+        category: C::Fleet,
+        label: "Sticky State Staleness",
+        help: "Milliseconds before an ASK/ERR/WAIT/IDLE row falls back to a live scan; 0 = never",
+        kind: RowKind::Number {
+            min: 0,
+            max: 86_400_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.healthy_state_stale_ms",
+        category: C::Fleet,
+        label: "Healthy State Staleness",
+        help: "Milliseconds before a RUNNING/DONE row stops suppressing the live scan",
+        kind: RowKind::Number {
+            min: 0,
+            max: 86_400_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "fleet.tmux_idle_after_secs",
+        category: C::Fleet,
+        label: "tmux Idle After",
+        help: "Seconds of pane silence before tmux discovery calls a session between turns",
+        kind: RowKind::Number {
+            min: 1,
+            max: 86_400,
+        },
+    }), // ── Fleet bridge ───────────────────────────────────────────────────────
     // Parsed by `fleet::bridge::config` off the same file; `ainb-core` carries
     // it as an opaque passthrough, so these rows are declared by hand and are
     // exempt from the schema walk (see EXTERNAL_PREFIXES).
@@ -931,6 +1076,122 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
             max: 604_800,
         },
     }),
+    // ── Usage client ───────────────────────────────────────────────────────
+    // Core's half of usage. `[usage]` above is the burndown plugin's and is
+    // read-only here; see `UsageClientConfig` for why these are not folded in.
+    Entry::Row(ConfigRow {
+        key: "usage_client.headroom_port",
+        category: C::Usage,
+        label: "Headroom Proxy Port",
+        help: "Port the ainb-managed Headroom compression proxy listens on",
+        kind: RowKind::Number {
+            min: 1,
+            max: 65_535,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage_client.fetch_timeout_secs",
+        category: C::Usage,
+        label: "Usage Fetch Timeout",
+        help: "Seconds `ainb usage` waits for data; raise it against a huge session archive",
+        kind: RowKind::Number {
+            min: 1,
+            max: 86_400,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage_client.codex_ttl_secs",
+        category: C::Usage,
+        label: "Codex Statusline TTL",
+        help: "Seconds between Codex statusline usage refreshes",
+        kind: RowKind::Number {
+            min: 1,
+            max: 86_400,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "usage_client.cache_db",
+        category: C::Usage,
+        label: "Usage Cache DB",
+        help: "Path to the usage cache database; blank derives it under the state dir",
+        kind: RowKind::Text,
+    }),
+    // ── Daemons ────────────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "daemons.stale_after_ms",
+        category: C::Daemons,
+        label: "Heartbeat Staleness",
+        help: "Milliseconds without a heartbeat before a live-pid daemon reads stale",
+        kind: RowKind::Number {
+            min: 1_000,
+            max: 86_400_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "daemons.attention_stale_after_ms",
+        category: C::Daemons,
+        label: "Bridge Push Staleness",
+        help: "Milliseconds without a successful attention poll before the bridge reads broken",
+        kind: RowKind::Number {
+            min: 1_000,
+            max: 86_400_000,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "notifyd.os_debounce_secs",
+        category: C::Daemons,
+        label: "OS Notification Debounce",
+        help: "Seconds one session/event pair waits before it may notify again",
+        kind: RowKind::Number {
+            min: 0,
+            max: 86_400,
+        },
+    }),
+    Entry::Row(ConfigRow {
+        key: "notifyd.approval_timeout_secs",
+        category: C::Daemons,
+        label: "Approval Timeout",
+        help: "Seconds an unanswered permission request waits before it is auto-DENIED",
+        kind: RowKind::Number { min: 1, max: 630 },
+    }),
+    // ── Web dashboard ──────────────────────────────────────────────────────
+    // No token row: `--token` puts it in the OS keychain, never in this file.
+    Entry::Row(ConfigRow {
+        key: "web.listen",
+        category: C::Web,
+        label: "Listen Address",
+        help: "host:port `ainb web` binds by default; --listen still overrides",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "web.read_only",
+        category: C::Web,
+        label: "Read-Only",
+        help: "Serve viewer-only: the live terminal and POST /api/answer are refused",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "web.insecure_bind",
+        category: C::Web,
+        label: "Allow Insecure Bind",
+        help: "Permit a non-loopback bind with no token; honoured only with read-only",
+        kind: RowKind::Bool,
+    }),
+    // ── ACP adapters ───────────────────────────────────────────────────────
+    Entry::Row(ConfigRow {
+        key: "acp.adapters.*.command",
+        category: C::Acp,
+        label: "Adapter Command",
+        help: "Executable to spawn for this adapter; blank resolves its name on PATH",
+        kind: RowKind::Text,
+    }),
+    Entry::Row(ConfigRow {
+        key: "acp.adapters.*.permission_mode",
+        category: C::Acp,
+        label: "Permission Mode",
+        help: "Mode pinned at session/new and re-asserted after every session/load",
+        kind: RowKind::Choice(&["default", "acceptEdits", "bypassPermissions", "plan"]),
+    }),
     // ── Sections owned by other crates ─────────────────────────────────────
     // Same file, different parser. See EXTERNAL_PREFIXES.
     Entry::Row(ConfigRow {
@@ -957,7 +1218,69 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
             max: 36_500,
         },
     }),
+    // ── Hangar daemon ──────────────────────────────────────────────────────
+    // A SECOND write backend: these live in the `daemon_config` SQLite table,
+    // not in config.toml, and are written over the daemon's control socket.
+    // Mirrored from `ainb_hangar_core::daemon_config::DAEMON_CONFIG_REGISTRY`
+    // (which cannot be iterated into a `const`), and pinned to it by
+    // `hangar_daemon_rows_match_the_daemon_registry`.
+    Entry::Row(ConfigRow {
+        key: "hangar_daemon.autostandup.enabled",
+        category: C::HangarDaemon,
+        label: "Auto-standup",
+        help: "Globally enable the auto-standup watcher (opt-in)",
+        kind: RowKind::Bool,
+    }),
+    Entry::Row(ConfigRow {
+        key: "hangar_daemon.autostandup.stagnant_min",
+        category: C::HangarDaemon,
+        label: "Stagnant Minutes",
+        help: "Minutes a session must be idle before a standup fires",
+        kind: RowKind::Number { min: 1, max: 1440 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "hangar_daemon.autostandup.cooldown_min",
+        category: C::HangarDaemon,
+        label: "Cooldown Minutes",
+        help: "Per-session minutes between successive standups",
+        kind: RowKind::Number { min: 1, max: 1440 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "hangar_daemon.autostandup.max_concurrent",
+        category: C::HangarDaemon,
+        label: "Max Concurrent",
+        help: "Maximum simultaneous in-flight standups",
+        kind: RowKind::Number { min: 1, max: 64 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "hangar_daemon.card_agent.default",
+        category: C::HangarDaemon,
+        label: "Default Agent",
+        help: "Host-wide default provider backend for new cards",
+        kind: RowKind::Choice(&["claude", "codex", "copilot"]),
+    }),
+    Entry::Row(ConfigRow {
+        key: "hangar_daemon.workspace.creation_disabled",
+        category: C::HangarDaemon,
+        label: "Lock Workspace Creation",
+        help: "Refuse every new-workspace create on this instance (self-host lockdown)",
+        kind: RowKind::Bool,
+    }),
 ];
+
+/// The registry-key prefix for a knob backed by the Hangar daemon's
+/// `daemon_config` SQLite table rather than config.toml.
+///
+/// Strip it to get the `daemon_config` key
+/// (`hangar_daemon.autostandup.enabled` → `autostandup.enabled`).
+pub const HANGAR_DAEMON_PREFIX: &str = "hangar_daemon.";
+
+/// The `daemon_config` key a `hangar_daemon.*` registry key names, or `None`
+/// for any other key.
+#[must_use]
+pub fn hangar_daemon_key(key: &str) -> Option<&str> {
+    key.strip_prefix(HANGAR_DAEMON_PREFIX)
+}
 
 /// Top-level prefixes that live in `config.toml` but not in
 /// [`AppConfig`](crate::config::AppConfig)'s serde shape.
@@ -965,10 +1288,17 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
 /// `[fleet.bridge]` is carried as an opaque `toml::Value` passthrough (its
 /// tokens are parsed by `fleet::bridge::config`), and `[skills]` /
 /// `[session_reader]` are parsed off the same file by `ainb-cli` and the
-/// session-reader plugin. Their leaves are registered by hand above and are
-/// skipped by the schema walk in both directions: nothing here can prove they
-/// exist, so nothing here should claim they don't.
-pub const EXTERNAL_PREFIXES: &[&str] = &["fleet.bridge.", "skills.", "session_reader."];
+/// session-reader plugin. `hangar_daemon.` is not in this file at all: it is
+/// the Hangar daemon's `daemon_config` SQLite table, reached over the control
+/// socket. Their leaves are registered by hand above and are skipped by the
+/// schema walk in both directions: nothing here can prove they exist, so
+/// nothing here should claim they don't.
+pub const EXTERNAL_PREFIXES: &[&str] = &[
+    "fleet.bridge.",
+    "skills.",
+    "session_reader.",
+    "hangar_daemon.",
+];
 
 /// Registry keys whose schema field is an `Option`: clearing the widget must
 /// REMOVE the key rather than store an empty value.
@@ -983,6 +1313,7 @@ pub const EXTERNAL_PREFIXES: &[&str] = &["fleet.bridge.", "skills.", "session_re
 /// by `optional_keys_match_the_schema` — which DERIVES the true set by dropping
 /// each leaf and checking whether serde puts it back.
 pub const OPTIONAL_KEYS: &[&str] = &[
+    "acp.adapters.*.command",
     "authentication.github_method",
     "container_templates.*.config.command",
     "container_templates.*.config.cpu_limit",
@@ -999,8 +1330,10 @@ pub const OPTIONAL_KEYS: &[&str] = &[
     "fleet.cost.session_usd",
     "fleet.interview.surface",
     "fleet.terminal",
+    "general.home",
     "ui_preferences.preferred_editor",
     "usage.model_aliases.*",
+    "usage_client.cache_db",
 ];
 
 /// True when clearing this row's widget should remove the key.
@@ -1012,6 +1345,7 @@ pub fn is_optional(key: &str) -> bool {
 /// Registry paths whose direct children are user-chosen map keys rather than
 /// schema field names. The child segment normalises to `*`.
 const MAP_PARENTS: &[&str] = &[
+    "acp.adapters",
     "container_templates",
     "container_templates.*.config.environment",
     "container_templates.*.config.image_source.build_args",
@@ -1484,11 +1818,13 @@ mod tests {
     use crate::app::state::SessionFilter;
     use crate::config::container::{ImageSource, VolumeMount};
     use crate::config::{
-        AppConfig, AuthenticationConfig, ClaudeAuthProvider, CliProvider, ContainerTemplate,
-        ContainerTemplateConfig, CostBudgetConfig, CurrencyConfig, DockerConfig, FleetConfig,
-        InterviewConfig, McpInstallation, McpPoolConfig, McpServerConfig, McpServerDefinition,
-        PluginsConfig, PresetsConfig, StatuslineDecision, TmuxDecision, UiPreferences, UsageConfig,
-        UsagePlan, UsagePlanId, UsagePlanProvider, WorkspaceDefaults, WorktreeCollisionBehavior,
+        AcpAdapterConfig, AcpConfig, AppConfig, AuthenticationConfig, ClaudeAuthProvider,
+        CliProvider, ContainerTemplate, ContainerTemplateConfig, CostBudgetConfig, CurrencyConfig,
+        DaemonsConfig, DockerConfig, FleetConfig, GeneralConfig, InterviewConfig, McpInstallation,
+        McpPoolConfig, McpServerConfig, McpServerDefinition, NotifydConfig, PluginsConfig,
+        PresetsConfig, StatuslineDecision, TmuxDecision, UiConfig, UiPreferences,
+        UsageClientConfig, UsageConfig, UsagePlan, UsagePlanId, UsagePlanProvider, WebServerConfig,
+        WorkspaceDefaults, WorktreeCollisionBehavior,
     };
     use std::collections::{BTreeMap, HashMap};
 
@@ -1522,6 +1858,8 @@ mod tests {
                 workspace_scan_paths: vec!["/tmp/repos".into()],
                 max_repositories: 500,
                 worktree_collision_behavior: WorktreeCollisionBehavior::Error,
+                scan_max_depth: 4,
+                scan_cache_ttl_secs: 1800,
             },
             ui_preferences: UiPreferences {
                 theme: "light".to_string(),
@@ -1582,6 +1920,12 @@ mod tests {
                     surface: Some("fleet".to_string()),
                 },
                 terminal: Some("ghostty".to_string()),
+                idle_min: 7,
+                transport: "broker".to_string(),
+                enrich: false,
+                state_stale_ms: 120_000,
+                healthy_state_stale_ms: 240_000,
+                tmux_idle_after_secs: 90,
                 // `[fleet.bridge]` is an opaque passthrough parsed elsewhere;
                 // its rows are hand-declared and walk-exempt. See
                 // EXTERNAL_PREFIXES.
@@ -1592,6 +1936,47 @@ mod tests {
                 idle_grace_secs: 300,
                 monitor_refresh_secs: 2,
                 daemon_idle_grace_secs: 900,
+            },
+            general: GeneralConfig {
+                syntax_highlight: false,
+                skill_install_real_homes: false,
+                home: Some("/tmp/ainb-home".to_string()),
+            },
+            ui: UiConfig {
+                tick_rate_ms: 16,
+                app_tick_ms: 500,
+                session_query_limit: 250,
+                session_lookback_hours: 12,
+                inbox_list_limit: 100,
+                double_click_ms: 400,
+            },
+            daemons: DaemonsConfig {
+                stale_after_ms: 120_000,
+                attention_stale_after_ms: 60_000,
+            },
+            usage_client: UsageClientConfig {
+                headroom_port: 9787,
+                fetch_timeout_secs: 300,
+                codex_ttl_secs: 30,
+                cache_db: Some("/tmp/usage.db".to_string()),
+            },
+            notifyd: NotifydConfig {
+                os_debounce_secs: 30,
+                approval_timeout_secs: 300,
+            },
+            web: WebServerConfig {
+                listen: "0.0.0.0:8420".to_string(),
+                read_only: true,
+                insecure_bind: true,
+            },
+            acp: AcpConfig {
+                adapters: HashMap::from([(
+                    "claude-agent-acp".to_string(),
+                    AcpAdapterConfig {
+                        command: Some("/opt/bin/claude-agent-acp".to_string()),
+                        permission_mode: "acceptEdits".to_string(),
+                    },
+                )]),
             },
         }
     }
@@ -2018,6 +2403,70 @@ mod tests {
             "workspace_defaults.worktree_collision_behavior",
             &collisions,
         );
+    }
+
+    /// The `hangar_daemon.*` rows must name exactly the daemon's own knobs, in
+    /// the same shape.
+    ///
+    /// They cannot be generated: `CONFIG_REGISTRY` is a `static` of const
+    /// values and `DAEMON_CONFIG_REGISTRY` cannot be iterated into one. So they
+    /// are hand-mirrored and pinned here instead. Adding a daemon knob without
+    /// adding a row leaves it unreachable from the settings screen and from
+    /// `ainb config set`, which is the drift this whole registry exists to
+    /// stop, one backend over.
+    #[test]
+    fn hangar_daemon_rows_match_the_daemon_registry() {
+        use ainb_hangar_core::daemon_config::{ConfigKind, DAEMON_CONFIG_REGISTRY};
+
+        let mirrored: Vec<&str> = CONFIG_REGISTRY
+            .iter()
+            .filter_map(|entry| hangar_daemon_key(entry.key()))
+            .collect();
+        let declared: Vec<&str> = DAEMON_CONFIG_REGISTRY.iter().map(|d| d.key).collect();
+        assert_eq!(
+            mirrored, declared,
+            "the hangar_daemon.* rows have drifted from DAEMON_CONFIG_REGISTRY"
+        );
+
+        for descriptor in DAEMON_CONFIG_REGISTRY {
+            let key = format!("{HANGAR_DAEMON_PREFIX}{}", descriptor.key);
+            let row = row(&key).unwrap_or_else(|| panic!("{key} is registered"));
+            match descriptor.kind {
+                ConfigKind::Bool => assert_eq!(
+                    row.kind,
+                    RowKind::Bool,
+                    "{key} is a bool in the daemon registry"
+                ),
+                ConfigKind::Int { min, max, .. } => assert_eq!(
+                    row.kind,
+                    RowKind::Number { min, max },
+                    "{key} must carry the daemon's own range"
+                ),
+                ConfigKind::Enum { variants } => match row.kind {
+                    RowKind::Choice(options) => assert_eq!(
+                        options, variants,
+                        "{key} must offer the daemon's own variants"
+                    ),
+                    other => panic!("{key} must be a choice row, got {other:?}"),
+                },
+            }
+            // The mirrored default has to be one the daemon would itself accept,
+            // or the row seeds with a value the store would reject on save.
+            descriptor
+                .validate(descriptor.default)
+                .unwrap_or_else(|why| panic!("{key} default is invalid: {why}"));
+        }
+    }
+
+    /// A `hangar_daemon.*` key is walk-exempt: it is not in config.toml at all.
+    #[test]
+    fn hangar_daemon_keys_are_external() {
+        assert!(is_external("hangar_daemon.autostandup.enabled"));
+        assert_eq!(
+            hangar_daemon_key("hangar_daemon.card_agent.default"),
+            Some("card_agent.default")
+        );
+        assert_eq!(hangar_daemon_key("docker.timeout"), None);
     }
 
     // --- key normalisation ---

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -156,15 +156,8 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "general.skill_install_real_homes",
         category: C::General,
         label: "Install Skills To Real Tool Homes",
-        help: "Write installs to ~/.claude, ~/.codex … instead of ainb's managed sandbox",
+        help: "Write installs to ~/.claude, ~/.codex … not ainb's sandbox (restart to apply)",
         kind: RowKind::Bool,
-    }),
-    Entry::Row(ConfigRow {
-        key: "general.home",
-        category: C::General,
-        label: "State Directory",
-        help: "Base dir for ainb state (<home>/.agents-in-a-box); blank = your home dir",
-        kind: RowKind::Text,
     }),
     Entry::Row(ConfigRow {
         key: "presets.file",
@@ -553,7 +546,8 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
             min: 0,
             max: 604_800,
         },
-    }), // ── UI preferences ─────────────────────────────────────────────────────
+    }),
+    // ── UI preferences ─────────────────────────────────────────────────────
     Entry::Row(ConfigRow {
         key: "ui_preferences.theme",
         category: C::Appearance,
@@ -629,14 +623,14 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "ui.tick_rate_ms",
         category: C::Appearance,
         label: "Event Poll Interval",
-        help: "Milliseconds between input polls; lower feels snappier and costs CPU",
+        help: "Milliseconds between input polls; lower feels snappier (restart to apply)",
         kind: RowKind::Number { min: 1, max: 1000 },
     }),
     Entry::Row(ConfigRow {
         key: "ui.app_tick_ms",
         category: C::Appearance,
         label: "App Tick Interval",
-        help: "Milliseconds between heavy periodic passes (previews, animation, refreshes)",
+        help: "Milliseconds between heavy periodic passes, e.g. previews (restart to apply)",
         kind: RowKind::Number {
             min: 1,
             max: 60_000,
@@ -843,7 +837,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "fleet.idle_min",
         category: C::Fleet,
         label: "Idle Threshold",
-        help: "Minutes of quiet before a session reads IDLE, for tmux and hook sources alike",
+        help: "Minutes of quiet before a session reads IDLE, tmux and hooks alike (restart)",
         kind: RowKind::Number {
             min: 1,
             max: 10_080,
@@ -853,7 +847,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "fleet.transport",
         category: C::Fleet,
         label: "Send Transport",
-        help: "How `ainb fleet send` delivers: tmux first, tmux only, or the broker",
+        help: "How `ainb fleet send` delivers: tmux first, tmux only, broker (restart)",
         kind: RowKind::Choice(&["tmux", "tmux-only", "broker"]),
     }),
     Entry::Row(ConfigRow {
@@ -887,12 +881,13 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "fleet.tmux_idle_after_secs",
         category: C::Fleet,
         label: "tmux Idle After",
-        help: "Seconds of pane silence before tmux discovery calls a session between turns",
+        help: "Seconds of pane silence before tmux discovery calls a session idle (restart)",
         kind: RowKind::Number {
             min: 1,
             max: 86_400,
         },
-    }), // ── Fleet bridge ───────────────────────────────────────────────────────
+    }),
+    // ── Fleet bridge ───────────────────────────────────────────────────────
     // Parsed by `fleet::bridge::config` off the same file; `ainb-core` carries
     // it as an opaque passthrough, so these rows are declared by hand and are
     // exempt from the schema walk (see EXTERNAL_PREFIXES).
@@ -1141,7 +1136,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "notifyd.os_debounce_secs",
         category: C::Daemons,
         label: "OS Notification Debounce",
-        help: "Seconds one session/event pair waits before it may notify again",
+        help: "Seconds one session/event pair waits before notifying again (daemon restart)",
         kind: RowKind::Number {
             min: 0,
             max: 86_400,
@@ -1151,7 +1146,7 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "notifyd.approval_timeout_secs",
         category: C::Daemons,
         label: "Approval Timeout",
-        help: "Seconds an unanswered permission request waits before it is auto-DENIED",
+        help: "Seconds an unanswered permission request waits before auto-DENY (daemon restart)",
         kind: RowKind::Number { min: 1, max: 630 },
     }),
     // ── Web dashboard ──────────────────────────────────────────────────────
@@ -1182,14 +1177,14 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         key: "acp.adapters.*.command",
         category: C::Acp,
         label: "Adapter Command",
-        help: "Executable to spawn for this adapter; blank resolves its name on PATH",
+        help: "Executable for this adapter; blank resolves its name on PATH (daemon restart)",
         kind: RowKind::Text,
     }),
     Entry::Row(ConfigRow {
         key: "acp.adapters.*.permission_mode",
         category: C::Acp,
         label: "Permission Mode",
-        help: "Mode pinned at session/new and re-asserted after every session/load",
+        help: "Mode pinned at session/new, re-asserted after session/load (daemon restart)",
         kind: RowKind::Choice(&["default", "acceptEdits", "bypassPermissions", "plan"]),
     }),
     // ── Sections owned by other crates ─────────────────────────────────────
@@ -1330,7 +1325,6 @@ pub const OPTIONAL_KEYS: &[&str] = &[
     "fleet.cost.session_usd",
     "fleet.interview.surface",
     "fleet.terminal",
-    "general.home",
     "ui_preferences.preferred_editor",
     "usage.model_aliases.*",
     "usage_client.cache_db",
@@ -1940,7 +1934,6 @@ mod tests {
             general: GeneralConfig {
                 syntax_highlight: false,
                 skill_install_real_homes: false,
-                home: Some("/tmp/ainb-home".to_string()),
             },
             ui: UiConfig {
                 tick_rate_ms: 16,

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -83,7 +83,31 @@ pub fn snapshot() -> Arc<AppConfig> {
 /// the caller only ever holds the user one.
 pub fn refresh_snapshot() {
     let loaded = Arc::new(AppConfig::load().unwrap_or_default());
-    *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(loaded);
+    *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(Arc::clone(&loaded));
+    // Re-publish, or the values children inherit stay frozen at startup. A
+    // child does not see them as self-planted, so the stale value OUTRANKS the
+    // child's own config: saving `fleet.idle_min` in the TUI would leave every
+    // plugin and subprocess on the old number until the TUI itself restarted.
+    republish_env_bridge(&loaded);
+}
+
+/// Re-plant the bridged variables after a config change.
+///
+/// Only the ones this process planted itself are overwritten — a variable the
+/// user exported still outranks config, which is the whole precedence
+/// contract.
+fn republish_env_bridge(config: &AppConfig) {
+    let planted: Vec<&'static str> = BRIDGED
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .as_ref()
+        .map(|set| set.iter().copied().collect())
+        .unwrap_or_default();
+    for name in planted {
+        std::env::remove_var(name);
+    }
+    *BRIDGED.write().unwrap_or_else(|e| e.into_inner()) = None;
+    export_env_bridge(config);
 }
 
 /// Install `config` as the snapshot. Test seam, and the escape hatch for a

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -105,6 +105,10 @@ pub fn refresh_snapshot() {
 #[cfg(test)]
 pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Install `config` as the snapshot.
+///
+/// Test seam, and the escape hatch for a caller that has already loaded and
+/// does not want a second read.
 pub fn install_snapshot(config: AppConfig) {
     *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(Arc::new(config));
 }
@@ -209,6 +213,10 @@ pub fn parse_bool_token(raw: &str) -> Option<bool> {
 /// while others join `.agents-in-a-box` onto it. A config key would have to
 /// pick one and silently relocate the other's files. The variable keeps working
 /// exactly as it does today; resolving the ambiguity is its own change.
+/// Name of the variable listing what this process's bridge planted.
+///
+/// Entries are `NAME=value`, separated by `\u{1}`. A child reads it to tell an
+/// inherited plant from a real user export.
 pub const INHERITED_MARKER: &str = "AINB_BRIDGED_VARS";
 
 pub fn export_env_bridge(config: &AppConfig) {
@@ -218,14 +226,22 @@ pub fn export_env_bridge(config: &AppConfig) {
     // see it in its own `BRIDGED`, and lets that stale value beat its own
     // config.toml — permanently, since only the parent ever republishes. A
     // session pane could never change a bridged key.
-    let inherited: BTreeSet<String> = std::env::var(INHERITED_MARKER)
-        .unwrap_or_default()
-        .split(',')
-        .filter(|name| !name.is_empty())
-        .map(str::to_string)
-        .collect();
-    for name in &inherited {
-        std::env::remove_var(name);
+    // NAME=value, not just NAME. With names alone this could not tell "still
+    // the parent's plant" from "the user overrode it in this shell", and
+    // removed both — so `AINB_FLEET_TRANSPORT=broker ainb fleet send` in a pane
+    // the TUI spawned had its override silently dropped, breaking the very
+    // `env > config` contract this module exists to guarantee. Only a value
+    // that still matches what the parent planted is cleared.
+    for entry in std::env::var(INHERITED_MARKER).unwrap_or_default().split('\u{1}') {
+        let Some((name, planted_value)) = entry.split_once('=') else {
+            continue;
+        };
+        if name.is_empty() {
+            continue;
+        }
+        if std::env::var(name).as_deref() == Ok(planted_value) {
+            std::env::remove_var(name);
+        }
     }
     let mut publish = |name: &'static str, value: String| {
         if std::env::var_os(name).is_none() {
@@ -273,11 +289,16 @@ pub fn export_env_bridge(config: &AppConfig) {
 
     // Hand the list to children so they can tell an inherited plant from a
     // real user export.
-    let names: Vec<&str> = planted.iter().copied().collect();
-    if names.is_empty() {
+    // `\u{1}` separates entries and never appears in a value, so a path or a
+    // comma-bearing setting cannot split an entry in half.
+    let entries: Vec<String> = planted
+        .iter()
+        .filter_map(|name| std::env::var(name).ok().map(|value| format!("{name}={value}")))
+        .collect();
+    if entries.is_empty() {
         std::env::remove_var(INHERITED_MARKER);
     } else {
-        std::env::set_var(INHERITED_MARKER, names.join(","));
+        std::env::set_var(INHERITED_MARKER, entries.join("\u{1}"));
     }
     *BRIDGED.write().unwrap_or_else(|e| e.into_inner()) = Some(planted);
 }
@@ -706,7 +727,7 @@ mod tests {
 
         // What a parent left behind.
         std::env::set_var("AINB_HEADROOM_PORT", "8787");
-        std::env::set_var(INHERITED_MARKER, "AINB_HEADROOM_PORT");
+        std::env::set_var(INHERITED_MARKER, "AINB_HEADROOM_PORT=8787");
 
         let mut config = AppConfig::default();
         config.usage_client.headroom_port = 9000;
@@ -716,6 +737,45 @@ mod tests {
             resolved("AINB_HEADROOM_PORT", config.usage_client.headroom_port),
             9000,
             "the parent's inherited plant beat this process's own config"
+        );
+
+        clear_bridged_for_test();
+        match prior_port {
+            Some(v) => std::env::set_var("AINB_HEADROOM_PORT", v),
+            None => std::env::remove_var("AINB_HEADROOM_PORT"),
+        }
+        match prior_marker {
+            Some(v) => std::env::set_var(INHERITED_MARKER, v),
+            None => std::env::remove_var(INHERITED_MARKER),
+        }
+    }
+
+    /// The case the marker exists to get right: BOTH an inherited plant and a
+    /// real override in the child's own shell.
+    ///
+    /// With names alone the child could not tell them apart and cleared the
+    /// override too, so `AINB_FLEET_TRANSPORT=broker ainb ...` in a pane the
+    /// TUI spawned silently fell back to config.
+    #[test]
+    fn a_child_override_survives_an_inherited_marker() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prior_port = std::env::var_os("AINB_HEADROOM_PORT");
+        let prior_marker = std::env::var_os(INHERITED_MARKER);
+        clear_bridged_for_test();
+
+        // The parent planted 8787 and said so; the user then overrode it here.
+        std::env::set_var(INHERITED_MARKER, "AINB_HEADROOM_PORT=8787");
+        std::env::set_var("AINB_HEADROOM_PORT", "7777");
+
+        let mut config = AppConfig::default();
+        config.usage_client.headroom_port = 9000;
+        export_env_bridge(&config);
+
+        assert_eq!(
+            resolved("AINB_HEADROOM_PORT", config.usage_client.headroom_port),
+            7777,
+            "the child's own override was discarded along with the inherited plant"
         );
 
         clear_bridged_for_test();

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -88,6 +88,16 @@ pub fn refresh_snapshot() {
 
 /// Install `config` as the snapshot. Test seam, and the escape hatch for a
 /// caller that has already loaded and does not want a second read.
+/// The one lock every test that mutates the environment or the snapshot must
+/// hold.
+///
+/// Both are process-global. A module that declares its own private mutex is
+/// guarding nothing — two different locks around the same `setenv` is still a
+/// `setenv`/`getenv` data race, and a snapshot installed by one test is read by
+/// every other test in the binary. There is exactly one of these on purpose.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub fn install_snapshot(config: AppConfig) {
     *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(Arc::new(config));
 }
@@ -621,7 +631,7 @@ mod tests {
 
     /// Env-mutating tests in this module serialize against each other.
     /// [reference: ENV_LOCK for parallel tests]
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use super::TEST_ENV_LOCK as ENV_LOCK;
 
     /// Set `name` for the duration of `body`, restoring it afterwards.
     ///

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -83,31 +83,14 @@ pub fn snapshot() -> Arc<AppConfig> {
 /// the caller only ever holds the user one.
 pub fn refresh_snapshot() {
     let loaded = Arc::new(AppConfig::load().unwrap_or_default());
-    *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(Arc::clone(&loaded));
-    // Re-publish, or the values children inherit stay frozen at startup. A
-    // child does not see them as self-planted, so the stale value OUTRANKS the
-    // child's own config: saving `fleet.idle_min` in the TUI would leave every
-    // plugin and subprocess on the old number until the TUI itself restarted.
-    republish_env_bridge(&loaded);
-}
-
-/// Re-plant the bridged variables after a config change.
-///
-/// Only the ones this process planted itself are overwritten — a variable the
-/// user exported still outranks config, which is the whole precedence
-/// contract.
-fn republish_env_bridge(config: &AppConfig) {
-    let planted: Vec<&'static str> = BRIDGED
-        .read()
-        .unwrap_or_else(|e| e.into_inner())
-        .as_ref()
-        .map(|set| set.iter().copied().collect())
-        .unwrap_or_default();
-    for name in planted {
-        std::env::remove_var(name);
-    }
-    *BRIDGED.write().unwrap_or_else(|e| e.into_inner()) = None;
-    export_env_bridge(config);
+    *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(loaded);
+    // Deliberately does NOT re-publish the env bridge. `save()` is called from
+    // all over the running TUI, and `set_var` racing another thread's `getenv`
+    // is a data race — the same reason `export_env_bridge` was moved to
+    // `main()` before any thread exists. Bridged values therefore stay at
+    // their startup value for out-of-crate readers; every row whose reader
+    // lives outside this crate says "(restart)" in its help so the screen does
+    // not promise a live change it cannot make.
 }
 
 /// Install `config` as the snapshot. Test seam, and the escape hatch for a
@@ -226,8 +209,24 @@ pub fn parse_bool_token(raw: &str) -> Option<bool> {
 /// while others join `.agents-in-a-box` onto it. A config key would have to
 /// pick one and silently relocate the other's files. The variable keeps working
 /// exactly as it does today; resolving the ambiguity is its own change.
+pub const INHERITED_MARKER: &str = "AINB_BRIDGED_VARS";
+
 pub fn export_env_bridge(config: &AppConfig) {
     let mut planted = BTreeSet::new();
+    // Anything a parent bridged is NOT a user override down here. Without
+    // this, a child inherits `AINB_HEADROOM_PORT=8787` from the TUI, does not
+    // see it in its own `BRIDGED`, and lets that stale value beat its own
+    // config.toml — permanently, since only the parent ever republishes. A
+    // session pane could never change a bridged key.
+    let inherited: BTreeSet<String> = std::env::var(INHERITED_MARKER)
+        .unwrap_or_default()
+        .split(',')
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .collect();
+    for name in &inherited {
+        std::env::remove_var(name);
+    }
     let mut publish = |name: &'static str, value: String| {
         if std::env::var_os(name).is_none() {
             std::env::set_var(name, value);
@@ -272,6 +271,14 @@ pub fn export_env_bridge(config: &AppConfig) {
         publish("AINB_USAGE_CACHE_DB", db.clone());
     }
 
+    // Hand the list to children so they can tell an inherited plant from a
+    // real user export.
+    let names: Vec<&str> = planted.iter().copied().collect();
+    if names.is_empty() {
+        std::env::remove_var(INHERITED_MARKER);
+    } else {
+        std::env::set_var(INHERITED_MARKER, names.join(","));
+    }
     *BRIDGED.write().unwrap_or_else(|e| e.into_inner()) = Some(planted);
 }
 
@@ -636,7 +643,7 @@ pub struct AcpAdapterConfig {
     pub permission_mode: String,
 }
 
-fn default_acp_permission_mode() -> String {
+pub(crate) fn default_acp_permission_mode() -> String {
     "default".to_string()
 }
 
@@ -683,6 +690,78 @@ mod tests {
     }
 
     /// The full ladder for a numeric knob, one rung at a time.
+    /// A variable a PARENT bridged must not beat this process's own config.
+    ///
+    /// The child does not have it in its own `BRIDGED`, so without the marker
+    /// `env_override` returned the inherited value and it won the ladder —
+    /// permanently, because only the parent ever republishes. A session pane
+    /// opened from the TUI could never change a bridged key.
+    #[test]
+    fn an_inherited_bridge_value_does_not_beat_the_child_config() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prior_port = std::env::var_os("AINB_HEADROOM_PORT");
+        let prior_marker = std::env::var_os(INHERITED_MARKER);
+        clear_bridged_for_test();
+
+        // What a parent left behind.
+        std::env::set_var("AINB_HEADROOM_PORT", "8787");
+        std::env::set_var(INHERITED_MARKER, "AINB_HEADROOM_PORT");
+
+        let mut config = AppConfig::default();
+        config.usage_client.headroom_port = 9000;
+        export_env_bridge(&config);
+
+        assert_eq!(
+            resolved("AINB_HEADROOM_PORT", config.usage_client.headroom_port),
+            9000,
+            "the parent's inherited plant beat this process's own config"
+        );
+
+        clear_bridged_for_test();
+        match prior_port {
+            Some(v) => std::env::set_var("AINB_HEADROOM_PORT", v),
+            None => std::env::remove_var("AINB_HEADROOM_PORT"),
+        }
+        match prior_marker {
+            Some(v) => std::env::set_var(INHERITED_MARKER, v),
+            None => std::env::remove_var(INHERITED_MARKER),
+        }
+    }
+
+    /// A real user export still wins — the marker must not swallow those.
+    #[test]
+    fn a_user_export_still_beats_config() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prior_port = std::env::var_os("AINB_HEADROOM_PORT");
+        let prior_marker = std::env::var_os(INHERITED_MARKER);
+        clear_bridged_for_test();
+
+        std::env::set_var("AINB_HEADROOM_PORT", "7777");
+        std::env::remove_var(INHERITED_MARKER);
+
+        let mut config = AppConfig::default();
+        config.usage_client.headroom_port = 9000;
+        export_env_bridge(&config);
+
+        assert_eq!(
+            resolved("AINB_HEADROOM_PORT", config.usage_client.headroom_port),
+            7777,
+            "an operator's own export must outrank config"
+        );
+
+        clear_bridged_for_test();
+        match prior_port {
+            Some(v) => std::env::set_var("AINB_HEADROOM_PORT", v),
+            None => std::env::remove_var("AINB_HEADROOM_PORT"),
+        }
+        match prior_marker {
+            Some(v) => std::env::set_var(INHERITED_MARKER, v),
+            None => std::env::remove_var(INHERITED_MARKER),
+        }
+    }
+
     #[test]
     fn headroom_port_ladder_is_env_then_config_then_default() {
         // `AINB_HEADROOM_PORT` is also mutated by `headroom::tests` and

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -127,7 +127,7 @@ fn is_self_planted(env_var: &str) -> bool {
 
 /// The raw env value for `env_var`, or `None` when it is unset or was planted
 /// by this process's own [`export_env_bridge`].
-fn env_override(env_var: &str) -> Option<String> {
+pub fn env_override(env_var: &str) -> Option<String> {
     if is_self_planted(env_var) {
         return None;
     }

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -1,0 +1,714 @@
+// ABOUTME: The config sections promoted out of env vars and hardcoded literals,
+// plus the `env > config > default` resolver every promoted read site uses.
+
+//! Promoted tunables.
+//!
+//! Before this module a knob was either an env var with a literal fallback
+//! (`AINB_HEADROOM_PORT` or 8787) or a bare `const` no user could reach. Both
+//! shapes hide the value from `ainb config` and from the settings screen, and
+//! the env-var shape repeatedly grew *two* fallbacks for one name. See
+//! [`FleetConfig::state_stale_ms`](crate::config::FleetConfig::state_stale_ms).
+//!
+//! Every knob here now has exactly one coded default, expressed once as a
+//! serde default on the field, and one resolution ladder:
+//!
+//! ```text
+//! env var  >  config.toml  >  the field's serde default
+//! ```
+//!
+//! matching the ladder the plugin `[[config]]` mechanism already uses. The env
+//! var keeps winning: scripts, CI and `just` recipes set them today and must
+//! not start losing to a file.
+//!
+//! ## Two ways a value reaches a reader
+//!
+//! A read site **inside `ainb`** resolves in code, via [`resolved`] /
+//! [`resolved_bool`] over [`snapshot`].
+//!
+//! A read site in another crate cannot: `ainb-fleet-core`, `ainb-adapters-tool`
+//! and the plugin binaries do not depend on `ainb`, and giving each of them its
+//! own config parser would make a fifth parser of one file. Those sites keep
+//! reading their env var, and [`export_env_bridge`] publishes the config value
+//! into the process environment once at startup, only where the variable is
+//! unset, so an operator's `AINB_FLEET_IDLE_MIN=2` still wins. Child processes
+//! (plugin subprocesses, the hangar daemon) inherit it for free, which is the
+//! same path their config already travels.
+
+use std::str::FromStr;
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use super::AppConfig;
+
+// ── The resolver ────────────────────────────────────────────────────────────
+
+/// The process-wide merged config, loaded once.
+///
+/// Read sites like `headroom::proxy_port()` are free functions with no
+/// `&AppConfig` in hand and are called from render paths, so re-reading four
+/// files per call is not an option. A failed load falls back to defaults rather
+/// than panicking: a broken config.toml must not take the port resolver with
+/// it.
+#[must_use]
+pub fn snapshot() -> &'static AppConfig {
+    static SNAPSHOT: OnceLock<AppConfig> = OnceLock::new();
+    SNAPSHOT.get_or_init(|| AppConfig::load().unwrap_or_default())
+}
+
+/// `env_var`, else `from_config`.
+///
+/// `from_config` is already the bottom two rungs of the ladder: it is the value
+/// serde produced, which is either what the file said or the field's coded
+/// default. An env value that does not parse is ignored rather than fatal:
+/// a typo in a shell profile must not brick the reader that consumes it.
+#[must_use]
+pub fn resolved<T: FromStr>(env_var: &str, from_config: T) -> T {
+    match std::env::var(env_var) {
+        Ok(raw) => raw.trim().parse().unwrap_or(from_config),
+        Err(_) => from_config,
+    }
+}
+
+/// [`resolved`] for booleans, which have no useful `FromStr`.
+///
+/// Accepts the tolerant token family the rest of ainb uses
+/// (`1`/`true`/`yes`/`on` and their negatives, case-insensitively), so the two
+/// promoted flags stop disagreeing about what "off" looks like:
+/// `AINB_FLEET_ENRICH` used to treat everything but `0` as on, while
+/// `AGENTS_BOX_SYNTAX_HIGHLIGHT` treated everything but `true` as off.
+#[must_use]
+pub fn resolved_bool(env_var: &str, from_config: bool) -> bool {
+    match std::env::var(env_var) {
+        Ok(raw) => parse_bool_token(&raw).unwrap_or(from_config),
+        Err(_) => from_config,
+    }
+}
+
+/// Parse one tolerant boolean token, or `None` when it is not one.
+#[must_use]
+pub fn parse_bool_token(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Publish config-sourced values into the process environment, for the read
+/// sites that live outside this crate.
+///
+/// Call ONCE from a binary's startup, before any thread is spawned, for the
+/// same reason and in the same place as
+/// [`AppConfig::migrate_legacy_paths`](crate::config::AppConfig::migrate_legacy_paths).
+///
+/// Only sets a variable that is currently unset, which is what keeps `env >
+/// config`: an operator who exported `AINB_FLEET_TRANSPORT=broker` for this
+/// shell still beats the file. `general.home` and `usage_client.cache_db` are
+/// `Option` and are skipped when unset, because exporting a derived default
+/// would freeze a path the readers deliberately compute themselves.
+pub fn export_env_bridge(config: &AppConfig) {
+    let publish = |name: &str, value: String| {
+        if std::env::var_os(name).is_none() {
+            std::env::set_var(name, value);
+        }
+    };
+
+    if let Some(home) = &config.general.home {
+        publish("AINB_HOME", home.clone());
+    }
+    publish(
+        "AINB_USE_REAL_HOMES",
+        config.general.skill_install_real_homes.to_string(),
+    );
+    publish("AINB_FLEET_IDLE_MIN", config.fleet.idle_min.to_string());
+    publish("AINB_FLEET_TRANSPORT", config.fleet.transport.clone());
+    publish("AINB_FLEET_ENRICH", config.fleet.enrich.to_string());
+    publish(
+        "AINB_FLEET_TMUX_IDLE_AFTER_SECS",
+        config.fleet.tmux_idle_after_secs.to_string(),
+    );
+    publish(
+        "AINB_FLEET_STATE_STALE_MS",
+        config.fleet.state_stale_ms.to_string(),
+    );
+    publish(
+        "AINB_FLEET_HEALTHY_STATE_STALE_MS",
+        config.fleet.healthy_state_stale_ms.to_string(),
+    );
+    publish(
+        "AINB_HEADROOM_PORT",
+        config.usage_client.headroom_port.to_string(),
+    );
+    publish(
+        "AINB_USAGE_TIMEOUT_SECS",
+        config.usage_client.fetch_timeout_secs.to_string(),
+    );
+    publish(
+        "AINB_CODEX_USAGE_TTL_SECS",
+        config.usage_client.codex_ttl_secs.to_string(),
+    );
+    if let Some(db) = &config.usage_client.cache_db {
+        publish("AINB_USAGE_CACHE_DB", db.clone());
+    }
+}
+
+// ── [general] ───────────────────────────────────────────────────────────────
+
+/// Cross-cutting knobs that belong to no other section.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [general]
+/// syntax_highlight = true
+/// home = "/Volumes/work/ainb"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GeneralConfig {
+    /// Colourise fenced code blocks in agent output. Off is a real preference
+    /// on a slow terminal or a low-contrast theme; `NO_COLOR` still wins over
+    /// both this and its env var.
+    #[serde(default = "crate::config::default_true")]
+    pub syntax_highlight: bool,
+
+    /// Install skills into each tool's REAL config dir (`~/.claude`,
+    /// `~/.codex`, …) rather than the managed sandbox under `home`.
+    ///
+    /// True is the shipped behaviour: an installed skill has to be where the
+    /// tool actually looks or it may as well not exist. False routes every
+    /// install into the sandbox, which is what a machine shared with a
+    /// hand-managed `~/.claude` wants.
+    #[serde(default = "crate::config::default_true")]
+    pub skill_install_real_homes: bool,
+
+    /// Base directory ainb keeps its state under: `<home>/.agents-in-a-box/…`.
+    ///
+    /// `None` means the OS home directory. This does NOT move config.toml,
+    /// which is always read from the OS home. A config file that said where
+    /// to find itself could not be found.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<String>,
+}
+
+impl Default for GeneralConfig {
+    fn default() -> Self {
+        Self {
+            syntax_highlight: true,
+            skill_install_real_homes: true,
+            home: None,
+        }
+    }
+}
+
+// ── [ui] ────────────────────────────────────────────────────────────────────
+
+/// TUI cadences and query bounds.
+///
+/// Separate from `[ui_preferences]` on purpose: that section holds what the
+/// interface LOOKS like (theme, which columns show, sidebar widths) and is
+/// written by the TUI itself. These are performance tunables (how often the
+/// loop wakes, how many rows a query returns) that a user changes for a slow
+/// terminal or a very large fleet and that nothing writes back.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [ui]
+/// tick_rate_ms = 16      # 60fps event polling
+/// inbox_list_limit = 500
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UiConfig {
+    /// Event-poll cadence in ms: how often the loop wakes to check for a
+    /// keystroke. Drives perceived input latency. ~30fps by default; lower
+    /// costs CPU, higher makes typing feel laggy.
+    #[serde(default = "default_tick_rate_ms")]
+    pub tick_rate_ms: u64,
+
+    /// App-tick cadence in ms for the heavy periodic work (mascot animation,
+    /// tmux preview capture, OAuth refresh checks). Deliberately much coarser
+    /// than `tick_rate_ms`; running it per poll starves the event loop.
+    #[serde(default = "default_app_tick_ms")]
+    pub app_tick_ms: u64,
+
+    /// How many recent hook events the attention-marker query reads per
+    /// refresh. Bounds query cost on a large notifications DB.
+    #[serde(default = "default_session_query_limit")]
+    pub session_query_limit: u32,
+
+    /// Rolling window (hours) an event can still mark a session from. Older
+    /// events never raise a `[?]`/`[!]` marker.
+    #[serde(default = "default_session_lookback_hours")]
+    pub session_lookback_hours: u32,
+
+    /// Rows the Inbox screen lists. Kept small because the query runs every
+    /// render.
+    #[serde(default = "default_inbox_list_limit")]
+    pub inbox_list_limit: u32,
+
+    /// Window (ms) in which two clicks count as a double-click on the sidebar
+    /// edge. Raise it if your hands or your terminal are slow.
+    #[serde(default = "default_double_click_ms")]
+    pub double_click_ms: u64,
+}
+
+fn default_tick_rate_ms() -> u64 {
+    33
+}
+fn default_app_tick_ms() -> u64 {
+    250
+}
+fn default_session_query_limit() -> u32 {
+    500
+}
+fn default_session_lookback_hours() -> u32 {
+    6
+}
+fn default_inbox_list_limit() -> u32 {
+    200
+}
+fn default_double_click_ms() -> u64 {
+    300
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            tick_rate_ms: default_tick_rate_ms(),
+            app_tick_ms: default_app_tick_ms(),
+            session_query_limit: default_session_query_limit(),
+            session_lookback_hours: default_session_lookback_hours(),
+            inbox_list_limit: default_inbox_list_limit(),
+            double_click_ms: default_double_click_ms(),
+        }
+    }
+}
+
+// ── [daemons] ───────────────────────────────────────────────────────────────
+
+/// How long a daemon may go quiet before the Daemons view calls it stale.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [daemons]
+/// stale_after_ms = 120000
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonsConfig {
+    /// A heartbeat older than this, from a pid that is STILL alive (a wedged
+    /// daemon that stopped ticking), reads as stale. A dead pid is caught
+    /// immediately regardless of this window.
+    #[serde(default = "default_stale_after_ms")]
+    pub stale_after_ms: i64,
+
+    /// The bridge's outbound-push window: how long it may go without a
+    /// SUCCESSFUL poll of the attention source before its proactive-push half
+    /// counts as broken. A distinct clock from `stale_after_ms`: that one asks
+    /// "is the process alive", this one "can it still do the job".
+    #[serde(default = "default_attention_stale_after_ms")]
+    pub attention_stale_after_ms: i64,
+}
+
+fn default_stale_after_ms() -> i64 {
+    90_000
+}
+fn default_attention_stale_after_ms() -> i64 {
+    45_000
+}
+
+impl Default for DaemonsConfig {
+    fn default() -> Self {
+        Self {
+            stale_after_ms: default_stale_after_ms(),
+            attention_stale_after_ms: default_attention_stale_after_ms(),
+        }
+    }
+}
+
+// ── [usage_client] ──────────────────────────────────────────────────────────
+
+/// How ainb FETCHES and caches usage data.
+///
+/// Deliberately not `[usage]`. That section is the burndown plugin's: it does
+/// its own load-modify-save against this same file, so core lists it in
+/// `NEVER_WRITE_PATHS` and the settings screen renders it read-only. These four
+/// knobs are core's: the proxy port core spawns on, the deadline core waits on
+/// the plugin for, the throttle on core's Codex statusline, and the path core's
+/// own usage cache opens. Putting them under `usage` would either make them
+/// unwritable from the only surface that offers them, or turn a clean
+/// section-level ownership boundary into a per-key allowlist that drifts.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [usage_client]
+/// headroom_port = 9787
+/// fetch_timeout_secs = 300
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UsageClientConfig {
+    /// Port the ainb-managed Headroom compression proxy listens on.
+    #[serde(default = "default_headroom_port")]
+    pub headroom_port: u16,
+
+    /// Hard deadline (seconds) for `ainb usage` to surface output. The first
+    /// scan of a large `~/.claude/projects` is slow and must finish before the
+    /// burndown dispatch returns; raise this against a very large archive.
+    #[serde(default = "default_fetch_timeout_secs")]
+    pub fetch_timeout_secs: u64,
+
+    /// Throttle (seconds) between Codex statusline usage refreshes.
+    #[serde(default = "default_codex_ttl_secs")]
+    pub codex_ttl_secs: u64,
+
+    /// Override for the usage cache DB. `None` derives
+    /// `<home>/.agents-in-a-box/cache/usage.db`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_db: Option<String>,
+}
+
+fn default_headroom_port() -> u16 {
+    8787
+}
+fn default_fetch_timeout_secs() -> u64 {
+    120
+}
+fn default_codex_ttl_secs() -> u64 {
+    60
+}
+
+impl Default for UsageClientConfig {
+    fn default() -> Self {
+        Self {
+            headroom_port: default_headroom_port(),
+            fetch_timeout_secs: default_fetch_timeout_secs(),
+            codex_ttl_secs: default_codex_ttl_secs(),
+            cache_db: None,
+        }
+    }
+}
+
+// ── [notifyd] ───────────────────────────────────────────────────────────────
+
+/// Notification-daemon knobs.
+///
+/// The daemon is a subprocess plugin and parses this table itself off the same
+/// config.toml (`ainb_plugin_notifyd::config`), exactly as `[session_reader]`
+/// does. It is mirrored here so `AppConfig` round-trips the section on save
+/// instead of deleting it, and so the settings screen has a schema to render.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [notifyd]
+/// os_debounce_secs = 30
+/// approval_timeout_secs = 900
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotifydConfig {
+    /// Per-`(session, event)` debounce window for OS notifications. Keeps a
+    /// noisy session from spamming Notification Center.
+    #[serde(default = "default_os_debounce_secs")]
+    pub os_debounce_secs: u64,
+
+    /// How long an unanswered permission request waits before the broker
+    /// auto-DENIES it.
+    ///
+    /// The bottom of a timeout ladder: broker AWAIT < the client's re-dial
+    /// deadline < Claude's `PermissionRequest` hook timeout. Raising it past
+    /// the client deadline (640s) means the hook is hard-killed before the
+    /// broker answers, so the ceiling here is deliberately below it.
+    #[serde(default = "default_approval_timeout_secs")]
+    pub approval_timeout_secs: u64,
+}
+
+fn default_os_debounce_secs() -> u64 {
+    60
+}
+fn default_approval_timeout_secs() -> u64 {
+    600
+}
+
+impl Default for NotifydConfig {
+    fn default() -> Self {
+        Self {
+            os_debounce_secs: default_os_debounce_secs(),
+            approval_timeout_secs: default_approval_timeout_secs(),
+        }
+    }
+}
+
+// ── [web] ───────────────────────────────────────────────────────────────────
+
+/// Defaults for `ainb web`, which had none: [`ainb_web::WebConfig`] was built
+/// from CLI flags on every run and persisted nothing, so anyone serving on a
+/// fixed address retyped it every time.
+///
+/// The CLI flags still win, because a flag is a per-invocation decision and
+/// must beat
+/// a file. The bearer token is deliberately absent: it goes to the OS keychain
+/// via `--token`, never into a world-readable toml.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [web]
+/// listen = "0.0.0.0:8420"
+/// read_only = true
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebServerConfig {
+    /// Address the dashboard binds. A non-loopback value still has to clear
+    /// `WebConfig::check_bind_security` at startup, so setting it here cannot
+    /// expose an unauthenticated surface that a flag could not.
+    #[serde(default = "default_web_listen")]
+    pub listen: String,
+
+    /// Serve viewer-only: every write surface (the WS terminal, `POST
+    /// /api/answer`) is refused.
+    #[serde(default)]
+    pub read_only: bool,
+
+    /// Allow a non-loopback bind with no token. Honoured only alongside
+    /// `read_only`; the security check refuses it otherwise.
+    #[serde(default)]
+    pub insecure_bind: bool,
+}
+
+fn default_web_listen() -> String {
+    "127.0.0.1:8420".to_string()
+}
+
+impl Default for WebServerConfig {
+    fn default() -> Self {
+        Self {
+            listen: default_web_listen(),
+            read_only: false,
+            insecure_bind: false,
+        }
+    }
+}
+
+// ── [acp] ───────────────────────────────────────────────────────────────────
+
+/// The ACP adapter registry, previously a hardcoded two-entry map in
+/// `ainb-hangar-daemon`'s `PoolConfig::default`, with no user surface at all:
+/// a provider absent from it simply cannot be created.
+///
+/// An empty `adapters` map (the default) keeps the built-in `claude-agent-acp`
+/// and `codex-acp` entries. Naming an adapter here overrides that entry;
+/// naming a new one adds it.
+///
+/// Example `config.toml`:
+/// ```toml
+/// [acp.adapters.claude-agent-acp]
+/// command = "/opt/homebrew/bin/claude-agent-acp"
+/// permission_mode = "acceptEdits"
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AcpConfig {
+    /// Adapter token → spawn recipe.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub adapters: std::collections::HashMap<String, AcpAdapterConfig>,
+}
+
+/// One ACP adapter's user-settable definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AcpAdapterConfig {
+    /// Executable to spawn. Defaults to the adapter's own token, resolved on
+    /// `PATH`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+
+    /// The permission mode PINNED at `session/new` and re-asserted after every
+    /// `session/load`. Never implicit: an adapter left to inherit ambient state
+    /// was observed picking up `bypassPermissions`, which silently disables the
+    /// whole permission surface.
+    #[serde(default = "default_acp_permission_mode")]
+    pub permission_mode: String,
+}
+
+fn default_acp_permission_mode() -> String {
+    "default".to_string()
+}
+
+impl Default for AcpAdapterConfig {
+    fn default() -> Self {
+        Self {
+            command: None,
+            permission_mode: default_acp_permission_mode(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Env-mutating tests in this module serialize against each other.
+    /// [reference: ENV_LOCK for parallel tests]
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Set `name` for the duration of `body`, restoring it afterwards.
+    fn with_env<T>(name: &str, value: Option<&str>, body: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var_os(name);
+        match value {
+            Some(v) => std::env::set_var(name, v),
+            None => std::env::remove_var(name),
+        }
+        let out = body();
+        match prior {
+            Some(v) => std::env::set_var(name, v),
+            None => std::env::remove_var(name),
+        }
+        out
+    }
+
+    fn from_toml(text: &str) -> AppConfig {
+        toml::from_str(text).expect("config parses")
+    }
+
+    /// The full ladder for a numeric knob, one rung at a time.
+    #[test]
+    fn headroom_port_ladder_is_env_then_config_then_default() {
+        // default: nothing set anywhere
+        let bare = from_toml("");
+        assert_eq!(bare.usage_client.headroom_port, 8787);
+        with_env("AINB_HEADROOM_PORT", None, || {
+            assert_eq!(
+                resolved("AINB_HEADROOM_PORT", bare.usage_client.headroom_port),
+                8787
+            );
+        });
+
+        // config beats default
+        let configured = from_toml("[usage_client]\nheadroom_port = 9001\n");
+        assert_eq!(configured.usage_client.headroom_port, 9001);
+        with_env("AINB_HEADROOM_PORT", None, || {
+            assert_eq!(
+                resolved("AINB_HEADROOM_PORT", configured.usage_client.headroom_port),
+                9001
+            );
+        });
+
+        // env beats config
+        with_env("AINB_HEADROOM_PORT", Some("9999"), || {
+            assert_eq!(
+                resolved("AINB_HEADROOM_PORT", configured.usage_client.headroom_port),
+                9999
+            );
+        });
+    }
+
+    /// The same ladder for a boolean, whose env form is a token family rather
+    /// than a `FromStr`.
+    #[test]
+    fn syntax_highlight_ladder_is_env_then_config_then_default() {
+        let bare = from_toml("");
+        assert!(bare.general.syntax_highlight);
+
+        let configured = from_toml("[general]\nsyntax_highlight = false\n");
+        assert!(!configured.general.syntax_highlight);
+        with_env("AGENTS_BOX_SYNTAX_HIGHLIGHT", None, || {
+            assert!(!resolved_bool(
+                "AGENTS_BOX_SYNTAX_HIGHLIGHT",
+                configured.general.syntax_highlight
+            ));
+            assert!(resolved_bool(
+                "AGENTS_BOX_SYNTAX_HIGHLIGHT",
+                bare.general.syntax_highlight
+            ));
+        });
+        with_env("AGENTS_BOX_SYNTAX_HIGHLIGHT", Some("1"), || {
+            assert!(resolved_bool(
+                "AGENTS_BOX_SYNTAX_HIGHLIGHT",
+                configured.general.syntax_highlight
+            ));
+        });
+    }
+
+    /// A third knob, in the section that used to carry two different defaults
+    /// for one env var.
+    #[test]
+    fn fleet_state_stale_ladder_is_env_then_config_then_default() {
+        let bare = from_toml("");
+        assert_eq!(bare.fleet.state_stale_ms, 0);
+        assert_eq!(bare.fleet.healthy_state_stale_ms, 300_000);
+
+        let configured = from_toml("[fleet]\nstate_stale_ms = 120000\n");
+        assert_eq!(configured.fleet.state_stale_ms, 120_000);
+        // The healthy floor is its OWN knob and keeps its own default.
+        assert_eq!(configured.fleet.healthy_state_stale_ms, 300_000);
+
+        with_env("AINB_FLEET_STATE_STALE_MS", None, || {
+            assert_eq!(
+                resolved("AINB_FLEET_STATE_STALE_MS", configured.fleet.state_stale_ms),
+                120_000
+            );
+        });
+        with_env("AINB_FLEET_STATE_STALE_MS", Some("7000"), || {
+            assert_eq!(
+                resolved("AINB_FLEET_STATE_STALE_MS", configured.fleet.state_stale_ms),
+                7_000
+            );
+        });
+    }
+
+    #[test]
+    fn an_unparseable_env_value_falls_back_instead_of_failing() {
+        with_env("AINB_HEADROOM_PORT", Some("not-a-port"), || {
+            assert_eq!(resolved("AINB_HEADROOM_PORT", 8787_u16), 8787);
+        });
+        with_env("AINB_FLEET_ENRICH", Some("maybe"), || {
+            assert!(resolved_bool("AINB_FLEET_ENRICH", true));
+        });
+    }
+
+    #[test]
+    fn bool_tokens_cover_both_legacy_spellings() {
+        // `AINB_FLEET_ENRICH=0` and `AGENTS_BOX_SYNTAX_HIGHLIGHT=true` are the
+        // two forms that existed before promotion; both must still mean what
+        // they used to.
+        assert_eq!(parse_bool_token("0"), Some(false));
+        assert_eq!(parse_bool_token("true"), Some(true));
+        assert_eq!(parse_bool_token("OFF"), Some(false));
+        assert_eq!(parse_bool_token(" yes "), Some(true));
+        assert_eq!(parse_bool_token("perhaps"), None);
+    }
+
+    #[test]
+    fn the_env_bridge_never_overwrites_an_existing_variable() {
+        let mut config = AppConfig::default();
+        config.fleet.transport = "broker".to_string();
+        with_env("AINB_FLEET_TRANSPORT", Some("tmux-only"), || {
+            export_env_bridge(&config);
+            assert_eq!(
+                std::env::var("AINB_FLEET_TRANSPORT").unwrap(),
+                "tmux-only",
+                "the bridge must not clobber an operator's env"
+            );
+        });
+    }
+
+    #[test]
+    fn the_env_bridge_publishes_a_config_value_when_the_variable_is_unset() {
+        let mut config = AppConfig::default();
+        config.fleet.idle_min = 42;
+        with_env("AINB_FLEET_IDLE_MIN", None, || {
+            export_env_bridge(&config);
+            assert_eq!(std::env::var("AINB_FLEET_IDLE_MIN").unwrap(), "42");
+            // Leave the process as we found it for the other tests.
+            std::env::remove_var("AINB_FLEET_IDLE_MIN");
+        });
+    }
+
+    #[test]
+    fn an_unset_optional_is_not_published() {
+        let config = AppConfig::default();
+        assert!(config.general.home.is_none());
+        with_env("AINB_HOME", None, || {
+            export_env_bridge(&config);
+            assert!(
+                std::env::var_os("AINB_HOME").is_none(),
+                "an absent general.home must not freeze AINB_HOME to a derived default"
+            );
+        });
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -34,8 +34,9 @@
 //! (plugin subprocesses, the hangar daemon) inherit it for free, which is the
 //! same path their config already travels.
 
+use std::collections::BTreeSet;
 use std::str::FromStr;
-use std::sync::OnceLock;
+use std::sync::{Arc, RwLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -43,17 +44,94 @@ use super::AppConfig;
 
 // ── The resolver ────────────────────────────────────────────────────────────
 
-/// The process-wide merged config, loaded once.
+/// The process-wide merged config the promoted read sites consult.
+///
+/// `RwLock`, not `OnceLock`. A value frozen at startup would make every
+/// promoted key settable and inert: the settings screen would report "saved"
+/// for `general.syntax_highlight` and code blocks would stay coloured until the
+/// next launch, which is the opposite of what promoting them was for. Writers
+/// call [`refresh_snapshot`] so a save takes effect on the next read.
+///
+/// `Arc` so a reader holds a cheap owned handle rather than the lock: a render
+/// path that kept the guard alive across a repaint would block the save it is
+/// racing.
+static SNAPSHOT: RwLock<Option<Arc<AppConfig>>> = RwLock::new(None);
+
+/// The current config.
 ///
 /// Read sites like `headroom::proxy_port()` are free functions with no
 /// `&AppConfig` in hand and are called from render paths, so re-reading four
-/// files per call is not an option. A failed load falls back to defaults rather
-/// than panicking: a broken config.toml must not take the port resolver with
-/// it.
+/// files per call is not an option. The first call loads; a failed load falls
+/// back to defaults rather than panicking, because a broken config.toml must
+/// not take the port resolver with it.
 #[must_use]
-pub fn snapshot() -> &'static AppConfig {
-    static SNAPSHOT: OnceLock<AppConfig> = OnceLock::new();
-    SNAPSHOT.get_or_init(|| AppConfig::load().unwrap_or_default())
+pub fn snapshot() -> Arc<AppConfig> {
+    if let Some(config) = SNAPSHOT.read().unwrap_or_else(|e| e.into_inner()).as_ref() {
+        return Arc::clone(config);
+    }
+    let mut slot = SNAPSHOT.write().unwrap_or_else(|e| e.into_inner());
+    // Another thread may have loaded while this one waited for the write lock.
+    Arc::clone(slot.get_or_insert_with(|| Arc::new(AppConfig::load().unwrap_or_default())))
+}
+
+/// Re-read config.toml into the snapshot.
+///
+/// Call after any successful write to the user config, so an edit made from the
+/// settings screen or `ainb config set` is live on the next read instead of on
+/// the next launch. Deliberately re-loads rather than taking the caller's
+/// in-memory struct: `load()` also merges the project and system layers, and
+/// the caller only ever holds the user one.
+pub fn refresh_snapshot() {
+    let loaded = Arc::new(AppConfig::load().unwrap_or_default());
+    *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(loaded);
+}
+
+/// Install `config` as the snapshot. Test seam, and the escape hatch for a
+/// caller that has already loaded and does not want a second read.
+pub fn install_snapshot(config: AppConfig) {
+    *SNAPSHOT.write().unwrap_or_else(|e| e.into_inner()) = Some(Arc::new(config));
+}
+
+/// Variables [`export_env_bridge`] planted into this process's own environment.
+///
+/// The bridge exists for readers in OTHER crates and in child processes, but it
+/// writes into the environment this process also reads. Without this set, the
+/// bridge would defeat its own ladder: publishing `AINB_HEADROOM_PORT=8787` at
+/// startup makes [`resolved`] find an env value on every later call, so
+/// `usage_client.headroom_port` could never change again and
+/// [`refresh_snapshot`] would have nothing to do. A name in here is treated as
+/// unset BY US and honoured by everyone else.
+///
+/// An operator's own export is never in this set, because the bridge only
+/// plants a variable that was unset.
+static BRIDGED: RwLock<Option<BTreeSet<&'static str>>> = RwLock::new(None);
+
+/// Forget which variables the bridge planted.
+///
+/// Tests only: `export_env_bridge` is once-per-process in production, but a test
+/// that plants `AINB_HEADROOM_PORT` would otherwise leave every later test in
+/// the binary ignoring that variable.
+#[cfg(test)]
+pub(crate) fn clear_bridged_for_test() {
+    *BRIDGED.write().unwrap_or_else(|e| e.into_inner()) = None;
+}
+
+/// Whether this process planted `env_var` itself, and so must not read it back.
+fn is_self_planted(env_var: &str) -> bool {
+    BRIDGED
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .as_ref()
+        .is_some_and(|planted| planted.contains(env_var))
+}
+
+/// The raw env value for `env_var`, or `None` when it is unset or was planted
+/// by this process's own [`export_env_bridge`].
+fn env_override(env_var: &str) -> Option<String> {
+    if is_self_planted(env_var) {
+        return None;
+    }
+    std::env::var(env_var).ok()
 }
 
 /// `env_var`, else `from_config`.
@@ -64,9 +142,9 @@ pub fn snapshot() -> &'static AppConfig {
 /// a typo in a shell profile must not brick the reader that consumes it.
 #[must_use]
 pub fn resolved<T: FromStr>(env_var: &str, from_config: T) -> T {
-    match std::env::var(env_var) {
-        Ok(raw) => raw.trim().parse().unwrap_or(from_config),
-        Err(_) => from_config,
+    match env_override(env_var) {
+        Some(raw) => raw.trim().parse().unwrap_or(from_config),
+        None => from_config,
     }
 }
 
@@ -79,9 +157,9 @@ pub fn resolved<T: FromStr>(env_var: &str, from_config: T) -> T {
 /// `AGENTS_BOX_SYNTAX_HIGHLIGHT` treated everything but `true` as off.
 #[must_use]
 pub fn resolved_bool(env_var: &str, from_config: bool) -> bool {
-    match std::env::var(env_var) {
-        Ok(raw) => parse_bool_token(&raw).unwrap_or(from_config),
-        Err(_) => from_config,
+    match env_override(env_var) {
+        Some(raw) => parse_bool_token(&raw).unwrap_or(from_config),
+        None => from_config,
     }
 }
 
@@ -104,19 +182,27 @@ pub fn parse_bool_token(raw: &str) -> Option<bool> {
 ///
 /// Only sets a variable that is currently unset, which is what keeps `env >
 /// config`: an operator who exported `AINB_FLEET_TRANSPORT=broker` for this
-/// shell still beats the file. `general.home` and `usage_client.cache_db` are
-/// `Option` and are skipped when unset, because exporting a derived default
-/// would freeze a path the readers deliberately compute themselves.
+/// shell still beats the file. `usage_client.cache_db` is `Option` and is
+/// skipped when unset, because exporting a derived default would freeze a path
+/// the reader deliberately computes itself.
+///
+/// `AINB_HOME` is deliberately NOT bridged. Its readers disagree about what it
+/// means: `ainb_skill_core::default_ainb_home` and
+/// `fleet::plumbing::paths::ainb_home` treat it as the state directory ITSELF,
+/// while others join `.agents-in-a-box` onto it. A config key would have to
+/// pick one and silently relocate the other's files. The variable keeps working
+/// exactly as it does today; resolving the ambiguity is its own change.
 pub fn export_env_bridge(config: &AppConfig) {
-    let publish = |name: &str, value: String| {
+    let mut planted = BTreeSet::new();
+    let mut publish = |name: &'static str, value: String| {
         if std::env::var_os(name).is_none() {
             std::env::set_var(name, value);
+            // Remembered so this process does not read its own plant back and
+            // pin the value for the rest of the run. See `BRIDGED`.
+            planted.insert(name);
         }
     };
 
-    if let Some(home) = &config.general.home {
-        publish("AINB_HOME", home.clone());
-    }
     publish(
         "AINB_USE_REAL_HOMES",
         config.general.skill_install_real_homes.to_string(),
@@ -151,6 +237,8 @@ pub fn export_env_bridge(config: &AppConfig) {
     if let Some(db) = &config.usage_client.cache_db {
         publish("AINB_USAGE_CACHE_DB", db.clone());
     }
+
+    *BRIDGED.write().unwrap_or_else(|e| e.into_inner()) = Some(planted);
 }
 
 // ── [general] ───────────────────────────────────────────────────────────────
@@ -161,7 +249,6 @@ pub fn export_env_bridge(config: &AppConfig) {
 /// ```toml
 /// [general]
 /// syntax_highlight = true
-/// home = "/Volumes/work/ainb"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GeneralConfig {
@@ -172,7 +259,7 @@ pub struct GeneralConfig {
     pub syntax_highlight: bool,
 
     /// Install skills into each tool's REAL config dir (`~/.claude`,
-    /// `~/.codex`, …) rather than the managed sandbox under `home`.
+    /// `~/.codex`, …) rather than ainb's managed sandbox.
     ///
     /// True is the shipped behaviour: an installed skill has to be where the
     /// tool actually looks or it may as well not exist. False routes every
@@ -180,14 +267,6 @@ pub struct GeneralConfig {
     /// hand-managed `~/.claude` wants.
     #[serde(default = "crate::config::default_true")]
     pub skill_install_real_homes: bool,
-
-    /// Base directory ainb keeps its state under: `<home>/.agents-in-a-box/…`.
-    ///
-    /// `None` means the OS home directory. This does NOT move config.toml,
-    /// which is always read from the OS home. A config file that said where
-    /// to find itself could not be found.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub home: Option<String>,
 }
 
 impl Default for GeneralConfig {
@@ -195,7 +274,6 @@ impl Default for GeneralConfig {
         Self {
             syntax_highlight: true,
             skill_install_real_homes: true,
-            home: None,
         }
     }
 }
@@ -546,6 +624,10 @@ mod tests {
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// Set `name` for the duration of `body`, restoring it afterwards.
+    ///
+    /// Also clears `BRIDGED` on the way out. That set is process-global, so a
+    /// test that runs `export_env_bridge` would otherwise leave every later
+    /// test in the binary silently ignoring the variables it planted.
     fn with_env<T>(name: &str, value: Option<&str>, body: impl FnOnce() -> T) -> T {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var_os(name);
@@ -558,6 +640,7 @@ mod tests {
             Some(v) => std::env::set_var(name, v),
             None => std::env::remove_var(name),
         }
+        clear_bridged_for_test();
         out
     }
 
@@ -568,6 +651,12 @@ mod tests {
     /// The full ladder for a numeric knob, one rung at a time.
     #[test]
     fn headroom_port_ladder_is_env_then_config_then_default() {
+        // `AINB_HEADROOM_PORT` is also mutated by `headroom::tests` and
+        // `interactive::session_manager::tests`, which serialize on
+        // HEADROOM_ENV_LOCK. A second, private mutex guards nothing: both locks
+        // have to be the same one for the variable to be safe.
+        let _headroom =
+            crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // default: nothing set anywhere
         let bare = from_toml("");
         assert_eq!(bare.usage_client.headroom_port, 8787);
@@ -673,6 +762,79 @@ mod tests {
         assert_eq!(parse_bool_token("perhaps"), None);
     }
 
+    /// The bridge must not pin the value it publishes.
+    ///
+    /// It writes into the environment this process also reads, so without the
+    /// self-planted guard `resolved` finds the startup value on every later
+    /// call: `usage_client.headroom_port` could never change again and
+    /// `refresh_snapshot` would have nothing to do. Fails before the guard with
+    /// `assertion `left == right` failed: left: 8787, right: 9001`.
+    #[test]
+    fn the_bridge_does_not_pin_the_value_it_published() {
+        // Deliberately NOT the headroom port: that variable is shared with two
+        // other test modules. `AINB_USAGE_TIMEOUT_SECS` has one reader and no
+        // other test.
+        let startup = AppConfig::default();
+        with_env("AINB_USAGE_TIMEOUT_SECS", None, || {
+            export_env_bridge(&startup);
+            assert_eq!(
+                std::env::var("AINB_USAGE_TIMEOUT_SECS").as_deref(),
+                Ok("120"),
+                "the bridge must publish for readers in other crates"
+            );
+            // A later config says 300. Nothing re-runs the bridge, so the
+            // planted 120 is still in the environment.
+            let edited = from_toml("[usage_client]\nfetch_timeout_secs = 300\n");
+            assert_eq!(
+                resolved(
+                    "AINB_USAGE_TIMEOUT_SECS",
+                    edited.usage_client.fetch_timeout_secs
+                ),
+                300,
+                "a value this process planted itself must not outrank the config"
+            );
+            std::env::remove_var("AINB_USAGE_TIMEOUT_SECS");
+        });
+    }
+
+    /// An operator's OWN export still wins, because the bridge never plants a
+    /// variable that was already set and so never records it.
+    #[test]
+    fn an_operator_export_still_outranks_the_config() {
+        with_env("AINB_USAGE_TIMEOUT_SECS", Some("4242"), || {
+            export_env_bridge(&AppConfig::default());
+            let edited = from_toml("[usage_client]\nfetch_timeout_secs = 300\n");
+            assert_eq!(
+                resolved(
+                    "AINB_USAGE_TIMEOUT_SECS",
+                    edited.usage_client.fetch_timeout_secs
+                ),
+                4242
+            );
+        });
+    }
+
+    /// `snapshot()` must reflect a config that changed after startup.
+    ///
+    /// With the old `OnceLock` this fails with
+    /// `assertion failed: !snapshot().general.syntax_highlight`: the first read
+    /// froze the value, so every promoted key was settable and inert.
+    #[test]
+    fn the_snapshot_picks_up_a_later_config() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        install_snapshot(AppConfig::default());
+        assert!(snapshot().general.syntax_highlight, "the shipped default");
+
+        install_snapshot(from_toml("[general]\nsyntax_highlight = false\n"));
+        assert!(
+            !snapshot().general.syntax_highlight,
+            "a config installed after the first read must be visible"
+        );
+
+        // And `refresh_snapshot` re-reads from disk rather than keeping it.
+        refresh_snapshot();
+    }
+
     #[test]
     fn the_env_bridge_never_overwrites_an_existing_variable() {
         let mut config = AppConfig::default();
@@ -702,13 +864,24 @@ mod tests {
     #[test]
     fn an_unset_optional_is_not_published() {
         let config = AppConfig::default();
-        assert!(config.general.home.is_none());
-        with_env("AINB_HOME", None, || {
+        assert!(config.usage_client.cache_db.is_none());
+        with_env("AINB_USAGE_CACHE_DB", None, || {
             export_env_bridge(&config);
             assert!(
-                std::env::var_os("AINB_HOME").is_none(),
-                "an absent general.home must not freeze AINB_HOME to a derived default"
+                std::env::var_os("AINB_USAGE_CACHE_DB").is_none(),
+                "an absent usage_client.cache_db must not freeze the derived path"
             );
+        });
+    }
+
+    /// `AINB_HOME` relocates the whole state directory and its readers do not
+    /// agree on what it names, so nothing here may set it. See
+    /// [`export_env_bridge`].
+    #[test]
+    fn the_bridge_never_touches_ainb_home() {
+        with_env("AINB_HOME", None, || {
+            export_env_bridge(&AppConfig::default());
+            assert!(std::env::var_os("AINB_HOME").is_none());
         });
     }
 }

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -1175,6 +1175,18 @@ pub fn collect() -> anyhow::Result<Vec<DaemonStatus>> {
 
 #[cfg(test)]
 mod tests {
+    /// Pin the tunables snapshot to defaults for this module.
+    ///
+    /// `stale_after_ms()` and `attention_stale_after_ms()` read the snapshot,
+    /// which lazily loads the developer's real
+    /// `~/.agents-in-a-box/config/config.toml` — so anyone who had set
+    /// `daemons.stale_after_ms` failed these tests locally while CI, with no
+    /// config file, passed. The fixtures below are built from the consts, so
+    /// the snapshot has to agree with them.
+    fn pin_default_snapshot() {
+        crate::config::tunables::install_snapshot(crate::config::AppConfig::default());
+    }
+
     use super::*;
     use tempfile::TempDir;
 
@@ -1588,6 +1600,7 @@ mod tests {
 
     #[test]
     fn bridge_whose_last_attention_poll_went_stale_is_degraded() {
+        pin_default_snapshot();
         let now = 1_000_000;
         let last_poll = now - (ATTENTION_STALE_AFTER_MS + 60_000);
         let mut h = bridge_hb(now - 3_600_000, now - 1_000, true, Some(last_poll));
@@ -1612,6 +1625,7 @@ mod tests {
 
     #[test]
     fn bridge_poll_exactly_at_the_window_edge_is_still_running() {
+        pin_default_snapshot();
         let now = 1_000_000;
         let s = classify_heartbeat(
             DaemonKind::Bridge,
@@ -1633,6 +1647,7 @@ mod tests {
 
     #[test]
     fn freshly_started_bridge_gets_one_window_before_degrading() {
+        pin_default_snapshot();
         let now = 1_000_000;
         // Up for 10s: the worker has not had its first poll yet. Degrading here
         // would make every bridge restart look broken for a minute.
@@ -1782,6 +1797,7 @@ mod tests {
 
     #[test]
     fn wedged_daemon_live_pid_but_old_beat_is_stale() {
+        pin_default_snapshot();
         let now = 1_000_000;
         let s = classify_heartbeat(
             DaemonKind::FleetDaemon,
@@ -1796,6 +1812,7 @@ mod tests {
 
     #[test]
     fn beat_exactly_at_window_edge_is_still_running() {
+        pin_default_snapshot();
         let now = 1_000_000;
         // age == STALE_AFTER_MS is NOT > the window, so still running. The
         // outbound poll is fresh so this isolates the liveness edge.

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -1183,8 +1183,14 @@ mod tests {
     /// `daemons.stale_after_ms` failed these tests locally while CI, with no
     /// config file, passed. The fixtures below are built from the consts, so
     /// the snapshot has to agree with them.
-    fn pin_default_snapshot() {
+    fn pin_default_snapshot() -> std::sync::MutexGuard<'static, ()> {
+        // The shared lock, held by the CALLER for the length of its test: the
+        // snapshot is process-global, so installing it without the lock races
+        // every other test that installs or reads one.
+        let guard =
+            crate::config::tunables::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         crate::config::tunables::install_snapshot(crate::config::AppConfig::default());
+        guard
     }
 
     use super::*;
@@ -1600,7 +1606,7 @@ mod tests {
 
     #[test]
     fn bridge_whose_last_attention_poll_went_stale_is_degraded() {
-        pin_default_snapshot();
+        let _snapshot_guard = pin_default_snapshot();
         let now = 1_000_000;
         let last_poll = now - (ATTENTION_STALE_AFTER_MS + 60_000);
         let mut h = bridge_hb(now - 3_600_000, now - 1_000, true, Some(last_poll));
@@ -1625,7 +1631,7 @@ mod tests {
 
     #[test]
     fn bridge_poll_exactly_at_the_window_edge_is_still_running() {
-        pin_default_snapshot();
+        let _snapshot_guard = pin_default_snapshot();
         let now = 1_000_000;
         let s = classify_heartbeat(
             DaemonKind::Bridge,
@@ -1647,7 +1653,7 @@ mod tests {
 
     #[test]
     fn freshly_started_bridge_gets_one_window_before_degrading() {
-        pin_default_snapshot();
+        let _snapshot_guard = pin_default_snapshot();
         let now = 1_000_000;
         // Up for 10s: the worker has not had its first poll yet. Degrading here
         // would make every bridge restart look broken for a minute.
@@ -1797,7 +1803,7 @@ mod tests {
 
     #[test]
     fn wedged_daemon_live_pid_but_old_beat_is_stale() {
-        pin_default_snapshot();
+        let _snapshot_guard = pin_default_snapshot();
         let now = 1_000_000;
         let s = classify_heartbeat(
             DaemonKind::FleetDaemon,
@@ -1812,7 +1818,7 @@ mod tests {
 
     #[test]
     fn beat_exactly_at_window_edge_is_still_running() {
-        pin_default_snapshot();
+        let _snapshot_guard = pin_default_snapshot();
         let now = 1_000_000;
         // age == STALE_AFTER_MS is NOT > the window, so still running. The
         // outbound poll is fresh so this isolates the liveness edge.

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -32,6 +32,15 @@ use super::heartbeat::{DaemonHeartbeat, PidCheck, is_pid_alive, pid_identity, pr
 /// 30s long-poll cycle and the fleet daemon's 5s tick with headroom.
 pub const STALE_AFTER_MS: i64 = 90_000;
 
+/// [`STALE_AFTER_MS`] with `daemons.stale_after_ms` applied.
+///
+/// A function, not a const, because the value now comes from config; the const
+/// stays as the coded default and as the value the unit tests reason against.
+#[must_use]
+pub fn stale_after_ms() -> i64 {
+    crate::config::tunables::snapshot().daemons.stale_after_ms
+}
+
 /// The outbound-push staleness window for the bridge.
 ///
 /// How long the bridge may go without a SUCCESSFUL poll of the attention source
@@ -45,6 +54,12 @@ pub const STALE_AFTER_MS: i64 = 90_000;
 /// bridge answered yes to the first and (silently) no to the second for its
 /// entire life, which is the blind spot this closes.
 pub const ATTENTION_STALE_AFTER_MS: i64 = 45_000;
+
+/// [`ATTENTION_STALE_AFTER_MS`] with `daemons.attention_stale_after_ms` applied.
+#[must_use]
+pub fn attention_stale_after_ms() -> i64 {
+    crate::config::tunables::snapshot().daemons.attention_stale_after_ms
+}
 
 /// Which daemon a [`DaemonStatus`] describes. Stable wire strings for the JSON
 /// surface and stable display names for the text/TUI surfaces.
@@ -467,7 +482,7 @@ fn classify_outbound(
     match hb.last_attention_poll_at {
         Some(last) => {
             let age = now_ms.saturating_sub(last);
-            if age <= ATTENTION_STALE_AFTER_MS {
+            if age <= attention_stale_after_ms() {
                 OutboundVerdict::Healthy
             } else {
                 OutboundVerdict::Unreachable(format!(
@@ -478,7 +493,7 @@ fn classify_outbound(
         }
         // Never polled. Give the worker one window to complete its first poll
         // before calling it broken, then say so in the operator's words.
-        None if uptime_ms <= ATTENTION_STALE_AFTER_MS => OutboundVerdict::Starting,
+        None if uptime_ms <= attention_stale_after_ms() => OutboundVerdict::Starting,
         None => OutboundVerdict::Unreachable(format!(
             "no successful attention/list poll in {}s of uptime ({cause})",
             uptime_ms / 1000
@@ -548,7 +563,7 @@ pub fn classify_heartbeat(
     // The pid is alive but the heartbeat went quiet past the window: the process
     // exists but its loop is wedged or paused. Report stopped+stale so we don't
     // claim a healthy daemon.
-    if age > STALE_AFTER_MS {
+    if age > stale_after_ms() {
         return DaemonStatus {
             kind,
             state: DaemonState::Stopped,
@@ -836,7 +851,7 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
 
     // The OS timer fires every `interval_min`; allow 2x the cadence + a 90s grace
     // before we call it stale (timers are not punctual to the second).
-    let window_ms = (interval_min as i64) * 60_000 * 2 + STALE_AFTER_MS;
+    let window_ms = (interval_min as i64) * 60_000 * 2 + stale_after_ms();
     let age = now_ms.saturating_sub(hbs.last_heartbeat_ms);
     if age > window_ms {
         return DaemonStatus {

--- a/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
@@ -210,6 +210,12 @@ impl CurrentStateIndex {
 /// `AINB_FLEET_STATE_STALE_MS` stays as the LAST rung so an existing override
 /// keeps doing what it did. Someone who set it to 0 to disable this floor must
 /// not silently get the 5-minute default back.
+///
+/// That rung is only reachable because `tunables::resolved` ignores a variable
+/// this process planted itself: `export_env_bridge` fills
+/// `AINB_FLEET_HEALTHY_STATE_STALE_MS` from config whenever it is unset, so
+/// without that guard the outer call would ALWAYS find a value and the legacy
+/// rung would be dead code. See `tunables::BRIDGED`.
 fn effective_stale_window_ms() -> i64 {
     let config = crate::config::tunables::snapshot();
     let legacy = crate::config::tunables::resolved(
@@ -322,6 +328,60 @@ fn context_from_state(kind: &str, context_json: Option<&str>) -> Option<NeedsCon
 
 #[cfg(test)]
 mod tests {
+    /// Env-mutating tests here serialize against each other.
+    /// [reference: ENV_LOCK for parallel tests]
+    static STALE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// The legacy `AINB_FLEET_STATE_STALE_MS` override must still disable the
+    /// healthy-kind floor.
+    ///
+    /// The regression this guards: `export_env_bridge` fills
+    /// `AINB_FLEET_HEALTHY_STATE_STALE_MS` from config whenever it is unset, so
+    /// an operator with `export AINB_FLEET_STATE_STALE_MS=0` in their profile
+    /// silently got the 5-minute floor back that they had turned off on `main`.
+    /// Without the self-planted guard in `tunables` this fails with
+    /// `assertion `left == right` failed: left: 300000, right: 0`.
+    #[test]
+    fn the_legacy_stale_env_var_still_disables_the_healthy_floor() {
+        let _guard = STALE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior_legacy = std::env::var_os("AINB_FLEET_STATE_STALE_MS");
+        let prior_new = std::env::var_os("AINB_FLEET_HEALTHY_STATE_STALE_MS");
+        std::env::set_var("AINB_FLEET_STATE_STALE_MS", "0");
+        std::env::remove_var("AINB_FLEET_HEALTHY_STATE_STALE_MS");
+
+        // Startup: the bridge publishes the config default for the NEW variable
+        // (300000) because nothing had set it, and leaves the legacy one alone.
+        let config = crate::config::AppConfig::default();
+        crate::config::tunables::install_snapshot(config.clone());
+        crate::config::tunables::export_env_bridge(&config);
+
+        assert_eq!(
+            effective_stale_window_ms(),
+            0,
+            "the legacy override must still win over a value the bridge planted"
+        );
+
+        crate::config::tunables::clear_bridged_for_test();
+        std::env::remove_var("AINB_FLEET_HEALTHY_STATE_STALE_MS");
+        match prior_legacy {
+            Some(v) => std::env::set_var("AINB_FLEET_STATE_STALE_MS", v),
+            None => std::env::remove_var("AINB_FLEET_STATE_STALE_MS"),
+        }
+        if let Some(v) = prior_new {
+            std::env::set_var("AINB_FLEET_HEALTHY_STATE_STALE_MS", v);
+        }
+    }
+
+    /// The two windows are separate knobs with separate defaults, which is the
+    /// bug they were split to fix: one env var used to drive both, with a
+    /// hardcoded 0 at one call site and 300000 at the other.
+    #[test]
+    fn the_sticky_and_healthy_windows_have_their_own_defaults() {
+        let bare: crate::config::AppConfig = toml::from_str("").expect("parses");
+        assert_eq!(bare.fleet.state_stale_ms, 0);
+        assert_eq!(bare.fleet.healthy_state_stale_ms, 300_000);
+    }
+
     use super::*;
     use crate::fleet::types::SessionSource;
 

--- a/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
@@ -218,11 +218,24 @@ impl CurrentStateIndex {
 /// rung would be dead code. See `tunables::BRIDGED`.
 fn effective_stale_window_ms() -> i64 {
     let config = crate::config::tunables::snapshot();
-    let legacy = crate::config::tunables::resolved(
-        "AINB_FLEET_STATE_STALE_MS",
+    // Order matters. The legacy variable is only a fallback for someone who
+    // has NOT set the new key: consulting it first made
+    // `fleet.healthy_state_stale_ms` unreachable for anyone with the old
+    // variable exported, so the settings row reported saved and the window
+    // never moved. One env var driving both clocks is the coupling the split
+    // exists to break.
+    let from_new = crate::config::tunables::resolved(
+        "AINB_FLEET_HEALTHY_STATE_STALE_MS",
         config.fleet.healthy_state_stale_ms,
     );
-    crate::config::tunables::resolved("AINB_FLEET_HEALTHY_STATE_STALE_MS", legacy).max(0)
+    let explicit_new = crate::config::tunables::env_override("AINB_FLEET_HEALTHY_STATE_STALE_MS")
+        .is_some()
+        || config.fleet.healthy_state_stale_ms
+            != crate::config::default_fleet_healthy_state_stale_ms();
+    if explicit_new {
+        return from_new.max(0);
+    }
+    crate::config::tunables::resolved("AINB_FLEET_STATE_STALE_MS", from_new).max(0)
 }
 
 /// Outcome of resolving one session against `current_state`.

--- a/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
@@ -196,23 +196,27 @@ impl CurrentStateIndex {
     }
 }
 
-/// Default staleness window (ms) applied ONLY to the HEALTHY-suppressing kinds
-/// (RUNNING/DONE) so a stale "healthy" row from a stopped daemon eventually
-/// falls back to a live tmux scan instead of masking a real need forever. A few
-/// minutes is long enough to outlast normal materializer latency but short
-/// enough that a dead daemon surfaces quickly. Overridable via
-/// `AINB_FLEET_STATE_STALE_MS` (a non-negative integer; 0 disables it).
-const DEFAULT_HEALTHY_STALE_WINDOW_MS: i64 = 5 * 60_000;
-
-/// The effective healthy-kind staleness window, honouring the
-/// `AINB_FLEET_STATE_STALE_MS` override (clamped to ≥ 0; unset/invalid → the
-/// default).
+/// The effective staleness window (ms) for the HEALTHY-suppressing kinds
+/// (RUNNING/DONE), so a stale "healthy" row from a stopped daemon eventually
+/// falls back to a live tmux scan instead of masking a real need forever.
+///
+/// Its own knob (`fleet.healthy_state_stale_ms`, default 5 minutes), because it
+/// is a different clock from the sticky-kind window in `cli::fleet::needs`. The
+/// two used to share the ONE env var `AINB_FLEET_STATE_STALE_MS` while
+/// hardcoding different fallbacks (300000 here, 0 there): setting it moved both
+/// clocks at once, and neither knob had a default you could name. They are now
+/// separate keys with one default each.
+///
+/// `AINB_FLEET_STATE_STALE_MS` stays as the LAST rung so an existing override
+/// keeps doing what it did. Someone who set it to 0 to disable this floor must
+/// not silently get the 5-minute default back.
 fn effective_stale_window_ms() -> i64 {
-    std::env::var("AINB_FLEET_STATE_STALE_MS")
-        .ok()
-        .and_then(|s| s.trim().parse::<i64>().ok())
-        .map(|v| v.max(0))
-        .unwrap_or(DEFAULT_HEALTHY_STALE_WINDOW_MS)
+    let config = crate::config::tunables::snapshot();
+    let legacy = crate::config::tunables::resolved(
+        "AINB_FLEET_STATE_STALE_MS",
+        config.fleet.healthy_state_stale_ms,
+    );
+    crate::config::tunables::resolved("AINB_FLEET_HEALTHY_STATE_STALE_MS", legacy).max(0)
 }
 
 /// Outcome of resolving one session against `current_state`.

--- a/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/read/current_state.rs
@@ -330,7 +330,7 @@ fn context_from_state(kind: &str, context_json: Option<&str>) -> Option<NeedsCon
 mod tests {
     /// Env-mutating tests here serialize against each other.
     /// [reference: ENV_LOCK for parallel tests]
-    static STALE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use crate::config::tunables::TEST_ENV_LOCK as STALE_ENV_LOCK;
 
     /// The legacy `AINB_FLEET_STATE_STALE_MS` override must still disable the
     /// healthy-kind floor.
@@ -352,6 +352,10 @@ mod tests {
         // Startup: the bridge publishes the config default for the NEW variable
         // (300000) because nothing had set it, and leaves the legacy one alone.
         let config = crate::config::AppConfig::default();
+        // Restored below: the snapshot is process-global, so leaving this
+        // installed makes every later test in the binary read it instead of
+        // its own config.
+        let previous = crate::config::tunables::snapshot();
         crate::config::tunables::install_snapshot(config.clone());
         crate::config::tunables::export_env_bridge(&config);
 
@@ -370,6 +374,7 @@ mod tests {
         if let Some(v) = prior_new {
             std::env::set_var("AINB_FLEET_HEALTHY_STATE_STALE_MS", v);
         }
+        crate::config::tunables::install_snapshot((*previous).clone());
     }
 
     /// The two windows are separate knobs with separate defaults, which is the

--- a/ainb-tui/crates/ainb-core/src/git/workspace_scanner.rs
+++ b/ainb-tui/crates/ainb-core/src/git/workspace_scanner.rs
@@ -45,9 +45,6 @@ pub struct RepositoryCache {
 impl RepositoryCache {
     const VERSION: u32 = 1;
     const CACHE_FILE: &'static str = "cache/repositories.json";
-    /// Coded default TTL (1 hour), overridden by
-    /// `workspace_defaults.scan_cache_ttl_secs`.
-    const DEFAULT_TTL_SECS: i64 = 3600;
 
     /// The effective freshness window for a cached scan.
     fn ttl_secs() -> i64 {

--- a/ainb-tui/crates/ainb-core/src/git/workspace_scanner.rs
+++ b/ainb-tui/crates/ainb-core/src/git/workspace_scanner.rs
@@ -45,7 +45,14 @@ pub struct RepositoryCache {
 impl RepositoryCache {
     const VERSION: u32 = 1;
     const CACHE_FILE: &'static str = "cache/repositories.json";
-    const DEFAULT_TTL_SECS: i64 = 3600; // 1 hour
+    /// Coded default TTL (1 hour), overridden by
+    /// `workspace_defaults.scan_cache_ttl_secs`.
+    const DEFAULT_TTL_SECS: i64 = 3600;
+
+    /// The effective freshness window for a cached scan.
+    fn ttl_secs() -> i64 {
+        crate::config::tunables::snapshot().workspace_defaults.scan_cache_ttl_secs
+    }
 
     /// Get the cache file path
     fn cache_path() -> PathBuf {
@@ -150,7 +157,7 @@ impl RepositoryCache {
 
         // 4. TTL check (fallback)
         let age = Utc::now() - self.last_scan;
-        if age.num_seconds() > Self::DEFAULT_TTL_SECS {
+        if age.num_seconds() > Self::ttl_secs() {
             debug!("Cache invalid: expired (age {} seconds)", age.num_seconds());
             return false;
         }
@@ -246,6 +253,19 @@ impl WorkspaceScanner {
     pub fn with_max_depth(mut self, depth: usize) -> Self {
         self.max_depth = depth;
         self
+    }
+
+    /// Apply `workspace_defaults` to a scanner: the exclude patterns it already
+    /// took, plus the scan depth.
+    ///
+    /// `with_max_depth` has existed since the scanner did and was never called
+    /// from anywhere, so the depth was effectively a constant 3 no matter what
+    /// a user configured. Both call sites go through here now, so the two
+    /// cannot configure a scan differently.
+    #[must_use]
+    pub fn with_workspace_defaults(self, defaults: &crate::config::WorkspaceDefaults) -> Self {
+        self.with_exclude_paths(defaults.exclude_paths.clone())
+            .with_max_depth(defaults.scan_max_depth)
     }
 
     /// Add additional exclude patterns from config

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -46,13 +46,13 @@ pub fn is_installed() -> bool {
 
 // ── Port resolution ──────────────────────────────────────────────────────────
 
-/// Effective port for the Headroom proxy.
-/// Reads `AINB_HEADROOM_PORT`; falls back to `HEADROOM_DEFAULT_PORT` (8787).
+/// Effective port for the Headroom proxy: `AINB_HEADROOM_PORT`, else
+/// `usage_client.headroom_port`, else [`HEADROOM_DEFAULT_PORT`] (8787).
 pub fn proxy_port() -> u16 {
-    std::env::var("AINB_HEADROOM_PORT")
-        .ok()
-        .and_then(|s| s.parse::<u16>().ok())
-        .unwrap_or(HEADROOM_DEFAULT_PORT)
+    crate::config::tunables::resolved(
+        "AINB_HEADROOM_PORT",
+        crate::config::tunables::snapshot().usage_client.headroom_port,
+    )
 }
 
 // ── Liveness probe ───────────────────────────────────────────────────────────

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -740,13 +740,11 @@ impl SessionStore {
 /// Default port for the ainb-managed Headroom compression proxy.
 pub const HEADROOM_DEFAULT_PORT: u16 = 8787;
 
-/// Base URL of the local Headroom proxy. Port overridable via `AINB_HEADROOM_PORT`.
+/// Base URL of the local Headroom proxy. One resolver with
+/// [`crate::headroom::proxy_port`], so the URL a session is pointed at and the
+/// port the proxy is spawned on cannot disagree.
 pub fn headroom_base_url() -> String {
-    let port = std::env::var("AINB_HEADROOM_PORT")
-        .ok()
-        .and_then(|s| s.parse::<u16>().ok())
-        .unwrap_or(HEADROOM_DEFAULT_PORT);
-    format!("http://127.0.0.1:{port}")
+    format!("http://127.0.0.1:{}", crate::headroom::proxy_port())
 }
 
 /// Shell `export … && ` prefix that routes a session's CLI through the local

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -126,8 +126,18 @@ fn main() -> Result<()> {
     // `migrate_legacy_paths` moves with it rather than staying behind: it folds
     // a stray older config.toml into the canonical one, and the bridge has to
     // read the merged result, not the pre-migration file.
-    config::AppConfig::migrate_legacy_paths();
-    config::tunables::export_env_bridge(&config::tunables::snapshot());
+    // Skipped for the pure-informational invocations. Otherwise `ainb --help`
+    // and `ainb --version` would each do a four-path config load and could
+    // WRITE config.toml through the legacy-path migration — surprising for a
+    // command that is meant to print and exit, and any warning raised during
+    // that load is discarded because the tracing subscriber does not exist yet.
+    let informational_only = std::env::args()
+        .skip(1)
+        .all(|arg| matches!(arg.as_str(), "-h" | "--help" | "-V" | "--version" | "help"));
+    if !informational_only {
+        config::AppConfig::migrate_legacy_paths();
+        config::tunables::export_env_bridge(&config::tunables::snapshot());
+    }
 
     if is_skill_manager_cli_invocation() {
         return ainb_cli::run();

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -110,6 +110,25 @@ fn is_skill_manager_cli_invocation() -> bool {
 }
 
 fn main() -> Result<()> {
+    // BEFORE the `ainb-cli` short-circuit and before any runtime exists.
+    //
+    // Two reasons, both bugs when this lived in `tokio_main`:
+    //
+    // 1. `skill` / `source` / `search` return through `ainb_cli::run()` above
+    //    without ever entering `tokio_main`, and `ainb-cli` does not depend on
+    //    this crate. So `general.skill_install_real_homes` never reached
+    //    `ainb skill install`, the one command it exists to govern.
+    // 2. `export_env_bridge` calls `std::env::set_var`. Inside `#[tokio::main]`
+    //    the worker threads and the tracing subscriber already exist, and a
+    //    `setenv` racing another thread's `getenv` is a data race (which is why
+    //    Rust 2024 made it `unsafe`). Here, `main` is still the only thread.
+    //
+    // `migrate_legacy_paths` moves with it rather than staying behind: it folds
+    // a stray older config.toml into the canonical one, and the bridge has to
+    // read the merged result, not the pre-migration file.
+    config::AppConfig::migrate_legacy_paths();
+    config::tunables::export_env_bridge(&config::tunables::snapshot());
+
     if is_skill_manager_cli_invocation() {
         return ainb_cli::run();
     }
@@ -121,21 +140,6 @@ async fn tokio_main() -> Result<()> {
     crate::perf::init();
     setup_logging();
     setup_panic_handler();
-
-    // Once per process, before anything calls AppConfig::load(). Older builds
-    // let the burndown and session-reader plugins keep a second config.toml one
-    // directory above the real one; this folds any leftover into the canonical
-    // file. Deliberately here rather than inside load(), which also runs in
-    // daemons and inside the TUI event loop.
-    config::AppConfig::migrate_legacy_paths();
-
-    // Publish the config-sourced values that crates outside `ainb` read as env
-    // vars (`AINB_HOME`, the fleet knobs, the headroom port), and that child
-    // processes (plugin subprocesses, the hangar daemon) inherit. Only fills
-    // variables that are unset, so an exported override still wins. Here, on
-    // the single-threaded startup path, because it mutates the process
-    // environment; see `config::tunables::export_env_bridge`.
-    config::tunables::export_env_bridge(config::tunables::snapshot());
 
     // Build the clap surface from the CommandRegistry. The base `ainb` command
     // (--format, after-help, etc.) lives in cli::root_clap_command(); each

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -441,7 +441,8 @@ async fn run_tui_loop(
     // latency. See `last_app_tick` below. Both cadences are
     // `[ui]` keys now: a slow terminal wants a coarser poll.
     let app_tick_rate =
-        Duration::from_millis(crate::config::tunables::snapshot().ui.app_tick_ms.max(1));
+        Duration::from_millis(crate::config::tunables::snapshot().ui.app_tick_ms.max(1))
+            .max(tick_rate);
     let mut last_tick = Instant::now();
     let mut last_app_tick = Instant::now();
 

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -129,6 +129,14 @@ async fn tokio_main() -> Result<()> {
     // daemons and inside the TUI event loop.
     config::AppConfig::migrate_legacy_paths();
 
+    // Publish the config-sourced values that crates outside `ainb` read as env
+    // vars (`AINB_HOME`, the fleet knobs, the headroom port), and that child
+    // processes (plugin subprocesses, the hangar daemon) inherit. Only fills
+    // variables that are unset, so an exported override still wins. Here, on
+    // the single-threaded startup path, because it mutates the process
+    // environment; see `config::tunables::export_env_bridge`.
+    config::tunables::export_env_bridge(config::tunables::snapshot());
+
     // Build the clap surface from the CommandRegistry. The base `ainb` command
     // (--format, after-help, etc.) lives in cli::root_clap_command(); each
     // built-in subcommand registers itself via CommandRegistry::built_ins().
@@ -396,7 +404,7 @@ async fn run_tui_loop(
     // screens via `App::tick_plugin_renders` and its `take_render_dirty`
     // gate. Set to ~30 fps so a keystroke lands in the next iter
     // (< 33 ms) rather than the next 250 ms window.
-    let tick_rate = Duration::from_millis(33);
+    let tick_rate = Duration::from_millis(crate::config::tunables::snapshot().ui.tick_rate_ms);
     // App-tick cadence: how often we run the heavy host-side periodic
     // work (mascot animation, OAuth refresh check, tmux preview
     // capture, async action dispatch, log streaming refresh,
@@ -405,8 +413,9 @@ async fn run_tui_loop(
     // loop, stall key processing, and burn CPU. 250 ms is the
     // pre-perf-PR cadence; keeping it isolates the tick-rate cut
     // to only the event-poll path that actually affects perceived
-    // latency. See `last_app_tick` below.
-    let app_tick_rate = Duration::from_millis(250);
+    // latency. See `last_app_tick` below. Both cadences are
+    // `[ui]` keys now: a slow terminal wants a coarser poll.
+    let app_tick_rate = Duration::from_millis(crate::config::tunables::snapshot().ui.app_tick_ms);
     let mut last_tick = Instant::now();
     let mut last_app_tick = Instant::now();
 

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -408,7 +408,11 @@ async fn run_tui_loop(
     // screens via `App::tick_plugin_renders` and its `take_render_dirty`
     // gate. Set to ~30 fps so a keystroke lands in the next iter
     // (< 33 ms) rather than the next 250 ms window.
-    let tick_rate = Duration::from_millis(crate::config::tunables::snapshot().ui.tick_rate_ms);
+    // `.max(1)`: the registry's `min` only gates the settings screen and
+    // `ainb config set`. A hand-edited `tick_rate_ms = 0` gives a zero poll
+    // timeout, so the loop never blocks and repaints continuously at 100% CPU.
+    let tick_rate =
+        Duration::from_millis(crate::config::tunables::snapshot().ui.tick_rate_ms.max(1));
     // App-tick cadence: how often we run the heavy host-side periodic
     // work (mascot animation, OAuth refresh check, tmux preview
     // capture, async action dispatch, log streaming refresh,
@@ -419,7 +423,8 @@ async fn run_tui_loop(
     // to only the event-poll path that actually affects perceived
     // latency. See `last_app_tick` below. Both cadences are
     // `[ui]` keys now: a slow terminal wants a coarser poll.
-    let app_tick_rate = Duration::from_millis(crate::config::tunables::snapshot().ui.app_tick_ms);
+    let app_tick_rate =
+        Duration::from_millis(crate::config::tunables::snapshot().ui.app_tick_ms.max(1));
     let mut last_tick = Instant::now();
     let mut last_app_tick = Instant::now();
 

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -131,9 +131,16 @@ fn main() -> Result<()> {
     // WRITE config.toml through the legacy-path migration — surprising for a
     // command that is meant to print and exit, and any warning raised during
     // that load is discarded because the tracing subscriber does not exist yet.
-    let informational_only = std::env::args()
-        .skip(1)
-        .all(|arg| matches!(arg.as_str(), "-h" | "--help" | "-V" | "--version" | "help"));
+    //
+    // `!args.is_empty()` matters: `all()` on an EMPTY iterator is `true`, so
+    // bare `ainb` — the normal way to open the TUI — would classify itself as
+    // informational and skip both the migration and the bridge, leaving every
+    // promoted key inert in the one invocation that most needs them.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let informational_only = !args.is_empty()
+        && args
+            .iter()
+            .all(|arg| matches!(arg.as_str(), "-h" | "--help" | "-V" | "--version" | "help"));
     if !informational_only {
         config::AppConfig::migrate_legacy_paths();
         config::tunables::export_env_bridge(&config::tunables::snapshot());
@@ -2157,4 +2164,37 @@ fn command_exists(cmd: &str) -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod informational_only_tests {
+    /// The predicate `main` uses to decide whether to skip the config load.
+    fn informational_only(args: &[&str]) -> bool {
+        !args.is_empty()
+            && args
+                .iter()
+                .all(|arg| matches!(*arg, "-h" | "--help" | "-V" | "--version" | "help"))
+    }
+
+    /// Bare `ainb` is the normal TUI launch and must NOT be treated as
+    /// informational. `all()` on an empty iterator is `true`, so the obvious
+    /// spelling skipped the config load and env bridge for the one invocation
+    /// that most needs them.
+    #[test]
+    fn bare_ainb_is_not_informational() {
+        assert!(!informational_only(&[]), "bare `ainb` must load config");
+        assert!(!informational_only(&["tui"]));
+        assert!(!informational_only(&["config", "show"]));
+        assert!(!informational_only(&["--help", "config"]));
+    }
+
+    #[test]
+    fn help_and_version_are_informational() {
+        for args in [&["--help"][..], &["-h"], &["--version"], &["-V"], &["help"]] {
+            assert!(
+                informational_only(args),
+                "{args:?} should skip the config load"
+            );
+        }
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/usage_cache/store.rs
+++ b/ainb-tui/crates/ainb-core/src/usage_cache/store.rs
@@ -351,10 +351,13 @@ impl Cache {
     }
 }
 
-/// Resolve the default cache DB path (`~/.agents-in-a-box/cache/usage.db`)
-/// honoring the `AINB_USAGE_CACHE_DB` env override (used by tests).
+/// Resolve the cache DB path: `AINB_USAGE_CACHE_DB` (used by tests), else
+/// `usage_client.cache_db`, else `~/.agents-in-a-box/cache/usage.db`.
 pub fn default_db_path() -> Option<PathBuf> {
     if let Some(p) = std::env::var_os("AINB_USAGE_CACHE_DB") {
+        return Some(PathBuf::from(p));
+    }
+    if let Some(p) = &crate::config::tunables::snapshot().usage_client.cache_db {
         return Some(PathBuf::from(p));
     }
     dirs::home_dir().map(|h| h.join(".agents-in-a-box").join("cache").join("usage.db"))

--- a/ainb-tui/crates/ainb-core/src/usage_cache/store.rs
+++ b/ainb-tui/crates/ainb-core/src/usage_cache/store.rs
@@ -354,7 +354,13 @@ impl Cache {
 /// Resolve the cache DB path: `AINB_USAGE_CACHE_DB` (used by tests), else
 /// `usage_client.cache_db`, else `~/.agents-in-a-box/cache/usage.db`.
 pub fn default_db_path() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("AINB_USAGE_CACHE_DB") {
+    // `env_override`, not a bare `var_os`: the bridge plants
+    // `AINB_USAGE_CACHE_DB` into the environment from `usage_client.cache_db`
+    // at startup, so a bare read keeps returning that startup value after the
+    // user edits or clears the key — and clearing it could never fall through
+    // to the derived path. `env_override` ignores the value the bridge planted
+    // itself, so only a real user-set variable wins.
+    if let Some(p) = crate::config::tunables::env_override("AINB_USAGE_CACHE_DB") {
         return Some(PathBuf::from(p));
     }
     if let Some(p) = crate::config::tunables::snapshot().usage_client.cache_db.as_deref() {

--- a/ainb-tui/crates/ainb-core/src/usage_cache/store.rs
+++ b/ainb-tui/crates/ainb-core/src/usage_cache/store.rs
@@ -357,7 +357,7 @@ pub fn default_db_path() -> Option<PathBuf> {
     if let Some(p) = std::env::var_os("AINB_USAGE_CACHE_DB") {
         return Some(PathBuf::from(p));
     }
-    if let Some(p) = &crate::config::tunables::snapshot().usage_client.cache_db {
+    if let Some(p) = crate::config::tunables::snapshot().usage_client.cache_db.as_deref() {
         return Some(PathBuf::from(p));
     }
     dirs::home_dir().map(|h| h.join(".agents-in-a-box").join("cache").join("usage.db"))

--- a/ainb-tui/crates/ainb-core/src/widgets/result_parser.rs
+++ b/ainb-tui/crates/ainb-core/src/widgets/result_parser.rs
@@ -208,9 +208,12 @@ fn format_code_block(
     );
 
     // Check if we should use highlighting (only for known languages)
-    let use_highlighting = language.is_some() &&
-        std::env::var("NO_COLOR").is_err() && // Respect NO_COLOR env var
-        std::env::var("AGENTS_BOX_SYNTAX_HIGHLIGHT").unwrap_or_else(|_| "true".to_string()) == "true";
+    let use_highlighting = language.is_some()
+        && std::env::var("NO_COLOR").is_err() // Respect NO_COLOR env var
+        && crate::config::tunables::resolved_bool(
+            "AGENTS_BOX_SYNTAX_HIGHLIGHT",
+            crate::config::tunables::snapshot().general.syntax_highlight,
+        );
 
     // Format code lines with optional syntax highlighting
     let formatted_lines = if use_highlighting {

--- a/ainb-tui/crates/ainb-core/tests/fleet_pending_listing.rs
+++ b/ainb-tui/crates/ainb-core/tests/fleet_pending_listing.rs
@@ -109,7 +109,7 @@ fn fleet_approve_listing_names_the_worktree_tool_input_and_age() {
 
     // Real broker on the isolated approve.sock.
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let state = BrokerState::new();
+    let state = BrokerState::with_timeout(ainb_plugin_notifyd::broker::DEFAULT_AWAIT_TIMEOUT);
     {
         let sock = paths.approve_socket.clone();
         rt.spawn(async move {

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_approve_roundtrip.rs
@@ -153,7 +153,8 @@ fn fleet_panel_approve_roundtrips_to_a_blocked_waiter() {
     // Real broker on the isolated approve.sock, riding a test-owned runtime.
     let paths = Paths::under(&hangar_home);
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let broker_state = BrokerState::new();
+    let broker_state =
+        BrokerState::with_timeout(ainb_plugin_notifyd::broker::DEFAULT_AWAIT_TIMEOUT);
     {
         let sock = paths.approve_socket.clone();
         let state = broker_state.clone();

--- a/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_fleet_panel_opens_and_answers.rs
@@ -283,7 +283,8 @@ fn fleet_panel_opens_renders_answers_and_returns_home() {
     // the exact JSON Claude receives to resume its AskUserQuestion tool call.
     let paths = Paths::under(&hangar_home);
     let broker_runtime = tokio::runtime::Runtime::new().expect("broker runtime");
-    let broker_state = BrokerState::new();
+    let broker_state =
+        BrokerState::with_timeout(ainb_plugin_notifyd::broker::DEFAULT_AWAIT_TIMEOUT);
     {
         let sock = paths.approve_socket.clone();
         let state = broker_state.clone();

--- a/ainb-tui/crates/ainb-core/tests/tripwire_skill_install_root_from_config.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_skill_install_root_from_config.rs
@@ -1,0 +1,161 @@
+//! Tripwire: `general.skill_install_real_homes = false` in config.toml actually
+//! reaches `ainb skill install`.
+//!
+//! Two failures this catches, both of which make the key inert while the
+//! settings screen reports it saved:
+//!
+//! 1. `export_env_bridge` running inside `tokio_main`. `skill` / `source` /
+//!    `search` return through `ainb_cli::run()` in `main()` BEFORE `tokio_main`
+//!    is ever entered, and `ainb-cli` does not depend on `ainb`, so the bridge
+//!    never ran for the one command this key governs and the skill landed in
+//!    the real `~/.claude/skills/` anyway.
+//! 2. The `AINB_USE_REAL_HOMES` gate in `ainb-adapters-tool` being dropped
+//!    again. It had no reader at all before P2b: real homes were
+//!    unconditional and the documented opt-out did nothing.
+//!
+//! Exercised through the real binary, because the bug is in `main()`'s ordering
+//! and no in-process test can observe it.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+/// A `$HOME` with onboarding skipped and the given `config.toml` body.
+fn seeded_home(body: &str) -> tempfile::TempDir {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_dir = home.path().join(".agents-in-a-box/config");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("onboarding.toml"),
+        format!(
+            r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+            ver = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .unwrap();
+    fs::write(config_dir.join("config.toml"), body).unwrap();
+    home
+}
+
+/// A local source directory holding one skill.
+fn seeded_source() -> tempfile::TempDir {
+    let src = tempfile::tempdir().expect("src tempdir");
+    fs::create_dir_all(src.path().join("skills/commit")).unwrap();
+    fs::write(
+        src.path().join("skills/commit/SKILL.md"),
+        "---\nname: commit\ndescription: tripwire fixture\n---\nbody\n",
+    )
+    .unwrap();
+    src
+}
+
+#[test]
+fn skill_install_honours_the_config_key_without_the_env_var() {
+    let bin = ainb_bin();
+    let home = seeded_home("[general]\nskill_install_real_homes = false\n");
+    let ainb_home = tempfile::tempdir().expect("ainb-home tempdir");
+    let src = seeded_source();
+    let local_uri = format!("local:{}", src.path().display());
+
+    // Deliberately NO `AINB_USE_REAL_HOMES`: the config key is the only signal.
+    let run = |args: &[&str]| {
+        Command::new(&bin)
+            .args(args)
+            .env("HOME", home.path())
+            .env("AINB_HOME", ainb_home.path())
+            .env_remove("AINB_USE_REAL_HOMES")
+            .output()
+            .expect("run ainb")
+    };
+
+    let add = run(&["source", "add", &local_uri, "--name", "fix"]);
+    assert!(
+        add.status.success(),
+        "source add failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let unit_uri = format!("{local_uri}@main/skills/commit");
+    let install = run(&[
+        "skill",
+        "install",
+        &unit_uri,
+        "--targets",
+        "claude",
+        "--yes",
+    ]);
+    assert!(
+        install.status.success(),
+        "skill install failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    let sandbox = ainb_home.path().join("tools/claude/skills/commit/SKILL.md");
+    let real_home = home.path().join(".claude/skills/commit/SKILL.md");
+    assert!(
+        sandbox.exists(),
+        "`general.skill_install_real_homes = false` must route the install into \
+         the managed sandbox at {}; stdout:\n{}",
+        sandbox.display(),
+        String::from_utf8_lossy(&install.stdout)
+    );
+    assert!(
+        !real_home.exists(),
+        "the skill must NOT also land in the real tool home at {}",
+        real_home.display()
+    );
+}
+
+/// The shipped default is unchanged: with no key and no env var, an install
+/// still lands where the tool actually looks.
+#[test]
+fn the_default_still_installs_into_the_real_tool_home() {
+    let bin = ainb_bin();
+    let home = seeded_home("");
+    let ainb_home = tempfile::tempdir().expect("ainb-home tempdir");
+    let src = seeded_source();
+    let local_uri = format!("local:{}", src.path().display());
+
+    let run = |args: &[&str]| {
+        Command::new(&bin)
+            .args(args)
+            .env("HOME", home.path())
+            .env("AINB_HOME", ainb_home.path())
+            .env_remove("AINB_USE_REAL_HOMES")
+            .output()
+            .expect("run ainb")
+    };
+
+    assert!(run(&["source", "add", &local_uri, "--name", "fix"]).status.success());
+    let unit_uri = format!("{local_uri}@main/skills/commit");
+    let install = run(&[
+        "skill",
+        "install",
+        &unit_uri,
+        "--targets",
+        "claude",
+        "--yes",
+    ]);
+    assert!(
+        install.status.success(),
+        "skill install failed: stderr={}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    assert!(
+        home.path().join(".claude/skills/commit/SKILL.md").exists(),
+        "the default must still install where the tool looks; stdout:\n{}",
+        String::from_utf8_lossy(&install.stdout)
+    );
+}

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
@@ -22,7 +22,24 @@ const LIST_FORMAT: &str = concat!(
 /// Sized above a slow tool call (a build, a full test suite) so a quiet-but-busy
 /// agent is not mislabelled idle, and well under the multi-hour gap that
 /// separates a working session from an abandoned one.
+///
+/// The coded default for [`idle_after_secs`].
 const IDLE_AFTER_SECS: i64 = 120;
+
+/// The effective idle threshold.
+///
+/// `fleet.tmux_idle_after_secs` reaches this crate as
+/// `AINB_FLEET_TMUX_IDLE_AFTER_SECS`, published by the host at startup
+/// (`ainb::config::tunables::export_env_bridge`). This crate cannot read
+/// config.toml itself: it does not depend on `ainb`, and giving it its own
+/// parser would make a fifth parser of one file.
+fn idle_after_secs() -> i64 {
+    std::env::var("AINB_FLEET_TMUX_IDLE_AFTER_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<i64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(IDLE_AFTER_SECS)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TmuxPaneRow {
@@ -62,12 +79,12 @@ impl TmuxPaneRow {
     /// This is an INFERRED observation, so a provider hook always outranks it
     /// (see `should_replace` in the fleet repo) — it only has to be right for
     /// sessions that emit no hooks at all, which is most of them.
-    const fn lifecycle(&self, now_secs: i64) -> LifecycleState {
+    fn lifecycle(&self, now_secs: i64) -> LifecycleState {
         if self.pane_dead {
             return LifecycleState::Exited;
         }
         match self.window_activity {
-            Some(activity) if now_secs.saturating_sub(activity) > IDLE_AFTER_SECS => {
+            Some(activity) if now_secs.saturating_sub(activity) > idle_after_secs() => {
                 LifecycleState::Idle
             }
             Some(_) => LifecycleState::Running,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -313,7 +313,11 @@ impl PoolConfig {
                 .adapters
                 .entry(name.clone())
                 .or_insert_with(|| AdapterConfig::new(name, DEFAULT_PERMISSION_MODE));
-            if let Some(command) = adapter.command {
+            // `filter(|c| !c.trim().is_empty())`: the registry seeds this row with
+            // `""` and its help says blank resolves the adapter's name on PATH. A
+            // hand-edited empty string would otherwise become an empty program path
+            // that cannot spawn.
+            if let Some(command) = adapter.command.filter(|c| !c.trim().is_empty()) {
                 entry.command = std::path::PathBuf::from(command);
             }
             if let Some(mode) = adapter.permission_mode {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -321,7 +321,20 @@ impl PoolConfig {
                 entry.command = std::path::PathBuf::from(command);
             }
             if let Some(mode) = adapter.permission_mode {
-                entry.permission_mode = mode;
+                // Validated here, not just in the settings screen: the row's
+                // Choice list gates the UI and `ainb config set`, but a hand-edited
+                // typo would otherwise reach `session/new` unchecked — and an
+                // unpinned adapter has been observed inheriting
+                // `bypassPermissions`, so a silent fall-through is not safe.
+                const MODES: &[&str] = &["default", "acceptEdits", "bypassPermissions", "plan"];
+                if MODES.contains(&mode.as_str()) {
+                    entry.permission_mode = mode;
+                } else {
+                    tracing::warn!(
+                        %mode,
+                        "unknown acp permission_mode in config; using \"default\""
+                    );
+                }
             }
         }
         config

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -163,6 +163,55 @@ const EXIT_QUIESCE: Duration = Duration::from_millis(50);
 
 // --------------------------------------------------------------------- config
 
+/// The permission mode an adapter gets when neither the built-in registry nor
+/// config names one.
+const DEFAULT_PERMISSION_MODE: &str = "default";
+
+/// One `[acp.adapters.<name>]` table, as written.
+///
+/// Both fields are `Option` so an absent key means "leave the built-in alone"
+/// rather than "reset it to a default": a table that only repoints `command`
+/// must not silently unpin the permission mode, which is the setting that stops
+/// an adapter inheriting `bypassPermissions` from ambient state.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct AcpAdapterToml {
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    permission_mode: Option<String>,
+}
+
+/// Read `[acp.adapters]` from `~/.agents-in-a-box/config/config.toml`.
+///
+/// Empty on any failure (no file, no `$HOME`, bad TOML, malformed table), with
+/// a warning: the built-in adapters are always the floor.
+fn acp_adapters_from_config() -> std::collections::HashMap<String, AcpAdapterToml> {
+    let Some(home) = std::env::var_os("HOME") else {
+        return HashMap::new();
+    };
+    let path = std::path::PathBuf::from(home)
+        .join(".agents-in-a-box")
+        .join("config")
+        .join("config.toml");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return HashMap::new();
+    };
+    let root: toml::Value = match toml::from_str(&text) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(%error, "acp: config.toml does not parse; using the built-in adapters");
+            return HashMap::new();
+        }
+    };
+    let Some(table) = root.get("acp").and_then(|acp| acp.get("adapters")).cloned() else {
+        return HashMap::new();
+    };
+    table.try_into().unwrap_or_else(|error| {
+        tracing::warn!(%error, "acp: [acp.adapters] is malformed; using the built-in adapters");
+        HashMap::new()
+    })
+}
+
 /// Pool tuning. Every knob the plan names, with its documented default.
 #[derive(Debug, Clone)]
 pub struct PoolConfig {
@@ -196,7 +245,7 @@ pub struct PoolConfig {
 
 impl Default for PoolConfig {
     fn default() -> Self {
-        let mode = "default".to_string();
+        let mode = DEFAULT_PERMISSION_MODE.to_string();
         let adapters = [
             ainb_acp::config::CLAUDE_ADAPTER,
             ainb_acp::config::CODEX_ADAPTER,
@@ -230,7 +279,7 @@ impl PoolConfig {
     /// untouched when the variable is unset or junk.
     #[must_use]
     pub fn from_env() -> Self {
-        let mut config = Self::default();
+        let mut config = Self::from_config();
         if let Some(ms) = std::env::var("AINB_ACP_TURN_DEADLINE_MS")
             .ok()
             .and_then(|raw| raw.trim().parse::<u64>().ok())
@@ -240,6 +289,36 @@ impl PoolConfig {
             config.sweep_interval = config
                 .sweep_interval
                 .min(Duration::from_millis(ms / 2).max(Duration::from_millis(100)));
+        }
+        config
+    }
+
+    /// [`PoolConfig::default`] with `[acp.adapters.*]` from the host config
+    /// applied.
+    ///
+    /// The adapter registry was a hardcoded two-entry map with no user surface
+    /// at all: a provider absent from it simply could not be created, and an
+    /// adapter installed anywhere but `PATH` could not be reached. A named
+    /// adapter here overrides the built-in entry; a new name adds one.
+    ///
+    /// Read directly off config.toml rather than through `ainb`, which this
+    /// crate does not depend on, mirroring how the session-reader plugin reads
+    /// `[session_reader]`. Every failure degrades to the built-ins: a malformed
+    /// table must not leave the daemon with no adapters at all.
+    #[must_use]
+    pub fn from_config() -> Self {
+        let mut config = Self::default();
+        for (name, adapter) in acp_adapters_from_config() {
+            let entry = config
+                .adapters
+                .entry(name.clone())
+                .or_insert_with(|| AdapterConfig::new(name, DEFAULT_PERMISSION_MODE));
+            if let Some(command) = adapter.command {
+                entry.command = std::path::PathBuf::from(command);
+            }
+            if let Some(mode) = adapter.permission_mode {
+                entry.permission_mode = mode;
+            }
         }
         config
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -13016,7 +13016,10 @@ mod tests {
         let listener = UnixListener::bind(&socket).unwrap();
         let server = tokio::spawn(ainb_plugin_notifyd::broker::serve(
             listener,
-            ainb_plugin_notifyd::broker::BrokerState::default(),
+            // Not `::default()`, which reads the developer's real config.toml.
+            ainb_plugin_notifyd::broker::BrokerState::with_timeout(
+                ainb_plugin_notifyd::broker::DEFAULT_AWAIT_TIMEOUT,
+            ),
         ));
         set_approve_socket_for_test(Some(socket));
         let created = FleetRepo::apply_event(

--- a/ainb-tui/crates/ainb-hangar-store/src/store.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/store.rs
@@ -124,6 +124,41 @@ impl Store {
         Self::ping_in_read_only(&dir).await
     }
 
+    /// Read every `daemon_config` row without creating or migrating anything.
+    ///
+    /// [`Self::open_default`] runs `backup_before_pending_migrations` (a whole
+    /// `VACUUM INTO` copy) and then `apply_migrations`. Doing that from a read
+    /// — the TUI's first tick, `ainb config show` — migrates a running
+    /// daemon's live schema out from under it after an upgrade, and blocks the
+    /// caller for the length of the copy. Reads use this instead; migration
+    /// ownership stays with daemon startup.
+    ///
+    /// `Ok(None)` when there is no database yet, so callers show defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be resolved, or if an existing
+    /// database cannot be read.
+    pub async fn read_daemon_config_read_only() -> anyhow::Result<Option<Vec<(String, String)>>> {
+        use sqlx::{ConnectOptions as _, Connection as _};
+
+        let db_path = Self::default_dir()?.join(DB_FILE_NAME);
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let mut conn = SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false)
+            .read_only(true)
+            .connect()
+            .await?;
+        let rows: Vec<(String, String)> = sqlx::query_as("SELECT key, value FROM daemon_config")
+            .fetch_all(&mut conn)
+            .await?;
+        conn.close().await?;
+        Ok(Some(rows))
+    }
+
     async fn ping_in_read_only(dir: &Path) -> anyhow::Result<()> {
         use sqlx::ConnectOptions as _;
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/Cargo.toml
+++ b/ainb-tui/crates/ainb-plugin-notifyd/Cargo.toml
@@ -31,6 +31,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+# Reads the host's `[notifyd]` table off config.toml, the same way
+# ainb-plugin-session-reader reads `[session_reader]`.
+toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/broker.rs
@@ -69,6 +69,17 @@ use tracing::{debug, error, warn};
 /// deny — never approve.
 pub const DEFAULT_AWAIT_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// The effective AWAIT ceiling: `notifyd.approval_timeout_secs` when config
+/// names one, else [`DEFAULT_AWAIT_TIMEOUT`].
+///
+/// Clamped by [`crate::config::NotifydConfig::approval_timeout`] so a
+/// configured value can shorten the wait but can never climb above the client's
+/// re-dial deadline and turn a deny into a hung hook.
+#[must_use]
+pub fn await_timeout() -> Duration {
+    crate::config::load().approval_timeout()
+}
+
 /// A human's answer to a permission request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -347,9 +358,9 @@ pub struct BrokerState {
 }
 
 impl BrokerState {
-    /// Fresh state with the default AWAIT timeout.
+    /// Fresh state with the configured AWAIT timeout. See [`await_timeout`].
     pub fn new() -> Self {
-        Self::with_timeout(DEFAULT_AWAIT_TIMEOUT)
+        Self::with_timeout(await_timeout())
     }
 
     /// Fresh state with a custom AWAIT timeout (tests use a tiny value).

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/config.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/config.rs
@@ -1,0 +1,180 @@
+// ABOUTME: Plugin-side reader for the `[notifyd]` table of the host config.
+
+//! Plugin-side config: the `[notifyd]` table of
+//! `~/.agents-in-a-box/config/config.toml`.
+//!
+//! Read-only, and read the same way `ainb-plugin-session-reader` reads its own
+//! table: the host owns the file, `PluginInitParams` carries no config channel,
+//! and every failure degrades to the coded defaults. A malformed config must
+//! never stop notifications, it may only fail to tune them.
+//!
+//! ```toml
+//! [notifyd]
+//! os_debounce_secs = 30
+//! approval_timeout_secs = 900
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Coded default OS-notification debounce, in seconds.
+pub const DEFAULT_OS_DEBOUNCE_SECS: u64 = 60;
+
+/// Coded default AWAIT ceiling for a permission request, in seconds.
+pub const DEFAULT_APPROVAL_TIMEOUT_SECS: u64 = 600;
+
+/// The ceiling on `approval_timeout_secs`.
+///
+/// The broker sits at the BOTTOM of a timeout ladder: broker AWAIT < the
+/// client's re-dial deadline (640s) < Claude's registered `PermissionRequest`
+/// hook timeout (660s). A configured value above the client deadline means the
+/// hook is hard-killed before the broker ever answers, which turns a
+/// deliberate deny into a silent hang, so it is clamped rather than trusted.
+pub const MAX_APPROVAL_TIMEOUT_SECS: u64 = 630;
+
+/// Parsed `[notifyd]` table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct NotifydConfig {
+    /// Per-`(session, event)` debounce window for OS notifications, in seconds.
+    pub os_debounce_secs: u64,
+    /// Seconds an unanswered permission request waits before it is auto-denied.
+    pub approval_timeout_secs: u64,
+}
+
+impl Default for NotifydConfig {
+    fn default() -> Self {
+        Self {
+            os_debounce_secs: DEFAULT_OS_DEBOUNCE_SECS,
+            approval_timeout_secs: DEFAULT_APPROVAL_TIMEOUT_SECS,
+        }
+    }
+}
+
+impl NotifydConfig {
+    /// The effective debounce window.
+    #[must_use]
+    pub fn os_debounce(self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.os_debounce_secs)
+    }
+
+    /// The effective AWAIT ceiling, clamped to [1, [`MAX_APPROVAL_TIMEOUT_SECS`]].
+    ///
+    /// `0` would auto-deny every request the instant it arrived; anything above
+    /// the ceiling breaks the timeout ladder (see [`MAX_APPROVAL_TIMEOUT_SECS`]).
+    #[must_use]
+    pub fn approval_timeout(self) -> std::time::Duration {
+        std::time::Duration::from_secs(
+            self.approval_timeout_secs.clamp(1, MAX_APPROVAL_TIMEOUT_SECS),
+        )
+    }
+}
+
+/// Load from the default host config path. Missing file, unreadable file,
+/// unparseable TOML, or a malformed `[notifyd]` table all degrade to
+/// [`NotifydConfig::default`].
+#[must_use]
+pub fn load() -> NotifydConfig {
+    match default_config_path() {
+        Some(path) => load_from(&path),
+        None => NotifydConfig::default(),
+    }
+}
+
+/// Load from an explicit path (testable entry point).
+#[must_use]
+pub fn load_from(path: &Path) -> NotifydConfig {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return NotifydConfig::default();
+    };
+    let root: toml::Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::warn!("notifyd: config parse failed ({err}); using defaults");
+            return NotifydConfig::default();
+        }
+    };
+    match root.get("notifyd").cloned() {
+        Some(table) => table.try_into().unwrap_or_else(|err| {
+            tracing::warn!("notifyd: [notifyd] table malformed ({err}); using defaults");
+            NotifydConfig::default()
+        }),
+        None => NotifydConfig::default(),
+    }
+}
+
+/// `~/.agents-in-a-box/config/config.toml`, resolved via `$HOME`.
+fn default_config_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".agents-in-a-box").join("config").join("config.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_config(dir: &TempDir, body: &str) -> PathBuf {
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, body).expect("write config");
+        path
+    }
+
+    #[test]
+    fn present_values_are_read() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(
+            &dir,
+            "[notifyd]\nos_debounce_secs = 15\napproval_timeout_secs = 120\n",
+        );
+        let cfg = load_from(&path);
+        assert_eq!(cfg.os_debounce().as_secs(), 15);
+        assert_eq!(cfg.approval_timeout().as_secs(), 120);
+    }
+
+    #[test]
+    fn a_partial_table_keeps_the_other_default() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "[notifyd]\nos_debounce_secs = 5\n");
+        let cfg = load_from(&path);
+        assert_eq!(cfg.os_debounce().as_secs(), 5);
+        assert_eq!(
+            cfg.approval_timeout().as_secs(),
+            DEFAULT_APPROVAL_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn missing_file_defaults() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(
+            load_from(&dir.path().join("nope.toml")),
+            NotifydConfig::default()
+        );
+    }
+
+    #[test]
+    fn a_broken_table_defaults_rather_than_failing() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "[notifyd]\nos_debounce_secs = \"soon\"\n");
+        assert_eq!(load_from(&path), NotifydConfig::default());
+    }
+
+    /// The AWAIT ceiling has to stay under the client's re-dial deadline, or a
+    /// configured value silently turns a deny into a hung hook.
+    #[test]
+    fn an_absurd_approval_timeout_is_clamped_to_the_ladder() {
+        let cfg = NotifydConfig {
+            os_debounce_secs: 60,
+            approval_timeout_secs: 86_400,
+        };
+        assert_eq!(cfg.approval_timeout().as_secs(), MAX_APPROVAL_TIMEOUT_SECS);
+
+        let instant = NotifydConfig {
+            os_debounce_secs: 60,
+            approval_timeout_secs: 0,
+        };
+        assert_eq!(instant.approval_timeout().as_secs(), 1);
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod broker;
 pub mod cli;
+pub mod config;
 pub mod envelope;
 pub mod fallback;
 pub mod ingest;

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/listener.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/listener.rs
@@ -680,11 +680,14 @@ mod tests {
             stream.shutdown().await.unwrap();
         }
 
-        // Give the daemon a tick to drain.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Inspect SQLite directly.
+        // Poll rather than sleeping a fixed 100ms: run_daemon now reads its
+        // config from disk at startup, so under parallel load the row had not
+        // landed by the time the assertion ran. Same fix as the sibling test.
         let store = Store::open(&db).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while store.count().unwrap() < 1 && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
         assert_eq!(store.count().unwrap(), 1);
 
         // Stop the daemon: send SIGTERM to our own PID — wait, that

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/listener.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/listener.rs
@@ -719,9 +719,21 @@ mod tests {
             stream.write_all(b"\n").await.unwrap();
             stream.shutdown().await.unwrap();
         }
-        tokio::time::sleep(Duration::from_millis(150)).await;
-
+        // Poll for the expected count rather than sleeping a fixed 150ms. The
+        // daemon reads its config from disk at startup, so under parallel load
+        // a fixed wait is not enough and the assertion fires before the writes
+        // land — the test then fails claiming telemetry was kept, which is the
+        // opposite of what went wrong.
         let store = Store::open(&db).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while store.count().unwrap() < 2 && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        // Settle briefly so a wrongly-kept telemetry event has a chance to
+        // appear too — otherwise this would pass the moment the two actionable
+        // ones land, and never catch an extra third.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
         // Only Stop + Notification:idle_prompt survived.
         assert_eq!(store.count().unwrap(), 2, "telemetry should be dropped");
         let events: std::collections::HashSet<String> = store

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -314,6 +314,16 @@ fn quote_applescript(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// A debouncer pinned to the CODED window.
+    ///
+    /// Never `Debouncer::new()` here: that reads the developer's real
+    /// `~/.agents-in-a-box/config/config.toml`, so anyone who has set
+    /// `notifyd.os_debounce_secs = 0` fails this suite locally while CI, with no
+    /// config file, passes. A unit test must not depend on the machine it runs on.
+    fn test_debouncer() -> Debouncer {
+        Debouncer::with_window(DEBOUNCE)
+    }
+
     use super::*;
     use serde_json::json;
 
@@ -494,7 +504,7 @@ mod tests {
         ])));
         let fired = notify(
             &env("Stop", "claude"),
-            &Debouncer::new(),
+            &test_debouncer(),
             &resolver,
             &transport,
         )
@@ -512,7 +522,7 @@ mod tests {
         ])));
         let fired = notify(
             &env("Stop", "claude"),
-            &Debouncer::new(),
+            &test_debouncer(),
             &resolver,
             &transport,
         )
@@ -528,7 +538,7 @@ mod tests {
         let resolver = StubResolver(ChannelResolution::Unknown);
         let fired = notify(
             &env("Notification:idle_prompt", "claude"),
-            &Debouncer::new(),
+            &test_debouncer(),
             &resolver,
             &transport,
         )
@@ -550,7 +560,7 @@ mod tests {
         ])));
         let fired = notify(
             &env("PostToolUse", "claude"),
-            &Debouncer::new(),
+            &test_debouncer(),
             &resolver,
             &transport,
         )
@@ -565,7 +575,7 @@ mod tests {
         // its (session, raw_event) key: a subsequent Os-routed event for the same
         // key still fires. This proves the Os gate is evaluated before the debounce.
         let transport = StubTransport::default();
-        let debouncer = Debouncer::new(); // 60s window
+        let debouncer = test_debouncer(); // the coded 60s window
         let e = env("Stop", "claude");
 
         let suppressed = notify(

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -23,8 +23,9 @@ use ainb_hangar_core::channel::{Channel, ChannelSet};
 
 use crate::envelope::Envelope;
 
-/// Default per-event debounce window. Keeps a noisy session from
-/// spamming the system notification UI.
+/// Coded per-event debounce window. Keeps a noisy session from spamming the
+/// system notification UI. The effective window is `notifyd.os_debounce_secs`
+/// when config.toml names one; see [`crate::config`].
 pub const DEBOUNCE: Duration = Duration::from_secs(60);
 
 /// A debouncer for OS notifications keyed by
@@ -36,9 +37,10 @@ pub struct Debouncer {
 }
 
 impl Debouncer {
-    /// Build a debouncer with the [`DEBOUNCE`] window.
+    /// Build a debouncer with the configured window
+    /// (`notifyd.os_debounce_secs`), falling back to [`DEBOUNCE`].
     pub fn new() -> Self {
-        Self::with_window(DEBOUNCE)
+        Self::with_window(crate::config::load().os_debounce())
     }
 
     /// Build a debouncer with an explicit window (used by tests).

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -1715,12 +1715,14 @@ Serve an SSE-live web dashboard (live terminal + web-push) for the fleet
 Usage: ainb web [OPTIONS]
 
 Options:
-      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
-      --listen <ADDR>    Address to bind (default loopback; non-loopback needs --token) [default: 127.0.0.1:8420]
-      --token <SECRET>   Bearer token required on every /api/* route (enables non-loopback bind)
-      --insecure-bind    Allow a non-loopback bind with no token. DANGEROUS: an unauthenticated bind exposes a control surface — the live WS terminal is interactive shell access to every fleet session. Only honored with --read-only (terminal disabled); otherwise refused. Use --token instead to expose the write surface safely
-      --read-only        Viewer-only: disable the live terminal write surface (the WS terminal is refused with 403)
-  -h, --help             Print help
+      --format <format>   Output format [default: text] [possible values: text, json, csv, markdown]
+      --listen <ADDR>     Address to bind (default: web.listen, or 127.0.0.1:8420; non-loopback needs --token)
+      --token <SECRET>    Bearer token required on every /api/* route (enables non-loopback bind)
+      --insecure-bind     Allow a non-loopback bind with no token. DANGEROUS: an unauthenticated bind exposes a control surface — the live WS terminal is interactive shell access to every fleet session. Only honored with --read-only (terminal disabled); otherwise refused. Use --token instead to expose the write surface safely
+      --read-only         Viewer-only: disable the live terminal write surface (the WS terminal is refused with 403)
+      --no-read-only      Serve the write surface for this run, overriding web.read_only
+      --no-insecure-bind  Refuse an unauthenticated non-loopback bind for this run, overriding web.insecure_bind
+  -h, --help              Print help
 
 EXAMPLES:
   ainb web                                       Serve on 127.0.0.1:8420 (loopback)


### PR DESCRIPTION
Last child of epic `agents-in-a-box-wg83` (bead `agents-in-a-box-njkf`), following #782.

#782 made every setting *in the schema* reachable from the settings menu. This adds the settings that were never in the schema at all.

## What was unreachable

| | before | now |
|---|---|---|
| env vars tuning behaviour | ~45, of which 3 had a config key | the genuine preferences have keys; env still overrides |
| hardcoded timeouts / limits / cadences | constants only | schema keys with ranges |
| Hangar daemon config | its own SQLite table + CLI | also a settings category, writing through to that table |
| `ainb web` | CLI flags only, never persisted | `[web]` keys; token stays in the keychain |
| ACP adapters | hardcoded, no surface at all | `[acp.adapters.<name>]` |

## Precedence

`env > config > default`, matching the ladder plugins already use — nothing that works today stops working.

Three ladder tests prove it, and they are real tripwires: making `resolved()` ignore the environment fails `headroom_port_ladder_is_env_then_config_then_default` and `fleet_state_stale_ladder_is_env_then_config_then_default`.

## Two bugs fixed along the way

- `AINB_FLEET_STATE_STALE_MS` had two different hardcoded fallbacks for what looked like one knob — `300000` in `fleet/read/current_state.rs`, `0` in `cli/fleet/needs.rs`. They were never the same thing; they are now two named keys with their own defaults.
- `workspace_scanner`'s `with_max_depth()` already existed and was simply never wired to anything a user could set.

## A note on `[usage]`

Core must not write that section — the burndown plugin owns it, and #782 added `NEVER_WRITE_PATHS` to enforce that. So the three usage-related knobs could not live there or they would have been unsettable. They are under a core-owned `usage_client` instead.

## Verification

Every new key has a registry row, so `every_leaf_has_an_entry` fails the build if one is added without one, and every new section is documented in `example.config.toml` inside a parse fence that `example_config_parses` deserializes as `AppConfig`.

Against the built binary:

```
$ ainb config set ui.tick_rate_ms 16
# comment preserved, one line changed
$ ainb config set ui.tick_rate_ms 99999
Error: 'ui.tick_rate_ms' must be between 1 and 1000, got 99999
```

Green: `ainb` lib 1998, `ainb-plugin-burndown` 229, behavioral 51, example_config_parses 4, both config tripwires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive configuration for UI, workspace scanning, fleet monitoring, usage caching, web access, notifications, ACP adapters, and daemon settings.
  * Added Hangar Daemon settings with validation and persistent storage.
  * Added configurable scan depth, timing thresholds, syntax highlighting, inbox limits, notification timeouts, and ACP adapter settings.
  * Added web command overrides for read-only and insecure-bind modes.
  * Added safer managed sandbox support for tool and skill installation.
  * Added configuration command support for viewing and updating Hangar Daemon settings.
* **Bug Fixes**
  * Improved configuration persistence, workspace scanning, timeout handling, stale-state thresholds, and proxy-port consistency.
  * Configuration changes now take effect without restarting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->