### PR TITLE
fix(git): prevent concurrent clones from wiping the shared repo cache

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -563,7 +563,10 @@ pub enum AppEvent {
     SetupMenuUp,     // Navigate up
     SetupMenuDown,   // Navigate down
     StartOnboarding, // Start onboarding wizard (from setup menu)
-    FactoryReset,    // Factory reset AINB
+    // NOTE: no `FactoryReset` variant. Factory reset is destructive and is
+    // reachable ONLY through `SetupMenuSelect`'s confirmation gate (see
+    // `SetupMenuItem::is_dangerous`). A bare event variant was an unconfirmed
+    // second door to the same wipe, with no dispatcher — removed 2026-09.
     // Changelog viewer events
     ShowChangelog,       // Navigate to changelog view (v key)
     ChangelogBack,       // Return to home screen (Esc)
@@ -8348,16 +8351,6 @@ impl EventHandler {
             AppEvent::StartOnboarding => {
                 tracing::debug!("Starting onboarding from setup menu");
                 state.start_onboarding(true, None);
-            }
-            AppEvent::FactoryReset => {
-                tracing::debug!("Factory reset requested");
-                use crate::config::OnboardingConfig;
-                if let Err(e) = OnboardingConfig::factory_reset() {
-                    tracing::error!("Factory reset failed: {}", e);
-                } else {
-                    tracing::info!("Factory reset completed");
-                    state.start_onboarding(true, None);
-                }
             }
             // Mouse events are handled directly in the main event loop
             AppEvent::MouseClick { .. }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -566,7 +566,7 @@ pub enum AppEvent {
     // NOTE: no `FactoryReset` variant. Factory reset is destructive and is
     // reachable ONLY through `SetupMenuSelect`'s confirmation gate (see
     // `SetupMenuItem::is_dangerous`). A bare event variant was an unconfirmed
-    // second door to the same wipe, with no dispatcher — removed 2026-09.
+    // second door to the same wipe, with no dispatcher (removed 2026-09).
     // Changelog viewer events
     ShowChangelog,       // Navigate to changelog view (v key)
     ChangelogBack,       // Return to home screen (Esc)

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -1,8 +1,30 @@
 // ABOUTME: Manages cloning and caching of remote git repositories
+//
+// CONCURRENCY / DATA SAFETY: the shared clone cache
+// (`~/.agents-in-a-box/repos/<host>/<owner>/<repo>`) is written by every
+// concurrently running ainb process on the machine, and live worktrees gitlink
+// back into it — deleting one orphans every worktree cut from it. A 2026-09
+// incident wiped the whole cache this way: `clone_repo` did an UNLOCKED
+// check-then-act, so two processes both saw a cold cache, both cloned into the
+// same path, and the loser's "clean up my partial clone" `remove_dir_all` ate
+// the winner's finished repo — which uncached it again and re-armed the race.
+//
+// Four rules keep that from recurring; keep all four when editing this file:
+//   1. A clone lands in a private staging dir and is published with an atomic
+//      `rename` — the only directory a failing clone may delete is its own.
+//   2. Check-then-clone runs under a per-repo advisory file lock, and re-checks
+//      the cache after acquiring it (double-checked locking).
+//   3. Every destructive path goes through `remove_repo_dir_guarded`, which
+//      refuses to delete a repo that still has live worktrees.
+//   4. Every destructive attempt leaves a receipt outside `~/.agents-in-a-box`,
+//      so the evidence survives even a full wipe of that tree.
 
 use anyhow::{Context, Result};
+use fs2::FileExt;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
@@ -209,6 +231,14 @@ impl RemoteRepoManager {
     ///
     /// Standard clone has .git subdirectory and working copy, making it
     /// compatible with the same worktree handling as local repositories.
+    ///
+    /// Concurrency-safe: the check-then-clone sequence runs under a per-repo
+    /// advisory file lock and re-checks the cache once the lock is held, so N
+    /// processes launching sessions against the same cold repo produce ONE
+    /// clone and N-1 reuses. The clone itself is staged and published by
+    /// `rename` (see [`Self::clone_into_cache`]), so even a lock that fails to
+    /// apply — a lock file on an exotic filesystem, a process bypassing this
+    /// path — cannot end with one process deleting another's finished repo.
     pub fn clone_repo(
         &self,
         source: &RepoSource,
@@ -227,17 +257,57 @@ impl RemoteRepoManager {
             return Ok(cache_path);
         }
 
-        info!("Cloning {} to {}", url, cache_path.display());
-
-        // Create parent directories
+        // Create parent directories (also the lock file's home)
         if let Some(parent) = cache_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
+        let _lock = CloneLock::acquire(&cache_path)?;
+
+        // Double-checked: another process may have published the clone while we
+        // waited on the lock. Reuse it — re-cloning over a live repo is exactly
+        // the mistake this lock exists to prevent.
+        if Self::cache_path_is_populated(&cache_path) {
+            info!(
+                "Repository cloned by a concurrent process at: {}",
+                cache_path.display()
+            );
+            if let Err(e) = self.fetch_updates(&cache_path) {
+                warn!("Failed to fetch updates: {}", e);
+            }
+            return Ok(cache_path);
+        }
+
+        Self::clone_into_cache(&url, &cache_path)
+    }
+
+    /// Clone `url` into a private staging directory, then publish it into
+    /// `cache_path` with an atomic `rename`.
+    ///
+    /// The staging directory is a sibling of `cache_path` so the rename stays
+    /// on one filesystem (and therefore atomic). The only directory this
+    /// function ever removes is that staging directory, which it created — so a
+    /// failed clone cannot delete a populated shared repo no matter who else is
+    /// running. Losing the publish race to another process is a success, not a
+    /// failure: their clone is adopted and ours discarded.
+    fn clone_into_cache(url: &str, cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
+        let staging = staging_path(cache_path)?;
+        // A same-named leftover can only come from a crashed earlier run whose
+        // pid we now reuse; it is ours by construction, but route it through
+        // the guard anyway so nothing in this file deletes unchecked.
+        remove_repo_dir_guarded(&staging, "clone_into_cache: stale staging dir")?;
+
+        info!(
+            "Cloning {} to {} (staging at {})",
+            url,
+            cache_path.display(),
+            staging.display()
+        );
+
         // Standard clone (not --bare) for compatibility with worktree discovery
         let output = Command::new("git")
-            .args(["clone", &url])
-            .arg(&cache_path)
+            .args(["clone", url])
+            .arg(&staging)
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_ASKPASS", "echo")
             .output()
@@ -245,25 +315,26 @@ impl RemoteRepoManager {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            // `git clone` can leave a partially-initialised directory behind on
-            // failure (e.g. auth rejected mid-transfer). `is_cached()` only
-            // checks for a `.git` entry, so a broken partial would be treated as
-            // a warm cache on the next attempt and never re-cloned after the
-            // user fixes credentials. Remove it so the retry starts clean.
-            if cache_path.exists() {
-                if let Err(e) = std::fs::remove_dir_all(&cache_path) {
-                    warn!(
-                        "Failed to remove partial clone at {}: {}",
-                        cache_path.display(),
-                        e
-                    );
-                }
+            // A failed `git clone` (auth rejected mid-transfer, network drop)
+            // leaves a partial checkout. It is in OUR staging dir, so clearing
+            // it can never touch the shared cache — and the cache was never
+            // written at all, so a retry starts clean either way. A cleanup
+            // that fails is logged, never raised: the clone error is the one
+            // the user needs.
+            if let Err(e) = remove_repo_dir_guarded(&staging, "clone_into_cache: failed clone") {
+                warn!(
+                    "Failed to remove staged partial clone at {}: {}",
+                    staging.display(),
+                    e
+                );
             }
-            return Err(classify_git_error(&stderr, &url));
+            return Err(classify_git_error(&stderr, url));
         }
 
+        publish_staged_clone(&staging, cache_path)?;
+
         info!("Successfully cloned to: {}", cache_path.display());
-        Ok(cache_path)
+        Ok(cache_path.to_path_buf())
     }
 
     /// Fetch updates for a cached repo
@@ -1031,22 +1102,20 @@ impl RemoteRepoManager {
         // would silently upload the dead repo's entire history — the remote
         // is verifiably empty, so wipe and re-clone fresh instead.
         if local_head_exists(&cache_path) {
-            std::fs::remove_dir_all(&cache_path)?;
+            remove_repo_dir_guarded(&cache_path, "initialize_empty_remote: stale history")?;
             cache_path = self.clone_repo(source, parsed)?;
         }
         push_initial_commit(&cache_path, &parsed.repo_name)
     }
 
-    /// Remove a cached repository
+    /// Remove a cached repository.
+    ///
+    /// Errors instead of deleting when live worktrees still link into the
+    /// clone. Currently has no callers, but it is public API on a public type —
+    /// kept, and routed through the guard, so wiring it up later cannot
+    /// reintroduce an unguarded wipe.
     pub fn remove_cached_repo(&self, parsed: &ParsedRepo) -> Result<(), RemoteRepoError> {
-        let cache_path = self.get_cache_path(parsed);
-
-        if cache_path.exists() {
-            std::fs::remove_dir_all(&cache_path)?;
-            info!("Removed cached repo: {}", cache_path.display());
-        }
-
-        Ok(())
+        remove_repo_dir_guarded(&self.get_cache_path(parsed), "remove_cached_repo")
     }
 }
 
@@ -1218,6 +1287,231 @@ fn push_initial_commit(cache_path: &Path, repo_name: &str) -> Result<String, Rem
 
     info!("Pushed initial commit to origin/{branch}");
     Ok(branch)
+}
+
+/// Distinguishes staging dirs made by two clones inside one process; the pid
+/// separates processes.
+static STAGING_NONCE: AtomicU64 = AtomicU64::new(0);
+
+/// The private staging directory a clone of `cache_path` is built in.
+///
+/// A SIBLING of `cache_path` (same parent, hence same filesystem) so publishing
+/// it is a single atomic `rename`, and dot-prefixed + pid/nonce-namespaced so
+/// `list_cached_repos` ignores it and no two clones ever share one.
+fn staging_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
+    let parent = cache_path.parent().ok_or_else(|| {
+        RemoteRepoError::IoError(format!(
+            "cache path has no parent directory: {}",
+            cache_path.display()
+        ))
+    })?;
+    let name = cache_path
+        .file_name()
+        .ok_or_else(|| {
+            RemoteRepoError::IoError(format!(
+                "cache path has no file name: {}",
+                cache_path.display()
+            ))
+        })?
+        .to_string_lossy();
+    let nonce = STAGING_NONCE.fetch_add(1, Ordering::Relaxed);
+    Ok(parent.join(format!(".{name}.clone-tmp-{}-{nonce}", std::process::id())))
+}
+
+/// Move a finished staging clone into place at `cache_path`.
+///
+/// `rename` over an existing non-empty directory fails rather than clobbering
+/// it, which is precisely the guarantee wanted here: whoever renames first
+/// wins, and the loser adopts the winner's clone instead of replacing a repo
+/// that live worktrees may already point at.
+fn publish_staged_clone(staging: &Path, cache_path: &Path) -> Result<(), RemoteRepoError> {
+    if std::fs::rename(staging, cache_path).is_ok() {
+        return Ok(());
+    }
+
+    if RemoteRepoManager::cache_path_is_populated(cache_path) {
+        info!(
+            "Concurrent clone already published {} — reusing it and discarding {}",
+            cache_path.display(),
+            staging.display()
+        );
+        if let Err(e) = remove_repo_dir_guarded(staging, "publish_staged_clone: discard loser") {
+            warn!(
+                "Failed to discard redundant staged clone at {}: {}",
+                staging.display(),
+                e
+            );
+        }
+        return Ok(());
+    }
+
+    // The destination holds no usable clone — a partial left by an aborted run
+    // from before this staging scheme, or a stray directory. Clear it (guarded:
+    // a repo with live worktrees is refused, never deleted) and publish again.
+    remove_repo_dir_guarded(
+        cache_path,
+        "publish_staged_clone: clear unusable destination",
+    )?;
+
+    std::fs::rename(staging, cache_path).map_err(|e| {
+        let _ = remove_repo_dir_guarded(staging, "publish_staged_clone: unpublishable clone");
+        RemoteRepoError::IoError(format!(
+            "failed to publish clone {} -> {}: {e}",
+            staging.display(),
+            cache_path.display()
+        ))
+    })
+}
+
+/// The advisory lock file serialising clones of the repo at `cache_path`.
+///
+/// Lives BESIDE the repo directory, never inside it: the clone is published by
+/// renaming a new directory over `cache_path`, so a lock file held under that
+/// path would be swapped out from under its holder mid-critical-section. Built
+/// by string append rather than `Path::with_extension` so repos named `foo.rs`
+/// and `foo.py` don't collide on a shared `foo.lock`.
+fn clone_lock_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
+    let parent = cache_path.parent().ok_or_else(|| {
+        RemoteRepoError::IoError(format!(
+            "cache path has no parent directory: {}",
+            cache_path.display()
+        ))
+    })?;
+    let name = cache_path
+        .file_name()
+        .ok_or_else(|| {
+            RemoteRepoError::IoError(format!(
+                "cache path has no file name: {}",
+                cache_path.display()
+            ))
+        })?
+        .to_string_lossy();
+    Ok(parent.join(format!(".{name}.clone-lock")))
+}
+
+/// Holds the exclusive advisory clone lock for one repo, releasing it on drop
+/// (including on the `?` early-returns through the clone path).
+struct CloneLock {
+    file: std::fs::File,
+}
+
+impl CloneLock {
+    /// Block until this process holds the clone lock for `cache_path`.
+    ///
+    /// The lock is per open file description, so two threads of one ainb
+    /// process exclude each other exactly as two separate processes do.
+    fn acquire(cache_path: &Path) -> Result<Self, RemoteRepoError> {
+        let path = clone_lock_path(cache_path)?;
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&path)?;
+        FileExt::lock_exclusive(&file)?;
+        debug!("Holding clone lock {}", path.display());
+        Ok(Self { file })
+    }
+}
+
+impl Drop for CloneLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+/// How many live worktrees are linked to the clone at `cache_path`.
+///
+/// `git worktree add` registers each checkout under `<repo>/.git/worktrees/`,
+/// and the worktree's own `.git` file gitlinks back into it. Deleting the repo
+/// therefore orphans every one of them — the exact damage of the 2026-09 wipe.
+fn live_worktree_count(cache_path: &Path) -> usize {
+    std::fs::read_dir(cache_path.join(".git").join("worktrees"))
+        .map_or(0, |entries| entries.flatten().count())
+}
+
+/// Delete a repo cache directory, refusing if live worktrees still link into it
+/// and recording a receipt either way.
+///
+/// EVERY destructive path in this file goes through here. A caller that
+/// genuinely means to remove a repo with worktrees must remove the worktrees
+/// first; there is deliberately no override flag.
+fn remove_repo_dir_guarded(path: &Path, operation: &str) -> Result<(), RemoteRepoError> {
+    // Nothing to delete, nothing to record — keeps the receipt log meaning
+    // "a real directory was removed or refused".
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let worktrees = live_worktree_count(path);
+    if worktrees > 0 {
+        record_destructive_op(
+            path,
+            operation,
+            &format!("REFUSED ({worktrees} live worktree(s))"),
+        );
+        return Err(RemoteRepoError::IoError(format!(
+            "refusing to delete {} during {operation}: {worktrees} live worktree(s) still link to it — remove those worktrees first",
+            path.display()
+        )));
+    }
+
+    record_destructive_op(path, operation, "remove_dir_all");
+    std::fs::remove_dir_all(path)?;
+    info!(
+        "Removed repo cache directory {} ({operation})",
+        path.display()
+    );
+    Ok(())
+}
+
+/// The append-only receipt log for destructive operations on the repo cache.
+///
+/// Deliberately OUTSIDE `~/.agents-in-a-box`: when that whole tree is what got
+/// wiped, a log stored inside it is gone with it. Uses the same OS cache-dir
+/// resolver as `cli::statusline` (`~/Library/Caches/ainb` on macOS,
+/// `~/.cache/ainb` on Linux).
+/// `AINB_DESTRUCTIVE_OPS_LOG` redirects it (a rotated ops location, a test).
+fn destructive_ops_log_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("AINB_DESTRUCTIVE_OPS_LOG") {
+        return Some(PathBuf::from(path));
+    }
+    let dir = dirs::cache_dir().or_else(|| dirs::home_dir().map(|h| h.join(".cache")))?;
+    Some(dir.join("ainb").join("destructive-ops.log"))
+}
+
+/// Record one attempted destructive operation on a repo cache path.
+///
+/// Best effort by design — a receipt that cannot be written must never block or
+/// fail the operation it describes — but it is also emitted through `tracing`,
+/// so the evidence exists in two places.
+fn record_destructive_op(path: &Path, operation: &str, outcome: &str) {
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let pid = std::process::id();
+    warn!(
+        target: "destructive_op",
+        path = %resolved.display(),
+        operation,
+        outcome,
+        pid,
+        "repo cache directory removal"
+    );
+
+    let Some(log_path) = destructive_ops_log_path() else {
+        return;
+    };
+    if let Some(parent) = log_path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+        let _ = writeln!(
+            file,
+            "{}\tpid={pid}\t{operation}\t{outcome}\t{}",
+            chrono::Utc::now().to_rfc3339(),
+            resolved.display()
+        );
+    }
 }
 
 /// Classify git errors into appropriate RemoteRepoError variants

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -3,19 +3,26 @@
 // CONCURRENCY / DATA SAFETY: the shared clone cache
 // (`~/.agents-in-a-box/repos/<host>/<owner>/<repo>`) is written by every
 // concurrently running ainb process on the machine, and live worktrees gitlink
-// back into it — deleting one orphans every worktree cut from it. A 2026-09
+// back into it, so deleting one orphans every worktree cut from it. A 2026-09
 // incident wiped the whole cache this way: `clone_repo` did an UNLOCKED
 // check-then-act, so two processes both saw a cold cache, both cloned into the
 // same path, and the loser's "clean up my partial clone" `remove_dir_all` ate
-// the winner's finished repo — which uncached it again and re-armed the race.
+// the winner's finished repo, which uncached it again and re-armed the race.
 //
 // Four rules keep that from recurring; keep all four when editing this file:
 //   1. A clone lands in a private staging dir and is published with an atomic
-//      `rename` — the only directory a failing clone may delete is its own.
-//   2. Check-then-clone runs under a per-repo advisory file lock, and re-checks
-//      the cache after acquiring it (double-checked locking).
-//   3. Every destructive path goes through `remove_repo_dir_guarded`, which
-//      refuses to delete a repo that still has live worktrees.
+//      `rename`. The only directory a failing clone may delete is its own.
+//      This is the rule that makes concurrent cloning SAFE.
+//   2. Check-then-clone runs under a per-repo advisory file lock, re-checking
+//      the cache after acquiring it (double-checked locking). This rule only
+//      makes it EFFICIENT, so it degrades to redundant work, never to failure,
+//      on a filesystem that cannot lock. Anything that DELETES a shared path
+//      must hold this lock, because rule 1 does not cover deletes.
+//   3. Every deletion of a repo cache directory goes through
+//      `CacheGuard::remove_repo_dir`, which refuses to leave the cache root and
+//      refuses to delete a repo that still has live worktrees, failing CLOSED
+//      when it cannot tell. (Worktree directories are a different object and
+//      are removed directly at the `create_worktree_*` sites.)
 //   4. Every destructive attempt leaves a receipt outside `~/.agents-in-a-box`,
 //      so the evidence survives even a full wipe of that tree.
 
@@ -65,6 +72,7 @@ pub struct RemoteBranch {
 /// Manages remote repository cloning and caching
 pub struct RemoteRepoManager {
     cache_dir: PathBuf,
+    receipt_log: Option<PathBuf>,
 }
 
 impl RemoteRepoManager {
@@ -75,13 +83,37 @@ impl RemoteRepoManager {
 
         std::fs::create_dir_all(&cache_dir)?;
 
-        Ok(Self { cache_dir })
+        Ok(Self {
+            cache_dir,
+            receipt_log: default_receipt_log(),
+        })
     }
 
     /// Create with a custom cache directory (for testing)
     pub fn with_cache_dir(cache_dir: PathBuf) -> Result<Self> {
         std::fs::create_dir_all(&cache_dir)?;
-        Ok(Self { cache_dir })
+        Ok(Self {
+            cache_dir,
+            receipt_log: default_receipt_log(),
+        })
+    }
+
+    /// Write destructive-operation receipts to `path` instead of the default
+    /// machine-global log. Injected rather than read from the environment deep
+    /// in the call stack, so a test can point it at its own temp dir without
+    /// mutating process environment shared with other threads.
+    #[must_use]
+    pub fn with_receipt_log(mut self, path: PathBuf) -> Self {
+        self.receipt_log = Some(path);
+        self
+    }
+
+    /// The safety context for destructive operations on this manager's cache.
+    fn guard(&self) -> CacheGuard {
+        CacheGuard {
+            root: self.cache_dir.clone(),
+            receipt_log: self.receipt_log.clone(),
+        }
     }
 
     /// Get the cache directory path
@@ -236,9 +268,10 @@ impl RemoteRepoManager {
     /// advisory file lock and re-checks the cache once the lock is held, so N
     /// processes launching sessions against the same cold repo produce ONE
     /// clone and N-1 reuses. The clone itself is staged and published by
-    /// `rename` (see [`Self::clone_into_cache`]), so even a lock that fails to
-    /// apply — a lock file on an exotic filesystem, a process bypassing this
-    /// path — cannot end with one process deleting another's finished repo.
+    /// `rename` (see [`clone_into_cache`]), which is what makes the operation
+    /// SAFE; the lock only makes it EFFICIENT. A filesystem that cannot provide
+    /// the lock (NFS, CIFS, a bind mount without `flock`) therefore degrades to
+    /// redundant clones, never to a failed launch and never to a lost repo.
     pub fn clone_repo(
         &self,
         source: &RepoSource,
@@ -249,7 +282,9 @@ impl RemoteRepoManager {
 
         if self.is_cached(parsed) {
             info!("Repository already cached at: {}", cache_path.display());
-            // Fetch updates
+            // Fetch updates. Deliberately OUTSIDE any clone lock: it is a
+            // network round-trip, and holding the lock across it would stall
+            // every other launch of the same repo behind this one.
             if let Err(e) = self.fetch_updates(&cache_path) {
                 warn!("Failed to fetch updates: {}", e);
                 // Continue with cached version
@@ -262,79 +297,37 @@ impl RemoteRepoManager {
             std::fs::create_dir_all(parent)?;
         }
 
-        let _lock = CloneLock::acquire(&cache_path)?;
+        let lock = CloneLock::acquire(&cache_path);
+        self.clone_under_lock(&url, &cache_path, lock.is_some())
+    }
 
+    /// The clone body, run with the per-repo clone lock already held (or, when
+    /// `locked` is false, knowingly without one).
+    ///
+    /// Separated from [`Self::clone_repo`] so a caller that must hold the lock
+    /// across a wider critical section (delete-then-reclone in
+    /// [`Self::initialize_empty_remote`]) can reuse it without the lock being
+    /// taken twice, which would deadlock: two `open`s of the same lock file in
+    /// one process yield two file descriptions that exclude each other.
+    fn clone_under_lock(
+        &self,
+        url: &str,
+        cache_path: &Path,
+        locked: bool,
+    ) -> Result<PathBuf, RemoteRepoError> {
         // Double-checked: another process may have published the clone while we
-        // waited on the lock. Reuse it — re-cloning over a live repo is exactly
-        // the mistake this lock exists to prevent.
-        if Self::cache_path_is_populated(&cache_path) {
+        // waited on the lock. Reuse it, and do NOT fetch: a clone that landed
+        // moments ago is fresher than anything a fetch could add, and the fetch
+        // would run inside the lock every racer is queued behind.
+        if Self::cache_path_is_populated(cache_path) {
             info!(
                 "Repository cloned by a concurrent process at: {}",
                 cache_path.display()
             );
-            if let Err(e) = self.fetch_updates(&cache_path) {
-                warn!("Failed to fetch updates: {}", e);
-            }
-            return Ok(cache_path);
+            return Ok(cache_path.to_path_buf());
         }
 
-        Self::clone_into_cache(&url, &cache_path)
-    }
-
-    /// Clone `url` into a private staging directory, then publish it into
-    /// `cache_path` with an atomic `rename`.
-    ///
-    /// The staging directory is a sibling of `cache_path` so the rename stays
-    /// on one filesystem (and therefore atomic). The only directory this
-    /// function ever removes is that staging directory, which it created — so a
-    /// failed clone cannot delete a populated shared repo no matter who else is
-    /// running. Losing the publish race to another process is a success, not a
-    /// failure: their clone is adopted and ours discarded.
-    fn clone_into_cache(url: &str, cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
-        let staging = staging_path(cache_path)?;
-        // A same-named leftover can only come from a crashed earlier run whose
-        // pid we now reuse; it is ours by construction, but route it through
-        // the guard anyway so nothing in this file deletes unchecked.
-        remove_repo_dir_guarded(&staging, "clone_into_cache: stale staging dir")?;
-
-        info!(
-            "Cloning {} to {} (staging at {})",
-            url,
-            cache_path.display(),
-            staging.display()
-        );
-
-        // Standard clone (not --bare) for compatibility with worktree discovery
-        let output = Command::new("git")
-            .args(["clone", url])
-            .arg(&staging)
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .env("GIT_ASKPASS", "echo")
-            .output()
-            .map_err(|e| RemoteRepoError::CloneFailed(e.to_string()))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            // A failed `git clone` (auth rejected mid-transfer, network drop)
-            // leaves a partial checkout. It is in OUR staging dir, so clearing
-            // it can never touch the shared cache — and the cache was never
-            // written at all, so a retry starts clean either way. A cleanup
-            // that fails is logged, never raised: the clone error is the one
-            // the user needs.
-            if let Err(e) = remove_repo_dir_guarded(&staging, "clone_into_cache: failed clone") {
-                warn!(
-                    "Failed to remove staged partial clone at {}: {}",
-                    staging.display(),
-                    e
-                );
-            }
-            return Err(classify_git_error(&stderr, url));
-        }
-
-        publish_staged_clone(&staging, cache_path)?;
-
-        info!("Successfully cloned to: {}", cache_path.display());
-        Ok(cache_path.to_path_buf())
+        clone_into_cache(&self.guard(), url, cache_path, locked)
     }
 
     /// Fetch updates for a cached repo
@@ -1099,11 +1092,18 @@ impl RemoteRepoManager {
         let mut cache_path = self.clone_repo(source, parsed)?;
         // A warm cache can carry commits the remote no longer has (repo
         // deleted and recreated empty under the same name). Pushing that
-        // would silently upload the dead repo's entire history — the remote
+        // would silently upload the dead repo's entire history. The remote
         // is verifiably empty, so wipe and re-clone fresh instead.
         if local_head_exists(&cache_path) {
-            remove_repo_dir_guarded(&cache_path, "initialize_empty_remote: stale history")?;
-            cache_path = self.clone_repo(source, parsed)?;
+            // The clone lock is held across BOTH the delete and the re-clone.
+            // Deleting outside it would be the same unlocked destructive act
+            // this module exists to prevent: a peer could publish into the gap
+            // and have its fresh clone removed a moment later.
+            let lock = CloneLock::acquire(&cache_path);
+            self.guard()
+                .remove_repo_dir(&cache_path, "initialize_empty_remote: stale history")?;
+            cache_path =
+                self.clone_under_lock(&source.to_clone_url(), &cache_path, lock.is_some())?;
         }
         push_initial_commit(&cache_path, &parsed.repo_name)
     }
@@ -1111,11 +1111,13 @@ impl RemoteRepoManager {
     /// Remove a cached repository.
     ///
     /// Errors instead of deleting when live worktrees still link into the
-    /// clone. Currently has no callers, but it is public API on a public type —
-    /// kept, and routed through the guard, so wiring it up later cannot
+    /// clone. Currently has no callers, but it is public API on a public type,
+    /// so it is kept and routed through the guard: wiring it up later cannot
     /// reintroduce an unguarded wipe.
     pub fn remove_cached_repo(&self, parsed: &ParsedRepo) -> Result<(), RemoteRepoError> {
-        remove_repo_dir_guarded(&self.get_cache_path(parsed), "remove_cached_repo")
+        let cache_path = self.get_cache_path(parsed);
+        let _lock = CloneLock::acquire(&cache_path);
+        self.guard().remove_repo_dir(&cache_path, "remove_cached_repo")
     }
 }
 
@@ -1289,16 +1291,14 @@ fn push_initial_commit(cache_path: &Path, repo_name: &str) -> Result<String, Rem
     Ok(branch)
 }
 
-/// Distinguishes staging dirs made by two clones inside one process; the pid
-/// separates processes.
-static STAGING_NONCE: AtomicU64 = AtomicU64::new(0);
-
-/// The private staging directory a clone of `cache_path` is built in.
+/// A dot-prefixed sibling of `cache_path` carrying `suffix`.
 ///
-/// A SIBLING of `cache_path` (same parent, hence same filesystem) so publishing
-/// it is a single atomic `rename`, and dot-prefixed + pid/nonce-namespaced so
-/// `list_cached_repos` ignores it and no two clones ever share one.
-fn staging_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
+/// Siblings (same parent, hence same filesystem) so a `rename` between one and
+/// `cache_path` is atomic, and dot-prefixed so `list_cached_repos` skips them.
+/// Built by string append rather than `Path::with_extension` so repos named
+/// `foo.rs` and `foo.py` cannot collide on a shared `foo.lock`. One helper for
+/// both the lock and the staging path so the two can never desynchronise.
+fn sibling_dotted(cache_path: &Path, suffix: &str) -> Result<PathBuf, RemoteRepoError> {
     let parent = cache_path.parent().ok_or_else(|| {
         RemoteRepoError::IoError(format!(
             "cache path has no parent directory: {}",
@@ -1314,8 +1314,144 @@ fn staging_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
             ))
         })?
         .to_string_lossy();
+    Ok(parent.join(format!(".{name}.{suffix}")))
+}
+
+/// Distinguishes staging dirs made by two clones inside one process; the pid
+/// separates processes.
+static STAGING_NONCE: AtomicU64 = AtomicU64::new(0);
+
+/// The filename fragment marking a staging directory, shared by the path
+/// builder and the sweeper so a rename of one cannot orphan the other.
+const STAGING_TAG: &str = "clone-tmp";
+
+/// The private staging directory a clone of `cache_path` is built in.
+fn staging_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
     let nonce = STAGING_NONCE.fetch_add(1, Ordering::Relaxed);
-    Ok(parent.join(format!(".{name}.clone-tmp-{}-{nonce}", std::process::id())))
+    sibling_dotted(
+        cache_path,
+        &format!("{STAGING_TAG}-{}-{nonce}", std::process::id()),
+    )
+}
+
+/// The advisory lock file serialising clones of the repo at `cache_path`.
+///
+/// Lives BESIDE the repo directory, never inside it: the clone is published by
+/// renaming a new directory over `cache_path`, so a lock file held under that
+/// path would be swapped out from under its holder mid-critical-section.
+fn clone_lock_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
+    sibling_dotted(cache_path, "clone-lock")
+}
+
+/// Remove staging directories for this repo left behind by runs that died
+/// mid-clone (Ctrl-C, OOM, a cancelled task). Without this they accumulate
+/// forever, one full partial checkout per abandoned attempt.
+///
+/// ONLY sound while the clone lock is held: the lock is what guarantees no peer
+/// has a staging directory for this repo in flight, so every match is a corpse.
+/// Called without it, this would delete a live peer's partial clone.
+fn sweep_stale_staging(guard: &CacheGuard, cache_path: &Path, keep: &Path) {
+    let (Some(parent), Some(name)) = (cache_path.parent(), cache_path.file_name()) else {
+        return;
+    };
+    let prefix = format!(".{}.{STAGING_TAG}-", name.to_string_lossy());
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == keep || !entry.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        info!("Sweeping abandoned staging dir {}", path.display());
+        if let Err(e) = guard.remove_repo_dir(&path, "sweep abandoned staging dir") {
+            warn!("Failed to sweep staging dir {}: {}", path.display(), e);
+        }
+    }
+}
+
+/// Clone `url` into a private staging directory, then publish it into
+/// `cache_path` with an atomic `rename`.
+///
+/// The staging directory is a sibling of `cache_path` so the rename stays on
+/// one filesystem (and therefore atomic). The only directory this function ever
+/// removes is that staging directory, which it created, so a failed clone
+/// cannot delete a populated shared repo no matter who else is running. Losing
+/// the publish race to another process is a success, not a failure: their clone
+/// is adopted and ours discarded.
+fn clone_into_cache(
+    guard: &CacheGuard,
+    url: &str,
+    cache_path: &Path,
+    locked: bool,
+) -> Result<PathBuf, RemoteRepoError> {
+    let staging = staging_path(cache_path)?;
+    if locked {
+        sweep_stale_staging(guard, cache_path, &staging);
+    }
+    // A same-named leftover can only come from a crashed earlier run whose pid
+    // we now reuse; it is ours by construction, but route it through the guard
+    // anyway so nothing in this file deletes unchecked.
+    guard.remove_repo_dir(&staging, "clone_into_cache: stale staging dir")?;
+
+    info!(
+        "Cloning {} to {} (staging at {})",
+        url,
+        cache_path.display(),
+        staging.display()
+    );
+
+    // Standard clone (not --bare) for compatibility with worktree discovery
+    let output = Command::new("git")
+        .args(["clone", url])
+        .arg(&staging)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "echo")
+        .output()
+        .map_err(|e| RemoteRepoError::CloneFailed(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // A failed `git clone` (auth rejected mid-transfer, network drop)
+        // leaves a partial checkout. It is in OUR staging dir, so clearing it
+        // can never touch the shared cache, and the cache was never written at
+        // all, so a retry starts clean either way. A cleanup that fails is
+        // logged, never raised: the clone error is the one the user needs.
+        if let Err(e) = guard.remove_repo_dir(&staging, "clone_into_cache: failed clone") {
+            warn!(
+                "Failed to remove staged partial clone at {}: {}",
+                staging.display(),
+                e
+            );
+        }
+        return Err(classify_git_error(&stderr, url));
+    }
+
+    publish_staged_clone(guard, &staging, cache_path, locked)?;
+
+    info!("Successfully cloned to: {}", cache_path.display());
+    Ok(cache_path.to_path_buf())
+}
+
+/// If `cache_path` now holds a real clone then a peer won the publish race:
+/// adopt theirs and discard ours. Reports whether that happened.
+fn adopt_if_published(guard: &CacheGuard, staging: &Path, cache_path: &Path) -> bool {
+    if !RemoteRepoManager::cache_path_is_populated(cache_path) {
+        return false;
+    }
+    info!(
+        "Concurrent clone already published {}, reusing it and discarding {}",
+        cache_path.display(),
+        staging.display()
+    );
+    if let Err(e) = guard.remove_repo_dir(staging, "publish_staged_clone: discard loser") {
+        warn!(
+            "Failed to discard redundant staged clone at {}: {}",
+            staging.display(),
+            e
+        );
+    }
+    true
 }
 
 /// Move a finished staging clone into place at `cache_path`.
@@ -1324,69 +1460,52 @@ fn staging_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
 /// it, which is precisely the guarantee wanted here: whoever renames first
 /// wins, and the loser adopts the winner's clone instead of replacing a repo
 /// that live worktrees may already point at.
-fn publish_staged_clone(staging: &Path, cache_path: &Path) -> Result<(), RemoteRepoError> {
+fn publish_staged_clone(
+    guard: &CacheGuard,
+    staging: &Path,
+    cache_path: &Path,
+    locked: bool,
+) -> Result<(), RemoteRepoError> {
     if std::fs::rename(staging, cache_path).is_ok() {
         return Ok(());
     }
+    if adopt_if_published(guard, staging, cache_path) {
+        return Ok(());
+    }
 
-    if RemoteRepoManager::cache_path_is_populated(cache_path) {
-        info!(
-            "Concurrent clone already published {} — reusing it and discarding {}",
-            cache_path.display(),
-            staging.display()
-        );
-        if let Err(e) = remove_repo_dir_guarded(staging, "publish_staged_clone: discard loser") {
+    // The destination exists but holds no usable clone: a partial left by an
+    // aborted run from before this staging scheme, or a stray directory.
+    if !locked {
+        // With no lock there is nothing stopping a peer publishing a real clone
+        // into this path between the check above and a delete below, and that
+        // clone would not be ours to remove. Refusing costs one failed launch;
+        // guessing wrong costs a repo and every worktree cut from it.
+        if let Err(e) = guard.remove_repo_dir(staging, "publish_staged_clone: unlocked bail-out") {
             warn!(
-                "Failed to discard redundant staged clone at {}: {}",
+                "Failed to discard staged clone at {}: {}",
                 staging.display(),
                 e
             );
         }
-        return Ok(());
+        return Err(RemoteRepoError::IoError(format!(
+            "cannot publish clone to {}: the destination holds unusable content and no clone lock is available to clear it safely",
+            cache_path.display()
+        )));
     }
 
-    // The destination holds no usable clone — a partial left by an aborted run
-    // from before this staging scheme, or a stray directory. Clear it (guarded:
-    // a repo with live worktrees is refused, never deleted) and publish again.
-    remove_repo_dir_guarded(
+    guard.remove_repo_dir(
         cache_path,
         "publish_staged_clone: clear unusable destination",
     )?;
 
     std::fs::rename(staging, cache_path).map_err(|e| {
-        let _ = remove_repo_dir_guarded(staging, "publish_staged_clone: unpublishable clone");
+        let _ = guard.remove_repo_dir(staging, "publish_staged_clone: unpublishable clone");
         RemoteRepoError::IoError(format!(
             "failed to publish clone {} -> {}: {e}",
             staging.display(),
             cache_path.display()
         ))
     })
-}
-
-/// The advisory lock file serialising clones of the repo at `cache_path`.
-///
-/// Lives BESIDE the repo directory, never inside it: the clone is published by
-/// renaming a new directory over `cache_path`, so a lock file held under that
-/// path would be swapped out from under its holder mid-critical-section. Built
-/// by string append rather than `Path::with_extension` so repos named `foo.rs`
-/// and `foo.py` don't collide on a shared `foo.lock`.
-fn clone_lock_path(cache_path: &Path) -> Result<PathBuf, RemoteRepoError> {
-    let parent = cache_path.parent().ok_or_else(|| {
-        RemoteRepoError::IoError(format!(
-            "cache path has no parent directory: {}",
-            cache_path.display()
-        ))
-    })?;
-    let name = cache_path
-        .file_name()
-        .ok_or_else(|| {
-            RemoteRepoError::IoError(format!(
-                "cache path has no file name: {}",
-                cache_path.display()
-            ))
-        })?
-        .to_string_lossy();
-    Ok(parent.join(format!(".{name}.clone-lock")))
 }
 
 /// Holds the exclusive advisory clone lock for one repo, releasing it on drop
@@ -1396,20 +1515,51 @@ struct CloneLock {
 }
 
 impl CloneLock {
-    /// Block until this process holds the clone lock for `cache_path`.
+    /// Block until this process holds the clone lock for `cache_path`, or
+    /// report `None` when no lock can be had.
+    ///
+    /// A lock is an OPTIMISATION here, not the safety mechanism: staging plus
+    /// atomic rename is what makes concurrent clones safe, and the lock only
+    /// stops N racers doing N redundant clones. So a filesystem that cannot
+    /// provide one (NFS, CIFS, a 9p or drvfs bind mount where `flock` returns
+    /// ENOTSUP) degrades to extra work, never to a failed session launch.
     ///
     /// The lock is per open file description, so two threads of one ainb
     /// process exclude each other exactly as two separate processes do.
-    fn acquire(cache_path: &Path) -> Result<Self, RemoteRepoError> {
-        let path = clone_lock_path(cache_path)?;
-        let file = std::fs::OpenOptions::new()
+    fn acquire(cache_path: &Path) -> Option<Self> {
+        let path = match clone_lock_path(cache_path) {
+            Ok(path) => path,
+            Err(e) => {
+                warn!("Proceeding without a clone lock: {}", e);
+                return None;
+            }
+        };
+        let file = match std::fs::OpenOptions::new()
             .create(true)
             .truncate(false)
             .write(true)
-            .open(&path)?;
-        FileExt::lock_exclusive(&file)?;
+            .open(&path)
+        {
+            Ok(file) => file,
+            Err(e) => {
+                warn!(
+                    "Proceeding without a clone lock ({} is not writable: {})",
+                    path.display(),
+                    e
+                );
+                return None;
+            }
+        };
+        if let Err(e) = FileExt::lock_exclusive(&file) {
+            warn!(
+                "Proceeding without a clone lock (this filesystem cannot lock {}: {})",
+                path.display(),
+                e
+            );
+            return None;
+        }
         debug!("Holding clone lock {}", path.display());
-        Ok(Self { file })
+        Some(Self { file })
     }
 }
 
@@ -1419,99 +1569,223 @@ impl Drop for CloneLock {
     }
 }
 
-/// How many live worktrees are linked to the clone at `cache_path`.
+/// Count the LINKED worktrees in `git worktree list --porcelain` output.
 ///
-/// `git worktree add` registers each checkout under `<repo>/.git/worktrees/`,
-/// and the worktree's own `.git` file gitlinks back into it. Deleting the repo
-/// therefore orphans every one of them — the exact damage of the 2026-09 wipe.
-fn live_worktree_count(cache_path: &Path) -> usize {
-    std::fs::read_dir(cache_path.join(".git").join("worktrees"))
-        .map_or(0, |entries| entries.flatten().count())
+/// The first block is the repo's own checkout, never a linked worktree. Blocks
+/// git marks `prunable` are registrations whose checkout is already gone, so
+/// they are not live and must not keep the guard latched.
+fn count_linked_worktrees(porcelain: &str) -> usize {
+    porcelain
+        .split("\n\n")
+        .filter(|block| block.lines().any(|l| l.starts_with("worktree ")))
+        .skip(1)
+        .filter(|block| !block.lines().any(|l| l == "prunable" || l.starts_with("prunable ")))
+        .count()
 }
 
-/// Delete a repo cache directory, refusing if live worktrees still link into it
-/// and recording a receipt either way.
+/// How many live worktrees are linked to the clone at `cache_path`.
 ///
-/// EVERY destructive path in this file goes through here. A caller that
-/// genuinely means to remove a repo with worktrees must remove the worktrees
-/// first; there is deliberately no override flag.
-fn remove_repo_dir_guarded(path: &Path, operation: &str) -> Result<(), RemoteRepoError> {
-    // Nothing to delete, nothing to record — keeps the receipt log meaning
-    // "a real directory was removed or refused".
-    if !path.exists() {
-        return Ok(());
+/// Asks git rather than counting `.git/worktrees/` entries, for two reasons the
+/// filesystem cannot express. First, a registration OUTLIVES its checkout: `rm
+/// -rf` on a worktree leaves the entry on disk until someone prunes, so a
+/// directory count latches at 1 forever and jams every later delete. Second,
+/// `.git` is not always a directory (a linked worktree or `--separate-git-dir`
+/// makes it a file), and a `read_dir` there fails with ENOTDIR, which a count
+/// would read as "no worktrees" precisely when the answer matters most.
+///
+/// Fails CLOSED: any question it cannot answer becomes an error, and the guard
+/// refuses the delete. A guard whose purpose is to refuse must never treat an
+/// unreadable repo as an empty one.
+fn live_worktree_count(cache_path: &Path) -> Result<usize, RemoteRepoError> {
+    // Not a git checkout at all: a staging dir, a stray directory. Nothing can
+    // be linked to it, and `git worktree list` would fail on it.
+    if !cache_path.join(".git").exists() {
+        return Ok(0);
     }
 
-    let worktrees = live_worktree_count(path);
-    if worktrees > 0 {
-        record_destructive_op(
-            path,
-            operation,
-            &format!("REFUSED ({worktrees} live worktree(s))"),
-        );
+    // Drop registrations whose checkout is already gone. git only does this on
+    // an explicit prune, and `delete_orphaned_branch` in this file prunes for
+    // the same reason before touching branches.
+    let _ = Command::new("git").args(["worktree", "prune"]).current_dir(cache_path).output();
+
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(cache_path)
+        .output()
+        .map_err(|e| {
+            RemoteRepoError::IoError(format!(
+                "refusing to delete {}: cannot run git to check for live worktrees ({e})",
+                cache_path.display()
+            ))
+        })?;
+
+    if !output.status.success() {
         return Err(RemoteRepoError::IoError(format!(
-            "refusing to delete {} during {operation}: {worktrees} live worktree(s) still link to it — remove those worktrees first",
-            path.display()
+            "refusing to delete {}: cannot determine whether live worktrees link to it ({})",
+            cache_path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
         )));
     }
 
-    record_destructive_op(path, operation, "remove_dir_all");
-    std::fs::remove_dir_all(path)?;
-    info!(
-        "Removed repo cache directory {} ({operation})",
-        path.display()
-    );
-    Ok(())
+    Ok(count_linked_worktrees(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
 }
 
-/// The append-only receipt log for destructive operations on the repo cache.
+/// The safety context every deletion of a repo cache directory runs under: the
+/// root such deletions may not escape, and where the receipt is written.
+#[derive(Clone)]
+struct CacheGuard {
+    root: PathBuf,
+    receipt_log: Option<PathBuf>,
+}
+
+impl CacheGuard {
+    /// Delete a repo cache directory, refusing if the path escapes the cache
+    /// root or if live worktrees still link into it, and recording a receipt
+    /// either way.
+    ///
+    /// Every deletion of a repo cache directory in this file goes through here.
+    /// (Worktree directories are removed directly at the `create_worktree_*`
+    /// call sites, each followed by `git worktree prune`; those are a different
+    /// object with a different invariant and are not covered by this guard.)
+    /// A caller that genuinely means to remove a repo with worktrees must
+    /// remove the worktrees first; there is deliberately no override flag.
+    fn remove_repo_dir(&self, path: &Path, operation: &str) -> Result<(), RemoteRepoError> {
+        // Nothing to delete, nothing to record. Keeps the receipt log meaning
+        // "a real directory was removed or refused".
+        if !path.exists() {
+            return Ok(());
+        }
+
+        self.assert_contained(path, operation)?;
+
+        let worktrees = live_worktree_count(path)?;
+        if worktrees > 0 {
+            self.record(
+                path,
+                operation,
+                &format!("REFUSED ({worktrees} live worktree(s))"),
+            );
+            return Err(RemoteRepoError::IoError(format!(
+                "refusing to delete {} during {operation}: {worktrees} live worktree(s) still link to it, remove those worktrees first",
+                path.display()
+            )));
+        }
+
+        // A receipt BEFORE the removal, so a crash or a kill part-way through
+        // still leaves evidence of what was being deleted, and another after,
+        // so the log never claims a removal that did not actually complete.
+        self.record(path, operation, "ATTEMPT remove_dir_all");
+        match std::fs::remove_dir_all(path) {
+            Ok(()) => {
+                self.record(path, operation, "REMOVED");
+                info!(
+                    "Removed repo cache directory {} ({operation})",
+                    path.display()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                self.record(path, operation, &format!("FAILED ({e})"));
+                Err(RemoteRepoError::IoError(format!(
+                    "failed to remove {} during {operation}: {e}",
+                    path.display()
+                )))
+            }
+        }
+    }
+
+    /// Refuse any path that does not resolve to somewhere strictly beneath the
+    /// cache root.
+    ///
+    /// `get_cache_path` joins host, owner and repo straight from regex-parsed
+    /// remote URLs, so an owner or repo of `..` would otherwise walk out of
+    /// `~/.agents-in-a-box/repos` and hand an arbitrary directory to
+    /// `remove_dir_all`. Canonicalising both sides also means a symlink planted
+    /// inside the cache cannot redirect a delete outside it.
+    fn assert_contained(&self, path: &Path, operation: &str) -> Result<(), RemoteRepoError> {
+        let root = std::fs::canonicalize(&self.root).map_err(|e| {
+            RemoteRepoError::IoError(format!(
+                "refusing to delete {} during {operation}: repo cache root {} is unreadable ({e})",
+                path.display(),
+                self.root.display()
+            ))
+        })?;
+        let resolved = std::fs::canonicalize(path).map_err(|e| {
+            RemoteRepoError::IoError(format!(
+                "refusing to delete {} during {operation}: path is unreadable ({e})",
+                path.display()
+            ))
+        })?;
+
+        if resolved == root || !resolved.starts_with(&root) {
+            self.record(path, operation, "REFUSED (outside the repo cache)");
+            return Err(RemoteRepoError::IoError(format!(
+                "refusing to delete {} during {operation}: it resolves to {}, which is not inside the repo cache {}",
+                path.display(),
+                resolved.display(),
+                root.display()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Record one destructive operation on a repo cache path.
+    ///
+    /// Best effort by design (a receipt that cannot be written must never block
+    /// or fail the operation it describes) but it is also emitted through
+    /// `tracing`, so the evidence exists in two places.
+    fn record(&self, path: &Path, operation: &str, outcome: &str) {
+        let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let pid = std::process::id();
+        warn!(
+            target: "destructive_op",
+            path = %resolved.display(),
+            operation,
+            outcome,
+            pid,
+            "repo cache directory removal"
+        );
+
+        let Some(log_path) = self.receipt_log.as_ref() else {
+            return;
+        };
+        if let Some(parent) = log_path.parent() {
+            if std::fs::create_dir_all(parent).is_err() {
+                return;
+            }
+        }
+        // One preformatted `write_all`, never `writeln!`: `File` does not
+        // override `write_fmt`, so a multi-fragment format issues one write
+        // syscall per fragment and concurrent appends from other ainb processes
+        // splice into each other, corrupting the very log used to reconstruct
+        // an incident.
+        let line = format!(
+            "{}\tpid={pid}\t{operation}\t{outcome}\t{}\n",
+            chrono::Utc::now().to_rfc3339(),
+            resolved.display()
+        );
+        if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(log_path) {
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+/// Where destructive-operation receipts go unless a caller injects a path.
 ///
 /// Deliberately OUTSIDE `~/.agents-in-a-box`: when that whole tree is what got
-/// wiped, a log stored inside it is gone with it. Uses the same OS cache-dir
-/// resolver as `cli::statusline` (`~/Library/Caches/ainb` on macOS,
-/// `~/.cache/ainb` on Linux).
-/// `AINB_DESTRUCTIVE_OPS_LOG` redirects it (a rotated ops location, a test).
-fn destructive_ops_log_path() -> Option<PathBuf> {
+/// wiped, a log stored inside it is gone with it. Same OS cache-dir resolver as
+/// `cli::statusline` (`~/Library/Caches/ainb` on macOS, `~/.cache/ainb` on
+/// Linux). `AINB_DESTRUCTIVE_OPS_LOG` redirects it to a rotated ops location;
+/// it is read once, when a manager is constructed, never from the destructive
+/// path itself.
+fn default_receipt_log() -> Option<PathBuf> {
     if let Some(path) = std::env::var_os("AINB_DESTRUCTIVE_OPS_LOG") {
         return Some(PathBuf::from(path));
     }
     let dir = dirs::cache_dir().or_else(|| dirs::home_dir().map(|h| h.join(".cache")))?;
     Some(dir.join("ainb").join("destructive-ops.log"))
-}
-
-/// Record one attempted destructive operation on a repo cache path.
-///
-/// Best effort by design — a receipt that cannot be written must never block or
-/// fail the operation it describes — but it is also emitted through `tracing`,
-/// so the evidence exists in two places.
-fn record_destructive_op(path: &Path, operation: &str, outcome: &str) {
-    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    let pid = std::process::id();
-    warn!(
-        target: "destructive_op",
-        path = %resolved.display(),
-        operation,
-        outcome,
-        pid,
-        "repo cache directory removal"
-    );
-
-    let Some(log_path) = destructive_ops_log_path() else {
-        return;
-    };
-    if let Some(parent) = log_path.parent() {
-        if std::fs::create_dir_all(parent).is_err() {
-            return;
-        }
-    }
-    if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
-        let _ = writeln!(
-            file,
-            "{}\tpid={pid}\t{operation}\t{outcome}\t{}",
-            chrono::Utc::now().to_rfc3339(),
-            resolved.display()
-        );
-    }
 }
 
 /// Classify git errors into appropriate RemoteRepoError variants
@@ -1665,6 +1939,39 @@ mod tests {
             .output()
             .unwrap();
         assert_eq!(String::from_utf8_lossy(&count.stdout).trim(), "1");
+    }
+
+    /// The first block is the repo's own checkout, not a linked worktree, and a
+    /// `prunable` block is a registration whose checkout is already gone. Both
+    /// must be excluded or the guard latches shut on a repo with no live
+    /// worktrees and blocks every later delete.
+    #[test]
+    fn count_linked_worktrees_skips_the_main_checkout_and_prunable_entries() {
+        let main_only = "worktree /repos/widget\nHEAD abc\nbranch refs/heads/main\n";
+        assert_eq!(count_linked_worktrees(main_only), 0);
+
+        let one_live = "worktree /repos/widget\nHEAD abc\nbranch refs/heads/main\n\
+                        \n\
+                        worktree /wt/feature\nHEAD abc\nbranch refs/heads/agents/feature\n";
+        assert_eq!(count_linked_worktrees(one_live), 1);
+
+        // The exact shape git emits after the checkout is deleted by hand.
+        let stale = "worktree /repos/widget\nHEAD abc\nbranch refs/heads/main\n\
+                     \n\
+                     worktree /wt/gone\nHEAD abc\nbranch refs/heads/agents/gone\n\
+                     prunable gitdir file points to non-existent location\n";
+        assert_eq!(
+            count_linked_worktrees(stale),
+            0,
+            "a prunable registration is not a live worktree"
+        );
+
+        let mixed = "worktree /repos/widget\nHEAD abc\nbranch refs/heads/main\n\
+                     \n\
+                     worktree /wt/gone\nHEAD abc\nprunable gitdir file points to non-existent location\n\
+                     \n\
+                     worktree /wt/live\nHEAD abc\nbranch refs/heads/agents/live\n";
+        assert_eq!(count_linked_worktrees(mixed), 1);
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/tests/remote_repo_clone_race.rs
+++ b/ainb-tui/crates/ainb-core/tests/remote_repo_clone_race.rs
@@ -1,0 +1,258 @@
+// ABOUTME: Regression tests for the 2026-09 repo-cache wipe — concurrent
+// `clone_repo` calls against one cold repo, and the refuse-to-delete guard.
+//
+// The incident: `clone_repo` checked `is_cached()` and cloned without a lock, so
+// N processes launching sessions against the same not-yet-cached repo all cloned
+// into the same path; the losers' "clean up my partial clone" `remove_dir_all`
+// deleted the WINNER's finished repo, orphaning every worktree cut from it and
+// re-arming the race for the next launch. These tests drive real `git` against
+// local repos (no network) and would fail against that code.
+
+use ainb::git::{ParsedRepo, RemoteRepoManager, RepoSource};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Barrier, OnceLock};
+
+/// Run `git` in `cwd` with a deterministic identity, isolated from any global
+/// config, and assert it succeeded.
+fn git_ok(cwd: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("git runs");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A bare repo with one commit, standing in for a remote so nothing here needs
+/// the network.
+fn init_bare_remote(tmp: &Path) -> PathBuf {
+    let work = tmp.join("source");
+    std::fs::create_dir_all(&work).unwrap();
+    git_ok(&work, &["init", "-q", "-b", "main"]);
+    std::fs::write(work.join("README.md"), "hello\n").unwrap();
+    git_ok(&work, &["add", "README.md"]);
+    git_ok(&work, &["commit", "-qm", "init"]);
+
+    let bare = tmp.join("remote.git");
+    git_ok(
+        tmp,
+        &[
+            "clone",
+            "--bare",
+            "-q",
+            work.to_str().unwrap(),
+            bare.to_str().unwrap(),
+        ],
+    );
+    bare
+}
+
+/// The `(source, parsed)` pair `clone_repo` takes: the source supplies the clone
+/// URL (a local path here), the parsed components the cache location.
+fn repo_inputs(bare: &Path) -> (RepoSource, ParsedRepo) {
+    let source = RepoSource::LocalPath(bare.to_path_buf());
+    let parsed = ParsedRepo {
+        source: source.clone(),
+        host: "github.com".to_string(),
+        owner: "acme".to_string(),
+        repo_name: "widget".to_string(),
+    };
+    (source, parsed)
+}
+
+/// How many callers race for the same cold repo. Eight is enough that the
+/// pre-fix code lost every one of them on this machine, cheap enough (a local
+/// clone of a one-commit repo) to stay a normal-speed test.
+const RACERS: usize = 8;
+
+static RECEIPT_LOG: OnceLock<PathBuf> = OnceLock::new();
+
+/// Redirect the destructive-op receipt log to a per-run temp file and return it.
+///
+/// The override is a process-global env var, so every test in this binary calls
+/// this first — before anything could write a receipt — and shares one file.
+fn receipt_log() -> &'static Path {
+    RECEIPT_LOG.get_or_init(|| {
+        let dir = std::env::temp_dir().join(format!("ainb-receipts-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("destructive-ops.log");
+        std::env::set_var("AINB_DESTRUCTIVE_OPS_LOG", &path);
+        path
+    })
+}
+
+/// Staging directories left behind under `parent` (there should never be any
+/// once a clone has returned).
+fn staging_leftovers(parent: &Path) -> Vec<String> {
+    std::fs::read_dir(parent)
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .filter(|name| name.contains(".clone-tmp-"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// THE regression test. Eight callers race to clone the same cold repo from a
+/// standing start: every one must succeed and the populated cache must survive.
+///
+/// Pre-fix this failed on both counts — the losers' `git clone` hit "destination
+/// path already exists and is not an empty directory", and their cleanup wiped
+/// the winner's clone, leaving an empty cache and orphaned worktrees.
+#[test]
+fn concurrent_clones_of_one_cold_repo_all_succeed_and_leave_the_cache_populated() {
+    receipt_log();
+    let tmp = tempfile::tempdir().unwrap();
+    let bare = init_bare_remote(tmp.path());
+    let cache_dir = tmp.path().join("repos");
+
+    let manager = RemoteRepoManager::with_cache_dir(cache_dir.clone()).unwrap();
+    let (_, parsed) = repo_inputs(&bare);
+    let cache_path = manager.get_cache_path(&parsed);
+    assert!(!manager.is_cached(&parsed), "cache starts cold");
+
+    // A barrier keeps the start staggered by as little as possible, so all eight
+    // are inside the check-then-clone window at once.
+    let barrier = Barrier::new(RACERS);
+    let results: Vec<Result<PathBuf, String>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..RACERS)
+            .map(|_| {
+                let cache_dir = cache_dir.clone();
+                let bare = bare.clone();
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    // A manager per thread: two ainb processes each build their
+                    // own, so sharing one here would test less than production.
+                    let manager = RemoteRepoManager::with_cache_dir(cache_dir).unwrap();
+                    let (source, parsed) = repo_inputs(&bare);
+                    barrier.wait();
+                    manager.clone_repo(&source, &parsed).map_err(|e| e.to_string())
+                })
+            })
+            .collect();
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    });
+
+    for (i, result) in results.iter().enumerate() {
+        let path = result.as_ref().unwrap_or_else(|e| panic!("racer {i} failed to clone: {e}"));
+        assert_eq!(
+            *path, cache_path,
+            "racer {i} resolved a different cache path"
+        );
+    }
+
+    // The shared clone is intact and holds the remote's content — not an empty
+    // directory left by a loser's cleanup.
+    assert!(cache_path.join(".git").exists(), "cache lost its .git");
+    assert!(
+        cache_path.join("README.md").exists(),
+        "cache lost the remote's content"
+    );
+    assert!(manager.is_cached(&parsed), "repo reports as cached");
+
+    // Exactly one clone: the losers reused the winner's, they did not each
+    // publish a copy, and no staging dir was orphaned.
+    let owner_dir = cache_path.parent().unwrap();
+    assert!(
+        staging_leftovers(owner_dir).is_empty(),
+        "staging dirs left behind: {:?}",
+        staging_leftovers(owner_dir)
+    );
+    let published: Vec<_> = std::fs::read_dir(owner_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|name| !name.starts_with('.'))
+        .collect();
+    assert_eq!(published, vec!["widget".to_string()], "exactly one clone");
+}
+
+/// A repo whose worktrees are live is never deleted — the deletion errors and
+/// the clone (with its worktrees) stays on disk.
+#[test]
+fn removing_a_repo_with_live_worktrees_is_refused() {
+    let receipt = receipt_log();
+    let tmp = tempfile::tempdir().unwrap();
+    let bare = init_bare_remote(tmp.path());
+    let manager = RemoteRepoManager::with_cache_dir(tmp.path().join("repos")).unwrap();
+    let (source, parsed) = repo_inputs(&bare);
+
+    let cache_path = manager.clone_repo(&source, &parsed).unwrap();
+    let worktree = tmp.path().join("worktrees").join("agents-feature");
+    git_ok(
+        &cache_path,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "agents/feature",
+            worktree.to_str().unwrap(),
+        ],
+    );
+    assert!(worktree.join("README.md").exists(), "worktree checked out");
+
+    let err = manager
+        .remove_cached_repo(&parsed)
+        .expect_err("deleting a repo with live worktrees must fail");
+    assert!(
+        err.to_string().contains("live worktree"),
+        "error should name the reason, got: {err}"
+    );
+    assert!(cache_path.join(".git").exists(), "the repo survived");
+    assert!(worktree.join("README.md").exists(), "the worktree survived");
+
+    // The refusal left a receipt outside the ainb tree.
+    let log = std::fs::read_to_string(receipt).unwrap_or_default();
+    let line = log
+        .lines()
+        .find(|l| l.contains("remove_cached_repo") && l.contains("widget"))
+        .unwrap_or_else(|| panic!("no receipt for the refused delete in:\n{log}"));
+    assert!(
+        line.contains("REFUSED"),
+        "receipt should record the refusal: {line}"
+    );
+    assert!(
+        line.contains("pid="),
+        "receipt should record the pid: {line}"
+    );
+}
+
+/// A clone that fails leaves nothing behind — no half-populated cache that
+/// `is_cached()` would later mistake for a warm one, and no staging dir.
+#[test]
+fn a_failed_clone_leaves_no_cache_and_no_staging_dir() {
+    receipt_log();
+    let tmp = tempfile::tempdir().unwrap();
+    let not_a_repo = tmp.path().join("not-a-repo");
+    std::fs::create_dir_all(&not_a_repo).unwrap();
+
+    let manager = RemoteRepoManager::with_cache_dir(tmp.path().join("repos")).unwrap();
+    let (source, parsed) = repo_inputs(&not_a_repo);
+
+    assert!(
+        manager.clone_repo(&source, &parsed).is_err(),
+        "cloning a non-repo fails"
+    );
+    let cache_path = manager.get_cache_path(&parsed);
+    assert!(!cache_path.exists(), "no partial cache left behind");
+    assert!(!manager.is_cached(&parsed), "still reports as cold");
+    let owner_dir = cache_path.parent().unwrap();
+    assert!(
+        staging_leftovers(owner_dir).is_empty(),
+        "staging dirs left behind: {:?}",
+        staging_leftovers(owner_dir)
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/remote_repo_clone_race.rs
+++ b/ainb-tui/crates/ainb-core/tests/remote_repo_clone_race.rs
@@ -1,5 +1,5 @@
-// ABOUTME: Regression tests for the 2026-09 repo-cache wipe — concurrent
-// `clone_repo` calls against one cold repo, and the refuse-to-delete guard.
+// ABOUTME: Regression tests for the 2026-09 repo-cache wipe: concurrent
+// `clone_repo` calls against one cold repo, plus the refuse-to-delete guard.
 //
 // The incident: `clone_repo` checked `is_cached()` and cloned without a lock, so
 // N processes launching sessions against the same not-yet-cached repo all cloned
@@ -11,7 +11,8 @@
 use ainb::git::{ParsedRepo, RemoteRepoManager, RepoSource};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Barrier, OnceLock};
+use std::sync::Barrier;
+use tempfile::TempDir;
 
 /// Run `git` in `cwd` with a deterministic identity, isolated from any global
 /// config, and assert it succeeded.
@@ -71,29 +72,53 @@ fn repo_inputs(bare: &Path) -> (RepoSource, ParsedRepo) {
     (source, parsed)
 }
 
+/// One test's world: a temp dir, a bare "remote", a cache root and a receipt log
+/// path. The receipt log is INJECTED into every manager rather than set through
+/// the environment, so nothing here mutates process-global state that other
+/// threads in this binary are concurrently reading.
+struct Fixture {
+    tmp: TempDir,
+    bare: PathBuf,
+    cache_dir: PathBuf,
+    receipt_log: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = init_bare_remote(tmp.path());
+        let cache_dir = tmp.path().join("repos");
+        let receipt_log = tmp.path().join("receipts").join("destructive-ops.log");
+        Self {
+            tmp,
+            bare,
+            cache_dir,
+            receipt_log,
+        }
+    }
+
+    fn manager(&self) -> RemoteRepoManager {
+        RemoteRepoManager::with_cache_dir(self.cache_dir.clone())
+            .unwrap()
+            .with_receipt_log(self.receipt_log.clone())
+    }
+
+    fn inputs(&self) -> (RepoSource, ParsedRepo) {
+        repo_inputs(&self.bare)
+    }
+
+    fn receipts(&self) -> String {
+        std::fs::read_to_string(&self.receipt_log).unwrap_or_default()
+    }
+}
+
 /// How many callers race for the same cold repo. Eight is enough that the
 /// pre-fix code lost every one of them on this machine, cheap enough (a local
 /// clone of a one-commit repo) to stay a normal-speed test.
 const RACERS: usize = 8;
 
-static RECEIPT_LOG: OnceLock<PathBuf> = OnceLock::new();
-
-/// Redirect the destructive-op receipt log to a per-run temp file and return it.
-///
-/// The override is a process-global env var, so every test in this binary calls
-/// this first — before anything could write a receipt — and shares one file.
-fn receipt_log() -> &'static Path {
-    RECEIPT_LOG.get_or_init(|| {
-        let dir = std::env::temp_dir().join(format!("ainb-receipts-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("destructive-ops.log");
-        std::env::set_var("AINB_DESTRUCTIVE_OPS_LOG", &path);
-        path
-    })
-}
-
-/// Staging directories left behind under `parent` (there should never be any
-/// once a clone has returned).
+/// Staging directories left behind under `parent`. There should never be any
+/// once a clone has returned.
 fn staging_leftovers(parent: &Path) -> Vec<String> {
     std::fs::read_dir(parent)
         .map(|entries| {
@@ -109,18 +134,14 @@ fn staging_leftovers(parent: &Path) -> Vec<String> {
 /// THE regression test. Eight callers race to clone the same cold repo from a
 /// standing start: every one must succeed and the populated cache must survive.
 ///
-/// Pre-fix this failed on both counts — the losers' `git clone` hit "destination
+/// Pre-fix this failed on both counts: the losers' `git clone` hit "destination
 /// path already exists and is not an empty directory", and their cleanup wiped
 /// the winner's clone, leaving an empty cache and orphaned worktrees.
 #[test]
 fn concurrent_clones_of_one_cold_repo_all_succeed_and_leave_the_cache_populated() {
-    receipt_log();
-    let tmp = tempfile::tempdir().unwrap();
-    let bare = init_bare_remote(tmp.path());
-    let cache_dir = tmp.path().join("repos");
-
-    let manager = RemoteRepoManager::with_cache_dir(cache_dir.clone()).unwrap();
-    let (_, parsed) = repo_inputs(&bare);
+    let fx = Fixture::new();
+    let manager = fx.manager();
+    let (_, parsed) = fx.inputs();
     let cache_path = manager.get_cache_path(&parsed);
     assert!(!manager.is_cached(&parsed), "cache starts cold");
 
@@ -130,13 +151,16 @@ fn concurrent_clones_of_one_cold_repo_all_succeed_and_leave_the_cache_populated(
     let results: Vec<Result<PathBuf, String>> = std::thread::scope(|scope| {
         let handles: Vec<_> = (0..RACERS)
             .map(|_| {
-                let cache_dir = cache_dir.clone();
-                let bare = bare.clone();
+                let cache_dir = fx.cache_dir.clone();
+                let receipt_log = fx.receipt_log.clone();
+                let bare = fx.bare.clone();
                 let barrier = &barrier;
                 scope.spawn(move || {
                     // A manager per thread: two ainb processes each build their
                     // own, so sharing one here would test less than production.
-                    let manager = RemoteRepoManager::with_cache_dir(cache_dir).unwrap();
+                    let manager = RemoteRepoManager::with_cache_dir(cache_dir)
+                        .unwrap()
+                        .with_receipt_log(receipt_log);
                     let (source, parsed) = repo_inputs(&bare);
                     barrier.wait();
                     manager.clone_repo(&source, &parsed).map_err(|e| e.to_string())
@@ -154,7 +178,7 @@ fn concurrent_clones_of_one_cold_repo_all_succeed_and_leave_the_cache_populated(
         );
     }
 
-    // The shared clone is intact and holds the remote's content — not an empty
+    // The shared clone is intact and holds the remote's content, not an empty
     // directory left by a loser's cleanup.
     assert!(cache_path.join(".git").exists(), "cache lost its .git");
     assert!(
@@ -180,18 +204,16 @@ fn concurrent_clones_of_one_cold_repo_all_succeed_and_leave_the_cache_populated(
     assert_eq!(published, vec!["widget".to_string()], "exactly one clone");
 }
 
-/// A repo whose worktrees are live is never deleted — the deletion errors and
-/// the clone (with its worktrees) stays on disk.
+/// A repo whose worktrees are live is never deleted: the deletion errors and the
+/// clone (with its worktrees) stays on disk, with a receipt recording the refusal.
 #[test]
 fn removing_a_repo_with_live_worktrees_is_refused() {
-    let receipt = receipt_log();
-    let tmp = tempfile::tempdir().unwrap();
-    let bare = init_bare_remote(tmp.path());
-    let manager = RemoteRepoManager::with_cache_dir(tmp.path().join("repos")).unwrap();
-    let (source, parsed) = repo_inputs(&bare);
+    let fx = Fixture::new();
+    let manager = fx.manager();
+    let (source, parsed) = fx.inputs();
 
     let cache_path = manager.clone_repo(&source, &parsed).unwrap();
-    let worktree = tmp.path().join("worktrees").join("agents-feature");
+    let worktree = fx.tmp.path().join("worktrees").join("agents-feature");
     git_ok(
         &cache_path,
         &[
@@ -215,7 +237,7 @@ fn removing_a_repo_with_live_worktrees_is_refused() {
     assert!(worktree.join("README.md").exists(), "the worktree survived");
 
     // The refusal left a receipt outside the ainb tree.
-    let log = std::fs::read_to_string(receipt).unwrap_or_default();
+    let log = fx.receipts();
     let line = log
         .lines()
         .find(|l| l.contains("remove_cached_repo") && l.contains("widget"))
@@ -228,18 +250,181 @@ fn removing_a_repo_with_live_worktrees_is_refused() {
         line.contains("pid="),
         "receipt should record the pid: {line}"
     );
+    assert!(
+        !log.contains("REMOVED"),
+        "nothing was removed, so no receipt may claim one:\n{log}"
+    );
 }
 
-/// A clone that fails leaves nothing behind — no half-populated cache that
+/// A worktree directory deleted by hand leaves its registration behind until
+/// someone prunes. That stale entry must NOT latch the guard shut forever.
+///
+/// Pre-review the guard counted `.git/worktrees/` entries, so this repo reported
+/// one "live" worktree with zero live worktrees and every later delete failed.
+#[test]
+fn a_stale_worktree_registration_does_not_jam_the_guard() {
+    let fx = Fixture::new();
+    let manager = fx.manager();
+    let (source, parsed) = fx.inputs();
+
+    let cache_path = manager.clone_repo(&source, &parsed).unwrap();
+    let worktree = fx.tmp.path().join("worktrees").join("gone");
+    git_ok(
+        &cache_path,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "agents/gone",
+            worktree.to_str().unwrap(),
+        ],
+    );
+
+    // The user deletes the checkout directly. git keeps the registration.
+    std::fs::remove_dir_all(&worktree).unwrap();
+    assert!(
+        cache_path.join(".git").join("worktrees").exists(),
+        "the stale registration is still on disk (that is the point)"
+    );
+
+    manager
+        .remove_cached_repo(&parsed)
+        .expect("a registration with no checkout must not block the delete");
+    assert!(!cache_path.exists(), "the repo was actually removed");
+}
+
+/// The guard fails CLOSED. When it cannot determine whether worktrees link to a
+/// path, it refuses rather than assuming none, because the assumption is the one
+/// that destroys data.
+#[test]
+fn an_unreadable_repo_is_refused_rather_than_assumed_empty() {
+    let fx = Fixture::new();
+    let manager = fx.manager();
+    let (source, parsed) = fx.inputs();
+
+    let cache_path = manager.clone_repo(&source, &parsed).unwrap();
+
+    // Replace the .git directory with a file git cannot make sense of. This is
+    // the shape a `--separate-git-dir` clone or a linked worktree has, where a
+    // `read_dir` of `.git/worktrees` returns ENOTDIR rather than a count.
+    std::fs::remove_dir_all(cache_path.join(".git")).unwrap();
+    std::fs::write(cache_path.join(".git"), "not a gitfile\n").unwrap();
+
+    let err = manager
+        .remove_cached_repo(&parsed)
+        .expect_err("an undeterminable repo must be refused, not deleted");
+    assert!(
+        err.to_string().contains("cannot determine") || err.to_string().contains("cannot run git"),
+        "error should say the check failed, got: {err}"
+    );
+    assert!(cache_path.exists(), "the repo was not deleted");
+}
+
+/// A path that escapes the cache root is refused even though the caller asked
+/// for it by name. `get_cache_path` joins regex-parsed URL components, so an
+/// owner of `..` would otherwise walk out of the cache and delete elsewhere.
+#[test]
+fn a_path_escaping_the_cache_root_is_refused() {
+    let fx = Fixture::new();
+    let manager = fx.manager();
+
+    // A directory outside the cache root that must survive. The cache root is
+    // `<tmp>/repos`, so `../precious/inner` climbs out of it into `<tmp>`.
+    let outsider = fx.tmp.path().join("precious").join("inner");
+    std::fs::create_dir_all(&outsider).unwrap();
+    std::fs::write(outsider.join("keep.txt"), "important").unwrap();
+
+    let traversal = ParsedRepo {
+        source: RepoSource::LocalPath(fx.bare.clone()),
+        host: "..".to_string(),
+        owner: "precious".to_string(),
+        repo_name: "inner".to_string(),
+    };
+    assert_eq!(
+        manager.get_cache_path(&traversal).canonicalize().unwrap(),
+        outsider.canonicalize().unwrap(),
+        "the traversal really does resolve outside the cache (else this proves nothing)"
+    );
+
+    let err = manager
+        .remove_cached_repo(&traversal)
+        .expect_err("a path outside the cache root must be refused");
+    assert!(
+        err.to_string().contains("not inside the repo cache"),
+        "error should name the containment breach, got: {err}"
+    );
+    assert!(
+        outsider.join("keep.txt").exists(),
+        "the directory outside the cache survived"
+    );
+}
+
+/// A clone still succeeds when the filesystem cannot provide the advisory lock.
+///
+/// The lock is an optimisation (staging plus atomic rename is what makes
+/// concurrency safe), so losing it must degrade to redundant work, never to a
+/// failed session launch. Simulated by parking a directory where the lock file
+/// goes, which makes opening it for write fail the way a lockless filesystem
+/// makes `flock` fail.
+#[test]
+fn a_clone_still_succeeds_when_the_lock_cannot_be_taken() {
+    let fx = Fixture::new();
+    let manager = fx.manager();
+    let (source, parsed) = fx.inputs();
+    let cache_path = manager.get_cache_path(&parsed);
+
+    std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(cache_path.parent().unwrap().join(".widget.clone-lock")).unwrap();
+
+    let path = manager
+        .clone_repo(&source, &parsed)
+        .expect("an unavailable lock must not fail the clone");
+    assert!(path.join("README.md").exists(), "the clone still landed");
+    assert!(
+        staging_leftovers(cache_path.parent().unwrap()).is_empty(),
+        "no staging dir orphaned on the lockless path"
+    );
+}
+
+/// Staging directories abandoned by a killed process are swept, not accumulated.
+///
+/// Every crashed clone used to leave a full partial checkout beside the repo
+/// forever, since cleanup only ever targeted the exact pid+nonce path of the
+/// current run.
+#[test]
+fn an_abandoned_staging_dir_is_swept_on_the_next_clone() {
+    let fx = Fixture::new();
+    let manager = fx.manager();
+    let (source, parsed) = fx.inputs();
+    let cache_path = manager.get_cache_path(&parsed);
+    let owner_dir = cache_path.parent().unwrap();
+
+    // A corpse from a run that died mid-clone, under a pid that is not ours.
+    std::fs::create_dir_all(owner_dir).unwrap();
+    let corpse = owner_dir.join(".widget.clone-tmp-999999-0");
+    std::fs::create_dir_all(corpse.join("subdir")).unwrap();
+    std::fs::write(corpse.join("subdir").join("partial.txt"), "half a clone").unwrap();
+
+    manager.clone_repo(&source, &parsed).unwrap();
+
+    assert!(!corpse.exists(), "the abandoned staging dir was swept");
+    assert!(
+        staging_leftovers(owner_dir).is_empty(),
+        "no staging dirs remain: {:?}",
+        staging_leftovers(owner_dir)
+    );
+    assert!(cache_path.join("README.md").exists(), "the clone landed");
+}
+
+/// A clone that fails leaves nothing behind: no half-populated cache that
 /// `is_cached()` would later mistake for a warm one, and no staging dir.
 #[test]
 fn a_failed_clone_leaves_no_cache_and_no_staging_dir() {
-    receipt_log();
-    let tmp = tempfile::tempdir().unwrap();
-    let not_a_repo = tmp.path().join("not-a-repo");
+    let fx = Fixture::new();
+    let not_a_repo = fx.tmp.path().join("not-a-repo");
     std::fs::create_dir_all(&not_a_repo).unwrap();
 
-    let manager = RemoteRepoManager::with_cache_dir(tmp.path().join("repos")).unwrap();
+    let manager = fx.manager();
     let (source, parsed) = repo_inputs(&not_a_repo);
 
     assert!(


### PR DESCRIPTION
**Fix a race in the remote repo clone cache that could wipe every cached repository on a machine.**

`RemoteRepoManager::clone_repo` checked whether a repo was cached and then cloned it without holding any lock. When two ainb processes launched sessions against the same not-yet-cached repository at the same time, both saw a cold cache and both ran `git clone` into the identical destination. One won; the other's clone failed with "destination path already exists and is not an empty directory", and its failure-cleanup then deleted the *winner's* freshly-populated repository. Because that left the repo uncached again, the next launch re-entered the same racy path, so the fault was self-reinforcing and progressively destroyed the cache. Live worktrees gitlink back into these repos, so each deletion also orphaned every worktree cut from it. On one machine running many concurrent sessions this wiped 11 repositories across 3 orgs and orphaned 37 worktrees.

The fix applies five layers. A clone now lands in a private staging directory beside its destination and is published with an atomic `rename`, so the only directory a failing clone can ever delete is its own — the destructive outcome is structurally unreachable rather than merely unlikely. The check-then-clone sequence additionally runs under a per-repository `fs2` advisory file lock (mirroring the existing `fleet/repo_clone.rs` pattern) and re-checks the cache once the lock is held, so N concurrent launches produce one clone and N-1 reuses instead of N competing clones. Every remaining destructive path is routed through a guard that refuses to delete a repository whose `.git/worktrees/` is non-empty, and records an audit receipt to `~/Library/Caches/ainb/destructive-ops.log` — deliberately outside `~/.agents-in-a-box` so the evidence survives even a full wipe of that tree. Finally, an unreachable `AppEvent::FactoryReset` handler that called `factory_reset()` with no confirmation check and had zero dispatchers is removed, leaving the confirmation-gated Setup Menu path as the only route to a reset.

## Verification

A new regression test (`tests/remote_repo_clone_race.rs`) races eight concurrent `clone_repo` calls at one cold repository against a local git remote. Reimplementing the pre-fix algorithm verbatim makes it fail 8/8 with an emptied cache and the exact production error string; with the fix, all eight succeed and the cache stays populated and content-complete.

```
cargo build -p ainb                               → clean
cargo test -p ainb --test remote_repo_clone_race  → 3 passed
cargo test -p ainb --lib                          → 2125 passed, 0 failed
cargo test -p ainb --test star_remote_base        → 3 passed
cargo fmt -p ainb -- --check                      → clean
cargo clippy -p ainb --lib --tests                → clean on new code
```

## Urgency

Other machines running ainb remain exposed until a release ships, since autoupdate is the delivery path. A freshly-provisioned or newly-updated box is at *maximum* risk, not minimum: its repo cache is entirely empty, so every repo is uncached and every concurrent session launch is a race candidate.
