### PR TITLE
fix: ainb config path showed three of four files, all mislabelled

### DIFF
--- a/ainb-tui/CLAUDE.md
+++ b/ainb-tui/CLAUDE.md
@@ -197,10 +197,16 @@ The config auto-detects and uses it if installed.
 
 ## Configuration
 
-Configuration files are loaded from (in order of precedence):
-1. `./.ainb/config.toml` (project-level; legacy `./.agents-box/config.toml` still read)
-2. `~/.agents-in-a-box/config/config.toml` (user-level)
-3. `/etc/agents-in-a-box/config.toml` (system-level)
+Configuration is read from four locations (`ainb config path` lists them):
+1. `./.ainb/config.toml` (project-level)
+2. `./.agents-box/config.toml` (project-level, legacy name)
+3. `~/.agents-in-a-box/config/config.toml` (user-level)
+4. `/etc/agents-in-a-box/config.toml` (system-level)
+
+**Known issue:** precedence currently runs the wrong way — the system file
+overrides the user's, which overrides a project's. Reordering alone is unsafe
+because `merge_loaded` assigns some fields unconditionally, so a project file
+that omits a section resets it to defaults; the two land together.
 
 See `config/example.config.toml` for all available options with documentation.
 

--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -2,10 +2,19 @@
 # ==============================
 # Copy this file to: ~/.agents-in-a-box/config/config.toml
 #
-# Configuration is loaded from (in order of precedence):
-#   1. ./.agents-box/config.toml  (project-level)
-#   2. ~/.agents-in-a-box/config/config.toml  (user-level)
-#   3. /etc/agents-in-a-box/config.toml  (system-level)
+# Configuration is read from four locations. `ainb config path` prints them
+# with a mark against the ones that exist:
+#   ./.ainb/config.toml                    (project-level)
+#   ./.agents-box/config.toml              (project-level, legacy name)
+#   ~/.agents-in-a-box/config/config.toml  (user-level)
+#   /etc/agents-in-a-box/config.toml       (system-level)
+#
+# KNOWN ISSUE: which one wins is currently the reverse of what you would
+# expect — the system file overrides the user's, which overrides a project's.
+# Fixing the order alone is unsafe today, because merging a layer also resets
+# a few fields it does not mention, so a small project file would silently
+# clear settings from your user config. Both are being fixed together; until
+# then, prefer keeping settings in ONE of these files.
 
 version = "0.1.0"
 

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -355,17 +355,19 @@ fn cmd_reset(force: bool) -> Result<()> {
 
 /// Show all config file locations with existence markers
 fn cmd_path(format: OutputFormat) -> Result<()> {
+    // Merge order, not a claimed precedence ranking. `load` applies these in
+    // order and each overrides the previous, so this IS the precedence — and
+    // today it runs the surprising way round, with the system file last and
+    // therefore strongest. Printing the real order beats printing a ranking
+    // the loader does not implement.
     let paths = AppConfig::get_config_paths();
-
-    let scopes = ["project", "user", "system"];
 
     match format {
         OutputFormat::Json => {
             let entries: Vec<ConfigPathEntry> = paths
                 .iter()
-                .zip(scopes.iter())
-                .map(|(path, scope)| ConfigPathEntry {
-                    scope: (*scope).to_string(),
+                .map(|(scope, path)| ConfigPathEntry {
+                    scope: scope.as_str().to_string(),
                     path: path.display().to_string(),
                     exists: path.exists(),
                 })
@@ -375,18 +377,25 @@ fn cmd_path(format: OutputFormat) -> Result<()> {
             println!("{json}");
         }
         OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
-            let labels = ["Project config", "User config", "System config"];
-
-            println!("Configuration file locations (highest precedence first):");
+            println!("Configuration file locations, in load order:");
+            println!("(each file overrides the ones above it)");
             println!("{}", "\u{2501}".repeat(60));
 
-            for (i, path) in paths.iter().enumerate() {
-                let exists = path.exists();
-                let marker = if exists { "\u{2713}" } else { "\u{2717}" };
-                let label = labels.get(i).unwrap_or(&"Config");
-                println!("  {marker} {label}: {}", path.display());
+            for (scope, path) in &paths {
+                let marker = if path.exists() {
+                    "\u{2713}"
+                } else {
+                    "\u{2717}"
+                };
+                println!("  {marker} {}: {}", scope.label(), path.display());
             }
 
+            println!();
+            println!(
+                "Note: the system file currently overrides the user's, and the user's\n\
+                 overrides a project's. That is the reverse of what you would expect\n\
+                 and is being fixed; until then, keep settings in one of these files."
+            );
             println!();
             println!("Use 'ainb config edit' to open the user config in your editor.");
         }

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -1604,6 +1604,45 @@ fn migrate_stray_user_config(canonical: &Path) {
         "merged stray config.toml into the user config"
     );
 }
+/// Which layer a config file belongs to.
+///
+/// Carried alongside the path so a caller cannot mislabel it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigScope {
+    /// `/etc/agents-in-a-box/config.toml` — lowest precedence.
+    System,
+    /// `~/.agents-in-a-box/config/config.toml`.
+    User,
+    /// `./.agents-box/config.toml`, the legacy project location.
+    ProjectLegacy,
+    /// `./.ainb/config.toml` — highest precedence.
+    Project,
+}
+
+impl ConfigScope {
+    /// Human label for `ainb config path`.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::System => "System config",
+            Self::User => "User config",
+            Self::ProjectLegacy => "Project config (legacy .agents-box)",
+            Self::Project => "Project config",
+        }
+    }
+
+    /// Stable machine name for `--format json`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::User => "user",
+            Self::ProjectLegacy => "project-legacy",
+            Self::Project => "project",
+        }
+    }
+}
+
 impl AppConfig {
     /// One-shot cleanup of config files left behind by older builds.
     ///
@@ -1625,7 +1664,7 @@ impl AppConfig {
         let mut config = Self::default();
 
         // Load each config file and merge
-        for path in config_paths {
+        for (_scope, path) in config_paths {
             if path.exists() {
                 let content = fs::read_to_string(&path)
                     .with_context(|| format!("Failed to read config from {}", path.display()))?;
@@ -1858,25 +1897,44 @@ impl AppConfig {
         )
     }
 
-    /// Get configuration file paths in order of precedence
-    pub fn get_config_paths() -> Vec<PathBuf> {
+    /// Every config file location, in the order [`Self::load`] merges them.
+    ///
+    /// Each file overrides the last, so the LAST entry wins — which today means
+    /// the system config outranks the user's and a project's. That is the
+    /// inverse of what the docs and `ainb config path` describe, and it is not
+    /// fixed here: `merge_loaded` assigns several fields unconditionally
+    /// (`authentication.cli_provider`, `ui_preferences.statusline_decision`,
+    /// `workspace_defaults.max_repositories`, …), so "last file wins" currently
+    /// means "the last file's serde DEFAULTS win" for those. Reordering without
+    /// first making the merge per-field lets a project file containing only
+    /// `[docker] timeout = 22` reset a user's provider, wizard decisions and
+    /// scan limit — and the next `save()` writes that reset into their file.
+    ///
+    /// See `agents-in-a-box-l0sq`: the reorder lands with that change,
+    /// not before it.
+    ///
+    /// Returns the scope with each path. They used to be parallel arrays zipped
+    /// at the call site, where four paths met three labels and the last one was
+    /// silently dropped.
+    pub fn get_config_paths() -> Vec<(ConfigScope, PathBuf)> {
         let mut paths = vec![];
 
-        // 1. Local project config — `.ainb/` is canonical; `.agents-box/`
-        //    is the legacy location, still read but listed first so an
-        //    `.ainb/` file wins when both exist (later files override).
         if let Ok(cwd) = std::env::current_dir() {
-            paths.push(cwd.join(".agents-box").join("config.toml"));
-            paths.push(cwd.join(".ainb").join("config.toml"));
+            paths.push((
+                ConfigScope::ProjectLegacy,
+                cwd.join(".agents-box").join("config.toml"),
+            ));
+            paths.push((ConfigScope::Project, cwd.join(".ainb").join("config.toml")));
         }
 
-        // 2. User config (~/.agents-in-a-box/config/config.toml)
         if let Ok(config_dir) = Self::get_user_config_dir() {
-            paths.push(config_dir.join("config.toml"));
+            paths.push((ConfigScope::User, config_dir.join("config.toml")));
         }
 
-        // 3. System config
-        paths.push(PathBuf::from("/etc/agents-in-a-box/config.toml"));
+        paths.push((
+            ConfigScope::System,
+            PathBuf::from("/etc/agents-in-a-box/config.toml"),
+        ));
 
         paths
     }
@@ -3239,8 +3297,8 @@ show_git_status = false
     #[test]
     fn project_config_paths_prefer_ainb_over_legacy() {
         let paths = AppConfig::get_config_paths();
-        let ainb = paths.iter().position(|p| p.ends_with(".ainb/config.toml"));
-        let legacy = paths.iter().position(|p| p.ends_with(".agents-box/config.toml"));
+        let ainb = paths.iter().position(|(_, p)| p.ends_with(".ainb/config.toml"));
+        let legacy = paths.iter().position(|(_, p)| p.ends_with(".agents-box/config.toml"));
         let (ainb, legacy) = (
             ainb.expect(".ainb path missing"),
             legacy.expect("legacy path missing"),


### PR DESCRIPTION
Bead `agents-in-a-box-hyu3`, **half of it**. Please read the scope note before the diff.

## What this fixes

`ainb config path` zipped four paths against three scope labels:

```rust
let scopes = ["project", "user", "system"];
paths.iter().zip(scopes.iter())
```

So `/etc/agents-in-a-box/config.toml` was never printed at all, and each remaining path took its neighbour's name — the legacy `.agents-box` file was labelled "project", `.ainb` was labelled "user", and the real user config was labelled "system".

Fixed structurally: `get_config_paths()` returns a `ConfigScope` with each path, so a caller cannot pair them up wrongly.

```
$ ainb config path
Configuration file locations, in load order:
(each file overrides the ones above it)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  ✗ Project config (legacy .agents-box): …/.agents-box/config.toml
  ✗ Project config: …/.ainb/config.toml
  ✗ User config: ~/.agents-in-a-box/config/config.toml
  ✗ System config: /etc/agents-in-a-box/config.toml

Note: the system file currently overrides the user's, and the user's
overrides a project's. That is the reverse of what you would expect
and is being fixed; until then, keep settings in one of these files.
```

The header also stops claiming "highest precedence first", which was false. It prints load order and says each file overrides the ones above it, which is what actually happens.

## What this deliberately does NOT fix

The bead's other half is that precedence runs backwards — the system file wins, a project's loses. **I wrote that fix, tested it, and backed it out**, because reordering alone is actively harmful today.

`merge_loaded` is not a key-by-key merge. Several fields are assigned unconditionally from whichever layer is merged last:

```rust
self.authentication.cli_provider          = other.authentication.cli_provider;
self.ui_preferences.statusline_decision   = other.ui_preferences.statusline_decision;
self.workspace_defaults.max_repositories  = other.workspace_defaults.max_repositories;
```

So "last file wins" means "the last file's serde **defaults** win" for those. With the order flipped, a project config containing nothing but `[docker] timeout = 22` produces this — measured against the built binary, not reasoned about:

| key | user config | after load, with the flip |
|---|---|---|
| `authentication.cli_provider` | `codex` | `claude` |
| `workspace_defaults.max_repositories` | `99` | `500` |
| `ui_preferences.show_git_status` | `false` | `true` |
| `ui_preferences.statusline_decision` | `declined` | `unset` |

And it persists: many commands load → mutate → save, so the reset gets written into the user's own file. `statusline_decision` returning to `unset` means the init wizard re-prompts forever, which is the exact thing that field exists to prevent. `ainb mcp import` creates `./.ainb/config.toml`, so a single import would poison every later run in that repo.

The reorder lands together with the per-field merge (`agents-in-a-box-l0sq`), not before it. `get_config_paths()`'s doc comment says so, and the CLI warns users in the meantime.

## Verification

`ainb` lib 2020, behavioral 51, example_config_parses 4. The listing above is captured from the built binary.
