### PR TITLE
feat(hangar-daemon): stream a process run's transcript live (spine A2)

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/event_outbox.rs
@@ -22,10 +22,17 @@
 //!
 //! ## Which events persist
 //!
-//! ALL of them. Where the inbox is a curated digest, the outbox is the RAW log:
-//! [`outbox_fields`] is total over [`HangarEvent`], so every variant — including
-//! the high-frequency `TaskProgress` / `TaskMessage` heartbeats — lands a row.
-//! A new variant is a compile error to ignore.
+//! Everything emitted through [`EventSink::emit`](crate::events::EventSink::emit).
+//! Where the inbox is a curated digest, the outbox is the RAW log:
+//! [`outbox_fields`] is total over [`HangarEvent`], so a new variant is a compile
+//! error to ignore.
+//!
+//! Two variants never reach it at runtime: a running task's `TaskMessage` /
+//! `TaskProgress` ride
+//! [`emit_live`](crate::events::EventSink::emit_live) instead, whose durable
+//! source is the provider's own `{logs}/<provider>.jsonl` rather than this log
+//! (track A step A2). Their arms below exist for totality only, exactly like the
+//! attention arms.
 //!
 //! ## Delivery semantics
 //!
@@ -66,6 +73,9 @@ pub fn outbox_fields(event: &HangarEvent) -> (&'static str, Option<String>) {
         HangarEvent::TaskStarted { task_id, .. } => {
             ("task_started", Some(task_id.as_str().to_string()))
         }
+        // A2: emitted through `emit_live`, which never reaches the outbox drain.
+        // These arms keep the match total (a new variant is still a compile error
+        // to ignore); the transcript's durable source is the provider's jsonl.
         HangarEvent::TaskProgress { task_id, .. } => {
             ("task_progress", Some(task_id.as_str().to_string()))
         }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
@@ -74,6 +74,17 @@ pub struct ScopedEvent {
 pub struct EventBroker {
     tx: broadcast::Sender<ScopedEvent>,
     outbox_tx: Option<mpsc::UnboundedSender<ScopedEvent>>,
+    /// A running task's TRANSCRIPT (`TaskMessage` / `TaskProgress`, track A step
+    /// A2). Its OWN channel, for the same reason the three below have theirs:
+    /// volume. One chatty run emits a `TaskMessage` per stream-json line, which
+    /// on the shared workspace channel would evict other tasks' and other
+    /// WORKSPACES' `TaskStarted` / `TaskFinished` / `IssueUpdated` from the
+    /// 256-slot ring. Those are the events a lagging plugin cannot recover: a
+    /// transcript line deliberately does NOT arm a snapshot re-pull, so nothing
+    /// polls afterwards and a dropped `TaskFinished` pins a run banner at
+    /// "running" forever. Partitioned, a burst can only evict transcript lines,
+    /// which the `board_card_timeline` re-read backfills.
+    task_stream_tx: broadcast::Sender<ScopedEvent>,
     /// The FLEET-WIDE attention channel (spec P2). Attention events are NOT
     /// workspace-partitioned — the control centre answers for the whole host, and
     /// a hand-started session has no workspace to scope by — so `AttentionRaised`
@@ -125,6 +136,7 @@ impl EventBroker {
     #[must_use]
     pub fn new() -> Self {
         let (tx, _rx) = broadcast::channel(CHANNEL_CAPACITY);
+        let (task_stream_tx, _tsrx) = broadcast::channel(CHANNEL_CAPACITY);
         let (attention_tx, _arx) = broadcast::channel(CHANNEL_CAPACITY);
         let (fleet_tx, _frx) = broadcast::channel(CHANNEL_CAPACITY);
         let (message_tx, _mrx) = broadcast::channel(CHANNEL_CAPACITY);
@@ -132,6 +144,7 @@ impl EventBroker {
         let (notify_tx, _nrx) = broadcast::channel(CHANNEL_CAPACITY);
         Self {
             tx,
+            task_stream_tx,
             outbox_tx: None,
             attention_tx,
             fleet_tx,
@@ -152,6 +165,7 @@ impl EventBroker {
     #[must_use]
     pub fn with_outbox() -> (Self, mpsc::UnboundedReceiver<ScopedEvent>) {
         let (tx, _rx) = broadcast::channel(CHANNEL_CAPACITY);
+        let (task_stream_tx, _tsrx) = broadcast::channel(CHANNEL_CAPACITY);
         let (attention_tx, _arx) = broadcast::channel(CHANNEL_CAPACITY);
         let (fleet_tx, _frx) = broadcast::channel(CHANNEL_CAPACITY);
         let (message_tx, _mrx) = broadcast::channel(CHANNEL_CAPACITY);
@@ -161,6 +175,7 @@ impl EventBroker {
         (
             Self {
                 tx,
+                task_stream_tx,
                 outbox_tx: Some(outbox_tx),
                 attention_tx,
                 fleet_tx,
@@ -177,6 +192,7 @@ impl EventBroker {
     pub fn sink(&self) -> EventSink {
         EventSink {
             tx: self.tx.clone(),
+            task_stream_tx: self.task_stream_tx.clone(),
             outbox_tx: self.outbox_tx.clone(),
             attention_tx: self.attention_tx.clone(),
             fleet_tx: self.fleet_tx.clone(),
@@ -192,6 +208,16 @@ impl EventBroker {
     #[must_use]
     pub fn subscribe(&self) -> broadcast::Receiver<ScopedEvent> {
         self.tx.subscribe()
+    }
+
+    /// A fresh receiver onto the running-task TRANSCRIPT stream (track A step
+    /// A2). The RPC server opens one per `workspace/subscribe` alongside
+    /// [`Self::subscribe`], and filters it by the same workspace: the two are one
+    /// subscription split across two channels so a transcript burst cannot evict
+    /// the lifecycle events beside it.
+    #[must_use]
+    pub fn subscribe_task_stream(&self) -> broadcast::Receiver<ScopedEvent> {
+        self.task_stream_tx.subscribe()
     }
 
     /// A fresh receiver onto the FLEET-WIDE attention stream (spec P2). The RPC
@@ -244,6 +270,7 @@ impl EventBroker {
 #[derive(Debug, Clone)]
 pub struct EventSink {
     tx: broadcast::Sender<ScopedEvent>,
+    task_stream_tx: broadcast::Sender<ScopedEvent>,
     outbox_tx: Option<mpsc::UnboundedSender<ScopedEvent>>,
     attention_tx: broadcast::Sender<HangarEvent>,
     fleet_tx: broadcast::Sender<i64>,
@@ -289,8 +316,12 @@ impl EventSink {
     /// Same shape as [`Self::emit_attention`]: a stream whose durable source is
     /// somewhere other than the event log stays off the log. Best-effort and
     /// non-blocking: with no live subscriber the broadcast is dropped.
+    ///
+    /// It rides its OWN broadcast, not [`Self::emit`]'s: see
+    /// [`EventBroker::task_stream_tx`] for why a run's line volume must not share
+    /// a ring with the lifecycle events nothing re-polls.
     pub fn emit_live(&self, workspace_id: &str, event: HangarEvent) {
-        let _ = self.tx.send(ScopedEvent {
+        let _ = self.task_stream_tx.send(ScopedEvent {
             workspace_id: workspace_id.to_string(),
             event,
         });

--- a/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
@@ -273,6 +273,29 @@ impl EventSink {
         let _ = self.tx.send(scoped);
     }
 
+    /// Publish `event` to LIVE workspace subscribers only, skipping the durable
+    /// outbox: the channel for a running task's transcript
+    /// ([`HangarEvent::TaskMessage`] / [`HangarEvent::TaskProgress`], track A
+    /// step A2).
+    ///
+    /// [`Self::emit`] appends one `event_log` row per event, and every one of
+    /// those commits takes the single `SQLite` write lock the whole control plane
+    /// shares. A run's transcript is thousands of lines, so logging it there
+    /// would put the transcript through that lock a second time for no gain: it
+    /// is ALREADY durable in the provider's `{logs}/<provider>.jsonl`, and
+    /// `hangar/board_card_timeline` re-reads it from exactly there. A subscriber
+    /// that missed the live lines backfills from that read, not from a replay.
+    ///
+    /// Same shape as [`Self::emit_attention`]: a stream whose durable source is
+    /// somewhere other than the event log stays off the log. Best-effort and
+    /// non-blocking: with no live subscriber the broadcast is dropped.
+    pub fn emit_live(&self, workspace_id: &str, event: HangarEvent) {
+        let _ = self.tx.send(ScopedEvent {
+            workspace_id: workspace_id.to_string(),
+            event,
+        });
+    }
+
     /// Publish an attention `event` on the FLEET-WIDE attention stream (spec P2).
     ///
     /// Only `HangarEvent::AttentionRaised` / `AttentionAnswered` belong here. This

--- a/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/events.rs
@@ -84,6 +84,13 @@ pub struct EventBroker {
     /// polls afterwards and a dropped `TaskFinished` pins a run banner at
     /// "running" forever. Partitioned, a burst can only evict transcript lines,
     /// which the `board_card_timeline` re-read backfills.
+    ///
+    /// ponytail: this confines the RING, not the connection's outbound queue.
+    /// Both forwarders clone the same 64-deep `out_tx` and await on it, so a
+    /// transcript flood can still head-of-line-block the lifecycle forwarder and
+    /// stop it draining `tx`. Closing that needs a per-stream outbound queue or a
+    /// lossy transcript send, which is A6-scale work; the ring split is what makes
+    /// the common case (a slow reader, not a stopped one) safe.
     task_stream_tx: broadcast::Sender<ScopedEvent>,
     /// The FLEET-WIDE attention channel (spec P2). Attention events are NOT
     /// workspace-partitioned — the control centre answers for the whole host, and
@@ -417,7 +424,7 @@ pub fn encode_notification_frame(method: &str, params: &serde_json::Value) -> Ve
 mod tests {
     use super::*;
     use ainb_hangar_core::ids::TaskId;
-    use ainb_hangar_proto::events::TaskResult;
+    use ainb_hangar_proto::events::{MessageKind, TaskResult};
 
     fn finished(task: &str) -> HangarEvent {
         HangarEvent::TaskFinished {
@@ -559,6 +566,57 @@ mod tests {
             outbox_rx.recv().await.unwrap().event,
             HangarEvent::TaskFinished { .. }
         ));
+    }
+
+    /// `emit_live` must land on the TRANSCRIPT stream and NOT on the workspace
+    /// broadcast. Reverting it to `self.tx.send(...)` leaves every other test in
+    /// the suite green (both forwarders feed one socket, so the tripwire cannot
+    /// tell, and the `event_log` assertion only catches a revert to `emit`), which
+    /// would silently restore the eviction the split exists to prevent.
+    ///
+    /// `try_recv` rather than `recv`, deliberately: both sends complete before the
+    /// first check, so an empty channel is a decided answer, not a slow one. A
+    /// revert fails on the first line instead of hanging the suite.
+    #[test]
+    fn emit_live_lands_on_the_transcript_stream_and_not_the_workspace_one() {
+        let (broker, mut outbox_rx) = EventBroker::with_outbox();
+        let mut transcript = broker.subscribe_task_stream();
+        let mut workspace = broker.subscribe();
+
+        broker.sink().emit_live(
+            "ws-a",
+            HangarEvent::TaskMessage {
+                task_id: TaskId::from_str("t1".to_string()).unwrap(),
+                kind: MessageKind::Agent,
+                body: "a streamed line".into(),
+            },
+        );
+        // The sentinel proves the other two channels are EMPTY of the line rather
+        // than merely behind it.
+        broker.sink().emit("ws-a", finished("t1"));
+
+        let got = transcript.try_recv().expect("the transcript stream carries the line");
+        assert_eq!(got.workspace_id, "ws-a");
+        assert!(matches!(got.event, HangarEvent::TaskMessage { .. }));
+        assert!(
+            transcript.try_recv().is_err(),
+            "the workspace sentinel must NOT ride the transcript stream"
+        );
+
+        assert!(
+            matches!(
+                workspace.try_recv().unwrap().event,
+                HangarEvent::TaskFinished { .. }
+            ),
+            "the workspace stream's first item is the sentinel, not the transcript line"
+        );
+        assert!(
+            matches!(
+                outbox_rx.try_recv().unwrap().event,
+                HangarEvent::TaskFinished { .. }
+            ),
+            "the durable outbox never carries a transcript line"
+        );
     }
 
     /// A wakeup with no live subscriber is dropped, never an error: the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -420,6 +420,10 @@ async fn serve_conn(
     // The connection's event subscription: at most one forwarder; a
     // re-subscribe replaces it (last subscribe wins, no duplicate delivery).
     let mut forwarder: Option<tokio::task::JoinHandle<()>> = None;
+    // The TRANSCRIPT half of the same workspace subscription (track A step A2),
+    // on its own broadcast so a run's line volume cannot evict the lifecycle
+    // events `forwarder` carries. Registered and replaced with it.
+    let mut task_stream_forwarder: Option<tokio::task::JoinHandle<()>> = None;
     // The connection's FLEET-WIDE attention subscription (spec P2), independent
     // of the workspace forwarder: a connection may hold both (workspace events +
     // attention nudges) or either. A re-subscribe replaces it.
@@ -457,6 +461,7 @@ async fn serve_conn(
                 h.as_ref().is_some_and(|h| !h.is_finished())
             };
             let subscribed = live(&forwarder)
+                || live(&task_stream_forwarder)
                 || live(&attention_forwarder)
                 || live(&fleet_forwarder)
                 || live(&message_forwarder)
@@ -479,6 +484,10 @@ async fn serve_conn(
             // the snapshot query runs stay buffered in this receiver and are
             // drained after the acknowledgement, closing the snapshot-to-live
             // handoff gap without allowing an event to precede the response.
+            let pending_task_stream_rx = req.as_ref().ok().and_then(|request| {
+                (request.method == methods::WORKSPACE_SUBSCRIBE)
+                    .then(|| broker.subscribe_task_stream())
+            });
             let pending_attention_rx = req.as_ref().ok().and_then(|request| {
                 (request.method == methods::ATTENTION_SUBSCRIBE)
                     .then(|| broker.subscribe_attention())
@@ -536,6 +545,20 @@ async fn serve_conn(
                             ws.clone(),
                             out_tx.clone(),
                         ));
+                        // A2: the same subscription's TRANSCRIPT half, drained
+                        // from its own broadcast so a chatty run cannot evict the
+                        // lifecycle events above it (see `EventBroker`). Two
+                        // forwarders means a `TaskFinished` can overtake the last
+                        // `TaskMessage` of its run; both consumers key on the task
+                        // id and neither orders across the two, so the only effect
+                        // is a banner clearing a beat early.
+                        if let Some(old) = task_stream_forwarder.take() {
+                            old.abort();
+                        }
+                        let rx = pending_task_stream_rx
+                            .unwrap_or_else(|| broker.subscribe_task_stream());
+                        task_stream_forwarder =
+                            Some(spawn_event_forwarder(rx, ws.clone(), out_tx.clone()));
                         // T1 resume: a client that carried a `since_seq` catches
                         // up on every durable event after that cursor before it
                         // goes live. Best-effort (a read fault is logged, the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -548,10 +548,16 @@ async fn serve_conn(
                         // A2: the same subscription's TRANSCRIPT half, drained
                         // from its own broadcast so a chatty run cannot evict the
                         // lifecycle events above it (see `EventBroker`). Two
-                        // forwarders means a `TaskFinished` can overtake the last
-                        // `TaskMessage` of its run; both consumers key on the task
-                        // id and neither orders across the two, so the only effect
-                        // is a banner clearing a beat early.
+                        // forwarders means the two streams are unordered against
+                        // each other in BOTH directions: a `TaskFinished` can
+                        // overtake its run's last `TaskMessage`, and a
+                        // `TaskMessage` can overtake the `TaskStarted` that opens
+                        // the banner. Every consumer guards on the task id and on
+                        // the banner already existing, so the late arrival is
+                        // dropped either way (pinned by
+                        // `banner_hides_on_task_finished_event`); the visible
+                        // effect is a banner clearing a beat early, or a first
+                        // transcript line missed before it opens.
                         if let Some(old) = task_stream_forwarder.take() {
                             old.abort();
                         }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1062,10 +1062,13 @@ fn subscribe_after_id(req: &RpcRequest) -> Option<String> {
 /// so a replayed frame is byte-identical to the live one it mirrors — a resuming
 /// subscriber cannot tell catch-up from live.
 ///
-/// The backlog is **paged in-loop**, not read once: the durable log holds one
-/// row per emitted event (including high-frequency `TaskProgress`/`TaskMessage`
-/// heartbeats), so a single active task can exceed [`REPLAY_BATCH`] during a
-/// disconnect. A single capped read delivers the OLDEST `REPLAY_BATCH` events
+/// The backlog is **paged in-loop**, not read once: the durable log holds one row
+/// per emitted event, so a busy workspace (a board advancing a run through its
+/// lifecycle, a squad fanning out) can exceed [`REPLAY_BATCH`] during a
+/// disconnect. Transcript lines are NOT in that backlog since track A step A2
+/// (they ride `emit_live`, off the log), so the volume here is lower than it
+/// once was, but the paging is what makes the read correct rather than merely
+/// sufficient. A single capped read delivers the OLDEST `REPLAY_BATCH` events
 /// and would silently drop the newest `(since_seq + REPLAY_BATCH, head]` window
 /// — the live forwarder (registered before this call) only carries events
 /// emitted after subscribe, and the ack advances the client's cursor to the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -552,10 +552,10 @@ async fn serve_conn(
                         // each other in BOTH directions: a `TaskFinished` can
                         // overtake its run's last `TaskMessage`, and a
                         // `TaskMessage` can overtake the `TaskStarted` that opens
-                        // the banner. Every consumer guards on the task id and on
-                        // the banner already existing, so the late arrival is
-                        // dropped either way (pinned by
-                        // `banner_hides_on_task_finished_event`); the visible
+                        // the banner. Only `TaskStarted` constructs a banner and
+                        // every consumer guards on the task id, so a late arrival
+                        // is dropped either way and leaves no state behind (pinned
+                        // by `banner_hides_on_task_finished_event`); the visible
                         // effect is a banner clearing a beat early, or a first
                         // transcript line missed before it opens.
                         if let Some(old) = task_stream_forwarder.take() {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -1376,6 +1376,16 @@ async fn execute_claimed(
     // spawns a retry child). `provider` was captured up front (before the setup
     // umbrella) so both the timeout terminalise and this run attribute the same
     // backend.
+
+    // A2: bind this run's live transcript stream before the spawn, so every
+    // stream-json line the headless provider writes reaches subscribed plugins
+    // as a `TaskMessage` while the run is still in flight. It is the first
+    // producer for an event the board timeline overlay, the run banner and task
+    // detail have all been able to consume since P3. Bound per RUN (it carries
+    // this task's id + workspace) on the runner the claim loop already clones
+    // per run, NOT on the daemon-wide `RunnerConfig`. The interactive arm below
+    // takes the same value and ignores it: that path captures no stdout.
+    let runner = &runner.with_task_stream(&task.workspace_id, &task.id, events);
     let provider_run = async {
         if mode == Mode::Interactive {
             // The interactive path is DELIBERATELY unsandboxed (see

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -1753,11 +1753,16 @@ impl Runner {
         // never deadlock on a full pipe buffer.
         let tail_lines = self.cfg.tail_lines;
         let stream = self.stream.clone();
-        // A2: aborted if this future is DROPPED (the cancel arm in `run_loop`).
-        // A bare `JoinHandle` detaches on drop, so the reader would keep draining
-        // the pipe and emitting `TaskMessage` (plus the closing `TaskProgress`)
-        // after the task had already finalised and pushed `TaskFinished`, painting
-        // transcript onto a run the operator was told was over.
+        // A2: aborted if this future is DROPPED, which is the cancel arm in
+        // `run_loop` and ALSO the `child.wait()` error below (`status?` returns
+        // without awaiting this handle). A bare `JoinHandle` detaches on drop, so
+        // the reader would keep draining the pipe and emitting `TaskMessage` (plus
+        // the closing `TaskProgress`) after the task had already finalised and
+        // pushed `TaskFinished`, painting transcript onto a run the operator was
+        // told was over. The cost on the wait-error path is that the JSONL tail is
+        // cut where the abort lands instead of at EOF; that path is an OS-level
+        // wait fault, where the run is failing anyway and a truncated log beats a
+        // reader still writing to a finalised task's file.
         let stdout_task = AbortOnDrop::new(tokio::spawn(async move {
             stream_stdout(stdout, log_file, tail_lines, stream).await
         }));
@@ -2054,9 +2059,11 @@ async fn stream_stdout(
         writeln!(log_file, "{line}")?;
         // Parsed ONCE and read twice: the transcript classifier and the runner's
         // own session / usage / terminal fields want the same bytes, and
-        // `StreamLine` deserialises from a borrowed `&Value` so neither pass costs
-        // a re-parse or a clone. A line that is not valid JSON is skipped by both,
-        // exactly as it was when each parsed for itself.
+        // `StreamLine` deserialises from a borrowed `&Value` so the second read
+        // costs no re-parse (its owned `String` fields are still cloned out of the
+        // `Value`; the saving is the parse, not the copy). A line that is not
+        // valid JSON is skipped by both, exactly as it was when each parsed for
+        // itself.
         let parsed_line = serde_json::from_str::<serde_json::Value>(line.trim()).ok();
         if let (Some(stream), Some(value)) = (&stream, &parsed_line) {
             for (kind, body) in classifier.classify_value(value) {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -141,6 +141,35 @@ impl RunStream {
     }
 }
 
+/// A spawned task aborted when dropped, rather than detached.
+///
+/// `tokio::spawn`'s handle detaches on drop, which on the cancel path would
+/// leave the stdout reader alive and still emitting. `tokio_util`'s
+/// `AbortOnDropHandle` is the same thing but gated behind its `rt` feature,
+/// which is not enabled here and is not worth turning on across the workspace
+/// for twelve lines.
+#[derive(Debug)]
+struct AbortOnDrop<T>(Option<tokio::task::JoinHandle<T>>);
+
+impl<T> AbortOnDrop<T> {
+    fn new(handle: tokio::task::JoinHandle<T>) -> Self {
+        Self(Some(handle))
+    }
+
+    /// Take the handle back, disarming the abort (the normal completion path).
+    fn into_inner(mut self) -> tokio::task::JoinHandle<T> {
+        self.0.take().expect("the handle is taken exactly once")
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.0 {
+            handle.abort();
+        }
+    }
+}
+
 /// The env vars a provider subprocess is allowed to inherit.
 ///
 /// Deny-by-default: the child receives *only* these 12 vars (when present in the
@@ -1717,8 +1746,14 @@ impl Runner {
         // never deadlock on a full pipe buffer.
         let tail_lines = self.cfg.tail_lines;
         let stream = self.stream.clone();
-        let stdout_task =
-            tokio::spawn(async move { stream_stdout(stdout, log_file, tail_lines, stream).await });
+        // A2: aborted if this future is DROPPED (the cancel arm in `run_loop`).
+        // A bare `JoinHandle` detaches on drop, so the reader would keep draining
+        // the pipe and emitting `TaskMessage` (plus the closing `TaskProgress`)
+        // after the task had already finalised and pushed `TaskFinished`, painting
+        // transcript onto a run the operator was told was over.
+        let stdout_task = AbortOnDrop::new(tokio::spawn(async move {
+            stream_stdout(stdout, log_file, tail_lines, stream).await
+        }));
         let stderr_task = tokio::spawn(async move { tail_reader(stderr, tail_lines).await });
 
         let timed_out = match tokio::time::timeout(self.cfg.max_runtime, child.wait()).await {
@@ -1744,6 +1779,7 @@ impl Runner {
             terminal,
             stdout_tail,
         } = stdout_task
+            .into_inner()
             .await
             .map_err(|e| std::io::Error::other(format!("stdout task join: {e}")))??;
         let stderr_tail = stderr_task

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -40,13 +40,17 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use ainb_hangar_core::ids::TaskId;
+use ainb_hangar_proto::events::{HangarEvent, MessageKind};
+use ainb_hangar_proto::transcript::StreamJsonClassifier;
 use ainb_hangar_store::service::fail::FailureReason;
 use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
+use crate::events::EventSink;
 use crate::execenv::ExecEnv;
 
 /// Where a provider run executes (spec F5).
@@ -80,6 +84,60 @@ impl RunLocation {
             cwd: env.workdir.clone(),
             extra_root: None,
         }
+    }
+}
+
+/// How often a running task publishes a [`HangarEvent::TaskProgress`] heartbeat.
+///
+/// The transcript itself is unthrottled (one event per classified line) because
+/// a transcript line is the thing the operator is watching; the tool count and
+/// elapsed clock beside it only need to look live.
+const PROGRESS_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The live half of one run's transcript: every stdout line the provider writes,
+/// classified and pushed to the task's workspace subscribers as it happens
+/// (track A step A2).
+///
+/// The durable half is unchanged: [`stream_stdout`] still tees every raw line
+/// to `{logs}/<provider>.jsonl`, which stays the source of truth the
+/// `hangar/board_card_timeline` read replays from. This publishes the SAME lines
+/// through the SAME [`StreamJsonClassifier`] the durable read classifies with, so
+/// a line appended live and its later re-read twin are byte-identical.
+///
+/// Bound per RUN rather than per daemon (it carries this task's id + workspace),
+/// so it hangs off [`Runner::with_task_stream`] instead of the static
+/// [`RunnerConfig`].
+#[derive(Debug, Clone)]
+pub struct RunStream {
+    events: EventSink,
+    /// The task's owning workspace, resolved row id (the subscription filter).
+    workspace_id: String,
+    task_id: TaskId,
+}
+
+impl RunStream {
+    /// Publish one classified transcript line.
+    fn line(&self, kind: MessageKind, body: String) {
+        self.events.emit_live(
+            &self.workspace_id,
+            HangarEvent::TaskMessage {
+                task_id: self.task_id.clone(),
+                kind,
+                body,
+            },
+        );
+    }
+
+    /// Publish the run's cumulative tool count + elapsed clock.
+    fn progress(&self, tool_calls: u32, elapsed: Duration) {
+        self.events.emit_live(
+            &self.workspace_id,
+            HangarEvent::TaskProgress {
+                task_id: self.task_id.clone(),
+                tool_calls,
+                elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+            },
+        );
     }
 }
 
@@ -766,6 +824,10 @@ pub trait Provider {
 #[derive(Debug, Clone)]
 pub struct Runner {
     cfg: RunnerConfig,
+    /// Where this run's live transcript goes, or `None` for a runner not bound
+    /// to a task (the daemon-wide one the claim loop clones per run, and every
+    /// test harness). See [`Self::with_task_stream`].
+    stream: Option<RunStream>,
 }
 
 impl Provider for Runner {
@@ -778,7 +840,29 @@ impl Runner {
     /// Construct a runner from its static [`RunnerConfig`].
     #[must_use]
     pub const fn new(cfg: RunnerConfig) -> Self {
-        Self { cfg }
+        Self { cfg, stream: None }
+    }
+
+    /// This runner, bound to one task's live transcript stream (track A step A2).
+    ///
+    /// The claim loop already clones the daemon-wide runner per run, so binding
+    /// here costs nothing extra and keeps the task id off the daemon-wide
+    /// [`RunnerConfig`], where it does not belong. A run whose id is not a
+    /// well-formed [`TaskId`] simply streams nothing, best-effort, mirroring
+    /// every other emission site: the durable jsonl and the FSM are unaffected.
+    ///
+    /// Only the HEADLESS path streams. The interactive (tmux) path captures no
+    /// stdout at all, so there is nothing to classify there.
+    #[must_use]
+    pub fn with_task_stream(&self, workspace_id: &str, task_id: &str, events: &EventSink) -> Self {
+        Self {
+            cfg: self.cfg.clone(),
+            stream: TaskId::from_str(task_id.to_string()).ok().map(|task_id| RunStream {
+                events: events.clone(),
+                workspace_id: workspace_id.to_string(),
+                task_id,
+            }),
+        }
     }
 
     /// The hard wall-clock deadline each run is bounded by (the interactive tmux
@@ -1632,8 +1716,9 @@ impl Runner {
         // tail. Both run concurrently with the wait so a chatty provider can
         // never deadlock on a full pipe buffer.
         let tail_lines = self.cfg.tail_lines;
+        let stream = self.stream.clone();
         let stdout_task =
-            tokio::spawn(async move { stream_stdout(stdout, log_file, tail_lines).await });
+            tokio::spawn(async move { stream_stdout(stdout, log_file, tail_lines, stream).await });
         let stderr_task = tokio::spawn(async move { tail_reader(stderr, tail_lines).await });
 
         let timed_out = match tokio::time::timeout(self.cfg.max_runtime, child.wait()).await {
@@ -1880,6 +1965,13 @@ where
 /// stream's final tally/outcome wins). A `result` reporting neither tokens nor
 /// cost (e.g. a bare `{"type":"result","content":"ok"}`) leaves `usage` `None`.
 ///
+/// With a [`RunStream`] bound (track A step A2) this is also the run's LIVE
+/// transcript producer: each line is classified as it is read and published to
+/// the task's workspace subscribers. The durable tee is untouched: the live
+/// pass reads the same line the `writeln!` just wrote and never gates it, so a
+/// stream fault could not cost the run its log even if emission could fail
+/// (it cannot: the sink is non-blocking and lossy by contract).
+///
 /// # Drift canary
 ///
 /// The terminal shapes matched here are pinned against claude 2.1.211 / codex
@@ -1895,6 +1987,7 @@ async fn stream_stdout(
     stdout: tokio::process::ChildStdout,
     mut log_file: std::fs::File,
     tail_lines: usize,
+    stream: Option<RunStream>,
 ) -> std::io::Result<StreamCapture> {
     use std::io::Write;
 
@@ -1903,9 +1996,35 @@ async fn stream_stdout(
     let mut usage: Option<ProviderUsage> = None;
     let mut terminal: Option<TerminalSignal> = None;
     let mut tail: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+    // A2 live transcript. ONE classifier for the whole run, never one per line:
+    // a `tool_result` takes its tool name and duration from the `tool_use` line
+    // that came before it, so the state has to span lines. `started` clocks the
+    // first byte of stdout, not the spawn, which is the closest the reader can
+    // get to when the agent actually began talking.
+    let mut classifier = StreamJsonClassifier::default();
+    let started = Instant::now();
+    let mut tool_calls: u32 = 0;
+    let mut next_progress = started;
 
     while let Some(line) = reader.next_line().await? {
         writeln!(log_file, "{line}")?;
+        if let Some(stream) = &stream {
+            for (kind, body) in classifier.classify_line(&line) {
+                if kind == MessageKind::ToolCall {
+                    tool_calls = tool_calls.saturating_add(1);
+                }
+                stream.line(kind, body);
+            }
+            // Heartbeat on a coarse tick so a chatty provider does not turn the
+            // run banner into a per-line repaint. Checked after the lines so the
+            // first tick (which fires immediately) already carries the first
+            // tool count.
+            let now = Instant::now();
+            if now >= next_progress {
+                next_progress = now + PROGRESS_INTERVAL;
+                stream.progress(tool_calls, now.duration_since(started));
+            }
+        }
         if let Ok(parsed) = serde_json::from_str::<StreamLine>(&line) {
             match parsed.kind.as_str() {
                 // claude session handle — first wins.
@@ -1949,6 +2068,12 @@ async fn stream_stdout(
             }
         }
         push_tail(&mut tail, line, tail_lines);
+    }
+    // One last heartbeat at EOF. Without it a run whose whole transcript lands
+    // inside a single tick publishes only the tick that fired on its FIRST line,
+    // so the banner would report the tool count from before any tool ran.
+    if let Some(stream) = &stream {
+        stream.progress(tool_calls, started.elapsed());
     }
     log_file.flush()?;
     Ok(StreamCapture {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/runner.rs
@@ -87,11 +87,18 @@ impl RunLocation {
     }
 }
 
-/// How often a running task publishes a [`HangarEvent::TaskProgress`] heartbeat.
+/// Floor on how often a running task republishes its
+/// [`HangarEvent::TaskProgress`] tally.
 ///
 /// The transcript itself is unthrottled (one event per classified line) because
-/// a transcript line is the thing the operator is watching; the tool count and
-/// elapsed clock beside it only need to look live.
+/// a transcript line is the thing the operator is watching; the tool COUNT beside
+/// it changes far less often and does not need a repaint per line.
+///
+/// Not a timer: the tick is driven by stdout, so a silent provider publishes
+/// nothing until it speaks again (or until the closing tick at EOF). The elapsed
+/// clock rides along because the event carries the field, but no consumer reads
+/// it today, and a consumer that wanted a ticking clock would have to run its own
+/// rather than wait on this.
 const PROGRESS_INTERVAL: Duration = Duration::from_secs(1);
 
 /// The live half of one run's transcript: every stdout line the provider writes,
@@ -2034,9 +2041,10 @@ async fn stream_stdout(
     let mut tail: std::collections::VecDeque<String> = std::collections::VecDeque::new();
     // A2 live transcript. ONE classifier for the whole run, never one per line:
     // a `tool_result` takes its tool name and duration from the `tool_use` line
-    // that came before it, so the state has to span lines. `started` clocks the
-    // first byte of stdout, not the spawn, which is the closest the reader can
-    // get to when the agent actually began talking.
+    // that came before it, so the state has to span lines. `started` clocks from
+    // just before the first read, so the elapsed it reports excludes the spawn and
+    // sandbox setup: this reader's own view of how long the agent has been
+    // talking, not the task's wall clock (the FSM owns that).
     let mut classifier = StreamJsonClassifier::default();
     let started = Instant::now();
     let mut tool_calls: u32 = 0;
@@ -2044,16 +2052,22 @@ async fn stream_stdout(
 
     while let Some(line) = reader.next_line().await? {
         writeln!(log_file, "{line}")?;
-        if let Some(stream) = &stream {
-            for (kind, body) in classifier.classify_line(&line) {
+        // Parsed ONCE and read twice: the transcript classifier and the runner's
+        // own session / usage / terminal fields want the same bytes, and
+        // `StreamLine` deserialises from a borrowed `&Value` so neither pass costs
+        // a re-parse or a clone. A line that is not valid JSON is skipped by both,
+        // exactly as it was when each parsed for itself.
+        let parsed_line = serde_json::from_str::<serde_json::Value>(line.trim()).ok();
+        if let (Some(stream), Some(value)) = (&stream, &parsed_line) {
+            for (kind, body) in classifier.classify_value(value) {
                 if kind == MessageKind::ToolCall {
                     tool_calls = tool_calls.saturating_add(1);
                 }
                 stream.line(kind, body);
             }
-            // Heartbeat on a coarse tick so a chatty provider does not turn the
-            // run banner into a per-line repaint. Checked after the lines so the
-            // first tick (which fires immediately) already carries the first
+            // Republish the tally on a coarse tick so a chatty provider does not
+            // turn the run banner into a per-line repaint. Checked after the lines
+            // so the first tick (which fires immediately) already carries the first
             // tool count.
             let now = Instant::now();
             if now >= next_progress {
@@ -2061,7 +2075,7 @@ async fn stream_stdout(
                 stream.progress(tool_calls, now.duration_since(started));
             }
         }
-        if let Ok(parsed) = serde_json::from_str::<StreamLine>(&line) {
+        if let Some(parsed) = parsed_line.as_ref().and_then(|v| StreamLine::deserialize(v).ok()) {
             match parsed.kind.as_str() {
                 // claude session handle — first wins.
                 "system" => {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
@@ -98,7 +98,7 @@ async fn a_process_run_streams_the_same_transcript_it_later_re_reads() {
 
     let scale = u64::from(tripwire_support::budget_scale());
     let run = sub.collect_run(Duration::from_secs(30 * scale)).await;
-    let live = run.transcript;
+    let live = run.transcript.clone();
 
     // The FSM terminal is the signal the provider's stdout is closed and its log
     // flushed, so the durable read below sees the whole file.
@@ -134,9 +134,11 @@ async fn a_process_run_streams_the_same_transcript_it_later_re_reads() {
     assert!(
         !live.is_empty(),
         "a running task must stream TaskMessage events; got none.\n\
+         events seen on the connection: {:?}\n\
          durable jsonl was:\n{}\ndaemon logs:\n{}",
+        run.seen,
         durable.jsonl,
-        tripwire_support::dump_daemon_logs(home.path())
+        read_daemon_log(home.path())
     );
     // And it must be a real transcript, not one lane: the fake provider emits
     // prose, thinking, a tool call and its result, so all four lanes must show.
@@ -267,6 +269,21 @@ async fn enqueue_task(pool: &SqlitePool, ids: &tripwire_support::SeededIds) {
     .execute(pool)
     .await
     .expect("enqueue task");
+}
+
+/// The daemon's own structured log under the test's `AINB_HANGAR_HOME` (NOT
+/// `$HOME`, which is where `tripwire_support::dump_daemon_logs` looks and why it
+/// found nothing here).
+fn read_daemon_log(home: &Path) -> String {
+    let dir = home.join("hangar").join("logs");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return format!("(no daemon logs at {})", dir.display());
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// The daemon's control socket under `AINB_HANGAR_HOME`.
@@ -433,6 +450,11 @@ impl Client {
                 continue;
             }
             let event = &frame["params"];
+            run.seen.push(format!(
+                "{}({})",
+                event["event"].as_str().unwrap_or("?"),
+                event["task_id"].as_str().unwrap_or("-")
+            ));
             if event["task_id"] != TASK_ID {
                 continue;
             }
@@ -462,4 +484,8 @@ struct LiveRun {
     /// The tool count off the LAST `TaskProgress`: the run's final tally, since
     /// the producer emits a closing tick at stdout EOF.
     last_tool_calls: Option<u64>,
+    /// Every event tag seen on the connection, ANY task, in arrival order. Only
+    /// read when an assertion fails: it separates "the producer emitted nothing"
+    /// from "the subscription went live too late to see it".
+    seen: Vec<String>,
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
@@ -1,0 +1,465 @@
+//! Track A test T1, the PROCESS half: a running task streams its transcript
+//! live, in the SAME taxonomy the durable re-read returns.
+//!
+//! ```text
+//!  seed world + issue + board card        spawn the real daemon binary
+//!         │                                          │
+//!         ▼                                          ▼
+//!  subscribe the workspace over hangar.sock ──▶ INSERT queued task
+//!         │                                          │
+//!         │                          claim ─▶ running ─▶ fake claude
+//!         │                                          │ stream-json lines
+//!         ▼                                          ▼
+//!  live: TaskMessage(kind, body)…        durable: logs/claude.jsonl
+//!         └────────────── must be EQUAL ─────────────┘
+//!                  (hangar/board_card_timeline, classified)
+//! ```
+//!
+//! Both sides are the real thing: a genuine `ainb-hangar-daemon` process, a real
+//! Unix-socket subscription, a real provider subprocess writing real
+//! stream-json, and the real `hangar/board_card_timeline` read the TUI's
+//! transcript pane backfills from.
+//!
+//! What this pins, and why each half is needed:
+//!
+//! * **the producer exists at all.** Before track A step A2, `TaskMessage` had
+//!   consumers (the board timeline overlay, the run banner, task detail) and no
+//!   producer anywhere in `src/`. An empty live sequence fails the emptiness
+//!   assertion, not merely the equality one: two empty vectors are equal.
+//! * **one taxonomy, not two.** The live sequence is compared to the durable
+//!   read put through `transcript::classify_stream_json`, which is exactly what
+//!   the plugin does with the same bytes. A live producer that classified
+//!   differently (its own parser, a per-line classifier that loses a
+//!   `tool_result`'s tool name) would diverge here even though both halves
+//!   "work".
+//!
+//! SKIPs cleanly when tmux is unavailable, like every other tripwire.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+mod tripwire_support;
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use ainb_hangar_core::ids::WorkspaceId;
+use ainb_hangar_proto::events::{EVENT_METHOD, MessageKind};
+use ainb_hangar_proto::transcript::classify_stream_json;
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use ainb_hangar_store::repo::board::BoardRepo;
+use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqlitePoolOptions;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tripwire_support::{DaemonSession, daemon_bin, seed_world, wait_for_db};
+
+const BOARD_ID: &str = "board-live";
+const COLUMN_ID: &str = "col-live";
+const ISSUE_ID: &str = "issue-live-1";
+const TASK_ID: &str = "task-live-1";
+
+#[tokio::test]
+async fn a_process_run_streams_the_same_transcript_it_later_re_reads() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping live-stream tripwire");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    seed_card(&pool, &ids).await;
+
+    let fake_claude = fake_claude_full_transcript(home.path(), "live-stream-1");
+    let session = DaemonSession::spawn(
+        &daemon_bin(),
+        home.path(),
+        &[
+            ("AINB_HANGAR_HOME", home.path().to_str().unwrap()),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_CLAUDE_PATH", fake_claude.to_str().unwrap()),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+        ],
+    );
+
+    // Subscribe BEFORE enqueueing. The live stream is fire-and-forget with no
+    // replay behind it (a transcript line never lands in the durable event log,
+    // see `EventSink::emit_live`), so a subscription opened after the claim would
+    // legitimately miss the head of the run and this test would be asserting on
+    // a truncated sequence.
+    let mut sub = Client::connect(&rpc_socket(home.path())).await;
+    sub.auth_from_file(home.path()).await;
+    sub.subscribe(&ids.workspace_id).await;
+
+    enqueue_task(&pool, &ids).await;
+
+    let scale = u64::from(tripwire_support::budget_scale());
+    let run = sub.collect_run(Duration::from_secs(30 * scale)).await;
+    let live = run.transcript;
+
+    // The FSM terminal is the signal the provider's stdout is closed and its log
+    // flushed, so the durable read below sees the whole file.
+    let _ = wait_for_db(&pool, TASK_ID, "done", Duration::from_secs(30 * scale)).await;
+
+    let timeline = sub
+        .call(
+            methods::HANGAR_BOARD_CARD_TIMELINE,
+            serde_json::json!({
+                "workspace_id": ids.workspace_id,
+                "board_id": BOARD_ID,
+                "issue_id": ISSUE_ID,
+            }),
+        )
+        .await;
+    drop(session); // kill the tmux session by exact name before asserting
+
+    assert!(
+        timeline["error"].is_null(),
+        "board_card_timeline must answer: {timeline}"
+    );
+    let durable: ainb_hangar_proto::snapshots::BoardCardTimelineResult =
+        serde_json::from_value(timeline["result"].clone()).expect("decode timeline result");
+    assert_eq!(
+        durable.task_id.as_deref(),
+        Some(TASK_ID),
+        "the timeline must resolve the card's run"
+    );
+    let re_read = classify_stream_json(&durable.jsonl);
+
+    // NEGATIVE, and it must come first: a producer that emits nothing would make
+    // the equality below trivially true against an empty re-read.
+    assert!(
+        !live.is_empty(),
+        "a running task must stream TaskMessage events; got none.\n\
+         durable jsonl was:\n{}\ndaemon logs:\n{}",
+        durable.jsonl,
+        tripwire_support::dump_daemon_logs(home.path())
+    );
+    // And it must be a real transcript, not one lane: the fake provider emits
+    // prose, thinking, a tool call and its result, so all four lanes must show.
+    for want in [
+        MessageKind::Agent,
+        MessageKind::Thinking,
+        MessageKind::ToolCall,
+        MessageKind::ToolResult,
+    ] {
+        assert!(
+            live.iter().any(|(kind, _)| *kind == want),
+            "the live stream must carry a {want:?} line; got {live:#?}"
+        );
+    }
+
+    // THE ASSERTION: live and durable are the same sequence, kind for kind and
+    // byte for byte. This is what makes the expanded run view identical whether
+    // it filled live or backfilled from the timeline read.
+    assert_eq!(
+        live, re_read,
+        "the live TaskMessage sequence must equal the durable re-read\n\
+         durable jsonl was:\n{}",
+        durable.jsonl
+    );
+
+    // The run banner's other half: the heartbeat lands, and its FINAL tally
+    // counts the one tool the fake provider called. A counter that never
+    // incremented (or a producer whose last tick predates the tool) reads 0 here
+    // even with the transcript above perfectly correct.
+    assert_eq!(
+        run.last_tool_calls,
+        Some(1),
+        "the closing TaskProgress must report the run's one tool call"
+    );
+}
+
+/// A fake `claude` emitting a stream-json transcript that exercises every lane
+/// the classifier has: the `system` handle, assistant prose, a thinking block, a
+/// `tool_use` and its matching `tool_result` (which resolves its tool NAME only
+/// from the earlier line, so this also proves the producer keeps ONE classifier
+/// for the whole run), and the terminal `result`.
+fn fake_claude_full_transcript(dir: &Path, session_id: &str) -> PathBuf {
+    let lines = [
+        format!(r#"{{"type":"system","subtype":"init","session_id":"{session_id}"}}"#),
+        r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Reading the routes file."}]}}"#.to_string(),
+        r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"The handler is probably unregistered."}]}}"#.to_string(),
+        r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Edit","input":{"file_path":"api/src/routes.ts"}}]}}"#.to_string(),
+        r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"1 file changed"}]}}"#.to_string(),
+        r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Route registered."}]}}"#.to_string(),
+        r#"{"type":"result","subtype":"success","content":"ok"}"#.to_string(),
+    ];
+    // Single-quoted so the JSON's double quotes survive `sh`; the payloads carry
+    // no single quote of their own.
+    let body = lines.iter().fold("#!/bin/sh\n".to_string(), |mut acc, line| {
+        acc.push_str(&format!("echo '{line}'\n"));
+        acc
+    }) + "exit 0\n";
+    write_executable(dir, "fake-claude-transcript.sh", &body)
+}
+
+/// Write `body` to `dir/name` and make it executable.
+fn write_executable(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod script");
+    }
+    path
+}
+
+/// Seed the issue + board + column + card `board_card_timeline` resolves through
+/// (it refuses an issue that is not a card on the named board).
+async fn seed_card(pool: &SqlitePool, ids: &tripwire_support::SeededIds) {
+    let ws = WorkspaceId::from_str(ids.workspace_id.clone()).expect("ws id");
+    let now = tripwire_support::now_ms();
+    IssueRepo::insert(
+        pool,
+        &NewIssue {
+            id: ISSUE_ID.into(),
+            workspace_id: ids.workspace_id.clone(),
+            title: "Register the route".into(),
+            description: None,
+            state: "open".into(),
+            assignee: None,
+            creator: ainb_hangar_core::actor::ActorRef::new(
+                ainb_hangar_core::actor::ActorKind::Member,
+                "user-trip",
+            )
+            .unwrap(),
+            created_at: now,
+            priority: 0,
+            due_date: None,
+            labels: Vec::new(),
+            parent_issue_id: None,
+            stage: None,
+            acceptance_criteria: Vec::new(),
+            context_refs: Vec::new(),
+        },
+    )
+    .await
+    .expect("insert issue");
+    BoardRepo::create(pool, &ws, BOARD_ID, "Delivery", now)
+        .await
+        .expect("create board");
+    BoardRepo::column_add(pool, &ws, BOARD_ID, COLUMN_ID, "Todo", None, false)
+        .await
+        .expect("add column");
+    BoardRepo::card_add(pool, &ws, BOARD_ID, ISSUE_ID, Some(COLUMN_ID), now)
+        .await
+        .expect("place card");
+}
+
+/// Enqueue the card's run.
+async fn enqueue_task(pool: &SqlitePool, ids: &tripwire_support::SeededIds) {
+    sqlx::query(
+        "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, issue_id, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(TASK_ID)
+    .bind(&ids.workspace_id)
+    .bind(&ids.runtime_id)
+    .bind(&ids.agent_id)
+    .bind(ISSUE_ID)
+    .bind(tripwire_support::now_ms())
+    .execute(pool)
+    .await
+    .expect("enqueue task");
+}
+
+/// The daemon's control socket under `AINB_HANGAR_HOME`.
+fn rpc_socket(home: &Path) -> PathBuf {
+    home.join("hangar.sock")
+}
+
+/// Open a `SQLite` WAL pool at `db_path` (creating the file if absent).
+async fn open_pool(db_path: &Path) -> SqlitePool {
+    let opts = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+    SqlitePoolOptions::new().connect_with(opts).await.expect("open pool")
+}
+
+/// One subscribed client connection: a persistent buffered reader half plus a
+/// writer half.
+///
+/// The reader half MUST live for the whole connection: a fresh `BufReader` per
+/// call would buffer-and-drop pushed notification frames arriving between a
+/// request and its response, which on this test is the entire subject matter.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    /// Poll-connect until the daemon's accept loop is up, then split the stream.
+    async fn connect(socket_path: &Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(e) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "daemon socket never came up at {}: {e}",
+                        socket_path.display()
+                    );
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    /// Send one Content-Length framed request.
+    async fn send(&mut self, method: &str, params: serde_json::Value) {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).unwrap();
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.unwrap();
+        self.writer.flush().await.unwrap();
+    }
+
+    /// Read one frame body as raw JSON (response OR pushed notification), or
+    /// `None` on timeout.
+    async fn read_frame(&mut self, timeout: Duration) -> Option<serde_json::Value> {
+        tokio::time::timeout(timeout, self.read_frame_inner()).await.ok()
+    }
+
+    async fn read_frame_inner(&mut self) -> serde_json::Value {
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.unwrap();
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let t = line.trim_end_matches("\r\n");
+            if t.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.unwrap();
+                return serde_json::from_slice(&body).unwrap();
+            }
+            if let Some((name, v)) = t.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = v.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    /// Send `method` and read frames until its response (a frame with an `id`)
+    /// arrives. Notifications interleaved before it are discarded.
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        self.send(method, params).await;
+        loop {
+            let frame = self
+                .read_frame(Duration::from_secs(15))
+                .await
+                .unwrap_or_else(|| panic!("no response to {method} within 15s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    /// Authenticate exactly as a real client does: read the plaintext the daemon
+    /// minted at boot and present it on the first `auth/hello` frame.
+    async fn auth_from_file(&mut self, home: &Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(home);
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let token = loop {
+            if let Ok(t) = std::fs::read_to_string(&token_path) {
+                break t;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "daemon never minted {}",
+                token_path.display()
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        };
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+
+    /// Subscribe a workspace and assert the ack.
+    async fn subscribe(&mut self, workspace_id: &str) {
+        let resp = self
+            .call(
+                methods::WORKSPACE_SUBSCRIBE,
+                serde_json::json!({ "workspace_id": workspace_id }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "subscribe must ack: {resp}");
+    }
+
+    /// Collect this run's live stream: every `TaskMessage` for [`TASK_ID`] in
+    /// arrival order, plus the tool count off the LAST `TaskProgress`, up to the
+    /// run's `TaskFinished`.
+    ///
+    /// Terminating on `TaskFinished` (rather than a silence window) is what keeps
+    /// this honest against the durable read: it is the same boundary the durable
+    /// file has, so a producer that kept emitting past the terminal would be
+    /// caught by the equality assertion rather than hidden by a short timeout.
+    async fn collect_run(&mut self, budget: Duration) -> LiveRun {
+        let deadline = Instant::now() + budget;
+        let mut run = LiveRun::default();
+        loop {
+            let frame = match deadline.checked_duration_since(Instant::now()) {
+                Some(remaining) => self.read_frame(remaining).await,
+                None => None,
+            };
+            let Some(frame) = frame else {
+                panic!("the run never reported TaskFinished within {budget:?}; got {run:#?}")
+            };
+            if frame.get("id").is_some() || frame["method"] != EVENT_METHOD {
+                continue;
+            }
+            let event = &frame["params"];
+            if event["task_id"] != TASK_ID {
+                continue;
+            }
+            match event["event"].as_str() {
+                Some("task_message") => {
+                    let kind: MessageKind =
+                        serde_json::from_value(event["kind"].clone()).expect("decode kind");
+                    let body = event["body"].as_str().expect("body is a string").to_string();
+                    run.transcript.push((kind, body));
+                }
+                Some("task_progress") => {
+                    run.last_tool_calls =
+                        Some(event["tool_calls"].as_u64().expect("tool_calls is a number"));
+                }
+                Some("task_finished") => return run,
+                _ => {}
+            }
+        }
+    }
+}
+
+/// What one run pushed over the live stream before its terminal.
+#[derive(Debug, Default)]
+struct LiveRun {
+    /// Every `TaskMessage` `(kind, body)`, in arrival order.
+    transcript: Vec<(MessageKind, String)>,
+    /// The tool count off the LAST `TaskProgress`: the run's final tally, since
+    /// the producer emits a closing tick at stdout EOF.
+    last_tool_calls: Option<u64>,
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
@@ -33,6 +33,16 @@
 //!   `tool_result`'s tool name) would diverge here even though both halves
 //!   "work".
 //!
+//! # The equality holds under the read's 512 KiB tail, not beyond it
+//!
+//! `board_card_timeline` returns a bounded TAIL of the provider log, so this
+//! equality is exact only for a run whose whole transcript fits it. Past that the
+//! re-read starts mid-file with a fresh classifier, and a `tool_result` whose
+//! `tool_use` fell outside the window degrades to the unnamed `tool` form while
+//! the live line kept the name. That is a property of the READ, not of the
+//! producer, and A6 (which replaces this read) must not inherit "live always
+//! equals durable" as an unconditional invariant.
+//!
 //! SKIPs cleanly when tmux is unavailable, like every other tripwire.
 
 #![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
@@ -48,8 +58,8 @@ use ainb_hangar_proto::transcript::classify_stream_json;
 use ainb_hangar_proto::{RpcId, RpcRequest, methods};
 use ainb_hangar_store::repo::board::BoardRepo;
 use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
-use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, SqlitePool};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -101,8 +111,15 @@ async fn a_process_run_streams_the_same_transcript_it_later_re_reads() {
     let live = run.transcript.clone();
 
     // The FSM terminal is the signal the provider's stdout is closed and its log
-    // flushed, so the durable read below sees the whole file.
-    let _ = wait_for_db(&pool, TASK_ID, "done", Duration::from_secs(30 * scale)).await;
+    // flushed, so the durable read below sees the whole file. A run that never
+    // reached `done` would leave the equality below comparing against a partial
+    // file, so read the status back rather than trusting the wait.
+    let row = wait_for_db(&pool, TASK_ID, "done", Duration::from_secs(30 * scale)).await;
+    assert_eq!(
+        row.get::<String, _>("status"),
+        "done",
+        "the run must finish before the durable file is read"
+    );
 
     let timeline = sub
         .call(
@@ -162,6 +179,21 @@ async fn a_process_run_streams_the_same_transcript_it_later_re_reads() {
         "the live TaskMessage sequence must equal the durable re-read\n\
          durable jsonl was:\n{}",
         durable.jsonl
+    );
+
+    // The one deliberate design decision in this change, pinned: the transcript
+    // rides `emit_live`, so it never lands an `event_log` row. Swapping it back to
+    // `emit` would leave every assertion above green while putting thousands of
+    // INSERTs per run through the one write lock the control plane shares.
+    let logged: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM event_log WHERE event_type IN ('task_message', 'task_progress')",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count transcript rows in the durable event log");
+    assert_eq!(
+        logged, 0,
+        "a transcript line must never reach the durable event log"
     );
 
     // The run banner's other half: the heartbeat lands, and its FINAL tally

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_live_stream.rs
@@ -58,8 +58,8 @@ use ainb_hangar_proto::transcript::classify_stream_json;
 use ainb_hangar_proto::{RpcId, RpcRequest, methods};
 use ainb_hangar_store::repo::board::BoardRepo;
 use ainb_hangar_store::repo::issue::{IssueRepo, NewIssue};
+use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
-use sqlx::{Row, SqlitePool};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -114,12 +114,9 @@ async fn a_process_run_streams_the_same_transcript_it_later_re_reads() {
     // flushed, so the durable read below sees the whole file. A run that never
     // reached `done` would leave the equality below comparing against a partial
     // file, so read the status back rather than trusting the wait.
-    let row = wait_for_db(&pool, TASK_ID, "done", Duration::from_secs(30 * scale)).await;
-    assert_eq!(
-        row.get::<String, _>("status"),
-        "done",
-        "the run must finish before the durable file is read"
-    );
+    // `wait_for_db` returns ONLY on a match and panics on timeout, so reaching the
+    // next line is the assertion.
+    let _ = wait_for_db(&pool, TASK_ID, "done", Duration::from_secs(30 * scale)).await;
 
     let timeline = sub
         .call(

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -40,6 +40,17 @@ use crate::events::MessageKind;
 /// Clip a one-line summary / snippet to this many display chars (char-safe).
 const SUMMARY_MAX: usize = 84;
 
+/// Hard ceiling on a single classified body, in display chars.
+///
+/// Generous on purpose: this is a leak backstop, not a display width. A provider
+/// is free to emit a megabyte of prose or a base64 blob in one block, and since
+/// A2 every classified body is also a live `TaskMessage` held in a bounded
+/// broadcast ring and framed to every subscriber, so an uncapped body is an
+/// unbounded allocation on the hot path. Applied in [`push_lines`], through which
+/// BOTH the live producer and the durable re-read classify, so the two stay
+/// byte-identical. No real transcript line comes close.
+const BODY_MAX: usize = 8192;
+
 /// Most `tool_use` ids remembered while awaiting their `tool_result`. Claude
 /// issues a handful per message; this is a leak backstop, not a working limit.
 const MAX_PENDING_TOOLS: usize = 256;
@@ -314,7 +325,7 @@ fn push_lines(out: &mut Vec<(MessageKind, String)>, kind: MessageKind, text: &st
         if line.trim().is_empty() {
             continue;
         }
-        out.push((kind, line.to_string()));
+        out.push((kind, truncate_chars(line, BODY_MAX)));
     }
 }
 
@@ -423,6 +434,26 @@ fn short_id(id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// An arbitrarily large provider block is capped, not carried whole: since A2
+    /// every classified body is also a live `TaskMessage` sitting in a bounded
+    /// broadcast ring and framed to every subscriber.
+    #[test]
+    fn a_huge_text_block_is_capped() {
+        let huge = "x".repeat(100_000);
+        let line = serde_json::json!({
+            "type": "assistant",
+            "message": { "content": [{ "type": "text", "text": huge }] },
+        })
+        .to_string();
+        let out = classify_stream_json(&line);
+        assert_eq!(out.len(), 1, "one block, one body");
+        assert_eq!(
+            out[0].1.chars().count(),
+            BODY_MAX,
+            "the body is capped at BODY_MAX display chars"
+        );
+    }
+
     use super::*;
 
     /// A live classifier lives for a whole run, so a resolved tool must leave

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -95,8 +95,18 @@ impl StreamJsonClassifier {
         let Ok(v) = serde_json::from_str::<Value>(line) else {
             return Vec::new();
         };
+        self.classify_value(&v)
+    }
+
+    /// [`Self::classify_line`] for a line the caller has ALREADY parsed.
+    ///
+    /// The live producer reads each line for two purposes (the transcript and the
+    /// runner's own session/usage/terminal fields), and parsing the same bytes
+    /// twice for that is waste it can hand back.
+    #[must_use]
+    pub fn classify_value(&mut self, line: &Value) -> Vec<(MessageKind, String)> {
         let mut out = Vec::new();
-        self.fold(&v, &mut out);
+        self.fold(line, &mut out);
         out
     }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -46,10 +46,16 @@ const SUMMARY_MAX: usize = 84;
 /// is free to emit a megabyte of prose or a base64 blob in one block, and since
 /// A2 every classified body is also a live `TaskMessage` held in a bounded
 /// broadcast ring and framed to every subscriber, so an uncapped body is an
-/// unbounded allocation on the hot path. Applied in [`push_lines`], through which
-/// BOTH the live producer and the durable re-read classify, so the two stay
-/// byte-identical. No real transcript line comes close.
+/// unbounded allocation on the hot path. No real transcript line comes close.
 const BODY_MAX: usize = 8192;
+
+/// Ceiling on the entries ONE transcript line may classify into.
+///
+/// A single JSON line carrying a multi-line text block yields one entry per
+/// line, so the per-body cap above bounds each entry without bounding their
+/// count. Same backstop reasoning: a megabyte of newlines is a megabyte of
+/// `TaskMessage`s.
+const ENTRIES_PER_LINE_MAX: usize = 512;
 
 /// Most `tool_use` ids remembered while awaiting their `tool_result`. Claude
 /// issues a handful per message; this is a leak backstop, not a working limit.
@@ -118,6 +124,17 @@ impl StreamJsonClassifier {
     pub fn classify_value(&mut self, line: &Value) -> Vec<(MessageKind, String)> {
         let mut out = Vec::new();
         self.fold(line, &mut out);
+        // The ONE place every entry passes through, so the backstops live here
+        // rather than at the six `out.push` sites: a tool `name` and a `subtype`
+        // are provider strings too, and capping only the prose in `push_lines`
+        // left those uncapped. Both live producer and durable re-read classify
+        // through this function, so the two stay byte-identical.
+        out.truncate(ENTRIES_PER_LINE_MAX);
+        for (_, body) in &mut out {
+            if body.chars().count() > BODY_MAX {
+                *body = truncate_chars(body, BODY_MAX);
+            }
+        }
         out
     }
 
@@ -325,7 +342,7 @@ fn push_lines(out: &mut Vec<(MessageKind, String)>, kind: MessageKind, text: &st
         if line.trim().is_empty() {
             continue;
         }
-        out.push((kind, truncate_chars(line, BODY_MAX)));
+        out.push((kind, line.to_string()));
     }
 }
 
@@ -434,6 +451,35 @@ fn short_id(id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// A tool NAME is a provider string too, and it does not go through
+    /// `push_lines`. Capping only the prose left this one uncapped.
+    #[test]
+    fn a_huge_tool_name_is_capped_too() {
+        let line = serde_json::json!({
+            "type": "assistant",
+            "message": { "content": [{
+                "type": "tool_use", "id": "t1", "name": "N".repeat(50_000), "input": {},
+            }] },
+        })
+        .to_string();
+        let out = classify_stream_json(&line);
+        assert_eq!(out[0].0, MessageKind::ToolCall);
+        assert_eq!(out[0].1.chars().count(), BODY_MAX);
+    }
+
+    /// One JSON line holding a multi-line block yields one entry per line, so the
+    /// per-body cap bounds each entry without bounding their count.
+    #[test]
+    fn one_line_cannot_classify_into_unbounded_entries() {
+        let block = "line\n".repeat(ENTRIES_PER_LINE_MAX * 3);
+        let line = serde_json::json!({
+            "type": "assistant",
+            "message": { "content": [{ "type": "text", "text": block }] },
+        })
+        .to_string();
+        assert_eq!(classify_stream_json(&line).len(), ENTRIES_PER_LINE_MAX);
+    }
+
     /// The cap counts CHARS, not bytes: provider prose carries non-ASCII
     /// routinely, and a byte-index truncation would panic on a UTF-8 boundary.
     #[test]

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -129,7 +129,14 @@ impl StreamJsonClassifier {
         // are provider strings too, and capping only the prose in `push_lines`
         // left those uncapped. Both live producer and durable re-read classify
         // through this function, so the two stay byte-identical.
-        out.truncate(ENTRIES_PER_LINE_MAX);
+        if out.len() > ENTRIES_PER_LINE_MAX {
+            // Say so rather than dropping silently, the way BODY_MAX appends its
+            // ellipsis: a 600-line block otherwise loses 88 lines with no sign, in
+            // both halves.
+            let dropped = out.len() - (ENTRIES_PER_LINE_MAX - 1);
+            out.truncate(ENTRIES_PER_LINE_MAX - 1);
+            out.push((MessageKind::ToolResult, format!("… {dropped} more lines")));
+        }
         for (_, body) in &mut out {
             if body.chars().count() > BODY_MAX {
                 *body = truncate_chars(body, BODY_MAX);
@@ -477,7 +484,13 @@ mod tests {
             "message": { "content": [{ "type": "text", "text": block }] },
         })
         .to_string();
-        assert_eq!(classify_stream_json(&line).len(), ENTRIES_PER_LINE_MAX);
+        let out = classify_stream_json(&line);
+        assert_eq!(out.len(), ENTRIES_PER_LINE_MAX);
+        assert!(
+            out.last().unwrap().1.starts_with("… "),
+            "the drop is marked, not silent: {:?}",
+            out.last()
+        );
     }
 
     /// The cap counts CHARS, not bytes: provider prose carries non-ASCII

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -486,11 +486,9 @@ mod tests {
         .to_string();
         let out = classify_stream_json(&line);
         assert_eq!(out.len(), ENTRIES_PER_LINE_MAX);
-        assert!(
-            out.last().unwrap().1.starts_with("… "),
-            "the drop is marked, not silent: {:?}",
-            out.last()
-        );
+        // The COUNT, not just the prefix: an off-by-one here ships silently.
+        let dropped = ENTRIES_PER_LINE_MAX * 3 - (ENTRIES_PER_LINE_MAX - 1);
+        assert_eq!(out.last().unwrap().1, format!("… {dropped} more lines"));
     }
 
     /// The cap counts CHARS, not bytes: provider prose carries non-ASCII

--- a/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/transcript.rs
@@ -434,6 +434,25 @@ fn short_id(id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// The cap counts CHARS, not bytes: provider prose carries non-ASCII
+    /// routinely, and a byte-index truncation would panic on a UTF-8 boundary.
+    #[test]
+    fn the_body_cap_never_splits_a_multibyte_char() {
+        // 3 bytes per char, so a byte-index cut at BODY_MAX would land mid-char.
+        let huge = "日".repeat(BODY_MAX * 2);
+        let line = serde_json::json!({
+            "type": "assistant",
+            "message": { "content": [{ "type": "text", "text": huge }] },
+        })
+        .to_string();
+        let out = classify_stream_json(&line);
+        assert_eq!(out[0].1.chars().count(), BODY_MAX, "capped by chars");
+        assert!(
+            out[0].1.ends_with('…'),
+            "the elision marker survives intact"
+        );
+    }
+
     /// An arbitrarily large provider block is capped, not carried whole: since A2
     /// every classified body is also a live `TaskMessage` sitting in a bounded
     /// broadcast ring and framed to every subscriber.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3150,6 +3150,22 @@ impl HangarPlugin {
         }
     }
 
+    /// Arm the live-line buffer when `req_id` is the timeline fetch, so lines
+    /// streaming in during the round trip are replayed onto the fresh overlay
+    /// (see [`Self::timeline_fetch_buffer`]).
+    ///
+    /// Arms only when UNARMED: both replies carry the same req id, so overwriting
+    /// on a second open would hand reply 1 fetch 2's buffer and leave reply 2
+    /// nothing to replay, reopening the hole this closes.
+    ///
+    /// Split out of the dispatch below purely so it is reachable from a test: the
+    /// dispatch needs a `HostClient`, which has no public constructor.
+    fn arm_timeline_buffer_for(&mut self, req_id: i64) {
+        if req_id == BOARD_CARD_TIMELINE_REQ_ID {
+            self.timeline_fetch_buffer.get_or_insert_with(Default::default);
+        }
+    }
+
     /// Fire a deferred board mutation RPC raised by the Boards screen (P4 / D8,
     /// ccc / D6, D16).
     ///
@@ -3347,14 +3363,7 @@ impl HangarPlugin {
             // Handled above as a local note; never reached here.
             BoardsAction::CardAttach { .. } => return,
         };
-        // Arm the live-line buffer for the timeline round trip (see
-        // `timeline_fetch_buffer`); the reply drains it onto the fresh overlay.
-        if req_id == BOARD_CARD_TIMELINE_REQ_ID {
-            // Arm only when unarmed: both replies carry the same req id, so
-            // overwriting on a second open would hand reply 1 fetch 2's buffer and
-            // leave reply 2 nothing to replay, reopening the hole this closes.
-            self.timeline_fetch_buffer.get_or_insert_with(Default::default);
-        }
+        self.arm_timeline_buffer_for(req_id);
         let Ok(body) = encode_request(req_id, method, params) else {
             return;
         };
@@ -6462,11 +6471,29 @@ mod tests {
             "already here".to_string(),
         ));
         p.timeline_fetch_buffer = Some(armed);
-        p.timeline_fetch_buffer.get_or_insert_with(Default::default);
+        p.arm_timeline_buffer_for(BOARD_CARD_TIMELINE_REQ_ID);
         assert_eq!(
             p.timeline_fetch_buffer.as_ref().map(std::collections::VecDeque::len),
             Some(1),
             "re-arming must keep what the first fetch already buffered"
+        );
+    }
+
+    /// The timeline fetch arms the buffer; no other board RPC does. Pins the
+    /// condition itself, which the two drain tests cannot: they set the buffer by
+    /// hand, so both stay green if the arming is deleted.
+    #[test]
+    fn only_the_timeline_fetch_arms_the_buffer() {
+        let mut p = HangarPlugin::new();
+        p.arm_timeline_buffer_for(BOARDS_REQ_ID);
+        assert!(
+            p.timeline_fetch_buffer.is_none(),
+            "a board list fetch must not arm it"
+        );
+        p.arm_timeline_buffer_for(BOARD_CARD_TIMELINE_REQ_ID);
+        assert!(
+            p.timeline_fetch_buffer.is_some(),
+            "the timeline fetch must arm it"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -1230,6 +1230,13 @@ impl HangarPlugin {
         } = &event
         {
             if let Some(buffered) = &mut self.timeline_fetch_buffer {
+                // Bounded like the overlay it feeds: a reply that never arrives
+                // (daemon gone mid-fetch) would otherwise buffer every line of
+                // every run for the rest of the session. Oldest out, same as
+                // `TimelineView::append_line`.
+                if buffered.len() >= crate::screen::boards::TimelineView::MAX_ENTRIES {
+                    buffered.remove(0);
+                }
                 buffered.push((task_id.as_str().to_string(), *kind, body.clone()));
             }
             self.screens.boards.fold_timeline_message(task_id.as_str(), *kind, body.clone());
@@ -1851,6 +1858,10 @@ impl HangarPlugin {
     /// that never ran (empty transcript), surfaces a note instead of an overlay so
     /// the key never dead-ends.
     fn apply_board_card_timeline(&mut self, resp: &RpcResponse) {
+        // Disarm FIRST, so every return below drops the buffer rather than leaving
+        // it armed to grow for the rest of the session: this handler returns early
+        // on a daemon error and on two decode failures.
+        let buffered = self.timeline_fetch_buffer.take().unwrap_or_default();
         if let Some(err) = &resp.error {
             self.screens.boards.set_note(format!("timeline failed: {}", err.message));
             return;
@@ -1884,7 +1895,7 @@ impl HangarPlugin {
         // above is as of the daemon's read, so those lines are in neither half
         // without this. `fold_timeline_message` filters by task id, so a line for
         // a different run is discarded here exactly as it would have been live.
-        for (task_id, kind, body) in self.timeline_fetch_buffer.take().unwrap_or_default() {
+        for (task_id, kind, body) in buffered {
             self.screens.boards.fold_timeline_message(&task_id, kind, body);
         }
     }
@@ -6337,6 +6348,29 @@ mod tests {
         assert!(
             p.timeline_fetch_buffer.is_none(),
             "the buffer is disarmed by the reply"
+        );
+    }
+
+    /// A failed timeline fetch must DISARM the buffer, not leave it armed. The
+    /// handler returns early on a daemon error, so an armed buffer would keep
+    /// growing for the rest of the session, holding every line of every run.
+    #[test]
+    fn a_failed_timeline_fetch_disarms_the_buffer() {
+        let mut p = HangarPlugin::new();
+        p.timeline_fetch_buffer = Some(Vec::new());
+        p.apply_board_card_timeline(&ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(BOARD_CARD_TIMELINE_REQ_ID),
+            result: None,
+            error: Some(ainb_hangar_proto::RpcError {
+                code: -32000,
+                message: "no such board".into(),
+                data: None,
+            }),
+        });
+        assert!(
+            p.timeline_fetch_buffer.is_none(),
+            "a rejected fetch must disarm the buffer, not leak it"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -520,6 +520,15 @@ pub struct HangarPlugin {
     /// [`fold_board_mouse`](crate::board_mouse::fold_board_mouse) against. Rebuilt
     /// each render; `None` off those screens (a click there resolves to nothing).
     board_layout: Option<crate::widgets::card_board::BoardLayout>,
+    /// Live transcript lines that arrived while a `board_card_timeline` fetch was
+    /// in flight, `None` when no fetch is pending (F6 / track A step A2).
+    ///
+    /// The reply REPLACES the overlay's entries with the snapshot the daemon read
+    /// off disk, so without this a line emitted after that read but before the
+    /// reply lands is dropped and never repaired: the durable file is not re-read
+    /// and the live stream has no replay. Buffered here and replayed onto the
+    /// fresh overlay, the transcript is continuous across the open.
+    timeline_fetch_buffer: Option<Vec<(String, ainb_hangar_proto::events::MessageKind, String)>>,
     /// List-screen mouse intents `handle_mouse` produced (63l.6), drained on the
     /// next `render`. Like the issue board's queue, this is the inline,
     /// non-blocking stash: the spawned `render` binds each to the active screen's
@@ -694,6 +703,7 @@ impl Default for HangarPlugin {
             pending_issue_priority_update: None,
             pending_issue_assignee_update: None,
             board_layout: None,
+            timeline_fetch_buffer: None,
             pending_board_mouse_intents: Vec::new(),
             list_context_menu: None,
             wizard_dispatch_in_flight: None,
@@ -1219,6 +1229,9 @@ impl HangarPlugin {
             body,
         } = &event
         {
+            if let Some(buffered) = &mut self.timeline_fetch_buffer {
+                buffered.push((task_id.as_str().to_string(), *kind, body.clone()));
+            }
             self.screens.boards.fold_timeline_message(task_id.as_str(), *kind, body.clone());
         }
         // A transcript line moves no name the inbox lookup holds (agent label,
@@ -1867,6 +1880,13 @@ impl HangarPlugin {
         self.screens.boards.set_timeline(crate::screen::boards::TimelineView::new(
             title, r.task_id, entries,
         ));
+        // Replay whatever streamed in while the fetch was in flight: the snapshot
+        // above is as of the daemon's read, so those lines are in neither half
+        // without this. `fold_timeline_message` filters by task id, so a line for
+        // a different run is discarded here exactly as it would have been live.
+        for (task_id, kind, body) in self.timeline_fetch_buffer.take().unwrap_or_default() {
+            self.screens.boards.fold_timeline_message(&task_id, kind, body);
+        }
     }
 
     /// Fold a `profile/get` result into the selected profile's detail (P5): the
@@ -3274,6 +3294,11 @@ impl HangarPlugin {
             // Handled above as a local note; never reached here.
             BoardsAction::CardAttach { .. } => return,
         };
+        // Arm the live-line buffer for the timeline round trip (see
+        // `timeline_fetch_buffer`); the reply drains it onto the fresh overlay.
+        if req_id == BOARD_CARD_TIMELINE_REQ_ID {
+            self.timeline_fetch_buffer = Some(Vec::new());
+        }
         let Ok(body) = encode_request(req_id, method, params) else {
             return;
         };
@@ -6251,6 +6276,68 @@ mod tests {
         };
         p.on_daemon_response(&resp);
         assert!(matches!(p.conn.state(), ConnState::Error(_)));
+    }
+
+    /// A line that streams in WHILE a `board_card_timeline` fetch is in flight
+    /// must survive the reply, which replaces the overlay's entries with the
+    /// snapshot the daemon read off disk. Nothing re-reads that file and the live
+    /// stream has no replay, so a dropped line here is a permanent hole in the
+    /// transcript the operator is watching.
+    #[test]
+    fn a_line_streamed_during_the_timeline_fetch_survives_the_reply() {
+        use ainb_hangar_core::ids::TaskId;
+        use ainb_hangar_proto::events::{EVENT_METHOD, MessageKind};
+
+        let mut p = HangarPlugin::new();
+        // The fetch is in flight: the overlay does not exist yet, so without the
+        // buffer this line has nowhere to land.
+        p.timeline_fetch_buffer = Some(Vec::new());
+        p.on_daemon_event(&serde_json::json!({
+            "method": EVENT_METHOD,
+            "params": serde_json::to_value(&HangarEvent::TaskMessage {
+                task_id: TaskId::from_str("t1").unwrap(),
+                kind: MessageKind::Agent,
+                body: "mid-fetch line".into(),
+            })
+            .unwrap(),
+        }));
+
+        // The reply lands with a snapshot taken BEFORE that line was written.
+        p.apply_board_card_timeline(&ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(BOARD_CARD_TIMELINE_REQ_ID),
+            result: Some(
+                serde_json::to_value(ainb_hangar_proto::snapshots::BoardCardTimelineResult {
+                    task_id: Some("t1".into()),
+                    provider: Some("claude".into()),
+                    jsonl: r#"{"type":"assistant","message":{"content":[{"type":"text","text":"earlier line"}]}}"#
+                        .into(),
+                })
+                .unwrap(),
+            ),
+            error: None,
+        });
+
+        let bodies: Vec<&str> = p
+            .screens
+            .boards
+            .timeline()
+            .expect("the reply opens the overlay")
+            .entries()
+            .iter()
+            .filter_map(|e| match e {
+                crate::screen::task_detail::ViewEntry::Line(l) => Some(l.body()),
+                crate::screen::task_detail::ViewEntry::CollapsedThinking { .. } => None,
+            })
+            .collect();
+        assert!(
+            bodies.contains(&"mid-fetch line"),
+            "the line streamed during the fetch must be replayed onto the overlay; got {bodies:?}"
+        );
+        assert!(
+            p.timeline_fetch_buffer.is_none(),
+            "the buffer is disarmed by the reply"
+        );
     }
 
     /// A `TaskMessage` (transcript line) must NOT arm a snapshot re-pull — the

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -3160,6 +3160,15 @@ impl HangarPlugin {
     ///
     /// Split out of the dispatch below purely so it is reachable from a test: the
     /// dispatch needs a `HostClient`, which has no public constructor.
+    ///
+    /// ponytail: the CALL is still unguarded. This helper is tested, but deleting
+    /// `self.arm_timeline_buffer_for(req_id)` from the dispatch fails no test
+    /// (verified: 0 of 50 plugin suites), and silently reopens the hole where a
+    /// timeline opened mid-run loses every line between the daemon's read and the
+    /// overlay install. Closing it needs either a `HostClient` test seam in
+    /// `ainb-plugin-sdk-rust` or widening all 16 arms of the dispatch match to
+    /// carry a `#[must_use]` buffer beside the request. Both cost more than the
+    /// line is worth today; revisit when A6 reworks this seam.
     fn arm_timeline_buffer_for(&mut self, req_id: i64) {
         if req_id == BOARD_CARD_TIMELINE_REQ_ID {
             self.timeline_fetch_buffer.get_or_insert_with(Default::default);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -753,9 +753,17 @@ fn answer_verdict_note(
 /// it. Both halves are the same `(kind, body)` from the same classifier, so the
 /// overlap is an exact prefix/suffix match. Returns 0 when they do not overlap.
 ///
-/// ponytail: the longest match wins, checked longest-first over at most the
-/// buffer's length; that is O(n*m) worst case on a few thousand short entries,
-/// which happens once per timeline open. A rolling hash if a profile ever says so.
+/// Both sides are scoped to ONE task before this runs, so a concurrent run's
+/// lines cannot break the match.
+///
+/// ponytail: the seam is GUESSED from content, not identified. Longest match
+/// wins, so a repeated `(kind, body)` at the seam (snapshot tail `[X, X]`,
+/// buffer `[X, Y]`) reads as overlap 2 and drops a genuine `X`. Losing a
+/// duplicate line beats printing one twice, which is why the bias is this way
+/// round; carrying the daemon's line ordinal on `TaskMessage` would identify the
+/// seam instead of guessing it, and that is the fix if it ever matters.
+/// Longest-first costs O(n*m) worst case on a few thousand short entries, once
+/// per timeline open.
 fn leading_overlap(
     snapshot: &[crate::screen::task_detail::ViewEntry],
     buffered: &std::collections::VecDeque<(String, ainb_hangar_proto::events::MessageKind, String)>,
@@ -764,7 +772,7 @@ fn leading_overlap(
         .iter()
         .filter_map(|e| match e {
             crate::screen::task_detail::ViewEntry::Line(l) => Some((l.kind(), l.body())),
-            crate::screen::task_detail::ViewEntry::CollapsedThinking { .. } => None,
+            _ => None,
         })
         .collect();
     let max = buffered.len().min(tail.len());
@@ -1911,6 +1919,12 @@ impl HangarPlugin {
             return;
         };
         let entries = crate::widgets::jsonl_timeline::parse_timeline(&r.jsonl);
+        // The buffer collects EVERY task's lines, so drop the foreign ones before
+        // measuring: a concurrent run's line at or before the seam would otherwise
+        // break the match and replay the whole overlap twice. The replay below
+        // discards them anyway, so this only moves the filter earlier.
+        let mut buffered = buffered;
+        buffered.retain(|(t, _, _)| Some(t.as_str()) == r.task_id.as_deref());
         // The buffer arms before the request goes out, while the snapshot covers
         // the log up to the daemon's read, and the runner writes each line to the
         // JSONL BEFORE it emits it. So every line in that window is in BOTH halves,

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -528,7 +528,9 @@ pub struct HangarPlugin {
     /// reply lands is dropped and never repaired: the durable file is not re-read
     /// and the live stream has no replay. Buffered here and replayed onto the
     /// fresh overlay, the transcript is continuous across the open.
-    timeline_fetch_buffer: Option<Vec<(String, ainb_hangar_proto::events::MessageKind, String)>>,
+    timeline_fetch_buffer: Option<
+        std::collections::VecDeque<(String, ainb_hangar_proto::events::MessageKind, String)>,
+    >,
     /// List-screen mouse intents `handle_mouse` produced (63l.6), drained on the
     /// next `render`. Like the issue board's queue, this is the inline,
     /// non-blocking stash: the spawned `render` binds each to the active screen's
@@ -741,6 +743,40 @@ fn answer_verdict_note(
             format!("answer failed: {detail}")
         }
     })
+}
+
+/// How many LEADING entries of `buffered` the tail of `snapshot` already carries.
+///
+/// The timeline snapshot and the live buffer overlap by construction: the buffer
+/// arms when the request is written, the snapshot covers the log up to the
+/// daemon's read, and the runner writes each line to the JSONL before emitting
+/// it. Both halves are the same `(kind, body)` from the same classifier, so the
+/// overlap is an exact prefix/suffix match. Returns 0 when they do not overlap.
+///
+/// ponytail: the longest match wins, checked longest-first over at most the
+/// buffer's length; that is O(n*m) worst case on a few thousand short entries,
+/// which happens once per timeline open. A rolling hash if a profile ever says so.
+fn leading_overlap(
+    snapshot: &[crate::screen::task_detail::ViewEntry],
+    buffered: &std::collections::VecDeque<(String, ainb_hangar_proto::events::MessageKind, String)>,
+) -> usize {
+    let tail: Vec<(ainb_hangar_proto::events::MessageKind, &str)> = snapshot
+        .iter()
+        .filter_map(|e| match e {
+            crate::screen::task_detail::ViewEntry::Line(l) => Some((l.kind(), l.body())),
+            crate::screen::task_detail::ViewEntry::CollapsedThinking { .. } => None,
+        })
+        .collect();
+    let max = buffered.len().min(tail.len());
+    (1..=max)
+        .rev()
+        .find(|&n| {
+            tail[tail.len() - n..]
+                .iter()
+                .zip(buffered.iter().take(n))
+                .all(|((sk, sb), (_, bk, bb))| sk == bk && sb == bb)
+        })
+        .unwrap_or(0)
 }
 
 impl HangarPlugin {
@@ -1235,9 +1271,9 @@ impl HangarPlugin {
                 // every run for the rest of the session. Oldest out, same as
                 // `TimelineView::append_line`.
                 if buffered.len() >= crate::screen::boards::TimelineView::MAX_ENTRIES {
-                    buffered.remove(0);
+                    buffered.pop_front();
                 }
-                buffered.push((task_id.as_str().to_string(), *kind, body.clone()));
+                buffered.push_back((task_id.as_str().to_string(), *kind, body.clone()));
             }
             self.screens.boards.fold_timeline_message(task_id.as_str(), *kind, body.clone());
         }
@@ -1875,6 +1911,12 @@ impl HangarPlugin {
             return;
         };
         let entries = crate::widgets::jsonl_timeline::parse_timeline(&r.jsonl);
+        // The buffer arms before the request goes out, while the snapshot covers
+        // the log up to the daemon's read, and the runner writes each line to the
+        // JSONL BEFORE it emits it. So every line in that window is in BOTH halves,
+        // and `append_line` does not dedupe. Measure the overlap here, while
+        // `entries` is still ours, and skip that many on replay below.
+        let overlap = leading_overlap(&entries, &buffered);
         // A card that NEVER ran (no task) with no transcript: a note, not an empty
         // overlay. But a run that HAS started (task present) yet not emitted its
         // first JSONL line still opens the overlay with zero entries, so the F6
@@ -1891,11 +1933,11 @@ impl HangarPlugin {
         self.screens.boards.set_timeline(crate::screen::boards::TimelineView::new(
             title, r.task_id, entries,
         ));
-        // Replay whatever streamed in while the fetch was in flight: the snapshot
-        // above is as of the daemon's read, so those lines are in neither half
-        // without this. `fold_timeline_message` filters by task id, so a line for
-        // a different run is discarded here exactly as it would have been live.
-        for (task_id, kind, body) in buffered {
+        // Replay whatever streamed in while the fetch was in flight, minus the
+        // overlap measured above. `fold_timeline_message` filters by task id, so a
+        // line for a different run is discarded here exactly as it would have been
+        // live.
+        for (task_id, kind, body) in buffered.into_iter().skip(overlap) {
             self.screens.boards.fold_timeline_message(&task_id, kind, body);
         }
     }
@@ -3308,7 +3350,10 @@ impl HangarPlugin {
         // Arm the live-line buffer for the timeline round trip (see
         // `timeline_fetch_buffer`); the reply drains it onto the fresh overlay.
         if req_id == BOARD_CARD_TIMELINE_REQ_ID {
-            self.timeline_fetch_buffer = Some(Vec::new());
+            // Arm only when unarmed: both replies carry the same req id, so
+            // overwriting on a second open would hand reply 1 fetch 2's buffer and
+            // leave reply 2 nothing to replay, reopening the hole this closes.
+            self.timeline_fetch_buffer.get_or_insert_with(Default::default);
         }
         let Ok(body) = encode_request(req_id, method, params) else {
             return;
@@ -6302,7 +6347,7 @@ mod tests {
         let mut p = HangarPlugin::new();
         // The fetch is in flight: the overlay does not exist yet, so without the
         // buffer this line has nowhere to land.
-        p.timeline_fetch_buffer = Some(Vec::new());
+        p.timeline_fetch_buffer = Some(std::collections::VecDeque::new());
         p.on_daemon_event(&serde_json::json!({
             "method": EVENT_METHOD,
             "params": serde_json::to_value(&HangarEvent::TaskMessage {
@@ -6351,13 +6396,87 @@ mod tests {
         );
     }
 
+    /// A line in the window `[buffer armed, daemon read]` is in BOTH halves: the
+    /// runner writes it to the JSONL before it emits it. `append_line` does not
+    /// dedupe, so replaying the buffer whole duplicates the overlap.
+    #[test]
+    fn the_overlap_between_snapshot_and_buffer_is_not_replayed_twice() {
+        use ainb_hangar_proto::events::MessageKind;
+
+        let mut p = HangarPlugin::new();
+        // Both lines are already in the snapshot; the second also streamed live.
+        let mut armed = std::collections::VecDeque::new();
+        armed.push_back(("t1".to_string(), MessageKind::Agent, "second".to_string()));
+        armed.push_back(("t1".to_string(), MessageKind::Agent, "third".to_string()));
+        p.timeline_fetch_buffer = Some(armed);
+
+        let jsonl = [
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"first"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}"#,
+        ]
+        .join("\n");
+        p.apply_board_card_timeline(&ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(BOARD_CARD_TIMELINE_REQ_ID),
+            result: Some(
+                serde_json::to_value(ainb_hangar_proto::snapshots::BoardCardTimelineResult {
+                    task_id: Some("t1".into()),
+                    provider: Some("claude".into()),
+                    jsonl,
+                })
+                .unwrap(),
+            ),
+            error: None,
+        });
+
+        let bodies: Vec<&str> = p
+            .screens
+            .boards
+            .timeline()
+            .expect("overlay opens")
+            .entries()
+            .iter()
+            .filter_map(|e| match e {
+                crate::screen::task_detail::ViewEntry::Line(l) => Some(l.body()),
+                crate::screen::task_detail::ViewEntry::CollapsedThinking { .. } => None,
+            })
+            .collect();
+        assert_eq!(
+            bodies,
+            vec!["first", "second", "third"],
+            "the overlapping line appears once, and the live-only line still lands"
+        );
+    }
+
+    /// A second open while one fetch is in flight must NOT overwrite the buffer:
+    /// both replies carry the same req id, so reply 1 would drain fetch 2's buffer
+    /// and reply 2 would find nothing.
+    #[test]
+    fn a_second_timeline_fetch_keeps_the_buffered_lines() {
+        use ainb_hangar_proto::events::MessageKind;
+        let mut p = HangarPlugin::new();
+        let mut armed = std::collections::VecDeque::new();
+        armed.push_back((
+            "t1".to_string(),
+            MessageKind::Agent,
+            "already here".to_string(),
+        ));
+        p.timeline_fetch_buffer = Some(armed);
+        p.timeline_fetch_buffer.get_or_insert_with(Default::default);
+        assert_eq!(
+            p.timeline_fetch_buffer.as_ref().map(std::collections::VecDeque::len),
+            Some(1),
+            "re-arming must keep what the first fetch already buffered"
+        );
+    }
+
     /// A failed timeline fetch must DISARM the buffer, not leave it armed. The
     /// handler returns early on a daemon error, so an armed buffer would keep
     /// growing for the rest of the session, holding every line of every run.
     #[test]
     fn a_failed_timeline_fetch_disarms_the_buffer() {
         let mut p = HangarPlugin::new();
-        p.timeline_fetch_buffer = Some(Vec::new());
+        p.timeline_fetch_buffer = Some(std::collections::VecDeque::new());
         p.apply_board_card_timeline(&ainb_hangar_proto::RpcResponse {
             jsonrpc: "2.0".into(),
             id: RpcId::Number(BOARD_CARD_TIMELINE_REQ_ID),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -750,15 +750,16 @@ fn answer_verdict_note(
 /// The timeline snapshot and the live buffer overlap by construction: the buffer
 /// arms when the request is written, the snapshot covers the log up to the
 /// daemon's read, and the runner writes each line to the JSONL before emitting
-/// it. Both halves are the same `(kind, body)` from the same classifier, so the
-/// overlap is an exact prefix/suffix match. Returns 0 when they do not overlap.
+/// it. Both halves are the same `(kind, body)` from the same classifier, so an
+/// overlap shows up as a matching prefix/suffix. Returns 0 when none matches.
 ///
 /// Both sides are scoped to ONE task before this runs, so a concurrent run's
 /// lines cannot break the match.
 ///
 /// ponytail: the seam is GUESSED from content, not identified. Longest match
 /// wins, so a repeated `(kind, body)` at the seam (snapshot tail `[X, X]`,
-/// buffer `[X, Y]`) reads as overlap 2 and drops a genuine `X`. Losing a
+/// buffer `[X, Y]`) matches at length 1 and replays `[Y]`, dropping the second
+/// genuine `X` if there was one. Losing a
 /// duplicate line beats printing one twice, which is why the bias is this way
 /// round; carrying the daemon's line ordinal on `TaskMessage` would identify the
 /// seam instead of guessing it, and that is the fix if it ever matters.
@@ -3164,29 +3165,23 @@ impl HangarPlugin {
         }
     }
 
-    /// Arm the live-line buffer when `req_id` is the timeline fetch, so lines
-    /// streaming in during the round trip are replayed onto the fresh overlay
-    /// (see [`Self::timeline_fetch_buffer`]).
+    /// Arm the live-line buffer and return the timeline fetch's request id, so
+    /// lines streaming in during the round trip are replayed onto the fresh
+    /// overlay (see [`Self::timeline_fetch_buffer`]).
+    ///
+    /// Returns the id rather than taking one: called from inside the
+    /// `CardTimeline` arm that BUILDS the request, so the arming and the fetch are
+    /// one expression and cannot be separated. Deleting the arming deletes the
+    /// fetch, which fails loudly instead of silently reopening the hole where a
+    /// timeline opened mid-run loses every line between the daemon's read and the
+    /// overlay install.
     ///
     /// Arms only when UNARMED: both replies carry the same req id, so overwriting
     /// on a second open would hand reply 1 fetch 2's buffer and leave reply 2
-    /// nothing to replay, reopening the hole this closes.
-    ///
-    /// Split out of the dispatch below purely so it is reachable from a test: the
-    /// dispatch needs a `HostClient`, which has no public constructor.
-    ///
-    /// ponytail: the CALL is still unguarded. This helper is tested, but deleting
-    /// `self.arm_timeline_buffer_for(req_id)` from the dispatch fails no test
-    /// (verified: 0 of 50 plugin suites), and silently reopens the hole where a
-    /// timeline opened mid-run loses every line between the daemon's read and the
-    /// overlay install. Closing it needs either a `HostClient` test seam in
-    /// `ainb-plugin-sdk-rust` or widening all 16 arms of the dispatch match to
-    /// carry a `#[must_use]` buffer beside the request. Both cost more than the
-    /// line is worth today; revisit when A6 reworks this seam.
-    fn arm_timeline_buffer_for(&mut self, req_id: i64) {
-        if req_id == BOARD_CARD_TIMELINE_REQ_ID {
-            self.timeline_fetch_buffer.get_or_insert_with(Default::default);
-        }
+    /// nothing to replay.
+    fn arm_timeline_buffer(&mut self) -> i64 {
+        self.timeline_fetch_buffer.get_or_insert_with(Default::default);
+        BOARD_CARD_TIMELINE_REQ_ID
     }
 
     /// Fire a deferred board mutation RPC raised by the Boards screen (P4 / D8,
@@ -3340,7 +3335,9 @@ impl HangarPlugin {
             // Timeline fetch answers under its own req id with the raw transcript;
             // the reply handler parses it into the overlay.
             BoardsAction::CardTimeline { board_id, issue_id } => (
-                BOARD_CARD_TIMELINE_REQ_ID,
+                // Armed HERE, in the arm that builds the request, so the buffer and
+                // the fetch cannot be separated. See `arm_timeline_buffer`.
+                self.arm_timeline_buffer(),
                 daemon_methods::HANGAR_BOARD_CARD_TIMELINE,
                 serde_json::json!({ "workspace_id": ws, "board_id": board_id, "issue_id": issue_id }),
             ),
@@ -3386,7 +3383,6 @@ impl HangarPlugin {
             // Handled above as a local note; never reached here.
             BoardsAction::CardAttach { .. } => return,
         };
-        self.arm_timeline_buffer_for(req_id);
         let Ok(body) = encode_request(req_id, method, params) else {
             return;
         };
@@ -6480,6 +6476,64 @@ mod tests {
         );
     }
 
+    /// The buffer holds EVERY task's lines, so a concurrent run's line must not
+    /// reach the overlay OR shift the overlap. Deleting the `retain` leaves the
+    /// whole crate green, because every other fixture uses one task id.
+    #[test]
+    fn a_concurrent_runs_line_neither_shifts_the_overlap_nor_lands() {
+        use ainb_hangar_proto::events::MessageKind;
+
+        let mut p = HangarPlugin::new();
+        let mut armed = std::collections::VecDeque::new();
+        // A FOREIGN line first: without the retain it breaks the prefix match, so
+        // the overlap collapses to 0 and "second" is replayed on top of itself.
+        armed.push_back((
+            "t2".to_string(),
+            MessageKind::Agent,
+            "other run".to_string(),
+        ));
+        armed.push_back(("t1".to_string(), MessageKind::Agent, "second".to_string()));
+        armed.push_back(("t1".to_string(), MessageKind::Agent, "third".to_string()));
+        p.timeline_fetch_buffer = Some(armed);
+
+        let jsonl = [
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"first"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}"#,
+        ]
+        .join("\n");
+        p.apply_board_card_timeline(&ainb_hangar_proto::RpcResponse {
+            jsonrpc: "2.0".into(),
+            id: RpcId::Number(BOARD_CARD_TIMELINE_REQ_ID),
+            result: Some(
+                serde_json::to_value(ainb_hangar_proto::snapshots::BoardCardTimelineResult {
+                    task_id: Some("t1".into()),
+                    provider: Some("claude".into()),
+                    jsonl,
+                })
+                .unwrap(),
+            ),
+            error: None,
+        });
+
+        let bodies: Vec<&str> = p
+            .screens
+            .boards
+            .timeline()
+            .expect("overlay opens")
+            .entries()
+            .iter()
+            .filter_map(|e| match e {
+                crate::screen::task_detail::ViewEntry::Line(l) => Some(l.body()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            bodies,
+            vec!["first", "second", "third"],
+            "the foreign line neither lands nor breaks the dedupe"
+        );
+    }
+
     /// A second open while one fetch is in flight must NOT overwrite the buffer:
     /// both replies carry the same req id, so reply 1 would drain fetch 2's buffer
     /// and reply 2 would find nothing.
@@ -6494,7 +6548,7 @@ mod tests {
             "already here".to_string(),
         ));
         p.timeline_fetch_buffer = Some(armed);
-        p.arm_timeline_buffer_for(BOARD_CARD_TIMELINE_REQ_ID);
+        p.arm_timeline_buffer();
         assert_eq!(
             p.timeline_fetch_buffer.as_ref().map(std::collections::VecDeque::len),
             Some(1),
@@ -6502,22 +6556,17 @@ mod tests {
         );
     }
 
-    /// The timeline fetch arms the buffer; no other board RPC does. Pins the
-    /// condition itself, which the two drain tests cannot: they set the buffer by
-    /// hand, so both stay green if the arming is deleted.
+    /// Arming installs the buffer AND yields the fetch's request id, so the
+    /// dispatch cannot obtain one without the other.
     #[test]
-    fn only_the_timeline_fetch_arms_the_buffer() {
+    fn arming_the_buffer_yields_the_timeline_request_id() {
         let mut p = HangarPlugin::new();
-        p.arm_timeline_buffer_for(BOARDS_REQ_ID);
         assert!(
             p.timeline_fetch_buffer.is_none(),
-            "a board list fetch must not arm it"
+            "unarmed before the fetch"
         );
-        p.arm_timeline_buffer_for(BOARD_CARD_TIMELINE_REQ_ID);
-        assert!(
-            p.timeline_fetch_buffer.is_some(),
-            "the timeline fetch must arm it"
-        );
+        assert_eq!(p.arm_timeline_buffer(), BOARD_CARD_TIMELINE_REQ_ID);
+        assert!(p.timeline_fetch_buffer.is_some(), "the fetch arms it");
     }
 
     /// A failed timeline fetch must DISARM the buffer, not leave it armed. The

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/boards.rs
@@ -99,7 +99,7 @@ impl TimelineView {
     /// Cap on the live-appended transcript entries: a long run streams without
     /// bound, so the tail view keeps only the most recent lines (dropping the
     /// oldest), matching the daemon's 512 KiB tail on the initial fetch.
-    const MAX_ENTRIES: usize = 5000;
+    pub(crate) const MAX_ENTRIES: usize = 5000;
 
     /// Append one live transcript line (from a `TaskMessage` on this task's run),
     /// following the tail: if the view was scrolled to the last entry it advances

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/banner_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/banner_reducer_test.rs
@@ -56,7 +56,14 @@ fn banner_elapsed_increments_on_tick() {
     assert_eq!(s.banner().unwrap().elapsed_secs, e0 + 2);
 }
 
-/// `TaskFinished` hides the banner.
+/// `TaskFinished` hides the banner, and a LATE transcript event for the same
+/// task does not resurrect it.
+///
+/// The daemon splits the transcript onto its own broadcast (track A step A2), so
+/// a `TaskMessage` / `TaskProgress` can arrive after its run's `TaskFinished`.
+/// Both arms guard on a banner that exists AND matches, which is the only reason
+/// that reordering is harmless; without the guards a late event would leave a
+/// zombie banner pinned across every screen.
 #[test]
 fn banner_hides_on_task_finished_event() {
     let mut s = BannerState::default();
@@ -73,6 +80,25 @@ fn banner_hides_on_task_finished_event() {
     )
     .state;
     assert!(s.banner().is_none());
+
+    for late in [
+        HangarEvent::TaskMessage {
+            task_id: task(),
+            kind: MessageKind::Agent,
+            body: "a line that lost the race".into(),
+        },
+        HangarEvent::TaskProgress {
+            task_id: task(),
+            tool_calls: 7,
+            elapsed_ms: 1_000,
+        },
+    ] {
+        s = reduce_banner(&s, BannerEvent::Event(late)).state;
+        assert!(
+            s.banner().is_none(),
+            "a late transcript event must not revive the banner"
+        );
+    }
 }
 
 /// A capital-`X` keystroke emits a cancel intent regardless of the originating

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/banner_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/banner_reducer_test.rs
@@ -61,9 +61,10 @@ fn banner_elapsed_increments_on_tick() {
 ///
 /// The daemon splits the transcript onto its own broadcast (track A step A2), so
 /// a `TaskMessage` / `TaskProgress` can arrive after its run's `TaskFinished`.
-/// Both arms guard on a banner that exists AND matches, which is the only reason
-/// that reordering is harmless; without the guards a late event would leave a
-/// zombie banner pinned across every screen.
+/// Only `TaskStarted` constructs a banner, so a late event cannot resurrect one;
+/// what the guards prevent is the leftover state a hidden banner would otherwise
+/// keep accumulating, which is why the message text is asserted and not just the
+/// banner's absence.
 #[test]
 fn banner_hides_on_task_finished_event() {
     let mut s = BannerState::default();
@@ -103,6 +104,32 @@ fn banner_hides_on_task_finished_event() {
             "and must not write through to the hidden banner's message"
         );
     }
+}
+
+/// A FOREIGN task's progress must not write into this banner. Nothing exercised
+/// the task-id filter, so deleting it shipped a banner showing another run's
+/// tool count.
+#[test]
+fn a_foreign_tasks_progress_does_not_touch_the_banner() {
+    let mut s = BannerState::default();
+    s = reduce_banner(&s, BannerEvent::Event(queued())).state;
+    s = reduce_banner(&s, BannerEvent::Event(started())).state;
+    assert_eq!(s.banner().unwrap().tool_calls, 0);
+
+    s = reduce_banner(
+        &s,
+        BannerEvent::Event(HangarEvent::TaskProgress {
+            task_id: TaskId::from_str("t2").unwrap(),
+            tool_calls: 99,
+            elapsed_ms: 1_000,
+        }),
+    )
+    .state;
+    assert_eq!(
+        s.banner().unwrap().tool_calls,
+        0,
+        "another run's tool count must not land on this banner"
+    );
 }
 
 /// A capital-`X` keystroke emits a cancel intent regardless of the originating

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/banner_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/banner_reducer_test.rs
@@ -98,6 +98,10 @@ fn banner_hides_on_task_finished_event() {
             s.banner().is_none(),
             "a late transcript event must not revive the banner"
         );
+        assert!(
+            s.latest_message().is_empty(),
+            "and must not write through to the hidden banner's message"
+        );
     }
 }
 


### PR DESCRIPTION
Track A step A2, the PROCESS executor half. The ACP half lands in A5.

## The producer

`HangarEvent::TaskMessage` and `TaskProgress` have had consumers since P3 and
no producer anywhere in `src/`. Verified again before writing one:

```
rg 'HangarEvent::TaskMessage' crates/ --glob '!**/tests/**'
  -> event_outbox.rs (routing), inbox_aggregator.rs (ignore),
     plugin.rs:1197, banner_state.rs:135, task_detail.rs:761  [all consumers]
```

So the board timeline's live append, the run banner's tool count, and task
detail's transcript arm were all dead code waiting for a producer. This is it:

```
  stream_stdout (runner.rs)
       │ writeln! logs/<provider>.jsonl        (durable, byte-identical to today)
       │
       └─▶ StreamJsonClassifier::classify_line
                    │
                    ├─▶ TaskMessage { task_id, kind, body }   per classified entry
                    └─▶ TaskProgress { tool_calls, elapsed }  1s tick + one at EOF
```

ONE `StreamJsonClassifier` per run, not per line. A `tool_result` takes its tool
name and duration from the earlier `tool_use` line, so a fresh classifier per
line degrades `Edit  1 file changed` to `tool  1 file changed`. That is one of
the three falsifiers below.

The EOF tick exists because a run whose whole transcript lands inside one second
would otherwise publish only the tick that fired on its FIRST line, so the
banner would report the tool count from before any tool ran.

Zero plugin changes. All three consumers, including the task-detail append arm
the plan listed as possibly needed, already existed.

## The seam, and why this one

The plan suggested `RunnerConfig.sink`. I put it on `Runner` instead:
`Runner::with_task_stream(workspace_id, task_id, events) -> Runner`.

- The sink is per RUN, not per daemon: it carries this task's id and workspace.
  `RunnerConfig` is static daemon config and that is the wrong home for a task id.
- The claim loop already clones the daemon-wide runner per run
  (`run_loop.rs:628`), so binding costs nothing extra.
- A field on `RunnerConfig` would have touched all ten `RunnerConfig { .. }`
  construction sites. This touches none.

Nothing threads through the four provider specs or any `run_*` entry point. The
interactive arm takes the same bound runner and ignores it: that path captures
no stdout, so there is nothing to classify.

## The fork I took: `emit_live`, not `emit`

`EventSink::emit` appends one `event_log` row per event, and every one of those
commits takes the single SQLite write lock the whole control plane shares. A
claude run is thousands of lines, so emitting the transcript through `emit`
would dual-write it into SQLite, which is exactly what `store_writer.rs:14`
warns against and what the A2 brief forbids.

So: `EventSink::emit_live`, live broadcast only, no outbox row. Same shape as
`emit_attention`, which already bypasses the outbox for the same reason (a
stream whose durable source is elsewhere stays off the log,
`event_outbox.rs:88-93`). `outbox_fields` stays total, so a new variant is still
a compile error to ignore.

Nothing is lost: the transcript is already durable in `{logs}/<provider>.jsonl`,
and `hangar/board_card_timeline` re-reads it from exactly there. A subscriber
that missed the live lines backfills from that read, not from an event replay.
That is the same backfill B4's transcript pane uses.

Known ceiling, unchanged from today's design: the live broadcast is capacity 256
and lossy, so a provider that bursts faster than a subscriber drains will drop
that subscriber's oldest events. Pre-existing for every event; the next snapshot
pull reconciles. Not throttling `TaskMessage` is deliberate per the plan
(`plugin.rs:1177` exists precisely so a transcript line does NOT arm a snapshot
re-pull).

## What T1 proves

`tests/tripwire_task_live_stream.rs`. A real `ainb-hangar-daemon` binary, a real
provider subprocess writing real stream-json, a real Unix-socket subscription
opened BEFORE the enqueue, and the real `hangar/board_card_timeline` read.

```
subscribe ─▶ enqueue ─▶ claim ─▶ fake claude ─▶ TaskMessage…  ─┐
                                       │                       ├─ must be EQUAL
                              logs/claude.jsonl ─▶ timeline ───┘
                                                  (classified)
```

Assertions, in order, because order matters:

1. the live sequence is NOT empty (two empty vectors are equal, so a producer
   that emits nothing must fail on this line, not pass the equality),
2. all four lanes are present (Agent, Thinking, ToolCall, ToolResult),
3. live `(kind, body)` == `classify_stream_json(timeline.jsonl)`, byte for byte,
4. the closing `TaskProgress` reports the run's one tool call.

Falsified three ways before landing, each observed RED:

| falsifier | failure |
|---|---|
| producer not bound | `must stream TaskMessage events; got none` |
| classifier per line | `left: (ToolResult, "tool  1 file changed")` vs `right: (ToolResult, "Edit  1 file changed")` |
| no EOF progress tick | `left: Some(0)` vs `right: Some(1)` |

Named `tripwire_*` in `ainb-hangar-daemon/tests/`, so it rides the existing
`hangar-e2e` lane with zero workflow edits. SKIPs cleanly without tmux.

## Verification

Green locally: T1, `argv_golden_matrix` (unchanged and untouched, A2 adds no
argv), `runner_claude`, `runner_codex`, `runner_antigravity`, `rpc_event_push`,
`rpc_event_replay`, `inbox_subscriber_fanout`,
`tripwire_task_happy_path_claude_provider`, `tripwire_board_auto_move_e2e`,
`tripwire_pr_capture`, `tripwire_soak_stream_backpressure`, and the 611
`-p ainb-hangar-daemon --lib` tests. `cargo fmt --all --check` clean. The CI
span-guard clippy gate (`-D clippy::await_holding_invalid_type`) clean.

## Out of scope

The ACP executor and the `HANGAR_TASK_EXECUTOR` flag (A5, which completes T1's
other half against the same assertion), the unified durable read (A6), any UI
restructure (B4).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live task transcript streaming for subscribed workspace clients.
  * Task updates now include messages, tool activity, and periodic progress during headless runs.
  * Live updates are delivered immediately without being added to durable event history.
  * Improved timeline loading so transcript updates received during refreshes are preserved without duplication.

* **Reliability**
  * Added safeguards to limit oversized transcript messages and excessive entries.
  * Prevented cancelled runs from continuing to emit transcript updates.

* **Tests**
  * Added end-to-end coverage for transcript content, message types, task completion, and tool-count reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Late correction: the timeline arm IS coupled

An earlier revision of this body recorded the dispatch arm as having no
regression guard, on the estimate that coupling it to the request would mean
widening all 16 arms of the board-action match. That estimate was wrong: `ws` is
already an owned `String` at the match, so `&mut self` inside the `CardTimeline`
arm compiles and only that one arm changes.

`arm_timeline_buffer` now installs the buffer and returns the fetch's request
id, and is called from inside the arm that builds the request. The two cannot be
separated: deleting the arming deletes the fetch, which fails loudly instead of
silently reopening the mid-run hole. No `HostClient` seam, no cross-crate change.
