### PR TITLE
docs: generate the architecture diagrams, rewrite the value proposition around outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ A Rust-based terminal application for managing AI coding sessions with git workt
 - **Usage analytics** — Built-in token + session tracking by day, week, provider, and project. Know where your budget went — then cut it with [The Token Optimisation Playbook](https://stevengonsalvez.com/blog/token-optimisation-playbook)
 - **Easy onboarding** — First-run setup wizard checks dependencies, configures auth, and gets you creating sessions in minutes
 - **Live log streaming** — Real-time viewer with level filtering and search across all running sessions
-- **Scriptable CLI** — 40 commands (every TUI action, plus headless `witr`, `learnings search`, `diff-review --format json`, …), with `--format json` on session state, config, git, usage, fleet, and most daemons. **[📘 Full CLI reference →](docs/tui/cli.md)** — a generated, multi-hierarchy man page covering every subcommand.
+- **Scriptable CLI** — 41 commands (every TUI action, plus headless `witr`, `learnings search`, `diff-review --format json`, …), with `--format json` on session state, config, git, usage, fleet, and most daemons. **[📘 Full CLI reference →](docs/tui/cli.md)** — a generated, multi-hierarchy man page covering every subcommand.
 
 ### CLI — Scriptable Equivalent of Every TUI Feature
 
@@ -337,7 +337,7 @@ ainb config set authentication.default_model opus
 ainb completion zsh > ~/.zsh/completions/_ainb
 ```
 
-**40 top-level commands** — `tui`, `run`, `list`, `label`, `logs`, `attach`, `status`, `kill`, `auth`, `recover`, `config`, `git`, `favorites`, `init`, `doctor`, `reflect`, `presets`, `usage`, `statusline`, `claudecode`, `codex`, `tmux`, `otel`, `completion`, `abtop`, `web`, `witr`, `learnings`, `plugin`, `fleet`, `headroom`, `daemon`, `mcp`, `notifyd`, `hangar`, `rtk`, `diff-review`, `skill`, `source`, `search` — with nested subcommands for recover / config / git / favorites / presets / plugin / fleet / hangar / mcp / daemon / usage / skill / source.
+**41 top-level commands** — `tui`, `run`, `list`, `label`, `logs`, `attach`, `status`, `kill`, `auth`, `recover`, `config`, `git`, `favorites`, `init`, `doctor`, `reflect`, `presets`, `usage`, `statusline`, `claudecode`, `codex`, `tmux`, `otel`, `completion`, `abtop`, `web`, `witr`, `learnings`, `plugin`, `fleet`, `headroom`, `daemon`, `mcp`, `notifyd`, `hangar`, `rtk`, `update`, `diff-review`, `skill`, `source`, `search` — with nested subcommands for recover / config / git / favorites / presets / plugin / fleet / hangar / mcp / daemon / usage / skill / source.
 
 **[📘 Full CLI reference → docs/tui/cli.md](docs/tui/cli.md)**
 
@@ -427,7 +427,7 @@ brew install ainb   # or brew upgrade ainb
 `ainb` boots a plugin host at startup. Some screens — notably **Analytics / Usage (the burndown dashboard)** — are provided by subprocess plugins that the host discovers and loads automatically. **All plugins are enabled by default**; you only need the controls below to turn them off or scope which ones load.
 
 <p align="center">
-  <img src="docs/assets/diagrams/plugin-architecture.svg" alt="ainb v2 plugin architecture — host, JSON-RPC stdio, plugin subprocesses, capability gate, event bus" width="860">
+  <img src="docs/assets/diagrams/plugin-architecture.svg" alt="ainb v2 plugin architecture: the host and its runtime, the JSON-RPC method sets on each side of the wire, the six in-tree plugins, and the two ways a plugin can draw" width="860">
 </p>
 
 **How it works (in brief):** a v2 plugin is a **native subprocess** that speaks **JSON-RPC 2.0 over Content-Length-framed stdio** — no wasm, no in-process linking. The host (`ainb-core`) discovers each plugin from `dist/plugins/<id>/`, spawns it, and exchanges messages: `plugin/render` (the plugin returns a `WireBuffer` of cells the host blits), `plugin/handle_key`, `plugin/cli_dispatch` (routes `ainb <namespace> …`), plus reverse `host/snapshot/publish` calls over an **event bus**. Each plugin declares its `[capabilities]` in `manifest.toml`; the runtime denies any ungranted host call with JSON-RPC `-32001`. A plugin screen can render **two ways**: in-process via a `WireBuffer` (host owns the terminal — e.g. **burndown**), or as a **host-embedded foreign TTY** where ainb suspends and hands the terminal to an external interactive program (e.g. **witr**'s `witr -i` browser). Full walkthrough: [`docs/plugins/`](docs/plugins/overview.md).
@@ -608,7 +608,7 @@ The `/reflect` skill captures learnings. The `/research` and `/prime` skills ret
 ## Architecture
 
 <p align="center">
-  <img src="docs/assets/diagrams/ecosystem-architecture.svg" alt="agents-in-a-box ecosystem architecture — ainb TUI Rust workspace, JSON-RPC plugin host, fleet orchestration, portable toolkit deploying to 9+ tool homes, reflect GraphRAG memory, and the on-disk state that ties them together" width="900">
+  <img src="docs/assets/diagrams/ecosystem-architecture.svg" alt="agents-in-a-box ecosystem architecture: the ainb TUI host, the v2 plugin host and its six in-tree plugins, the nine daemons the TUI supervises, the separate toolkit and reflect-memory repos, and how it is distributed" width="900">
 </p>
 
 ```

--- a/docs/assets/diagrams/ecosystem-architecture.svg
+++ b/docs/assets/diagrams/ecosystem-architecture.svg
@@ -1,225 +1,135 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1720 1150" width="1720" height="1150">
-  <style>text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif; }</style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1660 930" width="1660" height="930" role="img" aria-label="agents-in-a-box ecosystem architecture: the TUI host, the v2 plugin host, the daemons it supervises, the separate toolkit and memory repos, and distribution">
+  <style>text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Arial,sans-serif;}@media (prefers-color-scheme: dark){.bg{fill:#0F0F18;}.ink{fill:#DCDCE6;}.mute{fill:#9A9AB0;}.accent{fill:#E08A63;}.accentfill{fill:#E08A63;}.card{fill:#191923;stroke:#2E2E3E;}.chip{fill:#20202C;stroke:#2E2E3E;}.line{stroke:#7A7A92;}.alt{stroke:#8FA86B;}.linefill{fill:#7A7A92;}.altfill{fill:#8FA86B;}}</style>
   <defs>
-    <marker id="arr" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" fill="#5A554E"/></marker>
-    <marker id="arrClay" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" fill="#D97757"/></marker>
-    <marker id="arrOlive" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" fill="#788C5D"/></marker>
-    <filter id="soft" x="-10%" y="-10%" width="120%" height="130%"><feDropShadow dx="0" dy="1.5" stdDeviation="3" flood-color="#141413" flood-opacity="0.07"/></filter>
+    <marker id="arr" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" class="linefill" fill="#8A857C"/></marker>
+    <marker id="arrAlt" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" class="altfill" fill="#5F7048"/></marker>
   </defs>
-  <rect width="1720" height="1150" fill="#FAF9F5"/>
-  <text x="40" y="46" fill="#141413" font-size="27" font-weight="800">agents-in-a-box</text>
-  <rect x="40" y="56" width="252" height="4" rx="2" fill="#D97757"/>
-  <text x="312" y="46" fill="#6B655B" font-size="16">Ecosystem architecture - TUI orchestrator, plugin host, fleet control, portable toolkit, GraphRAG memory</text>
-  <rect x="40" y="100" width="560" height="540" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="64" y="132" fill="#141413" font-size="16.5" font-weight="700">1 - ainb TUI - Rust workspace (11 crates)</text>
-  <text x="64" y="151" fill="#6B655B" font-size="11.5">terminal UI + CLI, single binary, tmux-persistent sessions</text>
-  <rect x="64" y="170" width="512" height="92" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="320.0" y="203" text-anchor="middle" fill="#141413" font-size="15" font-weight="700">ainb-core</text>
-  <text x="320.0" y="224" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">TUI: home - sessions - usage - inbox - code review</text>
-  <text x="320.0" y="242" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">CLI: run - list - attach - usage - plugin - fleet - doctor</text>
-  <path d="M 140,262 V 296" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <path d="M 320,262 V 296" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <path d="M 500,262 V 296" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="64" y="300" width="152" height="84" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="140.0" y="329" text-anchor="middle" fill="#141413" font-size="13" font-weight="700">Docker</text>
-  <text x="140.0" y="348" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Bollard API</text>
-  <text x="140.0" y="364" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">per-session env</text>
-  <rect x="244" y="300" width="152" height="84" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="320.0" y="329" text-anchor="middle" fill="#141413" font-size="13" font-weight="700">Git worktrees</text>
-  <text x="320.0" y="348" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">branch-per-</text>
-  <text x="320.0" y="364" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">session isolation</text>
-  <rect x="424" y="300" width="152" height="84" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="500.0" y="329" text-anchor="middle" fill="#141413" font-size="13" font-weight="700">tmux</text>
-  <text x="500.0" y="348" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">PTY attach</text>
-  <text x="500.0" y="364" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">send-keys</text>
-  <path d="M 140,384 V 410" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <path d="M 320,384 V 410" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <path d="M 500,384 V 410" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="64" y="414" width="512" height="66" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="320.0" y="442" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">Provider adapters</text>
-  <text x="320.0" y="462" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">claude - codex - gemini - copilot (Provider trait)</text>
-  <rect x="64" y="508" width="512" height="56" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="320.0" y="531" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.agents-in-a-box/</text>
-  <text x="320.0" y="549" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">config.toml - favorites.yaml - presets - plugin root</text>
-  <text x="320" y="606" text-anchor="middle" fill="#6B655B" font-size="11.5">crates: core + plugin-protocol / runtime / sdk-rust / testkit / cts-v2 / types + 4 plugin binaries</text>
-  <rect x="660" y="100" width="480" height="350" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="684" y="132" fill="#141413" font-size="16.5" font-weight="700">2 - Plugin host - subprocess runtime</text>
-  <text x="684" y="151" fill="#6B655B" font-size="11.5">manifest v2 discovery from ~/.agents-in-a-box/plugins/</text>
-  <rect x="684" y="156" width="432" height="62" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="900.0" y="182" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">ainb-plugin-runtime</text>
-  <text x="900.0" y="202" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">spawn - lifecycle FSM - snapshot/action bus - render frames</text>
-  <path d="M 900,218 V 268" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="824" y="239" width="152" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="900" y="248" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">JSON-RPC 2.0 over stdio</text>
-  <rect x="684" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="733.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">burndown</text>
-  <text x="733.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">usage + cost</text>
-  <text x="733.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">analytics</text>
-  <rect x="795" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="844.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">session-reader</text>
-  <text x="844.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">JSONL parse</text>
-  <text x="844.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">SQLite cache</text>
-  <rect x="906" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="955.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">notifyd</text>
-  <text x="955.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">notifications</text>
-  <text x="955.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">inbox feed</text>
-  <rect x="1017" y="272" width="99" height="92" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1066.5" y="305" text-anchor="middle" fill="#141413" font-size="12" font-weight="700">witr</text>
-  <text x="1066.5" y="323" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">process</text>
-  <text x="1066.5" y="339" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">causality</text>
-  <rect x="684" y="386" width="432" height="44" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="900.0" y="411" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="600">SDK + conformance: protocol - sdk-rust - testkit - cts-v2 (21 axes)</text>
-  <rect x="1200" y="100" width="480" height="350" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="1224" y="132" fill="#141413" font-size="16.5" font-weight="700">3 - Toolkit - write once, deploy to 9+ tools</text>
-  <text x="1224" y="151" fill="#6B655B" font-size="11.5">ainb-toolkit (external repo) — github.com/stevengonsalvez/ainb-toolkit</text>
-  <rect x="1224" y="156" width="432" height="64" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1440.0" y="183" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">ainb-toolkit: skills/ agents/ …</text>
-  <text x="1440.0" y="203" text-anchor="middle" fill="#141413" font-size="11.5" font-weight="400">94 skills - 16 agents - 16 hooks - workflows - knowledge</text>
-  <path d="M 1340,220 V 248" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="1224" y="252" width="300" height="70" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1374" y="276" text-anchor="middle" fill="#141413" font-size="14" font-weight="700">bootstrap.js</text>
-  <text x="1374" y="294" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">TOOL_DIR templating</text>
-  <text x="1374" y="310" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">external-dependencies.yaml</text>
-  <path d="M 1340,322 V 342" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="1355" y="323" width="47" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="1378" y="332" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">deploy</text>
-  <rect x="1224" y="346" width="432" height="70" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1440.0" y="368" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">Tool homes (9+)</text>
-  <text x="1440.0" y="388" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">~/.claude - ~/.codex - ~/.copilot - ~/.gemini</text>
-  <text x="1440.0" y="404" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">hermes - nanoclaw - cursor - amazon q - ...</text>
-  <path d="M 1580,342 V 224" fill="none" stroke="#5A554E" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr)"/>
-  <rect x="1531" y="277.5" width="98" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="1580" y="286" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">/sync-learnings</text>
-  <rect x="660" y="500" width="480" height="310" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="684" y="532" fill="#141413" font-size="16.5" font-weight="700">4 - Fleet orchestration - ainb fleet</text>
-  <text x="684" y="551" fill="#6B655B" font-size="11.5">drive every agent session on the host</text>
-  <rect x="684" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="731.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">discover</text>
-  <text x="731.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">ainb - peers</text>
-  <text x="731.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">db - bg jobs</text>
-  <path d="M 778,600 H 798" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="798" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="845.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">merge</text>
-  <text x="845.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">dedup</text>
-  <text x="845.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">by cwd</text>
-  <path d="M 892,600 H 912" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="912" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="959.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">read</text>
-  <text x="959.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">JSONL tail -</text>
-  <text x="959.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">pane - needs</text>
-  <path d="M 1006,600 H 1026" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="1026" y="556" width="94" height="88" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1073.0" y="587" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">send</text>
-  <text x="1073.0" y="606" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">broker first,</text>
-  <text x="1073.0" y="622" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">tmux fallback</text>
-  <rect x="684" y="668" width="436" height="44" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="902.0" y="693" text-anchor="middle" fill="#141413" font-size="12" font-weight="600">verbs: standup - broadcast - sequence - needs - daemon</text>
-  <rect x="684" y="736" width="436" height="54" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="902.0" y="758" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">claude-peers broker - HTTP :7899</text>
-  <text x="902.0" y="776" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">register - heartbeat - send-message - poll</text>
-  <rect x="1200" y="500" width="480" height="310" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="1224" y="532" fill="#141413" font-size="16.5" font-weight="700">5 - reflect - GraphRAG memory</text>
-  <text x="1224" y="551" fill="#6B655B" font-size="11.5">correct once, never again - cross-tool learnings</text>
-  <rect x="1224" y="556" width="432" height="60" rx="10" fill="#C9D2B8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1440.0" y="581" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">plugins/reflect (Claude plugin)</text>
-  <text x="1440.0" y="601" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">PreCompact drain - SessionStart recall - /reflect skills</text>
-  <path d="M 1400,616 V 644" fill="none" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
-  <rect x="1413" y="625" width="47" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="1436" y="634" text-anchor="middle" fill="#788C5D" font-size="11" font-weight="600">ingest</text>
-  <rect x="1224" y="648" width="340" height="60" rx="10" fill="#C9D2B8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1394.0" y="674" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">reflect-kb CLI (python)</text>
-  <text x="1394.0" y="693" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">nano-graphrag - nano-vectordb - sidecars</text>
-  <path d="M 1400,708 V 736" fill="none" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
-  <rect x="1400" y="717" width="96" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="1448" y="726" text-anchor="middle" fill="#788C5D" font-size="11" font-weight="600">index - search</text>
-  <rect x="1224" y="740" width="432" height="54" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1440.0" y="762" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.claude/global-learnings/</text>
-  <text x="1440.0" y="780" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">documents/*.md - *.entities.yaml - graph cache</text>
-  <path d="M 1610,740 V 620" fill="none" stroke="#788C5D" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arrOlive)"/>
-  <rect x="1587" y="675.5" width="45" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="1610" y="684" text-anchor="middle" fill="#788C5D" font-size="10.5" font-weight="600">recall</text>
-  <rect x="40" y="690" width="560" height="130" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="64" y="722" fill="#141413" font-size="16.5" font-weight="700">Live agent sessions</text>
-  <text x="64" y="741" fill="#6B655B" font-size="11.5">tmux panes - Docker containers - git worktrees</text>
-  <rect x="64" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="122.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">claude</text>
-  <text x="122.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Claude Code</text>
-  <rect x="198" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="256.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">codex</text>
-  <text x="256.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Codex CLI</text>
-  <rect x="332" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="390.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">gemini</text>
-  <text x="390.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Gemini CLI</text>
-  <rect x="466" y="736" width="116" height="60" rx="10" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="524.0" y="762" text-anchor="middle" fill="#141413" font-size="13.5" font-weight="700">copilot</text>
-  <text x="524.0" y="781" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">Copilot CLI</text>
-  <rect x="40" y="870" width="1100" height="150" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="64" y="902" fill="#141413" font-size="16.5" font-weight="700">Data on disk</text>
-  <rect x="64" y="920" width="250" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="189.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.claude/projects/</text>
-  <text x="189.0" y="963" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">**/*.jsonl transcripts</text>
-  <text x="189.0" y="980" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">turns - usage - stop_reason</text>
-  <rect x="334" y="920" width="230" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="449.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.codex/sessions/</text>
-  <text x="449.0" y="963" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">rollout-*.jsonl</text>
-  <text x="449.0" y="980" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">written by codex CLI</text>
-  <rect x="584" y="920" width="220" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="694.0" y="953" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.claude-peers.db</text>
-  <text x="694.0" y="971" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">peer registry (SQLite)</text>
-  <rect x="824" y="920" width="292" height="76" rx="10" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="970.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">~/.agents-in-a-box/plugins/</text>
-  <text x="970.0" y="963" text-anchor="middle" fill="#141413" font-size="11" font-weight="400">manifests + plugin binaries</text>
-  <text x="970.0" y="980" text-anchor="middle" fill="#141413" font-size="10" font-weight="400">discovered by plugin runtime</text>
-  <rect x="1200" y="870" width="480" height="150" rx="16" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.4" filter="url(#soft)"/>
-  <text x="1224" y="902" fill="#141413" font-size="16.5" font-weight="700">6 - Distribution + docs</text>
-  <rect x="1224" y="920" width="130" height="76" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1289.0" y="953" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">Homebrew</text>
-  <text x="1289.0" y="972" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">tap -> ainb</text>
-  <rect x="1370" y="920" width="130" height="76" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1435.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">docs/ tree</text>
-  <text x="1435.0" y="963" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">tui - toolkit -</text>
-  <text x="1435.0" y="980" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">plugins - kb</text>
-  <rect x="1516" y="920" width="140" height="76" rx="10" fill="#E3DACC" stroke="#3D3A36" stroke-width="1.6"/>
-  <text x="1586.0" y="945" text-anchor="middle" fill="#141413" font-size="12.5" font-weight="700">Starlight site</text>
-  <text x="1586.0" y="963" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">website/site -></text>
-  <text x="1586.0" y="980" text-anchor="middle" fill="#141413" font-size="10.5" font-weight="400">GitHub Pages</text>
-  <path d="M 600,210 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="594" y="187.5" width="69" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="628" y="196" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">spawn host</text>
-  <path d="M 600,560 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="591" y="537.5" width="75" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="628" y="546" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">fleet verbs</text>
-  <path d="M 320,640 V 684" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="272" y="658" width="96" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="320" y="667" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">spawn - attach</text>
-  <path d="M 190,820 V 914" fill="none" stroke="#5A554E" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr)"/>
-  <rect x="151" y="843" width="78" height="17" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="190" y="852" text-anchor="middle" fill="#5A554E" font-size="11" font-weight="600">write JSONL</text>
-  <path d="M 250,920 V 898 H 628 V 568 A 8 8 0 0 0 628,552 V 330 H 654" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="552" y="473.5" width="151" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="628" y="482" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">plugins read transcripts</text>
-  <path d="M 290,920 V 905 H 752 A 8 8 0 0 1 768,905 H 1160 V 578 H 1194" fill="none" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
-  <rect x="877" y="892.5" width="216" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="985" y="901" text-anchor="middle" fill="#788C5D" font-size="10.5" font-weight="600">harvest transcripts -> ingest queue</text>
-  <path d="M 760,790 V 914" fill="none" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <rect x="717" y="836.5" width="86" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="760" y="845" text-anchor="middle" fill="#5A554E" font-size="10.5" font-weight="600">peer registry</text>
-  <path d="M 684,762 H 644 A 8 8 0 0 0 628,762 H 606" fill="none" stroke="#D97757" stroke-width="2" marker-end="url(#arrClay)"/>
-  <rect x="596" y="739.5" width="92" height="16.5" rx="4" fill="#FAF9F5" opacity="0.95"/>
-  <text x="642" y="748" text-anchor="middle" fill="#D97757" font-size="10.5" font-weight="600">deliver prompt</text>
-  <rect x="40" y="1050" width="660" height="64" rx="10" fill="#FFFFFF" stroke="#3D3A36" stroke-width="1.2"/>
-  <text x="60" y="1075" fill="#141413" font-size="12.5" font-weight="700">Legend</text>
-  <line x1="130" y1="1071" x2="166" y2="1071" stroke="#5A554E" stroke-width="2" marker-end="url(#arr)"/>
-  <text x="174" y="1075" fill="#6B655B" font-size="11.5">data / control flow</text>
-  <line x1="130" y1="1097" x2="166" y2="1097" stroke="#5A554E" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr)"/>
-  <text x="174" y="1101" fill="#6B655B" font-size="11.5">write / feedback</text>
-  <line x1="330" y1="1071" x2="366" y2="1071" stroke="#D97757" stroke-width="2" marker-end="url(#arrClay)"/>
-  <text x="374" y="1075" fill="#6B655B" font-size="11.5">fleet prompt delivery</text>
-  <line x1="330" y1="1097" x2="366" y2="1097" stroke="#788C5D" stroke-width="2" marker-end="url(#arrOlive)"/>
-  <text x="374" y="1101" fill="#6B655B" font-size="11.5">learning loop (reflect)</text>
-  <rect x="530" y="1062" width="14" height="14" rx="4" fill="#F1C0A8" stroke="#3D3A36" stroke-width="1.2"/>
-  <text x="552" y="1073" fill="#6B655B" font-size="11.5">active component</text>
-  <rect x="530" y="1088" width="14" height="14" rx="4" fill="#ECEAE4" stroke="#3D3A36" stroke-width="1.2"/>
-  <text x="552" y="1099" fill="#6B655B" font-size="11.5">storage / state</text>
-  <text x="1680" y="1100" text-anchor="end" fill="#6B655B" font-size="11">agents-in-a-box monorepo - ainb-tui v1.5 - ainb-toolkit (external) - reflect-kb</text>
+  <rect width="1660" height="930" class="bg" fill="#FAF9F5"/>
+  <text x="36" y="44" font-size="26" class="ink" fill="#141413" text-anchor="start" font-weight="800">agents-in-a-box</text>
+  <rect x="36" y="54" width="238" height="4" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="294" y="44" font-size="15" class="mute" fill="#6B655B" text-anchor="start">Ecosystem architecture</text>
+  <text x="1624" y="44" font-size="12" class="mute" fill="#6B655B" text-anchor="end">ainb v1.22.13 · 34-crate Rust workspace</text>
+  <rect x="36" y="84" width="780" height="292" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="84" width="4" height="292" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="112" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">1</text>
+  <text x="74" y="112" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">ainb TUI host</text>
+  <text x="54" y="132" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">one binary · 28 screens · 41 CLI commands · Unix only</text>
+  <rect x="54" y="148" width="367" height="48" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="168" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">git worktrees</text>
+  <text x="65" y="183" font-size="10" class="mute" fill="#6B655B" text-anchor="start">a branch and a directory per session</text>
+  <rect x="430" y="148" width="367" height="48" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="441" y="168" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">tmux / PTY</text>
+  <text x="441" y="183" font-size="10" class="mute" fill="#6B655B" text-anchor="start">attach · send-keys · survives sleep</text>
+  <rect x="54" y="205" width="367" height="48" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="225" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">provider adapters</text>
+  <text x="65" y="240" font-size="10" class="mute" fill="#6B655B" text-anchor="start">claude · codex · gemini · copilot</text>
+  <rect x="430" y="205" width="367" height="48" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="441" y="225" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">session store</text>
+  <text x="441" y="240" font-size="10" class="mute" fill="#6B655B" text-anchor="start">~/.agents-in-a-box/</text>
+  <rect x="54" y="266" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="286" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">screens</text>
+  <text x="65" y="301" font-size="10" class="mute" fill="#6B655B" text-anchor="start">home · sessions · fleet · hangar · inbox · stats · review · daemons · skills</text>
+  <rect x="54" y="318" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="338" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">config</text>
+  <text x="65" y="353" font-size="10" class="mute" fill="#6B655B" text-anchor="start">config.toml · favorites · presets · plugin root</text>
+  <rect x="844" y="84" width="780" height="292" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="844" y="84" width="4" height="292" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="862" y="112" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">2</text>
+  <text x="882" y="112" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Plugin host (v2 ABI)</text>
+  <text x="862" y="132" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">subprocess · JSON-RPC 2.0 over stdio · capabilities default-deny</text>
+  <rect x="862" y="148" width="242" height="34" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="873" y="168" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">burndown</text>
+  <rect x="1113" y="148" width="242" height="34" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1124" y="168" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">session-reader</text>
+  <rect x="1364" y="148" width="242" height="34" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1375" y="168" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">witr</text>
+  <rect x="862" y="191" width="242" height="34" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="873" y="211" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">learnings</text>
+  <rect x="1113" y="191" width="242" height="34" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1124" y="211" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">abtop</text>
+  <rect x="1364" y="191" width="242" height="34" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1375" y="211" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">hangar-tui</text>
+  <rect x="862" y="242" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="873" y="262" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">runtime</text>
+  <text x="873" y="277" font-size="10" class="mute" fill="#6B655B" text-anchor="start">spawn · lifecycle FSM · snapshot bus · render frames · -32001 on denial</text>
+  <rect x="862" y="294" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="873" y="314" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">SDK + conformance</text>
+  <text x="873" y="329" font-size="10" class="mute" fill="#6B655B" text-anchor="start">protocol · sdk-rust · testkit · cts-v2 (21 axes)</text>
+  <rect x="36" y="396" width="1588" height="164" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="396" width="4" height="164" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="424" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">3</text>
+  <text x="74" y="424" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Daemons</text>
+  <text x="54" y="444" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">long-lived processes the TUI supervises · started, stopped and health-checked from the Daemons screen</text>
+  <rect x="54" y="460" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="480" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">bridge</text>
+  <text x="65" y="495" font-size="10" class="mute" fill="#6B655B" text-anchor="start">Telegram · Slack · Discord</text>
+  <rect x="366" y="460" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="377" y="480" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">notifyd</text>
+  <text x="377" y="495" font-size="10" class="mute" fill="#6B655B" text-anchor="start">notifications into the Inbox</text>
+  <rect x="678" y="460" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="689" y="480" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">approve-broker</text>
+  <text x="689" y="495" font-size="10" class="mute" fill="#6B655B" text-anchor="start">permission prompts</text>
+  <rect x="990" y="460" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1001" y="480" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">atc</text>
+  <text x="1001" y="495" font-size="10" class="mute" fill="#6B655B" text-anchor="start">always-on watcher</text>
+  <rect x="1302" y="460" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1313" y="480" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">fleet-daemon</text>
+  <text x="1313" y="495" font-size="10" class="mute" fill="#6B655B" text-anchor="start">API-error auto-continue</text>
+  <rect x="54" y="513" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="533" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">mcp-pool</text>
+  <text x="65" y="548" font-size="10" class="mute" fill="#6B655B" text-anchor="start">one MCP server, shared</text>
+  <rect x="366" y="513" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="377" y="533" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">hangar-daemon</text>
+  <text x="377" y="548" font-size="10" class="mute" fill="#6B655B" text-anchor="start">boards · tasks · 144 RPC methods</text>
+  <rect x="678" y="513" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="689" y="533" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">headroom-proxy</text>
+  <text x="689" y="548" font-size="10" class="mute" fill="#6B655B" text-anchor="start">context compression</text>
+  <rect x="990" y="513" width="303" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1001" y="533" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">release-checker</text>
+  <text x="1001" y="548" font-size="10" class="mute" fill="#6B655B" text-anchor="start">signed update check</text>
+  <rect x="36" y="580" width="780" height="168" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="580" width="4" height="168" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="608" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">4</text>
+  <text x="74" y="608" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Toolkit (separate repo)</text>
+  <text x="54" y="628" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">stevengonsalvez/ainb-toolkit · consumed as a pinned source</text>
+  <rect x="54" y="644" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="664" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">94 skills · 16 agents</text>
+  <text x="65" y="679" font-size="10" class="mute" fill="#6B655B" text-anchor="start">written once, deployed everywhere</text>
+  <rect x="54" y="694" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="714" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">9 tool homes</text>
+  <text x="65" y="729" font-size="10" class="mute" fill="#6B655B" text-anchor="start">claude · codex · copilot · gemini · cursor · amazonq · claude-desktop · cline · roo</text>
+  <rect x="844" y="580" width="780" height="168" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="844" y="580" width="4" height="168" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="862" y="608" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">5</text>
+  <text x="882" y="608" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Memory (separate repo)</text>
+  <text x="862" y="628" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">stevengonsalvez/ainb-reflect-memory · CLI only, no library API</text>
+  <rect x="862" y="644" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="873" y="664" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">reflect</text>
+  <text x="873" y="679" font-size="10" class="mute" fill="#6B655B" text-anchor="start">/reflect captures · /recall retrieves</text>
+  <rect x="862" y="694" width="744" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="873" y="714" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">two-tier index</text>
+  <text x="873" y="729" font-size="10" class="mute" fill="#6B655B" text-anchor="start">GraphRAG across projects · vector search for fast hits</text>
+  <rect x="36" y="768" width="1588" height="100" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="768" width="4" height="100" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="796" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">6</text>
+  <text x="74" y="796" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Distribution</text>
+  <text x="54" y="816" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">how it reaches a machine, and how it is documented</text>
+  <rect x="54" y="830" width="381" height="32" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="850" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">Homebrew</text>
+  <text x="65" y="865" font-size="10" class="mute" fill="#6B655B" text-anchor="start">brew install ainb</text>
+  <rect x="444" y="830" width="381" height="32" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="455" y="850" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">install.sh</text>
+  <text x="455" y="865" font-size="10" class="mute" fill="#6B655B" text-anchor="start">one-liner elsewhere</text>
+  <rect x="834" y="830" width="381" height="32" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="845" y="850" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">docs/</text>
+  <text x="845" y="865" font-size="10" class="mute" fill="#6B655B" text-anchor="start">single source of truth</text>
+  <rect x="1224" y="830" width="381" height="32" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="1235" y="850" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">ainb.app</text>
+  <text x="1235" y="865" font-size="10" class="mute" fill="#6B655B" text-anchor="start">Astro Starlight on Pages</text>
+  <path d="M426 376 L426 392" class="line" fill="none" stroke="#8A857C" stroke-width="1.6" marker-end="url(#arr)"/>
+  <path d="M1234 376 L1234 392" class="line" fill="none" stroke="#8A857C" stroke-width="1.6" marker-end="url(#arr)"/>
+  <path d="M426 560 L426 576" class="alt" fill="none" stroke="#5F7048" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#arrAlt)"/>
+  <path d="M1234 560 L1234 576" class="alt" fill="none" stroke="#5F7048" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#arrAlt)"/>
+  <text x="36" y="892" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">Solid: supervises.   Dashed: reads and writes.</text>
+  <text x="1624" y="892" font-size="11.5" class="mute" fill="#6B655B" text-anchor="end">Regenerate: python3 docs/assets/diagrams/generate-diagrams.py</text>
 </svg>

--- a/docs/assets/diagrams/generate-diagrams.py
+++ b/docs/assets/diagrams/generate-diagrams.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Generate the architecture diagrams under docs/assets/diagrams/.
+
+The diagram used to be hand-authored, which is how it ended up advertising
+"11 crates" and "v1.5" long after the workspace passed 34 crates and v1.22,
+and how it kept listing notifyd as a plugin when notifyd is a daemon.
+
+Everything countable is read from the repo at generation time, so regenerating
+picks up drift instead of preserving it:
+
+    python3 docs/assets/diagrams/generate-diagrams.py
+
+Emits ecosystem-architecture.svg and plugin-architecture.svg, rewriting them in
+place, and prints the facts it used so a reviewer can check them.
+
+Colours: every element carries its light value as a presentation attribute and
+a class. The embedded stylesheet only repaints for dark mode. GitHub sanitises
+SVG CSS, so the README still gets a correct light diagram while the docsite
+follows the reader's colour scheme.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+ROOT = Path(__file__).resolve().parents[3]
+DIAGRAMS = ROOT / "docs/assets/diagrams"
+OUT_ECO = DIAGRAMS / "ecosystem-architecture.svg"
+OUT_PLUGIN = DIAGRAMS / "plugin-architecture.svg"
+
+# ---------------------------------------------------------------- live facts
+
+
+def crate_count() -> int:
+    """Workspace members, from cargo, so `default-members` cannot inflate it
+    the way a naive grep over Cargo.toml does."""
+    try:
+        out = subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            cwd=ROOT / "ainb-tui", capture_output=True, text=True,
+            timeout=180, check=True,
+        ).stdout
+        return len(json.loads(out)["packages"])
+    except Exception:  # noqa: BLE001 - fall back to the members array
+        txt = (ROOT / "ainb-tui/Cargo.toml").read_text()
+        m = re.search(r"^members\s*=\s*\[(.*?)\]", txt, re.S | re.M)
+        return len(re.findall(r'"[^"]+"', m.group(1))) if m else 0
+
+
+def workspace_version() -> str:
+    txt = (ROOT / "ainb-tui/Cargo.toml").read_text()
+    m = re.search(r'^version\s*=\s*"([^"]+)"', txt, re.M)
+    return m.group(1) if m else "?"
+
+
+def staged_plugins() -> list[str]:
+    """Plugin ids the build script stages into dist/plugins/<id>/."""
+    txt = (ROOT / "ainb-tui/scripts/build-plugins.sh").read_text()
+    return re.findall(r"^build_plugin\s+\S+\s+(\S+)", txt, re.M)
+
+
+def daemon_kinds() -> list[str]:
+    """Stable lowercase daemon ids, from DaemonKind::id()."""
+    txt = (ROOT / "ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs").read_text()
+    block = re.search(r"pub fn id\(self\).*?\{(.*?)\n    \}", txt, re.S)
+    return re.findall(r'=>\s*"([a-z-]+)"', block.group(1)) if block else []
+
+
+def screen_count() -> int:
+    txt = (ROOT / "ainb-tui/crates/ainb-core/src/app/screens/mod.rs").read_text()
+    return len(re.findall(r"^\s*pub const ", txt, re.M))
+
+
+def cli_command_count() -> int:
+    """Registry built-ins, plus `tui` and `diff-review` wired up inline in
+    main.rs, plus the commands routed to the separate ainb-cli crate."""
+    reg = (ROOT / "ainb-tui/crates/ainb-core/src/cli/registry.rs").read_text()
+    m = re.search(r"pub fn built_ins\(\) -> Self \{(.*?)\n    \}", reg, re.S)
+    registry = len(re.findall(r"^\s*r\.register\(", m.group(1), re.M)) if m else 0
+    main = (ROOT / "ainb-tui/crates/ainb-core/src/main.rs").read_text()
+    routed = re.search(r"SKILL_MANAGER_CLI_COMMANDS[^=]*=\s*&?\[([^\]]*)\]", main, re.S)
+    routed_n = len(re.findall(r'"[^"]+"', routed.group(1))) if routed else 0
+    return registry + 2 + routed_n
+
+
+def tool_adapters() -> list[str]:
+    txt = (ROOT / "ainb-tui/crates/ainb-adapters-tool/src/lib.rs").read_text()
+    m = re.search(r"fn adapter_by_name.*?match name \{(.*?)\n    \}", txt, re.S)
+    return re.findall(r'"([a-z-]+)"\s*=>', m.group(1)) if m else []
+
+
+def rpc_method_count() -> int:
+    txt = (ROOT / "ainb-tui/crates/ainb-hangar-proto/src/methods.rs").read_text()
+    m = re.search(r"ALL_METHODS[^=]*=\s*&?\[(.*?)\];", txt, re.S)
+    if not m:
+        return 0
+    return len([
+        x for x in m.group(1).split(",")
+        if x.strip() and not x.strip().startswith("//")
+    ])
+
+
+def toolkit_counts() -> tuple[int, int]:
+    """Skills and agents from the toolkit's generated catalog, if reachable."""
+    try:
+        import yaml  # noqa: PLC0415
+    except ImportError:
+        return (0, 0)
+    try:
+        url = "repos/stevengonsalvez/ainb-toolkit/contents/catalog.yaml"
+        raw = subprocess.run(
+            ["gh", "api", url, "--jq", ".download_url"],
+            capture_output=True, text=True, timeout=25, check=True,
+        ).stdout.strip()
+        body = subprocess.run(
+            ["curl", "-sL", "--max-time", "25", raw],
+            capture_output=True, text=True, timeout=30, check=True,
+        ).stdout
+        cat = yaml.safe_load(body)["components"]
+        return (len(cat["skills"]), sum(len(v) for v in cat["agents"].values()))
+    except Exception:  # noqa: BLE001 - offline is fine, we just omit the numbers
+        return (0, 0)
+
+
+# ------------------------------------------------------------------ drawing
+
+W, H = 1660, 930
+PAD = 36
+
+LIGHT = dict(bg="#FAF9F5", card="#FFFFFF", edge="#E4E0D8", ink="#141413",
+             mute="#6B655B", chip="#F4F1EA", accent="#C25A38", alt="#5F7048",
+             line="#8A857C")
+DARK = dict(bg="#0F0F18", card="#191923", edge="#2E2E3E", ink="#DCDCE6",
+            mute="#9A9AB0", chip="#20202C", accent="#E08A63", alt="#8FA86B",
+            line="#7A7A92")
+
+parts: list[str] = []
+
+
+def esc(t: object) -> str:
+    return escape(str(t))
+
+
+def text(x, y, s, size=13, cls="ink", weight=None, anchor="start"):
+    w = f' font-weight="{weight}"' if weight else ""
+    parts.append(
+        f'<text x="{x}" y="{y}" font-size="{size}" class="{cls}" fill="{LIGHT[cls]}"'
+        f' text-anchor="{anchor}"{w}>{esc(s)}</text>'
+    )
+
+
+def box(x, y, w, h, cls="card", rx=10):
+    parts.append(
+        f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{rx}" class="{cls}"'
+        f' fill="{LIGHT[cls]}" stroke="{LIGHT["edge"]}" stroke-width="1"/>'
+    )
+
+
+def section(x, y, w, h, num, title, subtitle):
+    box(x, y, w, h, "card")
+    parts.append(
+        f'<rect x="{x}" y="{y}" width="4" height="{h}" rx="2"'
+        f' class="accentfill" fill="{LIGHT["accent"]}"/>'
+    )
+    text(x + 18, y + 28, num, 15, "accent", 800)
+    text(x + 38, y + 28, title, 15, "ink", 700)
+    text(x + 18, y + 48, subtitle, 11.5, "mute")
+
+
+def chip(x, y, w, h, label, sub=None):
+    box(x, y, w, h, "chip", 7)
+    text(x + 11, y + 20, label, 12, "ink", 600)
+    if sub:
+        text(x + 11, y + 35, sub, 10, "mute")
+
+
+def grid(x, y, items, cols, cw, ch, gap=9):
+    """Lay chips out in a grid; return the y just below the last row."""
+    for i, it in enumerate(items):
+        chip(x + (i % cols) * (cw + gap), y + (i // cols) * (ch + gap),
+             cw, ch, it[0], it[1] if len(it) > 1 else None)
+    return y + ((len(items) + cols - 1) // cols) * (ch + gap)
+
+
+def arrow(x1, y1, x2, y2, cls="line", dash=False):
+    d = ' stroke-dasharray="5 4"' if dash else ""
+    marker = "arrAlt" if cls == "alt" else "arr"
+    parts.append(
+        f'<path d="M{x1} {y1} L{x2} {y2}" class="{cls}" fill="none"'
+        f' stroke="{LIGHT[cls]}" stroke-width="1.6"{d} marker-end="url(#{marker})"/>'
+    )
+
+
+def build() -> str:
+    crates, ver = crate_count(), workspace_version()
+    plugins, daemons = staged_plugins(), daemon_kinds()
+    screens, cmds = screen_count(), cli_command_count()
+    adapters, rpcs = tool_adapters(), rpc_method_count()
+    skills, agents = toolkit_counts()
+
+    parts.clear()
+    colw = (W - PAD * 2 - 28) // 2
+    left, right = PAD, PAD + colw + 28
+
+    text(PAD, 44, "agents-in-a-box", 26, "ink", 800)
+    parts.append(
+        f'<rect x="{PAD}" y="54" width="238" height="4" rx="2"'
+        f' class="accentfill" fill="{LIGHT["accent"]}"/>'
+    )
+    text(PAD + 258, 44, "Ecosystem architecture", 15, "mute")
+    text(W - PAD, 44, f"ainb v{ver} · {crates}-crate Rust workspace",
+         12, "mute", anchor="end")
+
+    # 1 - TUI host
+    y = 84
+    section(left, y, colw, 292, "1", "ainb TUI host",
+            f"one binary · {screens} screens · {cmds} CLI commands · Unix only")
+    yy = grid(left + 18, y + 64, [
+        ("git worktrees", "a branch and a directory per session"),
+        ("tmux / PTY", "attach · send-keys · survives sleep"),
+        ("provider adapters", "claude · codex · gemini · copilot"),
+        ("session store", "~/.agents-in-a-box/"),
+    ], 2, (colw - 45) // 2, 48)
+    chip(left + 18, yy + 4, colw - 36, 44, "screens",
+         "home · sessions · fleet · hangar · inbox · stats · review · daemons · skills")
+    chip(left + 18, yy + 56, colw - 36, 44, "config",
+         "config.toml · favorites · presets · plugin root")
+
+    # 2 - plugin host
+    section(right, y, colw, 292, "2", "Plugin host (v2 ABI)",
+            "subprocess · JSON-RPC 2.0 over stdio · capabilities default-deny")
+    yy = grid(right + 18, y + 64, [(p,) for p in plugins], 3,
+              (colw - 54) // 3, 34)
+    chip(right + 18, yy + 8, colw - 36, 44, "runtime",
+         "spawn · lifecycle FSM · snapshot bus · render frames · -32001 on denial")
+    chip(right + 18, yy + 60, colw - 36, 44, "SDK + conformance",
+         "protocol · sdk-rust · testkit · cts-v2 (21 axes)")
+
+    # 3 - daemons. These are NOT plugins; the old diagram put notifyd in the
+    # plugin box, which was the most misleading thing on it.
+    y2 = y + 312
+    section(left, y2, W - PAD * 2, 164, "3", "Daemons",
+            "long-lived processes the TUI supervises · started, stopped and "
+            "health-checked from the Daemons screen")
+    blurb = {
+        "notifyd": "notifications into the Inbox",
+        "hangar-daemon": f"boards · tasks · {rpcs} RPC methods",
+        "mcp-pool": "one MCP server, shared",
+        "headroom-proxy": "context compression",
+        "atc": "always-on watcher",
+        "bridge": "Telegram · Slack · Discord",
+        "approve-broker": "permission prompts",
+        "fleet-daemon": "API-error auto-continue",
+        "release-checker": "signed update check",
+    }
+    grid(left + 18, y2 + 64, [(d, blurb.get(d, "")) for d in daemons], 5,
+         (W - PAD * 2 - 36 - 4 * 9) // 5, 44)
+
+    # 4 - toolkit
+    y3 = y2 + 184
+    section(left, y3, colw, 168, "4", "Toolkit (separate repo)",
+            "stevengonsalvez/ainb-toolkit · consumed as a pinned source")
+    chip(left + 18, y3 + 64, colw - 36, 44,
+         f"{skills} skills · {agents} agents" if skills else "skills · agents · workflows",
+         "written once, deployed everywhere")
+    chip(left + 18, y3 + 114, colw - 36, 44,
+         f"{len(adapters)} tool homes", " · ".join(adapters))
+
+    # 5 - memory
+    section(right, y3, colw, 168, "5", "Memory (separate repo)",
+            "stevengonsalvez/ainb-reflect-memory · CLI only, no library API")
+    chip(right + 18, y3 + 64, colw - 36, 44, "reflect",
+         "/reflect captures · /recall retrieves")
+    chip(right + 18, y3 + 114, colw - 36, 44, "two-tier index",
+         "GraphRAG across projects · vector search for fast hits")
+
+    # 6 - distribution
+    y4 = y3 + 188
+    section(left, y4, W - PAD * 2, 100, "6", "Distribution",
+            "how it reaches a machine, and how it is documented")
+    grid(left + 18, y4 + 62, [
+        ("Homebrew", "brew install ainb"),
+        ("install.sh", "one-liner elsewhere"),
+        ("docs/", "single source of truth"),
+        ("ainb.app", "Astro Starlight on Pages"),
+    ], 4, (W - PAD * 2 - 36 - 3 * 9) // 4, 32)
+
+    arrow(left + colw // 2, y + 292, left + colw // 2, y2 - 4)
+    arrow(right + colw // 2, y + 292, right + colw // 2, y2 - 4)
+    arrow(left + colw // 2, y2 + 164, left + colw // 2, y3 - 4, "alt", True)
+    arrow(right + colw // 2, y2 + 164, right + colw // 2, y3 - 4, "alt", True)
+
+    ly = y4 + 124
+    text(PAD, ly, "Solid: supervises.   Dashed: reads and writes.", 11.5, "mute")
+    text(W - PAD, ly,
+         "Regenerate: python3 docs/assets/diagrams/generate-diagrams.py",
+         11.5, "mute", anchor="end")
+
+    d = DARK
+    style = (
+        'text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",'
+        '"Helvetica Neue",Arial,sans-serif;}'
+        "@media (prefers-color-scheme: dark){"
+        f".bg{{fill:{d['bg']};}}"
+        f".ink{{fill:{d['ink']};}}.mute{{fill:{d['mute']};}}"
+        f".accent{{fill:{d['accent']};}}.accentfill{{fill:{d['accent']};}}"
+        f".card{{fill:{d['card']};stroke:{d['edge']};}}"
+        f".chip{{fill:{d['chip']};stroke:{d['edge']};}}"
+        f".line{{stroke:{d['line']};}}.alt{{stroke:{d['alt']};}}"
+        f".linefill{{fill:{d['line']};}}.altfill{{fill:{d['alt']};}}"
+        "}"
+    )
+
+    return wrap(W, H, "agents-in-a-box ecosystem architecture: the TUI host, "
+                "the v2 plugin host, the daemons it supervises, the separate "
+                "toolkit and memory repos, and distribution"), dict(
+        crates=crates, ver=ver, screens=screens, cmds=cmds, plugins=plugins,
+        daemons=daemons, adapters=adapters, rpcs=rpcs, skills=skills,
+        agents=agents,
+    )
+
+
+def wrap(w: int, h: int, label: str) -> str:
+    """Close the current `parts` buffer into a finished SVG document."""
+    d = DARK
+    style = (
+        'text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",'
+        '"Helvetica Neue",Arial,sans-serif;}'
+        "@media (prefers-color-scheme: dark){"
+        f".bg{{fill:{d['bg']};}}"
+        f".ink{{fill:{d['ink']};}}.mute{{fill:{d['mute']};}}"
+        f".accent{{fill:{d['accent']};}}.accentfill{{fill:{d['accent']};}}"
+        f".card{{fill:{d['card']};stroke:{d['edge']};}}"
+        f".chip{{fill:{d['chip']};stroke:{d['edge']};}}"
+        f".line{{stroke:{d['line']};}}.alt{{stroke:{d['alt']};}}"
+        f".linefill{{fill:{d['line']};}}.altfill{{fill:{d['alt']};}}"
+        "}"
+    )
+    body = "\n  ".join(parts)
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}"'
+        f' width="{w}" height="{h}" role="img" aria-label="{esc(label)}">\n'
+        f"  <style>{style}</style>\n"
+        f"  <defs>\n"
+        f'    <marker id="arr" markerWidth="9" markerHeight="8" refX="7.5"'
+        f' refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8"'
+        f' class="linefill" fill="{LIGHT["line"]}"/></marker>\n'
+        f'    <marker id="arrAlt" markerWidth="9" markerHeight="8" refX="7.5"'
+        f' refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8"'
+        f' class="altfill" fill="{LIGHT["alt"]}"/></marker>\n'
+        f"  </defs>\n"
+        f'  <rect width="{w}" height="{h}" class="bg" fill="{LIGHT["bg"]}"/>\n'
+        f"  {body}\n</svg>\n"
+    )
+
+
+def build_plugin_diagram() -> tuple[str, dict]:
+    """The v2 plugin ABI: what the host owns, what a plugin owns, and the two
+    ways a plugin can put pixels on screen."""
+    plugins = staged_plugins()
+    pw, ph = 1500, 800
+    parts.clear()
+
+    text(PAD, 44, "ainb v2 plugin architecture", 24, "ink", 800)
+    parts.append(
+        f'<rect x="{PAD}" y="54" width="238" height="4" rx="2"'
+        f' class="accentfill" fill="{LIGHT["accent"]}"/>'
+    )
+    text(PAD, 74, "native subprocess · JSON-RPC 2.0 over Content-Length stdio",
+         13, "mute")
+
+    inner = pw - PAD * 2 - 36
+
+    # host
+    section(PAD, 98, pw - PAD * 2, 134, "1", "Host (binary: ainb)",
+            "owns the terminal · discovers, spawns and supervises every plugin")
+    grid(PAD + 18, 98 + 64, [
+        ("ainb-core", "ratatui TUI, owns the terminal"),
+        ("ainb-plugin-runtime", "discover · spawn · route · restart"),
+        ("capability gate", "default-deny, refuses with -32001"),
+    ], 3, (inner - 2 * 9) // 3, 44)
+
+    # the wire
+    section(PAD, 252, pw - PAD * 2, 128, "2", "The wire",
+            "one process per plugin, framed stdio, no shared memory")
+    grid(PAD + 18, 252 + 62, [
+        ("plugin/*", "init · render · handle_key · handle_event · cli_dispatch · shutdown"),
+        ("host/*", "snapshot get/publish/subscribe · action invoke · log · fs · fetch"),
+    ], 2, (inner - 9) // 2, 44)
+
+    # plugins
+    section(PAD, 400, pw - PAD * 2, 178, "3", f"Plugins ({len(plugins)} ship in-tree)",
+            "each declares its capabilities in manifest.toml; the host enforces them")
+    blurb = {
+        "burndown": "Stats screen · ainb usage",
+        "session-reader": "publisher, no screen",
+        "witr": "ainb witr · foreign TTY",
+        "learnings": "Memory screen · search",
+        "abtop": "agent monitor · foreign TTY",
+        "hangar-tui": "Hangar screen · daemon client",
+    }
+    grid(PAD + 18, 400 + 62, [(p, blurb.get(p, "")) for p in plugins], 3,
+         (inner - 2 * 9) // 3, 44)
+
+    # render modes
+    section(PAD, 598, pw - PAD * 2, 122, "4", "Two ways to draw",
+            "in-process frames, or hand the terminal over entirely")
+    grid(PAD + 18, 598 + 62, [
+        ("WireBuffer", "plugin returns frames, host composites them"),
+        ("foreign TTY", "host suspends, tmux attaches the real binary, host resumes"),
+    ], 2, (inner - 9) // 2, 44)
+
+    arrow(pw // 2, 232, pw // 2, 248)
+    arrow(pw // 2, 380, pw // 2, 396)
+
+    text(PAD, 762, "Capabilities are default-deny: a plugin reaches the network, "
+                   "the filesystem or your secrets only if its manifest asks and you agree.",
+         11.5, "mute")
+    text(pw - PAD, 762,
+         "Regenerate: python3 docs/assets/diagrams/generate-diagrams.py",
+         11.5, "mute", anchor="end")
+
+    return wrap(pw, ph, "ainb v2 plugin architecture: host, wire protocol, "
+                        "in-tree plugins and the two render modes"), {"plugins": plugins}
+
+
+if __name__ == "__main__":
+    svg, facts = build()
+    OUT_ECO.write_text(svg)
+    for k, v in facts.items():
+        print(f"  {k}: {v}")
+    psvg, pfacts = build_plugin_diagram()
+    OUT_PLUGIN.write_text(psvg)
+    print(f"  plugin diagram: {pfacts['plugins']}")
+    for f in (OUT_ECO, OUT_PLUGIN):
+        print(f"wrote {f.relative_to(ROOT)} ({f.stat().st_size} bytes)", file=sys.stderr)

--- a/docs/assets/diagrams/plugin-architecture.svg
+++ b/docs/assets/diagrams/plugin-architecture.svg
@@ -1,96 +1,74 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" width="960" height="700">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 800" width="1500" height="800" role="img" aria-label="ainb v2 plugin architecture: host, wire protocol, in-tree plugins and the two render modes">
+  <style>text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Arial,sans-serif;}@media (prefers-color-scheme: dark){.bg{fill:#0F0F18;}.ink{fill:#DCDCE6;}.mute{fill:#9A9AB0;}.accent{fill:#E08A63;}.accentfill{fill:#E08A63;}.card{fill:#191923;stroke:#2E2E3E;}.chip{fill:#20202C;stroke:#2E2E3E;}.line{stroke:#7A7A92;}.alt{stroke:#8FA86B;}.linefill{fill:#7A7A92;}.altfill{fill:#8FA86B;}}</style>
   <defs>
-    <marker id="arrowA" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
-    </marker>
-    <marker id="arrowB" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/>
-    </marker>
-    <marker id="arrowC" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#2563eb"/>
-    </marker>
-    <marker id="arrowE" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#f97316"/>
-    </marker>
-    <marker id="arrowF" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#7c3aed"/>
-    </marker>
-    <marker id="arrowG" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/>
-    </marker>
-    <marker id="arrowH" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6b7280"/>
-    </marker>
-    <filter id="shadowSoft" x="-20%" y="-20%" width="140%" height="160%">
-      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#0f172a" flood-opacity="0.12"/>
-    </filter>
-    <filter id="shadowGlass" x="-20%" y="-20%" width="140%" height="160%">
-      <feDropShadow dx="0" dy="10" stdDeviation="16" flood-color="#020617" flood-opacity="0.28"/>
-    </filter>
-    <style>
-    text { font-family: 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif; }
-    .title { font-size: 30px; font-weight: 700; fill: #111827; }
-    .subtitle { font-size: 14px; font-weight: 500; fill: #6b7280; }
-    .section { font-size: 13px; font-weight: 700; fill: #2563eb; letter-spacing: 1.4px; }
-    .section-sub { font-size: 12px; font-weight: 500; fill: #94a3b8; }
-    .node-title { font-size: 18px; font-weight: 700; fill: #111827; }
-    .node-sub { font-size: 12px; font-weight: 500; fill: #6b7280; }
-    .node-type { font-size: 12px; font-weight: 700; fill: #9ca3af; letter-spacing: 0.08em; }
-    .arrow-label { font-size: 12px; font-weight: 600; fill: #6b7280; }
-    .legend { font-size: 12px; font-weight: 500; fill: #6b7280; }
-    .footnote { font-size: 12px; font-weight: 500; fill: #94a3b8; }
-    </style>
+    <marker id="arr" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" class="linefill" fill="#8A857C"/></marker>
+    <marker id="arrAlt" markerWidth="9" markerHeight="8" refX="7.5" refY="4" orient="auto"><polygon points="0 0, 8.5 4, 0 8" class="altfill" fill="#5F7048"/></marker>
   </defs>
-  <rect width="960.0" height="700.0" fill="#ffffff"/>
-  <text x="480.0" y="56" text-anchor="middle" class="title">ainb v2 plugin architecture</text>
-  <text x="480.0" y="82" text-anchor="middle" class="subtitle">native subprocess · JSON-RPC 2.0 over Content-Length stdio</text>
-  <path d="M 480.0,152.0 L 480.0,176.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
-  <path d="M 480.0,242.0 L 480.0,286.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
-  <path d="M 480.0,330.0 L 480.0,350.4 L 190.0,371.6 L 190.0,392.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
-  <path d="M 480.0,330.0 L 480.0,392.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
-  <path d="M 480.0,330.0 L 480.0,350.4 L 770.0,371.6 L 770.0,392.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
-  <path d="M 344.0,451.0 L 326.0,451.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)" stroke-dasharray="6,4"/>
-  <path d="M 770.0,510.0 L 770.0,566.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)" stroke-dasharray="6,4"/>
-  <rect x="290.0" y="78.0" width="380.0" height="74.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
-  <text x="480.0" y="96.0" text-anchor="middle" class="node-type">binary: ainb</text>
-  <text x="480.0" y="121.0" text-anchor="middle" class="node-title">ainb-core  ·  host</text>
-  <text x="480.0" y="143.0" text-anchor="middle" class="node-sub">ratatui TUI — owns the terminal</text>
-  <rect x="290.0" y="176.0" width="380.0" height="66.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
-  <text x="480.0" y="209.0" text-anchor="middle" class="node-title">ainb-plugin-runtime</text>
-  <text x="480.0" y="231.0" text-anchor="middle" class="node-sub">discover · spawn · route · capability gate (-32001)</text>
-  <rect x="120.0" y="286.0" width="720.0" height="44.0" rx="10.0" fill="#1f2937" stroke="#374151" stroke-width="1.8" filter="url(#shadowSoft)"/>
-  <text x="480.0" y="308.0" text-anchor="middle" class="node-title">JSON-RPC 2.0   ·   Content-Length framed stdio</text>
-  <rect x="54.0" y="392.0" width="272.0" height="118.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
-  <text x="190.0" y="410.0" text-anchor="middle" class="node-type">WireBuffer render</text>
-  <text x="190.0" y="457.0" text-anchor="middle" class="node-title">burndown</text>
-  <text x="190.0" y="479.0" text-anchor="middle" class="node-sub">Analytics screen · ainb usage</text>
-  <rect x="344.0" y="392.0" width="272.0" height="118.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
-  <text x="480.0" y="410.0" text-anchor="middle" class="node-type">sessions.usage_data</text>
-  <text x="480.0" y="457.0" text-anchor="middle" class="node-title">session-reader</text>
-  <text x="480.0" y="479.0" text-anchor="middle" class="node-sub">publisher · no screen</text>
-  <rect x="634.0" y="392.0" width="272.0" height="118.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
-  <text x="770.0" y="410.0" text-anchor="middle" class="node-type">caps: spawn_subprocess</text>
-  <text x="770.0" y="457.0" text-anchor="middle" class="node-title">witr</text>
-  <text x="770.0" y="479.0" text-anchor="middle" class="node-sub">ainb witr CLI + /witr slash</text>
-  <rect x="634.0" y="566.0" width="272.0" height="64.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
-  <text x="770.0" y="598.0" text-anchor="middle" class="node-title">witr -i  (foreign TTY)</text>
-  <text x="770.0" y="620.0" text-anchor="middle" class="node-sub">host suspends → tmux attach → resume</text>
-  <rect x="459.0" y="150.0" width="42" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
-  <text x="480.0" y="164.0" text-anchor="middle" class="arrow-label">owns</text>
-  <rect x="399.0" y="250.0" width="126" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
-  <text x="462.0" y="264.0" text-anchor="middle" class="arrow-label">plugin/* methods</text>
-  <rect x="261.5" y="331.0" width="147" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
-  <text x="335.0" y="345.0" text-anchor="middle" class="arrow-label">render · handle_key</text>
-  <rect x="576.0" y="331.0" width="98" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
-  <text x="625.0" y="345.0" text-anchor="middle" class="arrow-label">cli_dispatch</text>
-  <rect x="244.0" y="437.0" width="182" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
-  <text x="335.0" y="451.0" text-anchor="middle" class="arrow-label">usage_data via event bus</text>
-  <rect x="685.5" y="524.0" width="133" height="20" rx="6" fill="#ffffff" opacity="0.94"/>
-  <text x="752.0" y="538.0" text-anchor="middle" class="arrow-label">press w → handoff</text>
-  <line x1="42.0" y1="600.0" x2="72.0" y2="600.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
-  <text x="82.0" y="604.0" class="legend">JSON-RPC (render / keys / cli)</text>
-  <line x1="42.0" y1="622.0" x2="72.0" y2="622.0" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
-  <text x="82.0" y="626.0" class="legend">event-bus snapshot data</text>
-  <line x1="42.0" y1="644.0" x2="72.0" y2="644.0" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
-  <text x="82.0" y="648.0" class="legend">foreign-TTY handoff (dashed)</text>
+  <rect width="1500" height="800" class="bg" fill="#FAF9F5"/>
+  <text x="36" y="44" font-size="24" class="ink" fill="#141413" text-anchor="start" font-weight="800">ainb v2 plugin architecture</text>
+  <rect x="36" y="54" width="238" height="4" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="36" y="74" font-size="13" class="mute" fill="#6B655B" text-anchor="start">native subprocess · JSON-RPC 2.0 over Content-Length stdio</text>
+  <rect x="36" y="98" width="1428" height="134" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="98" width="4" height="134" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="126" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">1</text>
+  <text x="74" y="126" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Host (binary: ainb)</text>
+  <text x="54" y="146" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">owns the terminal · discovers, spawns and supervises every plugin</text>
+  <rect x="54" y="162" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="182" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">ainb-core</text>
+  <text x="65" y="197" font-size="10" class="mute" fill="#6B655B" text-anchor="start">ratatui TUI, owns the terminal</text>
+  <rect x="521" y="162" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="532" y="182" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">ainb-plugin-runtime</text>
+  <text x="532" y="197" font-size="10" class="mute" fill="#6B655B" text-anchor="start">discover · spawn · route · restart</text>
+  <rect x="988" y="162" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="999" y="182" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">capability gate</text>
+  <text x="999" y="197" font-size="10" class="mute" fill="#6B655B" text-anchor="start">default-deny, refuses with -32001</text>
+  <rect x="36" y="252" width="1428" height="128" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="252" width="4" height="128" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="280" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">2</text>
+  <text x="74" y="280" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">The wire</text>
+  <text x="54" y="300" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">one process per plugin, framed stdio, no shared memory</text>
+  <rect x="54" y="314" width="691" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="334" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">plugin/*</text>
+  <text x="65" y="349" font-size="10" class="mute" fill="#6B655B" text-anchor="start">init · render · handle_key · handle_event · cli_dispatch · shutdown</text>
+  <rect x="754" y="314" width="691" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="765" y="334" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">host/*</text>
+  <text x="765" y="349" font-size="10" class="mute" fill="#6B655B" text-anchor="start">snapshot get/publish/subscribe · action invoke · log · fs · fetch</text>
+  <rect x="36" y="400" width="1428" height="178" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="400" width="4" height="178" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="428" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">3</text>
+  <text x="74" y="428" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Plugins (6 ship in-tree)</text>
+  <text x="54" y="448" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">each declares its capabilities in manifest.toml; the host enforces them</text>
+  <rect x="54" y="462" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="482" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">burndown</text>
+  <text x="65" y="497" font-size="10" class="mute" fill="#6B655B" text-anchor="start">Stats screen · ainb usage</text>
+  <rect x="521" y="462" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="532" y="482" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">session-reader</text>
+  <text x="532" y="497" font-size="10" class="mute" fill="#6B655B" text-anchor="start">publisher, no screen</text>
+  <rect x="988" y="462" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="999" y="482" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">witr</text>
+  <text x="999" y="497" font-size="10" class="mute" fill="#6B655B" text-anchor="start">ainb witr · foreign TTY</text>
+  <rect x="54" y="515" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="535" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">learnings</text>
+  <text x="65" y="550" font-size="10" class="mute" fill="#6B655B" text-anchor="start">Memory screen · search</text>
+  <rect x="521" y="515" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="532" y="535" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">abtop</text>
+  <text x="532" y="550" font-size="10" class="mute" fill="#6B655B" text-anchor="start">agent monitor · foreign TTY</text>
+  <rect x="988" y="515" width="458" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="999" y="535" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">hangar-tui</text>
+  <text x="999" y="550" font-size="10" class="mute" fill="#6B655B" text-anchor="start">Hangar screen · daemon client</text>
+  <rect x="36" y="598" width="1428" height="122" rx="10" class="card" fill="#FFFFFF" stroke="#E4E0D8" stroke-width="1"/>
+  <rect x="36" y="598" width="4" height="122" rx="2" class="accentfill" fill="#C25A38"/>
+  <text x="54" y="626" font-size="15" class="accent" fill="#C25A38" text-anchor="start" font-weight="800">4</text>
+  <text x="74" y="626" font-size="15" class="ink" fill="#141413" text-anchor="start" font-weight="700">Two ways to draw</text>
+  <text x="54" y="646" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">in-process frames, or hand the terminal over entirely</text>
+  <rect x="54" y="660" width="691" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="65" y="680" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">WireBuffer</text>
+  <text x="65" y="695" font-size="10" class="mute" fill="#6B655B" text-anchor="start">plugin returns frames, host composites them</text>
+  <rect x="754" y="660" width="691" height="44" rx="7" class="chip" fill="#F4F1EA" stroke="#E4E0D8" stroke-width="1"/>
+  <text x="765" y="680" font-size="12" class="ink" fill="#141413" text-anchor="start" font-weight="600">foreign TTY</text>
+  <text x="765" y="695" font-size="10" class="mute" fill="#6B655B" text-anchor="start">host suspends, tmux attaches the real binary, host resumes</text>
+  <path d="M750 232 L750 248" class="line" fill="none" stroke="#8A857C" stroke-width="1.6" marker-end="url(#arr)"/>
+  <path d="M750 380 L750 396" class="line" fill="none" stroke="#8A857C" stroke-width="1.6" marker-end="url(#arr)"/>
+  <text x="36" y="762" font-size="11.5" class="mute" fill="#6B655B" text-anchor="start">Capabilities are default-deny: a plugin reaches the network, the filesystem or your secrets only if its manifest asks and you agree.</text>
+  <text x="1464" y="762" font-size="11.5" class="mute" fill="#6B655B" text-anchor="end">Regenerate: python3 docs/assets/diagrams/generate-diagrams.py</text>
 </svg>

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -14,7 +14,7 @@ Plugins only see the host capabilities they declare in their manifest, and they 
 
 ## Architecture at a glance
 
-![ainb v2 plugin architecture — host, JSON-RPC stdio, plugin subprocesses, capability gate, event bus](../assets/diagrams/plugin-architecture.svg)
+![ainb v2 plugin architecture: the host and its runtime, the JSON-RPC method sets on each side of the wire, the six in-tree plugins, and the two ways a plugin can draw](../assets/diagrams/plugin-architecture.svg)
 
 The host (`ainb-core`) spawns each plugin as a child process and drives it over **JSON-RPC 2.0 / Content-Length-framed stdio**. Host→plugin methods: `plugin/init` (with the granted capabilities), `plugin/render` (host sends a `Viewport`, plugin returns a `WireBuffer`), `plugin/handle_key`, `plugin/handle_event`, `plugin/cli_dispatch`, `plugin/shutdown`. Plugin→host (reverse) calls: `host/snapshot/publish` + `host/snapshot/subscribe` (the **event bus**) and `host/action/invoke`. The `ainb-plugin-runtime` enforces capabilities — an ungranted host-fn call comes back as JSON-RPC `-32001` (`CAPABILITY_DENIED`).
 

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -10,7 +10,7 @@ How the four components of agents-in-a-box fit together.
 
 ## Ecosystem map
 
-![agents-in-a-box ecosystem architecture — ainb TUI Rust workspace, JSON-RPC plugin host, fleet orchestration, portable toolkit deploying to 9+ tool homes, reflect GraphRAG memory, and the on-disk state that ties them together](../assets/diagrams/ecosystem-architecture.svg)
+![agents-in-a-box ecosystem architecture: the ainb TUI host, the v2 plugin host and its six in-tree plugins, the nine daemons the TUI supervises, the separate toolkit and reflect-memory repos, and how it is distributed](../assets/diagrams/ecosystem-architecture.svg)
 
 Solid arrows are data/control flow, dashed arrows are writes and feedback, clay is fleet prompt delivery, and olive is the learning loop. The small hops where lines cross are jump-overs — the lines do not connect.
 

--- a/docs/product/value.md
+++ b/docs/product/value.md
@@ -81,7 +81,7 @@ opening anything.
 
 ### It scripts
 
-Every TUI action has a CLI equivalent across 40 commands, and session state,
+Every TUI action has a CLI equivalent across 41 commands, and session state,
 config, git, usage, fleet and most daemons speak `--format json`. Pipe it to
 `jq`, drive it from CI.
 

--- a/docs/product/value.md
+++ b/docs/product/value.md
@@ -2,75 +2,146 @@
 title: "Value proposition"
 ---
 
-What you get when you adopt agents-in-a-box.
+What changes about your day when you adopt agents-in-a-box.
 
 ---
 
 ## The promise
 
-**Run agents. Worktree per session. No cross-contamination.**
+**Run a fleet. Lose nothing.**
 
-That's the whole pitch. The rest is what makes it real:
+Every agent gets its own worktree, its own tmux session, and a line item on your
+bill. One agent is a chat window. Five agents is an operations problem, and that
+is the part nothing else solves.
 
 ---
 
-## What you get
+## What changes
 
-### Multi-provider session management in one tool
+### Your agents stop destroying each other's work
 
-Spawn Claude Code, Codex, Gemini, Copilot, Kiro, or a raw shell session from the same interface. Model picker per session (Sonnet · Opus · Haiku). Keyboard-driven. No web dashboard.
+Every session gets its own branch and its own worktree directory. No stash
+dance, no index lock races, no half-committed file from one agent landing in
+another's diff. Worktrees are cleaned up when a session is killed cleanly.
 
-### Git worktree isolation by default
+### Closing your laptop stops costing you a session
 
-Every session gets its own branch and worktree directory. No stash dance. No cross-contamination between parallel sessions. Auto-cleanup when sessions are killed cleanly.
+Sessions are tmux-backed, so they survive terminal disconnects, SSH drops and
+sleep. Reattach with `ainb attach <name>` or from the TUI and keep typing. When
+something does die badly, `ainb recover` finds the orphans and resumes them
+rather than leaving you to read `tmux ls` and guess.
 
-### tmux-backed persistence
+### You stop polling your own agents
 
-Sessions survive terminal disconnects, SSH drops, laptop sleep. Reattach any time with `ainb attach <name>` or via the TUI.
+Press `f` and the Fleet panel tells you which agents are blocked on you right
+now, and what they asked. Answer from that one screen without attaching to
+anything. Every approval, completion and error lands in a single Inbox instead
+of scattering across panes you have to remember to check.
 
-### Built-in usage analytics
+### Work happens while you are not watching
 
-Token and session attribution per day, week, project, model, and provider. Burndown dashboard with optimisation hints. No external service needed — reads local JSONL logs.
+Hangar holds a board of tasks that agents pull from, so you stop being the
+scheduler. Squads fan one job across several agents instead of running them one
+at a time. Autopilots fire on a schedule and report back. ATC is an always-on
+watcher that works the queue while you are away.
 
-### Scriptable end-to-end
+### You see what an agent changed before you trust it
 
-Every TUI operation is also a CLI subcommand. `--format json` on every command. Pipe to `jq`, drive from CI, automate workflows.
+Hunk-by-hunk review with syntax highlighting and word-level emphasis, on the
+session's real diff. `ainb diff-review` does the same thing headless, so a
+review can gate a merge without opening the TUI at all.
 
-### A portable toolkit that follows you across tools
+### The bill stops surprising you
 
-94 skills (plan, implement, validate, commit, swarm-create, …) and 16 specialised agents (backend-developer, code-reviewer, security-agent, deep-reasoner, …). Write them once; deploy to Claude Code, Codex, Copilot, Gemini, Amazon Q, Cursor, Cline, Roo, and Claude Desktop. One source, 9 targets. The toolkit lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo; ainb's skill manager syncs from it as a pinned external source.
+Token and cost attribution per day, week, project, model and provider, read from
+local JSONL logs with no external service involved. Per-project attribution
+tells you which repo actually burned the budget, which no provider console will.
+Headroom compresses context on opted-in sessions so a long run stops walking
+into the context wall.
 
-### A plugin system you can actually use
+### You stop re-explaining your codebase
 
-Add a TUI screen, a CLI subcommand, a statusline segment without forking the host. Native binaries over JSON-RPC. Capability-gated — your plugin can't reach the network unless you say it can. Two reference implementations ship in-tree; copy-paste a starting point.
+`/reflect` captures the non-obvious things you work out during a session.
+`/recall` brings them back in the next one. GraphRAG underneath for cross-project
+questions, vector search for fast hits.
 
-### A knowledge system that learns across sessions
+### Your rules follow you between tools
 
-`/reflect` captures non-obvious learnings as you work. `/recall` retrieves them in future sessions. GraphRAG underneath for cross-project queries; QMD vector search for fast hits. 170+ learnings indexed across the maintainer's own dev work, growing.
+94 skills and 16 specialised agents, written once and deployed to Claude Code,
+Codex, Copilot, Gemini, Amazon Q, Cursor, Cline, Roo and Claude Desktop. One
+source, nine targets, so a rule you fix stays fixed everywhere instead of drifting
+between nine copies.
+
+### It reaches past your terminal
+
+Bridge the fleet to Telegram, Slack or Discord and answer an agent from your
+phone. `ainb web` serves a read-only dashboard for a glance from a browser. The
+Claude Code statusline can carry your live rate-limit and spend without you
+opening anything.
+
+### It scripts
+
+Every TUI action has a CLI equivalent across 40 commands, and session state,
+config, git, usage, fleet and most daemons speak `--format json`. Pipe it to
+`jq`, drive it from CI.
+
+### You can extend it without forking
+
+Add a TUI screen, a CLI subcommand or a statusline segment as a native binary
+speaking JSON-RPC. Capabilities are default-deny, so a plugin cannot reach the
+network or your secrets unless its manifest says so and you agree. Six plugins
+ship in-tree as worked examples.
 
 ---
 
 ## What it costs you
 
-- **One install command.** `brew install ainb` (macOS, Linux). One-liner `install.sh` for everything else.
-- **No subscription.** MIT-licensed. No accounts, no metering.
-- **No vendor lock-in.** ainb-toolkit deploys to 11 AI tools; the TUI orchestrates four providers. You can swap out any layer.
-- **No cloud dependency.** Everything runs locally. The only network traffic is what your AI provider (Claude, Codex, etc.) makes on your behalf.
+- **One install command.** `brew install ainb` on macOS and Linux, an
+  `install.sh` one-liner elsewhere.
+- **No subscription.** MIT-licensed, no accounts, no metering.
+- **No cloud dependency.** Everything runs locally. The only network traffic is
+  what your AI provider makes on your behalf.
+- **No vendor lock-in.** The TUI talks to providers through a PTY, not an SDK,
+  so swapping a layer is a config change rather than a migration.
 
 ---
 
-## What it's worth
+## What it will not do
 
-If you're running ≥2 parallel AI coding sessions a week and tracking your own token spend, agents-in-a-box pays for itself in the first week — purely on saved worktree-management toil. The burndown dashboard alone replaces a dashboard you'd otherwise build yourself (or live without).
+Worth knowing before you install rather than twenty minutes in:
 
-If you're authoring AI skills or agents and supporting them across multiple tools (Claude Code + Codex + Copilot), the ainb-toolkit's deploy-everywhere bootstrap replaces nine custom packaging scripts.
+- **Worktrees isolate git state, not your environment.** Two agents still share
+  port 3000, your database and `node_modules`. If they need different services
+  running, that is still your problem to arrange.
+- **tmux and git are required**, not optional.
+- **No native Windows.** It uses PTY and POSIX file modes. WSL2 works.
+- **`ainb otel` sets up Grafana Alloy** to carry Claude Code's telemetry. ainb
+  does not emit telemetry of its own, and nothing here phones home.
+- **Memory starts empty.** The learnings browser is worth exactly what `reflect`
+  has written into it so far.
+- **ATC and headroom are opt-in**, needing a hook plugin and an external binary
+  respectively.
 
-If you're building a TUI extension or a custom analytics dashboard for your team's AI usage, the v2 plugin system lets you ship that as a 500-line binary instead of a fork.
+---
+
+## What it is worth
+
+Running two or more parallel sessions a week, the worktree and tmux handling
+alone pays for the install in the first week, and the burndown dashboard
+replaces one you would otherwise build or live without.
+
+Authoring skills or agents across several tools, the toolkit's deploy-everywhere
+bootstrap replaces the per-tool packaging scripts you would otherwise maintain
+by hand.
+
+Building a TUI extension or a team usage dashboard, the v2 plugin system lets
+you ship it as a small binary against a versioned contract instead of a fork you
+have to keep rebasing.
 
 ---
 
 ## See also
 
-- [What is agents-in-a-box?](what-is-ainb.md) — start-here
-- [Whole-system architecture](architecture.md) — diagram + components
+- [What is agents-in-a-box?](what-is-ainb.md) · start here
+- [Whole-system architecture](architecture.md) · diagram + components
 - [Install](../tui/install.md)

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -2,19 +2,41 @@
 title: "Architecture deep-dive"
 ---
 
-> **Status:** stub. Authoritative content currently lives at `docs/product/architecture.md + ainb-tui/CLAUDE.md`.
-> Migration of that file into this path is gated on Stevie's approval.
+Where to find the architecture documentation, by depth.
 
-Whole-monorepo architecture: every component, every boundary, every data flow.
+## Start here
 
-## What this page will contain
+[**Whole-system architecture**](../product/architecture.md) is the page you
+probably want. It carries the ecosystem diagram, the box diagram, the data and
+control flow walkthroughs, the on-disk layout and the boundary contracts
+between components.
 
-- Components recap
-- Boundary contracts
-- Data flow walkthroughs (session start, plugin spawn, snapshot fan-out, reflection capture)
-- On-disk layout (~/.agents-in-a-box/, ~/.claude/, ~/.reflect/, dist/plugins/)
-- Why the choices we made
+## By component
+
+| Component | Page |
+|---|---|
+| The TUI host: crates, threading, render loop | [TUI architecture](../tui/architecture.md) |
+| The v2 plugin ABI: wire format, capabilities, conformance | [Plugin spec v2](../plugins/spec-v2.md) |
+| Hangar: the managed-agents control plane | [Hangar architecture](../hangar/architecture.md) |
+| Knowledge capture and recall | [Knowledge system overview](../knowledge/overview.md) |
+| Which repo holds what | [Repositories](repositories.md) |
+
+## Diagrams
+
+The two system diagrams are generated, not drawn by hand, because the
+hand-drawn originals kept outliving the code they described. Regenerate them
+after any structural change:
+
+```bash
+python3 docs/assets/diagrams/generate-diagrams.py
+```
+
+The script reads crate count, workspace version, staged plugin ids, daemon
+kinds, screen and CLI command counts, tool adapters and the Hangar RPC registry
+straight from the source, and prints every figure it used so a reviewer can
+check them against the rendered diagram.
 
 ## See also
 
 - [Docs hub](../README.md)
+- [Glossary](glossary.md)


### PR DESCRIPTION
### The diagrams are now generated

Both were hand-authored SVG, which is why they drifted. The ecosystem map advertised **11 crates** and **v1.5** against a 34-crate workspace on **v1.22.13**, put **notifyd in the plugin box** when it is a daemon, and omitted Hangar, ATC, headroom, the MCP pool, abtop and learnings entirely. The plugin diagram showed 3 plugins out of 6.

`generate-diagrams.py` reads from source: crate count (via `cargo metadata`, so `default-members` cannot inflate it the way a grep does), workspace version, staged plugin ids, `DaemonKind` ids, screen and CLI counts, tool adapters, and the Hangar RPC registry. It prints every figure it used so a reviewer can check the render.

**It caught drift on its first run**: an `update` command had landed since the counts were last taken, so the real CLI surface is **41**, not 40. Corrected in the README and the value page.

Colours are presentation attributes with CSS only repainting for dark mode, because GitHub sanitises SVG CSS and both diagrams sit in the README. Verified zero `var()` references.

The ecosystem map now has a **separate Daemons band** for the nine supervised processes, which is the correction that matters most: readers were being told notifyd was a plugin.

### The value proposition now leads with outcomes

Every heading named a component ("a plugin system you can actually use", "multi-provider session management in one tool"), and the page stopped at session isolation, so Hangar, Fleet, ATC, the Inbox, the MCP pool, headroom, the bridge and the web dashboard were all invisible.

Eleven outcome headings now, plus a "what it will not do" section. Also drops two claims corrected elsewhere but still standing here: nine tool targets rather than eleven, and json on most commands rather than every one.

### Also

`docs/reference/architecture.md` was a stub saying the content lived elsewhere, gated on an approval that never came. It now routes by depth and documents how to regenerate the diagrams.

69 pages build, 0 broken links.