### PR TITLE
fix(hangar-daemon): answer ACP permissions from attention/answer (spine A3)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -190,6 +190,12 @@ async fn claim(
 /// already closed (or convergence will close) the ask; reopening our claim
 /// there would leave a row nothing can ever answer, so the claim is kept and
 /// the operator is told the answer did not reach the adapter.
+///
+/// The pool is the process-wide installed one ([`crate::acp_pool::active_handle`],
+/// installed once at daemon boot). A caller that parks permissions on a
+/// private `AcpPool` (a task executor building its own) raises rows this arm
+/// can only answer `NoTarget`: everything that raises must route through the
+/// installed pool.
 async fn answer_acp(
     pool: &SqlitePool,
     events: &EventSink,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -178,11 +178,17 @@ async fn claim(
 /// not on a screen), so a text the adapter never offered refuses with the row
 /// still open, and a missing pool is a `NoTarget` with nothing claimed. Once
 /// claimed, the pool's answer is a HAND-OFF to the adapter's pending JSON-RPC
-/// id, never an acknowledgement (ACP defines none), and any refusal from the
-/// pool reopens the row like a failed tmux send would. The actor's own
+/// id, never an acknowledgement (ACP defines none). The actor's own
 /// `retire_attention` runs the same conditional flip after the hand-off and
 /// finds the row already ours: benign, and what keeps `answered_by` naming the
 /// surface that answered rather than a generic "operator".
+///
+/// Only an `UnknownOption` refusal reopens the row: the pool answers it with
+/// the responder STILL PARKED, so a corrected answer can land. `NotWaiting`
+/// and `NoSession` mean the responder is spent or gone and the pool has
+/// already closed (or convergence will close) the ask; reopening our claim
+/// there would leave a row nothing can ever answer, so the claim is kept and
+/// the operator is told the answer did not reach the adapter.
 async fn answer_acp(
     pool: &SqlitePool,
     events: &EventSink,
@@ -226,16 +232,18 @@ async fn answer_acp(
                 via: format!("acp ({}, option {option})", permission.session_key),
             });
         }
+        PermissionAnswer::UnknownOption => {
+            reopen_on_failed_delivery(pool, events, row, params, now_ms).await?;
+            format!("the adapter never offered option {option_id}")
+        }
         PermissionAnswer::NotWaiting => {
             "the ACP permission is no longer waiting (answered elsewhere, or the adapter moved on)"
                 .to_string()
         }
-        PermissionAnswer::UnknownOption => format!("the adapter never offered option {option_id}"),
         PermissionAnswer::NoSession => {
             format!("no live ACP session for {}", permission.session_key)
         }
     };
-    reopen_on_failed_delivery(pool, events, row, params, now_ms).await?;
     Ok(AnswerResult::DeliveryFailed { reason })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -274,30 +274,35 @@ struct AcpOption {
 }
 
 impl AcpPermission {
-    /// The id of the option `answer` names: an option id verbatim, else the
-    /// label verbatim, case-insensitively, or a 1-based digit (the rules of
-    /// [`picker_position`]). Anything else is refused by the caller, and so is
-    /// a label two options share: the tmux path reads the pane echo to catch
-    /// a wrong pick, nothing here can, and an adapter offering "Allow" for
-    /// both `allow_once` and `allow_always` must not hand out the broader
-    /// grant by list order.
+    /// The id of the option `answer` names: an option id, a label (verbatim
+    /// or case-insensitively) or, naming none of those, a 1-based digit (the
+    /// rules of [`picker_position`]). Anything else is refused by the caller,
+    /// and so is an answer that names MORE THAN ONE option across those rules
+    /// (a label two options share, or one option's id that is another's
+    /// label): the tmux path reads the pane echo to catch a wrong pick,
+    /// nothing here can, and an adapter offering "Allow" for both `allow_once`
+    /// and `allow_always` must not hand out the broader grant by list order.
     fn option_id(&self, answer: &str) -> Option<String> {
         let wanted = answer.trim();
         if wanted.is_empty() {
             return None;
         }
-        let rules: [&dyn Fn(&AcpOption) -> bool; 3] = [
-            &|o| o.option_id == wanted,
-            &|o| o.name.trim() == wanted,
-            &|o| o.name.trim().eq_ignore_ascii_case(wanted),
-        ];
-        for rule in rules {
-            let mut hits = self.options.iter().filter(|o| rule(o));
-            match (hits.next(), hits.next()) {
-                (Some(only), None) => return Some(only.option_id.clone()),
-                (Some(_), Some(_)) => return None,
-                (None, _) => {}
-            }
+        let mut named: Vec<&str> = self
+            .options
+            .iter()
+            .filter(|o| {
+                o.option_id == wanted
+                    || o.name.trim() == wanted
+                    || o.name.trim().eq_ignore_ascii_case(wanted)
+            })
+            .map(|o| o.option_id.as_str())
+            .collect();
+        named.sort_unstable();
+        named.dedup();
+        match named.as_slice() {
+            [only] => return Some((*only).to_string()),
+            [_, _, ..] => return None,
+            [] => {}
         }
         match wanted.parse::<usize>() {
             Ok(n) if (1..=self.options.len()).contains(&n) => {
@@ -1110,9 +1115,11 @@ mod tests {
         assert_eq!(p.option_id("yes"), None);
     }
 
-    /// A label two options share is refused by label (no pane echo can catch
-    /// a wrong pick here); the same options stay answerable by id or digit.
-    /// A blank answer never selects an option, even one whose id is blank.
+    /// An answer naming more than one option is refused (no pane echo can
+    /// catch a wrong pick here): a label two options share, the same label in
+    /// two cases, or one option's id that is another option's label. The same
+    /// options stay answerable by an unshared id or by digit. A blank answer
+    /// never selects an option, even one whose id is blank.
     #[test]
     fn acp_option_id_refuses_shared_labels_and_blank_answers() {
         let shared = acp_permission_from_payload(
@@ -1120,9 +1127,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            shared.option_id("Allow").as_deref(),
-            Some("allow-once"),
-            "one exact hit wins"
+            shared.option_id("Allow"),
+            None,
+            "an exact hit plus a case-insensitive hit name two options: refused"
         );
         assert_eq!(
             shared.option_id("ALLOW"),
@@ -1143,6 +1150,18 @@ mod tests {
         assert_eq!(twins.option_id("Allow"), None, "two exact hits: refused");
         assert_eq!(twins.option_id("b").as_deref(), Some("b"));
         assert_eq!(twins.option_id("1").as_deref(), Some("a"));
+
+        let crossed = acp_permission_from_payload(
+            r#"{"kind":"acp_permission","sessionKey":"k","requestFingerprint":"f","options":[{"optionId":"Reject","name":"Allow","kind":"allow_once"},{"optionId":"y","name":"Reject","kind":"reject_once"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            crossed.option_id("Reject"),
+            None,
+            "one option's id is another's label: refused, never the id by rule order"
+        );
+        assert_eq!(crossed.option_id("y").as_deref(), Some("y"));
+        assert_eq!(crossed.option_id("2").as_deref(), Some("y"));
 
         let blank_id = acp_permission_from_payload(
             r#"{"kind":"acp_permission","sessionKey":"k","requestFingerprint":"f","options":[{"optionId":"","name":"","kind":"allow_once"}]}"#,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -266,15 +266,36 @@ struct AcpOption {
 
 impl AcpPermission {
     /// The id of the option `answer` names: an option id verbatim, else the
-    /// label verbatim, case-insensitively, or a 1-based digit (the same rules
-    /// as [`picker_position`]). Anything else is refused by the caller.
+    /// label verbatim, case-insensitively, or a 1-based digit (the rules of
+    /// [`picker_position`]). Anything else is refused by the caller, and so is
+    /// a label two options share: the tmux path reads the pane echo to catch
+    /// a wrong pick, nothing here can, and an adapter offering "Allow" for
+    /// both `allow_once` and `allow_always` must not hand out the broader
+    /// grant by list order.
     fn option_id(&self, answer: &str) -> Option<String> {
         let wanted = answer.trim();
-        if let Some(option) = self.options.iter().find(|o| o.option_id == wanted) {
-            return Some(option.option_id.clone());
+        if wanted.is_empty() {
+            return None;
         }
-        let names: Vec<String> = self.options.iter().map(|o| o.name.clone()).collect();
-        picker_position(&names, wanted).map(|i| self.options[i].option_id.clone())
+        let rules: [&dyn Fn(&AcpOption) -> bool; 3] = [
+            &|o| o.option_id == wanted,
+            &|o| o.name.trim() == wanted,
+            &|o| o.name.trim().eq_ignore_ascii_case(wanted),
+        ];
+        for rule in rules {
+            let mut hits = self.options.iter().filter(|o| rule(o));
+            match (hits.next(), hits.next()) {
+                (Some(only), None) => return Some(only.option_id.clone()),
+                (Some(_), Some(_)) => return None,
+                (None, _) => {}
+            }
+        }
+        match wanted.parse::<usize>() {
+            Ok(n) if (1..=self.options.len()).contains(&n) => {
+                Some(self.options[n - 1].option_id.clone())
+            }
+            _ => None,
+        }
     }
 }
 
@@ -1046,6 +1067,48 @@ mod tests {
         assert_eq!(p.option_id(""), None);
         assert_eq!(p.option_id("   "), None);
         assert_eq!(p.option_id("yes"), None);
+    }
+
+    /// A label two options share is refused by label (no pane echo can catch
+    /// a wrong pick here); the same options stay answerable by id or digit.
+    /// A blank answer never selects an option, even one whose id is blank.
+    #[test]
+    fn acp_option_id_refuses_shared_labels_and_blank_answers() {
+        let shared = acp_permission_from_payload(
+            r#"{"kind":"acp_permission","sessionKey":"k","requestFingerprint":"f","options":[{"optionId":"allow-once","name":"Allow","kind":"allow_once"},{"optionId":"allow-always","name":"allow","kind":"allow_always"},{"optionId":"reject-once","name":"Reject","kind":"reject_once"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            shared.option_id("Allow").as_deref(),
+            Some("allow-once"),
+            "one exact hit wins"
+        );
+        assert_eq!(
+            shared.option_id("ALLOW"),
+            None,
+            "two case-insensitive hits: refused"
+        );
+        assert_eq!(
+            shared.option_id("allow-always").as_deref(),
+            Some("allow-always")
+        );
+        assert_eq!(shared.option_id("2").as_deref(), Some("allow-always"));
+        assert_eq!(shared.option_id("Reject").as_deref(), Some("reject-once"));
+
+        let twins = acp_permission_from_payload(
+            r#"{"kind":"acp_permission","sessionKey":"k","requestFingerprint":"f","options":[{"optionId":"a","name":"Allow","kind":"allow_once"},{"optionId":"b","name":"Allow","kind":"allow_always"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(twins.option_id("Allow"), None, "two exact hits: refused");
+        assert_eq!(twins.option_id("b").as_deref(), Some("b"));
+        assert_eq!(twins.option_id("1").as_deref(), Some("a"));
+
+        let blank_id = acp_permission_from_payload(
+            r#"{"kind":"acp_permission","sessionKey":"k","requestFingerprint":"f","options":[{"optionId":"","name":"","kind":"allow_once"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(blank_id.option_id(""), None);
+        assert_eq!(blank_id.option_id("  "), None);
     }
 
     /// A multi-select or non-ASK payload never routes by position (the caller

--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -44,6 +44,7 @@ use ainb_hangar_store::repo::attention::{AttentionRepo, AttentionRow};
 use sqlx::SqlitePool;
 use std::time::{Duration, Instant};
 
+use crate::acp_pool::{PermissionAnswer, PermissionDecision};
 use crate::events::EventSink;
 
 /// The resolved delivery target for an answer, or a refusal.
@@ -197,13 +198,11 @@ async fn answer_acp(
     row: &AttentionRow,
     permission: &AcpPermission,
 ) -> Result<AnswerResult, sqlx::Error> {
-    use crate::acp_pool::{PermissionAnswer, PermissionDecision};
-
-    let Some(option_id) = permission.option_id(&params.answer) else {
+    let Some(decision) = permission.decision(&params.answer) else {
         let offered: Vec<&str> = permission.options.iter().map(|o| o.name.as_str()).collect();
         return Ok(AnswerResult::DeliveryFailed {
             reason: format!(
-                "the adapter expects one of its {} options ({}), by label, id or number; free text is not sent",
+                "the adapter expects one of its {} options ({}), by label, id or number, or deny; free text is not sent",
                 offered.len(),
                 offered.join(", ")
             ),
@@ -219,11 +218,7 @@ async fn answer_acp(
     }
 
     let outcome = acp
-        .answer_permission(
-            &permission.session_key,
-            &permission.fingerprint,
-            PermissionDecision::Option(option_id.clone()),
-        )
+        .answer_permission(&permission.session_key, &permission.fingerprint, decision)
         .await;
     let reason = match outcome {
         PermissionAnswer::Delivered(option) => {
@@ -234,7 +229,7 @@ async fn answer_acp(
         }
         PermissionAnswer::UnknownOption => {
             reopen_on_failed_delivery(pool, events, row, params, now_ms).await?;
-            format!("the adapter never offered option {option_id}")
+            format!("the adapter never offered option {}", params.answer.trim())
         }
         PermissionAnswer::NotWaiting => {
             "the ACP permission is no longer waiting (answered elsewhere, or the adapter moved on)"
@@ -296,6 +291,21 @@ impl AcpPermission {
             }
             _ => None,
         }
+    }
+
+    /// What `answer` asks the pool to do: one of the adapter's options
+    /// ([`Self::option_id`]), else `Deny` for the reserved words `deny` and
+    /// `cancel`. `Deny` takes the adapter's first reject-flavoured option and,
+    /// against an adapter that offers none, answers `Cancelled` (the refusal
+    /// ACP defines), which is the only way an inbox can decline such an ask.
+    /// An option the adapter labelled "Deny" wins over the reserved word.
+    fn decision(&self, answer: &str) -> Option<PermissionDecision> {
+        if let Some(id) = self.option_id(answer) {
+            return Some(PermissionDecision::Option(id));
+        }
+        let wanted = answer.trim();
+        (wanted.eq_ignore_ascii_case("deny") || wanted.eq_ignore_ascii_case("cancel"))
+            .then_some(PermissionDecision::Deny)
     }
 }
 
@@ -1116,6 +1126,32 @@ mod tests {
         .unwrap();
         assert_eq!(blank_id.option_id(""), None);
         assert_eq!(blank_id.option_id("  "), None);
+    }
+
+    /// `deny` / `cancel` decline without naming an option (the pool takes the
+    /// first reject option, or answers Cancelled when there is none); an
+    /// option the adapter actually labelled "Deny" wins over the reserved
+    /// word, and anything else is still no decision.
+    #[test]
+    fn acp_decision_maps_the_reserved_words_to_deny() {
+        let p = acp_permission_from_payload(ACP_PAYLOAD).unwrap();
+        assert_eq!(
+            p.decision("Reject"),
+            Some(PermissionDecision::Option("reject-once".into()))
+        );
+        assert_eq!(p.decision("deny"), Some(PermissionDecision::Deny));
+        assert_eq!(p.decision(" CANCEL "), Some(PermissionDecision::Deny));
+        assert_eq!(p.decision("no"), None);
+        assert_eq!(p.decision(""), None);
+
+        let labelled = acp_permission_from_payload(
+            r#"{"kind":"acp_permission","sessionKey":"k","requestFingerprint":"f","options":[{"optionId":"go","name":"Allow","kind":"allow_once"},{"optionId":"stop","name":"Deny","kind":"reject_once"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            labelled.decision("deny"),
+            Some(PermissionDecision::Option("stop".into()))
+        );
     }
 
     /// A multi-select or non-ASK payload never routes by position (the caller

--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -89,7 +89,15 @@ pub async fn answer(
 
     // An ACP permission has no pane: it is routed by the row's OWN session key
     // to the responder the pool parked, so neither the C1 guard nor tmux applies.
-    if let Some(permission) = acp_permission_from_payload(&row.payload) {
+    // Branch on the KIND, not on a successful parse: an ACP row carries the
+    // actor's cwd, so one this arm cannot read must never fall through to the
+    // cwd correlation and be typed into a same-cwd pane that never asked.
+    if is_acp_permission_payload(&row.payload) {
+        let Some(permission) = acp_permission_from_payload(&row.payload) else {
+            return Ok(AnswerResult::NoTarget {
+                reason: "malformed ACP permission row; nothing can route it".to_string(),
+            });
+        };
         return answer_acp(pool, events, params, now_ms, &row, &permission).await;
     }
 
@@ -315,11 +323,21 @@ impl AcpPermission {
     }
 }
 
+/// Does this payload claim to be an ACP permission? Decides the ARM, so a row
+/// of this kind the parser rejects still never reaches tmux resolution.
+fn is_acp_permission_payload(payload: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(payload)
+        .ok()
+        .and_then(|v| v.get("kind").and_then(|k| k.as_str()).map(|k| k == "acp_permission"))
+        .unwrap_or(false)
+}
+
 /// The ACP permission a row's payload carries, or `None` for any other payload
 /// (a hook ASK, an ERR, an escalation). A payload claiming the kind without a
-/// session key, a fingerprint or any option is not routable and is `None` too,
-/// and so is one with a malformed option: dropping just that option would
-/// shift the 1-based digits against the full list a surface renders.
+/// session key, a fingerprint or any option is `None` too, and so is one with
+/// a malformed option: dropping just that option would shift the 1-based
+/// digits against the full list a surface renders. The caller answers such a
+/// row `NoTarget` (see [`is_acp_permission_payload`]).
 fn acp_permission_from_payload(payload: &str) -> Option<AcpPermission> {
     let v: serde_json::Value = serde_json::from_str(payload).ok()?;
     if v.get("kind").and_then(|k| k.as_str()) != Some("acp_permission") {
@@ -1795,6 +1813,10 @@ mod tests {
     /// The row `SessionActor::raise_permission` inserts: an Approval with no
     /// workspace, its payload the ACP permission.
     async fn seed_acp_row(pool: &SqlitePool, id: &str) {
+        seed_acp_row_with(pool, id, ACP_PAYLOAD).await;
+    }
+
+    async fn seed_acp_row_with(pool: &SqlitePool, id: &str, payload: &str) {
         AttentionRepo::insert(
             pool,
             &NewAttention {
@@ -1803,7 +1825,7 @@ mod tests {
                 cwd: "/work/x".to_string(),
                 workspace_id: None,
                 kind: AttentionKind::Approval,
-                payload: ACP_PAYLOAD.to_string(),
+                payload: payload.to_string(),
                 degraded: false,
                 created_at: 1_000,
                 raise_transcript: None,
@@ -1844,6 +1866,36 @@ mod tests {
     /// With no pool installed in this process there is nothing to hand the
     /// option to: `NoTarget`, and the row is NOT claimed (it is answerable once
     /// a daemon with a pool is up, or convergence closes it).
+    /// A row that CLAIMS to be an ACP permission but cannot be read never
+    /// falls through to tmux resolution: it carries the actor's cwd, and the
+    /// cwd correlation would type the answer into a same-cwd pane that never
+    /// asked. It is `NoTarget` by kind, with the row left open.
+    #[tokio::test]
+    async fn a_malformed_acp_row_is_no_target_and_never_reaches_tmux() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let malformed = ACP_PAYLOAD.replace(r#""optionId":"allow-once","#, "");
+        assert!(is_acp_permission_payload(&malformed));
+        assert_eq!(acp_permission_from_payload(&malformed), None);
+        seed_acp_row_with(store.pool(), "p1", &malformed).await;
+        let (_b, sink) = broker_sink();
+        let params = AnswerParams {
+            attention_id: "p1".into(),
+            answer: "Reject".into(),
+            answered_by: "tui".into(),
+            is_answer: true,
+        };
+        let res = answer(store.pool(), &sink, &params, 5000).await.unwrap();
+        match res {
+            AnswerResult::NoTarget { reason } => {
+                assert!(reason.contains("malformed ACP permission"), "{reason}");
+            }
+            other => panic!("expected NoTarget, got {other:?}"),
+        }
+        let row = AttentionRepo::get(store.pool(), "p1").await.unwrap().unwrap();
+        assert_eq!(row.state, "open");
+    }
+
     #[tokio::test]
     async fn an_acp_row_without_a_pool_is_no_target_and_stays_open() {
         let dir = tempfile::tempdir().unwrap();

--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -301,24 +301,26 @@ impl AcpPermission {
 
 /// The ACP permission a row's payload carries, or `None` for any other payload
 /// (a hook ASK, an ERR, an escalation). A payload claiming the kind without a
-/// session key, a fingerprint or any option is not routable and is `None` too.
+/// session key, a fingerprint or any option is not routable and is `None` too,
+/// and so is one with a malformed option: dropping just that option would
+/// shift the 1-based digits against the full list a surface renders.
 fn acp_permission_from_payload(payload: &str) -> Option<AcpPermission> {
     let v: serde_json::Value = serde_json::from_str(payload).ok()?;
     if v.get("kind").and_then(|k| k.as_str()) != Some("acp_permission") {
         return None;
     }
     let text = |key: &str| v.get(key)?.as_str().filter(|s| !s.is_empty()).map(str::to_string);
-    let options: Vec<AcpOption> = v
+    let options = v
         .get("options")?
         .as_array()?
         .iter()
-        .filter_map(|o| {
+        .map(|o| {
             Some(AcpOption {
                 option_id: o.get("optionId")?.as_str()?.to_string(),
                 name: o.get("name").and_then(|n| n.as_str()).unwrap_or_default().to_string(),
             })
         })
-        .collect();
+        .collect::<Option<Vec<AcpOption>>>()?;
     (!options.is_empty()).then_some(AcpPermission {
         session_key: text("sessionKey")?,
         fingerprint: text("requestFingerprint")?,
@@ -1046,6 +1048,11 @@ mod tests {
             ),
             None,
             "no options, nothing to choose"
+        );
+        assert_eq!(
+            acp_permission_from_payload(&ACP_PAYLOAD.replace(r#""optionId":"allow-once","#, "")),
+            None,
+            "a malformed option makes the whole row unroutable, never a shifted digit"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/answer.rs
@@ -28,6 +28,11 @@
 //! may exit, or the ambiguity may resolve). Only once a unique target is known
 //! does the router claim the row (win-or-lose) and deliver via the one verified
 //! send path ([`send`], the multi-line-submit-verified tmux path).
+//!
+//! An ACP `session/request_permission` row is the one exception to the pane
+//! path: it carries its own pool session key and the adapter's option set, so
+//! it is answered through [`crate::acp_pool::AcpPool::answer_permission`]
+//! (`answer_acp`) with the same first-answer-wins claim and no tmux at all.
 
 use ainb_fleet_core::discover::{discover_from_ainb, discover_from_peers, merge_sessions};
 use ainb_fleet_core::read::jsonl_tail::latest_transcript_for_cwd;
@@ -81,6 +86,12 @@ pub async fn answer(
         });
     }
 
+    // An ACP permission has no pane: it is routed by the row's OWN session key
+    // to the responder the pool parked, so neither the C1 guard nor tmux applies.
+    if let Some(permission) = acp_permission_from_payload(&row.payload) {
+        return answer_acp(pool, events, params, now_ms, &row, &permission).await;
+    }
+
     // C1: resolve the delivery target BEFORE claiming, so an ambiguous / dead
     // target leaves the row open and answerable later.
     match resolve_target(
@@ -96,20 +107,8 @@ pub async fn answer(
         Target::Send(session) => {
             // Claim the answer. A second surface that also resolved a target loses
             // this flip (0 rows) and delivers nothing.
-            let flipped = AttentionRepo::mark_answered_if_open(
-                pool,
-                &params.attention_id,
-                &params.answered_by,
-                &params.answer,
-                now_ms,
-            )
-            .await?;
-            if flipped == 0 {
-                let by = AttentionRepo::get(pool, &params.attention_id)
-                    .await?
-                    .and_then(|r| r.answered_by)
-                    .unwrap_or_else(|| "unknown".to_string());
-                return Ok(AnswerResult::AlreadyAnswered { by });
+            if let Some(lost) = claim(pool, params, now_ms).await? {
+                return Ok(lost);
             }
 
             // We won: deliver via the one verified send path. Only a CONFIRMED
@@ -145,6 +144,157 @@ pub async fn answer(
             }
         }
     }
+}
+
+/// Claim the row for this answer (first-answer-wins). `Some` is the loser's
+/// result: a second surface already flipped it and this one delivers nothing.
+async fn claim(
+    pool: &SqlitePool,
+    params: &AnswerParams,
+    now_ms: i64,
+) -> Result<Option<AnswerResult>, sqlx::Error> {
+    let flipped = AttentionRepo::mark_answered_if_open(
+        pool,
+        &params.attention_id,
+        &params.answered_by,
+        &params.answer,
+        now_ms,
+    )
+    .await?;
+    if flipped > 0 {
+        return Ok(None);
+    }
+    let by = AttentionRepo::get(pool, &params.attention_id)
+        .await?
+        .and_then(|r| r.answered_by)
+        .unwrap_or_else(|| "unknown".to_string());
+    Ok(Some(AnswerResult::AlreadyAnswered { by }))
+}
+
+/// Answer a parked ACP `session/request_permission`: claim the row, then hand
+/// the chosen option to the pool's parked responder.
+///
+/// The option is matched BEFORE the claim (the options live in the payload,
+/// not on a screen), so a text the adapter never offered refuses with the row
+/// still open, and a missing pool is a `NoTarget` with nothing claimed. Once
+/// claimed, the pool's answer is a HAND-OFF to the adapter's pending JSON-RPC
+/// id, never an acknowledgement (ACP defines none), and any refusal from the
+/// pool reopens the row like a failed tmux send would. The actor's own
+/// `retire_attention` runs the same conditional flip after the hand-off and
+/// finds the row already ours: benign, and what keeps `answered_by` naming the
+/// surface that answered rather than a generic "operator".
+async fn answer_acp(
+    pool: &SqlitePool,
+    events: &EventSink,
+    params: &AnswerParams,
+    now_ms: i64,
+    row: &AttentionRow,
+    permission: &AcpPermission,
+) -> Result<AnswerResult, sqlx::Error> {
+    use crate::acp_pool::{PermissionAnswer, PermissionDecision};
+
+    let Some(option_id) = permission.option_id(&params.answer) else {
+        let offered: Vec<&str> = permission.options.iter().map(|o| o.name.as_str()).collect();
+        return Ok(AnswerResult::DeliveryFailed {
+            reason: format!(
+                "the adapter expects one of its {} options ({}), by label, id or number; free text is not sent",
+                offered.len(),
+                offered.join(", ")
+            ),
+        });
+    };
+    let Some(acp) = crate::acp_pool::active_handle().await else {
+        return Ok(AnswerResult::NoTarget {
+            reason: "no ACP pool is running in this daemon".to_string(),
+        });
+    };
+    if let Some(lost) = claim(pool, params, now_ms).await? {
+        return Ok(lost);
+    }
+
+    let outcome = acp
+        .answer_permission(
+            &permission.session_key,
+            &permission.fingerprint,
+            PermissionDecision::Option(option_id.clone()),
+        )
+        .await;
+    let reason = match outcome {
+        PermissionAnswer::Delivered(option) => {
+            emit_answered(events, params);
+            return Ok(AnswerResult::Delivered {
+                via: format!("acp ({}, option {option})", permission.session_key),
+            });
+        }
+        PermissionAnswer::NotWaiting => {
+            "the ACP permission is no longer waiting (answered elsewhere, or the adapter moved on)"
+                .to_string()
+        }
+        PermissionAnswer::UnknownOption => format!("the adapter never offered option {option_id}"),
+        PermissionAnswer::NoSession => {
+            format!("no live ACP session for {}", permission.session_key)
+        }
+    };
+    reopen_on_failed_delivery(pool, events, row, params, now_ms).await?;
+    Ok(AnswerResult::DeliveryFailed { reason })
+}
+
+/// The parked ACP permission an attention row describes: the payload
+/// `SessionActor::raise_permission` writes, `kind = "acp_permission"` with the
+/// pool session key, the request fingerprint and the adapter's own options.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AcpPermission {
+    session_key: String,
+    fingerprint: String,
+    options: Vec<AcpOption>,
+}
+
+/// One option the adapter offered, as `options_wire` serialises it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AcpOption {
+    option_id: String,
+    name: String,
+}
+
+impl AcpPermission {
+    /// The id of the option `answer` names: an option id verbatim, else the
+    /// label verbatim, case-insensitively, or a 1-based digit (the same rules
+    /// as [`picker_position`]). Anything else is refused by the caller.
+    fn option_id(&self, answer: &str) -> Option<String> {
+        let wanted = answer.trim();
+        if let Some(option) = self.options.iter().find(|o| o.option_id == wanted) {
+            return Some(option.option_id.clone());
+        }
+        let names: Vec<String> = self.options.iter().map(|o| o.name.clone()).collect();
+        picker_position(&names, wanted).map(|i| self.options[i].option_id.clone())
+    }
+}
+
+/// The ACP permission a row's payload carries, or `None` for any other payload
+/// (a hook ASK, an ERR, an escalation). A payload claiming the kind without a
+/// session key, a fingerprint or any option is not routable and is `None` too.
+fn acp_permission_from_payload(payload: &str) -> Option<AcpPermission> {
+    let v: serde_json::Value = serde_json::from_str(payload).ok()?;
+    if v.get("kind").and_then(|k| k.as_str()) != Some("acp_permission") {
+        return None;
+    }
+    let text = |key: &str| v.get(key)?.as_str().filter(|s| !s.is_empty()).map(str::to_string);
+    let options: Vec<AcpOption> = v
+        .get("options")?
+        .as_array()?
+        .iter()
+        .filter_map(|o| {
+            Some(AcpOption {
+                option_id: o.get("optionId")?.as_str()?.to_string(),
+                name: o.get("name").and_then(|n| n.as_str()).unwrap_or_default().to_string(),
+            })
+        })
+        .collect();
+    (!options.is_empty()).then_some(AcpPermission {
+        session_key: text("sessionKey")?,
+        fingerprint: text("requestFingerprint")?,
+        options,
+    })
 }
 
 /// How an answer reaches the agent, decided by [`route_answer`] from the row's
@@ -827,6 +977,69 @@ mod tests {
         assert_eq!(picker_position(&ambiguous, "deploy"), None);
     }
 
+    /// The payload shape `SessionActor::raise_permission` writes for an ACP
+    /// `session/request_permission` (the fixture adapter's two options).
+    const ACP_PAYLOAD: &str = r#"{"kind":"acp_permission","sessionKey":"acp:claude:01J","acpSessionId":"fake-session-1","requestFingerprint":"f00d","rpcId":9000,"options":[{"optionId":"allow-once","name":"Allow once","kind":"allow_once"},{"optionId":"reject-once","name":"Reject","kind":"reject_once"}],"toolCall":{"toolCallId":"tool-1","title":"rm -rf /tmp/fixture"}}"#;
+
+    /// Only the `acp_permission` kind routes to the pool, and only when it
+    /// carries what the pool needs to find the parked responder.
+    #[test]
+    fn acp_permission_from_payload_reads_the_raise_shape_only() {
+        let permission = acp_permission_from_payload(ACP_PAYLOAD).expect("acp payload");
+        assert_eq!(permission.session_key, "acp:claude:01J");
+        assert_eq!(permission.fingerprint, "f00d");
+        assert_eq!(
+            permission.options,
+            vec![
+                AcpOption {
+                    option_id: "allow-once".into(),
+                    name: "Allow once".into()
+                },
+                AcpOption {
+                    option_id: "reject-once".into(),
+                    name: "Reject".into()
+                },
+            ]
+        );
+        assert_eq!(acp_permission_from_payload(ASK_PAYLOAD), None);
+        assert_eq!(acp_permission_from_payload("{}"), None);
+        assert_eq!(acp_permission_from_payload("not json"), None);
+        assert_eq!(
+            acp_permission_from_payload(
+                &ACP_PAYLOAD.replace("\"requestFingerprint\":\"f00d\",", "")
+            ),
+            None,
+            "no fingerprint, nothing to answer"
+        );
+        assert_eq!(
+            acp_permission_from_payload(
+                r#"{"kind":"acp_permission","sessionKey":"k","requestFingerprint":"f","options":[]}"#
+            ),
+            None,
+            "no options, nothing to choose"
+        );
+    }
+
+    /// An ACP answer resolves to the adapter's OPTION ID: by id, by label
+    /// (verbatim or case-insensitive) or by 1-based digit, mirroring the tmux
+    /// picker rules; anything else, prefixes and blanks included, is refused.
+    #[test]
+    fn acp_option_id_resolves_id_label_and_digit_only() {
+        let p = acp_permission_from_payload(ACP_PAYLOAD).unwrap();
+        assert_eq!(p.option_id("reject-once").as_deref(), Some("reject-once"));
+        assert_eq!(p.option_id("Reject").as_deref(), Some("reject-once"));
+        assert_eq!(p.option_id("REJECT").as_deref(), Some("reject-once"));
+        assert_eq!(p.option_id(" Allow once ").as_deref(), Some("allow-once"));
+        assert_eq!(p.option_id("1").as_deref(), Some("allow-once"));
+        assert_eq!(p.option_id("2").as_deref(), Some("reject-once"));
+        assert_eq!(p.option_id("3"), None, "out of range digit");
+        assert_eq!(p.option_id("Allow"), None, "a prefix is never a pick");
+        assert_eq!(p.option_id("allow"), None);
+        assert_eq!(p.option_id(""), None);
+        assert_eq!(p.option_id("   "), None);
+        assert_eq!(p.option_id("yes"), None);
+    }
+
     /// A multi-select or non-ASK payload never routes by position (the caller
     /// keeps the text send), and a free-text ASK has no labels at all.
     #[test]
@@ -1457,5 +1670,80 @@ mod tests {
             row.state, "open",
             "an unresolved answer leaves the row open"
         );
+    }
+
+    /// The row `SessionActor::raise_permission` inserts: an Approval with no
+    /// workspace, its payload the ACP permission.
+    async fn seed_acp_row(pool: &SqlitePool, id: &str) {
+        AttentionRepo::insert(
+            pool,
+            &NewAttention {
+                id: id.to_string(),
+                session_id: "acp:claude:01J".to_string(),
+                cwd: "/work/x".to_string(),
+                workspace_id: None,
+                kind: AttentionKind::Approval,
+                payload: ACP_PAYLOAD.to_string(),
+                degraded: false,
+                created_at: 1_000,
+                raise_transcript: None,
+                channels: ainb_hangar_core::channel::ChannelSet::NONE,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    /// An ACP row never reaches tmux target resolution: an answer naming none
+    /// of the adapter's options is refused from the payload alone, before any
+    /// claim, and the row stays open for a surface that sends a real option.
+    #[tokio::test]
+    async fn an_acp_row_refuses_free_text_before_claiming() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_acp_row(store.pool(), "p1").await;
+        let (_b, sink) = broker_sink();
+        let params = AnswerParams {
+            attention_id: "p1".into(),
+            answer: "sure, go ahead".into(),
+            answered_by: "tui".into(),
+            is_answer: true,
+        };
+        let res = answer(store.pool(), &sink, &params, 5000).await.unwrap();
+        match res {
+            AnswerResult::DeliveryFailed { reason } => {
+                assert!(reason.contains("Allow once, Reject"), "{reason}");
+            }
+            other => panic!("expected DeliveryFailed, got {other:?}"),
+        }
+        let row = AttentionRepo::get(store.pool(), "p1").await.unwrap().unwrap();
+        assert_eq!(row.state, "open");
+        assert!(row.answered_by.is_none());
+    }
+
+    /// With no pool installed in this process there is nothing to hand the
+    /// option to: `NoTarget`, and the row is NOT claimed (it is answerable once
+    /// a daemon with a pool is up, or convergence closes it).
+    #[tokio::test]
+    async fn an_acp_row_without_a_pool_is_no_target_and_stays_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        seed_acp_row(store.pool(), "p1").await;
+        let (_b, sink) = broker_sink();
+        let params = AnswerParams {
+            attention_id: "p1".into(),
+            answer: "Reject".into(),
+            answered_by: "tui".into(),
+            is_answer: true,
+        };
+        let res = answer(store.pool(), &sink, &params, 5000).await.unwrap();
+        match res {
+            AnswerResult::NoTarget { reason } => {
+                assert!(reason.contains("no ACP pool"), "{reason}");
+            }
+            other => panic!("expected NoTarget, got {other:?}"),
+        }
+        let row = AttentionRepo::get(store.pool(), "p1").await.unwrap().unwrap();
+        assert_eq!(row.state, "open");
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -46,6 +46,7 @@ use ainb_hangar_daemon::events::EventBroker;
 use ainb_hangar_daemon::rpc::{self, DaemonHealth};
 use ainb_hangar_proto::{RpcId, RpcRequest, methods};
 use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::attention::{AttentionKind, AttentionRepo, NewAttention};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -1118,6 +1119,73 @@ async fn a_permission_answered_through_attention_answer_reaches_the_adapter() {
             .count(),
         1,
         "the loser delivered nothing"
+    );
+
+    // A row whose responder is gone (the ask was answered or the adapter moved
+    // on: the pool says NotWaiting; or the session has no actor at all:
+    // NoSession) is NOT reopened: nothing could ever answer it again, so the
+    // claim stands and the operator is told the answer did not land. Both rows
+    // are planted by hand with the live session's payload shape.
+    for (row_id, row_session, expect) in [
+        (
+            "ghost-not-waiting",
+            session_key.as_str(),
+            "no longer waiting",
+        ),
+        ("ghost-no-session", "acp:nobody-home", "no live ACP session"),
+    ] {
+        let mut ghost = payload.clone();
+        ghost["sessionKey"] = serde_json::json!(row_session);
+        ghost["requestFingerprint"] = serde_json::json!(format!("spent-{row_id}"));
+        AttentionRepo::insert(
+            harness.store.pool(),
+            &NewAttention {
+                id: row_id.to_string(),
+                session_id: row_session.to_string(),
+                cwd: harness.dir.to_string_lossy().into_owned(),
+                workspace_id: None,
+                kind: AttentionKind::Approval,
+                payload: ghost.to_string(),
+                degraded: false,
+                created_at: 1,
+                raise_transcript: None,
+                channels: ainb_hangar_core::channel::ChannelSet::default(),
+            },
+        )
+        .await
+        .expect("plant a spent row");
+        let spent = client
+            .call(
+                methods::ATTENTION_ANSWER,
+                serde_json::json!({
+                    "attention_id": row_id,
+                    "answer": "Reject",
+                    "answered_by": "tui",
+                }),
+            )
+            .await;
+        assert_eq!(spent["result"]["outcome"], "delivery_failed", "{spent}");
+        assert!(
+            spent["result"]["reason"].as_str().unwrap_or_default().contains(expect),
+            "{row_id}: {spent}"
+        );
+        let (state, answered_by): (String, Option<String>) =
+            sqlx::query_as("SELECT state, answered_by FROM attention WHERE id = ?")
+                .bind(row_id)
+                .fetch_one(harness.store.pool())
+                .await
+                .expect("attention row");
+        assert_eq!(state, "answered", "{row_id}: a spent ask is not reopened");
+        assert_eq!(answered_by.as_deref(), Some("tui"), "{row_id}");
+    }
+    assert_eq!(
+        std::fs::read_to_string(&log)
+            .expect("rpc log")
+            .lines()
+            .filter(|line| line.starts_with("permission:"))
+            .count(),
+        1,
+        "no spent row reached the adapter"
     );
 
     harness.finish().await;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -957,6 +957,172 @@ async fn a_permission_round_trips_through_fleet_action() {
     harness.finish().await;
 }
 
+/// The Control Center's path (move 1 test T3, the answer half): the SAME
+/// permission answered through `attention/answer`, never `fleet/action`. The
+/// answer is the option's LABEL, as an inbox that renders the adapter's own
+/// options sends it, and the non-default option, so a delivery that quietly
+/// took the highlighted default (defect 26) cannot pass. Asserts the row flips
+/// to the answering surface, the turn completes, the adapter saw exactly one
+/// permission response and it selected the operator's option, and a second
+/// answer loses first-answer-wins.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_permission_answered_through_attention_answer_reaches_the_adapter() {
+    let evidence = tempfile::tempdir().expect("evidence dir");
+    let log = evidence.path().join("rpc.log");
+    let harness = Harness::start(
+        &[
+            ("FAKE_ACP_PERMISSION_SESSIONS", "*"),
+            ("FAKE_ACP_CHUNKS", "1"),
+            ("FAKE_ACP_RPC_LOG", log.to_str().expect("utf8")),
+        ],
+        |_| {},
+    )
+    .await;
+    let mut client = harness.client().await;
+    let (session_key, _scope) = harness.create_session(&mut client, None).await;
+
+    let sent = client
+        .call(
+            methods::FLEET_MESSAGE_SEND,
+            serde_json::json!({
+                "targets": [session_key],
+                "text": "rm -rf /tmp/fixture",
+                "request_id": "req-acp-attention-answer",
+            }),
+        )
+        .await;
+    assert!(sent["error"].is_null(), "{sent}");
+    let message_id = sent["result"]["message_id"].as_str().expect("message id").to_string();
+
+    let (attention_id, payload) = harness.await_open_attention(&session_key).await;
+    assert_eq!(payload["kind"], "acp_permission", "{payload}");
+    let (kind,): (String,) = sqlx::query_as("SELECT kind FROM attention WHERE id = ?")
+        .bind(&attention_id)
+        .fetch_one(harness.store.pool())
+        .await
+        .expect("attention row");
+    assert_eq!(kind, "approval", "the row the inbox lists under PERM");
+
+    // Free text the adapter never offered is refused with the row untouched:
+    // an inbox cannot type a sentence into a closed option set.
+    let refused = client
+        .call(
+            methods::ATTENTION_ANSWER,
+            serde_json::json!({
+                "attention_id": attention_id,
+                "answer": "looks fine to me",
+                "answered_by": "tui",
+            }),
+        )
+        .await;
+    assert!(refused["error"].is_null(), "{refused}");
+    assert_eq!(
+        refused["result"]["outcome"], "delivery_failed",
+        "free text is refused: {refused}"
+    );
+    let (still_open,): (String,) = sqlx::query_as("SELECT state FROM attention WHERE id = ?")
+        .bind(&attention_id)
+        .fetch_one(harness.store.pool())
+        .await
+        .expect("attention row");
+    assert_eq!(still_open, "open", "the refusal left the ask open");
+
+    // The operator's pick, by label, NOT the first/allow option.
+    let answered = client
+        .call(
+            methods::ATTENTION_ANSWER,
+            serde_json::json!({
+                "attention_id": attention_id,
+                "answer": "Reject",
+                "answered_by": "tui",
+            }),
+        )
+        .await;
+    assert!(answered["error"].is_null(), "{answered}");
+    assert_eq!(
+        answered["result"]["outcome"], "delivered",
+        "the label reached the adapter's responder: {answered}"
+    );
+    let via = answered["result"]["via"].as_str().unwrap_or_default();
+    assert!(
+        via.starts_with("acp (") && via.contains("reject-once"),
+        "delivered over ACP with the option id it resolved to, not tmux: {via}"
+    );
+
+    // The turn the permission blocked completes, and the adapter ACTED on the
+    // operator's option rather than the default.
+    harness.await_delivered(&message_id, &session_key).await;
+    let text = harness.transcript_text(&session_key).await;
+    assert!(
+        text.contains("permission:selected:reject-once"),
+        "the adapter observed the operator's selection: {text}"
+    );
+    assert!(
+        !text.contains("permission:selected:allow-once") && !text.contains("permission:cancelled"),
+        "never the default and never a cancellation: {text}"
+    );
+    let recorded = std::fs::read_to_string(&log).expect("rpc log");
+    let permissions: Vec<&str> =
+        recorded.lines().filter(|line| line.starts_with("permission:")).collect();
+    assert_eq!(
+        permissions.len(),
+        1,
+        "exactly one permission response reached the adapter: {permissions:?}"
+    );
+    assert!(
+        permissions[0].ends_with(":selected"),
+        "and it was a selection: {permissions:?}"
+    );
+
+    // The row names the surface that answered, not a generic operator, and the
+    // Fleet session no longer advertises the ask.
+    let (state, answered_by, answer): (String, Option<String>, Option<String>) =
+        sqlx::query_as("SELECT state, answered_by, answer FROM attention WHERE id = ?")
+            .bind(&attention_id)
+            .fetch_one(harness.store.pool())
+            .await
+            .expect("attention row");
+    assert_eq!(state, "answered");
+    assert_eq!(answered_by.as_deref(), Some("tui"));
+    assert_eq!(answer.as_deref(), Some("Reject"));
+    let (attention_state, current): (String, Option<String>) = sqlx::query_as(
+        "SELECT attention_state, current_request_fingerprint FROM fleet_session \
+         WHERE session_key = ?",
+    )
+    .bind(&session_key)
+    .fetch_one(harness.store.pool())
+    .await
+    .expect("fleet row");
+    assert_eq!(attention_state, "NONE");
+    assert_eq!(current, None);
+
+    // First-answer-wins: a second surface is told who won and nothing is
+    // delivered again (the log still holds one permission line).
+    let late = client
+        .call(
+            methods::ATTENTION_ANSWER,
+            serde_json::json!({
+                "attention_id": attention_id,
+                "answer": "Allow once",
+                "answered_by": "web",
+            }),
+        )
+        .await;
+    assert_eq!(late["result"]["outcome"], "already_answered", "{late}");
+    assert_eq!(late["result"]["by"], "tui", "{late}");
+    assert_eq!(
+        std::fs::read_to_string(&log)
+            .expect("rpc log")
+            .lines()
+            .filter(|line| line.starts_with("permission:"))
+            .count(),
+        1,
+        "the loser delivered nothing"
+    );
+
+    harness.finish().await;
+}
+
 /// The optimistic-concurrency guard on `fleet/action`, with the version
 /// CONTROLLED rather than observed: an answer naming a version older than the
 /// session's is refused BEFORE it reaches the pool, the ask survives, and no

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -1203,7 +1203,58 @@ async fn a_permission_answered_through_attention_answer_reaches_the_adapter() {
         .await;
     assert!(sent["error"].is_null(), "{sent}");
     let message_id = sent["result"]["message_id"].as_str().expect("message id").to_string();
-    let (second_id, _) = harness.await_open_attention(&session_key).await;
+    let (second_id, second_payload) = harness.await_open_attention(&session_key).await;
+
+    // The one pool refusal that DOES reopen: a row whose options drifted from
+    // the adapter's live ask (same fingerprint, an id the adapter never
+    // offered). The pool refuses with the responder still parked, so the row
+    // goes back to open for a corrected answer, and the real ask is untouched.
+    let mut drifted = second_payload.clone();
+    drifted["options"] =
+        serde_json::json!([{"optionId": "bogus", "name": "Bogus", "kind": "allow_once"}]);
+    AttentionRepo::insert(
+        harness.store.pool(),
+        &NewAttention {
+            id: "drifted-options".to_string(),
+            session_id: session_key.clone(),
+            cwd: harness.dir.to_string_lossy().into_owned(),
+            workspace_id: None,
+            kind: AttentionKind::Approval,
+            payload: drifted.to_string(),
+            degraded: false,
+            created_at: 1,
+            raise_transcript: None,
+            channels: ainb_hangar_core::channel::ChannelSet::default(),
+        },
+    )
+    .await
+    .expect("plant a drifted row");
+    let unknown = client
+        .call(
+            methods::ATTENTION_ANSWER,
+            serde_json::json!({
+                "attention_id": "drifted-options",
+                "answer": "Bogus",
+                "answered_by": "tui",
+            }),
+        )
+        .await;
+    assert_eq!(unknown["result"]["outcome"], "delivery_failed", "{unknown}");
+    assert!(
+        unknown["result"]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("never offered option Bogus"),
+        "{unknown}"
+    );
+    let (state, answered_by): (String, Option<String>) =
+        sqlx::query_as("SELECT state, answered_by FROM attention WHERE id = 'drifted-options'")
+            .fetch_one(harness.store.pool())
+            .await
+            .expect("attention row");
+    assert_eq!(state, "open", "an unknown option reopens the row");
+    assert_eq!(answered_by, None);
+
     let denied = client
         .call(
             methods::ATTENTION_ANSWER,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -1188,6 +1188,45 @@ async fn a_permission_answered_through_attention_answer_reaches_the_adapter() {
         "no spent row reached the adapter"
     );
 
+    // The reserved word: a second turn raises a second ask, and `deny` (no
+    // option is labelled that) declines it through the adapter's own reject
+    // option, so an inbox can refuse without knowing the adapter's labels.
+    let sent = client
+        .call(
+            methods::FLEET_MESSAGE_SEND,
+            serde_json::json!({
+                "targets": [session_key],
+                "text": "rm -rf /tmp/fixture again",
+                "request_id": "req-acp-attention-deny",
+            }),
+        )
+        .await;
+    assert!(sent["error"].is_null(), "{sent}");
+    let message_id = sent["result"]["message_id"].as_str().expect("message id").to_string();
+    let (second_id, _) = harness.await_open_attention(&session_key).await;
+    let denied = client
+        .call(
+            methods::ATTENTION_ANSWER,
+            serde_json::json!({
+                "attention_id": second_id,
+                "answer": "deny",
+                "answered_by": "tui",
+            }),
+        )
+        .await;
+    assert_eq!(denied["result"]["outcome"], "delivered", "{denied}");
+    assert!(
+        denied["result"]["via"].as_str().unwrap_or_default().contains("reject-once"),
+        "deny took the adapter's reject option: {denied}"
+    );
+    harness.await_delivered(&message_id, &session_key).await;
+    let text = harness.transcript_text(&session_key).await;
+    assert_eq!(
+        text.matches("permission:selected:reject-once").count(),
+        2,
+        "the second ask was rejected on the wire too: {text}"
+    );
+
     harness.finish().await;
 }
 


### PR DESCRIPTION
## What

Move 1 step A3 (`docs/hangar/renovation/move1-acp-tasks.md` section 3b, PLAN.md track A).

An ACP `session/request_permission` already becomes an `Approval` attention row (`acp_pool.rs::raise_permission`), but the Control Center answers rows through `attention/answer` -> `answer::answer`, which had zero ACP handling: the row fell into tmux target resolution, found no pane, and stayed open. Only `fleet/action` could reach the parked responder, and the Control Center never calls it. ACP chat permissions were therefore unanswerable from the surface an operator actually uses.

```
raise_permission ──▶ Approval row {kind: acp_permission, sessionKey, requestFingerprint, options}
                              │
        attention/answer ─────┤ (Control Center)          fleet/action ── (Fleet screen)
                              ▼                                  ▼
                   answer::answer                         execute_acp_action
                   NEW: answer_acp ──▶ pool.answer_permission ◀── (unchanged)
                   (was: tmux resolve -> NoTarget, row open)
```

## Change

`crates/ainb-hangar-daemon/src/answer.rs`

- ACP arm at the top of `answer::answer`, after the row read and the already-answered short-circuit, before target resolution.
- `acp_permission_from_payload` reads the exact payload `raise_permission` writes (`kind = "acp_permission"`, `sessionKey`, `requestFingerprint`, `options[{optionId, name, kind}]`). Anything else, including a payload missing any of those, is not this arm.
- `AcpPermission::option_id` maps the answer text onto an option: option id verbatim, else label verbatim, label case-insensitively, or 1-based digit. It reuses `picker_position`, so the rules are the tmux picker's rules by construction. Anything else refuses.
- Order inside `answer_acp`: option match, then `active_handle()`, then the claim. Free text and a missing pool leave the row open and unclaimed (`DeliveryFailed` / `NoTarget`). After the claim, only `UnknownOption` reopens the row (the pool answers it with the responder still parked); `NotWaiting` and `NoSession` mean the responder is spent or gone and the pool already closed the ask, so the claim is kept and `DeliveryFailed` names the reason (review P1: reopening there left a row nothing could ever answer).
- Label matching refuses a label two options share (no pane echo can catch a wrong pick here); id and digit stay unambiguous. Blank answers never match, including an option with an empty id. A malformed option (no string `optionId`) makes the whole row unroutable rather than shifting the digit index against the list a surface renders.
- The reserved words `deny` / `cancel` map to `PermissionDecision::Deny` when no option carries that label, so an inbox can decline an ask whose adapter offers no reject option (the pool answers `Cancelled`, the refusal ACP defines); an option the adapter itself labelled "Deny" wins.
- `mark_answered_if_open` stays the first-answer-wins gate (extracted into `claim`, shared by both arms). The actor's own `retire_attention` runs the same conditional flip after the hand-off and finds the row already claimed, which is benign and what keeps `answered_by` naming the surface (`tui`) rather than `operator`.
- No tmux, no pane capture on this arm. The four tmux refusal cases in `route_answer` are untouched.

`fleet/action`'s `execute_acp_action` is left alone: its `StructuredAnswer` passes the option id straight through and `choose_option` in the actor already matches by id, so there was no duplicated matching to fold into the helper.

## Tests

- `answer.rs` unit tests (pure): payload recognition (raise shape only, rejects ASK / empty / missing fingerprint / no options), option matching (id, label, case-insensitive, digit; refuses prefix, out-of-range digit, blank, free text), plus two store-integration tests: free text is refused before any claim, and no installed pool is `NoTarget` with the row untouched.
- `tests/rpc_acp.rs::a_permission_answered_through_attention_answer_reaches_the_adapter`: the T3 answer half over the real Unix socket with the fake adapter. Free text via `attention/answer` refused with the row open; the option LABEL `Reject` (the non-default) delivered; the blocked turn completes; transcript shows `permission:selected:reject-once`; `FAKE_ACP_RPC_LOG` holds exactly one `permission:` line and it is a selection; the row is `answered` by `tui`; the Fleet session is back to `NONE`; a second surface gets `already_answered` by `tui` and the log still holds one line. Then: a spent-fingerprint row on the live actor (`NotWaiting`) and a row on a session with no actor (`NoSession`) both stay `answered` by `tui` with no extra permission response reaching the adapter; and a second ask declined with `deny` selects the adapter's reject option on the wire.
- Unit tests for the shared-label refusal, the blank-answer guard, the malformed-option abort and the `deny`/`cancel` mapping.

Fork taken: the daemon-over-socket form of T3 rather than an in-process `answer::answer` call, because `rpc_acp.rs` already had the socket harness plus fake adapter wired, so the wire test cost nothing extra and proves the RPC path the Control Center actually uses.

Ran:

```
cargo test -p ainb-hangar-daemon --lib -- answer::          31 passed (25 existing + 6 new)
cargo test -p ainb-hangar-daemon --test rpc_acp             12 passed (11 existing + 1 new)
cargo test -p ainb-hangar-daemon --test rpc_attention        3 passed
cargo fmt --all --check                                     clean
cargo clippy -p ainb-hangar-daemon --lib --tests            no new warnings in touched hunks
```

## Not in this PR

- The Control Center still renders an `acp_permission` payload as `CardBody::Other` and marks `Approval` as not inline-answerable (`control_center.rs::is_answerable`). That is track B (B3). Once B3 sends the option label, this arm answers it; until then the arm is reachable from any `attention/answer` caller (web, bridge, tests).
- For A5 (the ACP task executor), two things this arm depends on and does not change:
  - `acp_pool.rs::raise_permission` hardcodes `workspace_id: None` on the attention row. A task-raised permission therefore lands unscoped and will not appear in a workspace-filtered inbox even though this arm routes it fine. A5 must carry the raising task's workspace id onto the row. Not changed here: another agent is editing `acp_pool.rs`.
  - The arm resolves the pool via the process-wide `acp_pool::active_handle()` (installed once at daemon boot). A5's executor must park permissions on that installed pool, not a private `AcpPool`, or every task permission answers `NoTarget` from the inbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ACP permission requests can now be answered through the standard attention flow.
  * Invalid free-text responses leave the request open for another answer.
  * Valid option labels are correctly delivered to the ACP adapter.
  * Only the first submitted answer is accepted, preventing duplicate responses.
  * Answered requests now correctly clear their pending session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
