### PR TITLE
refactor(hangar-daemon): ACP pool prerequisites for task execution (spine A4)

### DIFF
--- a/ainb-tui/crates/ainb-acp/src/bin/fake_acp_adapter.rs
+++ b/ainb-tui/crates/ainb-acp/src/bin/fake_acp_adapter.rs
@@ -37,6 +37,7 @@
 //! | `FAKE_ACP_PERMISSION_NO_ALLOW` | offer only reject-flavoured options, so `Approve` has nothing to select |
 //! | `FAKE_ACP_DIE_AFTER_CHUNKS` | emit the turn's updates, then exit WITHOUT replying to `session/prompt` |
 //! | `FAKE_ACP_FAIL_TURN_SESSIONS` | comma list (or `*`) whose prompt answers `stopReason: refusal` |
+//! | `FAKE_ACP_STOP_REASON` | `stopReason` answered by every non-refused prompt (default `end_turn`; e.g. `max_tokens`) |
 //! | `FAKE_ACP_HANG_PROMPTS` | comma list (or `*`) of prompt TEXTS whose turn never answers |
 //! | `FAKE_ACP_ECHO_PROMPT` | append the prompt text to the final agent message |
 //! | `FAKE_ACP_GHOST_SESSION` | per turn, emit one `session/update` AND one `session/request_permission` for THIS adapter session id, which no client session owns |
@@ -355,9 +356,9 @@ fn prompt(out: &SharedOut, pending: &Pending, id: &serde_json::Value, params: &s
     }
     flip_mode(out, &session_id);
     let stop = if selected("FAKE_ACP_FAIL_TURN_SESSIONS", &session_id) {
-        "refusal"
+        "refusal".to_string()
     } else {
-        "end_turn"
+        var("FAKE_ACP_STOP_REASON").unwrap_or_else(|| "end_turn".to_string())
     };
     respond(out, id, &serde_json::json!({"stopReason": stop}));
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -630,38 +630,54 @@ impl AcpPool {
     /// a process already running under `key` keeps the recipe it was spawned
     /// with until it stops.
     pub fn register_adapter(&self, key: impl Into<String>, adapter: AdapterConfig) {
-        if let Ok(mut adapters) = self.adapters.lock() {
-            adapters.insert(key.into(), adapter);
-        }
+        self.adapters.lock().expect("adapter registry").insert(key.into(), adapter);
     }
 
     /// Remove `key` from the live registry and stop its process, if one is
     /// running. Returns whether `key` was registered.
     ///
+    /// Runs UNDER the key's spawn gate, the lock
+    /// [`AcpPool::provider_process`] holds for the whole of a spawn, and that
+    /// is what makes the removal complete rather than racy. A spawn already
+    /// past the gate lands in `providers` before this call gets the gate, and
+    /// is stopped below; one that has not taken the gate yet re-reads the
+    /// registry under it and refuses, because the recipe lookup happens INSIDE
+    /// the gate. So no process can exist under an unregistered key once this
+    /// returns. The gate leaves `spawn_locks` only while it is held, so a
+    /// re-register under the same key cannot run two spawns against each other.
+    ///
     /// The stop is INTENTIONAL, exactly like the idle sweep's: it neither counts
     /// on the breaker nor leaves a phantom `exited` row on the health pane, and
-    /// the breaker and spawn-lock entries for the key go with it so a fleet of
-    /// short-lived task keys does not accrete bookkeeping. Sessions hosted on
-    /// the process converge through the ordinary exit path. A spawn still in
-    /// flight under `key` is not interrupted: it lands in `providers` as usual
-    /// and the idle sweep reclaims it once its tenants leave, so a caller that
-    /// wants a clean stop tears its sessions down first.
+    /// the breaker entry goes with it so a fleet of short-lived task keys does
+    /// not accrete bookkeeping. Sessions hosted on the process converge through
+    /// the ordinary exit path.
     pub async fn unregister_adapter(&self, key: &str) -> bool {
-        let was_registered =
-            self.adapters.lock().is_ok_and(|mut adapters| adapters.remove(key).is_some());
-        if let Ok(mut locks) = self.spawn_locks.lock() {
-            locks.remove(key);
-        }
+        let gate = self.spawn_locks.lock().expect("spawn lock map").get(key).map(Arc::clone);
+        let _held = match gate.as_ref() {
+            Some(gate) => Some(gate.lock().await),
+            None => None,
+        };
+        let was_registered = self.adapters.lock().expect("adapter registry").remove(key).is_some();
+        self.spawn_locks.lock().expect("spawn lock map").remove(key);
         if let Ok(mut circuits) = self.circuits.lock() {
             circuits.remove(key);
         }
-        let process = self.providers.lock().await.remove(key);
-        if let Some(process) = process {
-            tracing::info!(provider = %key, "stopping the adapter process of an unregistered key");
-            process.stopping.store(true, Ordering::Relaxed);
-            process.process.kill();
+        if self.stop_process(key).await {
+            tracing::info!(provider = %key, "stopped the adapter process of an unregistered key");
         }
         was_registered
+    }
+
+    /// Stop the process under `key` on purpose: drop it from `providers`, mark
+    /// it so its exit is not counted as a crash, and kill it. `false` when
+    /// there was none.
+    async fn stop_process(&self, key: &str) -> bool {
+        let process = self.providers.lock().await.remove(key);
+        process.is_some_and(|process| {
+            process.stopping.store(true, Ordering::Relaxed);
+            process.process.kill();
+            true
+        })
     }
 
     /// Hand one prompt to the recipient's OWN session (never a broadcast
@@ -984,18 +1000,12 @@ impl AcpPool {
                 .collect()
         };
         for provider in expired {
-            let process = {
-                let mut providers = self.providers.lock().await;
-                providers.remove(&provider)
-            };
-            if let Some(process) = process {
+            if self.stop_process(&provider).await {
                 tracing::info!(
                     %provider,
                     idle_window_secs = self.config.process_idle_window.as_secs(),
-                    "stopping an acp adapter process that has been idle for its whole window"
+                    "stopped an acp adapter process that had been idle for its whole window"
                 );
-                process.stopping.store(true, Ordering::Relaxed);
-                process.process.kill();
             }
         }
     }
@@ -1060,6 +1070,16 @@ impl AcpPool {
         }
     }
 
+    /// The spawn recipe for `provider` from the live registry.
+    fn adapter_config(&self, provider: &str) -> Result<AdapterConfig, AcpError> {
+        self.adapters
+            .lock()
+            .expect("adapter registry")
+            .get(provider)
+            .cloned()
+            .ok_or_else(|| not_in_registry(provider))
+    }
+
     /// The live process for `provider`, or `None` when there is none.
     async fn live_process(&self, provider: &str) -> Option<Arc<ProviderProcess>> {
         let mut providers = self.providers.lock().await;
@@ -1092,6 +1112,12 @@ impl AcpPool {
         if let Some(existing) = self.live_process(provider).await {
             return Ok(existing);
         }
+        // The registry BEFORE the gate: an unknown key must not mint a spawn
+        // lock, or every prompt against a key `unregister_adapter` already
+        // cleaned up would put its entry straight back.
+        if !self.knows(provider) {
+            return Err(not_in_registry(provider));
+        }
         let gate = {
             let mut locks = self.spawn_locks.lock().expect("spawn lock map");
             Arc::clone(
@@ -1101,22 +1127,13 @@ impl AcpPool {
             )
         };
         let _spawning = gate.lock().await;
-        // Another caller may have spawned it while we waited on the gate.
+        // Another caller may have spawned it while we waited on the gate, or an
+        // `unregister_adapter` that held the gate may have taken the key out of
+        // the registry, which is why the recipe is read HERE and not above.
         if let Some(existing) = self.live_process(provider).await {
             return Ok(existing);
         }
-        let config = self
-            .adapters
-            .lock()
-            .ok()
-            .and_then(|adapters| adapters.get(provider).cloned())
-            .ok_or_else(|| AcpError::Spawn {
-                adapter: provider.to_string(),
-                source: std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "provider is not in the adapter registry",
-                ),
-            })?;
+        let config = self.adapter_config(provider)?;
         let span = tracing::info_span!(
             "acp.spawn",
             provider = %provider,
@@ -3103,6 +3120,17 @@ async fn resolve_leg(
             "acp delivery leg was already resolved"
         ),
         Err(error) => tracing::error!(%error, "could not claim the acp delivery leg"),
+    }
+}
+
+/// The spawn refusal for a key the live registry does not hold.
+fn not_in_registry(provider: &str) -> AcpError {
+    AcpError::Spawn {
+        adapter: provider.to_string(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "provider is not in the adapter registry",
+        ),
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -139,6 +139,12 @@ pub const DELIVERY_PROVIDER_AT_CAPACITY: &str = "provider_at_capacity";
 /// Terminal, never requeued: retrying an adapter that will not hold the mode
 /// just drives the same session in the wrong permission regime a second time.
 pub const DELIVERY_MODE_UNPROVEN: &str = "mode_unproven";
+/// Prefix of the token a DELIVERED leg carries: `stop=<StopReason>`.
+///
+/// The reason is the upstream enum's Debug name, so `stop=EndTurn`,
+/// `stop=MaxTokens`, `stop=MaxTurnRequests`. A FAILED turn carries the same
+/// reason after [`DELIVERY_TURN_FAILED`] instead.
+pub const DELIVERY_STOP_PREFIX: &str = "stop=";
 
 /// The resume path fingerprint carried on the next delivery's receipt detail
 /// and in the `acp.context_rebuilt` marker: the adapter still had the session.
@@ -1934,9 +1940,15 @@ impl SessionActor {
         self.pump().await;
 
         let (marker, state, detail) = match &result {
-            Ok(response) if turn_succeeded(response) => {
-                (Lifecycle::TurnCompleted, "DELIVERED", None)
-            }
+            // The stop reason rides on a SUCCESS too: `turn_succeeded` folds
+            // `EndTurn`, `MaxTokens` and `MaxTurnRequests` into one DELIVERED,
+            // and a task caller has to tell "the agent finished" from "the
+            // agent ran out of budget" without opening the transcript.
+            Ok(response) if turn_succeeded(response) => (
+                Lifecycle::TurnCompleted,
+                "DELIVERED",
+                Some(format!("{DELIVERY_STOP_PREFIX}{:?}", response.stop_reason)),
+            ),
             Ok(response) => (
                 Lifecycle::TurnFailed,
                 "FAILED",

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -700,11 +700,13 @@ impl AcpPool {
     /// there was none.
     async fn stop_process(&self, key: &str) -> bool {
         let process = self.providers.lock().await.remove(key);
-        process.is_some_and(|process| {
+        if let Some(process) = process {
             process.stopping.store(true, Ordering::Relaxed);
             process.process.kill();
             true
-        })
+        } else {
+            false
+        }
     }
 
     /// Hand one prompt to the recipient's OWN session (never a broadcast

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -139,10 +139,14 @@ pub const DELIVERY_PROVIDER_AT_CAPACITY: &str = "provider_at_capacity";
 /// Terminal, never requeued: retrying an adapter that will not hold the mode
 /// just drives the same session in the wrong permission regime a second time.
 pub const DELIVERY_MODE_UNPROVEN: &str = "mode_unproven";
-/// Prefix of the token a DELIVERED leg carries: `stop=<StopReason>`.
+/// Prefix of the token a leg carries when the turn stopped for a reason worth
+/// naming: `stop=<StopReason>`.
 ///
-/// The reason is the upstream enum's Debug name, so `stop=EndTurn`,
-/// `stop=MaxTokens`, `stop=MaxTurnRequests`. A FAILED turn carries the same
+/// ABSENT on a DELIVERED leg means the ordinary `EndTurn`, the same way an
+/// absent [`RESUME_LOADED`] on the same leg means the context never had to be
+/// rebuilt: `DELIVERED` already says the agent finished, so a token on every
+/// turn would put a non-event in front of the operator, and in front of the
+/// `resume=` half they do need on a narrow pane. A FAILED turn carries its
 /// reason after [`DELIVERY_TURN_FAILED`] instead.
 pub const DELIVERY_STOP_PREFIX: &str = "stop=";
 
@@ -2017,14 +2021,18 @@ impl SessionActor {
         self.pump().await;
 
         let (marker, state, detail) = match &result {
-            // The stop reason rides on a SUCCESS too: `turn_succeeded` folds
-            // `EndTurn`, `MaxTokens` and `MaxTurnRequests` into one DELIVERED,
-            // and a task caller has to tell "the agent finished" from "the
-            // agent ran out of budget" without opening the transcript.
+            // The stop reason rides on a SUCCESS too, because `turn_succeeded`
+            // folds `EndTurn`, `MaxTokens` and `MaxTurnRequests` into one
+            // DELIVERED and a task caller has to tell "the agent finished" from
+            // "the agent ran out of budget" without opening the transcript. Only
+            // the two that say something, though: among DELIVERED legs no token
+            // unambiguously means `EndTurn`, so writing one would spend the
+            // operator's line width on every ordinary turn.
             Ok(response) if turn_succeeded(response) => (
                 Lifecycle::TurnCompleted,
                 "DELIVERED",
-                Some(format!("{DELIVERY_STOP_PREFIX}{:?}", response.stop_reason)),
+                (!matches!(response.stop_reason, StopReason::EndTurn))
+                    .then(|| format!("{DELIVERY_STOP_PREFIX}{:?}", response.stop_reason)),
             ),
             Ok(response) => (
                 Lifecycle::TurnFailed,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -140,7 +140,8 @@ pub const DELIVERY_PROVIDER_AT_CAPACITY: &str = "provider_at_capacity";
 /// just drives the same session in the wrong permission regime a second time.
 pub const DELIVERY_MODE_UNPROVEN: &str = "mode_unproven";
 /// Prefix of the token a leg carries when the turn stopped for a reason worth
-/// naming: `stop=<StopReason>`.
+/// naming: `stop=<reason>`, in the ACP wire spelling ([`stop_reason_token`]),
+/// so `stop=max_tokens`, `stop=max_turn_requests`, `stop=refusal`.
 ///
 /// ABSENT on a DELIVERED leg means the ordinary `EndTurn`, the same way an
 /// absent [`RESUME_LOADED`] on the same leg means the context never had to be
@@ -2031,15 +2032,21 @@ impl SessionActor {
             Ok(response) if turn_succeeded(response) => (
                 Lifecycle::TurnCompleted,
                 "DELIVERED",
-                (!matches!(response.stop_reason, StopReason::EndTurn))
-                    .then(|| format!("{DELIVERY_STOP_PREFIX}{:?}", response.stop_reason)),
+                (!matches!(response.stop_reason, StopReason::EndTurn)).then(|| {
+                    format!(
+                        "{DELIVERY_STOP_PREFIX}{}",
+                        stop_reason_token(response.stop_reason)
+                    )
+                }),
             ),
+            // The same `stop=` shape as the success arm, so a reader parses ONE
+            // field whichever side of `turn_succeeded` the turn fell on.
             Ok(response) => (
                 Lifecycle::TurnFailed,
                 "FAILED",
                 Some(format!(
-                    "{DELIVERY_TURN_FAILED}; {:?}",
-                    response.stop_reason
+                    "{DELIVERY_TURN_FAILED}; {DELIVERY_STOP_PREFIX}{}",
+                    stop_reason_token(response.stop_reason)
                 )),
             ),
             // The request WAS issued, so the honest answer is UNKNOWN. A resend
@@ -3139,6 +3146,24 @@ fn not_in_registry(provider: &str) -> AcpError {
             std::io::ErrorKind::NotFound,
             "provider is not in the adapter registry",
         ),
+    }
+}
+
+/// The persisted token for a stop reason: the ACP wire name, snake_case like
+/// every other token in this taxonomy.
+///
+/// An explicit match rather than the enum's Debug name, because the upstream
+/// enum is `#[non_exhaustive]` and a token that reaches the store and the
+/// operator's screen must not change spelling when a variant is renamed
+/// upstream or arrive as a name nothing else in the vocabulary looks like.
+const fn stop_reason_token(reason: StopReason) -> &'static str {
+    match reason {
+        StopReason::EndTurn => "end_turn",
+        StopReason::MaxTokens => "max_tokens",
+        StopReason::MaxTurnRequests => "max_turn_requests",
+        StopReason::Refusal => "refusal",
+        StopReason::Cancelled => "cancelled",
+        _ => "unknown",
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -608,9 +608,14 @@ impl AcpPool {
     }
 
     /// Whether the live registry knows how to spawn `provider`.
+    ///
+    /// Panics on a poisoned registry rather than answering `false`, which
+    /// [`AcpPool::provider_process`] would report as "provider is not in the
+    /// adapter registry": a lie about which thing broke, now that this gates
+    /// the spawn.
     #[must_use]
     pub fn knows(&self, provider: &str) -> bool {
-        self.adapters.lock().is_ok_and(|adapters| adapters.contains_key(provider))
+        self.adapters.lock().expect("adapter registry").contains_key(provider)
     }
 
     /// The pinned permission mode for `provider`, or `default`.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -641,15 +641,32 @@ impl AcpPool {
     /// Remove `key` from the live registry and stop its process, if one is
     /// running. Returns whether `key` was registered.
     ///
-    /// Runs UNDER the key's spawn gate, the lock
-    /// [`AcpPool::provider_process`] holds for the whole of a spawn, and that
-    /// is what makes the removal complete rather than racy. A spawn already
-    /// past the gate lands in `providers` before this call gets the gate, and
-    /// is stopped below; one that has not taken the gate yet re-reads the
-    /// registry under it and refuses, because the recipe lookup happens INSIDE
-    /// the gate. So no process can exist under an unregistered key once this
-    /// returns. The gate leaves `spawn_locks` only while it is held, so a
-    /// re-register under the same key cannot run two spawns against each other.
+    /// The registry entry goes FIRST, and only then does this take the key's
+    /// spawn gate. That order is the whole proof, and the other one is a race.
+    ///
+    /// A spawn reads the recipe ([`AcpPool::adapter_config`]) inside the gate,
+    /// so by then it has already published its gate in `spawn_locks`. Order
+    /// that recipe read against the `adapters` removal below, the two being
+    /// mutations of one mutex-guarded map and so totally ordered:
+    ///
+    /// * recipe read FIRST: its gate was published even earlier, therefore
+    ///   before the removal, therefore before the `spawn_locks` read here, so
+    ///   this call sees that gate and blocks on it until the spawn has put its
+    ///   process in `providers`, where `stop_process` below then kills it;
+    /// * removal FIRST: the recipe read finds nothing and the spawn refuses.
+    ///
+    /// Either way no process exists under an unregistered key once this
+    /// returns. Read `spawn_locks` before removing the registry entry and the
+    /// second case gains a third leg (gate not yet published, recipe read still
+    /// wins the race), which leaves a live process under the removed key that
+    /// `provider_process` keeps serving, because `live_process` runs before its
+    /// `knows` check.
+    ///
+    /// NOT claimed: "exactly one spawn per key across an unregister then a
+    /// re-register". A spawn parked between publishing its gate and taking it
+    /// holds a stale `Arc` while a re-registered spawn mints a fresh gate, so
+    /// the two do not serialise. Closing that needs a generation counter, which
+    /// is a different claim and has no caller yet.
     ///
     /// The stop is INTENTIONAL, exactly like the idle sweep's: it neither counts
     /// on the breaker nor leaves a phantom `exited` row on the health pane, and
@@ -657,12 +674,12 @@ impl AcpPool {
     /// not accrete bookkeeping. Sessions hosted on the process converge through
     /// the ordinary exit path.
     pub async fn unregister_adapter(&self, key: &str) -> bool {
+        let was_registered = self.adapters.lock().expect("adapter registry").remove(key).is_some();
         let gate = self.spawn_locks.lock().expect("spawn lock map").get(key).map(Arc::clone);
         let _held = match gate.as_ref() {
             Some(gate) => Some(gate.lock().await),
             None => None,
         };
-        let was_registered = self.adapters.lock().expect("adapter registry").remove(key).is_some();
         self.spawn_locks.lock().expect("spawn lock map").remove(key);
         if let Ok(mut circuits) = self.circuits.lock() {
             circuits.remove(key);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -223,8 +223,10 @@ fn acp_adapters_from_config() -> std::collections::HashMap<String, AcpAdapterTom
 /// Pool tuning. Every knob the plan names, with its documented default.
 #[derive(Debug, Clone)]
 pub struct PoolConfig {
-    /// The adapter registry: token to spawn recipe. A provider absent here
-    /// cannot be created by `fleet/acp_session_create`.
+    /// The adapter registry the pool STARTS with: token to spawn recipe. The
+    /// live registry ([`AcpPool::register_adapter`]) grows past this at
+    /// runtime; a provider in neither cannot be created by
+    /// `fleet/acp_session_create`.
     pub adapters: HashMap<String, AdapterConfig>,
     /// Sessions multiplexed on ONE provider process before the LRU evicts.
     ///
@@ -346,21 +348,6 @@ impl PoolConfig {
             }
         }
         config
-    }
-
-    /// The pinned permission mode for `provider`, or `default`.
-    #[must_use]
-    pub fn permission_mode(&self, provider: &str) -> String {
-        self.adapters.get(provider).map_or_else(
-            || "default".to_string(),
-            |config| config.permission_mode.clone(),
-        )
-    }
-
-    /// Whether the registry knows how to spawn `provider`.
-    #[must_use]
-    pub fn knows(&self, provider: &str) -> bool {
-        self.adapters.contains_key(provider)
     }
 }
 
@@ -567,6 +554,11 @@ pub struct AcpPool {
     store: Store,
     events: crate::events::EventSink,
     config: PoolConfig,
+    /// The LIVE adapter registry: seeded from [`PoolConfig::adapters`], grown
+    /// by [`AcpPool::register_adapter`] and shrunk by
+    /// [`AcpPool::unregister_adapter`]. Keyed by the same string as
+    /// `providers`, so one key is one spawn recipe AND at most one process.
+    adapters: StdMutex<HashMap<String, AdapterConfig>>,
     providers: tokio::sync::Mutex<HashMap<String, Arc<ProviderProcess>>>,
     /// One spawn at a time per provider, held INSTEAD of the `providers` map
     /// lock: `AdapterProcess::spawn` runs initialize plus the mode assertion and
@@ -590,6 +582,7 @@ impl AcpPool {
         Arc::new(Self {
             store,
             events,
+            adapters: StdMutex::new(config.adapters.clone()),
             config,
             providers: tokio::sync::Mutex::new(HashMap::new()),
             spawn_locks: StdMutex::new(HashMap::new()),
@@ -601,11 +594,74 @@ impl AcpPool {
         })
     }
 
-    /// The adapter registry this pool validates `fleet/acp_session_create`
-    /// against.
+    /// The tuning this pool was built with. Its `adapters` is the SEED; ask
+    /// [`AcpPool::knows`] and [`AcpPool::permission_mode`] about the live
+    /// registry.
     #[must_use]
     pub const fn config(&self) -> &PoolConfig {
         &self.config
+    }
+
+    /// Whether the live registry knows how to spawn `provider`.
+    #[must_use]
+    pub fn knows(&self, provider: &str) -> bool {
+        self.adapters.lock().is_ok_and(|adapters| adapters.contains_key(provider))
+    }
+
+    /// The pinned permission mode for `provider`, or `default`.
+    #[must_use]
+    pub fn permission_mode(&self, provider: &str) -> String {
+        self.adapters
+            .lock()
+            .ok()
+            .and_then(|adapters| {
+                adapters.get(provider).map(|config| config.permission_mode.clone())
+            })
+            .unwrap_or_else(|| "default".to_string())
+    }
+
+    /// Add `adapter` to the live registry under `key`, so a session whose
+    /// `provider` is `key` spawns from THIS recipe on its first prompt.
+    ///
+    /// This is how a task gets its own adapter process: register under a
+    /// synthetic key (`claude-agent-acp#task:<id>`) whose recipe carries the
+    /// task's command wrapper, environment and permission mode, and the pool's
+    /// one-process-per-key rule does the isolation. Replaces an existing entry;
+    /// a process already running under `key` keeps the recipe it was spawned
+    /// with until it stops.
+    pub fn register_adapter(&self, key: impl Into<String>, adapter: AdapterConfig) {
+        if let Ok(mut adapters) = self.adapters.lock() {
+            adapters.insert(key.into(), adapter);
+        }
+    }
+
+    /// Remove `key` from the live registry and stop its process, if one is
+    /// running. Returns whether `key` was registered.
+    ///
+    /// The stop is INTENTIONAL, exactly like the idle sweep's: it neither counts
+    /// on the breaker nor leaves a phantom `exited` row on the health pane, and
+    /// the breaker and spawn-lock entries for the key go with it so a fleet of
+    /// short-lived task keys does not accrete bookkeeping. Sessions hosted on
+    /// the process converge through the ordinary exit path. A spawn still in
+    /// flight under `key` is not interrupted: it lands in `providers` as usual
+    /// and the idle sweep reclaims it once its tenants leave, so a caller that
+    /// wants a clean stop tears its sessions down first.
+    pub async fn unregister_adapter(&self, key: &str) -> bool {
+        let was_registered =
+            self.adapters.lock().is_ok_and(|mut adapters| adapters.remove(key).is_some());
+        if let Ok(mut locks) = self.spawn_locks.lock() {
+            locks.remove(key);
+        }
+        if let Ok(mut circuits) = self.circuits.lock() {
+            circuits.remove(key);
+        }
+        let process = self.providers.lock().await.remove(key);
+        if let Some(process) = process {
+            tracing::info!(provider = %key, "stopping the adapter process of an unregistered key");
+            process.stopping.store(true, Ordering::Relaxed);
+            process.process.kill();
+        }
+        was_registered
     }
 
     /// Hand one prompt to the recipient's OWN session (never a broadcast
@@ -1049,8 +1105,12 @@ impl AcpPool {
         if let Some(existing) = self.live_process(provider).await {
             return Ok(existing);
         }
-        let config =
-            self.config.adapters.get(provider).cloned().ok_or_else(|| AcpError::Spawn {
+        let config = self
+            .adapters
+            .lock()
+            .ok()
+            .and_then(|adapters| adapters.get(provider).cloned())
+            .ok_or_else(|| AcpError::Spawn {
                 adapter: provider.to_string(),
                 source: std::io::Error::new(
                     std::io::ErrorKind::NotFound,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -1,0 +1,193 @@
+//! One ACP session on the chat bus, from either door.
+//!
+//! `fleet/acp_session_create` and a task caller need the same write: mint the
+//! `fleet_session` + `fleet_acp_session` PAIR for a scope. It is ONE
+//! transaction here and both doors call it, so the RPC and a task cannot drift
+//! into two slightly different rows for the same thing. Nothing is spawned: the
+//! pool starts the adapter lazily on the first prompt, so a session that never
+//! receives a message costs nothing but a row.
+
+use ainb_hangar_core::clock::{HangarClock, SystemClock};
+use ainb_hangar_core::idgen::SystemIdGen;
+use ainb_hangar_store::repo::fleet::{FleetSessionPatch, NewFleetEvent, ObservationAuthority};
+use ainb_hangar_store::repo::fleet_acp_session::{
+    FleetAcpSessionError, FleetAcpSessionRepo, FleetAcpSessionRow, NewFleetAcpSession,
+};
+use sqlx::SqlitePool;
+
+use crate::events::EventSink;
+
+/// Why [`ensure`] refused.
+///
+/// The first two are the caller's fault and render as `invalid_params` on the
+/// wire; [`EnsureError::Store`] is the daemon's and renders as `internal`.
+#[derive(Debug, thiserror::Error)]
+pub enum EnsureError {
+    /// The provider token is in neither the pool's registry nor the built-ins.
+    #[error(
+        "unknown ACP provider {provider:?}; known adapters are {} and {}",
+        ainb_acp::config::CLAUDE_ADAPTER,
+        ainb_acp::config::CODEX_ADAPTER
+    )]
+    UnknownProvider {
+        /// The token that was asked for.
+        provider: String,
+    },
+    /// The scope already has a live session for a DIFFERENT provider or cwd.
+    #[error(
+        "scope_key {scope_key:?} is already held by a session whose {field} is {held:?}, \
+         not {asked:?}; stop it before creating a different one"
+    )]
+    ScopeHeld {
+        /// The contested scope.
+        scope_key: String,
+        /// Which column disagrees: `provider` or `cwd`.
+        field: &'static str,
+        /// What the incumbent session has.
+        held: String,
+        /// What the caller asked for.
+        asked: String,
+    },
+    /// `SQLite` failed.
+    #[error("acp session create: {0}")]
+    Store(#[from] FleetAcpSessionError),
+}
+
+/// Find the live ACP session for `scope_key`, or mint one: the `fleet_session`
+/// + `fleet_acp_session` pair under one key, in one transaction, no spawn.
+///
+/// `scope_key` defaults to `session:<session_key>` (a private scope). Idempotent
+/// per LIVE scope, but only while the caller asked for the same session:
+/// answering a `codex-acp` create with a live `claude-agent-acp` key would
+/// silently hand back a session that prompts a DIFFERENT agent than the caller
+/// believes it is driving, and answering a create for `~/work/api` with a
+/// session rooted at `~/work/web` would run every later prompt against a
+/// different repository. Both misroute in silence for the whole life of the
+/// scope, so both are [`EnsureError::ScopeHeld`].
+///
+/// The provider is validated against the ADAPTER REGISTRY, not the schema: the
+/// store only length-checks `provider` so the next adapter needs no migration,
+/// which makes this the one place an unknown token is refused. With no pool
+/// installed (the daemon is still booting, or a test) the built-in names stand
+/// in for it.
+pub async fn ensure(
+    pool: &SqlitePool,
+    events: &EventSink,
+    provider: &str,
+    cwd: &str,
+    scope_key: Option<&str>,
+) -> Result<FleetAcpSessionRow, EnsureError> {
+    let acp = crate::acp_pool::active_handle().await;
+    let known = acp.as_ref().map_or_else(
+        || ainb_acp::config::AdapterConfig::is_known_adapter(provider),
+        |pool| pool.config().knows(provider),
+    );
+    if !known {
+        return Err(EnsureError::UnknownProvider {
+            provider: provider.to_string(),
+        });
+    }
+    let permission_mode = acp.as_ref().map_or_else(
+        || "default".to_string(),
+        |pool| pool.config().permission_mode(provider),
+    );
+
+    let session_key = FleetAcpSessionRepo::mint_session_key(&SystemIdGen);
+    let scope_key = scope_key.map_or_else(|| format!("session:{session_key}"), str::to_string);
+    let now = SystemClock.now_ms();
+    let event = NewFleetEvent {
+        event_id: format!("acp-session-create:{session_key}"),
+        session_key: session_key.clone(),
+        observed_at: now,
+        authority: ObservationAuthority::Authoritative,
+        event_type: "acp_session_created".to_string(),
+        payload: serde_json::json!({
+            "provider": provider,
+            "cwd": cwd,
+            "scopeKey": scope_key,
+            "permissionMode": permission_mode,
+        })
+        .to_string(),
+        patch: FleetSessionPatch {
+            // `acp` on the WIRE, with the concrete adapter in
+            // `fleet_acp_session.provider`. The snapshot maps this token to
+            // `FleetProvider::Acp`; anything else would render as Unknown.
+            provider: Some(crate::acp_pool::ACP_PROVIDER_TOKEN.to_string()),
+            cwd: Some(cwd.to_string()),
+            display_name: crate::fleet::display_name_for_cwd(cwd),
+            management_state: Some("MANAGED".to_string()),
+            capabilities: Some(acp_capabilities()),
+            confidence: Some("HIGH".to_string()),
+            lifecycle_state: Some("IDLE".to_string()),
+            attention_state: Some("NONE".to_string()),
+            transport_health: Some("HEALTHY".to_string()),
+            ..FleetSessionPatch::default()
+        },
+    };
+    let (row, revision) = FleetAcpSessionRepo::insert_with_fleet_session(
+        pool,
+        &NewFleetAcpSession {
+            session_key: session_key.clone(),
+            scope_key,
+            provider: provider.to_string(),
+            cwd: cwd.to_string(),
+            permission_mode,
+            state: "IDLE".to_string(),
+            created_at: now,
+            last_active_at: now,
+        },
+        &event,
+    )
+    .await?;
+    // The scope was ALREADY held by a live session, so this create replayed
+    // onto it instead of minting the key above. Graft 4 rejects the same class
+    // of replay on `fleet_message`; this is its ACP twin.
+    if row.session_key != session_key {
+        let mismatch = if row.provider == provider {
+            (row.cwd != cwd).then(|| ("cwd", row.cwd.clone(), cwd.to_string()))
+        } else {
+            Some(("provider", row.provider.clone(), provider.to_string()))
+        };
+        if let Some((field, held, asked)) = mismatch {
+            return Err(EnsureError::ScopeHeld {
+                scope_key: row.scope_key,
+                field,
+                held,
+                asked,
+            });
+        }
+    }
+    if let Some(revision) = revision {
+        events.emit_fleet_revision(revision);
+    }
+    Ok(row)
+}
+
+/// EXACTLY the actions Phase 5 wires, and nothing else.
+///
+/// `action_capability` gates on this JSON before any handler runs, so an unset
+/// flag is a Rejected receipt rather than an action that reaches the pool and
+/// fails somewhere less legible.
+fn acp_capabilities() -> String {
+    serde_json::to_string(&ainb_hangar_proto::fleet::FleetCapabilities {
+        structured_answer: true,
+        structured_dismiss: false,
+        approvals: true,
+        approval_session: false,
+        send_prompt: true,
+        continue_turn: false,
+        retry: false,
+        interrupt: true,
+        start: false,
+        stop: true,
+        restart: false,
+        kill: true,
+        archive: false,
+        // An ACP session has no pane. Leaving these true would make the tmux
+        // surfaces offer attach/paste for a session that can never honour it.
+        tmux_attach: false,
+        tmux_text: false,
+        verified_picker: false,
+    })
+    .unwrap_or_else(|_| "{}".to_string())
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -23,16 +23,20 @@ use crate::events::EventSink;
 
 /// Why [`ensure`] refused.
 ///
-/// The first two are the caller's fault and render as `invalid_params` on the
-/// wire; [`EnsureError::Store`] is the daemon's and renders as `internal`.
+/// Everything but [`EnsureError::Store`] is the caller's fault and renders as
+/// `invalid_params` on the wire; `Store` is the daemon's and renders as
+/// `internal`.
 #[derive(Debug, thiserror::Error)]
 pub enum EnsureError {
+    /// A session rooted nowhere cannot be prompted.
+    #[error("cwd must not be empty")]
+    EmptyCwd,
+    /// An explicit scope that is blank is a typo, not a request for a private
+    /// scope (leave it out for that).
+    #[error("scope_key must not be empty")]
+    EmptyScopeKey,
     /// The provider token is in neither the pool's registry nor the built-ins.
-    #[error(
-        "unknown ACP provider {provider:?}; known adapters are {} and {}",
-        ainb_acp::config::CLAUDE_ADAPTER,
-        ainb_acp::config::CODEX_ADAPTER
-    )]
+    #[error("unknown ACP provider {provider:?}; it is not in the adapter registry")]
     UnknownProvider {
         /// The token that was asked for.
         provider: String,
@@ -81,6 +85,15 @@ pub async fn ensure(
     cwd: &str,
     scope_key: Option<&str>,
 ) -> Result<FleetAcpSessionRow, EnsureError> {
+    // Validated HERE, not at the RPC door: the task caller comes through the
+    // same function and must not be able to mint a rootless or blank-scoped
+    // session either.
+    if cwd.trim().is_empty() {
+        return Err(EnsureError::EmptyCwd);
+    }
+    if scope_key.is_some_and(|scope| scope.trim().is_empty()) {
+        return Err(EnsureError::EmptyScopeKey);
+    }
     let acp = crate::acp_pool::active_handle().await;
     let known = acp.as_ref().map_or_else(
         || ainb_acp::config::AdapterConfig::is_known_adapter(provider),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -1,17 +1,21 @@
 //! One ACP session on the chat bus, from either door.
 //!
-//! `fleet/acp_session_create` and a task caller need the same write: mint the
-//! `fleet_session` + `fleet_acp_session` PAIR for a scope. It is ONE
-//! transaction here and both doors call it, so the RPC and a task cannot drift
-//! into two slightly different rows for the same thing. Nothing is spawned: the
-//! pool starts the adapter lazily on the first prompt, so a session that never
-//! receives a message costs nothing but a row.
+//! `fleet/acp_session_create` and a task caller need the same two writes: mint
+//! the `fleet_session` + `fleet_acp_session` PAIR for a scope, and put a prompt
+//! on the bus with its PENDING delivery leg. Each is ONE transaction here and
+//! both doors call it, so the RPC and a task cannot drift into two slightly
+//! different rows for the same thing. Neither spawns anything: the pool starts
+//! the adapter lazily on the first prompt, so a session that never receives a
+//! message costs nothing but a row.
 
 use ainb_hangar_core::clock::{HangarClock, SystemClock};
-use ainb_hangar_core::idgen::SystemIdGen;
+use ainb_hangar_core::idgen::{IdGen, SystemIdGen};
 use ainb_hangar_store::repo::fleet::{FleetSessionPatch, NewFleetEvent, ObservationAuthority};
 use ainb_hangar_store::repo::fleet_acp_session::{
     FleetAcpSessionError, FleetAcpSessionRepo, FleetAcpSessionRow, NewFleetAcpSession,
+};
+use ainb_hangar_store::repo::fleet_message::{
+    FleetMessageError, FleetMessageRepo, NewFleetMessage,
 };
 use sqlx::SqlitePool;
 
@@ -161,6 +165,43 @@ pub async fn ensure(
         events.emit_fleet_revision(revision);
     }
     Ok(row)
+}
+
+/// Put `text` on the bus addressed to `session_key`.
+///
+/// One `user` message row in the session's own scope plus its PENDING delivery
+/// leg, in one transaction. Returns the message id the caller hands to
+/// `AcpPool::submit_prompt`.
+///
+/// The leg is what the pool resolves at turn end, so a prompt that skipped
+/// this would have no receipt for anyone to read. `sender` names the door
+/// (`operator`, `task:<id>`); the timeline shows it and nothing routes on it.
+pub async fn enqueue(
+    pool: &SqlitePool,
+    session_key: &str,
+    sender: &str,
+    text: &str,
+) -> Result<String, FleetMessageError> {
+    let scope_key = FleetAcpSessionRepo::get(pool, session_key)
+        .await?
+        .map_or_else(|| format!("session:{session_key}"), |row| row.scope_key);
+    let row = FleetMessageRepo::insert_message_with_deliveries(
+        pool,
+        &NewFleetMessage {
+            id: SystemIdGen.new_ulid(),
+            request_id: None,
+            request_fingerprint: None,
+            scope_key,
+            origin_message_id: None,
+            sender: sender.to_string(),
+            kind: "user".to_string(),
+            body: text.to_string(),
+            created_at: SystemClock.now_ms(),
+        },
+        std::slice::from_ref(&session_key.to_string()),
+    )
+    .await?;
+    Ok(row.id)
 }
 
 /// EXACTLY the actions Phase 5 wires, and nothing else.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -84,7 +84,7 @@ pub async fn ensure(
     let acp = crate::acp_pool::active_handle().await;
     let known = acp.as_ref().map_or_else(
         || ainb_acp::config::AdapterConfig::is_known_adapter(provider),
-        |pool| pool.config().knows(provider),
+        |pool| pool.knows(provider),
     );
     if !known {
         return Err(EnsureError::UnknownProvider {
@@ -93,7 +93,7 @@ pub async fn ensure(
     }
     let permission_mode = acp.as_ref().map_or_else(
         || "default".to_string(),
-        |pool| pool.config().permission_mode(provider),
+        |pool| pool.permission_mode(provider),
     );
 
     let session_key = FleetAcpSessionRepo::mint_session_key(&SystemIdGen);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -19,6 +19,11 @@ use crate::run_loop::{DaemonConfig, run};
 /// ([`acp_pool::converge_dirty_sessions_at_boot`], run from [`boot`]), the
 /// process-exit path and the turn-deadline sweep all fan out to.
 pub mod acp_pool;
+/// One ACP session on the chat bus, from either door: [`acp_session::ensure`]
+/// mints the `fleet_session` + `fleet_acp_session` pair for a scope and
+/// [`acp_session::enqueue`] puts a prompt on the bus with its PENDING leg.
+/// `fleet/acp_session_create` and a task caller share these two transactions.
+pub mod acp_session;
 /// Beads CLI adapter — shells out to `bd` and parses `--json` (P2.2).
 ///
 /// The answer router (spec P2): deliver one attention answer from any surface,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5901,9 +5901,9 @@ fn normalize_picker_text(value: &str) -> String {
 /// `session_key`, in ONE transaction, with NO process spawn.
 ///
 /// R3's entry point. Without it no ACP recipient can ever exist, and
-/// `message_send` deliberately never auto-provisions one. The pool spawns the
-/// adapter lazily on the first prompt, so a create that never receives a message
-/// costs nothing but a row.
+/// `message_send` deliberately never auto-provisions one. The write itself is
+/// [`crate::acp_session::ensure`], shared with the task executor; this handler
+/// is the capability gate and the parameter check in front of it.
 async fn handle_fleet_acp_session_create(
     pool: &SqlitePool,
     req: &RpcRequest,
@@ -5912,8 +5912,8 @@ async fn handle_fleet_acp_session_create(
     use ainb_hangar_proto::fleet::{
         FLEET_CAPABILITY_ACP_SPAWN, FleetAcpSessionCreateParams, FleetAcpSessionCreateResult,
     };
-    use ainb_hangar_store::repo::fleet::{FleetSessionPatch, NewFleetEvent, ObservationAuthority};
-    use ainb_hangar_store::repo::fleet_acp_session::{FleetAcpSessionRepo, NewFleetAcpSession};
+
+    use crate::acp_session::EnsureError;
 
     require_fleet_capability(FLEET_CAPABILITY_ACP_SPAWN)?;
     let params: FleetAcpSessionCreateParams = parse_params(req, "{ provider, cwd, scope_key? }")?;
@@ -5923,134 +5923,24 @@ async fn handle_fleet_acp_session_create(
     if params.scope_key.as_deref().is_some_and(|scope| scope.trim().is_empty()) {
         return Err(invalid_params("scope_key must not be empty"));
     }
-    // Validated against the ADAPTER REGISTRY, not the schema: the store only
-    // length-checks `provider` so the next adapter needs no migration, which
-    // makes this the one place an unknown token is refused.
-    let acp = crate::acp_pool::active_handle().await;
-    let known = acp.as_ref().map_or_else(
-        || ainb_acp::config::AdapterConfig::is_known_adapter(&params.provider),
-        |pool| pool.config().knows(&params.provider),
-    );
-    if !known {
-        return Err(invalid_params(&format!(
-            "unknown ACP provider {:?}; known adapters are {} and {}",
-            params.provider,
-            ainb_acp::config::CLAUDE_ADAPTER,
-            ainb_acp::config::CODEX_ADAPTER
-        )));
-    }
-    let permission_mode = acp.as_ref().map_or_else(
-        || "default".to_string(),
-        |pool| pool.config().permission_mode(&params.provider),
-    );
-
-    let session_key = FleetAcpSessionRepo::mint_session_key(&SystemIdGen);
-    let scope_key = params.scope_key.clone().unwrap_or_else(|| format!("session:{session_key}"));
-    let now = SystemClock.now_ms();
-    let event = NewFleetEvent {
-        event_id: format!("acp-session-create:{session_key}"),
-        session_key: session_key.clone(),
-        observed_at: now,
-        authority: ObservationAuthority::Authoritative,
-        event_type: "acp_session_created".to_string(),
-        payload: serde_json::json!({
-            "provider": params.provider,
-            "cwd": params.cwd,
-            "scopeKey": scope_key,
-            "permissionMode": permission_mode,
-        })
-        .to_string(),
-        patch: FleetSessionPatch {
-            // `acp` on the WIRE, with the concrete adapter in
-            // `fleet_acp_session.provider`. The snapshot maps this token to
-            // `FleetProvider::Acp`; anything else would render as Unknown.
-            provider: Some(crate::acp_pool::ACP_PROVIDER_TOKEN.to_string()),
-            cwd: Some(params.cwd.clone()),
-            display_name: crate::fleet::display_name_for_cwd(&params.cwd),
-            management_state: Some("MANAGED".to_string()),
-            capabilities: Some(acp_capabilities()),
-            confidence: Some("HIGH".to_string()),
-            lifecycle_state: Some("IDLE".to_string()),
-            attention_state: Some("NONE".to_string()),
-            transport_health: Some("HEALTHY".to_string()),
-            ..FleetSessionPatch::default()
-        },
-    };
-    let (row, revision) = FleetAcpSessionRepo::insert_with_fleet_session(
+    let row = crate::acp_session::ensure(
         pool,
-        &NewFleetAcpSession {
-            session_key: session_key.clone(),
-            scope_key,
-            provider: params.provider.clone(),
-            cwd: params.cwd.clone(),
-            permission_mode,
-            state: "IDLE".to_string(),
-            created_at: now,
-            last_active_at: now,
-        },
-        &event,
+        events,
+        &params.provider,
+        &params.cwd,
+        params.scope_key.as_deref(),
     )
     .await
-    .map_err(|error| internal(&format!("acp session create: {error}")))?;
-    // The scope was ALREADY held by a live session, so this create replayed onto
-    // it instead of minting the key above. Idempotent only while the caller
-    // asked for the same SESSION: answering a `codex-acp` create with a live
-    // `claude-agent-acp` key would silently hand back a session that prompts a
-    // DIFFERENT agent than the caller believes it is driving, and answering a
-    // create for `~/work/api` with a session rooted at `~/work/web` would run
-    // every later prompt against a different repository. Both misroute in
-    // silence for the whole life of the scope. Graft 4 rejects the same class
-    // of replay on `fleet_message`; this is its ACP twin.
-    if row.session_key != session_key {
-        let mismatch = if row.provider == params.provider {
-            (row.cwd != params.cwd).then(|| ("cwd", row.cwd.clone(), params.cwd.clone()))
-        } else {
-            Some(("provider", row.provider.clone(), params.provider.clone()))
-        };
-        if let Some((field, held, asked)) = mismatch {
-            return Err(invalid_params(&format!(
-                "scope_key {:?} is already held by a session whose {field} is {held:?}, \
-                 not {asked:?}; stop it before creating a different one",
-                row.scope_key
-            )));
+    .map_err(|error| match error {
+        EnsureError::UnknownProvider { .. } | EnsureError::ScopeHeld { .. } => {
+            invalid_params(&error.to_string())
         }
-    }
-    if let Some(revision) = revision {
-        events.emit_fleet_revision(revision);
-    }
+        EnsureError::Store(_) => internal(&error.to_string()),
+    })?;
     to_value(&FleetAcpSessionCreateResult {
         session_key: row.session_key,
         scope_key: row.scope_key,
     })
-}
-
-/// EXACTLY the actions Phase 5 wires, and nothing else.
-///
-/// `action_capability` gates on this JSON before any handler runs, so an unset
-/// flag is a Rejected receipt rather than an action that reaches the pool and
-/// fails somewhere less legible.
-fn acp_capabilities() -> String {
-    serde_json::to_string(&ainb_hangar_proto::fleet::FleetCapabilities {
-        structured_answer: true,
-        structured_dismiss: false,
-        approvals: true,
-        approval_session: false,
-        send_prompt: true,
-        continue_turn: false,
-        retry: false,
-        interrupt: true,
-        start: false,
-        stop: true,
-        restart: false,
-        kill: true,
-        archive: false,
-        // An ACP session has no pane. Leaving these true would make the tmux
-        // surfaces offer attach/paste for a session that can never honour it.
-        tmux_attach: false,
-        tmux_text: false,
-        verified_picker: false,
-    })
-    .unwrap_or_else(|_| "{}".to_string())
 }
 
 /// One chat delivery to an ACP recipient: persist nothing new, just hand the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -6001,7 +6001,7 @@ async fn execute_acp_action(
             // An operator prompt joins the SAME bus a chat message does, so it
             // gets a message row, a delivery leg, and a threaded reply rather
             // than a turn nothing can correlate afterwards.
-            match acp_operator_message(pool, &session.session_key, text).await {
+            match crate::acp_session::enqueue(pool, &session.session_key, "operator", text).await {
                 Ok(message_id) => {
                     let outcome = acp.submit_prompt(&session.session_key, &message_id, text).await;
                     match outcome {
@@ -6168,42 +6168,6 @@ fn acp_permission_receipt(
             Some("no live ACP session for this key".to_string()),
         ),
     }
-}
-
-/// Persist an operator's direct `SendPrompt` as a chat message plus its leg, so
-/// the ACP turn resolves through exactly one receipt path.
-async fn acp_operator_message(
-    pool: &SqlitePool,
-    session_key: &str,
-    text: &str,
-) -> Result<String, sqlx::Error> {
-    use ainb_hangar_store::repo::fleet_acp_session::FleetAcpSessionRepo;
-    use ainb_hangar_store::repo::fleet_message::{FleetMessageRepo, NewFleetMessage};
-
-    let scope_key = FleetAcpSessionRepo::get(pool, session_key)
-        .await?
-        .map_or_else(|| format!("session:{session_key}"), |row| row.scope_key);
-    let row = FleetMessageRepo::insert_message_with_deliveries(
-        pool,
-        &NewFleetMessage {
-            id: SystemIdGen.new_ulid(),
-            request_id: None,
-            request_fingerprint: None,
-            scope_key,
-            origin_message_id: None,
-            sender: "operator".to_string(),
-            kind: "user".to_string(),
-            body: text.to_string(),
-            created_at: SystemClock.now_ms(),
-        },
-        std::slice::from_ref(&session_key.to_string()),
-    )
-    .await
-    .map_err(|error| match error {
-        ainb_hangar_store::repo::fleet_message::FleetMessageError::Sql(sql) => sql,
-        other => sqlx::Error::Protocol(other.to_string()),
-    })?;
-    Ok(row.id)
 }
 
 fn action_capability(

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5901,9 +5901,9 @@ fn normalize_picker_text(value: &str) -> String {
 /// `session_key`, in ONE transaction, with NO process spawn.
 ///
 /// R3's entry point. Without it no ACP recipient can ever exist, and
-/// `message_send` deliberately never auto-provisions one. The write itself is
-/// [`crate::acp_session::ensure`], shared with the task executor; this handler
-/// is the capability gate and the parameter check in front of it.
+/// `message_send` deliberately never auto-provisions one. The write and its
+/// validation are [`crate::acp_session::ensure`], shared with the task
+/// executor; this handler is the capability gate in front of it.
 async fn handle_fleet_acp_session_create(
     pool: &SqlitePool,
     req: &RpcRequest,
@@ -5917,12 +5917,6 @@ async fn handle_fleet_acp_session_create(
 
     require_fleet_capability(FLEET_CAPABILITY_ACP_SPAWN)?;
     let params: FleetAcpSessionCreateParams = parse_params(req, "{ provider, cwd, scope_key? }")?;
-    if params.cwd.trim().is_empty() {
-        return Err(invalid_params("cwd must not be empty"));
-    }
-    if params.scope_key.as_deref().is_some_and(|scope| scope.trim().is_empty()) {
-        return Err(invalid_params("scope_key must not be empty"));
-    }
     let row = crate::acp_session::ensure(
         pool,
         events,
@@ -5932,10 +5926,8 @@ async fn handle_fleet_acp_session_create(
     )
     .await
     .map_err(|error| match error {
-        EnsureError::UnknownProvider { .. } | EnsureError::ScopeHeld { .. } => {
-            invalid_params(&error.to_string())
-        }
         EnsureError::Store(_) => internal(&error.to_string()),
+        _ => invalid_params(&error.to_string()),
     })?;
     to_value(&FleetAcpSessionCreateResult {
         session_key: row.session_key,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -401,6 +401,45 @@ async fn a_turn_puts_one_message_on_the_timeline_and_every_chunk_in_the_transcri
     }
 }
 
+/// The receipt names WHY the turn stopped whenever that is not the ordinary
+/// finish, in one shape on both sides of `turn_succeeded`.
+///
+/// A turn the agent ended for want of budget is DELIVERED (its reply landed)
+/// carrying `stop=max_tokens`: that is the "finished vs ran out" distinction a
+/// task caller needs without opening the transcript, and the only stop token
+/// the pool writes on a success. A refusal is FAILED with the same `stop=`
+/// token after `turn_failed`, so one parser reads both shapes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_receipt_names_the_stop_reason_on_both_sides_of_success() {
+    // `fake-session-2` is the SECOND adapter session this process mints, so it
+    // is the refused one: the budget turn below resolves before it is asked
+    // for.
+    let (_dir, store, pool) = harness(&[
+        ("FAKE_ACP_CHUNKS", "1"),
+        ("FAKE_ACP_STOP_REASON", "max_tokens"),
+        ("FAKE_ACP_FAIL_TURN_SESSIONS", "fake-session-2"),
+    ])
+    .await;
+
+    let budget = seed_session(&store, "acp:budget").await;
+    let message_id = seed_message(&store, &budget.session_key, "go").await;
+    pool.submit_prompt(&budget.session_key, &message_id, "go").await;
+    let (state, detail) = await_terminal(&store, &message_id, &budget.session_key).await;
+    assert_eq!(state, "DELIVERED", "{detail:?}");
+    assert_eq!(
+        detail.as_deref(),
+        Some("stop=max_tokens"),
+        "the reply landed, and the receipt says the agent stopped on budget"
+    );
+
+    let refused = seed_session(&store, "acp:refused").await;
+    let message_id = seed_message(&store, &refused.session_key, "go").await;
+    pool.submit_prompt(&refused.session_key, &message_id, "go").await;
+    let (state, detail) = await_terminal(&store, &message_id, &refused.session_key).await;
+    assert_eq!(state, "FAILED", "{detail:?}");
+    assert_eq!(detail.as_deref(), Some("turn_failed; stop=refusal"));
+}
+
 /// Two sessions multiplexed on ONE adapter process keep their transcripts
 /// apart. Cross-attribution would put one tenant's output in another's log.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -353,8 +353,10 @@ async fn a_turn_puts_one_message_on_the_timeline_and_every_chunk_in_the_transcri
     let (state, detail) = await_terminal(&store, &message_id, &session.session_key).await;
     assert_eq!(state, "DELIVERED", "detail: {detail:?}");
     assert_eq!(
-        detail, None,
-        "a first-ever turn resumed nothing, so its receipt carries no resume fingerprint"
+        detail.as_deref(),
+        Some("stop=EndTurn"),
+        "a first-ever turn resumed nothing, so its receipt carries the stop reason and no \
+         resume fingerprint"
     );
 
     // Timeline: exactly ONE agent row, threaded to the prompt.
@@ -707,10 +709,10 @@ async fn the_deadline_sweep_cancels_only_the_overdue_session() {
     assert_eq!(
         delivery_state(&store, &healthy_message, &healthy.session_key).await,
         // A brand-new session resumed NOTHING, so its receipt detail stays
-        // NULL: the resume fingerprint is reserved for a context that was
-        // actually lost and rebuilt, and it carries nothing about the deadline
-        // that hit its neighbour either.
-        Some(("DELIVERED".to_string(), None)),
+        // Only the stop reason: the resume fingerprint is reserved for a
+        // context that was actually lost and rebuilt, and it carries nothing
+        // about the deadline that hit its neighbour either.
+        Some(("DELIVERED".to_string(), Some("stop=EndTurn".to_string()))),
         "the other tenant of the same process is untouched"
     );
     assert!(
@@ -1780,7 +1782,7 @@ async fn a_forced_rebuild_keeps_the_session_key(shape: &str, key: &str) {
     assert_eq!(state, "DELIVERED", "{detail:?}");
     assert_eq!(
         detail.as_deref(),
-        Some("resume=reprimed"),
+        Some("stop=EndTurn; resume=reprimed"),
         "the receipt names the path that built this turn's context"
     );
 
@@ -1892,7 +1894,7 @@ async fn an_opaque_load_failure_rebuilds_on_the_second_attempt_only() {
     );
     assert_eq!(
         detail.as_deref(),
-        Some("resume=reprimed"),
+        Some("stop=EndTurn; resume=reprimed"),
         "and it must say so: the context came from the corpus, not from the adapter"
     );
 
@@ -1948,7 +1950,7 @@ async fn a_load_that_reverts_the_mode_is_re_applied_and_the_turn_proceeds() {
     );
     assert_eq!(
         detail.as_deref(),
-        Some("resume=loaded"),
+        Some("stop=EndTurn; resume=loaded"),
         "and the session was RESUMED, not rebuilt"
     );
     let lines = rpc_log(&log);
@@ -2093,7 +2095,7 @@ async fn a_load_whose_history_replays_writes_zero_transcript_rows() {
     pool.submit_prompt(&session.session_key, &message_id, "hi").await;
     let (state, detail) = await_terminal(&store, &message_id, &session.session_key).await;
     assert_eq!(state, "DELIVERED", "{detail:?}");
-    assert_eq!(detail.as_deref(), Some("resume=loaded"));
+    assert_eq!(detail.as_deref(), Some("stop=EndTurn; resume=loaded"));
 
     let rows = transcript(&store, &session.session_key).await;
     let kinds: Vec<&str> = rows.iter().map(|(kind, _)| kind.as_str()).collect();
@@ -2269,8 +2271,9 @@ async fn a_first_ever_turn_in_a_burst_is_fresh_not_reprimed() {
     let (state, detail) = await_terminal(&store, &first, &session.session_key).await;
     assert_eq!(state, "DELIVERED", "{detail:?}");
     assert_eq!(
-        detail, None,
-        "a session with no history rebuilt nothing, so its receipt claims nothing"
+        detail.as_deref(),
+        Some("stop=EndTurn"),
+        "a session with no history rebuilt nothing, so its receipt claims no resume path"
     );
     assert!(
         !transcript(&store, &session.session_key)

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -1862,6 +1862,53 @@ async fn a_runtime_registered_adapter_gets_its_own_process_and_removal_reaps_it(
     assert_eq!(state, "DELIVERED", "{detail:?}");
 }
 
+/// `acp_session::ensure` is the ONE door both the create RPC and a task caller
+/// come through, so the input guards live IN it: a blank cwd, an explicit blank
+/// scope or an unknown provider is refused before anything is written,
+/// whichever door asked.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ensure_refuses_a_blank_cwd_or_scope_before_writing_anything() {
+    use ainb_hangar_daemon::acp_session::{EnsureError, ensure};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+    let events = EventBroker::new().sink();
+    let claude = ainb_acp::config::CLAUDE_ADAPTER;
+
+    let blank_cwd = ensure(store.pool(), &events, claude, "  ", None).await;
+    assert!(
+        matches!(blank_cwd, Err(EnsureError::EmptyCwd)),
+        "{blank_cwd:?}"
+    );
+    let blank_scope = ensure(store.pool(), &events, claude, "/tmp/acp", Some(" ")).await;
+    assert!(
+        matches!(blank_scope, Err(EnsureError::EmptyScopeKey)),
+        "{blank_scope:?}"
+    );
+    let unknown = ensure(store.pool(), &events, "gpt-agent-acp", "/tmp/acp", None).await;
+    assert!(
+        matches!(unknown, Err(EnsureError::UnknownProvider { .. })),
+        "{unknown:?}"
+    );
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM fleet_acp_session")
+        .fetch_one(store.pool())
+        .await
+        .expect("count");
+    assert_eq!(rows, 0, "a refused ensure persists nothing");
+
+    // The same call with sound inputs mints the pair, and a replay finds it.
+    let minted = ensure(store.pool(), &events, claude, "/tmp/acp", Some("task:t-9"))
+        .await
+        .expect("mint");
+    let found = ensure(store.pool(), &events, claude, "/tmp/acp", Some("task:t-9"))
+        .await
+        .expect("replay");
+    assert_eq!(
+        found.session_key, minted.session_key,
+        "idempotent per live scope"
+    );
+}
+
 /// A cancel is per SESSION: convergence is idempotent and leaves the scope
 /// reusable without a restart.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -361,10 +361,8 @@ async fn a_turn_puts_one_message_on_the_timeline_and_every_chunk_in_the_transcri
     let (state, detail) = await_terminal(&store, &message_id, &session.session_key).await;
     assert_eq!(state, "DELIVERED", "detail: {detail:?}");
     assert_eq!(
-        detail.as_deref(),
-        Some("stop=EndTurn"),
-        "a first-ever turn resumed nothing, so its receipt carries the stop reason and no \
-         resume fingerprint"
+        detail, None,
+        "a first-ever turn resumed nothing, so its receipt carries no resume fingerprint"
     );
 
     // Timeline: exactly ONE agent row, threaded to the prompt.
@@ -717,10 +715,10 @@ async fn the_deadline_sweep_cancels_only_the_overdue_session() {
     assert_eq!(
         delivery_state(&store, &healthy_message, &healthy.session_key).await,
         // A brand-new session resumed NOTHING, so its receipt detail stays
-        // Only the stop reason: the resume fingerprint is reserved for a
-        // context that was actually lost and rebuilt, and it carries nothing
-        // about the deadline that hit its neighbour either.
-        Some(("DELIVERED".to_string(), Some("stop=EndTurn".to_string()))),
+        // NULL: the resume fingerprint is reserved for a context that was
+        // actually lost and rebuilt, and it carries nothing about the deadline
+        // that hit its neighbour either.
+        Some(("DELIVERED".to_string(), None)),
         "the other tenant of the same process is untouched"
     );
     assert!(
@@ -1930,7 +1928,7 @@ async fn a_forced_rebuild_keeps_the_session_key(shape: &str, key: &str) {
     assert_eq!(state, "DELIVERED", "{detail:?}");
     assert_eq!(
         detail.as_deref(),
-        Some("stop=EndTurn; resume=reprimed"),
+        Some("resume=reprimed"),
         "the receipt names the path that built this turn's context"
     );
 
@@ -2042,7 +2040,7 @@ async fn an_opaque_load_failure_rebuilds_on_the_second_attempt_only() {
     );
     assert_eq!(
         detail.as_deref(),
-        Some("stop=EndTurn; resume=reprimed"),
+        Some("resume=reprimed"),
         "and it must say so: the context came from the corpus, not from the adapter"
     );
 
@@ -2098,7 +2096,7 @@ async fn a_load_that_reverts_the_mode_is_re_applied_and_the_turn_proceeds() {
     );
     assert_eq!(
         detail.as_deref(),
-        Some("stop=EndTurn; resume=loaded"),
+        Some("resume=loaded"),
         "and the session was RESUMED, not rebuilt"
     );
     let lines = rpc_log(&log);
@@ -2243,7 +2241,7 @@ async fn a_load_whose_history_replays_writes_zero_transcript_rows() {
     pool.submit_prompt(&session.session_key, &message_id, "hi").await;
     let (state, detail) = await_terminal(&store, &message_id, &session.session_key).await;
     assert_eq!(state, "DELIVERED", "{detail:?}");
-    assert_eq!(detail.as_deref(), Some("stop=EndTurn; resume=loaded"));
+    assert_eq!(detail.as_deref(), Some("resume=loaded"));
 
     let rows = transcript(&store, &session.session_key).await;
     let kinds: Vec<&str> = rows.iter().map(|(kind, _)| kind.as_str()).collect();
@@ -2419,9 +2417,8 @@ async fn a_first_ever_turn_in_a_burst_is_fresh_not_reprimed() {
     let (state, detail) = await_terminal(&store, &first, &session.session_key).await;
     assert_eq!(state, "DELIVERED", "{detail:?}");
     assert_eq!(
-        detail.as_deref(),
-        Some("stop=EndTurn"),
-        "a session with no history rebuilt nothing, so its receipt claims no resume path"
+        detail, None,
+        "a session with no history rebuilt nothing, so its receipt claims nothing"
     );
     assert!(
         !transcript(&store, &session.session_key)

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -1783,19 +1783,29 @@ async fn a_runtime_registered_adapter_gets_its_own_process_and_removal_reaps_it(
         detail.as_deref().is_some_and(|detail| detail.starts_with("adapter_exit")),
         "the leg names the exit, not a deadline or an operator: {detail:?}"
     );
+    // Only the shared process is left, and no `exited` row lingers for the
+    // removed key: its breaker entry went with it, so the health pane does not
+    // keep advertising a process nobody can prompt.
     let health = pool.health().await;
     let providers: Vec<&str> = health.processes.iter().map(|row| row.provider.as_str()).collect();
     assert_eq!(
         providers,
         [ainb_acp::config::CLAUDE_ADAPTER],
-        "only the shared process survives"
+        "only the shared process survives, with no phantom row for the removed key"
     );
-    assert!(
-        health.processes[0].breaker_failures == 0,
-        "an intentional stop is not a crash on anyone's breaker: {health:?}"
+    let shared_row = health
+        .processes
+        .iter()
+        .find(|row| row.provider == ainb_acp::config::CLAUDE_ADAPTER)
+        .expect("shared process row");
+    assert_eq!(
+        shared_row.breaker_failures, 0,
+        "the neighbour's intentional stop is not a crash on the shared breaker"
     );
 
-    // Nothing respawns under the removed key, and the shared tenant is untouched.
+    // Nothing respawns under the removed key (the registry is consulted before
+    // a spawn lock is minted, and the removal ran under that lock), and the
+    // shared tenant is untouched.
     let after = seed_message(&store, &task.session_key, "ccc").await;
     pool.submit_prompt(&task.session_key, &after, "ccc").await;
     let (state, _) = await_terminal(&store, &after, &task.session_key).await;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -35,6 +35,9 @@
 //! * **I12** transcript wakeups arrive DURING the turn, not at its end.
 //! * **LRU** the oldest idle session is evicted while the process stays warm,
 //!   and a process stops only after its idle window has actually elapsed.
+//! * **Runtime registry** an adapter registered after construction under its
+//!   own key gets its own process, and unregistering the key reaps exactly
+//!   that process.
 //! * **I16 boot** a session a daemon killed with SIGKILL left mid-turn is
 //!   converged at startup, with no pool and no operator.
 //! * **Re-prime corpus is history** the delivery-join corpus stops BELOW the
@@ -137,6 +140,11 @@ async fn harness_with_broker(
 
 /// Create one ACP session pair exactly as `fleet/acp_session_create` does.
 async fn seed_session(store: &Store, session_key: &str) -> FleetAcpSessionRow {
+    seed_session_for(store, session_key, ainb_acp::config::CLAUDE_ADAPTER).await
+}
+
+/// [`seed_session`] on a specific adapter key.
+async fn seed_session_for(store: &Store, session_key: &str, provider: &str) -> FleetAcpSessionRow {
     let scope_key = format!("session:{session_key}");
     let event = NewFleetEvent {
         event_id: format!("acp-session-create:{session_key}"),
@@ -159,7 +167,7 @@ async fn seed_session(store: &Store, session_key: &str) -> FleetAcpSessionRow {
         &NewFleetAcpSession {
             session_key: session_key.to_string(),
             scope_key,
-            provider: ainb_acp::config::CLAUDE_ADAPTER.to_string(),
+            provider: provider.to_string(),
             cwd: "/tmp/acp".to_string(),
             permission_mode: "default".to_string(),
             state: "IDLE".to_string(),
@@ -1675,6 +1683,136 @@ async fn a_zero_session_process_stops_after_its_idle_window() {
         pool.health().await.processes.is_empty(),
         "a tenant-free process is stopped once its idle window has elapsed"
     );
+}
+
+/// An adapter registered AFTER the pool was built, under its own key, is a
+/// process of its own: a session whose provider is that key spawns from the
+/// registered recipe rather than joining the shared provider's process, and
+/// unregistering the key kills exactly that process. This is the isolation a
+/// per-task adapter (`claude-agent-acp#task:<id>`) rests on.
+///
+/// The kill is proven through the store, not the process table: the task
+/// session is left with a HUNG turn when the key is removed, and the only
+/// thing that can resolve that leg inside the test's window is the process
+/// exit path (the deadline sweep is thirty minutes away).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_runtime_registered_adapter_gets_its_own_process_and_removal_reaps_it() {
+    let evidence = tempfile::tempdir().expect("evidence dir");
+    let shared_log = evidence.path().join("shared.log");
+    let task_log = evidence.path().join("task.log");
+    let (_dir, store, pool) = harness(&[
+        ("FAKE_ACP_CHUNKS", "1"),
+        ("FAKE_ACP_RPC_LOG", shared_log.to_str().expect("utf8")),
+    ])
+    .await;
+    let task_key = format!("{}#task:t-1", ainb_acp::config::CLAUDE_ADAPTER);
+    assert!(!pool.knows(&task_key), "the seed registry has no task keys");
+
+    pool.register_adapter(
+        &task_key,
+        ainb_acp::config::AdapterConfig::new(&task_key, "acceptEdits")
+            .command(fake_adapter())
+            .extra_env(vec![
+                ("FAKE_ACP_CHUNKS".to_string(), "1".to_string()),
+                ("FAKE_ACP_HANG_PROMPTS".to_string(), "hang".to_string()),
+                (
+                    "FAKE_ACP_RPC_LOG".to_string(),
+                    task_log.to_str().expect("utf8").to_string(),
+                ),
+            ]),
+    );
+    assert!(pool.knows(&task_key));
+    assert_eq!(
+        pool.permission_mode(&task_key),
+        "acceptEdits",
+        "the registered recipe's mode is what a create would pin"
+    );
+
+    let shared = seed_session(&store, "acp:shared-tenant").await;
+    let task = seed_session_for(&store, "acp:task-tenant", &task_key).await;
+    let shared_message = seed_message(&store, &shared.session_key, "a").await;
+    let task_message = seed_message(&store, &task.session_key, "bb").await;
+    pool.submit_prompt(&shared.session_key, &shared_message, "a").await;
+    pool.submit_prompt(&task.session_key, &task_message, "bb").await;
+    let (state, detail) = await_terminal(&store, &shared_message, &shared.session_key).await;
+    assert_eq!(state, "DELIVERED", "{detail:?}");
+    let (state, detail) = await_terminal(&store, &task_message, &task.session_key).await;
+    assert_eq!(state, "DELIVERED", "{detail:?}");
+
+    // Two processes, one per key: the task did not ride the shared adapter.
+    let health = pool.health().await;
+    let mut providers: Vec<&str> =
+        health.processes.iter().map(|row| row.provider.as_str()).collect();
+    providers.sort_unstable();
+    assert_eq!(
+        providers,
+        [ainb_acp::config::CLAUDE_ADAPTER, task_key.as_str()],
+        "one process under each key"
+    );
+    assert_eq!(
+        rpc_log(&task_log).iter().filter(|line| *line == "spawn").count(),
+        1,
+        "the task's recipe spawned exactly once: {:?}",
+        rpc_log(&task_log)
+    );
+    assert_eq!(
+        rpc_log(&shared_log).iter().filter(|line| *line == "spawn").count(),
+        1,
+        "and the shared adapter spawned exactly once: {:?}",
+        rpc_log(&shared_log)
+    );
+
+    // Leave the task mid-turn, then remove its key.
+    let hung = seed_message(&store, &task.session_key, "hang").await;
+    pool.submit_prompt(&task.session_key, &hung, "hang").await;
+    await_open_turn(&store, &task.session_key).await;
+    assert!(
+        pool.unregister_adapter(&task_key).await,
+        "the key was registered"
+    );
+    assert!(!pool.knows(&task_key));
+    assert!(
+        !pool.unregister_adapter(&task_key).await,
+        "a second removal reports the key already gone"
+    );
+
+    // The hung turn resolved through the exit path: the process really died.
+    let (state, detail) = await_terminal(&store, &hung, &task.session_key).await;
+    assert_eq!(state, "UNKNOWN", "{detail:?}");
+    assert!(
+        detail.as_deref().is_some_and(|detail| detail.starts_with("adapter_exit")),
+        "the leg names the exit, not a deadline or an operator: {detail:?}"
+    );
+    let health = pool.health().await;
+    let providers: Vec<&str> = health.processes.iter().map(|row| row.provider.as_str()).collect();
+    assert_eq!(
+        providers,
+        [ainb_acp::config::CLAUDE_ADAPTER],
+        "only the shared process survives"
+    );
+    assert!(
+        health.processes[0].breaker_failures == 0,
+        "an intentional stop is not a crash on anyone's breaker: {health:?}"
+    );
+
+    // Nothing respawns under the removed key, and the shared tenant is untouched.
+    let after = seed_message(&store, &task.session_key, "ccc").await;
+    pool.submit_prompt(&task.session_key, &after, "ccc").await;
+    let (state, _) = await_terminal(&store, &after, &task.session_key).await;
+    assert_eq!(
+        state, "FAILED",
+        "a prompt on an unregistered key cannot deliver"
+    );
+    assert_eq!(
+        rpc_log(&task_log).iter().filter(|line| *line == "spawn").count(),
+        1,
+        "the removed recipe was never spawned again: {:?}",
+        rpc_log(&task_log)
+    );
+    let shared_again = seed_message(&store, &shared.session_key, "dddd").await;
+    pool.submit_prompt(&shared.session_key, &shared_again, "dddd").await;
+    let (state, detail) = await_terminal(&store, &shared_again, &shared.session_key).await;
+    assert_eq!(state, "DELIVERED", "{detail:?}");
 }
 
 /// A cancel is per SESSION: convergence is idempotent and leaves the scope

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_resume_real.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_resume_real.rs
@@ -306,11 +306,9 @@ async fn a_forced_load_failure_falls_back_to_reprime(adapter: &str, key: &str) {
     .await;
     let (state, detail) = await_terminal(&store, &asked, key).await;
     assert_eq!(state, "DELIVERED", "{detail}");
-    // A delivered leg leads with the adapter's stop reason; the resume path is
-    // appended after it, and that is the half this probe is about.
-    assert!(
-        detail.ends_with("; resume=reprimed"),
-        "the load could not have succeeded, so the rebuild leg must have run: {detail}"
+    assert_eq!(
+        detail, "resume=reprimed",
+        "the load could not have succeeded, so the rebuild leg must have run"
     );
     assert!(
         transcript_kinds(&store, key).await.iter().any(|(kind, payload)| {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_resume_real.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_resume_real.rs
@@ -306,9 +306,11 @@ async fn a_forced_load_failure_falls_back_to_reprime(adapter: &str, key: &str) {
     .await;
     let (state, detail) = await_terminal(&store, &asked, key).await;
     assert_eq!(state, "DELIVERED", "{detail}");
-    assert_eq!(
-        detail, "resume=reprimed",
-        "the load could not have succeeded, so the rebuild leg must have run"
+    // A delivered leg leads with the adapter's stop reason; the resume path is
+    // appended after it, and that is the half this probe is about.
+    assert!(
+        detail.ends_with("; resume=reprimed"),
+        "the load could not have succeeded, so the rebuild leg must have run: {detail}"
     );
     assert!(
         transcript_kinds(&store, key).await.iter().any(|(kind, payload)| {

--- a/docs/hangar/renovation/move1-acp-tasks.md
+++ b/docs/hangar/renovation/move1-acp-tasks.md
@@ -334,17 +334,22 @@ documents. Poll cost is one indexed read per second per running ACP task, capped
 
 ### 2f. RunOutcome mapping
 
-Needs one 3-line pool change so a success carries its stop reason: at `acp_pool.rs:1936-1947`
-the success arm passes `detail = None`; make it `Some(format!("stop={:?}",
-response.stop_reason))`. Additive -- the detail already gets `resume=...` appended the same
-way (`:1959-1963`) and no reader parses it strictly.
+Landed in A4: a leg carries `stop=<reason>` in the ACP wire spelling
+(`acp_pool::stop_reason_token`, snake_case like every other token here), and carries it only
+when the reason is worth naming. An ordinary `EndTurn` writes NO token, exactly as an
+un-rebuilt context writes no `resume=`, so a DELIVERED leg with no `stop=` IS the success
+case.
+
+Read the detail as a `; `-joined TOKEN SET, never by equality: a leg can be `stop=max_tokens;
+resume=reprimed`, and a plain success can be `resume=loaded` rather than NULL. Match on the
+presence and value of the `stop=` token.
 
 | leg `state` | leg `detail` | `RunOutcome` | retry disposition |
 |---|---|---|---|
-| `DELIVERED` | `stop=EndTurn` | `Success(result)` | n/a |
-| `DELIVERED` | `stop=MaxTokens` / `stop=MaxTurnRequests` | `Failed{IterationLimit}` | FreshRetry |
-| `FAILED` | `turn_failed; Refusal` | `Failed{AgentError}` | NoRetry |
-| `FAILED` | `turn_failed; Cancelled` | `Cancelled(result)` | n/a |
+| `DELIVERED` | no `stop=` token | `Success(result)` | n/a |
+| `DELIVERED` | `stop=max_tokens` / `stop=max_turn_requests` | `Failed{IterationLimit}` | FreshRetry |
+| `FAILED` | `turn_failed; stop=refusal` | `Failed{AgentError}` | NoRetry |
+| `FAILED` | `turn_failed; stop=cancelled` | `Cancelled(result)` | n/a |
 | `FAILED` | `spawn_failed` / `mode_unproven` / `turn_unrecorded` | `Failed{SpawnError}` | NoRetry |
 | `FAILED` | `session_gone` | `Failed{ProvisionError}` | NoRetry |
 | `FAILED` | `breaker_open` / `provider_at_capacity` / `queue_full` | `Failed{RuntimeOffline}` | ResumeRetry |


### PR DESCRIPTION
## Summary

Spine step A4 (`docs/hangar/renovation/PLAN.md`, track A; `move1-acp-tasks.md` sections 1g, 2e-2f, 5b, 7 step 4): the three pool prerequisites a task caller needs before `run_acp` (A5) can exist. No behaviour change on the chat path for an ordinary turn.

The four original commits, one concern each:

1. **Stop reason on a delivered leg.** `finish_turn` recorded the adapter's stop reason only on failure; a success folded `EndTurn` / `MaxTokens` / `MaxTurnRequests` into one bare `DELIVERED`. A delivered leg now carries `stop=<reason>` (`DELIVERY_STOP_PREFIX`) when the reason is not the ordinary `EndTurn`, joined to the existing `resume=` suffix the same way. The 2f outcome mapping reads this.
2. **`acp_session::ensure`** extracted from `fleet/acp_session_create`: parameter guards, registry check, permission-mode read, paired insert, live-scope replay guard, one transaction, typed `EnsureError`. The RPC keeps its capability gate and maps onto the same codes and messages, so the socket tests pass unchanged.
3. **`acp_session::enqueue`** extracted from the `SendPrompt` action: message row plus PENDING leg, one transaction, `sender` parameterised (`operator` today, `task:<id>` in A5).
4. **Runtime adapter registry.** `AcpPool` holds a live `adapters` map seeded from `PoolConfig`; `register_adapter(key, AdapterConfig)`, `unregister_adapter(key)`, `knows`, `permission_mode`. `provider_process` and `ensure` read the live map. Unregistering stops the key's process the way the idle sweep does (intentional stop: no breaker count, no phantom health row) and drops its breaker entry.

Not in this PR (A5): `run_acp`, the executor flag, the cancel arm, per-task adapter construction.

## Review round 1: 12 findings fixed, 1 answered

Five further commits, one concern each.

**`fix(hangar-daemon): close the adapter unregister/spawn race`** (findings 1, 2, 3, 10, 11, 12)

`unregister_adapter` removed the registry entry, the spawn lock and the process without ever taking the key's spawn gate, so it raced an in-flight spawn three ways:

* a re-register under the same key could run two unserialised spawns, and the loser was orphaned (never killed, supervisor alive, its `Arc::ptr_eq` removal a no-op);
* a spawn that landed after the removal left a live process under a key the pool says it does not know, which `live_process` then kept serving (the idle sweep only fires at zero tenants, so a busy session was never reclaimed);
* the first prompt after a removal re-created the very `spawn_locks` entry the removal had just deleted, because `provider_process` minted the gate before it looked the key up.

The removal now runs UNDER the gate, and `provider_process` reads the registry twice for two different reasons: before the gate so an unknown key never mints a lock entry, and again inside it (`adapter_config`) so a spawn that was waiting on a removal refuses instead of spawning. Between the two, no process can exist under an unregistered key once `unregister_adapter` returns, which makes the test's "a prompt on an unregistered key cannot deliver" an invariant rather than a race won. Also folds the intentional-stop sequence the idle sweep and the removal had verbatim into one `stop_process`, makes `register_adapter` panic on a poisoned registry lock the way `provider_process` already does rather than silently reporting success, and pins the surviving breaker count by provider key instead of by row index.

**`fix(hangar-daemon): keep an ordinary finish off the delivered leg`** (finding 4)

`stop=EndTurn` fired on every ordinary turn on the operator's primary surface, and it is PREPENDED, so a narrow pane truncated away the `resume=reprimed` half that carries signal to make room for the half that says nothing happened. The token now goes out only for a reason worth naming, exactly how `resume=` already behaves on the same leg: absence means the context was never rebuilt, so absence can mean the turn ended ordinarily. Suppressed at the emit site, not in the renderers (two of them, in two crates), so no proto surface and no renderer change. Reverts the receipt churn in the seven assertions that had been repinned to `stop=EndTurn`.

**`fix(hangar-daemon): persist stop reasons as their ACP wire names`** (findings 5, 6)

`{:?}` put a Rust Debug name (`MaxTokens`) into an operator-facing, DB-persisted, greppable token where every neighbour is snake_case (`adapter_exit`, `turn_failed`, `resume=loaded`) and so is the ACP wire name; `StopReason` is `#[non_exhaustive]` too. An explicit match pins `max_tokens` / `max_turn_requests` / `refusal` / `cancelled` with an `unknown` catch-all. The FAILED arm now carries the same `stop=` prefix as the success arm, so a caller parses one field shape, not two.

**`test(hangar-daemon): pin a non-EndTurn stop reason on a delivered leg`** (finding 7)

Every stop-reason assertion covered `EndTurn`, the one reason the pool no longer writes, so nothing exercised the "finished" versus "ran out of budget" distinction the field exists for. The fake adapter could only answer `end_turn` or `refusal`, so it gets a `FAKE_ACP_STOP_REASON` knob, and the new test drives a DELIVERED leg to `stop=max_tokens` and a refusal to `turn_failed; stop=refusal`.

**`fix(hangar-daemon): guard cwd and scope inside acp_session::ensure`** (findings 8, 9)

The extraction left the two parameter guards behind in the RPC handler, so the second door it exists for, the task caller, could mint a session with `cwd: ""` or a blank scope. Both move into `ensure` as `EnsureError` variants with the Display strings copied verbatim, so the `invalid_params` text on the wire is byte-identical. The unknown-provider refusal stops naming the two built-ins: `knows()` consults a registry that grows at runtime, so a task key that IS registered was missing from a message claiming to enumerate everything known.

**Finding 13, noted not fixed.** `DELIVERY_STOP_PREFIX`, `register_adapter` and `unregister_adapter` still have zero production callers here: one test exercises the register/unregister pair and nothing parses the prefix. That is what "prerequisite" means for this step. A5 lands all three callers (`run_acp` registers the per-task adapter, unregisters it on task end, and reads the stop reason off the leg for the 2f outcome mapping); if A5 slips, this API should come out rather than sit dead.

## Review round 2

Round 2 confirmed 12 of 13 closed and reopened finding 3 with a proven counter-interleaving. Five more commits.

**`fix(hangar-daemon): drop the registry entry before taking its gate`** (finding 3, reopened, and the doc that overclaimed it)

The round-1 dichotomy was wrong. It assumed the gate is always visible to `unregister_adapter`, but a spawn that has passed `knows()` and not yet reached `spawn_locks.entry()` is invisible to that read: it yields `None`, nothing serialises the two, and the spawn's `adapter_config` can still win the registry race, so its process lands under the removed key where `live_process` (which runs BEFORE the `knows` check) keeps serving it. Same hole as the original finding, through a window a few tens of nanoseconds wide.

Removing from `adapters` FIRST and only then reading and taking the gate closes it, no new state. A spawn reads the recipe inside the gate, so it publishes that gate strictly earlier; if the recipe read beats the removal then so did the gate publication, and the `spawn_locks` read that now follows the removal must see it. Every spawn is then either blocked on a gate this call holds, or refused by a registry that no longer has its key. The doc now states that guarantee and the one it does not make.

No test: the interleaving needs a spawn suspended between `knows()` and `adapter_config` while a removal runs, and there is no injection point to hold it there. Adding one would mean test-only state in the spawn path for a race with no production caller yet. The sequential invariant stays covered by `a_runtime_registered_adapter_gets_its_own_process_and_removal_reaps_it`.

**`fix(hangar-daemon): let knows() panic on a poisoned adapter registry`**

`knows` answering `false` on a poisoned lock was harmless while it was advisory. It now gates `provider_process`, so a poisoned registry surfaced as "provider is not in the adapter registry", a claim about the caller's key rather than the mutex that broke. Same `.expect("adapter registry")` as every other load-bearing read of that map.

**`style(hangar-daemon): spell stop_process as a branch, not a predicate`**

`is_some_and` with a closure that kills a process and returns a constant `true` read as a question about the process.

**`docs(hangar): correct the 2f outcome tokens A5 maps from`**

The 2f outcome table named the tokens the design asked for; A4 shipped four differently (no token at all for an ordinary finish, snake_case budget reasons, `stop=` prefix on the failure rows), and the prose still prescribed the `format!("stop={:?}", ..)` this PR rejects. Four silent string-match misses were waiting in A5. Also states the trap that was only implicit: the detail is a `; `-joined token SET, so a success can read `resume=loaded` and a budget stop `stop=max_tokens; resume=reprimed`. Match on the token, not the whole string.

Also fixed: this section's round-1 heading claimed 13 of 13 while the body said finding 13 was a note.

## Forks taken

- **One module, not two.** The plan names `acp_session::ensure` and `acp_message::enqueue`. Both are "one ACP session on the bus" and together are 200 lines, so they share `acp_session.rs`. Split later if a third caller wants only one.
- **`ensure` returns the `FleetAcpSessionRow`**, not just `session_key`: the RPC needs `scope_key` back and the task caller will want `cwd` and `permission_mode` without a second read.
- **`enqueue` returns `FleetMessageError`** instead of squeezing it into `sqlx::Error` as the private helper did. The action receipt still reads `store_error; <error>`.
- **No chat-path change for an ordinary turn.** A DELIVERED ACP receipt renders exactly as it did before this PR; only a `max_tokens` / `max_turn_requests` finish adds a token. Both renderers print `detail` verbatim and nothing parses it.
- **No tombstone map for the removal race.** Finding 3 suggested tombstoning an unregistered key so a late spawn kills instead of inserting. Ordering the two statements in `unregister_adapter` closes it with no new state instead (see round 2 below). What that does NOT buy is "exactly one spawn per key across an unregister then a re-register": a spawn parked between publishing its gate and taking it holds a stale `Arc` while a re-registered spawn mints a fresh one. That needs a generation counter, it is a narrower claim than the one finding 3 asked for, and it has no caller until A5.
- **`UnknownProvider` names the registry rather than listing it.** Enumerating live keys in a refusal would leak synthetic per-task keys into an operator-facing message for no gain.
- **`PoolConfig::knows` / `permission_mode` deleted** rather than left reading the seed: their only caller was the create handler, and a stale registry reader is exactly the bug this step exists to prevent.

## Verification

Fake adapter only (`ainb-acp`'s `fake_acp_adapter`), no credentials.

- `cargo test -p ainb-hangar-daemon --test acp_pool`: 45 passed, 0 failed (43 before this round, plus `a_receipt_names_the_stop_reason_on_both_sides_of_success` and `ensure_refuses_a_blank_cwd_or_scope_before_writing_anything`).
- `cargo test -p ainb-hangar-daemon --lib -- acp_pool`: 2 passed, 0 failed.
- `cargo test -p ainb-hangar-daemon --test rpc_acp`: 11 passed, 0 failed, unchanged. These drive `fleet/acp_session_create` and the `SendPrompt` action over the socket, so both extractions are covered by the tests that existed before them.
- `cargo fmt --all --check` clean.
- **Mutation check on the register/unregister test:** with `process.process.kill()` removed from `unregister_adapter`, the test fails (`delivery ... never resolved`). The reap proof is a turn left hung on the task adapter that can only resolve `UNKNOWN adapter_exit` through the process-exit path; the health-map assertion alone would not have caught a no-op kill.

## Known edges, stated

- A prompt on a session whose provider key was unregistered resolves `FAILED adapter_exit` after the I6 requeue, not `spawn_failed`. Pre-existing behaviour for any registry miss; the test asserts `FAILED` and no respawn, not the token.
- `unregister_adapter` now waits on the key's spawn gate, so it blocks for as long as an in-flight spawn takes (bounded by the adapter spawn timeout). That is the price of a removal that is complete when it returns.
- The narrow interleaving where a spawn passes the pre-gate `knows()` check just as a removal runs can leave an empty `spawn_locks` entry behind for that key. It holds no process and no recipe, and the spawn itself still refuses.
- Two spawns across an unregister then a re-register still do not serialise (stale gate `Arc` versus a fresh gate). Stated on `unregister_adapter`; a generation counter is the fix if A5 ever re-registers a key it has just removed.
