### PR TITLE
ci: stop a changes failure from stranding every open PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,15 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     needs: changes
+    # Bare `!cancelled()`, with NO relevance clause: it exists so this job is
+    # never SKIPPED. `needs: changes` carries an implicit `success()`, so one
+    # failure in `changes` would skip this job, and GitHub does not expand
+    # `strategy.matrix` for a job it never dispatches: it reports a single
+    # check under the literal unexpanded name. Ruleset 11610771 requires the
+    # EXPANDED names, so that one skip strands every open PR on "Expected".
+    # The relevance clause stays on the steps, where a gated-out PR still
+    # costs no compute and the check still reports under its real name.
+    if: '!cancelled()'
     # 40 against a 28.7min p95. A macOS leg once sat here for 97 minutes with
     # the nextest step never recording a completion, and with no budget set
     # nothing would have killed it before GitHub's 360min default.
@@ -375,6 +384,15 @@ jobs:
   ainb-hooks:
     name: ainb-hooks (${{ matrix.os }})
     needs: changes
+    # Bare `!cancelled()`, with NO relevance clause: it exists so this job is
+    # never SKIPPED. `needs: changes` carries an implicit `success()`, so one
+    # failure in `changes` would skip this job, and GitHub does not expand
+    # `strategy.matrix` for a job it never dispatches: it reports a single
+    # check under the literal unexpanded name. Ruleset 11610771 requires the
+    # EXPANDED names, so that one skip strands every open PR on "Expected".
+    # The relevance clause stays on the steps, where a gated-out PR still
+    # costs no compute and the check still reports under its real name.
+    if: '!cancelled()'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
@@ -401,7 +419,10 @@ jobs:
       # nothing is ever proven and reaping silently becomes a no-op, which fails
       # `reap_signals_a_notifyd_serving_this_home` on Linux while macOS passes.
       - name: Install tmux and lsof (Linux only; macOS runner ships them)
-        if: matrix.os == 'ubuntu-latest'
+        if: >-
+          matrix.os == 'ubuntu-latest' && !cancelled() &&
+          (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
         run: sudo apt-get update && sudo apt-get install -y tmux jq lsof
       - name: Verify hook script parses on the runner
         if: >-
@@ -471,6 +492,15 @@ jobs:
   fleet-send-tmux:
     name: fleet send integrity (${{ matrix.os }})
     needs: changes
+    # Bare `!cancelled()`, with NO relevance clause: it exists so this job is
+    # never SKIPPED. `needs: changes` carries an implicit `success()`, so one
+    # failure in `changes` would skip this job, and GitHub does not expand
+    # `strategy.matrix` for a job it never dispatches: it reports a single
+    # check under the literal unexpanded name. Ruleset 11610771 requires the
+    # EXPANDED names, so that one skip strands every open PR on "Expected".
+    # The relevance clause stays on the steps, where a gated-out PR still
+    # costs no compute and the check still reports under its real name.
+    if: '!cancelled()'
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
@@ -531,6 +561,15 @@ jobs:
   hangar-e2e:
     name: hangar-e2e (${{ matrix.os }})
     needs: changes
+    # Bare `!cancelled()`, with NO relevance clause: it exists so this job is
+    # never SKIPPED. `needs: changes` carries an implicit `success()`, so one
+    # failure in `changes` would skip this job, and GitHub does not expand
+    # `strategy.matrix` for a job it never dispatches: it reports a single
+    # check under the literal unexpanded name. Ruleset 11610771 requires the
+    # EXPANDED names, so that one skip strands every open PR on "Expected".
+    # The relevance clause stays on the steps, where a gated-out PR still
+    # costs no compute and the check still reports under its real name.
+    if: '!cancelled()'
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/toolkit-validation.yml
+++ b/.github/workflows/toolkit-validation.yml
@@ -78,10 +78,12 @@ jobs:
           workspaces: ainb-tui
 
       - name: Clone pinned ainb-toolkit
+        env:
+          TOOLKIT_DIR: ${{ github.workspace }}/ainb-toolkit
         run: |
           git clone --depth 1 --branch "${AINB_TOOLKIT_REF}" \
             https://github.com/stevengonsalvez/ainb-toolkit.git \
-            "${{ github.workspace }}/ainb-toolkit"
+            "${TOOLKIT_DIR}"
 
       - name: Enforce every embedded template skill resolves in ainb-toolkit
         env:
@@ -93,10 +95,12 @@ jobs:
           cargo test -p ainb-hangar-core --test template_registry_tests -- --nocapture
 
       - name: Generate catalog index from the pinned ainb-toolkit (sanity)
+        env:
+          TOOLKIT_DIR: ${{ github.workspace }}/ainb-toolkit
         run: |
           cd ainb-tui
           cargo run -p xtask -- gen-catalog-index \
-            --toolkit-root "${{ github.workspace }}/ainb-toolkit" \
+            --toolkit-root "${TOOLKIT_DIR}" \
             --release-tag "${AINB_TOOLKIT_REF}" \
             --out "${RUNNER_TEMP}/catalog-index.json"
           # Owned URIs must pin the cloned ainb-toolkit ref.


### PR DESCRIPTION
Follow-up to #799, found during its review. Latent, pre-existing, and unpleasant when it fires.

### The lockout

`test`, `ainb-hooks`, `fleet-send-tmux` and `hangar-e2e` carry `needs: changes` with **no job-level `if:`**, so the implicit `success()` applies. One failure in the `changes` job skips all four.

GitHub does not expand `strategy.matrix` for a job it never dispatches. A skipped matrix job reports a **single** check under the literal unexpanded name. Confirmed on run 32952756689, where release.yml's 3-target `build` job reported as:

```
skipped   Build ${{ matrix.target }}
```

Ruleset 11610771 on `main` requires the expanded names:

```
Test (ubuntu-latest)
Test (macos-latest)
hangar-e2e (ubuntu-latest)
hangar-e2e (macos-latest)
```

So a single bad `changes` run strands **every open PR** on "Expected", with no recovery except editing the ruleset. `changes` is one `dorny/paths-filter` step, so this is unlikely, not impossible, and the blast radius is the whole repo.

### The fix

A bare `!cancelled()` on those four jobs. No relevance clause: the point is that the job is never *skipped*, so it always dispatches and always reports under its real expanded matrix name.

**The relevance clause deliberately stays on the steps.** Moving it up to the job is exactly what made #793 unsafe: it let a docs-only PR skip the job and hit the same unexpanded-name problem from the other direction. Here the job always dispatches, while a gated-out PR still runs zero steps and costs no compute. Correctness over the runner-allocation saving.

### Also in scope

- `ci.yml` "Install tmux and lsof" had no relevance clause, so a docs-only PR still paid for an `apt-get update && install` on the ubuntu leg. Now gated.
- `toolkit-validation.yml` interpolated `${{ github.workspace }}` straight into two `run:` bodies, where the runner expands it before the shell sees it. Both now bind through `env:`. The third use was already an `env:` value and is fine.

### Verification

`actionlint -shellcheck=` exit 0. All four jobs confirmed via YAML parse to carry the new guard, and no `github.workspace` remains inside a `run:` body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request validation reliability when an earlier change-detection check fails.
  - Required checks now continue to report results instead of remaining indefinitely in an “Expected” state.
  - Preserved selective execution so only relevant validation steps run.

- **Chores**
  - Improved consistency and maintainability of toolkit validation and automated testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->