### PR TITLE
fix(hangar): stop the summary counting tests a build error never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,7 +637,7 @@ jobs:
       # `no such command: nextest`.
       - uses: taiki-e/install-action@nextest
         if: >-
-          always() && (github.event_name != 'pull_request' ||
+          !cancelled() && (github.event_name != 'pull_request' ||
           needs.changes.outputs.relevant != 'false')
       # macOS runner images do NOT ship tmux (actions/runner-images macos-15
       # README) — without installing it here the macOS leg is vacuously green:

--- a/scripts/hangar/run_acceptance_tests.sh
+++ b/scripts/hangar/run_acceptance_tests.sh
@@ -78,7 +78,6 @@ run_group() {
         if [ "$a" = "--test" ]; then n=$((n + 1)); fi
     done
     [ "$n" -gt 0 ] || return 0
-    ran=$((ran + n))
 
     local log rc
     log="$(mktemp)"
@@ -128,6 +127,15 @@ run_group() {
         printf 'FAIL %s: nextest exited %s with no per-test failure (build error?)\n' \
             "$label" "$rc" >&2
         group_fails=1
+        # `ran` deliberately gets NOTHING here. nextest builds the whole group
+        # before running any of it, so a compile error in ONE target means ZERO
+        # of this group's targets executed. Counting `n` up front made that case
+        # print `ran=68 failed=1 skipped=0`, i.e. 67 phantom green tripwires, in
+        # the summary line of the script whose entire job is catching vacuous
+        # green. A counter that lies in exactly the scenario it exists to detect
+        # is worse than no counter, because people trust it.
+    else
+        ran=$((ran + n))
     fi
     rm -f "$log"
     skips=$((skips + group_skips))

--- a/scripts/hangar/run_all_tripwires.sh
+++ b/scripts/hangar/run_all_tripwires.sh
@@ -131,7 +131,6 @@ run_group() {
         if [ "$a" = "--test" ]; then n=$((n + 1)); fi
     done
     [ "$n" -gt 0 ] || return 0
-    ran=$((ran + n))
 
     local log rc
     log="$(mktemp)"
@@ -181,6 +180,15 @@ run_group() {
         printf 'FAIL %s: nextest exited %s with no per-test failure (build error?)\n' \
             "$label" "$rc" >&2
         group_fails=1
+        # `ran` deliberately gets NOTHING here. nextest builds the whole group
+        # before running any of it, so a compile error in ONE target means ZERO
+        # of this group's targets executed. Counting `n` up front made that case
+        # print `ran=68 failed=1 skipped=0`, i.e. 67 phantom green tripwires, in
+        # the summary line of the script whose entire job is catching vacuous
+        # green. A counter that lies in exactly the scenario it exists to detect
+        # is worse than no counter, because people trust it.
+    else
+        ran=$((ran + n))
     fi
     rm -f "$log"
     skips=$((skips + group_skips))


### PR DESCRIPTION
Two findings from the independent post-merge review of `a70f36b3` (#795), tracked on #808. Both are live on `main` and both sit inside the machinery that exists to catch vacuous green.

The third P2 from that review, the silent `turn.is_none()` refusal in `acp_pool.rs`, is deliberately **not** here: it touches daemon code and needs a permission delivered with no open turn to test properly, which is a different size of change and deserves its own PR.

### 1. The counter lied in exactly the case it exists to detect

`ran` was incremented from the `--test` flag count **before** the run. nextest builds a whole group before running any of it, so a compile error in one target means **zero** of that group's targets executed, and the summary printed:

```
hangar tripwires: ran=68 failed=1 skipped=0
```

67 phantom green tripwires, in the script whose entire purpose is catching fake green. The exit code was always correct and CI did go red, so this misled a human reading the log rather than the gate itself. That is still the worse failure of the two, because a counter people trust is worse than no counter.

Now counted after the run, with the build-error branch deliberately counting nothing. Verified by driving the branch directly:

| scenario | before | after |
|---|---|---|
| compile error in one target of 68 | `ran=68 failed=1` | `ran=0 failed=1` |
| one test genuinely fails | `ran=68 failed=1` | `ran=68 failed=1` |
| all green | `ran=68 failed=0` | `ran=68 failed=0` |

Only the misreporting case moves.

### 2. The last `always()` in `ci.yml`

The nextest install step added alongside the hangar suites was gated `always()`. That branch was written before #799 converted every gate, and the merge preserved the stale form, so the file carried **one** `always()` while its own header twenty lines up says:

> The gates below say `!cancelled()`, never `always()`. `always()` runs a job or step even when the run has been CANCELLED

The other 41 gates are `!cancelled()`. The practical cost is one wasted install step on a cancelled run; the real cost is that a lone contradiction of a stated rule is what the next person reads as permission. `grep -rn 'always()' .github/workflows/` now returns only the header's own rule text.

### Verification

- `actionlint -shellcheck=` exit 0; `ci.yml` parses.
- `bash -n` clean on both scripts.
- Counter behaviour verified per the table above.
- Target selection is untouched by this diff; it changes only when the counter is incremented and one gate keyword.