### PR TITLE
fix(hangar): close parked ACP permissions when the turn ends

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -1591,7 +1591,7 @@ impl SessionActor {
             }
         }
         self.pump().await;
-        self.cancel_parked().await;
+        self.cancel_parked("hangar-converge").await;
         // Close the queue BEFORE the last drain: after this a `submit_prompt`
         // gets `Closed` (answered `session_gone`) rather than landing a job in a
         // buffer nobody will ever read.
@@ -2006,7 +2006,7 @@ impl SessionActor {
         // first moment the turn is known to be over, not a second copy of the
         // repair. The process-exit route gets here an `EXIT_QUIESCE` later at
         // best, and only once this actor finishes the write set below.
-        self.cancel_parked().await;
+        self.cancel_parked("hangar-turn-end").await;
         // ONE transaction (I4): the reply, its receipt and the released session
         // land together or not at all. Four separate commits left a daemon
         // death between them showing an answer with no receipt, or a receipt
@@ -2492,7 +2492,7 @@ impl SessionActor {
         if let Ok(mut slot) = self.stats.turn_started_at.lock() {
             *slot = None;
         }
-        self.cancel_parked().await;
+        self.cancel_parked("hangar-converge").await;
         // BEFORE the shared routine, so each drained prompt carries its own
         // enumerated cause instead of being swept up as an anonymous stuck leg.
         self.drain_queue(cause.detail()).await;
@@ -2511,6 +2511,16 @@ impl SessionActor {
 
     /// Raise the attention row R8 exists for, and PARK the responder.
     async fn raise_permission(&mut self, permission: PermissionRequest) {
+        // No open turn means nothing is left to answer this. The request was
+        // already in the actor's channel when `finish_turn` retired the parked
+        // set, so raising it now would insert an attention row AFTER the
+        // receipt committed and the session went IDLE: the same ghost row
+        // `finish_turn` closes, through a narrower window. Refuse it at the
+        // door instead of parking a responder nobody will ever reach.
+        if self.turn.is_none() {
+            let _ = permission.answer_cancelled();
+            return;
+        }
         let fingerprint = permission_fingerprint(&self.session_key, &permission);
         let payload = serde_json::json!({
             "kind": "acp_permission",
@@ -2708,15 +2718,19 @@ impl SessionActor {
     }
 
     /// Answer every parked permission `Cancelled` and close its row.
-    /// Convergence's job: a permission whose adapter is gone must never survive
-    /// as a ghost row.
-    async fn cancel_parked(&mut self) {
+    /// A permission whose adapter is gone must never survive as a ghost row.
+    ///
+    /// `answered_by` is the caller's own name, not a constant: turn end and
+    /// convergence both retire parked permissions, and a row stamped
+    /// `hangar-converge` by the turn-end path would report a repair that never
+    /// ran, over-counting adapter crashes in any audit over that column.
+    async fn cancel_parked(&mut self, answered_by: &str) {
         let parked: Vec<ParkedPermission> = self.parked.drain().map(|(_, value)| value).collect();
         self.stats.pending_permissions.store(0, Ordering::Relaxed);
         for permission in parked {
             let attention_id = permission.attention_id;
             let _ = permission.request.answer_cancelled();
-            self.retire_attention(&attention_id, "hangar-converge", "cancelled").await;
+            self.retire_attention(&attention_id, answered_by, "cancelled").await;
         }
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -57,7 +57,9 @@
 //! * **A blocked permission is answerable.** `session/request_permission` parks
 //!   its responder here and raises an attention row; the answer arrives through
 //!   `fleet/action` and reaches the adapter's pending JSON-RPC id. A permission
-//!   whose adapter dies is resolved by convergence, never left as a ghost row.
+//!   whose adapter dies is retired the moment its turn ends, and by convergence
+//!   when no turn was open to end, never left as a ghost row for an operator to
+//!   click at a delivery they can already see resolved.
 //!   EVERY parked ask is answerable, not just the newest: an adapter running
 //!   parallel tool calls blocks on several at once, and `parked` (not
 //!   `fleet_session.current_request_fingerprint`, which has room for one) is
@@ -1992,6 +1994,19 @@ impl SessionActor {
                 body,
                 created_at: now,
             });
+        // A permission still parked when the turn ENDS has no answerable
+        // responder left: the adapter either died holding it (the `Err` leg) or
+        // finished the turn without waiting for it. It is retired HERE, BEFORE
+        // the receipt lands, because the receipt is what every reader treats as
+        // "this turn is over": left to convergence, the attention list keeps
+        // advertising an approval to click for a delivery the operator can
+        // already see resolved (R8/I7's ghost row). Convergence still does this
+        // and must, for a session with no open turn and for a daemon that died
+        // mid-turn; this is that same `cancel_parked` pulled forward to the
+        // first moment the turn is known to be over, not a second copy of the
+        // repair. The process-exit route gets here an `EXIT_QUIESCE` later at
+        // best, and only once this actor finishes the write set below.
+        self.cancel_parked().await;
         // ONE transaction (I4): the reply, its receipt and the released session
         // land together or not at all. Four separate commits left a daemon
         // death between them showing an answer with no receipt, or a receipt

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -1164,7 +1164,13 @@ async fn an_adapter_death_closes_every_parked_permission() {
             row_state, "answered",
             "{attention_id} survived its dead adapter as a ghost row"
         );
-        assert_eq!(answered_by.as_deref(), Some("hangar-converge"));
+        // `hangar-turn-end`, NOT `hangar-converge`: the adapter dying ends the
+        // turn, and `finish_turn` retires the parked set before the receipt
+        // commits. This assertion read `hangar-converge` while the turn-end
+        // path was doing the work under a shared constant, so it claimed to
+        // cover a branch it never reached. Pinning the real author keeps it
+        // honest, and keeps convergence's own coverage distinguishable.
+        assert_eq!(answered_by.as_deref(), Some("hangar-turn-end"));
     }
     let open: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM attention WHERE session_id = ? AND state = 'open'",

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -1298,7 +1298,7 @@ async fn an_adapter_death_mid_permission_leaves_no_ghost_row() {
         "the fixture process was live"
     );
 
-    // The ask closes on its own, with convergence named as the answerer.
+    // The ask closes on its own, named by whichever path got there first.
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         let (state, answered_by): (String, Option<String>) =
@@ -1309,7 +1309,19 @@ async fn an_adapter_death_mid_permission_leaves_no_ghost_row() {
                 .expect("attention row");
         if state != "open" {
             assert_eq!(state, "answered", "a ghost ask must be closed, not deleted");
-            assert_eq!(answered_by.as_deref(), Some("hangar-converge"));
+            // Turn end reaches a parked permission before convergence does:
+            // the adapter's death ends the turn, and `finish_turn` retires the
+            // parked set before the receipt commits. Convergence remains the
+            // path for a session with no open turn and for a daemon that died
+            // mid-turn, so accept either author rather than pinning the one
+            // that happens to lose the race.
+            assert!(
+                matches!(
+                    answered_by.as_deref(),
+                    Some("hangar-turn-end" | "hangar-converge")
+                ),
+                "a ghost ask must name the path that closed it, got {answered_by:?}"
+            );
             break;
         }
         assert!(


### PR DESCRIPTION
Fixes the intermittent `an_adapter_death_closes_every_parked_permission` failure in `acp_pool.rs`, most recently job 98167152900 (run 32965551214):

```
assertion `left == right` failed: 01M0YZT1CMKK98PAP5YR562SKH survived its dead adapter as a ghost row
  left:  "open"
 right: "answered"
```

### What was wrong

A permission parked when its adapter dies stayed open until the process-exit event reached the session actor, which is at least one `EXIT_QUIESCE` after the delivery receipt has already gone terminal. In that window the attention list advertises an approval to click for a turn the operator can already see resolved. With two permissions parked the window is wide enough for CI to catch it, which is why the single-permission sibling test `an_adapter_death_mid_permission_leaves_no_ghost_row` kept passing while this one did not.

### The fix

Retire every parked permission in `finish_turn`, before the receipt commits, so "the turn is over" and "nothing is still waiting on this session" land in one observable step. This is the existing `cancel_parked` pulled forward to the first moment the turn is known to be over, not a second copy of the repair. Convergence keeps doing it too, and must: it is still the only path for a session with no open turn to end, and for a daemon that died mid-turn.

### Review notes

- **Transaction boundary.** The new `cancel_parked().await` sits outside and immediately before `commit_turn_end`, the single I4 transaction. A crash in that window retires attention rows without the receipt landing, but the in-memory `parked` map dies with the process either way, and convergence still finishes the turn. The failure the transaction exists to prevent, a receipt landing for a session still marked mid-turn, is untouched.
- **Idempotent.** `cancel_parked` opens with `self.parked.drain()`, so convergence running afterwards iterates nothing.
- **Chokepoint.** `finish_turn` has exactly one caller. The three cancel sites now cover turn end, actor shutdown, and converge.
- **Span guards.** Passes CI's own gate, `cargo clippy -p ainb-hangar-daemon -p ainb-acp --lib -- -D clippy::await_holding_invalid_type`, exit 0.
- **Worth a second opinion:** the premise that a permission still parked at turn end has no answerable responder left. That is an assertion about adapter behaviour rather than something the code proves locally. If an adapter can legitimately keep a permission answerable past the end of its turn, this cancels it.

### Verification

- full `acp_pool` suite: 42 passed, 0 failed
- the target test looped 12 times through `cargo test`: 12 passed, 0 failed

A local loop cannot prove a rare race is gone. Several green CI runs are the real verdict.