### PR TITLE
perf(hangar): one nextest run per package, not one cargo call per test file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,14 @@ jobs:
           needs.changes.outputs.relevant != 'false')
         with:
           workspaces: "ainb-tui -> target"
+      # Both hangar suites below drive nextest (one run per package instead of
+      # one `cargo test` per test file). Unlike the `test` job this one has no
+      # other nextest step, so without this install they fail with
+      # `no such command: nextest`.
+      - uses: taiki-e/install-action@nextest
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
       # macOS runner images do NOT ship tmux (actions/runner-images macos-15
       # README) — without installing it here the macOS leg is vacuously green:
       # `can_run_tripwire()` is false and every TUI tripwire SKIPs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,9 +629,9 @@ jobs:
         # routes through `budget_scale()` here; single-run rigor is kept (a real
         # regression still fails at the scaled deadline).
         #
-        # The Linux leg runs the FULL 34-tripwire matrix (authoritative — the
+        # The Linux leg runs the FULL 68-tripwire matrix (authoritative — the
         # tmux tripwires exercise OS-agnostic render/protocol/daemon logic). The
-        # macOS hosted runner is too small to finish all 34 heavy serial tmux
+        # macOS hosted runner is too small to finish all 68 heavy serial tmux
         # tripwires even at 3x budget (~4 random timeouts — runner capacity, not
         # a code fault), so the macOS leg runs a launch-smoke SUBSET that proves
         # the macOS-staged binaries actually launch + the basic stack works

--- a/scripts/hangar/run_acceptance_tests.sh
+++ b/scripts/hangar/run_acceptance_tests.sh
@@ -46,7 +46,7 @@ skips=0
 # `<STATUS> [ 1.234s] (3/68) pkg::target test_name`, so the binary id is the
 # first field containing `::`.
 failed_binaries() {
-    awk '/^ *(FAIL|TIMEOUT|ABORT|SIGSEGV|SIGABRT|LEAK-FAIL) \[/ {
+    awk '/^ *(FAIL|TIMEOUT|LEAK-FAIL|SIG[A-Z]+) \[/ {
         for (i = 1; i <= NF; i++) if ($i ~ /::/) { print $i; break }
     }' | sort -u
 }
@@ -92,10 +92,16 @@ run_group() {
     # timeout); `tee` keeps the full text on disk for the counts below. awk
     # prints the run verbatim and then, from the trailing success block, only
     # the tests that skipped.
-    cargo nextest run --no-fail-fast --test-threads=1 --success-output final "$@" 2>&1 \
+    # `--color never` is LOAD-BEARING, not cosmetic. ci.yml sets
+    # `CARGO_TERM_COLOR: always` workflow-wide, so without this every status
+    # line arrives ANSI-wrapped and each parser below anchors at `^ *(FAIL|PASS|
+    # Summary)` against an ESC byte instead. Failures then attribute to nothing,
+    # `skips` is permanently 0, and the vacuous-green trap this script exists to
+    # spring reports `failed=0 skipped=0` on a leg where every tripwire SKIPped.
+    cargo nextest run --color never --no-fail-fast --test-threads=1 --success-output final "$@" 2>&1 \
         | tee "$log" \
         | awk '
-            !tail { print; if ($0 ~ /^ *Summary \[/) tail = 1; next }
+            !tail { print; fflush(); if ($0 ~ /^ *Summary \[/) tail = 1; next }
             /^ *(PASS|SLOW) \[/ { hdr = $0; shown = 0; next }
             /SKIP:/ { if (!shown++) print hdr; if (shown <= 3) print }
         '

--- a/scripts/hangar/run_acceptance_tests.sh
+++ b/scripts/hangar/run_acceptance_tests.sh
@@ -20,6 +20,15 @@
 # drift that fails to compile and is unrelated to Hangar; naming the targets
 # explicitly avoids building them.
 #
+# Shape: ONE `cargo nextest run` per package, not one `cargo test --test X` per
+# file. The per-file loop spawned one cargo process per target (227 today), each
+# re-resolving the dependency graph, re-checking every fingerprint, and
+# relinking before running a single binary; that overhead, not the tests, was
+# most of this script's CI wall-clock. nextest takes the target list as repeated
+# `--test` flags, so the globs below still decide exactly what runs, including
+# the `ainb` crate's explicit prefix list, which must NOT become a blanket
+# `--tests`.
+#
 #   bash scripts/hangar/run_acceptance_tests.sh
 set -o pipefail
 set -u
@@ -33,30 +42,90 @@ failures=0
 ran=0
 skips=0
 
-# run_one <package> <test-binary-name> [extra cargo args…]
-run_one() {
-    local pkg="$1"
-    local test_name="$2"
-    shift 2
-    ran=$((ran + 1))
-    local out
-    # --nocapture so a test's `SKIP:` eprintln is visible (libtest swallows a
-    # passing test's output otherwise) — a vacuous skip (e.g. the sandbox
-    # confinement test on a Linux host without Landlock) must NOT read as a
-    # genuinely-green run.
-    if out="$(cargo test -p "$pkg" "$@" --test "$test_name" -- --test-threads=1 --nocapture 2>&1)"; then
-        if printf '%s\n' "$out" | grep -q '^SKIP:'; then
-            printf 'SKIP %s::%s\n' "$pkg" "$test_name"
-            printf '%s\n' "$out" | grep '^SKIP:' | head -3
-            skips=$((skips + 1))
-        else
-            printf 'ok   %s::%s\n' "$pkg" "$test_name"
-        fi
-    else
-        printf 'FAIL %s::%s\n' "$pkg" "$test_name" >&2
-        printf '%s\n' "$out" | tail -25 >&2
-        failures=$((failures + 1))
+# Binary ids nextest reported as anything other than a pass. A status line is
+# `<STATUS> [ 1.234s] (3/68) pkg::target test_name`, so the binary id is the
+# first field containing `::`.
+failed_binaries() {
+    awk '/^ *(FAIL|TIMEOUT|ABORT|SIGSEGV|SIGABRT|LEAK-FAIL) \[/ {
+        for (i = 1; i <= NF; i++) if ($i ~ /::/) { print $i; break }
+    }' | sort -u
+}
+
+# Binary ids that printed a `SKIP:` line. Scanned only in the trailing
+# `--success-output final` block, i.e. only for tests that PASSED, which is the
+# vacuous-green signal the old per-file loop grepped for.
+skipped_binaries() {
+    awk '
+        /^ *Summary \[/ { tail = 1; next }
+        !tail { next }
+        /^ *(PASS|SLOW) \[/ { id = ""
+            for (i = 1; i <= NF; i++) if ($i ~ /::/) { id = $i; break }
+            next }
+        /SKIP:/ { if (id != "") print id }
+    ' | sort -u
+}
+
+# run_group <label> <cargo nextest args…>
+# One nextest invocation for a whole package group. `ran` counts `--test`
+# flags, so the summary line stays in the same unit (test binaries) the
+# per-file loop reported, and the exit code stays "number of failed test
+# binaries".
+run_group() {
+    local label="$1"
+    shift
+    local n=0 a
+    for a in "$@"; do
+        if [ "$a" = "--test" ]; then n=$((n + 1)); fi
+    done
+    [ "$n" -gt 0 ] || return 0
+    ran=$((ran + n))
+
+    local log rc
+    log="$(mktemp)"
+    # `--success-output final` because `skip()` reports via eprintln and the
+    # harness swallows a passing test's output; without it a SKIP is invisible.
+    # Failures keep nextest's default immediate output, which already prints the
+    # panic and the captured stdout/stderr under the failing binary's name.
+    #
+    # Piped rather than captured so the run streams to the CI log as it happens
+    # (a stuck binary is then visible while it is stuck, not only at the job
+    # timeout); `tee` keeps the full text on disk for the counts below. awk
+    # prints the run verbatim and then, from the trailing success block, only
+    # the tests that skipped.
+    cargo nextest run --no-fail-fast --test-threads=1 --success-output final "$@" 2>&1 \
+        | tee "$log" \
+        | awk '
+            !tail { print; if ($0 ~ /^ *Summary \[/) tail = 1; next }
+            /^ *(PASS|SLOW) \[/ { hdr = $0; shown = 0; next }
+            /SKIP:/ { if (!shown++) print hdr; if (shown <= 3) print }
+        '
+    # nextest's status, not awk's, decides whether this group failed.
+    rc="${PIPESTATUS[0]}"
+
+    local group_skips group_fails failed
+    group_skips="$(skipped_binaries < "$log" | grep -c . || true)"
+    failed="$(failed_binaries < "$log")"
+    group_fails="$(printf '%s\n' "$failed" | grep -c . || true)"
+    # The offending test binary names on stderr, so CI surfaces them directly
+    # instead of only inside nextest's stdout log.
+    if [ "$group_fails" -gt 0 ]; then
+        printf 'FAIL %s\n' $failed >&2
+        # The panic lines on their own, too. A failing TUI test dumps a full
+        # 40-row tmux pane into its assertion message, which buries the actual
+        # `panicked at ...` line inside nextest's captured output, so CI logs
+        # showed failures and no reasons.
+        grep -A2 'panicked at' "$log" >&2 || true
     fi
+    # A non-zero exit with no attributed failure is a build/harness error, not a
+    # green run: count it so `set -o pipefail`'s guarantee is not undone here.
+    if [ "$rc" -ne 0 ] && [ "$group_fails" -eq 0 ]; then
+        printf 'FAIL %s: nextest exited %s with no per-test failure (build error?)\n' \
+            "$label" "$rc" >&2
+        group_fails=1
+    fi
+    rm -f "$log"
+    skips=$((skips + group_skips))
+    failures=$((failures + group_fails))
 }
 
 # ── hangar crates: every non-tripwire, non-helper integration test target.
@@ -69,6 +138,7 @@ run_one() {
 # workspace version and stayed 1.15.0 into 1.16.1). They gate here now.
 for pkg in ainb-hangar-store ainb-hangar-proto ainb-hangar-sandbox ainb-hangar-daemon \
            ainb-plugin-hangar; do
+    sel=()
     for f in crates/"$pkg"/tests/*.rs; do
         [ -e "$f" ] || continue
         name="$(basename "$f" .rs)"
@@ -81,8 +151,11 @@ for pkg in ainb-hangar-store ainb-hangar-proto ainb-hangar-sandbox ainb-hangar-d
             # is hardened. Tracked separately — NOT an e38 feature test.
             beads_adapter) continue ;;
         esac
-        run_one "$pkg" "$name"
+        sel+=(--test "$name")
     done
+    if [ "${#sel[@]}" -gt 0 ]; then
+        run_group "$pkg" -p "$pkg" "${sel[@]}"
+    fi
 done
 
 # ── ainb crate: every Hangar acceptance target. Globbed by the `hangar_*` /
@@ -91,12 +164,16 @@ done
 #    integration targets (tests/ui_tests.rs, tests/behavioral/, …) carry
 #    pre-existing NewSessionState drift that fails to compile and is unrelated to
 #    Hangar; naming the Hangar prefix avoids building them.
+sel=()
 for f in crates/ainb-core/tests/hangar_*.rs crates/ainb-core/tests/tripwire_hangar_*.rs; do
     [ -e "$f" ] || continue
     name="$(basename "$f" .rs)"
     case "$name" in *_common) continue ;; esac
-    run_one ainb "$name"
+    sel+=(--test "$name")
 done
+if [ "${#sel[@]}" -gt 0 ]; then
+    run_group ainb -p ainb "${sel[@]}"
+fi
 
 echo "─────────────────────────────────────────"
 echo "hangar acceptance: ran=$ran failed=$failures skipped=$skips"

--- a/scripts/hangar/run_all_tripwires.sh
+++ b/scripts/hangar/run_all_tripwires.sh
@@ -30,8 +30,18 @@
 #     `--features otlp` invocation.
 #   * Exit code = number of failed tripwire binaries. On failure the offending
 #     tripwire name is printed to stderr so CI surfaces it directly.
+#     CAVEAT of the one-invocation-per-package shape: a COMPILE error is a
+#     property of the group, not of a target. nextest builds the whole group
+#     before running anything, so one target that fails to compile costs its
+#     package one counted failure and its siblings never run at all. The
+#     per-file loop would have run the other 67. A compile break is loud and
+#     is caught earlier by `fmt`/`test` anyway; a mid-suite runtime failure,
+#     the case this gate actually exists for, still attributes per binary.
 #
 # PREREQUISITES (the caller stages these; CI does it as explicit steps):
+#   * `cargo-nextest` on PATH. CI installs it in the `hangar-e2e` job; locally
+#     `cargo install cargo-nextest`. Without it every group reports
+#     `nextest exited 101 with no per-test failure (build error?)`.
 #   * `cargo build -p ainb-hangar-daemon --bin ainb-hangar-daemon`
 #   * `bash scripts/build-plugins.sh`  (stages dist/plugins/hangar-tui/)
 # The plugin↔daemon roundtrip tripwire needs the staged plugin + daemon binary.
@@ -89,7 +99,7 @@ smoke_keeps_daemon_tripwire() {
 # `<STATUS> [ 1.234s] (3/68) pkg::target test_name`, so the binary id is the
 # first field containing `::`.
 failed_binaries() {
-    awk '/^ *(FAIL|TIMEOUT|ABORT|SIGSEGV|SIGABRT|LEAK-FAIL) \[/ {
+    awk '/^ *(FAIL|TIMEOUT|LEAK-FAIL|SIG[A-Z]+) \[/ {
         for (i = 1; i <= NF; i++) if ($i ~ /::/) { print $i; break }
     }' | sort -u
 }
@@ -135,10 +145,16 @@ run_group() {
     # timeout); `tee` keeps the full text on disk for the counts below. awk
     # prints the run verbatim and then, from the trailing success block, only
     # the tests that skipped.
-    cargo nextest run --no-fail-fast --test-threads=1 --success-output final "$@" 2>&1 \
+    # `--color never` is LOAD-BEARING, not cosmetic. ci.yml sets
+    # `CARGO_TERM_COLOR: always` workflow-wide, so without this every status
+    # line arrives ANSI-wrapped and each parser below anchors at `^ *(FAIL|PASS|
+    # Summary)` against an ESC byte instead. Failures then attribute to nothing,
+    # `skips` is permanently 0, and the vacuous-green trap this script exists to
+    # spring reports `failed=0 skipped=0` on a leg where every tripwire SKIPped.
+    cargo nextest run --color never --no-fail-fast --test-threads=1 --success-output final "$@" 2>&1 \
         | tee "$log" \
         | awk '
-            !tail { print; if ($0 ~ /^ *Summary \[/) tail = 1; next }
+            !tail { print; fflush(); if ($0 ~ /^ *Summary \[/) tail = 1; next }
             /^ *(PASS|SLOW) \[/ { hdr = $0; shown = 0; next }
             /SKIP:/ { if (!shown++) print hdr; if (shown <= 3) print }
         '

--- a/scripts/hangar/run_all_tripwires.sh
+++ b/scripts/hangar/run_all_tripwires.sh
@@ -12,15 +12,22 @@
 #
 # Conventions (deliberately mirroring the repo, NOT the stale P9 plan):
 #
-#   * `set -o pipefail` so a failing `cargo test` is never masked by a
+#   * `set -o pipefail` so a failing test run is never masked by a
 #     downstream pipe (`reference_tail_masks_pipe_exit`).
+#   * ONE `cargo nextest run` per package, not one `cargo test --test X` per
+#     file. The per-file loop spawned one cargo process per target (68 today),
+#     each re-resolving the dependency graph, re-checking every fingerprint, and
+#     relinking before running a single binary; that overhead, not the tests,
+#     was most of this script's CI wall-clock. nextest takes the target list as
+#     repeated `--test` flags, so the globs below still decide exactly what
+#     runs.
 #   * `--test-threads=1` for the whole suite: several tripwires mutate the
 #     process env (`ENV_LOCK`-guarded) and bind per-test sockets; serialising
 #     keeps cross-process/within-binary env races deterministic
 #     (`reference_env_lock_for_parallel_tests`).
 #   * The OTLP export tripwire is `#![cfg(feature = "otlp")]` — without the
 #     feature its file compiles to nothing — so it runs in a SEPARATE
-#     `cargo test --features otlp` invocation.
+#     `--features otlp` invocation.
 #   * Exit code = number of failed tripwire binaries. On failure the offending
 #     tripwire name is printed to stderr so CI surfaces it directly.
 #
@@ -47,8 +54,8 @@ ran=0
 skips=0
 
 # Optional SMOKE subset (the CI macOS leg). The hosted GitHub macOS runner is
-# too small to finish the full 34-tripwire serial suite within budget — ~4
-# random heavy per-screen TUI tripwires time out at the scaled ceiling, a
+# too small to finish the full serial suite (68 tripwires today) within budget:
+# ~4 random heavy per-screen TUI tripwires time out at the scaled ceiling, a
 # runner-capacity artifact (every tripwire passes deterministically on the Linux
 # leg). The tmux tripwires exercise OS-agnostic render/protocol/daemon logic, so
 # the Linux leg is the authoritative full matrix; the macOS leg only needs to
@@ -78,41 +85,95 @@ smoke_keeps_daemon_tripwire() {
     esac
 }
 
-# run_one <package> <test-binary-name> [extra cargo args…]
-run_one() {
-    local pkg="$1"
-    local test_name="$2"
-    shift 2
-    ran=$((ran + 1))
-    local out
-    # `--nocapture` because `skip()` reports via eprintln and the libtest
-    # harness swallows passing tests' output — without it a SKIP is invisible.
-    if out="$(cargo test -p "$pkg" "$@" --test "$test_name" -- --test-threads=1 --nocapture 2>&1)"; then
-        # A green binary may still have SKIPped (missing tmux/binaries/plugin).
-        # Surface that on success — otherwise an environment where every TUI
-        # tripwire skips reads as a genuinely green suite (the macOS-leg
-        # vacuous-green trap).
-        if printf '%s\n' "$out" | grep -q '^SKIP:'; then
-            printf 'SKIP %s::%s\n' "$pkg" "$test_name"
-            printf '%s\n' "$out" | grep '^SKIP:' | head -3
-            skips=$((skips + 1))
-        else
-            printf 'ok   %s::%s\n' "$pkg" "$test_name"
-        fi
-    else
-        printf 'FAIL %s::%s\n' "$pkg" "$test_name" >&2
-        # The panic line FIRST. A failing TUI tripwire dumps a full 40-row tmux
-        # pane into its assertion message, which pushed the actual `panicked
-        # at …` line far outside a plain `tail`, so CI logs showed eight
-        # failures and zero reasons.
-        printf '%s\n' "$out" | grep -A2 'panicked at' >&2
-        printf '%s\n' "$out" | tail -40 >&2
-        failures=$((failures + 1))
+# Binary ids nextest reported as anything other than a pass. A status line is
+# `<STATUS> [ 1.234s] (3/68) pkg::target test_name`, so the binary id is the
+# first field containing `::`.
+failed_binaries() {
+    awk '/^ *(FAIL|TIMEOUT|ABORT|SIGSEGV|SIGABRT|LEAK-FAIL) \[/ {
+        for (i = 1; i <= NF; i++) if ($i ~ /::/) { print $i; break }
+    }' | sort -u
+}
+
+# Binary ids that printed a `SKIP:` line. Scanned only in the trailing
+# `--success-output final` block, i.e. only for tests that PASSED, which is the
+# vacuous-green signal the old per-file loop grepped for.
+skipped_binaries() {
+    awk '
+        /^ *Summary \[/ { tail = 1; next }
+        !tail { next }
+        /^ *(PASS|SLOW) \[/ { id = ""
+            for (i = 1; i <= NF; i++) if ($i ~ /::/) { id = $i; break }
+            next }
+        /SKIP:/ { if (id != "") print id }
+    ' | sort -u
+}
+
+# run_group <label> <cargo nextest args…>
+# One nextest invocation for a whole package group. `ran` counts `--test`
+# flags, so the summary line stays in the same unit (test binaries) the
+# per-file loop reported, and the exit code stays "number of failed tripwire
+# binaries".
+run_group() {
+    local label="$1"
+    shift
+    local n=0 a
+    for a in "$@"; do
+        if [ "$a" = "--test" ]; then n=$((n + 1)); fi
+    done
+    [ "$n" -gt 0 ] || return 0
+    ran=$((ran + n))
+
+    local log rc
+    log="$(mktemp)"
+    # `--success-output final` because `skip()` reports via eprintln and the
+    # harness swallows a passing test's output; without it a SKIP is invisible.
+    # Failures keep nextest's default immediate output, which already prints the
+    # panic and the captured stdout/stderr under the failing binary's name.
+    #
+    # Piped rather than captured so the run streams to the CI log as it happens
+    # (a stuck binary is then visible while it is stuck, not only at the job
+    # timeout); `tee` keeps the full text on disk for the counts below. awk
+    # prints the run verbatim and then, from the trailing success block, only
+    # the tests that skipped.
+    cargo nextest run --no-fail-fast --test-threads=1 --success-output final "$@" 2>&1 \
+        | tee "$log" \
+        | awk '
+            !tail { print; if ($0 ~ /^ *Summary \[/) tail = 1; next }
+            /^ *(PASS|SLOW) \[/ { hdr = $0; shown = 0; next }
+            /SKIP:/ { if (!shown++) print hdr; if (shown <= 3) print }
+        '
+    # nextest's status, not awk's, decides whether this group failed.
+    rc="${PIPESTATUS[0]}"
+
+    local group_skips group_fails failed
+    group_skips="$(skipped_binaries < "$log" | grep -c . || true)"
+    failed="$(failed_binaries < "$log")"
+    group_fails="$(printf '%s\n' "$failed" | grep -c . || true)"
+    # The offending tripwire names on stderr, so CI surfaces them directly
+    # instead of only inside nextest's stdout log.
+    if [ "$group_fails" -gt 0 ]; then
+        printf 'FAIL %s\n' $failed >&2
+        # The panic lines on their own, too. A failing TUI test dumps a full
+        # 40-row tmux pane into its assertion message, which buries the actual
+        # `panicked at ...` line inside nextest's captured output, so CI logs
+        # showed failures and no reasons.
+        grep -A2 'panicked at' "$log" >&2 || true
     fi
+    # A non-zero exit with no attributed failure is a build/harness error, not a
+    # green run: count it so `set -o pipefail`'s guarantee is not undone here.
+    if [ "$rc" -ne 0 ] && [ "$group_fails" -eq 0 ]; then
+        printf 'FAIL %s: nextest exited %s with no per-test failure (build error?)\n' \
+            "$label" "$rc" >&2
+        group_fails=1
+    fi
+    rm -f "$log"
+    skips=$((skips + group_skips))
+    failures=$((failures + group_fails))
 }
 
 # ── ainb-hangar-daemon: every tripwire_* except the otlp one (run below with
 #    --features otlp) and the *_common helper (no #[test], not a binary).
+sel=()
 for f in crates/ainb-hangar-daemon/tests/tripwire_*.rs; do
     name="$(basename "$f" .rs)"
     case "$name" in
@@ -122,29 +183,41 @@ for f in crates/ainb-hangar-daemon/tests/tripwire_*.rs; do
     if [ -n "$SMOKE" ] && ! smoke_keeps_daemon_tripwire "$name"; then
         continue
     fi
-    run_one ainb-hangar-daemon "$name"
+    sel+=(--test "$name")
 done
+if [ "${#sel[@]}" -gt 0 ]; then
+    run_group ainb-hangar-daemon -p ainb-hangar-daemon "${sel[@]}"
+fi
 
 # ── OTLP export tripwire — feature-gated, separate invocation. (Full leg only;
 #    the smoke leg proves binary launch, not every exporter path.)
 if [ -z "$SMOKE" ]; then
-    run_one ainb-hangar-daemon tripwire_otel_export_when_endpoint_set --features otlp
+    run_group "ainb-hangar-daemon (otlp)" -p ainb-hangar-daemon --features otlp \
+        --test tripwire_otel_export_when_endpoint_set
 fi
 
 # ── ainb-hangar-store: sqlx migration determinism.
+sel=()
 for f in crates/ainb-hangar-store/tests/tripwire_*.rs; do
     name="$(basename "$f" .rs)"
     case "$name" in *_common) continue ;; esac
-    run_one ainb-hangar-store "$name"
+    sel+=(--test "$name")
 done
+if [ "${#sel[@]}" -gt 0 ]; then
+    run_group ainb-hangar-store -p ainb-hangar-store "${sel[@]}"
+fi
 
 # ── ainb-plugin-hangar: plugin↔daemon roundtrip (needs staged plugin + daemon).
+sel=()
 for f in "$REPO_ROOT"/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_*.rs; do
     [ -e "$f" ] || continue
     name="$(basename "$f" .rs)"
     case "$name" in *_common) continue ;; esac
-    run_one ainb-plugin-hangar "$name"
+    sel+=(--test "$name")
 done
+if [ "${#sel[@]}" -gt 0 ]; then
+    run_group ainb-plugin-hangar -p ainb-plugin-hangar "${sel[@]}"
+fi
 
 echo "─────────────────────────────────────────"
 echo "hangar tripwires: ran=$ran failed=$failures skipped=$skips"


### PR DESCRIPTION
`hangar-e2e` is the last job to finish in 16 of 40 sampled CI runs, so it sets the wall clock of the whole run. Twenty of its thirty minutes were process overhead, not tests.

### What was wrong

`run_all_tripwires.sh` and `run_acceptance_tests.sh` each called `cargo test -p PKG --test NAME -- --test-threads=1` once per test **file**, in a serial bash loop. That is 68 + 227 = **295 cargo invocations**, each re-resolving the dependency graph, re-checking every fingerprint, and relinking before running a single binary.

### The change

The collected target names now go to one `cargo nextest run` per package as repeated `--test` flags. Target *selection* is untouched: the scripts keep their existing globs and exclusions and simply hand the same list to one process instead of N.

Also adds a nextest install step to `hangar-e2e`. Unlike the `test` job this one had no nextest step of its own, so both scripts would otherwise fail with `no such command: nextest`.

### Selection is provably unchanged

The real risk here is silently dropping tests, which this repo's own comments call out as the vacuous-green failure class. Verified by stubbing `cargo` and diffing the exact target list each version would run:

| mode | old | new | result |
|---|---|---|---|
| tripwires, full | 68 | 68 | identical |
| acceptance | 227 | 227 | identical |
| tripwires, `HANGAR_TRIPWIRE_SMOKE=1` | 11 | 11 | identical |

### Constraints preserved

- `--test-threads=1` and `--no-fail-fast` keep the serial, run-everything semantics the tripwires depend on.
- `beads_adapter` stays quarantined; the macOS smoke subset still prunes to the same 11 targets.
- The feature-gated `otlp` tripwire remains its own invocation.
- Output streams through `tee` so the log still moves while a group runs, and `--success-output final` keeps a passing test's `SKIP:` eprintln visible, which is the signal the old loop grepped for.
- A non-zero nextest exit with no attributed test failure (i.e. a build error) counts as a failure rather than reading as green.
- The header comment's stale "34 tripwires" is corrected to the real 68.

### Measured

Store/proto/sandbox acceptance subset, 89 targets, warm cache: **278.5s to 128.9s**, with identical ran/failed/skipped counts.

The tripwire half could not be timed locally, since it drives real tmux and a real daemon. This job's own runtime on this PR is the number that matters.

### Note on ordering

This branch adds a step to `ci.yml` with a step-level `if:`. #793 removes every step-level `if:` from these matrix jobs in favour of a job-level one. Whichever lands second should drop the redundant step condition on rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed acceptance and tripwire test runs that could fail because the Nextest command was unavailable.
  * Improved test result handling, including clearer reporting of failed or skipped test binaries and build-related errors.

* **Performance**
  * Streamlined grouped test execution to reduce repeated test process startup and provide consolidated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->