### PR TITLE
refactor(hangar-proto): one stream-json classifier for durable and live transcripts (spine A1)

### DIFF
--- a/ainb-tui/crates/ainb-acp/tests/real_adapter.rs
+++ b/ainb-tui/crates/ainb-acp/tests/real_adapter.rs
@@ -181,3 +181,170 @@ fn permission_sink() -> tokio::sync::mpsc::UnboundedSender<ainb_acp::client::Per
     std::mem::forget(rx);
     tx
 }
+
+/// Move 1 probe A0 (`docs/hangar/renovation/move1-acp-tasks.md` §3c): does
+/// `claude-agent-acp` surface the `AskUserQuestion` tool as a
+/// `session/request_permission` carrying the question's options, or does it
+/// only appear as a `ToolCall` update the client is never asked about?
+///
+/// The exit criterion for move 1 hangs on the answer, so this is a PROBE, not
+/// an assertion of either: it drives one turn, logs every `session/update` and
+/// every permission request raw (to stderr, and to `AINB_ACP_PROBE_LOG` when
+/// set), answers any permission (the option named "blue" when offered, else
+/// the first) so the turn can finish, and prints one `A0 VERDICT:` line:
+/// `REQUEST_PERMISSION` / `TOOL CALL ONLY` / `NOT OFFERED`, with the agent's
+/// own reply as evidence. It only fails when the turn cannot run to
+/// completion, because that is the "could not run" outcome.
+///
+/// Recorded 2026-09-02 against `@zed-industries/claude-agent-acp` 0.23.1:
+/// NOT OFFERED. The adapter's `session/new` passes
+/// `disallowedTools: ["AskUserQuestion"]` to the SDK (`dist/acp-agent.js`,
+/// "Disable this for now, not a great way to expose this over ACP"), and the
+/// agent's own `ToolSearch` for it returns no match. Ordinary tool permissions
+/// (a `Skill` call here) DO arrive as `session/request_permission` with
+/// `allow_always` / `allow` / `reject`, and answering one unblocks the turn.
+#[tokio::test]
+#[ignore = "real adapter + credentials"]
+async fn claude_agent_acp_ask_user_question_probe() {
+    let Some(config) = gated(CLAUDE_ADAPTER) else {
+        return;
+    };
+    let cwd = tempfile::tempdir().expect("probe cwd");
+    // claude-agent-acp merges `~/.claude/settings.json` (user) under the cwd's
+    // `.claude/settings.json` (project) and refuses `session/new` outright when
+    // the merged `permissions.defaultMode` is an alias it does not know (the
+    // operator's `auto` is one, observed on 0.23.1). A project-level override
+    // in the throwaway cwd keeps the probe off the operator's global config.
+    std::fs::create_dir_all(cwd.path().join(".claude")).expect("probe .claude dir");
+    std::fs::write(
+        cwd.path().join(".claude/settings.json"),
+        r#"{"permissions":{"defaultMode":"default"}}"#,
+    )
+    .expect("probe project settings");
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (permission_tx, mut permission_rx) = mpsc::unbounded_channel();
+    let process = AdapterProcess::spawn(&config, tx, permission_tx)
+        .await
+        .expect("spawn real adapter");
+    let mut log = vec![format!(
+        "agentInfo {:?} mode {}",
+        process.info(),
+        config.permission_mode
+    )];
+    let session = process.new_session(cwd.path()).await.expect("session/new");
+
+    let prompt = "Use the AskUserQuestion tool to ask me exactly one question, \
+                  \"Which colour?\", with exactly two options: \"red\" and \"blue\". \
+                  Do not use any other tool. After I answer, reply with only the \
+                  option I chose, in lower case, and nothing else.";
+    let turn = process.prompt(&session, prompt);
+    tokio::pin!(turn);
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(180));
+    tokio::pin!(deadline);
+
+    // Counted only when the tool call itself is named AskUserQuestion (its
+    // `title` or `_meta.claudeCode.toolName`), never when another tool merely
+    // mentions it: the agent's own ToolSearch for the tool must not count as
+    // the tool.
+    let mut permissions = 0usize;
+    let mut ask_permissions = 0usize;
+    let mut ask_tool_calls = 0usize;
+    let mut answered_with = None;
+    let mut agent_text = String::new();
+    let outcome = loop {
+        tokio::select! {
+            result = &mut turn => break Some(result),
+            Some(notification) = rx.recv() => {
+                let value = serde_json::to_value(&notification).unwrap_or_default();
+                let update = &value["update"];
+                if names_tool(update, "AskUserQuestion") {
+                    ask_tool_calls += 1;
+                }
+                if update["sessionUpdate"] == "agent_message_chunk" {
+                    agent_text.push_str(update["content"]["text"].as_str().unwrap_or_default());
+                }
+                log.push(format!("update {value}"));
+            }
+            Some(permission) = permission_rx.recv() => {
+                permissions += 1;
+                let tool_call = serde_json::to_value(&permission.request.tool_call).unwrap_or_default();
+                if names_tool(&tool_call, "AskUserQuestion") {
+                    ask_permissions += 1;
+                }
+                let options = permission.options_wire();
+                log.push(format!("request_permission tool_call={tool_call} options={options:?}"));
+                // Prefer the option that is NOT the first one offered, so the
+                // final reply proves the agent acted on the pick rather than on
+                // a highlighted default (defect 26's bug class).
+                let pick = options
+                    .iter()
+                    .find(|o| o["name"].as_str().is_some_and(|n| n.to_lowercase().contains("blue")))
+                    .or_else(|| options.first())
+                    .and_then(|o| o["optionId"].as_str().map(str::to_string));
+                match pick {
+                    Some(id) => {
+                        log.push(format!("answered optionId={id}"));
+                        answered_with = Some(id.clone());
+                        permission.answer_selected(&id).expect("answer the permission");
+                    }
+                    None => {
+                        log.push("answered cancelled (no options offered)".to_string());
+                        permission.answer_cancelled().expect("cancel the permission");
+                    }
+                }
+            }
+            () = &mut deadline => break None,
+        }
+    };
+    // Late notifications can trail the prompt reply; keep them in the log
+    // (bounded, so a chatty adapter cannot keep the probe alive forever).
+    let mut trailing = 0usize;
+    while trailing < 200 {
+        let Ok(Some(notification)) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await
+        else {
+            break;
+        };
+        trailing += 1;
+        log.push(format!(
+            "update {}",
+            serde_json::to_string(&notification).unwrap_or_default()
+        ));
+    }
+    log.push(format!(
+        "turn outcome {outcome:?} (trailing notifications: {trailing})"
+    ));
+
+    let verdict = match (ask_permissions, ask_tool_calls) {
+        (0, 0) => format!(
+            "NOT OFFERED: no AskUserQuestion tool call and no request_permission for it \
+             ({permissions} request_permission(s) for other tools, answered {answered_with:?}); \
+             agent said: {agent_text:?}"
+        ),
+        (0, n) => format!(
+            "TOOL CALL ONLY: AskUserQuestion in {n} tool_call update(s), no request_permission \
+             for it; agent said: {agent_text:?}"
+        ),
+        (p, n) => format!(
+            "REQUEST_PERMISSION: {p} request(s) for AskUserQuestion ({n} tool_call update(s)), \
+             answered with {answered_with:?}; agent said: {agent_text:?}"
+        ),
+    };
+    log.push(format!("A0 VERDICT: {verdict}"));
+    let text = log.join("\n");
+    eprintln!("{text}");
+    if let Ok(path) = std::env::var("AINB_ACP_PROBE_LOG") {
+        std::fs::write(&path, format!("{text}\n")).expect("write AINB_ACP_PROBE_LOG");
+    }
+    assert!(
+        outcome.is_some(),
+        "the probe turn did not complete within 180s"
+    );
+}
+
+/// True when a `tool_call` / `tool_call_update` payload (or a permission's
+/// `tool_call`) is for `tool`: claude-agent-acp puts the Claude Code tool name
+/// in `title` and again in `_meta.claudeCode.toolName`.
+fn names_tool(tool_call: &serde_json::Value, tool: &str) -> bool {
+    tool_call["title"] == tool || tool_call["_meta"]["claudeCode"]["toolName"] == tool
+}

--- a/ainb-tui/crates/ainb-acp/tests/real_adapter.rs
+++ b/ainb-tui/crates/ainb-acp/tests/real_adapter.rs
@@ -191,7 +191,8 @@ fn permission_sink() -> tokio::sync::mpsc::UnboundedSender<ainb_acp::client::Per
 /// an assertion of either: it drives one turn, logs every `session/update` and
 /// every permission request raw (to stderr, and to `AINB_ACP_PROBE_LOG` when
 /// set), answers any permission (the option named "blue" when offered, else
-/// the first) so the turn can finish, and prints one `A0 VERDICT:` line:
+/// the one-shot allow, never always-allow) so the turn can finish, and prints
+/// one `A0 VERDICT:` line:
 /// `REQUEST_PERMISSION` / `TOOL CALL ONLY` / `NOT OFFERED`, with the agent's
 /// own reply as evidence. It only fails when the turn cannot run to
 /// completion, because that is the "could not run" outcome.
@@ -273,12 +274,16 @@ async fn claude_agent_acp_ask_user_question_probe() {
                 }
                 let options = permission.options_wire();
                 log.push(format!("request_permission tool_call={tool_call} options={options:?}"));
-                // Prefer the option that is NOT the first one offered, so the
-                // final reply proves the agent acted on the pick rather than on
-                // a highlighted default (defect 26's bug class).
+                // If the question's own options arrived, pick the one that is
+                // NOT first, so the reply proves the agent acted on the pick
+                // rather than on a highlighted default (defect 26's bug class).
+                // Otherwise this is an ordinary tool permission against a real
+                // credentialed agent: grant the narrowest one-shot allow, never
+                // "always", and take the first option only if there is none.
                 let pick = options
                     .iter()
                     .find(|o| o["name"].as_str().is_some_and(|n| n.to_lowercase().contains("blue")))
+                    .or_else(|| options.iter().find(|o| o["kind"] == "allow_once"))
                     .or_else(|| options.first())
                     .and_then(|o| o["optionId"].as_str().map(str::to_string));
                 match pick {

--- a/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
@@ -23,6 +23,7 @@ pub mod pr_status;
 pub mod reprime;
 pub mod settings;
 pub mod snapshots;
+pub mod transcript;
 
 /// Re-export the notification routing vocabulary (tcp T5) so proto-only consumers
 /// (ainb-web, the hangar plugin) reach [`Channel`] / [`ChannelSet`] without a

--- a/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/methods.rs
@@ -1323,7 +1323,7 @@ pub const HANGAR_BOARD_CARD_REMOVE: &str = "hangar/board_card_remove";
 /// [`crate::snapshots::BoardCardTimelineResult`] — the RAW provider stream-json
 /// (`claude.jsonl` / `codex.jsonl`) the card's newest task teed to disk, bounded
 /// to a tail so a huge run never floods the socket. The plugin parses it into the
-/// transcript taxonomy ([`ainb-plugin-hangar`'s `jsonl_timeline`]). A card that
+/// transcript taxonomy ([`crate::transcript::classify_stream_json`]). A card that
 /// never ran (or whose log is gone) yields an empty transcript, never an error. A
 /// read, workspace-scoped via the board.
 pub const HANGAR_BOARD_CARD_TIMELINE: &str = "hangar/board_card_timeline";

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -66,8 +66,6 @@ pub fn classify_stream_json(jsonl: &str) -> Vec<(MessageKind, String)> {
 /// instance, in order.
 #[derive(Debug, Default)]
 pub struct StreamJsonClassifier {
-    /// Lines produced by the current [`Self::classify_line`] call.
-    out: Vec<(MessageKind, String)>,
     /// `tool_use_id` → the tool name, so a later tool_result can name its tool.
     tool_names: HashMap<String, String>,
     /// `tool_use_id` → the tool_use line's timestamp (epoch ms), so a tool_result
@@ -92,50 +90,43 @@ impl StreamJsonClassifier {
         let Ok(v) = serde_json::from_str::<Value>(line) else {
             return Vec::new();
         };
-        self.fold(&v);
-        std::mem::take(&mut self.out)
+        let mut out = Vec::new();
+        self.fold(&v, &mut out);
+        out
     }
 
-    /// Fold one decoded JSONL line into the output.
-    fn fold(&mut self, v: &Value) {
+    /// Fold one decoded JSONL line into `out`.
+    fn fold(&mut self, v: &Value, out: &mut Vec<(MessageKind, String)>) {
         // Codex envelope: `{"msg":{"type":…}}`, unwrap to the inner event.
         if let Some(msg) = v.get("msg").filter(|m| m.is_object()) {
-            self.fold_codex_msg(msg);
+            fold_codex_msg(msg, out);
             return;
         }
         match v.get("type").and_then(Value::as_str).unwrap_or("") {
-            "system" => self.fold_system(v),
-            "assistant" => self.fold_message(v, ts_of(v)),
-            "user" => self.fold_message(v, ts_of(v)),
-            "result" => self.fold_result(v),
+            "system" => fold_system(v, out),
+            "assistant" => self.fold_message(v, ts_of(v), out),
+            "user" => self.fold_message(v, ts_of(v), out),
+            "result" => fold_result(v, out),
             // An explicit error line (some providers emit one) → the error lane.
             "error" => {
                 if let Some(text) = v.get("error").and_then(value_text) {
-                    push_lines(&mut self.out, MessageKind::Error, &text);
+                    push_lines(out, MessageKind::Error, &text);
                 }
             }
             _ => {}
         }
     }
 
-    /// A `system` line marks a run boundary: surface it as a slate status line
-    /// so the session id / subtype reads without inventing a taxonomy lane.
-    fn fold_system(&mut self, v: &Value) {
-        let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("system");
-        let session = v.get("session_id").and_then(Value::as_str).map(short_id).unwrap_or_default();
-        let body = if session.is_empty() {
-            format!("· {subtype}")
-        } else {
-            format!("· {subtype} · session {session}")
-        };
-        self.out.push((MessageKind::ToolResult, body));
-    }
-
     /// An `assistant` / `user` line carries a `message.content` block array. Each
     /// block maps to a lane: text → agent prose, thinking → the thinking lane,
     /// tool_use → a tool call (name + compact input), tool_result → a tool result
     /// (named + a per-tool duration when both timestamps are known).
-    fn fold_message(&mut self, v: &Value, line_ts: Option<i64>) {
+    fn fold_message(
+        &mut self,
+        v: &Value,
+        line_ts: Option<i64>,
+        out: &mut Vec<(MessageKind, String)>,
+    ) {
         let content = v.get("message").and_then(|m| m.get("content")).and_then(Value::as_array);
         let Some(blocks) = content else {
             return;
@@ -144,16 +135,16 @@ impl StreamJsonClassifier {
             match block.get("type").and_then(Value::as_str).unwrap_or("") {
                 "text" => {
                     if let Some(t) = block.get("text").and_then(Value::as_str) {
-                        push_lines(&mut self.out, MessageKind::Agent, t);
+                        push_lines(out, MessageKind::Agent, t);
                     }
                 }
                 "thinking" => {
                     if let Some(t) = block.get("thinking").and_then(Value::as_str) {
-                        push_lines(&mut self.out, MessageKind::Thinking, t);
+                        push_lines(out, MessageKind::Thinking, t);
                     }
                 }
-                "tool_use" => self.fold_tool_use(block, line_ts),
-                "tool_result" => self.fold_tool_result(block, line_ts),
+                "tool_use" => self.fold_tool_use(block, line_ts, out),
+                "tool_result" => self.fold_tool_result(block, line_ts, out),
                 _ => {}
             }
         }
@@ -161,7 +152,12 @@ impl StreamJsonClassifier {
 
     /// A `tool_use` block: emit a blue tool-call line (`<name>  <compact input>`)
     /// and remember the tool's name + start timestamp for its result.
-    fn fold_tool_use(&mut self, block: &Value, line_ts: Option<i64>) {
+    fn fold_tool_use(
+        &mut self,
+        block: &Value,
+        line_ts: Option<i64>,
+        out: &mut Vec<(MessageKind, String)>,
+    ) {
         let name = block.get("name").and_then(Value::as_str).unwrap_or("tool");
         let summary = compact_input(block.get("input"));
         let body = if summary.is_empty() {
@@ -169,7 +165,7 @@ impl StreamJsonClassifier {
         } else {
             format!("{name}  {summary}")
         };
-        self.out.push((MessageKind::ToolCall, body));
+        out.push((MessageKind::ToolCall, body));
         if let Some(id) = block.get("id").and_then(Value::as_str) {
             self.tool_names.insert(id.to_string(), name.to_string());
             if let Some(ts) = line_ts {
@@ -181,7 +177,12 @@ impl StreamJsonClassifier {
     /// A `tool_result` block: emit a slate result line naming its tool (resolved
     /// from the matching tool_use) and, when both carry a timestamp, its duration.
     /// An `is_error` result renders in the red error lane instead.
-    fn fold_tool_result(&mut self, block: &Value, line_ts: Option<i64>) {
+    fn fold_tool_result(
+        &mut self,
+        block: &Value,
+        line_ts: Option<i64>,
+        out: &mut Vec<(MessageKind, String)>,
+    ) {
         let id = block.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
         let name = self.tool_names.get(id).map_or("tool", String::as_str);
         let snippet = block
@@ -203,53 +204,66 @@ impl StreamJsonClassifier {
         } else {
             MessageKind::ToolResult
         };
-        self.out.push((lane, body));
+        out.push((lane, body));
     }
+}
 
-    /// The terminal `result` line: the LAST REPLY block (the final assistant text)
-    /// plus a slate run-status transition (subtype · cost · wall-clock duration).
-    fn fold_result(&mut self, v: &Value) {
-        let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("result");
-        let mut status = format!("· {subtype}");
-        if let Some(cost) = v.get("total_cost_usd").and_then(Value::as_f64) {
-            if cost > 0.0 {
-                status.push_str(&format!(" · ${cost:.4}"));
-            }
-        }
-        if let Some(dur) = v.get("duration_ms").and_then(Value::as_i64) {
-            status.push_str(&format!(" · {}", fmt_dur(dur)));
-        }
-        let lane = if subtype.contains("error") {
-            MessageKind::Error
-        } else {
-            MessageKind::ToolResult
-        };
-        self.out.push((lane, status));
-        if let Some(reply) = v.get("result").and_then(value_text) {
-            if !reply.trim().is_empty() {
-                self.out.push((MessageKind::Agent, "LAST REPLY".to_string()));
-                push_lines(&mut self.out, MessageKind::Agent, &reply);
-            }
+/// A `system` line marks a run boundary: surface it as a slate status line
+/// so the session id / subtype reads without inventing a taxonomy lane.
+fn fold_system(v: &Value, out: &mut Vec<(MessageKind, String)>) {
+    let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("system");
+    let session = v.get("session_id").and_then(Value::as_str).map(short_id).unwrap_or_default();
+    let body = if session.is_empty() {
+        format!("· {subtype}")
+    } else {
+        format!("· {subtype} · session {session}")
+    };
+    out.push((MessageKind::ToolResult, body));
+}
+
+/// The terminal `result` line: the LAST REPLY block (the final assistant text)
+/// plus a slate run-status transition (subtype · cost · wall-clock duration).
+fn fold_result(v: &Value, out: &mut Vec<(MessageKind, String)>) {
+    let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("result");
+    let mut status = format!("· {subtype}");
+    if let Some(cost) = v.get("total_cost_usd").and_then(Value::as_f64) {
+        if cost > 0.0 {
+            status.push_str(&format!(" · ${cost:.4}"));
         }
     }
-
-    /// Best-effort codex `{"msg":{…}}` handling: an `agent_message` is prose, an
-    /// `error` is the error lane; other codex event types are skipped (never
-    /// mis-rendered as another provider's shape).
-    fn fold_codex_msg(&mut self, msg: &Value) {
-        match msg.get("type").and_then(Value::as_str).unwrap_or("") {
-            "agent_message" | "agent_message_delta" => {
-                if let Some(t) = msg.get("message").and_then(Value::as_str) {
-                    push_lines(&mut self.out, MessageKind::Agent, t);
-                }
-            }
-            "error" => {
-                if let Some(t) = msg.get("message").and_then(value_text) {
-                    push_lines(&mut self.out, MessageKind::Error, &t);
-                }
-            }
-            _ => {}
+    if let Some(dur) = v.get("duration_ms").and_then(Value::as_i64) {
+        status.push_str(&format!(" · {}", fmt_dur(dur)));
+    }
+    let lane = if subtype.contains("error") {
+        MessageKind::Error
+    } else {
+        MessageKind::ToolResult
+    };
+    out.push((lane, status));
+    if let Some(reply) = v.get("result").and_then(value_text) {
+        if !reply.trim().is_empty() {
+            out.push((MessageKind::Agent, "LAST REPLY".to_string()));
+            push_lines(out, MessageKind::Agent, &reply);
         }
+    }
+}
+
+/// Best-effort codex `{"msg":{…}}` handling: an `agent_message` is prose, an
+/// `error` is the error lane; other codex event types are skipped (never
+/// mis-rendered as another provider's shape).
+fn fold_codex_msg(msg: &Value, out: &mut Vec<(MessageKind, String)>) {
+    match msg.get("type").and_then(Value::as_str).unwrap_or("") {
+        "agent_message" | "agent_message_delta" => {
+            if let Some(t) = msg.get("message").and_then(Value::as_str) {
+                push_lines(out, MessageKind::Agent, t);
+            }
+        }
+        "error" => {
+            if let Some(t) = msg.get("message").and_then(value_text) {
+                push_lines(out, MessageKind::Error, &t);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -39,6 +39,10 @@ use crate::events::MessageKind;
 /// Clip a one-line summary / snippet to this many display chars (char-safe).
 const SUMMARY_MAX: usize = 84;
 
+/// Most `tool_use` ids remembered while awaiting their `tool_result`. Claude
+/// issues a handful per message; this is a leak backstop, not a working limit.
+const MAX_PENDING_TOOLS: usize = 256;
+
 /// Classify a whole provider `stream-json` transcript into `(kind, body)` lines
 /// in stream order.
 ///
@@ -167,6 +171,14 @@ impl StreamJsonClassifier {
         };
         out.push((MessageKind::ToolCall, body));
         if let Some(id) = block.get("id").and_then(Value::as_str) {
+            // ponytail: a tool_use whose result never arrives (cancelled run,
+            // malformed log) would pin its entry forever in a long-lived
+            // classifier; past this many in flight, forget them all rather
+            // than track age. Raise the cap before adding an LRU.
+            if self.tool_names.len() >= MAX_PENDING_TOOLS {
+                self.tool_names.clear();
+                self.tool_starts.clear();
+            }
             self.tool_names.insert(id.to_string(), name.to_string());
             if let Some(ts) = line_ts {
                 self.tool_starts.insert(id.to_string(), ts);
@@ -176,7 +188,8 @@ impl StreamJsonClassifier {
 
     /// A `tool_result` block: emit a slate result line naming its tool (resolved
     /// from the matching tool_use) and, when both carry a timestamp, its duration.
-    /// An `is_error` result renders in the red error lane instead.
+    /// An `is_error` result renders in the red error lane instead. The tool's
+    /// entry is consumed here, so a live classifier does not grow per tool call.
     fn fold_tool_result(
         &mut self,
         block: &Value,
@@ -184,13 +197,17 @@ impl StreamJsonClassifier {
         out: &mut Vec<(MessageKind, String)>,
     ) {
         let id = block.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
-        let name = self.tool_names.get(id).map_or("tool", String::as_str);
+        let name = self.tool_names.remove(id).unwrap_or_else(|| "tool".to_string());
         let snippet = block
             .get("content")
             .and_then(value_text)
             .map(|s| truncate_chars(&one_line(&s), SUMMARY_MAX))
             .unwrap_or_default();
-        let dur = self.tool_starts.get(id).zip(line_ts).map(|(start, end)| fmt_dur(end - start));
+        let dur = self
+            .tool_starts
+            .remove(id)
+            .zip(line_ts)
+            .map(|(start, end)| fmt_dur(end - start));
         let mut body = match (snippet.is_empty(), &dur) {
             (true, Some(d)) => format!("{name}  ({d})"),
             (true, None) => name.to_string(),
@@ -388,5 +405,48 @@ fn short_id(id: &str) -> String {
         id.to_string()
     } else {
         id.chars().skip(n - 8).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A live classifier lives for a whole run, so a resolved tool must leave
+    /// both maps, and unresolved ones must not pile up past the backstop.
+    #[test]
+    fn tool_entries_are_consumed_by_their_result_and_capped_without_one() {
+        let mut c = StreamJsonClassifier::default();
+        let _ = c.classify_line(
+            r#"{"type":"assistant","timestamp":1000,"message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]}}"#,
+        );
+        assert_eq!((c.tool_names.len(), c.tool_starts.len()), (1, 1));
+        let lines = c.classify_line(
+            r#"{"type":"user","timestamp":1500,"message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}"#,
+        );
+        assert_eq!(
+            lines,
+            vec![(MessageKind::ToolResult, "Bash  ok  (500ms)".to_string())]
+        );
+        assert!(
+            c.tool_names.is_empty() && c.tool_starts.is_empty(),
+            "resolved id evicted"
+        );
+
+        for i in 0..(MAX_PENDING_TOOLS * 2) {
+            let _ = c.classify_line(&format!(
+                r#"{{"type":"assistant","timestamp":1,"message":{{"content":[{{"type":"tool_use","id":"u{i}","name":"Read","input":{{}}}}]}}}}"#
+            ));
+        }
+        assert!(
+            c.tool_names.len() <= MAX_PENDING_TOOLS,
+            "{}",
+            c.tool_names.len()
+        );
+        assert!(
+            c.tool_starts.len() <= MAX_PENDING_TOOLS,
+            "{}",
+            c.tool_starts.len()
+        );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -1,0 +1,378 @@
+//! Provider `stream-json` transcript classifier: one line taxonomy for every
+//! executor, durable and live.
+//!
+//! A provider run tees its CLI stream-json to disk (`{logs}/claude.jsonl` /
+//! `{logs}/codex.jsonl`, see the daemon runner). This module turns those lines
+//! into `(MessageKind, body)` pairs in the 5-colour transcript taxonomy
+//! ([`MessageKind`]): tool CALLS (name + a compact input), their RESULTS (with
+//! a per-tool duration when the log carries timestamps), assistant prose,
+//! extended thinking, and a closing LAST REPLY + run-status line.
+//!
+//! It lives in the proto crate so the daemon (the live `TaskMessage` producer
+//! and the durable timeline read) and the plugin (the on-disk timeline render)
+//! share exactly one classifier: a live-appended line and its later re-read
+//! twin are byte-identical.
+//!
+//! # Robust to a truncated / mid-write file (the aws lesson: files lag)
+//!
+//! Classification is line-oriented and **never fails**: a line that is not
+//! valid JSON (the common case for the LAST line of a file the daemon is still
+//! appending to) is skipped, not fatal. A recognised line with missing fields
+//! degrades to what it can show. A shape the classifier does not know (a future
+//! line type, a different provider) is skipped rather than mis-rendered. So a
+//! partial file classifies its complete prefix and simply stops: never a panic,
+//! never a half-decoded line.
+//!
+//! # Provider shapes
+//!
+//! Handles the `claude -p --output-format stream-json` line taxonomy
+//! (`system` / `assistant` / `user`(tool_result) / `result`) fully, and the codex
+//! `exec --json` `{"msg":{"type":…}}` envelope on a best-effort basis (an
+//! unrecognised codex line is skipped, never mis-attributed).
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::events::MessageKind;
+
+/// Clip a one-line summary / snippet to this many display chars (char-safe).
+const SUMMARY_MAX: usize = 84;
+
+/// Classify a whole provider `stream-json` transcript into `(kind, body)` lines
+/// in stream order.
+///
+/// Line-oriented and total: unparseable / unknown lines are skipped (a
+/// mid-write tail never breaks the result), so the output is the transcript's
+/// complete decoded prefix. See the module docs for the shape taxonomy +
+/// robustness contract. A live producer that sees one line at a time keeps a
+/// [`StreamJsonClassifier`] instead, so tool results still resolve their tool
+/// name and duration across lines.
+#[must_use]
+pub fn classify_stream_json(jsonl: &str) -> Vec<(MessageKind, String)> {
+    let mut classifier = StreamJsonClassifier::default();
+    let mut out = Vec::new();
+    for line in jsonl.lines() {
+        out.extend(classifier.classify_line(line));
+    }
+    out
+}
+
+/// The running classification state for one transcript.
+///
+/// Stateful across lines on purpose: a `tool_result` names its tool and carries
+/// a per-tool duration only because the earlier `tool_use` line's name and
+/// timestamp were remembered. Feed every line of one run through the same
+/// instance, in order.
+#[derive(Debug, Default)]
+pub struct StreamJsonClassifier {
+    /// Lines produced by the current [`Self::classify_line`] call.
+    out: Vec<(MessageKind, String)>,
+    /// `tool_use_id` → the tool name, so a later tool_result can name its tool.
+    tool_names: HashMap<String, String>,
+    /// `tool_use_id` → the tool_use line's timestamp (epoch ms), so a tool_result
+    /// carrying its own timestamp yields a per-tool duration.
+    tool_starts: HashMap<String, i64>,
+}
+
+impl StreamJsonClassifier {
+    /// Classify one raw transcript line into zero or more `(kind, body)` lines.
+    ///
+    /// Blank, non-JSON and unknown-shape lines yield nothing; a multi-line text
+    /// block yields one entry per non-empty line so a renderer painting one
+    /// entry per row never overflows.
+    #[must_use]
+    pub fn classify_line(&mut self, line: &str) -> Vec<(MessageKind, String)> {
+        let line = line.trim();
+        if line.is_empty() {
+            return Vec::new();
+        }
+        // A line that is not valid JSON (a truncated tail the daemon is still
+        // appending to, or a stray log line) is skipped, never fatal.
+        let Ok(v) = serde_json::from_str::<Value>(line) else {
+            return Vec::new();
+        };
+        self.fold(&v);
+        std::mem::take(&mut self.out)
+    }
+
+    /// Fold one decoded JSONL line into the output.
+    fn fold(&mut self, v: &Value) {
+        // Codex envelope: `{"msg":{"type":…}}`, unwrap to the inner event.
+        if let Some(msg) = v.get("msg").filter(|m| m.is_object()) {
+            self.fold_codex_msg(msg);
+            return;
+        }
+        match v.get("type").and_then(Value::as_str).unwrap_or("") {
+            "system" => self.fold_system(v),
+            "assistant" => self.fold_message(v, ts_of(v)),
+            "user" => self.fold_message(v, ts_of(v)),
+            "result" => self.fold_result(v),
+            // An explicit error line (some providers emit one) → the error lane.
+            "error" => {
+                if let Some(text) = v.get("error").and_then(value_text) {
+                    push_lines(&mut self.out, MessageKind::Error, &text);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// A `system` line marks a run boundary: surface it as a slate status line
+    /// so the session id / subtype reads without inventing a taxonomy lane.
+    fn fold_system(&mut self, v: &Value) {
+        let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("system");
+        let session = v.get("session_id").and_then(Value::as_str).map(short_id).unwrap_or_default();
+        let body = if session.is_empty() {
+            format!("· {subtype}")
+        } else {
+            format!("· {subtype} · session {session}")
+        };
+        self.out.push((MessageKind::ToolResult, body));
+    }
+
+    /// An `assistant` / `user` line carries a `message.content` block array. Each
+    /// block maps to a lane: text → agent prose, thinking → the thinking lane,
+    /// tool_use → a tool call (name + compact input), tool_result → a tool result
+    /// (named + a per-tool duration when both timestamps are known).
+    fn fold_message(&mut self, v: &Value, line_ts: Option<i64>) {
+        let content = v.get("message").and_then(|m| m.get("content")).and_then(Value::as_array);
+        let Some(blocks) = content else {
+            return;
+        };
+        for block in blocks {
+            match block.get("type").and_then(Value::as_str).unwrap_or("") {
+                "text" => {
+                    if let Some(t) = block.get("text").and_then(Value::as_str) {
+                        push_lines(&mut self.out, MessageKind::Agent, t);
+                    }
+                }
+                "thinking" => {
+                    if let Some(t) = block.get("thinking").and_then(Value::as_str) {
+                        push_lines(&mut self.out, MessageKind::Thinking, t);
+                    }
+                }
+                "tool_use" => self.fold_tool_use(block, line_ts),
+                "tool_result" => self.fold_tool_result(block, line_ts),
+                _ => {}
+            }
+        }
+    }
+
+    /// A `tool_use` block: emit a blue tool-call line (`<name>  <compact input>`)
+    /// and remember the tool's name + start timestamp for its result.
+    fn fold_tool_use(&mut self, block: &Value, line_ts: Option<i64>) {
+        let name = block.get("name").and_then(Value::as_str).unwrap_or("tool");
+        let summary = compact_input(block.get("input"));
+        let body = if summary.is_empty() {
+            name.to_string()
+        } else {
+            format!("{name}  {summary}")
+        };
+        self.out.push((MessageKind::ToolCall, body));
+        if let Some(id) = block.get("id").and_then(Value::as_str) {
+            self.tool_names.insert(id.to_string(), name.to_string());
+            if let Some(ts) = line_ts {
+                self.tool_starts.insert(id.to_string(), ts);
+            }
+        }
+    }
+
+    /// A `tool_result` block: emit a slate result line naming its tool (resolved
+    /// from the matching tool_use) and, when both carry a timestamp, its duration.
+    /// An `is_error` result renders in the red error lane instead.
+    fn fold_tool_result(&mut self, block: &Value, line_ts: Option<i64>) {
+        let id = block.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
+        let name = self.tool_names.get(id).map_or("tool", String::as_str);
+        let snippet = block
+            .get("content")
+            .and_then(value_text)
+            .map(|s| truncate_chars(&one_line(&s), SUMMARY_MAX))
+            .unwrap_or_default();
+        let dur = self.tool_starts.get(id).zip(line_ts).map(|(start, end)| fmt_dur(end - start));
+        let mut body = match (snippet.is_empty(), &dur) {
+            (true, Some(d)) => format!("{name}  ({d})"),
+            (true, None) => name.to_string(),
+            (false, Some(d)) => format!("{name}  {snippet}  ({d})"),
+            (false, None) => format!("{name}  {snippet}"),
+        };
+        let is_error = block.get("is_error").and_then(Value::as_bool).unwrap_or(false);
+        let lane = if is_error {
+            body = format!("{body}  [error]");
+            MessageKind::Error
+        } else {
+            MessageKind::ToolResult
+        };
+        self.out.push((lane, body));
+    }
+
+    /// The terminal `result` line: the LAST REPLY block (the final assistant text)
+    /// plus a slate run-status transition (subtype · cost · wall-clock duration).
+    fn fold_result(&mut self, v: &Value) {
+        let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("result");
+        let mut status = format!("· {subtype}");
+        if let Some(cost) = v.get("total_cost_usd").and_then(Value::as_f64) {
+            if cost > 0.0 {
+                status.push_str(&format!(" · ${cost:.4}"));
+            }
+        }
+        if let Some(dur) = v.get("duration_ms").and_then(Value::as_i64) {
+            status.push_str(&format!(" · {}", fmt_dur(dur)));
+        }
+        let lane = if subtype.contains("error") {
+            MessageKind::Error
+        } else {
+            MessageKind::ToolResult
+        };
+        self.out.push((lane, status));
+        if let Some(reply) = v.get("result").and_then(value_text) {
+            if !reply.trim().is_empty() {
+                self.out.push((MessageKind::Agent, "LAST REPLY".to_string()));
+                push_lines(&mut self.out, MessageKind::Agent, &reply);
+            }
+        }
+    }
+
+    /// Best-effort codex `{"msg":{…}}` handling: an `agent_message` is prose, an
+    /// `error` is the error lane; other codex event types are skipped (never
+    /// mis-rendered as another provider's shape).
+    fn fold_codex_msg(&mut self, msg: &Value) {
+        match msg.get("type").and_then(Value::as_str).unwrap_or("") {
+            "agent_message" | "agent_message_delta" => {
+                if let Some(t) = msg.get("message").and_then(Value::as_str) {
+                    push_lines(&mut self.out, MessageKind::Agent, t);
+                }
+            }
+            "error" => {
+                if let Some(t) = msg.get("message").and_then(value_text) {
+                    push_lines(&mut self.out, MessageKind::Error, &t);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// The line's timestamp as epoch ms, from a numeric `timestamp` / `ts` field.
+/// Only a numeric millisecond value is honoured: a per-tool duration is a
+/// best-effort enrichment, absent (no duration shown) when the log carries no
+/// machine timestamp rather than guessed.
+fn ts_of(v: &Value) -> Option<i64> {
+    v.get("timestamp").or_else(|| v.get("ts")).and_then(Value::as_i64)
+}
+
+/// Split `text` into non-empty trimmed lines and push one entry per line in
+/// `kind`'s lane, so a multi-line block never overflows a single render row (the
+/// renderer paints one entry per row). Empty input pushes nothing.
+fn push_lines(out: &mut Vec<(MessageKind, String)>, kind: MessageKind, text: &str) {
+    for line in text.lines() {
+        let line = line.trim_end();
+        if line.trim().is_empty() {
+            continue;
+        }
+        out.push((kind, line.to_string()));
+    }
+}
+
+/// A compact one-line summary of a tool_use `input` object: the most telling
+/// field for the common tools (a shell command, a file path, a query / pattern),
+/// else a truncated flat rendering, so a tool call reads at a glance without the
+/// full JSON payload.
+fn compact_input(input: Option<&Value>) -> String {
+    let Some(obj) = input.and_then(Value::as_object) else {
+        return input.map(compact_value).unwrap_or_default();
+    };
+    for key in [
+        "command",
+        "file_path",
+        "path",
+        "pattern",
+        "query",
+        "url",
+        "prompt",
+    ] {
+        if let Some(s) = obj.get(key).and_then(value_text) {
+            return truncate_chars(&one_line(&s), SUMMARY_MAX);
+        }
+    }
+    // No telling field: a flat, truncated key=val rendering.
+    let flat = obj
+        .iter()
+        .map(|(k, val)| format!("{k}={}", one_line(&compact_value(val))))
+        .collect::<Vec<_>>()
+        .join(" ");
+    truncate_chars(&flat, SUMMARY_MAX)
+}
+
+/// Read a JSON value as display text: a string as-is, else its compact JSON.
+/// A tool_result `content` is often an array of `{type:"text", text:…}` blocks;
+/// join their text. A plain string content is returned verbatim.
+fn value_text(v: &Value) -> Option<String> {
+    match v {
+        Value::String(s) => Some(s.clone()),
+        Value::Array(items) => {
+            let joined = items
+                .iter()
+                .filter_map(|it| {
+                    it.get("text")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                        .or_else(|| it.as_str().map(str::to_string))
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            (!joined.is_empty()).then_some(joined)
+        }
+        Value::Null => None,
+        other => Some(other.to_string()),
+    }
+}
+
+/// A short flat rendering of any JSON value for a compact input summary.
+fn compact_value(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Collapse all whitespace runs (incl. newlines) to single spaces, trimmed;
+/// keeps a summary on one render row.
+fn one_line(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Format a duration in ms as a compact `Nms` / `N.Ns` / `NmNs` string. A
+/// negative delta (clock skew between two lines) reads `0ms` rather than a
+/// nonsense value.
+fn fmt_dur(ms: i64) -> String {
+    let ms = ms.max(0);
+    if ms < 1000 {
+        format!("{ms}ms")
+    } else if ms < 60_000 {
+        format!("{:.1}s", ms as f64 / 1000.0)
+    } else {
+        format!("{}m{}s", ms / 60_000, (ms % 60_000) / 1000)
+    }
+}
+
+/// Truncate to `max` display chars with a trailing ellipsis on overflow
+/// (char-safe: never byte-slices, the utf8-truncate trap).
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let prefix: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{prefix}…")
+    }
+}
+
+/// The last 8 chars of a session id (char-safe), or the whole id when short.
+fn short_id(id: &str) -> String {
+    let n = id.chars().count();
+    if n <= 8 {
+        id.to_string()
+    } else {
+        id.chars().skip(n - 8).collect()
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -9,9 +9,10 @@
 //! extended thinking, and a closing LAST REPLY + run-status line.
 //!
 //! It lives in the proto crate so the daemon (the live `TaskMessage` producer
-//! and the durable timeline read) and the plugin (the on-disk timeline render)
-//! share exactly one classifier: a live-appended line and its later re-read
-//! twin are byte-identical.
+//! and the durable timeline read, track A steps A2 and A6) and the plugin (the
+//! on-disk timeline render, the only caller today) can share exactly one
+//! classifier, so that a live-appended line and its later re-read twin are
+//! byte-identical.
 //!
 //! # Robust to a truncated / mid-write file (the aws lesson: files lag)
 //!

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -190,7 +190,9 @@ impl StreamJsonClassifier {
     /// A `tool_result` block: emit a slate result line naming its tool (resolved
     /// from the matching tool_use) and, when both carry a timestamp, its duration.
     /// An `is_error` result renders in the red error lane instead. The tool's
-    /// entry is consumed here, so a live classifier does not grow per tool call.
+    /// entry is consumed here, so a live classifier does not grow per tool call;
+    /// a repeated result for an already-consumed id (a re-delivered tail line)
+    /// therefore degrades to the unnamed `tool` form with no duration.
     fn fold_tool_result(
         &mut self,
         block: &Value,
@@ -432,6 +434,14 @@ mod tests {
         assert!(
             c.tool_names.is_empty() && c.tool_starts.is_empty(),
             "resolved id evicted"
+        );
+        // A re-delivered result for the consumed id is the unnamed form.
+        let repeat = c.classify_line(
+            r#"{"type":"user","timestamp":1500,"message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}"#,
+        );
+        assert_eq!(
+            repeat,
+            vec![(MessageKind::ToolResult, "tool  ok".to_string())]
         );
 
         for i in 0..(MAX_PENDING_TOOLS * 2) {

--- a/ainb-tui/crates/ainb-hangar-proto/tests/transcript_classify.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/transcript_classify.rs
@@ -125,6 +125,21 @@ fn best_effort_codex_agent_message() {
     );
 }
 
+/// A top-level `{"type":"error"}` line and a codex `{"msg":{"type":"error"}}`
+/// both land in the error lane with their message: an error line vanishing
+/// from the timeline is the defect these two arms exist to prevent.
+#[test]
+fn explicit_error_lines_land_in_the_error_lane() {
+    let jsonl = "{\"type\":\"error\",\"error\":\"rate limited\"}\n{\"msg\":{\"type\":\"error\",\"message\":\"codex broke\"}}\n";
+    assert_eq!(
+        classify_stream_json(jsonl),
+        vec![
+            (MessageKind::Error, "rate limited".to_string()),
+            (MessageKind::Error, "codex broke".to_string()),
+        ]
+    );
+}
+
 /// An empty transcript is an empty timeline (not a panic).
 #[test]
 fn empty_input_is_empty() {

--- a/ainb-tui/crates/ainb-hangar-proto/tests/transcript_classify.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/tests/transcript_classify.rs
@@ -1,0 +1,153 @@
+//! The stream-json classifier's behaviour, pinned at its new home (move 1 step
+//! 1, test T0). These are the plugin's `jsonl_timeline` tests moved verbatim,
+//! asserting on `(MessageKind, body)` pairs instead of `ViewEntry`s: the
+//! classifier is now shared by the daemon's live stream and durable read and
+//! the plugin's on-disk render, so a regression here is attributable to the
+//! move, not to a later consumer.
+
+use ainb_hangar_proto::events::MessageKind;
+use ainb_hangar_proto::transcript::{StreamJsonClassifier, classify_stream_json};
+
+/// A claude-shape transcript: system init, an assistant text + a timestamped
+/// tool_use, the tool_result (also timestamped → a duration), and the result
+/// line with a LAST REPLY. The classifier surfaces each lane, names the tool on
+/// its result, and attaches the per-tool duration.
+#[test]
+fn parses_claude_shape_with_tool_durations_and_last_reply() {
+    let jsonl = r#"
+{"type":"system","subtype":"init","session_id":"abc123session","tools":["Bash"]}
+{"type":"assistant","timestamp":1000,"message":{"content":[{"type":"text","text":"Let me check the tests."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"cargo test --workspace"}}]}}
+{"type":"user","timestamp":2500,"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"test result: ok. 42 passed"}]}}
+{"type":"result","subtype":"success","total_cost_usd":0.1234,"duration_ms":4200,"result":"All 42 tests pass."}
+"#;
+    let lanes = classify_stream_json(jsonl);
+
+    // The tool call reads its name + compact command.
+    assert!(
+        lanes.iter().any(|(k, b)| *k == MessageKind::ToolCall
+            && b.contains("Bash")
+            && b.contains("cargo test --workspace")),
+        "tool call surfaces name + command: {lanes:?}"
+    );
+    // The tool result names the tool AND carries the per-tool duration
+    // (2500ms - 1000ms = 1.5s).
+    assert!(
+        lanes.iter().any(|(k, b)| *k == MessageKind::ToolResult
+            && b.contains("Bash")
+            && b.contains("1.5s")),
+        "tool result carries the duration: {lanes:?}"
+    );
+    // The assistant prose lands in the agent lane.
+    assert!(
+        lanes
+            .iter()
+            .any(|(k, b)| *k == MessageKind::Agent && b.contains("check the tests")),
+        "assistant prose in the agent lane: {lanes:?}"
+    );
+    // The result surfaces a LAST REPLY block + a status transition with cost +
+    // total duration.
+    assert!(
+        lanes.iter().any(|(k, b)| *k == MessageKind::Agent && b == "LAST REPLY"),
+        "a LAST REPLY marker: {lanes:?}"
+    );
+    assert!(
+        lanes
+            .iter()
+            .any(|(k, b)| *k == MessageKind::Agent && b.contains("All 42 tests pass")),
+        "the final reply text: {lanes:?}"
+    );
+    assert!(
+        lanes.iter().any(|(k, b)| *k == MessageKind::ToolResult
+            && b.contains("success")
+            && b.contains("$0.1234")
+            && b.contains("4.2s")),
+        "a run-status transition with cost + duration: {lanes:?}"
+    );
+}
+
+/// A file the daemon is still appending to ends in a TRUNCATED line (invalid
+/// JSON). The classifier yields the complete prefix and skips the partial tail:
+/// never a panic, never a half-decoded entry.
+#[test]
+fn tolerates_a_truncated_mid_write_tail() {
+    let jsonl = concat!(
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"done\"}]}}\n",
+        "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tex" // cut mid-write
+    );
+    let lanes = classify_stream_json(jsonl);
+    assert_eq!(lanes.len(), 1, "only the complete line parsed: {lanes:?}");
+    assert_eq!(lanes[0], (MessageKind::Agent, "done".to_string()));
+}
+
+/// Blank lines, non-JSON log noise, and an unknown line type are all skipped
+/// without error (robust to a mixed / future-shaped file).
+#[test]
+fn skips_blank_noise_and_unknown_lines() {
+    let jsonl = "\n\nnot json at all\n{\"type\":\"future_kind\",\"x\":1}\n{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n";
+    assert_eq!(
+        classify_stream_json(jsonl),
+        vec![(MessageKind::Agent, "hi".to_string())]
+    );
+}
+
+/// A tool_use with no matching (timestamped) result renders the call without a
+/// duration, and an `is_error` tool_result lands in the red error lane.
+#[test]
+fn tool_without_timestamps_has_no_duration_and_errors_are_red() {
+    let jsonl = r#"
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t9","name":"Read","input":{"file_path":"/etc/hosts"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t9","content":"boom","is_error":true}]}}
+"#;
+    let lanes = classify_stream_json(jsonl);
+    assert!(
+        lanes.iter().any(|(k, b)| *k == MessageKind::ToolCall
+            && b.contains("Read")
+            && b.contains("/etc/hosts")
+            && !b.contains('(')),
+        "no duration parens when timestamps are absent: {lanes:?}"
+    );
+    assert!(
+        lanes
+            .iter()
+            .any(|(k, b)| *k == MessageKind::Error && b.contains("Read") && b.contains("boom")),
+        "an is_error result is in the error lane: {lanes:?}"
+    );
+}
+
+/// A codex `{"msg":{…}}` agent_message is surfaced as prose; an unknown codex
+/// event is skipped.
+#[test]
+fn best_effort_codex_agent_message() {
+    let jsonl = "{\"msg\":{\"type\":\"agent_message\",\"message\":\"shipping it\"}}\n{\"msg\":{\"type\":\"token_count\",\"n\":5}}\n";
+    assert_eq!(
+        classify_stream_json(jsonl),
+        vec![(MessageKind::Agent, "shipping it".to_string())]
+    );
+}
+
+/// An empty transcript is an empty timeline (not a panic).
+#[test]
+fn empty_input_is_empty() {
+    assert!(classify_stream_json("").is_empty());
+    assert!(classify_stream_json("   \n  \n").is_empty());
+}
+
+/// The live producer feeds one line at a time through one classifier; that must
+/// yield exactly what the whole-file read yields, including the cross-line tool
+/// name and duration on the result (the reason the classifier is stateful).
+#[test]
+fn line_at_a_time_matches_the_whole_file() {
+    let jsonl = r#"
+{"type":"assistant","timestamp":1000,"message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}}
+{"type":"user","timestamp":1250,"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"a b c"}]}}
+{"type":"result","subtype":"success","duration_ms":900,"result":"three files"}
+"#;
+    let mut classifier = StreamJsonClassifier::default();
+    let live: Vec<_> = jsonl.lines().flat_map(|l| classifier.classify_line(l)).collect();
+    assert_eq!(live, classify_stream_json(jsonl));
+    assert!(
+        live.iter()
+            .any(|(k, b)| *k == MessageKind::ToolResult && b == "Bash  a b c  (250ms)"),
+        "the result names its tool and carries the duration: {live:?}"
+    );
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
@@ -1,498 +1,72 @@
-//! Prettied JSONL timeline parser (tcp T3 / F6, discharges the P10 §4.9 deferral).
+//! Prettied JSONL timeline (tcp T3 / F6, discharges the P10 §4.9 deferral).
 //!
 //! A provider run tees its CLI stream-json to disk (`{logs}/claude.jsonl` /
 //! `{logs}/codex.jsonl`, see the daemon runner). This module turns that on-disk
 //! transcript into the same [`ViewEntry`](crate::screen::task_detail::ViewEntry)
 //! shape the *live* task-detail transcript renders through
 //! ([`crate::widgets::transcript::render_transcript`]), so a card's history reads
-//! with the identical 5-colour taxonomy — tool CALLS (name + a compact input),
-//! their RESULTS (with a per-tool duration when the log carries timestamps),
-//! assistant prose, extended thinking, and a closing LAST REPLY + run-status line.
+//! with the identical 5-colour taxonomy.
 //!
-//! # Robust to a truncated / mid-write file (the aws lesson: files lag)
-//!
-//! [`parse_timeline`] is line-oriented and **never fails**: a line that is not
-//! valid JSON (the common case for the LAST line of a file the daemon is still
-//! appending to) is skipped, not fatal. A recognised line with missing fields
-//! degrades to what it can show. A shape the parser does not know (a future line
-//! type, a different provider) is skipped rather than mis-rendered. So a partial
-//! file renders its complete prefix and simply stops — never a panic, never a
-//! half-decoded line.
-//!
-//! # Provider shapes
-//!
-//! Handles the `claude -p --output-format stream-json` line taxonomy
-//! (`system` / `assistant` / `user`(tool_result) / `result`) fully, and the codex
-//! `exec --json` `{"msg":{"type":…}}` envelope on a best-effort basis (an
-//! unrecognised codex line is skipped, never mis-attributed).
+//! The classification itself lives in
+//! [`ainb_hangar_proto::transcript`], shared with the daemon's live
+//! `TaskMessage` producer and durable timeline read, so a line streamed live
+//! and the same line re-read from disk are byte-identical. That module also
+//! documents the provider shapes and the truncated / mid-write robustness
+//! contract; this one only wraps its output in the plugin's view type.
 
-use ainb_hangar_proto::events::MessageKind;
-use serde_json::Value;
+use ainb_hangar_proto::transcript::classify_stream_json;
 
 use crate::screen::task_detail::ViewEntry;
-
-/// Clip a one-line summary / snippet to this many display chars (char-safe).
-const SUMMARY_MAX: usize = 84;
 
 /// Parse a provider `stream-json` transcript into the timeline view entries the
 /// shared transcript renderer paints.
 ///
 /// Line-oriented and total: unparseable / unknown lines are skipped (a
 /// mid-write tail never breaks the render), so the result is the transcript's
-/// complete decoded prefix in stream order. See the module docs for the shape
-/// taxonomy + robustness contract.
+/// complete decoded prefix in stream order.
 #[must_use]
 pub fn parse_timeline(jsonl: &str) -> Vec<ViewEntry> {
-    let mut p = Parser::default();
-    for line in jsonl.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        // A line that is not valid JSON (a truncated tail the daemon is still
-        // appending to, or a stray log line) is skipped, never fatal.
-        let Ok(v) = serde_json::from_str::<Value>(line) else {
-            continue;
-        };
-        p.fold(&v);
-    }
-    p.out
-}
-
-/// The running parse state: the emitted entries plus the tool_use id → (name,
-/// start-timestamp) map used to attach a duration + name to each tool_result.
-#[derive(Default)]
-struct Parser {
-    out: Vec<ViewEntry>,
-    /// `tool_use_id` → the tool name, so a later tool_result can name its tool.
-    tool_names: std::collections::HashMap<String, String>,
-    /// `tool_use_id` → the tool_use line's timestamp (epoch ms), so a tool_result
-    /// carrying its own timestamp yields a per-tool duration.
-    tool_starts: std::collections::HashMap<String, i64>,
-}
-
-impl Parser {
-    /// Fold one decoded JSONL line into the timeline.
-    fn fold(&mut self, v: &Value) {
-        // Codex envelope: `{"msg":{"type":…}}` — unwrap to the inner event.
-        if let Some(msg) = v.get("msg").filter(|m| m.is_object()) {
-            self.fold_codex_msg(msg);
-            return;
-        }
-        match v.get("type").and_then(Value::as_str).unwrap_or("") {
-            "system" => self.fold_system(v),
-            "assistant" => self.fold_message(v, ts_of(v)),
-            "user" => self.fold_message(v, ts_of(v)),
-            "result" => self.fold_result(v),
-            // An explicit error line (some providers emit one) → the error lane.
-            "error" => {
-                if let Some(text) = v.get("error").and_then(value_text) {
-                    push_lines(&mut self.out, MessageKind::Error, &text);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    /// A `system` line marks a run boundary — surface it as a slate status line so
-    /// the session id / subtype reads without inventing a taxonomy lane.
-    fn fold_system(&mut self, v: &Value) {
-        let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("system");
-        let session = v.get("session_id").and_then(Value::as_str).map(short_id).unwrap_or_default();
-        let body = if session.is_empty() {
-            format!("· {subtype}")
-        } else {
-            format!("· {subtype} · session {session}")
-        };
-        self.out.push(ViewEntry::line(MessageKind::ToolResult, body));
-    }
-
-    /// An `assistant` / `user` line carries a `message.content` block array. Each
-    /// block maps to a lane: text → agent prose, thinking → the thinking lane,
-    /// tool_use → a tool call (name + compact input), tool_result → a tool result
-    /// (named + a per-tool duration when both timestamps are known).
-    fn fold_message(&mut self, v: &Value, line_ts: Option<i64>) {
-        let content = v.get("message").and_then(|m| m.get("content")).and_then(Value::as_array);
-        let Some(blocks) = content else {
-            return;
-        };
-        for block in blocks {
-            match block.get("type").and_then(Value::as_str).unwrap_or("") {
-                "text" => {
-                    if let Some(t) = block.get("text").and_then(Value::as_str) {
-                        push_lines(&mut self.out, MessageKind::Agent, t);
-                    }
-                }
-                "thinking" => {
-                    if let Some(t) = block.get("thinking").and_then(Value::as_str) {
-                        push_lines(&mut self.out, MessageKind::Thinking, t);
-                    }
-                }
-                "tool_use" => self.fold_tool_use(block, line_ts),
-                "tool_result" => self.fold_tool_result(block, line_ts),
-                _ => {}
-            }
-        }
-    }
-
-    /// A `tool_use` block: emit a blue tool-call line (`<name>  <compact input>`)
-    /// and remember the tool's name + start timestamp for its result.
-    fn fold_tool_use(&mut self, block: &Value, line_ts: Option<i64>) {
-        let name = block.get("name").and_then(Value::as_str).unwrap_or("tool");
-        let summary = compact_input(block.get("input"));
-        let body = if summary.is_empty() {
-            name.to_string()
-        } else {
-            format!("{name}  {summary}")
-        };
-        self.out.push(ViewEntry::line(MessageKind::ToolCall, body));
-        if let Some(id) = block.get("id").and_then(Value::as_str) {
-            self.tool_names.insert(id.to_string(), name.to_string());
-            if let Some(ts) = line_ts {
-                self.tool_starts.insert(id.to_string(), ts);
-            }
-        }
-    }
-
-    /// A `tool_result` block: emit a slate result line naming its tool (resolved
-    /// from the matching tool_use) and, when both carry a timestamp, its duration.
-    /// An `is_error` result renders in the red error lane instead.
-    fn fold_tool_result(&mut self, block: &Value, line_ts: Option<i64>) {
-        let id = block.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
-        let name = self.tool_names.get(id).map(String::as_str).unwrap_or("tool");
-        let snippet = block
-            .get("content")
-            .and_then(value_text)
-            .map(|s| truncate_chars(&one_line(&s), SUMMARY_MAX))
-            .unwrap_or_default();
-        let dur = self.tool_starts.get(id).zip(line_ts).map(|(start, end)| fmt_dur(end - start));
-        let mut body = match (snippet.is_empty(), &dur) {
-            (true, Some(d)) => format!("{name}  ({d})"),
-            (true, None) => name.to_string(),
-            (false, Some(d)) => format!("{name}  {snippet}  ({d})"),
-            (false, None) => format!("{name}  {snippet}"),
-        };
-        let is_error = block.get("is_error").and_then(Value::as_bool).unwrap_or(false);
-        let lane = if is_error {
-            body = format!("{body}  [error]");
-            MessageKind::Error
-        } else {
-            MessageKind::ToolResult
-        };
-        self.out.push(ViewEntry::line(lane, body));
-    }
-
-    /// The terminal `result` line: the LAST REPLY block (the final assistant text)
-    /// plus a slate run-status transition (subtype · cost · wall-clock duration).
-    fn fold_result(&mut self, v: &Value) {
-        let subtype = v.get("subtype").and_then(Value::as_str).unwrap_or("result");
-        let mut status = format!("· {subtype}");
-        if let Some(cost) = v.get("total_cost_usd").and_then(Value::as_f64) {
-            if cost > 0.0 {
-                status.push_str(&format!(" · ${cost:.4}"));
-            }
-        }
-        if let Some(dur) = v.get("duration_ms").and_then(Value::as_i64) {
-            status.push_str(&format!(" · {}", fmt_dur(dur)));
-        }
-        let lane = if subtype.contains("error") {
-            MessageKind::Error
-        } else {
-            MessageKind::ToolResult
-        };
-        self.out.push(ViewEntry::line(lane, status));
-        if let Some(reply) = v.get("result").and_then(value_text) {
-            if !reply.trim().is_empty() {
-                self.out.push(ViewEntry::line(MessageKind::Agent, "LAST REPLY"));
-                push_lines(&mut self.out, MessageKind::Agent, &reply);
-            }
-        }
-    }
-
-    /// Best-effort codex `{"msg":{…}}` handling: an `agent_message` is prose, an
-    /// `error` is the error lane; other codex event types are skipped (never
-    /// mis-rendered as another provider's shape).
-    fn fold_codex_msg(&mut self, msg: &Value) {
-        match msg.get("type").and_then(Value::as_str).unwrap_or("") {
-            "agent_message" | "agent_message_delta" => {
-                if let Some(t) = msg.get("message").and_then(Value::as_str) {
-                    push_lines(&mut self.out, MessageKind::Agent, t);
-                }
-            }
-            "error" => {
-                if let Some(t) = msg.get("message").and_then(value_text) {
-                    push_lines(&mut self.out, MessageKind::Error, &t);
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
-/// The line's timestamp as epoch ms, from a numeric `timestamp` / `ts` field.
-/// Only a numeric millisecond value is honoured — a per-tool duration is a
-/// best-effort enrichment, absent (no duration shown) when the log carries no
-/// machine timestamp rather than guessed.
-fn ts_of(v: &Value) -> Option<i64> {
-    v.get("timestamp").or_else(|| v.get("ts")).and_then(Value::as_i64)
-}
-
-/// Split `text` into non-empty trimmed lines and push one entry per line in
-/// `kind`'s lane, so a multi-line block never overflows a single render row (the
-/// renderer paints one entry per row). Empty input pushes nothing.
-fn push_lines(out: &mut Vec<ViewEntry>, kind: MessageKind, text: &str) {
-    for line in text.lines() {
-        let line = line.trim_end();
-        if line.trim().is_empty() {
-            continue;
-        }
-        out.push(ViewEntry::line(kind, line.to_string()));
-    }
-}
-
-/// A compact one-line summary of a tool_use `input` object: the most telling
-/// field for the common tools (a shell command, a file path, a query / pattern),
-/// else a truncated flat rendering — so a tool call reads at a glance without the
-/// full JSON payload.
-fn compact_input(input: Option<&Value>) -> String {
-    let Some(obj) = input.and_then(Value::as_object) else {
-        return input.map(compact_value).unwrap_or_default();
-    };
-    for key in [
-        "command",
-        "file_path",
-        "path",
-        "pattern",
-        "query",
-        "url",
-        "prompt",
-    ] {
-        if let Some(s) = obj.get(key).and_then(value_text) {
-            return truncate_chars(&one_line(&s), SUMMARY_MAX);
-        }
-    }
-    // No telling field — a flat, truncated key=val rendering.
-    let flat = obj
-        .iter()
-        .map(|(k, val)| format!("{k}={}", one_line(&compact_value(val))))
-        .collect::<Vec<_>>()
-        .join(" ");
-    truncate_chars(&flat, SUMMARY_MAX)
-}
-
-/// Read a JSON value as display text: a string as-is, else its compact JSON.
-/// A tool_result `content` is often an array of `{type:"text", text:…}` blocks —
-/// join their text; a plain string content is returned verbatim.
-fn value_text(v: &Value) -> Option<String> {
-    match v {
-        Value::String(s) => Some(s.clone()),
-        Value::Array(items) => {
-            let joined = items
-                .iter()
-                .filter_map(|it| {
-                    it.get("text")
-                        .and_then(Value::as_str)
-                        .map(str::to_string)
-                        .or_else(|| it.as_str().map(str::to_string))
-                })
-                .collect::<Vec<_>>()
-                .join(" ");
-            (!joined.is_empty()).then_some(joined)
-        }
-        Value::Null => None,
-        other => Some(other.to_string()),
-    }
-}
-
-/// A short flat rendering of any JSON value for a compact input summary.
-fn compact_value(v: &Value) -> String {
-    match v {
-        Value::String(s) => s.clone(),
-        other => other.to_string(),
-    }
-}
-
-/// Collapse all whitespace runs (incl. newlines) to single spaces, trimmed —
-/// keeps a summary on one render row.
-fn one_line(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-/// Format a duration in ms as a compact `Nms` / `N.Ns` / `NmNs` string. A
-/// negative delta (clock skew between two lines) reads `0ms` rather than a
-/// nonsense value.
-fn fmt_dur(ms: i64) -> String {
-    let ms = ms.max(0);
-    if ms < 1000 {
-        format!("{ms}ms")
-    } else if ms < 60_000 {
-        format!("{:.1}s", ms as f64 / 1000.0)
-    } else {
-        format!("{}m{}s", ms / 60_000, (ms % 60_000) / 1000)
-    }
-}
-
-/// Truncate to `max` display chars with a trailing ellipsis on overflow
-/// (char-safe — never byte-slices, the utf8-truncate trap).
-fn truncate_chars(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let prefix: String = s.chars().take(max.saturating_sub(1)).collect();
-        format!("{prefix}…")
-    }
-}
-
-/// The last 8 chars of a session id (char-safe), or the whole id when short.
-fn short_id(id: &str) -> String {
-    let n = id.chars().count();
-    if n <= 8 {
-        id.to_string()
-    } else {
-        id.chars().skip(n - 8).collect()
-    }
+    classify_stream_json(jsonl)
+        .into_iter()
+        .map(|(kind, body)| ViewEntry::line(kind, body))
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
+    use ainb_hangar_proto::events::MessageKind;
+
     use super::*;
-    use crate::screen::task_detail::ViewEntry;
 
-    /// Flatten the parsed entries into `(MessageKind, body)` pairs for assertions.
-    fn lanes(entries: &[ViewEntry]) -> Vec<(MessageKind, String)> {
-        entries
+    /// A claude-shape run: the wrapper yields one plain `ViewEntry::Line` per
+    /// classified line, in the classifier's lanes and order (system status,
+    /// prose, tool call, tool result, run status, LAST REPLY marker + text).
+    #[test]
+    fn wrapper_yields_line_entries_in_the_classifier_lanes() {
+        let jsonl = r#"
+{"type":"system","subtype":"init","session_id":"abc123session"}
+{"type":"assistant","timestamp":1000,"message":{"content":[{"type":"text","text":"Let me check."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"cargo test"}}]}}
+{"type":"user","timestamp":2500,"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}}
+{"type":"result","subtype":"success","duration_ms":4200,"result":"All green."}
+"#;
+        let kinds: Vec<MessageKind> = parse_timeline(jsonl)
             .iter()
-            .filter_map(|e| match e {
-                ViewEntry::Line(l) => Some((l.kind(), l.body().to_string())),
-                ViewEntry::CollapsedThinking { .. } => None,
+            .map(|e| match e {
+                ViewEntry::Line(l) => l.kind(),
+                ViewEntry::CollapsedThinking { .. } => panic!("the wrapper never folds: {e:?}"),
             })
-            .collect()
-    }
-
-    /// A claude-shape transcript: system init, an assistant text + a timestamped
-    /// tool_use, the tool_result (also timestamped → a duration), and the result
-    /// line with a LAST REPLY. The parser surfaces each lane, names the tool on
-    /// its result, and attaches the per-tool duration.
-    #[test]
-    fn parses_claude_shape_with_tool_durations_and_last_reply() {
-        let jsonl = r#"
-{"type":"system","subtype":"init","session_id":"abc123session","tools":["Bash"]}
-{"type":"assistant","timestamp":1000,"message":{"content":[{"type":"text","text":"Let me check the tests."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"cargo test --workspace"}}]}}
-{"type":"user","timestamp":2500,"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"test result: ok. 42 passed"}]}}
-{"type":"result","subtype":"success","total_cost_usd":0.1234,"duration_ms":4200,"result":"All 42 tests pass."}
-"#;
-        let entries = parse_timeline(jsonl);
-        let lanes = lanes(&entries);
-
-        // The tool call reads its name + compact command.
-        assert!(
-            lanes.iter().any(|(k, b)| *k == MessageKind::ToolCall
-                && b.contains("Bash")
-                && b.contains("cargo test --workspace")),
-            "tool call surfaces name + command: {lanes:?}"
-        );
-        // The tool result names the tool AND carries the per-tool duration
-        // (2500ms - 1000ms = 1.5s).
-        assert!(
-            lanes.iter().any(|(k, b)| *k == MessageKind::ToolResult
-                && b.contains("Bash")
-                && b.contains("1.5s")),
-            "tool result carries the duration: {lanes:?}"
-        );
-        // The assistant prose lands in the agent lane.
-        assert!(
-            lanes
-                .iter()
-                .any(|(k, b)| *k == MessageKind::Agent && b.contains("check the tests")),
-            "assistant prose in the agent lane: {lanes:?}"
-        );
-        // The result surfaces a LAST REPLY block + a status transition with cost +
-        // total duration.
-        assert!(
-            lanes.iter().any(|(k, b)| *k == MessageKind::Agent && b == "LAST REPLY"),
-            "a LAST REPLY marker: {lanes:?}"
-        );
-        assert!(
-            lanes
-                .iter()
-                .any(|(k, b)| *k == MessageKind::Agent && b.contains("All 42 tests pass")),
-            "the final reply text: {lanes:?}"
-        );
-        assert!(
-            lanes.iter().any(|(k, b)| *k == MessageKind::ToolResult
-                && b.contains("success")
-                && b.contains("$0.1234")
-                && b.contains("4.2s")),
-            "a run-status transition with cost + duration: {lanes:?}"
-        );
-    }
-
-    /// A file the daemon is still appending to ends in a TRUNCATED line (invalid
-    /// JSON). The parser renders the complete prefix and skips the partial tail —
-    /// never a panic, never a half-decoded entry.
-    #[test]
-    fn tolerates_a_truncated_mid_write_tail() {
-        let jsonl = concat!(
-            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"done\"}]}}\n",
-            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tex" // cut mid-write
-        );
-        let entries = parse_timeline(jsonl);
-        let lanes = lanes(&entries);
-        assert_eq!(lanes.len(), 1, "only the complete line parsed: {lanes:?}");
-        assert_eq!(lanes[0], (MessageKind::Agent, "done".to_string()));
-    }
-
-    /// Blank lines, non-JSON log noise, and an unknown line type are all skipped
-    /// without error (robust to a mixed / future-shaped file).
-    #[test]
-    fn skips_blank_noise_and_unknown_lines() {
-        let jsonl = "\n\nnot json at all\n{\"type\":\"future_kind\",\"x\":1}\n{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n";
-        let entries = parse_timeline(jsonl);
+            .collect();
         assert_eq!(
-            lanes(&entries),
-            vec![(MessageKind::Agent, "hi".to_string())]
+            kinds,
+            vec![
+                MessageKind::ToolResult,
+                MessageKind::Agent,
+                MessageKind::ToolCall,
+                MessageKind::ToolResult,
+                MessageKind::ToolResult,
+                MessageKind::Agent,
+                MessageKind::Agent,
+            ]
         );
-    }
-
-    /// A tool_use with no matching (timestamped) result renders the call without a
-    /// duration, and an `is_error` tool_result lands in the red error lane.
-    #[test]
-    fn tool_without_timestamps_has_no_duration_and_errors_are_red() {
-        let jsonl = r#"
-{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t9","name":"Read","input":{"file_path":"/etc/hosts"}}]}}
-{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t9","content":"boom","is_error":true}]}}
-"#;
-        let lanes = lanes(&parse_timeline(jsonl));
-        assert!(
-            lanes.iter().any(|(k, b)| *k == MessageKind::ToolCall
-                && b.contains("Read")
-                && b.contains("/etc/hosts")
-                && !b.contains('(')),
-            "no duration parens when timestamps are absent: {lanes:?}"
-        );
-        assert!(
-            lanes
-                .iter()
-                .any(|(k, b)| *k == MessageKind::Error && b.contains("Read") && b.contains("boom")),
-            "an is_error result is in the error lane: {lanes:?}"
-        );
-    }
-
-    /// A codex `{"msg":{…}}` agent_message is surfaced as prose; an unknown codex
-    /// event is skipped.
-    #[test]
-    fn best_effort_codex_agent_message() {
-        let jsonl = "{\"msg\":{\"type\":\"agent_message\",\"message\":\"shipping it\"}}\n{\"msg\":{\"type\":\"token_count\",\"n\":5}}\n";
-        assert_eq!(
-            lanes(&parse_timeline(jsonl)),
-            vec![(MessageKind::Agent, "shipping it".to_string())]
-        );
-    }
-
-    /// An empty transcript is an empty timeline (not a panic).
-    #[test]
-    fn empty_input_is_empty() {
-        assert!(parse_timeline("").is_empty());
-        assert!(parse_timeline("   \n  \n").is_empty());
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
@@ -69,4 +69,48 @@ mod tests {
             ]
         );
     }
+
+    /// T0 (move 1 step 1): the classifier move is behaviour-preserving. One
+    /// fixture spanning both provider shapes (claude's system / assistant /
+    /// tool_result / result taxonomy, an explicit error line, and the codex
+    /// `{"msg":{…}}` envelope) classified through proto directly and through
+    /// this wrapper yields the identical `(kind, body)` sequence: what the
+    /// daemon streams live is what the plugin renders from disk.
+    #[test]
+    fn t0_wrapper_matches_the_proto_classifier_on_both_provider_shapes() {
+        let jsonl = r#"
+{"type":"system","subtype":"init","session_id":"abc123session"}
+{"type":"assistant","timestamp":1000,"message":{"content":[{"type":"thinking","thinking":"plan\nthen act"},{"type":"text","text":"Let me check."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"cargo test"}}]}}
+{"type":"user","timestamp":2500,"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"boom","is_error":true}]}}
+{"type":"error","error":"rate limited"}
+not json at all
+{"msg":{"type":"agent_message","message":"shipping it"}}
+{"msg":{"type":"error","message":"codex broke"}}
+{"msg":{"type":"token_count","n":5}}
+{"type":"result","subtype":"success","total_cost_usd":0.1234,"duration_ms":4200,"result":"All green."}
+"#;
+        let via_wrapper: Vec<(MessageKind, String)> = parse_timeline(jsonl)
+            .iter()
+            .map(|e| match e {
+                ViewEntry::Line(l) => (l.kind(), l.body().to_string()),
+                ViewEntry::CollapsedThinking { .. } => panic!("the wrapper never folds: {e:?}"),
+            })
+            .collect();
+        let via_proto = classify_stream_json(jsonl);
+        assert_eq!(via_wrapper, via_proto);
+        // Every lane of the taxonomy is exercised, so a lane silently dropped
+        // by either side would not compare equal by being absent from both.
+        for kind in [
+            MessageKind::Agent,
+            MessageKind::Thinking,
+            MessageKind::ToolCall,
+            MessageKind::ToolResult,
+            MessageKind::Error,
+        ] {
+            assert!(
+                via_proto.iter().any(|(k, _)| *k == kind),
+                "fixture must exercise {kind:?}: {via_proto:?}"
+            );
+        }
+    }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
@@ -39,68 +39,33 @@ mod tests {
 
     use super::*;
 
-    /// A claude-shape run: the wrapper yields one plain `ViewEntry::Line` per
-    /// classified line, in the classifier's lanes and order (system status,
-    /// prose, tool call, tool result, run status, LAST REPLY marker + text).
+    /// The wrapper is a map over `classify_stream_json`, so this pins only what
+    /// the map can get wrong: every entry is a plain `ViewEntry::Line` (never a
+    /// thinking fold, never a comment) carrying the classifier's kind and body
+    /// unchanged, across every lane of the taxonomy. The move itself is pinned
+    /// against the pre-move behaviour in `ainb-hangar-proto`'s
+    /// `tests/transcript_classify.rs` (T0).
     #[test]
-    fn wrapper_yields_line_entries_in_the_classifier_lanes() {
-        let jsonl = r#"
-{"type":"system","subtype":"init","session_id":"abc123session"}
-{"type":"assistant","timestamp":1000,"message":{"content":[{"type":"text","text":"Let me check."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"cargo test"}}]}}
-{"type":"user","timestamp":2500,"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}}
-{"type":"result","subtype":"success","duration_ms":4200,"result":"All green."}
-"#;
-        let kinds: Vec<MessageKind> = parse_timeline(jsonl)
-            .iter()
-            .map(|e| match e {
-                ViewEntry::Line(l) => l.kind(),
-                ViewEntry::CollapsedThinking { .. } => panic!("the wrapper never folds: {e:?}"),
-            })
-            .collect();
-        assert_eq!(
-            kinds,
-            vec![
-                MessageKind::ToolResult,
-                MessageKind::Agent,
-                MessageKind::ToolCall,
-                MessageKind::ToolResult,
-                MessageKind::ToolResult,
-                MessageKind::Agent,
-                MessageKind::Agent,
-            ]
-        );
-    }
-
-    /// T0 (move 1 step 1): the classifier move is behaviour-preserving. One
-    /// fixture spanning both provider shapes (claude's system / assistant /
-    /// tool_result / result taxonomy, an explicit error line, and the codex
-    /// `{"msg":{…}}` envelope) classified through proto directly and through
-    /// this wrapper yields the identical `(kind, body)` sequence: what the
-    /// daemon streams live is what the plugin renders from disk.
-    #[test]
-    fn t0_wrapper_matches_the_proto_classifier_on_both_provider_shapes() {
+    fn wrapper_preserves_kind_and_body_and_folds_nothing() {
         let jsonl = r#"
 {"type":"system","subtype":"init","session_id":"abc123session"}
 {"type":"assistant","timestamp":1000,"message":{"content":[{"type":"thinking","thinking":"plan\nthen act"},{"type":"text","text":"Let me check."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"cargo test"}}]}}
 {"type":"user","timestamp":2500,"message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"boom","is_error":true}]}}
-{"type":"error","error":"rate limited"}
-not json at all
 {"msg":{"type":"agent_message","message":"shipping it"}}
-{"msg":{"type":"error","message":"codex broke"}}
-{"msg":{"type":"token_count","n":5}}
 {"type":"result","subtype":"success","total_cost_usd":0.1234,"duration_ms":4200,"result":"All green."}
 "#;
         let via_wrapper: Vec<(MessageKind, String)> = parse_timeline(jsonl)
             .iter()
             .map(|e| match e {
-                ViewEntry::Line(l) => (l.kind(), l.body().to_string()),
+                ViewEntry::Line(l) => {
+                    assert!(!l.is_comment(), "a disk line is never a comment: {l:?}");
+                    (l.kind(), l.body().to_string())
+                }
                 ViewEntry::CollapsedThinking { .. } => panic!("the wrapper never folds: {e:?}"),
             })
             .collect();
         let via_proto = classify_stream_json(jsonl);
         assert_eq!(via_wrapper, via_proto);
-        // Every lane of the taxonomy is exercised, so a lane silently dropped
-        // by either side would not compare equal by being absent from both.
         for kind in [
             MessageKind::Agent,
             MessageKind::Thinking,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/widgets/jsonl_timeline.rs
@@ -7,12 +7,13 @@
 //! ([`crate::widgets::transcript::render_transcript`]), so a card's history reads
 //! with the identical 5-colour taxonomy.
 //!
-//! The classification itself lives in
-//! [`ainb_hangar_proto::transcript`], shared with the daemon's live
-//! `TaskMessage` producer and durable timeline read, so a line streamed live
-//! and the same line re-read from disk are byte-identical. That module also
-//! documents the provider shapes and the truncated / mid-write robustness
-//! contract; this one only wraps its output in the plugin's view type.
+//! The classification itself lives in [`ainb_hangar_proto::transcript`] so
+//! the daemon can call the same function when it starts producing the live
+//! `TaskMessage` stream (track A step A2): from then on a line streamed live
+//! and the same line re-read from disk classify identically. Today this
+//! wrapper is the only caller. That module documents the provider shapes and
+//! the truncated / mid-write robustness contract; this one only wraps its
+//! output in the plugin's view type.
 
 use ainb_hangar_proto::transcript::classify_stream_json;
 


### PR DESCRIPTION
Track A of `docs/hangar/renovation/PLAN.md`: steps A1 (classifier move) and A0 (AskUserQuestion probe). Detail in `docs/hangar/renovation/move1-acp-tasks.md` sections 2b, 3c, 6 (T0) and 7 (step 1).

## What moved (A1, pure refactor)

```
before                                        after
plugin: widgets/jsonl_timeline.rs (498 l)     proto:  transcript.rs          classify_stream_json(&str) -> Vec<(MessageKind, String)>
   parse_timeline(&str) -> Vec<ViewEntry>                                    StreamJsonClassifier::classify_line(&mut self, &str)
   + 6 tests                                  proto:  tests/transcript_classify.rs   the 6 tests + line-at-a-time == whole-file
                                              plugin: widgets/jsonl_timeline.rs (wrapper, 5 lines of body)
                                                 parse_timeline(&str) -> Vec<ViewEntry>   unchanged signature, callers untouched
```

- `ainb-hangar-proto::transcript` is the one classifier for the durable timeline read, the live `TaskMessage` producer (A2) and the plugin's on-disk render. `MessageKind` already lives in proto; core cannot host it (proto depends on core).
- The classifier stays stateful (`StreamJsonClassifier`) on purpose: a `tool_result` names its tool and carries a duration only via the earlier `tool_use` line. A stateless per-line function would have silently dropped both. `classify_stream_json` is the whole-file convenience over it.
- `boards.rs` and `plugin.rs` still call `parse_timeline`; no plugin caller changed. `ViewEntry`, the thinking collapse and the renderer stay in the plugin.
- Nine commits, one concern each: the proto module + moved tests, the plugin wrapper, the wrapper test, the A0 probe, then the review fixes: `out` as a local (0f727b11), tool entries evicted on resolve + capped (b26ce846), docs worded as what A2 delivers (166126cc), wrapper test renamed for what it catches (746f42c9), probe grants one-shot allow only (eaf354f8).

## Proof of no behaviour change

- T0 is `crates/ainb-hangar-proto/tests/transcript_classify.rs`: the 6 original tests pass verbatim against `classify_stream_json`, and `line_at_a_time_matches_the_whole_file` pins the per-line entry point (`StreamJsonClassifier::classify_line`) equal to the whole-file one, including the cross-line tool name + duration.
- The plugin keeps one wrapper test (`jsonl_timeline::tests::wrapper_preserves_kind_and_body_and_folds_nothing`): `parse_timeline` is a map over the proto call, so it pins only what the map can get wrong (kind and body preserved, no thinking fold, no comment flag) across every lane.
- `cargo test -p ainb-hangar-proto` (105 + 5 + 7 + 16 + 7 + 6 pass), `cargo test -p ainb-plugin-hangar` (552 lib pass; integration suites pass, one unrelated timing flake `autopilot_right_click_run_now_fires_autopilot` failed once under concurrent load and passed on rerun), `cargo test -p ainb-acp` (all pass, 5 ignored real-adapter tests). `cargo fmt --all --check` clean. `ainb-plugin-protocol` untouched.

## A0 verdict: AskUserQuestion is NOT OFFERED by claude-agent-acp 0.23.1

Probe: `crates/ainb-acp/tests/real_adapter.rs::claude_agent_acp_ask_user_question_probe` (`#[ignore]`, gated on `AINB_ACP_REAL_ADAPTERS=1`). Run three times on 2026-09-02 against `@zed-industries/claude-agent-acp` 0.23.1 (`@anthropic-ai/claude-agent-sdk` 0.2.83), permission mode `default`, operator's own `claude` login via HOME.

Evidence, source: `dist/acp-agent.js:944` in the adapter's `newSession`:

```js
// Disable this for now, not a great way to expose this over ACP at the moment (in progress work so we can revisit)
const disallowedTools = ["AskUserQuestion"];
...
disallowedTools: [...(userProvidedOptions?.disallowedTools || []), ...disallowedTools],
```

Evidence, runtime (both runs):

```
update ... "title":"ToolSearch","rawInput":{"query":"select:AskUserQuestion","max_results":1}
update ... "toolResponse":{"matches":[],"query":"select:AskUserQuestion","total_deferred_tools":22}
update ... "text":"No matching deferred tools found"
agent_message_chunk: "AskUserQuestion isn't available as a standalone tool in this environment. ... Which colour: red or blue?"
turn outcome Some(Ok(PromptResponse { stop_reason: EndTurn, meta: None }))
A0 VERDICT: NOT OFFERED: no AskUserQuestion tool call and no request_permission for it ...
```

The agent asked in prose and ENDED THE TURN without waiting: nothing blocked, nobody was asked. So of the three outcomes in 3c, it is (3), the tool is not offered. Per the plan, Half B step 3 of the exit criterion becomes a tool-permission approval.

That fallback is live-proven by the same probe: in runs 1 and 3 the agent invoked the `Skill` tool, which arrived as `session/request_permission` with options `allow_always` / `allow` / `reject` (`kind` `allow_always` / `allow_once` / `reject_once`); answering it (`allow_always` in run 1, the one-shot `allow` in run 3 after the review fix) unblocked the turn.

Two more findings from the run, not fixed here:

1. The adapter merges `~/.claude/settings.json` (user) under `<cwd>/.claude/settings.json` (project) and refuses `session/new` (`-32603 Invalid permissions.defaultMode: auto.`) when the merged `permissions.defaultMode` is an alias it does not know; the operator's is `auto`. With the operator's HOME the daemon's ACP path cannot create a session on this box today. The probe overrides it in its throwaway cwd. A5's per-task adapter process should set `CLAUDE_CONFIG_DIR` (the adapter honours it) or write the project override.
2. Through HOME the ACP session inherits the operator's whole `~/.claude`: skills (`/interview` showed up in `available_commands_update`), CLAUDE.md (the agent addressed "Stevie"). Same fix as 1; open question 2 in PLAN.md (credential path) should be decided with this in view.

Raw logs: `a0-probe.log` (run 2), `a0-probe-run1.log` (run 1), `a0-probe-run3.log` (run 3), in the session scratchpad.
