### PR TITLE
fix(daemons): two defects only visible when the TUI is actually driven

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc_supervisor.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc_supervisor.rs
@@ -395,9 +395,10 @@ it down — but check `ps -p {pid}` if it lingers"
                 Ok(None) => {}
                 Err(e) => out.notes.push(format!("policy not rendered for the new brain: {e}")),
             }
-            if let Some(pid) = out.lite_stopped_pid {
-                out.notes.push(format!("lite scanner stopped (pid {pid})"));
-            }
+            // The stop is already noted where it happens, in the `Signalled`
+            // arm above. Repeating it here printed "lite scanner stopped (pid
+            // N)" twice on every lite → full switch that actually stopped one.
+            //
             // Re-assert the scheduler through `repair`, which is the verb that
             // already guarantees exactly one of (daemon cron, local timer) ends
             // up active. Reimplementing that choice here is how a second

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/atc_supervisor.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/atc_supervisor.rs
@@ -161,6 +161,20 @@ its next action, but neither controller was started or stopped"
     });
 
     if matches!(format, OutputFormat::Text) {
+        // Notes FIRST, the transition LAST.
+        //
+        // The Daemons screen badges a row with the last non-empty line of the
+        // action's stdout, so whatever ends this block becomes the ATC row's
+        // health. Ending with the mode help made the row report
+        // `switch: `ainb fleet atc mode <name> --set full`` in place of what the
+        // switch actually did; ending with a note made it report a scheduler
+        // detail. The one line worth badging is the transition.
+        //
+        // The full help is not reprinted at all: whoever switched has just read
+        // it, inline on that same screen, and `mode <name>` prints it on demand.
+        for note in &reconcile.notes {
+            println!("  {note}");
+        }
         if unchanged {
             println!(
                 "ATC '{}' already in {} mode — nothing changed.",
@@ -169,18 +183,12 @@ its next action, but neither controller was started or stopped"
             );
         } else {
             println!(
-                "ATC '{}' switched {} → {}.",
+                "ATC '{}' switched {} → {} (owner: {}).",
                 meta.name,
                 previous.id(),
-                meta.mode.id()
+                meta.mode.id(),
+                meta.mode.owner().label()
             );
-        }
-        for note in &reconcile.notes {
-            println!("  {note}");
-        }
-        println!();
-        for line in mode_help(meta.mode, &meta.provider) {
-            println!("  {line}");
         }
     } else {
         println!("{}", serde_json::to_string_pretty(&summary)?);

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -227,7 +227,19 @@ impl ActionMenu {
         // Same rule as `offers`: with nothing provisioned there is no tmux
         // session, so attaching could only fail. `provision` is the entry that
         // gets you one.
-        if self.kind == DaemonKind::Atc && !self.row.unprovisioned() {
+        //
+        // LITE has no session either, and that is by design, not a fault to
+        // repair: `fleet atc setup --mode lite` spawns no brain at all, because
+        // a session nothing ever nudges would burn a slot and lie to every
+        // liveness surface. So the entry could only ever attach a session that
+        // was never created, which is the failure this whole method exists to
+        // keep off the menu. An UNKNOWN mode still offers it: `None` means the
+        // meta would not parse or several instances made it ambiguous, and
+        // hiding a working attach on a guess is the worse error.
+        if self.kind == DaemonKind::Atc
+            && !self.row.unprovisioned()
+            && self.row.mode != Some(SupervisorMode::Lite)
+        {
             entries.push(MenuEntry::OpenMissionControl);
         }
         if has_error {
@@ -1623,6 +1635,42 @@ mod tests {
                 mode.id()
             );
         }
+    }
+
+    /// The defect the probe fix exists to clear, asserted where it was actually
+    /// visible: the MENU, not the status field the menu reads.
+    ///
+    /// A probe-level assertion on `atc_instance` pins the input; it says nothing
+    /// about the row being usable, which is the thing that was broken. Both
+    /// halves are needed, because either one can be right while the other is not
+    /// (and was: `atc_instance` alone still leaves mission control offered).
+    #[test]
+    fn a_lite_atc_row_offers_the_lifecycle_verbs_but_not_a_session_lite_never_creates() {
+        let mut state = seeded_state_with_atc(vec![atc_row()], SupervisorMode::Lite);
+        state.open_menu();
+        let entries = state.menu.as_ref().expect("menu opens on the ATC row").entries(false);
+
+        for verb in [Action::Start, Action::Restart, Action::Stop] {
+            assert!(
+                entries.contains(&MenuEntry::Act(verb)),
+                "a provisioned lite row must offer {}: {entries:?}",
+                verb.id()
+            );
+        }
+        assert!(
+            entries.contains(&MenuEntry::Act(Action::ModeFull)),
+            "a lite row must offer the switch out of lite: {entries:?}"
+        );
+        assert!(
+            !entries.contains(&MenuEntry::Act(Action::Provision)),
+            "the instance IS provisioned, and provision refuses: {entries:?}"
+        );
+        // `setup --mode lite` spawns no brain session, so this could only ever
+        // attach one that was never created.
+        assert!(
+            !entries.contains(&MenuEntry::OpenMissionControl),
+            "lite has no mission control to open: {entries:?}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -657,7 +657,13 @@ fn run_daemon_action(kind_id: &str, verb: &str, action: Action) -> ActionOutcome
             let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
             let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
             let ok = out.status.success();
-            let first_line = |s: &str| {
+            // The LAST non-empty line, not the first — it was named `first_line`
+            // for long enough that a CLI ending its output with a help block
+            // badged the row with the help's closing line. Every verb reachable
+            // from this menu therefore has to end its stdout with the sentence
+            // worth badging; `fleet atc mode --set` prints its notes first for
+            // exactly this reason.
+            let badge_line = |s: &str| {
                 s.lines()
                     .rev()
                     .find(|l| !l.trim().is_empty())
@@ -666,7 +672,7 @@ fn run_daemon_action(kind_id: &str, verb: &str, action: Action) -> ActionOutcome
                     .to_string()
             };
             let summary = if ok {
-                let line = first_line(&stdout);
+                let line = badge_line(&stdout);
                 if line.is_empty() {
                     format!("{verb} ok")
                 } else {

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -210,24 +210,20 @@ impl ActionMenu {
     /// The entries for this menu. `view last error` only appears when there IS
     /// one — an always-present entry that usually does nothing is noise.
     fn entries(&self, has_error: bool) -> Vec<MenuEntry> {
-        // Per-kind, not `Action::ALL`: only the daemon that owns the Codex
-        // transport offers `pair`.
-        let mut entries: Vec<MenuEntry> = Action::for_kind(self.kind)
+        // Per-kind AND per-mode, not `Action::ALL`: only the daemon that owns
+        // the Codex transport offers `pair`, and ATC offers exactly the
+        // supervisor mode it is NOT in.
+        //
+        // `for_kind_in_mode` is asked for that rather than the menu re-deriving
+        // it: the same rule already decides what `ainb daemon atc --help`
+        // documents, and a second copy here is a rule that can drift on one
+        // surface while the other keeps the old answer. `offers` still gates
+        // every verb it returns, so an unprovisioned row is filtered as before.
+        let mut entries: Vec<MenuEntry> = Action::for_kind_in_mode(self.kind, self.row.mode)
             .into_iter()
             .filter(|action| self.offers(*action))
             .map(MenuEntry::Act)
             .collect();
-        // The supervisor mode the fleet is NOT in. Offering both would put
-        // "switch to the mode you are already in" on screen, and offering it on
-        // an unprovisioned row would name a switch with nothing to switch.
-        if self.kind == DaemonKind::Atc && !self.row.unprovisioned() {
-            if let Some(mode) = self.row.mode {
-                entries.push(MenuEntry::Act(match mode.other() {
-                    SupervisorMode::Lite => Action::ModeLite,
-                    SupervisorMode::Full => Action::ModeFull,
-                }));
-            }
-        }
         // Same rule as `offers`: with nothing provisioned there is no tmux
         // session, so attaching could only fail. `provision` is the entry that
         // gets you one.

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -241,10 +241,23 @@ pub struct DaemonStatus {
 /// lite mode with no scanner running: the fleet HAS a designated owner and that
 /// owner is absent, which is a different problem from an unconfigured ATC and
 /// takes a different fix (`ainb daemon atc start`, not `fleet atc setup`).
+///
+/// `home` is the ainb home being probed, and the scanner heartbeat is read from
+/// it rather than from the process-global default. The full-mode path already
+/// resolves everything it reads relative to the caller's `home`; reading the
+/// heartbeat from somewhere else made the lite branch the one thing in this
+/// probe that could not be exercised against a fixture, which is how three of
+/// its four returns went untested.
+///
+/// `orphan` is carried in, not recomputed: every full-mode return reports the
+/// installed timer that fires into nothing, and a lite row that dropped it
+/// showed neither the warning nor the `remove-orphan` verb that clears it.
 fn probe_atc_lite(
+    home: &Path,
     paths: &crate::fleet::atc::paths::AtcPaths,
     meta: &crate::fleet::atc::meta::AtcMeta,
     now_ms: i64,
+    orphan: Option<String>,
 ) -> DaemonStatus {
     use crate::fleet::atc::heartbeat::HeartbeatState;
     use crate::fleet::atc::supervisor::{SupervisorMode, lite_heartbeat_id};
@@ -261,12 +274,13 @@ fn probe_atc_lite(
         .map(|s| HeartbeatState::from_json_or_default(&s))
         .and_then(|s| s.last_active_ms);
 
-    let Some(hb) = DaemonHeartbeat::read(&lite_heartbeat_id(&name)) else {
+    let Some(hb) = DaemonHeartbeat::read_in(home, &lite_heartbeat_id(&name)) else {
         return DaemonStatus {
             kind,
             state: DaemonState::Degraded,
             channel,
             atc_instance: Some(name.clone()),
+            scheduler_orphan: orphan,
             last_activity_at: last_active,
             reason: format!(
                 "lite mode is the owner of this fleet but no scanner is running; \
@@ -284,6 +298,7 @@ fn probe_atc_lite(
             pid: Some(hb.pid),
             channel,
             atc_instance: Some(name.clone()),
+            scheduler_orphan: orphan,
             last_activity_at: last_active,
             ..DaemonStatus::stopped(
                 kind,
@@ -299,6 +314,7 @@ fn probe_atc_lite(
             pid: Some(hb.pid),
             channel,
             atc_instance: Some(name.clone()),
+            scheduler_orphan: orphan,
             last_activity_at: last_active,
             reason: format!(
                 "lite scanner alive (pid {}) but its last scan was {}s ago — wedged?",
@@ -314,7 +330,8 @@ fn probe_atc_lite(
         pid: Some(hb.pid),
         connected: true,
         channel,
-        atc_instance: Some(name.clone()),
+        atc_instance: Some(name),
+        scheduler_orphan: orphan,
         last_activity_at: last_active,
         error_count: hb.error_count,
         last_error: hb.last_error.clone(),
@@ -913,10 +930,10 @@ fn hangar_daemon_census() -> usize {
 /// Identity, not bare liveness: a recycled pid is a tombstone from a crashed
 /// scanner, and counting it as running would let a dead lite instance claim the
 /// row from a healthy full one.
-fn lite_scanner_is_live(name: &str) -> bool {
+fn lite_scanner_is_live(home: &Path, name: &str) -> bool {
     use crate::fleet::atc::supervisor::lite_heartbeat_id;
     use crate::fleet::daemons::heartbeat::{DaemonHeartbeat, PidCheck, pid_identity};
-    DaemonHeartbeat::read(&lite_heartbeat_id(name))
+    DaemonHeartbeat::read_in(home, &lite_heartbeat_id(name))
         .is_some_and(|hb| pid_identity(hb.pid, hb.started_at) == PidCheck::Matched)
 }
 
@@ -1009,7 +1026,7 @@ pub(crate) fn probe_atc_with(
         if meta.mode != SupervisorMode::Lite {
             continue;
         }
-        if lite_scanner_is_live(&meta.name) {
+        if lite_scanner_is_live(home, &meta.name) {
             lite_running = Some((p, meta));
             break;
         }
@@ -1018,7 +1035,7 @@ pub(crate) fn probe_atc_with(
         }
     }
     if let Some((p, meta)) = lite_running {
-        return probe_atc_lite(&p, &meta, now_ms);
+        return probe_atc_lite(home, &p, &meta, now_ms, orphan);
     }
 
     // Pick the most-recently-beating instance as the representative row, and
@@ -1079,14 +1096,13 @@ pub(crate) fn probe_atc_with(
         }
     }
 
-    let fall_back_to_idle_lite = |reason_if_none: DaemonStatus| -> DaemonStatus {
-        match &lite_idle {
-            Some((p, meta)) => probe_atc_lite(p, meta, now_ms),
-            None => reason_if_none,
-        }
-    };
-
     let Some((name, hbs, interval_min, provider)) = best else {
+        // A provisioned lite instance has no full-mode heartbeat by design, so
+        // it takes the lite probe rather than any of the stories below, which
+        // are all about a scheduler that has stopped beating.
+        if let Some((p, meta)) = &lite_idle {
+            return probe_atc_lite(home, p, meta, now_ms, orphan);
+        }
         // No enabled instance produced a usable heartbeat. If NONE of the
         // provisioned instances are even enabled, the daemon is configured off.
         let reason = if enabled_count == 0 {
@@ -1097,14 +1113,11 @@ pub(crate) fn probe_atc_with(
         } else {
             format!("{enabled_count} enabled instance(s), none have beaten yet")
         };
-        // Through the lite fallback: a provisioned lite instance has no
-        // full-mode heartbeat by design, so "none have beaten yet" is the wrong
-        // story to tell about it.
-        return fall_back_to_idle_lite(DaemonStatus {
+        return DaemonStatus {
             atc_instance: names.first().cloned(),
             scheduler_orphan: orphan,
             ..DaemonStatus::stopped(kind, reason)
-        });
+        };
     };
 
     if hbs.last_heartbeat_ms == 0 {
@@ -2595,6 +2608,109 @@ mod tests {
             s.atc_instance.as_deref(),
             Some("tower"),
             "a lite row must name its instance or the menu treats it as unprovisioned"
+        );
+    }
+
+    /// Write the lite scanner's daemon heartbeat under the probed home.
+    ///
+    /// Under the home, not the process default: the fix that named the instance
+    /// touched all FOUR of `probe_atc_lite`'s returns, and only the
+    /// no-scanner-at-all one was reachable from a fixture while the heartbeat
+    /// was read from wherever the developer's real ainb home happened to be.
+    /// Deleting the field from the other three left the suite green.
+    fn write_lite_heartbeat(
+        home: &std::path::Path,
+        name: &str,
+        pid: u32,
+        started_at: i64,
+        last_heartbeat_at: i64,
+    ) {
+        use crate::fleet::atc::supervisor::lite_heartbeat_id;
+        use crate::fleet::daemons::heartbeat::heartbeat_path_in;
+        let path = heartbeat_path_in(home, &lite_heartbeat_id(name));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!(
+                r#"{{"pid":{pid},"started_at":{started_at},"last_heartbeat_at":{last_heartbeat_at},"connected":true,"error_count":0}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Our own pid, with the `started_at` that makes the identity check MATCH.
+    /// A fabricated timestamp reads as a recycled pid and takes a different
+    /// branch, so the healthy row can only be reached through the real one.
+    fn live_self() -> (u32, i64) {
+        let pid = std::process::id();
+        let started = super::super::heartbeat::process_start_ms(pid).expect("self start readable");
+        (pid, started)
+    }
+
+    #[test]
+    fn every_lite_row_names_its_instance_whatever_its_scanner_is_doing() {
+        // The menu reads `atc_instance` and nothing else to decide whether the
+        // row is provisioned, so ONE branch getting it right is not the fix:
+        // a wedged or crashed scanner is exactly when the operator opens the
+        // menu, and those rows must offer the same verbs a healthy one does.
+        let now = super::super::heartbeat::now_ms();
+        let (pid, started) = live_self();
+        let stale = stale_after_ms();
+
+        for (case, hb, expected) in [
+            ("no scanner at all", None, DaemonState::Degraded),
+            (
+                "crashed: nothing owns the recorded pid",
+                Some((0x7fff_ffff, now - 60_000, now)),
+                DaemonState::Stopped,
+            ),
+            (
+                "wedged: alive but not scanning",
+                Some((pid, started, now - stale - 60_000)),
+                DaemonState::Degraded,
+            ),
+            (
+                "healthy: alive and scanning",
+                Some((pid, started, now)),
+                DaemonState::Running,
+            ),
+        ] {
+            let home = TempDir::new().unwrap();
+            write_lite_instance(home.path(), "tower", now - 1000);
+            if let Some((pid, started, beat)) = hb {
+                write_lite_heartbeat(home.path(), "tower", pid, started, beat);
+            }
+
+            let s = probe_atc_with(home.path(), now, &|_| Some(true), &[]);
+            assert_eq!(s.state, expected, "{case}: reason {}", s.reason);
+            assert_eq!(
+                s.atc_instance.as_deref(),
+                Some("tower"),
+                "{case}: a lite row must name its instance or the menu treats it as unprovisioned"
+            );
+        }
+    }
+
+    #[test]
+    fn a_lite_row_still_names_a_timer_firing_into_nothing() {
+        // Every full-mode return carries the orphan; the lite ones dropped it,
+        // so a lite fleet with a stale full-mode unit beside it showed neither
+        // the warning nor `remove-orphan`, the one verb that clears it. The
+        // orphan outlives the switch that made the fleet lite, so this is the
+        // ordinary state after `mode --set lite` fails to tear a unit down.
+        let now = super::super::heartbeat::now_ms();
+        let (pid, started) = live_self();
+        let home = TempDir::new().unwrap();
+        write_lite_instance(home.path(), "tower", now - 1000);
+        write_lite_heartbeat(home.path(), "tower", pid, started, now);
+
+        let s = probe_atc_with(home.path(), now, &|_| Some(true), &["gone".to_string()]);
+
+        assert_eq!(s.state, DaemonState::Running, "reason: {}", s.reason);
+        assert_eq!(
+            s.scheduler_orphan.as_deref(),
+            Some("gone"),
+            "the stale unit must be named on a lite row too"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemons/probe.rs
@@ -266,6 +266,7 @@ fn probe_atc_lite(
             kind,
             state: DaemonState::Degraded,
             channel,
+            atc_instance: Some(name.clone()),
             last_activity_at: last_active,
             reason: format!(
                 "lite mode is the owner of this fleet but no scanner is running; \
@@ -282,6 +283,7 @@ fn probe_atc_lite(
             state: DaemonState::Stopped,
             pid: Some(hb.pid),
             channel,
+            atc_instance: Some(name.clone()),
             last_activity_at: last_active,
             ..DaemonStatus::stopped(
                 kind,
@@ -296,6 +298,7 @@ fn probe_atc_lite(
             state: DaemonState::Degraded,
             pid: Some(hb.pid),
             channel,
+            atc_instance: Some(name.clone()),
             last_activity_at: last_active,
             reason: format!(
                 "lite scanner alive (pid {}) but its last scan was {}s ago — wedged?",
@@ -311,6 +314,7 @@ fn probe_atc_lite(
         pid: Some(hb.pid),
         connected: true,
         channel,
+        atc_instance: Some(name.clone()),
         last_activity_at: last_active,
         error_count: hb.error_count,
         last_error: hb.last_error.clone(),
@@ -2570,6 +2574,27 @@ mod tests {
             s.reason.contains("heartbeat timer for 'main'"),
             "the orphan timer must be named: {}",
             s.reason
+        );
+    }
+
+    #[test]
+    fn a_lite_row_names_its_instance_so_the_menu_offers_real_verbs() {
+        // The Daemons menu is state-driven off `atc_instance`: `None` means
+        // "nothing provisioned", and the row then offers ONLY `provision`.
+        // Every lite status left that field unset, so a perfectly healthy lite
+        // fleet showed a menu with no lifecycle verbs and no mode switch — and
+        // `provision` itself refuses, because an instance does exist. The row
+        // became unusable. Only driving the TUI showed it; every unit test
+        // asserted on state and channel, which were both correct.
+        let home = TempDir::new().unwrap();
+        let now = super::super::heartbeat::now_ms();
+        write_lite_instance(home.path(), "tower", now - 1000);
+
+        let s = probe_atc_with(home.path(), now, &|_| Some(true), &[]);
+        assert_eq!(
+            s.atc_instance.as_deref(),
+            Some("tower"),
+            "a lite row must name its instance or the menu treats it as unprovisioned"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/tests/atc_supervisor_mode.rs
+++ b/ainb-tui/crates/ainb-core/tests/atc_supervisor_mode.rs
@@ -364,6 +364,62 @@ fn switching_reports_the_transition_and_is_idempotent() {
 }
 
 #[test]
+fn the_switch_ends_with_the_transition_so_the_daemons_row_badges_it() {
+    // The Daemons screen badges an ATC row with the LAST non-empty line of the
+    // action's stdout (`run_daemon_action` in components/daemons.rs). That makes
+    // the print order here a contract, not a layout choice: ending the block
+    // with the mode help badged the row with the help's closing line,
+    // "switch: `ainb fleet atc mode <name> --set full`", in place of what the
+    // switch did. Ending with a note badged it with a scheduler detail.
+    //
+    // Asserted against the real binary's stdout, because the ordering is the
+    // whole fix and nothing else in the tree would notice it being undone.
+    let home = home_for("badge");
+    let name = instance("badge");
+    assert!(setup(&home, &name, &[]).status.success());
+
+    // --no-reconcile both keeps the test off the developer's schedulers AND
+    // guarantees a note, so this proves the notes really do come FIRST rather
+    // than passing on an empty list.
+    let out = run(
+        &home,
+        &[
+            "fleet",
+            "atc",
+            "mode",
+            &name,
+            "--set",
+            "lite",
+            "--no-reconcile",
+        ],
+    );
+    assert!(out.status.success(), "{}", stderr(&out));
+    let text = String::from_utf8_lossy(&out.stdout);
+
+    let last = text
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .expect("the switch says something")
+        .trim();
+    assert!(
+        last.starts_with(&format!("ATC '{name}' switched full → lite")),
+        "the row badges this line, so it must be the transition, got {last:?} from:\n{text}"
+    );
+    assert!(
+        text.contains("--no-reconcile:"),
+        "the note must still be printed, above the transition:\n{text}"
+    );
+    // The help belongs to `mode <name>` and to the inline panel on that same
+    // screen. Reprinting it here is what put a help line where health goes.
+    assert!(
+        !text.contains("--set full"),
+        "the switch must not reprint the mode help:\n{text}"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
 fn reading_the_mode_never_changes_it() {
     // Switching the thing that drives a whole fleet must take an explicit
     // --set; looking at it must not be enough.


### PR DESCRIPTION
## Found by actually driving the TUI

Everything before this shipped on unit and integration tests. Stevie asked whether the Daemons screen had been verified *through the TUI, in a separate ainb home*. It had not. Doing that found two defects that every existing test was blind to — both of them in the affordance the whole supervisor feature exists to provide.

Method: real `ainb tui` in a detached tmux session, isolated `HOME` and `AINB_HOME`, an ATC instance written straight to disk (no `setup`, so nothing touched launchd or the real `main` instance), navigated to the Daemons screen, and driven through a full → lite → full round trip with pane captures at each step.

## 1. A lite ATC row offered no verbs at all

The menu is state-driven off `DaemonStatus::atc_instance`: `None` means "nothing provisioned", and the row then offers only `provision`. Every status `probe_atc_lite` returns left that field unset, so a healthy lite fleet rendered:

```
╭ ATC ───────────────────────────╮
│▶ provision                     │      ← and nothing else
╰────────────────────────────────╯
```

No start, no stop, no restart, no mode switch — and `provision` itself refuses, because an instance *does* exist. The row was unusable in exactly the mode this feature added.

Invisible to tests because `state`, `channel` and `reason` were all correct; the assertions were on those three. `atc_instance` is newer, and the lite path never learned about it.

After:

```
╭ ATC ───────────────────────────╮
│▶ start                         │
│  restart                       │
│  stop                          │
│  switch to full mode           │
│  open mission control          │
╰────────────────────────────────╯
```

## 2. The row's health badge showed help text

The Daemons screen badges a row with the **last non-empty line** of an action's stdout. `fleet atc mode --set` ended by printing eight lines of mode help, so after a switch the ATC row reported:

```
ATC  ● running  13084  …  switch: `ainb fleet atc mode <name> --set full`
```

The closing line of a help block, sitting where the row's health belongs, in place of what the switch actually did.

Notes now print first and the transition last, and the full help is not reprinted after a switch at all — whoever just switched has read it, inline on that same screen, and `mode <name>` still prints it on demand.

```
ATC  ◐ degraded  …  ATC 'tower' switched lite → full (owner: full heartbeat).
```

## What the round trip did confirm

One ATC row and no fleet-daemon row (#830 working in the real UI); the inline mode help rendering in full with the hooks panel intact beside it; the menu offering exactly the mode the fleet is not in; the switch persisting to `meta.json`; the lite scanner actually starting, taking its flock, writing its heartbeat and logging its scans; and the row flipping to `● running` with its pid.

## Verification

2220 lib tests pass (the 3 failures are the host-config env-var tests that fail identically on unmodified `origin/main`). One regression test added for the `atc_instance` gap, which is the one of the two a test can hold.

Sandbox left clean: no launchd unit created, no scanner leaked, temp home removed, the real `main` instance untouched.
