### PR TITLE
fix(git): never delete a shared repo cache on clone failure

### DIFF
--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -245,20 +245,22 @@ impl RemoteRepoManager {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            // `git clone` can leave a partially-initialised directory behind on
-            // failure (e.g. auth rejected mid-transfer). `is_cached()` only
-            // checks for a `.git` entry, so a broken partial would be treated as
-            // a warm cache on the next attempt and never re-cloned after the
-            // user fixes credentials. Remove it so the retry starts clean.
-            if cache_path.exists() {
-                if let Err(e) = std::fs::remove_dir_all(&cache_path) {
-                    warn!(
-                        "Failed to remove partial clone at {}: {}",
-                        cache_path.display(),
-                        e
-                    );
-                }
-            }
+            // Deliberately leave whatever `git clone` wrote at `cache_path`.
+            //
+            // This used to remove the directory so a partial clone (auth
+            // rejected mid-transfer, say) could not masquerade as a warm cache
+            // on the next attempt. That cleanup could not tell a partial of its
+            // own making from a complete clone another process had just
+            // published into the same path, because the two are indistinguishable
+            // from the final path alone. Concurrent launches against one
+            // uncached repo therefore ended with the loser deleting the
+            // winner's finished repository, taking every worktree gitlinked
+            // into it with it, and leaving the path uncached so the next launch
+            // raced again.
+            //
+            // Nothing here may delete a shared path it did not create. A
+            // partial left behind is a recoverable annoyance; a deleted
+            // repository is not.
             return Err(classify_git_error(&stderr, &url));
         }
 

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -258,9 +258,16 @@ impl RemoteRepoManager {
             // into it with it, and leaving the path uncached so the next launch
             // raced again.
             //
-            // Nothing here may delete a shared path it did not create. A
-            // partial left behind is a recoverable annoyance; a deleted
-            // repository is not.
+            // Nothing here may delete a shared path it did not create.
+            //
+            // The cost is that a partial does still read as a warm cache on the
+            // next attempt, because `cache_path_is_populated` only tests for a
+            // `.git` entry, and there is no in-app way to clear it: the user
+            // has to remove the directory by hand. That is a bad failure worth
+            // fixing properly, by cloning into private staging and publishing
+            // with an atomic rename so a finished clone is distinguishable from
+            // an interrupted one. It is not worth fixing with a delete that
+            // cannot tell the two apart.
             return Err(classify_git_error(&stderr, &url));
         }
 
@@ -1254,6 +1261,53 @@ fn classify_git_error(stderr: &str, url: &str) -> RemoteRepoError {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// A failed clone must leave the cache directory exactly as it found it.
+    ///
+    /// This behaviour has been flipped twice: 98c61245 added a `remove_dir_all`
+    /// so a partial clone could not masquerade as a warm cache, and 90d98105
+    /// removed it again after that cleanup was found deleting whole
+    /// repositories that a concurrent process had just published into the same
+    /// path, orphaning every worktree gitlinked into them. The deletion cannot
+    /// distinguish its own partial from a peer's finished clone, so it must not
+    /// happen at all. Pin it, so a third flip has to argue with a red test.
+    #[test]
+    fn a_failed_clone_leaves_the_cache_directory_untouched() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = RemoteRepoManager::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+        let source = RepoSource::from_input("https://github.com/owner/does-not-exist").unwrap();
+        let parsed = source.parse_components().unwrap();
+        let cache_path = manager.get_cache_path(&parsed);
+
+        // Content a peer put here, with no `.git` yet, so `is_cached` is false
+        // and `clone_repo` proceeds to clone rather than short-circuiting on
+        // the warm-cache branch. `git clone` then refuses a non-empty
+        // destination, which is precisely how the losing racer failed in the
+        // incident: no network required, and the failure is deterministic.
+        std::fs::create_dir_all(&cache_path).unwrap();
+        let sentinel = cache_path.join("sentinel");
+        std::fs::write(&sentinel, b"a peer's work").unwrap();
+        assert!(!manager.is_cached(&parsed), "precondition: cache is cold");
+
+        let err = manager
+            .clone_repo(&source, &parsed)
+            .expect_err("cloning into a non-empty directory should fail");
+
+        assert!(
+            matches!(err, RemoteRepoError::CloneFailed(_)),
+            "unexpected error variant: {err:?}"
+        );
+        assert!(
+            sentinel.exists(),
+            "the failed clone deleted a cache directory it did not create"
+        );
+        assert_eq!(
+            std::fs::read(&sentinel).unwrap(),
+            b"a peer's work",
+            "the failed clone modified a cache directory it did not create"
+        );
+    }
 
     #[test]
     fn test_cache_path_generation() {


### PR DESCRIPTION
Reverts the partial-clone cleanup added in `98c61245`, which is the confirmed cause of the 2026-09-01 incident that destroyed 11 cached repositories across 3 orgs and orphaned 37 worktrees on a developer machine.

## What happened

`RemoteRepoManager::clone_repo` checks `is_cached()` and, if false, clones directly into the shared `cache_path`. On clone failure it removed that whole directory, so a partial clone (auth rejected mid-transfer, say) could not masquerade as a warm cache on the next attempt.

That cleanup cannot tell a partial of its own making from a complete clone another process has just published into the same path: from the final path alone the two are indistinguishable. So when two processes launched sessions against the same not-yet-cached repository, both saw a cold cache, both cloned into the identical destination, one won, and the loser's clone failed with "destination path already exists and is not an empty directory". The loser's cleanup then deleted the winner's fully-populated repository. Live worktrees gitlink back into these repos, so each deletion also orphaned every worktree cut from it, and because the path was left uncached the next launch raced again. The failure was self-reinforcing and progressively emptied the cache.

Reproduced 8/8 with concurrent racers against a cold cache, emitting the exact production error string.

## The change

Leave whatever the failed clone wrote in place, and return the error. Nothing in this path may delete a shared directory it did not create. A partial left behind is a recoverable annoyance; a deleted repository is not.

Net effect is the removal of the only unattended deletion of a shared repo cache directory in the codebase. The two remaining deletions of that directory are `initialize_empty_remote` (requires an explicit user keypress on an empty-remote verdict) and `remove_cached_repo` (no callers).

## What this deliberately does not fix

Scope is kept to containment so it can ship immediately; the following are tracked for a follow-up:

- The original motivation for `98c61245` returns: a broken partial reads as a warm cache, because `cache_path_is_populated` only tests `exists() && .git/exists()`. The real remedy is a trustworthy completion boundary (clone into private staging, publish by atomic no-overwrite rename) rather than deleting the destination. A local structural predicate alone cannot distinguish a successfully cloned empty remote from a clone interrupted before receiving refs.
- A losing racer now gets a failed session launch rather than destroying the winner's repository. Better, but still a failure; the staging change resolves it properly.
- `initialize_empty_remote` deletes the shared cache after checking only `local_head_exists`, with no linked-worktree check, so it can still orphan worktrees. It should refuse stale cached history rather than delete it.
- Cache path components are not validated for containment, so a crafted owner or repo name can widen the target beyond `<host>/<owner>/<repo>`.

## Verification

```
cargo build -p ainb        → clean
cargo test -p ainb --lib   → 2125 passed, 0 failed
cargo fmt -p ainb --check   → clean
```

This supersedes #807, which attempted a four-layer hardening (staging, advisory locking, a worktree guard, an audit log). Two rounds of review found 14 findings each, and the second round's most serious were introduced by the first round's fixes, including a guard that pruned away the very worktree registrations it was meant to refuse on. That approach is being replaced by this containment plus a smaller, properly scoped follow-up.
