### PR TITLE
fix: one clone cache root for the CLI and the TUI

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -29,7 +29,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     validate_provider_installed(&provider)?;
 
     // Step 1: Resolve repository path
-    let repo_path = resolve_repo_path(&args)?;
+    let repo_path = resolve_repo_path(&args).await?;
     info!("Using repository: {}", repo_path.display());
 
     // Step 2: Determine workspace name and working directory
@@ -394,7 +394,7 @@ fn setup_mcp_pool(work_dir: &std::path::Path, session_name: &str) {
 }
 
 /// Resolve the repository path from args or current directory
-fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
+async fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
     // Priority: --repo > --remote-repo > current directory
     if let Some(ref repo) = args.repo {
         let path = if repo.is_absolute() {
@@ -412,7 +412,7 @@ fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
 
     if let Some(ref remote) = args.remote_repo {
         // Clone or fetch remote repository
-        return clone_remote_repo(remote);
+        return clone_remote_repo(remote).await;
     }
 
     // Use current directory
@@ -496,7 +496,7 @@ fn github_shorthand(remote: &str) -> Option<crate::git::RepoSource> {
 /// groups on a session's source repository path, so the same repo rendered as
 /// two identically-named rows depending on whether the session was spawned
 /// from the CLI or the TUI.
-fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
+async fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
     let (source, parsed) = parse_remote_repo(remote)?;
     let manager = crate::git::RemoteRepoManager::new()?;
 
@@ -506,13 +506,14 @@ fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
     // probe would race a concurrent publish and `clone_repo` re-checks anyway.
     println!("Preparing {}...", source.to_clone_url());
 
-    // Blocking git under `#[tokio::main]`: `ainb run` resolves its repo as the
-    // second statement of `execute`, before anything is spawned onto the
-    // runtime, so there is no task to starve. This is narrower than the
-    // `Command::output().await` it replaced — the TUI's own call sites wrap the
-    // same manager in `spawn_blocking` because they run inside a live event
-    // loop. Anything that starts work before repo resolution must do the same.
-    manager.clone_repo(&source, &parsed).map_err(|e| anyhow::anyhow!(e))
+    // `RemoteRepoManager` shells out synchronously, and this replaced a
+    // `tokio::process::Command::output().await`, so hand it to a blocking
+    // thread rather than holding a runtime worker for the whole transfer. The
+    // TUI's own call sites do the same with this manager.
+    tokio::task::spawn_blocking(move || manager.clone_repo(&source, &parsed))
+        .await
+        .context("clone task panicked")?
+        .map_err(|e| anyhow::anyhow!(e))
 }
 
 // The current-branch lookup lives in `crate::git::current_branch_at`. It used

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -431,17 +431,25 @@ fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
 /// Parse a `--remote-repo` value into the source and the host/owner/repo
 /// components `RemoteRepoManager` keys its cache path on.
 ///
-/// Parses with `from_input` rather than smart-parse `parse_with` so an
-/// `owner/repo` value cannot be captured by a directory of that name under the
-/// cwd, then REJECTS anything that did not classify as a remote. Both parsers
-/// have a `LocalPath` fallback that swallows unrecognised input, and a local
-/// path is not something this flag can clone: `to_clone_url` hands the raw
-/// string to `git clone`, so a value beginning with `-` would be read by git as
-/// an option rather than a repository. Local checkouts belong on `--repo`.
+/// Reads a bare `owner/repo` as a GitHub shorthand first (see
+/// [`github_shorthand`]), falls back to `from_input` for URL forms, and then
+/// REJECTS anything that did not classify as a remote. `from_input` is used
+/// rather than smart-parse `parse_with` so an `owner/repo` value cannot be
+/// captured by a directory of that name under the cwd; both parsers have a
+/// `LocalPath` fallback that swallows unrecognised input, and a local path is
+/// not something this flag can clone: `to_clone_url` hands the raw string to
+/// `git clone`, so a value beginning with `-` would be read by git as an option
+/// rather than a repository. Local checkouts belong on `--repo`.
 fn parse_remote_repo(remote: &str) -> Result<(crate::git::RepoSource, crate::git::ParsedRepo)> {
-    #[allow(deprecated)]
-    let source = crate::git::RepoSource::from_input(remote)
-        .with_context(|| format!("Cannot parse --remote-repo value: {remote}"))?;
+    let source = match github_shorthand(remote) {
+        Some(source) => source,
+        None =>
+        {
+            #[allow(deprecated)]
+            crate::git::RepoSource::from_input(remote)
+                .with_context(|| format!("Cannot parse --remote-repo value: {remote}"))?
+        }
+    };
     anyhow::ensure!(
         source.is_remote(),
         "--remote-repo needs a remote: `owner/repo`, an https:// URL, or git@host:owner/repo. \
@@ -451,6 +459,32 @@ fn parse_remote_repo(remote: &str) -> Result<(crate::git::RepoSource, crate::git
         .parse_components()
         .with_context(|| format!("Cannot extract repo components from: {remote}"))?;
     Ok((source, parsed))
+}
+
+/// Read `owner/repo` as a GitHub shorthand, which is what `--remote-repo`
+/// declares its bare values to be.
+///
+/// `from_input`'s own shorthand branch rejects a `.` anywhere in the value, so
+/// `mrdoob/three.js` fell through to its no-protocol-URL heuristic and became
+/// `https://mrdoob/three.js`, which has no owner segment to parse. The inline
+/// clone this replaced wrapped every bare value into
+/// `https://github.com/<value>.git`, so dotted repo names used to work.
+///
+/// Deliberately strict about what counts as a bare shorthand: a segment that
+/// carries a scheme, a host, a path, or a leading `-` is left to `from_input`,
+/// which classifies URLs, and to the `is_remote` gate, which rejects the rest.
+fn github_shorthand(remote: &str) -> Option<crate::git::RepoSource> {
+    let (owner, repo) = remote.split_once('/')?;
+    let repo = repo.strip_suffix(".git").unwrap_or(repo);
+    let bare = |segment: &str| {
+        !segment.is_empty()
+            && !segment.contains(['/', '\\', ':', ' ', '@'])
+            && !segment.starts_with(['-', '.', '~'])
+    };
+    (bare(owner) && bare(repo)).then(|| crate::git::RepoSource::GithubShorthand {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    })
 }
 
 /// Clone (or fetch) a remote repository into AINB's shared clone cache.
@@ -466,8 +500,18 @@ fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
     let (source, parsed) = parse_remote_repo(remote)?;
     let manager = crate::git::RemoteRepoManager::new()?;
 
-    // Blocking git under `#[tokio::main]`: `ainb run` resolves its repo before
-    // anything else is on the runtime, so there is no task to starve.
+    // `clone_repo` reports through `info!`, which a plain `ainb run` does not
+    // print, so say something before a transfer that can take minutes. Phrased
+    // for both outcomes rather than probing `is_cached` for a better verb: the
+    // probe would race a concurrent publish and `clone_repo` re-checks anyway.
+    println!("Preparing {}...", source.to_clone_url());
+
+    // Blocking git under `#[tokio::main]`: `ainb run` resolves its repo as the
+    // second statement of `execute`, before anything is spawned onto the
+    // runtime, so there is no task to starve. This is narrower than the
+    // `Command::output().await` it replaced — the TUI's own call sites wrap the
+    // same manager in `spawn_blocking` because they run inside a live event
+    // loop. Anything that starts work before repo resolution must do the same.
     manager.clone_repo(&source, &parsed).map_err(|e| anyhow::anyhow!(e))
 }
 
@@ -724,6 +768,7 @@ mod tests {
 
         for remote in [
             "stevengonsalvez/agents-in-a-box",
+            "stevengonsalvez/agents-in-a-box.git",
             "https://github.com/stevengonsalvez/agents-in-a-box.git",
         ] {
             let (_source, parsed) = parse_remote_repo(remote).expect("parse");
@@ -731,6 +776,33 @@ mod tests {
                 manager.get_cache_path(&parsed),
                 tmp.path().join("github.com").join("stevengonsalvez").join("agents-in-a-box"),
                 "{remote} must resolve to the host/owner/repo cache path the TUI uses"
+            );
+        }
+    }
+
+    /// A repo whose NAME contains a dot is an ordinary GitHub shorthand.
+    ///
+    /// `from_input`'s shorthand branch rejects a `.` anywhere in the value, so
+    /// `mrdoob/three.js` became `https://mrdoob/three.js` and failed to parse.
+    /// The inline clone this replaced wrapped bare values into
+    /// `https://github.com/<value>.git`, so these used to clone fine.
+    #[test]
+    fn remote_repo_accepts_shorthand_with_a_dotted_repo_name() {
+        for (remote, owner, repo) in [
+            ("mrdoob/three.js", "mrdoob", "three.js"),
+            ("chartjs/Chart.js", "chartjs", "Chart.js"),
+            ("socketio/socket.io", "socketio", "socket.io"),
+        ] {
+            let (_source, parsed) = parse_remote_repo(remote)
+                .unwrap_or_else(|e| panic!("{remote} must parse as a shorthand: {e}"));
+            assert_eq!(
+                (
+                    parsed.host.as_str(),
+                    parsed.owner.as_str(),
+                    parsed.repo_name.as_str()
+                ),
+                ("github.com", owner, repo),
+                "{remote}"
             );
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -432,7 +432,7 @@ async fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
 /// components `RemoteRepoManager` keys its cache path on.
 ///
 /// Reads a bare `owner/repo` as a GitHub shorthand first (see
-/// [`github_shorthand`]), falls back to `from_input` for URL forms, and then
+/// [`crate::git::RepoSource::github_shorthand`]), falls back to `from_input` for URL forms, and then
 /// REJECTS anything that did not classify as a remote. `from_input` is used
 /// rather than smart-parse `parse_with` so an `owner/repo` value cannot be
 /// captured by a directory of that name under the cwd; both parsers have a
@@ -441,7 +441,7 @@ async fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
 /// `git clone`, so a value beginning with `-` would be read by git as an option
 /// rather than a repository. Local checkouts belong on `--repo`.
 fn parse_remote_repo(remote: &str) -> Result<(crate::git::RepoSource, crate::git::ParsedRepo)> {
-    let source = match github_shorthand(remote) {
+    let source = match crate::git::RepoSource::github_shorthand(remote) {
         Some(source) => source,
         None =>
         {
@@ -459,32 +459,6 @@ fn parse_remote_repo(remote: &str) -> Result<(crate::git::RepoSource, crate::git
         .parse_components()
         .with_context(|| format!("Cannot extract repo components from: {remote}"))?;
     Ok((source, parsed))
-}
-
-/// Read `owner/repo` as a GitHub shorthand, which is what `--remote-repo`
-/// declares its bare values to be.
-///
-/// `from_input`'s own shorthand branch rejects a `.` anywhere in the value, so
-/// `mrdoob/three.js` fell through to its no-protocol-URL heuristic and became
-/// `https://mrdoob/three.js`, which has no owner segment to parse. The inline
-/// clone this replaced wrapped every bare value into
-/// `https://github.com/<value>.git`, so dotted repo names used to work.
-///
-/// Deliberately strict about what counts as a bare shorthand: a segment that
-/// carries a scheme, a host, a path, or a leading `-` is left to `from_input`,
-/// which classifies URLs, and to the `is_remote` gate, which rejects the rest.
-fn github_shorthand(remote: &str) -> Option<crate::git::RepoSource> {
-    let (owner, repo) = remote.split_once('/')?;
-    let repo = repo.strip_suffix(".git").unwrap_or(repo);
-    let bare = |segment: &str| {
-        !segment.is_empty()
-            && !segment.contains(['/', '\\', ':', ' ', '@'])
-            && !segment.starts_with(['-', '.', '~'])
-    };
-    (bare(owner) && bare(repo)).then(|| crate::git::RepoSource::GithubShorthand {
-        owner: owner.to_string(),
-        repo: repo.to_string(),
-    })
 }
 
 /// Clone (or fetch) a remote repository into AINB's shared clone cache.
@@ -793,6 +767,9 @@ mod tests {
             ("mrdoob/three.js", "mrdoob", "three.js"),
             ("chartjs/Chart.js", "chartjs", "Chart.js"),
             ("socketio/socket.io", "socketio", "socket.io"),
+            // Surrounding whitespace is trimmed rather than carried into the
+            // clone URL and the cache directory name.
+            (" mrdoob/three.js\n", "mrdoob", "three.js"),
         ] {
             let (_source, parsed) = parse_remote_repo(remote)
                 .unwrap_or_else(|e| panic!("{remote} must parse as a shorthand: {e}"));
@@ -847,6 +824,27 @@ mod tests {
             assert!(
                 parse_remote_repo(remote).is_err(),
                 "{remote} is not a remote and must not reach `git clone`"
+            );
+        }
+    }
+
+    /// A host-shaped `<host>/<repo>` is NOT a GitHub shorthand.
+    ///
+    /// Reading it as one turns a clean local parse error into a GitHub clone
+    /// attempt, which reports back as "Authentication failed - check your git
+    /// credentials" — the worst available answer for someone who typed a
+    /// GitLab path. The dot in the OWNER segment is what separates it from a
+    /// dotted repo NAME like `mrdoob/three.js`.
+    #[test]
+    fn remote_repo_does_not_read_a_host_path_as_a_shorthand() {
+        for remote in ["gitlab.com/repo", "git.example.com/repo"] {
+            assert!(
+                crate::git::RepoSource::github_shorthand(remote).is_none(),
+                "{remote} has a host-shaped owner and is not a shorthand"
+            );
+            assert!(
+                parse_remote_repo(remote).is_err(),
+                "{remote} must fail locally, not as a GitHub credentials error"
             );
         }
     }

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -8,7 +8,6 @@
 use anyhow::{Context, Result};
 use chrono::Utc;
 use std::path::PathBuf;
-use tokio::process::Command;
 use tokio::time::{Duration, Instant, sleep};
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -30,7 +29,7 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     validate_provider_installed(&provider)?;
 
     // Step 1: Resolve repository path
-    let repo_path = resolve_repo_path(&args).await?;
+    let repo_path = resolve_repo_path(&args)?;
     info!("Using repository: {}", repo_path.display());
 
     // Step 2: Determine workspace name and working directory
@@ -395,7 +394,7 @@ fn setup_mcp_pool(work_dir: &std::path::Path, session_name: &str) {
 }
 
 /// Resolve the repository path from args or current directory
-async fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
+fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
     // Priority: --repo > --remote-repo > current directory
     if let Some(ref repo) = args.repo {
         let path = if repo.is_absolute() {
@@ -413,7 +412,7 @@ async fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
 
     if let Some(ref remote) = args.remote_repo {
         // Clone or fetch remote repository
-        return clone_remote_repo(remote).await;
+        return clone_remote_repo(remote);
     }
 
     // Use current directory
@@ -429,68 +428,42 @@ async fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
     Ok(current_dir)
 }
 
-/// Clone a remote repository to a local cache directory
-async fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
-    // Normalize remote URL
-    let url = if remote.starts_with("http") || remote.starts_with("git@") {
-        remote.to_string()
-    } else {
-        // Assume GitHub shorthand: owner/repo
-        format!("https://github.com/{remote}.git")
-    };
+/// Parse a `--remote-repo` value into the source and the host/owner/repo
+/// components `RemoteRepoManager` keys its cache path on.
+///
+/// Uses `from_input` rather than smart-parse `parse_with`: `--remote-repo` is
+/// remote by contract, and `parse_with` would resolve `owner/repo` to a local
+/// directory of that name under the cwd.
+fn parse_remote_repo(remote: &str) -> Result<(crate::git::RepoSource, crate::git::ParsedRepo)> {
+    #[allow(deprecated)]
+    let source = crate::git::RepoSource::from_input(remote)
+        .with_context(|| format!("Cannot parse --remote-repo value: {remote}"))?;
+    let parsed = source
+        .parse_components()
+        .with_context(|| format!("Cannot extract repo components from: {remote}"))?;
+    Ok((source, parsed))
+}
 
-    // Extract repo name for cache directory (sanitized to prevent path traversal)
-    let repo_name = url
-        .trim_end_matches(".git")
-        .rsplit('/')
-        .next()
-        .unwrap_or("repo")
-        .replace("..", "")
-        .replace(['/', '\\'], "-");
+/// Clone (or fetch) a remote repository into AINB's shared clone cache.
+///
+/// Routes through [`RemoteRepoManager`] so the CLI lands clones in the SAME
+/// place the TUI does: `~/.agents-in-a-box/repos/<host>/<owner>/<repo>`. This
+/// used to clone into a private flat `~/.agents-in-a-box/repo-cache/<repo>`,
+/// which gave one GitHub repo two on-disk roots. The workspace list keys its
+/// groups on a session's source repository path, so the same repo rendered as
+/// two identically-named rows depending on whether the session was spawned
+/// from the CLI or the TUI.
+fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
+    let (source, parsed) = parse_remote_repo(remote)?;
 
-    // Validate repo name is safe
-    let repo_name = if repo_name.is_empty() || repo_name == "." {
-        "repo".to_string()
-    } else {
-        repo_name
-    };
-
-    let cache_dir = dirs::home_dir()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
-        .join(".agents-in-a-box")
-        .join("repo-cache");
-
-    std::fs::create_dir_all(&cache_dir)?;
-
-    let repo_path = cache_dir.join(repo_name);
-
-    if repo_path.exists() {
+    let manager = crate::git::RemoteRepoManager::new()?;
+    if manager.is_cached(&parsed) {
         info!("Repository already cached, fetching updates...");
-        let output = Command::new("git")
-            .current_dir(&repo_path)
-            .args(["fetch", "--all"])
-            .output()
-            .await?;
-
-        if !output.status.success() {
-            warn!(
-                "Failed to fetch updates: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
     } else {
-        println!("Cloning {url}...");
-        let output = Command::new("git").arg("clone").arg(&url).arg(&repo_path).output().await?;
-
-        if !output.status.success() {
-            anyhow::bail!(
-                "Failed to clone repository: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
+        println!("Cloning {}...", source.to_clone_url());
     }
 
-    Ok(repo_path)
+    manager.clone_repo(&source, &parsed).map_err(|e| anyhow::anyhow!(e))
 }
 
 // The current-branch lookup lives in `crate::git::current_branch_at`. It used
@@ -730,6 +703,50 @@ mod tests {
     use crate::cli::Tool;
 
     use crate::test_support::git_bin;
+
+    /// `--remote-repo` must land in the SAME cache root the TUI clones into:
+    /// `<cache>/<host>/<owner>/<repo>`. The CLI used to clone into a private
+    /// flat `~/.agents-in-a-box/repo-cache/<repo>`, which gave one GitHub repo
+    /// two on-disk roots and split its sessions into two identically-named
+    /// workspace groups (the list keys groups on the source repository path).
+    ///
+    /// Asserts the path the CLI derives, not a clone: no network.
+    #[test]
+    fn remote_repo_resolves_into_the_shared_clone_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let manager = crate::git::RemoteRepoManager::with_cache_dir(tmp.path().to_path_buf())
+            .expect("manager");
+
+        for remote in [
+            "stevengonsalvez/agents-in-a-box",
+            "https://github.com/stevengonsalvez/agents-in-a-box.git",
+        ] {
+            let (_source, parsed) = parse_remote_repo(remote).expect("parse");
+            assert_eq!(
+                manager.get_cache_path(&parsed),
+                tmp.path().join("github.com").join("stevengonsalvez").join("agents-in-a-box"),
+                "{remote} must resolve to the host/owner/repo cache path the TUI uses"
+            );
+        }
+    }
+
+    /// A `--remote-repo` value whose path segments climb out of the cache root
+    /// must be rejected, not joined. `get_cache_path` concatenates
+    /// host/owner/repo onto the cache dir, so `../..` would otherwise land the
+    /// clone on the AINB state directory itself.
+    #[test]
+    fn remote_repo_rejects_path_traversal() {
+        for remote in [
+            "https://github.com/../../evil",
+            "https://github.com/owner/..",
+            "git@github.com:../evil.git",
+        ] {
+            assert!(
+                parse_remote_repo(remote).is_err(),
+                "{remote} must not resolve to a cache path"
+            );
+        }
+    }
 
     /// Run a git command in `dir`, failing the test with git's own stderr.
     fn git(dir: &std::path::Path, args: &[&str]) {

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -431,13 +431,22 @@ fn resolve_repo_path(args: &RunArgs) -> Result<PathBuf> {
 /// Parse a `--remote-repo` value into the source and the host/owner/repo
 /// components `RemoteRepoManager` keys its cache path on.
 ///
-/// Uses `from_input` rather than smart-parse `parse_with`: `--remote-repo` is
-/// remote by contract, and `parse_with` would resolve `owner/repo` to a local
-/// directory of that name under the cwd.
+/// Parses with `from_input` rather than smart-parse `parse_with` so an
+/// `owner/repo` value cannot be captured by a directory of that name under the
+/// cwd, then REJECTS anything that did not classify as a remote. Both parsers
+/// have a `LocalPath` fallback that swallows unrecognised input, and a local
+/// path is not something this flag can clone: `to_clone_url` hands the raw
+/// string to `git clone`, so a value beginning with `-` would be read by git as
+/// an option rather than a repository. Local checkouts belong on `--repo`.
 fn parse_remote_repo(remote: &str) -> Result<(crate::git::RepoSource, crate::git::ParsedRepo)> {
     #[allow(deprecated)]
     let source = crate::git::RepoSource::from_input(remote)
         .with_context(|| format!("Cannot parse --remote-repo value: {remote}"))?;
+    anyhow::ensure!(
+        source.is_remote(),
+        "--remote-repo needs a remote: `owner/repo`, an https:// URL, or git@host:owner/repo. \
+         Use --repo for a local checkout. Got: {remote}"
+    );
     let parsed = source
         .parse_components()
         .with_context(|| format!("Cannot extract repo components from: {remote}"))?;
@@ -455,14 +464,10 @@ fn parse_remote_repo(remote: &str) -> Result<(crate::git::RepoSource, crate::git
 /// from the CLI or the TUI.
 fn clone_remote_repo(remote: &str) -> Result<PathBuf> {
     let (source, parsed) = parse_remote_repo(remote)?;
-
     let manager = crate::git::RemoteRepoManager::new()?;
-    if manager.is_cached(&parsed) {
-        info!("Repository already cached, fetching updates...");
-    } else {
-        println!("Cloning {}...", source.to_clone_url());
-    }
 
+    // Blocking git under `#[tokio::main]`: `ainb run` resolves its repo before
+    // anything else is on the runtime, so there is no task to starve.
     manager.clone_repo(&source, &parsed).map_err(|e| anyhow::anyhow!(e))
 }
 
@@ -744,6 +749,31 @@ mod tests {
             assert!(
                 parse_remote_repo(remote).is_err(),
                 "{remote} must not resolve to a cache path"
+            );
+        }
+    }
+
+    /// Anything that does not classify as a remote must be rejected outright.
+    ///
+    /// `from_input` falls back to `LocalPath` for unrecognised input and
+    /// `to_clone_url` then hands that string to `git clone` verbatim, so a
+    /// value starting with `-` would be read by git as an option. The clone
+    /// this replaced wrapped every non-URL value into
+    /// `https://github.com/<value>.git`, which made the shape unreachable;
+    /// routing through `RemoteRepoManager` removes that accidental guard, so
+    /// the flag has to reject non-remotes itself.
+    #[test]
+    fn remote_repo_rejects_values_that_are_not_remotes() {
+        for remote in [
+            "--upload-pack=touch /tmp/pwn",
+            "-u",
+            "/Users/someone/checkout",
+            "~/checkout",
+            "myrepo",
+        ] {
+            assert!(
+                parse_remote_repo(remote).is_err(),
+                "{remote} is not a remote and must not reach `git clone`"
             );
         }
     }

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -40,6 +40,18 @@ pub struct RemoteBranch {
     pub is_default: bool,
 }
 
+/// Argv prefixes that end option parsing with `--` before the remote URL.
+///
+/// The URL is user-supplied and reaches git as a positional, so a value
+/// beginning with `-` would otherwise be read as an option. `git clone
+/// --upload-pack=<cmd> <dest>` executes `<cmd>` with the destination as the
+/// repository; `git ls-remote --upload-pack=<cmd>` with no repository left
+/// falls back to `origin` and executes `<cmd>` against it. Both verified
+/// against real git. Keep the `--` last in each of these.
+const CLONE_ARGV: [&str; 2] = ["clone", "--"];
+const LS_REMOTE_HEADS_ARGV: [&str; 4] = ["ls-remote", "--heads", "--refs", "--"];
+const LS_REMOTE_SYMREF_ARGV: [&str; 3] = ["ls-remote", "--symref", "--"];
+
 /// Manages remote repository cloning and caching
 pub struct RemoteRepoManager {
     cache_dir: PathBuf,
@@ -111,7 +123,8 @@ impl RemoteRepoManager {
         info!("Listing remote branches for: {}", url);
 
         let output = Command::new("git")
-            .args(["ls-remote", "--heads", "--refs", "--", &url])
+            .args(LS_REMOTE_HEADS_ARGV)
+            .arg(&url)
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_ASKPASS", "echo")
             .output()
@@ -179,7 +192,8 @@ impl RemoteRepoManager {
         let url = source.to_clone_url();
 
         let output = Command::new("git")
-            .args(["ls-remote", "--symref", "--", &url, "HEAD"])
+            .args(LS_REMOTE_SYMREF_ARGV)
+            .args([&url, "HEAD"])
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_ASKPASS", "echo")
             .output()
@@ -238,7 +252,8 @@ impl RemoteRepoManager {
         // `--` ends option parsing: a source string beginning with `-` reaches
         // here from user input, and git would otherwise read it as an option.
         let output = Command::new("git")
-            .args(["clone", "--", &url])
+            .args(CLONE_ARGV)
+            .arg(&url)
             .arg(&cache_path)
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_ASKPASS", "echo")
@@ -1263,6 +1278,25 @@ fn classify_git_error(stderr: &str, url: &str) -> RemoteRepoError {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// Every git invocation that takes the user-supplied URL as a positional
+    /// must end option parsing first.
+    ///
+    /// A shape pin, not a behavioural test. The clone site is driven against
+    /// real git below; the two `ls-remote` sites are exploitable only through
+    /// git's no-repository fallback to `origin`, which needs the process cwd to
+    /// be a repo with a local origin — not something a test can arrange without
+    /// mutating the cwd out from under the parallel suite.
+    #[test]
+    fn every_git_argv_ends_option_parsing_before_the_url() {
+        for argv in [
+            CLONE_ARGV.as_slice(),
+            LS_REMOTE_HEADS_ARGV.as_slice(),
+            LS_REMOTE_SYMREF_ARGV.as_slice(),
+        ] {
+            assert_eq!(argv.last(), Some(&"--"), "{argv:?} must end with `--`");
+        }
+    }
 
     /// A source string beginning with `-` must reach git as a repository, not
     /// as an option.

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -1264,6 +1264,74 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// A source string beginning with `-` must reach git as a repository, not
+    /// as an option.
+    ///
+    /// `git clone <url> <dest>` takes two positionals, so without a `--`
+    /// separator git reads the url as an option and the destination as the
+    /// repository: `git clone --upload-pack=<cmd> <repo>` runs `<cmd>`. Verified
+    /// against real git, and reachable from `ainb run --remote-repo` and from
+    /// any TUI source that survives to `to_clone_url`.
+    #[test]
+    fn a_source_that_looks_like_an_option_cannot_reach_git_as_one() {
+        let temp_dir = TempDir::new().unwrap();
+        let probe = temp_dir.path().join("payload-ran");
+
+        // The destination `clone_repo` derives. A bare repo satisfies "exists
+        // but is not a warm cache" (no `.git` child), so the clone branch runs,
+        // and it is a real repository, which is what makes the payload fire
+        // when git is allowed to treat it as the clone source.
+        let manager = RemoteRepoManager::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+        let parsed = ParsedRepo {
+            source: RepoSource::Filter(String::new()),
+            host: "h".to_string(),
+            owner: "o".to_string(),
+            repo_name: "payload-probe.git".to_string(),
+        };
+        let cache_path = manager.get_cache_path(&parsed);
+        std::fs::create_dir_all(&cache_path).unwrap();
+        let init = std::process::Command::new(crate::test_support::git_bin())
+            .args(["init", "-q", "--bare"])
+            .arg(&cache_path)
+            .output()
+            .expect("git init");
+        assert!(init.status.success(), "git init --bare failed");
+        assert!(
+            !manager.is_cached(&parsed),
+            "precondition: destination is not a warm cache"
+        );
+
+        // `Filter` passes its string through `to_clone_url` untouched, which is
+        // exactly what an unsanitised remote value would do.
+        let source = RepoSource::Filter(format!("--upload-pack=touch {}", probe.display()));
+
+        let err = manager.clone_repo(&source, &parsed).expect_err("an option is not a repository");
+        assert!(
+            matches!(
+                err,
+                RemoteRepoError::NotFound(_) | RemoteRepoError::CloneFailed(_)
+            ),
+            "unexpected error: {err:?}"
+        );
+
+        // `clone_repo` runs git in the test process's cwd, so a regression
+        // clones into `./payload-probe` there. Clear it before failing.
+        let leaked = std::path::Path::new("payload-probe");
+        let leaked_exists = leaked.exists();
+        if leaked_exists {
+            let _ = std::fs::remove_dir_all(leaked);
+        }
+
+        assert!(
+            !probe.exists(),
+            "git executed the source string as --upload-pack"
+        );
+        assert!(
+            !leaked_exists,
+            "git treated the destination as the clone source"
+        );
+    }
+
     /// A failed clone must leave the cache directory exactly as it found it.
     ///
     /// This behaviour has been flipped twice: 98c61245 added a `remove_dir_all`

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -43,11 +43,19 @@ pub struct RemoteBranch {
 /// Argv prefixes that end option parsing with `--` before the remote URL.
 ///
 /// The URL is user-supplied and reaches git as a positional, so a value
-/// beginning with `-` would otherwise be read as an option. `git clone
-/// --upload-pack=<cmd> <dest>` executes `<cmd>` with the destination as the
-/// repository; `git ls-remote --upload-pack=<cmd>` with no repository left
-/// falls back to `origin` and executes `<cmd>` against it. Both verified
-/// against real git. Keep the `--` last in each of these.
+/// beginning with `-` would otherwise be read as an option, and whatever
+/// positional survives becomes the repository. All three verified against real
+/// git:
+///
+/// - `git clone --upload-pack=<cmd> <dest>` executes `<cmd>` with the
+///   destination as the repository.
+/// - `git ls-remote --symref --upload-pack=<cmd> HEAD` executes `<cmd>` with
+///   the ref pattern as the repository, from ANY cwd — no repo required.
+/// - `git ls-remote --heads --refs --upload-pack=<cmd>` has no positional left,
+///   so it fires only through the fallback to `origin`, i.e. when the process
+///   cwd is a repo with a local origin.
+///
+/// Keep the `--` last in each of these.
 const CLONE_ARGV: [&str; 2] = ["clone", "--"];
 const LS_REMOTE_HEADS_ARGV: [&str; 4] = ["ls-remote", "--heads", "--refs", "--"];
 const LS_REMOTE_SYMREF_ARGV: [&str; 3] = ["ls-remote", "--symref", "--"];
@@ -1282,11 +1290,11 @@ mod tests {
     /// Every git invocation that takes the user-supplied URL as a positional
     /// must end option parsing first.
     ///
-    /// A shape pin, not a behavioural test. The clone site is driven against
-    /// real git below; the two `ls-remote` sites are exploitable only through
-    /// git's no-repository fallback to `origin`, which needs the process cwd to
-    /// be a repo with a local origin — not something a test can arrange without
-    /// mutating the cwd out from under the parallel suite.
+    /// A shape pin. The clone and symref sites are each driven against real
+    /// git below; the heads site fires only through git's no-repository
+    /// fallback to `origin`, which needs the process cwd to be a repo with a
+    /// local origin — not something a test can arrange without mutating the cwd
+    /// out from under the parallel suite, so this pin is its only guard.
     #[test]
     fn every_git_argv_ends_option_parsing_before_the_url() {
         for argv in [
@@ -1363,6 +1371,27 @@ mod tests {
         assert!(
             !leaked_exists,
             "git treated the destination as the clone source"
+        );
+    }
+
+    /// The symref probe passes TWO positionals (`<url>` then `HEAD`), so
+    /// without `--` git consumes the url as an option and reads `HEAD` as the
+    /// repository — executing the payload from any cwd, with no repo and no
+    /// network. Same family as the clone site, and unlike the heads site it
+    /// needs no `origin` to fire, so it can be driven directly.
+    #[test]
+    fn a_default_branch_probe_cannot_run_the_source_string_as_an_option() {
+        let temp_dir = TempDir::new().unwrap();
+        let probe = temp_dir.path().join("symref-ran");
+        let manager = RemoteRepoManager::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+        // `Filter` passes its string through `to_clone_url` untouched.
+        let source = RepoSource::Filter(format!("--upload-pack=touch {}", probe.display()));
+
+        assert_eq!(manager.get_default_branch_name(&source), None);
+        assert!(
+            !probe.exists(),
+            "git executed the source string as --upload-pack"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/git/remote_repo_manager.rs
@@ -111,7 +111,7 @@ impl RemoteRepoManager {
         info!("Listing remote branches for: {}", url);
 
         let output = Command::new("git")
-            .args(["ls-remote", "--heads", "--refs", &url])
+            .args(["ls-remote", "--heads", "--refs", "--", &url])
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_ASKPASS", "echo")
             .output()
@@ -179,7 +179,7 @@ impl RemoteRepoManager {
         let url = source.to_clone_url();
 
         let output = Command::new("git")
-            .args(["ls-remote", "--symref", &url, "HEAD"])
+            .args(["ls-remote", "--symref", "--", &url, "HEAD"])
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_ASKPASS", "echo")
             .output()
@@ -234,9 +234,11 @@ impl RemoteRepoManager {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Standard clone (not --bare) for compatibility with worktree discovery
+        // Standard clone (not --bare) for compatibility with worktree discovery.
+        // `--` ends option parsing: a source string beginning with `-` reaches
+        // here from user input, and git would otherwise read it as an option.
         let output = Command::new("git")
-            .args(["clone", &url])
+            .args(["clone", "--", &url])
             .arg(&cache_path)
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_ASKPASS", "echo")

--- a/ainb-tui/crates/ainb-core/src/git/repo_source.rs
+++ b/ainb-tui/crates/ainb-core/src/git/repo_source.rs
@@ -92,7 +92,11 @@ impl RepoSource {
             return Ok(RepoSource::LocalPath(expanded));
         }
 
-        // GitHub shorthand: owner/repo (no spaces, exactly one slash, no protocol)
+        // GitHub shorthand: owner/repo (no spaces, exactly one slash, no protocol).
+        // Stricter than [`github_shorthand`], which callers that already KNOW
+        // their value is a remote use instead: this branch rejects a `.`
+        // anywhere, so a dotted repo NAME (`mrdoob/three.js`) falls through to
+        // the no-protocol-URL heuristic below. Keep the two in step.
         if !input.contains(' ')
             && input.matches('/').count() == 1
             && !input.contains(':')
@@ -115,6 +119,36 @@ impl RepoSource {
 
         // Fallback: treat as local path
         Ok(RepoSource::LocalPath(PathBuf::from(input)))
+    }
+
+    /// Read `owner/repo` as a GitHub shorthand, for callers whose input is a
+    /// remote by declaration (`ainb run --remote-repo`, and anything else that
+    /// has already ruled out a local path).
+    ///
+    /// Looser than [`RepoSource::from_input`]'s own shorthand branch in exactly
+    /// one way: a dot is allowed in the repo NAME, so `mrdoob/three.js` and
+    /// `socketio/socket.io` classify as shorthands instead of falling through
+    /// to the no-protocol-URL heuristic and parsing as `https://mrdoob/three.js`.
+    /// A dot in the OWNER still disqualifies the value, which is what keeps a
+    /// host-shaped `gitlab.com/repo` out: it belongs to that heuristic, and
+    /// answering it with a GitHub clone turns a parse error into a misleading
+    /// "check your git credentials".
+    ///
+    /// `None` for anything carrying a scheme, host, path, or leading `-`;
+    /// those are left to `from_input` to classify.
+    pub(crate) fn github_shorthand(input: &str) -> Option<Self> {
+        let (owner, repo) = input.trim().split_once('/')?;
+        let repo = repo.strip_suffix(".git").unwrap_or(repo);
+        let bare = |segment: &str| {
+            !segment.is_empty()
+                && !segment.contains(['/', '\\', ':', '@'])
+                && !segment.contains(char::is_whitespace)
+                && !segment.starts_with(['-', '.', '~'])
+        };
+        (bare(owner) && !owner.contains('.') && bare(repo)).then(|| Self::GithubShorthand {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+        })
     }
 
     /// Convert to canonical git URL for cloning.

--- a/ainb-tui/crates/ainb-core/src/git/repo_source.rs
+++ b/ainb-tui/crates/ainb-core/src/git/repo_source.rs
@@ -185,16 +185,17 @@ impl RepoSource {
                 owner: safe_segment("owner", owner)?,
                 repo_name: safe_segment("repo", repo)?,
             }),
-            RepoSource::LocalPath(path) => {
-                let repo_name =
-                    path.file_name().and_then(|n| n.to_str()).unwrap_or("unknown").to_string();
-                Ok(ParsedRepo {
-                    source: self.clone(),
-                    host: "local".to_string(),
-                    owner: String::new(),
-                    repo_name,
-                })
-            }
+            // A local checkout has no host/owner to key a clone cache on. This
+            // used to answer host="local", owner="" and the path basename,
+            // which `get_cache_path` joined into `<cache>/local//<basename>` —
+            // a path two unrelated checkouts of the same basename share. No
+            // caller wants that: every clone path is gated on a remote variant
+            // already, and the one consumer that reached here built a
+            // meaningless `/<basename>` shorthand out of it.
+            RepoSource::LocalPath(path) => Err(RepoSourceError::ParseError(format!(
+                "local checkout has no remote components: {}",
+                path.display()
+            ))),
             // SshSession is an interactive session, not a clone — no components
             // to extract. Filter is unparseable text and likewise has no
             // owner/repo to expose.
@@ -500,6 +501,20 @@ fn parse_ssh_url(url: &str, source: RepoSource) -> Result<ParsedRepo, RepoSource
 #[allow(deprecated)] // existing legacy `from_input` tests pre-date finding #14
 mod tests {
     use super::*;
+
+    /// A local checkout must not produce cache components.
+    ///
+    /// `get_cache_path` joins host/owner/repo onto the clone cache, and the
+    /// old `Ok` answer had an empty owner, so `~/a/api` and `~/b/api` collapsed
+    /// onto one `<cache>/local/api` clone.
+    #[test]
+    fn local_path_has_no_remote_components() {
+        let source = RepoSource::LocalPath("/home/foo/api".into());
+        assert!(
+            source.parse_components().is_err(),
+            "a local checkout is not a clone source"
+        );
+    }
 
     #[test]
     fn test_https_url_detection() {

--- a/ainb-tui/crates/ainb-core/src/git/repo_source.rs
+++ b/ainb-tui/crates/ainb-core/src/git/repo_source.rs
@@ -182,8 +182,8 @@ impl RepoSource {
             RepoSource::GithubShorthand { owner, repo } => Ok(ParsedRepo {
                 source: self.clone(),
                 host: "github.com".to_string(),
-                owner: owner.clone(),
-                repo_name: repo.clone(),
+                owner: safe_segment("owner", owner)?,
+                repo_name: safe_segment("repo", repo)?,
             }),
             RepoSource::LocalPath(path) => {
                 let repo_name =
@@ -397,6 +397,22 @@ fn ensure_git_suffix(url: &str) -> String {
     }
 }
 
+/// Reject a host/owner/repo segment that would escape the clone-cache root.
+///
+/// `RemoteRepoManager::get_cache_path` joins these three segments straight onto
+/// `~/.agents-in-a-box/repos`, so `https://github.com/../..` would otherwise
+/// resolve to the AINB state dir itself. The CLI used to carry its own
+/// `.replace("..", "")` sanitiser; the guard belongs here, where every caller
+/// that builds a cache path goes through it.
+fn safe_segment(kind: &str, value: &str) -> Result<String, RepoSourceError> {
+    if value.is_empty() || value == "." || value == ".." || value.contains(['/', '\\']) {
+        return Err(RepoSourceError::ParseError(format!(
+            "Unsafe {kind} segment: {value:?}"
+        )));
+    }
+    Ok(value.to_string())
+}
+
 /// Parse HTTPS URL into components
 fn parse_https_url(url: &str, source: RepoSource) -> Result<ParsedRepo, RepoSourceError> {
     // https://github.com/owner/repo.git or https://github.com/owner/repo
@@ -411,9 +427,9 @@ fn parse_https_url(url: &str, source: RepoSource) -> Result<ParsedRepo, RepoSour
     let parts: Vec<&str> = without_protocol.split('/').collect();
 
     if parts.len() >= 3 {
-        let host = parts[0].to_string();
-        let owner = parts[1].to_string();
-        let repo_name = parts[2].to_string();
+        let host = safe_segment("host", parts[0])?;
+        let owner = safe_segment("owner", parts[1])?;
+        let repo_name = safe_segment("repo", parts[2])?;
 
         Ok(ParsedRepo {
             source,
@@ -467,9 +483,9 @@ fn parse_ssh_url(url: &str, source: RepoSource) -> Result<ParsedRepo, RepoSource
         if path_parts.len() >= 2 {
             return Ok(ParsedRepo {
                 source,
-                host,
-                owner: path_parts[0].to_string(),
-                repo_name: path_parts[1].to_string(),
+                host: safe_segment("host", &host)?,
+                owner: safe_segment("owner", path_parts[0])?,
+                repo_name: safe_segment("repo", path_parts[1])?,
             });
         }
     }

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -137,7 +137,7 @@ Solid arrows are data/control flow, dashed arrows are writes and feedback, clay 
 ├── worktrees/
 │   ├── by-session/<id>        symlink → real worktree
 │   └── <branch>/              the actual worktree
-├── repo-cache/                cloned remotes
+├── repos/<host>/<owner>/<repo>  cloned remotes (TUI and CLI share this)
 ├── favorites.json             saved repos
 ├── plugins/<name>/            plugin-writable state (gated by capability)
 └── logs/agents-in-a-box-*.jsonl   structured logs (host + plugin stderr)


### PR DESCRIPTION
## Problem

The workspace list showed the same repository as two separate groups with the
same name. Sessions spawned from the TUI and from `ainb run --remote-repo`
ended up in different groups.

```
before                                  after
┌──────────┐   repo-cache/<repo>        ┌──────────┐
│ ainb run │──────────────────┐         │ ainb run │───┐
└──────────┘                  │         └──────────┘   │  repos/<host>/<owner>/<repo>
┌──────────┐   repos/h/o/r    │         ┌──────────┐   ├──────────────▶ one root
│   TUI    │──────────────────┘         │   TUI    │───┘
└──────────┘   = 2 groups, same name    └──────────┘   = 1 group
```

Two clone roots existed for one remote:

- TUI: `RemoteRepoManager::new()` → `~/.agents-in-a-box/repos/<host>/<owner>/<repo>`
- CLI: `clone_remote_repo` → `~/.agents-in-a-box/repo-cache/<repo>`

The workspace list keys its groups on a session's source repository path
(`app/state.rs`, `workspace_key = canonical_key(source_repository)`) and takes
the display label from the worktree directory basename, so one repo with two
on-disk roots rendered as two identically-named rows.

Observed locally:

```
f/pr-sweep        git-common-dir = .../repos/github.com/stevengonsalvez/agents-in-a-box/.git
f/atc-supervisor  git-common-dir = .../repo-cache/agents-in-a-box/.git
```

Same remote URL, two clones. `repo-cache/` also held `fleet-lambda`, `fpl` and
`shotclubhouse`, each latently able to split the same way.

## Change

`--remote-repo` routes through `RemoteRepoManager`, the same clone-or-fetch
path the TUI uses. The flat layout's owner collision goes with it: `alice/api`
and `bob/api` no longer share one clone.

Three hardening commits came out of review of that move:

- `RepoSource::parse_components` now rejects host/owner/repo segments that
  escape the cache root. `get_cache_path` joins them straight onto the cache
  dir, so `https://github.com/../..` resolved to the AINB state directory.
  The CLI carried its own `.replace("..", "")` for this; the guard belongs in
  the parser every cache-path caller goes through.
- `--remote-repo` rejects values that are not remotes. `from_input` falls back
  to `LocalPath` for unrecognised input and `to_clone_url` hands that string to
  `git clone` verbatim, so `--remote-repo '--upload-pack=...'` reached git as
  an option. The inline clone this replaced wrapped every non-URL value into
  `https://github.com/<value>.git`, which made the shape unreachable; routing
  through `RemoteRepoManager` removed that accidental guard.
- `git clone` and `git ls-remote` take `--` before the URL, so a source
  beginning with `-` cannot be read as an option from any caller.

## Tests

New, in `cli::run::tests`:

- `remote_repo_resolves_into_the_shared_clone_root` — `owner/repo` and the
  https URL both resolve to `<cache>/github.com/<owner>/<repo>`. No network.
- `remote_repo_rejects_path_traversal` — `https://github.com/../../evil`,
  `https://github.com/owner/..`, `git@github.com:../evil.git`.
- `remote_repo_rejects_values_that_are_not_remotes` —
  `--upload-pack=touch /tmp/pwn`, `-u`, absolute and `~` paths, bare `myrepo`.

`cargo test -p ainb --lib`: 2125 passed, 9 failed. The same 9 fail on the base
commit with these files reverted (env/global-state interference between tests;
each passes when run alone). `cargo fmt --check -p ainb` clean, no new clippy
findings in the touched files.

## Not included

Existing `~/.agents-in-a-box/repo-cache/*` clones are left in place. Their live
sessions keep rendering a second row until retired; re-pointing those worktrees
is a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Remote repositories now use a shared cache, allowing the CLI and TUI to reuse cloned repositories.
  * Remote repository inputs are validated more strictly, rejecting local paths, option-like values, and unsafe path segments.
  * Git operations now safely handle repository URLs that begin with a hyphen.

* **Documentation**
  * Updated architecture documentation to reflect the shared remote-repository cache location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->