### PR TITLE
fix(tui): confirm before bulk-deleting sessions

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "tracing-subscriber",
  "tui-term",
  "two-face",
+ "unicode-width 0.2.2",
  "url",
  "uuid",
  "vt100",

--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -135,6 +135,8 @@ ansi-to-tui = "8.0.1"
 # Dracula theme + extra grammars (two-face). syntect→ratatui span conversion
 # is inlined.
 similar = { version = "2", features = ["inline"] }
+# Display width for sizing terminal text; already in the tree via ratatui.
+unicode-width = "0.2"
 two-face = "0.5"
 # TRANSITIVE VERSION CAP, not a real dependency: time 0.3.48 (released
 # 2026-06-11/12) fails to compile against this graph — E0119 "conflicting

--- a/ainb-tui/crates/ainb-core/Cargo.toml
+++ b/ainb-tui/crates/ainb-core/Cargo.toml
@@ -92,6 +92,7 @@ ansi-to-tui = { workspace = true }
 # Code Review diff surface
 similar = { workspace = true }
 two-face = { workspace = true }
+unicode-width = { workspace = true }
 # Version cap only (no code uses it directly) — pins the TRANSITIVE time
 # crate below the broken 0.3.48 release. See the workspace manifest comment
 # for the E0119 story + removal condition.

--- a/ainb-tui/crates/ainb-core/src/app/attach_handler.rs
+++ b/ainb-tui/crates/ainb-core/src/app/attach_handler.rs
@@ -133,7 +133,9 @@ impl<'a> AttachHandler<'a> {
         let check = Command::new("tmux")
             .arg("has-session")
             .arg("-t")
-            .arg(session_name)
+            // Exact target: a bare name prefix-matches, so a live
+            // "feat-auth-2" would answer for a dead "feat-auth".
+            .arg(format!("={session_name}"))
             .output()
             .await
             .context("Failed to check if tmux session exists")?;

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -4458,13 +4458,12 @@ impl EventHandler {
                 } else if other_count > 0 {
                     state.show_kill_other_tmux_sessions_confirmation(other_names);
                 } else if managed_count > 0 {
-                    let ids: Vec<uuid::Uuid> = state.selected_sessions.iter().copied().collect();
-                    state.add_success_notification(format!(
-                        "Deleting {} selected session(s)...",
-                        managed_count
-                    ));
-                    state.pending_async_action = Some(AsyncAction::BulkDeleteSessions(ids));
-                    state.selected_sessions.clear();
+                    // Checked rows get the SAME tri-option dialog as a single
+                    // row: bulk delete used to fire immediately here, which
+                    // destroyed every selected worktree (and any uncommitted
+                    // work in it) with no way back.
+                    let ids = state.selected_session_ids_in_order();
+                    state.show_bulk_delete_or_stop_confirmation(ids);
                 // Check if we're in the SSH Sessions section
                 } else if state.is_ssh_session_selected() {
                     if let Some(ssh_session) = state.selected_ssh_session() {
@@ -4570,13 +4569,8 @@ impl EventHandler {
                 } else if other_count > 0 {
                     state.show_kill_other_tmux_sessions_confirmation(other_names);
                 } else {
-                    let ids: Vec<uuid::Uuid> = state.selected_sessions.iter().copied().collect();
-                    state.add_success_notification(format!(
-                        "Deleting {} selected session(s)...",
-                        managed_count
-                    ));
-                    state.pending_async_action = Some(AsyncAction::BulkDeleteSessions(ids));
-                    state.selected_sessions.clear();
+                    let ids = state.selected_session_ids_in_order();
+                    state.show_bulk_delete_or_stop_confirmation(ids);
                 }
             }
             AppEvent::ResumeSession(trigger) => {
@@ -4731,6 +4725,24 @@ impl EventHandler {
                             crate::app::state::ConfirmAction::StopSession(session_id) => {
                                 state.pending_async_action =
                                     Some(AsyncAction::StopSession(session_id));
+                            }
+                            crate::app::state::ConfirmAction::BulkDeleteSessions(session_ids) => {
+                                state.add_success_notification(format!(
+                                    "Deleting {} selected session(s)...",
+                                    session_ids.len()
+                                ));
+                                state.selected_sessions.clear();
+                                state.pending_async_action =
+                                    Some(AsyncAction::BulkDeleteSessions(session_ids));
+                            }
+                            crate::app::state::ConfirmAction::BulkStopSessions(session_ids) => {
+                                state.add_success_notification(format!(
+                                    "Stopping {} selected session(s)...",
+                                    session_ids.len()
+                                ));
+                                state.selected_sessions.clear();
+                                state.pending_async_action =
+                                    Some(AsyncAction::BulkStopSessions(session_ids));
                             }
                             crate::app::state::ConfirmAction::KillOtherTmux(session_name) => {
                                 state.pending_async_action =

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -4723,7 +4723,13 @@ impl EventHandler {
                                     "Deleting {} selected session(s)...",
                                     session_ids.len()
                                 ));
-                                state.selected_sessions.clear();
+                                // Only the rows being acted on lose their check.
+                                // A mixed selection's Stop covers a subset, and
+                                // silently dropping the rest would make the user
+                                // re-select them.
+                                for id in &session_ids {
+                                    state.selected_sessions.remove(id);
+                                }
                                 state.pending_async_action =
                                     Some(AsyncAction::BulkDeleteSessions(session_ids));
                             }
@@ -4732,7 +4738,9 @@ impl EventHandler {
                                     "Stopping {} selected session(s)...",
                                     session_ids.len()
                                 ));
-                                state.selected_sessions.clear();
+                                for id in &session_ids {
+                                    state.selected_sessions.remove(id);
+                                }
                                 state.pending_async_action =
                                     Some(AsyncAction::BulkStopSessions(session_ids));
                             }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -2191,21 +2191,14 @@ impl EventHandler {
                 // Enter on a Stopped interactive session = resume it.
                 // Enter on a Running session = attach (mirrors 'a').
                 // Other selection types fall through to None to preserve prior behaviour.
-                use crate::models::{SessionAgentType, SessionMode, SessionStatus};
+                use crate::models::SessionStatus;
                 // Checked rows win over cursor: with a multi-select active,
                 // Enter starts every selected resumable session, not just the
                 // highlighted one.
                 if !state.selected_sessions.is_empty() {
                     Some(AppEvent::ResumeSelectedSessions("Enter".to_string()))
                 } else if let Some(session) = state.selected_session() {
-                    let is_interactive = matches!(session.mode, SessionMode::Interactive)
-                        && matches!(
-                            session.agent_type,
-                            SessionAgentType::Claude
-                                | SessionAgentType::Codex
-                                | SessionAgentType::Gemini
-                                | SessionAgentType::Copilot
-                        );
+                    let is_interactive = crate::app::state::is_stoppable_interactive(session);
                     if is_interactive && matches!(session.status, SessionStatus::Stopped) {
                         Some(AppEvent::ResumeSession("Enter".to_string()))
                     } else {
@@ -2221,20 +2214,13 @@ impl EventHandler {
                 // moved to 'A' so the menu bar's `r resume` hint matches what
                 // the key actually does (one key, one meaning). Pressing 'r'
                 // on a non-resumable selection is a no-op.
-                use crate::models::{SessionAgentType, SessionMode, SessionStatus};
+                use crate::models::SessionStatus;
                 // Checked rows win over cursor: with a multi-select active,
                 // 'r' resumes every selected resumable session.
                 if !state.selected_sessions.is_empty() {
                     Some(AppEvent::ResumeSelectedSessions("r".to_string()))
                 } else if let Some(session) = state.selected_session() {
-                    let is_interactive = matches!(session.mode, SessionMode::Interactive)
-                        && matches!(
-                            session.agent_type,
-                            SessionAgentType::Claude
-                                | SessionAgentType::Codex
-                                | SessionAgentType::Gemini
-                                | SessionAgentType::Copilot
-                        );
+                    let is_interactive = crate::app::state::is_stoppable_interactive(session);
                     if is_interactive && matches!(session.status, SessionStatus::Stopped) {
                         Some(AppEvent::ResumeSession("r".to_string()))
                     } else {

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -9601,7 +9601,7 @@ mod panel_back_tests {
         impl Drop for SessionGuard {
             fn drop(&mut self) {
                 let _ = std::process::Command::new("tmux")
-                    .args(["kill-session", "-t", &self.0])
+                    .args(["kill-session", "-t", &format!("={}", self.0)])
                     .status();
             }
         }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -4552,7 +4552,7 @@ impl EventHandler {
                 let other_count = other_names.len();
                 if managed_count == 0 && other_count == 0 {
                     state.add_warning_notification(
-                        "No sessions selected. Use Space to select sessions first.".to_string(),
+                        crate::app::state::NOTHING_SELECTED_WARNING.to_string(),
                     );
                 } else if managed_count > 0 && other_count > 0 {
                     state.add_warning_notification(

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -4517,15 +4517,7 @@ impl EventHandler {
                     // tri-option Stop / Delete / Cancel dialog so the user can
                     // soft-stop without losing the worktree. Boss/Docker, SSH,
                     // and Shell sessions stick with the binary delete flow.
-                    use crate::models::{SessionAgentType, SessionMode};
-                    let is_interactive_agent = matches!(session.mode, SessionMode::Interactive)
-                        && matches!(
-                            session.agent_type,
-                            SessionAgentType::Claude
-                                | SessionAgentType::Codex
-                                | SessionAgentType::Gemini
-                                | SessionAgentType::Copilot
-                        );
+                    let is_interactive_agent = crate::app::state::is_stoppable_interactive(session);
                     let session_id = session.id;
                     if is_interactive_agent {
                         state.show_delete_or_stop_confirmation(session_id);

--- a/ainb-tui/crates/ainb-core/src/app/snapshot.rs
+++ b/ainb-tui/crates/ainb-core/src/app/snapshot.rs
@@ -128,7 +128,7 @@ impl SnapshotManager {
 
     async fn check_tmux_alive(session_name: &str) -> bool {
         Command::new("tmux")
-            .args(["has-session", "-t", session_name])
+            .args(["has-session", "-t", &format!("={session_name}")])
             .output()
             .await
             .map(|o| o.status.success())

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -916,35 +916,34 @@ pub(crate) const fn is_stoppable_interactive(session: &crate::models::session::S
         )
 }
 
-/// What one worktree has to lose.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum UncommittedProbe {
-    /// No worktree is registered for the session, so there is nothing to lose.
-    NoWorktree,
-    Clean,
-    Dirty(usize),
-    /// The worktree exists but its status could not be read. Never fold this
-    /// into Clean: a delete confirmation that says nothing is read as "nothing
-    /// to lose".
-    Unknown,
+/// What one selection has to lose, as the bulk dialog reports it.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct BulkWorktreeStatus {
+    /// `(session name, uncommitted file count)` per dirty tree.
+    pub dirty: Vec<(String, usize)>,
+    /// Trees that are there but could not be read. Never folded into "clean".
+    pub unchecked: usize,
+    /// Selected sessions that have a tree on disk, which is what a delete
+    /// actually removes.
+    pub with_worktree: usize,
 }
 
-/// Read one session's worktree status. Shared by the single-row and the bulk
-/// confirmation so both dialogs answer the same way for the same session.
-fn session_uncommitted_probe(
-    worktree_manager: &crate::git::WorktreeManager,
-    session_id: Uuid,
-) -> UncommittedProbe {
-    use crate::git::WorktreeError;
-    match worktree_manager.uncommitted_file_count(session_id) {
-        Ok(0) => UncommittedProbe::Clean,
-        Ok(count) => UncommittedProbe::Dirty(count),
-        // A session with no registered worktree is an ordinary case, not a
-        // failure: warning about it every time trains the user to skip past the
-        // warning that matters.
-        Err(WorktreeError::NotFound(_)) => UncommittedProbe::NoWorktree,
-        Err(_) => UncommittedProbe::Unknown,
+/// Count what `git status --porcelain` reports in `path`, or `Err` when it
+/// cannot be read. Ignored files are not counted, see
+/// `WorktreeManager::uncommitted_file_count`.
+fn uncommitted_count_at(path: &std::path::Path) -> Result<usize, ()> {
+    let output = std::process::Command::new("git")
+        .current_dir(path)
+        .args(["status", "--porcelain"])
+        .output()
+        .map_err(|_| ())?;
+    if !output.status.success() {
+        return Err(());
     }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .count())
 }
 
 /// Shown when a bulk key is pressed with nothing checked.
@@ -7806,8 +7805,8 @@ impl AppState {
     /// two cannot apply different skip rules or different wording to the same
     /// session.
     fn check_session_uncommitted_warning(&self, session_id: Uuid) -> Option<String> {
-        let (dirty, unchecked) = self.bulk_uncommitted_counts(&[session_id]);
-        Self::format_bulk_uncommitted_warning(&dirty, unchecked)
+        let status = self.bulk_uncommitted_counts(&[session_id]);
+        Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked)
     }
 
     /// Show the tri-option Stop all / Delete all / Cancel dialog for every
@@ -7834,19 +7833,12 @@ impl AppState {
         // many worktrees, what can be stopped) is answered from this, rather
         // than walking the workspace list once per question per id.
         let mut names: Vec<String> = Vec::with_capacity(count);
-        let mut worktree_count = 0;
         let mut stoppable: Vec<Uuid> = Vec::new();
         let mut already_stopped = 0;
         let mut no_stop_path = 0;
         for id in &session_ids {
             let session = self.find_session(*id);
             names.push(session.map_or_else(|| unknown_session_label(*id), |s| s.name.clone()));
-            // Shell sessions have no dedicated worktree, so counting them in
-            // "Delete removes N worktree(s)" would inflate the number on the one
-            // dialog whose job is to state the destructive scope accurately.
-            if session.is_none_or(|s| !matches!(s.agent_type, SessionAgentType::Shell)) {
-                worktree_count += 1;
-            }
             // Stop only means something for interactive agent sessions: it kills
             // tmux and the session resumes later. Boss (Docker) and Shell
             // sessions have no such path, and an already-Stopped session has
@@ -7861,8 +7853,10 @@ impl AppState {
             }
         }
 
-        let (dirty, unchecked) = self.bulk_uncommitted_counts(&session_ids);
-        let warning = Self::format_bulk_uncommitted_warning(&dirty, unchecked);
+        let status = self.bulk_uncommitted_counts(&session_ids);
+        // What Delete actually removes: trees on disk, not selected rows.
+        let worktree_count = status.with_worktree;
+        let warning = Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked);
         let summary = Self::format_bulk_session_summary(&names);
 
         self.confirmation_dialog = Some(if stoppable.len() == count {
@@ -7941,14 +7935,15 @@ impl AppState {
         )
     }
 
-    /// `(dirty sessions, sessions whose status could not be read)`.
+    /// What the selection has to lose.
     ///
-    /// A session whose worktree status cannot be read is NOT reported as clean:
-    /// it is counted as unchecked so the dialog can say so, because "unknown"
-    /// and "nothing to lose" must never look the same on a delete confirmation.
-    /// A session with no registered worktree has nothing to lose and is not
-    /// counted either way. Shell sessions are skipped entirely.
-    fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> (Vec<(String, usize)>, usize) {
+    /// Probes each distinct worktree once, not each session: two sessions can
+    /// resolve to the same tree, and reporting its four modified files twice
+    /// would say eight. A tree whose status cannot be read is NOT reported as
+    /// clean, because "unknown" and "nothing to lose" must never look the same
+    /// on a delete confirmation. Shell sessions have no dedicated tree and are
+    /// skipped entirely.
+    fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> BulkWorktreeStatus {
         use crate::git::WorktreeManager;
         use crate::models::SessionAgentType;
 
@@ -7957,11 +7952,11 @@ impl AppState {
         /// child processes off a single keypress.
         const MAX_CONCURRENT_PROBES: usize = 8;
 
-        // Sessions with a worktree worth probing, paired with their names. An id
-        // that no longer resolves to a session row is probed anyway: the probe
-        // needs only the uuid, and a worktree whose session vanished from the
-        // list is the one most likely to be holding forgotten work.
-        let probes: Vec<(Uuid, String)> = session_ids
+        // Sessions with a tree worth probing, paired with their names. An id that
+        // no longer resolves to a session row is probed anyway: the probe needs
+        // only the uuid, and a tree whose session vanished from the list is the
+        // one most likely to be holding forgotten work.
+        let candidates: Vec<(Uuid, String)> = session_ids
             .iter()
             .filter_map(|id| match self.find_session(*id) {
                 None => Some((*id, unknown_session_label(*id))),
@@ -7969,46 +7964,72 @@ impl AppState {
                 Some(session) => Some((*id, session.name.clone())),
             })
             .collect();
-        let mut unchecked = 0;
 
         let Ok(worktree_manager) = WorktreeManager::new() else {
-            return (Vec::new(), probes.len());
+            return BulkWorktreeStatus {
+                dirty: Vec::new(),
+                unchecked: candidates.len(),
+                with_worktree: candidates.len(),
+            };
         };
 
-        // `uncommitted_file_count` shells out to `git status` per worktree and
-        // this runs inline on a keypress. Batching does not reduce the number of
-        // calls, one per probed session either way; it bounds how many run at
-        // once so a large selection cannot spawn a thread and a child process
-        // per row all at the same time.
-        let mut results: Vec<UncommittedProbe> = Vec::with_capacity(probes.len());
-        for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
-            let batch_results: Vec<UncommittedProbe> = std::thread::scope(|scope| {
-                // Spawn every probe in the batch before joining any of them,
-                // otherwise they run one at a time.
-                let mut handles = Vec::with_capacity(batch.len());
-                for (id, _) in batch {
-                    let worktree_manager = &worktree_manager;
-                    let id = *id;
-                    handles
-                        .push(scope.spawn(move || session_uncommitted_probe(worktree_manager, id)));
+        // Resolve paths first: it is a stat, not a subprocess, and it collapses
+        // sessions that share a tree into one probe.
+        let mut probes: Vec<(PathBuf, String)> = Vec::new();
+        let mut seen_paths: HashSet<PathBuf> = HashSet::new();
+        let mut status = BulkWorktreeStatus::default();
+        for (id, name) in candidates {
+            match worktree_manager.worktree_path(id) {
+                // Nothing on disk: deleting this session destroys no files.
+                Err(crate::git::WorktreeError::NotFound(_)) => {}
+                Err(_) => {
+                    // Something is there and could not be resolved.
+                    status.unchecked += 1;
+                    status.with_worktree += 1;
                 }
-                handles
-                    .into_iter()
-                    .map(|h| h.join().unwrap_or(UncommittedProbe::Unknown))
-                    .collect()
-            });
-            results.extend(batch_results);
-        }
-
-        let mut dirty = Vec::new();
-        for ((_, name), probe) in probes.into_iter().zip(results) {
-            match probe {
-                UncommittedProbe::Clean | UncommittedProbe::NoWorktree => {}
-                UncommittedProbe::Dirty(count) => dirty.push((name, count)),
-                UncommittedProbe::Unknown => unchecked += 1,
+                Ok(path) => {
+                    // Count distinct trees: two sessions sharing one tree means
+                    // delete removes one directory, not two.
+                    if seen_paths.insert(path.clone()) {
+                        status.with_worktree += 1;
+                        probes.push((path, name));
+                    }
+                }
             }
         }
-        (dirty, unchecked)
+
+        // `git status` is a subprocess per tree and this runs inline on a
+        // keypress. Batching does not reduce the number of calls, one per tree
+        // either way; it bounds how many run at once so a large selection cannot
+        // spawn a thread and a child process per tree all at the same time. A
+        // single probe skips the threads entirely.
+        let counts: Vec<Result<usize, ()>> = if probes.len() == 1 {
+            vec![uncommitted_count_at(&probes[0].0)]
+        } else {
+            let mut counts = Vec::with_capacity(probes.len());
+            for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
+                let batch_counts: Vec<Result<usize, ()>> = std::thread::scope(|scope| {
+                    // Spawn every probe in the batch before joining any of them,
+                    // otherwise they run one at a time.
+                    let mut handles = Vec::with_capacity(batch.len());
+                    for (path, _) in batch {
+                        handles.push(scope.spawn(move || uncommitted_count_at(path)));
+                    }
+                    handles.into_iter().map(|h| h.join().unwrap_or(Err(()))).collect()
+                });
+                counts.extend(batch_counts);
+            }
+            counts
+        };
+
+        for ((_, name), count) in probes.into_iter().zip(counts) {
+            match count {
+                Ok(0) => {}
+                Ok(count) => status.dirty.push((name, count)),
+                Err(()) => status.unchecked += 1,
+            }
+        }
+        status
     }
 
     /// Aggregate uncommitted-work warning for the bulk dialog: this is exactly
@@ -8115,19 +8136,24 @@ impl AppState {
         });
     }
 
-    /// Show confirmation dialog for killing multiple "other" tmux sessions
+    /// Show confirmation dialog for killing multiple "other" tmux sessions.
+    ///
+    /// Names them, like the managed-session bulk dialog reached by the same key:
+    /// a count alone does not tell the user whether the selection is the one
+    /// they meant.
     pub fn show_kill_other_tmux_sessions_confirmation(&mut self, session_names: Vec<String>) {
         let count = session_names.len();
-        info!(
-            "Showing kill confirmation for {} other tmux sessions",
-            count
-        );
+        info!("Showing kill confirmation for {count} other tmux sessions");
+        let listed = truncate_list(session_names.iter().cloned());
         self.confirmation_dialog = Some(ConfirmationDialog {
             title: "Kill tmux Sessions".to_string(),
-            message: format!("Are you sure you want to kill {} tmux session(s)?", count),
+            message: format!(
+                "Kill {count} tmux session(s): {listed}?\nThese are not managed by ainb, so \
+                 only the tmux session is killed."
+            ),
             confirm_action: ConfirmAction::KillOtherTmuxSessions(session_names),
-            selected_option: false,
-            warning: Some("This closes all selected external tmux sessions.".to_string()),
+            selected_option: false, // Default to "No"
+            warning: None,
             options: None,
             selected_index: 0,
         });
@@ -10396,6 +10422,9 @@ impl AppState {
                 .is_some_and(|s| matches!(s.status, SessionStatus::Stopped))
             {
                 already_stopped += 1;
+                // Unchecked optimistically on confirmation, but nothing was done
+                // to it, so put the check back like the failure path does.
+                self.selected_sessions.insert(id);
                 continue;
             }
             if let Err(e) = self.stop_interactive_session(id, "D→Stop (bulk)").await {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7820,7 +7820,7 @@ impl AppState {
             .find_session(session_id)
             .map_or_else(|| unknown_session_label(session_id), |s| s.name.clone());
         let status = Self::bulk_uncommitted_counts(&[(session_id, name)]);
-        Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked)
+        Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked, 1)
     }
 
     /// Show the tri-option Stop all / Delete all / Cancel dialog for every
@@ -7879,7 +7879,7 @@ impl AppState {
         } else {
             "their worktrees".to_string()
         };
-        let warning = Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked);
+        let warning = Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked, count);
         let summary = Self::format_bulk_session_summary(&id_names);
 
         self.confirmation_dialog = Some(if stoppable.len() == count {
@@ -7975,7 +7975,7 @@ impl AppState {
         /// child processes off a single keypress.
         const MAX_CONCURRENT_PROBES: usize = 8;
 
-        let Ok(worktree_manager) = WorktreeManager::new() else {
+        let Ok(worktree_manager) = WorktreeManager::for_reading() else {
             warn!("Cannot resolve worktrees: uncommitted work is unknown for this selection");
             return BulkWorktreeStatus {
                 dirty: Vec::new(),
@@ -7990,28 +7990,41 @@ impl AppState {
         // resolved, including ones with no session row and Shell sessions: what
         // delete removes is whatever `by-session/<uuid>` points at, so anything
         // with a directory gets probed and counted.
-        let mut probes: Vec<(PathBuf, String)> = Vec::new();
-        let mut seen: HashSet<PathBuf> = HashSet::new();
+        let mut probes: Vec<(PathBuf, Vec<String>)> = Vec::new();
+        let mut seen: HashMap<PathBuf, usize> = HashMap::new();
         let mut status = BulkWorktreeStatus::default();
         for (id, name) in names {
-            let Some(dir) = worktree_manager.session_dir(*id) else {
+            let dir = match worktree_manager.session_dir(*id) {
                 // Nothing on disk: deleting this session destroys no files.
-                continue;
+                Ok(None) => continue,
+                Ok(Some(dir)) => dir,
+                Err(e) => {
+                    // The link is there and could not be followed, which is
+                    // unknown, not empty.
+                    warn!("Could not resolve the worktree for {id}: {e}");
+                    status.unchecked += 1;
+                    status.with_worktree += 1;
+                    continue;
+                }
             };
             // Canonicalise before deduping, or /tmp and /private/tmp count twice
             // on macOS. Fall back to the raw path when it cannot be resolved.
             let key = dir.canonicalize().unwrap_or_else(|_| dir.clone());
-            if seen.insert(key) {
+            // Sessions sharing a tree are named together: naming only the first
+            // would tell the user the others have nothing to lose.
+            if let Some(&idx) = seen.get(&key) {
+                probes[idx].1.push(name.clone());
+            } else {
+                seen.insert(key, probes.len());
                 status.with_worktree += 1;
-                probes.push((dir, name.clone()));
+                probes.push((dir, vec![name.clone()]));
             }
         }
 
         // `git status` is a subprocess per tree and this runs inline on a
         // keypress. Batching does not reduce the number of calls, one per tree
         // either way; it bounds how many run at once so a large selection cannot
-        // spawn a thread and a child process per tree all at the same time. A
-        // single probe skips the threads entirely.
+        // spawn a thread and a child process per tree all at the same time.
         let mut counts: Vec<Result<usize, ()>> = Vec::with_capacity(probes.len());
         for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
             let batch_counts: Vec<Result<usize, ()>> = std::thread::scope(|scope| {
@@ -8026,10 +8039,10 @@ impl AppState {
             counts.extend(batch_counts);
         }
 
-        for ((_, name), count) in probes.into_iter().zip(counts) {
+        for ((_, names), count) in probes.into_iter().zip(counts) {
             match count {
                 Ok(0) => {}
-                Ok(count) => status.dirty.push((name, count)),
+                Ok(count) => status.dirty.push((names.join(", "), count)),
                 Err(()) => status.unchecked += 1,
             }
         }
@@ -8039,12 +8052,22 @@ impl AppState {
     /// Aggregate uncommitted-work warning for the bulk dialog: this is exactly
     /// the work "Delete all" would destroy, so it names the dirty sessions
     /// rather than reporting a bare total.
+    /// `selected` is how many rows the dialog is about, which decides the
+    /// wording: on a one-row dialog naming the session and saying "1 session(s)"
+    /// repeats what the user is looking at, but in a bulk selection the name is
+    /// the whole point of the warning.
     fn format_bulk_uncommitted_warning(
         dirty: &[(String, usize)],
         unchecked: usize,
+        selected: usize,
     ) -> Option<String> {
         if dirty.is_empty() {
-            return (unchecked > 0).then(|| {
+            if unchecked == 0 {
+                return None;
+            }
+            return Some(if selected == 1 {
+                "⚠️ could not check this worktree for uncommitted work".to_string()
+            } else {
                 format!("⚠️ could not check {unchecked} session(s) for uncommitted work")
             });
         }
@@ -8055,10 +8078,7 @@ impl AppState {
         } else {
             String::new()
         };
-        if dirty.len() == 1 && unchecked == 0 {
-            // One row: naming it and saying "1 session(s)" repeats what the user
-            // is already looking at, and a long branch name would wrap the
-            // banner across three rows.
+        if selected == 1 && unchecked == 0 {
             return Some(format!("⚠️ {total} uncommitted file(s) in worktree"));
         }
         Some(format!(
@@ -10432,10 +10452,9 @@ impl AppState {
                 .find_session(id)
                 .is_some_and(|s| matches!(s.status, SessionStatus::Stopped))
             {
+                // The dialog excludes these from the action, so their check was
+                // never cleared and there is nothing to restore.
                 already_stopped += 1;
-                // Unchecked optimistically on confirmation, but nothing was done
-                // to it, so put the check back like the failure path does.
-                self.selected_sessions.insert(id);
                 continue;
             }
             if let Err(e) = self.stop_interactive_session(id, "D→Stop (bulk)").await {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -951,9 +951,6 @@ fn session_uncommitted_probe(
 pub(crate) const NOTHING_SELECTED_WARNING: &str =
     "No sessions selected. Use Space to select sessions first.";
 
-/// Shown on a single-session dialog whose worktree status could not be read.
-const UNCHECKED_SINGLE_WARNING: &str = "⚠️ could not check this worktree for uncommitted work";
-
 /// Render at most three items, then "and N more". Shared by the bulk dialog's
 /// message and its warning so the two cannot truncate at different lengths or
 /// word it differently.
@@ -7802,34 +7799,15 @@ impl AppState {
         ));
     }
 
-    /// Check if a session's worktree has uncommitted changes.
-    /// Returns None for Shell sessions (no dedicated worktree) or if there is
-    /// nothing to lose. Shares `session_uncommitted_probe` with the bulk path so
-    /// the two dialogs cannot report different answers for the same session.
+    /// Uncommitted-work warning for one session, or None when there is nothing
+    /// to say.
+    ///
+    /// Runs the same code as the bulk dialog on a one-element selection, so the
+    /// two cannot apply different skip rules or different wording to the same
+    /// session.
     fn check_session_uncommitted_warning(&self, session_id: Uuid) -> Option<String> {
-        use crate::git::WorktreeManager;
-        use crate::models::SessionAgentType;
-
-        // Find the session to check its type
-        let session = self.find_session(session_id)?;
-
-        // Skip for Shell sessions - they don't have dedicated worktrees
-        if matches!(session.agent_type, SessionAgentType::Shell) {
-            return None;
-        }
-
-        // A manager we cannot even build means the status is unknown, not clean:
-        // the bulk path says so and this one has to agree.
-        let Ok(worktree_manager) = WorktreeManager::new() else {
-            return Some(UNCHECKED_SINGLE_WARNING.to_string());
-        };
-        match session_uncommitted_probe(&worktree_manager, session_id) {
-            UncommittedProbe::Dirty(count) => {
-                Some(format!("⚠️ {count} uncommitted file(s) in worktree"))
-            }
-            UncommittedProbe::Unknown => Some(UNCHECKED_SINGLE_WARNING.to_string()),
-            UncommittedProbe::NoWorktree | UncommittedProbe::Clean => None,
-        }
+        let (dirty, unchecked) = self.bulk_uncommitted_counts(&[session_id]);
+        Self::format_bulk_uncommitted_warning(&dirty, unchecked)
     }
 
     /// Show the tri-option Stop all / Delete all / Cancel dialog for every
@@ -7852,49 +7830,40 @@ impl AppState {
             count
         );
 
-        let names: Vec<String> = session_ids
-            .iter()
-            .map(|id| {
-                self.find_session(*id)
-                    .map_or_else(|| unknown_session_label(*id), |s| s.name.clone())
-            })
-            .collect();
-        // Shell sessions have no dedicated worktree, so counting them in "Delete
-        // removes N worktree(s)" would inflate the number on the one dialog
-        // whose job is to state the destructive scope accurately.
-        let worktree_count = session_ids
-            .iter()
-            .filter(|id| {
-                self.find_session(**id)
-                    .is_none_or(|s| !matches!(s.agent_type, crate::models::SessionAgentType::Shell))
-            })
-            .count();
-        let (dirty, unchecked) = self.bulk_uncommitted_counts(&session_ids);
-        let warning = Self::format_bulk_uncommitted_warning(&dirty, unchecked);
-        let summary = Self::format_bulk_session_summary(&names);
-
-        // Stop only means something for interactive agent sessions: it kills
-        // tmux and the session resumes later. Boss (Docker) and Shell sessions
-        // have no such path, so a mixed selection offers Stop for the sessions
-        // it actually applies to rather than dropping the safe option for
-        // everyone because one row cannot use it.
-        // Already-Stopped sessions are excluded too: offering "Stop all" for a
-        // selection that is entirely stopped makes the default a no-op, and the
-        // user pressing Enter on it would lose their selection for nothing. The
-        // two exclusions are counted apart because the dialog has to say which
-        // one applies: "cannot be stopped" and "already stopped" are opposite
-        // claims about whether the session can come back.
+        // One pass over the selection: every later question (what to name, how
+        // many worktrees, what can be stopped) is answered from this, rather
+        // than walking the workspace list once per question per id.
+        let mut names: Vec<String> = Vec::with_capacity(count);
+        let mut worktree_count = 0;
         let mut stoppable: Vec<Uuid> = Vec::new();
         let mut already_stopped = 0;
         let mut no_stop_path = 0;
         for id in &session_ids {
-            match self.find_session(*id) {
+            let session = self.find_session(*id);
+            names.push(session.map_or_else(|| unknown_session_label(*id), |s| s.name.clone()));
+            // Shell sessions have no dedicated worktree, so counting them in
+            // "Delete removes N worktree(s)" would inflate the number on the one
+            // dialog whose job is to state the destructive scope accurately.
+            if session.is_none_or(|s| !matches!(s.agent_type, SessionAgentType::Shell)) {
+                worktree_count += 1;
+            }
+            // Stop only means something for interactive agent sessions: it kills
+            // tmux and the session resumes later. Boss (Docker) and Shell
+            // sessions have no such path, and an already-Stopped session has
+            // nothing to stop. The two exclusions are counted apart because the
+            // dialog has to say which applies: "cannot be stopped" and "already
+            // stopped" are opposite claims about whether it can come back.
+            match session {
                 Some(s) if !is_stoppable_interactive(s) => no_stop_path += 1,
                 Some(s) if matches!(s.status, SessionStatus::Stopped) => already_stopped += 1,
                 Some(_) => stoppable.push(*id),
                 None => no_stop_path += 1,
             }
         }
+
+        let (dirty, unchecked) = self.bulk_uncommitted_counts(&session_ids);
+        let warning = Self::format_bulk_uncommitted_warning(&dirty, unchecked);
+        let summary = Self::format_bulk_session_summary(&names);
 
         self.confirmation_dialog = Some(if stoppable.len() == count {
             stop_or_delete_dialog(
@@ -7930,12 +7899,17 @@ impl AppState {
         } else {
             let stoppable_count = stoppable.len();
             let rest = count - stoppable_count;
-            let excluded = if no_stop_path == 0 {
-                format!("the other {rest} are already stopped")
-            } else if already_stopped == 0 {
-                format!("the other {rest} cannot be stopped")
+            let (subject, verb) = if rest == 1 {
+                ("the other one".to_string(), "is")
             } else {
-                format!("the other {rest} are already stopped or cannot be stopped")
+                (format!("the other {rest}"), "are")
+            };
+            let excluded = if no_stop_path == 0 {
+                format!("{subject} {verb} already stopped")
+            } else if already_stopped == 0 {
+                format!("{subject} cannot be stopped")
+            } else {
+                format!("{subject} {verb} already stopped or cannot be stopped")
             };
             stop_or_delete_dialog(
                 format!("Stop or Delete {count} Session(s)"),
@@ -10427,6 +10401,10 @@ impl AppState {
             if let Err(e) = self.stop_interactive_session(id, "D→Stop (bulk)").await {
                 error!("Failed to stop session {}: {}", id, e);
                 failed += 1;
+                // The row was unchecked optimistically when the user confirmed.
+                // It is still running, so put the check back rather than making
+                // the user hunt for it.
+                self.selected_sessions.insert(id);
             } else {
                 stopped += 1;
             }
@@ -10939,6 +10917,9 @@ impl AppState {
                         if let Err(e) = self.delete_session_core(id).await {
                             error!("Failed to delete session {}: {}", id, e);
                             failed += 1;
+                            // Still there, so keep it checked: the row was
+                            // unchecked optimistically on confirmation.
+                            self.selected_sessions.insert(id);
                         } else {
                             deleted += 1;
                         }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -916,6 +916,37 @@ pub(crate) const fn is_stoppable_interactive(session: &crate::models::session::S
         )
 }
 
+/// What one worktree has to lose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UncommittedProbe {
+    /// No worktree is registered for the session, so there is nothing to lose.
+    NoWorktree,
+    Clean,
+    Dirty(usize),
+    /// The worktree exists but its status could not be read. Never fold this
+    /// into Clean: a delete confirmation that says nothing is read as "nothing
+    /// to lose".
+    Unknown,
+}
+
+/// Read one session's worktree status. Shared by the single-row and the bulk
+/// confirmation so both dialogs answer the same way for the same session.
+fn session_uncommitted_probe(
+    worktree_manager: &crate::git::WorktreeManager,
+    session_id: Uuid,
+) -> UncommittedProbe {
+    use crate::git::WorktreeError;
+    match worktree_manager.uncommitted_file_count(session_id) {
+        Ok(0) => UncommittedProbe::Clean,
+        Ok(count) => UncommittedProbe::Dirty(count),
+        // A session with no registered worktree is an ordinary case, not a
+        // failure: warning about it every time trains the user to skip past the
+        // warning that matters.
+        Err(WorktreeError::NotFound(_)) => UncommittedProbe::NoWorktree,
+        Err(_) => UncommittedProbe::Unknown,
+    }
+}
+
 /// Label for a selected id that no longer resolves to a session. The id is kept
 /// in the bulk action (so nothing silently drops out of a delete) but a full
 /// 36-character uuid would eat three rows of the dialog on its own.
@@ -6648,24 +6679,14 @@ impl AppState {
     /// Running sessions are excluded so a bulk resume never kills+recreates a
     /// live tmux session. Order is unspecified (sourced from a HashSet).
     pub fn selected_resumable_session_ids(&self) -> Vec<Uuid> {
-        use crate::models::{SessionAgentType, SessionMode, SessionStatus};
+        use crate::models::SessionStatus;
         self.selected_sessions
             .iter()
             .copied()
             .filter(|id| {
-                self.find_session(*id)
-                    .map(|s| {
-                        let is_interactive = matches!(s.mode, SessionMode::Interactive)
-                            && matches!(
-                                s.agent_type,
-                                SessionAgentType::Claude
-                                    | SessionAgentType::Codex
-                                    | SessionAgentType::Gemini
-                                    | SessionAgentType::Copilot
-                            );
-                        is_interactive && matches!(s.status, SessionStatus::Stopped)
-                    })
-                    .unwrap_or(false)
+                self.find_session(*id).is_some_and(|s| {
+                    is_stoppable_interactive(s) && matches!(s.status, SessionStatus::Stopped)
+                })
             })
             .collect()
     }
@@ -6684,7 +6705,13 @@ impl AppState {
             .map(|s| s.id)
             .filter(|id| self.selected_sessions.contains(id) && seen.insert(*id))
             .collect();
-        ordered.extend(self.selected_sessions.iter().copied().filter(|id| !seen.contains(id)));
+        // Ids that resolve to no session have no list position, so they are
+        // sorted rather than left in HashSet order, which Rust randomises per
+        // process and would make the dialog text differ run to run.
+        let mut orphans: Vec<Uuid> =
+            self.selected_sessions.iter().copied().filter(|id| !seen.contains(id)).collect();
+        orphans.sort();
+        ordered.extend(orphans);
         ordered
     }
 
@@ -7752,7 +7779,9 @@ impl AppState {
     }
 
     /// Check if a session's worktree has uncommitted changes.
-    /// Returns None for Shell sessions (no dedicated worktree) or if no uncommitted changes.
+    /// Returns None for Shell sessions (no dedicated worktree) or if there is
+    /// nothing to lose. Shares `session_uncommitted_probe` with the bulk path so
+    /// the two dialogs cannot report different answers for the same session.
     fn check_session_uncommitted_warning(&self, session_id: Uuid) -> Option<String> {
         use crate::git::WorktreeManager;
         use crate::models::SessionAgentType;
@@ -7765,14 +7794,15 @@ impl AppState {
             return None;
         }
 
-        // Try to check worktree status
         let worktree_manager = WorktreeManager::new().ok()?;
-        let count = worktree_manager.uncommitted_file_count(session_id).ok()?;
-
-        if count > 0 {
-            Some(format!("⚠️ {} uncommitted file(s) in worktree", count))
-        } else {
-            None
+        match session_uncommitted_probe(&worktree_manager, session_id) {
+            UncommittedProbe::Dirty(count) => {
+                Some(format!("⚠️ {count} uncommitted file(s) in worktree"))
+            }
+            UncommittedProbe::Unknown => {
+                Some("⚠️ could not check this worktree for uncommitted work".to_string())
+            }
+            UncommittedProbe::NoWorktree | UncommittedProbe::Clean => None,
         }
     }
 
@@ -7803,13 +7833,16 @@ impl AppState {
 
         // Stop only means something for interactive agent sessions: it kills
         // tmux and the session resumes later. Boss (Docker) and Shell sessions
-        // have no such path, so a selection containing one gets the binary
-        // delete confirmation rather than a Stop button that would lie.
-        let all_stoppable = session_ids
+        // have no such path, so a mixed selection offers Stop for the sessions
+        // it actually applies to rather than dropping the safe option for
+        // everyone because one row cannot use it.
+        let stoppable: Vec<Uuid> = session_ids
             .iter()
-            .all(|id| self.find_session(*id).is_some_and(is_stoppable_interactive));
+            .copied()
+            .filter(|id| self.find_session(*id).is_some_and(is_stoppable_interactive))
+            .collect();
 
-        self.confirmation_dialog = Some(if all_stoppable {
+        self.confirmation_dialog = Some(if stoppable.len() == count {
             stop_or_delete_dialog(
                 format!("Stop or Delete {count} Session(s)"),
                 format!(
@@ -7817,19 +7850,15 @@ impl AppState {
                      Delete removes {count} worktree(s)."
                 ),
                 warning,
-                (
-                    "Stop all",
-                    ConfirmAction::BulkStopSessions(session_ids.clone()),
-                ),
+                ("Stop all", ConfirmAction::BulkStopSessions(stoppable)),
                 ("Delete all", ConfirmAction::BulkDeleteSessions(session_ids)),
             )
-        } else {
+        } else if stoppable.is_empty() {
             ConfirmationDialog {
                 title: format!("Delete {count} Session(s)"),
                 message: format!(
-                    "{summary}\nThis removes {count} worktree(s). The selection includes \
-                     sessions that cannot be stopped and resumed, so Delete is the only \
-                     option offered."
+                    "{summary}\nThis removes {count} worktree(s). None of these sessions \
+                     can be stopped and resumed, so Delete is the only option offered."
                 ),
                 confirm_action: ConfirmAction::BulkDeleteSessions(session_ids),
                 selected_option: false, // Default = No
@@ -7837,6 +7866,21 @@ impl AppState {
                 options: None,
                 selected_index: 0,
             }
+        } else {
+            let stoppable_count = stoppable.len();
+            stop_or_delete_dialog(
+                format!("Stop or Delete {count} Session(s)"),
+                format!(
+                    "{summary}\nStop applies to the {stoppable_count} that can be resumed \
+                     and keeps their worktrees. Delete removes all {count} worktree(s)."
+                ),
+                warning,
+                (
+                    &format!("Stop {stoppable_count}"),
+                    ConfirmAction::BulkStopSessions(stoppable),
+                ),
+                ("Delete all", ConfirmAction::BulkDeleteSessions(session_ids)),
+            )
         });
     }
 
@@ -7866,10 +7910,16 @@ impl AppState {
     /// A session whose worktree status cannot be read is NOT reported as clean:
     /// it is counted as unchecked so the dialog can say so, because "unknown"
     /// and "nothing to lose" must never look the same on a delete confirmation.
-    /// Shell sessions have no dedicated worktree, so they are skipped entirely.
+    /// A session with no registered worktree has nothing to lose and is not
+    /// counted either way. Shell sessions are skipped entirely.
     fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> (Vec<(String, usize)>, usize) {
         use crate::git::WorktreeManager;
         use crate::models::SessionAgentType;
+
+        /// Probes in flight at once. Each one forks a `git status`, so the fan
+        /// out is bounded: a 40-row selection must not spawn 40 threads and 40
+        /// child processes off a single keypress.
+        const MAX_CONCURRENT_PROBES: usize = 8;
 
         // Sessions with a worktree worth probing, paired with their names.
         let mut probes: Vec<(Uuid, String)> = Vec::new();
@@ -7888,26 +7938,33 @@ impl AppState {
         };
 
         // `uncommitted_file_count` shells out to `git status` per worktree and
-        // this runs inline on a keypress, so the probes go out together: a
-        // 12-session selection costs about one status call, not twelve.
-        let counts: Vec<Result<usize, ()>> = std::thread::scope(|scope| {
-            let handles: Vec<_> = probes
-                .iter()
-                .map(|(id, _)| {
-                    let worktree_manager = &worktree_manager;
-                    let id = *id;
-                    scope.spawn(move || worktree_manager.uncommitted_file_count(id).map_err(|_| ()))
-                })
-                .collect();
-            handles.into_iter().map(|h| h.join().unwrap_or(Err(()))).collect()
-        });
+        // this runs inline on a keypress, so probes go out in bounded batches:
+        // a 12-session selection costs about two status calls, not twelve.
+        let mut results: Vec<UncommittedProbe> = Vec::with_capacity(probes.len());
+        for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
+            let batch_results: Vec<UncommittedProbe> = std::thread::scope(|scope| {
+                let handles: Vec<_> = batch
+                    .iter()
+                    .map(|(id, _)| {
+                        let worktree_manager = &worktree_manager;
+                        let id = *id;
+                        scope.spawn(move || session_uncommitted_probe(worktree_manager, id))
+                    })
+                    .collect::<Vec<_>>();
+                handles
+                    .into_iter()
+                    .map(|h| h.join().unwrap_or(UncommittedProbe::Unknown))
+                    .collect()
+            });
+            results.extend(batch_results);
+        }
 
         let mut dirty = Vec::new();
-        for ((_, name), count) in probes.into_iter().zip(counts) {
-            match count {
-                Ok(0) => {}
-                Ok(count) => dirty.push((name, count)),
-                Err(()) => unchecked += 1,
+        for ((_, name), probe) in probes.into_iter().zip(results) {
+            match probe {
+                UncommittedProbe::Clean | UncommittedProbe::NoWorktree => {}
+                UncommittedProbe::Dirty(count) => dirty.push((name, count)),
+                UncommittedProbe::Unknown => unchecked += 1,
             }
         }
         (dirty, unchecked)
@@ -10210,29 +10267,38 @@ impl AppState {
         let worktree_path = self.find_session(session_id).map(|s| s.workspace_path.clone());
 
         let result: anyhow::Result<()> = if let Some(ref name) = tmux_name {
-            // Hard constraint: kill only the exact named session. NEVER kill-server.
+            // Hard constraint: kill only the exact named session, never a prefix
+            // match. `-t name` resolves exact, then prefix, then fnmatch, so
+            // killing "feat-auth" would take out a live "feat-auth-2"; `=name`
+            // forces exact. NEVER kill-server.
             let output = tokio::process::Command::new("tmux")
-                .args(["kill-session", "-t", name])
+                .args(["kill-session", "-t", &format!("={name}")])
                 .output()
-                .await?;
+                .await;
 
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                // tmux returns non-zero when the session is already gone — treat as success
-                // since the post-condition (no tmux session) is what we care about.
-                if stderr.contains("can't find session") || stderr.contains("no server running") {
-                    info!("tmux session '{}' already gone — proceeding", name);
-                } else {
-                    return Err(anyhow::anyhow!(
-                        "Failed to kill tmux session '{}': {}",
-                        name,
-                        stderr
-                    ));
+            // Every exit path below falls through to the audit record and the
+            // Stopped flip: a failed kill still has to leave a trail.
+            match output {
+                Err(e) => Err(anyhow::anyhow!("Failed to run tmux kill-session: {e}")),
+                Ok(output) if output.status.success() => {
+                    info!("Killed tmux session: {name}");
+                    Ok(())
                 }
-            } else {
-                info!("Killed tmux session: {}", name);
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    // tmux returns non-zero when the session is already gone, which
+                    // is the post-condition we want, so treat it as success.
+                    if stderr.contains("can't find session") || stderr.contains("no server running")
+                    {
+                        info!("tmux session '{name}' already gone, proceeding");
+                        Ok(())
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "Failed to kill tmux session '{name}': {stderr}"
+                        ))
+                    }
+                }
             }
-            Ok(())
         } else {
             warn!(
                 "No tmux_session_name for {} — nothing to kill, just marking Stopped",
@@ -10273,10 +10339,22 @@ impl AppState {
     /// `by-session/<uuid>` symlinks all survive and every session stays
     /// resumable. The caller refreshes the workspace view once afterwards.
     async fn bulk_stop_sessions(&mut self, session_ids: Vec<Uuid>) {
+        use crate::models::SessionStatus;
+
         let total = session_ids.len();
         let mut stopped = 0;
+        let mut already_stopped = 0;
         let mut failed = 0;
         for id in session_ids {
+            // Already Stopped means there is nothing to kill; counting it as a
+            // stop would report "Stopped 10" for work that stopped 5.
+            if self
+                .find_session(id)
+                .is_some_and(|s| matches!(s.status, SessionStatus::Stopped))
+            {
+                already_stopped += 1;
+                continue;
+            }
             if let Err(e) = self.stop_interactive_session(id, "D→Stop (bulk)").await {
                 error!("Failed to stop session {}: {}", id, e);
                 failed += 1;
@@ -10287,6 +10365,10 @@ impl AppState {
         if failed > 0 {
             self.add_warning_notification(format!(
                 "Stopped {stopped}/{total} sessions ({failed} failed)"
+            ));
+        } else if already_stopped > 0 {
+            self.add_success_notification(format!(
+                "Stopped {stopped} session(s) ({already_stopped} already stopped)"
             ));
         } else {
             self.add_success_notification(format!("Stopped {stopped} session(s)"));

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7773,7 +7773,7 @@ impl AppState {
             session_id
         );
 
-        // Check for uncommitted changes in worktree (only for non-Shell sessions)
+        // Check for uncommitted changes in the session's worktree
         let warning = self.check_session_uncommitted_warning(session_id);
 
         self.confirmation_dialog = Some(ConfirmationDialog {
@@ -7816,7 +7816,10 @@ impl AppState {
     /// two cannot apply different skip rules or different wording to the same
     /// session.
     fn check_session_uncommitted_warning(&self, session_id: Uuid) -> Option<String> {
-        let status = self.bulk_uncommitted_counts(&[session_id]);
+        let name = self
+            .find_session(session_id)
+            .map_or_else(|| unknown_session_label(session_id), |s| s.name.clone());
+        let status = Self::bulk_uncommitted_counts(&[(session_id, name)]);
         Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked)
     }
 
@@ -7843,13 +7846,16 @@ impl AppState {
         // One pass over the selection: every later question (what to name, how
         // many worktrees, what can be stopped) is answered from this, rather
         // than walking the workspace list once per question per id.
-        let mut names: Vec<String> = Vec::with_capacity(count);
+        let mut id_names: Vec<(Uuid, String)> = Vec::with_capacity(count);
         let mut stoppable: Vec<Uuid> = Vec::new();
         let mut already_stopped = 0;
         let mut no_stop_path = 0;
         for id in &session_ids {
             let session = self.find_session(*id);
-            names.push(session.map_or_else(|| unknown_session_label(*id), |s| s.name.clone()));
+            id_names.push((
+                *id,
+                session.map_or_else(|| unknown_session_label(*id), |s| s.name.clone()),
+            ));
             // Stop only means something for interactive agent sessions: it kills
             // tmux and the session resumes later. Boss (Docker) and Shell
             // sessions have no such path, and an already-Stopped session has
@@ -7864,7 +7870,7 @@ impl AppState {
             }
         }
 
-        let status = self.bulk_uncommitted_counts(&session_ids);
+        let status = Self::bulk_uncommitted_counts(&id_names);
         // What Delete actually removes: distinct trees on disk, not selected
         // rows. When nothing could be resolved the number is a guess, so the
         // message says "their worktrees" rather than printing a figure as fact.
@@ -7874,7 +7880,7 @@ impl AppState {
             "their worktrees".to_string()
         };
         let warning = Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked);
-        let summary = Self::format_bulk_session_summary(&names);
+        let summary = Self::format_bulk_session_summary(&id_names);
 
         self.confirmation_dialog = Some(if stoppable.len() == count {
             stop_or_delete_dialog(
@@ -7940,7 +7946,7 @@ impl AppState {
 
     /// One-line "which sessions are affected" summary for the bulk dialog.
     /// Long selections are truncated so the message still fits the dialog.
-    fn format_bulk_session_summary(names: &[String]) -> String {
+    fn format_bulk_session_summary(names: &[(Uuid, String)]) -> String {
         debug_assert!(
             !names.is_empty(),
             "the caller returns early on an empty selection"
@@ -7948,7 +7954,7 @@ impl AppState {
         format!(
             "{} session(s): {}",
             names.len(),
-            truncate_list(names.iter().cloned())
+            truncate_list(names.iter().map(|(_, name)| name.clone()))
         )
     }
 
@@ -7958,25 +7964,16 @@ impl AppState {
     /// resolve to the same tree, and reporting its four modified files twice
     /// would say eight. A tree whose status cannot be read is NOT reported as
     /// clean, because "unknown" and "nothing to lose" must never look the same
-    /// on a delete confirmation. Shell sessions have no dedicated tree and are
-    /// skipped entirely.
-    fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> BulkWorktreeStatus {
+    /// on a delete confirmation. Every selected id is resolved, Shell sessions
+    /// included: what delete removes is whatever `by-session/<uuid>` points at,
+    /// so anything with a directory is counted and probed.
+    fn bulk_uncommitted_counts(names: &[(Uuid, String)]) -> BulkWorktreeStatus {
         use crate::git::WorktreeManager;
 
         /// Probes in flight at once. Each one forks a `git status`, so the fan
         /// out is bounded: a 40-row selection must not spawn 40 threads and 40
         /// child processes off a single keypress.
         const MAX_CONCURRENT_PROBES: usize = 8;
-
-        let names: Vec<(Uuid, String)> = session_ids
-            .iter()
-            .map(|id| {
-                let name = self
-                    .find_session(*id)
-                    .map_or_else(|| unknown_session_label(*id), |s| s.name.clone());
-                (*id, name)
-            })
-            .collect();
 
         let Ok(worktree_manager) = WorktreeManager::new() else {
             warn!("Cannot resolve worktrees: uncommitted work is unknown for this selection");
@@ -7997,7 +7994,7 @@ impl AppState {
         let mut seen: HashSet<PathBuf> = HashSet::new();
         let mut status = BulkWorktreeStatus::default();
         for (id, name) in names {
-            let Some(dir) = worktree_manager.session_dir(id) else {
+            let Some(dir) = worktree_manager.session_dir(*id) else {
                 // Nothing on disk: deleting this session destroys no files.
                 continue;
             };
@@ -8006,7 +8003,7 @@ impl AppState {
             let key = dir.canonicalize().unwrap_or_else(|_| dir.clone());
             if seen.insert(key) {
                 status.with_worktree += 1;
-                probes.push((dir, name));
+                probes.push((dir, name.clone()));
             }
         }
 
@@ -8015,24 +8012,19 @@ impl AppState {
         // either way; it bounds how many run at once so a large selection cannot
         // spawn a thread and a child process per tree all at the same time. A
         // single probe skips the threads entirely.
-        let counts: Vec<Result<usize, ()>> = if probes.len() == 1 {
-            vec![probe_tree(&probes[0].0)]
-        } else {
-            let mut counts = Vec::with_capacity(probes.len());
-            for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
-                let batch_counts: Vec<Result<usize, ()>> = std::thread::scope(|scope| {
-                    // Spawn every probe in the batch before joining any of them,
-                    // otherwise they run one at a time.
-                    let mut handles = Vec::with_capacity(batch.len());
-                    for (path, _) in batch {
-                        handles.push(scope.spawn(move || probe_tree(path)));
-                    }
-                    handles.into_iter().map(|h| h.join().unwrap_or(Err(()))).collect()
-                });
-                counts.extend(batch_counts);
-            }
-            counts
-        };
+        let mut counts: Vec<Result<usize, ()>> = Vec::with_capacity(probes.len());
+        for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
+            let batch_counts: Vec<Result<usize, ()>> = std::thread::scope(|scope| {
+                // Spawn every probe in the batch before joining any of them,
+                // otherwise they run one at a time.
+                let mut handles = Vec::with_capacity(batch.len());
+                for (path, _) in batch {
+                    handles.push(scope.spawn(move || probe_tree(path)));
+                }
+                handles.into_iter().map(|h| h.join().unwrap_or(Err(()))).collect()
+            });
+            counts.extend(batch_counts);
+        }
 
         for ((_, name), count) in probes.into_iter().zip(counts) {
             match count {
@@ -8063,6 +8055,12 @@ impl AppState {
         } else {
             String::new()
         };
+        if dirty.len() == 1 && unchecked == 0 {
+            // One row: naming it and saying "1 session(s)" repeats what the user
+            // is already looking at, and a long branch name would wrap the
+            // banner across three rows.
+            return Some(format!("⚠️ {total} uncommitted file(s) in worktree"));
+        }
         Some(format!(
             "⚠️ {} uncommitted file(s) in {} session(s): {}{}",
             total,

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -947,6 +947,21 @@ fn session_uncommitted_probe(
     }
 }
 
+/// Render at most three items, then "and N more". Shared by the bulk dialog's
+/// message and its warning so the two cannot truncate at different lengths or
+/// word it differently.
+fn truncate_list(items: impl Iterator<Item = String>) -> String {
+    const MAX_NAMED: usize = 3;
+    let items: Vec<String> = items.collect();
+    let shown = items.len().min(MAX_NAMED);
+    let listed = items[..shown].join(", ");
+    if items.len() > shown {
+        format!("{listed}, and {} more", items.len() - shown)
+    } else {
+        listed
+    }
+}
+
 /// Label for a selected id that no longer resolves to a session. The id is kept
 /// in the bulk action (so nothing silently drops out of a delete) but a full
 /// 36-character uuid would eat three rows of the dialog on its own.
@@ -7814,6 +7829,14 @@ impl AppState {
     /// delete immediately, taking uncommitted work with it; it now gets the same
     /// dialog, the same Stop default, and an aggregate uncommitted-work warning.
     pub fn show_bulk_delete_or_stop_confirmation(&mut self, session_ids: Vec<Uuid>) {
+        use crate::models::SessionStatus;
+
+        if session_ids.is_empty() {
+            self.add_warning_notification(
+                "No sessions selected. Use Space to select sessions first.".to_string(),
+            );
+            return;
+        }
         let count = session_ids.len();
         info!(
             "Showing bulk Stop/Delete/Cancel dialog for {} session(s)",
@@ -7836,10 +7859,17 @@ impl AppState {
         // have no such path, so a mixed selection offers Stop for the sessions
         // it actually applies to rather than dropping the safe option for
         // everyone because one row cannot use it.
+        // Already-Stopped sessions are excluded too: offering "Stop all" for a
+        // selection that is entirely stopped makes the default a no-op, and the
+        // user pressing Enter on it would lose their selection for nothing.
         let stoppable: Vec<Uuid> = session_ids
             .iter()
             .copied()
-            .filter(|id| self.find_session(*id).is_some_and(is_stoppable_interactive))
+            .filter(|id| {
+                self.find_session(*id).is_some_and(|s| {
+                    is_stoppable_interactive(s) && !matches!(s.status, SessionStatus::Stopped)
+                })
+            })
             .collect();
 
         self.confirmation_dialog = Some(if stoppable.len() == count {
@@ -7887,21 +7917,13 @@ impl AppState {
     /// One-line "which sessions are affected" summary for the bulk dialog.
     /// Long selections are truncated so the message still fits the dialog.
     fn format_bulk_session_summary(names: &[String]) -> String {
-        const MAX_NAMED: usize = 3;
         if names.is_empty() {
             return "No sessions selected".to_string();
         }
-        let shown = names.len().min(MAX_NAMED);
-        let more = names.len() - shown;
-        let tail = if more > 0 {
-            format!(", and {more} more")
-        } else {
-            String::new()
-        };
         format!(
-            "{} session(s): {}{tail}",
+            "{} session(s): {}",
             names.len(),
-            names[..shown].join(", ")
+            truncate_list(names.iter().cloned())
         )
     }
 
@@ -7921,36 +7943,41 @@ impl AppState {
         /// child processes off a single keypress.
         const MAX_CONCURRENT_PROBES: usize = 8;
 
-        // Sessions with a worktree worth probing, paired with their names.
-        let mut probes: Vec<(Uuid, String)> = Vec::new();
+        // Sessions with a worktree worth probing, paired with their names. An id
+        // that no longer resolves to a session row is probed anyway: the probe
+        // needs only the uuid, and a worktree whose session vanished from the
+        // list is the one most likely to be holding forgotten work.
+        let probes: Vec<(Uuid, String)> = session_ids
+            .iter()
+            .filter_map(|id| match self.find_session(*id) {
+                None => Some((*id, unknown_session_label(*id))),
+                Some(session) if matches!(session.agent_type, SessionAgentType::Shell) => None,
+                Some(session) => Some((*id, session.name.clone())),
+            })
+            .collect();
         let mut unchecked = 0;
-        for id in session_ids {
-            match self.find_session(*id) {
-                // An id we cannot resolve to a session is unknown, not clean.
-                None => unchecked += 1,
-                Some(session) if matches!(session.agent_type, SessionAgentType::Shell) => {}
-                Some(session) => probes.push((*id, session.name.clone())),
-            }
-        }
 
         let Ok(worktree_manager) = WorktreeManager::new() else {
-            return (Vec::new(), unchecked + probes.len());
+            return (Vec::new(), probes.len());
         };
 
         // `uncommitted_file_count` shells out to `git status` per worktree and
-        // this runs inline on a keypress, so probes go out in bounded batches:
-        // a 12-session selection costs about two status calls, not twelve.
+        // this runs inline on a keypress. Batching does not reduce the number of
+        // calls, one per probed session either way; it bounds how many run at
+        // once so a large selection cannot spawn a thread and a child process
+        // per row all at the same time.
         let mut results: Vec<UncommittedProbe> = Vec::with_capacity(probes.len());
         for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
             let batch_results: Vec<UncommittedProbe> = std::thread::scope(|scope| {
-                let handles: Vec<_> = batch
-                    .iter()
-                    .map(|(id, _)| {
-                        let worktree_manager = &worktree_manager;
-                        let id = *id;
-                        scope.spawn(move || session_uncommitted_probe(worktree_manager, id))
-                    })
-                    .collect::<Vec<_>>();
+                // Spawn every probe in the batch before joining any of them,
+                // otherwise they run one at a time.
+                let mut handles = Vec::with_capacity(batch.len());
+                for (id, _) in batch {
+                    let worktree_manager = &worktree_manager;
+                    let id = *id;
+                    handles
+                        .push(scope.spawn(move || session_uncommitted_probe(worktree_manager, id)));
+                }
                 handles
                     .into_iter()
                     .map(|h| h.join().unwrap_or(UncommittedProbe::Unknown))
@@ -7977,35 +8004,23 @@ impl AppState {
         dirty: &[(String, usize)],
         unchecked: usize,
     ) -> Option<String> {
-        const MAX_NAMED: usize = 3;
         if dirty.is_empty() {
             return (unchecked > 0).then(|| {
                 format!("⚠️ could not check {unchecked} session(s) for uncommitted work")
             });
         }
         let total: usize = dirty.iter().map(|(_, count)| *count).sum();
-        let shown = dirty.len().min(MAX_NAMED);
-        let listed = dirty[..shown]
-            .iter()
-            .map(|(name, count)| format!("{name} ({count})"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let more = if dirty.len() > shown {
-            format!(", and {} more", dirty.len() - shown)
-        } else {
-            String::new()
-        };
+        let listed = truncate_list(dirty.iter().map(|(name, count)| format!("{name} ({count})")));
         let unknown = if unchecked > 0 {
             format!("; {unchecked} more could not be checked")
         } else {
             String::new()
         };
         Some(format!(
-            "⚠️ {} uncommitted file(s) in {} session(s): {}{}{}",
+            "⚠️ {} uncommitted file(s) in {} session(s): {}{}",
             total,
             dirty.len(),
             listed,
-            more,
             unknown
         ))
     }
@@ -10081,7 +10096,13 @@ impl AppState {
 
         for session_name in &orphaned_shells {
             info!("Killing orphaned tmux shell session: {}", session_name);
-            match Command::new("tmux").args(["kill-session", "-t", session_name]).output().await {
+            // `=name` so an orphan named "shell-x" cannot take out a live
+            // "shell-x-2" via tmux's prefix matching.
+            match Command::new("tmux")
+                .args(["kill-session", "-t", &format!("={session_name}")])
+                .output()
+                .await
+            {
                 Ok(output) if output.status.success() => {
                     killed_count += 1;
                     info!("Successfully killed tmux session: {}", session_name);
@@ -10307,12 +10328,18 @@ impl AppState {
             Ok(())
         };
 
-        // Drop the live tmux handle but DO NOT touch SessionStore or worktree.
-        self.tmux_sessions.remove(&session_id);
+        // Only a successful kill flips the row to Stopped. Marking a session
+        // Stopped while its agent is still running is worse than reporting the
+        // failure: the row invites a resume, which would tear down and replace
+        // the live agent.
+        if result.is_ok() {
+            // Drop the live tmux handle but DO NOT touch SessionStore or worktree.
+            self.tmux_sessions.remove(&session_id);
 
-        if let Some(session) = self.find_session_mut(session_id) {
-            session.set_status(SessionStatus::Stopped);
-            session.is_attached = false;
+            if let Some(session) = self.find_session_mut(session_id) {
+                session.set_status(SessionStatus::Stopped);
+                session.is_attached = false;
+            }
         }
 
         let audit_result = match &result {
@@ -10363,8 +10390,14 @@ impl AppState {
             }
         }
         if failed > 0 {
+            let attempted = total - already_stopped;
+            let skipped = if already_stopped > 0 {
+                format!(", {already_stopped} already stopped")
+            } else {
+                String::new()
+            };
             self.add_warning_notification(format!(
-                "Stopped {stopped}/{total} sessions ({failed} failed)"
+                "Stopped {stopped}/{attempted} sessions ({failed} failed{skipped})"
             ));
         } else if already_stopped > 0 {
             self.add_success_notification(format!(
@@ -10423,9 +10456,15 @@ impl AppState {
 
             // Recreate the tmux session at the worktree. If something is already
             // listening on this name (shouldn't be, since we set Stopped), kill it
-            // first so we get a clean shell — narrow target, never wildcard.
+            // first so we get a clean shell. `=name` forces an exact target:
+            // bare `-t name` falls through to prefix matching, so resuming
+            // "feat-auth" would kill a live "feat-auth-2".
             let _ = tokio::process::Command::new("tmux")
-                .args(["kill-session", "-t", &metadata.tmux_session_name])
+                .args([
+                    "kill-session",
+                    "-t",
+                    &format!("={}", metadata.tmux_session_name),
+                ])
                 .output()
                 .await;
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -859,6 +859,71 @@ pub enum ConfirmAction {
     Cancel,            // No-op terminator for tri-option dialogs
 }
 
+/// Assemble the shared Stop / Delete / Cancel dialog.
+///
+/// One builder for the single-row and the bulk path, so a future safety change
+/// (a new warning, a different default) lands on both at once. Stop is always
+/// `selected_index: 0`: the safe option is the one an accidental Enter picks.
+fn stop_or_delete_dialog(
+    title: String,
+    message: String,
+    warning: Option<String>,
+    stop: (&str, ConfirmAction),
+    delete: (&str, ConfirmAction),
+) -> ConfirmationDialog {
+    let (stop_label, stop_action) = stop;
+    let (delete_label, delete_action) = delete;
+    ConfirmationDialog {
+        title,
+        message,
+        // confirm_action mirrors the default (Stop) so the legacy binary
+        // ConfirmationConfirm handler still does the safe thing if it ever runs
+        // without options.
+        confirm_action: stop_action.clone(),
+        selected_option: true,
+        warning,
+        options: Some(vec![
+            DialogOption {
+                label: stop_label.to_string(),
+                action: stop_action,
+            },
+            DialogOption {
+                label: delete_label.to_string(),
+                action: delete_action,
+            },
+            DialogOption {
+                label: "Cancel".to_string(),
+                action: ConfirmAction::Cancel,
+            },
+        ]),
+        selected_index: 0, // Default = Stop (safe option)
+    }
+}
+
+/// `true` for the sessions Stop actually applies to: interactive agent sessions,
+/// where killing tmux leaves a worktree that resumes later. Boss (Docker) and
+/// Shell sessions have no soft-stop, so they only ever get a delete
+/// confirmation.
+pub(crate) const fn is_stoppable_interactive(session: &crate::models::session::Session) -> bool {
+    use crate::models::{SessionAgentType, SessionMode};
+    matches!(session.mode, SessionMode::Interactive)
+        && matches!(
+            session.agent_type,
+            SessionAgentType::Claude
+                | SessionAgentType::Codex
+                | SessionAgentType::Gemini
+                | SessionAgentType::Copilot
+        )
+}
+
+/// Label for a selected id that no longer resolves to a session. The id is kept
+/// in the bulk action (so nothing silently drops out of a delete) but a full
+/// 36-character uuid would eat three rows of the dialog on its own.
+fn unknown_session_label(id: Uuid) -> String {
+    let id = id.to_string();
+    format!("unknown ({})", &id[..8])
+}
+
 // ============================================================================
 // MCP Pool observability overlay
 // ============================================================================
@@ -6611,19 +6676,15 @@ impl AppState {
     /// any workspace are kept, at the end, so nothing silently drops out of a
     /// bulk operation.
     pub fn selected_session_ids_in_order(&self) -> Vec<Uuid> {
+        let mut seen: HashSet<Uuid> = HashSet::new();
         let mut ordered: Vec<Uuid> = self
             .workspaces
             .iter()
             .flat_map(|w| w.sessions.iter())
             .map(|s| s.id)
-            .filter(|id| self.selected_sessions.contains(id))
+            .filter(|id| self.selected_sessions.contains(id) && seen.insert(*id))
             .collect();
-        ordered.extend(
-            self.selected_sessions
-                .iter()
-                .copied()
-                .filter(|id| self.find_session(*id).is_none()),
-        );
+        ordered.extend(self.selected_sessions.iter().copied().filter(|id| !seen.contains(id)));
         ordered
     }
 
@@ -7681,33 +7742,13 @@ impl AppState {
 
         let warning = self.check_session_uncommitted_warning(session_id);
 
-        let options = vec![
-            DialogOption {
-                label: "Stop".to_string(),
-                action: ConfirmAction::StopSession(session_id),
-            },
-            DialogOption {
-                label: "Delete".to_string(),
-                action: ConfirmAction::DeleteSession(session_id),
-            },
-            DialogOption {
-                label: "Cancel".to_string(),
-                action: ConfirmAction::Cancel,
-            },
-        ];
-
-        self.confirmation_dialog = Some(ConfirmationDialog {
-            title: "Stop or Delete Session".to_string(),
-            message: "Stop keeps the worktree and resumes later. Delete removes the worktree."
-                .to_string(),
-            // confirm_action mirrors the default (Stop) so the legacy ConfirmationConfirm
-            // handler still has something sensible if it ever runs without options.
-            confirm_action: ConfirmAction::StopSession(session_id),
-            selected_option: true,
+        self.confirmation_dialog = Some(stop_or_delete_dialog(
+            "Stop or Delete Session".to_string(),
+            "Stop keeps the worktree and resumes later. Delete removes the worktree.".to_string(),
             warning,
-            options: Some(options),
-            selected_index: 0, // Default = Stop (safe option)
-        });
+            ("Stop", ConfirmAction::StopSession(session_id)),
+            ("Delete", ConfirmAction::DeleteSession(session_id)),
+        ));
     }
 
     /// Check if a session's worktree has uncommitted changes.
@@ -7751,40 +7792,51 @@ impl AppState {
 
         let names: Vec<String> = session_ids
             .iter()
-            .map(|id| self.find_session(*id).map_or_else(|| id.to_string(), |s| s.name.clone()))
+            .map(|id| {
+                self.find_session(*id)
+                    .map_or_else(|| unknown_session_label(*id), |s| s.name.clone())
+            })
             .collect();
-        let warning =
-            Self::format_bulk_uncommitted_warning(&self.bulk_uncommitted_counts(&session_ids));
+        let (dirty, unchecked) = self.bulk_uncommitted_counts(&session_ids);
+        let warning = Self::format_bulk_uncommitted_warning(&dirty, unchecked);
+        let summary = Self::format_bulk_session_summary(&names);
 
-        let options = vec![
-            DialogOption {
-                label: "Stop all".to_string(),
-                action: ConfirmAction::BulkStopSessions(session_ids.clone()),
-            },
-            DialogOption {
-                label: "Delete all".to_string(),
-                action: ConfirmAction::BulkDeleteSessions(session_ids.clone()),
-            },
-            DialogOption {
-                label: "Cancel".to_string(),
-                action: ConfirmAction::Cancel,
-            },
-        ];
+        // Stop only means something for interactive agent sessions: it kills
+        // tmux and the session resumes later. Boss (Docker) and Shell sessions
+        // have no such path, so a selection containing one gets the binary
+        // delete confirmation rather than a Stop button that would lie.
+        let all_stoppable = session_ids
+            .iter()
+            .all(|id| self.find_session(*id).is_some_and(is_stoppable_interactive));
 
-        self.confirmation_dialog = Some(ConfirmationDialog {
-            title: format!("Stop or Delete {count} Session(s)"),
-            message: format!(
-                "{}\nStop keeps every worktree and resumes later. Delete removes {} worktree(s).",
-                Self::format_bulk_session_summary(&names),
-                count
-            ),
-            // confirm_action mirrors the default (Stop all) for the legacy
-            // binary ConfirmationConfirm path.
-            confirm_action: ConfirmAction::BulkStopSessions(session_ids),
-            selected_option: true,
-            warning,
-            options: Some(options),
-            selected_index: 0, // Default = Stop all (safe option)
+        self.confirmation_dialog = Some(if all_stoppable {
+            stop_or_delete_dialog(
+                format!("Stop or Delete {count} Session(s)"),
+                format!(
+                    "{summary}\nStop keeps every worktree and resumes later. \
+                     Delete removes {count} worktree(s)."
+                ),
+                warning,
+                (
+                    "Stop all",
+                    ConfirmAction::BulkStopSessions(session_ids.clone()),
+                ),
+                ("Delete all", ConfirmAction::BulkDeleteSessions(session_ids)),
+            )
+        } else {
+            ConfirmationDialog {
+                title: format!("Delete {count} Session(s)"),
+                message: format!(
+                    "{summary}\nThis removes {count} worktree(s). The selection includes \
+                     sessions that cannot be stopped and resumed, so Delete is the only \
+                     option offered."
+                ),
+                confirm_action: ConfirmAction::BulkDeleteSessions(session_ids),
+                selected_option: false, // Default = No
+                warning,
+                options: None,
+                selected_index: 0,
+            }
         });
     }
 
@@ -7809,37 +7861,70 @@ impl AppState {
         )
     }
 
-    /// `(session name, uncommitted file count)` for every selected session whose
-    /// worktree is dirty. Sessions with clean or unreadable worktrees, and Shell
-    /// sessions (no dedicated worktree), are omitted.
-    fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> Vec<(String, usize)> {
+    /// `(dirty sessions, sessions whose status could not be read)`.
+    ///
+    /// A session whose worktree status cannot be read is NOT reported as clean:
+    /// it is counted as unchecked so the dialog can say so, because "unknown"
+    /// and "nothing to lose" must never look the same on a delete confirmation.
+    /// Shell sessions have no dedicated worktree, so they are skipped entirely.
+    fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> (Vec<(String, usize)>, usize) {
         use crate::git::WorktreeManager;
         use crate::models::SessionAgentType;
 
+        // Sessions with a worktree worth probing, paired with their names.
+        let mut probes: Vec<(Uuid, String)> = Vec::new();
+        let mut unchecked = 0;
+        for id in session_ids {
+            match self.find_session(*id) {
+                // An id we cannot resolve to a session is unknown, not clean.
+                None => unchecked += 1,
+                Some(session) if matches!(session.agent_type, SessionAgentType::Shell) => {}
+                Some(session) => probes.push((*id, session.name.clone())),
+            }
+        }
+
         let Ok(worktree_manager) = WorktreeManager::new() else {
-            return Vec::new();
+            return (Vec::new(), unchecked + probes.len());
         };
 
-        session_ids
-            .iter()
-            .filter_map(|id| {
-                let session = self.find_session(*id)?;
-                if matches!(session.agent_type, SessionAgentType::Shell) {
-                    return None;
-                }
-                let count = worktree_manager.uncommitted_file_count(*id).ok()?;
-                (count > 0).then(|| (session.name.clone(), count))
-            })
-            .collect()
+        // `uncommitted_file_count` shells out to `git status` per worktree and
+        // this runs inline on a keypress, so the probes go out together: a
+        // 12-session selection costs about one status call, not twelve.
+        let counts: Vec<Result<usize, ()>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = probes
+                .iter()
+                .map(|(id, _)| {
+                    let worktree_manager = &worktree_manager;
+                    let id = *id;
+                    scope.spawn(move || worktree_manager.uncommitted_file_count(id).map_err(|_| ()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap_or(Err(()))).collect()
+        });
+
+        let mut dirty = Vec::new();
+        for ((_, name), count) in probes.into_iter().zip(counts) {
+            match count {
+                Ok(0) => {}
+                Ok(count) => dirty.push((name, count)),
+                Err(()) => unchecked += 1,
+            }
+        }
+        (dirty, unchecked)
     }
 
     /// Aggregate uncommitted-work warning for the bulk dialog: this is exactly
     /// the work "Delete all" would destroy, so it names the dirty sessions
     /// rather than reporting a bare total.
-    fn format_bulk_uncommitted_warning(dirty: &[(String, usize)]) -> Option<String> {
+    fn format_bulk_uncommitted_warning(
+        dirty: &[(String, usize)],
+        unchecked: usize,
+    ) -> Option<String> {
         const MAX_NAMED: usize = 3;
         if dirty.is_empty() {
-            return None;
+            return (unchecked > 0).then(|| {
+                format!("⚠️ could not check {unchecked} session(s) for uncommitted work")
+            });
         }
         let total: usize = dirty.iter().map(|(_, count)| *count).sum();
         let shown = dirty.len().min(MAX_NAMED);
@@ -7849,16 +7934,22 @@ impl AppState {
             .collect::<Vec<_>>()
             .join(", ");
         let more = if dirty.len() > shown {
-            format!(", +{} more", dirty.len() - shown)
+            format!(", and {} more", dirty.len() - shown)
+        } else {
+            String::new()
+        };
+        let unknown = if unchecked > 0 {
+            format!("; {unchecked} more could not be checked")
         } else {
             String::new()
         };
         Some(format!(
-            "⚠️ {} uncommitted file(s) in {} session(s): {}{}",
+            "⚠️ {} uncommitted file(s) in {} session(s): {}{}{}",
             total,
             dirty.len(),
             listed,
-            more
+            more,
+            unknown
         ))
     }
 
@@ -10090,7 +10181,11 @@ impl AppState {
     ///
     /// The session is rediscovered as `Stopped` on the next workspace reload (and
     /// across TUI restarts) and can be resumed via `resume_interactive_session`.
-    async fn stop_interactive_session(&mut self, session_id: Uuid) -> anyhow::Result<()> {
+    async fn stop_interactive_session(
+        &mut self,
+        session_id: Uuid,
+        trigger_key: &str,
+    ) -> anyhow::Result<()> {
         use crate::interactive::SessionStore;
         use crate::models::SessionStatus;
 
@@ -10162,7 +10257,7 @@ impl AppState {
             session_id,
             tmux_name,
             worktree_path,
-            AuditTrigger::UserKeypress("D→Stop".to_string()),
+            AuditTrigger::UserKeypress(trigger_key.to_string()),
             audit_result,
         );
 
@@ -10182,7 +10277,7 @@ impl AppState {
         let mut stopped = 0;
         let mut failed = 0;
         for id in session_ids {
-            if let Err(e) = self.stop_interactive_session(id).await {
+            if let Err(e) = self.stop_interactive_session(id, "D→Stop (bulk)").await {
                 error!("Failed to stop session {}: {}", id, e);
                 failed += 1;
             } else {
@@ -10629,7 +10724,7 @@ impl AppState {
                     }
                 }
                 AsyncAction::StopSession(session_id) => {
-                    if let Err(e) = self.stop_interactive_session(session_id).await {
+                    if let Err(e) = self.stop_interactive_session(session_id, "D→Stop").await {
                         error!("Failed to stop session {}: {}", session_id, e);
                         self.add_error_notification(format!("Stop failed: {}", e));
                     }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -844,6 +844,8 @@ pub struct DialogOption {
 pub enum ConfirmAction {
     DeleteSession(Uuid),
     StopSession(Uuid), // Soft-stop interactive session (tmux only; preserves worktree)
+    BulkDeleteSessions(Vec<Uuid>), // Delete every multi-selected session (removes worktrees)
+    BulkStopSessions(Vec<Uuid>), // Soft-stop every multi-selected session (preserves worktrees)
     KillOtherTmux(String), // Kill a non-agents-in-a-box tmux session by name
     KillOtherTmuxSessions(Vec<String>), // Kill multiple non-agents-in-a-box tmux sessions by name
     KillWorkspaceShell(usize), // Kill workspace shell by workspace index
@@ -3824,6 +3826,7 @@ pub enum AsyncAction {
     ResumeSession(Uuid, String), // Recreate tmux for a Stopped interactive session; String is the trigger key for audit
     BulkResumeSessions(Vec<Uuid>, String), // Resume multiple Stopped interactive sessions; String is the trigger key for audit
     BulkDeleteSessions(Vec<Uuid>),         // Bulk delete multiple sessions
+    BulkStopSessions(Vec<Uuid>), // Soft-stop multiple interactive sessions (tmux only; preserves worktrees)
     RefreshWorkspaces,                     // Manual refresh of workspace data
     FetchContainerLogs(Uuid),              // Fetch container logs for a session
     AttachToContainer(Uuid),               // Attach to a container session
@@ -7710,6 +7713,131 @@ impl AppState {
         }
     }
 
+    /// Show the tri-option Stop all / Delete all / Cancel dialog for every
+    /// multi-selected session.
+    ///
+    /// The single-row flow has always defaulted to Stop so a stray `d` cannot
+    /// destroy a worktree. The bulk flow used to skip confirmation entirely and
+    /// delete immediately, taking uncommitted work with it; it now gets the same
+    /// dialog, the same Stop default, and an aggregate uncommitted-work warning.
+    pub fn show_bulk_delete_or_stop_confirmation(&mut self, session_ids: Vec<Uuid>) {
+        let count = session_ids.len();
+        info!(
+            "Showing bulk Stop/Delete/Cancel dialog for {} session(s)",
+            count
+        );
+
+        let names: Vec<String> = session_ids
+            .iter()
+            .map(|id| {
+                self.find_session(*id)
+                    .map(|s| s.name.clone())
+                    .unwrap_or_else(|| id.to_string())
+            })
+            .collect();
+        let warning =
+            Self::format_bulk_uncommitted_warning(&self.bulk_uncommitted_counts(&session_ids));
+
+        let options = vec![
+            DialogOption {
+                label: "Stop all".to_string(),
+                action: ConfirmAction::BulkStopSessions(session_ids.clone()),
+            },
+            DialogOption {
+                label: "Delete all".to_string(),
+                action: ConfirmAction::BulkDeleteSessions(session_ids.clone()),
+            },
+            DialogOption {
+                label: "Cancel".to_string(),
+                action: ConfirmAction::Cancel,
+            },
+        ];
+
+        self.confirmation_dialog = Some(ConfirmationDialog {
+            title: format!("Stop or Delete {} Session(s)", count),
+            message: format!(
+                "{}\nStop keeps every worktree and resumes later. Delete removes {} worktree(s).",
+                Self::format_bulk_session_summary(&names),
+                count
+            ),
+            // confirm_action mirrors the default (Stop all) for the legacy
+            // binary ConfirmationConfirm path.
+            confirm_action: ConfirmAction::BulkStopSessions(session_ids),
+            selected_option: true,
+            warning,
+            options: Some(options),
+            selected_index: 0, // Default = Stop all (safe option)
+        });
+    }
+
+    /// One-line "which sessions are affected" summary for the bulk dialog.
+    /// Long selections are truncated so the message still fits the dialog.
+    fn format_bulk_session_summary(names: &[String]) -> String {
+        const MAX_NAMED: usize = 3;
+        if names.is_empty() {
+            return "No sessions selected".to_string();
+        }
+        let shown = names.len().min(MAX_NAMED);
+        let mut summary = format!("{} session(s): {}", names.len(), names[..shown].join(", "));
+        if names.len() > shown {
+            summary.push_str(&format!(", and {} more", names.len() - shown));
+        }
+        summary
+    }
+
+    /// `(session name, uncommitted file count)` for every selected session whose
+    /// worktree is dirty. Sessions with clean or unreadable worktrees, and Shell
+    /// sessions (no dedicated worktree), are omitted.
+    fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> Vec<(String, usize)> {
+        use crate::git::WorktreeManager;
+        use crate::models::SessionAgentType;
+
+        let Ok(worktree_manager) = WorktreeManager::new() else {
+            return Vec::new();
+        };
+
+        session_ids
+            .iter()
+            .filter_map(|id| {
+                let session = self.find_session(*id)?;
+                if matches!(session.agent_type, SessionAgentType::Shell) {
+                    return None;
+                }
+                let count = worktree_manager.uncommitted_file_count(*id).ok()?;
+                (count > 0).then(|| (session.name.clone(), count))
+            })
+            .collect()
+    }
+
+    /// Aggregate uncommitted-work warning for the bulk dialog: this is exactly
+    /// the work "Delete all" would destroy, so it names the dirty sessions
+    /// rather than reporting a bare total.
+    fn format_bulk_uncommitted_warning(dirty: &[(String, usize)]) -> Option<String> {
+        const MAX_NAMED: usize = 3;
+        if dirty.is_empty() {
+            return None;
+        }
+        let total: usize = dirty.iter().map(|(_, count)| *count).sum();
+        let shown = dirty.len().min(MAX_NAMED);
+        let listed = dirty[..shown]
+            .iter()
+            .map(|(name, count)| format!("{} ({})", name, count))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let more = if dirty.len() > shown {
+            format!(", +{} more", dirty.len() - shown)
+        } else {
+            String::new()
+        };
+        Some(format!(
+            "⚠️ {} uncommitted file(s) in {} session(s): {}{}",
+            total,
+            dirty.len(),
+            listed,
+            more
+        ))
+    }
+
     /// `true` if ainb should offer to run `abtop --setup` (the Claude
     /// rate-limit StatusLine hook) before opening abtop for the first time.
     /// Offered until the hook has run (its `~/.claude/abtop-rate-limits.json`
@@ -10014,11 +10142,37 @@ impl AppState {
             audit_result,
         );
 
-        // Mirror delete_session: refresh workspace view so the Stopped indicator is rendered.
-        self.load_real_workspaces().await;
-        self.ui_needs_refresh = true;
-
+        // The caller owns the workspace refresh so a bulk stop repaints once
+        // instead of rescanning every workspace per session.
         result
+    }
+
+    /// Soft-stop every session in `session_ids`.
+    ///
+    /// Each one goes through `stop_interactive_session`, so tmux is killed and
+    /// nothing else is: worktrees, the `sessions.json` entries, and the
+    /// `by-session/<uuid>` symlinks all survive and every session stays
+    /// resumable. The caller refreshes the workspace view once afterwards.
+    async fn bulk_stop_sessions(&mut self, session_ids: Vec<Uuid>) {
+        let total = session_ids.len();
+        let mut stopped = 0;
+        let mut failed = 0;
+        for id in session_ids {
+            if let Err(e) = self.stop_interactive_session(id).await {
+                error!("Failed to stop session {}: {}", id, e);
+                failed += 1;
+            } else {
+                stopped += 1;
+            }
+        }
+        if failed > 0 {
+            self.add_warning_notification(format!(
+                "Stopped {}/{} sessions ({} failed)",
+                stopped, total, failed
+            ));
+        } else {
+            self.add_success_notification(format!("Stopped {} session(s)", stopped));
+        }
     }
 
     /// Resume a previously-stopped interactive session.
@@ -10456,6 +10610,9 @@ impl AppState {
                         error!("Failed to stop session {}: {}", session_id, e);
                         self.add_error_notification(format!("Stop failed: {}", e));
                     }
+                    // Refresh so the Stopped indicator is rendered.
+                    self.load_real_workspaces().await;
+                    self.ui_needs_refresh = true;
                 }
                 AsyncAction::ResumeSession(session_id, trigger) => {
                     if let Err(e) = self.resume_interactive_session(session_id, trigger).await {
@@ -10486,6 +10643,11 @@ impl AppState {
                     } else {
                         self.add_success_notification(format!("Resumed {} session(s)", resumed));
                     }
+                    self.ui_needs_refresh = true;
+                }
+                AsyncAction::BulkStopSessions(session_ids) => {
+                    self.bulk_stop_sessions(session_ids).await;
+                    self.load_real_workspaces().await;
                     self.ui_needs_refresh = true;
                 }
                 AsyncAction::BulkDeleteSessions(session_ids) => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -917,33 +917,40 @@ pub(crate) const fn is_stoppable_interactive(session: &crate::models::session::S
 }
 
 /// What one selection has to lose, as the bulk dialog reports it.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct BulkWorktreeStatus {
     /// `(session name, uncommitted file count)` per dirty tree.
     pub dirty: Vec<(String, usize)>,
     /// Trees that are there but could not be read. Never folded into "clean".
     pub unchecked: usize,
-    /// Selected sessions that have a tree on disk, which is what a delete
-    /// actually removes.
+    /// Distinct trees on disk, which is what a delete actually removes.
     pub with_worktree: usize,
+    /// False when nothing could be resolved, so `with_worktree` is a guess and
+    /// the dialog must not print it as a fact.
+    pub worktree_count_known: bool,
 }
 
-/// Count what `git status --porcelain` reports in `path`, or `Err` when it
-/// cannot be read. Ignored files are not counted, see
-/// `WorktreeManager::uncommitted_file_count`.
-fn uncommitted_count_at(path: &std::path::Path) -> Result<usize, ()> {
-    let output = std::process::Command::new("git")
-        .current_dir(path)
-        .args(["status", "--porcelain"])
-        .output()
-        .map_err(|_| ())?;
-    if !output.status.success() {
-        return Err(());
+impl Default for BulkWorktreeStatus {
+    fn default() -> Self {
+        Self {
+            dirty: Vec::new(),
+            unchecked: 0,
+            with_worktree: 0,
+            worktree_count_known: true,
+        }
     }
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|l| !l.is_empty())
-        .count())
+}
+
+/// One tree's uncommitted count, with the reason logged when it cannot be read:
+/// "could not check N session(s)" is undiagnosable otherwise.
+fn probe_tree(path: &std::path::Path) -> Result<usize, ()> {
+    crate::git::WorktreeManager::uncommitted_file_count_at(path).map_err(|e| {
+        warn!(
+            "Could not check {} for uncommitted work: {}",
+            path.display(),
+            e
+        );
+    })
 }
 
 /// Shown when a bulk key is pressed with nothing checked.
@@ -4938,7 +4945,11 @@ impl AppState {
                 if let Some(shell) = preserved_shells.get(&workspace.path) {
                     // Only restore if the tmux session still exists
                     let check = tokio::process::Command::new("tmux")
-                        .args(["has-session", "-t", &shell.tmux_session_name])
+                        .args([
+                            "has-session",
+                            "-t",
+                            &format!("={}", shell.tmux_session_name),
+                        ])
                         .output()
                         .await;
 
@@ -7854,8 +7865,14 @@ impl AppState {
         }
 
         let status = self.bulk_uncommitted_counts(&session_ids);
-        // What Delete actually removes: trees on disk, not selected rows.
-        let worktree_count = status.with_worktree;
+        // What Delete actually removes: distinct trees on disk, not selected
+        // rows. When nothing could be resolved the number is a guess, so the
+        // message says "their worktrees" rather than printing a figure as fact.
+        let removes = if status.worktree_count_known {
+            format!("{} worktree(s)", status.with_worktree)
+        } else {
+            "their worktrees".to_string()
+        };
         let warning = Self::format_bulk_uncommitted_warning(&status.dirty, status.unchecked);
         let summary = Self::format_bulk_session_summary(&names);
 
@@ -7864,7 +7881,7 @@ impl AppState {
                 format!("Stop or Delete {count} Session(s)"),
                 format!(
                     "{summary}\nStop keeps every worktree and resumes later. \
-                     Delete removes {worktree_count} worktree(s)."
+                     Delete removes {removes}."
                 ),
                 warning,
                 ("Stop all", ConfirmAction::BulkStopSessions(stoppable)),
@@ -7882,7 +7899,7 @@ impl AppState {
                 title: format!("Delete {count} Session(s)"),
                 message: format!(
                     "{summary}\n{reason}, so Delete is the only option offered. \
-                     It removes {worktree_count} worktree(s)."
+                     It removes {removes}."
                 ),
                 confirm_action: ConfirmAction::BulkDeleteSessions(session_ids),
                 selected_option: false, // Default = No
@@ -7909,7 +7926,7 @@ impl AppState {
                 format!("Stop or Delete {count} Session(s)"),
                 format!(
                     "{summary}\nStop covers {stoppable_count} and keeps their worktrees, \
-                     {excluded}. Delete removes {worktree_count} worktree(s)."
+                     {excluded}. Delete removes {removes}."
                 ),
                 warning,
                 (
@@ -7945,56 +7962,51 @@ impl AppState {
     /// skipped entirely.
     fn bulk_uncommitted_counts(&self, session_ids: &[Uuid]) -> BulkWorktreeStatus {
         use crate::git::WorktreeManager;
-        use crate::models::SessionAgentType;
 
         /// Probes in flight at once. Each one forks a `git status`, so the fan
         /// out is bounded: a 40-row selection must not spawn 40 threads and 40
         /// child processes off a single keypress.
         const MAX_CONCURRENT_PROBES: usize = 8;
 
-        // Sessions with a tree worth probing, paired with their names. An id that
-        // no longer resolves to a session row is probed anyway: the probe needs
-        // only the uuid, and a tree whose session vanished from the list is the
-        // one most likely to be holding forgotten work.
-        let candidates: Vec<(Uuid, String)> = session_ids
+        let names: Vec<(Uuid, String)> = session_ids
             .iter()
-            .filter_map(|id| match self.find_session(*id) {
-                None => Some((*id, unknown_session_label(*id))),
-                Some(session) if matches!(session.agent_type, SessionAgentType::Shell) => None,
-                Some(session) => Some((*id, session.name.clone())),
+            .map(|id| {
+                let name = self
+                    .find_session(*id)
+                    .map_or_else(|| unknown_session_label(*id), |s| s.name.clone());
+                (*id, name)
             })
             .collect();
 
         let Ok(worktree_manager) = WorktreeManager::new() else {
+            warn!("Cannot resolve worktrees: uncommitted work is unknown for this selection");
             return BulkWorktreeStatus {
                 dirty: Vec::new(),
-                unchecked: candidates.len(),
-                with_worktree: candidates.len(),
+                unchecked: names.len(),
+                with_worktree: names.len(),
+                worktree_count_known: false,
             };
         };
 
-        // Resolve paths first: it is a stat, not a subprocess, and it collapses
-        // sessions that share a tree into one probe.
+        // Resolve directories first: a stat, not a subprocess, and it collapses
+        // sessions that share a tree into one probe. Every selected id is
+        // resolved, including ones with no session row and Shell sessions: what
+        // delete removes is whatever `by-session/<uuid>` points at, so anything
+        // with a directory gets probed and counted.
         let mut probes: Vec<(PathBuf, String)> = Vec::new();
-        let mut seen_paths: HashSet<PathBuf> = HashSet::new();
+        let mut seen: HashSet<PathBuf> = HashSet::new();
         let mut status = BulkWorktreeStatus::default();
-        for (id, name) in candidates {
-            match worktree_manager.worktree_path(id) {
+        for (id, name) in names {
+            let Some(dir) = worktree_manager.session_dir(id) else {
                 // Nothing on disk: deleting this session destroys no files.
-                Err(crate::git::WorktreeError::NotFound(_)) => {}
-                Err(_) => {
-                    // Something is there and could not be resolved.
-                    status.unchecked += 1;
-                    status.with_worktree += 1;
-                }
-                Ok(path) => {
-                    // Count distinct trees: two sessions sharing one tree means
-                    // delete removes one directory, not two.
-                    if seen_paths.insert(path.clone()) {
-                        status.with_worktree += 1;
-                        probes.push((path, name));
-                    }
-                }
+                continue;
+            };
+            // Canonicalise before deduping, or /tmp and /private/tmp count twice
+            // on macOS. Fall back to the raw path when it cannot be resolved.
+            let key = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+            if seen.insert(key) {
+                status.with_worktree += 1;
+                probes.push((dir, name));
             }
         }
 
@@ -8004,7 +8016,7 @@ impl AppState {
         // spawn a thread and a child process per tree all at the same time. A
         // single probe skips the threads entirely.
         let counts: Vec<Result<usize, ()>> = if probes.len() == 1 {
-            vec![uncommitted_count_at(&probes[0].0)]
+            vec![probe_tree(&probes[0].0)]
         } else {
             let mut counts = Vec::with_capacity(probes.len());
             for batch in probes.chunks(MAX_CONCURRENT_PROBES) {
@@ -8013,7 +8025,7 @@ impl AppState {
                     // otherwise they run one at a time.
                     let mut handles = Vec::with_capacity(batch.len());
                     for (path, _) in batch {
-                        handles.push(scope.spawn(move || uncommitted_count_at(path)));
+                        handles.push(scope.spawn(move || probe_tree(path)));
                     }
                     handles.into_iter().map(|h| h.join().unwrap_or(Err(()))).collect()
                 });
@@ -8153,7 +8165,7 @@ impl AppState {
             ),
             confirm_action: ConfirmAction::KillOtherTmuxSessions(session_names),
             selected_option: false, // Default to "No"
-            warning: None,
+            warning: Some("⚠️ This closes all selected external tmux sessions".to_string()),
             options: None,
             selected_index: 0,
         });
@@ -10337,8 +10349,9 @@ impl AppState {
                 .output()
                 .await;
 
-            // Every exit path below falls through to the audit record and the
-            // Stopped flip: a failed kill still has to leave a trail.
+            // Every exit path below reaches the audit record: a failed kill
+            // still has to leave a trail. Only a successful one flips the row
+            // to Stopped, see below.
             match output {
                 Err(e) => Err(anyhow::anyhow!("Failed to run tmux kill-session: {e}")),
                 Ok(output) if output.status.success() => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7861,16 +7861,21 @@ impl AppState {
         // everyone because one row cannot use it.
         // Already-Stopped sessions are excluded too: offering "Stop all" for a
         // selection that is entirely stopped makes the default a no-op, and the
-        // user pressing Enter on it would lose their selection for nothing.
-        let stoppable: Vec<Uuid> = session_ids
-            .iter()
-            .copied()
-            .filter(|id| {
-                self.find_session(*id).is_some_and(|s| {
-                    is_stoppable_interactive(s) && !matches!(s.status, SessionStatus::Stopped)
-                })
-            })
-            .collect();
+        // user pressing Enter on it would lose their selection for nothing. The
+        // two exclusions are counted apart because the dialog has to say which
+        // one applies: "cannot be stopped" and "already stopped" are opposite
+        // claims about whether the session can come back.
+        let mut stoppable: Vec<Uuid> = Vec::new();
+        let mut already_stopped = 0;
+        let mut no_stop_path = 0;
+        for id in &session_ids {
+            match self.find_session(*id) {
+                Some(s) if !is_stoppable_interactive(s) => no_stop_path += 1,
+                Some(s) if matches!(s.status, SessionStatus::Stopped) => already_stopped += 1,
+                Some(_) => stoppable.push(*id),
+                None => no_stop_path += 1,
+            }
+        }
 
         self.confirmation_dialog = Some(if stoppable.len() == count {
             stop_or_delete_dialog(
@@ -7884,11 +7889,18 @@ impl AppState {
                 ("Delete all", ConfirmAction::BulkDeleteSessions(session_ids)),
             )
         } else if stoppable.is_empty() {
+            let reason = if no_stop_path == 0 {
+                "Every one of these is already stopped, so there is nothing to stop"
+            } else if already_stopped == 0 {
+                "None of these sessions can be stopped and resumed"
+            } else {
+                "These sessions are either already stopped or have no stop path"
+            };
             ConfirmationDialog {
                 title: format!("Delete {count} Session(s)"),
                 message: format!(
-                    "{summary}\nThis removes {count} worktree(s). None of these sessions \
-                     can be stopped and resumed, so Delete is the only option offered."
+                    "{summary}\n{reason}, so Delete is the only option offered. \
+                     It removes {count} worktree(s)."
                 ),
                 confirm_action: ConfirmAction::BulkDeleteSessions(session_ids),
                 selected_option: false, // Default = No
@@ -7898,11 +7910,19 @@ impl AppState {
             }
         } else {
             let stoppable_count = stoppable.len();
+            let rest = count - stoppable_count;
+            let excluded = if no_stop_path == 0 {
+                format!("the other {rest} are already stopped")
+            } else if already_stopped == 0 {
+                format!("the other {rest} cannot be stopped")
+            } else {
+                format!("the other {rest} are already stopped or cannot be stopped")
+            };
             stop_or_delete_dialog(
                 format!("Stop or Delete {count} Session(s)"),
                 format!(
-                    "{summary}\nStop applies to the {stoppable_count} that can be resumed \
-                     and keeps their worktrees. Delete removes all {count} worktree(s)."
+                    "{summary}\nStop covers {stoppable_count} and keeps their worktrees, \
+                     {excluded}. Delete removes all {count} worktree(s)."
                 ),
                 warning,
                 (
@@ -7917,9 +7937,10 @@ impl AppState {
     /// One-line "which sessions are affected" summary for the bulk dialog.
     /// Long selections are truncated so the message still fits the dialog.
     fn format_bulk_session_summary(names: &[String]) -> String {
-        if names.is_empty() {
-            return "No sessions selected".to_string();
-        }
+        debug_assert!(
+            !names.is_empty(),
+            "the caller returns early on an empty selection"
+        );
         format!(
             "{} session(s): {}",
             names.len(),

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3826,7 +3826,7 @@ pub enum AsyncAction {
     ResumeSession(Uuid, String), // Recreate tmux for a Stopped interactive session; String is the trigger key for audit
     BulkResumeSessions(Vec<Uuid>, String), // Resume multiple Stopped interactive sessions; String is the trigger key for audit
     BulkDeleteSessions(Vec<Uuid>),         // Bulk delete multiple sessions
-    BulkStopSessions(Vec<Uuid>), // Soft-stop multiple interactive sessions (tmux only; preserves worktrees)
+    BulkStopSessions(Vec<Uuid>),           // Soft-stop many sessions (tmux only; keeps worktrees)
     RefreshWorkspaces,                     // Manual refresh of workspace data
     FetchContainerLogs(Uuid),              // Fetch container logs for a session
     AttachToContainer(Uuid),               // Attach to a container session
@@ -7752,9 +7752,7 @@ impl AppState {
         let names: Vec<String> = session_ids
             .iter()
             .map(|id| {
-                self.find_session(*id)
-                    .map(|s| s.name.clone())
-                    .unwrap_or_else(|| id.to_string())
+                self.find_session(*id).map(|s| s.name.clone()).unwrap_or_else(|| id.to_string())
             })
             .collect();
         let warning =

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -7751,9 +7751,7 @@ impl AppState {
 
         let names: Vec<String> = session_ids
             .iter()
-            .map(|id| {
-                self.find_session(*id).map(|s| s.name.clone()).unwrap_or_else(|| id.to_string())
-            })
+            .map(|id| self.find_session(*id).map_or_else(|| id.to_string(), |s| s.name.clone()))
             .collect();
         let warning =
             Self::format_bulk_uncommitted_warning(&self.bulk_uncommitted_counts(&session_ids));
@@ -7774,7 +7772,7 @@ impl AppState {
         ];
 
         self.confirmation_dialog = Some(ConfirmationDialog {
-            title: format!("Stop or Delete {} Session(s)", count),
+            title: format!("Stop or Delete {count} Session(s)"),
             message: format!(
                 "{}\nStop keeps every worktree and resumes later. Delete removes {} worktree(s).",
                 Self::format_bulk_session_summary(&names),
@@ -7798,11 +7796,17 @@ impl AppState {
             return "No sessions selected".to_string();
         }
         let shown = names.len().min(MAX_NAMED);
-        let mut summary = format!("{} session(s): {}", names.len(), names[..shown].join(", "));
-        if names.len() > shown {
-            summary.push_str(&format!(", and {} more", names.len() - shown));
-        }
-        summary
+        let more = names.len() - shown;
+        let tail = if more > 0 {
+            format!(", and {more} more")
+        } else {
+            String::new()
+        };
+        format!(
+            "{} session(s): {}{tail}",
+            names.len(),
+            names[..shown].join(", ")
+        )
     }
 
     /// `(session name, uncommitted file count)` for every selected session whose
@@ -7841,7 +7845,7 @@ impl AppState {
         let shown = dirty.len().min(MAX_NAMED);
         let listed = dirty[..shown]
             .iter()
-            .map(|(name, count)| format!("{} ({})", name, count))
+            .map(|(name, count)| format!("{name} ({count})"))
             .collect::<Vec<_>>()
             .join(", ");
         let more = if dirty.len() > shown {
@@ -10187,11 +10191,10 @@ impl AppState {
         }
         if failed > 0 {
             self.add_warning_notification(format!(
-                "Stopped {}/{} sessions ({} failed)",
-                stopped, total, failed
+                "Stopped {stopped}/{total} sessions ({failed} failed)"
             ));
         } else {
-            self.add_success_notification(format!("Stopped {} session(s)", stopped));
+            self.add_success_notification(format!("Stopped {stopped} session(s)"));
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -6605,6 +6605,28 @@ impl AppState {
             .collect()
     }
 
+    /// Multi-selected managed session ids in list order (workspace, then
+    /// session), so a dialog that names them reads the same way the list does
+    /// instead of following `HashSet` iteration order. Ids no longer present in
+    /// any workspace are kept, at the end, so nothing silently drops out of a
+    /// bulk operation.
+    pub fn selected_session_ids_in_order(&self) -> Vec<Uuid> {
+        let mut ordered: Vec<Uuid> = self
+            .workspaces
+            .iter()
+            .flat_map(|w| w.sessions.iter())
+            .map(|s| s.id)
+            .filter(|id| self.selected_sessions.contains(id))
+            .collect();
+        ordered.extend(
+            self.selected_sessions
+                .iter()
+                .copied()
+                .filter(|id| self.find_session(*id).is_none()),
+        );
+        ordered
+    }
+
     /// Toggle multi-select for the currently highlighted "Other tmux" session.
     pub fn toggle_select_other_tmux_session(&mut self) {
         if let Some(session) = self.selected_other_tmux_session() {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -947,6 +947,13 @@ fn session_uncommitted_probe(
     }
 }
 
+/// Shown when a bulk key is pressed with nothing checked.
+pub(crate) const NOTHING_SELECTED_WARNING: &str =
+    "No sessions selected. Use Space to select sessions first.";
+
+/// Shown on a single-session dialog whose worktree status could not be read.
+const UNCHECKED_SINGLE_WARNING: &str = "⚠️ could not check this worktree for uncommitted work";
+
 /// Render at most three items, then "and N more". Shared by the bulk dialog's
 /// message and its warning so the two cannot truncate at different lengths or
 /// word it differently.
@@ -6692,12 +6699,14 @@ impl AppState {
     /// Of the multi-selected managed sessions, return the IDs that can actually
     /// be resumed: interactive agent sessions that are currently Stopped.
     /// Running sessions are excluded so a bulk resume never kills+recreates a
-    /// live tmux session. Order is unspecified (sourced from a HashSet).
+    /// live tmux session. Returned in list order, like the delete path.
     pub fn selected_resumable_session_ids(&self) -> Vec<Uuid> {
         use crate::models::SessionStatus;
-        self.selected_sessions
-            .iter()
-            .copied()
+        // List order, like the delete path: the order sessions are resumed in,
+        // and the order they appear in the log and the audit trail, should not
+        // be the per-process randomisation of HashSet iteration.
+        self.selected_session_ids_in_order()
+            .into_iter()
             .filter(|id| {
                 self.find_session(*id).is_some_and(|s| {
                     is_stoppable_interactive(s) && matches!(s.status, SessionStatus::Stopped)
@@ -7809,14 +7818,16 @@ impl AppState {
             return None;
         }
 
-        let worktree_manager = WorktreeManager::new().ok()?;
+        // A manager we cannot even build means the status is unknown, not clean:
+        // the bulk path says so and this one has to agree.
+        let Ok(worktree_manager) = WorktreeManager::new() else {
+            return Some(UNCHECKED_SINGLE_WARNING.to_string());
+        };
         match session_uncommitted_probe(&worktree_manager, session_id) {
             UncommittedProbe::Dirty(count) => {
                 Some(format!("⚠️ {count} uncommitted file(s) in worktree"))
             }
-            UncommittedProbe::Unknown => {
-                Some("⚠️ could not check this worktree for uncommitted work".to_string())
-            }
+            UncommittedProbe::Unknown => Some(UNCHECKED_SINGLE_WARNING.to_string()),
             UncommittedProbe::NoWorktree | UncommittedProbe::Clean => None,
         }
     }
@@ -7832,9 +7843,7 @@ impl AppState {
         use crate::models::SessionStatus;
 
         if session_ids.is_empty() {
-            self.add_warning_notification(
-                "No sessions selected. Use Space to select sessions first.".to_string(),
-            );
+            self.add_warning_notification(NOTHING_SELECTED_WARNING.to_string());
             return;
         }
         let count = session_ids.len();
@@ -7850,6 +7859,16 @@ impl AppState {
                     .map_or_else(|| unknown_session_label(*id), |s| s.name.clone())
             })
             .collect();
+        // Shell sessions have no dedicated worktree, so counting them in "Delete
+        // removes N worktree(s)" would inflate the number on the one dialog
+        // whose job is to state the destructive scope accurately.
+        let worktree_count = session_ids
+            .iter()
+            .filter(|id| {
+                self.find_session(**id)
+                    .is_none_or(|s| !matches!(s.agent_type, crate::models::SessionAgentType::Shell))
+            })
+            .count();
         let (dirty, unchecked) = self.bulk_uncommitted_counts(&session_ids);
         let warning = Self::format_bulk_uncommitted_warning(&dirty, unchecked);
         let summary = Self::format_bulk_session_summary(&names);
@@ -7882,7 +7901,7 @@ impl AppState {
                 format!("Stop or Delete {count} Session(s)"),
                 format!(
                     "{summary}\nStop keeps every worktree and resumes later. \
-                     Delete removes {count} worktree(s)."
+                     Delete removes {worktree_count} worktree(s)."
                 ),
                 warning,
                 ("Stop all", ConfirmAction::BulkStopSessions(stoppable)),
@@ -7900,7 +7919,7 @@ impl AppState {
                 title: format!("Delete {count} Session(s)"),
                 message: format!(
                     "{summary}\n{reason}, so Delete is the only option offered. \
-                     It removes {count} worktree(s)."
+                     It removes {worktree_count} worktree(s)."
                 ),
                 confirm_action: ConfirmAction::BulkDeleteSessions(session_ids),
                 selected_option: false, // Default = No
@@ -7922,7 +7941,7 @@ impl AppState {
                 format!("Stop or Delete {count} Session(s)"),
                 format!(
                     "{summary}\nStop covers {stoppable_count} and keeps their worktrees, \
-                     {excluded}. Delete removes all {count} worktree(s)."
+                     {excluded}. Delete removes {worktree_count} worktree(s)."
                 ),
                 warning,
                 (
@@ -10394,8 +10413,10 @@ impl AppState {
         let mut already_stopped = 0;
         let mut failed = 0;
         for id in session_ids {
-            // Already Stopped means there is nothing to kill; counting it as a
-            // stop would report "Stopped 10" for work that stopped 5.
+            // The dialog already filters these out, so this is normally zero.
+            // It still has to be here: a session can reach Stopped between the
+            // dialog opening and this running, and counting it as a stop would
+            // report "Stopped 10" for what stopped 5.
             if self
                 .find_session(id)
                 .is_some_and(|s| matches!(s.status, SessionStatus::Stopped))

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2461,7 +2461,7 @@ mod tests {
             assert_eq!(delete_ids.len(), 3, "Delete still covers everything");
             assert!(delete_ids.contains(&boss_id));
             assert!(
-                dialog.message.contains("the other 1 cannot be stopped"),
+                dialog.message.contains("the other one cannot be stopped"),
                 "a Boss row is excluded because it has no stop path, not because it \
                  is already stopped: {}",
                 dialog.message
@@ -2495,7 +2495,7 @@ mod tests {
                 "Stop covers only the running session"
             );
             assert!(
-                dialog.message.contains("the other 1 are already stopped"),
+                dialog.message.contains("the other one is already stopped"),
                 "{}",
                 dialog.message
             );
@@ -2694,9 +2694,11 @@ mod tests {
                     SessionStatus::Running,
                 );
                 session.workspace_path = worktree.to_string_lossy().to_string();
-                // No tmux session name: nothing to kill, so the test never shells
-                // out to tmux and never touches another session's server.
-                session.tmux_session_name = None;
+                // A name that exists nowhere, so the real kill path runs and
+                // reports "can't find session". Safe only because the kill
+                // targets `=name`: a bare `-t` would prefix-match and could
+                // reach a developer's live session.
+                session.tmux_session_name = Some(format!("ainb-test-{}", session.id));
                 ids.push(session.id);
                 worktrees.push(worktree);
                 ws.add_session(session);

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2096,6 +2096,241 @@ mod tests {
             "use_case selection must survive the State -> Config -> disk mapping"
         );
     }
+
+    // ========================================================================
+    // Bulk delete confirmation
+    //
+    // Pressing `d` (or Shift+D) with rows checked used to queue
+    // BulkDeleteSessions immediately: no dialog, no Stop option, no
+    // uncommitted-work warning, and every selected worktree was removed. These
+    // tests pin the confirmation step in place.
+    // ========================================================================
+
+    /// Two checked, running interactive sessions, plus their ids in list order.
+    fn state_with_checked_sessions(names: &[&str]) -> (AppState, Vec<uuid::Uuid>) {
+        use crate::models::SessionStatus;
+
+        let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
+        let mut ids = Vec::new();
+        for name in names {
+            let session = resumable_session(
+                name,
+                SessionMode::Interactive,
+                SessionAgentType::Claude,
+                SessionStatus::Running,
+            );
+            ids.push(session.id);
+            ws.add_session(session);
+        }
+
+        let mut state = AppState::new();
+        state.workspaces.push(ws);
+        for id in &ids {
+            state.selected_sessions.insert(*id);
+        }
+        (state, ids)
+    }
+
+    /// The regression guard: `d` with rows checked must ask first. If the
+    /// confirmation is removed this goes red on `pending_async_action`.
+    #[test]
+    fn bulk_delete_asks_before_destroying_anything() {
+        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+        assert!(
+            state.pending_async_action.is_none(),
+            "bulk delete must not queue any action before the user confirms"
+        );
+        let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
+        let opts = dialog.options.as_ref().expect("tri-option dialog");
+        assert_eq!(opts.len(), 3, "Stop all / Delete all / Cancel");
+        assert_eq!(opts[0].label, "Stop all");
+        assert_eq!(opts[1].label, "Delete all");
+        assert_eq!(opts[2].label, "Cancel");
+        assert_eq!(dialog.selected_index, 0, "Default = Stop all (safe option)");
+        assert!(matches!(
+            &opts[0].action,
+            ConfirmAction::BulkStopSessions(got) if got == &ids
+        ));
+        assert!(matches!(
+            &opts[1].action,
+            ConfirmAction::BulkDeleteSessions(got) if got == &ids
+        ));
+        assert!(matches!(opts[2].action, ConfirmAction::Cancel));
+        assert_eq!(
+            state.selected_sessions.len(),
+            2,
+            "selection survives until the user picks an outcome"
+        );
+    }
+
+    /// Shift+D (the explicit bulk key) takes the same confirmed path as `d`.
+    #[test]
+    fn bulk_delete_selected_sessions_asks_before_destroying_anything() {
+        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+
+        EventHandler::process_event(AppEvent::DeleteSelectedSessions, &mut state);
+
+        assert!(state.pending_async_action.is_none());
+        let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
+        assert!(matches!(
+            &dialog.options.as_ref().expect("tri-option dialog")[0].action,
+            ConfirmAction::BulkStopSessions(got) if got == &ids
+        ));
+    }
+
+    /// The dialog names the sessions and says how many are affected.
+    #[test]
+    fn bulk_delete_dialog_names_the_affected_sessions() {
+        let (mut state, _ids) = state_with_checked_sessions(&["alpha", "beta"]);
+
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+        let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
+        assert_eq!(dialog.title, "Stop or Delete 2 Session(s)");
+        assert!(dialog.message.contains("2 session(s): alpha, beta"), "{}", dialog.message);
+        assert!(dialog.message.contains("Stop keeps every worktree"), "{}", dialog.message);
+    }
+
+    /// Accepting the default (Stop all) must queue a stop, never a delete.
+    #[test]
+    fn bulk_dialog_default_option_queues_stop_not_delete() {
+        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+        EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+
+        assert!(matches!(
+            state.pending_async_action,
+            Some(AsyncAction::BulkStopSessions(ref got)) if got == &ids
+        ));
+        assert!(state.selected_sessions.is_empty(), "selection consumed");
+        assert!(state.confirmation_dialog.is_none());
+    }
+
+    /// Explicitly choosing Delete all still deletes, so the fix does not remove
+    /// the capability, only the surprise.
+    #[test]
+    fn bulk_dialog_delete_option_queues_bulk_delete() {
+        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+        EventHandler::process_event(AppEvent::ConfirmationToggle, &mut state);
+
+        EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+
+        assert!(matches!(
+            state.pending_async_action,
+            Some(AsyncAction::BulkDeleteSessions(ref got)) if got == &ids
+        ));
+    }
+
+    /// Cancel (either the option or Esc) leaves the selection and every session
+    /// exactly as it was.
+    #[test]
+    fn bulk_dialog_cancel_does_nothing() {
+        let (mut state, _ids) = state_with_checked_sessions(&["alpha", "beta"]);
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+        EventHandler::process_event(AppEvent::ConfirmationPrev, &mut state); // wrap to Cancel
+
+        EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+
+        assert!(state.pending_async_action.is_none(), "Cancel queues nothing");
+        assert_eq!(state.selected_sessions.len(), 2, "selection untouched");
+
+        // Esc on a freshly-opened dialog is equally inert.
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+        EventHandler::process_event(AppEvent::ConfirmationCancel, &mut state);
+        assert!(state.confirmation_dialog.is_none());
+        assert!(state.pending_async_action.is_none());
+        assert_eq!(state.selected_sessions.len(), 2);
+    }
+
+    /// Long selections stay readable: three names, then a count.
+    #[test]
+    fn bulk_session_summary_truncates_long_selections() {
+        let names: Vec<String> = (1..=12).map(|i| format!("s{}", i)).collect();
+        assert_eq!(
+            AppState::format_bulk_session_summary(&names),
+            "12 session(s): s1, s2, s3, and 9 more"
+        );
+        assert_eq!(
+            AppState::format_bulk_session_summary(&["only".to_string()]),
+            "1 session(s): only"
+        );
+    }
+
+    /// The uncommitted-work warning is the whole point of the dialog: it names
+    /// the sessions whose work "Delete all" would destroy.
+    #[test]
+    fn bulk_uncommitted_warning_names_the_dirty_sessions() {
+        assert_eq!(AppState::format_bulk_uncommitted_warning(&[]), None);
+
+        let dirty = vec![("alpha".to_string(), 3), ("beta".to_string(), 1)];
+        let warning =
+            AppState::format_bulk_uncommitted_warning(&dirty).expect("dirty sessions warn");
+        assert!(warning.contains("4 uncommitted file(s)"), "{}", warning);
+        assert!(warning.contains("2 session(s)"), "{}", warning);
+        assert!(warning.contains("alpha (3)"), "{}", warning);
+        assert!(warning.contains("beta (1)"), "{}", warning);
+
+        let many: Vec<(String, usize)> =
+            (1..=5).map(|i| (format!("s{}", i), i as usize)).collect();
+        let warning =
+            AppState::format_bulk_uncommitted_warning(&many).expect("dirty sessions warn");
+        assert!(warning.contains("+2 more"), "{}", warning);
+    }
+
+    /// Stop must leave every worktree on disk. This is the outcome the original
+    /// bug destroyed, so it is asserted against real directories.
+    #[tokio::test]
+    async fn bulk_stop_preserves_every_worktree() {
+        use crate::models::SessionStatus;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ws = crate::models::Workspace::new("ws".to_string(), tmp.path().to_path_buf());
+        let mut ids = Vec::new();
+        let mut worktrees = Vec::new();
+
+        for name in ["alpha", "beta", "gamma"] {
+            let worktree = tmp.path().join(name);
+            std::fs::create_dir_all(&worktree).expect("create worktree");
+            std::fs::write(worktree.join("uncommitted.txt"), b"work").expect("write file");
+
+            let mut session = resumable_session(
+                name,
+                SessionMode::Interactive,
+                SessionAgentType::Claude,
+                SessionStatus::Running,
+            );
+            session.workspace_path = worktree.to_string_lossy().to_string();
+            // No tmux session name: nothing to kill, so the test never shells
+            // out to tmux and never touches another session's server.
+            session.tmux_session_name = None;
+            ids.push(session.id);
+            worktrees.push(worktree);
+            ws.add_session(session);
+        }
+
+        let mut state = AppState::new();
+        state.workspaces.push(ws);
+
+        state.bulk_stop_sessions(ids.clone()).await;
+
+        for worktree in &worktrees {
+            assert!(worktree.is_dir(), "Stop must keep {}", worktree.display());
+            assert!(
+                worktree.join("uncommitted.txt").exists(),
+                "Stop must keep the uncommitted work in {}",
+                worktree.display()
+            );
+        }
+        for id in &ids {
+            let session = state.find_session(*id).expect("session still registered");
+            assert!(matches!(session.status, SessionStatus::Stopped));
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -470,7 +470,9 @@ mod tests {
         struct ExactTmuxSession(String);
         impl Drop for ExactTmuxSession {
             fn drop(&mut self) {
-                let _ = Command::new("tmux").args(["kill-session", "-t", &self.0]).output();
+                let _ = Command::new("tmux")
+                    .args(["kill-session", "-t", &format!("={}", self.0)])
+                    .output();
             }
         }
 
@@ -2537,6 +2539,8 @@ mod tests {
         with_ainb_home_async(|| async {
             use crate::models::SessionStatus;
 
+            // No tmux name on these, so the stop never shells out and the test
+            // does not need a tmux binary.
             let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
             let mut ids = Vec::new();
             for (name, status) in [
@@ -2654,6 +2658,64 @@ mod tests {
             state.show_bulk_delete_or_stop_confirmation(Vec::new());
             assert!(state.confirmation_dialog.is_none());
             assert!(state.pending_async_action.is_none());
+        });
+    }
+
+    /// Two sessions pointing at the same tree must be probed once: reporting
+    /// its four modified files twice would tell the user eight are at risk, and
+    /// "Delete removes N worktree(s)" would count the tree twice too.
+    #[test]
+    fn bulk_worktree_status_counts_a_shared_tree_once() {
+        use crate::models::SessionStatus;
+
+        with_ainb_home(|| {
+            if std::process::Command::new("git").arg("--version").status().is_err() {
+                eprintln!("SKIP: git unavailable");
+                return;
+            }
+
+            // One real repo with an uncommitted file, two sessions symlinked to it.
+            let home = std::env::var("AINB_HOME").expect("pinned by with_ainb_home");
+            let by_session = std::path::PathBuf::from(&home)
+                .join(".agents-in-a-box")
+                .join("worktrees")
+                .join("by-session");
+            std::fs::create_dir_all(&by_session).expect("by-session");
+            let tree = std::path::PathBuf::from(&home).join("shared-tree");
+            std::fs::create_dir_all(&tree).expect("tree");
+            assert!(
+                std::process::Command::new("git")
+                    .args(["init", "-q"])
+                    .current_dir(&tree)
+                    .status()
+                    .expect("git init")
+                    .success()
+            );
+            std::fs::write(tree.join("dirty.txt"), b"work").expect("write");
+
+            let mut ws = crate::models::Workspace::new("ws".to_string(), tree.clone());
+            let mut ids = Vec::new();
+            for name in ["alpha", "beta"] {
+                let session = resumable_session(
+                    name,
+                    SessionMode::Interactive,
+                    SessionAgentType::Claude,
+                    SessionStatus::Running,
+                );
+                std::os::unix::fs::symlink(&tree, by_session.join(session.id.to_string()))
+                    .expect("symlink");
+                ids.push(session.id);
+                ws.add_session(session);
+            }
+            let mut state = AppState::new();
+            state.workspaces.push(ws);
+
+            let status = state.bulk_uncommitted_counts(&ids);
+
+            assert_eq!(status.with_worktree, 1, "one tree, not two");
+            assert_eq!(status.dirty.len(), 1, "probed once");
+            assert_eq!(status.dirty[0].1, 1, "one dirty file, not two");
+            assert_eq!(status.unchecked, 0);
         });
     }
 

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2276,11 +2276,11 @@ mod tests {
     /// the sessions whose work "Delete all" would destroy.
     #[test]
     fn bulk_uncommitted_warning_names_the_dirty_sessions() {
-        assert_eq!(AppState::format_bulk_uncommitted_warning(&[]), None);
+        assert_eq!(AppState::format_bulk_uncommitted_warning(&[], 0), None);
 
         let dirty = vec![("alpha".to_string(), 3), ("beta".to_string(), 1)];
         let warning =
-            AppState::format_bulk_uncommitted_warning(&dirty).expect("dirty sessions warn");
+            AppState::format_bulk_uncommitted_warning(&dirty, 0).expect("dirty sessions warn");
         assert!(warning.contains("4 uncommitted file(s)"), "{}", warning);
         assert!(warning.contains("2 session(s)"), "{}", warning);
         assert!(warning.contains("alpha (3)"), "{}", warning);
@@ -2288,8 +2288,101 @@ mod tests {
 
         let many: Vec<(String, usize)> = (1usize..=5).map(|i| (format!("s{i}"), i)).collect();
         let warning =
-            AppState::format_bulk_uncommitted_warning(&many).expect("dirty sessions warn");
-        assert!(warning.contains("+2 more"), "{}", warning);
+            AppState::format_bulk_uncommitted_warning(&many, 0).expect("dirty sessions warn");
+        assert!(warning.contains("and 2 more"), "{}", warning);
+    }
+
+    /// A worktree whose status cannot be read must never read as clean: the
+    /// dialog says it could not be checked, so "no warning" keeps meaning
+    /// "nothing to lose".
+    #[test]
+    fn bulk_uncommitted_warning_reports_what_could_not_be_checked() {
+        let warning =
+            AppState::format_bulk_uncommitted_warning(&[], 3).expect("unchecked sessions warn");
+        assert!(
+            warning.contains("could not check 3 session(s)"),
+            "{}",
+            warning
+        );
+
+        let dirty = vec![("alpha".to_string(), 2)];
+        let warning =
+            AppState::format_bulk_uncommitted_warning(&dirty, 2).expect("dirty sessions warn");
+        assert!(warning.contains("alpha (2)"), "{}", warning);
+        assert!(
+            warning.contains("2 more could not be checked"),
+            "{}",
+            warning
+        );
+    }
+
+    /// Stop is meaningless for a Boss (Docker) session: killing tmux leaves the
+    /// container running. A selection containing one must fall back to the
+    /// binary delete confirmation, defaulting to No, rather than offering a
+    /// Stop button that would lie about what happened.
+    #[test]
+    fn bulk_dialog_without_a_stop_path_falls_back_to_delete_confirmation() {
+        use crate::models::SessionStatus;
+
+        let (mut state, _ids) = state_with_checked_sessions(&["alpha"]);
+        let boss = resumable_session(
+            "boss",
+            SessionMode::Boss,
+            SessionAgentType::Claude,
+            SessionStatus::Running,
+        );
+        let boss_id = boss.id;
+        state.workspaces[0].add_session(boss);
+        state.selected_sessions.insert(boss_id);
+
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+        assert!(state.pending_async_action.is_none(), "still asks first");
+        let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
+        assert!(
+            dialog.options.is_none(),
+            "no Stop option for a Boss session"
+        );
+        assert!(!dialog.selected_option, "Default = No");
+        assert!(matches!(
+            dialog.confirm_action,
+            ConfirmAction::BulkDeleteSessions(_)
+        ));
+    }
+
+    /// A checked id that no longer resolves to a session still takes part in the
+    /// bulk action (nothing silently drops out of a delete), but the dialog
+    /// shows a short label rather than a full 36-character uuid.
+    #[test]
+    fn bulk_dialog_labels_unresolvable_ids_without_dumping_a_uuid() {
+        let (mut state, ids) = state_with_checked_sessions(&["alpha"]);
+        let stale = uuid::Uuid::new_v4();
+        state.selected_sessions.insert(stale);
+
+        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+        let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
+        assert!(dialog.message.contains("unknown ("), "{}", dialog.message);
+        assert!(
+            !dialog.message.contains(&stale.to_string()),
+            "the full uuid would eat three rows of the dialog: {}",
+            dialog.message
+        );
+        let queued = match &dialog.confirm_action {
+            ConfirmAction::BulkDeleteSessions(queued) | ConfirmAction::BulkStopSessions(queued) => {
+                queued.clone()
+            }
+            other => panic!("unexpected action: {other:?}"),
+        };
+        assert!(queued.contains(&stale), "stale ids stay in the action");
+        assert!(queued.contains(&ids[0]));
+    }
+
+    /// Multi-select ids come out in list order, once each.
+    #[test]
+    fn selected_session_ids_in_order_dedups_and_follows_the_list() {
+        let (state, ids) = state_with_checked_sessions(&["alpha", "beta", "gamma"]);
+        assert_eq!(state.selected_session_ids_in_order(), ids);
     }
 
     /// Stop must leave every worktree on disk. This is the outcome the original

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2664,8 +2664,14 @@ mod tests {
         assert_eq!(state.selected_session_ids_in_order(), ids);
     }
 
-    /// Stop must leave every worktree on disk. This is the outcome the original
-    /// bug destroyed, so it is asserted against real directories.
+    /// End to end for the safe path: check the rows, press `d`, accept the
+    /// default, and every worktree is still on disk afterwards.
+    ///
+    /// The keypress and the confirmation are driven through the real event
+    /// handler, so re-introducing the original bug (queuing a bulk delete from
+    /// `d`) fails this test at the action assertion before any directory is
+    /// touched. Only the stop is executed; the delete action is never run,
+    /// because running it in a test would remove real directories.
     #[tokio::test]
     async fn bulk_stop_preserves_every_worktree() {
         with_ainb_home_async(|| async {
@@ -2698,8 +2704,26 @@ mod tests {
 
             let mut state = AppState::new();
             state.workspaces.push(ws);
+            for id in &ids {
+                state.selected_sessions.insert(*id);
+            }
 
-            state.bulk_stop_sessions(ids.clone()).await;
+            // `d` with rows checked, then Enter on the default option.
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            assert!(
+                state.pending_async_action.is_none(),
+                "the keypress must not queue anything before the user confirms"
+            );
+            EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+
+            let queued = state.pending_async_action.take();
+            let stop_ids = match queued {
+                Some(AsyncAction::BulkStopSessions(stop_ids)) => stop_ids,
+                other => panic!("the default must be a stop, not {other:?}"),
+            };
+            assert_eq!(stop_ids, ids, "every checked session is stopped");
+
+            state.bulk_stop_sessions(stop_ids).await;
 
             for worktree in &worktrees {
                 assert!(worktree.is_dir(), "Stop must keep {}", worktree.display());

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2337,13 +2337,14 @@ mod tests {
     /// Long selections stay readable: three names, then a count.
     #[test]
     fn bulk_session_summary_truncates_long_selections() {
-        let names: Vec<String> = (1..=12).map(|i| format!("s{i}")).collect();
+        let names: Vec<(uuid::Uuid, String)> =
+            (1..=12).map(|i| (uuid::Uuid::new_v4(), format!("s{i}"))).collect();
         assert_eq!(
             AppState::format_bulk_session_summary(&names),
             "12 session(s): s1, s2, s3, and 9 more"
         );
         assert_eq!(
-            AppState::format_bulk_session_summary(&["only".to_string()]),
+            AppState::format_bulk_session_summary(&[(uuid::Uuid::new_v4(), "only".to_string())]),
             "1 session(s): only"
         );
     }
@@ -2710,7 +2711,9 @@ mod tests {
             let mut state = AppState::new();
             state.workspaces.push(ws);
 
-            let status = state.bulk_uncommitted_counts(&ids);
+            let id_names: Vec<(uuid::Uuid, String)> =
+                ids.iter().map(|id| (*id, "n".to_string())).collect();
+            let status = AppState::bulk_uncommitted_counts(&id_names);
 
             assert_eq!(status.with_worktree, 1, "one tree, not two");
             assert_eq!(status.dirty.len(), 1, "probed once");
@@ -2750,7 +2753,7 @@ mod tests {
             let mut state = AppState::new();
             state.workspaces.push(ws);
 
-            let status = state.bulk_uncommitted_counts(&[id]);
+            let status = AppState::bulk_uncommitted_counts(&[(id, "shell".to_string())]);
 
             assert_eq!(
                 status.with_worktree, 1,
@@ -2758,9 +2761,39 @@ mod tests {
             );
             assert_eq!(
                 status.unchecked, 1,
-                "not a git tree, so its contents are unknown"
+                "not a git tree, so its contents are unknown, whether or not the \
+                 temp directory happens to sit inside some other repository"
             );
+            assert!(status.dirty.is_empty(), "no ancestor repository's files");
         });
+    }
+
+    /// A session directory that is not a checkout must never be answered for by
+    /// an ancestor repository: `git status` walks up, so probing a plain folder
+    /// nested inside a repo would report hundreds of files the session does not
+    /// own, on the dialog whose entire job is to state what is at risk.
+    #[test]
+    fn a_plain_directory_inside_a_repo_is_unknown_not_dirty() {
+        if std::process::Command::new("git").arg("--version").status().is_err() {
+            eprintln!("SKIP: git unavailable");
+            return;
+        }
+        let outer = tempfile::tempdir().expect("tempdir");
+        assert!(
+            std::process::Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(outer.path())
+                .status()
+                .expect("git init")
+                .success()
+        );
+        std::fs::write(outer.path().join("dirty.txt"), b"work").expect("write");
+        let nested = outer.path().join("not-a-checkout");
+        std::fs::create_dir_all(&nested).expect("nested");
+
+        let err = crate::git::WorktreeManager::uncommitted_file_count_at(&nested)
+            .expect_err("a plain directory is not a checkout");
+        assert!(format!("{err}").contains("no .git"), "{err}");
     }
 
     /// Multi-select ids come out in list order, once each.

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2719,6 +2719,50 @@ mod tests {
         });
     }
 
+    /// A Shell session's row is deletable like any other, and delete removes
+    /// whatever its `by-session` symlink points at, so it must be counted and
+    /// probed rather than assumed to own nothing.
+    #[test]
+    fn bulk_worktree_status_counts_a_shell_session_with_a_tree() {
+        use crate::models::SessionStatus;
+
+        with_ainb_home(|| {
+            let home = std::env::var("AINB_HOME").expect("pinned by with_ainb_home");
+            let by_session = std::path::PathBuf::from(&home)
+                .join(".agents-in-a-box")
+                .join("worktrees")
+                .join("by-session");
+            std::fs::create_dir_all(&by_session).expect("by-session");
+            let tree = std::path::PathBuf::from(&home).join("shell-tree");
+            std::fs::create_dir_all(&tree).expect("tree");
+
+            let session = resumable_session(
+                "shell",
+                SessionMode::Interactive,
+                SessionAgentType::Shell,
+                SessionStatus::Running,
+            );
+            std::os::unix::fs::symlink(&tree, by_session.join(session.id.to_string()))
+                .expect("symlink");
+            let id = session.id;
+            let mut ws = crate::models::Workspace::new("ws".to_string(), tree);
+            ws.add_session(session);
+            let mut state = AppState::new();
+            state.workspaces.push(ws);
+
+            let status = state.bulk_uncommitted_counts(&[id]);
+
+            assert_eq!(
+                status.with_worktree, 1,
+                "delete would remove this directory"
+            );
+            assert_eq!(
+                status.unchecked, 1,
+                "not a git tree, so its contents are unknown"
+            );
+        });
+    }
+
     /// Multi-select ids come out in list order, once each.
     #[test]
     fn selected_session_ids_in_order_dedups_and_follows_the_list() {
@@ -2738,6 +2782,13 @@ mod tests {
     async fn bulk_stop_preserves_every_worktree() {
         with_ainb_home_async(|| async {
             use crate::models::SessionStatus;
+
+            // The stop path shells out to tmux; without the binary every stop
+            // reports failure and the status assertions below are meaningless.
+            if std::process::Command::new("tmux").arg("-V").status().is_err() {
+                eprintln!("SKIP: tmux unavailable");
+                return;
+            }
 
             let tmp = tempfile::tempdir().expect("tempdir");
             let mut ws = crate::models::Workspace::new("ws".to_string(), tmp.path().to_path_buf());

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2190,8 +2190,16 @@ mod tests {
 
         let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
         assert_eq!(dialog.title, "Stop or Delete 2 Session(s)");
-        assert!(dialog.message.contains("2 session(s): alpha, beta"), "{}", dialog.message);
-        assert!(dialog.message.contains("Stop keeps every worktree"), "{}", dialog.message);
+        assert!(
+            dialog.message.contains("2 session(s): alpha, beta"),
+            "{}",
+            dialog.message
+        );
+        assert!(
+            dialog.message.contains("Stop keeps every worktree"),
+            "{}",
+            dialog.message
+        );
     }
 
     /// Accepting the default (Stop all) must queue a stop, never a delete.
@@ -2236,7 +2244,10 @@ mod tests {
 
         EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
 
-        assert!(state.pending_async_action.is_none(), "Cancel queues nothing");
+        assert!(
+            state.pending_async_action.is_none(),
+            "Cancel queues nothing"
+        );
         assert_eq!(state.selected_sessions.len(), 2, "selection untouched");
 
         // Esc on a freshly-opened dialog is equally inert.
@@ -2275,8 +2286,7 @@ mod tests {
         assert!(warning.contains("alpha (3)"), "{}", warning);
         assert!(warning.contains("beta (1)"), "{}", warning);
 
-        let many: Vec<(String, usize)> =
-            (1..=5).map(|i| (format!("s{}", i), i as usize)).collect();
+        let many: Vec<(String, usize)> = (1..=5).map(|i| (format!("s{}", i), i as usize)).collect();
         let warning =
             AppState::format_bulk_uncommitted_warning(&many).expect("dirty sessions warn");
         assert!(warning.contains("+2 more"), "{}", warning);

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2113,20 +2113,38 @@ mod tests {
     /// it. Without this these tests would touch the developer's real
     /// `~/.agents-in-a-box`. The lock is the crate-wide env lock, not a private
     /// one, so this serialises against EVERY `AINB_HOME`-mutating test in the
-    /// binary rather than just other callers here.
+    /// binary rather than just other callers here. The restore runs from `Drop`,
+    /// so a failing assertion inside `body` cannot leave a deleted tempdir path
+    /// in the env for every later test in the binary.
     fn with_ainb_home<R>(body: impl FnOnce() -> R) -> R {
-        let _g = crate::headroom::HEADROOM_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let dir = tempfile::tempdir().expect("tempdir");
-        let prev = std::env::var("AINB_HOME").ok();
-        std::env::set_var("AINB_HOME", dir.path());
-        let out = body();
-        match prev {
-            Some(v) => std::env::set_var("AINB_HOME", v),
-            None => std::env::remove_var("AINB_HOME"),
+        struct RestoreAinbHome {
+            previous: Option<String>,
+            _guard: std::sync::MutexGuard<'static, ()>,
+            _dir: tempfile::TempDir,
         }
-        out
+
+        impl Drop for RestoreAinbHome {
+            fn drop(&mut self) {
+                match self.previous.take() {
+                    Some(v) => std::env::set_var("AINB_HOME", v),
+                    None => std::env::remove_var("AINB_HOME"),
+                }
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _restore = RestoreAinbHome {
+            _guard: crate::headroom::HEADROOM_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            previous: {
+                let previous = std::env::var("AINB_HOME").ok();
+                std::env::set_var("AINB_HOME", dir.path());
+                previous
+            },
+            _dir: dir,
+        };
+        body()
     }
 
     /// Two checked, running interactive sessions, plus their ids in list order.
@@ -2487,6 +2505,81 @@ mod tests {
             .join(" | ");
         assert!(message.contains("Stopped 1 session(s)"), "{message}");
         assert!(message.contains("1 already stopped"), "{message}");
+    }
+
+    /// A selection that is already entirely stopped has nothing to stop, so
+    /// offering "Stop all" as the default would make Enter a no-op that also
+    /// throws the selection away.
+    #[test]
+    fn bulk_dialog_offers_no_stop_when_everything_is_already_stopped() {
+        use crate::models::SessionStatus;
+
+        with_ainb_home(|| {
+            let mut state = AppState::new();
+            let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
+            for name in ["a", "b"] {
+                let session = resumable_session(
+                    name,
+                    SessionMode::Interactive,
+                    SessionAgentType::Claude,
+                    SessionStatus::Stopped,
+                );
+                state.selected_sessions.insert(session.id);
+                ws.add_session(session);
+            }
+            state.workspaces.push(ws);
+
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+            let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
+            assert!(dialog.options.is_none(), "nothing left to stop");
+            assert!(!dialog.selected_option, "Default = No");
+        });
+    }
+
+    /// Stopping the stoppable subset must leave the rows it did not touch
+    /// checked, or the user has to find and re-select them.
+    #[test]
+    fn bulk_stop_of_a_subset_keeps_the_untouched_rows_selected() {
+        use crate::models::SessionStatus;
+
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+            let boss = resumable_session(
+                "boss",
+                SessionMode::Boss,
+                SessionAgentType::Claude,
+                SessionStatus::Running,
+            );
+            let boss_id = boss.id;
+            state.workspaces[0].add_session(boss);
+            state.selected_sessions.insert(boss_id);
+
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+
+            assert!(matches!(
+                state.pending_async_action,
+                Some(AsyncAction::BulkStopSessions(ref got)) if got == &ids
+            ));
+            assert_eq!(
+                state.selected_sessions.iter().copied().collect::<Vec<_>>(),
+                vec![boss_id],
+                "the row Stop did not touch stays checked"
+            );
+        });
+    }
+
+    /// An empty selection has nothing to confirm, so it must not open a
+    /// "Stop or Delete 0 Session(s)" dialog whose Delete deletes nothing.
+    #[test]
+    fn bulk_dialog_refuses_an_empty_selection() {
+        with_ainb_home(|| {
+            let mut state = AppState::new();
+            state.show_bulk_delete_or_stop_confirmation(Vec::new());
+            assert!(state.confirmation_dialog.is_none());
+            assert!(state.pending_async_action.is_none());
+        });
     }
 
     /// Multi-select ids come out in list order, once each.

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2261,7 +2261,7 @@ mod tests {
     /// Long selections stay readable: three names, then a count.
     #[test]
     fn bulk_session_summary_truncates_long_selections() {
-        let names: Vec<String> = (1..=12).map(|i| format!("s{}", i)).collect();
+        let names: Vec<String> = (1..=12).map(|i| format!("s{i}")).collect();
         assert_eq!(
             AppState::format_bulk_session_summary(&names),
             "12 session(s): s1, s2, s3, and 9 more"
@@ -2286,7 +2286,7 @@ mod tests {
         assert!(warning.contains("alpha (3)"), "{}", warning);
         assert!(warning.contains("beta (1)"), "{}", warning);
 
-        let many: Vec<(String, usize)> = (1..=5).map(|i| (format!("s{}", i), i as usize)).collect();
+        let many: Vec<(String, usize)> = (1usize..=5).map(|i| (format!("s{i}"), i)).collect();
         let warning =
             AppState::format_bulk_uncommitted_warning(&many).expect("dirty sessions warn");
         assert!(warning.contains("+2 more"), "{}", warning);

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2106,6 +2106,29 @@ mod tests {
     // tests pin the confirmation step in place.
     // ========================================================================
 
+    /// Point `AINB_HOME` at a tempdir for the duration of `body`.
+    ///
+    /// Opening the bulk dialog probes worktrees, which builds a
+    /// `WorktreeManager` and so reads `AINB_HOME` and creates directories under
+    /// it. Without this these tests would touch the developer's real
+    /// `~/.agents-in-a-box`. The lock is the crate-wide env lock, not a private
+    /// one, so this serialises against EVERY `AINB_HOME`-mutating test in the
+    /// binary rather than just other callers here.
+    fn with_ainb_home<R>(body: impl FnOnce() -> R) -> R {
+        let _g = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var("AINB_HOME").ok();
+        std::env::set_var("AINB_HOME", dir.path());
+        let out = body();
+        match prev {
+            Some(v) => std::env::set_var("AINB_HOME", v),
+            None => std::env::remove_var("AINB_HOME"),
+        }
+        out
+    }
+
     /// Two checked, running interactive sessions, plus their ids in list order.
     fn state_with_checked_sessions(names: &[&str]) -> (AppState, Vec<uuid::Uuid>) {
         use crate::models::SessionStatus;
@@ -2135,127 +2158,139 @@ mod tests {
     /// confirmation is removed this goes red on `pending_async_action`.
     #[test]
     fn bulk_delete_asks_before_destroying_anything() {
-        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
 
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
 
-        assert!(
-            state.pending_async_action.is_none(),
-            "bulk delete must not queue any action before the user confirms"
-        );
-        let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
-        let opts = dialog.options.as_ref().expect("tri-option dialog");
-        assert_eq!(opts.len(), 3, "Stop all / Delete all / Cancel");
-        assert_eq!(opts[0].label, "Stop all");
-        assert_eq!(opts[1].label, "Delete all");
-        assert_eq!(opts[2].label, "Cancel");
-        assert_eq!(dialog.selected_index, 0, "Default = Stop all (safe option)");
-        assert!(matches!(
-            &opts[0].action,
-            ConfirmAction::BulkStopSessions(got) if got == &ids
-        ));
-        assert!(matches!(
-            &opts[1].action,
-            ConfirmAction::BulkDeleteSessions(got) if got == &ids
-        ));
-        assert!(matches!(opts[2].action, ConfirmAction::Cancel));
-        assert_eq!(
-            state.selected_sessions.len(),
-            2,
-            "selection survives until the user picks an outcome"
-        );
+            assert!(
+                state.pending_async_action.is_none(),
+                "bulk delete must not queue any action before the user confirms"
+            );
+            let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
+            let opts = dialog.options.as_ref().expect("tri-option dialog");
+            assert_eq!(opts.len(), 3, "Stop all / Delete all / Cancel");
+            assert_eq!(opts[0].label, "Stop all");
+            assert_eq!(opts[1].label, "Delete all");
+            assert_eq!(opts[2].label, "Cancel");
+            assert_eq!(dialog.selected_index, 0, "Default = Stop all (safe option)");
+            assert!(matches!(
+                &opts[0].action,
+                ConfirmAction::BulkStopSessions(got) if got == &ids
+            ));
+            assert!(matches!(
+                &opts[1].action,
+                ConfirmAction::BulkDeleteSessions(got) if got == &ids
+            ));
+            assert!(matches!(opts[2].action, ConfirmAction::Cancel));
+            assert_eq!(
+                state.selected_sessions.len(),
+                2,
+                "selection survives until the user picks an outcome"
+            );
+        });
     }
 
     /// Shift+D (the explicit bulk key) takes the same confirmed path as `d`.
     #[test]
     fn bulk_delete_selected_sessions_asks_before_destroying_anything() {
-        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
 
-        EventHandler::process_event(AppEvent::DeleteSelectedSessions, &mut state);
+            EventHandler::process_event(AppEvent::DeleteSelectedSessions, &mut state);
 
-        assert!(state.pending_async_action.is_none());
-        let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
-        assert!(matches!(
-            &dialog.options.as_ref().expect("tri-option dialog")[0].action,
-            ConfirmAction::BulkStopSessions(got) if got == &ids
-        ));
+            assert!(state.pending_async_action.is_none());
+            let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
+            assert!(matches!(
+                &dialog.options.as_ref().expect("tri-option dialog")[0].action,
+                ConfirmAction::BulkStopSessions(got) if got == &ids
+            ));
+        });
     }
 
     /// The dialog names the sessions and says how many are affected.
     #[test]
     fn bulk_delete_dialog_names_the_affected_sessions() {
-        let (mut state, _ids) = state_with_checked_sessions(&["alpha", "beta"]);
+        with_ainb_home(|| {
+            let (mut state, _ids) = state_with_checked_sessions(&["alpha", "beta"]);
 
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
 
-        let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
-        assert_eq!(dialog.title, "Stop or Delete 2 Session(s)");
-        assert!(
-            dialog.message.contains("2 session(s): alpha, beta"),
-            "{}",
-            dialog.message
-        );
-        assert!(
-            dialog.message.contains("Stop keeps every worktree"),
-            "{}",
-            dialog.message
-        );
+            let dialog = state.confirmation_dialog.as_ref().expect("bulk confirmation dialog");
+            assert_eq!(dialog.title, "Stop or Delete 2 Session(s)");
+            assert!(
+                dialog.message.contains("2 session(s): alpha, beta"),
+                "{}",
+                dialog.message
+            );
+            assert!(
+                dialog.message.contains("Stop keeps every worktree"),
+                "{}",
+                dialog.message
+            );
+        });
     }
 
     /// Accepting the default (Stop all) must queue a stop, never a delete.
     #[test]
     fn bulk_dialog_default_option_queues_stop_not_delete() {
-        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
 
-        EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+            EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
 
-        assert!(matches!(
-            state.pending_async_action,
-            Some(AsyncAction::BulkStopSessions(ref got)) if got == &ids
-        ));
-        assert!(state.selected_sessions.is_empty(), "selection consumed");
-        assert!(state.confirmation_dialog.is_none());
+            assert!(matches!(
+                state.pending_async_action,
+                Some(AsyncAction::BulkStopSessions(ref got)) if got == &ids
+            ));
+            assert!(state.selected_sessions.is_empty(), "selection consumed");
+            assert!(state.confirmation_dialog.is_none());
+        });
     }
 
     /// Explicitly choosing Delete all still deletes, so the fix does not remove
     /// the capability, only the surprise.
     #[test]
     fn bulk_dialog_delete_option_queues_bulk_delete() {
-        let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
-        EventHandler::process_event(AppEvent::ConfirmationToggle, &mut state);
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::ConfirmationToggle, &mut state);
 
-        EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+            EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
 
-        assert!(matches!(
-            state.pending_async_action,
-            Some(AsyncAction::BulkDeleteSessions(ref got)) if got == &ids
-        ));
+            assert!(matches!(
+                state.pending_async_action,
+                Some(AsyncAction::BulkDeleteSessions(ref got)) if got == &ids
+            ));
+        });
     }
 
     /// Cancel (either the option or Esc) leaves the selection and every session
     /// exactly as it was.
     #[test]
     fn bulk_dialog_cancel_does_nothing() {
-        let (mut state, _ids) = state_with_checked_sessions(&["alpha", "beta"]);
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
-        EventHandler::process_event(AppEvent::ConfirmationPrev, &mut state); // wrap to Cancel
+        with_ainb_home(|| {
+            let (mut state, _ids) = state_with_checked_sessions(&["alpha", "beta"]);
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::ConfirmationPrev, &mut state); // wrap to Cancel
 
-        EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
+            EventHandler::process_event(AppEvent::ConfirmationConfirm, &mut state);
 
-        assert!(
-            state.pending_async_action.is_none(),
-            "Cancel queues nothing"
-        );
-        assert_eq!(state.selected_sessions.len(), 2, "selection untouched");
+            assert!(
+                state.pending_async_action.is_none(),
+                "Cancel queues nothing"
+            );
+            assert_eq!(state.selected_sessions.len(), 2, "selection untouched");
 
-        // Esc on a freshly-opened dialog is equally inert.
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
-        EventHandler::process_event(AppEvent::ConfirmationCancel, &mut state);
-        assert!(state.confirmation_dialog.is_none());
-        assert!(state.pending_async_action.is_none());
-        assert_eq!(state.selected_sessions.len(), 2);
+            // Esc on a freshly-opened dialog is equally inert.
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::ConfirmationCancel, &mut state);
+            assert!(state.confirmation_dialog.is_none());
+            assert!(state.pending_async_action.is_none());
+            assert_eq!(state.selected_sessions.len(), 2);
+        });
     }
 
     /// Long selections stay readable: three names, then a count.
@@ -2317,65 +2352,141 @@ mod tests {
     }
 
     /// Stop is meaningless for a Boss (Docker) session: killing tmux leaves the
-    /// container running. A selection containing one must fall back to the
-    /// binary delete confirmation, defaulting to No, rather than offering a
+    /// container running. A selection of only such sessions must fall back to
+    /// the binary delete confirmation, defaulting to No, rather than offering a
     /// Stop button that would lie about what happened.
     #[test]
-    fn bulk_dialog_without_a_stop_path_falls_back_to_delete_confirmation() {
+    fn bulk_dialog_without_any_stop_path_falls_back_to_delete_confirmation() {
         use crate::models::SessionStatus;
 
-        let (mut state, _ids) = state_with_checked_sessions(&["alpha"]);
-        let boss = resumable_session(
-            "boss",
-            SessionMode::Boss,
-            SessionAgentType::Claude,
-            SessionStatus::Running,
-        );
-        let boss_id = boss.id;
-        state.workspaces[0].add_session(boss);
-        state.selected_sessions.insert(boss_id);
+        with_ainb_home(|| {
+            let mut state = AppState::new();
+            let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
+            for name in ["boss-a", "boss-b"] {
+                let session = resumable_session(
+                    name,
+                    SessionMode::Boss,
+                    SessionAgentType::Claude,
+                    SessionStatus::Running,
+                );
+                state.selected_sessions.insert(session.id);
+                ws.add_session(session);
+            }
+            state.workspaces.push(ws);
 
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
 
-        assert!(state.pending_async_action.is_none(), "still asks first");
-        let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
-        assert!(
-            dialog.options.is_none(),
-            "no Stop option for a Boss session"
-        );
-        assert!(!dialog.selected_option, "Default = No");
-        assert!(matches!(
-            dialog.confirm_action,
-            ConfirmAction::BulkDeleteSessions(_)
-        ));
+            assert!(state.pending_async_action.is_none(), "still asks first");
+            let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
+            assert!(dialog.options.is_none(), "no Stop option for Boss sessions");
+            assert!(!dialog.selected_option, "Default = No");
+            assert!(matches!(
+                dialog.confirm_action,
+                ConfirmAction::BulkDeleteSessions(_)
+            ));
+        });
+    }
+
+    /// One Boss row in the selection must not strip the safe option from the
+    /// rows that can use it: Stop covers the stoppable subset, Delete still
+    /// covers everything, and Stop stays the default.
+    #[test]
+    fn bulk_dialog_offers_stop_for_the_stoppable_subset_of_a_mixed_selection() {
+        use crate::models::SessionStatus;
+
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["alpha", "beta"]);
+            let boss = resumable_session(
+                "boss",
+                SessionMode::Boss,
+                SessionAgentType::Claude,
+                SessionStatus::Running,
+            );
+            let boss_id = boss.id;
+            state.workspaces[0].add_session(boss);
+            state.selected_sessions.insert(boss_id);
+
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+            let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
+            let opts = dialog.options.as_ref().expect("tri-option dialog");
+            assert_eq!(dialog.selected_index, 0, "Stop is still the default");
+            assert_eq!(opts[0].label, "Stop 2", "names how many Stop covers");
+            assert!(
+                matches!(&opts[0].action, ConfirmAction::BulkStopSessions(got) if got == &ids),
+                "Stop covers only the two interactive sessions"
+            );
+            let ConfirmAction::BulkDeleteSessions(delete_ids) = &opts[1].action else {
+                panic!("second option must delete");
+            };
+            assert_eq!(delete_ids.len(), 3, "Delete still covers everything");
+            assert!(delete_ids.contains(&boss_id));
+        });
     }
 
     /// A checked id that no longer resolves to a session still takes part in the
-    /// bulk action (nothing silently drops out of a delete), but the dialog
-    /// shows a short label rather than a full 36-character uuid.
+    /// bulk delete (nothing silently drops out), but the dialog shows a short
+    /// label rather than a full 36-character uuid.
     #[test]
     fn bulk_dialog_labels_unresolvable_ids_without_dumping_a_uuid() {
-        let (mut state, ids) = state_with_checked_sessions(&["alpha"]);
-        let stale = uuid::Uuid::new_v4();
-        state.selected_sessions.insert(stale);
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["alpha"]);
+            let stale = uuid::Uuid::new_v4();
+            state.selected_sessions.insert(stale);
 
-        EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
 
-        let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
-        assert!(dialog.message.contains("unknown ("), "{}", dialog.message);
-        assert!(
-            !dialog.message.contains(&stale.to_string()),
-            "the full uuid would eat three rows of the dialog: {}",
-            dialog.message
-        );
-        let queued = match &dialog.confirm_action {
-            ConfirmAction::BulkDeleteSessions(queued) | ConfirmAction::BulkStopSessions(queued) => {
-                queued.clone()
-            }
-            other => panic!("unexpected action: {other:?}"),
-        };
-        assert!(queued.contains(&stale), "stale ids stay in the action");
-        assert!(queued.contains(&ids[0]));
+            let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
+            assert!(dialog.message.contains("unknown ("), "{}", dialog.message);
+            assert!(
+                !dialog.message.contains(&stale.to_string()),
+                "the full uuid would eat three rows of the dialog: {}",
+                dialog.message
+            );
+            let opts = dialog.options.as_ref().expect("tri-option dialog");
+            let ConfirmAction::BulkDeleteSessions(delete_ids) = &opts[1].action else {
+                panic!("second option must delete");
+            };
+            assert!(delete_ids.contains(&stale), "stale ids stay in the delete");
+            assert!(delete_ids.contains(&ids[0]));
+        });
+    }
+
+    /// A bulk stop must not claim to have stopped sessions that were already
+    /// stopped: the count is what the user reads to know the operation worked.
+    #[tokio::test]
+    async fn bulk_stop_reports_already_stopped_sessions_separately() {
+        use crate::models::SessionStatus;
+
+        let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
+        let mut ids = Vec::new();
+        for (name, status) in [
+            ("running", SessionStatus::Running),
+            ("already", SessionStatus::Stopped),
+        ] {
+            let mut session = resumable_session(
+                name,
+                SessionMode::Interactive,
+                SessionAgentType::Claude,
+                status,
+            );
+            session.tmux_session_name = None;
+            ids.push(session.id);
+            ws.add_session(session);
+        }
+        let mut state = AppState::new();
+        state.workspaces.push(ws);
+
+        state.bulk_stop_sessions(ids).await;
+
+        let message = state
+            .notifications
+            .iter()
+            .map(|n| n.message.clone())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(message.contains("Stopped 1 session(s)"), "{message}");
+        assert!(message.contains("1 already stopped"), "{message}");
     }
 
     /// Multi-select ids come out in list order, once each.

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2106,6 +2106,38 @@ mod tests {
     // tests pin the confirmation step in place.
     // ========================================================================
 
+    struct RestoreAinbHome {
+        previous: Option<String>,
+        _guard: std::sync::MutexGuard<'static, ()>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl Drop for RestoreAinbHome {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(v) => std::env::set_var("AINB_HOME", v),
+                None => std::env::remove_var("AINB_HOME"),
+            }
+        }
+    }
+
+    /// Take the crate-wide env lock and point `AINB_HOME` at a fresh tempdir
+    /// until the returned guard drops.
+    fn pin_ainb_home() -> RestoreAinbHome {
+        let dir = tempfile::tempdir().expect("tempdir");
+        RestoreAinbHome {
+            _guard: crate::headroom::HEADROOM_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            previous: {
+                let previous = std::env::var("AINB_HOME").ok();
+                std::env::set_var("AINB_HOME", dir.path());
+                previous
+            },
+            _dir: dir,
+        }
+    }
+
     /// Point `AINB_HOME` at a tempdir for the duration of `body`.
     ///
     /// Opening the bulk dialog probes worktrees, which builds a
@@ -2117,34 +2149,23 @@ mod tests {
     /// so a failing assertion inside `body` cannot leave a deleted tempdir path
     /// in the env for every later test in the binary.
     fn with_ainb_home<R>(body: impl FnOnce() -> R) -> R {
-        struct RestoreAinbHome {
-            previous: Option<String>,
-            _guard: std::sync::MutexGuard<'static, ()>,
-            _dir: tempfile::TempDir,
-        }
-
-        impl Drop for RestoreAinbHome {
-            fn drop(&mut self) {
-                match self.previous.take() {
-                    Some(v) => std::env::set_var("AINB_HOME", v),
-                    None => std::env::remove_var("AINB_HOME"),
-                }
-            }
-        }
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let _restore = RestoreAinbHome {
-            _guard: crate::headroom::HEADROOM_ENV_LOCK
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
-            previous: {
-                let previous = std::env::var("AINB_HOME").ok();
-                std::env::set_var("AINB_HOME", dir.path());
-                previous
-            },
-            _dir: dir,
-        };
+        let _restore = pin_ainb_home();
         body()
+    }
+
+    /// `with_ainb_home` for an async body. `stop_interactive_session` falls back
+    /// to `SessionStore::load()`, which reads `AINB_HOME`, so the bulk-stop tests
+    /// need the same isolation the synchronous ones get.
+    // The env guard is deliberately held across the await: that is what makes the
+    // isolation cover the whole body. Test-only, single-threaded.
+    #[allow(clippy::future_not_send)]
+    async fn with_ainb_home_async<F, Fut, R>(body: F) -> R
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = R>,
+    {
+        let _restore = pin_ainb_home();
+        body().await
     }
 
     /// Two checked, running interactive sessions, plus their ids in list order.
@@ -2439,6 +2460,45 @@ mod tests {
             };
             assert_eq!(delete_ids.len(), 3, "Delete still covers everything");
             assert!(delete_ids.contains(&boss_id));
+            assert!(
+                dialog.message.contains("the other 1 cannot be stopped"),
+                "a Boss row is excluded because it has no stop path, not because it \
+                 is already stopped: {}",
+                dialog.message
+            );
+        });
+    }
+
+    /// When the excluded rows are merely already stopped, the message must say
+    /// so rather than claiming they cannot be stopped at all.
+    #[test]
+    fn bulk_dialog_names_already_stopped_rows_as_the_reason_they_are_excluded() {
+        use crate::models::SessionStatus;
+
+        with_ainb_home(|| {
+            let (mut state, ids) = state_with_checked_sessions(&["running"]);
+            let stopped = resumable_session(
+                "stopped",
+                SessionMode::Interactive,
+                SessionAgentType::Claude,
+                SessionStatus::Stopped,
+            );
+            state.selected_sessions.insert(stopped.id);
+            state.workspaces[0].add_session(stopped);
+
+            EventHandler::process_event(AppEvent::DeleteSession, &mut state);
+
+            let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
+            let opts = dialog.options.as_ref().expect("tri-option dialog");
+            assert!(
+                matches!(&opts[0].action, ConfirmAction::BulkStopSessions(got) if got == &ids),
+                "Stop covers only the running session"
+            );
+            assert!(
+                dialog.message.contains("the other 1 are already stopped"),
+                "{}",
+                dialog.message
+            );
         });
     }
 
@@ -2474,37 +2534,40 @@ mod tests {
     /// stopped: the count is what the user reads to know the operation worked.
     #[tokio::test]
     async fn bulk_stop_reports_already_stopped_sessions_separately() {
-        use crate::models::SessionStatus;
+        with_ainb_home_async(|| async {
+            use crate::models::SessionStatus;
 
-        let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
-        let mut ids = Vec::new();
-        for (name, status) in [
-            ("running", SessionStatus::Running),
-            ("already", SessionStatus::Stopped),
-        ] {
-            let mut session = resumable_session(
-                name,
-                SessionMode::Interactive,
-                SessionAgentType::Claude,
-                status,
-            );
-            session.tmux_session_name = None;
-            ids.push(session.id);
-            ws.add_session(session);
-        }
-        let mut state = AppState::new();
-        state.workspaces.push(ws);
+            let mut ws = crate::models::Workspace::new("ws".to_string(), PathBuf::from("/tmp/ws"));
+            let mut ids = Vec::new();
+            for (name, status) in [
+                ("running", SessionStatus::Running),
+                ("already", SessionStatus::Stopped),
+            ] {
+                let mut session = resumable_session(
+                    name,
+                    SessionMode::Interactive,
+                    SessionAgentType::Claude,
+                    status,
+                );
+                session.tmux_session_name = None;
+                ids.push(session.id);
+                ws.add_session(session);
+            }
+            let mut state = AppState::new();
+            state.workspaces.push(ws);
 
-        state.bulk_stop_sessions(ids).await;
+            state.bulk_stop_sessions(ids).await;
 
-        let message = state
-            .notifications
-            .iter()
-            .map(|n| n.message.clone())
-            .collect::<Vec<_>>()
-            .join(" | ");
-        assert!(message.contains("Stopped 1 session(s)"), "{message}");
-        assert!(message.contains("1 already stopped"), "{message}");
+            let message = state
+                .notifications
+                .iter()
+                .map(|n| n.message.clone())
+                .collect::<Vec<_>>()
+                .join(" | ");
+            assert!(message.contains("Stopped 1 session(s)"), "{message}");
+            assert!(message.contains("1 already stopped"), "{message}");
+        })
+        .await;
     }
 
     /// A selection that is already entirely stopped has nothing to stop, so
@@ -2534,6 +2597,18 @@ mod tests {
             let dialog = state.confirmation_dialog.as_ref().expect("confirmation dialog");
             assert!(dialog.options.is_none(), "nothing left to stop");
             assert!(!dialog.selected_option, "Default = No");
+            assert!(
+                dialog.message.contains("already stopped"),
+                "the message must say why Stop is absent, and these sessions are \
+                 resumable, so claiming they cannot be stopped and resumed would be \
+                 the opposite of the truth: {}",
+                dialog.message
+            );
+            assert!(
+                !dialog.message.contains("None of these sessions can be stopped"),
+                "{}",
+                dialog.message
+            );
         });
     }
 
@@ -2593,50 +2668,53 @@ mod tests {
     /// bug destroyed, so it is asserted against real directories.
     #[tokio::test]
     async fn bulk_stop_preserves_every_worktree() {
-        use crate::models::SessionStatus;
+        with_ainb_home_async(|| async {
+            use crate::models::SessionStatus;
 
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let mut ws = crate::models::Workspace::new("ws".to_string(), tmp.path().to_path_buf());
-        let mut ids = Vec::new();
-        let mut worktrees = Vec::new();
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let mut ws = crate::models::Workspace::new("ws".to_string(), tmp.path().to_path_buf());
+            let mut ids = Vec::new();
+            let mut worktrees = Vec::new();
 
-        for name in ["alpha", "beta", "gamma"] {
-            let worktree = tmp.path().join(name);
-            std::fs::create_dir_all(&worktree).expect("create worktree");
-            std::fs::write(worktree.join("uncommitted.txt"), b"work").expect("write file");
+            for name in ["alpha", "beta", "gamma"] {
+                let worktree = tmp.path().join(name);
+                std::fs::create_dir_all(&worktree).expect("create worktree");
+                std::fs::write(worktree.join("uncommitted.txt"), b"work").expect("write file");
 
-            let mut session = resumable_session(
-                name,
-                SessionMode::Interactive,
-                SessionAgentType::Claude,
-                SessionStatus::Running,
-            );
-            session.workspace_path = worktree.to_string_lossy().to_string();
-            // No tmux session name: nothing to kill, so the test never shells
-            // out to tmux and never touches another session's server.
-            session.tmux_session_name = None;
-            ids.push(session.id);
-            worktrees.push(worktree);
-            ws.add_session(session);
-        }
+                let mut session = resumable_session(
+                    name,
+                    SessionMode::Interactive,
+                    SessionAgentType::Claude,
+                    SessionStatus::Running,
+                );
+                session.workspace_path = worktree.to_string_lossy().to_string();
+                // No tmux session name: nothing to kill, so the test never shells
+                // out to tmux and never touches another session's server.
+                session.tmux_session_name = None;
+                ids.push(session.id);
+                worktrees.push(worktree);
+                ws.add_session(session);
+            }
 
-        let mut state = AppState::new();
-        state.workspaces.push(ws);
+            let mut state = AppState::new();
+            state.workspaces.push(ws);
 
-        state.bulk_stop_sessions(ids.clone()).await;
+            state.bulk_stop_sessions(ids.clone()).await;
 
-        for worktree in &worktrees {
-            assert!(worktree.is_dir(), "Stop must keep {}", worktree.display());
-            assert!(
-                worktree.join("uncommitted.txt").exists(),
-                "Stop must keep the uncommitted work in {}",
-                worktree.display()
-            );
-        }
-        for id in &ids {
-            let session = state.find_session(*id).expect("session still registered");
-            assert!(matches!(session.status, SessionStatus::Stopped));
-        }
+            for worktree in &worktrees {
+                assert!(worktree.is_dir(), "Stop must keep {}", worktree.display());
+                assert!(
+                    worktree.join("uncommitted.txt").exists(),
+                    "Stop must keep the uncommitted work in {}",
+                    worktree.display()
+                );
+            }
+            for id in &ids {
+                let session = state.find_session(*id).expect("session still registered");
+                assert!(matches!(session.status, SessionStatus::Stopped));
+            }
+        })
+        .await;
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2353,11 +2353,11 @@ mod tests {
     /// the sessions whose work "Delete all" would destroy.
     #[test]
     fn bulk_uncommitted_warning_names_the_dirty_sessions() {
-        assert_eq!(AppState::format_bulk_uncommitted_warning(&[], 0), None);
+        assert_eq!(AppState::format_bulk_uncommitted_warning(&[], 0, 2), None);
 
         let dirty = vec![("alpha".to_string(), 3), ("beta".to_string(), 1)];
         let warning =
-            AppState::format_bulk_uncommitted_warning(&dirty, 0).expect("dirty sessions warn");
+            AppState::format_bulk_uncommitted_warning(&dirty, 0, 2).expect("dirty sessions warn");
         assert!(warning.contains("4 uncommitted file(s)"), "{}", warning);
         assert!(warning.contains("2 session(s)"), "{}", warning);
         assert!(warning.contains("alpha (3)"), "{}", warning);
@@ -2365,7 +2365,7 @@ mod tests {
 
         let many: Vec<(String, usize)> = (1usize..=5).map(|i| (format!("s{i}"), i)).collect();
         let warning =
-            AppState::format_bulk_uncommitted_warning(&many, 0).expect("dirty sessions warn");
+            AppState::format_bulk_uncommitted_warning(&many, 0, 5).expect("dirty sessions warn");
         assert!(warning.contains("and 2 more"), "{}", warning);
     }
 
@@ -2375,7 +2375,7 @@ mod tests {
     #[test]
     fn bulk_uncommitted_warning_reports_what_could_not_be_checked() {
         let warning =
-            AppState::format_bulk_uncommitted_warning(&[], 3).expect("unchecked sessions warn");
+            AppState::format_bulk_uncommitted_warning(&[], 3, 3).expect("unchecked sessions warn");
         assert!(
             warning.contains("could not check 3 session(s)"),
             "{}",
@@ -2384,7 +2384,7 @@ mod tests {
 
         let dirty = vec![("alpha".to_string(), 2)];
         let warning =
-            AppState::format_bulk_uncommitted_warning(&dirty, 2).expect("dirty sessions warn");
+            AppState::format_bulk_uncommitted_warning(&dirty, 2, 3).expect("dirty sessions warn");
         assert!(warning.contains("alpha (2)"), "{}", warning);
         assert!(
             warning.contains("2 more could not be checked"),
@@ -2711,13 +2711,20 @@ mod tests {
             let mut state = AppState::new();
             state.workspaces.push(ws);
 
-            let id_names: Vec<(uuid::Uuid, String)> =
-                ids.iter().map(|id| (*id, "n".to_string())).collect();
+            let id_names: Vec<(uuid::Uuid, String)> = ids
+                .iter()
+                .zip(["alpha", "beta"])
+                .map(|(id, name)| (*id, name.to_string()))
+                .collect();
             let status = AppState::bulk_uncommitted_counts(&id_names);
 
             assert_eq!(status.with_worktree, 1, "one tree, not two");
             assert_eq!(status.dirty.len(), 1, "probed once");
             assert_eq!(status.dirty[0].1, 1, "one dirty file, not two");
+            assert_eq!(
+                status.dirty[0].0, "alpha, beta",
+                "both sessions map to the dirty tree, so both are named"
+            );
             assert_eq!(status.unchecked, 0);
         });
     }
@@ -2794,6 +2801,38 @@ mod tests {
         let err = crate::git::WorktreeManager::uncommitted_file_count_at(&nested)
             .expect_err("a plain directory is not a checkout");
         assert!(format!("{err}").contains("no .git"), "{err}");
+    }
+
+    /// In a bulk selection the name is the point of the warning, even when only
+    /// one of the selected sessions turns out to be dirty. Only a one-row dialog
+    /// drops it, because there the name is the row the user is looking at.
+    #[test]
+    fn bulk_warning_names_the_dirty_session_even_when_only_one_is_dirty() {
+        let dirty = vec![("beta".to_string(), 3)];
+
+        let bulk = AppState::format_bulk_uncommitted_warning(&dirty, 0, 12)
+            .expect("one dirty session in a bulk selection still warns");
+        assert!(bulk.contains("beta (3)"), "{bulk}");
+
+        let single = AppState::format_bulk_uncommitted_warning(&dirty, 0, 1)
+            .expect("a single-row dialog still warns");
+        assert_eq!(single, "⚠️ 3 uncommitted file(s) in worktree");
+    }
+
+    /// A single-row dialog must not hedge in the plural about "1 session(s)"
+    /// when its own worktree could not be read.
+    #[test]
+    fn single_row_unchecked_warning_reads_singly() {
+        let single = AppState::format_bulk_uncommitted_warning(&[], 1, 1)
+            .expect("an unreadable worktree warns");
+        assert_eq!(
+            single,
+            "⚠️ could not check this worktree for uncommitted work"
+        );
+
+        let bulk = AppState::format_bulk_uncommitted_warning(&[], 2, 6)
+            .expect("unreadable worktrees warn");
+        assert!(bulk.contains("could not check 2 session(s)"), "{bulk}");
     }
 
     /// Multi-select ids come out in list order, once each.

--- a/ainb-tui/crates/ainb-core/src/cli/attach.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/attach.rs
@@ -18,7 +18,7 @@ pub async fn execute(args: AttachArgs) -> Result<()> {
 
     // Check tmux session exists
     let exists = Command::new("tmux")
-        .args(["has-session", "-t", tmux_name])
+        .args(["has-session", "-t", &format!("={tmux_name}")])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);

--- a/ainb-tui/crates/ainb-core/src/cli/logs.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/logs.rs
@@ -36,7 +36,10 @@ pub async fn execute(args: LogsArgs) -> Result<()> {
 
 /// Check if a tmux session exists
 async fn tmux_session_exists(session_name: &str) -> bool {
-    let output = Command::new("tmux").args(["has-session", "-t", session_name]).output().await;
+    let output = Command::new("tmux")
+        .args(["has-session", "-t", &format!("={session_name}")])
+        .output()
+        .await;
 
     matches!(output, Ok(o) if o.status.success())
 }

--- a/ainb-tui/crates/ainb-core/src/cli/recover.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/recover.rs
@@ -84,7 +84,7 @@ pub struct OrphanedSession {
 /// Check if a tmux session exists by name
 fn tmux_session_exists(name: &str) -> bool {
     Command::new("tmux")
-        .args(["has-session", "-t", name])
+        .args(["has-session", "-t", &format!("={name}")])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)

--- a/ainb-tui/crates/ainb-core/src/cli/recover.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/recover.rs
@@ -487,7 +487,10 @@ fn cleanup_single_orphan(orphan: &OrphanedSession) -> Result<()> {
     // 1. Kill tmux session if alive
     if orphan.is_tmux_alive {
         if let Some(ref tmux_name) = orphan.tmux_session_name {
-            let _ = Command::new("tmux").args(["kill-session", "-t", tmux_name]).output();
+            // Exact target, never a prefix match.
+            let _ = Command::new("tmux")
+                .args(["kill-session", "-t", &format!("={tmux_name}")])
+                .output();
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/cli/status.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/status.rs
@@ -160,7 +160,13 @@ pub async fn kill(args: KillArgs) -> Result<()> {
     println!("Killing tmux session '{}'...", session.tmux_session_name);
 
     let output = Command::new("tmux")
-        .args(["kill-session", "-t", &session.tmux_session_name])
+        // Exact target: a bare `-t` resolves exact, then prefix, so this could
+        // otherwise kill a different, live session whose name starts the same.
+        .args([
+            "kill-session",
+            "-t",
+            &format!("={}", session.tmux_session_name),
+        ])
         .output()
         .context("Failed to execute tmux kill-session")?;
 

--- a/ainb-tui/crates/ainb-core/src/cli/status.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/status.rs
@@ -28,7 +28,7 @@ pub struct StatusOutput {
 /// Check if a tmux session exists
 fn tmux_session_exists(tmux_session_name: &str) -> bool {
     Command::new("tmux")
-        .args(["has-session", "-t", tmux_session_name])
+        .args(["has-session", "-t", &format!("={tmux_session_name}")])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)

--- a/ainb-tui/crates/ainb-core/src/cli/statusline.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/statusline.rs
@@ -672,7 +672,9 @@ mod tests {
     fn headroom_segment_reflects_base_url_routing() {
         // Shared lock: this test mutates ANTHROPIC_BASE_URL + AINB_HEADROOM_PORT,
         // which other tests read in parallel (cargo runs tests in-process).
-        let _guard = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _guard = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let key = "ANTHROPIC_BASE_URL";
         let old = std::env::var_os(key);
         let port_old = std::env::var_os("AINB_HEADROOM_PORT");

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -6,6 +6,10 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
+// TUI palette (see .claude/skills/tui-screen/SKILL.md).
+const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
+const DARK_BG: Color = Color::Rgb(25, 25, 35);
+
 /// Borders (2) + one message row + two button rows: the smallest box that can
 /// show a confirmation and the keys that answer it.
 const MIN_DIALOG_HEIGHT: u16 = 5;
@@ -61,8 +65,10 @@ impl ConfirmationDialogComponent {
             let constraints = if warning_rows > 0 {
                 vec![
                     Constraint::Length(warning_rows), // Warning
-                    Constraint::Min(1),               // Message
-                    Constraint::Length(2),            // Buttons
+                    // Min(0): on a box too short for both, the message yields
+                    // and the warning keeps its rows.
+                    Constraint::Min(0),    // Message
+                    Constraint::Length(2), // Buttons
                 ]
             } else {
                 vec![
@@ -176,10 +182,27 @@ fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
         .constraints([Constraint::Min(0), Constraint::Length(button_row)])
         .split(area);
     if chunks[0].height > 0 {
-        let title = Paragraph::new(dialog.title.clone())
-            .style(Style::default().fg(Color::White).bg(Color::Black))
-            .wrap(Wrap { trim: true });
-        frame.render_widget(title, chunks[0]);
+        // The warning outranks the title here: on a destructive dialog the one
+        // line worth the space is the one saying what would be lost.
+        let (text, style) = dialog.warning.as_ref().map_or_else(
+            || {
+                (
+                    dialog.title.clone(),
+                    Style::default().fg(SOFT_WHITE).bg(DARK_BG),
+                )
+            },
+            |warning| {
+                (
+                    warning.clone(),
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )
+            },
+        );
+        let line = Paragraph::new(text).style(style).wrap(Wrap { trim: true });
+        frame.render_widget(line, chunks[0]);
     }
     render_buttons(frame, chunks[1], dialog);
 }
@@ -216,7 +239,12 @@ fn dialog_layout(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16
     // message.
     let needed = wanted_warning.saturating_add(message_rows).saturating_add(4);
     let height = base.max(needed).min(max_height);
-    let warning_rows = wanted_warning.min(height.saturating_sub(MIN_DIALOG_HEIGHT));
+    // Rows left once the borders and buttons are paid for. The warning gets what
+    // it needs up to that; when the box is too short for both, the warning keeps
+    // its row and the message is the one that goes, because the warning is the
+    // text a delete confirmation exists to show.
+    let spare = height.saturating_sub(4);
+    let warning_rows = wanted_warning.min(spare);
     (height, warning_rows)
 }
 
@@ -224,9 +252,9 @@ fn dialog_layout(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16
 /// with `Wrap { trim: true }` (which never splits a word that fits on a line).
 ///
 /// Deliberately counts chars rather than display columns, so a run of
-/// double-width (CJK) glyphs is under-counted; the extra row added per paragraph
-/// absorbs that and the odd wide emoji. Measure display width here if that stops
-/// being enough.
+/// double-width (CJK) glyphs is under-counted; the single extra row absorbs that
+/// and the odd wide emoji. Measure display width here if that stops being
+/// enough.
 fn wrapped_line_count(text: &str, width: u16) -> u16 {
     let width = width.max(1) as usize;
     let mut rows: usize = 0;
@@ -249,9 +277,10 @@ fn wrapped_line_count(text: &str, width: u16) -> u16 {
                 used -= width;
             }
         }
-        rows += paragraph_rows + 1; // one row of slack, see above
+        rows += paragraph_rows;
     }
-    u16::try_from(rows.max(1)).unwrap_or(u16::MAX)
+    // One row of slack for the whole text, not per line: see above.
+    u16::try_from(rows.max(1).saturating_add(1)).unwrap_or(u16::MAX)
 }
 
 #[cfg(test)]
@@ -333,11 +362,11 @@ mod tests {
         }
     }
 
-    /// A short terminal must not squeeze the button row to nothing: the warning
-    /// banner yields first, because a destructive dialog whose Stop / Delete /
-    /// Cancel row is invisible is worse than one with no banner.
+    /// A short terminal must not squeeze the button row to nothing, and the
+    /// warning outranks the message for the rows that are left: a destructive
+    /// dialog exists to show what would be lost, and the buttons that answer it.
     #[test]
-    fn a_short_dialog_drops_the_warning_before_the_buttons() {
+    fn a_short_dialog_keeps_the_warning_and_the_buttons() {
         let d = dialog(
             "12 session(s): alpha, beta, gamma, and 9 more",
             Some("⚠️ 40 uncommitted file(s) in 12 session(s): alpha (12), beta (9), gamma (7)"),
@@ -346,9 +375,13 @@ mod tests {
             let (box_height, warning_rows) = dialog_layout(&d, 60, height);
             let inner = box_height - 2;
             assert!(
-                warning_rows + 2 < inner,
+                warning_rows + 2 <= inner,
                 "at height {height} the warning ({warning_rows}) leaves no room for the \
-                 message and buttons in {inner} inner rows"
+                 buttons in {inner} inner rows"
+            );
+            assert!(
+                warning_rows > 0,
+                "at height {height} the warning vanished entirely"
             );
         }
     }

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -19,20 +19,16 @@ impl ConfirmationDialogComponent {
 
     pub fn render(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         if let Some(dialog) = &state.confirmation_dialog {
-            // Borders (2) + one message row + two button rows is the smallest
-            // drawable dialog; below that the arithmetic underflows and there is
-            // nothing meaningful to show anyway.
+            // Too small for a bordered box. The dialog still owns the keyboard,
+            // so draw the buttons alone rather than leaving an invisible modal
+            // that swallows every keypress.
             if area.width < 10 || area.height < MIN_DIALOG_HEIGHT {
+                render_compact(frame, area, dialog);
                 return;
             }
             // Calculate dialog size (center it)
             let dialog_width = 60.min(area.width - 4);
-            let dialog_height = dialog_height(dialog, dialog_width, area.height);
-            // What the box can actually spare for the warning: the message keeps
-            // at least one row and the buttons keep both of theirs, so a tall
-            // warning never squeezes the Stop/Delete/Cancel row to nothing.
-            let warning_rows = warning_row_count(dialog, dialog_width)
-                .min(dialog_height.saturating_sub(MIN_DIALOG_HEIGHT));
+            let (dialog_height, warning_rows) = dialog_layout(dialog, dialog_width, area.height);
 
             let dialog_area = Rect {
                 x: (area.width - dialog_width) / 2,
@@ -166,6 +162,28 @@ fn render_buttons(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
     }
 }
 
+/// Last-resort rendering for an area too small to hold a bordered dialog: the
+/// title on one row (if there is one to spare) and the buttons underneath, so
+/// the modal that is holding the keyboard is at least visible and answerable.
+fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    frame.render_widget(Clear, area);
+    let button_row = area.height.min(2);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(button_row)])
+        .split(area);
+    if chunks[0].height > 0 {
+        let title = Paragraph::new(dialog.title.clone())
+            .style(Style::default().fg(Color::White).bg(Color::Black))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(title, chunks[0]);
+    }
+    render_buttons(frame, chunks[1], dialog);
+}
+
 /// Rows the warning block occupies, 0 when the dialog has no warning.
 ///
 /// At least 3 so short warnings keep the banner they have always had, and at
@@ -182,16 +200,24 @@ fn warning_row_count(dialog: &ConfirmationDialog, dialog_width: u16) -> u16 {
 /// wrapped body needs more rows, in which case the box grows rather than
 /// clipping. The bulk Stop/Delete dialog names the sessions it affects, so it
 /// is routinely taller than the fixed size allowed.
-fn dialog_height(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16) -> u16 {
+/// `(box height, rows the warning banner gets)`, computed together so the two
+/// cannot disagree. The box is the historic fixed size (8, or 11 with a
+/// warning) unless the wrapped body needs more rows, in which case it grows
+/// rather than clipping; the bulk Stop/Delete dialog names the sessions it
+/// affects, so it is routinely taller than the fixed size allowed. When the box
+/// cannot grow far enough, the banner yields first: the message keeps a row and
+/// the buttons keep both of theirs, so the answer is never invisible.
+fn dialog_layout(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16) -> (u16, u16) {
     let message_rows = wrapped_line_count(&dialog.message, dialog_width.saturating_sub(2));
+    let wanted_warning = warning_row_count(dialog, dialog_width);
     let base = if dialog.warning.is_some() { 11 } else { 8 };
     // 2 borders + warning block + message + 2 button rows, saturating because
     // `wrapped_line_count` is allowed to return u16::MAX for a pathological
     // message.
-    let needed = warning_row_count(dialog, dialog_width)
-        .saturating_add(message_rows)
-        .saturating_add(4);
-    base.max(needed).min(max_height)
+    let needed = wanted_warning.saturating_add(message_rows).saturating_add(4);
+    let height = base.max(needed).min(max_height);
+    let warning_rows = wanted_warning.min(height.saturating_sub(MIN_DIALOG_HEIGHT));
+    (height, warning_rows)
 }
 
 /// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
@@ -248,13 +274,14 @@ mod tests {
     /// Short dialogs keep the size they have always had.
     #[test]
     fn short_dialogs_keep_their_historic_size() {
-        assert_eq!(dialog_height(&dialog("Are you sure?", None), 60, 40), 8);
+        assert_eq!(dialog_layout(&dialog("Are you sure?", None), 60, 40).0, 8);
         assert_eq!(
-            dialog_height(
+            dialog_layout(
                 &dialog("Are you sure?", Some("⚠️ 1 uncommitted file(s)")),
                 60,
                 40
-            ),
+            )
+            .0,
             11
         );
     }
@@ -269,8 +296,7 @@ mod tests {
             long_message,
             Some("⚠️ 4 uncommitted file(s) in 2 session(s): alpha (3)"),
         );
-        let height = dialog_height(&d, 60, 40);
-        let warning_rows = warning_row_count(&d, 60);
+        let (height, warning_rows) = dialog_layout(&d, 60, 40);
         let message_rows = wrapped_line_count(&d.message, 58);
         // 2 borders + warning + message + 2 button rows must all fit.
         assert!(
@@ -298,7 +324,7 @@ mod tests {
     fn tiny_terminals_are_clamped_not_underflowed() {
         let d = dialog("Are you sure?", None);
         for height in MIN_DIALOG_HEIGHT..=12u16 {
-            let computed = dialog_height(&d, 60, height);
+            let (computed, _) = dialog_layout(&d, 60, height);
             assert!(
                 computed >= 2,
                 "height {computed} would underflow inner_area"
@@ -317,9 +343,7 @@ mod tests {
             Some("⚠️ 40 uncommitted file(s) in 12 session(s): alpha (12), beta (9), gamma (7)"),
         );
         for height in MIN_DIALOG_HEIGHT..=14u16 {
-            let box_height = dialog_height(&d, 60, height);
-            let warning_rows =
-                warning_row_count(&d, 60).min(box_height.saturating_sub(MIN_DIALOG_HEIGHT));
+            let (box_height, warning_rows) = dialog_layout(&d, 60, height);
             let inner = box_height - 2;
             assert!(
                 warning_rows + 2 < inner,
@@ -335,7 +359,7 @@ mod tests {
         let huge = "line\n".repeat(70_000);
         let d = dialog(&huge, Some("⚠️ warning"));
         assert_eq!(
-            dialog_height(&d, 60, 40),
+            dialog_layout(&d, 60, 40).0,
             40,
             "clamped to the area, no panic"
         );

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -1,6 +1,8 @@
 // ABOUTME: Confirmation dialog component for displaying yes/no prompts with keyboard navigation
 
 use crate::app::state::{AppState, ConfirmationDialog};
+use unicode_width::UnicodeWidthStr;
+
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
@@ -182,30 +184,39 @@ fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(0), Constraint::Length(button_row)])
         .split(area);
-    if chunks[0].height > 0 {
-        // The warning outranks everything here: on a destructive dialog the one
-        // line worth the space is the one saying what would be lost. Without a
-        // warning the message wins, since it names the sessions and says what
-        // the buttons do; the title only repeats the count.
-        let (text, style) = dialog.warning.as_ref().map_or_else(
-            || {
-                (
-                    dialog.message.clone(),
-                    Style::default().fg(SOFT_WHITE).bg(DARK_BG),
-                )
-            },
-            |warning| {
-                (
-                    warning.clone(),
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                )
-            },
-        );
-        let line = Paragraph::new(text).style(style).wrap(Wrap { trim: true });
-        frame.render_widget(line, chunks[0]);
+    // Warning first: on a destructive dialog the line worth the space is the one
+    // saying what would be lost. The message comes next, since it names the
+    // sessions and says what the buttons do; the title only repeats the count.
+    let mut lines: Vec<(String, Style)> = Vec::new();
+    if let Some(warning) = dialog.warning.as_ref() {
+        lines.push((
+            warning.clone(),
+            Style::default().fg(Color::Black).bg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ));
+    }
+    lines.push((
+        dialog.message.clone(),
+        Style::default().fg(SOFT_WHITE).bg(DARK_BG),
+    ));
+
+    let text_area = chunks[0];
+    if text_area.height > 0 {
+        let rows = usize::from(text_area.height).min(lines.len());
+        let per_line = text_area.height / u16::try_from(rows).unwrap_or(1);
+        let mut y = text_area.y;
+        for (text, style) in lines.into_iter().take(rows) {
+            let row = Rect {
+                x: text_area.x,
+                y,
+                width: text_area.width,
+                height: per_line.max(1),
+            };
+            frame.render_widget(
+                Paragraph::new(text).style(style).wrap(Wrap { trim: true }),
+                row,
+            );
+            y += per_line.max(1);
+        }
     }
     render_buttons(frame, chunks[1], dialog);
 }
@@ -252,30 +263,12 @@ fn dialog_layout(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16
 /// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
 /// with `Wrap { trim: true }` (which never splits a word that fits on a line).
 ///
-/// Terminal columns a string occupies.
+/// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
+/// with `Wrap { trim: true }` (which never splits a word that fits on a line).
 ///
-/// A coarse East Asian Wide / Fullwidth table rather than a `unicode-width`
-/// dependency: this only sizes a dialog box, and the caller adds a slack row.
-fn display_columns(text: &str) -> usize {
-    text.chars()
-        .map(|c| {
-            let c = c as u32;
-            let wide = (0x1100..=0x115F).contains(&c)      // Hangul Jamo
-                || (0x2E80..=0xA4CF).contains(&c)          // CJK radicals through Yi
-                || (0xAC00..=0xD7A3).contains(&c)          // Hangul syllables
-                || (0xF900..=0xFAFF).contains(&c)          // CJK compatibility
-                || (0xFE30..=0xFE6F).contains(&c)          // CJK compatibility forms
-                || (0xFF00..=0xFF60).contains(&c)          // Fullwidth forms
-                || (0xFFE0..=0xFFE6).contains(&c)          // Fullwidth signs
-                || (0x1F300..=0x1FAFF).contains(&c); // Emoji
-            usize::from(wide) + 1
-        })
-        .sum()
-}
-
-/// Measures display columns, not chars, so a warning naming CJK sessions is not
-/// under-counted and clipped. The remaining slack row covers the odd glyph the
-/// coarse width table below gets wrong.
+/// Measures display columns via `unicode-width`, so a warning naming CJK
+/// sessions is not under-counted and clipped. One slack row is added for the
+/// whole text.
 fn wrapped_line_count(text: &str, width: u16) -> u16 {
     let width = width.max(1) as usize;
     let mut rows: usize = 0;
@@ -283,7 +276,7 @@ fn wrapped_line_count(text: &str, width: u16) -> u16 {
         let mut paragraph_rows = 1usize;
         let mut used = 0usize;
         for word in paragraph.split_whitespace() {
-            let len = display_columns(word);
+            let len = UnicodeWidthStr::width(word);
             if used == 0 {
                 used = len;
             } else if used + 1 + len <= width {
@@ -374,8 +367,8 @@ mod tests {
     #[test]
     fn wrapped_line_count_measures_display_columns() {
         let cjk = "日本語ブランチ".repeat(6); // 42 chars, 84 columns
-        assert_eq!(display_columns("日本語"), 6);
-        assert_eq!(display_columns("abc"), 3);
+        assert_eq!(UnicodeWidthStr::width("日本語"), 6);
+        assert_eq!(UnicodeWidthStr::width("abc"), 3);
         assert!(
             wrapped_line_count(&cjk, 40) >= 3,
             "84 columns at width 40 needs 3 rows, not 2"

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -15,10 +15,14 @@ impl ConfirmationDialogComponent {
 
     pub fn render(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         if let Some(dialog) = &state.confirmation_dialog {
+            // Below this there is no room for borders, a message and buttons,
+            // and the arithmetic below would underflow.
+            if area.width < 10 || area.height < 6 {
+                return;
+            }
             // Calculate dialog size (center it)
-            // Increase height if warning is present
             let dialog_width = 60.min(area.width - 4);
-            let warning_lines = warning_line_count(dialog, dialog_width);
+            let warning_rows = warning_row_count(dialog, dialog_width);
             let dialog_height = dialog_height(dialog, dialog_width, area.height);
 
             let dialog_area = Rect {
@@ -51,9 +55,9 @@ impl ConfirmationDialogComponent {
             // Build constraints based on whether warning is present
             let constraints = if dialog.warning.is_some() {
                 vec![
-                    Constraint::Length(warning_lines.max(3)), // Warning
-                    Constraint::Min(1),                       // Message
-                    Constraint::Length(2),                    // Buttons
+                    Constraint::Length(warning_rows), // Warning
+                    Constraint::Min(1),               // Message
+                    Constraint::Length(2),            // Buttons
                 ]
             } else {
                 vec![
@@ -93,67 +97,74 @@ impl ConfirmationDialogComponent {
 
             frame.render_widget(message, chunks[message_chunk]);
 
-            // Render buttons. Tri-option mode (e.g. Stop / Delete / Cancel) takes
-            // precedence; binary mode is used by all legacy callsites.
-            if let Some(options) = dialog.options.as_ref() {
-                let n = options.len().max(1);
-                let pct = (100u16 / n as u16).max(1);
-                let constraints: Vec<Constraint> =
-                    (0..n).map(|_| Constraint::Percentage(pct)).collect();
-                let button_chunks = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .constraints(constraints)
-                    .split(chunks[button_chunk]);
-
-                for (i, opt) in options.iter().enumerate() {
-                    let style = if i == dialog.selected_index {
-                        Style::default().fg(Color::Black).bg(Color::White)
-                    } else {
-                        Style::default().fg(Color::White)
-                    };
-                    let label = format!("[ {} ]", opt.label);
-                    let button = Paragraph::new(label).style(style).alignment(Alignment::Center);
-                    if let Some(area) = button_chunks.get(i) {
-                        frame.render_widget(button, *area);
-                    }
-                }
-            } else {
-                let button_chunks = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .split(chunks[button_chunk]);
-
-                // Yes button
-                let yes_style = if dialog.selected_option {
-                    Style::default().fg(Color::Black).bg(Color::White)
-                } else {
-                    Style::default().fg(Color::White)
-                };
-
-                let yes_button =
-                    Paragraph::new("Yes").style(yes_style).alignment(Alignment::Center);
-
-                frame.render_widget(yes_button, button_chunks[0]);
-
-                // No button
-                let no_style = if !dialog.selected_option {
-                    Style::default().fg(Color::Black).bg(Color::White)
-                } else {
-                    Style::default().fg(Color::White)
-                };
-
-                let no_button = Paragraph::new("No").style(no_style).alignment(Alignment::Center);
-
-                frame.render_widget(no_button, button_chunks[1]);
-            }
+            render_buttons(frame, chunks[button_chunk], dialog);
         }
     }
 }
 
+/// Draw the dialog's buttons. Tri-option mode (e.g. Stop / Delete / Cancel)
+/// takes precedence; binary mode is used by all legacy callsites.
+fn render_buttons(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
+    if let Some(options) = dialog.options.as_ref() {
+        let n = options.len().max(1);
+        let pct = (100u16 / n as u16).max(1);
+        let constraints: Vec<Constraint> = (0..n).map(|_| Constraint::Percentage(pct)).collect();
+        let button_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(constraints)
+            .split(area);
+
+        for (i, opt) in options.iter().enumerate() {
+            let style = if i == dialog.selected_index {
+                Style::default().fg(Color::Black).bg(Color::White)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let label = format!("[ {} ]", opt.label);
+            let button = Paragraph::new(label).style(style).alignment(Alignment::Center);
+            if let Some(area) = button_chunks.get(i) {
+                frame.render_widget(button, *area);
+            }
+        }
+    } else {
+        let button_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area);
+
+        // Yes button
+        let yes_style = if dialog.selected_option {
+            Style::default().fg(Color::Black).bg(Color::White)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        let yes_button = Paragraph::new("Yes").style(yes_style).alignment(Alignment::Center);
+
+        frame.render_widget(yes_button, button_chunks[0]);
+
+        // No button
+        let no_style = if !dialog.selected_option {
+            Style::default().fg(Color::Black).bg(Color::White)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        let no_button = Paragraph::new("No").style(no_style).alignment(Alignment::Center);
+
+        frame.render_widget(no_button, button_chunks[1]);
+    }
+}
+
 /// Rows the warning block occupies, 0 when the dialog has no warning.
-fn warning_line_count(dialog: &ConfirmationDialog, dialog_width: u16) -> u16 {
+///
+/// At least 3 so short warnings keep the banner they have always had, and at
+/// most 6 so one long warning cannot push the buttons off screen. The height
+/// calculation uses this same number, so the box always reserves exactly what
+/// the layout hands out.
+fn warning_row_count(dialog: &ConfirmationDialog, dialog_width: u16) -> u16 {
     dialog.warning.as_ref().map_or(0, |w| {
-        wrapped_line_count(w, dialog_width.saturating_sub(2)).clamp(1, 4)
+        wrapped_line_count(w, dialog_width.saturating_sub(2)).clamp(3, 6)
     })
 }
 
@@ -162,17 +173,122 @@ fn warning_line_count(dialog: &ConfirmationDialog, dialog_width: u16) -> u16 {
 /// clipping. The bulk Stop/Delete dialog names the sessions it affects, so it
 /// is routinely taller than the fixed size allowed.
 fn dialog_height(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16) -> u16 {
-    let message_lines = wrapped_line_count(&dialog.message, dialog_width.saturating_sub(2));
+    let message_rows = wrapped_line_count(&dialog.message, dialog_width.saturating_sub(2));
     let base = if dialog.warning.is_some() { 11 } else { 8 };
     // 2 borders + warning block + message + 2 button rows.
-    let needed = 4 + warning_line_count(dialog, dialog_width) + message_lines;
+    let needed = 4 + warning_row_count(dialog, dialog_width) + message_rows;
     base.max(needed).min(max_height)
 }
 
-/// Lines `text` occupies once wrapped to `width`, counting explicit newlines.
-/// Character-count based, which is close enough for sizing a dialog box.
+/// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
+/// with `Wrap { trim: true }` (which never splits a word that fits on a line).
+///
+/// ponytail: counts chars, not display columns, so a run of double-width (CJK)
+/// glyphs is under-counted; the extra row added per paragraph absorbs that and
+/// the odd wide emoji. Measure display width here if that stops being enough.
 fn wrapped_line_count(text: &str, width: u16) -> u16 {
     let width = width.max(1) as usize;
-    let lines: usize = text.lines().map(|line| line.chars().count().max(1).div_ceil(width)).sum();
-    u16::try_from(lines.max(1)).unwrap_or(u16::MAX)
+    let mut rows: usize = 0;
+    for paragraph in text.lines() {
+        let mut paragraph_rows = 1usize;
+        let mut used = 0usize;
+        for word in paragraph.split_whitespace() {
+            let len = word.chars().count();
+            if used == 0 {
+                used = len;
+            } else if used + 1 + len <= width {
+                used += 1 + len;
+            } else {
+                paragraph_rows += 1;
+                used = len;
+            }
+            // A word longer than the line spills onto further rows.
+            while used > width {
+                paragraph_rows += 1;
+                used -= width;
+            }
+        }
+        rows += paragraph_rows + 1; // one row of slack, see above
+    }
+    u16::try_from(rows.max(1)).unwrap_or(u16::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::state::ConfirmAction;
+
+    fn dialog(message: &str, warning: Option<&str>) -> ConfirmationDialog {
+        ConfirmationDialog {
+            title: "T".to_string(),
+            message: message.to_string(),
+            confirm_action: ConfirmAction::Cancel,
+            selected_option: false,
+            warning: warning.map(str::to_string),
+            options: None,
+            selected_index: 0,
+        }
+    }
+
+    /// Short dialogs keep the size they have always had.
+    #[test]
+    fn short_dialogs_keep_their_historic_size() {
+        assert_eq!(dialog_height(&dialog("Are you sure?", None), 60, 40), 8);
+        assert_eq!(
+            dialog_height(
+                &dialog("Are you sure?", Some("⚠️ 1 uncommitted file(s)")),
+                60,
+                40
+            ),
+            11
+        );
+    }
+
+    /// The height must reserve exactly the rows the layout hands to the warning,
+    /// or the message is clipped by the difference.
+    #[test]
+    fn height_reserves_the_rows_the_layout_gives_the_warning() {
+        let long_message = "12 session(s): alpha, beta, gamma, and 9 more\n\
+             Stop keeps every worktree and resumes later. Delete removes 12 worktree(s).";
+        let d = dialog(
+            long_message,
+            Some("⚠️ 4 uncommitted file(s) in 2 session(s): alpha (3)"),
+        );
+        let height = dialog_height(&d, 60, 40);
+        let warning_rows = warning_row_count(&d, 60);
+        let message_rows = wrapped_line_count(&d.message, 58);
+        // 2 borders + warning + message + 2 button rows must all fit.
+        assert!(
+            height >= 4 + warning_rows + message_rows,
+            "height {height} clips a {message_rows}-row message under a {warning_rows}-row warning"
+        );
+    }
+
+    /// Word wrap never splits a word that fits, so the estimate must not fall
+    /// below the row count a greedy wrap actually produces.
+    #[test]
+    fn wrapped_line_count_accounts_for_word_wrapping() {
+        // Three 10-char words at width 20 wrap to 2 rows, not ceil(32/20) = 2
+        // by character count alone; the slack row keeps the estimate safe.
+        assert!(wrapped_line_count("abcdefghij abcdefghij abcdefghij", 20) >= 2);
+        // A word longer than the line still spills across rows.
+        assert!(wrapped_line_count(&"x".repeat(45), 20) >= 3);
+        // Explicit newlines each start a new row.
+        assert!(wrapped_line_count("a\nb\nc", 60) >= 3);
+    }
+
+    /// A terminal too small for borders, a message and buttons must not
+    /// underflow the inner-area arithmetic.
+    #[test]
+    fn tiny_terminals_are_clamped_not_underflowed() {
+        let d = dialog("Are you sure?", None);
+        for height in 6..=12u16 {
+            let computed = dialog_height(&d, 60, height);
+            assert!(
+                computed >= 2,
+                "height {computed} would underflow inner_area"
+            );
+            assert!(computed <= height, "dialog must fit the area");
+        }
+    }
 }

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -256,13 +256,18 @@ fn dialog_layout(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16
     // its row and the message is the one that goes, because the warning is the
     // text a delete confirmation exists to show.
     let spare = height.saturating_sub(4);
-    let warning_rows = wanted_warning.min(spare);
+    // The message keeps a row whenever there are two to share: it is the only
+    // line naming what is about to be destroyed. Only when a single row is left
+    // does the warning take it, since "40 uncommitted files" outranks the names
+    // when there is room for exactly one of them.
+    let warning_rows = if spare >= 2 {
+        wanted_warning.min(spare - 1)
+    } else {
+        wanted_warning.min(spare)
+    };
     (height, warning_rows)
 }
 
-/// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
-/// with `Wrap { trim: true }` (which never splits a word that fits on a line).
-///
 /// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
 /// with `Wrap { trim: true }` (which never splits a word that fits on a line).
 ///
@@ -411,6 +416,15 @@ mod tests {
                 warning_rows > 0,
                 "at height {height} the warning vanished entirely"
             );
+            // Two rows to share means the message keeps one: it is the only line
+            // that names what is about to be destroyed.
+            let spare = box_height - 4;
+            if spare >= 2 {
+                assert!(
+                    spare - warning_rows >= 1,
+                    "at height {height} the message got no row"
+                );
+            }
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -168,9 +168,10 @@ fn render_buttons(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
     }
 }
 
-/// Last-resort rendering for an area too small to hold a bordered dialog: the
-/// title on one row (if there is one to spare) and the buttons underneath, so
-/// the modal that is holding the keyboard is at least visible and answerable.
+/// Last-resort rendering for an area too small to hold a bordered dialog: one
+/// row of text (the warning if there is one, else the message) and the buttons
+/// underneath, so the modal that is holding the keyboard is at least visible and
+/// answerable.
 fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
     if area.height == 0 || area.width == 0 {
         return;
@@ -251,10 +252,30 @@ fn dialog_layout(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16
 /// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
 /// with `Wrap { trim: true }` (which never splits a word that fits on a line).
 ///
-/// Deliberately counts chars rather than display columns, so a run of
-/// double-width (CJK) glyphs is under-counted; the single extra row absorbs that
-/// and the odd wide emoji. Measure display width here if that stops being
-/// enough.
+/// Terminal columns a string occupies.
+///
+/// A coarse East Asian Wide / Fullwidth table rather than a `unicode-width`
+/// dependency: this only sizes a dialog box, and the caller adds a slack row.
+fn display_columns(text: &str) -> usize {
+    text.chars()
+        .map(|c| {
+            let c = c as u32;
+            let wide = (0x1100..=0x115F).contains(&c)      // Hangul Jamo
+                || (0x2E80..=0xA4CF).contains(&c)          // CJK radicals through Yi
+                || (0xAC00..=0xD7A3).contains(&c)          // Hangul syllables
+                || (0xF900..=0xFAFF).contains(&c)          // CJK compatibility
+                || (0xFE30..=0xFE6F).contains(&c)          // CJK compatibility forms
+                || (0xFF00..=0xFF60).contains(&c)          // Fullwidth forms
+                || (0xFFE0..=0xFFE6).contains(&c)          // Fullwidth signs
+                || (0x1F300..=0x1FAFF).contains(&c); // Emoji
+            usize::from(wide) + 1
+        })
+        .sum()
+}
+
+/// Measures display columns, not chars, so a warning naming CJK sessions is not
+/// under-counted and clipped. The remaining slack row covers the odd glyph the
+/// coarse width table below gets wrong.
 fn wrapped_line_count(text: &str, width: u16) -> u16 {
     let width = width.max(1) as usize;
     let mut rows: usize = 0;
@@ -262,7 +283,7 @@ fn wrapped_line_count(text: &str, width: u16) -> u16 {
         let mut paragraph_rows = 1usize;
         let mut used = 0usize;
         for word in paragraph.split_whitespace() {
-            let len = word.chars().count();
+            let len = display_columns(word);
             if used == 0 {
                 used = len;
             } else if used + 1 + len <= width {
@@ -345,6 +366,20 @@ mod tests {
         assert!(wrapped_line_count(&"x".repeat(45), 20) >= 3);
         // Explicit newlines each start a new row.
         assert!(wrapped_line_count("a\nb\nc", 60) >= 3);
+    }
+
+    /// Double-width glyphs must not be counted as one column, or the box is
+    /// sized too small and the warning is clipped exactly where it names the
+    /// sessions.
+    #[test]
+    fn wrapped_line_count_measures_display_columns() {
+        let cjk = "日本語ブランチ".repeat(6); // 42 chars, 84 columns
+        assert_eq!(display_columns("日本語"), 6);
+        assert_eq!(display_columns("abc"), 3);
+        assert!(
+            wrapped_line_count(&cjk, 40) >= 3,
+            "84 columns at width 40 needs 3 rows, not 2"
+        );
     }
 
     /// A terminal too small for borders, a message and buttons must not

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -6,6 +6,10 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
+/// Borders (2) + one message row + two button rows: the smallest box that can
+/// show a confirmation and the keys that answer it.
+const MIN_DIALOG_HEIGHT: u16 = 5;
+
 pub struct ConfirmationDialogComponent;
 
 impl ConfirmationDialogComponent {
@@ -15,15 +19,20 @@ impl ConfirmationDialogComponent {
 
     pub fn render(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         if let Some(dialog) = &state.confirmation_dialog {
-            // Below this there is no room for borders, a message and buttons,
-            // and the arithmetic below would underflow.
-            if area.width < 10 || area.height < 6 {
+            // Borders (2) + one message row + two button rows is the smallest
+            // drawable dialog; below that the arithmetic underflows and there is
+            // nothing meaningful to show anyway.
+            if area.width < 10 || area.height < MIN_DIALOG_HEIGHT {
                 return;
             }
             // Calculate dialog size (center it)
             let dialog_width = 60.min(area.width - 4);
-            let warning_rows = warning_row_count(dialog, dialog_width);
             let dialog_height = dialog_height(dialog, dialog_width, area.height);
+            // What the box can actually spare for the warning: the message keeps
+            // at least one row and the buttons keep both of theirs, so a tall
+            // warning never squeezes the Stop/Delete/Cancel row to nothing.
+            let warning_rows = warning_row_count(dialog, dialog_width)
+                .min(dialog_height.saturating_sub(MIN_DIALOG_HEIGHT));
 
             let dialog_area = Rect {
                 x: (area.width - dialog_width) / 2,
@@ -53,7 +62,7 @@ impl ConfirmationDialogComponent {
             };
 
             // Build constraints based on whether warning is present
-            let constraints = if dialog.warning.is_some() {
+            let constraints = if warning_rows > 0 {
                 vec![
                     Constraint::Length(warning_rows), // Warning
                     Constraint::Min(1),               // Message
@@ -72,7 +81,8 @@ impl ConfirmationDialogComponent {
                 .split(inner_area);
 
             // Determine which chunk indices to use based on warning presence
-            let (message_chunk, button_chunk) = if let Some(warning_text) = &dialog.warning {
+            let warning_text = dialog.warning.as_ref().filter(|_| warning_rows > 0);
+            let (message_chunk, button_chunk) = if let Some(warning_text) = warning_text {
                 // Render warning with yellow/orange highlight
                 let warning = Paragraph::new(warning_text.as_str())
                     .style(
@@ -175,17 +185,22 @@ fn warning_row_count(dialog: &ConfirmationDialog, dialog_width: u16) -> u16 {
 fn dialog_height(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16) -> u16 {
     let message_rows = wrapped_line_count(&dialog.message, dialog_width.saturating_sub(2));
     let base = if dialog.warning.is_some() { 11 } else { 8 };
-    // 2 borders + warning block + message + 2 button rows.
-    let needed = 4 + warning_row_count(dialog, dialog_width) + message_rows;
+    // 2 borders + warning block + message + 2 button rows, saturating because
+    // `wrapped_line_count` is allowed to return u16::MAX for a pathological
+    // message.
+    let needed = warning_row_count(dialog, dialog_width)
+        .saturating_add(message_rows)
+        .saturating_add(4);
     base.max(needed).min(max_height)
 }
 
 /// Rows `text` needs at `width`, emulating the greedy word wrap ratatui applies
 /// with `Wrap { trim: true }` (which never splits a word that fits on a line).
 ///
-/// ponytail: counts chars, not display columns, so a run of double-width (CJK)
-/// glyphs is under-counted; the extra row added per paragraph absorbs that and
-/// the odd wide emoji. Measure display width here if that stops being enough.
+/// Deliberately counts chars rather than display columns, so a run of
+/// double-width (CJK) glyphs is under-counted; the extra row added per paragraph
+/// absorbs that and the odd wide emoji. Measure display width here if that stops
+/// being enough.
 fn wrapped_line_count(text: &str, width: u16) -> u16 {
     let width = width.max(1) as usize;
     let mut rows: usize = 0;
@@ -282,7 +297,7 @@ mod tests {
     #[test]
     fn tiny_terminals_are_clamped_not_underflowed() {
         let d = dialog("Are you sure?", None);
-        for height in 6..=12u16 {
+        for height in MIN_DIALOG_HEIGHT..=12u16 {
             let computed = dialog_height(&d, 60, height);
             assert!(
                 computed >= 2,
@@ -290,5 +305,39 @@ mod tests {
             );
             assert!(computed <= height, "dialog must fit the area");
         }
+    }
+
+    /// A short terminal must not squeeze the button row to nothing: the warning
+    /// banner yields first, because a destructive dialog whose Stop / Delete /
+    /// Cancel row is invisible is worse than one with no banner.
+    #[test]
+    fn a_short_dialog_drops_the_warning_before_the_buttons() {
+        let d = dialog(
+            "12 session(s): alpha, beta, gamma, and 9 more",
+            Some("⚠️ 40 uncommitted file(s) in 12 session(s): alpha (12), beta (9), gamma (7)"),
+        );
+        for height in MIN_DIALOG_HEIGHT..=14u16 {
+            let box_height = dialog_height(&d, 60, height);
+            let warning_rows =
+                warning_row_count(&d, 60).min(box_height.saturating_sub(MIN_DIALOG_HEIGHT));
+            let inner = box_height - 2;
+            assert!(
+                warning_rows + 2 < inner,
+                "at height {height} the warning ({warning_rows}) leaves no room for the \
+                 message and buttons in {inner} inner rows"
+            );
+        }
+    }
+
+    /// A pathological message must not overflow the height arithmetic.
+    #[test]
+    fn a_huge_message_saturates_instead_of_overflowing() {
+        let huge = "line\n".repeat(70_000);
+        let d = dialog(&huge, Some("⚠️ warning"));
+        assert_eq!(
+            dialog_height(&d, 60, 40),
+            40,
+            "clamped to the area, no panic"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -178,15 +178,16 @@ fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
     if area.height == 0 || area.width == 0 {
         return;
     }
-    frame.render_widget(Clear, area);
     let button_row = area.height.min(2);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(0), Constraint::Length(button_row)])
         .split(area);
+
     // Warning first: on a destructive dialog the line worth the space is the one
-    // saying what would be lost. The message comes next, since it names the
-    // sessions and says what the buttons do; the title only repeats the count.
+    // saying what would be lost. Then the message, which names the sessions and
+    // says what the buttons do. The title last, since it only repeats the count,
+    // but it is the only text that identifies WHICH dialog this is.
     let mut lines: Vec<(String, Style)> = Vec::new();
     if let Some(warning) = dialog.warning.as_ref() {
         lines.push((
@@ -198,26 +199,34 @@ fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
         dialog.message.clone(),
         Style::default().fg(SOFT_WHITE).bg(DARK_BG),
     ));
+    lines.push((
+        dialog.title.clone(),
+        Style::default().fg(SOFT_WHITE).bg(DARK_BG).add_modifier(Modifier::BOLD),
+    ));
 
     let text_area = chunks[0];
-    if text_area.height > 0 {
-        let rows = usize::from(text_area.height).min(lines.len());
-        let per_line = text_area.height / u16::try_from(rows).unwrap_or(1);
-        let mut y = text_area.y;
+    let rows = usize::from(text_area.height).min(lines.len());
+    // Clear only the rows actually drawn: wiping the whole frame would take the
+    // list the user is looking at with it.
+    if rows > 0 {
+        let used = Rect {
+            height: u16::try_from(rows).unwrap_or(text_area.height),
+            ..text_area
+        };
+        frame.render_widget(Clear, used);
+        let mut y = used.y;
         for (text, style) in lines.into_iter().take(rows) {
             let row = Rect {
-                x: text_area.x,
+                x: used.x,
                 y,
-                width: text_area.width,
-                height: per_line.max(1),
+                width: used.width,
+                height: 1,
             };
-            frame.render_widget(
-                Paragraph::new(text).style(style).wrap(Wrap { trim: true }),
-                row,
-            );
-            y += per_line.max(1);
+            frame.render_widget(Paragraph::new(text).style(style), row);
+            y += 1;
         }
     }
+    frame.render_widget(Clear, chunks[1]);
     render_buttons(frame, chunks[1], dialog);
 }
 
@@ -374,6 +383,9 @@ mod tests {
         let cjk = "日本語ブランチ".repeat(6); // 42 chars, 84 columns
         assert_eq!(UnicodeWidthStr::width("日本語"), 6);
         assert_eq!(UnicodeWidthStr::width("abc"), 3);
+        // The warning sign every dialog warning starts with is an emoji
+        // presentation sequence, and unicode-width already scores it wide.
+        assert_eq!(UnicodeWidthStr::width("⚠️"), 2);
         assert!(
             wrapped_line_count(&cjk, 40) >= 3,
             "84 columns at width 40 needs 3 rows, not 2"

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -182,12 +182,14 @@ fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
         .constraints([Constraint::Min(0), Constraint::Length(button_row)])
         .split(area);
     if chunks[0].height > 0 {
-        // The warning outranks the title here: on a destructive dialog the one
-        // line worth the space is the one saying what would be lost.
+        // The warning outranks everything here: on a destructive dialog the one
+        // line worth the space is the one saying what would be lost. Without a
+        // warning the message wins, since it names the sessions and says what
+        // the buttons do; the title only repeats the count.
         let (text, style) = dialog.warning.as_ref().map_or_else(
             || {
                 (
-                    dialog.title.clone(),
+                    dialog.message.clone(),
                     Style::default().fg(SOFT_WHITE).bg(DARK_BG),
                 )
             },
@@ -209,27 +211,25 @@ fn render_compact(frame: &mut Frame, area: Rect, dialog: &ConfirmationDialog) {
 
 /// Rows the warning block occupies, 0 when the dialog has no warning.
 ///
-/// At least 3 so short warnings keep the banner they have always had, and at
-/// most 6 so one long warning cannot push the buttons off screen. The height
-/// calculation uses this same number, so the box always reserves exactly what
-/// the layout hands out.
+/// At least 3, so short warnings keep the banner they have always had. No upper
+/// cap here: `dialog_layout` already limits the banner to the rows the box can
+/// spare, and capping twice truncated long warnings mid-sentence on terminals
+/// with room to show them, losing the tail that says the warning is incomplete.
 fn warning_row_count(dialog: &ConfirmationDialog, dialog_width: u16) -> u16 {
     dialog.warning.as_ref().map_or(0, |w| {
-        wrapped_line_count(w, dialog_width.saturating_sub(2)).clamp(3, 6)
+        wrapped_line_count(w, dialog_width.saturating_sub(2)).max(3)
     })
 }
 
-/// Dialog height: the historic fixed size (8, or 11 with a warning) unless the
-/// wrapped body needs more rows, in which case the box grows rather than
-/// clipping. The bulk Stop/Delete dialog names the sessions it affects, so it
-/// is routinely taller than the fixed size allowed.
 /// `(box height, rows the warning banner gets)`, computed together so the two
-/// cannot disagree. The box is the historic fixed size (8, or 11 with a
-/// warning) unless the wrapped body needs more rows, in which case it grows
-/// rather than clipping; the bulk Stop/Delete dialog names the sessions it
-/// affects, so it is routinely taller than the fixed size allowed. When the box
-/// cannot grow far enough, the banner yields first: the message keeps a row and
-/// the buttons keep both of theirs, so the answer is never invisible.
+/// cannot disagree.
+///
+/// The box is the historic fixed size (8, or 11 with a warning) unless the
+/// wrapped body needs more rows, in which case it grows rather than clipping:
+/// the bulk Stop/Delete dialog names the sessions it affects, so it is routinely
+/// taller than the fixed size allowed. When the box cannot grow far enough the
+/// message yields, not the banner, so a delete confirmation never hides what
+/// would be lost or the buttons that answer it.
 fn dialog_layout(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16) -> (u16, u16) {
     let message_rows = wrapped_line_count(&dialog.message, dialog_width.saturating_sub(2));
     let wanted_warning = warning_row_count(dialog, dialog_width);

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -18,7 +18,20 @@ impl ConfirmationDialogComponent {
             // Calculate dialog size (center it)
             // Increase height if warning is present
             let dialog_width = 60.min(area.width - 4);
-            let dialog_height = if dialog.warning.is_some() { 11 } else { 8 };
+            // Base heights keep every existing dialog pixel-identical; a longer
+            // body (the bulk Stop/Delete dialog names the sessions it affects)
+            // grows the box instead of being clipped.
+            let text_width = dialog_width.saturating_sub(2);
+            let warning_lines = dialog
+                .warning
+                .as_ref()
+                .map(|w| wrapped_line_count(w, text_width).clamp(1, 4))
+                .unwrap_or(0);
+            let message_lines = wrapped_line_count(&dialog.message, text_width);
+            let base_height = if dialog.warning.is_some() { 11 } else { 8 };
+            // 2 borders + warning block + message + 2 button rows.
+            let needed_height = 4 + warning_lines + message_lines;
+            let dialog_height = base_height.max(needed_height).min(area.height);
 
             let dialog_area = Rect {
                 x: (area.width - dialog_width) / 2,
@@ -50,7 +63,7 @@ impl ConfirmationDialogComponent {
             // Build constraints based on whether warning is present
             let constraints = if dialog.warning.is_some() {
                 vec![
-                    Constraint::Length(3), // Warning
+                    Constraint::Length(warning_lines.max(3)), // Warning
                     Constraint::Min(1),    // Message
                     Constraint::Length(2), // Buttons
                 ]
@@ -147,4 +160,15 @@ impl ConfirmationDialogComponent {
             }
         }
     }
+}
+
+/// Lines `text` occupies once wrapped to `width`, counting explicit newlines.
+/// Character-count based, which is close enough for sizing a dialog box.
+fn wrapped_line_count(text: &str, width: u16) -> u16 {
+    let width = width.max(1) as usize;
+    let lines: usize = text
+        .lines()
+        .map(|line| line.chars().count().max(1).div_ceil(width))
+        .sum();
+    lines.max(1).min(u16::MAX as usize) as u16
 }

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -64,8 +64,8 @@ impl ConfirmationDialogComponent {
             let constraints = if dialog.warning.is_some() {
                 vec![
                     Constraint::Length(warning_lines.max(3)), // Warning
-                    Constraint::Min(1),    // Message
-                    Constraint::Length(2), // Buttons
+                    Constraint::Min(1),                       // Message
+                    Constraint::Length(2),                    // Buttons
                 ]
             } else {
                 vec![
@@ -166,9 +166,6 @@ impl ConfirmationDialogComponent {
 /// Character-count based, which is close enough for sizing a dialog box.
 fn wrapped_line_count(text: &str, width: u16) -> u16 {
     let width = width.max(1) as usize;
-    let lines: usize = text
-        .lines()
-        .map(|line| line.chars().count().max(1).div_ceil(width))
-        .sum();
+    let lines: usize = text.lines().map(|line| line.chars().count().max(1).div_ceil(width)).sum();
     lines.max(1).min(u16::MAX as usize) as u16
 }

--- a/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
+++ b/ainb-tui/crates/ainb-core/src/components/confirmation_dialog.rs
@@ -1,6 +1,6 @@
 // ABOUTME: Confirmation dialog component for displaying yes/no prompts with keyboard navigation
 
-use crate::app::state::AppState;
+use crate::app::state::{AppState, ConfirmationDialog};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
@@ -18,20 +18,8 @@ impl ConfirmationDialogComponent {
             // Calculate dialog size (center it)
             // Increase height if warning is present
             let dialog_width = 60.min(area.width - 4);
-            // Base heights keep every existing dialog pixel-identical; a longer
-            // body (the bulk Stop/Delete dialog names the sessions it affects)
-            // grows the box instead of being clipped.
-            let text_width = dialog_width.saturating_sub(2);
-            let warning_lines = dialog
-                .warning
-                .as_ref()
-                .map(|w| wrapped_line_count(w, text_width).clamp(1, 4))
-                .unwrap_or(0);
-            let message_lines = wrapped_line_count(&dialog.message, text_width);
-            let base_height = if dialog.warning.is_some() { 11 } else { 8 };
-            // 2 borders + warning block + message + 2 button rows.
-            let needed_height = 4 + warning_lines + message_lines;
-            let dialog_height = base_height.max(needed_height).min(area.height);
+            let warning_lines = warning_line_count(dialog, dialog_width);
+            let dialog_height = dialog_height(dialog, dialog_width, area.height);
 
             let dialog_area = Rect {
                 x: (area.width - dialog_width) / 2,
@@ -162,10 +150,29 @@ impl ConfirmationDialogComponent {
     }
 }
 
+/// Rows the warning block occupies, 0 when the dialog has no warning.
+fn warning_line_count(dialog: &ConfirmationDialog, dialog_width: u16) -> u16 {
+    dialog.warning.as_ref().map_or(0, |w| {
+        wrapped_line_count(w, dialog_width.saturating_sub(2)).clamp(1, 4)
+    })
+}
+
+/// Dialog height: the historic fixed size (8, or 11 with a warning) unless the
+/// wrapped body needs more rows, in which case the box grows rather than
+/// clipping. The bulk Stop/Delete dialog names the sessions it affects, so it
+/// is routinely taller than the fixed size allowed.
+fn dialog_height(dialog: &ConfirmationDialog, dialog_width: u16, max_height: u16) -> u16 {
+    let message_lines = wrapped_line_count(&dialog.message, dialog_width.saturating_sub(2));
+    let base = if dialog.warning.is_some() { 11 } else { 8 };
+    // 2 borders + warning block + message + 2 button rows.
+    let needed = 4 + warning_line_count(dialog, dialog_width) + message_lines;
+    base.max(needed).min(max_height)
+}
+
 /// Lines `text` occupies once wrapped to `width`, counting explicit newlines.
 /// Character-count based, which is close enough for sizing a dialog box.
 fn wrapped_line_count(text: &str, width: u16) -> u16 {
     let width = width.max(1) as usize;
     let lines: usize = text.lines().map(|line| line.chars().count().max(1).div_ceil(width)).sum();
-    lines.max(1).min(u16::MAX as usize) as u16
+    u16::try_from(lines.max(1)).unwrap_or(u16::MAX)
 }

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -781,7 +781,10 @@ impl SessionRecoveryState {
         let check_result = Command::new("tmux").args(["has-session", "-t", &new_session]).output();
         if check_result.map(|o| o.status.success()).unwrap_or(false) {
             // Kill existing session to avoid conflicts
-            let _ = Command::new("tmux").args(["kill-session", "-t", &new_session]).output();
+            // Exact target, never a prefix match.
+            let _ = Command::new("tmux")
+                .args(["kill-session", "-t", &format!("={new_session}")])
+                .output();
         }
 
         // Create new tmux session in the worktree directory

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -369,7 +369,7 @@ impl SessionRecoveryState {
 
                         // Check if tmux session exists
                         let tmux_alive = Command::new("tmux")
-                            .args(["has-session", "-t", &session])
+                            .args(["has-session", "-t", &format!("={session}")])
                             .output()
                             .map(|o| o.status.success())
                             .unwrap_or(false);
@@ -481,7 +481,7 @@ impl SessionRecoveryState {
 
                                     if let Some(ref id) = session_id {
                                         let tmux_alive = Command::new("tmux")
-                                            .args(["has-session", "-t", id])
+                                            .args(["has-session", "-t", &format!("={id}")])
                                             .output()
                                             .map(|o| o.status.success())
                                             .unwrap_or(false);
@@ -778,7 +778,9 @@ impl SessionRecoveryState {
         let new_session = Self::generate_tmux_name(&worktree_folder, &branch);
 
         // Check if session with this name already exists and kill it
-        let check_result = Command::new("tmux").args(["has-session", "-t", &new_session]).output();
+        let check_result = Command::new("tmux")
+            .args(["has-session", "-t", &format!("={new_session}")])
+            .output();
         if check_result.map(|o| o.status.success()).unwrap_or(false) {
             // Kill existing session to avoid conflicts
             // Exact target, never a prefix match.

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -312,8 +312,15 @@ impl WorktreeManager {
     /// resolution fails for trees that are perfectly readable, such as a plain
     /// clone whose `.git` is a directory rather than a worktree pointer file.
     ///
-    /// Every failure is `NotFound`: either there is no tree here or it is not a
-    /// git checkout.
+    /// Errors carry meaning that callers depend on:
+    ///
+    /// - `NotFound`: there is nothing on disk here. Deleting the session
+    ///   destroys no files.
+    /// - `CommandFailed`: a directory is there but it is not a git checkout, so
+    ///   its contents cannot be inspected. Deleting the session still removes
+    ///   the directory, so this is "unknown", never "nothing to lose".
+    /// - `Io`: the path could not be read (permissions, a racing removal). Also
+    ///   unknown.
     pub fn worktree_path(&self, session_id: Uuid) -> Result<PathBuf, WorktreeError> {
         let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
         tracing::debug!("Looking for session path: {:?}", session_path);
@@ -340,9 +347,11 @@ impl WorktreeManager {
             )));
         }
 
-        // Check if it's a valid git worktree (has .git file or directory)
+        // A directory with no `.git` still holds files, and deleting the session
+        // removes it, so this is NOT NotFound: reporting "nothing to lose" here
+        // is how a confirmation dialog stays silent while files are destroyed.
         if !worktree_path.join(".git").exists() {
-            return Err(WorktreeError::NotFound(format!(
+            return Err(WorktreeError::CommandFailed(format!(
                 "Not a git worktree (no .git): {}",
                 worktree_path.display()
             )));
@@ -812,15 +821,18 @@ impl WorktreeManager {
         Ok(())
     }
 
-    /// Get count of uncommitted files (staged, unstaged, or untracked) in a worktree
-    ///
-    /// Used to warn users before deleting a session with uncommitted changes.
-    /// How many files `git status --porcelain` reports in the session's tree.
+    /// How many files `git status --porcelain` reports in the session's tree:
+    /// staged, unstaged and untracked. Used to warn before deleting a session
+    /// that still has work in it.
     ///
     /// Resolves only the path, so a tree this can read reports a real number
     /// even when its branch, commit or parent repository cannot be resolved: a
     /// caller warning about uncommitted work must not be told "unknown" for a
     /// plain clone.
+    ///
+    /// Ignored files are not counted, so a tree holding only ignored files reads
+    /// as clean. Counting them would mean counting `target/` and `node_modules/`
+    /// on every session, which buries the signal this exists to give.
     pub fn uncommitted_file_count(&self, session_id: Uuid) -> Result<usize, WorktreeError> {
         let worktree_path = self.worktree_path(session_id)?;
 

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -42,6 +42,22 @@ pub struct WorktreeManager {
 }
 
 impl WorktreeManager {
+    /// Like `new`, but without creating anything.
+    ///
+    /// `new` does three `create_dir_all` calls, which is wrong for a read-only
+    /// question like "what would deleting these lose": merely opening a
+    /// confirmation dialog should not write to `~/.agents-in-a-box`, and on an
+    /// unwritable home it would fail for a reason unrelated to the sessions.
+    pub fn for_reading() -> Result<Self> {
+        let home_dir = match std::env::var_os("AINB_HOME") {
+            Some(h) => PathBuf::from(h),
+            None => dirs::home_dir().context("Failed to get home directory")?,
+        };
+        Ok(Self {
+            base_worktree_dir: home_dir.join(".agents-in-a-box").join("worktrees"),
+        })
+    }
+
     pub fn new() -> Result<Self> {
         // Honor `AINB_HOME` as a base-dir override (matches SessionStore), keeping
         // production at `~/.agents-in-a-box/worktrees` while letting tests isolate.
@@ -198,18 +214,12 @@ impl WorktreeManager {
     pub fn remove_worktree(&self, session_id: Uuid) -> Result<(), WorktreeError> {
         info!("Removing worktree for session {}", session_id);
 
-        // Find the actual worktree path (it might be in by-name directory)
+        // The same resolver the dialog uses to say what this removes, so the
+        // estimate and the destruction cannot describe different directories.
         let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
-        let worktree_path = if session_path.exists() && session_path.is_symlink() {
-            std::fs::read_link(&session_path)?
-        } else {
-            // Fallback to old location for backward compatibility
-            self.base_worktree_dir.join(session_id.to_string())
-        };
-
-        if !worktree_path.exists() {
-            return Err(WorktreeError::NotFound(worktree_path.display().to_string()));
-        }
+        let worktree_path = self.session_dir(session_id)?.ok_or_else(|| {
+            WorktreeError::NotFound(format!("Session {session_id} worktree not found"))
+        })?;
 
         // Get the original repository path to remove worktree properly
         if let Ok(repo) = Repository::open(&worktree_path) {
@@ -304,12 +314,16 @@ impl WorktreeManager {
         Ok(worktrees)
     }
 
-    /// The directory a session's tree lives in, if anything is there.
+    /// The directory a session's tree lives in.
     ///
     /// Resolution only: no `.git` check, no branch, no commit. Callers that need
     /// to know what a delete would remove use this, because a directory with no
     /// `.git` is still a directory full of files.
-    pub fn session_dir(&self, session_id: Uuid) -> Option<PathBuf> {
+    ///
+    /// `Ok(None)` means nothing is there. An unreadable symlink is `Err`, never
+    /// `Ok(None)`: a caller warning about what would be lost must not report a
+    /// tree it could not resolve as "nothing to lose".
+    pub fn session_dir(&self, session_id: Uuid) -> Result<Option<PathBuf>, WorktreeError> {
         let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
         tracing::debug!(
             "Looking for session path: {:?} (exists: {}, is_symlink: {})",
@@ -326,7 +340,9 @@ impl WorktreeManager {
                 }
                 Err(e) => {
                     tracing::debug!("Failed to read symlink {:?}: {}", session_path, e);
-                    return None;
+                    // The link is there and we cannot follow it, which is
+                    // unknown, not empty.
+                    return Err(WorktreeError::Io(e));
                 }
             }
         } else {
@@ -336,7 +352,7 @@ impl WorktreeManager {
             old_path
         };
 
-        worktree_path.exists().then_some(worktree_path)
+        Ok(worktree_path.exists().then_some(worktree_path))
     }
 
     /// How many files `git status --porcelain` reports in `path`.
@@ -383,7 +399,7 @@ impl WorktreeManager {
 
     pub fn get_worktree_info(&self, session_id: Uuid) -> Result<WorktreeInfo, WorktreeError> {
         let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
-        let worktree_path = self.session_dir(session_id).ok_or_else(|| {
+        let worktree_path = self.session_dir(session_id)?.ok_or_else(|| {
             WorktreeError::NotFound(format!("Session {session_id} worktree not found"))
         })?;
 

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -304,6 +304,65 @@ impl WorktreeManager {
         Ok(worktrees)
     }
 
+    /// The directory a session's tree lives in, if anything is there.
+    ///
+    /// Resolution only: no `.git` check, no branch, no commit. Callers that need
+    /// to know what a delete would remove use this, because a directory with no
+    /// `.git` is still a directory full of files.
+    pub fn session_dir(&self, session_id: Uuid) -> Option<PathBuf> {
+        let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
+        tracing::debug!(
+            "Looking for session path: {:?} (exists: {}, is_symlink: {})",
+            session_path,
+            session_path.exists(),
+            session_path.is_symlink()
+        );
+
+        let worktree_path = if session_path.exists() && session_path.is_symlink() {
+            match std::fs::read_link(&session_path) {
+                Ok(resolved) => {
+                    tracing::debug!("Resolved symlink to: {:?}", resolved);
+                    resolved
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to read symlink {:?}: {}", session_path, e);
+                    return None;
+                }
+            }
+        } else {
+            // Fallback to old location for backward compatibility
+            let old_path = self.base_worktree_dir.join(session_id.to_string());
+            tracing::debug!("Using fallback path: {:?}", old_path);
+            old_path
+        };
+
+        worktree_path.exists().then_some(worktree_path)
+    }
+
+    /// How many files `git status --porcelain` reports in `path`.
+    ///
+    /// Ignored files are not counted, so a tree holding only ignored files reads
+    /// as clean. Counting them would mean counting `target/` and
+    /// `node_modules/` on every session, which buries the signal this exists to
+    /// give.
+    pub fn uncommitted_file_count_at(path: &Path) -> Result<usize, WorktreeError> {
+        let output =
+            Command::new("git").current_dir(path).args(["status", "--porcelain"]).output()?;
+
+        if !output.status.success() {
+            return Err(WorktreeError::CommandFailed(format!(
+                "git status failed in {}: {}",
+                path.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .count())
+    }
+
     /// Resolve a session's working tree on disk.
     ///
     /// Only the path: no branch, no commit, no main-repository lookup. Callers
@@ -322,30 +381,9 @@ impl WorktreeManager {
     /// - `Io`: the path could not be read (permissions, a racing removal). Also
     ///   unknown.
     pub fn worktree_path(&self, session_id: Uuid) -> Result<PathBuf, WorktreeError> {
-        let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
-        tracing::debug!("Looking for session path: {:?}", session_path);
-
-        let worktree_path = if session_path.exists() && session_path.is_symlink() {
-            std::fs::read_link(&session_path)?
-        } else {
-            // Fallback to old location for backward compatibility
-            let old_path = self.base_worktree_dir.join(session_id.to_string());
-            if old_path.exists() {
-                old_path
-            } else {
-                return Err(WorktreeError::NotFound(format!(
-                    "Session {session_id} worktree not found"
-                )));
-            }
-        };
-
-        // Check if the symlink target exists
-        if !worktree_path.exists() {
-            return Err(WorktreeError::NotFound(format!(
-                "Symlink target does not exist: {}",
-                worktree_path.display()
-            )));
-        }
+        let worktree_path = self.session_dir(session_id).ok_or_else(|| {
+            WorktreeError::NotFound(format!("Session {session_id} worktree not found"))
+        })?;
 
         // A directory with no `.git` still holds files, and deleting the session
         // removes it, so this is NOT NotFound: reporting "nothing to lose" here
@@ -821,39 +859,14 @@ impl WorktreeManager {
         Ok(())
     }
 
-    /// How many files `git status --porcelain` reports in the session's tree:
-    /// staged, unstaged and untracked. Used to warn before deleting a session
-    /// that still has work in it.
+    /// `uncommitted_file_count_at` for the session's tree.
     ///
     /// Resolves only the path, so a tree this can read reports a real number
     /// even when its branch, commit or parent repository cannot be resolved: a
     /// caller warning about uncommitted work must not be told "unknown" for a
     /// plain clone.
-    ///
-    /// Ignored files are not counted, so a tree holding only ignored files reads
-    /// as clean. Counting them would mean counting `target/` and `node_modules/`
-    /// on every session, which buries the signal this exists to give.
     pub fn uncommitted_file_count(&self, session_id: Uuid) -> Result<usize, WorktreeError> {
-        let worktree_path = self.worktree_path(session_id)?;
-
-        let output = Command::new("git")
-            .current_dir(&worktree_path)
-            .args(["status", "--porcelain"])
-            .output()?;
-
-        if !output.status.success() {
-            return Err(WorktreeError::CommandFailed(format!(
-                "Failed to get git status: {}",
-                String::from_utf8_lossy(&output.stderr)
-            )));
-        }
-
-        let count = String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .filter(|l| !l.is_empty())
-            .count();
-
-        Ok(count)
+        Self::uncommitted_file_count_at(&self.worktree_path(session_id)?)
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -304,35 +304,33 @@ impl WorktreeManager {
         Ok(worktrees)
     }
 
-    pub fn get_worktree_info(&self, session_id: Uuid) -> Result<WorktreeInfo, WorktreeError> {
-        // Find the actual worktree path (might be in by-name directory)
+    /// Resolve a session's working tree on disk.
+    ///
+    /// Only the path: no branch, no commit, no main-repository lookup. Callers
+    /// that just need to run a git command in the tree (the uncommitted-changes
+    /// probe, say) use this rather than `get_worktree_info`, whose extra
+    /// resolution fails for trees that are perfectly readable, such as a plain
+    /// clone whose `.git` is a directory rather than a worktree pointer file.
+    ///
+    /// Every failure is `NotFound`: either there is no tree here or it is not a
+    /// git checkout.
+    pub fn worktree_path(&self, session_id: Uuid) -> Result<PathBuf, WorktreeError> {
         let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
         tracing::debug!("Looking for session path: {:?}", session_path);
-        tracing::debug!(
-            "Session path exists: {}, is_symlink: {}",
-            session_path.exists(),
-            session_path.is_symlink()
-        );
 
         let worktree_path = if session_path.exists() && session_path.is_symlink() {
-            let resolved_path = std::fs::read_link(&session_path)?;
-            tracing::debug!("Resolved symlink to: {:?}", resolved_path);
-            resolved_path
+            std::fs::read_link(&session_path)?
         } else {
             // Fallback to old location for backward compatibility
             let old_path = self.base_worktree_dir.join(session_id.to_string());
-            tracing::debug!("Using fallback path: {:?}", old_path);
             if old_path.exists() {
                 old_path
             } else {
                 return Err(WorktreeError::NotFound(format!(
-                    "Session {} worktree not found",
-                    session_id
+                    "Session {session_id} worktree not found"
                 )));
             }
         };
-
-        tracing::debug!("Final worktree path: {:?}", worktree_path);
 
         // Check if the symlink target exists
         if !worktree_path.exists() {
@@ -343,13 +341,21 @@ impl WorktreeManager {
         }
 
         // Check if it's a valid git worktree (has .git file or directory)
-        let git_path = worktree_path.join(".git");
-        if !git_path.exists() {
+        if !worktree_path.join(".git").exists() {
             return Err(WorktreeError::NotFound(format!(
                 "Not a git worktree (no .git): {}",
                 worktree_path.display()
             )));
         }
+
+        Ok(worktree_path)
+    }
+
+    pub fn get_worktree_info(&self, session_id: Uuid) -> Result<WorktreeInfo, WorktreeError> {
+        let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
+        let worktree_path = self.worktree_path(session_id)?;
+
+        tracing::debug!("Final worktree path: {:?}", worktree_path);
 
         let repo = match Repository::open(&worktree_path) {
             Ok(r) => r,
@@ -809,11 +815,17 @@ impl WorktreeManager {
     /// Get count of uncommitted files (staged, unstaged, or untracked) in a worktree
     ///
     /// Used to warn users before deleting a session with uncommitted changes.
+    /// How many files `git status --porcelain` reports in the session's tree.
+    ///
+    /// Resolves only the path, so a tree this can read reports a real number
+    /// even when its branch, commit or parent repository cannot be resolved: a
+    /// caller warning about uncommitted work must not be told "unknown" for a
+    /// plain clone.
     pub fn uncommitted_file_count(&self, session_id: Uuid) -> Result<usize, WorktreeError> {
-        let worktree_info = self.get_worktree_info(session_id)?;
+        let worktree_path = self.worktree_path(session_id)?;
 
         let output = Command::new("git")
-            .current_dir(&worktree_info.path)
+            .current_dir(&worktree_path)
             .args(["status", "--porcelain"])
             .output()?;
 

--- a/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/worktree_manager.rs
@@ -341,13 +341,31 @@ impl WorktreeManager {
 
     /// How many files `git status --porcelain` reports in `path`.
     ///
+    /// `path` must be the root of a checkout; a directory that is not one is an
+    /// error here, which callers report as "could not check", never as clean.
+    ///
     /// Ignored files are not counted, so a tree holding only ignored files reads
     /// as clean. Counting them would mean counting `target/` and
     /// `node_modules/` on every session, which buries the signal this exists to
     /// give.
     pub fn uncommitted_file_count_at(path: &Path) -> Result<usize, WorktreeError> {
-        let output =
-            Command::new("git").current_dir(path).args(["status", "--porcelain"]).output()?;
+        // Without this, `git` walks up to the nearest ancestor repository and
+        // answers for THAT tree, so a plain directory nested under any repo
+        // reports hundreds of files the session does not own.
+        if !path.join(".git").exists() {
+            return Err(WorktreeError::CommandFailed(format!(
+                "Not a git worktree (no .git): {}",
+                path.display()
+            )));
+        }
+
+        // `--no-optional-locks` keeps the probe read-only. A plain `git status`
+        // refreshes and rewrites the index, taking `.git/index.lock`, and this
+        // runs against trees with live agents committing in them.
+        let output = Command::new("git")
+            .current_dir(path)
+            .args(["--no-optional-locks", "status", "--porcelain"])
+            .output()?;
 
         if !output.status.success() {
             return Err(WorktreeError::CommandFailed(format!(
@@ -363,46 +381,22 @@ impl WorktreeManager {
             .count())
     }
 
-    /// Resolve a session's working tree on disk.
-    ///
-    /// Only the path: no branch, no commit, no main-repository lookup. Callers
-    /// that just need to run a git command in the tree (the uncommitted-changes
-    /// probe, say) use this rather than `get_worktree_info`, whose extra
-    /// resolution fails for trees that are perfectly readable, such as a plain
-    /// clone whose `.git` is a directory rather than a worktree pointer file.
-    ///
-    /// Errors carry meaning that callers depend on:
-    ///
-    /// - `NotFound`: there is nothing on disk here. Deleting the session
-    ///   destroys no files.
-    /// - `CommandFailed`: a directory is there but it is not a git checkout, so
-    ///   its contents cannot be inspected. Deleting the session still removes
-    ///   the directory, so this is "unknown", never "nothing to lose".
-    /// - `Io`: the path could not be read (permissions, a racing removal). Also
-    ///   unknown.
-    pub fn worktree_path(&self, session_id: Uuid) -> Result<PathBuf, WorktreeError> {
+    pub fn get_worktree_info(&self, session_id: Uuid) -> Result<WorktreeInfo, WorktreeError> {
+        let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
         let worktree_path = self.session_dir(session_id).ok_or_else(|| {
             WorktreeError::NotFound(format!("Session {session_id} worktree not found"))
         })?;
 
-        // A directory with no `.git` still holds files, and deleting the session
-        // removes it, so this is NOT NotFound: reporting "nothing to lose" here
-        // is how a confirmation dialog stays silent while files are destroyed.
+        tracing::debug!("Final worktree path: {:?}", worktree_path);
+
+        // Check if it's a valid git worktree (has .git file or directory).
+        // NotFound here, as it always has been: callers match on it.
         if !worktree_path.join(".git").exists() {
-            return Err(WorktreeError::CommandFailed(format!(
+            return Err(WorktreeError::NotFound(format!(
                 "Not a git worktree (no .git): {}",
                 worktree_path.display()
             )));
         }
-
-        Ok(worktree_path)
-    }
-
-    pub fn get_worktree_info(&self, session_id: Uuid) -> Result<WorktreeInfo, WorktreeError> {
-        let session_path = self.base_worktree_dir.join("by-session").join(session_id.to_string());
-        let worktree_path = self.worktree_path(session_id)?;
-
-        tracing::debug!("Final worktree path: {:?}", worktree_path);
 
         let repo = match Repository::open(&worktree_path) {
             Ok(r) => r,
@@ -857,16 +851,6 @@ impl WorktreeManager {
         }
 
         Ok(())
-    }
-
-    /// `uncommitted_file_count_at` for the session's tree.
-    ///
-    /// Resolves only the path, so a tree this can read reports a real number
-    /// even when its branch, commit or parent repository cannot be resolved: a
-    /// caller warning about uncommitted work must not be told "unknown" for a
-    /// plain clone.
-    pub fn uncommitted_file_count(&self, session_id: Uuid) -> Result<usize, WorktreeError> {
-        Self::uncommitted_file_count_at(&self.worktree_path(session_id)?)
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/headroom/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/headroom/mod.rs
@@ -328,7 +328,7 @@ mod tests {
     /// `proxy_port()` must honor `AINB_HEADROOM_PORT` override.
     #[test]
     fn proxy_port_honors_override() {
-        let _guard = HEADROOM_ENV_LOCK.lock().unwrap();
+        let _guard = HEADROOM_ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         // Isolate: stash any existing value, set ours, restore after.
         let key = "AINB_HEADROOM_PORT";
         let old = std::env::var_os(key);

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1984,7 +1984,11 @@ impl InteractiveSessionManager {
             .ok_or(InteractiveSessionError::SessionNotFound(session_id))?;
 
         let output = Command::new("tmux")
-            .args(["has-session", "-t", &session.tmux_session_name])
+            .args([
+                "has-session",
+                "-t",
+                &format!("={}", session.tmux_session_name),
+            ])
             .output()
             .await?;
 

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1831,9 +1831,13 @@ impl InteractiveSessionManager {
                     let tmux_name =
                         Self::generate_tmux_name(&worktree_folder, &worktree.branch_name);
                     let legacy_name = Self::generate_tmux_name_legacy(&worktree.branch_name);
-                    // Check if new format session exists, otherwise try legacy
+                    // Check if new format session exists, otherwise try legacy.
+                    // `=name` is exact: a bare `-t` prefix-matches, so a live
+                    // "feat-auth-2" would answer for "feat-auth" and we would
+                    // then kill the exact "feat-auth", which matches nothing,
+                    // leaving the real session running with its worktree gone.
                     let check_new = std::process::Command::new("tmux")
-                        .args(["has-session", "-t", &tmux_name])
+                        .args(["has-session", "-t", &format!("={tmux_name}")])
                         .output();
                     let final_name = if check_new.map(|o| o.status.success()).unwrap_or(false) {
                         info!("Found tmux session with new format: {}", tmux_name);

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -1874,7 +1874,13 @@ impl InteractiveSessionManager {
 
         if let Some(ref name) = tmux_session_name {
             info!("Attempting to kill tmux session: {}", name);
-            let output = Command::new("tmux").args(["kill-session", "-t", name]).output().await?;
+            // `=name` forces an exact target: bare `-t name` resolves exact, then
+            // prefix, then fnmatch, so deleting "feat-auth" would kill a live
+            // "feat-auth-2".
+            let output = Command::new("tmux")
+                .args(["kill-session", "-t", &format!("={name}")])
+                .output()
+                .await?;
 
             if output.status.success() {
                 info!("Successfully killed tmux session: {}", name);
@@ -2033,14 +2039,22 @@ impl InteractiveSessionManager {
         work_dir: &Path,
     ) -> Result<(), InteractiveSessionError> {
         // Check if session already exists
-        let check = Command::new("tmux").args(["has-session", "-t", session_name]).output().await?;
+        // Both targets are exact. `has-session -t name` prefix-matches, so a live
+        // "feat-auth-2" would answer for "feat-auth" and the kill below would
+        // then destroy it.
+        let exact_target = format!("={session_name}");
+        let check =
+            Command::new("tmux").args(["has-session", "-t", &exact_target]).output().await?;
 
         if check.status.success() {
             warn!(
                 "Tmux session '{}' already exists, killing it first",
                 session_name
             );
-            Command::new("tmux").args(["kill-session", "-t", session_name]).output().await?;
+            Command::new("tmux")
+                .args(["kill-session", "-t", &exact_target])
+                .output()
+                .await?;
         }
 
         // Create new detached tmux session

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -2996,6 +2996,9 @@ trust_level = "trusted"
 
     #[cfg(unix)]
     #[tokio::test]
+    // The env guard is deliberately held across the awaits: that is what makes
+    // the AINB_HOME isolation cover the whole body. Test-only, single-threaded.
+    #[allow(clippy::await_holding_lock)]
     async fn failed_launch_rollback_removes_only_exact_owned_resources() {
         if !Command::new("tmux")
             .arg("-V")
@@ -3007,7 +3010,9 @@ trust_level = "trusted"
             return;
         }
 
-        let _env = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _env = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let home = tempfile::tempdir().expect("temp home");
         let prior_home = std::env::var_os("AINB_HOME");
         std::env::set_var("AINB_HOME", home.path());
@@ -3174,7 +3179,9 @@ trust_level = "trusted"
 
         // Hold the shared env lock + force the default port so the base URL is
         // deterministic regardless of other tests mutating AINB_HEADROOM_PORT.
-        let _guard = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _guard = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let old = std::env::var_os("AINB_HEADROOM_PORT");
         std::env::remove_var("AINB_HEADROOM_PORT");
 
@@ -3204,7 +3211,9 @@ trust_level = "trusted"
 
     #[test]
     fn headroom_base_url_honors_port_override() {
-        let _guard = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _guard = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let key = "AINB_HEADROOM_PORT";
         let old = std::env::var_os(key);
 
@@ -3306,7 +3315,9 @@ trust_level = "trusted"
     fn atc_control_dir_renders_as_an_atc_instance() {
         // AINB_HOME is process-global; serialise with every other env-mutating
         // test in the crate via the shared lock.
-        let _env = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _env = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let home = tempfile::tempdir().expect("tempdir");
         // Save and restore rather than blindly removing: a runner that sets
@@ -3801,7 +3812,9 @@ trust_level = "trusted"
         // AINB_HOME is process-global; serialise with every other env-mutating
         // test in the crate (including `concurrent_mutate_does_not_lose_updates`)
         // via the shared lock so parallel runs don't clobber each other's home.
-        let _env = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _env = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let dir = TempDir::new().expect("tempdir");
         // Point AINB_HOME at our temp dir so SessionStore::storage_path() uses it.
@@ -3849,12 +3862,17 @@ trust_level = "trusted"
     }
 
     #[tokio::test]
+    // The env guard is deliberately held across the awaits: that is what makes
+    // the AINB_HOME isolation cover the whole body. Test-only, single-threaded.
+    #[allow(clippy::await_holding_lock)]
     async fn persisted_launch_settings_survive_live_session_discovery() {
         use crate::models::session::SessionAgentType;
         use chrono::Utc;
         use tempfile::TempDir;
 
-        let _env = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _env = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let dir = TempDir::new().expect("tempdir");
         std::env::set_var("AINB_HOME", dir.path());
@@ -3961,7 +3979,9 @@ trust_level = "trusted"
         use std::sync::{Arc, Barrier};
         use tempfile::TempDir;
 
-        let _env = crate::headroom::HEADROOM_ENV_LOCK.lock().unwrap();
+        let _env = crate::headroom::HEADROOM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let dir = TempDir::new().expect("tempdir");
         std::env::set_var("AINB_HOME", dir.path());

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -1622,7 +1622,7 @@ async fn run_tui_loop(
 
                         // Check if session already exists
                         let has_session = Command::new("tmux")
-                            .args(["has-session", "-t", &tmux_name])
+                            .args(["has-session", "-t", &format!("={tmux_name}")])
                             .output()
                             .await
                             .map(|o| o.status.success())

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -1284,8 +1284,11 @@ async fn run_tui_loop(
 
                         info!("Killing other tmux session '{}'", session_name);
 
+                        // `=name` is an exact target. A bare `-t` resolves
+                        // exact, then prefix, so killing "feat-auth" could take
+                        // out a live "feat-auth-2".
                         let output = Command::new("tmux")
-                            .args(["kill-session", "-t", &session_name])
+                            .args(["kill-session", "-t", &format!("={session_name}")])
                             .output()
                             .await;
 
@@ -1339,8 +1342,9 @@ async fn run_tui_loop(
                         for session_name in &session_names {
                             info!("Killing other tmux session '{}'", session_name);
 
+                            // Exact target, see the single-session kill above.
                             let output = Command::new("tmux")
-                                .args(["kill-session", "-t", session_name])
+                                .args(["kill-session", "-t", &format!("={session_name}")])
                                 .output()
                                 .await;
 
@@ -1716,8 +1720,9 @@ async fn run_tui_loop(
 
                         if let Some((tmux_name, workspace_name)) = shell_info {
                             // Kill the tmux session
+                            // Exact target: a bare `-t` prefix-matches.
                             let _ = Command::new("tmux")
-                                .args(["kill-session", "-t", &tmux_name])
+                                .args(["kill-session", "-t", &format!("={tmux_name}")])
                                 .output()
                                 .await;
 

--- a/ainb-tui/crates/ainb-core/src/otel/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/otel/mod.rs
@@ -490,7 +490,7 @@ pub fn alloy_session_running() -> bool {
     // `tmux has-session` writes "can't find session" to stderr on a miss —
     // silence it; the exit status is the signal we care about.
     Command::new("tmux")
-        .args(["has-session", "-t", ALLOY_TMUX_SESSION])
+        .args(["has-session", "-t", &format!("={ALLOY_TMUX_SESSION}")])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -468,7 +468,7 @@ mod tests {
 
         // The session must still exist — tmux owns it, not our client.
         let alive = Command::new("tmux")
-            .args(["has-session", "-t", &session])
+            .args(["has-session", "-t", &format!("={session}")])
             .status()
             .map(|s| s.success())
             .unwrap_or(false);

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -311,7 +311,8 @@ mod tests {
     /// wildcard/kill-server, per the tmux safety rule).
     fn new_session(tag: &str) -> String {
         let name = format!("ainb-embed-test-{}-{}", tag, std::process::id());
-        let _ = Command::new("tmux").args(["kill-session", "-t", &name]).output();
+        // Exact target, never a prefix match.
+        let _ = Command::new("tmux").args(["kill-session", "-t", &format!("={name}")]).output();
         let ok = Command::new("tmux")
             .args([
                 "new-session",
@@ -332,7 +333,8 @@ mod tests {
     }
 
     fn kill_session(name: &str) {
-        let _ = Command::new("tmux").args(["kill-session", "-t", name]).output();
+        // Exact target, never a prefix match.
+        let _ = Command::new("tmux").args(["kill-session", "-t", &format!("={name}")]).output();
     }
 
     fn screen_contains(client: &EmbedClient, needle: &str, deadline: Instant) -> bool {

--- a/ainb-tui/crates/ainb-core/src/tmux/process_detection.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/process_detection.rs
@@ -138,7 +138,7 @@ impl ClaudeProcessDetector {
     /// * `Err(_)` - Error running tmux command
     pub fn session_exists(&self, tmux_session_name: &str) -> Result<bool> {
         let output = Command::new("tmux")
-            .args(&["has-session", "-t", tmux_session_name])
+            .args(["has-session", "-t", &format!("={tmux_session_name}")])
             .output()
             .context("Failed to execute tmux has-session")?;
 

--- a/ainb-tui/crates/ainb-core/src/tmux/session.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/session.rs
@@ -261,7 +261,9 @@ impl TmuxSession {
 
         // Kill the tmux session
         let output = Command::new("tmux")
-            .args(["kill-session", "-t", &self.sanitized_name])
+            // Exact target: a bare `-t` prefix-matches, so cleaning up
+            // "ainb-repo-feat-auth" could kill a live "ainb-repo-feat-auth-2".
+            .args(["kill-session", "-t", &format!("={}", self.sanitized_name)])
             .output()
             .await?;
 

--- a/ainb-tui/crates/ainb-core/src/tmux/session.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/session.rs
@@ -242,7 +242,7 @@ impl TmuxSession {
     /// * `bool` - True if the session exists, false otherwise
     pub async fn does_session_exist(&self) -> bool {
         let output = Command::new("tmux")
-            .args(["has-session", "-t", &self.sanitized_name])
+            .args(["has-session", "-t", &format!("={}", self.sanitized_name)])
             .output()
             .await;
 

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/send/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/send/tmux.rs
@@ -1216,7 +1216,7 @@ fn last_prompt_line_pending(pane: &str, base: Option<PasteTally>) -> bool {
 
 pub async fn tmux_session_exists(name: &str) -> bool {
     Command::new("tmux")
-        .args(["has-session", "-t", name])
+        .args(["has-session", "-t", &format!("={name}")])
         .status()
         .await
         .is_ok_and(|s| s.success())

--- a/ainb-tui/crates/ainb-hangar-daemon/src/interactive.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/interactive.rs
@@ -71,7 +71,12 @@ pub fn session_name_for(task_id: &str) -> String {
 /// Best-effort: a session already gone yields a non-zero status that is ignored
 /// (killing an absent session is a harmless no-op).
 pub(crate) async fn kill_session(session_name: &str) {
-    let _ = Command::new("tmux").args(["kill-session", "-t", session_name]).status().await;
+    // `=name` is exact. A bare `-t` resolves exact, then prefix, so a reap of a
+    // dead "ainb-run-abc" could kill a live "ainb-run-abc2".
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", &format!("={session_name}")])
+        .status()
+        .await;
 }
 
 /// A spawned interactive tmux session awaiting completion.
@@ -243,7 +248,7 @@ impl TmuxRun {
     /// abort never returns while an orphan pane is still alive.
     async fn kill_and_confirm_reaped(&self) {
         let killed = Command::new("tmux")
-            .args(["kill-session", "-t", &self.session_name])
+            .args(["kill-session", "-t", &format!("={}", self.session_name)])
             .status()
             .await;
         if let Ok(s) = killed {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -4377,7 +4377,9 @@ fn managed_codex_tmux_name(thread_id: &str, now_ms: i64) -> String {
 async fn kill_tmux_session_exact(session_name: &str) -> Result<(), String> {
     let tmux_binary = std::ffi::OsString::from("tmux");
     let output = tokio::process::Command::new(tmux_binary)
-        .args(["kill-session", "-t", session_name])
+        // The name says exact, so the target has to be: a bare `-t` resolves
+        // exact, then prefix, then fnmatch.
+        .args(["kill-session", "-t", &format!("={session_name}")])
         .output()
         .await
         .map_err(|error| format!("exact tmux stop failed: {error}"))?;


### PR DESCRIPTION
## The bug

In the TUI, pressing `d` on a single session shows a Stop / Delete / Cancel dialog that defaults to **Stop** and preserves the worktree.

With rows checked (multi-select), the same key took a different branch and fired a destructive bulk delete **immediately**: no dialog, no Stop option, no uncommitted-work warning. `AppEvent::DeleteSession` set `AsyncAction::BulkDeleteSessions(ids)` directly, which runs `delete_session_core` -> `delete_interactive_session` -> `remove_session` -> `remove_worktree`. Shift+D (`DeleteSelectedSessions`) had the same hole.

Real-world impact on 2026-09-01: one keypress with 12 rows checked destroyed 12 worktrees in under three minutes. Several held uncommitted work, and two of those branches existed on no remote, so that work is gone permanently.

## The fix

Both bulk paths now go through the same confirmation machinery as the single-row path, generalised to one-or-many rather than duplicated:

- `show_bulk_delete_or_stop_confirmation` builds the existing tri-option `ConfirmationDialog`: **Stop all / Delete all / Cancel**, `selected_index: 0` so the safe option is the default, exactly like the single-row dialog.
- The dialog states how many sessions are affected and names them (`2 session(s): alpha, beta`), truncating to three names plus `and N more` for long selections.
- The uncommitted-work warning is carried into the bulk path. `bulk_uncommitted_counts` walks the selected sessions and the warning names the dirty ones with their file counts (`4 uncommitted file(s) in 2 session(s): alpha (3), beta (1)`), because that is precisely the work Delete all would destroy.
- New `ConfirmAction::BulkStopSessions` / `AsyncAction::BulkStopSessions` stop every selected session through the existing `stop_interactive_session`, so tmux is killed and the worktree, the `sessions.json` entry, and the `by-session/<uuid>` symlink all survive.
- Selected ids are collected in list order rather than `HashSet` order, so the names the dialog prints match the list.

Two supporting changes:

- The workspace refresh moved out of `stop_interactive_session` and up to its callers, so a bulk stop repaints once instead of rescanning every workspace per session (12 selected sessions used to mean 12 full rescans).
- The confirmation dialog box was a fixed 8 rows (11 with a warning), which clipped the bulk message and its multi-session warning. It now grows when the wrapped body needs more rows; short dialogs keep their existing size exactly.

`remove_worktree`'s `--force` retry behaviour is untouched, as agreed.

## Tests

Nine behavioural tests in `state_tests.rs`, following the crate's existing conventions:

| Test | Proves |
|---|---|
| `bulk_delete_asks_before_destroying_anything` | `d` with rows checked queues nothing; dialog is Stop all / Delete all / Cancel, defaulting to Stop; selection survives |
| `bulk_delete_selected_sessions_asks_before_destroying_anything` | Shift+D takes the same confirmed path |
| `bulk_delete_dialog_names_the_affected_sessions` | count and names are in the dialog |
| `bulk_dialog_default_option_queues_stop_not_delete` | accepting the default queues a stop, never a delete |
| `bulk_dialog_delete_option_queues_bulk_delete` | Delete all still deletes |
| `bulk_dialog_cancel_does_nothing` | Cancel and Esc both queue nothing and leave the selection intact |
| `bulk_session_summary_truncates_long_selections` | long lists stay readable |
| `bulk_uncommitted_warning_names_the_dirty_sessions` | the warning names dirty sessions and their file counts |
| `bulk_stop_preserves_every_worktree` | runs the real bulk stop over real directories and asserts every worktree, and the uncommitted file in it, is still on disk |

Verified the suite catches the original bug: reverting the confirmation (queuing `BulkDeleteSessions` directly again) turns four of these red, including `bulk_delete_asks_before_destroying_anything`. Restored and green again.

## Verification

- `cargo build -p ainb`: passes.
- `cargo test -p ainb --lib`: 2125 passed, 9 failed. All 9 failures are pre-existing and unrelated (env-var/`ENV_LOCK` tests in `fleet::read::current_state`, `headroom`, and `interactive::session_manager`). Proven by checking the four touched files out at the base commit `296065a3` and re-running: the identical 9 fail there, with 2116 passing (the 9 new tests being the difference).
- `cargo fmt -p ainb -- --check`: clean.
- `cargo clippy -p ainb --lib --tests`: no diagnostics on any new or moved line. The lints that remain in the touched files sit on pre-existing code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added confirmation before bulk session actions.
  - Choose to stop sessions, delete sessions, or cancel.
  - Bulk actions accurately report worktree counts and preserve worktrees when stopping.
  - Selections remain intact when actions are canceled or partially fail.

- **Bug Fixes**
  - Confirmation dialogs now resize correctly in small terminals and preserve warning text.
  - Improved handling of already-stopped sessions.
  - Prevented similarly named sessions from being stopped or deleted accidentally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->