### PR TITLE
fix(hangar): stop a daemon under an ephemeral home outliving its launcher

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5303,7 +5303,9 @@ impl AppState {
                 // Quiet: this runs while the TUI holds the alternate screen, so
                 // the announcing variant's stdout lands on top of the frame.
                 Self::spawn_blocking_restart(tx, kind, || {
-                    crate::cli::hangar::run_daemon_restart_quiet()
+                    crate::cli::hangar::run_daemon_restart_quiet(
+                        crate::cli::hangar::LauncherLifetime::Persistent,
+                    )
                 })
             }
             DaemonRow::Mcp => {
@@ -5425,9 +5427,11 @@ impl AppState {
         o.hangar_start_status = Some("starting / upgrading Hangar daemon…".to_string());
         tokio::spawn(async move {
             let line = tokio::task::spawn_blocking(|| {
-                crate::cli::hangar::start_or_upgrade_daemon_from_current()
-                    .map(|_| "Hangar running against current Ainb".to_string())
-                    .unwrap_or_else(|e| format!("Hangar start / upgrade failed: {e:#}"))
+                crate::cli::hangar::start_or_upgrade_daemon_from_current(
+                    crate::cli::hangar::LauncherLifetime::Persistent,
+                )
+                .map(|_| "Hangar running against current Ainb".to_string())
+                .unwrap_or_else(|e| format!("Hangar start / upgrade failed: {e:#}"))
             })
             .await
             .unwrap_or_else(|e| format!("Hangar start failed: {e}"));

--- a/ainb-tui/crates/ainb-core/src/cli/doctor.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/doctor.rs
@@ -151,9 +151,11 @@ fn repair_stale_daemons(daemons: &[crate::fleet::daemons::DaemonStatus]) -> Vec<
     }
     let hangar = crate::cli::hangar::daemon_runtime_status();
     if hangar.old {
-        let outcome = crate::cli::hangar::start_or_upgrade_daemon_from_current()
-            .map(|_| "Hangar restarted against current Ainb".to_string())
-            .unwrap_or_else(|error| format!("Hangar restart failed: {error:#}"));
+        let outcome = crate::cli::hangar::start_or_upgrade_daemon_from_current(
+            crate::cli::hangar::LauncherLifetime::Ephemeral,
+        )
+        .map(|_| "Hangar restarted against current Ainb".to_string())
+        .unwrap_or_else(|error| format!("Hangar restart failed: {error:#}"));
         outcomes.push(outcome);
     }
     if outcomes.is_empty() {

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8708,6 +8708,48 @@ fn open_daemon_stderr_log(log_dir: &std::path::Path) -> Result<std::fs::File> {
         .with_context(|| format!("open daemon stderr log {}", path.display()))
 }
 
+/// True when `path` sits under the system temp dir.
+///
+/// Both sides are canonicalized on the second attempt because macOS `$TMPDIR`
+/// (`/var/folders/...`) is reached through a symlink to `/private/var/...`, so a
+/// caller that resolved its home would otherwise slip past a raw prefix test.
+fn is_under_temp_dir(path: &std::path::Path) -> bool {
+    let temp = std::env::temp_dir();
+    if path.starts_with(&temp) {
+        return true;
+    }
+    let real = |p: &std::path::Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    real(path).starts_with(real(&temp))
+}
+
+/// Bind a daemon we are about to spawn to our own lifetime when its home is
+/// ephemeral.
+///
+/// A daemon whose hangar home lives under the system temp dir can never be
+/// found again: `single_instance`, `hangar daemon stop` and the pid file are all
+/// home-scoped, and the home dies with whoever created it (any harness running
+/// under `HOME=$(mktemp -d)`). macOS has no `PR_SET_PDEATHSIG` and the child is
+/// detached into its own process group, so it reparents to launchd and runs
+/// forever. Arming the daemon's parent-death watchdog makes it exit with us.
+///
+/// Inert in production: a real home under `$HOME` never sits under `temp_dir()`,
+/// so the Homebrew daemon and a deliberate dev-build daemon are untouched.
+/// Issue #784.
+fn arm_watchdog_for_ephemeral_home(
+    command: &mut std::process::Command,
+    hangar_home: &std::path::Path,
+) {
+    if !is_under_temp_dir(hangar_home) {
+        return;
+    }
+    let pid = std::process::id().to_string();
+    // Both names: the daemon binary we launch may be an installed build that
+    // predates the rename and only knows the legacy one.
+    command
+        .env(ainb_hangar_daemon::PARENT_PID_ENV, &pid)
+        .env(ainb_hangar_daemon::LEGACY_PARENT_PID_ENV, &pid);
+}
+
 /// Spawn the daemon as a detached background child unless it is already running,
 /// recording its EXACT pid. When `announce` is true the outcome is printed
 /// (the `hangar daemon start` CLI verb); the TUI autostart passes `false`.
@@ -8785,6 +8827,9 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
     {
         use std::os::unix::process::CommandExt;
         command.process_group(0);
+    }
+    if let Ok(home) = ainb_hangar_daemon::hangar_dir() {
+        arm_watchdog_for_ephemeral_home(&mut command, &home);
     }
     let mut child = command.spawn().with_context(|| format!("spawn daemon `{launched}`"))?;
 
@@ -9204,6 +9249,9 @@ fn respawn_once(bin: &std::path::Path, args: &[&str]) -> Result<Option<u32>> {
     {
         use std::os::unix::process::CommandExt;
         command.process_group(0);
+    }
+    if let Ok(home) = ainb_hangar_daemon::hangar_dir() {
+        arm_watchdog_for_ephemeral_home(&mut command, &home);
     }
     let child = command.spawn().context("respawn daemon")?;
     std::thread::sleep(std::time::Duration::from_millis(400));
@@ -10707,6 +10755,94 @@ fn json_string(s: &str) -> String {
     }
     out.push('"');
     out
+}
+
+#[cfg(test)]
+mod ephemeral_home_watchdog_tests {
+    //! Issue #784: a daemon autostarted under `HOME=$(mktemp -d)` outlives
+    //! every guard in the system, because all of them are home-scoped and the
+    //! home is deleted with its creator. The spawner arms the daemon's
+    //! parent-death watchdog for exactly those homes, and for no other.
+    //!
+    //! Nothing here spawns a process: the assertion is on the `Command` the
+    //! spawner would have run.
+
+    use super::arm_watchdog_for_ephemeral_home;
+
+    /// The value the spawned daemon would see for `key`, if any.
+    fn env_of(command: &std::process::Command, key: &str) -> Option<String> {
+        command.get_envs().find_map(|(name, value)| {
+            (name == key).then(|| {
+                value
+                    .expect("watchdog env is set, never removed")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+        })
+    }
+
+    fn armed_for(hangar_home: &std::path::Path) -> Option<String> {
+        let mut command = std::process::Command::new("/bin/true");
+        arm_watchdog_for_ephemeral_home(&mut command, hangar_home);
+        env_of(&command, ainb_hangar_daemon::PARENT_PID_ENV)
+    }
+
+    #[test]
+    fn arms_the_watchdog_for_a_home_under_the_temp_dir() {
+        let home = std::env::temp_dir().join(".tmpQ9x7fk").join(".agents-in-a-box");
+        assert_eq!(
+            armed_for(&home).as_deref(),
+            Some(std::process::id().to_string().as_str()),
+            "a daemon under {} must be bound to this process",
+            home.display()
+        );
+    }
+
+    #[test]
+    fn arms_the_legacy_name_too_for_an_older_daemon_binary() {
+        // The installed daemon we launch can predate the rename; it would
+        // ignore the new name and become immortal again.
+        let home = std::env::temp_dir().join(".tmpQ9x7fk").join(".agents-in-a-box");
+        let mut command = std::process::Command::new("/bin/true");
+        arm_watchdog_for_ephemeral_home(&mut command, &home);
+        assert_eq!(
+            env_of(&command, ainb_hangar_daemon::LEGACY_PARENT_PID_ENV),
+            env_of(&command, ainb_hangar_daemon::PARENT_PID_ENV)
+        );
+    }
+
+    #[test]
+    fn leaves_a_real_home_alone() {
+        // The Homebrew daemon and a deliberate dev-build daemon must keep
+        // outliving the `ainb` invocation that started them.
+        let home = std::path::Path::new("/Users/example/.agents-in-a-box");
+        assert_eq!(
+            armed_for(home),
+            None,
+            "a real home must not arm the watchdog"
+        );
+    }
+
+    #[test]
+    fn leaves_the_running_users_real_home_alone() {
+        // Same claim, against the home this machine actually resolves, so the
+        // test fails if `temp_dir()` ever starts prefixing it.
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let home = home.join(".agents-in-a-box");
+        if super::is_under_temp_dir(&home) {
+            // This very suite is running under an ephemeral `$HOME`, which is
+            // the case the other test covers. Nothing to assert here.
+            return;
+        }
+        assert_eq!(
+            armed_for(&home),
+            None,
+            "{} must not arm the watchdog",
+            home.display()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8635,7 +8635,8 @@ async fn run_daemon_run() -> Result<()> {
 /// `$AINB_HANGAR_HOME` this process resolved, so it shares one home; its stdout/
 /// stderr go to the daemon's own rolling log, not this terminal.
 fn run_daemon_start() -> Result<()> {
-    start_or_upgrade_daemon(true)
+    // Ephemeral: this verb exists to leave a daemon running after `ainb` exits.
+    start_or_upgrade_daemon(true, LauncherLifetime::Ephemeral)
 }
 
 /// Best-effort autostart of the Hangar daemon before the TUI connects.
@@ -8645,30 +8646,31 @@ fn run_daemon_start() -> Result<()> {
 /// daemon comes up). Quiet — no stdout, since the TUI owns the terminal. Mirrors
 /// `mcp_pool`'s `ensure_daemon` warn-and-continue.
 pub fn ensure_hangar_daemon() {
-    if let Err(e) = start_or_upgrade_daemon(false) {
+    // Persistent: the TUI is the daemon's consumer and outlives it.
+    if let Err(e) = start_or_upgrade_daemon(false, LauncherLifetime::Persistent) {
         tracing::warn!(error = %e, "hangar daemon autostart failed (TUI continues)");
     }
 }
 
 /// Start a missing daemon, or hand an older released owner to this Ainb
 /// binary. Used by the Daemons screen's explicit upgrade control.
-pub(crate) fn start_or_upgrade_daemon_from_current() -> Result<()> {
-    start_or_upgrade_daemon(false)
+pub(crate) fn start_or_upgrade_daemon_from_current(launcher: LauncherLifetime) -> Result<()> {
+    start_or_upgrade_daemon(false, launcher)
 }
 
 /// Start a missing daemon, or hand off an older recorded release to this one.
 ///
 /// Unknown, equal, prerelease, and newer owners are deliberately left alone:
 /// autostart may upgrade a released daemon but must not guess or downgrade.
-fn start_or_upgrade_daemon(announce: bool) -> Result<()> {
+fn start_or_upgrade_daemon(announce: bool, launcher: LauncherLifetime) -> Result<()> {
     let pid = running_daemon_pid().ok().flatten();
     let running = running_daemon_version(pid);
     let result = if pid.is_some()
         && daemon_upgrade_required(running.as_deref(), env!("CARGO_PKG_VERSION"))
     {
-        restart_daemon(announce)
+        restart_daemon(announce, launcher)
     } else {
-        start_daemon_if_stopped(announce)
+        start_daemon_if_stopped(announce, launcher)
     };
     result
 }
@@ -8710,39 +8712,94 @@ fn open_daemon_stderr_log(log_dir: &std::path::Path) -> Result<std::fs::File> {
 
 /// True when `path` sits under the system temp dir.
 ///
-/// Both sides are canonicalized on the second attempt because macOS `$TMPDIR`
-/// (`/var/folders/...`) is reached through a symlink to `/private/var/...`, so a
-/// caller that resolved its home would otherwise slip past a raw prefix test.
+/// Checks `$TMPDIR` plus the fixed `/tmp` and `/var/tmp` roots, because on macOS
+/// `std::env::temp_dir()` is `$TMPDIR` (`/var/folders/...`) and says nothing
+/// about `/tmp` — which is where this repo's own recording harnesses put their
+/// homes (`mktemp -d /tmp/bj.XXXXXX`).
+///
+/// Both sides are canonicalized on the second attempt because those roots are
+/// reached through symlinks on macOS (`/tmp` -> `/private/tmp`), so a caller
+/// that resolved its home would otherwise slip past a raw prefix test.
 fn is_under_temp_dir(path: &std::path::Path) -> bool {
-    let temp = std::env::temp_dir();
-    if path.starts_with(&temp) {
-        return true;
-    }
     let real = |p: &std::path::Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
-    real(path).starts_with(real(&temp))
+    let resolved = real(path);
+    [
+        std::env::temp_dir(),
+        std::path::PathBuf::from("/tmp"),
+        std::path::PathBuf::from("/var/tmp"),
+    ]
+    .iter()
+    .any(|root| path.starts_with(root) || resolved.starts_with(real(root)))
 }
 
-/// Bind a daemon we are about to spawn to our own lifetime when its home is
-/// ephemeral.
+/// Does the process launching a daemon stay alive to use it?
 ///
-/// A daemon whose hangar home lives under the system temp dir can never be
-/// found again: `single_instance`, `hangar daemon stop` and the pid file are all
-/// home-scoped, and the home dies with whoever created it (any harness running
-/// under `HOME=$(mktemp -d)`). macOS has no `PR_SET_PDEATHSIG` and the child is
-/// detached into its own process group, so it reparents to launchd and runs
-/// forever. Arming the daemon's parent-death watchdog makes it exit with us.
+/// The parent-death watchdog is only ever correct for a launcher that outlives
+/// the daemon it wants. `ainb hangar daemon start` and `ainb doctor` exit about
+/// a second after the spawn: binding a daemon to one of those would stand it
+/// down immediately and report success for a process that is already dying.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LauncherLifetime {
+    /// The TUI: it lives for as long as the daemon is wanted.
+    Persistent,
+    /// A one-shot CLI verb, which is expected to leave the daemon behind.
+    Ephemeral,
+}
+
+/// Should the daemon we are about to spawn be bound to this process's life?
 ///
-/// Inert in production: a real home under `$HOME` never sits under `temp_dir()`,
-/// so the Homebrew daemon and a deliberate dev-build daemon are untouched.
-/// Issue #784.
+/// Three conditions, all required:
+///
+/// 1. We outlive it. A one-shot verb must leave a daemon that survives it.
+/// 2. Its home is ephemeral, so no other guard can ever address it again:
+///    `single_instance`, `hangar daemon stop` and the pid file are all
+///    home-scoped, and the home dies with whoever created it (any harness
+///    running under `HOME=$(mktemp -d)`). macOS has no `PR_SET_PDEATHSIG` and
+///    the child is detached into its own process group, so it otherwise
+///    reparents to launchd and runs forever.
+/// 3. Nobody upstream already declared a parent. A harness that set the env var
+///    itself named a longer-lived owner on purpose; overriding it with our pid
+///    would kill the daemon the harness is still driving.
+///
+/// Inert for a home under a real `$HOME`, so the Homebrew daemon is untouched.
+/// A deliberate dev-build daemon on a temp `AINB_HANGAR_HOME` IS in scope, but
+/// only when started by a persistent launcher. Issue #784.
+fn should_bind_daemon_to_parent(
+    hangar_home: &std::path::Path,
+    launcher: LauncherLifetime,
+    parent_already_declared: bool,
+) -> bool {
+    launcher == LauncherLifetime::Persistent
+        && !parent_already_declared
+        && is_under_temp_dir(hangar_home)
+}
+
+/// Arm the spawned daemon's parent-death watchdog when [`should_bind_daemon_to_parent`]
+/// says this daemon must not outlive us.
 fn arm_watchdog_for_ephemeral_home(
     command: &mut std::process::Command,
     hangar_home: &std::path::Path,
+    launcher: LauncherLifetime,
 ) {
-    if !is_under_temp_dir(hangar_home) {
+    let declared = [
+        ainb_hangar_daemon::PARENT_PID_ENV,
+        ainb_hangar_daemon::LEGACY_PARENT_PID_ENV,
+    ]
+    .iter()
+    .any(|key| std::env::var_os(key).is_some_and(|value| !value.is_empty()));
+
+    if !should_bind_daemon_to_parent(hangar_home, launcher, declared) {
         return;
     }
     let pid = std::process::id().to_string();
+    // A daemon that stands down for this reason writes its last line into
+    // <home>/hangar/logs, inside the home that is about to be deleted. Say so
+    // here too, where the log survives.
+    tracing::info!(
+        home = %hangar_home.display(),
+        parent = %pid,
+        "hangar home is ephemeral; binding the daemon's life to this process"
+    );
     // Both names: the daemon binary we launch may be an installed build that
     // predates the rename and only knows the legacy one.
     command
@@ -8753,7 +8810,7 @@ fn arm_watchdog_for_ephemeral_home(
 /// Spawn the daemon as a detached background child unless it is already running,
 /// recording its EXACT pid. When `announce` is true the outcome is printed
 /// (the `hangar daemon start` CLI verb); the TUI autostart passes `false`.
-pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
+pub(crate) fn start_daemon_if_stopped(announce: bool, launcher: LauncherLifetime) -> Result<()> {
     // `resolve_daemon_launch` self-execs `(current_exe, ["hangar","daemon","run"])`
     // on both of its fallback paths. Under `cargo test` that exe is the TEST
     // binary, and libtest reads the argv as name filters, so the "daemon" is a
@@ -8829,7 +8886,7 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
         command.process_group(0);
     }
     if let Ok(home) = ainb_hangar_daemon::hangar_dir() {
-        arm_watchdog_for_ephemeral_home(&mut command, &home);
+        arm_watchdog_for_ephemeral_home(&mut command, &home, launcher);
     }
     let mut child = command.spawn().with_context(|| format!("spawn daemon `{launched}`"))?;
 
@@ -8859,7 +8916,7 @@ pub(crate) fn start_daemon_if_stopped(announce: bool) -> Result<()> {
         // the incumbent it lost to has since exited too. Nothing is wrong here,
         // the home is simply free again, so try once more before calling it a
         // failure. Only a second empty-handed attempt is worth an error.
-        if let Some(pid) = respawn_once(&bin, &args)? {
+        if let Some(pid) = respawn_once(&bin, &args, launcher)? {
             owner = Some(pid);
         } else {
             anyhow::bail!(
@@ -9181,7 +9238,7 @@ fn run_daemon_stop() -> Result<()> {
 /// else autostarted it. Report the stop problem and start anyway: if the old
 /// daemon is somehow still up, `start` is a no-op that says so.
 pub(crate) fn run_daemon_restart() -> Result<()> {
-    restart_daemon(true)
+    restart_daemon(true, LauncherLifetime::Ephemeral)
 }
 
 /// Restart the daemon without printing anything.
@@ -9190,11 +9247,11 @@ pub(crate) fn run_daemon_restart() -> Result<()> {
 /// background thread does not scroll — it smears over whatever the renderer
 /// last painted, and nothing repaints it away. Every other daemon the Daemons
 /// screen restarts is already silent; this is the Hangar equivalent.
-pub(crate) fn run_daemon_restart_quiet() -> Result<()> {
-    restart_daemon(false)
+pub(crate) fn run_daemon_restart_quiet(launcher: LauncherLifetime) -> Result<()> {
+    restart_daemon(false, launcher)
 }
 
-fn restart_daemon(announce: bool) -> Result<()> {
+fn restart_daemon(announce: bool, launcher: LauncherLifetime) -> Result<()> {
     if let Err(e) = stop_daemon(announce) {
         if announce {
             println!("hangar daemon: stop reported a problem, starting anyway: {e}");
@@ -9223,7 +9280,7 @@ fn restart_daemon(announce: bool) -> Result<()> {
             return Ok(());
         }
     }
-    start_daemon_if_stopped(announce)
+    start_daemon_if_stopped(announce, launcher)
 }
 
 /// Spawn the daemon once more and report the pid that ends up owning the home.
@@ -9231,7 +9288,11 @@ fn restart_daemon(announce: bool) -> Result<()> {
 /// Used only on the "our child declined and the incumbent then vanished" path:
 /// the home was contested a moment ago and is free now, which is a race to
 /// re-run, not a failure to report.
-fn respawn_once(bin: &std::path::Path, args: &[&str]) -> Result<Option<u32>> {
+fn respawn_once(
+    bin: &std::path::Path,
+    args: &[&str],
+    launcher: LauncherLifetime,
+) -> Result<Option<u32>> {
     // Same rule as `start_daemon_if_stopped`: never detach a test harness.
     if crate::self_exec_guard::running_under_cargo_test() {
         anyhow::bail!(
@@ -9251,7 +9312,7 @@ fn respawn_once(bin: &std::path::Path, args: &[&str]) -> Result<Option<u32>> {
         command.process_group(0);
     }
     if let Ok(home) = ainb_hangar_daemon::hangar_dir() {
-        arm_watchdog_for_ephemeral_home(&mut command, &home);
+        arm_watchdog_for_ephemeral_home(&mut command, &home, launcher);
     }
     let child = command.spawn().context("respawn daemon")?;
     std::thread::sleep(std::time::Duration::from_millis(400));
@@ -10761,16 +10822,24 @@ fn json_string(s: &str) -> String {
 mod ephemeral_home_watchdog_tests {
     //! Issue #784: a daemon autostarted under `HOME=$(mktemp -d)` outlives
     //! every guard in the system, because all of them are home-scoped and the
-    //! home is deleted with its creator. The spawner arms the daemon's
-    //! parent-death watchdog for exactly those homes, and for no other.
+    //! home is deleted with its creator. The spawner binds such a daemon to its
+    //! own life, and only when it is a launcher that outlives it.
     //!
-    //! Nothing here spawns a process: the assertion is on the `Command` the
-    //! spawner would have run.
+    //! Nothing here spawns a process: the decision is a pure function, and the
+    //! wiring assertion is on the `Command` the spawner would have run.
 
-    use super::arm_watchdog_for_ephemeral_home;
+    use super::{LauncherLifetime, arm_watchdog_for_ephemeral_home, should_bind_daemon_to_parent};
 
-    /// The value the spawned daemon would see for `key`, if any.
-    fn env_of(command: &std::process::Command, key: &str) -> Option<String> {
+    /// A home of the shape a `HOME=$(mktemp -d)` harness produces under `root`.
+    fn ephemeral_home(root: &str) -> std::path::PathBuf {
+        std::path::Path::new(root).join("bj.Q9x7fk").join(".agents-in-a-box")
+    }
+
+    /// The value the spawned daemon would see for `key` — but ONLY from an
+    /// explicit mutation. `Command::get_envs` does not report the inherited
+    /// environment, so `None` here means "we did not set it", not "the child
+    /// will not see it".
+    fn explicitly_set_env(command: &std::process::Command, key: &str) -> Option<String> {
         command.get_envs().find_map(|(name, value)| {
             (name == key).then(|| {
                 value
@@ -10781,67 +10850,120 @@ mod ephemeral_home_watchdog_tests {
         })
     }
 
-    fn armed_for(hangar_home: &std::path::Path) -> Option<String> {
-        let mut command = std::process::Command::new("/bin/true");
-        arm_watchdog_for_ephemeral_home(&mut command, hangar_home);
-        env_of(&command, ainb_hangar_daemon::PARENT_PID_ENV)
+    #[test]
+    fn binds_a_persistent_launcher_to_an_ephemeral_home() {
+        for root in ["/tmp", "/var/tmp"] {
+            assert!(
+                should_bind_daemon_to_parent(
+                    &ephemeral_home(root),
+                    LauncherLifetime::Persistent,
+                    false
+                ),
+                "a home under {root} is ephemeral"
+            );
+        }
+        // `$TMPDIR` too, which on macOS is neither of the above.
+        assert!(should_bind_daemon_to_parent(
+            &std::env::temp_dir().join("bj.Q9x7fk").join(".agents-in-a-box"),
+            LauncherLifetime::Persistent,
+            false
+        ));
     }
 
     #[test]
-    fn arms_the_watchdog_for_a_home_under_the_temp_dir() {
-        let home = std::env::temp_dir().join(".tmpQ9x7fk").join(".agents-in-a-box");
-        assert_eq!(
-            armed_for(&home).as_deref(),
-            Some(std::process::id().to_string().as_str()),
-            "a daemon under {} must be bound to this process",
-            home.display()
-        );
+    fn never_binds_a_daemon_a_one_shot_verb_must_leave_behind() {
+        // `ainb hangar daemon start` and `ainb doctor` exit ~1s after the
+        // spawn. Binding there stands the daemon down immediately, while the
+        // verb reports that it started one.
+        assert!(!should_bind_daemon_to_parent(
+            &ephemeral_home("/tmp"),
+            LauncherLifetime::Ephemeral,
+            false
+        ));
     }
 
     #[test]
-    fn arms_the_legacy_name_too_for_an_older_daemon_binary() {
-        // The installed daemon we launch can predate the rename; it would
-        // ignore the new name and become immortal again.
-        let home = std::env::temp_dir().join(".tmpQ9x7fk").join(".agents-in-a-box");
-        let mut command = std::process::Command::new("/bin/true");
-        arm_watchdog_for_ephemeral_home(&mut command, &home);
-        assert_eq!(
-            env_of(&command, ainb_hangar_daemon::LEGACY_PARENT_PID_ENV),
-            env_of(&command, ainb_hangar_daemon::PARENT_PID_ENV)
-        );
+    fn never_overrides_a_parent_a_harness_already_declared() {
+        // A harness that set the env var itself named a longer-lived owner on
+        // purpose; replacing it with our pid kills the daemon it is driving.
+        assert!(!should_bind_daemon_to_parent(
+            &ephemeral_home("/tmp"),
+            LauncherLifetime::Persistent,
+            true
+        ));
     }
 
     #[test]
     fn leaves_a_real_home_alone() {
-        // The Homebrew daemon and a deliberate dev-build daemon must keep
-        // outliving the `ainb` invocation that started them.
-        let home = std::path::Path::new("/Users/example/.agents-in-a-box");
-        assert_eq!(
-            armed_for(home),
-            None,
-            "a real home must not arm the watchdog"
-        );
+        // The Homebrew daemon must keep outliving the invocation that started it.
+        assert!(!should_bind_daemon_to_parent(
+            std::path::Path::new("/Users/example/.agents-in-a-box"),
+            LauncherLifetime::Persistent,
+            false
+        ));
     }
 
     #[test]
     fn leaves_the_running_users_real_home_alone() {
         // Same claim, against the home this machine actually resolves, so the
-        // test fails if `temp_dir()` ever starts prefixing it.
+        // test fails if the temp roots ever start prefixing it.
         let Some(home) = dirs::home_dir() else {
             return;
         };
         let home = home.join(".agents-in-a-box");
         if super::is_under_temp_dir(&home) {
             // This very suite is running under an ephemeral `$HOME`, which is
-            // the case the other test covers. Nothing to assert here.
+            // the case the other tests cover. Nothing to assert here.
+            return;
+        }
+        assert!(!should_bind_daemon_to_parent(
+            &home,
+            LauncherLifetime::Persistent,
+            false
+        ));
+    }
+
+    #[test]
+    fn arms_both_env_names_when_it_binds() {
+        // The installed daemon we launch can predate the rename; it would
+        // ignore the new name and become immortal again.
+        let mut command = std::process::Command::new("/bin/true");
+        arm_watchdog_for_ephemeral_home(
+            &mut command,
+            &ephemeral_home("/tmp"),
+            LauncherLifetime::Persistent,
+        );
+        let ours = std::process::id().to_string();
+        // Skipped when the suite itself runs with a parent already declared:
+        // then the no-override rule wins, which its own test covers.
+        let declared = [
+            ainb_hangar_daemon::PARENT_PID_ENV,
+            ainb_hangar_daemon::LEGACY_PARENT_PID_ENV,
+        ]
+        .iter()
+        .any(|key| std::env::var_os(key).is_some_and(|value| !value.is_empty()));
+        if declared {
             return;
         }
         assert_eq!(
-            armed_for(&home),
-            None,
-            "{} must not arm the watchdog",
-            home.display()
+            explicitly_set_env(&command, ainb_hangar_daemon::PARENT_PID_ENV).as_deref(),
+            Some(ours.as_str())
         );
+        assert_eq!(
+            explicitly_set_env(&command, ainb_hangar_daemon::LEGACY_PARENT_PID_ENV).as_deref(),
+            Some(ours.as_str())
+        );
+    }
+
+    #[test]
+    fn sets_nothing_when_it_does_not_bind() {
+        let mut command = std::process::Command::new("/bin/true");
+        arm_watchdog_for_ephemeral_home(
+            &mut command,
+            &ephemeral_home("/tmp"),
+            LauncherLifetime::Ephemeral,
+        );
+        assert_eq!(command.get_envs().count(), 0);
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8645,9 +8645,8 @@ fn run_daemon_start() -> Result<()> {
 /// and swallowed so the TUI still launches (it shows the offline panel until the
 /// daemon comes up). Quiet — no stdout, since the TUI owns the terminal. Mirrors
 /// `mcp_pool`'s `ensure_daemon` warn-and-continue.
-pub fn ensure_hangar_daemon() {
-    // Persistent: the TUI is the daemon's consumer and outlives it.
-    if let Err(e) = start_or_upgrade_daemon(false, LauncherLifetime::Persistent) {
+pub fn ensure_hangar_daemon(launcher: LauncherLifetime) {
+    if let Err(e) = start_or_upgrade_daemon(false, launcher) {
         tracing::warn!(error = %e, "hangar daemon autostart failed (TUI continues)");
     }
 }
@@ -8729,6 +8728,9 @@ fn is_under_temp_dir(path: &std::path::Path) -> bool {
         std::path::PathBuf::from("/var/tmp"),
     ]
     .iter()
+    // A `TMPDIR=/` makes every path on the machine read as ephemeral, the real
+    // home included. Nothing is learned from a root that contains everything.
+    .filter(|root| root.parent().is_some())
     .any(|root| path.starts_with(root) || resolved.starts_with(real(root)))
 }
 
@@ -8764,6 +8766,12 @@ pub(crate) enum LauncherLifetime {
 /// Inert for a home under a real `$HOME`, so the Homebrew daemon is untouched.
 /// A deliberate dev-build daemon on a temp `AINB_HANGAR_HOME` IS in scope, but
 /// only when started by a persistent launcher. Issue #784.
+///
+/// Known gap: a restart carries no binding forward. `ainb doctor` or
+/// `hangar daemon restart` replacing a daemon that the TUI had bound leaves an
+/// unbound one behind, which is the pre-#784 behaviour rather than a new leak.
+/// Reading the incumbent's environment to inherit its parent is the fix, and it
+/// is deliberately not attempted here.
 fn should_bind_daemon_to_parent(
     hangar_home: &std::path::Path,
     launcher: LauncherLifetime,

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -131,7 +131,9 @@ pub(crate) async fn ensure_codex_remote_thread(
             "Codex Headroom is unavailable with shared remote control; disable Headroom for this session"
         );
     }
-    crate::cli::hangar::ensure_hangar_daemon();
+    // Ephemeral: `ainb run` prints its summary and exits, while the daemon has
+    // to keep serving the tmux session it just created.
+    crate::cli::hangar::ensure_hangar_daemon(crate::cli::hangar::LauncherLifetime::Ephemeral);
     let client = crate::fleet::bridge::daemon::DaemonClient::from_env()
         .map_err(|error| anyhow::anyhow!("connect to Ainb Codex runtime: {error}"))?;
     client

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -180,7 +180,8 @@ async fn tokio_main() -> Result<()> {
                 // a fresh home shows a runtime + a seeded agent (the boot seed runs in
                 // the daemon) instead of an offline panel. Idempotent + non-fatal — a
                 // spawn failure is logged and the TUI still launches.
-                cli::hangar::ensure_hangar_daemon();
+                // Persistent: the TUI is the daemon's consumer and outlives it.
+                cli::hangar::ensure_hangar_daemon(cli::hangar::LauncherLifetime::Persistent);
                 // Same contract for the rest: clear heartbeats left by daemons
                 // that are already gone, and hand a drifted notifyd to this
                 // binary. Without it an upgraded ainb kept talking to the

--- a/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
@@ -208,6 +208,70 @@ fn daemon_start_status_stop_round_trip() {
     }
 }
 
+/// Issue #784's guard binds a daemon to the process that launched it when the
+/// hangar home is ephemeral. That is only ever correct for a launcher which
+/// outlives the daemon (the TUI). `ainb hangar daemon start` exits about a
+/// second after the spawn, and its whole contract is to leave a daemon behind:
+/// arming there would stand the new daemon down and still report success.
+///
+/// Deliberately does NOT set `HANGAR_TEST_PARENT_PID`, unlike `run`: with a
+/// parent already declared the guard declines anyway, which would hide the
+/// regression this test exists to catch.
+#[test]
+fn daemon_start_under_a_temp_home_outlives_the_cli_invocation() {
+    reap_orphaned_test_daemons();
+    let Some(daemon) = daemon_bin() else {
+        eprintln!("SKIP: ainb-hangar-daemon binary not built beside ainb");
+        return;
+    };
+    // Under `$TMPDIR`, so the home IS ephemeral by the guard's definition.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+
+    let out = Command::new(ainb_bin())
+        .args(["hangar", "daemon", "start"])
+        .env("AINB_HANGAR_HOME", home)
+        .env("HOME", home)
+        .env("AINB_HANGAR_DAEMON_BIN", &daemon)
+        .env("HANGAR_DAEMON_RUNTIME_ID", "rt-lifecycle-outlives")
+        .env("HANGAR_DAEMON_DISABLE_CLAIM", "1")
+        .env("AINB_CODEX_MANAGED", "0")
+        .env_remove("HANGAR_TEST_PARENT_PID")
+        .env_remove("AINB_HANGAR_PARENT_PID")
+        .output()
+        .expect("spawn ainb");
+    assert!(
+        out.status.success(),
+        "daemon start should exit 0; out={}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let pid = read_pid(home).expect("daemon start wrote a pid file");
+    let _cleanup = ExactPidCleanup(pid);
+    assert!(
+        wait_until(Duration::from_secs(10), || home
+            .join("hangar.sock")
+            .exists()),
+        "the started daemon must reach its run loop"
+    );
+
+    // `ainb` has exited by now (`output()` waited for it). A daemon wrongly
+    // bound to it SIGINTs itself on the watchdog's next tick, ~1s later.
+    std::thread::sleep(Duration::from_secs(3));
+    assert!(
+        pid_alive(pid),
+        "daemon {pid} must outlive the `ainb hangar daemon start` that spawned it"
+    );
+
+    let (ok, out) = run(home, &daemon, &["hangar", "daemon", "stop"]);
+    assert!(ok, "daemon stop should exit 0; out={out}");
+    assert!(
+        wait_until(Duration::from_secs(10), || !pid_alive(pid)),
+        "the stopped daemon pid {pid} must die"
+    );
+}
+
 #[test]
 fn daemon_exits_when_its_test_parent_is_sigkilled() {
     reap_orphaned_test_daemons();

--- a/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_daemon_lifecycle_cli.rs
@@ -247,8 +247,13 @@ fn daemon_start_under_a_temp_home_outlives_the_cli_invocation() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    let pid = read_pid(home).expect("daemon start wrote a pid file");
-    let _cleanup = ExactPidCleanup(pid);
+    // Cleanup BEFORE the unwrap: this daemon is deliberately spawned with no
+    // parent binding, and `reap_orphaned_test_daemons` cannot find it (it runs
+    // the sibling daemon binary, not `<ainb> hangar daemon run`), so a panic
+    // between here and the stop below would leak it permanently.
+    let pid = read_pid(home);
+    let _cleanup = pid.map(ExactPidCleanup);
+    let pid = pid.expect("daemon start wrote a pid file");
     assert!(
         wait_until(Duration::from_secs(10), || home
             .join("hangar.sock")

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -667,9 +667,14 @@ pub const LEGACY_PARENT_PID_ENV: &str = "HANGAR_TEST_PARENT_PID";
 /// launchd, so normal Rust drop cleanup cannot run. Signal this process through
 /// its existing Ctrl-C shutdown path instead.
 fn spawn_parent_watchdog() {
+    // `filter` before the fallback: a set-but-EMPTY new name would otherwise
+    // read as a declaration, hide the legacy name, and arm nothing. The spawner
+    // treats empty as undeclared too.
     let Some(parent_pid) = std::env::var(PARENT_PID_ENV)
-        .or_else(|_| std::env::var(LEGACY_PARENT_PID_ENV))
         .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var(LEGACY_PARENT_PID_ENV).ok())
+        .filter(|value| !value.is_empty())
         .and_then(|value| value.parse::<i32>().ok())
         .filter(|pid| *pid > 1)
     else {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -644,12 +644,28 @@ impl Drop for PidFile {
     }
 }
 
-/// Test-only parent-death backstop. The tripwire harness gives every daemon its
-/// own parent PID. When the harness is SIGKILLed or OOM-reaped, macOS reparents
-/// the daemon to launchd, so normal Rust drop cleanup cannot run. Signal this
-/// process through its existing Ctrl-C shutdown path instead.
-fn spawn_test_parent_watchdog() {
-    let Some(parent_pid) = std::env::var("HANGAR_TEST_PARENT_PID")
+/// Env var naming the process whose death this daemon must not outlive.
+///
+/// Set by the tripwire harness, and by `start_daemon_if_stopped` whenever the
+/// resolved hangar home is ephemeral (issue #784).
+pub const PARENT_PID_ENV: &str = "AINB_HANGAR_PARENT_PID";
+
+/// Former name of [`PARENT_PID_ENV`], still honoured so a spawner and a daemon
+/// binary from different versions agree (the installed daemon can be older than
+/// the `ainb` that launches it).
+pub const LEGACY_PARENT_PID_ENV: &str = "HANGAR_TEST_PARENT_PID";
+
+/// Parent-death backstop. The caller gives this daemon its own parent PID: the
+/// tripwire harness always, and the TUI autostart when the hangar home is
+/// ephemeral, because every other guard (`single_instance`, `daemon stop`, the
+/// pid file) is scoped to a home that dies with its creator.
+///
+/// When the parent is SIGKILLed or OOM-reaped, macOS reparents the daemon to
+/// launchd, so normal Rust drop cleanup cannot run. Signal this process through
+/// its existing Ctrl-C shutdown path instead.
+fn spawn_parent_watchdog() {
+    let Some(parent_pid) = std::env::var(PARENT_PID_ENV)
+        .or_else(|_| std::env::var(LEGACY_PARENT_PID_ENV))
         .ok()
         .and_then(|value| value.parse::<i32>().ok())
         .filter(|pid| *pid > 1)
@@ -664,7 +680,7 @@ fn spawn_test_parent_watchdog() {
             match nix::sys::signal::kill(nix::unistd::Pid::from_raw(parent_pid), None) {
                 Ok(()) | Err(nix::errno::Errno::EPERM) => {}
                 Err(nix::errno::Errno::ESRCH) => {
-                    tracing::warn!(parent_pid, "tripwire parent exited, stopping daemon");
+                    tracing::warn!(parent_pid, "watched parent exited, stopping daemon");
                     let _ = nix::sys::signal::kill(
                         nix::unistd::Pid::from_raw(std::process::id() as i32),
                         nix::sys::signal::Signal::SIGINT,
@@ -672,7 +688,7 @@ fn spawn_test_parent_watchdog() {
                     return;
                 }
                 Err(error) => {
-                    tracing::warn!(parent_pid, %error, "could not check tripwire parent");
+                    tracing::warn!(parent_pid, %error, "could not check watched parent");
                 }
             }
         }
@@ -696,7 +712,7 @@ fn spawn_test_parent_watchdog() {
 /// Returns an error if the store cannot be opened (directory not writable, a
 /// migration fails) or if the run loop's shutdown handler fails.
 pub async fn boot(once: bool) -> anyhow::Result<()> {
-    spawn_test_parent_watchdog();
+    spawn_parent_watchdog();
     let dir = hangar_dir()?;
 
     // FIRST, before the store, the broker, the sweepers and `rpc::bind`. Every

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -653,6 +653,9 @@ pub const PARENT_PID_ENV: &str = "AINB_HANGAR_PARENT_PID";
 /// Former name of [`PARENT_PID_ENV`], still honoured so a spawner and a daemon
 /// binary from different versions agree (the installed daemon can be older than
 /// the `ainb` that launches it).
+///
+/// Compatibility shim: remove once no released `ainb` older than the rename is
+/// still spawning daemons, and update the tripwire harnesses that set it.
 pub const LEGACY_PARENT_PID_ENV: &str = "HANGAR_TEST_PARENT_PID";
 
 /// Parent-death backstop. The caller gives this daemon its own parent PID: the


### PR DESCRIPTION
Closes #784.

## The bug

Every guard in the hangar daemon is keyed to a hangar home: the `single_instance` lock lives at `<home>/hangar/daemon.lock`, `hangar daemon stop` is home-scoped with no `--all`, and the pid file is written into that home. A run under `HOME=$(mktemp -d)` (tests, scripts, agent harnesses) resolves a home that is deleted the moment the harness exits, so none of them can ever address that daemon again. macOS has no `PR_SET_PDEATHSIG`, and the daemon is spawned detached into its own process group, so it reparents to launchd and runs forever. 86 such daemons were reaped from one machine in a day.

## The fix

Arm the daemon's existing parent-death watchdog when, and only when, the resolved hangar home sits under `std::env::temp_dir()`. A real home under `$HOME` never matches, so the Homebrew daemon and a deliberate dev-build daemon still outlive the invocation that started them; the single-instance contract is untouched.

Both spawn paths are covered: `start_daemon_if_stopped` and `respawn_once`.

The watchdog's env var is renamed `HANGAR_TEST_PARENT_PID` -> `AINB_HANGAR_PARENT_PID`, since it is no longer test-only. The daemon still reads the legacy name (an installed daemon binary can be older than the `ainb` that launches it), and the spawner sets both for the same reason.

## Tests

`cli::hangar::ephemeral_home_watchdog_tests` asserts, on the `Command` the spawner would run and without spawning anything:

- a home under `temp_dir()` is armed with this process's pid
- the legacy env name carries the same pid
- `/Users/example/.agents-in-a-box` is left alone
- this machine's real resolved home is left alone

## Not done here

- No argv-matching reaper: it cannot tell which home a given `hangar daemon run` serves and would kill daemons belonging to other homes, the hazard documented at `single_instance.rs:324-326`.
- No change to the single-instance contract; the lock is working correctly.
- Follow-ups from the issue left open: escalating `Held::Unknown` in `watch_ownership`, and the one-off cleanup of the leaked `.tmp*/.agents-in-a-box` homes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon lifecycle handling for temporary homes and persistent launches.
  * Daemons started by one-shot commands now remain available after the command exits.
  * Improved reliability when temporary directories use symlinks or alternate temporary roots.
  * Added support for current and legacy parent-process configuration.
  * Prevented existing parent-process settings from being overwritten.
  * Improved daemon cleanup and shutdown behavior across command-line and interactive launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->