### PR TITLE
DO NOT MERGE: probe changes-job failure semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
       acp: ${{ steps.filter.outputs.acp }}
     steps:
+      # THROWAWAY PROBE, DO NOT MERGE. Forces the `changes` job to FAIL before
+      # the filter can set `relevant`, so downstream jobs see a missing output.
+      - name: Force changes to fail (probe)
+        run: exit 1
       - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter


### PR DESCRIPTION
Throwaway probe. Forces the `changes` job to fail so we can read what `needs.changes.outputs.relevant` resolves to in downstream job/step guards. Branch will be deleted.