### PR TITLE
fix(daemons): one supervisor row, unless two supervisors are really running

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/daemon.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/daemon.rs
@@ -978,7 +978,23 @@ mod tests {
                 .map(|r| r.kind)
                 .collect();
         view.extend(crate::fleet::daemons::probe::collect_socket_daemons().iter().map(|r| r.kind));
-        assert_eq!(view, CONTROLLABLE.to_vec());
+
+        // SUBSET, not equality. The view is now conditional: the fleet daemon
+        // takes a row only when it is actually running, because ATC is the
+        // supervisor and a permanently-stopped row presented the two as a
+        // choice. So the invariant is the one that matters — every row the view
+        // can show is controllable, so no row ever offers actions the CLI would
+        // reject — rather than "every controllable kind is always on screen".
+        for kind in &view {
+            assert!(
+                CONTROLLABLE.contains(kind),
+                "{} has a row but no lifecycle verbs",
+                kind.id()
+            );
+        }
+        // And the conditional row is still controllable, because hiding a row is
+        // a display decision: `ainb daemon fleet-daemon stop` must keep working.
+        assert!(CONTROLLABLE.contains(&DaemonKind::FleetDaemon));
     }
 
     /// Every argv this module delegates to must actually parse against the real

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -2472,10 +2472,15 @@ mod tests {
         let shared = Mutex::new(Snapshot::default());
         collect_into(&shared);
         let guard = shared.lock().unwrap();
-        assert_eq!(
+        // At most every controllable daemon, and never more. Not equality: the
+        // fleet-daemon row is conditional now (it appears only while one is
+        // actually running, since ATC is the supervisor), so on the machine
+        // running this test it is normally absent.
+        assert!(
+            !guard.rows.is_empty() && guard.rows.len() <= crate::cli::daemon::CONTROLLABLE.len(),
+            "collect published {} rows, expected 1..={}",
             guard.rows.len(),
-            crate::cli::daemon::CONTROLLABLE.len(),
-            "collect publishes every daemon"
+            crate::cli::daemon::CONTROLLABLE.len()
         );
         assert!(
             guard.collected_at_ms > 0,

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -1489,13 +1489,55 @@ pub fn annotate_bridge_config(rows: &mut [DaemonStatus], problem: Option<&str>) 
 /// `now_ms` is the single clock the staleness checks measure against.
 #[must_use]
 pub fn collect_in(ainb_home: &Path, notifyd_base: &Path, now_ms: i64) -> Vec<DaemonStatus> {
-    vec![
+    let mut rows = vec![
         probe_heartbeat_daemon(ainb_home, DaemonKind::Bridge, now_ms),
         probe_notifyd(notifyd_base, now_ms),
         probe_approve_broker(notifyd_base, now_ms),
         probe_atc(ainb_home, now_ms),
-        probe_heartbeat_daemon(ainb_home, DaemonKind::FleetDaemon, now_ms),
-    ]
+    ];
+    // ONE supervisor row, unless there are genuinely two supervisors.
+    //
+    // ATC is the fleet's supervisor and the standalone daemon is the thing it
+    // replaced: `ainb fleet daemon` refuses to start against a fleet ATC owns in
+    // either mode, so on any normal host this row is a permanent "stopped"
+    // occupying a line on the screen whose whole job is to say who is running.
+    // Worse, it presents the two as a CHOICE, which is exactly the competing
+    // control path the supervisor exists to remove.
+    //
+    // It is NOT hidden unconditionally. A daemon that is actually up got there
+    // through `--force-race`, which means two controllers really are sending
+    // into the same panes — the single state an operator most needs to see, and
+    // the one where a tidy screen would be a lie.
+    let mut fleet_daemon = probe_heartbeat_daemon(ainb_home, DaemonKind::FleetDaemon, now_ms);
+    if fleet_daemon_is_visible(&fleet_daemon) {
+        // Say WHY it is on screen. A bare "running" row next to a running ATC
+        // reads as two healthy daemons; it is actually the double-supervision
+        // both of them refuse by default, and it needs to read as a fault.
+        if rows
+            .iter()
+            .any(|r| r.kind == DaemonKind::Atc && r.state != DaemonState::Stopped)
+        {
+            fleet_daemon.state = DaemonState::Degraded;
+            fleet_daemon.reason = format!(
+                "RACING ATC — both are auto-continuing the same panes, and ATC's per-session \
+retry cap cannot hold while this is up. {}",
+                fleet_daemon.reason
+            );
+        }
+        rows.push(fleet_daemon);
+    }
+    rows
+}
+
+/// Does the standalone fleet daemon deserve a row?
+///
+/// Only when it is not stopped. `Stopped` is the state ATC's existence makes
+/// permanent; every other state means something is running, or that we could not
+/// tell — and `Unknown` earns a row for the same reason `Running` does, since
+/// "the probe itself failed" is not evidence that nothing is racing ATC.
+#[must_use]
+fn fleet_daemon_is_visible(row: &DaemonStatus) -> bool {
+    !matches!(row.state, DaemonState::Stopped)
 }
 
 /// The socket-probed daemons, appended after the heartbeat ones.
@@ -2877,7 +2919,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_in_returns_all_heartbeat_daemons_in_stable_order() {
+    fn collect_in_returns_the_heartbeat_daemons_in_stable_order() {
         let home = TempDir::new().unwrap();
         let notifyd = TempDir::new().unwrap();
         let rows = collect_in(
@@ -2885,14 +2927,83 @@ mod tests {
             notifyd.path(),
             super::super::heartbeat::now_ms(),
         );
-        assert_eq!(rows.len(), 5);
+        assert_eq!(rows.len(), 4);
         assert_eq!(rows[0].kind, DaemonKind::Bridge);
         assert_eq!(rows[1].kind, DaemonKind::Notifyd);
         assert_eq!(rows[2].kind, DaemonKind::ApproveBroker);
         assert_eq!(rows[3].kind, DaemonKind::Atc);
-        assert_eq!(rows[4].kind, DaemonKind::FleetDaemon);
         // Empty homes → everything stopped, never a false running.
         assert!(rows.iter().all(|r| r.state == DaemonState::Stopped));
+    }
+
+    #[test]
+    fn a_stopped_fleet_daemon_gets_no_row_beside_the_supervisor() {
+        // ATC is the supervisor and the standalone daemon is what it replaced,
+        // so on a normal host that row is a permanent "stopped" presenting the
+        // two as a choice — the competing control path the supervisor exists to
+        // remove, still on the screen an operator reads to see who is running.
+        let home = TempDir::new().unwrap();
+        let notifyd = TempDir::new().unwrap();
+        let rows = collect_in(
+            home.path(),
+            notifyd.path(),
+            super::super::heartbeat::now_ms(),
+        );
+        assert!(
+            !rows.iter().any(|r| r.kind == DaemonKind::FleetDaemon),
+            "a stopped fleet daemon must not take a row: {:?}",
+            rows.iter().map(|r| r.kind).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_running_fleet_daemon_still_gets_a_row_and_is_named_as_racing() {
+        // The one state a tidy screen must NOT hide. A daemon that is up got
+        // there through --force-race, so two controllers really are sending into
+        // the same panes and ATC's retry cap cannot hold.
+        let home = TempDir::new().unwrap();
+        let notifyd = TempDir::new().unwrap();
+        let now = super::super::heartbeat::now_ms();
+
+        // A live fleet-daemon heartbeat: this process, so the pid checks pass.
+        let daemons = home.path().join("daemons");
+        std::fs::create_dir_all(&daemons).unwrap();
+        let hb = super::super::heartbeat::DaemonHeartbeat::starting();
+        hb.write_in(home.path(), DaemonKind::FleetDaemon.id()).unwrap();
+
+        // And a beating ATC, so the two genuinely overlap.
+        let atc = home.path().join("atc").join("tower");
+        std::fs::create_dir_all(&atc).unwrap();
+        std::fs::write(
+            atc.join("meta.json"),
+            r#"{"name":"tower","heartbeat_enabled":true,"heartbeat_interval_min":15,"idle_pause_min":60}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            atc.join("heartbeat-state.json"),
+            format!(
+                r#"{{"last_heartbeat_ms":{},"last_active_ms":{},"continue_counts":{{}}}}"#,
+                now - 1000,
+                now - 1000
+            ),
+        )
+        .unwrap();
+
+        let rows = collect_in(home.path(), notifyd.path(), now);
+        let fleet = rows
+            .iter()
+            .find(|r| r.kind == DaemonKind::FleetDaemon)
+            .expect("a live fleet daemon must keep its row");
+        assert_eq!(
+            fleet.state,
+            DaemonState::Degraded,
+            "racing ATC is a fault, not a healthy second daemon"
+        );
+        assert!(
+            fleet.reason.contains("RACING ATC"),
+            "the row must say why it is here: {}",
+            fleet.reason
+        );
     }
 
     /// The Daemons view is meant to be the ONE place every managed process

--- a/plugins/ainb-fleet/skills/daemons/SKILL.md
+++ b/plugins/ainb-fleet/skills/daemons/SKILL.md
@@ -40,11 +40,26 @@ shows `stopped` with a stale-heartbeat reason here.
 | **phone bridge** | `bridge` | heartbeat file (`~/.agents-in-a-box/daemons/bridge.json`) + pid-identity cross-check |
 | **notifyd** | `notifyd` | PID-file liveness + bound Unix socket + sqlite DB file present |
 | **ATC** | `atc` | mode-dependent: in `full`, the most-recently-beating instance's `heartbeat-state.json` (timer-driven; no resident pid); in `lite`, the scan loop's own heartbeat + pid |
-| **fleet daemon** | `fleet-daemon` | heartbeat file + pid-identity cross-check |
+| **fleet daemon** | `fleet-daemon` | heartbeat file + pid-identity cross-check — **conditional row**, see below |
 
-Rows are always emitted in this exact order (bridge, notifyd, ATC, fleet
-daemon), even when every daemon is stopped — so "everything stopped" is a
-legible four-row table, never an empty one.
+Rows are emitted in this exact order (bridge, notifyd, ATC, then the fleet
+daemon when it has a row), even when every daemon is stopped — so "everything
+stopped" is a legible table, never an empty one.
+
+**The fleet daemon is a conditional row.** ATC is the fleet's supervisor and the
+standalone daemon is what it replaced, so a permanently-stopped row for it
+presented the two as a choice — the competing control path the supervisor exists
+to remove, still on the screen you read to see who is running. It is therefore
+listed only when it is NOT stopped.
+
+That is deliberately not "always hidden". A daemon that is up got there through
+`--force-race`, which means two controllers really are auto-continuing the same
+panes and ATC's per-session retry cap cannot hold. That row appears, reports
+`degraded`, and its reason opens with `RACING ATC`. Hiding it would make the one
+state you most need to see the only one the screen does not show.
+
+The row is only a display decision: `ainb daemon fleet-daemon start|stop|restart`
+keeps working whether or not a row is drawn.
 
 ## Run
 


### PR DESCRIPTION
## The report

> "in the latest installed one, I can still see fleet daemon and atc as two lines in the daemon screen"

Two causes, and the second one is the real bug.

The installed build (`1.23.2`, cut 20:00 UTC) predates #814 by thirty minutes, so it has none of the supervisor work. But **upgrading would not have fixed it**: on current main the Daemons screen still lists both rows.

## What was wrong

#814 made ATC the fleet's single supervisor and neutralised the standalone daemon — `ainb fleet daemon` now refuses to start against a fleet ATC owns in either mode. What it did not do is take the daemon off the screen. So the surface an operator reads to see *who is running* still showed:

```
ATC           ● running   tower · FULL(claude) · every 15m
fleet daemon  ○ stopped   no heartbeat — not running this session
```

A permanently-stopped row, presenting the two as a choice. That is precisely the competing control path the supervisor exists to remove, still visible — and the exclusivity being enforced underneath does not help, because nothing on screen says so.

The original brief asked for *one operator-visible ATC supervisor*. It also asked not to reduce existing Fleet functionality, and I read those as "keep the daemon, keep its row". Keeping the CLI verb was right; keeping the row was not. Those are different things, and only one of them is what the operator looks at.

## What changed

The fleet-daemon row is now conditional: it is listed only when it is **not** stopped.

Deliberately not "always hidden". A daemon that is UP got there through `--force-race`, which means two controllers really are auto-continuing the same panes and ATC's per-session retry cap cannot hold while it runs. That is the single state an operator most needs to see, and a tidy screen that omitted it would be worse than the two rows it replaced. So when it does appear it is not a neutral second daemon — it reports `degraded` and its reason opens with `RACING ATC`.

```
normal                          anomalous (--force-race)
  ATC   ● running  FULL(claude)   ATC           ● running   FULL(claude)
  (no fleet daemon row)           fleet daemon  ◐ degraded  RACING ATC — both are
                                                auto-continuing the same panes…
```

Hiding a row is a display decision only. `ainb daemon fleet-daemon start|stop|restart` and `ainb fleet daemon` keep working exactly as before, whether or not a row is drawn — which is what keeps "no reduction in Fleet functionality" true.

## The tests that had to change, and why that is the interesting part

Two tests asserted `the view lists exactly the controllable set`. A conditional row breaks that by construction, so the temptation is to relax them to nothing. The invariant that actually earns its keep is the **subset**: every row the view can show is controllable, so no row ever offers an action the CLI would reject. That is the property those tests were really protecting; equality was just the cheapest way to spell it while the list was fixed.

Added: a stopped daemon gets no row beside the supervisor, and a running one keeps its row AND is named as racing.

## Verification

2219 lib tests pass. The 3 failures are the host-config env-var tests that fail identically on unmodified `origin/main`. No new clippy warnings in the touched file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fleet daemon status now appears only when the daemon is running or otherwise active.
  * Active race conditions with ATC are clearly reported as degraded with a “RACING ATC” reason.
  * Daemon status displays and controls now remain accurate when the fleet daemon is stopped or conditionally hidden.

* **Documentation**
  * Updated daemon monitoring documentation to describe conditional visibility, status reporting, row ordering, and available lifecycle commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->