### PR TITLE
fix(daemons): stop ATC and hangar reporting green while half-dead

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/daemon.rs
@@ -281,9 +281,24 @@ fn atc_instance() -> Result<String> {
 fn atc(action: Action) -> Result<String> {
     let name = atc_instance()?;
     match action {
-        // `repair` re-asserts the OS timer and the daemon registration, which is
-        // exactly what starting a stopped ATC means.
-        Action::Start | Action::Restart => delegate(&["fleet", "atc", "repair", &name]),
+        // ATC has two halves and they fail independently. `repair` re-asserts
+        // the SCHEDULER (OS timer + daemon registration); it does nothing about
+        // the Claude session the scheduler beats into. Starting an ATC whose
+        // session has died must respawn the session, and `setup` is the verb
+        // that does it — idempotent, and it preserves state.json / task-log.md.
+        //
+        // Routing everything through `repair` is why "start" failed with
+        // "the daemon did NOT accept the unregister" on a host whose only
+        // actual fault was a dead tmux session: the wrong half was being fixed,
+        // and the scheduler guard then refused a change it did not need.
+        Action::Start | Action::Restart => {
+            let session = crate::tmux::sanitize_session_name(&name);
+            if crate::fleet::daemons::probe::tmux_session_alive(&session) {
+                delegate(&["fleet", "atc", "repair", &name])
+            } else {
+                delegate(&["fleet", "atc", "setup", &name])
+            }
+        }
         // No confirmation flag: `fleet atc teardown` takes only <name> and
         // --purge. Passing --yes made clap reject the whole invocation, so
         // `stop` failed every time.

--- a/ainb-tui/crates/ainb-core/src/cli/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/daemon.rs
@@ -278,6 +278,43 @@ fn atc_instance() -> Result<String> {
     }
 }
 
+/// Respawn a dead ATC session WITHOUT resetting the instance's configuration.
+///
+/// `fleet atc setup` rebuilds meta from `AtcMeta::new` and applies only the
+/// flags it is given, so a bare `setup <name>` silently resets an instance
+/// provisioned at 10m back to the 15m default, and flips a deliberately
+/// disabled heartbeat back on. Pressing Start must not reconfigure anything,
+/// so the current values are read off meta.json and passed straight back.
+fn respawn_atc_session(name: &str) -> Result<String> {
+    let home = crate::fleet::plumbing::paths::ainb_home()?;
+    let paths = crate::fleet::atc::paths::AtcPaths::under_root(&home.join("atc"), name);
+    let meta = std::fs::read_to_string(&paths.meta)
+        .ok()
+        .and_then(|raw| crate::fleet::atc::meta::AtcMeta::from_json(&raw).ok())
+        .with_context(|| {
+            format!(
+                "reading {} to respawn without reconfiguring it",
+                paths.meta.display()
+            )
+        })?;
+    let interval = meta.heartbeat_interval_min.to_string();
+    let idle_pause = meta.idle_pause_min.to_string();
+    let mut argv = vec![
+        "fleet",
+        "atc",
+        "setup",
+        name,
+        "--interval",
+        &interval,
+        "--idle-pause",
+        &idle_pause,
+    ];
+    if !meta.heartbeat_enabled {
+        argv.push("--no-heartbeat");
+    }
+    delegate(&argv)
+}
+
 fn atc(action: Action) -> Result<String> {
     let name = atc_instance()?;
     match action {
@@ -285,18 +322,21 @@ fn atc(action: Action) -> Result<String> {
         // the SCHEDULER (OS timer + daemon registration); it does nothing about
         // the Claude session the scheduler beats into. Starting an ATC whose
         // session has died must respawn the session, and `setup` is the verb
-        // that does it — idempotent, and it preserves state.json / task-log.md.
+        // that does it: idempotent, and it preserves state.json / task-log.md.
         //
         // Routing everything through `repair` is why "start" failed with
         // "the daemon did NOT accept the unregister" on a host whose only
         // actual fault was a dead tmux session: the wrong half was being fixed,
         // and the scheduler guard then refused a change it did not need.
         Action::Start | Action::Restart => {
-            let session = crate::tmux::sanitize_session_name(&name);
-            if crate::fleet::daemons::probe::tmux_session_alive(&session) {
-                delegate(&["fleet", "atc", "repair", &name])
+            let session = crate::fleet::atc::meta::AtcMeta::new(&name).tmux_session();
+            // Only a PROVEN dead session takes the respawn path. `None` means
+            // the check could not run, and guessing "dead" there would rewrite
+            // a healthy instance's config for an environment problem.
+            if crate::tmux::session_alive(&session) == Some(false) {
+                respawn_atc_session(&name)
             } else {
-                delegate(&["fleet", "atc", "setup", &name])
+                delegate(&["fleet", "atc", "repair", &name])
             }
         }
         // No confirmation flag: `fleet atc teardown` takes only <name> and
@@ -515,6 +555,29 @@ mod tests {
             &["notifyd", "restart"],
             &["notifyd", "stop"],
             &["fleet", "atc", "repair", "main"],
+            // Start on a dead session respawns it, passing the instance's own
+            // settings back so nothing is reconfigured.
+            &[
+                "fleet",
+                "atc",
+                "setup",
+                "main",
+                "--interval",
+                "10",
+                "--idle-pause",
+                "60",
+            ],
+            &[
+                "fleet",
+                "atc",
+                "setup",
+                "main",
+                "--interval",
+                "10",
+                "--idle-pause",
+                "60",
+                "--no-heartbeat",
+            ],
             &["fleet", "atc", "teardown", "main"],
             &["fleet", "bridge", "install"],
             &["fleet", "bridge", "uninstall"],

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/daemon.rs
@@ -31,7 +31,18 @@ fn atc_holding_the_fleet() -> Option<String> {
     let home = crate::fleet::plumbing::paths::ainb_home().ok()?;
     let status =
         crate::fleet::daemons::probe::probe_atc(&home, crate::fleet::daemons::heartbeat::now_ms());
-    if status.state != crate::fleet::daemons::probe::DaemonState::Running {
+    // Degraded counts as HOLDING. This guard was written when the ATC probe had
+    // two outcomes, so "not Running" meant "not supervising". A degraded ATC is
+    // one whose scheduler is still registered and still firing, so starting the
+    // fleet daemon alongside it is exactly the double-supervision this refuses:
+    // both watchers auto-continue into the same panes and ATC's per-session
+    // retry cap is defeated by an uncapped daemon. Only a stopped or unknown
+    // instance is safe to ignore.
+    if !matches!(
+        status.state,
+        crate::fleet::daemons::probe::DaemonState::Running
+            | crate::fleet::daemons::probe::DaemonState::Degraded
+    ) {
         return None;
     }
     // `probe_atc` puts the winning instance name in the channel label.

--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -8035,7 +8035,7 @@ fn pid_owns_a_home(pid: u32, socket: &std::path::Path) -> bool {
 /// fallback's exact credit rule is testable without spawning a process.
 ///
 /// A recognised daemon shape counts, EXCEPT from a `cargo test` binary.
-fn argv_credits_a_daemon(args: &str) -> bool {
+pub(crate) fn argv_credits_a_daemon(args: &str) -> bool {
     !is_cargo_test_binary(args) && ainb_hangar_daemon::single_instance::is_hangar_daemon_args(args)
 }
 

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -767,33 +767,17 @@ pub fn probe_approve_broker(base: &Path, now_ms: i64) -> DaemonStatus {
 /// provisioned instance with `heartbeat_enabled` whose last heartbeat is within
 /// the cadence window. Reads, never re-emits.
 #[must_use]
-/// Whether a tmux session with this exact name exists.
-///
-/// Sync on purpose: the probe is sync and runs on the render path, so this
-/// stays a single `tmux has-session` (~2ms) rather than dragging an async
-/// runtime into the daemons screen.
-pub(crate) fn tmux_session_alive(session: &str) -> bool {
-    std::process::Command::new("tmux")
-        .args(["has-session", "-t", session])
-        .output()
-        .is_ok_and(|out| out.status.success())
-}
-
-/// The inputs [`hangar_status_for`] reads, mirroring the fields it used to take
-/// straight off `daemon_runtime_status()`.
-struct HangarRuntime {
-    pid: Option<u32>,
-    version: Option<String>,
-    old: bool,
-}
-
 /// Count of `hangar daemon run` processes visible on this host.
 ///
 /// CONTEXT ONLY, never on its own an error. The single-instance guard is
 /// PER-HOME: a machine running N ainb homes (worktrees, temp homes in tests)
 /// legitimately has N daemons, and treating that as a fault was the exact
-/// false positive a earlier orphan hunt had to unpick. The authoritative
+/// false positive an earlier orphan hunt had to unpick. The authoritative
 /// signal for THIS home stays `running_daemon_pid()`.
+///
+/// Matched on argv shape rather than a substring: `ps` output also carries
+/// shell wrappers and greps whose command line merely mentions the phrase, and
+/// a count shown to an operator mid-diagnosis has to be the real one.
 fn hangar_daemon_census() -> usize {
     std::process::Command::new("ps")
         .args(["-axo", "args="])
@@ -802,14 +786,14 @@ fn hangar_daemon_census() -> usize {
         .map(|out| {
             String::from_utf8_lossy(&out.stdout)
                 .lines()
-                .filter(|line| line.contains("hangar daemon run"))
+                .filter(|line| crate::cli::hangar::argv_credits_a_daemon(line))
                 .count()
         })
         .unwrap_or(0)
 }
 
 pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
-    probe_atc_with(home, now_ms, &tmux_session_alive)
+    probe_atc_with(home, now_ms, &crate::tmux::session_alive)
 }
 
 /// [`probe_atc`] with the session check injected.
@@ -820,7 +804,7 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
 pub(crate) fn probe_atc_with(
     home: &Path,
     now_ms: i64,
-    session_alive: &dyn Fn(&str) -> bool,
+    session_alive: &dyn Fn(&str) -> Option<bool>,
 ) -> DaemonStatus {
     use crate::fleet::atc::heartbeat::HeartbeatState;
     use crate::fleet::atc::meta::AtcMeta;
@@ -926,10 +910,19 @@ pub(crate) fn probe_atc_with(
     // The OS timer writes that file whether or not the Claude session it beats
     // into still exists, so a dead `tmux_<name>` reports Running forever: the
     // timer fires, finds nothing, exits 0, and task-log.md silently stops
-    // growing. Probing the session is the only way to tell the halves apart —
+    // growing. Probing the session is the only way to tell the halves apart,
     // the same split the bridge already models with inbound vs outbound.
-    let session = crate::tmux::sanitize_session_name(&name);
-    if !session_alive(&session) {
+    let session = AtcMeta::new(&name).tmux_session();
+    // The advice names `daemon atc start`, not `fleet atc setup`: bare setup
+    // rebuilds meta from defaults, so it would silently reset a 10m instance to
+    // 15m while "fixing" it. `daemon atc start` reads the current settings and
+    // passes them back.
+    //
+    // Only a PROVEN dead session degrades the row. `None` means the check
+    // itself could not run (tmux off PATH, a wedged server), and reporting an
+    // environment problem as an ATC fault would send the operator to a repair
+    // that rewrites a healthy instance.
+    if session_alive(&session) == Some(false) {
         return DaemonStatus {
             kind,
             state: DaemonState::Degraded,
@@ -937,7 +930,7 @@ pub(crate) fn probe_atc_with(
             channel: Some(format!("{name} (every {interval_min}m)")),
             last_activity_at: hbs.last_active_ms,
             reason: format!(
-                "heartbeat firing every {interval_min}m but session {session} is GONE — beats are landing nowhere; `ainb fleet atc setup {name}` respawns it"
+                "heartbeat firing every {interval_min}m but session {session} is GONE. Beats are landing nowhere; `ainb daemon atc start` respawns it"
             ),
             ..DaemonStatus::running(kind)
         };
@@ -1067,7 +1060,6 @@ pub fn probe_mcp_pool() -> DaemonStatus {
 /// socket connect answers the separate question of whether it is still serving.
 #[must_use]
 pub fn probe_hangar_daemon() -> DaemonStatus {
-    let kind = DaemonKind::HangarDaemon;
     let runtime = crate::cli::hangar::daemon_runtime_status();
     let serving = crate::fleet::bridge::daemon::socket_path()
         .is_some_and(|socket| socket_is_listening(&socket));
@@ -1093,23 +1085,22 @@ pub(crate) fn hangar_status_for(
     census: impl Fn() -> usize,
 ) -> DaemonStatus {
     let kind = DaemonKind::HangarDaemon;
-    let runtime = HangarRuntime { pid, version, old };
-    match (runtime.pid, serving) {
+    match (pid, serving) {
         (None, false) => DaemonStatus::stopped(kind, "not running".to_string()),
         // A recorded owner with a dead socket is the half-alive case the
         // Daemons screen exists to make visible.
         (Some(pid), false) => DaemonStatus {
             state: DaemonState::Degraded,
             pid: Some(pid),
-            version_current: runtime.version.as_deref().map(|v| v == env!("CARGO_PKG_VERSION")),
-            version: runtime.version,
+            version_current: version.as_deref().map(|v| v == env!("CARGO_PKG_VERSION")),
+            version,
             reason: format!("pid {pid} owns this home but the socket is not accepting"),
             ..DaemonStatus::running(kind)
         },
         // Socket answering while this home records NO owner: something else is
         // serving our socket. That is the split-brain that makes
         // `ainb fleet atc repair` bail with "the daemon did NOT accept the
-        // unregister" — the verb dials the socket, a daemon this home does not
+        // unregister": the verb dials the socket, a daemon this home does not
         // own answers, and the registration lives somewhere else entirely.
         (None, true) => DaemonStatus {
             state: DaemonState::Degraded,
@@ -1117,18 +1108,18 @@ pub(crate) fn hangar_status_for(
             channel: Some("unix socket".to_string()),
             reason: format!(
                 "socket is served by a daemon this home does not own ({} running \
-host-wide) — `ainb hangar daemon restart` re-takes ownership",
+host-wide); `ainb hangar daemon restart` re-takes ownership",
                 census()
             ),
             ..DaemonStatus::running(kind)
         },
         (pid, true) => DaemonStatus {
             pid,
-            version_current: runtime.version.as_deref().map(|v| v == env!("CARGO_PKG_VERSION")),
-            version: runtime.version,
+            version_current: version.as_deref().map(|v| v == env!("CARGO_PKG_VERSION")),
+            version,
             connected: true,
             channel: Some("unix socket".to_string()),
-            reason: if runtime.old {
+            reason: if old {
                 "serving — older than this ainb, restart to upgrade".to_string()
             } else {
                 "socket serving".to_string()
@@ -2198,7 +2189,7 @@ mod tests {
     #[test]
     fn probe_atc_no_instance_is_stopped() {
         let home = TempDir::new().unwrap();
-        let s = probe_atc_with(home.path(), 0, &|_| true);
+        let s = probe_atc_with(home.path(), 0, &|_| Some(true));
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(s.reason.contains("no ATC instance"));
     }
@@ -2223,7 +2214,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let s = probe_atc_with(home.path(), now, &|_| true);
+        let s = probe_atc_with(home.path(), now, &|_| Some(true));
         assert_eq!(s.state, DaemonState::Running);
         assert!(s.connected);
         assert!(s.channel.as_deref().unwrap().contains("primary"));
@@ -2253,7 +2244,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let s = probe_atc_with(home.path(), now, &|_| false);
+        let s = probe_atc_with(home.path(), now, &|_| Some(false));
         assert_eq!(
             s.state,
             DaemonState::Degraded,
@@ -2266,7 +2257,7 @@ mod tests {
             s.reason
         );
         assert!(
-            s.reason.contains("atc setup primary"),
+            s.reason.contains("ainb daemon atc start"),
             "reason must name the fix: {}",
             s.reason
         );
@@ -2319,13 +2310,32 @@ mod tests {
         assert!(s.reason.contains("not accepting"), "{}", s.reason);
     }
 
-    /// A session check is only meaningful if it can actually fail; a name this
-    /// long cannot exist as a tmux session on any host running the suite.
+    /// The check has to be able to say BOTH things, and it has to compare
+    /// exactly: bare `has-session -t foo` resolves by prefix, so it exits 0 for
+    /// a live `foo-fix` while `foo` itself is long gone. That is precisely the
+    /// false green this module exists to stop, so the prefix case is asserted.
     #[test]
-    fn tmux_session_alive_is_false_for_an_impossible_name() {
-        assert!(!super::tmux_session_alive(
-            "ainb-probe-selftest-session-that-cannot-exist-0000"
-        ));
+    fn session_alive_is_exact_and_answers_both_ways() {
+        let name = "ainb_probe_selftest_alpha";
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={name}")])
+            .output();
+        let spawned = std::process::Command::new("tmux")
+            .args(["new-session", "-d", "-s", name])
+            .output();
+        if !spawned.is_ok_and(|o| o.status.success()) {
+            return; // no usable tmux on this host; nothing to assert
+        }
+        assert_eq!(crate::tmux::session_alive(name), Some(true), "live session");
+        assert_eq!(
+            crate::tmux::session_alive("ainb_probe_selftest_alph"),
+            Some(false),
+            "a prefix of a live session must NOT count as that session"
+        );
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={name}")])
+            .output();
+        assert_eq!(crate::tmux::session_alive(name), Some(false), "after kill");
     }
 
     #[test]
@@ -2351,7 +2361,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let s = probe_atc_with(home.path(), now, &|_| true);
+        let s = probe_atc_with(home.path(), now, &|_| Some(true));
         assert_eq!(
             s.state,
             DaemonState::Stopped,
@@ -2391,7 +2401,7 @@ mod tests {
             )
             .unwrap();
         }
-        let s = probe_atc_with(home.path(), now, &|_| true);
+        let s = probe_atc_with(home.path(), now, &|_| Some(true));
         assert_eq!(s.state, DaemonState::Running);
         assert!(
             s.channel.as_deref().unwrap().contains("on"),
@@ -2420,7 +2430,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let s = probe_atc_with(home.path(), now, &|_| true);
+        let s = probe_atc_with(home.path(), now, &|_| Some(true));
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(s.reason.contains("stale"));
     }

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -767,7 +767,32 @@ pub fn probe_approve_broker(base: &Path, now_ms: i64) -> DaemonStatus {
 /// provisioned instance with `heartbeat_enabled` whose last heartbeat is within
 /// the cadence window. Reads, never re-emits.
 #[must_use]
+/// Whether a tmux session with this exact name exists.
+///
+/// Sync on purpose: the probe is sync and runs on the render path, so this
+/// stays a single `tmux has-session` (~2ms) rather than dragging an async
+/// runtime into the daemons screen.
+pub(crate) fn tmux_session_alive(session: &str) -> bool {
+    std::process::Command::new("tmux")
+        .args(["has-session", "-t", session])
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
 pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
+    probe_atc_with(home, now_ms, &tmux_session_alive)
+}
+
+/// [`probe_atc`] with the session check injected.
+///
+/// Split out so the liveness branch is testable: a temp-home fixture has no
+/// tmux session, so a hard-wired `tmux has-session` would report every test
+/// instance as degraded and the healthy path could never be asserted.
+pub(crate) fn probe_atc_with(
+    home: &Path,
+    now_ms: i64,
+    session_alive: &dyn Fn(&str) -> bool,
+) -> DaemonStatus {
     use crate::fleet::atc::heartbeat::HeartbeatState;
     use crate::fleet::atc::meta::AtcMeta;
     use crate::fleet::atc::paths::{AtcPaths, list_instance_names_in};
@@ -865,6 +890,27 @@ pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
                     age / 60_000
                 ),
             )
+        };
+    }
+
+    // ATC has TWO halves and the heartbeat file only evidences one of them.
+    // The OS timer writes that file whether or not the Claude session it beats
+    // into still exists, so a dead `tmux_<name>` reports Running forever: the
+    // timer fires, finds nothing, exits 0, and task-log.md silently stops
+    // growing. Probing the session is the only way to tell the halves apart —
+    // the same split the bridge already models with inbound vs outbound.
+    let session = crate::tmux::sanitize_session_name(&name);
+    if !session_alive(&session) {
+        return DaemonStatus {
+            kind,
+            state: DaemonState::Degraded,
+            connected: false,
+            channel: Some(format!("{name} (every {interval_min}m)")),
+            last_activity_at: hbs.last_active_ms,
+            reason: format!(
+                "heartbeat firing every {interval_min}m but session {session} is GONE — beats are landing nowhere; `ainb fleet atc setup {name}` respawns it"
+            ),
+            ..DaemonStatus::running(kind)
         };
     }
 
@@ -2084,7 +2130,7 @@ mod tests {
     #[test]
     fn probe_atc_no_instance_is_stopped() {
         let home = TempDir::new().unwrap();
-        let s = probe_atc(home.path(), 0);
+        let s = probe_atc_with(home.path(), 0, &|_| true);
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(s.reason.contains("no ATC instance"));
     }
@@ -2109,10 +2155,62 @@ mod tests {
             ),
         )
         .unwrap();
-        let s = probe_atc(home.path(), now);
+        let s = probe_atc_with(home.path(), now, &|_| true);
         assert_eq!(s.state, DaemonState::Running);
         assert!(s.connected);
         assert!(s.channel.as_deref().unwrap().contains("primary"));
+    }
+
+    /// The regression this split exists for: the OS timer writes the heartbeat
+    /// file whether or not the session it beats into is alive, so a fresh beat
+    /// is NOT evidence ATC is working. Observed in the wild as a green row over
+    /// a session that had been gone three days.
+    #[test]
+    fn probe_atc_fresh_heartbeat_with_dead_session_is_degraded() {
+        let home = TempDir::new().unwrap();
+        let atc_dir = home.path().join("atc").join("primary");
+        std::fs::create_dir_all(&atc_dir).unwrap();
+        std::fs::write(
+            atc_dir.join("meta.json"),
+            r#"{"name":"primary","heartbeat_enabled":true,"heartbeat_interval_min":10,"idle_pause_min":60}"#,
+        )
+        .unwrap();
+        let now = super::super::heartbeat::now_ms();
+        std::fs::write(
+            atc_dir.join("heartbeat-state.json"),
+            format!(
+                r#"{{"last_heartbeat_ms":{},"last_active_ms":{},"continue_counts":{{}}}}"#,
+                now - 1000,
+                now - 2000
+            ),
+        )
+        .unwrap();
+        let s = probe_atc_with(home.path(), now, &|_| false);
+        assert_eq!(
+            s.state,
+            DaemonState::Degraded,
+            "dead session must not read as Running"
+        );
+        assert!(!s.connected);
+        assert!(
+            s.reason.contains("tmux_primary") && s.reason.contains("GONE"),
+            "reason must name the missing session: {}",
+            s.reason
+        );
+        assert!(
+            s.reason.contains("atc setup primary"),
+            "reason must name the fix: {}",
+            s.reason
+        );
+    }
+
+    /// A session check is only meaningful if it can actually fail; a name this
+    /// long cannot exist as a tmux session on any host running the suite.
+    #[test]
+    fn tmux_session_alive_is_false_for_an_impossible_name() {
+        assert!(!super::tmux_session_alive(
+            "ainb-probe-selftest-session-that-cannot-exist-0000"
+        ));
     }
 
     #[test]
@@ -2138,7 +2236,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let s = probe_atc(home.path(), now);
+        let s = probe_atc_with(home.path(), now, &|_| true);
         assert_eq!(
             s.state,
             DaemonState::Stopped,
@@ -2178,7 +2276,7 @@ mod tests {
             )
             .unwrap();
         }
-        let s = probe_atc(home.path(), now);
+        let s = probe_atc_with(home.path(), now, &|_| true);
         assert_eq!(s.state, DaemonState::Running);
         assert!(
             s.channel.as_deref().unwrap().contains("on"),
@@ -2207,7 +2305,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let s = probe_atc(home.path(), now);
+        let s = probe_atc_with(home.path(), now, &|_| true);
         assert_eq!(s.state, DaemonState::Stopped);
         assert!(s.reason.contains("stale"));
     }

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -779,6 +779,35 @@ pub(crate) fn tmux_session_alive(session: &str) -> bool {
         .is_ok_and(|out| out.status.success())
 }
 
+/// The inputs [`hangar_status_for`] reads, mirroring the fields it used to take
+/// straight off `daemon_runtime_status()`.
+struct HangarRuntime {
+    pid: Option<u32>,
+    version: Option<String>,
+    old: bool,
+}
+
+/// Count of `hangar daemon run` processes visible on this host.
+///
+/// CONTEXT ONLY, never on its own an error. The single-instance guard is
+/// PER-HOME: a machine running N ainb homes (worktrees, temp homes in tests)
+/// legitimately has N daemons, and treating that as a fault was the exact
+/// false positive a earlier orphan hunt had to unpick. The authoritative
+/// signal for THIS home stays `running_daemon_pid()`.
+fn hangar_daemon_census() -> usize {
+    std::process::Command::new("ps")
+        .args(["-axo", "args="])
+        .output()
+        .ok()
+        .map(|out| {
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .filter(|line| line.contains("hangar daemon run"))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
 pub fn probe_atc(home: &Path, now_ms: i64) -> DaemonStatus {
     probe_atc_with(home, now_ms, &tmux_session_alive)
 }
@@ -1042,6 +1071,29 @@ pub fn probe_hangar_daemon() -> DaemonStatus {
     let runtime = crate::cli::hangar::daemon_runtime_status();
     let serving = crate::fleet::bridge::daemon::socket_path()
         .is_some_and(|socket| socket_is_listening(&socket));
+    hangar_status_for(
+        runtime.pid,
+        runtime.version,
+        runtime.old,
+        serving,
+        hangar_daemon_census,
+    )
+}
+
+/// [`probe_hangar_daemon`]'s decision, with every input passed in.
+///
+/// Split out so the ownership cases are testable: the interesting one is a
+/// socket that answers while this home records no owner, which cannot be
+/// staged against a real daemon without racing the host's own.
+pub(crate) fn hangar_status_for(
+    pid: Option<u32>,
+    version: Option<String>,
+    old: bool,
+    serving: bool,
+    census: impl Fn() -> usize,
+) -> DaemonStatus {
+    let kind = DaemonKind::HangarDaemon;
+    let runtime = HangarRuntime { pid, version, old };
     match (runtime.pid, serving) {
         (None, false) => DaemonStatus::stopped(kind, "not running".to_string()),
         // A recorded owner with a dead socket is the half-alive case the
@@ -1052,6 +1104,22 @@ pub fn probe_hangar_daemon() -> DaemonStatus {
             version_current: runtime.version.as_deref().map(|v| v == env!("CARGO_PKG_VERSION")),
             version: runtime.version,
             reason: format!("pid {pid} owns this home but the socket is not accepting"),
+            ..DaemonStatus::running(kind)
+        },
+        // Socket answering while this home records NO owner: something else is
+        // serving our socket. That is the split-brain that makes
+        // `ainb fleet atc repair` bail with "the daemon did NOT accept the
+        // unregister" — the verb dials the socket, a daemon this home does not
+        // own answers, and the registration lives somewhere else entirely.
+        (None, true) => DaemonStatus {
+            state: DaemonState::Degraded,
+            connected: true,
+            channel: Some("unix socket".to_string()),
+            reason: format!(
+                "socket is served by a daemon this home does not own ({} running \
+host-wide) — `ainb hangar daemon restart` re-takes ownership",
+                census()
+            ),
             ..DaemonStatus::running(kind)
         },
         (pid, true) => DaemonStatus {
@@ -2202,6 +2270,53 @@ mod tests {
             "reason must name the fix: {}",
             s.reason
         );
+    }
+
+    /// The split-brain that makes `ainb fleet atc repair` bail with "the daemon
+    /// did NOT accept the unregister": a socket answers, but this home records
+    /// no owner, so the verb dials a daemon whose registration lives elsewhere.
+    #[test]
+    fn hangar_socket_served_without_a_recorded_owner_is_degraded() {
+        let s = super::hangar_status_for(None, None, false, true, || 3);
+        assert_eq!(
+            s.state,
+            DaemonState::Degraded,
+            "unowned socket must not read as Running"
+        );
+        assert!(s.connected, "the socket IS answering; that half is fine");
+        assert!(
+            s.reason.contains("does not own") && s.reason.contains('3'),
+            "reason must say it is unowned and how many are host-wide: {}",
+            s.reason
+        );
+        assert!(
+            s.reason.contains("hangar daemon restart"),
+            "reason must name the fix: {}",
+            s.reason
+        );
+    }
+
+    /// The census is CONTEXT, never the fault: one ainb home per worktree is
+    /// normal, and counting host-wide daemons as strays was the false positive
+    /// this branch had to avoid.
+    #[test]
+    fn hangar_owned_socket_stays_running_however_many_homes_exist() {
+        let s = super::hangar_status_for(Some(42), None, false, true, || 9);
+        assert_eq!(s.state, DaemonState::Running);
+        assert_eq!(s.pid, Some(42));
+        assert!(
+            !s.reason.contains('9'),
+            "census must not leak into a healthy row: {}",
+            s.reason
+        );
+    }
+
+    /// A recorded owner with a dead socket is the other half-alive case.
+    #[test]
+    fn hangar_recorded_owner_with_dead_socket_is_degraded() {
+        let s = super::hangar_status_for(Some(7), None, false, false, || 1);
+        assert_eq!(s.state, DaemonState::Degraded);
+        assert!(s.reason.contains("not accepting"), "{}", s.reason);
     }
 
     /// A session check is only meaningful if it can actually fail; a name this

--- a/ainb-tui/crates/ainb-core/src/tmux/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/mod.rs
@@ -19,6 +19,49 @@ use anyhow::Result;
 use tokio::process::Command;
 use tracing::debug;
 
+/// Whether a tmux session with EXACTLY this name exists.
+///
+/// `Some(true)` / `Some(false)` are proven answers. `None` means the question
+/// could not be answered: tmux missing from PATH (a launchd-spawned process
+/// gets a minimal one), a wedged server, or a fork that failed under load.
+/// Callers must not read `None` as "dead": a liveness check that turns an
+/// environment problem into a fault would report a healthy session as broken.
+///
+/// The `=` prefix is load-bearing. Bare `has-session -t foo` resolves by
+/// prefix and fnmatch, so it exits 0 for `foo-fix` when `foo` itself is long
+/// gone. Only `-t =foo` compares exactly.
+///
+/// Bounded: a wedged tmux server never returns, and every caller here sits on
+/// a collector loop that must keep publishing.
+#[must_use]
+pub fn session_alive(session: &str) -> Option<bool> {
+    let mut child = std::process::Command::new("tmux")
+        .args(["has-session", "-t", &format!("={session}")])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    let deadline = std::time::Instant::now() + SESSION_PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status.success()),
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            // Wedged or unreadable: kill the child so it cannot outlive the
+            // probe, and report "unknown" rather than guessing.
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
+/// How long [`session_alive`] waits before calling the answer unknown.
+const SESSION_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Sanitize a name into the tmux session name `ainb` actually spawns under.
 ///
 /// This is the single source of truth shared by [`session::TmuxSession`] (the


### PR DESCRIPTION
## The bug, observed live

The Daemons screen showed:

```
atc: running, connected=true
reason: "heartbeat alive — last beat 6m ago"
```

while `tmux_main` had been gone **three days** and `task-log.md` had not grown in 79 hours.

ATC has two halves that fail independently — an OS timer, and the Claude session it beats into. `probe_atc` only ever read `heartbeat-state.json`, which the **timer** writes. So every beat fired, found no session, exited 0, and nothing surfaced it: the one file the probe consulted was still being updated on schedule.

`grep -c tmux_session_exists probe.rs` → `0`.

## What changed

| commit | row | now |
|---|---|---|
| `probe the ATC session` | atc | `Degraded` when timer alive + session dead, reason names the session and the fix |
| `flag a hangar socket this home does not own` | hangar-daemon | `Degraded` on `(None, true)` — socket answers, this home records no owner |
| `start ATC by respawning its dead session` | — | `daemon atc start` picks the broken half instead of always calling `repair` |

Live, from the patched binary:

```
atc: state=degraded connected=false
  reason: heartbeat firing every 10m but session tmux_main is GONE —
          beats are landing nowhere; `ainb fleet atc setup main` respawns it
```

## Why start was failing

`daemon atc start` routed unconditionally to `fleet atc repair`, which re-asserts the **scheduler**. On a host whose only fault was a dead session that produced:

> Error: cannot repair ATC 'main': the daemon is reachable and did NOT accept the unregister, so it may still hold the heartbeat cron.

Wrong half. Start/restart now route to `setup` (idempotent, preserves `state.json` / `task-log.md`) when the session is dead, and to `repair` when it is alive. That is the same verb the Daemons screen dispatches, so the row's advice and its button now agree.

## The false positive this deliberately avoids

Counting `hangar daemon run` processes host-wide and calling the extras strays would be **wrong**: the single-instance guard is per-home, so N ainb homes legitimately means N daemons. Ownership of *this* home stays the authoritative signal; the census rides along as context only, and `hangar_owned_socket_stays_running_however_many_homes_exist` asserts it never leaks into a healthy row.

## Testing

`cargo test -p ainb --lib` → **2025 passed, 0 failed** (rebased onto main, 167 commits).

Four new cases, each pinning a branch that previously could not be reached:

- `probe_atc_fresh_heartbeat_with_dead_session_is_degraded` — the exact wild regression
- `hangar_socket_served_without_a_recorded_owner_is_degraded`
- `hangar_owned_socket_stays_running_however_many_homes_exist` — the census must not fire
- `tmux_session_alive_is_false_for_an_impossible_name` — the check can actually fail

Both probes had their decision split from their I/O (`probe_atc_with`, `hangar_status_for`) so the branches are testable at all: a temp-home fixture has no tmux session, so a hard-wired `has-session` would have reported every existing test instance as degraded.