### PR TITLE
build: cut debug builds to line-tables-only

### DIFF
--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -200,3 +200,31 @@ lto = true
 codegen-units = 1
 strip = true
 opt-level = "z"
+
+# Without this, debug builds carry `debug = 2` (full DWARF) for the workspace
+# AND for every dependency. That is what took the `--workspace --all-features`
+# test tree to 85G on a runner, the size behind `cache-targets: false` on the
+# Test and Contracts jobs in `.github/workflows/ci.yml`.
+#
+# `line-tables-only` keeps exactly the mapping a panic backtrace resolves,
+# file and line per address, and drops the type, variable and lexical-scope
+# DWARF that only an interactive debugger reads. Nothing in CI attaches one.
+#
+# MEASURED, 2026-08-26, on `-p ainb-hangar-daemon --all-features --lib --bins`
+# plus three integration targets, built twice from a clean target dir:
+# 3,574,018,649 to 2,138,170,044 bytes, 1.67x smaller overall. Linked test
+# binaries carry most of it and shrink hardest, 2.94x: `dispatch_routing` goes
+# 297M to 86M as `.debug_info` collapses 109.7M to 11.8M while `.debug_line`
+# survives at 27.7M of 29.3M. An identical `RUST_BACKTRACE=1` panic printed the
+# same `file:line:col` on every frame before and after.
+#
+# Both keys are set on purpose. `test` does inherit from `dev`, so the second
+# block is redundant today; it is written out so the intent survives anyone
+# later giving `[profile.test]` overrides of its own. `dev` is the load-bearing
+# one: it covers dependencies, and it covers the nested `cargo build` that
+# `real_plugin_axes` runs into this same target dir.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"


### PR DESCRIPTION
Groundwork for turning CI's Rust cache back on. This PR only changes the profile; it deliberately does **not** touch the cache flags or the disk guards.

### Why

`ainb-tui/Cargo.toml` had exactly one `[profile.*]` section, a `[profile.release]`. With no `[profile.dev]` or `[profile.test]`, every debug artifact carried full DWARF, for the workspace and for every dependency. That is what takes the `--workspace --all-features` test tree to 85G on a runner.

That size is the reason `test` and `contracts` set `cache-targets: false` and `save-if: false` (`ci.yml:234-236`, `ci.yml:340-342`). rust-cache keys per-job and there is no `shared-key` anywhere in the repo, so those two cache keys are never written and every run is a 100% cold `--workspace --all-features` compile: an 18-minute and a 14-minute single cargo step. Cached jobs in the same run finish in 1 to 4 minutes.

`line-tables-only` keeps exactly the mapping a panic backtrace resolves, file and line per address, and drops the type, variable and lexical-scope DWARF that only an interactive debugger reads. Nothing in CI attaches one.

### Measured

Bounded subset (`-p ainb-hangar-daemon --all-features --lib --bins` plus three integration targets), built twice from a clean target dir:

| | before | after | ratio |
|---|---|---|---|
| subset target dir | 3,574,018,649 B | 2,138,170,044 B | 1.67x |
| linked test binary `dispatch_routing` | 297M | 86M | 2.94x |
| its `.debug_info` | 109.7M | 11.8M | 9.3x |
| its `.debug_line` | 29.3M | 27.7M | preserved |

An identical `RUST_BACKTRACE=1` panic printed the same `file:line:col` on every frame before and after.

The whole-workspace figure is an **extrapolation** from that ratio, not a measurement: the box this was measured on could not host an 85G build.

### What this PR deliberately does not do

At 1.67x, an 85G tree lands near 51G, still under the 90G the headroom assert at `ci.yml:203` demands. So the cache flags stay as they are and the reclaim/headroom steps at `ci.yml:192-215` and `ci.yml:329-333` stay in place. They are cheap insurance, and they should only come out once a real CI run measures the new footprint against that gate. Merging this PR is what produces that measurement.

Both profile keys are set on purpose. `test` does inherit from `dev`, so the second block is redundant today; it is written out so the intent survives anyone later giving `[profile.test]` overrides of its own. `dev` is the load-bearing one: it covers dependencies, and it covers the nested `cargo build` that `real_plugin_axes` runs into this same target dir.