### PR TITLE
fix(hangar-store): boot a database that applied the other migration 93

### DIFF
--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -325,6 +325,55 @@ mod migration_tests {
                 .unwrap();
         assert_eq!(present, 1, "0087 must be reconciled, not run");
     }
+    /// Two migration files sharing a version number merge cleanly, because the
+    /// filenames differ and git sees no textual conflict, then fail at runtime
+    /// on `UNIQUE constraint failed: _sqlx_migrations.version` for every fresh
+    /// database. It has happened twice: 0082 (fixed by renumbering the
+    /// attention migration to 0084) and 0093, where an unmerged branch and main
+    /// both took the slot. Diff the numbers, not the filenames.
+    #[test]
+    fn every_migration_file_has_a_unique_version() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+        let mut by_version: std::collections::BTreeMap<u32, Vec<String>> =
+            std::collections::BTreeMap::new();
+        for entry in std::fs::read_dir(&dir).expect("migrations/ must be readable") {
+            let name = entry.unwrap().file_name().to_string_lossy().into_owned();
+            let Some(stem) = name.strip_suffix(".sql") else {
+                continue;
+            };
+            let (digits, slug) = stem
+                .split_once('_')
+                .unwrap_or_else(|| panic!("{name} does not follow NNNN_<slug>.sql"));
+            assert_eq!(
+                digits.len(),
+                4,
+                "{name} must use a 4-digit zero-padded ordinal"
+            );
+            assert!(
+                !slug.is_empty(),
+                "{name} must carry a slug after the ordinal"
+            );
+            let version: u32 = digits
+                .parse()
+                .unwrap_or_else(|_| panic!("{name} must start with a 4-digit ordinal"));
+            by_version.entry(version).or_default().push(name);
+        }
+        assert!(
+            !by_version.is_empty(),
+            "no migrations found in {}",
+            dir.display()
+        );
+        let clashes: Vec<String> = by_version
+            .iter()
+            .filter(|(_, files)| files.len() > 1)
+            .map(|(version, files)| format!("{version}: {}", files.join(", ")))
+            .collect();
+        assert!(
+            clashes.is_empty(),
+            "migration versions claimed more than once: {}",
+            clashes.join("; ")
+        );
+    }
 }
 
 /// Probe whether the LIVE database has drifted away from the schema this

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -155,6 +155,15 @@ const FOREIGN_MIGRATION_93_INDEX: &str = "idx_fleet_provider_event_retention";
 ///
 /// Keyed on the foreign description, so a database whose 93 is main's own is
 /// untouched, and so is one that never reached 93.
+///
+/// This runs OUTSIDE `store::backup_before_pending_migrations`, whose gate is
+/// numeric: `MAX(version)` is already 93 here, so it reads an ordinary boot and
+/// takes no snapshot. That is deliberate rather than an oversight. Teaching the
+/// gate about this row would make a failed `VACUUM INTO` abort the open, so a
+/// host short on disk would be left with a database it cannot repair AND cannot
+/// boot, which is the exact failure this function exists to remove. The trade
+/// is only sound because the repair touches no user data: one index drop, whose
+/// definition lives in the file that owns it, and one bookkeeping row.
 async fn reconcile_foreign_migration_93(pool: &SqlitePool) -> anyhow::Result<()> {
     let mut connection = pool.acquire().await?;
     (&mut *connection).ensure_migrations_table().await?;
@@ -319,6 +328,37 @@ mod migration_tests {
         count == 1
     }
 
+    /// Rewind an up-to-date database to what a machine that booted a build of
+    /// the unmerged branch carries: main's 93 never ran, the branch's did, and
+    /// 93 is recorded under the branch file's description and checksum.
+    async fn seed_unmerged_0093(pool: &SqlitePool) {
+        sqlx::query("DROP INDEX IF EXISTS idx_board_card_issue")
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM _sqlx_migrations WHERE version = 93")
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO _sqlx_migrations \
+             (version, description, success, checksum, execution_time) \
+             VALUES (93, 'fleet provider event retention', TRUE, ?, -1)",
+        )
+        .bind(vec![0xde_u8, 0xad, 0xbe, 0xef])
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE INDEX idx_fleet_provider_event_retention \
+             ON fleet_provider_event(observed_at) \
+             WHERE raw_payload <> '' AND projection_revision IS NOT NULL AND source <> 'acp'",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
     /// The property that matters, and the one a recorded-versions check cannot
     /// see: after migrating, the COLUMNS are actually there.
     ///
@@ -461,34 +501,7 @@ mod migration_tests {
     async fn a_database_that_ran_the_unmerged_0093_still_upgrades() {
         let pool = memory_pool().await;
         apply_migrations(&pool).await.unwrap();
-
-        // Rewind to what such a database looks like: main's 93 never ran, the
-        // branch's did, and 93 is recorded under its description and checksum.
-        sqlx::query("DROP INDEX IF EXISTS idx_board_card_issue")
-            .execute(&pool)
-            .await
-            .unwrap();
-        sqlx::query("DELETE FROM _sqlx_migrations WHERE version = 93")
-            .execute(&pool)
-            .await
-            .unwrap();
-        sqlx::query(
-            "INSERT INTO _sqlx_migrations \
-             (version, description, success, checksum, execution_time) \
-             VALUES (93, 'fleet provider event retention', TRUE, ?, -1)",
-        )
-        .bind(vec![0xde_u8, 0xad, 0xbe, 0xef])
-        .execute(&pool)
-        .await
-        .unwrap();
-        sqlx::query(
-            "CREATE INDEX idx_fleet_provider_event_retention \
-             ON fleet_provider_event(observed_at) \
-             WHERE raw_payload <> '' AND projection_revision IS NOT NULL AND source <> 'acp'",
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
+        seed_unmerged_0093(&pool).await;
 
         apply_migrations(&pool)
             .await
@@ -522,6 +535,37 @@ mod migration_tests {
         apply_migrations(&pool).await.unwrap();
         apply_migrations(&pool).await.unwrap();
         assert!(index_exists(&pool, "idx_board_card_issue").await);
+    }
+
+    /// The daemon does not call [`apply_migrations`] directly: it boots through
+    /// [`Store::open_in`], which runs `backup_before_pending_migrations` first.
+    /// That gate compares version NUMBERS only, and on this database
+    /// `MAX(version)` is already 93, so it reads an ordinary boot and takes no
+    /// snapshot. Pin the real path, including the absent backup, because that
+    /// absence is why the repair has to be safe without one.
+    #[tokio::test]
+    async fn the_daemon_boot_path_repairs_the_unmerged_0093() {
+        let home = tempfile::tempdir().expect("create a home for the database");
+        let store = Store::open_in(home.path()).await.expect("first boot");
+        seed_unmerged_0093(store.pool()).await;
+        drop(store);
+
+        let store = Store::open_in(home.path())
+            .await
+            .expect("the daemon must boot against a database carrying the unmerged 0093");
+
+        let description: String =
+            sqlx::query_scalar("SELECT description FROM _sqlx_migrations WHERE version = 93")
+                .fetch_one(store.pool())
+                .await
+                .unwrap();
+        assert_eq!(description, "board card issue index");
+        assert!(index_exists(store.pool(), "idx_board_card_issue").await);
+        assert!(!index_exists(store.pool(), "idx_fleet_provider_event_retention").await);
+        assert!(
+            !home.path().join("hangar.db.pre-93.bak").exists(),
+            "the numeric backup gate cannot see this repair, so nothing must depend on a snapshot"
+        );
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -118,7 +118,71 @@ pub mod test_support;
 pub async fn apply_migrations(pool: &SqlitePool) -> anyhow::Result<()> {
     let migrator = sqlx::migrate!("./migrations");
     reconcile_superseded_codex_launch_migrations(pool, &migrator).await?;
+    reconcile_foreign_migration_93(pool).await?;
     migrator.run(pool).await?;
+    Ok(())
+}
+
+/// The description version 93 carries on a database that booted a build of the
+/// unmerged branch, i.e. `0093_fleet_provider_event_retention.sql`. SQLx spells
+/// a description by replacing the filename slug's underscores with spaces.
+const FOREIGN_MIGRATION_93_DESCRIPTION: &str = "fleet provider event retention";
+
+/// The only object that file created, and the only thing to unwind.
+const FOREIGN_MIGRATION_93_INDEX: &str = "idx_fleet_provider_event_retention";
+
+/// Unwind a version 93 that belongs to a different migration entirely.
+///
+/// Two unrelated files claimed 93 while one of them sat unmerged:
+/// `0093_board_card_issue_index.sql` on main (shipped in v1.23.2) and
+/// `0093_fleet_provider_event_retention.sql` on the branch. A machine that
+/// booted a branch build recorded 93 under the branch file's text, so every
+/// later boot of a released binary dies in SQLx's checksum guard with
+/// `migration 93 was previously applied but has been modified` and the daemon
+/// never starts at all. The guard is right; the version number was wrong.
+///
+/// Unlike the 0087/0089/0090 reconciliation above, the loser here is not an
+/// inert file this binary can record as applied: it is not embedded in this
+/// binary in any form. So the repair is the other direction. Drop the index it
+/// created and delete its row, leaving the database exactly as if that branch
+/// build had never run, and let SQLx apply main's 93 normally.
+///
+/// Nothing is lost. The index is a pure read optimisation over rows the branch
+/// migration never wrote to, and the branch's sweep code is not in this binary.
+/// Unwinding it, rather than only unsticking the row, is what lets the branch
+/// re-land under a free version: its `CREATE INDEX` has no `IF NOT EXISTS`, so
+/// an orphan left behind would fail the renumbered file on this same machine.
+///
+/// Keyed on the foreign description, so a database whose 93 is main's own is
+/// untouched, and so is one that never reached 93.
+async fn reconcile_foreign_migration_93(pool: &SqlitePool) -> anyhow::Result<()> {
+    let mut connection = pool.acquire().await?;
+    (&mut *connection).ensure_migrations_table().await?;
+    let foreign: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM _sqlx_migrations WHERE version = 93 AND description = ?",
+    )
+    .bind(FOREIGN_MIGRATION_93_DESCRIPTION)
+    .fetch_one(&mut *connection)
+    .await?;
+    if foreign == 0 {
+        return Ok(());
+    }
+
+    sqlx::query(&format!(
+        "DROP INDEX IF EXISTS {FOREIGN_MIGRATION_93_INDEX}"
+    ))
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query("DELETE FROM _sqlx_migrations WHERE version = 93 AND description = ?")
+        .bind(FOREIGN_MIGRATION_93_DESCRIPTION)
+        .execute(&mut *connection)
+        .await?;
+    tracing::warn!(
+        version = 93,
+        description = FOREIGN_MIGRATION_93_DESCRIPTION,
+        "unwound a migration that claimed a version number owned by another file; \
+         re-applying this binary's migration 93"
+    );
     Ok(())
 }
 
@@ -244,6 +308,17 @@ mod migration_tests {
             .collect()
     }
 
+    async fn index_exists(pool: &SqlitePool, name: &str) -> bool {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        count == 1
+    }
+
     /// The property that matters, and the one a recorded-versions check cannot
     /// see: after migrating, the COLUMNS are actually there.
     ///
@@ -325,6 +400,7 @@ mod migration_tests {
                 .unwrap();
         assert_eq!(present, 1, "0087 must be reconciled, not run");
     }
+
     /// Two migration files sharing a version number merge cleanly, because the
     /// filenames differ and git sees no textual conflict, then fail at runtime
     /// on `UNIQUE constraint failed: _sqlx_migrations.version` for every fresh
@@ -373,6 +449,79 @@ mod migration_tests {
             "migration versions claimed more than once: {}",
             clashes.join("; ")
         );
+    }
+
+    /// A database that booted a build of PR #790 recorded version 93 as
+    /// `fleet provider event retention`. Main's 93 is `board_card_issue_index`,
+    /// so every later boot dies on `migration 93 was previously applied but has
+    /// been modified` and the daemon never starts. The repair has to undo the
+    /// foreign migration, not just unstick the row: leaving its index behind
+    /// would fail the renumbered file the moment #790 lands.
+    #[tokio::test]
+    async fn a_database_that_ran_the_unmerged_0093_still_upgrades() {
+        let pool = memory_pool().await;
+        apply_migrations(&pool).await.unwrap();
+
+        // Rewind to what such a database looks like: main's 93 never ran, the
+        // branch's did, and 93 is recorded under its description and checksum.
+        sqlx::query("DROP INDEX IF EXISTS idx_board_card_issue")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM _sqlx_migrations WHERE version = 93")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO _sqlx_migrations \
+             (version, description, success, checksum, execution_time) \
+             VALUES (93, 'fleet provider event retention', TRUE, ?, -1)",
+        )
+        .bind(vec![0xde_u8, 0xad, 0xbe, 0xef])
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE INDEX idx_fleet_provider_event_retention \
+             ON fleet_provider_event(observed_at) \
+             WHERE raw_payload <> '' AND projection_revision IS NOT NULL AND source <> 'acp'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        apply_migrations(&pool)
+            .await
+            .expect("a database carrying the unmerged 0093 must still upgrade");
+
+        assert!(
+            index_exists(&pool, "idx_board_card_issue").await,
+            "main's 0093 never ran"
+        );
+        assert!(
+            !index_exists(&pool, "idx_fleet_provider_event_retention").await,
+            "the foreign migration's index must be unwound, or the renumbered file cannot apply"
+        );
+        let description: String =
+            sqlx::query_scalar("SELECT description FROM _sqlx_migrations WHERE version = 93")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(description, "board card issue index");
+
+        // Re-running is a no-op: the row now matches, so the repair must not fire.
+        apply_migrations(&pool).await.unwrap();
+        assert!(index_exists(&pool, "idx_board_card_issue").await);
+    }
+
+    /// The repair is keyed on the foreign description, so an untouched database
+    /// must pass straight through it with its index intact.
+    #[tokio::test]
+    async fn a_healthy_database_keeps_its_board_card_index() {
+        let pool = memory_pool().await;
+        apply_migrations(&pool).await.unwrap();
+        apply_migrations(&pool).await.unwrap();
+        assert!(index_exists(&pool, "idx_board_card_issue").await);
     }
 }
 


### PR DESCRIPTION
## The collision

Version 93 was claimed by two unrelated migration files:

| file | landed in | on |
|---|---|---|
| `0093_board_card_issue_index.sql` | 1bff3371, released in **v1.23.2** | `main` |
| `0093_fleet_provider_event_retention.sql` | 189c513b (2026-08-30) | the branch behind #790, unmerged |

Two files with different names and the same ordinal merge cleanly, because git
sees no textual conflict, so nothing caught it at PR time. #790 has since
renumbered its file to `0094` (in its 2026-09-03 merge of `main`), so `main`
itself is coherent again. What is **not** repaired is any database that booted a
build of that branch while it still carried `0093`.

## The symptom

SQLx checksums the full text of every applied migration. A machine that ran a
branch build recorded version 93 under the *retention* file's text, so every
later boot of a released binary dies in the checksum guard:

```
Error: run hangar daemon (foreground)

Caused by:
    migration 93 was previously applied but has been modified
```

The daemon then never starts, `~/.agents-in-a-box/hangar.sock` never appears,
and every Codex launch fails with `connect hangar.sock: Connection refused`.
The guard is behaving correctly. The version number was wrong.

## The fix

`reconcile_foreign_migration_93` runs before `Migrator::run`, in the same slot
as the existing `reconcile_superseded_codex_launch_migrations`.

The 0087/0089/0090 reconciliation records a superseded-but-embedded file as
applied. That direction is not available here: the retention file is not
embedded in this binary in any form, so nothing can satisfy the row. The repair
goes the other way. When version 93 is recorded under the description
`fleet provider event retention`:

1. `DROP INDEX IF EXISTS idx_fleet_provider_event_retention`
2. delete that `_sqlx_migrations` row

which leaves the database exactly as if the branch build had never run, and
SQLx then applies `main`'s 93 normally.

Dropping the index matters as much as unsticking the row. `0094`'s
`CREATE INDEX` still carries no `IF NOT EXISTS`, so an orphan left behind would
fail that file on this same machine the moment #790 lands. And nothing is lost:
the index is a pure read optimisation over rows nothing has written to, and the
sweep that uses it is not in this binary.

The repair is keyed on the foreign description, so a database whose 93 is
`main`'s own never enters it, and neither does one that never reached 93.

## Upgrade paths

| database last written by | on this build |
|---|---|
| fresh | migrates normally |
| <= v1.23.1 (max version 92) | 93 applies normally |
| v1.23.2 (93 = board card issue index) | untouched, no repair fires |
| a #790 branch build (93 = fleet provider event retention) | **repaired, boots** |

No user-run sqlite surgery, no data loss, and re-running is a no-op.

## Guard

`every_migration_file_has_a_unique_version` reads `migrations/` and fails if two
files claim one ordinal. This has now happened twice: 0082 (fixed by
renumbering the attention migration to 0084 in 2a2657dd) and 0093. The
failure mode both times is a clean merge followed by
`UNIQUE constraint failed: _sqlx_migrations.version` on every fresh database.

It fires at test time, so be honest about when that is. A branch that adds
`00NN` while `main` has not taken `00NN` yet passes: the duplicate only exists
once the two trees meet, so the guard fails on the branch's next sync with
`main`, on the merge queue, and on `main` itself. That is early enough to keep a
collision off `main`, and it is exactly the point 0082 and 0093 both got through.

It is NOT early enough to protect a developer who runs a branch build before
that sync, which is how this collision reached a real database. Nothing at test
time can catch that: the ordinal is only wrong relative to a tree the branch has
not seen. That case is what the repair above exists for, and why the repair is
the part that had to ship, not the guard.

## Verification

- `a_database_that_ran_the_unmerged_0093_still_upgrades` seeds the exact broken
  state and fails with the real error before the fix, passes after.
- `a_healthy_database_keeps_its_board_card_index` proves an untouched database
  is not disturbed.
- `cargo test -p ainb-hangar-store`: 309 + 41 tests, all green.
- `cargo build -p ainb`, `cargo fmt --all --check`: clean.

End to end against a throwaway `AINB_HANGAR_HOME` seeded into the broken state
(the real `~/.agents-in-a-box/hangar.db` was never opened):

```
$ ainb --version                      # the installed release
ainb 1.23.2 (c4006da, 2026-09-02, ci)
$ AINB_HANGAR_HOME=$D ainb hangar issue list
Error: open hangar database
Caused by:
    migration 93 was previously applied but has been modified

$ AINB_HANGAR_HOME=$D ./target/debug/ainb hangar issue list
WARN ainb_hangar_store: unwound a migration that claimed a version number owned
     by another file; re-applying this binary's migration 93
     version=93 description="fleet provider event retention"
no issues

$ sqlite3 $D/hangar.db 'SELECT version, description FROM _sqlx_migrations WHERE version >= 92'
92|agent runtime instance id
93|board card issue index
```

