### PR TITLE
docs(ci): record what a failed changes job resolves to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,29 @@ jobs:
   #
   # `on.push` keeps its own `paths:` — push runs are not required checks, so
   # main-branch CI cost is unchanged.
+  #
+  # WHAT HAPPENS WHEN THIS JOB ITSELF FAILS. The four matrix jobs below
+  # (`test`, `ainb-hooks`, `fleet-send-tmux`, `hangar-e2e`) gate their STEPS
+  # on `needs.changes.outputs.relevant != 'false'`. If a failed `changes`
+  # made that comparison false, all four would conclude GREEN having
+  # executed nothing: the required checks would be satisfied by four jobs
+  # that ran no tests, and a PR could merge untested. That is NOT what
+  # happens, and it is measured rather than assumed:
+  #
+  # Run 33393560903 forced this job to fail before dorny/paths-filter could
+  # set `relevant` (the filter step reports `skipped`, so the output is
+  # genuinely absent, not stale). All sixteen jobs dispatched, the four
+  # matrix jobs reported under their EXPANDED names, and the step-level
+  # guards RAN: `ainb-hooks (ubuntu-latest)` (job 99492659192) concluded
+  # success with all seven of its real steps executed, and both
+  # `fleet send integrity` legs did the same. A missing output resolves to
+  # the empty string, and `'' != 'false'` is true.
+  #
+  # Worth re-measuring if GitHub ever changes that resolution, because the
+  # failure would be SILENT: a job green-with-every-step-skipped is
+  # indistinguishable from a real pass in `gh pr checks` or in any job-level
+  # summary. Only the `steps[]` conclusions from
+  # `/actions/runs/<id>/jobs` tell the two apart.
   # ────────────────────────────────────────────────────────────────────────────
   changes:
     name: Detect relevant changes
@@ -186,6 +209,9 @@ jobs:
     # EXPANDED names, so that one skip strands every open PR on "Expected".
     # The relevance clause stays on the steps, where a gated-out PR still
     # costs no compute and the check still reports under its real name.
+    # MEASURED (run 33393560903): when `changes` FAILS, `relevant` is left
+    # unset, an unset output resolves to '', and `'' != 'false'` is TRUE, so
+    # those step guards RUN rather than skip. See the `changes` job above.
     if: '!cancelled()'
     # 40 against a 28.7min p95. A macOS leg once sat here for 97 minutes with
     # the nextest step never recording a completion, and with no budget set
@@ -392,6 +418,9 @@ jobs:
     # EXPANDED names, so that one skip strands every open PR on "Expected".
     # The relevance clause stays on the steps, where a gated-out PR still
     # costs no compute and the check still reports under its real name.
+    # MEASURED (run 33393560903): when `changes` FAILS, `relevant` is left
+    # unset, an unset output resolves to '', and `'' != 'false'` is TRUE, so
+    # those step guards RUN rather than skip. See the `changes` job above.
     if: '!cancelled()'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
@@ -500,6 +529,9 @@ jobs:
     # EXPANDED names, so that one skip strands every open PR on "Expected".
     # The relevance clause stays on the steps, where a gated-out PR still
     # costs no compute and the check still reports under its real name.
+    # MEASURED (run 33393560903): when `changes` FAILS, `relevant` is left
+    # unset, an unset output resolves to '', and `'' != 'false'` is TRUE, so
+    # those step guards RUN rather than skip. See the `changes` job above.
     if: '!cancelled()'
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
@@ -569,6 +601,9 @@ jobs:
     # EXPANDED names, so that one skip strands every open PR on "Expected".
     # The relevance clause stays on the steps, where a gated-out PR still
     # costs no compute and the check still reports under its real name.
+    # MEASURED (run 33393560903): when `changes` FAILS, `relevant` is left
+    # unset, an unset output resolves to '', and `'' != 'false'` is TRUE, so
+    # those step guards RUN rather than skip. See the `changes` job above.
     if: '!cancelled()'
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Comment-only change to `.github/workflows/ci.yml`. No behaviour changes.

## Why

#801 gave `test`, `ainb-hooks`, `fleet-send-tmux` and `hangar-e2e` a bare job-level `if: '!cancelled()'` so a failing `changes` job can never skip them (a skipped matrix job reports one check under the unexpanded literal name, which strands every open PR against ruleset 11610771's expanded names).

The dispatch-and-expand half of that was confirmed against a real run. The other half was not, because no run in this repo's history had ever had `changes` actually fail. The relevance clause moved down onto the steps, where each one reads:

```yaml
needs.changes.outputs.relevant != 'false'
```

If a failed `changes` made that comparison **false**, all four jobs would conclude green having executed nothing, the required checks would be satisfied by four jobs that ran no tests, and a PR could merge untested. That would not have undone #801 (the lockout stays fixed either way), but it would have been a second-order hole, and a silent one.

## What was measured

Probe run **33393560903** on a throwaway branch, since deleted. A step forced `changes` to fail before `dorny/paths-filter` could set its output:

```
Detect relevant changes (job 99492631277) -> failure
  2. Force changes to fail (probe)   -> completed/failure
  3. Run dorny/paths-filter@v3       -> completed/skipped   <- `relevant` never set
```

So the output was genuinely absent, not stale. Downstream:

| job | id | dispatched | check name | steps |
|---|---|---|---|---|
| `ainb-hooks (ubuntu-latest)` | 99492659192 | yes | expanded | **all 7 real steps ran, job success** |
| `fleet send integrity (ubuntu-latest)` | 99492659133 | yes | expanded | all ran, job success |
| `fleet send integrity (macos-latest)` | 99492659132 | yes | expanded | all ran, job success |
| `Test (ubuntu-latest)` | 99492659178 | yes | expanded | checkout, disk reclaim, headroom assert, toolchain, nextest install all `success`; `cargo nextest` in progress at cancel |
| `Test (macos-latest)` | 99492659198 | yes | expanded | same |
| `ainb-hooks (macos-latest)` | 99492659205 | yes | expanded | ran |
| `hangar-e2e (ubuntu-latest)` | 99492659280 | yes | expanded | ran |
| `hangar-e2e (macos-latest)` | 99492659302 | yes | expanded | ran |

Sixteen jobs dispatched. All four expanded names reported. The only `skipped` steps anywhere were the OS-conditional ones (`runner.os == 'Linux'` on the macOS legs), which is unrelated.

**Verdict: a missing output resolves to the empty string, `'' != 'false'` is true, the steps run in full.** No untested-merge hole.

## Why write it down

The falsifier would have been invisible. A job concluding `success` with every step `skipped` looks identical to a real pass in `gh pr checks` and in any job-level summary. Only `steps[]` from `/actions/runs/<id>/jobs` distinguishes them, so the comment names both the result and how to re-measure it if GitHub's resolution ever changes.

Probe branch `tmp/probe-changes-failure` and its draft PR #802 are closed and deleted; the run was cancelled once the step conclusions were read.
