### PR TITLE
docs: finish the architecture audit (34 crates, fleet + hooks diagrams)

### DIFF
--- a/docs/assets/diagrams/ainb-fleet.svg
+++ b/docs/assets/diagrams/ainb-fleet.svg
@@ -57,8 +57,10 @@
   <text x="140.0" y="376.0" text-anchor="middle" class="node-sub">agent loads the skills</text>
   <rect x="300.0" y="120.0" width="290.0" height="200.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
   <text x="445.0" y="138.0" text-anchor="middle" class="node-type">TEACHING LAYER</text>
-  <text x="445.0" y="226.0" text-anchor="middle" class="node-title">ainb-fleet skills</text>
-  <text x="445.0" y="248.0" text-anchor="middle" class="node-sub">standup · broadcast · sequence · needs · fleet-needs · daemon</text>
+  <text x="445.0" y="212.0" text-anchor="middle" class="node-title">ainb-fleet skills (12)</text>
+  <text x="445.0" y="234.0" text-anchor="middle" class="node-sub">standup · broadcast · sequence · needs</text>
+  <text x="445.0" y="252.0" text-anchor="middle" class="node-sub">fleet-needs · daemon · daemons · cost</text>
+  <text x="445.0" y="270.0" text-anchor="middle" class="node-sub">atc · bridge · ainb-fleet · ainb-spawn</text>
   <rect x="320.0" y="380.0" width="250.0" height="90.0" rx="10.0" fill="#ffffff" stroke="#d1d5db" stroke-width="1.8" filter="url(#shadowSoft)"/>
   <text x="445.0" y="398.0" text-anchor="middle" class="node-type">DETERMINISTIC</text>
   <text x="445.0" y="431.0" text-anchor="middle" class="node-title">hangar workflow</text>

--- a/docs/assets/diagrams/ainb-hooks.svg
+++ b/docs/assets/diagrams/ainb-hooks.svg
@@ -43,7 +43,7 @@
   </defs>
   <rect width="960.0" height="700.0" fill="#ffffff"/>
   <text x="480.0" y="56" text-anchor="middle" class="title">ainb-hooks — lifecycle events to the notification inbox</text>
-  <text x="480.0" y="82" text-anchor="middle" class="subtitle">CLAUDE CODE / CODEX PLUGIN · v0.1.0</text>
+  <text x="480.0" y="82" text-anchor="middle" class="subtitle">CLAUDE CODE / CODEX PLUGIN · v0.4.8</text>
   <path d="M 280.0,180.0 L 380.0,180.0" fill="none" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#arrowA)"/>
   <path d="M 590.0,180.0 L 690.0,180.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>
   <path d="M 790.0,225.0 L 790.0,330.0" fill="none" stroke="#f97316" stroke-width="2.4" marker-end="url(#arrowE)"/>

--- a/docs/tui/architecture.md
+++ b/docs/tui/architecture.md
@@ -6,23 +6,79 @@ title: "TUI architecture"
 
 ## Workspace crates
 
-Members are declared in `ainb-tui/Cargo.toml` (`default-members = ["crates/ainb-core"]`):
+34 members, declared in `ainb-tui/Cargo.toml`. `default-members` is
+`["crates/ainb-core", "crates/ainb-hangar-daemon"]`, so a bare `cargo build`
+produces the TUI and the Hangar daemon.
+
+### The host
 
 | Crate | Role |
-|-------|------|
-| `ainb-core` | The TUI app + `ainb` CLI binary. All screens, event loop, session/git/tmux/docker integration. |
-| `ainb-plugin-runtime` | Host-side plugin runtime that loads and supervises v2 plugins. |
-| `ainb-plugin-sdk-rust` | Rust SDK for authoring v2 plugins. |
-| `ainb-plugin-protocol` | Wire protocol / JSON-RPC types shared by host and plugins. |
-| `ainb-plugin-types-sessions` | Shared session data types exposed to plugins. |
-| `ainb-plugin-burndown` | In-tree v2 reference plugin: usage/burndown analytics. |
-| `ainb-plugin-notifyd` | In-tree v2 reference plugin: notifications. |
-| `ainb-plugin-session-reader` | In-tree v2 reference plugin: session data backend. |
-| `ainb-plugin-cts-v2` | Conformance test suite for the v2 plugin ABI. |
-| `ainb-plugin-testkit` | Test harness for plugin authors. |
-| `xtask` | Workspace task runner (build/release helpers). |
+|---|---|
+| `ainb-core` | The TUI app and the `ainb` binary: screens, event loop, session, git, tmux and provider integration. |
+| `ainb-cli` | The skill-manager CLI (`ainb skill`, `source`, `search`), routed before the async runtime starts. |
+| `ainb-web` | Read-only SSE web dashboard over the fleet. |
+| `xtask` | Workspace automation: builds canary plugins and release helpers. |
 
-The workspace pins `version = "1.2.0"`, Rust edition 2021, and forbids `unsafe_code`.
+### Plugin platform
+
+| Crate | Role |
+|---|---|
+| `ainb-plugin-protocol` | Wire types: JSON-RPC 2.0 envelopes, Content-Length framing, error codes. |
+| `ainb-plugin-runtime` | Host side: subprocess spawn, lifecycle FSM, snapshot and action bus, capability gate. |
+| `ainb-plugin-sdk-rust` | Rust SDK for writing a plugin. |
+| `ainb-plugin-testkit` | In-process harness so a plugin author can test without a subprocess. |
+| `ainb-plugin-cts-v2` | Conformance suite: 18 numbered axes plus 3 canaries, 21 in total. |
+| `ainb-plugin-types-sessions` | Shared session schema exposed across the wire. |
+
+### In-tree plugins
+
+Six, staged into `dist/plugins/<id>/` by `scripts/build-plugins.sh`.
+
+| Crate | Plugin id | Role |
+|---|---|---|
+| `ainb-plugin-burndown` | `burndown` | Usage and cost analytics; owns the Stats screen and `ainb usage`. |
+| `ainb-plugin-session-reader` | `session-reader` | Silent publisher: walks provider logs, feeds burndown. |
+| `ainb-plugin-witr` | `witr` | Process-causality tracing; wraps the external `witr` binary. |
+| `ainb-plugin-abtop` | `abtop` | Live agent-process monitor; wraps the external `abtop` binary. |
+| `ainb-plugin-learnings` | `learnings` | Browse, search and graph the knowledge base. |
+| `ainb-plugin-hangar` | `hangar-tui` | The Hangar screen; a client of the Hangar daemon. |
+
+> `ainb-plugin-notifyd` is **not** a plugin despite the crate name. It builds
+> the `ainb-notifyd` daemon, which listens on a Unix socket and writes to
+> SQLite; the Inbox screen reads that store. It has no plugin manifest and
+> speaks no plugin ABI.
+
+### Hangar
+
+Seven crates behind the managed-agents control plane.
+
+| Crate | Role |
+|---|---|
+| `ainb-hangar-core` | IO-free domain types: actors, ids, task status, clock. |
+| `ainb-hangar-proto` | The daemon's JSON-RPC surface; `ALL_METHODS` is the registry. |
+| `ainb-hangar-store` | SQLite pool, embedded migrations, repository wrappers. |
+| `ainb-hangar-client` | The one client onto the daemon's socket. |
+| `ainb-hangar-daemon` | The control plane itself: scheduler, task FSM, agent runner. |
+| `ainb-hangar-sandbox` | Filesystem-confined spawn wrapper (Seatbelt on macOS). |
+| `ainb-hangar-secrets` | Read/write bridge onto the OS keychain. |
+
+### Fleet, skills and support
+
+| Crate | Role |
+|---|---|
+| `ainb-fleet-core` | Session discovery, needs classification, verified tmux delivery. |
+| `ainb-fleet-tools` | The fleet copilot's MCP tool server. |
+| `ainb-acp` | Agent Client Protocol client, transcript reducer, store writer. |
+| `ainb-skill-core` | Manifest-driven install, sync and removal of skills and agents. |
+| `ainb-adapters-source` | Where units come from: git, local, marketplace. |
+| `ainb-adapters-tool` | Where units go: the nine tool homes. |
+| `ainb-diff` | Confirm-diff rendering for the skill installer. |
+| `ainb-fetch` | Shared HTTP fetch with caching. |
+| `ainb-usage` | Usage and cost primitives shared by burndown and fleet cost. |
+| `ainb-model-rates` | Per-model pricing tables. |
+
+Rust edition 2021, `unsafe_code` forbidden. Regenerate the counts above with
+`cargo metadata --no-deps`.
 
 ## ainb-core module tree
 


### PR DESCRIPTION
Second pass over the architecture surfaces, after the generated system diagrams landed in #788.

### The crate table listed 10 of 34

`docs/tui/architecture.md` stopped at the plugin platform, so the seven Hangar crates, the fleet crates, the skill-manager crates and three of the six in-tree plugins were undocumented. It also pinned the workspace at **1.2.0** (actual **1.22.13**) and gave `default-members` as just `ainb-core`, when the Hangar daemon is one too.

Now grouped by purpose, with plugin ids beside the crates that build them. Verified against `cargo metadata`: all 34 named, none missing.

It repeated the notifyd error too, listing `ainb-plugin-notifyd` as an "in-tree v2 reference plugin". It builds the `ainb-notifyd` daemon, has no manifest and speaks no plugin ABI. Called out explicitly, since the crate name invites the mistake.

### Two per-component diagrams

- **ainb-fleet** showed six skills on a line that already overflowed its box. There are twelve; now wrapped across three lines that fit.
- **ainb-hooks** claimed v0.1.0 against a `plugin.json` saying 0.4.8.

The other five (`burndown`, `notifyd`, `reflect`, `session-reader`, `witr`) I checked and left alone: they are tightly scoped and accurate, and notifyd's correctly draws it as a daemon.

69 pages build.