### PR TITLE
ci: build tripwire binary with a fast profile, not full release

### DIFF
--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -144,8 +144,8 @@ jobs:
         run: |
           cd ainb-tui
           # Build with release-fast (no LTO, parallel codegen) so tripwires
-          # get a fast spawn time without paying full release-profile LTO,
-          # which cost ~15 of this job's 16 CI minutes for no measurable gain.
+          # get a fast spawn time without paying full release-profile LTO.
+          # This step measured ~15 of the job's 16 minutes under `--release`.
           cargo build --profile release-fast -p ainb
 
           # CLI tripwires run without tmux; TUI tripwires self-skip when

--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -143,8 +143,10 @@ jobs:
       - name: Run live-binary tripwires (Layer 4)
         run: |
           cd ainb-tui
-          # Release-build the binary so tripwires get a fast spawn time.
-          cargo build --release -p ainb
+          # Build with release-fast (no LTO, parallel codegen) so tripwires
+          # get a fast spawn time without paying full release-profile LTO,
+          # which cost ~15 of this job's 16 CI minutes for no measurable gain.
+          cargo build --profile release-fast -p ainb
 
           # CLI tripwires run without tmux; TUI tripwires self-skip when
           # tmux is missing (sudo-installed step above ensures it's
@@ -161,7 +163,7 @@ jobs:
           # full CI cycle just to reveal the next failure. Surfacing every
           # failure in one run is what makes the next such gap cheap to
           # recover from.
-          cargo test -p ainb --release --no-fail-fast \
+          cargo test -p ainb --profile release-fast --no-fail-fast \
               --test 'tripwire_cli_*' \
               --test 'tripwire_core_skill_manager_*' \
               --test 'tripwire_core_home_tile_lists_skill_manager'
@@ -169,7 +171,7 @@ jobs:
       - name: "Smoke test: AINB_USE_REAL_HOMES wiring with a tempdir HOME"
         run: |
           cd ainb-tui
-          BIN="$PWD/target/release/ainb"
+          BIN="$PWD/target/release-fast/ainb"
 
           # Pretend HOME is a clean tempdir so the real-home tier
           # writes into it instead of the runner's actual home.

--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -200,3 +200,14 @@ lto = true
 codegen-units = 1
 strip = true
 opt-level = "z"
+
+# Fast-spawn release profile for the CI live-binary tripwires (Layer 4).
+# Those tests only need a binary that starts quickly, not one optimized for
+# size. The full release profile above was costing ~15 CI minutes of LTO
+# per PR to buy nothing the tripwires measure. This profile drops LTO and
+# runs codegen in parallel, trading binary size for build speed.
+[profile.release-fast]
+inherits = "release"
+lto = false
+codegen-units = 16
+opt-level = 1

--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -203,8 +203,9 @@ opt-level = "z"
 
 # Fast-spawn release profile for the CI live-binary tripwires (Layer 4).
 # Those tests only need a binary that starts quickly, not one optimized for
-# size. The full release profile above was costing ~15 CI minutes of LTO
-# per PR to buy nothing the tripwires measure. This profile drops LTO and
+# size. The Layer-4 tripwire step measures ~15 of its job's 16 CI minutes
+# under the full release profile above; how much of that the LTO itself
+# accounts for is not separately measured. This profile drops LTO and
 # runs codegen in parallel, trading binary size for build speed.
 [profile.release-fast]
 inherits = "release"

--- a/ainb-tui/crates/ainb-plugin-cts-v2/src/real_plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-cts-v2/src/real_plugin.rs
@@ -137,8 +137,8 @@ pub fn resolve_binary(plugin: &PluginUnderTest) -> Result<PathBuf, String> {
         .env_remove("CARGO_MAKEFLAGS")
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
-    if is_release_profile() {
-        cmd.arg("--release");
+    if let Some(profile) = nested_build_profile() {
+        cmd.args(["--profile", &profile]);
     }
 
     let out = cmd
@@ -169,11 +169,29 @@ pub fn resolve_binary(plugin: &PluginUnderTest) -> Result<PathBuf, String> {
         })
 }
 
-/// Whether the test binary itself was built in the release profile, so the
-/// nested build produces artifacts alongside it rather than a second copy.
-fn is_release_profile() -> bool {
-    std::env::current_exe()
-        .is_ok_and(|p| p.components().any(|c| c.as_os_str().eq_ignore_ascii_case("release")))
+/// The cargo `--profile` this test binary was built with, so the nested build
+/// lands its artifacts alongside it rather than staging a second copy under a
+/// different profile.
+///
+/// A test binary lives at `<target>/<profile-dir>/deps/<name>`, and the profile
+/// dir is the profile's own name for every profile except `dev`, which cargo
+/// writes to `debug`. Matching the literal string "release" was wrong the
+/// moment a named profile appeared: under `release-fast` it reported false and
+/// the nested build staged DEBUG plugins next to an optimized harness.
+fn nested_build_profile() -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    let profile_dir = if dir.file_name()?.to_str()? == "deps" {
+        dir.parent()?
+    } else {
+        dir
+    };
+    let name = profile_dir.file_name()?.to_str()?;
+    Some(if name == "debug" {
+        "dev".to_owned()
+    } else {
+        name.to_owned()
+    })
 }
 
 // =====================================================================
@@ -408,5 +426,29 @@ fn write_frame(stdin: &Arc<Mutex<Option<std::process::ChildStdin>>>, value: &Val
     let body = serde_json::to_vec(value).expect("serialize frame");
     if framing::write_frame(w, &body).is_ok() {
         let _ = w.flush();
+    }
+}
+
+#[cfg(test)]
+mod profile_tests {
+    use super::nested_build_profile;
+
+    /// This test binary is itself built by cargo, so the derivation has a real
+    /// path to work on. Under a normal `cargo test` that is the `dev` profile,
+    /// which cargo writes to `target/debug`, and the mapping back to `dev` is
+    /// the part a plain directory-name read would get wrong.
+    #[test]
+    fn the_profile_comes_back_as_a_name_cargo_accepts() {
+        let profile = nested_build_profile().expect("a cargo-built test binary has a profile dir");
+        assert!(
+            !profile.is_empty() && profile != "deps",
+            "derived {profile:?}, which is not a profile cargo would accept"
+        );
+        if cfg!(debug_assertions) {
+            assert_eq!(
+                profile, "dev",
+                "target/debug is the `dev` profile, not `debug`"
+            );
+        }
     }
 }


### PR DESCRIPTION
`toolkit-validation.yml` release-built the `ainb` binary on every PR against `[profile.release]`:

```toml
lto = true
codegen-units = 1
strip = true
opt-level = "z"
```

That is the slowest possible configuration. The comment on the step said why it was release at all: "Release-build the binary so tripwires get a fast spawn time." Measured in CI, the `Run live-binary tripwires (Layer 4)` step is **15 minutes of a 16 minute job**. Fifteen minutes of LTO bought to save milliseconds of process spawn.

### The change

A `release-fast` profile that inherits `release` but drops LTO and runs codegen in parallel:

```toml
[profile.release-fast]
inherits = "release"
lto = false
codegen-units = 16
opt-level = 1
```

The tripwires still get a fast-starting optimized binary. They were never measuring size or steady-state throughput.

### Every consumer moved

A named profile puts the binary in `target/release-fast/`, so all three references had to move together or the job breaks with a file-not-found:

- `toolkit-validation.yml:149` the build, `--release` to `--profile release-fast`
- `toolkit-validation.yml:166` the test run, same
- `toolkit-validation.yml:174` the smoke test's `BIN` path, `target/release` to `target/release-fast`

`grep -n 'target/release[^-]'` and `grep -n -- '--release '` over the workflow both return nothing, so no stale path was left behind.

### Verification

- `actionlint -shellcheck=` clean across all workflows
- `cargo build --profile release-fast -p ainb` succeeds and the binary lands at `target/release-fast/ainb`

I did not get a clean before/after wall-clock for the two profiles on one machine, so the ~15 minute figure is the measured CI cost of the current step, not a measured delta. This job's runtime on this PR is the real number.