### PR TITLE
docs(hangar): renovation plan, spine first with a parallel crisp-UI track

### DIFF
--- a/docs/hangar/renovation/PLAN.md
+++ b/docs/hangar/renovation/PLAN.md
@@ -19,6 +19,32 @@ are NOT ACP: they run as provider CLI subprocesses (headless `claude -p` stream-
 detached tmux session). ACP exists and works, for fleet chat only. Every screen holds the
 data and paints the ULID.
 
+## The execution view (the requirement both tracks serve)
+
+Open a ticket, expand its execution view, watch the run. This is how Multica does it: the
+issue page carries an execution log (runs of this issue, running on top, failed first),
+each run expands into a transcript with the five-kind taxonomy (agent text, thinking, tool
+call, result, error) that fills live over the socket, and a sticky live card above it says
+"agent is working · 7m 17s · 10 tool calls". Hangar gets the same view, and it must look
+identical whether the run came from `claude -p`, `codex exec --json` or an ACP adapter:
+
+```
+ticket ─▶ [execution view]
+            runs of this issue (running on top, failed first)      ◔ impl-1  running 2m     ▶ expand
+                                                                    ✗ rev-1   failed 9m       exit 65
+                                                                    ● impl-1  done 21m        PR #7 ✓
+            expanded run ──▶ transcript, live                        ● text     Registering the route…
+                             same classifier for every executor      ▸ tool     Edit api/src/routes.ts
+                                                                     ✓ result   3 files changed
+                                                                     ⚠ error    npm test exit 1
+```
+
+Acceptance: a run started under each executor shows the same `(kind, body)` sequence live
+in the expanded view as the durable re-read returns after it finishes (track A test T1),
+and the view is reachable from the ticket in one key (track B4). Today neither half exists:
+`HangarEvent::TaskMessage` has consumers but no producer, and task detail never fetches
+the timeline it could already read.
+
 ## Two tracks
 
 ```
@@ -41,7 +67,7 @@ half-builds across them: B3 renders the same attention rows A3 makes answerable 
 ### Move 1: two first-class executors, one live run-event stream (detail: `move1-acp-tasks.md`)
 
 Operator requirements folded in: BOTH `claude -p` (stream-json) and ACP are first-class
-task executors, BOTH stream results back to the task live, selection is
+task executors, BOTH stream results back to the task live into the execution view above, selection is
 `HANGAR_TASK_EXECUTOR=acp|process` (default `process` until ACP is proven) with a per-agent
 override later. Structured human-in-the-loop is ACP-only in move 1; the process path keeps
 the hook route for AskUserQuestion.
@@ -89,7 +115,7 @@ recorded before/after with a vhs tape under `docs/hangar/proofs/crisp/`.
 | B1 | Resolve every id to a name: agent names on task detail, usage, cards; inbox lines as `<agent> <verb> <HGR-n> <title>`; transcript backfill on open; R-on-done note; roster refresh on wizard open; `@` filter cursor; Ctrl+U in rename; branch elide; failed-first ordering (defects 5-9, 12, 21) | M | task detail says `Agent: impl-1`, inbox reads as sentences, detail opens with a transcript |
 | B2 | Cards and hint bars: card footer swaps by state (`◔ impl-1 · running 2m · PR ✓`, `● impl-1 · ASK 40s`, `◇ blocked by MHAJBV`), `◇ None` never prints, hint grammar (5 contextual + 3 globals, verb first), Boards' second hint band deleted, `N working` chip wired, one `vocab.rs` for status words | M | idle, running and asking cards side by side; Boards with one hint bar |
 | B3 | Inbox becomes the one attention surface: `needs you` block (attention rows, inline answer lifted from Control Center) above `recent` (inbox entries recomposed), filters; the board chip and Control tab become views of it | M | the P3 human loop driven entirely from `I` |
-| B4 | Detail screen: sticky live run card (`◔ impl-1 is working · 7m 17s · 10 tools · $0.42`), one meta line, transcript + activity panes, facet panel gone; keeps the `Acceptance: 0/3` / `Props:` / `Meta:` literals four tripwires assert | M | run card ticking while the transcript streams |
+| B4 | Detail screen = the execution view: sticky live run card (`◔ impl-1 is working · 7m 17s · 10 tools · $0.42`), one meta line, execution log (runs of this issue from `run_history`, running on top, failed first, `enter` expands), transcript pane fed by `board_card_timeline` now and by the live `TaskMessage` stream once A2 lands, activity pane, facet panel gone; keeps the `Acceptance: 0/3` / `Props:` / `Meta:` literals four tripwires assert | M | run card ticking while the expanded run streams |
 | B5 | Tab strip 16 to 7 (`1 2 K B I A ,` plus `? q`), nine screens behind `^P Go:` and Settings, `Kanban` relabelled `Runs`, help rewritten; add `palette_reaches_every_demoted_screen` | S | 7 tabs at 80 columns, `^P usage` still lands |
 
 Do not attempt in track B (they belong to the spine): collapsing issue/card/task state, any

--- a/docs/hangar/renovation/PLAN.md
+++ b/docs/hangar/renovation/PLAN.md
@@ -1,0 +1,115 @@
+# Hangar renovation plan: spine first, crisp in parallel
+
+Status: proposed 2026-09-02, after the prove-hangar run (PR #815).
+Decision record: https://explainers.stevengonsalvez.com/hangar-renovation/ (option C chosen).
+Appendices in this directory: `exec-map.md` (how a task executes today, counted surface,
+brittle seams), `move1-acp-tasks.md` (track A move 1 in full), `crisp-ui-track.md`
+(track B in full). Every file:line in the appendices was read at `7d2b10d3`, which is
+`main` after #815.
+
+## The diagnosis in one paragraph
+
+Hangar cloned Multica's surface (157 RPC methods, 20 screens, 123 CLI commands, 93
+migrations) and missed its spine. Multica's spine is one noun (the issue), one execution
+record per trigger (the task), one place to watch it (the issue page with a live run card).
+Hangar has nine row-level concepts for "a thing an agent is doing", four state stores for
+one unit of work, three boards, three attention surfaces, two disjoint write paths into one
+database, and a human-in-the-loop that types digits into a screen-scraped tmux pane. Tasks
+are NOT ACP: they run as provider CLI subprocesses (headless `claude -p` stream-json, or a
+detached tmux session). ACP exists and works, for fleet chat only. Every screen holds the
+data and paints the ULID.
+
+## Two tracks
+
+```
+                 week 1            week 2            week 3+
+track B  crisp   B1 names ─▶ B2 cards ─▶ B3 inbox ─▶ B4 detail ─▶ B5 tabs
+(plugin only)    ▲ ships in days, each step recorded, no schema, no new RPC
+                 │
+track A  spine   A0 probe ─▶ A1 classifier ─▶ A2 process stream ─▶ A3 ACP answer arm
+(daemon)                     ─▶ A4 pool prereqs ─▶ A5 run_acp + flag ─▶ A6 read/PR ─▶ A7 usage ─▶ A8 per-agent
+                 then move 2 (issue-with-runs, one writer), move 3 (surface collapse), move 4 (`ainb hangar up`)
+```
+
+The tracks touch different files. Two seams connect them and are named so nobody
+half-builds across them: B3 renders the same attention rows A3 makes answerable for ACP
+(same `attention/answer` RPC, byte for byte); B4's transcript pane consumes A2's live
+`TaskMessage` stream when it lands and backfills from the timeline read until then.
+
+## Track A: the spine
+
+### Move 1: two first-class executors, one live run-event stream (detail: `move1-acp-tasks.md`)
+
+Operator requirements folded in: BOTH `claude -p` (stream-json) and ACP are first-class
+task executors, BOTH stream results back to the task live, selection is
+`HANGAR_TASK_EXECUTOR=acp|process` (default `process` until ACP is proven) with a per-agent
+override later. Structured human-in-the-loop is ACP-only in move 1; the process path keeps
+the hook route for AskUserQuestion.
+
+| # | step | size | why it is orderable |
+|---|------|------|---------------------|
+| A0 | Probe: does `claude-agent-acp` surface `AskUserQuestion` as `session/request_permission`? One `#[ignore]` test in `crates/ainb-acp/tests/real_adapter.rs` | 30 min | gates the exit criterion; if no, the criterion becomes a tool-permission approval |
+| A1 | Move the stream-json classifier from the plugin (`widgets/jsonl_timeline.rs`) into `ainb-hangar-proto::transcript`; pure refactor | M | one classifier for durable and live, both executors |
+| A2 | Live stream for the PROCESS executor: `stream_stdout` emits `HangarEvent::TaskMessage` per line (the event exists in proto with no producer today), task detail appends live | M | value with zero ACP: the board timeline and run banner go live for the first time |
+| A3 | ACP answer arm at the top of `answer.rs`: an `acp_permission` row answers through `pool.answer_permission`, not tmux | S | fixes ACP chat permissions from Control Center, broken today |
+| A4 | Pool prerequisites: `stop=<StopReason>` on the delivered leg, extract `acp_session::ensure` / `acp_message::enqueue`, `register_adapter` on `PoolConfig` | S | no chat-path behaviour change |
+| A5 | `acp_task::run_acp` + the flag: one new arm in `execute_claimed` (the shape `run_interactive` already has), per-task adapter process (sandbox, agent_env, permission mode are per process), leg poll bounded by `HANGAR_PROVIDER_MAX_RUNTIME_MS`, outcome mapping table, cancel arm | L | finalize path (success/failure/cancel, board advance, retry) untouched |
+| A6 | Unified durable read: `board_card_timeline` reads `fleet_provider_event` rows for ACP runs; PR URL captured from the transcript | M | |
+| A7 | Usage: `acp.usage` rows into `ProviderUsage` | S | |
+| A8 | Per-agent selection via `agent.provider` = adapter token; no migration | S | |
+
+Exit criterion, two halves: (A) a card run under each executor shows its transcript growing
+live with the same taxonomy; (B) the Boxtrack P3 leg reproduced with zero tmux: no
+`tmux_hangar-*` session, no `*.jsonl`, the ask lands as an attention row, the answer goes
+through `attention/answer` to the adapter's pending JSON-RPC id, and the transcript shows
+the agent acting on the chosen option (the class of bug defect 26 caught).
+
+Decisions already taken in the appendix and adopted here: no `TaskExecutor` trait (a third
+`if` arm, extract the trait when a fourth executor exists); no turn-complete future (poll
+the always-resolved delivery leg); per-task adapter process, not the shared pool
+(permission mode, `agent_env` and the sandbox are all per process, and the shared pool caps
+task turns at 4 per provider); `interactive` + `acp` is refused at dispatch, not downgraded.
+
+### Moves 2-4 (scoped after move 1 lands)
+
+| move | what | size | deletes |
+|------|------|------|---------|
+| 2 | One noun, one writer: issue status becomes a CHECK'd category enum, runs attach to the issue, stages are sub-issues or stage columns on one board, `board_card` is position only; the CLI drops its 18 `Store::open_default` calls and speaks RPC through `ainb-hangar-client`; TUI applies deltas instead of refetching snapshots | L | Kanban task board, separate pipeline board, the nine best-effort twin writes in `board.rs`, `fleet_confirm` as a second answer mechanism |
+| 3 | One surface: six screens (Issues, Issue, Inbox, Agents, Usage, Settings), chat as a pane; track B lands most of the visible half early | M | Control Center, Fleet queue, Boards, Kanban, Skills, Autopilots, Profiles, Squads, Logs, Daemon as tabs |
+| 4 | `ainb hangar up`: start daemon, detect installed CLIs, register the host runtime with one default agent per CLI, open on an empty board; one config file replaces 30 env vars | M | install.json seeding, onboarding version checks, the Landlock-crashes-Bun surprise |
+
+## Track B: crisp UI (detail: `crisp-ui-track.md`)
+
+Plugin only. No schema, no new RPC (one trivially additive relaxation: `board_id` optional
+on `board_card_timeline` so an uncarded issue can backfill its transcript). Every step is
+recorded before/after with a vhs tape under `docs/hangar/proofs/crisp/`.
+
+| # | step | size | the shot that proves it |
+|---|------|------|-------------------------|
+| B1 | Resolve every id to a name: agent names on task detail, usage, cards; inbox lines as `<agent> <verb> <HGR-n> <title>`; transcript backfill on open; R-on-done note; roster refresh on wizard open; `@` filter cursor; Ctrl+U in rename; branch elide; failed-first ordering (defects 5-9, 12, 21) | M | task detail says `Agent: impl-1`, inbox reads as sentences, detail opens with a transcript |
+| B2 | Cards and hint bars: card footer swaps by state (`◔ impl-1 · running 2m · PR ✓`, `● impl-1 · ASK 40s`, `◇ blocked by MHAJBV`), `◇ None` never prints, hint grammar (5 contextual + 3 globals, verb first), Boards' second hint band deleted, `N working` chip wired, one `vocab.rs` for status words | M | idle, running and asking cards side by side; Boards with one hint bar |
+| B3 | Inbox becomes the one attention surface: `needs you` block (attention rows, inline answer lifted from Control Center) above `recent` (inbox entries recomposed), filters; the board chip and Control tab become views of it | M | the P3 human loop driven entirely from `I` |
+| B4 | Detail screen: sticky live run card (`◔ impl-1 is working · 7m 17s · 10 tools · $0.42`), one meta line, transcript + activity panes, facet panel gone; keeps the `Acceptance: 0/3` / `Props:` / `Meta:` literals four tripwires assert | M | run card ticking while the transcript streams |
+| B5 | Tab strip 16 to 7 (`1 2 K B I A ,` plus `? q`), nine screens behind `^P Go:` and Settings, `Kanban` relabelled `Runs`, help rewritten; add `palette_reaches_every_demoted_screen` | S | 7 tabs at 80 columns, `^P usage` still lands |
+
+Do not attempt in track B (they belong to the spine): collapsing issue/card/task state, any
+plugin-side write that is not an existing RPC or any polling to hide defect 15, anything on
+the answer delivery path, a live transcript for interactive runs (there is no capture),
+unifying the attention / confirm / receipt stores, gating done on acceptance, board-card
+authoring (defects 16, 17).
+
+## Risks
+
+| risk | sev | mitigation |
+|------|-----|------------|
+| `claude-agent-acp` does not surface AskUserQuestion as a permission request | high | A0 probe first; exit criterion falls back to a tool-permission approval, still zero tmux |
+| Third-party adapters (Zed's claude-agent-acp, codex-acp) regress on the task path | med | pin adapter versions, per-provider crash breaker already exists, `process` stays default |
+| Two big migrations in move 2 on a 93-migration schema | med | extend `migration_upgrade_full_chain`, never bypass it |
+| Track B snapshot churn (13 card snapshots, 3 control-center snapshots) | low | one snapshot refresh per step, reviewed as images |
+| Tripwires assert screen text | low | each B step names the tripwires it touches; four literals are kept verbatim |
+
+## Open questions
+
+1. AskUserQuestion under ACP (A0). Owner: first task of track A.
+2. Adapter credential path: passthrough `CLAUDE_CODE_OAUTH_TOKEN` or let the adapter use the keychain? Prove on the first live smoke run, do not hard-wire.
+3. Whether `agent.provider` should carry the executor (A8) or a new column; decided after A5 ships.

--- a/docs/hangar/renovation/crisp-ui-track.md
+++ b/docs/hangar/renovation/crisp-ui-track.md
@@ -1,0 +1,498 @@
+> Appendix to `docs/hangar/renovation/PLAN.md`. Planning pass output, unedited except for punctuation.
+
+# Crisp UI track: hangar-tui plugin
+
+Parallel to the spine renovation (ACP task execution, issue/card/task state collapse).
+Ships in days. Plugin-only, plus two trivially-additive proto/daemon relaxations named below.
+All anchors are `ainb-tui/crates/ainb-plugin-hangar/` unless prefixed.
+
+Evidence: `docs/hangar/proofs/fullstack/p1-*.png` .. `p4-*.png`, `REPORT.md` defect ledger,
+`docs/hangar/tui-keybindings.md`, exec-map section 2.
+
+---
+
+## 0. The one-line diagnosis
+
+Every screen has the DATA and paints the ID. The plugin holds `hangar/agents_list`,
+`hangar/issues_list`, `hangar/tasks_list` and `hangar/run_history` in memory, then renders
+`agent:01M1FHM2YSRSXZQFR29ZAYF56V`, `Task started: 01M1GVN6MAF3121GEDM1E66KW5`, `◔0` and
+`Project: 01M1FH6AG5YJF1S`. Exactly ONE screen (Kanban) resolves names, and it is the one
+screen that reads crisp. The crispness gap is a resolution + composition gap, not a data gap.
+
+Second theme: the plugin advertises 16 tabs, 18 router keys, up to 24 simultaneous hints and
+three separate attention surfaces (Control `C`, Inbox `I`, the board `N need you` chip) for a
+loop that has four verbs (author, run, answer, read the result).
+
+---
+
+## 1. Screen-by-screen crispness audit
+
+### 1.1 Issues board (`1`) - `p1-2`, `p1-3`
+
+```
+┌ noise ─────────────────────────────┐  ┌ missing ──────────────────────────┐
+│ 7 columns x ~250px, 85% dead space │  │ agent on the card                 │
+│ `◇ None` priority chip on every    │  │ run state / elapsed               │
+│   card (default P3 = "None")       │  │ PR badge (Kanban has it)          │
+│ `◔0` assignee = first char of a    │  │ attention flag ("this asked you") │
+│   raw ULID (defect 8 on the board) │  │ "N working" (chip exists, dead)   │
+│ 11 footer hints + 4 filter chips   │  └───────────────────────────────────┘
+└────────────────────────────────────┘
+```
+
+- `widgets/card_board.rs:165` `BoardCard` carries `display_id, title, priority,
+  assignee_initial, linked, subtasks, not_dispatched`. No agent, no run state, no elapsed,
+  no PR. p1-3 is a card mid-run that renders identically to an untouched backlog card.
+- `widgets/card_board.rs:662` paints `◔` + `card.assignee_initial`, the FIRST CHAR of
+  `agent:<ulid>`, hence `◔0` in every still.
+- `widgets/card_board.rs:280` `PriorityChip::None.glyph() = '◇'`, label `"None"`
+  (`:262`). Default priority 0 maps to `None` (`:243`), so `◇ None` prints on every
+  untriaged card: 100% of cards in every still, zero information.
+- Working chip: `widgets/working_chip.rs:30` renders, `issue_list.rs:2814` calls it,
+  `app_screens.rs:649` declares `working_count` .. and **nothing ever assigns it**
+  (`grep working_count src/` returns only the declaration + two reads). Always 0. The
+  `issue_board_snapshot` .snap shows `⬡⬡` because the test seeds it directly.
+- Wizard titled `New task` (`p1-2`) but it creates an ISSUE. Vocabulary collision with the
+  `2 Task` tab.
+
+### 1.2 Kanban / runs (`K`) - `p1-4`
+
+The reference implementation, already crisp. `kanban.rs:509 card_title` composes
+`agent · age · status · branch · PR ✓`; `kanban.rs:264 set_agent_names` resolves the roster;
+`kanban.rs:555 card_pr_chip` renders the CI rollup.
+
+Two flaws:
+- Branch printed raw: `ainb/01M1FKF4BDNQ3JK5CQSS3N9GP8` (28 chars) wraps to a second line
+  and pushes the PR chip off the tile (`kanban.rs:520`). The doc comment at `:502-508`
+  predicts this exact failure and it happens anyway.
+- Card footer still the generic `◇ None ◔i` from `card_board.rs`, duplicating the state
+  already on the title line.
+
+### 1.3 Boards / pipeline (`B`) - `p2-6`
+
+- **Two hint bars.** `boards.rs:2672 BOARDS_HINTS` (16 pairs) painted by
+  `boards.rs:2692 render_hint_band` at the TOP, plus `chrome.rs:196` `Screen::Boards`
+  (5 pairs) + 3 globals at the BOTTOM. 24 hints, overlapping subsets, different keys.
+- Health chips `● daemon ok  ● roles covered  ○ wip 1/1 QA  ● 0 stuck` are the best line in
+  the app and are weighted the same as everything else.
+- Card in a role-gated column with a live run shows nothing about the run (same
+  `card_board.rs` widget). `wip 1/1 QA` in the header is the only evidence a run exists.
+- `◔T` = first char of the tester agent's id. Same defect 8.
+
+### 1.4 Task / issue detail (`2`) - `p2-1`
+
+- 6 header rows of key/value, 5 of which read `, ` or `unassigned`.
+  `task_detail.rs:1113-1126` prints `Assignee: unassigned  Agent: , ` on a dispatched issue
+  (defect 8).
+- A **second, floating facet panel** flush-right at the same vertical position repeats
+  `Status`/`Assignee`, adds `Project: 01M1FH6AG5YJF1S` (raw ULID) and `Notes: Add GET
+  /api/tick` (mid-word truncation).
+- `Repo:` prints the full absolute path `/home/claude/ainb-e2e-home/projects/boxtrack`.
+- **~80% of the screen is empty.** No live run card, no transcript, no activity, nothing.
+  A `TranscriptEntry` model exists (`task_detail.rs:158`) but nothing backfills it on open
+  (defect 7).
+- 8 footer hints including both `X:cancel` and `x:delete`.
+
+### 1.5 Control Center (`C`) - `p3-5`
+
+- Session row is a bare ULID `▸ASK 01M1GVN6MAF… 0s`. No issue, no agent, no title.
+- `control_center.rs:809` paints `age 0s · tok: · tools: · Δ: · hook · host`: three of
+  six fields are permanently `, `. Dead columns rendered as data.
+- The OPTIONS block (`①②` + Recommended + descriptions) is genuinely good and is the thing
+  the Inbox should inherit.
+- 60% dead width, 85% dead height.
+
+### 1.6 Inbox (`I`) - `p4-6`
+
+Worst screen in the app, and the one multica says should be the single attention surface.
+
+- 35 rows of `Task started: <26-char ULID>` / `Task finished (Success): <ULID>`.
+  `inbox.rs:134 render_entry` paints `{kind}{summary}` verbatim from the daemon.
+- No timestamps, no agent, no issue title, no unread markers per row, no grouping,
+  no filters, no ordering beyond newest-first.
+- Vocabulary: `(Success)` / `(Failure)` / `(Cancelled)` capitalised, versus the task FSM's
+  `done`/`failed`/`cancelled` everywhere else.
+- Real bug visible: `New issue: Boxtrack scaffold v2: TypeScript monorepo (api + webBoxtrack
+  scaffold v2: TypeScript monorepo (api + web)` - the title is concatenated with itself.
+- **`InboxEntryRow` already carries `subject_id`, `event`, `created_at`**
+  (`ainb-hangar-proto/src/events.rs:1051-1076`). Everything needed to render a human line is
+  in the plugin's own snapshots. Pure composition gap.
+
+### 1.7 Fleet (`F`) - `p4-7`
+
+- **Three stacked count rows saying the same thing** in two vocabularies:
+  - row 0: `1 Needs input 0  2 Idle 0  3 Completed 0  4 Running 0  [5 All 0]` (`fleet.rs:376`)
+  - row 1: `0 INPUT  0 RUN  0 IDLE  0 DONE` (`fleet.rs:2644`)
+  - row 2: `ACTION QUEUE · 0 sessions · F5 refresh` + `0/0` (`fleet.rs:2596`)
+- Empty state is broken grammar: `No all sessions` (`fleet.rs:2709`,
+  `format!("No {} sessions", state.filter.label().to_lowercase())`).
+
+### 1.8 Usage (`U`) - `p1-6`
+
+- `per agent` row prints the raw ULID (`usage_dashboard.rs:305`,
+  `put_str(.., &agent.agent_id, ..)`) - defect 8.
+- `recent runs` rows print the PROVIDER (`claude`), not the agent, not the issue, no
+  timestamp, no link (`usage_dashboard.rs:238 render_run_row`).
+- Chronological, not failed-first. The one failed run is at the bottom.
+- `total: ... (3 runs)` above a list of FOUR runs: the failed run has no usage row, so the
+  count and the list disagree on screen.
+
+### 1.9 Help (`?`) - `p4-1`
+
+Monotone gold, centred, no boxes, full-screen replacement rather than an overlay. Complete
+and accurate (`app_screens.rs:1509 HELP_LINES`, pinned by four tests). Lowest priority.
+
+### 1.10 Cross-cutting inconsistencies
+
+| axis | today | count |
+|---|---|---|
+| tab strip | 16 tabs, 138 cols, never fits 80 | `chrome.rs:45` |
+| router keys | 18 | `router.rs:30` |
+| attention surfaces | Control `C`, Inbox `I`, board `N need you` chip | 3 |
+| boards | Issues (7 lifecycle cols), Kanban (4 task-status cols), Boards (user cols) | 3 |
+| hint bars | footer everywhere + a second top band on Boards | 2 |
+| max hints on one screen | Boards: 16 + 5 + 3 | 24 |
+| run status words | `running/done/failed/cancelled` (task FSM), `Success/Failure/Cancelled` (inbox), `success/failed` (usage), `RUN/DONE` + `Running/Completed` (fleet) | 4 vocabularies |
+| id rendering | `HGR-3` (issues), `#1J7MR7` (kanban), `#AKQ408` (boards), full ULID (control, inbox, usage, facet panel) | 4 |
+
+---
+
+## 2. The crisp target
+
+### 2.1 Status vocabulary: one table, enforced by one helper
+
+Add `src/vocab.rs` with two total functions and make every screen call them.
+
+```
+run/task:    queued · running · done · failed · cancelled     (the CHECK'd FSM, 5 tokens)
+issue:       backlog · todo · in progress · in review · done · blocked · cancelled
+attention:   ASK · ERR · IDLE · WAIT                          (3-4 letter codes, uppercase)
+fleet lens:  needs input · running · idle · done              (one row, lowercase, delete row 1)
+```
+
+Rules: lowercase everywhere except the four attention codes. Never `Success`, never `DONE`,
+never `Completed`. One glyph per token, shared: `○ queued  ◔ running  ● done  ✗ failed  ⊘ cancelled`.
+
+### 2.2 Issue board card
+
+Footer swaps by state instead of growing a row. `CARD_ROWS` (`card_board.rs:355`) stays 5,
+so no geometry change and no column-capacity loss.
+
+```
+ idle card                            running card
+╭──────────────────────────────╮     ╭──────────────────────────────╮
+│ HGR-3                    ⧉   │     │ HGR-3                    ⧉   │
+│ Add GET /api/version         │     │ Add GET /api/version         │
+│ endpoint                     │     │ endpoint                     │
+│ ◆ High                 ⊟ 1/2 │     │ ◔ impl-1 · running 2m · PR ✓ │
+╰──────────────────────────────╯     ╰──────────────────────────────╯
+
+ card that is asking you              card refused dispatch
+╭──────────────────────────────╮     ╭──────────────────────────────╮
+│ HGR-7                        │     │ HGR-9                  ⚠     │
+│ Decide the sqlite location   │     │ Dependent B                  │
+│                              │     │                              │
+│ ● impl-1 · ASK 40s           │     │ ◇ blocked by MHAJBV          │
+╰──────────────────────────────╯     ╰──────────────────────────────╯
+```
+
+`BoardCard` gains three fields: `run: Option<RunChip { agent, state, elapsed_ms }>`,
+`pr: Option<PrChip>`, `attention: Option<AttentionKind>`. Footer priority: attention >
+run > priority chip. `◇ None` never prints again (drop the chip entirely when priority is
+the default, `card_board.rs:651-660`).
+
+### 2.3 Issue / task detail
+
+```
+┌ HGR-5 · Ticket stats: GET /api/tickets/stats ────────────────────────────────┐
+│ ◔ impl-1 is working · 7m 17s · 10 tools · $0.42       X cancel   a attach    │  live run card, sticky
+│   ainb/…N9GP8 → main   ·   PR #8 ✓ checks green                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ in progress · P2 · created 2026-09-02 · @boxtrack · main → main              │  ONE meta line (was 5)
+│ Acceptance: 0/3  □ GET /api/tickets/stats covered by vitest and green        │
+│                  □ npm run check green                                       │
+│                  □ pull request opened with the exact issue title            │
+│ Props: ◆ Sprint: S2  ◆ Owner: amy      Meta: -                               │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ Add GET /api/tickets/stats to the hono api under api/: returns {total, …}    │  brief, 2 lines + fold
+└──────────────────────────────────────────────────────────────────────────────┘
+┌ transcript ───────────────────────────┬ activity ────────────────────────────┐
+│ ● thinking  reading api/src/db.ts     │ 7m  impl-1 claimed the issue         │
+│ ▸ tool      Edit api/src/routes.ts    │ 6m  todo → in progress               │
+│ ✓ result    3 files changed           │ 2m  comment: started                 │
+│ ● text      Registering the route be… │                                      │
+│                             j/k scroll│                                      │
+└───────────────────────────────────────┴──────────────────────────────────────┘
+ R:retry  X:cancel  o:PR  a:criterion  ?:help  q:quit
+```
+
+- The floating right-hand facet panel from `p2-1` is deleted. `Project:` (raw ULID) and the
+  truncated `Notes:` go with it; `Status`/`Assignee` already live in the meta line.
+- Keep the literal substrings `Acceptance: 0/3`, `Props:`, `Meta:`, `◆ Sprint: S2` - four
+  tripwires assert them (section 4).
+- `Repo:` renders `@boxtrack` (the label), not the absolute path.
+- Terminal run: the live card becomes `● impl-1 finished · 2m09s · $0.58 · PR #6 ✓`.
+- Interactive run: the transcript pane says `interactive run - attach with a to see output`
+  and nothing else. There is no capture on that path (see section 5).
+
+### 2.4 Inbox as the one attention surface
+
+```
+Inbox  member:me   [2 need you] [35 unread]    (all) asks  runs  issues        I inbox
+┌ needs you ──────────────────────────────────────────────────────────────────┐
+│▸● ASK  40s   impl-1 on HGR-7 Decide the Boxtrack sqlite file location        │
+│   ① data/boxtrack.db (Recommended)   Repo-root data/ dir, outside api/src    │
+│   ② api/app.db                       Sits next to api package                │
+│   h/l pick · 1-9 or enter to answer                                          │
+│ ● ERR  3m    rev-1  on HGR-5 Ticket stats · agent_error exit 65              │
+└─────────────────────────────────────────────────────────────────────────────┘
+┌ recent ─────────────────────────────────────────────────────────────────────┐
+│ ✗ 9m   qa-1   failed   HGR-5 Ticket stats: GET /api/tickets/stats · exit 1   │
+│ ● 2m   impl-1 done     HGR-3 Add GET /api/version endpoint · PR #6 ✓         │
+│ ◔ 4m   impl-1 running  HGR-3 Add GET /api/version endpoint                   │
+│ + 12m  new issue       HGR-8 Dependent B: must refuse to run while A is open │
+└─────────────────────────────────────────────────────────────────────────────┘
+ enter:answer  r:mark read  f:filter  ^P:search  ?:help  q:quit
+```
+
+- `needs you` block is `attention/list` open rows, sorted by age. Inline answer is
+  `control_center.rs`'s existing option render + reducer, moved not rewritten
+  (`control_center.rs:645 render_control_center`, the answer path from `p3-5`).
+- `recent` block is `inbox_list` with each line recomposed locally:
+  `subject_id` -> tasks snapshot -> agent name + issue title; `event` -> a lowercase verb
+  from the vocab table; `created_at` -> relative age. Failed rows sort first inside their
+  age bucket.
+- Filters `(all) asks runs issues` are client-side over the cached rows, `f` cycles.
+- The board's `N need you` chip and the Control tab both become views of THIS state.
+
+### 2.5 Tab strip
+
+```
+before (16 tabs, 138 cols, wraps under 138, never fits 80):
+[1]Issues [2]Task [3]Skills [4]Autopilots [K]Kanban [B]Boards [D]Daemon [U]Usage
+[L]Logs [I]Inbox [C]Control [F]Fleet [S]Squads [P]Profiles [A]Agents [,]Settings
+
+after (7 tabs, 74 cols, fits the 80x24 floor with the right cluster intact):
+[1]Issues  [2]Task  [K]Runs  [B]Boards  [I]Inbox  [A]Agents  [,]Settings   ⬡⬡ 2 working  default ● online
+```
+
+Keys that survive in `ROUTER_KEYS` (`router.rs:30`): `1 2 K B I A , ? q` = **9** (from 18).
+
+Demoted, 9 keys / 8 screens: `3` Skills, `4` Autopilots, `D` Daemon, `U` Usage, `L` Logs,
+`C` Control, `F` Fleet, `S` Squads, `P` Profiles. Reachable two ways, both must land in the
+same commit as the demotion:
+
+1. `^P` palette gains a plugin-local `Go: <screen>` entry family, matched client-side and
+   merged ahead of the daemon's `hangar/search` results (`command_palette.rs`,
+   `SearchEntryKind` untouched - the Go entries are a separate local vec).
+2. `,` Settings gains a `More screens` section listing all nine with their palette names.
+
+`K` is relabelled `Runs` (it is the only run-centric board and `Kanban` names the widget,
+not the content). Hotkey unchanged, so muscle memory and `docs/hangar/tui-keybindings.md`
+survive with a label edit.
+
+### 2.6 Hint bar grammar
+
+```
+<= 5 contextual hints, then exactly 3 globals: ^P:search  ?:help  q:quit
+key:verb          verb is one bare imperative word, lowercase
+                  no two hints on a screen share a verb
+                  never advertise a router key (already enforced, chrome.rs:368)
+overflow          goes to the context menu (context_menu.rs) and `?`, never to a second bar
+```
+
+- Delete `boards.rs:2672 BOARDS_HINTS` and `boards.rs:2692 render_hint_band` outright. The
+  16 hints move to the existing card/column context menu. Boards footer becomes
+  `↵:run  a:attach  t:timeline  c:card  x:cancel` + globals.
+- Issues footer 9 -> 5: `c:create  ↵:open  a:assign  /:filter  x:delete`.
+- Task detail 5 -> 4: `R:retry  X:cancel  o:PR  a:criterion`. `x:delete` moves to the
+  context menu (`X` and `x` on one bar is a misfire waiting to happen).
+- Read-only panes (`Usage`, `Daemon`, `Logs`) keep the empty contextual list they already
+  have (`chrome.rs:207`).
+
+---
+
+## 3. Quick wins on data already in plugin memory
+
+Each is small, independent, and needs no new daemon call except where marked.
+
+| # | defect | fix | anchor |
+|---|---|---|---|
+| Q1 | 8 | Task detail `Assignee: agent:<ulid>` / `Agent: , ` -> resolve through the existing `agent_names(&actors)` map | `app_screens.rs:1241` (helper exists, Kanban's only caller is `kanban.rs:264`); apply at `task_detail.rs:1113-1126` |
+| Q2 | 8 | Usage `per agent` raw ULID -> agent display name, same map | `usage_dashboard.rs:305` |
+| Q3 | 8 | Board card `◔0` -> `◔ impl-1`, and drop `◇ None` when priority is default | `widgets/card_board.rs:651-670` |
+| Q4 | 7 | Transcript backfill on task-detail open: fire `hangar/board_card_timeline` and feed `jsonl_timeline::parse_timeline` into `TaskDetailState`. The whole pipeline already exists for Boards. **Needs one trivially-additive change**: make `BoardCardParams.board_id` an `Option<String>` and skip the board-membership guard when absent, so an uncarded issue resolves | plugin `plugin.rs:4936` (open path, fires nothing today), reuse `plugin.rs:1811 apply_board_card_timeline`; daemon `ainb-hangar-daemon/src/rpc/mod.rs:11226-11231` |
+| Q5 | 9 | `R` on a done task silently no-ops -> `push_system_line("this run finished; R only retries a failed or cancelled run")` before raising the intent | `task_detail.rs:573` (`TaskDetailIntent::RetryTask`), note sink `task_detail.rs:363` |
+| Q6 | 6 | Repo roster fetched once at connect, so a repo added later is unpickable -> re-fire `HANGAR_REPO_LIST` on wizard open | fetched at `plugin.rs:2592`; wizard opens at `issue_list.rs:1980 enter_create_mode` |
+| Q7 | 12 | Wizard `@` filter narrows but Enter picks `scratch`. **Root cause confirmed**: `repo_candidates` unconditionally prepends `RepoOption::scratch()` at index 0 regardless of the query, and the cursor resets to 0 on every keystroke. Fix: include scratch only when the query is empty or scratch fuzzy-matches | `boards.rs:451-459` (prepend), `issue_list.rs:2426-2431` (cursor reset) |
+| Q8 | 21 | Boards rename input types `u` for Ctrl+U -> add a `BoardsKey::ClearLine` arm | `boards.rs:1921 column_rename_key`; the key decode is `app_screens.rs:~2720 key_char` |
+| Q9 | - | Inbox lines: ULID -> `<agent> <verb> <HGR-n> <title>` + relative age + per-row unread dot, using `subject_id`/`event`/`created_at` already on the wire | `inbox.rs:134 render_entry`, row shape `ainb-hangar-proto/src/events.rs:1051` |
+| Q10 | - | Failed-first ordering in run lists (usage `recent runs`, inbox `recent`) | `usage_dashboard.rs:225-235` loop, `inbox.rs:120` loop |
+| Q11 | - | "N working" chip is dead code: `working_count` is declared and read but never assigned. Assign it from the tasks snapshot's running column and render `⬡⬡ 2 working` instead of bare glyphs | `app_screens.rs:649` (declared), `issue_list.rs:2814` (read), `widgets/working_chip.rs:30` (render) |
+| Q12 | - | Presence dots on agent rows: `widgets/presence_dot.rs:17` exists and is used only by its own test. Wire it into the Agents roster + agent picker rows alongside a workload chip (`N running / max_concurrent`) | `widgets/presence_dot.rs:17`, `widgets/actor_row.rs:76`, `screen/agents.rs` |
+| Q13 | 5 | Dispatch-refusal note: de-duplicate the text and name the blocking row (`a run is already active: 01M1FK… (running)`) resolved from the tasks snapshot. The phantom-on-terminal-rows half is daemon-side and stays open | note sink `boards.rs:3927` / `issue_list` note path |
+| Q14 | - | Kanban branch elide: `ainb/01M1FKF4BDNQ3JK5CQSS3N9GP8` -> `ainb/…N9GP8` so the PR chip stops falling off the tile | `kanban.rs:513-520` |
+| Q15 | - | Fleet: delete the duplicate count row and fix the empty-state grammar (`No all sessions` -> `no sessions yet · press 5 for all`) | `fleet.rs:2644` (row to delete), `fleet.rs:2709` (grammar) |
+| Q16 | - | Control Center stat strip prints three permanent em-dash columns (`tok: · tools: · Δ , `). Drop the unknown columns rather than rendering placeholders | `control_center.rs:809` |
+
+---
+
+## 4. Sequencing: 5 PR-sized steps
+
+Each step is independently shippable and independently recordable. Sizes are S (half day)
+and M (one to two days).
+
+### Step 1 (M) - Resolve every id to a name
+
+**Does:** Q1, Q2, Q3(name half only), Q4, Q5, Q6, Q7, Q8, Q9, Q10, Q13, Q14, Q16.
+**Touches:** `task_detail.rs`, `usage_dashboard.rs`, `inbox.rs`, `kanban.rs`, `boards.rs`,
+`issue_list.rs`, `plugin.rs`, `widgets/card_board.rs`, `control_center.rs`, plus
+`ainb-hangar-proto/src/snapshots.rs` + `ainb-hangar-daemon/src/rpc/mod.rs:11226` for the
+optional `board_id`.
+**Tripwires:** none of the seven. `tripwire_issue_acceptance_tick` asserts `Acceptance: 0/3`
+on task detail - **do not move that row in this step**.
+**Other tests to refresh:** `snapshot_kanban_layout__render_full_board_snapshot.snap`
+(branch elide), `usage_dashboard.rs:428 renders_totals_and_per_agent_rows`, `inbox.rs`
+in-module render tests, `boards.rs:3664 rename_column_edits_and_commits` (new Ctrl+U arm),
+`transcript_render_snapshot.rs`, `snapshot_control_center__*.snap` (3, stat strip).
+**Risk:** the `board_id` relaxation is the only non-plugin edit. Guard the workspace tenant
+check; only the board-membership check is skipped.
+
+### Step 2 (M) - Cards and hint bars
+
+**Does:** section 2.2 card footer state machine, section 2.6 hint grammar, Q11 working chip,
+Q15 fleet rows, `src/vocab.rs` and its first callers.
+**Touches:** `widgets/card_board.rs` (`BoardCard` +3 fields, `render_card` footer),
+`issue_list.rs` (card mapping + working count), `chrome.rs:169 footer_hints`,
+delete `boards.rs:2672 BOARDS_HINTS` + `:2692 render_hint_band`, `fleet.rs`.
+**Tripwires:** none of the seven directly. `tripwire_issue_blocked_cancelled` asserts
+`Blocked (1)` / `Cancelled (1)` / `Move to` (column headers + context menu, untouched);
+`tripwire_issue_properties_render` asserts `◆ Sprint: S2` on the properties row, not the
+card footer - verify the new footer glyph does not collide.
+**Other tests to refresh:** all 13 card snapshots (`issue_board_snapshot`,
+`snapshot_boards__*` x7, `snapshot_kanban_layout`, `autopilots_screen_snapshot`,
+`skill_screen_snapshot`), `fleet.rs:5321/5325/5518` count-row assertions.
+**Two chrome tests will FAIL and need a decision, not a mechanical update:**
+`chrome.rs:~434` pins `footer_hints(IssueList).contains(("x","delete"))` (keep it, `x` is
+in the 5) and `chrome.rs:~449` pins `("f","facets")` (drop the assertion, `f` moves to the
+context menu and stays in `HELP_LINES`).
+
+### Step 3 (M) - Inbox becomes the one attention surface
+
+**Does:** section 2.4. Left list (needs-you + recent), right/inline answer pane lifted from
+Control Center, client-side filters, failed-first ordering.
+**Touches:** `inbox.rs` (324 -> ~650), reuse `control_center.rs:645` render + the answer
+reducer verbatim, `plugin.rs` to feed `attention/list` into inbox state.
+**Tripwires:** none of the seven.
+**Other tests:** new `inbox.rs` render tests; `snapshot_control_center__*.snap` stay green
+because Control remains a screen until step 5.
+**Note:** this step unifies the SURFACE only. Do not merge the `attention` /
+`fleet_confirm` / `fleet_action_receipt` stores (section 5).
+
+### Step 4 (M) - Detail screen
+
+**Does:** section 2.3. Live run card, one meta line, transcript pane wired to Q4's backfill,
+activity pane, delete the floating facet panel.
+**Touches:** `task_detail.rs` (header collapse + panes), `widgets/facet_panel.rs` (drop the
+task-detail call site, keep the widget for the issue list), `widgets/transcript.rs`,
+`widgets/jsonl_timeline.rs`.
+**Tripwires - two bite here:**
+- `tripwire_issue_acceptance_tick` (`tests/tripwire_issue_acceptance_tick.rs:560-597`)
+  asserts `TARGET acceptance issue`, `Acceptance: 0/3`, `1/3`, `3/3`. Keep those literal
+  substrings in the new layout.
+- `tripwire_issue_properties_render` (`:577-599`) asserts `Props:`, `Meta:`,
+  `◆ Sprint: S2`, `◆ Owner: amy`. Keep the Props/Meta row.
+**Other tests:** `facet_panel_snapshot.rs`, `transcript_render_snapshot.rs`,
+`pr_badge_snapshot.rs`, `transcript_reducer_test.rs`.
+
+### Step 5 (S) - Tab strip, help, palette
+
+**Does:** section 2.5. 16 tabs -> 7, 18 router keys -> 9, `Go:` palette family, Settings
+`More screens` section, `HELP_LINES` rewrite, `Kanban` -> `Runs` label.
+**Touches:** `chrome.rs:45 PRIMARY_TABS`, `router.rs:30 ROUTER_KEYS` + `:46 is_router_key` +
+`:93 reduce_key` (delete 9 arms in lock-step), `app_screens.rs:1509 HELP_LINES`,
+`command_palette.rs`, `settings.rs`, `docs/hangar/tui-keybindings.md`.
+**Test changes, precisely:**
+- `router.rs:218 router_keys_all_have_a_reduce_key_arm` - **passes unchanged** provided the
+  const, `is_router_key` and `reduce_key` shrink together. It iterates `ROUTER_KEYS`, so a
+  smaller set is a smaller loop.
+- **Add** `palette_reaches_every_demoted_screen`: assert each of the 9 demoted `Screen`
+  variants has a `Go:` palette entry. Without this, the shrink can strand a screen and no
+  existing test notices.
+- `app_screens.rs:2664 help_overlay_names_every_router_key` - passes with fewer keys. The
+  `screens` HELP_LINES rows must still name all 7 survivors as `<key> <label>` pairs.
+- `app_screens.rs:2749 help_overlay_screen_keys_are_not_router_keys` - the new `more` block
+  lists `3 skills`, `U usage` etc. Those are no longer router keys, so `is_router_key`
+  returns false and the test passes. Widen the `in_screens` skip to also match a first
+  token of `more`, for intent.
+- `app_screens.rs:2694 help_overlay_screen_rows_pair_every_label_with_a_key` - the `more`
+  row is key/label pairs, passes.
+- `app_screens.rs:2786 help_overlay_clips_to_a_short_pane_from_the_top` - counts non-blank
+  lines, adjusts automatically.
+- `chrome.rs:368 footer_hint_keys_never_collide_with_reserved_router_keys` - gets strictly
+  looser (9 fewer reserved chars). Its screen list at `:378-389` enumerates `Screen`
+  variants, which all still exist. Passes.
+- `chrome.rs:~467-472` width test comments reference a "fifteen-tab strip"; update the
+  comment and the width assertion (the 7-tab strip is 74 cols, so it now fits 80).
+- `tests/screen_router_test.rs` - update any assertion that presses a demoted key.
+- `tests/tripwire_hangar_plugin_connects.rs` - asserts connect state, no screen text. Green.
+
+---
+
+## 5. Recording plan
+
+One vhs tape per step, before/after in the same gif, driven on the isolated instance the
+proving run used. Reuse `scripts/hangar/record-fullstack-p1.sh` as the harness template (it
+already bakes the iso `HOME`, `TMUX_TMPDIR`, `AINB_PLUGIN_ROOT`, `AINB_BIN` env and the
+`Wait+Screen@60s /navigate/` gate). Output under `docs/hangar/proofs/crisp/`.
+
+| step | tape | the shot that proves it |
+|---|---|---|
+| 1 | `c1-names.tape` | task detail showing `Agent: impl-1`, usage showing `impl-1` not the ULID, inbox showing `impl-1 done HGR-3 Add GET /api/version`, and a task-detail open that immediately paints a transcript |
+| 2 | `c2-cards.tape` | one Issues board with an idle card, a running card (`◔ impl-1 · running 2m · PR ✓`) and an ASK card side by side; Boards with ONE hint bar |
+| 3 | `c3-inbox.tape` | the full P3 human loop driven entirely from `I`: ASK appears in `needs you`, answer inline with `2`, row clears, `recent` gains the finished run |
+| 4 | `c4-detail.tape` | `2` on a live run: run card ticking, transcript streaming, acceptance still reading `Acceptance: 0/3`, then the same screen after the run finishes |
+| 5 | `c5-tabs.tape` | the 7-tab strip at 80 cols, then `^P` -> `usage` -> Usage screen, proving nothing was stranded |
+
+Every tape ends with a `Screenshot`, so the operator judges crispness from a still and the
+motion from the gif. Record green runs only, as the proving run did.
+
+---
+
+## 6. Do NOT attempt in this track
+
+These depend on the spine work. Half-building any of them here creates a second thing to
+unwind when ACP and the state collapse land.
+
+1. **Collapsing issue / card / task state.** Four stores, synchronised by a fan of
+   advance-only best-effort writes that log-and-swallow (`ainb-hangar-daemon/src/board.rs`
+   x9 functions; exec-map section 3.2). The plugin must keep rendering three vocabularies
+   until the daemon collapses them. Map them in `vocab.rs`, do not merge them.
+2. **Any plugin-side write that is not an existing RPC**, and no polling to paper over
+   defect 15 (CLI writes the store directly with no event, `cli/hangar/mod.rs`, 18 direct
+   `Store::open_default()`, zero `HangarEvent`). A "refresh every N seconds" workaround
+   hides the missing event and makes the single-writer fix harder to justify.
+3. **Anything that touches the answer delivery path.** `attention/answer` ->
+   `answer.rs:218 deliver` -> `capture_pane` + `send-keys` is load-bearing for correctness,
+   with four documented refusal conditions and a live-probed picker behaviour that changed
+   between Claude Code 2.1.257 and 2.1.258 (REPORT.md:72, :87). The Inbox in step 3 renders
+   and raises the same `attention/answer` RPC the Control Center raises today, byte for
+   byte. Do not add a "structured answer" affordance; that is ACP.
+4. **A live transcript for interactive runs.** There is no capture on that path:
+   `run_loop.rs:1559 run_interactive` produces no stream-json and `runner.rs:1327` sets
+   `structured = false`. The tmux pane is the sole artifact. Render `attach with a` and stop.
+5. **Unifying the attention / fleet_confirm / fleet_action_receipt stores.** Step 3 unifies
+   the surface. Two parallel "a human must answer" mechanisms plus a third receipt table is
+   a daemon-model problem (exec-map section 3.4).
+6. **Acceptance criteria gating done.** A task finalises `done` with 0/3 ticked by design
+   (REPORT.md:30). Render the ratio, do not enforce it.
+7. **Board card authoring: brief stage, or create-without-dispatch** (defects 16, 17). Both
+   need new RPC and brief-composition rules (`run_loop.rs:2548 build_prompt`).
+8. **PR badge capture** (defect 11). `pr_url` is parsed daemon-side from the bounded stdout
+   tail (`run_loop.rs:1708 parse_gh_pr_create_stdout`) and misses under stream-json. The
+   plugin renders whatever `pr_url` arrives and renders nothing when it is absent. Do not
+   synthesise a PR link from the branch name.
+9. **Deleting `Screen` variants** for the nine demoted screens. Only the router key goes.
+   The screens, their reducers, their snapshots and their tests all stay.
+10. **Daemon log noise** (defect 13, `Codex managed transport degraded` every 16s). Daemon
+    side. The Logs screen may add a rate-limit fold, but do not filter the row out.

--- a/docs/hangar/renovation/exec-map.md
+++ b/docs/hangar/renovation/exec-map.md
@@ -1,0 +1,476 @@
+# Hangar execution map (2026-09-02, at 7d2b10d3)
+
+Appendix to `docs/hangar/renovation/PLAN.md`. Produced by a read-only code archaeology pass; every claim carries a file:line. Paths are relative to the worktree the pass ran in; the tree is the same on `main` after PR #815.
+
+Mode: focused-query
+
+# Hangar task execution + surface inventory: `agents-in-a-box` @ `7d2b10d3` (branch `f/prove-hangar`, 2026-09-02)
+
+All paths absolute. Base: `/home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-prove-hangar--22bb34f4/ainb-tui/`
+
+Repo identity (confirmed):
+- `git rev-parse HEAD` → `7d2b10d3c54dae28930247627f97089a74898640`
+- `git remote get-url origin` → `https://github.com/stevengonsalvez/agents-in-a-box.git`
+- `git log -1` → `7d2b10d3 2026-09-02 16:47:08 +0000 steven gonsalvez`
+
+---
+
+## 1. How a hangar task executes: and where ACP fits
+
+**Plain answer: tasks execute as local CLI subprocesses (`claude` / `codex` / `copilot` / `agy`), spawned by the daemon's claim loop. ACP is used ONLY for fleet CHAT sessions: it never touches the task path.** Confirmed: `rg -in 'acp'` returns ZERO matches in both `run_loop.rs` and `runner.rs`.
+
+```
+┌──────────┐  issue_run /   ┌──────────────┐  PULL_SQL   ┌───────────────┐
+│ TUI/CLI  │  board_card_run│  run_card()  │────────────▶│agent_task_queue│
+└──────────┘───────────────▶└──────────────┘  (or direct)└───────┬───────┘
+                                                                 │ CLAIM_SQL
+                              ┌──────────────────────────────────▼────────┐
+                              │ run_loop: provision wt → env → sandbox    │
+                              └───┬───────────────────────────┬───────────┘
+                       headless   │                           │ interactive
+                    ┌─────────────▼──────────┐   ┌────────────▼──────────────┐
+                    │ claude -p --output-    │   │ tmux new-session -d       │
+                    │ format stream-json     │   │ `tmux_hangar-<task_id>`   │
+                    │ → {logs}/claude.jsonl  │   │ (NO sandbox, NO capture)  │
+                    └────────────────────────┘   └───────────────────────────┘
+```
+
+### a. issue → task row
+
+| Step | Location |
+|---|---|
+| `hangar/issue_run` handler | `.../crates/ainb-hangar-daemon/src/rpc/mod.rs:9651` |
+| `hangar/board_card_run` handler | `.../crates/ainb-hangar-daemon/src/rpc/mod.rs:9541` |
+| Shared launch core `run_card` | `.../crates/ainb-hangar-daemon/src/rpc/mod.rs:10148` |
+| Mode validation (`""`/`headless`/`interactive`, else invalid_params) | `rpc/mod.rs:9661-9669` |
+| Tenant guard (issue must exist in this workspace) | `rpc/mod.rs:9672-9676` |
+| Brief-or-link guard: **scoped to `issue_run` only**, NOT the shared core | `rpc/mod.rs:9684-9690` (test pins the asymmetry at `rpc/mod.rs:15648`) |
+| Remote-only repo favourite resolved to a LOCAL clone before dispatch | `rpc/mod.rs:9698-9706` |
+| Agent / assignee / source-branch / invoker overrides | `rpc/mod.rs:9707-9723` |
+| `run_card(...)` invocation, board tier skipped via `board_id = None` | `rpc/mod.rs:9724-9738` |
+| Result shape `BoardCardRunResult` (single vs squad) | `rpc/mod.rs:9748-9777` |
+| Squad fan-out vs single enqueue | `CardRunOutcome` at `rpc/mod.rs:9783`; fan-out service `.../crates/ainb-hangar-store/src/service/squad_assign.rs:319` |
+
+**Pull pipeline** (`.../crates/ainb-hangar-store/src/service/pull.rs`): a `board_card` in a role-gated column IS the queue. `PullService::pull_for_runtime` materialises at most ONE `agent_task_queue` row per tick via a single `INSERT…SELECT…RETURNING` (`PULL_SQL`, `pull.rs:531`; executed at `pull.rs:206`), gated on six predicates documented at `pull.rs:44-80`:
+
+1. Role gate: the column declares `services_role` and the agent holds it. `services_role IS NULL` (Backlog, Done, pre-0074 columns) is not a pull queue at all.
+2. WIP limit: column has fewer than `wip_limit` cards holding an active task; `NULL` = unlimited.
+3. One owner per card: the card's issue has NO active (`queued`/`dispatched`/`running`) task.
+4. Stage not already finished: the card's CURRENT column holds no `done` task at the card's CURRENT generation (the FINALIZE WINDOW guard; needs `board_column_id`, migration 0078).
+5. Prior-agent exclusion: on `excludes_prior_agent = 1`, an agent with a `done` task on this card may not take it (reviewer ≠ implementer). Failure direction: the card WAITS rather than being self-reviewed.
+6. Not blocked + agent has capacity: unfinished `card_dependency` blockers, and `max_concurrent_tasks`.
+
+Why the row is created by the puller and not a dispatcher: `agent_task_queue.agent_id` is `NOT NULL`, so a queued row always already names its agent; true pull needs the agent chosen at claim time, and making the column nullable is a full table rebuild on SQLite (`pull.rs:11-20`). Atomicity rests on SQLite serialising writes so a concurrent puller's sub-select observes this statement's committed row (`pull.rs:33-43`). Mutation proofs live at `.../crates/ainb-hangar-store/tests/pull_role_gate.rs`: they delete each clause verbatim from `PULL_SQL` and assert the forbidden pull then succeeds.
+
+**The row**: `agent_task_queue`, base schema `.../crates/ainb-hangar-store/migrations/0004_agent_task_queue.sql:22-39`, then **13 further migrations `ALTER`ing it**. Base columns: `id, workspace_id, runtime_id, agent_id, issue_id, status, result, session_id, work_dir, attempt, max_attempts, parent_task_id, failure_reason, created_at, started_at, finished_at`. `status` is CHECK-constrained to `queued|dispatched|running|done|failed|cancelled` (`0004…sql:28`). A partial unique index enforces ≤1 pending task per issue (`0004…sql:47-49`).
+
+Columns added later by ALTER: `agent_kind, autopilot_run_id, board_column_id, branch, dispatched_at, generation, mode, origin_id, origin_type, priority, repo_ref, run_group, session_name, source_branch, squad_id, target_branch, token_budget, trigger_comment_id`.
+
+The `Task` struct is 28 fields (`.../crates/ainb-hangar-store/src/repo/task.rs:77`):
+`id, workspace_id, runtime_id, agent_id, issue_id, status, result, session_id, work_dir, attempt, max_attempts, parent_task_id, failure_reason, priority, created_at, dispatched_at, started_at, finished_at, autopilot_run_id, mode, session_name, repo_ref, agent_kind, branch, generation, source_branch, squad_id, origin`.
+
+**Retry**: `maybe_spawn_retry` → `RetryService::maybe_retry_failed` inserts a CHILD task row (`run_loop.rs:2218-2240`). A collision with the per-(issue, agent) pending-unique index is treated as benign "already pending", not a fault (`run_loop.rs:2234-2237`).
+
+**Auto-run**: only via dependency unblock: `board.rs:439` reads `CardDependencyRepo::get_auto_run`, then `auto_run_dependent` (`.../crates/ainb-hangar-daemon/src/board.rs:452`). Card-level flag also set through `hangar/board_card_set_auto_run`.
+
+### b. Claim loop
+
+Entry `run_loop::run` at `.../crates/ainb-hangar-daemon/src/run_loop.rs:457`.
+
+Boot sequence: `log_sandbox_posture` (`run_loop.rs:469`, added because an exit-65 dispatch failure was ambiguous between "fix present, still failing" and "stale binary"), `spawn_sweepers` (`:470`), `spawn_gc_sweeper` (`:477`), `spawn_runtime_presence` (`:488`, deliberately before the `disable_claim` early-return), then `reclaim_orphans_on_restart` (`:517`) gated on the migration-0092 instance-id arrival so a re-registered runtime does not double-dispatch its own live runs.
+
+Per-tick order: **pull first, then claim**: deliberate, so a handoff to the next stage is one poll interval rather than two (`run_loop.rs:598-621`). A pull fault degrades the daemon to push-only rather than downing the loop (`run_loop.rs:617-621`). Then `ClaimTaskService::claim_for_runtime` (`run_loop.rs:623`).
+
+Executions spawn onto a `JoinSet` (`run_loop.rs:551`, `:633`) so a long-lived interactive run never wedges the claim loop; the per-agent `max_concurrent_tasks` cap needs no in-memory accounting because the claim SQL counts the agent's live `dispatched`+`running` rows (`run_loop.rs:536-544`). Shutdown reaps interactive tmux sessions by exact name on SIGINT only (SIGTERM is `daemon stop`/`restart`, whose panes are re-adopted by the next boot's reconciler) then `runs.shutdown()` awaits every aborted run so `kill_on_drop(true)` SIGKILLs land before return (`run_loop.rs:558-581`).
+
+Per-task path in `execute_claimed` (`run_loop.rs:1087`):
+
+- `workspace_slug` + `prepare_env` → task execenv tree (`run_loop.rs:1107-1115`). A setup fault **terminalises** via `finalize_setup_failure` rather than propagating, because a propagated error left the row `dispatched` and the stale-dispatch sweeper re-dispatched it into the same fault, looping invisibly until the 5min TTL relabelled it `timeout` with no cause (`run_loop.rs:1100-1106`).
+- One `CLAUDE.md` materialised in the execenv carrying the workspace context prompt AND (for a squad-LEADER task) the claim-time briefing; append-only, both parts best-effort (`run_loop.rs:1117-1145`).
+- `dispatch_mode(&task.mode)`: the ONE place the row's `mode` column becomes a `Mode`, carried on `ResolvedDispatch` so the exec-path branch and the argv can never disagree (`run_loop.rs:1155-1159`).
+- `resolve_dispatch` (agent → runtime → provider + model/cli_args/agent_env) at `run_loop.rs:1160-1172`; a resolve fault falls back to the default provider WITH the fallback prompt and is logged, never silently substituted.
+- Worktree provision `crate::workdir_provision::provision` (`run_loop.rs:1210-1225`). Two slugs: the FULL task id keys the volatile worktree (`~/.agents-in-a-box/worktrees/<taskid>` on branch `ainb/<id>`), while SCRATCH is keyed on `(issue, agent)` so reruns reuse a durable dir and squad members get distinct ones (`run_loop.rs:1195-1209`).
+- Typed FSM guard `LifecycleGuard::claimed()` (`run_loop.rs:1236`), cancel registry registered BEFORE the start transition to close the race window (`run_loop.rs:1238-1242`), then `dispatched → running` via `StartTaskService::start` (`run_loop.rs:1248-1264`). A cancel that won the race tears down the worktree and returns without running (`run_loop.rs:1255-1262`).
+- **Spawn-setup umbrella**: every await between the `running` commit and the provider spawn is bounded by ONE timeout (`run_loop.rs:1295-1325`): the board auto-move, the issue-lifecycle advance, the "started" progress comment, and `prepare_spawn_inputs` (`run_loop.rs:972`) which includes `resolve_cred_env` (`run_loop.rs:928`) with its own `CRED_READ_TIMEOUT`. Expiry → `FailureReason::SpawnTimeout`, classified `NoRetry` (`run_loop.rs:1329-1354`). Rationale at `run_loop.rs:1280-1294`: a wedge anywhere in that span was the forever-`running` black hole.
+- Credential resolution `.../crates/ainb-hangar-daemon/src/claude_cred.rs::resolve`: 4-step ladder documented in `ainb-tui/CLAUDE.md`: `HANGAR_CLAUDE_OAUTH_TOKEN` → system `claude` login read by shelling to `/usr/bin/security` → legacy stored token → nothing (run reaches `claude` and fails loudly). Backend built ONCE for the daemon's lifetime and shared across runs (`run_loop.rs:545-549`), injectable as a trait object for tests.
+- Env composition: `compose_child_env` in `.../crates/ainb-hangar-daemon/src/runner.rs`: allowlist filter over the source env plus agent_env layered on top; agent_env cannot shadow the daemon parent stamp (pinned by unit tests in the same file).
+- Sandbox: `.../crates/ainb-hangar-sandbox/src/lib.rs`: Seatbelt profile via `/usr/bin/sandbox-exec` on macOS (`imp_macos`), Landlock ruleset applied in a `pre_exec` hook on Linux (`imp_linux`), `Enforcement::None` passthrough elsewhere so the confinement test SKIPs rather than vacuously passing (`lib.rs:20-35`). Default ON on Linux / OFF on macOS (`run_loop.rs:295-303`); `HANGAR_DAEMON_DISABLE_SANDBOX` overrides: `"1"` forces OFF, `"0"` forces ON, anything else falls back to the platform default (`run_loop.rs:278-284`). Wired into `RunnerConfig` at `run_loop.rs:530-533`. Provider paths are canonicalised to absolute ONCE at config time because a bare `claude` emits a `(literal "claude")` Seatbelt rule the kernel never matches, denying exec of the real PATH-resolved binary (`run_loop.rs:191-218`, `resolve_provider_path:320`).
+
+### c. Execution backends
+
+Provider specs in `.../crates/ainb-hangar-daemon/src/runner.rs` (2421 lines): `claude_spec:1295`, `codex_spec:1368`, `copilot_spec:1468`, `antigravity_spec:1495`. Dispatch match at `run_loop.rs:1405-1449`.
+
+**Headless claude argv** (`runner.rs:1296-1320`):
+`-p --dangerously-skip-permissions --output-format stream-json --verbose [--model M] [cli_args…] -- <prompt>`
+Constants at `runner.rs:246` (`-p`), `:303-305` (`--output-format stream-json`), `:306-309` (`--verbose`, hard-required by `--print` + stream-json). `structured: mode == Mode::Headless` (`runner.rs:1327`): only the headless argv promises a structured terminal to finalize on, so the runner finalizes on claude's OWN reported outcome rather than the exit code (`runner.rs:1306-1309`).
+
+**Headless codex** (`runner.rs:1368-1399`): `exec --skip-git-repo-check -s danger-full-access --json [-m MODEL] [cli_args…] -- <prompt>`. Interactive omits ALL of `exec`, `--skip-git-repo-check` and the sandbox flag: `--skip-git-repo-check` is an `exec`-only flag and a hard parse error at top level (`runner.rs:1347-1361`). Retired model ids are substituted at the wire because a retired id dispatches into a blocking migration modal a headless run has nobody to dismiss (`runner.rs:1381-1394`).
+
+**Copilot** (`runner.rs:1468`, prompt flag `-p` at `:315`) carries `--allow-all-tools`, mandatory for non-interactive mode (`runner.rs:1291-1294`). **Antigravity** (`runner.rs:1495`): `agy -p --dangerously-skip-permissions --output-format stream-json [--model M] [cli_args…] -- <prompt>` headless; interactive drops `-p` and stream-json and adds `-i` (`runner.rs:1491-1495`, argv pinned by the unit test at `:2370`).
+
+**Output capture** (headless): `{env.logs}/{spec.log_file}` opened at `runner.rs:1571-1572`, stdout streamed line-by-line by `stream_stdout` (`runner.rs:1873-1953`) which appends each line to the log file AND to a bounded oldest-line-evicting ring tail (`TAIL_LINES`), read concurrently so it never blocks the claim loop. One log file per provider so a run of both keeps transcripts separate: `claude.jsonl` (`:1323`), `codex.jsonl` (`:1403`), `copilot.jsonl` (`:1482`), `antigravity.jsonl` (`:1518`).
+
+**Interactive** (`run_interactive`, `run_loop.rs:1559`; argv derived solely by `interactive_command`, `run_loop.rs:1538`): detached tmux session named **`tmux_hangar-<task_id>`** (`.../crates/ainb-hangar-daemon/src/interactive.rs:63`). **Deliberately unsandboxed and un-token-injected** so the attached claude reaches the Keychain and `~/.claude` natively and auto-refreshes; a static `CLAUDE_CODE_OAUTH_TOKEN` would override keychain auth and go stale mid-session (`run_loop.rs:1381-1386`). Completion is detected by the session being reaped, mapped onto the same `RunOutcome` the headless path returns (`run_loop.rs:1357-1361`). There is **no structured output capture on this path**: the pane is the sole artifact. `interactive_command` was extracted precisely because a prior shape hardcoded `Mode::Headless` inside `run_interactive` and kept 254 lib tests green while reintroducing the regression; the only coverage was a tmux tripwire that SKIPs when tmux is absent (`run_loop.rs:1530-1537`).
+
+Session naming and teardown use exact-name targeting (`=name`) because a bare `-t` resolves exact then prefix, so reaping `ainb-run-abc` could kill a live `ainb-run-abc2` (`interactive.rs:74-78`).
+
+**Brief composition** (`build_prompt`, `run_loop.rs:2548-2594`):
+```
+[stage_prompt]
+
+<issue.title>
+
+<issue.description>
+
+Linked issue: <issue.external_ref>
+```
+Falls back to the agent's own instructions (with the stage layer stacked below), then `FALLBACK_PROMPT` (`run_loop.rs:2584-2593`). The stage prompt is the migration-0076 `board_column.stage_prompt` of the card's column, constrained to PIPELINE boards (boards carrying ≥1 role-gated column) so a personal kanban board carding the same issue can never inject its own text; within a pipeline board the gating stage wins and `board_id` breaks ties (`stage_prompt_for_issue`, `run_loop.rs:2596-2627`). Best-effort: a store fault degrades to "no stage layer", never strands a dispatch.
+
+Acceptance criteria are NOT part of the brief: no `acceptance` read appears in `build_prompt`. (`acceptance_criterion_state` is migration 0054 and `hangar/issue_criterion_set`, a separate surface.)
+
+**Race + cancel**: `provider_run` is raced against the cancel token with `biased` ordering so an already-signalled cancel wins deterministically (`run_loop.rs:1452-1493`). Headless cancel drops the future, firing `kill_on_drop(true)` to SIGKILL the process group; interactive kills the detached session by exact name, since a dropped `wait` does not kill it (`run_loop.rs:1456-1469`). A provider that cannot be spawned/exec'd is converted to a terminal `FailureReason::SpawnError` (`NoRetry`) rather than propagating, because propagation left the row frozen `running` until the multi-hour TTL (`run_loop.rs:1470-1492`).
+
+**Terminal → FSM**: `finalize_success:1698` / `finalize_failure:1912` / `finalize_setup_failure:2095` / `finalize_cancelled:2177`, each preceded by a typed `lifecycle.fire(...)` edge (`run_loop.rs:1498-1520`).
+
+**PR capture**: `ainb_hangar_core::pr_url::parse_gh_pr_create_stdout` scans the **bounded stdout tail** for a canonical `gh pr create` URL, last one wins; a no-PR run yields `None` and the key is omitted entirely so the JSON stays byte-identical to the pre-P9 shape (`run_loop.rs:1708-1720`).
+
+**Finalize order on success** (`run_loop.rs:1731-1837`): `CompleteTaskService::complete` → `persist_usage` → `persist_run_branch` → `record_run_history` (+ OTLP task→run span) → `stats.record_completed` → `emit_task_finished` → `board::auto_move_after_terminal` → `board::record_task_outcome` → `board::advance_and_cascade_child` → `board::unblock_dependents_after_terminal` → progress comment → `teardown_workdir` (keep-if-dirty). A cancel that won the finalize race still tears down and records history, then returns Ok (`run_loop.rs:1746-1773`).
+
+**Issue lifecycle advance**: `advance_issue_lifecycle_after_transition` (`.../crates/ainb-hangar-daemon/src/board.rs:126-201`) maps `running → in_progress`, `done → Done`, and no-ops on `failed`/`cancelled`. Advance-only by `IssueLifecycle::advance_rank` (NOT `order()`, because `blocked` paints at column 5 right of `done` and comparing column order would freeze a blocked issue forever: `board.rs:115-119`); never revives a terminal issue (`board.rs:156-161`). A cancelled TASK deliberately does not set its ISSUE to `cancelled`: that is a human decision, not a consequence of one killed run (`board.rs:140-143`). `advance_issue_lifecycle_after_terminal` (`board.rs:225`) gates on the AGGREGATE drain via `TaskRepo::issue_aggregate_terminal_state`, so a squad member finishing does not mark the whole issue done; and a finished pipeline STAGE is explicitly not a finished ISSUE (`board.rs:215-219`).
+
+**Squad fan-out**: `SquadAssignService::assign_fanout` (`.../crates/ainb-hangar-store/src/service/squad_assign.rs:319`) resolves and validates every dispatch target before touching the queue. Note the historical direction: fan-out wrote one `agent_task_queue` row per member, so one issue became N simultaneous runs in N worktrees: which is the problem `PullService` was built to replace (`pull.rs:1-8`).
+
+### d. Where ACP fits: **it does not run tasks**
+
+| Fact | Evidence |
+|---|---|
+| ACP absent from the task path | `rg -in acp run_loop.rs runner.rs` → 0 matches (confirmed) |
+| ACP entry points are fleet-only | `.../crates/ainb-hangar-daemon/src/acp_pool.rs:1-16` names `fleet/message_send` and `fleet/action` as the two inbound edges |
+| ACP session creation mints a `fleet_session`, not a task | `rpc/mod.rs:5947-5989`: `provider: "acp"`, `management_state: MANAGED`, `lifecycle_state: IDLE`, `capabilities: acp_capabilities()` |
+| Provider token | `ACP_PROVIDER_TOKEN = "acp"` at `acp_pool.rs:160`; the concrete adapter lives in `fleet_acp_session.provider` (`rpc/mod.rs:5964-5967`) |
+| Providers that speak ACP | exactly two: `claude-agent-acp`, `codex-acp` (`.../crates/ainb-acp/src/config.rs:11-13`); unknown tokens refused at `rpc/mod.rs:5934-5941` |
+| Architecture | MULTIPLEXED: ONE adapter process per PROVIDER hosting many sessions, demuxed by ACP `sessionId` (`acp_pool.rs:1-16`, decided 2026-08-04) |
+| `ainb-acp` is a pure library | no `EventBroker`, no socket, no raw SQL: fenced by `.../crates/ainb-acp/tests/store_fence.rs` asserting `sqlx` never reaches its dependency set (`.../crates/ainb-acp/src/lib.rs:17-24`) |
+| Capability gate | `require_fleet_capability(FLEET_CAPABILITY_ACP_SPAWN)` at `rpc/mod.rs:5918` |
+
+Crate shape (`.../crates/ainb-acp/src/lib.rs:1-16`, 2887 LOC src / 1131 tests): `client` (spawns the adapter, speaks the wire via the upstream `agent-client-protocol` crate: nothing re-implements the protocol), `reducer` (normalises `session/update` into `TranscriptChunk`s), `store_writer` (batches into `fleet_provider_event` rows), `reprime` (resume prelude for adapters that cannot `session/load`, re-exported from `ainb-hangar-proto`), `circuit` (per-provider-process crash breaker).
+
+Adapter child env is built from nothing (`env_clear`) then filled from `BASE_ENV_ALLOWLIST = ["PATH", "HOME"]` plus configured passthrough/extra, because the spike observed a `bypassPermissions` leak via ambient-state inheritance (`config.rs:16-23`). `permission_mode` is PINNED at `session/new` and re-asserted after every `session/load` (`config.rs:32-38`).
+
+Five load-bearing properties, each with a test (`acp_pool.rs:19-68`): exact demux (an unclaimed `sessionId` is DROPPED, never cross-attributed); at-most-once prompt delivery; convergence is not boot-only; a turn ends in ONE transaction (receipt gates the reply); work is bounded but notifications are not (the `session/update` and `session/request_permission` demux channels are deliberately unbounded, with `transcript_bytes` on `hangar/daemon_health` as the observability ceiling).
+
+Approval attention rows: `raise_permission` at `acp_pool.rs:2513`, inserting `AttentionKind::Approval` (`acp_pool.rs:2549`); answered through `fleet/action` → `execute_acp_action` (`rpc/mod.rs:6088`), which reaches the adapter's **pending JSON-RPC id**. Convergence retires ghost rows on adapter death or turn end (`acp_pool.rs:1449-1456`). ACP sessions are exempt from the request-fingerprint staleness gate because an adapter running parallel tool calls raises several `session/request_permission` at once and the session row has room for exactly one; the pool's `parked` map is the authority (`rpc/mod.rs:3966-3980`).
+
+**So: tasks execute as sandboxed CLI subprocesses with stream-json/tmux capture; ACP is used for fleet chat sessions (`fleet_session.provider = "acp"`) and their tool-permission approvals.**
+
+### e. Human-in-the-loop: screen-scraping, with one structured island
+
+```
+ claude hook ──▶ ainb fleet atc hook ──▶ events.jsonl ──▶ attention_ingest
+                                                              │
+                                          attention row ◀─────┘
+                                                │
+   TUI Control Center ──── attention/answer ────┤
+                                                ▼
+                                       daemon answer.rs
+                                     capture_pane + route_answer
+                                                │
+                            ┌───────────────────┴──────────────┐
+                            ▼                                  ▼
+                 tmux send-keys -l  <text>          tmux send-keys <digit>
+                 (+ observed Enter)                 (picker by POSITION)
+```
+
+**Outbound (agent → human):**
+- Hook writer: `.../crates/ainb-core/src/cli/fleet/atc.rs:1358` (`hook`), inner `:1843`, core `:1891`/`:1917`, canonical line builder `:2440`, appender `:2545` (`<home>/events.jsonl`). PIPE_BUF atomicity constraint on the max embedded payload at `atc.rs:2340-2342`: the file is appended concurrently by many processes. Errors are swallowed to keep the Stop hook non-blocking (`atc.rs:1405`).
+- Ingest: `.../crates/ainb-hangar-daemon/src/attention_ingest.rs:1-55` (2116 lines). The daemon owns its OWN byte-offset cursor and reads the shared file directly rather than cross-reading notifyd's rusqlite, so the store boundary holds (`attention_ingest.rs:8-11`). Qualifying events: `Notification` / `Stop` / `SubagentStop`, run through the same `classify` (ASK > ERR > IDLE > WAIT) the fleet panel uses.
+- Idempotency id `att:<session>:<event_id>`; legacy lines fall back to byte offset. The cursor is a pure efficiency optimisation, not a correctness dependency (`attention_ingest.rs:28-42`). ASK rows additionally carry a `request_key` (migration 0084) because Claude re-fires `Notification` while a session stays blocked and **one live question was measured raising three cards** (`attention_ingest.rs:46-53`).
+- AskUserQuestion options are read from the **hook payload**, not the transcript, because Claude withholds the picker's `tool_use` row until the tool RESOLVES: a transcript read while the question is open finds nothing and no interview could ever raise a card (`attention_ingest.rs:21-25`).
+- ATC escalations flow through the SAME attention pipeline (`.../crates/ainb-hangar-daemon/src/atc.rs:75-131`), idempotent on `escalation:<instance>:<session>:<now>`, emitting `HangarEvent::AttentionRaised`.
+- `attention` table: migration 0025 (`attention.sql:57`), `kind` CHECK-constrained to six families (`0025…sql:30-62`), plus 0026 (raise transcript) and 0084 (request key).
+
+**Inbound (human → agent):**
+- Router: `.../crates/ainb-hangar-daemon/src/answer.rs:66` (`answer`, 1461 lines total). Two guarantees stated at `answer.rs:5-30`: first-answer-wins via the conditional `mark_answered_if_open` UPDATE, and C1 misroute refusal: an exact-id miss falls back to cwd correlation, but ambiguity (2+ sessions in the cwd, or a merged session aggregating 2+ sources) is REFUSED rather than guessed, and the cwd fallback is bound to the transcript captured at raise time so a different agent now occupying the cwd cannot be answered. Target resolution runs BEFORE the flip so an ambiguous/dead target leaves the row open.
+- `Route` enum `answer.rs:153-163`: `Picker(usize)` (drive the option picker by zero-based position), `Text` (type it), `Refuse(String)` (deliver nothing, reopen the row).
+- `route_answer` `answer.rs:176-215` refuses in FOUR distinct pane conditions: (a) a free-text ASK while some picker is on screen, (b) a picker on screen that is not this row's picker, (c) an option index ≥ 9 ("pickers beyond 9 options are not supported"), (d) an answer matching none of the picker's labels.
+- **Why position and not text** (`answer.rs:168-175`): an `AskUserQuestion` picker does not read typed text: typing the chosen label and pressing Enter "accepted whatever option was HIGHLIGHTED, so the store recorded the operator's pick while the agent acted on the default."
+- `deliver` `answer.rs:218-245`: the pane is read whenever keys would go into one, picker or not; a pane the daemon cannot read while the row says a picker is up is NOT typed into blind: the row stays open for a surface that can see the screen.
+- Transport: `ainb_fleet_core::send::send` (`.../crates/ainb-fleet-core/src/fleet/send/route.rs:152-180`): `TmuxFirst` / `TmuxOnly` / `PeersFirst`. Only two channels exist: tmux, and an HTTP broker to a peer `ainb` (which itself delivers via tmux). On `NotSubmitted` the broker is deliberately NOT tried, since the text is already parked in the composer and would be delivered twice (`route.rs:155-158`).
+- The measured basis for the scraping is documented at `.../crates/ainb-fleet-core/src/fleet/send/tmux.rs:1-60` (against claude 2.1.224 / tmux 3.6a / macOS, with captures kept in `pane_fixtures/`): a macOS PTY delivers at most 1022 bytes per `read()`; Claude Code classifies a single read of ≥801 chars as a PASTE; whether the trailing Enter submits depends on whether the CR lands in its OWN read: on a busy target it fuses into the payload's final read and is consumed as a literal newline, so nothing submits; retried Enters at +1.0s/+1.7s/+3.9s all arrived fused as `\r\r\r`, so **there is no safe fixed delay: the wait must be OBSERVED, and observed on the payload**. Payload goes out as ONE literal `send-keys -l` write after a `--` end-of-options terminator (without it a text starting with `-`, e.g. an interview label `--no`, is parsed as a flag and silently dropped). Verification looks at composer EMPTINESS rather than the payload, because `ainb run` creates every session at 80x24 and the composer viewport is tail-anchored: a 1546-byte payload rendered as 7 rows / 382 visible chars with its leading marker OFF-SCREEN. "Clear" must be dim-aware: an idle Claude renders a dim ghost of the previous prompt, a busy one renders a dim "Press up to edit queued messages" AFTER accepting the send, and in plain `capture-pane -p` both are byte-identical in shape to real input.
+
+**Is there any structured channel?** Repo-wide searches return **ZERO** hits for `--input-format`, `control_request`, `control_response`, `canUseTool`, `can_use_tool` across `*.rs` / `*.md` / `*.ts` / `*.py`. No Claude Code SDK dependency exists: `@anthropic-ai/claude-code` appears only as an install-catalog package name (`.../crates/ainb-core/src/setup/catalog.rs:391`, `.../crates/ainb-core/src/config/registry.rs:1994`, `.../crates/ainb-core/src/config/container.rs:155`, `.../crates/ainb-core/src/setup/installer.rs:322`).
+
+Structured HITL exists in exactly two places, **neither on the task path**:
+1. **ACP** `session/request_permission` → parked responder → attention row → `fleet/action` → `execute_acp_action` (`rpc/mod.rs:6088`) → the adapter's pending JSON-RPC id.
+2. **Codex app-server**, a persistent WebSocket JSON-RPC transport with one actor owning the reader and writer (`.../crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs:1-6`, 3701 lines) → `execute_codex_action` (`rpc/mod.rs:4663`). When the managed transport is not active it falls back to `verified_tmux_send` (`rpc/mod.rs:4066-4074`).
+
+`answer.rs` contains **zero** `acp`/`Acp` matches (confirmed by `rg -c`). The I8 arm in `fleet/action` exists precisely because without it an ACP `SendPrompt` fell into `verified_tmux_send` and reported "exact tmux process identity is unavailable" for a session that has no tmux pane by design (`rpc/mod.rs:4056-4062`).
+
+---
+
+## 2. Surface inventory (counted)
+
+**JSON-RPC methods**: `.../crates/ainb-hangar-proto/src/methods.rs` (2180 lines): **157 `pub const` method constants**, 159 distinct wire strings in the file. **154 dispatch arms** in the daemon (`rpc/mod.rs`, 16706 lines); the TUI plugin references **75**.
+
+| Prefix | Count |
+|---|---|
+| `hangar/` | 111 |
+| `fleet/` | 33 |
+| `atc/` | 4 |
+| `profile/` | 3 |
+| `attention/` | 3 |
+| `workspace/` | 2 |
+| `codex/` | 2 |
+| `auth/` | 1 |
+
+Full method list by prefix:
+
+- **atc/** (4): `escalate`, `list`, `register`, `unregister`
+- **attention/** (3): `answer`, `list`, `subscribe`
+- **auth/** (1): `hello`
+- **codex/** (2): `session_discard`, `session_ensure`
+- **profile/** (3): `get`, `list`, `upsert`
+- **workspace/** (2): `list`, `subscribe`
+- **fleet/** (33): `acp_session_create`, `action`, `activity_event`, `activity_list`, `broadcast`, `channel_create`, `channel_list`, `confirm_answer`, `confirm_event`, `confirm_list`, `copilot_configure`, `copilot_gate`, `message_event`, `message_list`, `message_send`, `message_subscribe`, `negotiate`, `quota_summary`, `receipt_get`, `receipt_list`, `reproject_claude_interview`, `resync_required`, `runtime_status`, `snapshot`, `start`, `subscribe`, `timeline`, `transcript_event`, `transcript_list`, `transcript_prune`, `transcript_subscribe`, `usage_dashboard`, `usage_summary`
+- **hangar/** (111): `agent_archive`, `agent_create`, `agent_delete`, `agent_skills_list`, `agent_update`, `agents_list`, `autopilot_collaborator_add`, `autopilot_collaborator_remove`, `autopilot_collaborators`, `autopilot_fire_now`, `autopilot_runs`, `autopilot_set_access_mode`, `autopilot_set_api_trigger`, `autopilot_set_enabled`, `autopilot_subscriber_add`, `autopilot_subscriber_remove`, `autopilot_subscribers`, `autopilot_trigger_api`, `autopilot_update`, `autopilot_versions`, `autopilots_list`, `board_card_add`, `board_card_assign_squad`, `board_card_cancel`, `board_card_create`, `board_card_dep_add`, `board_card_dep_remove`, `board_card_move`, `board_card_remove`, `board_card_reorder`, `board_card_run`, `board_card_set_auto_run`, `board_card_timeline`, `board_column_add`, `board_column_delete`, `board_column_reorder`, `board_column_update`, `board_create`, `board_delete`, `board_update`, `boards_list`, `comment_add`, `comment_mention_preview`, `daemon_config_get`, `daemon_config_list`, `daemon_config_set`, `daemon_health`, `dispatch_attempts_list`, `health`, `inbox_list`, `inbox_mark_read`, `invite_accept`, `invite_create`, `invite_decline`, `invite_revoke`, `issue_cancel_active`, `issue_create`, `issue_criterion_set`, `issue_delete`, `issue_label_attach`, `issue_label_detach`, `issue_link_add`, `issue_link_remove`, `issue_links`, `issue_metadata_delete`, `issue_metadata_get`, `issue_metadata_set`, `issue_property_clear`, `issue_property_set`, `issue_reaction_add`, `issue_reaction_remove`, `issue_run`, `issue_subscribe`, `issue_subscribers`, `issue_timeline`, `issue_unsubscribe`, `issue_update`, `issues_batch_update`, `issues_list`, `issues_search`, `member_remove`, `member_set_role`, `members_list`, `notify_rule_set`, `notify_rules_list`, `pr_status_refresh`, `properties_list`, `property_archive`, `property_define`, `repo_list`, `run_history`, `search`, `skill_attach`, `skill_detach`, `skill_get`, `skill_set_enabled`, `skills_list`, `skills_sync`, `squad_archive`, `squad_assign`, `squad_create`, `squad_fanout`, `squad_instructions_set`, `squad_member_add`, `squad_member_remove`, `squad_member_role_set`, `squads_list`, `task_retry`, `task_transition`, `tasks_list`, `usage_rollup`
+
+**TUI screens**: `.../crates/ainb-plugin-hangar/src/screen/`: **20 `Screen` variants** (`screen/mod.rs:58`) across **26 modules**.
+
+Variants: `IssueList`(1), `TaskDetail(TaskId)`(2), `AgentPicker(IssueId)`, `ActivityTimeline(IssueId)`(y), `SkillManager`(3), `Autopilots`(4), `Kanban`(K), `Boards`(B), `DaemonHealth`(D), `Usage`(U), `Logs`(L), `Inbox`(I), `ControlCenter`(C), `Fleet`(F), `Squads`(S), `Profiles`(P), `Agents`(A), `Settings`(,), `Help`(?), `CommandPalette`(Ctrl+P).
+
+Modules: `activity, agent_picker, agents, app_screens, autopilots, banner_state, boards, command_palette, context_menu, control_center, daemon_health, fleet, fleet_chat, inbox, issue_list, kanban, list_context_menu, logs, mod, profiles, router, settings, skill_manager, squads, task_detail, usage_dashboard`.
+
+`ROUTER_KEYS` = **18 chars**: `1 2 3 4 B K D U L I C F S P A , ? q` (`screen/router.rs:30`). `HOST_RESERVED_KEYS` is empty (`router.rs:42`) because `ainb-core` lists `hangar-tui` in `PLUGINS_WITH_OWN_HELP`. An invariant test (`router_keys_all_have_a_reduce_key_arm`) keeps the const and `reduce_key` in lock-step, and `is_reserved_key` (`router.rs:75`) exists because a screen-local binding on a router key is DEAD and an advertised hint on it lies to the user (issue #450).
+
+**CLI**: `ainb hangar` (`.../crates/ainb-core/src/cli/hangar/mod.rs:79`, 16175 lines): **18 top-level noun groups**, 32 `Subcommand` enums, **152 total variants**, 29 of which are group nodes (`#[command(subcommand)]`) → **123 executable leaf commands**.
+
+| Group | Leaves |
+|---|---|
+| `issue` | 18 (Create, List, Search, Show, Update, BatchState, Delete, Label, Criteria, Link, Subscribe, Unsubscribe, Subscribers, React, Why, Timeline, Property, Meta) + nested: Property 2, Meta 4, Link 3, React 3, Criteria 3, Label 2 |
+| `autopilot` | 14 + AutopilotActor 3 |
+| `daemon` | 10 + Cred 3, Config 3 |
+| `squad` | 10 |
+| `agent` | 9 |
+| `member` | 9 |
+| `skills` | 5 |
+| `workspace` | 4 |
+| `pipeline` | 3 (Init, Show, StagePrompt) |
+| `property` | 3 |
+| `templates` | 3 |
+| `auth` | 2 + Token 3, DaemonToken 1 |
+| `config` | 2 + EnvAllow 3, Warnings 1 |
+| `comment` | 2 |
+| `task` | 3 (List, Cancel, Retry) |
+| `beads` | 1 (Reconcile) |
+| `inbox` | 1 (List) |
+| `logs` | 1 (Tail) |
+
+Registered onto the clap tree at `.../crates/ainb-core/src/cli/registry.rs:3126-3160`; dispatch at `registry.rs:3159-3160` → `crate::cli::hangar::dispatch`.
+
+**Migrations**: **93** (`0001_init_workspace_user_member.sql` … `0093_board_card_issue_index.sql`), in `.../crates/ainb-hangar-store/migrations/`, creating **63 tables**:
+
+`activity_log, agent, agent_invocation_target, agent_runtime, agent_skill, agent_task_queue, atc_instance, atc_retry, attention, autopilot, autopilot_collaborator, autopilot_rule_version, autopilot_run, autopilot_run_copy, autopilot_subscriber, autopilot_webhook_delivery, beads_mapping, board, board_card, board_column, card_dependency, comment, daemon_config, daemon_socket_token, daemon_token, dispatch_attempt, event_log, fleet_acp_session, fleet_action_receipt, fleet_activity, fleet_channel, fleet_channel_member, fleet_confirm, fleet_event, fleet_message, fleet_message_delivery, fleet_provider_event, fleet_session, fleet_work_item, fleet_work_item_next, inbox_entry, interactive_codex_thread, issue, issue_cascade_barrier, issue_label, issue_property, issue_reaction, issue_subscriber, label, member, notify_rule, pat, profile, run_history, skill, skill_file, squad, squad_member, standup_session, task_usage, user, workspace, workspace_invitation`
+
+**LOC** (`src/**/*.rs` vs `tests/**/*.rs`):
+
+| Crate | src | files | tests | files |
+|---|---:|---:|---:|---:|
+| ainb-hangar-daemon | 72,454 | 64 | 55,886 | 151 |
+| ainb-plugin-hangar | 56,723 | 55 | 16,924 | 47 |
+| ainb-hangar-store | 40,185 | 66 | 27,711 | 84 |
+| ainb-hangar-proto | 12,883 | 11 | 1,029 | 4 |
+| ainb-hangar-core | 9,175 | 36 | 602 | 5 |
+| ainb-fleet-core | 8,902 | 26 | 818 | 1 |
+| ainb-acp | 2,887 | 7 | 1,131 | 5 |
+| ainb-hangar-client | 976 | 2 | 0 | 0 |
+| ainb-hangar-sandbox | 852 | 4 | 318 | 2 |
+| ainb-hangar-secrets | 371 | 4 | 225 | 2 |
+| **Total** | **205,408** | **275** | **104,644** | **301** |
+
+Workspace-wide `src` total across all crates: 489,710 lines.
+
+**Tripwires**: **170 files** named `tripwire*.rs` under `tests/`, containing **274 `#[test]`/`#[tokio::test]` fns**. 62 of those files are in `.../crates/ainb-hangar-daemon/tests/` (which holds 149 test files total).
+
+**Source files >3000 lines** (hangar surface):
+
+| Lines | File |
+|---:|---|
+| 16,706 | `.../crates/ainb-hangar-daemon/src/rpc/mod.rs` |
+| 9,204 | `.../crates/ainb-plugin-hangar/src/plugin.rs` |
+| 6,367 | `.../crates/ainb-plugin-hangar/src/screen/fleet.rs` |
+| 5,783 | `.../crates/ainb-hangar-daemon/src/fleet.rs` |
+| 5,121 | `.../crates/ainb-hangar-proto/src/snapshots.rs` |
+| 5,034 | `.../crates/ainb-plugin-hangar/src/screen/issue_list.rs` |
+| 4,868 | `.../crates/ainb-hangar-daemon/src/run_loop.rs` |
+| 4,470 | `.../crates/ainb-plugin-hangar/src/screen/boards.rs` |
+| 4,324 | `.../crates/ainb-hangar-daemon/src/rpc/snapshots.rs` |
+| 3,701 | `.../crates/ainb-hangar-daemon/src/fleet_provider/codex_manager.rs` |
+| 3,310 | `.../crates/ainb-plugin-hangar/src/screen/app_screens.rs` |
+| 3,230 | `.../crates/ainb-hangar-daemon/src/acp_pool.rs` |
+| 3,068 | `.../crates/ainb-hangar-store/src/repo/fleet.rs` |
+
+Outside the hangar crates but on the same operating surface:
+
+| Lines | File |
+|---:|---|
+| 16,175 | `.../crates/ainb-core/src/cli/hangar/mod.rs` |
+| 14,666 | `.../crates/ainb-core/src/app/state.rs` |
+| 10,689 | `.../crates/ainb-core/src/app/events.rs` |
+| 4,458 | `.../crates/ainb-core/src/interactive/session_manager.rs` |
+| 4,041 | `.../crates/ainb-core/src/config/mod.rs` |
+| 3,759 | `.../crates/ainb-core/src/cli/fleet/atc.rs` |
+| 3,561 | `.../crates/ainb-core/src/cli/registry.rs` |
+
+Other large files: `.../crates/ainb-hangar-daemon/src/runner.rs` 2421, `.../crates/ainb-hangar-daemon/src/attention_ingest.rs` 2116, `.../crates/ainb-hangar-proto/src/methods.rs` 2180, `.../crates/ainb-hangar-daemon/src/answer.rs` 1461, `.../crates/ainb-plugin-hangar/src/screen/fleet_chat.rs` 2901, `.../crates/ainb-hangar-daemon/src/board.rs` 688.
+
+---
+
+## 3. Seams that make the devX brittle (observed, not opinion)
+
+### 3.1 Terminal key-driving instead of a protocol
+
+- **103 `capture-pane` / `send-keys` / `has-session` / `list-sessions` call sites** in `src/` (excluding test modules) across `ainb-fleet-core`, `ainb-hangar-daemon`, `ainb-plugin-hangar`, `ainb-core`. Concentration: `.../crates/ainb-fleet-core/src/fleet/send/tmux.rs` (17), `.../crates/ainb-fleet-core/src/fleet/send/route.rs` (8), `.../crates/ainb-fleet-core/src/fleet/read/tmux_pane.rs` (5), `.../crates/ainb-core/src/tmux/process_detection.rs` (4), `.../crates/ainb-core/src/fleet/bridge/transport.rs` (4).
+- **The scraping is in the DAEMON, not the TUI.** The TUI plugin sends a structured `attention/answer` / `fleet/action` RPC over the unix socket; `answer.rs:218` (`deliver`) then reads the pane and drives keys. The plugin's own tmux use is limited to attaching a popup (`.../crates/ainb-plugin-hangar/src/plugin.rs:586` `launch_fleet_tmux_popup`, `:602` `fleet_tmux_attach_command`, applied at `:2887`) and rendering a copyable `tmux attach -t <name>` hint (`plugin.rs:3239-3254`). It never scrapes.
+- **The scrape is load-bearing for correctness, not cosmetics.** `route_answer` (`answer.rs:176`) refuses delivery in 4 distinct pane conditions (listed in §1e). A pane the daemon cannot read while the row says a picker is up leaves the row open rather than typing blind (`answer.rs:232-239`).
+- **Interactive tasks have no capture at all.** `run_interactive` (`run_loop.rs:1559`) produces no stream-json; the tmux pane is the sole record. `structured` is `false` for every interactive spec (`runner.rs:1327`), so the finalize cannot use the provider's own reported outcome and falls back to session-reaped detection.
+- Structured alternatives exist in-repo for exactly two providers (ACP `rpc/mod.rs:6088`; codex app-server `rpc/mod.rs:4663`), and **neither is reachable from a task**.
+- The tmux module's own header (`tmux.rs:1-60`) documents that the send path had to be re-derived from PTY read-size measurements, that no fixed Enter delay is safe, and that verification cannot look at the payload because the 80x24 composer is tail-anchored. That is the cost surface of not having a protocol.
+
+### 3.2 State duplicated across issue / card / task
+
+Four independent state stores for one unit of work:
+
+| Store | Column | Vocabulary |
+|---|---|---|
+| `issue` | `state` | `backlog`/`todo`/`in_progress`/`in_review`/`done`/`blocked`/`cancelled`, **free TEXT, no CHECK** (`migrations/0023_issue_lifecycle_vocab.sql:20`, `0049_issue_state_blocked_cancelled.sql`) |
+| `board_card` | `column_id` | per-board columns; position on a board (`0027_board.sql`, `0034_board_card_ord.sql`) |
+| `agent_task_queue` | `status` | CHECK'd 6-state FSM (`migrations/0004_agent_task_queue.sql:28`) |
+| in-process | `LifecycleGuard` | typed FSM re-asserting the same edges (`run_loop.rs:1236`, `crate::fsm`) |
+
+Synchronisation is a fan of best-effort, advance-only, never-blocking writes, all in `.../crates/ainb-hangar-daemon/src/board.rs`:
+`auto_move_after_transition:44`, `advance_issue_lifecycle_after_transition:126`, `advance_issue_lifecycle_after_terminal:225`, `auto_move_after_terminal:301`, `unblock_dependents_after_terminal:409`, `record_task_outcome:502`, `advance_and_cascade_child:537`, `maybe_cascade_child_done:571`, `deliver_cascade:616`.
+
+Every one logs-and-swallows on fault (e.g. `board.rs:150-153`, `board.rs:197-199`), so divergence is silent by construction. The code names the twinning explicitly: "Twin the durable-card move on the issue's own `state`" (`run_loop.rs:1813-1816`).
+
+Known asymmetries pinned in comments:
+- The default issue board buckets by `issue.state`, not the durable `board_card` the auto-move touches, so both must be written or "a plain task's card strands in Todo through its whole run" (`run_loop.rs:1300-1305`).
+- A finished pipeline STAGE is not a finished ISSUE: promoting on one stage's `done` aggregate marked a card `done` with Review and QA still to go (`board.rs:215-219`).
+- Migration 0078 added `board_column_id` to the task row so the pull SQL could answer "is this stage already finished"; the generation alone was not enough (`pull.rs:59-70`).
+- Advance ranking must use `advance_rank`, not board column `order()`, because `blocked` paints at column 5 right of `done` and column order would freeze a blocked issue forever (`board.rs:115-119`).
+- Migration 0023 rewrote legacy `open`→`todo` / `closed`→`done` in place, and deliberately leaves unknown tokens as-is, relying on the display layer to bucket them under Todo (`0023…sql:16-20`).
+
+A fifth state exists at the fleet layer: `fleet_session` carries `lifecycle_state` / `attention_state` / `management_state` / `transport_health` / `confidence` (`rpc/mod.rs:5970-5976`), and `fleet_acp_session` carries its own `state` (`rpc/mod.rs:5987`).
+
+### 3.3 CLI writes the store directly, bypassing the daemon
+
+`.../crates/ainb-core/src/cli/hangar/mod.rs` opens SQLite directly: **18 `Store::open_default()` calls**, **34 `sqlx::` uses**, and **ZERO** references to `ainb_hangar_client`, `HangarClient`, or any RPC call (`rg -c 'HangarClient|rpc_call|call_daemon|hangar_client'` → 0). The code says so in its own doc comments: "workspace-scoped and daemon-less" (`cli/hangar/mod.rs:5824`).
+
+Consequence, confirmed: every `hangar issue …` mutation goes through `run_issue_*(&store, …)` (`cli/hangar/mod.rs:5799-5820`) and emits **no `HangarEvent`**: `rg -c 'EventLogRepo|event_log'` in that file returns 0. The daemon's `EventSink` is the only producer of the pushes the TUI subscribes to (`emit_task_started` `run_loop.rs:2246`, `emit_task_finished` `run_loop.rs:2270`, `events.emit_attention` `atc.rs:131`).
+
+`ainb-hangar-client` (976 LOC) is consumed only by `.../crates/ainb-fleet-tools/src/fleet.rs`, `.../crates/ainb-fleet-tools/src/keyfile.rs`, `.../crates/ainb-core/src/fleet/bridge/daemon.rs`, and one daemon live test: never by the hangar CLI.
+
+The TUI plugin, by contrast, dials `{hangar_home}/hangar.sock` via the host `unix_socket_dial` capability and speaks framed JSON-RPC (`.../crates/ainb-plugin-hangar/src/plugin.rs:3-20`, `daemon_socket_path:80`, auth-first-frame note `:88-95`, `.../crates/ainb-plugin-hangar/src/jsonrpc_over_socket.rs`, `.../crates/ainb-plugin-hangar/src/connection.rs`).
+
+So there are **two disjoint write paths into one database**: daemon (events, subscribers, FSM services) and CLI (raw sqlx, silent).
+
+### 3.4 Duplicated concepts
+
+Nine distinct row-level concepts for "a thing an agent is doing", each with its own table(s) and RPC family:
+
+| Concept | Table(s) | RPC family |
+|---|---|---|
+| issue | `issue`, `issue_property`, `issue_label`, `issue_subscriber`, `issue_reaction`, `issue_cascade_barrier` | `hangar/issue_*` (28) |
+| board card | `board_card`, `board_column`, `card_dependency` | `hangar/board_*` (19) |
+| task | `agent_task_queue` | `hangar/task_*`, `hangar/*_run` |
+| dispatch attempt | `dispatch_attempt` (0058) | `hangar/dispatch_attempts_list` |
+| run | `run_history` (0029), `task_usage` (0022) | `hangar/run_history`, `hangar/usage_rollup` |
+| fleet session | `fleet_session`, `fleet_event`, `fleet_provider_event`, `fleet_action_receipt` (0044, 0071) | `fleet/*` (33) |
+| ACP session | `fleet_acp_session` (0082) | `fleet/acp_session_create` |
+| codex thread | `interactive_codex_thread` (0086, 0087, 0088, 0089, 0090, 0091: **six migrations**) | `codex/session_ensure`, `codex/session_discard` |
+| attention row | `attention` (0025, 0026, 0084) | `attention/*` (3) |
+
+Two parallel "a human must answer" mechanisms coexist: `attention` (six kinds, answered via `attention/answer` → tmux screen-scrape) and `fleet_confirm` (0044, answered via `fleet/confirm_answer`), with `fleet_action_receipt` as a third record of the same interaction.
+
+Two parallel transcript stores: `{logs}/<provider>.jsonl` on disk for tasks, parsed CLIENT-SIDE by `.../crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs`; and `fleet_provider_event` rows in SQLite for fleet/ACP sessions, written by `.../crates/ainb-acp/src/store_writer.rs`. The plugin renders both into the same `ViewEntry` shape (`jsonl_timeline.rs:1-11`).
+
+Three "session id" notions on one task: `agent_task_queue.session_id` (the provider's own id, pinned from stream-json), `session_name` (the tmux session for interactive), and `fleet_session.session_key` (the fleet-layer identity used by attention answering).
+
+### 3.5 Provider-specific branching
+
+**54 `Backend::{Claude,Codex,Copilot,Antigravity}` occurrences** in src: `run_loop.rs` 24, `runner.rs` 20, `claude_cred.rs` 7, remainder elsewhere. Four `*_spec` builders (`runner.rs:1295 / 1368 / 1468 / 1495`) plus a 4-arm dispatch match (`run_loop.rs:1405-1449`), each arm with a different signature (`run_claude_in_with_env` takes `cred_env`; the other three take `dispatch.agent_env.expose_for_child_env()`: "the ONE permitted plaintext escape").
+
+`AgentKind` (`.../crates/ainb-hangar-core/src/agent_kind.rs:35-46`) mirrors the same four. Its doc comment says Copilot "Selectable in the picker; dispatch returns a clear 'provider not yet wired' error until the third runner backend lands" (`agent_kind.rs:42-45`), while `run_loop.rs:1427` DOES route `Backend::Copilot` to `run_copilot_in` and `copilot_spec` exists at `runner.rs:1468`. **Doc and code disagree; I did not verify which is current** (inferred divergence, not confirmed behaviour).
+
+Provider divergence extends well past argv:
+- codex needs `exec --skip-git-repo-check -s danger-full-access --json` headless but NONE of them interactively (`runner.rs:1338-1345`), because `--skip-git-repo-check` is an `exec`-only flag and a top-level parse error.
+- codex carries a retired-model substitution at the wire (`runner.rs:1385-1394`).
+- claude requires `--verbose` whenever `--print` + stream-json are combined (`runner.rs:1306-1312`).
+- copilot requires `--allow-all-tools` for non-interactive mode (`runner.rs:1291-1294`).
+- Four separate log filenames (`runner.rs:1323, 1403, 1482, 1518`).
+- The client-side jsonl parser handles claude's taxonomy "fully" and codex's `{"msg":{...}}` envelope "on a best-effort basis"; copilot and antigravity shapes are unhandled and silently skipped (`jsonl_timeline.rs:22-27`).
+- `claude_cred.rs` has 7 Backend branches of its own.
+- `AINB_CODEX_BIN`, `AINB_CODEX_MANAGED`, `AINB_CODEX_APP_SERVER`, `AINB_TEST_CODEX_BINARY`, `CODEX_HOME`: five of the 30 daemon env vars are codex-specific.
+
+Separately, `fleet/action` fans to **three** transports by provider token (`rpc/mod.rs:4045-4075`): ACP (`execute_acp_action`), codex-managed (`execute_codex_action`, with a tmux fallback when the transport is inactive), and a tmux fallthrough (`verified_tmux_picker:5649` / `verified_tmux_send:5609`).
+
+A frozen `argv_golden_matrix` contract test exists to pin per-provider argv (`.../crates/ainb-hangar-daemon/tests/`, described in `ainb-tui/CLAUDE.md`), which is itself evidence of how much per-provider surface there is to freeze.
+
+### 3.6 Environment configuration
+
+**30 distinct env var names** read in `.../crates/ainb-hangar-daemon/src` (78 `env::var` call sites across all hangar crates; 57 distinct `HANGAR_*`/`AINB_*` string literals appear in src overall, so roughly 27 are referenced somewhere but not read in the daemon).
+
+```
+AINB_ACP_TURN_DEADLINE_MS   AINB_BIN                      AINB_CODEX_APP_SERVER
+AINB_CODEX_BIN              AINB_CODEX_MANAGED            AINB_FLEET_DISABLE_TMUX_DISCOVERY
+AINB_FLEET_USAGE_MIN_GAP_MS AINB_HANGAR_BOOT_TASK_ID      AINB_HANGAR_OWNERSHIP_WATCH_MS
+AINB_HANGAR_WEBHOOK_PORT    AINB_HOME                     AINB_TEST_CODEX_BINARY
+BEADS_DIR                   CODEX_HOME                    HANGAR_ANTIGRAVITY_PATH
+HANGAR_CLAUDE_PATH          HANGAR_CODEX_PATH             HANGAR_COPILOT_PATH
+HANGAR_DAEMON_DISABLE_CLAIM HANGAR_DAEMON_DISABLE_SANDBOX HANGAR_DAEMON_POLL_MS
+HANGAR_GC_INTERVAL_MS       HANGAR_KEEP_FAILED_RUNS       HANGAR_PRESENCE_SWEEP_MS
+HANGAR_PROVIDER_MAX_RUNTIME_MS  HANGAR_SPAWN_SETUP_TIMEOUT_MS
+HANGAR_SWEEP_DISPATCHED_TTL_MS  HANGAR_SWEEP_INTERVAL_MS
+HOME                        OTEL_EXPORTER_OTLP_ENDPOINT
+```
+
+Plus, read outside the daemon crate: `HANGAR_DAEMON_RUNTIME_ID` (`.../crates/ainb-hangar-store/src/bootstrap.rs`), `HANGAR_CLAUDE_OAUTH_TOKEN` (`.../crates/ainb-hangar-daemon/src/claude_cred.rs`), `AINB_HANGAR_HOME` (path resolution, `.../crates/ainb-hangar-core/src/paths.rs`: 3 env reads), `TMUX` (`.../crates/ainb-plugin-hangar/src/plugin.rs`), `FAKE_ACP_ENV_DUMP` (`.../crates/ainb-acp/src/bin/fake_acp_adapter.rs`), `PATH` (`.../crates/ainb-hangar-sandbox/src/lib.rs`).
+
+There is **no single registry** of these in code. `DaemonConfig::from_env` (`run_loop.rs:185-268`) covers 12; the rest are read at their point of use, via three different helpers (`std::env::var_os`, `env_u64` at `run_loop.rs:353`, `env_u64_opt` at `:358`). Only a subset is documented in `ainb-tui/CLAUDE.md` (the credential ladder and `HANGAR_CLAUDE_OAUTH_TOKEN`). A sandbox override that is neither `"0"` nor `"1"` silently falls back to the platform default (`run_loop.rs:278-284`) rather than erroring.
+
+### 3.7 Seams and pinch points worth naming [Feathers]
+
+Genuine seams (behaviour substitutable without editing in place):
+- `SecretBackend` trait object: `execute_claimed` takes it as `Arc<dyn ...>`, so a test injects an in-memory double instead of touching the real Keychain (`run_loop.rs:545-549`, `:1095`).
+- `HangarClock` / `IdGen` trait objects threaded through every service (`run_loop.rs:1091`, `pull.rs` signatures).
+- `interactive_command` (`run_loop.rs:1538`): the one place interactive argv is derived, reachable from a test without tmux, a provider binary, or a database. Extracted precisely because the previous shape let a test re-derive the argv *beside* the call rather than through it.
+- `route_answer` (`answer.rs:176`): pure function over `(pane, picker, answer)`, testable from fixtures.
+- `DaemonConfig::resolve_sandbox` (`run_loop.rs:278`): pure, so override precedence is testable without mutating process env.
+- `ainb-acp` as a whole: pure library, sqlx-fenced by test, promotable to a standalone process without redesign (`lib.rs:17-24`).
+- `PULL_SQL` as a string const (`pull.rs:531`): enables the clause-deletion mutation proofs.
+
+Pinch points (narrow interfaces where one characterization test covers a lot):
+- `execute_claimed` (`run_loop.rs:1087`): every task, every provider, every mode passes through it.
+- `run_card` (`rpc/mod.rs:10148`): every launch path (issue_run, board_card_run, autopilot, auto-run) converges here.
+- `answer` (`answer.rs:66`): every surface (TUI, web, bridge, ATC) answers through it.
+- `build_prompt` (`run_loop.rs:2548`): the single brief composer.
+
+Where behaviour is unverifiable without a harness:
+- The interactive tmux path has no structured output; the module comment itself notes the only coverage was "a tmux tripwire that SKIPs when tmux is absent" (`run_loop.rs:1536-1537`).
+- The tmux send timing behaviour is pinned to measured fixtures in `pane_fixtures/` against specific claude/tmux/macOS versions (`tmux.rs:13-16`); a provider UI change invalidates them silently.
+- The sandbox returns `Enforcement::None` on unsupported platforms and the confinement test SKIPs rather than asserting (`.../crates/ainb-hangar-sandbox/src/lib.rs:31-35`): correct, but it means CI on an unsupported platform proves nothing about confinement.
+
+---
+
+## Confidence
+
+**Confirmed by reading the code path:** the whole task execution flow (§1a–c); ACP's absence from the task path (zero-match grep on both `run_loop.rs` and `runner.rs`); ACP's fleet-session-only role and its two adapters; the tmux screen-scrape HITL path and its four refusal cases; the absence of any `--input-format` / control-request / SDK channel (zero-match repo-wide grep); the CLI's daemon-less direct-store access (18 `Store::open_default`, 0 client references); every count in §2, each from a command whose output was inspected.
+
+**Inferred, not verified by running:** the Copilot doc/code divergence in §3.5; the claim that CLI mutations produce no TUI update (I confirmed no event emission in the CLI file and that `EventSink` lives in the daemon, but did not run the pair and observe a stale TUI); the ~27 referenced-but-not-read env vars (derived from two greps, not from tracing each); the per-group leaf-count breakdown in the CLI table (derived from an AST-ish regex over the enum bodies, not from `--help` output).
+
+**Not examined:** `.../crates/ainb-plugin-hangar/src/screen/fleet.rs` (6,367 lines) and `.../crates/ainb-hangar-daemon/src/fleet.rs` (5,783 lines) internals; the autopilot scheduler and its cron/webhook surface; beads sync; the web crate; whether any tripwire exercises the interactive tmux path end-to-end under CI conditions.
+
+**Open questions a maintainer must answer:**
+1. Is `Backend::Copilot` dispatchable today, or does `agent_kind.rs:42-45` still hold? The two disagree.
+2. Is there any mechanism that reconciles `issue.state` against `board_card.column_id` after a swallowed best-effort write, or does divergence persist until a human moves the card?
+3. Do the 62 daemon tripwires run in CI? `default-members = ["crates/ainb-core", "crates/ainb-hangar-daemon"]` includes the daemon, so presumably yes: but `ainb-hangar-store` (84 test files) and `ainb-plugin-hangar` (47) are NOT in default-members, and per `ainb-tui/CLAUDE.md` a plain `cargo nextest run` silently skips them while still reporting a clean summary.
+4. Do `hangar issue`/`hangar task` CLI mutations need to notify a running daemon, or is the silent-write behaviour intentional? Nothing in the code marks it either way beyond the "daemon-less" comment.

--- a/docs/hangar/renovation/move1-acp-tasks.md
+++ b/docs/hangar/renovation/move1-acp-tasks.md
@@ -1,0 +1,697 @@
+> Appendix to `docs/hangar/renovation/PLAN.md`. Planning pass output, unedited except for punctuation.
+
+# Move 1: two first-class task executors (process | acp), one live run-event stream
+
+Base: `/home/claude/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-prove-hangar--22bb34f4/ainb-tui/`
+Every `file:line` verified by reading the file at HEAD of `f/prove-hangar`.
+Rev 2: folds in "both executors stream live", process path stays first class.
+
+---
+
+## 0. Recommendation, up front
+
+1. **No `TaskExecutor` trait.** The second executor already exists here and it is a
+   branch: `run_loop.rs:1387-1449` is `if mode == Mode::Interactive { run_interactive } else
+   { match backend }`, both arms returning `anyhow::Result<RunOutcome>`. A third arm is the
+   same seam for less code. Extract a trait when there is a fourth.
+2. **No new event type and no new stream.** `HangarEvent::TaskMessage` and
+   `HangarEvent::TaskProgress` already exist, are already routed by the outbox
+   (`event_outbox.rs:69-74`), already de-prioritised by the inbox aggregator
+   (`inbox_aggregator.rs:126-127`), and already have plugin CONSUMERS
+   (`plugin.rs:1197`, `banner_state.rs:135`). **Neither has a producer anywhere in `src/`.**
+   Move 1 writes the producers. That is the whole "one run-event stream".
+3. **Do not dual-write process stdout into `fleet_provider_event`.** `store_writer.rs:14`
+   says it plainly: every commit takes the single SQLite write lock the whole control plane
+   shares, and ACP is already "the new heavy writer". A claude run emits thousands of
+   stream-json lines. Each executor keeps its own durable store; the READ is unified
+   server-side, once.
+4. **Move the transcript classifier into `ainb-hangar-proto`** so the daemon and the plugin
+   share one taxonomy. It is a move of an existing 498-line file, not new code, and it is
+   what makes both producers honest.
+5. **No turn-complete future on the pool.** Poll the delivery leg the pool already resolves
+   on every path.
+6. **Per-task adapter process for ACP**, not the shared pool. Reasoning in section 5.
+
+---
+
+## 1. What the AcpPool gives a caller today, and what a TASK caller is missing
+
+### 1a. Session creation
+
+`fleet/acp_session_create` (`rpc/mod.rs:5907-6010`) mints the `fleet_session` +
+`fleet_acp_session` PAIR in one transaction, with **no process spawn**:
+
+| Step | Location |
+|---|---|
+| capability gate `FLEET_CAPABILITY_ACP_SPAWN` | `rpc/mod.rs:5918` |
+| adapter-registry validation (not schema) | `rpc/mod.rs:5929-5946` |
+| `permission_mode` read from `PoolConfig` | `rpc/mod.rs:5942-5946` |
+| `session_key` minted by `FleetAcpSessionRepo::mint_session_key` | `rpc/mod.rs:5948` |
+| `scope_key` = param or `session:<session_key>` | `rpc/mod.rs:5949` |
+| paired insert | `rpc/mod.rs:5979-5993` |
+| idempotent **per live scope** | `rpc/mod.rs:5994-6005` |
+
+`FleetAcpSessionRow` (`crates/ainb-hangar-store/src/repo/fleet_acp_session.rs:43-68`):
+`session_key, scope_key, provider, provider_version, acp_session_id, cwd, permission_mode,
+state, open_turn_id, open_turn_started_at, created_at, last_active_at`, plus migration
+0082's `model / reasoning_effort / persona`.
+
+**CONTRADICTS the brief.** The brief says "one process per provider means the sandbox and
+cwd can't be per task". **cwd IS per session already**: a column on `fleet_acp_session`,
+carried onto the actor (`acp_pool.rs:1528`), passed to `session/new` (`acp_pool.rs:2338-2341`)
+and `session/load` (`acp_pool.rs:2280-2287`). What is genuinely per-PROCESS: the child
+environment, the permission mode, and the OS sandbox. See section 5.
+
+### 1b. Sending a prompt and observing turn completion
+
+`AcpPool::submit_prompt(session_key, message_id, text) -> SubmitOutcome`
+(`acp_pool.rs:608-651`), fire and forget: `Queued` or `Rejected(&'static str)`. No future,
+no callback, no event addressed to the caller. The outcome lands in the store.
+
+```
+submit_prompt ──▶ actor queue (bounded, queue_depth=32)
+                     │ one turn in flight per session (acp_pool.rs:1584)
+                     ▼
+                  start_turn (acp_pool.rs:1720)
+                     │  ├─ leg already terminal? skip          (:1726)
+                     │  ├─ attach_with_one_requeue             (:2102)
+                     │  ├─ mode_violated? FAILED mode_unproven (:1772)
+                     │  ├─ in-flight permit (max 4/process)    (:1784)
+                     │  └─ record_turn (open_turn_id)          (:1853)
+                     ▼
+                  session/prompt on its own task               (:1831)
+                     ▼
+                  finish_turn (acp_pool.rs:1918)
+                     └─ commit_turn_end ── ONE txn ──▶ receipt + reply + IDLE (:2038)
+```
+
+`message_id` must already carry a PENDING delivery leg; `start_turn` re-reads it
+(`leg_is_pending` `acp_pool.rs:2874`) and drops the job otherwise. The chat path creates it
+with `acp_operator_message` (`rpc/mod.rs:6285-6317`).
+
+Leg row: `FleetMessageDeliveryRow` (`crates/ainb-hangar-store/src/repo/fleet_message.rs:73-86`),
+`state` in `PENDING|DELIVERED|FAILED|UNKNOWN|REJECTED`, `detail` an enumerated token from
+the taxonomy at `acp_pool.rs:100-141` (`queue_full, breaker_open, adapter_exit,
+operator_stop, turn_deadline, daemon_restart, spawn_failed, turn_failed, turn_unrecorded,
+session_gone, provider_at_capacity, mode_unproven`), plus `resume=loaded|reprimed`
+appended (`acp_pool.rs:1959-1963`).
+
+### 1c. Cancel
+
+`AcpPool::cancel(session_key, ConvergeCause)` (`acp_pool.rs:683`), turn-scoped
+`cancel_turn(..., Some(turn_id))` (`:692`), `teardown` (`:714`). `session/cancel` is a
+notification (`client.rs:545`) so it never blocks behind the turn it kills.
+
+### 1d. Resume
+
+`ensure_session` (`acp_pool.rs:2165`) does not depend on `session/load`: stored id +
+adapter advertises `loadSession` -> `try_load` (`:2259`); unknown session -> `rebuild`
+(`:2329`) = `session/new` plus a re-prime prelude prepended to the next prompt
+(`:1801-1804`), built by `render_resume_prelude` (`:2930`). Mode is re-asserted after every
+load (`client.rs:459-496`) because both real adapters revert it.
+
+### 1e. cwd / env / MCP / permission_mode
+
+- **cwd**: per session.
+- **env**: per PROCESS. `AdapterConfig { env_passthrough, extra_env }` (`config.rs:41-44`)
+  through `allowlisted_env` (`config.rs:117-143`) over `BASE_ENV_ALLOWLIST = ["PATH","HOME"]`
+  (`config.rs:22`), spawned `env_clear()` (`client.rs:684-701`).
+- **MCP**: per SESSION, deliberately (`client.rs:436-440`), via
+  `crate::copilot::session_mcp_servers(pool, scope_key)` (`acp_pool.rs:2278`, `:2336`).
+- **permission_mode**: per PROCESS (`config.rs:37`). Valid values validated at
+  `acp_pool.rs:331`: `default | acceptEdits | bypassPermissions | plan`.
+
+  **CONTRADICTS the brief.** It is not "pinned at `session/new`": upstream v1
+  `NewSessionRequest` has no mode field (`client.rs:34-43`). The mode is ASSERTED: read
+  `currentModeId` off the reply, and on a mismatch issue `session/set_mode` and require a
+  `current_mode_update` echo within 5 s (`client.rs:68`, `:612-665`). No echo is a hard
+  spawn failure. There is no `ask` mode.
+
+### 1f. request_permission park and answer
+
+Parked in the client holding the adapter's `Responder` (`client.rs:211-301`). The pool
+raises it (`raise_permission` `acp_pool.rs:2513`): refused at the door with no open turn
+(`:2520-2523`); fingerprint `permission_fingerprint` (`:3154`); `acp.permission` transcript
+row (`:2534`); `AttentionKind::Approval` with `session_id = session_key`, `cwd = actor cwd`,
+`workspace_id: None` (`:2544-2556`); fleet event `acp_permission_requested` setting
+`attention_state=APPROVAL` (`:2562-2581`).
+
+Answered by `answer_permission(session_key, fingerprint, PermissionDecision)`
+(`acp_pool.rs:654`) -> actor `answer` (`:2595`) -> `answer_selected`/`answer_cancelled`
+(`client.rs:277-300`) -> `retire_attention` (`:2664`). Reachable from the wire ONLY through
+`fleet/action` -> `execute_acp_action` (`rpc/mod.rs:6083-6200`).
+
+### 1g. What is MISSING for a task caller
+
+| Need | Status | Gap |
+|---|---|---|
+| per-worktree cwd | **present** | none |
+| turn-complete signal | **missing** | poll the delivery leg (section 2d) |
+| stop reason on a SUCCESS | **missing** | `finish_turn` records it only on failure (`acp_pool.rs:1936-1947`); `turn_succeeded` folds `EndTurn`/`MaxTokens`/`MaxTurnRequests` into one `DELIVERED` (`:3039-3044`). 3-line fix in 2e. |
+| usage / cost | **missing** | reducer classifies `UsageUpdate` to `ChunkKind::Usage` (`reducer.rs:318-320`) and persists an `acp.usage` row, but nothing parses it into `ProviderUsage` (`runner.rs:420-427`) |
+| PR URL capture | **missing** | today `parse_gh_pr_create_stdout(&result.stdout_tail)` (`run_loop.rs:1718`). ACP has no stdout tail: adapter stderr is INHERITED (`client.rs:690-697`), stdout is the JSON-RPC pipe. |
+| task -> ACP session mapping | **missing** | no column either side. Use `scope_key = "task:<task_id>"`: create is already idempotent per live scope, so no new column and no new write. |
+| turn deadline vs task runtime | **mismatch** | `turn_deadline` default 30 min (`acp_pool.rs:264`) vs `HANGAR_PROVIDER_MAX_RUNTIME_MS` |
+| concurrency ceiling | **mismatch** | `max_in_flight_per_process: 4` (`:261`), `max_sessions_per_provider: 16` (`:260`). A per-task process removes both. |
+
+---
+
+## 2. The seam, and the one live run-event stream
+
+### 2a. What "live" costs today: nothing, because nothing produces it
+
+```
+                            PRODUCER              CONSUMER
+HangarEvent::TaskMessage    NONE                  plugin.rs:1197 -> boards.rs:803 (timeline overlay)
+HangarEvent::TaskProgress   NONE                  banner_state.rs:135 (tool count + latest line)
+logs/<p>.jsonl              runner.rs:1908        board_card_timeline (pull) -> parse_timeline (client)
+fleet_provider_event        StoreWriter (ACP)     fleet/transcript_list -- NO plugin reader at all
+```
+
+Verified: `rg 'HangarEvent::TaskMessage' crates/ | grep -v tests/` returns only
+`event_outbox.rs:72` (routing) and `inbox_aggregator.rs:127` (ignore); same for
+`TaskProgress`. `rg 'TRANSCRIPT_LIST|transcript_list' crates/ainb-plugin-hangar/src`
+returns nothing.
+
+So the TUI's live task transcript, the board timeline's live append (`plugin.rs:1177`'s
+whole comment) and the run banner are all **dead code waiting for a producer**. Move 1
+writes it, once, for both executors. No new variant, no new RPC, no new subscription.
+
+### 2b. The shared classifier (the one refactor)
+
+Both producers need `line -> Vec<(MessageKind, String)>`. That function exists:
+`crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs` (498 lines, 6 tests). It is in the
+PLUGIN crate and returns the plugin type `ViewEntry`, so the daemon cannot use it, and
+`ViewEntry::line(kind, body)` (`screen/task_detail.rs`) shows it is `(MessageKind, String)`
+in a wrapper.
+
+**Move it to `ainb-hangar-proto` as `transcript::classify`.** `MessageKind` already lives
+there (`events.rs`), and both the daemon and the plugin already depend on that crate
+(`crates/ainb-plugin-hangar/Cargo.toml:28`). It cannot live in `ainb-hangar-core`:
+`ainb-hangar-proto` depends on core (`crates/ainb-hangar-proto/Cargo.toml:22`), not the
+other way round, so core cannot see `MessageKind`.
+
+```
+ainb-hangar-proto::transcript
+    classify_stream_json(line: &str) -> Vec<(MessageKind, String)>   // the moved parser
+    classify_acp(event_type: &str, raw_payload: &str) -> Vec<(MessageKind, String)>  // new, ~40 lines
+```
+
+The plugin keeps a 5-line wrapper mapping to `ViewEntry::line`. The 6 tests move with it.
+`ViewEntry`, the collapse grouping, and the renderer all stay in the plugin: only
+classification moves.
+
+`classify_acp` maps the seven `ChunkKind::event_type()` tokens (`reducer.rs:60-70`):
+
+| `event_type` | `MessageKind` |
+|---|---|
+| `acp.message` | agent prose |
+| `acp.user_message` | user/comment lane |
+| `acp.thought` | thinking |
+| `acp.tool_call` | tool call, name + compact input from the verbatim `block` |
+| `acp.plan` | tool call lane |
+| `acp.permission` | tool call lane, `[approval] <tool>` |
+| `acp.usage` | folded into the run-status line, not a transcript row |
+| `acp.transcript_truncated` (`store_writer.rs:71`) | error lane |
+
+Rejected alternative: synthesising fake claude stream-json out of `acp.*` rows so the
+existing client parser eats it. That is clever, not boring: two shapes to keep in sync and
+a round trip through a format neither side speaks.
+
+### 2c. Both producers
+
+```
+   ProcessExecutor                                       AcpExecutor
+   runner.rs stream_stdout:1907                          acp_pool.rs ingest:1678
+        │ writeln! logs/<p>.jsonl  (durable, unchanged)       │ StoreWriter -> fleet_provider_event
+        │                                                     │ (durable, unchanged)
+        └──▶ classify_stream_json ──┐         ┌── classify_acp ┘
+                                    ▼         ▼
+                    EventSink::emit(TaskMessage{task_id, kind, body})     per line/chunk
+                    EventSink::emit(TaskProgress{task_id, tool_calls, elapsed_ms})  throttled 1/s
+                                    │
+                    plugin: fold_timeline_message  plugin.rs:1197   ✅ exists
+                            banner_state.rs:135                     ✅ exists
+                            task_detail append                      ← 1 new arm (~10 lines)
+```
+
+**Process side.** `stream_stdout` (`runner.rs:1894-1960`) is a single clean loop with one
+`writeln!` and one `push_tail`. Add an optional `sink: Option<TaskLineSink>` to
+`RunnerConfig` (constructed once at `run_loop.rs:530-533`, so it threads with no new
+plumbing) and call it per line. `tool_calls` counts lines whose parsed `StreamLine` shows a
+tool_use content block; claude's shape is exact, codex is best-effort, copilot and
+antigravity count 0 -- **the same coverage the plugin's parser already documents**
+(`jsonl_timeline.rs:22-27`). One `ponytail:` comment naming that ceiling.
+
+**ACP side.** The actor's `ingest` (`acp_pool.rs:1678`) already receives every chunk before
+handing it to the writer. Emit there. The actor holds `pool.events` (the same `EventSink`,
+`acp_pool.rs:562`) so there is nothing to thread. The task's `task_id` comes from the
+`scope_key = task:<task_id>` the executor created the session under.
+
+**Throttle.** `TaskProgress` on a 1 s tick (the ACP actor already has one:
+`WriterConfig::flush_interval`, `acp_pool.rs:1556`). `TaskMessage` per line, deliberately
+unthrottled, because `plugin.rs:1177` exists precisely so a transcript line does NOT arm a
+snapshot re-pull. Do not invert that.
+
+### 2d. Executor selection
+
+```
+┌────────────────┐  agent.provider ends in "-acp"?  ┌──────────────┐
+│ resolve_dispatch│─────────── else ────────────────▶│ Executor     │
+│ run_loop:1160   │  HANGAR_TASK_EXECUTOR fallback   │ Process | Acp│
+└────────────────┘                                   └──────┬───────┘
+              ┌──────────────────────────────────────────────┴────────┐
+   Process ───▼────────────────┐                     Acp ─────────────▼──────────┐
+   │ mode==Interactive?        │                     │ acp_task::run_acp         │
+   │  yes -> run_interactive   │                     │ no tmux, no argv, no cred │
+   │  no  -> match backend     │                     └───────────────────────────┘
+   └───────────────────────────┘
+```
+
+- **Per agent (durable):** reuse the existing `agent.provider` column
+  (`crates/ainb-hangar-store/src/repo/agent.rs:107`) with the values `claude-agent-acp` /
+  `codex-acp`, which are already the adapter registry tokens (`config.rs:11-13`).
+  **No migration.**
+- **Per task (resolved):** `ResolvedDispatch` gains `executor: Executor`
+  (`run_loop.rs:2413-2436`), beside `mode`, for exactly the reason the doc comment there
+  gives: it lives on the dispatch so the exec-path branch and the argv cannot disagree.
+- **Daemon default:** `HANGAR_TASK_EXECUTOR=acp|process`, **default `process`**, read in
+  `DaemonConfig::from_env` (`run_loop.rs:185-268`) through a pure resolver shaped exactly
+  like `resolve_sandbox` (`run_loop.rs:278-284`) so precedence is testable without mutating
+  process env. Unrecognised value falls back to `process` with a warning, matching the
+  sandbox override's documented behaviour.
+- Precedence: agent > daemon default.
+- A true per-task override that differs from its agent needs a column on
+  `agent_task_queue`. **Deferred**, not designed around. Do NOT overload
+  `agent_task_queue.mode` (`""|headless|interactive`, validated `rpc/mod.rs:9661-9669`):
+  executor and interactivity are two axes and conflating them is the bug
+  `interactive_command` (`run_loop.rs:1538`) was extracted to prevent.
+
+### 2e. The branch, and `run_acp`
+
+Inside the `provider_run` async block (`run_loop.rs:1387`), one arm added above the
+existing two, nothing below `let outcome = ...` touched:
+
+```rust
+let provider_run = async {
+    if dispatch.executor == Executor::Acp {
+        crate::acp_task::run_acp(pool, &task, &dispatch, &location, task_env).await
+    } else if mode == Mode::Interactive {
+        run_interactive(...).await          // unchanged
+    } else {
+        match dispatch.backend { ... }      // unchanged
+    }
+};
+```
+
+The cancel arm (`run_loop.rs:1452-1469`) gains one case: dropping the future does not
+cancel an ACP turn, so it calls `pool.cancel(&session_key, ConvergeCause::OperatorStop)` --
+the exact analogue of the interactive arm's `kill_session`.
+
+`crates/ainb-hangar-daemon/src/acp_task.rs`:
+
+```
+1. pool = acp_pool::active_handle().await            (acp_pool.rs:1301)  None -> Failed{SpawnError}
+2. session_key = acp_session::ensure(provider, cwd = location.cwd, scope_key = "task:<id>")
+      Extracted from handle_fleet_acp_session_create's body (rpc/mod.rs:5979) so the RPC and
+      this share ONE transaction. One function, two callers.
+3. write session_key onto agent_task_queue.session_id
+4. message_id = acp_message::enqueue(session_key, prompt, sender = "task:<id>")
+      Extracted from acp_operator_message (rpc/mod.rs:6285) the same way.
+5. pool.submit_prompt(...).await;  Rejected(detail) -> map and return
+6. poll the leg every 1 s (FleetMessageRepo::deliveries_for_message) while PENDING.
+   Bounded by HANGAR_PROVIDER_MAX_RUNTIME_MS; on breach cancel(TurnDeadline) -> Failed{Timeout}.
+   It also terminates on its own: the pool's deadline sweep resolves the leg (acp_pool.rs:885, :264).
+7. build RunnerResult from the transcript, map the leg -> RunOutcome.
+```
+
+Why poll rather than add a `oneshot` to `PromptJob`: the leg is already resolved on every
+path in one transaction (`commit_turn_end` `:2038`, `resolve_leg` `:2986`, convergence
+`drain_queue` `:2471`). A oneshot is ~40 lines and one missed send leaves the task frozen
+`running` until the multi-hour TTL, which is the exact hazard `run_loop.rs:1280-1294`
+documents. Poll cost is one indexed read per second per running ACP task, capped by
+`max_concurrent_tasks`.
+
+### 2f. RunOutcome mapping
+
+Needs one 3-line pool change so a success carries its stop reason: at `acp_pool.rs:1936-1947`
+the success arm passes `detail = None`; make it `Some(format!("stop={:?}",
+response.stop_reason))`. Additive -- the detail already gets `resume=...` appended the same
+way (`:1959-1963`) and no reader parses it strictly.
+
+| leg `state` | leg `detail` | `RunOutcome` | retry disposition |
+|---|---|---|---|
+| `DELIVERED` | `stop=EndTurn` | `Success(result)` | n/a |
+| `DELIVERED` | `stop=MaxTokens` / `stop=MaxTurnRequests` | `Failed{IterationLimit}` | FreshRetry |
+| `FAILED` | `turn_failed; Refusal` | `Failed{AgentError}` | NoRetry |
+| `FAILED` | `turn_failed; Cancelled` | `Cancelled(result)` | n/a |
+| `FAILED` | `spawn_failed` / `mode_unproven` / `turn_unrecorded` | `Failed{SpawnError}` | NoRetry |
+| `FAILED` | `session_gone` | `Failed{ProvisionError}` | NoRetry |
+| `FAILED` | `breaker_open` / `provider_at_capacity` / `queue_full` | `Failed{RuntimeOffline}` | ResumeRetry |
+| `FAILED` | `operator_stop` | `Cancelled(result)` | n/a |
+| `UNKNOWN` | `adapter_exit; ...` | `Failed{RuntimeOffline}` | ResumeRetry |
+| `UNKNOWN` | `turn_deadline` | `Failed{Timeout}` | NoRetry |
+| `UNKNOWN` | `daemon_restart` | `Failed{RuntimeRecovery}` | ResumeRetry |
+| `REJECTED` | any | `Failed{SpawnError}` | NoRetry |
+| (unmapped detail) | | `Failed{ProviderContractDrift}` | NoRetry |
+
+Dispositions verified against `RetryService::retry_disposition`
+(`crates/ainb-hangar-store/src/service/retry.rs:325-352`). The unmapped arm is
+`ProviderContractDrift` deliberately, mirroring `runner.rs`'s existing fail-closed rule: an
+unknown detail token means the pool's taxonomy grew, not that the agent succeeded.
+
+`RunnerResult` for an ACP run: `exit_code: None`, `session_id: Some(session_key)`, `usage`
+from the `acp.usage` rows, `stdout_tail` = the turn's final agent message plus tool-result
+text (what PR capture scans), `stderr_tail: String::new()`.
+
+---
+
+## 3. Structured HITL
+
+### 3a. ACP-only, and say so
+
+**Structured HITL is ACP-only in Move 1.** The process executor keeps the existing hook and
+attention route, unchanged, untouched.
+
+State that route honestly, because it is narrower than it sounds:
+
+```
+executor=process, mode=interactive:
+   claude hook ─▶ ainb fleet atc hook ─▶ events.jsonl ─▶ attention_ingest ─▶ attention row
+   attention/answer ─▶ answer.rs:66 ─▶ capture_pane + tmux send-keys ─▶ the pane
+
+executor=process, mode=headless:
+   claude -p --dangerously-skip-permissions  (runner.rs:1296-1320)
+   -> NOTHING EVER ASKS. There is no HITL on this path and never was.
+
+executor=acp:
+   session/request_permission ─▶ parked responder + attention row (acp_pool.rs:2513)
+   answered ─▶ pool.answer_permission ─▶ the adapter's pending JSON-RPC id
+```
+
+So "the process path keeps the hook route" is true only for `mode=interactive`. The
+headless process path has no human-in-the-loop at all, by argv. That asymmetry is the
+reason ACP is worth doing, and it should be written down rather than implied.
+
+### 3b. The gap the brief does not account for
+
+The brief says permissions are answered "through the existing `fleet/action` path" and show
+"in the TUI inbox/control center". Both are true separately and **do not connect**:
+
+```
+acp_pool::raise_permission ──▶ attention row (Approval)
+              ┌───────────────────┴──────────────────┐
+              ▼                                      ▼
+  Control Center / Inbox                    Fleet screen
+  attention/answer  (plugin.rs:2093)        fleet/action  (plugin.rs:2773)
+              ▼                                      ▼
+  answer.rs:66  ── ZERO acp handling ──▶     execute_acp_action (rpc/mod.rs:6083)
+  capture_pane + tmux send-keys              pool.answer_permission ✅
+  (answer.rs:218-245)
+              ▼
+  no tmux pane for an ACP task worktree -> Target::NoTarget -> row stays open
+```
+
+`rg acp crates/ainb-hangar-daemon/src/answer.rs` returns nothing. Control Center is the
+surface an operator actually uses (`screen/control_center.rs:7`, `:539`) and it can only
+answer via `attention/answer`.
+
+**Fix, and it is the lazy one because it is the root-cause one:** an ACP arm at the TOP of
+`answer::answer` (`answer.rs:66`), before target resolution. The row's payload already
+carries everything (`acp_pool.rs:2525-2533`: `sessionKey`, `requestFingerprint`, `options`,
+`rpcId`, `toolCall`):
+
+```rust
+if row.payload_kind() == "acp_permission" {
+    // Routed by the row's OWN session_key -- no cwd correlation, so the C1
+    // ambiguity guard has nothing to refuse.
+    return acp_answer_result(
+        acp_pool::active_handle().await,
+        payload["sessionKey"], payload["requestFingerprint"],
+        match_answer_to_option(&payload["options"], &params.answer),
+    );
+}
+```
+
+~30 lines. It also fixes ACP **chat** permissions from Control Center, broken today for the
+same reason -- which is what makes it the root-cause fix rather than a task special case.
+`mark_answered_if_open` stays the first-answer-wins gate; the actor's `retire_attention`
+(`acp_pool.rs:2664`) calls the same conditional UPDATE, so a double call is benign.
+
+### 3c. AskUserQuestion under ACP: unverified
+
+**Probe before this is scoped as "AskUserQuestion answered from the TUI".** What the repo
+does prove:
+
+- `agent-client-protocol` pinned `=1.3.0` (`crates/ainb-acp/Cargo.toml:20`,
+  `crates/ainb-hangar-daemon/Cargo.toml:77`, `Cargo.lock:57-60`).
+- Exactly one agent-to-client REQUEST is wired: `session/request_permission`
+  (`client.rs:746-760`). No options-carrying tool-call request exists in the v1 set this
+  crate imports (`client.rs:52-58`).
+- The reducer folds `ToolCall` and `ToolCallUpdate` into one opaque `ChunkKind::ToolCall`
+  (`reducer.rs:312-314`). Nothing inspects a tool name, so an `AskUserQuestion` arriving as
+  a plain tool call becomes an `acp.tool_call` row that **blocks nothing and asks nobody**.
+- `rg AskUserQuestion crates/` hits only tmux/hook-era code, never anything ACP.
+
+Three possible adapter behaviours, none settled here: (1) it surfaces as
+`session/request_permission` with the question's options -- everything above already works,
+and `options_wire` (`client.rs:258-270`) already carries `optionId/name/kind`; (2) the
+adapter answers it itself and no human is ever asked; (3) the tool is not offered at all.
+
+**Falsifier, 30 minutes:** `crates/ainb-acp/tests/real_adapter.rs` already exists as the
+`#[ignore]`d real-adapter harness that CI explicitly skips (`.github/workflows/ci.yml:750-753`).
+Add one probe that prompts a real `claude-agent-acp` to ask a two-option question and
+records whether a `session/request_permission` fires. Until it runs, outcome (1) is a
+**hypothesis**.
+
+### 3d. What "interactive mode" becomes under ACP
+
+- `Mode::Interactive` + `Executor::Acp` is **refused at dispatch**, not silently downgraded.
+  `dispatch_mode` (`run_loop.rs:1155-1159`) terminalises with `ProvisionError` naming the
+  flag. Silently running headless is the class of bug `interactive_command`
+  (`run_loop.rs:1538`) was extracted to prevent.
+- The interactive/headless axis is replaced by the permission mode: `default` (the adapter
+  asks, the human answers through 3b) vs `bypassPermissions` (nothing asks, today's
+  `--dangerously-skip-permissions` equivalent).
+- **Constraint:** that mode is per adapter PROCESS (`config.rs:37`), so on a shared pool
+  every session on `claude-agent-acp` shares one. Second independent reason for a per-task
+  process (section 5).
+- The tmux path is untouched and reachable only under `executor=process`.
+
+---
+
+## 4. Transcript unification
+
+### 4a. Two durable stores, deliberately
+
+| Executor | Durable transcript | Written at |
+|---|---|---|
+| process | `{logs}/<provider>.jsonl` | `runner.rs:1908` |
+| acp | `fleet_provider_event`, `source='acp'`, `event_type='acp.<kind>'` | `crates/ainb-acp/src/store_writer.rs` |
+
+Keep both. Dual-writing process stdout into SQLite would put thousands of rows per run
+through the one write lock the whole control plane shares -- the exact hazard
+`store_writer.rs:14-21` documents about ACP already being the new heavy writer.
+
+### 4b. One read, server-side
+
+`handle_board_card_timeline` (`rpc/mod.rs:11215-11277`) already resolves the card's newest
+task and picks whichever of `claude.jsonl` / `codex.jsonl` exists (`:11259-11272`). Give it
+one branch and one return shape:
+
+```
+task -> scope_key "task:<id>" resolves to a fleet_acp_session?
+   yes -> FleetProviderEventRepo rows  -> transcript::classify_acp
+   no  -> read_tail(logs/<p>.jsonl)    -> transcript::classify_stream_json
+                    │
+                    ▼
+   BoardCardTimelineResult { task_id, provider, entries: Vec<TranscriptLine{kind, body}> }
+```
+
+`BoardCardTimelineResult.jsonl: String` (`snapshots.rs:2769-2772`) is replaced by
+`entries`. The plugin's `apply_board_card_timeline` (`plugin.rs:1811-1840`) stops calling
+`parse_timeline` and maps `entries` to `ViewEntry::line` -- ~5 lines changed, and the
+classifier it used to call now runs daemon-side against both stores. Daemon and plugin ship
+together (`ci.yml:667` stages the bundled plugins), so the wire change is internal.
+
+**PR capture** keeps working unchanged: `run_acp` builds `RunnerResult.stdout_tail` from the
+same classified entries, and `parse_gh_pr_create_stdout` (`run_loop.rs:1718`) finds the URL
+in the agent's own message and in tool-result text.
+
+### 4c. Live, per 2c
+
+`TaskMessage` carries `(kind, body)` straight from the same classifier, so a live-appended
+line and its later re-pulled twin are byte-identical. That is the payoff for moving the
+classifier instead of writing a second one.
+
+---
+
+## 5. Sandbox and credentials
+
+### 5a. What a task loses on a shared pool
+
+| Control | Where | Reaches an ACP adapter? |
+|---|---|---|
+| OS sandbox (Seatbelt / Landlock) | `crates/ainb-hangar-sandbox/src/lib.rs:147`, wired `run_loop.rs:530-533` | No. The pool spawns a bare `tokio::process::Command` (`client.rs:682-706`). |
+| env allowlist + `agent_env` | `compose_child_env` (`runner.rs`), built by `prepare_spawn_inputs` (`run_loop.rs:972-1042`) | No. Adapter env is per PROCESS. |
+| claude credential ladder | `claude_cred.rs::resolve` via `resolve_cred_env` (`run_loop.rs:928-958`) | No, and probably unwanted: the adapter authenticates itself. |
+| skills / profile materialisation | `run_loop.rs:1029-1041`, forwarded as `*_HOME` env keys | No (env-shaped). |
+| per-task cwd | `location.cwd` (`run_loop.rs:1210-1225`) | **Yes** |
+| per-task MCP | `agent.mcp_config` | **Yes** (`client.rs:436`) |
+
+### 5b. Recommendation: per-task adapter process
+
+Reasons, weightiest first:
+
+1. **The permission mode is per process** (`config.rs:37`, asserted `client.rs:612`). A
+   shared `claude-agent-acp` cannot host a `bypassPermissions` autopilot task and a
+   `default` interactive task at once. That alone forecloses the shared pool for tasks.
+2. **`agent_env` is per process.** It is the documented "ONE permitted plaintext escape"
+   (`run_loop.rs:1417`); leaking one task's secrets to every other tenant is a regression on
+   today's isolation.
+3. **The sandbox is per process.** Confinement is what `ainb-hangar-sandbox` exists for
+   (`lib.rs:1-10`).
+4. **The ceilings are wrong**: `max_in_flight_per_process: 4` (`acp_pool.rs:261`) would cap
+   the whole fleet's concurrent task turns at 4 per provider.
+5. The per-provider `SlotCircuit` breaker (`acp_pool.rs:967-1000`) means one crash-looping
+   task poisons every chat session on the same adapter.
+
+**Cost, honestly:** one adapter process per running task instead of one per provider. That
+is exactly today's model (one `claude` CLI per task), so not a regression, and the adapter
+dies with the task (`kill_on_drop(true)`, `client.rs:698`).
+
+**Mechanism.** `PoolConfig.adapters` is a `HashMap<String, AdapterConfig>`
+(`acp_pool.rs:222`) and `provider_process` (`:1026`) keys the live process map by the same
+string. Register a per-task adapter under `claude-agent-acp#task:<task_id>` whose config
+carries: `command` = the sandbox launcher wrapping the real adapter (mirroring
+`resolve_provider_path` `run_loop.rs:320` and `sandboxed_command` `lib.rs:147`);
+`extra_env` = what `prepare_spawn_inputs` already returns (task_env + agent_env + skills
+`*_HOME`); `permission_mode` per task. The pool then gives isolation for free: lazy spawn
+on first prompt (`:1026-1128`), idle reap (`stop_idle_processes` `:914`), one process per
+key. The only pool change is making `adapters` writable at runtime
+(`register_adapter` / removal on teardown), ~40 lines.
+
+**Landlock caveat:** `sandboxed_command` applies its ruleset in a `pre_exec` hook
+(`lib.rs:24-30`) and returns a `std::process::Command` (`into_inner` `:131`);
+`tokio::process::Command::from(std_cmd)` preserves it. On macOS the launcher is
+`/usr/bin/sandbox-exec`, a plain program swap. Both fit `AdapterConfig { command, args }`
+with no sandbox-crate change.
+
+**Credential:** do NOT inject `CLAUDE_CODE_OAUTH_TOKEN` by default. The ladder exists
+because a confined CLI child cannot reach the Keychain, and a static token goes stale in
+~8h (`ainb-tui/CLAUDE.md`). Start with `env_passthrough: ["CLAUDE_CODE_OAUTH_TOKEN"]`
+(already that field's documented purpose, `config.rs:38-40`) and prove which auth path the
+adapter takes in the first live run before hard-wiring either.
+
+---
+
+## 6. Test plan
+
+All of it runs with no adapter and no credentials, via
+`crates/ainb-acp/src/bin/fake_acp_adapter.rs` (585 lines, 20 env knobs) and a fake provider
+binary for the process side.
+
+| # | Test | File | Asserts |
+|---|---|---|---|
+| T0 | classifier move is behaviour-preserving | `crates/ainb-hangar-proto/tests/` | the 6 moved `jsonl_timeline` tests pass verbatim against `transcript::classify_stream_json`. Move first, in its own PR, so a later regression is attributable. |
+| T1 | **both executors stream live** | `crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs` | the SAME assertion run twice, once per executor: subscribe to the workspace event stream, run a task, collect `TaskMessage` events, assert the `(kind, body)` sequence equals what the durable read (`board_card_timeline`) returns for the same run. **This is the test that pins the requirement.** A producer that emits nothing, or emits a different taxonomy than the re-pull, fails it. |
+| T2 | ACP happy path | `tests/tripwire_acp_task_end_to_end.rs` | `HANGAR_TASK_EXECUTOR=acp` + fake adapter with `FAKE_ACP_ECHO_PROMPT=1`: `queued -> dispatched -> running -> done`; `result` carries the final message; `session_id` = the `session_key`; `fleet_provider_event` holds `acp.message` rows |
+| T3 | permission answered from the attention path | same file | `FAKE_ACP_PERMISSION_SESSIONS=*`: an approval row appears with the worktree cwd; answering via **`attention/answer`** (not `fleet/action`) delivers; the turn completes; the row flips `answered`; `FAKE_ACP_RPC_LOG` shows exactly one `permission` line. Pins the 3b fix. |
+| T4 | executor tripwire, both directions | `tests/tripwire_task_executor_flag.rs` | `=process` spawns a process (marker file) and writes `logs/claude.jsonl`; `=acp` spawns none, writes zero jsonl, writes N `fleet_provider_event` rows. Both asserted, because a flag that silently falls back keeps every other test green. |
+| T5 | outcome mapping | `tests/acp_task_outcome.rs`, pure unit | table-drives section 2f including the unmapped-detail arm. No daemon, no adapter. |
+| T6 | interactive + acp refused | in T4's file | terminalises `provision_error` naming the flag; `tmux has-session` on the exact name is non-zero |
+| T7 | cancel | in T2's file | `FAKE_ACP_HANG_SESSIONS=*` then `hangar/issue_cancel_active`: task `cancelled`, `FAKE_ACP_RPC_LOG` carries `cancel:<adapter session id>` |
+| T8 | unified durable read | `tests/timeline_both_executors.rs` | `board_card_timeline` returns the same `TranscriptLine` shape for a process run and an ACP run of the same brief |
+| T9 | **argv golden matrix UNCHANGED** | `tests/argv_golden_matrix.rs` | run unmodified. Move 1 adds no argv. Do not regenerate: a diff means the `process` path moved and is a real break (`ainb-tui/CLAUDE.md`, Contract Tests). |
+| T10 | env isolation | `crates/ainb-acp/tests/` (extends the allowlist tests) | `FAKE_ACP_ENV_DUMP` proves the per-task adapter got the task's `agent_env`, not the daemon's ambient secrets, and that task A never sees task B's |
+
+**CI wiring.** `hangar-e2e` already runs every `tripwire_*` in `ainb-hangar-daemon/tests/`
+via `scripts/hangar/run_all_tripwires.sh` (`ci.yml:703-725`), on ubuntu and macos, with the
+daemon built at `:655-659`. T1/T2/T3/T4/T6/T7 named `tripwire_*` land there with **zero
+workflow edits**. T5/T8 are plain `tests/` files needing the acceptance lane
+(`ci.yml:730-734`) or an explicit `-p ainb-hangar-daemon` nextest line. T0 needs
+`-p ainb-hangar-proto`, which is **outside `default-members`** -- a bare `cargo nextest run`
+skips it and still reports clean (`ainb-tui/CLAUDE.md`). T10 rides the `acp` job
+(`ci.yml:754-770`).
+
+**Live probe, manual and separate:** 3c's `AskUserQuestion` probe as `#[ignore]` in
+`real_adapter.rs`; the opt-in `chat-bus-smoke` lane (`ci.yml:817-840`) is where a real
+end-to-end task run belongs once one exists.
+
+---
+
+## 7. Delivery slicing
+
+Each step green on its own.
+
+| # | Step | Size | Deletes / defers |
+|---|---|---|---|
+| 1 | **Classifier move.** `jsonl_timeline` -> `ainb-hangar-proto::transcript::classify_stream_json`, returning `Vec<(MessageKind, String)>`; 5-line `ViewEntry` wrapper stays in the plugin; the 6 tests move. T0. Pure refactor, no behaviour change. | **M** | deletes the plugin's copy |
+| 2 | **Live stream for the PROCESS executor.** `RunnerConfig.sink`, per-line `TaskMessage` from `stream_stdout`, throttled `TaskProgress`, plus the task-detail append arm. Half of T1. **Ships value with no ACP at all**: the board timeline overlay and the run banner go live for the first time. | **M** | defers the ACP half |
+| 3 | **ACP answer arm in `answer.rs`.** Section 3b. Standalone, and fixes ACP CHAT permissions from Control Center which are broken today. | **S** | nothing |
+| 4 | **Pool prerequisites.** `stop=<StopReason>` on the DELIVERED detail (`acp_pool.rs:1936-1947`); extract `acp_session::ensure` and `acp_message::enqueue` out of the two RPC handlers; `register_adapter` on `PoolConfig`. No chat-path behaviour change. | **S** | the RPC handlers shrink |
+| 5 | **`acp_task::run_acp` + the flag.** `DaemonConfig.task_executor`, `ResolvedDispatch.executor`, the `execute_claimed` arm, the cancel case, the leg poll, the outcome mapping, per-task adapter process. Live `TaskMessage` from the actor completes T1. T2, T4, T5, T6, T7, T9, T10. | **L** | defers usage/cost, PR capture (step 6), per-agent selection (step 8), resume across a task retry |
+| 6 | **Unified durable read.** `board_card_timeline` ACP branch + `classify_acp`; `BoardCardTimelineResult.jsonl` -> `entries`; plugin maps to `ViewEntry`. PR capture from the same entries. T8. | **M** | defers `fleet/transcript_list` ever getting a TUI reader (it still has none, and does not need one) |
+| 7 | **Usage.** Parse `acp.usage` rows into `ProviderUsage` so `persist_usage` (`run_loop.rs:1777`) and the usage dashboard see ACP runs. | **S** | |
+| 8 | **Per-agent selection.** `agent.provider` accepting adapter tokens. No migration. | **S** | defers a per-task override column |
+
+Steps 1-3 are useful on their own with the executor flag still absent, which is what makes
+this orderable rather than one big-bang PR.
+
+### Exit criterion for "Move 1 done"
+
+Two halves, one per executor.
+
+**Half A -- streaming, both executors, no ACP required:**
+A card run under `executor=process` shows its transcript growing live in the board timeline
+overlay while the run is in flight, and the same run under `executor=acp` shows the same
+taxonomy from the same classifier. T1 is the mechanical form of this.
+
+**Half B -- the Boxtrack P3 leg (`docs/hangar/proofs/fullstack/REPORT.md:26`) with zero tmux:**
+
+1. Board card created, `Run` with `executor=acp`.
+2. `tmux list-sessions` shows no `tmux_hangar-<task_id>` at any point; the run's `logs/`
+   holds no `*.jsonl`.
+3. The agent raises a real decision; an approval attention row appears with the worktree cwd.
+4. Control Center (`C`) shows `1 need you` with the adapter's own option labels; the option
+   key answers it through `attention/answer`.
+5. The transcript shows the agent ACTING on the chosen option, not the default.
+6. The task reaches `done`, the card advances, the timeline renders from
+   `fleet_provider_event`.
+
+Step 5 is the one that matters and the one defect 26 caught last time (`REPORT.md:62`: the
+operator's pick was silently replaced by the highlighted default). ACP removes that bug
+class because the answer is an option id on a JSON-RPC responder, not a keystroke into a
+pane.
+
+**Half B step 3 is gated on the 3c probe.** If `claude-agent-acp` does not surface
+`AskUserQuestion` as `session/request_permission`, the criterion becomes a tool-permission
+approval (a Write or a Bash the adapter asks about) -- which the fake adapter already proves
+and which is still a full structured round trip with no tmux. Say so now rather than
+discovering it at proof time.
+
+---
+
+## Contradictions with the brief, collected
+
+1. **cwd IS per session** under the multiplex (`fleet_acp_session.cwd`, `acp_pool.rs:1528`,
+   `:2340`). Only env, permission mode and the OS sandbox are per process.
+2. **`permission_mode` is not "pinned at `session/new`"**: upstream v1 has no mode field, so
+   the client asserts it post hoc and requires an echo (`client.rs:34-43`, `:612-665`).
+   There is no `ask` mode; the axis is `default` vs `bypassPermissions`.
+3. **`fleet/action` is not the path the TUI inbox uses.** Control Center answers via
+   `attention/answer` (`plugin.rs:2093`) into `answer.rs`, which has zero ACP handling. An
+   ACP permission is unanswerable from Control Center today, for chat as well as tasks.
+4. **There is no live transcript channel to unify.** `HangarEvent::TaskMessage` and
+   `TaskProgress` have consumers and no producers anywhere in `src/`; the board timeline's
+   live append and the run banner are dead code. Move 1 writes the first producers rather
+   than designing a new stream.
+5. **The daemon cannot reuse the existing transcript parser** without moving it:
+   `jsonl_timeline` lives in the plugin crate and returns a plugin type, and
+   `ainb-hangar-core` cannot host it because `ainb-hangar-proto` depends on core, not the
+   reverse (`crates/ainb-hangar-proto/Cargo.toml:22`).
+6. **A "turn-complete future" does not exist and should not be added.** The delivery leg is
+   the existing always-resolved signal.
+7. **`agent-client-protocol` 1.3.0 exposes no options-carrying tool-call request.** The one
+   agent-to-client request wired here is `session/request_permission`. Whether
+   `AskUserQuestion` arrives that way is an adapter question this repo does not answer.


### PR DESCRIPTION
Plan docs only. Decision record: https://explainers.stevengonsalvez.com/hangar-renovation/ (option C). Plan: https://explainers.stevengonsalvez.com/hangar-renovation-plan/

- `docs/hangar/renovation/PLAN.md`: the two tracks, seams, risks, exit criteria
- `exec-map.md`: how a task executes today (CLI subprocess or tmux; ACP is fleet chat only), counted surface, brittle seams, all file:line at 7d2b10d3
- `move1-acp-tasks.md`: claude -p and ACP as first-class streaming executors behind `HANGAR_TASK_EXECUTOR`, structured HITL over ACP, per-task adapter process, tests, 8 PR-sized steps
- `crisp-ui-track.md`: five plugin-only steps (names, cards, inbox, detail, tabs) with mocks, tripwire impact and a recording plan

Follows PR #815.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Hangar renovation plan covering execution, UI, architecture, milestones, risks, and open questions.
  * Added a crisp UI planning appendix detailing status terminology, screen layouts, attention handling, tab reductions, and implementation steps.
  * Documented the current Hangar architecture, task execution flow, APIs, screens, commands, migrations, and known areas of complexity.
  * Added a detailed plan for supporting ACP task execution and unified live run-event streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->