### PR TITLE
fix: a project config now overrides the user's, not the other way round

### DIFF
--- a/ainb-tui/CLAUDE.md
+++ b/ainb-tui/CLAUDE.md
@@ -197,16 +197,13 @@ The config auto-detects and uses it if installed.
 
 ## Configuration
 
-Configuration is read from four locations (`ainb config path` lists them):
+Configuration files are read from these locations, highest precedence first.
+The most specific file wins, key by key — a file only overrides the keys it
+writes, so a project config cannot disturb unrelated user settings:
 1. `./.ainb/config.toml` (project-level)
 2. `./.agents-box/config.toml` (project-level, legacy name)
 3. `~/.agents-in-a-box/config/config.toml` (user-level)
 4. `/etc/agents-in-a-box/config.toml` (system-level)
-
-**Known issue:** precedence currently runs the wrong way — the system file
-overrides the user's, which overrides a project's. Reordering alone is unsafe
-because `merge_loaded` assigns some fields unconditionally, so a project file
-that omits a section resets it to defaults; the two land together.
 
 See `config/example.config.toml` for all available options with documentation.
 

--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -2,19 +2,17 @@
 # ==============================
 # Copy this file to: ~/.agents-in-a-box/config/config.toml
 #
-# Configuration is read from four locations. `ainb config path` prints them
-# with a mark against the ones that exist:
-#   ./.ainb/config.toml                    (project-level)
-#   ./.agents-box/config.toml              (project-level, legacy name)
-#   ~/.agents-in-a-box/config/config.toml  (user-level)
-#   /etc/agents-in-a-box/config.toml       (system-level)
+# Configuration is read from these four locations, HIGHEST precedence first.
+# The most specific file wins, key by key — a file only overrides the keys it
+# actually writes, so a small project config cannot disturb your other
+# settings:
+#   1. ./.ainb/config.toml                    (project-level)
+#   2. ./.agents-box/config.toml              (project-level, legacy name)
+#   3. ~/.agents-in-a-box/config/config.toml  (user-level)
+#   4. /etc/agents-in-a-box/config.toml       (system-level)
 #
-# KNOWN ISSUE: which one wins is currently the reverse of what you would
-# expect — the system file overrides the user's, which overrides a project's.
-# Fixing the order alone is unsafe today, because merging a layer also resets
-# a few fields it does not mention, so a small project file would silently
-# clear settings from your user config. Both are being fixed together; until
-# then, prefer keeping settings in ONE of these files.
+# `ainb config path` prints the same list with a mark against the ones that
+# exist.
 
 version = "0.1.0"
 

--- a/ainb-tui/config/example.config.toml
+++ b/ainb-tui/config/example.config.toml
@@ -41,7 +41,7 @@ version = "0.1.0"
 # =============================================================================
 [authentication]
 # Active CLI provider for agent sessions
-# Options: "claude" | "codex" | "gemini" | "copilot"
+# Options: "claude" | "codex" | "gemini" | "copilot" | "antigravity"
 cli_provider = "claude"
 
 # Claude-specific authentication provider

--- a/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/config_cmd.rs
@@ -355,12 +355,10 @@ fn cmd_reset(force: bool) -> Result<()> {
 
 /// Show all config file locations with existence markers
 fn cmd_path(format: OutputFormat) -> Result<()> {
-    // Merge order, not a claimed precedence ranking. `load` applies these in
-    // order and each overrides the previous, so this IS the precedence — and
-    // today it runs the surprising way round, with the system file last and
-    // therefore strongest. Printing the real order beats printing a ranking
-    // the loader does not implement.
-    let paths = AppConfig::get_config_paths();
+    // Reversed: `get_config_paths` returns lowest precedence first, because
+    // that is the order `load` merges in. Users want the strongest file at the
+    // top.
+    let paths: Vec<_> = AppConfig::get_config_paths().into_iter().rev().collect();
 
     match format {
         OutputFormat::Json => {
@@ -377,8 +375,8 @@ fn cmd_path(format: OutputFormat) -> Result<()> {
             println!("{json}");
         }
         OutputFormat::Text | OutputFormat::Csv | OutputFormat::Markdown => {
-            println!("Configuration file locations, in load order:");
-            println!("(each file overrides the ones above it)");
+            println!("Configuration file locations (highest precedence first):");
+            println!("(the most specific file wins, key by key)");
             println!("{}", "\u{2501}".repeat(60));
 
             for (scope, path) in &paths {
@@ -390,12 +388,6 @@ fn cmd_path(format: OutputFormat) -> Result<()> {
                 println!("  {marker} {}: {}", scope.label(), path.display());
             }
 
-            println!();
-            println!(
-                "Note: the system file currently overrides the user's, and the user's\n\
-                 overrides a project's. That is the reverse of what you would expect\n\
-                 and is being fixed; until then, keep settings in one of these files."
-            );
             println!();
             println!("Use 'ainb config edit' to open the user config in your editor.");
         }

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -227,6 +227,21 @@ fn default_claude_model() -> String {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
+    /// Every layer EXCEPT the user file, merged.
+    ///
+    /// `save()` writes the user file, but this struct is the merge of every
+    /// layer — so without knowing what the other layers already provide, a
+    /// save bakes their values into the user's own file. Since a project
+    /// config now outranks the user's, that means a repo's `.ainb/config.toml`
+    /// would overwrite the user's global settings the first time they toggled
+    /// anything in that repo. `ainb mcp import` writes such a file by default,
+    /// so this is not a corner case.
+    ///
+    /// Skipped by serde: it is provenance, not configuration, and must never
+    /// reach a config file.
+    #[serde(skip)]
+    inherited: toml::Table,
+
     /// Application version
     #[serde(default = "default_version")]
     pub version: String,
@@ -1818,12 +1833,30 @@ impl AppConfig {
             loaded.push(path);
         }
 
+        // The same merge with the user layer left out. Comparing against this
+        // is how `save()` tells "the user set this" from "a project or system
+        // file provides this".
+        let mut inherited = toml::Table::new();
+        for (scope, path) in Self::get_config_paths() {
+            if scope == ConfigScope::User || !path.exists() {
+                continue;
+            }
+            let Ok(content) = fs::read_to_string(&path) else {
+                continue;
+            };
+            if let Ok(layer) = parse_config_layer(&content) {
+                merge_config_tables(&mut inherited, layer);
+            }
+        }
+
         let mut config = Self::from_merged_layers(merged).with_context(|| {
             format!(
                 "Failed to load config merged from {}",
                 loaded.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
             )
         })?;
+
+        config.inherited = inherited;
 
         // Load built-in container templates if none exist
         if config.container_templates.is_empty() {
@@ -1964,7 +1997,29 @@ impl AppConfig {
             }
         }
 
+        // Write only what the USER layer owns. This struct is the merge of
+        // every layer, so a leaf whose value another layer already provides is
+        // not ours to persist — writing it would copy a project's or the
+        // system's setting into the user's global file, where it then applies
+        // everywhere. A leaf the user file already carries stays, even if it
+        // agrees with another layer: it was theirs before this save and
+        // dropping it would be a silent deletion.
+        let inherited = toml::Value::Table(self.inherited.clone());
+        let already_ours: std::collections::HashSet<String> = existing
+            .parse::<toml::Table>()
+            .map(|table| {
+                let mut leaves = Vec::new();
+                flatten_leaves(&table, String::new(), &mut leaves);
+                leaves.into_iter().map(|(key, _)| key).collect()
+            })
+            .unwrap_or_default();
+
         for (key, value) in &ours_leaves {
+            if !already_ours.contains(key)
+                && registry::navigate_toml(&inherited, key).is_ok_and(|from| from == value)
+            {
+                continue;
+            }
             set_document_key(&mut doc, key, value)?;
         }
         Ok(doc.to_string())
@@ -2133,6 +2188,7 @@ impl AppConfig {
 impl Default for AppConfig {
     fn default() -> Self {
         let mut config = Self {
+            inherited: toml::Table::new(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             authentication: AuthenticationConfig::default(),
             default_container_template: default_container_template(),
@@ -2876,6 +2932,69 @@ timeout = 60
         );
         // The whole point: it must still load.
         toml::from_str::<AppConfig>(&saved).expect("saved config no longer deserializes");
+    }
+
+    /// A save must not copy another layer's values into the user's file.
+    ///
+    /// This struct is the merge of every layer, and `save()` writes the USER
+    /// file. Now that a project config outranks the user's, a repo's
+    /// `.ainb/config.toml` would otherwise be baked into
+    /// `~/.agents-in-a-box/config/config.toml` the first time anything was
+    /// toggled in that repo — and `ainb mcp import` creates such a file by
+    /// default, so it is a path people actually walk.
+    #[test]
+    fn save_does_not_persist_values_another_layer_provides() {
+        let project = "[docker]\ntimeout = 22\n[fleet]\nterminal = \"ghostty\"\n";
+        let user_file = "[ui_preferences]\ntheme = \"dark\"\n";
+
+        // What `load()` would produce: user then project, project winning.
+        let mut config = AppConfig::from_layers([user_file, project]).expect("layers");
+        config.inherited = project.parse().expect("project layer");
+        // The user changes one thing in the settings screen.
+        config.ui_preferences.theme = "light".to_string();
+
+        let saved = config.overlay_onto_existing(user_file).expect("overlays");
+        let reparsed: toml::Table = saved.parse().expect("valid TOML");
+
+        assert_eq!(
+            reparsed["ui_preferences"]["theme"].as_str(),
+            Some("light"),
+            "the user's own edit was not saved"
+        );
+        // Asserted on VALUES, not section presence: a section whose fields all
+        // have serde defaults still serializes as an empty table, which is
+        // noise rather than a leaked setting.
+        assert!(
+            registry::navigate_toml(&toml::Value::Table(reparsed.clone()), "fleet.terminal")
+                .is_err(),
+            "the project's fleet.terminal was copied into the user's file:\n{saved}"
+        );
+        assert!(
+            registry::navigate_toml(&toml::Value::Table(reparsed.clone()), "docker.timeout")
+                .is_err(),
+            "the project's docker.timeout was copied into the user's file:\n{saved}"
+        );
+    }
+
+    /// The other half: a value the user file already carries stays, even when
+    /// another layer happens to agree. Dropping it would be a silent deletion
+    /// of something they set.
+    #[test]
+    fn save_keeps_a_user_value_another_layer_agrees_with() {
+        let project = "[docker]\ntimeout = 22\n";
+        let user_file = "[docker]\ntimeout = 22\n";
+
+        let mut config = AppConfig::from_layers([user_file, project]).expect("layers");
+        config.inherited = project.parse().expect("project layer");
+
+        let saved = config.overlay_onto_existing(user_file).expect("overlays");
+        let reparsed: toml::Table = saved.parse().expect("valid TOML");
+
+        assert_eq!(
+            reparsed["docker"]["timeout"].as_integer(),
+            Some(22),
+            "a value the user file already held was dropped:\n{saved}"
+        );
     }
 
     /// A settings save must not strip the file's comments.

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -1815,13 +1815,22 @@ impl AppConfig {
     /// the structs cannot work: the file's silence about a key is gone by
     /// then.
     pub fn load() -> Result<Self> {
-        // Lowest precedence first; later files override earlier ones.
+        // Read each file ONCE and fold it into both accumulators. Walking the
+        // paths twice meant a file created or rewritten between the passes
+        // landed in one and not the other — and since only the first pass
+        // propagated errors, the result was a `save()` that skipped a leaf
+        // whose value was not actually in the effective config, silently
+        // dropping the user's own setting. It is also half the syscalls and
+        // parsing in a function that runs in daemons, plugin startup and the
+        // TUI event loop.
         let mut merged = toml::Table::new();
+        let mut inherited = toml::Table::new();
         let mut loaded: Vec<PathBuf> = Vec::new();
 
         // `(scope, path)`: the scope travels with the path so `ainb config path`
-        // cannot mislabel it. The loader only needs the path.
-        for (_scope, path) in Self::get_config_paths() {
+        // cannot mislabel it, and `save()` needs it to know which layer is the
+        // user's own.
+        for (scope, path) in Self::get_config_paths() {
             if !path.exists() {
                 continue;
             }
@@ -1829,24 +1838,11 @@ impl AppConfig {
                 .with_context(|| format!("Failed to read config from {}", path.display()))?;
             let layer = parse_config_layer(&content)
                 .with_context(|| format!("Failed to parse config from {}", path.display()))?;
+            if scope != ConfigScope::User {
+                merge_config_tables(&mut inherited, layer.clone());
+            }
             merge_config_tables(&mut merged, layer);
             loaded.push(path);
-        }
-
-        // The same merge with the user layer left out. Comparing against this
-        // is how `save()` tells "the user set this" from "a project or system
-        // file provides this".
-        let mut inherited = toml::Table::new();
-        for (scope, path) in Self::get_config_paths() {
-            if scope == ConfigScope::User || !path.exists() {
-                continue;
-            }
-            let Ok(content) = fs::read_to_string(&path) else {
-                continue;
-            };
-            if let Ok(layer) = parse_config_layer(&content) {
-                merge_config_tables(&mut inherited, layer);
-            }
         }
 
         let mut config = Self::from_merged_layers(merged).with_context(|| {
@@ -1997,27 +1993,31 @@ impl AppConfig {
             }
         }
 
-        // Write only what the USER layer owns. This struct is the merge of
-        // every layer, so a leaf whose value another layer already provides is
-        // not ours to persist — writing it would copy a project's or the
-        // system's setting into the user's global file, where it then applies
-        // everywhere. A leaf the user file already carries stays, even if it
-        // agrees with another layer: it was theirs before this save and
-        // dropping it would be a silent deletion.
+        // Write only what the USER layer owns.
+        //
+        // `ours_leaves` comes from the MERGED table, so for any key another
+        // layer sets, the value here is THAT layer's. Writing it would copy a
+        // project's or the system's setting into the user's global file, where
+        // it then applies everywhere.
+        //
+        // A leaf is not ours when the merged value is exactly what the other
+        // layers provide AND it is not what the user file holds. That second
+        // clause is what distinguishes "the user edited this to the same thing"
+        // from "this value is simply not theirs" — and, crucially, preserves a
+        // user value the project layer disagrees with, which is the common
+        // case and the one a naive check gets backwards.
         let inherited = toml::Value::Table(self.inherited.clone());
-        let already_ours: std::collections::HashSet<String> = existing
+        let on_disk = existing
             .parse::<toml::Table>()
-            .map(|table| {
-                let mut leaves = Vec::new();
-                flatten_leaves(&table, String::new(), &mut leaves);
-                leaves.into_iter().map(|(key, _)| key).collect()
-            })
-            .unwrap_or_default();
+            .map(toml::Value::Table)
+            .unwrap_or_else(|_| toml::Value::Table(toml::Table::new()));
 
         for (key, value) in &ours_leaves {
-            if !already_ours.contains(key)
-                && registry::navigate_toml(&inherited, key).is_ok_and(|from| from == value)
-            {
+            let from_inherited = registry::navigate_toml(&inherited, key).ok();
+            let from_user = registry::navigate_toml(&on_disk, key).ok();
+            if from_inherited == Some(value) && from_user != Some(value) {
+                // Another layer provides exactly this, and the user file says
+                // something else (or nothing). Leave their file alone.
                 continue;
             }
             set_document_key(&mut doc, key, value)?;
@@ -2973,6 +2973,35 @@ timeout = 60
             registry::navigate_toml(&toml::Value::Table(reparsed.clone()), "docker.timeout")
                 .is_err(),
             "the project's docker.timeout was copied into the user's file:\n{saved}"
+        );
+    }
+
+    /// The case both other tests miss: the user file has the key AND the
+    /// project sets it to something ELSE.
+    ///
+    /// `ours_leaves` is flattened from the MERGED table, where the project has
+    /// already won, so writing it back put the project's value into the user's
+    /// global file — the exact clobber this whole change exists to stop, just
+    /// reachable only when the two layers disagree.
+    #[test]
+    fn save_does_not_overwrite_a_user_value_with_a_project_one() {
+        let project = "[docker]\ntimeout = 22\n";
+        let user_file = "[docker]\ntimeout = 11\n";
+
+        let mut config = AppConfig::from_layers([user_file, project]).expect("layers");
+        config.inherited = project.parse().expect("project layer");
+        assert_eq!(
+            config.docker.timeout, 22,
+            "the merge should favour the project"
+        );
+
+        let saved = config.overlay_onto_existing(user_file).expect("overlays");
+        let reparsed: toml::Table = saved.parse().expect("valid TOML");
+
+        assert_eq!(
+            reparsed["docker"]["timeout"].as_integer(),
+            Some(11),
+            "the project's value was written into the user's own file:\n{saved}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/config/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/config/mod.rs
@@ -2054,27 +2054,35 @@ impl AppConfig {
         )
     }
 
-    /// Every config file location, in the order [`Self::load`] merges them.
+    /// Every config file location, LOWEST precedence first.
     ///
-    /// Each file overrides the last, so the LAST entry wins — which today means
-    /// the system config outranks the user's and a project's. That is the
-    /// inverse of what the docs and `ainb config path` describe, and it is not
-    /// fixed here: `merge_loaded` assigns several fields unconditionally
-    /// (`authentication.cli_provider`, `ui_preferences.statusline_decision`,
-    /// `workspace_defaults.max_repositories`, …), so "last file wins" currently
-    /// means "the last file's serde DEFAULTS win" for those. Reordering without
-    /// first making the merge per-field lets a project file containing only
-    /// `[docker] timeout = 22` reset a user's provider, wizard decisions and
-    /// scan limit — and the next `save()` writes that reset into their file.
+    /// [`Self::load`] merges them in this order and each layer overrides the
+    /// last, so the final entry wins. That makes this list the definition of
+    /// precedence: system, then user, then the project files — most specific
+    /// wins, which is what `config/example.config.toml`, `CLAUDE.md` and
+    /// `ainb config path` have always described.
     ///
-    /// See `agents-in-a-box-l0sq`: the reorder lands with that change,
-    /// not before it.
+    /// It ran the other way until now, with the system file strongest.
+    /// Flipping it was unsafe while the merge was field-by-field: several
+    /// fields were assigned unconditionally, so "last file wins" meant "the
+    /// last file's serde DEFAULTS win" for them, and a project config holding
+    /// only `[docker] timeout` reset a user's provider and wizard decisions.
+    /// The per-key TOML merge removed that: a key absent from a layer simply is
+    /// not in that layer's table, so a file can only override what it writes.
     ///
-    /// Returns the scope with each path. They used to be parallel arrays zipped
-    /// at the call site, where four paths met three labels and the last one was
-    /// silently dropped.
+    /// Within the project pair, `.agents-box/` is the legacy location and
+    /// `.ainb/` is canonical, so `.ainb/` comes last and wins when both exist.
+    ///
+    /// Returns the scope with each path so a caller cannot mislabel them.
     pub fn get_config_paths() -> Vec<(ConfigScope, PathBuf)> {
-        let mut paths = vec![];
+        let mut paths = vec![(
+            ConfigScope::System,
+            PathBuf::from("/etc/agents-in-a-box/config.toml"),
+        )];
+
+        if let Ok(config_dir) = Self::get_user_config_dir() {
+            paths.push((ConfigScope::User, config_dir.join("config.toml")));
+        }
 
         if let Ok(cwd) = std::env::current_dir() {
             paths.push((
@@ -2083,15 +2091,6 @@ impl AppConfig {
             ));
             paths.push((ConfigScope::Project, cwd.join(".ainb").join("config.toml")));
         }
-
-        if let Ok(config_dir) = Self::get_user_config_dir() {
-            paths.push((ConfigScope::User, config_dir.join("config.toml")));
-        }
-
-        paths.push((
-            ConfigScope::System,
-            PathBuf::from("/etc/agents-in-a-box/config.toml"),
-        ));
 
         paths
     }
@@ -3207,6 +3206,77 @@ cursor-auto = "claude-sonnet-4-5"
         assert_eq!(
             config.usage.model_aliases.get("cursor-auto"),
             Some(&"claude-sonnet-4-5".to_string())
+        );
+    }
+
+    /// Precedence is most-specific-wins, and this list's ORDER is what defines
+    /// it: `load` merges in order and each layer overrides the last.
+    ///
+    /// It used to run the other way, so the system config beat the user's and a
+    /// project's — the inverse of what every document and `ainb config path`
+    /// described.
+    #[test]
+    fn config_paths_run_from_lowest_to_highest_precedence() {
+        let scopes: Vec<ConfigScope> =
+            AppConfig::get_config_paths().into_iter().map(|(scope, _)| scope).collect();
+
+        let position = |wanted: ConfigScope| {
+            scopes
+                .iter()
+                .position(|scope| *scope == wanted)
+                .unwrap_or_else(|| panic!("{wanted:?} missing from {scopes:?}"))
+        };
+
+        assert!(
+            position(ConfigScope::System) < position(ConfigScope::User),
+            "the user config must override the system's, got {scopes:?}"
+        );
+        assert!(
+            position(ConfigScope::User) < position(ConfigScope::ProjectLegacy),
+            "a project config must override the user's, got {scopes:?}"
+        );
+        assert!(
+            position(ConfigScope::ProjectLegacy) < position(ConfigScope::Project),
+            "canonical .ainb must override legacy .agents-box, got {scopes:?}"
+        );
+    }
+
+    /// The pair of properties this change depends on, asserted together: the
+    /// project layer wins for what it writes, and does NOT touch what it omits.
+    ///
+    /// The second half is why this reorder had to wait for the per-key merge.
+    /// With the old field-by-field merge, this same project file reset
+    /// `cli_provider` to `claude` and `statusline_decision` to `unset`.
+    #[test]
+    fn a_project_layer_wins_only_for_the_keys_it_writes() {
+        let user = r#"
+[authentication]
+cli_provider = "codex"
+
+[ui_preferences]
+statusline_decision = "declined"
+
+[workspace_defaults]
+max_repositories = 99
+
+[docker]
+timeout = 11
+"#;
+        let project = "[docker]\ntimeout = 22\n";
+
+        // In `load()` order: system, user, then project.
+        let config = AppConfig::from_layers([user, project]).expect("layers");
+
+        assert_eq!(
+            config.docker.timeout, 22,
+            "the project layer must win its own key"
+        );
+        assert_eq!(config.authentication.cli_provider, CliProvider::Codex);
+        assert_eq!(config.workspace_defaults.max_repositories, 99);
+        assert_eq!(
+            config.ui_preferences.statusline_decision,
+            StatuslineDecision::Declined,
+            "a project file that never mentions the wizard decision must not reset it"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -1838,6 +1838,7 @@ mod tests {
     /// against serde's actual output.
     fn fully_populated() -> AppConfig {
         AppConfig {
+            inherited: toml::Table::new(),
             version: "9.9.9".to_string(),
             authentication: AuthenticationConfig {
                 cli_provider: CliProvider::Codex,


### PR DESCRIPTION
Bead `agents-in-a-box-hyu3`, the second half. The first half (`ainb config path` showing three of four files) shipped in #798; this needed #800 first.

## The bug

`load()` merges the config paths in order and each layer overrides the last, so **the order of that list is the precedence**. It ran project → user → system, which meant:

> the **system** config won, and a project's `.ainb/config.toml` was the **weakest** layer.

That is the inverse of what `config/example.config.toml`, `CLAUDE.md` and `ainb config path` all describe. A repo pinning `[fleet.cost] session_usd = 2.0` was silently ignored for any key the user's global config also set.

The list now runs system → user → legacy `.agents-box` → `.ainb`. Most specific wins.

## Why this waited for #800

Flipping the order alone was actively harmful, and I backed exactly this change out of #798 after measuring it. With the old field-by-field merge, several fields were assigned unconditionally, so "last file wins" meant "the last file's serde **defaults** win". A project config holding only `[docker] timeout = 22` produced:

| key | user config | with the flip, before #800 |
|---|---|---|
| `authentication.cli_provider` | `codex` | `claude` |
| `workspace_defaults.max_repositories` | `99` | `500` |
| `ui_preferences.statusline_decision` | `declined` | `unset` |

#800 replaced that with a per-key TOML merge, so a key absent from a layer is simply not in that layer's table. The same scenario now, against the built binary:

```
$ cd repo-with-only-docker-timeout && ainb config show
cli_provider = "codex"          # untouched
max_repositories = 99           # untouched
statusline_decision = "declined" # untouched
timeout = 22                    # the project layer's own key wins
```

## Tests

- `config_paths_run_from_lowest_to_highest_precedence` pins the order, so a future reordering has to be deliberate.
- `a_project_layer_wins_only_for_the_keys_it_writes` asserts both halves together: the project layer wins its own key, and does not disturb the four it never mentions. That second half is the property that made this safe.

## Behaviour change

Anyone relying on a system or user config beating a project one will see that flip. It was never the documented behaviour, and the flipped direction is what every document already promised.

Green: `ainb` lib 2039, behavioral 51, example_config_parses 4, both config tripwires.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Antigravity as a supported agent CLI and usage plan provider.
  * Added Antigravity to available agent selections, including Hangar configuration.

* **Bug Fixes**
  * Corrected configuration precedence so the most specific settings take priority.
  * Project configuration now overrides only the keys it defines.
  * Saving configuration preserves inherited settings without copying them into user files.
  * Updated configuration path display to clearly explain precedence.

* **Documentation**
  * Updated configuration guidance and examples to reflect the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->